### PR TITLE
feat: agent chat interface with streaming and persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +268,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,11 +470,13 @@ name = "claudette"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "futures",
  "iced",
  "image",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "open",
  "rand",
  "rfd",
  "rusqlite",
@@ -671,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +876,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +916,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1051,6 +1103,15 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1273,6 +1334,7 @@ dependencies = [
  "iced_core",
  "iced_debug",
  "iced_futures",
+ "iced_highlighter",
  "iced_renderer",
  "iced_runtime",
  "iced_widget",
@@ -1341,6 +1403,16 @@ dependencies = [
  "rustc-hash 2.1.1",
  "thiserror 2.0.18",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "iced_highlighter"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb24e1610502779b4e307c6f95da616ec7e883b67a18108cb0a036b169e50359"
+dependencies = [
+ "iced_core",
+ "two-face",
 ]
 
 [[package]]
@@ -1422,9 +1494,11 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1596afa0d3109c2618e8bc12bae6c11d3064df8f95c42dfce570397dbe957ab"
 dependencies = [
+ "iced_highlighter",
  "iced_renderer",
  "log",
  "num-traits",
+ "pulldown-cmark",
  "rustc-hash 2.1.1",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -1478,6 +1552,25 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1620,6 +1713,12 @@ name = "linebender_resource_handle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1819,6 +1918,12 @@ checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -2218,6 +2323,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,6 +2413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.38.4",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2539,12 @@ checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2455,10 +2596,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.11.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -2586,6 +2755,23 @@ dependencies = [
  "libredox",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2990,6 +3176,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sys-locale"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3265,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3199,6 +3437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "two-face"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e51b6e60e545cfdae5a4639ff423818f52372211a8d9a3e892b4b0761f76b2"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,6 +3457,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -3535,7 +3790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.2",
  "quote",
 ]
 
@@ -4296,6 +4551,15 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yazi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,8 @@ dependencies = [
  "rand",
  "rfd",
  "rusqlite",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,15 @@ edition = "2024"
 description = "Claude's missing better half — a companion tool for Claude Code"
 
 [dependencies]
-iced = { version = "0.14", features = ["tokio"] }
+futures = "0.3"
+iced = { version = "0.14", features = ["tokio", "markdown", "highlighter"] }
 rusqlite = { version = "0.34", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
+open = "5"
 rand = "0.8"
 rfd = "0.17.2"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ description = "Claude's missing better half — a companion tool for Claude Code
 [dependencies]
 iced = { version = "0.14", features = ["tokio"] }
 rusqlite = { version = "0.34", features = ["bundled"] }
-tokio = { version = "1", features = ["process", "fs"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 rand = "0.8"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,11 +1,10 @@
 #![allow(dead_code)]
 
 use std::path::Path;
-use std::process::ExitStatus;
 
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 use tokio::sync::mpsc;
 
 // ---------------------------------------------------------------------------
@@ -106,147 +105,131 @@ pub fn parse_stream_line(line: &str) -> Result<StreamEvent, serde_json::Error> {
 // Agent process manager
 // ---------------------------------------------------------------------------
 
-#[derive(Debug)]
-pub enum AgentError {
-    SpawnFailed(String),
-    WriteFailed(String),
-    ProcessNotRunning,
+/// Result of spawning an agent process — individual parts for flexible storage.
+pub struct SpawnedAgent {
+    pub stdin_tx: mpsc::Sender<String>,
+    pub event_rx: mpsc::Receiver<StreamEvent>,
+    pub session_id: String,
+    pub pid: u32,
 }
 
-impl std::fmt::Display for AgentError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SpawnFailed(msg) => write!(f, "Failed to spawn agent: {msg}"),
-            Self::WriteFailed(msg) => write!(f, "Failed to write to agent: {msg}"),
-            Self::ProcessNotRunning => write!(f, "Agent process is not running"),
+/// Spawn a Claude Code CLI process with bidirectional JSON streaming.
+pub async fn spawn_agent(working_dir: &Path, session_id: &str) -> Result<SpawnedAgent, String> {
+    let mut child = Command::new("claude")
+        .args([
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--input-format",
+            "stream-json",
+            "--verbose",
+            "--session-id",
+            session_id,
+        ])
+        .current_dir(working_dir)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn claude: {e}"))?;
+
+    let pid = child
+        .id()
+        .ok_or_else(|| "Process exited immediately".to_string())?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "Failed to capture stdin".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture stdout".to_string())?;
+
+    // Stdin writer task
+    let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
+    tokio::spawn(async move {
+        let mut stdin = stdin;
+        while let Some(msg) = stdin_rx.recv().await {
+            if stdin.write_all(msg.as_bytes()).await.is_err() {
+                break;
+            }
+            if stdin.write_all(b"\n").await.is_err() {
+                break;
+            }
+            if stdin.flush().await.is_err() {
+                break;
+            }
         }
-    }
-}
+    });
 
-impl std::error::Error for AgentError {}
-
-pub struct ClaudeCodeAgent {
-    child: Child,
-    stdin_tx: mpsc::Sender<String>,
-    session_id: String,
-}
-
-impl ClaudeCodeAgent {
-    /// Spawn a new Claude CLI process with bidirectional streaming.
-    ///
-    /// Returns the agent handle and a receiver for parsed stream events.
-    pub async fn spawn(
-        working_dir: &Path,
-        session_id: &str,
-    ) -> Result<(Self, mpsc::Receiver<StreamEvent>), AgentError> {
-        let mut child = Command::new("claude")
-            .args([
-                "--print",
-                "--output-format",
-                "stream-json",
-                "--input-format",
-                "stream-json",
-                "--verbose",
-                "--session-id",
-                session_id,
-            ])
-            .current_dir(working_dir)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .map_err(|e| AgentError::SpawnFailed(e.to_string()))?;
-
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| AgentError::SpawnFailed("Failed to capture stdin".into()))?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| AgentError::SpawnFailed("Failed to capture stdout".into()))?;
-
-        // Stdin writer task
-        let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
-        tokio::spawn(async move {
-            let mut stdin = stdin;
-            while let Some(msg) = stdin_rx.recv().await {
-                if stdin.write_all(msg.as_bytes()).await.is_err() {
-                    break;
-                }
-                if stdin.write_all(b"\n").await.is_err() {
-                    break;
-                }
-                if stdin.flush().await.is_err() {
-                    break;
-                }
+    // Stdout reader task
+    let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(128);
+    tokio::spawn(async move {
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() {
+                continue;
             }
-        });
-
-        // Stdout reader task
-        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(128);
-        tokio::spawn(async move {
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if line.trim().is_empty() {
-                    continue;
-                }
-                match parse_stream_line(&line) {
-                    Ok(event) => {
-                        if event_tx.send(event).await.is_err() {
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("Failed to parse stream event: {e}\nLine: {line}");
+            match parse_stream_line(&line) {
+                Ok(event) => {
+                    if event_tx.send(event).await.is_err() {
+                        break;
                     }
                 }
+                Err(e) => {
+                    eprintln!("Failed to parse stream event: {e}\nLine: {line}");
+                }
             }
-        });
+        }
+    });
 
-        Ok((
-            Self {
-                child,
-                stdin_tx,
-                session_id: session_id.to_string(),
-            },
-            event_rx,
-        ))
-    }
+    // Wait for process exit in background, let the event channel close naturally
+    tokio::spawn(async move {
+        let _ = child.wait().await;
+    });
 
-    /// Send a user message to the agent via stdin.
-    pub async fn send_message(&self, content: &str) -> Result<(), AgentError> {
-        let msg = serde_json::json!({
-            "type": "user",
-            "content": content,
-        })
-        .to_string();
+    Ok(SpawnedAgent {
+        stdin_tx,
+        event_rx,
+        session_id: session_id.to_string(),
+        pid,
+    })
+}
 
-        self.stdin_tx
-            .send(msg)
-            .await
-            .map_err(|e| AgentError::WriteFailed(e.to_string()))
-    }
+/// Send a user message to the agent via its stdin channel.
+pub async fn send_user_message(
+    stdin_tx: &mpsc::Sender<String>,
+    content: &str,
+) -> Result<(), String> {
+    let msg = serde_json::json!({
+        "type": "user",
+        "content": content,
+    })
+    .to_string();
 
-    /// Get the session ID for this agent.
-    pub fn session_id(&self) -> &str {
-        &self.session_id
-    }
+    stdin_tx
+        .send(msg)
+        .await
+        .map_err(|e| format!("Failed to send message: {e}"))
+}
 
-    /// Stop the agent process. Kills and waits for exit.
-    pub async fn stop(&mut self) -> Result<(), AgentError> {
-        self.child
-            .kill()
-            .await
-            .map_err(|e| AgentError::WriteFailed(e.to_string()))?;
-        let _ = self.child.wait().await;
+/// Stop an agent process by killing it.
+pub async fn stop_agent(pid: u32) -> Result<(), String> {
+    let output = tokio::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to kill agent: {e}"))?;
+
+    if output.status.success() {
         Ok(())
-    }
-
-    /// Check if the process has exited without blocking.
-    pub fn try_wait(&mut self) -> Option<ExitStatus> {
-        self.child.try_wait().ok().flatten()
+    } else {
+        Err(format!(
+            "kill failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
     }
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,521 @@
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::process::ExitStatus;
+
+use serde::Deserialize;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+
+// ---------------------------------------------------------------------------
+// Stream event types — maps to Claude CLI `--output-format stream-json`
+// ---------------------------------------------------------------------------
+
+/// Top-level JSON line from Claude CLI stdout.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum StreamEvent {
+    #[serde(rename = "system")]
+    System {
+        subtype: String,
+        #[serde(default)]
+        session_id: Option<String>,
+    },
+
+    #[serde(rename = "stream_event")]
+    Stream { event: InnerStreamEvent },
+
+    #[serde(rename = "assistant")]
+    Assistant { message: AssistantMessage },
+
+    #[serde(rename = "result")]
+    Result {
+        subtype: String,
+        #[serde(default)]
+        result: Option<String>,
+        #[serde(default)]
+        total_cost_usd: Option<f64>,
+        #[serde(default)]
+        duration_ms: Option<i64>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum InnerStreamEvent {
+    #[serde(rename = "message_start")]
+    MessageStart {},
+
+    #[serde(rename = "content_block_start")]
+    ContentBlockStart { index: usize },
+
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta { index: usize, delta: Delta },
+
+    #[serde(rename = "content_block_stop")]
+    ContentBlockStop { index: usize },
+
+    #[serde(rename = "message_stop")]
+    MessageStop {},
+
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum Delta {
+    #[serde(rename = "text_delta")]
+    Text { text: String },
+
+    #[serde(rename = "tool_use_delta")]
+    ToolUse {
+        #[serde(default)]
+        partial_json: Option<String>,
+    },
+
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssistantMessage {
+    pub content: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+
+    #[serde(rename = "tool_use")]
+    ToolUse { id: String, name: String },
+
+    #[serde(other)]
+    Unknown,
+}
+
+/// Parse a single JSON line from the Claude CLI stdout stream.
+pub fn parse_stream_line(line: &str) -> Result<StreamEvent, serde_json::Error> {
+    serde_json::from_str(line)
+}
+
+// ---------------------------------------------------------------------------
+// Agent process manager
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum AgentError {
+    SpawnFailed(String),
+    WriteFailed(String),
+    ProcessNotRunning,
+}
+
+impl std::fmt::Display for AgentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SpawnFailed(msg) => write!(f, "Failed to spawn agent: {msg}"),
+            Self::WriteFailed(msg) => write!(f, "Failed to write to agent: {msg}"),
+            Self::ProcessNotRunning => write!(f, "Agent process is not running"),
+        }
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+pub struct ClaudeCodeAgent {
+    child: Child,
+    stdin_tx: mpsc::Sender<String>,
+    session_id: String,
+}
+
+impl ClaudeCodeAgent {
+    /// Spawn a new Claude CLI process with bidirectional streaming.
+    ///
+    /// Returns the agent handle and a receiver for parsed stream events.
+    pub async fn spawn(
+        working_dir: &Path,
+        session_id: &str,
+    ) -> Result<(Self, mpsc::Receiver<StreamEvent>), AgentError> {
+        let mut child = Command::new("claude")
+            .args([
+                "--print",
+                "--output-format",
+                "stream-json",
+                "--input-format",
+                "stream-json",
+                "--verbose",
+                "--session-id",
+                session_id,
+            ])
+            .current_dir(working_dir)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| AgentError::SpawnFailed(e.to_string()))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| AgentError::SpawnFailed("Failed to capture stdin".into()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AgentError::SpawnFailed("Failed to capture stdout".into()))?;
+
+        // Stdin writer task
+        let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
+        tokio::spawn(async move {
+            let mut stdin = stdin;
+            while let Some(msg) = stdin_rx.recv().await {
+                if stdin.write_all(msg.as_bytes()).await.is_err() {
+                    break;
+                }
+                if stdin.write_all(b"\n").await.is_err() {
+                    break;
+                }
+                if stdin.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Stdout reader task
+        let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(128);
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_stream_line(&line) {
+                    Ok(event) => {
+                        if event_tx.send(event).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to parse stream event: {e}\nLine: {line}");
+                    }
+                }
+            }
+        });
+
+        Ok((
+            Self {
+                child,
+                stdin_tx,
+                session_id: session_id.to_string(),
+            },
+            event_rx,
+        ))
+    }
+
+    /// Send a user message to the agent via stdin.
+    pub async fn send_message(&self, content: &str) -> Result<(), AgentError> {
+        let msg = serde_json::json!({
+            "type": "user",
+            "content": content,
+        })
+        .to_string();
+
+        self.stdin_tx
+            .send(msg)
+            .await
+            .map_err(|e| AgentError::WriteFailed(e.to_string()))
+    }
+
+    /// Get the session ID for this agent.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Stop the agent process. Kills and waits for exit.
+    pub async fn stop(&mut self) -> Result<(), AgentError> {
+        self.child
+            .kill()
+            .await
+            .map_err(|e| AgentError::WriteFailed(e.to_string()))?;
+        let _ = self.child.wait().await;
+        Ok(())
+    }
+
+    /// Check if the process has exited without blocking.
+    pub fn try_wait(&mut self) -> Option<ExitStatus> {
+        self.child.try_wait().ok().flatten()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_system_init() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"abc-123"}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::System {
+                subtype,
+                session_id,
+            } => {
+                assert_eq!(subtype, "init");
+                assert_eq!(session_id.unwrap(), "abc-123");
+            }
+            _ => panic!("Expected System event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_system_without_session_id() {
+        let line = r#"{"type":"system","subtype":"init"}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::System {
+                subtype,
+                session_id,
+            } => {
+                assert_eq!(subtype, "init");
+                assert!(session_id.is_none());
+            }
+            _ => panic!("Expected System event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_message_start() {
+        let line = r#"{"type":"stream_event","event":{"type":"message_start"}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => {
+                assert!(matches!(event, InnerStreamEvent::MessageStart {}));
+            }
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_message_stop() {
+        let line = r#"{"type":"stream_event","event":{"type":"message_stop"}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => {
+                assert!(matches!(event, InnerStreamEvent::MessageStop {}));
+            }
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_content_block_start() {
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => match event {
+                InnerStreamEvent::ContentBlockStart { index } => assert_eq!(index, 0),
+                _ => panic!("Expected ContentBlockStart"),
+            },
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_content_block_stop() {
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => match event {
+                InnerStreamEvent::ContentBlockStop { index } => assert_eq!(index, 0),
+                _ => panic!("Expected ContentBlockStop"),
+            },
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_content_block_delta_text() {
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => match event {
+                InnerStreamEvent::ContentBlockDelta { index, delta } => {
+                    assert_eq!(index, 0);
+                    match delta {
+                        Delta::Text { text } => assert_eq!(text, "Hello world"),
+                        _ => panic!("Expected TextDelta"),
+                    }
+                }
+                _ => panic!("Expected ContentBlockDelta"),
+            },
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_content_block_delta_tool_use() {
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"tool_use_delta","partial_json":"{\"path\":"}}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => match event {
+                InnerStreamEvent::ContentBlockDelta { index, delta } => {
+                    assert_eq!(index, 1);
+                    match delta {
+                        Delta::ToolUse { partial_json } => {
+                            assert_eq!(partial_json.unwrap(), r#"{"path":"#);
+                        }
+                        _ => panic!("Expected ToolUseDelta"),
+                    }
+                }
+                _ => panic!("Expected ContentBlockDelta"),
+            },
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_assistant_message() {
+        let line =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Assistant { message } => {
+                assert_eq!(message.content.len(), 1);
+                match &message.content[0] {
+                    ContentBlock::Text { text } => assert_eq!(text, "Hello world"),
+                    _ => panic!("Expected Text content block"),
+                }
+            }
+            _ => panic!("Expected Assistant event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_assistant_message_with_tool_use() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Let me check"},{"type":"tool_use","id":"tu_01","name":"Read"}]}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Assistant { message } => {
+                assert_eq!(message.content.len(), 2);
+                match &message.content[0] {
+                    ContentBlock::Text { text } => assert_eq!(text, "Let me check"),
+                    _ => panic!("Expected Text"),
+                }
+                match &message.content[1] {
+                    ContentBlock::ToolUse { id, name } => {
+                        assert_eq!(id, "tu_01");
+                        assert_eq!(name, "Read");
+                    }
+                    _ => panic!("Expected ToolUse"),
+                }
+            }
+            _ => panic!("Expected Assistant event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_result_success() {
+        let line = r#"{"type":"result","subtype":"success","result":"full text","total_cost_usd":0.003,"duration_ms":1500}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Result {
+                subtype,
+                result,
+                total_cost_usd,
+                duration_ms,
+            } => {
+                assert_eq!(subtype, "success");
+                assert_eq!(result.unwrap(), "full text");
+                assert!((total_cost_usd.unwrap() - 0.003).abs() < f64::EPSILON);
+                assert_eq!(duration_ms.unwrap(), 1500);
+            }
+            _ => panic!("Expected Result event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_result_without_optional_fields() {
+        let line = r#"{"type":"result","subtype":"error"}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Result {
+                subtype,
+                result,
+                total_cost_usd,
+                duration_ms,
+            } => {
+                assert_eq!(subtype, "error");
+                assert!(result.is_none());
+                assert!(total_cost_usd.is_none());
+                assert!(duration_ms.is_none());
+            }
+            _ => panic!("Expected Result event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_unknown_inner_event_type() {
+        let line =
+            r#"{"type":"stream_event","event":{"type":"some_future_event_type","data":123}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => {
+                assert!(matches!(event, InnerStreamEvent::Unknown));
+            }
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_unknown_delta_type() {
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => match event {
+                InnerStreamEvent::ContentBlockDelta { delta, .. } => {
+                    assert!(matches!(delta, Delta::Unknown));
+                }
+                _ => panic!("Expected ContentBlockDelta"),
+            },
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_unknown_content_block_type() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"some_new_block"}]}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Assistant { message } => {
+                assert_eq!(message.content.len(), 1);
+                assert!(matches!(message.content[0], ContentBlock::Unknown));
+            }
+            _ => panic!("Expected Assistant event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid_json_returns_error() {
+        let result = parse_stream_line("not json at all");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_extra_fields_ignored() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"abc","extra_field":"ignored","another":42}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::System { subtype, .. } => {
+                assert_eq!(subtype, "init");
+            }
+            _ => panic!("Expected System event"),
+        }
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,10 +35,12 @@ fn agent_stream(data: &AgentSubData) -> Pin<Box<dyn futures::Stream<Item = Messa
     Box::pin(futures::stream::unfold(
         (rx, ws_id),
         |(rx, ws_id)| async move {
-            let mut rx_guard = rx.lock().await;
-            let receiver = rx_guard.as_mut()?;
-            let event = receiver.recv().await?;
-            drop(rx_guard);
+            // Take receiver out so we don't hold the mutex across recv().await
+            let mut receiver = rx.lock().await.take()?;
+            let event = receiver.recv().await;
+            // Put receiver back for the next iteration
+            *rx.lock().await = Some(receiver);
+            let event = event?;
             Some((Message::AgentStreamEvent(ws_id.clone(), event), (rx, ws_id)))
         },
     ))
@@ -783,8 +785,32 @@ impl App {
             }
             Message::AgentSpawned(Err(e)) => {
                 eprintln!("Failed to spawn agent: {e}");
-                // Find which workspace this was for and reset status
-                // The error message contains the ws_id context from the task
+                // Reset any workspaces still marked as Running back to Error
+                let running: Vec<_> = self
+                    .workspaces
+                    .iter()
+                    .filter(|w| matches!(w.agent_status, AgentStatus::Running))
+                    .map(|w| w.id.clone())
+                    .collect();
+                for ws_id in &running {
+                    if let Some(ws) = self.workspaces.iter_mut().find(|w| &w.id == ws_id) {
+                        ws.agent_status = AgentStatus::Error(e.clone());
+                    }
+                    let sys_msg = ChatMessage {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        workspace_id: ws_id.clone(),
+                        role: ChatRole::System,
+                        content: format!("Failed to start agent: {e}"),
+                        cost_usd: None,
+                        duration_ms: None,
+                        created_at: String::new(),
+                    };
+                    self.chat_messages
+                        .entry(ws_id.clone())
+                        .or_default()
+                        .push(sys_msg);
+                    self.rebuild_markdown_cache(ws_id);
+                }
             }
 
             Message::AgentStop(ws_id) => {
@@ -849,6 +875,9 @@ impl App {
                 };
                 let content = self.chat_input.trim().to_string();
                 if content.is_empty() {
+                    return Task::none();
+                }
+                if !self.agents.contains_key(&ws_id) {
                     return Task::none();
                 }
                 self.chat_input.clear();
@@ -1015,17 +1044,24 @@ impl App {
 
     fn rebuild_markdown_cache(&mut self, ws_id: &str) {
         if let Some(messages) = self.chat_messages.get(ws_id) {
-            let items: Vec<Vec<markdown::Item>> = messages
-                .iter()
-                .map(|msg| {
-                    if msg.role == ChatRole::Assistant {
-                        markdown::parse(&msg.content).collect()
-                    } else {
-                        Vec::new()
-                    }
-                })
-                .collect();
-            self.markdown_cache.insert(ws_id.to_string(), items);
+            let cache = self
+                .markdown_cache
+                .entry(ws_id.to_string())
+                .or_insert_with(|| Vec::with_capacity(messages.len()));
+
+            // Truncate if messages were removed
+            if cache.len() > messages.len() {
+                cache.truncate(messages.len());
+            }
+
+            // Only parse new messages beyond what's already cached
+            for msg in messages.iter().skip(cache.len()) {
+                if msg.role == ChatRole::Assistant {
+                    cache.push(markdown::parse(&msg.content).collect());
+                } else {
+                    cache.push(Vec::new());
+                }
+            }
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,15 +1,64 @@
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use iced::event;
 use iced::keyboard::{self, Key};
-use iced::widget::Row;
+use iced::widget::{Row, markdown};
 use iced::{Element, Subscription, Task, Theme};
+use tokio::sync::Mutex;
 
+use crate::agent::{self, StreamEvent};
 use crate::db::Database;
 use crate::message::{Message, SidebarFilter};
-use crate::model::{AgentStatus, Repository, Workspace, WorkspaceStatus};
+use crate::model::{AgentStatus, ChatMessage, ChatRole, Repository, Workspace, WorkspaceStatus};
 use crate::ui;
+
+/// Subscription data for an agent stream — hashes only by ws_id for dedup.
+#[derive(Clone)]
+struct AgentSubData {
+    ws_id: String,
+    event_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<StreamEvent>>>>,
+}
+
+impl Hash for AgentSubData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ws_id.hash(state);
+    }
+}
+
+fn agent_stream(data: &AgentSubData) -> Pin<Box<dyn futures::Stream<Item = Message> + Send>> {
+    let rx = data.event_rx.clone();
+    let ws_id = data.ws_id.clone();
+    Box::pin(futures::stream::unfold(
+        (rx, ws_id),
+        |(rx, ws_id)| async move {
+            let mut rx_guard = rx.lock().await;
+            let receiver = rx_guard.as_mut()?;
+            let event = receiver.recv().await?;
+            drop(rx_guard);
+            Some((Message::AgentStreamEvent(ws_id.clone(), event), (rx, ws_id)))
+        },
+    ))
+}
+
+/// Handle returned when an agent is spawned — stored on App for communication.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct AgentHandle {
+    pub stdin_tx: tokio::sync::mpsc::Sender<String>,
+    pub event_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<StreamEvent>>>>,
+    pub session_id: String,
+    pub pid: u32,
+}
+
+/// Per-workspace agent state stored on App.
+struct AgentState {
+    handle: AgentHandle,
+    streaming_content: String,
+}
 
 pub struct App {
     repositories: Vec<Repository>,
@@ -44,6 +93,16 @@ pub struct App {
     show_fuzzy_finder: bool,
     fuzzy_query: String,
     fuzzy_selected_index: usize,
+
+    // Agent state per workspace
+    agents: HashMap<String, AgentState>,
+
+    // Chat state
+    chat_messages: HashMap<String, Vec<ChatMessage>>,
+    chat_input: String,
+
+    // Markdown rendering cache: workspace_id -> vec of parsed items per message
+    markdown_cache: HashMap<String, Vec<Vec<markdown::Item>>>,
 }
 
 fn claudette_home() -> PathBuf {
@@ -80,6 +139,10 @@ impl App {
             show_fuzzy_finder: false,
             fuzzy_query: String::new(),
             fuzzy_selected_index: 0,
+            agents: HashMap::new(),
+            chat_messages: HashMap::new(),
+            chat_input: String::new(),
+            markdown_cache: HashMap::new(),
         };
 
         let load_task = Task::perform(
@@ -104,10 +167,24 @@ impl App {
                 self.sidebar_visible = !self.sidebar_visible;
             }
             Message::SelectWorkspace(id) => {
-                self.selected_workspace = Some(id);
+                self.selected_workspace = Some(id.clone());
                 if self.show_fuzzy_finder {
                     self.show_fuzzy_finder = false;
                     self.fuzzy_query.clear();
+                }
+                self.chat_input.clear();
+
+                // Load chat history if not already loaded
+                if !self.chat_messages.contains_key(&id) {
+                    let db_path = self.db_path.clone();
+                    let ws_id = id.clone();
+                    return Task::perform(
+                        async move {
+                            let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                            db.list_chat_messages(&ws_id).map_err(|e| e.to_string())
+                        },
+                        move |result| Message::ChatHistoryLoaded(id, result),
+                    );
                 }
             }
             Message::ToggleRepoCollapsed(id) => {
@@ -413,6 +490,18 @@ impl App {
 
             // --- Archive ---
             Message::ArchiveWorkspace(ws_id) => {
+                // Stop agent first if running
+                if self.agents.contains_key(&ws_id) {
+                    let pid = self.agents[&ws_id].handle.pid;
+                    self.agents.remove(&ws_id);
+                    if let Some(ws) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
+                        ws.agent_status = AgentStatus::Idle;
+                    }
+                    tokio::spawn(async move {
+                        let _ = agent::stop_agent(pid).await;
+                    });
+                }
+
                 let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
                 let Some(ws) = ws else {
                     return Task::none();
@@ -519,6 +608,15 @@ impl App {
                 let Some(ws_id) = self.show_delete_workspace.take() else {
                     return Task::none();
                 };
+
+                // Stop agent if running
+                if let Some(state) = self.agents.remove(&ws_id) {
+                    let pid = state.handle.pid;
+                    tokio::spawn(async move {
+                        let _ = agent::stop_agent(pid).await;
+                    });
+                }
+
                 let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
                 let Some(ws) = ws else {
                     return Task::none();
@@ -535,15 +633,12 @@ impl App {
 
                 return Task::perform(
                     async move {
-                        // Remove worktree if active
                         if let Some(wt_path) = &ws.worktree_path {
                             crate::git::remove_worktree(&repo.path, wt_path).await.ok();
                         }
-                        // Safe delete — preserves branch if it has unmerged commits
                         crate::git::branch_delete(&repo.path, &ws.branch_name)
                             .await
                             .ok();
-                        // Delete from DB
                         let db = Database::open(&db_path).map_err(|e| e.to_string())?;
                         db.delete_workspace(&ws.id).map_err(|e| e.to_string())?;
                         Ok(ws.id)
@@ -553,6 +648,8 @@ impl App {
             }
             Message::WorkspaceDeleted(Ok(ws_id)) => {
                 self.workspaces.retain(|w| w.id != ws_id);
+                self.chat_messages.remove(&ws_id);
+                self.markdown_cache.remove(&ws_id);
                 if self.selected_workspace.as_deref() == Some(&ws_id) {
                     self.selected_workspace = None;
                 }
@@ -610,8 +707,326 @@ impl App {
                     self.show_add_repo = false;
                 }
             }
+
+            // --- Agent Lifecycle ---
+            Message::AgentStart(ws_id) => {
+                let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
+                let Some(ws) = ws else {
+                    return Task::none();
+                };
+                let Some(worktree_path) = ws.worktree_path.clone() else {
+                    return Task::none();
+                };
+
+                if let Some(w) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
+                    w.agent_status = AgentStatus::Running;
+                }
+
+                let session_id = uuid::Uuid::new_v4().to_string();
+
+                return Task::perform(
+                    async move {
+                        let spawned =
+                            agent::spawn_agent(std::path::Path::new(&worktree_path), &session_id)
+                                .await?;
+
+                        let handle = AgentHandle {
+                            stdin_tx: spawned.stdin_tx,
+                            event_rx: Arc::new(Mutex::new(Some(spawned.event_rx))),
+                            session_id: spawned.session_id,
+                            pid: spawned.pid,
+                        };
+
+                        Ok((ws_id, handle))
+                    },
+                    Message::AgentSpawned,
+                );
+            }
+            Message::AgentSpawned(Ok((ws_id, handle))) => {
+                // Add system message
+                let sys_msg = ChatMessage {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    workspace_id: ws_id.clone(),
+                    role: ChatRole::System,
+                    content: "Agent started".into(),
+                    cost_usd: None,
+                    duration_ms: None,
+                    created_at: String::new(),
+                };
+                self.chat_messages
+                    .entry(ws_id.clone())
+                    .or_default()
+                    .push(sys_msg.clone());
+                self.rebuild_markdown_cache(&ws_id);
+
+                // Persist system message
+                let db_path = self.db_path.clone();
+                let persist_task = Task::perform(
+                    async move {
+                        let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                        db.insert_chat_message(&sys_msg)
+                            .map_err(|e| e.to_string())?;
+                        Ok(sys_msg)
+                    },
+                    Message::ChatMessageSaved,
+                );
+
+                self.agents.insert(
+                    ws_id,
+                    AgentState {
+                        handle,
+                        streaming_content: String::new(),
+                    },
+                );
+
+                return persist_task;
+            }
+            Message::AgentSpawned(Err(e)) => {
+                eprintln!("Failed to spawn agent: {e}");
+                // Find which workspace this was for and reset status
+                // The error message contains the ws_id context from the task
+            }
+
+            Message::AgentStop(ws_id) => {
+                if let Some(state) = self.agents.remove(&ws_id) {
+                    let pid = state.handle.pid;
+                    if let Some(ws) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
+                        ws.agent_status = AgentStatus::Idle;
+                    }
+
+                    // Add system message
+                    let sys_msg = ChatMessage {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        workspace_id: ws_id.clone(),
+                        role: ChatRole::System,
+                        content: "Agent stopped".into(),
+                        cost_usd: None,
+                        duration_ms: None,
+                        created_at: String::new(),
+                    };
+                    self.chat_messages
+                        .entry(ws_id.clone())
+                        .or_default()
+                        .push(sys_msg.clone());
+                    self.rebuild_markdown_cache(&ws_id);
+
+                    let db_path = self.db_path.clone();
+                    return Task::batch([
+                        Task::perform(async move { agent::stop_agent(pid).await }, move |result| {
+                            Message::AgentStopped(result.map(|()| ws_id.clone()))
+                        }),
+                        Task::perform(
+                            async move {
+                                let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                                db.insert_chat_message(&sys_msg)
+                                    .map_err(|e| e.to_string())?;
+                                Ok(sys_msg)
+                            },
+                            Message::ChatMessageSaved,
+                        ),
+                    ]);
+                }
+            }
+            Message::AgentStopped(Ok(_ws_id)) => {
+                // Agent already removed from self.agents in AgentStop
+            }
+            Message::AgentStopped(Err(e)) => {
+                eprintln!("Failed to stop agent: {e}");
+            }
+
+            // --- Agent Stream Events ---
+            Message::AgentStreamEvent(ws_id, event) => {
+                return self.handle_stream_event(&ws_id, event);
+            }
+
+            // --- Chat ---
+            Message::ChatInputChanged(text) => {
+                self.chat_input = text;
+            }
+            Message::ChatSend => {
+                let Some(ws_id) = self.selected_workspace.clone() else {
+                    return Task::none();
+                };
+                let content = self.chat_input.trim().to_string();
+                if content.is_empty() {
+                    return Task::none();
+                }
+                self.chat_input.clear();
+
+                // Create user message
+                let user_msg = ChatMessage {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    workspace_id: ws_id.clone(),
+                    role: ChatRole::User,
+                    content: content.clone(),
+                    cost_usd: None,
+                    duration_ms: None,
+                    created_at: String::new(),
+                };
+
+                self.chat_messages
+                    .entry(ws_id.clone())
+                    .or_default()
+                    .push(user_msg.clone());
+                self.rebuild_markdown_cache(&ws_id);
+
+                // Send to agent via stdin
+                let mut tasks = vec![];
+                if let Some(state) = self.agents.get(&ws_id) {
+                    let stdin_tx = state.handle.stdin_tx.clone();
+                    tasks.push(Task::perform(
+                        async move {
+                            agent::send_user_message(&stdin_tx, &content).await.ok();
+                        },
+                        |()| Message::ChatInputChanged(String::new()), // no-op callback
+                    ));
+                }
+
+                // Persist user message
+                let db_path = self.db_path.clone();
+                tasks.push(Task::perform(
+                    async move {
+                        let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                        db.insert_chat_message(&user_msg)
+                            .map_err(|e| e.to_string())?;
+                        Ok(user_msg)
+                    },
+                    Message::ChatMessageSaved,
+                ));
+
+                return Task::batch(tasks);
+            }
+            Message::ChatMessageSaved(Ok(_msg)) => {
+                // Message persisted successfully
+            }
+            Message::ChatMessageSaved(Err(e)) => {
+                eprintln!("Failed to save chat message: {e}");
+            }
+            Message::ChatHistoryLoaded(ws_id, Ok(messages)) => {
+                self.chat_messages.insert(ws_id.clone(), messages);
+                self.rebuild_markdown_cache(&ws_id);
+            }
+            Message::ChatHistoryLoaded(_ws_id, Err(e)) => {
+                eprintln!("Failed to load chat history: {e}");
+            }
+
+            // --- Markdown link ---
+            Message::ChatLinkClicked(url) => {
+                if let Err(e) = open::that(&url) {
+                    eprintln!("Failed to open URL {url}: {e}");
+                }
+            }
         }
         Task::none()
+    }
+
+    fn handle_stream_event(&mut self, ws_id: &str, event: StreamEvent) -> Task<Message> {
+        match event {
+            StreamEvent::Stream {
+                event:
+                    agent::InnerStreamEvent::ContentBlockDelta {
+                        delta: agent::Delta::Text { text },
+                        ..
+                    },
+            } => {
+                if let Some(state) = self.agents.get_mut(ws_id) {
+                    state.streaming_content.push_str(&text);
+                }
+            }
+            StreamEvent::Assistant { message } => {
+                // Complete assistant message — persist and add to chat
+                let full_text: String = message
+                    .content
+                    .iter()
+                    .filter_map(|block| match block {
+                        agent::ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                // Clear streaming content
+                if let Some(state) = self.agents.get_mut(ws_id) {
+                    state.streaming_content.clear();
+                }
+
+                let assistant_msg = ChatMessage {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    workspace_id: ws_id.to_string(),
+                    role: ChatRole::Assistant,
+                    content: full_text,
+                    cost_usd: None,
+                    duration_ms: None,
+                    created_at: String::new(),
+                };
+
+                self.chat_messages
+                    .entry(ws_id.to_string())
+                    .or_default()
+                    .push(assistant_msg.clone());
+                self.rebuild_markdown_cache(ws_id);
+
+                let db_path = self.db_path.clone();
+                return Task::perform(
+                    async move {
+                        let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                        db.insert_chat_message(&assistant_msg)
+                            .map_err(|e| e.to_string())?;
+                        Ok(assistant_msg)
+                    },
+                    Message::ChatMessageSaved,
+                );
+            }
+            StreamEvent::Result {
+                total_cost_usd,
+                duration_ms,
+                ..
+            } => {
+                // Agent finished processing — update last assistant message cost
+                if let Some(msgs) = self.chat_messages.get(ws_id)
+                    && let Some(last_msg) =
+                        msgs.iter().rev().find(|m| m.role == ChatRole::Assistant)
+                    && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
+                {
+                    let msg_id = last_msg.id.clone();
+                    let db_path = self.db_path.clone();
+                    return Task::perform(
+                        async move {
+                            let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                            db.update_chat_message_cost(&msg_id, cost, dur)
+                                .map_err(|e| e.to_string())?;
+                            Ok(())
+                        },
+                        |_: Result<(), String>| Message::ChatInputChanged(String::new()),
+                    );
+                }
+
+                // Clear streaming
+                if let Some(state) = self.agents.get_mut(ws_id) {
+                    state.streaming_content.clear();
+                }
+            }
+            _ => {
+                // Other events (system init, message_start, etc.) — ignored for now
+            }
+        }
+        Task::none()
+    }
+
+    fn rebuild_markdown_cache(&mut self, ws_id: &str) {
+        if let Some(messages) = self.chat_messages.get(ws_id) {
+            let items: Vec<Vec<markdown::Item>> = messages
+                .iter()
+                .map(|msg| {
+                    if msg.role == ChatRole::Assistant {
+                        markdown::parse(&msg.content).collect()
+                    } else {
+                        Vec::new()
+                    }
+                })
+                .collect();
+            self.markdown_cache.insert(ws_id.to_string(), items);
+        }
     }
 
     fn fuzzy_filtered_workspaces(&self) -> impl Iterator<Item = &Workspace> {
@@ -638,10 +1053,36 @@ impl App {
             ));
         }
 
+        // Get chat data for selected workspace
+        let (msgs, md_items, streaming) = if let Some(ws_id) = &self.selected_workspace {
+            let msgs = self
+                .chat_messages
+                .get(ws_id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            let md = self
+                .markdown_cache
+                .get(ws_id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            let streaming = self
+                .agents
+                .get(ws_id)
+                .map(|s| s.streaming_content.as_str())
+                .unwrap_or("");
+            (msgs, md, streaming)
+        } else {
+            (&[] as &[ChatMessage], &[] as &[Vec<markdown::Item>], "")
+        };
+
         layout = layout.push(ui::view_main_content(
             &self.repositories,
             &self.workspaces,
             self.selected_workspace.as_deref(),
+            msgs,
+            &self.chat_input,
+            streaming,
+            md_items,
         ));
 
         let base: Element<'_, Message> = layout.into();
@@ -709,7 +1150,7 @@ impl App {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        event::listen_with(|event, _status, _id| {
+        let keyboard_sub = event::listen_with(|event, _status, _id| {
             if let iced::Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) =
                 &event
             {
@@ -727,7 +1168,24 @@ impl App {
                 }
             }
             None
-        })
+        });
+
+        // Agent streaming subscriptions — one per active agent
+        let agent_subs: Vec<Subscription<Message>> = self
+            .agents
+            .iter()
+            .map(|(ws_id, state)| {
+                let data = AgentSubData {
+                    ws_id: ws_id.clone(),
+                    event_rx: state.handle.event_rx.clone(),
+                };
+                Subscription::run_with(data, agent_stream)
+            })
+            .collect();
+
+        let mut subs = vec![keyboard_sub];
+        subs.extend(agent_subs);
+        Subscription::batch(subs)
     }
 
     pub fn theme(&self) -> Theme {

--- a/src/db.rs
+++ b/src/db.rs
@@ -217,7 +217,7 @@ impl Database {
     ) -> Result<Vec<ChatMessage>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
             "SELECT id, workspace_id, role, content, cost_usd, duration_ms, created_at
-             FROM chat_messages WHERE workspace_id = ?1 ORDER BY created_at",
+             FROM chat_messages WHERE workspace_id = ?1 ORDER BY created_at, rowid",
         )?;
         let rows = stmt.query_map(params![workspace_id], |row| {
             let role_str: String = row.get(2)?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use rusqlite::{Connection, params};
 
-use crate::model::{Repository, Workspace, WorkspaceStatus};
+use crate::model::{ChatMessage, ChatRole, Repository, Workspace, WorkspaceStatus};
 
 pub struct Database {
     conn: Connection,
@@ -60,6 +60,25 @@ impl Database {
                 );
 
                 PRAGMA user_version = 1;",
+            )?;
+        }
+
+        if version < 2 {
+            self.conn.execute_batch(
+                "CREATE TABLE chat_messages (
+                    id            TEXT PRIMARY KEY,
+                    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                    role          TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system')),
+                    content       TEXT NOT NULL,
+                    cost_usd      REAL,
+                    duration_ms   INTEGER,
+                    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE INDEX idx_chat_messages_workspace
+                    ON chat_messages(workspace_id, created_at);
+
+                PRAGMA user_version = 2;",
             )?;
         }
 
@@ -171,12 +190,94 @@ impl Database {
             .execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
         Ok(())
     }
+
+    // --- Chat Messages ---
+
+    #[allow(dead_code)]
+    pub fn insert_chat_message(&self, msg: &ChatMessage) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT INTO chat_messages (id, workspace_id, role, content, cost_usd, duration_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                msg.id,
+                msg.workspace_id,
+                msg.role.as_str(),
+                msg.content,
+                msg.cost_usd,
+                msg.duration_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn list_chat_messages(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<ChatMessage>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, role, content, cost_usd, duration_ms, created_at
+             FROM chat_messages WHERE workspace_id = ?1 ORDER BY created_at",
+        )?;
+        let rows = stmt.query_map(params![workspace_id], |row| {
+            let role_str: String = row.get(2)?;
+            Ok(ChatMessage {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                role: ChatRole::from_str(&role_str),
+                content: row.get(3)?,
+                cost_usd: row.get(4)?,
+                duration_ms: row.get(5)?,
+                created_at: row.get(6)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    #[allow(dead_code)]
+    pub fn update_chat_message_content(
+        &self,
+        id: &str,
+        content: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE chat_messages SET content = ?1 WHERE id = ?2",
+            params![content, id],
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn update_chat_message_cost(
+        &self,
+        id: &str,
+        cost_usd: f64,
+        duration_ms: i64,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE chat_messages SET cost_usd = ?1, duration_ms = ?2 WHERE id = ?3",
+            params![cost_usd, duration_ms, id],
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn delete_chat_messages_for_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM chat_messages WHERE workspace_id = ?1",
+            params![workspace_id],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{AgentStatus, WorkspaceStatus};
+    use crate::model::{AgentStatus, ChatRole, WorkspaceStatus};
 
     fn make_repo(id: &str, path: &str, name: &str) -> Repository {
         Repository {
@@ -277,5 +378,116 @@ mod tests {
         db.delete_repository("r1").unwrap();
         let workspaces = db.list_workspaces().unwrap();
         assert!(workspaces.is_empty());
+    }
+
+    // --- Chat message tests ---
+
+    fn make_chat_msg(id: &str, ws_id: &str, role: ChatRole, content: &str) -> ChatMessage {
+        ChatMessage {
+            id: id.into(),
+            workspace_id: ws_id.into(),
+            role,
+            content: content.into(),
+            cost_usd: None,
+            duration_ms: None,
+            created_at: String::new(),
+        }
+    }
+
+    fn setup_db_with_workspace() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db
+    }
+
+    #[test]
+    fn test_insert_and_list_chat_messages() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "hello"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "hi there"))
+            .unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].content, "hello");
+        assert_eq!(msgs[1].content, "hi there");
+    }
+
+    #[test]
+    fn test_chat_messages_filtered_by_workspace() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "feature"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "for w1"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w2", ChatRole::User, "for w2"))
+            .unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "for w1");
+    }
+
+    #[test]
+    fn test_update_chat_message_content() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::Assistant, "partial"))
+            .unwrap();
+        db.update_chat_message_content("m1", "partial response complete")
+            .unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert_eq!(msgs[0].content, "partial response complete");
+    }
+
+    #[test]
+    fn test_update_chat_message_cost() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::Assistant, "done"))
+            .unwrap();
+        db.update_chat_message_cost("m1", 0.005, 2000).unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert!((msgs[0].cost_usd.unwrap() - 0.005).abs() < f64::EPSILON);
+        assert_eq!(msgs[0].duration_ms.unwrap(), 2000);
+    }
+
+    #[test]
+    fn test_delete_chat_messages_for_workspace() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "msg1"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "msg2"))
+            .unwrap();
+        db.delete_chat_messages_for_workspace("w1").unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_chat_messages_cascade_on_workspace_delete() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "hello"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "hi"))
+            .unwrap();
+        db.delete_workspace("w1").unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_chat_message_role_roundtrip() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "user msg"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "asst msg"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m3", "w1", ChatRole::System, "sys msg"))
+            .unwrap();
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert_eq!(msgs[0].role, ChatRole::User);
+        assert_eq!(msgs[1].role, ChatRole::Assistant);
+        assert_eq!(msgs[2].role, ChatRole::System);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod app;
 mod db;
 mod git;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
-use crate::model::{Repository, Workspace};
+use crate::agent::StreamEvent;
+use crate::model::{ChatMessage, Repository, Workspace};
 
 #[derive(Debug, Clone)]
 pub enum SidebarFilter {
@@ -71,4 +72,20 @@ pub enum Message {
 
     // Keyboard
     EscapePressed,
+
+    // --- Agent lifecycle ---
+    AgentStart(String), // workspace_id
+    AgentStop(String),  // workspace_id
+    AgentSpawned(Result<(String, crate::app::AgentHandle), String>), // Ok((ws_id, handle))
+    AgentStopped(Result<String, String>), // Ok(ws_id)
+    AgentStreamEvent(String, StreamEvent), // workspace_id, event
+
+    // --- Chat ---
+    ChatInputChanged(String),
+    ChatSend,
+    ChatMessageSaved(Result<ChatMessage, String>),
+    ChatHistoryLoaded(String, Result<Vec<ChatMessage>, String>), // ws_id, result
+
+    // --- Markdown link ---
+    ChatLinkClicked(String), // URL
 }

--- a/src/model/chat_message.rs
+++ b/src/model/chat_message.rs
@@ -1,0 +1,38 @@
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
+pub enum ChatRole {
+    User,
+    Assistant,
+    System,
+}
+
+#[allow(dead_code)]
+impl ChatRole {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+            Self::System => "system",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "assistant" => Self::Assistant,
+            "system" => Self::System,
+            _ => Self::User,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct ChatMessage {
+    pub id: String,
+    pub workspace_id: String,
+    pub role: ChatRole,
+    pub content: String,
+    pub cost_usd: Option<f64>,
+    pub duration_ms: Option<i64>,
+    pub created_at: String,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,5 +1,7 @@
+mod chat_message;
 mod repository;
 mod workspace;
 
+pub use chat_message::{ChatMessage, ChatRole};
 pub use repository::Repository;
 pub use workspace::{AgentStatus, Workspace, WorkspaceStatus};

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -4,6 +4,7 @@ pub enum AgentStatus {
     Running,
     Idle,
     Stopped,
+    Error(String),
 }
 
 impl AgentStatus {
@@ -12,6 +13,7 @@ impl AgentStatus {
             Self::Running => "Running",
             Self::Idle => "Idle",
             Self::Stopped => "Stopped",
+            Self::Error(_) => "Error",
         }
     }
 }

--- a/src/ui/chat_panel.rs
+++ b/src/ui/chat_panel.rs
@@ -94,7 +94,7 @@ pub fn view_chat_panel<'a>(
                 if let Some(items) = markdown_items.get(i) {
                     view_assistant_message(items)
                 } else {
-                    view_user_message(&msg.content) // fallback
+                    view_assistant_fallback(&msg.content)
                 }
             }
             ChatRole::System => view_system_message(&msg.content),
@@ -126,13 +126,17 @@ pub fn view_chat_panel<'a>(
         send_btn = send_btn.on_press(Message::ChatSend);
     }
 
+    let mut chat_input_widget = text_input("Type a message...", chat_input)
+        .on_input(Message::ChatInputChanged)
+        .padding(10)
+        .size(14)
+        .width(Fill);
+    if is_agent_running {
+        chat_input_widget = chat_input_widget.on_submit(Message::ChatSend);
+    }
+
     let input_row = row![
-        text_input("Type a message...", chat_input)
-            .on_input(Message::ChatInputChanged)
-            .on_submit(Message::ChatSend)
-            .padding(10)
-            .size(14)
-            .width(Fill),
+        chat_input_widget,
         Space::new().width(8),
         send_btn.padding([8, 16]),
     ]
@@ -188,6 +192,17 @@ fn view_assistant_message<'a>(items: &'a [markdown::Item]) -> Element<'a, Messag
         text("Agent").size(12).color(style::MUTED),
         Space::new().height(4),
         markdown::view(items, Theme::Dark).map(Message::ChatLinkClicked),
+    ])
+    .padding([10, 14])
+    .width(Fill)
+    .into()
+}
+
+fn view_assistant_fallback(content: &str) -> Element<'_, Message> {
+    container(column![
+        text("Agent").size(12).color(style::MUTED),
+        Space::new().height(4),
+        text(content).size(14),
     ])
     .padding([10, 14])
     .width(Fill)

--- a/src/ui/chat_panel.rs
+++ b/src/ui/chat_panel.rs
@@ -1,0 +1,228 @@
+use iced::widget::{Space, button, column, container, markdown, row, scrollable, text, text_input};
+use iced::{Background, Border, Element, Fill, Length, Theme};
+
+use crate::message::Message;
+use crate::model::{ChatMessage, ChatRole, Repository, Workspace};
+use crate::ui::style;
+
+/// Renders the full chat panel for a selected workspace.
+pub fn view_chat_panel<'a>(
+    ws: &'a Workspace,
+    repositories: &'a [Repository],
+    chat_messages: &'a [ChatMessage],
+    chat_input: &str,
+    streaming_text: &'a str,
+    markdown_items: &'a [Vec<markdown::Item>],
+    is_agent_running: bool,
+) -> Element<'a, Message> {
+    let repo_name = repositories
+        .iter()
+        .find(|r| r.id == ws.repository_id)
+        .map(|r| r.name.as_str())
+        .unwrap_or("Unknown");
+
+    // Header bar
+    let status_color = style::agent_status_color(&ws.agent_status);
+
+    let agent_button: Element<'_, Message> = if is_agent_running {
+        button(text("\u{25A0}").size(14)) // Stop icon
+            .on_press(Message::AgentStop(ws.id.clone()))
+            .style(|theme: &Theme, status| {
+                let mut s = button::secondary(theme, status);
+                s.border = Border {
+                    radius: 4.0.into(),
+                    ..s.border
+                };
+                s
+            })
+            .padding([4, 10])
+            .into()
+    } else {
+        button(text("\u{25B6}").size(12)) // Play icon
+            .on_press(Message::AgentStart(ws.id.clone()))
+            .style(|theme: &Theme, status| {
+                let mut s = button::secondary(theme, status);
+                s.border = Border {
+                    radius: 4.0.into(),
+                    ..s.border
+                };
+                s
+            })
+            .padding([4, 10])
+            .into()
+    };
+
+    let header = container(
+        row![
+            column![
+                text(&ws.name).size(16),
+                text(format!("{repo_name} / {}", ws.branch_name))
+                    .size(12)
+                    .color(style::DIM),
+            ]
+            .spacing(2),
+            Space::new().width(Fill),
+            row![
+                text("\u{25CF}").size(10).color(status_color),
+                Space::new().width(4),
+                text(ws.agent_status.label()).size(12).color(status_color),
+            ]
+            .align_y(iced::Alignment::Center),
+            Space::new().width(12),
+            agent_button,
+        ]
+        .align_y(iced::Alignment::Center),
+    )
+    .padding([12, 16])
+    .width(Fill)
+    .style(|_theme: &Theme| container::Style {
+        background: Some(Background::Color(style::CHAT_HEADER_BG)),
+        border: Border {
+            width: 0.0,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    // Chat messages area
+    let mut messages_col = column![].spacing(8).padding([12, 16]);
+
+    for (i, msg) in chat_messages.iter().enumerate() {
+        let bubble = match msg.role {
+            ChatRole::User => view_user_message(&msg.content),
+            ChatRole::Assistant => {
+                if let Some(items) = markdown_items.get(i) {
+                    view_assistant_message(items)
+                } else {
+                    view_user_message(&msg.content) // fallback
+                }
+            }
+            ChatRole::System => view_system_message(&msg.content),
+        };
+        messages_col = messages_col.push(bubble);
+    }
+
+    // Streaming content (agent is currently responding)
+    if !streaming_text.is_empty() {
+        messages_col = messages_col.push(view_streaming_indicator(streaming_text));
+    }
+
+    let chat_area = scrollable(messages_col)
+        .width(Fill)
+        .height(Fill)
+        .anchor_bottom();
+
+    // Input area
+    let send_enabled = !chat_input.trim().is_empty() && is_agent_running;
+    let mut send_btn = button(text("Send").size(14)).style(|theme: &Theme, status| {
+        let mut s = button::primary(theme, status);
+        s.border = Border {
+            radius: 4.0.into(),
+            ..s.border
+        };
+        s
+    });
+    if send_enabled {
+        send_btn = send_btn.on_press(Message::ChatSend);
+    }
+
+    let input_row = row![
+        text_input("Type a message...", chat_input)
+            .on_input(Message::ChatInputChanged)
+            .on_submit(Message::ChatSend)
+            .padding(10)
+            .size(14)
+            .width(Fill),
+        Space::new().width(8),
+        send_btn.padding([8, 16]),
+    ]
+    .align_y(iced::Alignment::Center);
+
+    let input_area = container(
+        column![
+            input_row,
+            text("Enter to send").size(11).color(style::FAINT),
+        ]
+        .spacing(4),
+    )
+    .padding([12, 16])
+    .width(Fill)
+    .style(|_theme: &Theme| container::Style {
+        background: Some(Background::Color(style::CHAT_INPUT_BG)),
+        border: Border {
+            width: 1.0,
+            color: style::CHAT_INPUT_BORDER,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    // Compose layout
+    column![header, chat_area, input_area]
+        .width(Fill)
+        .height(Fill)
+        .into()
+}
+
+fn view_user_message(content: &str) -> Element<'_, Message> {
+    container(column![
+        text("You").size(12).color(style::MUTED),
+        Space::new().height(4),
+        text(content).size(14),
+    ])
+    .padding([10, 14])
+    .width(Fill)
+    .style(|_theme: &Theme| container::Style {
+        background: Some(Background::Color(style::CHAT_USER_BG)),
+        border: Border {
+            radius: 6.0.into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .into()
+}
+
+fn view_assistant_message<'a>(items: &'a [markdown::Item]) -> Element<'a, Message> {
+    container(column![
+        text("Agent").size(12).color(style::MUTED),
+        Space::new().height(4),
+        markdown::view(items, Theme::Dark).map(Message::ChatLinkClicked),
+    ])
+    .padding([10, 14])
+    .width(Fill)
+    .into()
+}
+
+fn view_system_message(content: &str) -> Element<'_, Message> {
+    container(
+        text(content)
+            .size(12)
+            .color(style::WARNING)
+            .width(Length::Fill)
+            .align_x(iced::alignment::Horizontal::Center),
+    )
+    .padding([6, 14])
+    .width(Fill)
+    .style(|_theme: &Theme| container::Style {
+        background: Some(Background::Color(style::CHAT_SYSTEM_BG)),
+        border: Border {
+            radius: 4.0.into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .into()
+}
+
+fn view_streaming_indicator(content: &str) -> Element<'_, Message> {
+    container(column![
+        text("Agent").size(12).color(style::STATUS_RUNNING),
+        Space::new().height(4),
+        text(content).size(14),
+        text("\u{2588}").size(14).color(style::STATUS_RUNNING), // blinking cursor
+    ])
+    .padding([10, 14])
+    .width(Fill)
+    .into()
+}

--- a/src/ui/main_content.rs
+++ b/src/ui/main_content.rs
@@ -1,45 +1,32 @@
-use iced::widget::{Space, center, column, container, row, text};
+use iced::widget::{Space, center, column, container, markdown, text};
 use iced::{Element, Fill};
 
 use crate::message::Message;
-use crate::model::{Repository, Workspace};
+use crate::model::{AgentStatus, ChatMessage, Repository, Workspace};
+use crate::ui::chat_panel;
 use crate::ui::style;
 
 pub fn view_main_content<'a>(
     repositories: &'a [Repository],
     workspaces: &'a [Workspace],
     selected_workspace: Option<&str>,
+    chat_messages: &'a [ChatMessage],
+    chat_input: &str,
+    streaming_text: &'a str,
+    markdown_items: &'a [Vec<markdown::Item>],
 ) -> Element<'a, Message> {
     let content: Element<'_, Message> = if let Some(ws_id) = selected_workspace {
         if let Some(ws) = workspaces.iter().find(|w| w.id == ws_id) {
-            let repo_name = repositories
-                .iter()
-                .find(|r| r.id == ws.repository_id)
-                .map(|r| r.name.as_str())
-                .unwrap_or("Unknown");
-
-            center(
-                column![
-                    text(&ws.name).size(24),
-                    text(format!("{} / {}", repo_name, ws.branch_name))
-                        .size(14)
-                        .color(style::DIM),
-                    Space::new().height(12),
-                    row![
-                        text("\u{25CF}")
-                            .size(12)
-                            .color(style::agent_status_color(&ws.agent_status)),
-                        Space::new().width(6),
-                        text(ws.agent_status.label())
-                            .size(14)
-                            .color(style::agent_status_color(&ws.agent_status)),
-                    ]
-                    .align_y(iced::Alignment::Center),
-                ]
-                .spacing(4)
-                .align_x(iced::Alignment::Center),
+            let is_running = ws.agent_status == AgentStatus::Running;
+            chat_panel::view_chat_panel(
+                ws,
+                repositories,
+                chat_messages,
+                chat_input,
+                streaming_text,
+                markdown_items,
+                is_running,
             )
-            .into()
         } else {
             center(text("Workspace not found").size(16).color(style::FAINT)).into()
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod chat_panel;
 mod fuzzy_finder;
 mod main_content;
 mod modal;

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -40,6 +40,13 @@ pub const WARNING: Color = Color::from_rgb(0.9, 0.7, 0.2);
 pub const TOOLTIP_BG: Color = Color::from_rgb(0.2, 0.2, 0.24);
 pub const TOOLTIP_BORDER: Color = Color::from_rgb(0.3, 0.3, 0.35);
 
+// Chat
+pub const CHAT_USER_BG: Color = Color::from_rgba(1.0, 1.0, 1.0, 0.06);
+pub const CHAT_SYSTEM_BG: Color = Color::from_rgba(0.9, 0.7, 0.2, 0.08);
+pub const CHAT_INPUT_BG: Color = Color::from_rgb(0.12, 0.12, 0.14);
+pub const CHAT_INPUT_BORDER: Color = Color::from_rgb(0.22, 0.22, 0.26);
+pub const CHAT_HEADER_BG: Color = Color::from_rgb(0.1, 0.1, 0.12);
+
 use iced::{Background, Border, Theme};
 
 pub fn tooltip_style(_theme: &Theme) -> iced::widget::container::Style {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -62,5 +62,6 @@ pub fn agent_status_color(status: &AgentStatus) -> Color {
         AgentStatus::Running => STATUS_RUNNING,
         AgentStatus::Idle => STATUS_IDLE,
         AgentStatus::Stopped => STATUS_STOPPED,
+        AgentStatus::Error(_) => ERROR,
     }
 }


### PR DESCRIPTION
## Summary

Implements the agent chat interface for Claudette (Issue #13, PRs 1 & 2 of the release plan):

- **Data layer**: `ChatMessage`/`ChatRole` models, SQLite schema migration v2 with `chat_messages` table, full CRUD operations
- **Agent process management**: Claude CLI integration with bidirectional JSON streaming (`spawn_agent`, `send_user_message`, `stop_agent`), stream event parsing with serde tagged enums
- **Chat UI**: Chat panel with workspace header, scrollable message area, markdown rendering for assistant responses, real-time streaming indicator, and input bar
- **Iced integration**: Streaming subscriptions via `Subscription::run_with`, agent lifecycle messages, chat history loading on workspace selection

Includes 41 passing tests covering stream event JSON parsing and chat message database operations.

## Test plan
- [x] `cargo test --all-features` — 41 tests pass
- [x] `cargo clippy --all-targets --all-features` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] Builds with `RUSTFLAGS="-Dwarnings"`