### PR TITLE
feat: add integrated terminal with alacritty backend and tab multiplexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "alacritty_terminal"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46319972e74179d707445f64aaa2893bbf6a111de3a9af29b7eb382f8b39e282"
+dependencies = [
+ "base64",
+ "bitflags 2.11.0",
+ "home",
+ "libc",
+ "log",
+ "miow",
+ "parking_lot",
+ "piper",
+ "polling",
+ "regex-automata",
+ "rustix 1.1.4",
+ "rustix-openpty",
+ "serde",
+ "signal-hook",
+ "unicode-width",
+ "vte",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,7 +88,7 @@ dependencies = [
  "cc",
  "cesu8",
  "jni",
- "jni-sys",
+ "jni-sys 0.3.1",
  "libc",
  "log",
  "ndk",
@@ -308,6 +339,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block"
@@ -472,6 +506,7 @@ dependencies = [
  "dirs",
  "futures",
  "iced",
+ "iced_term",
  "image",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -936,6 +971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1372,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1352,6 +1399,15 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "iced"
@@ -1427,6 +1483,7 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "log",
+ "lyon_path",
  "raw-window-handle",
  "rustc-hash 2.1.1",
  "thiserror 2.0.18",
@@ -1480,6 +1537,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f461d32a472194735c94901bf2fc70d493ee98a8b29e7e244f296c82826745"
+dependencies = [
+ "alacritty_terminal",
+ "anyhow",
+ "iced",
+ "iced_core",
+ "iced_graphics",
+ "open",
+ "tokio",
+]
+
+[[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1584,7 @@ dependencies = [
  "iced_debug",
  "iced_graphics",
  "log",
+ "lyon",
  "resvg",
  "rustc-hash 2.1.1",
  "thiserror 2.0.18",
@@ -1528,6 +1601,7 @@ dependencies = [
  "iced_renderer",
  "log",
  "num-traits",
+ "ouroboros",
  "pulldown-cmark",
  "rustc-hash 2.1.1",
  "thiserror 2.0.18",
@@ -1634,7 +1708,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1643,9 +1717,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1817,6 +1913,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 
 [[package]]
+name = "lyon"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0578bdecb7d6d88987b8b2b1e3a4e2f81df9d0ece1078623324a567904e7b7"
+dependencies = [
+ "lyon_algorithms",
+ "lyon_tessellation",
+]
+
+[[package]]
+name = "lyon_algorithms"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9815fac08e6fd96733a11dce4f9d15a3f338e96a2e2311ee21e1b738efc2bc0f"
+dependencies = [
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_geom"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_path"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e"
+dependencies = [
+ "lyon_geom",
+ "num-traits",
+]
+
+[[package]]
+name = "lyon_tessellation"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e43b7e44161571868f5c931d12583592c223c5583eef86b08aa02b7048a3552"
+dependencies = [
+ "float_next_after",
+ "lyon_path",
+ "num-traits",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +2030,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1953,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -1973,7 +2130,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2426,6 +2583,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,6 +2844,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2973,6 +3167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-openpty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de16c7c59892b870a6336f185dc10943517f1327447096bbb7bb32cd85e2393"
+dependencies = [
+ "errno",
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,6 +3306,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3234,6 +3449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3515,17 +3740,19 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3747,6 +3974,20 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "log",
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "walkdir"
@@ -4641,7 +4882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4652,7 +4893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn",
@@ -4790,6 +5031,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yazi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ description = "Claude's missing better half — a companion tool for Claude Code
 
 [dependencies]
 futures = "0.3"
-iced = { version = "0.14", features = ["tokio", "markdown", "highlighter", "svg"] }
+iced = { version = "0.14", features = ["tokio", "markdown", "highlighter", "svg", "canvas", "advanced"] }
+iced_term = "0.7"
 rusqlite = { version = "0.34", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1810,18 +1810,18 @@ impl App {
             ));
         }
 
-        // Wrap in Column with status bar at bottom
+        // Wrap in Column with toolbar at top
         let base: Element<'_, Message> = iced::widget::Column::new()
-            .push(
-                iced::widget::container(layout)
-                    .width(iced::Fill)
-                    .height(iced::Fill),
-            )
             .push(ui::view_status_bar(
                 self.sidebar_visible,
                 self.terminal_panel_visible,
                 self.right_sidebar_visible,
             ))
+            .push(
+                iced::widget::container(layout)
+                    .width(iced::Fill)
+                    .height(iced::Fill),
+            )
             .width(iced::Fill)
             .height(iced::Fill)
             .into();

--- a/src/app.rs
+++ b/src/app.rs
@@ -232,6 +232,9 @@ impl App {
                 let worktree_base = db
                     .get_app_setting("worktree_base_dir")
                     .map_err(|e| e.to_string())?;
+                // Seed the terminal ID counter above any existing DB IDs
+                let max_id = db.max_terminal_tab_id().map_err(|e| e.to_string())?;
+                terminal::seed_next_id(max_id as u64);
                 Ok((repos, workspaces, worktree_base))
             },
             Message::DataLoaded,

--- a/src/app.rs
+++ b/src/app.rs
@@ -667,6 +667,8 @@ impl App {
                                 .map_err(|e| e.to_string())?;
                         }
                         let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                        db.delete_terminal_tabs_for_workspace(&ws.id)
+                            .map_err(|e| e.to_string())?;
                         db.update_workspace_status(&ws.id, &WorkspaceStatus::Archived, None)
                             .map_err(|e| e.to_string())?;
                         Ok(ws.id)
@@ -1394,7 +1396,8 @@ impl App {
                         let sort_order = self
                             .terminal_tabs
                             .get(&ws_id)
-                            .map(|tabs| tabs.len() as i32)
+                            .and_then(|tabs| tabs.iter().map(|t| t.sort_order).max())
+                            .map(|max| max + 1)
                             .unwrap_or(0);
                         let tab = TerminalTab {
                             id: id as i64,
@@ -1516,10 +1519,23 @@ impl App {
                         iced_term::actions::Action::ChangeTitle(title) => {
                             for tabs in self.terminal_tabs.values_mut() {
                                 if let Some(tab) = tabs.iter_mut().find(|t| t.id == id as i64) {
-                                    tab.title = title;
+                                    tab.title = title.clone();
                                     break;
                                 }
                             }
+                            // Persist the updated title to the database
+                            let db_path = self.db_path.clone();
+                            let tab_id = id as i64;
+                            return Task::perform(
+                                async move {
+                                    if let Ok(db) = Database::open(&db_path)
+                                        && let Err(e) = db.update_terminal_tab_title(tab_id, &title)
+                                    {
+                                        eprintln!("Failed to update terminal tab title: {e}");
+                                    }
+                                },
+                                |()| Message::ApplyDockIcon, // fire-and-forget; ApplyDockIcon is idempotent
+                            );
                         }
                         iced_term::actions::Action::Ignore => {}
                     }
@@ -1571,7 +1587,8 @@ impl App {
                         let sort_order = self
                             .terminal_tabs
                             .get(&ws_id)
-                            .map(|tabs| tabs.len() as i32)
+                            .and_then(|tabs| tabs.iter().map(|t| t.sort_order).max())
+                            .map(|max| max + 1)
                             .unwrap_or(0);
                         let tab = TerminalTab {
                             id: id as i64,
@@ -1610,8 +1627,6 @@ impl App {
             }
             Message::DividerDragUpdate(x, y) => {
                 if self.dragging_divider.is_none() {
-                    // Not dragging — just track position for when a drag starts
-                    self.last_cursor_position = iced::Point::new(x, y);
                     return Task::none();
                 }
                 if !self.drag_cursor_initialized {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1516,6 +1516,11 @@ impl App {
             }
 
             Message::TerminalTabsLoaded(ws_id, Ok(tabs)) => {
+                if tabs.is_empty() {
+                    // Auto-create a terminal if none exist (always at least 1)
+                    self.terminal_tabs.insert(ws_id.clone(), Vec::new());
+                    return Task::done(Message::TerminalCreate(ws_id));
+                }
                 let ws = self.workspaces.iter().find(|w| w.id == ws_id);
                 if let Some(wt_path) = ws.and_then(|w| w.worktree_path.as_deref()) {
                     let mut first_id = None;

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 use crate::agent::{self, StreamEvent};
 use crate::db::Database;
 use crate::message::{Message, SidebarFilter};
-use crate::model::diff::{DiffFile, DiffViewMode, DiffViewState, FileDiff};
+use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
 use crate::model::{
     AgentStatus, ChatMessage, ChatRole, Repository, TerminalTab, Workspace, WorkspaceStatus,
 };
@@ -125,8 +125,11 @@ pub struct App {
     // Markdown rendering cache: workspace_id -> vec of parsed items per message
     markdown_cache: HashMap<String, Vec<Vec<markdown::Item>>>,
 
-    // Diff viewer state
-    diff_visible: bool,
+    // Right sidebar state
+    right_sidebar_visible: bool,
+    right_sidebar_tab: crate::message::RightSidebarTab,
+
+    // Diff state
     diff_files: Vec<DiffFile>,
     diff_selected_file: Option<String>,
     diff_content: Option<FileDiff>,
@@ -191,7 +194,8 @@ impl App {
             chat_messages: HashMap::new(),
             chat_input: String::new(),
             markdown_cache: HashMap::new(),
-            diff_visible: false,
+            right_sidebar_visible: true,
+            right_sidebar_tab: crate::message::RightSidebarTab::Changes,
             diff_files: Vec::new(),
             diff_selected_file: None,
             diff_content: None,
@@ -239,21 +243,19 @@ impl App {
                 self.chat_input.clear();
 
                 // Reset diff state when switching workspaces
-                let was_diff_visible = self.diff_visible;
-                if was_diff_visible {
-                    self.diff_files.clear();
-                    self.diff_selected_file = None;
-                    self.diff_content = None;
-                    self.diff_error = None;
-                    self.diff_merge_base = None;
-                    self.diff_revert_target = None;
-                    self.diff_visible = false;
-                }
+                self.diff_files.clear();
+                self.diff_selected_file = None;
+                self.diff_content = None;
+                self.diff_error = None;
+                self.diff_merge_base = None;
+                self.diff_revert_target = None;
 
                 let mut tasks = vec![];
 
-                if was_diff_visible {
-                    tasks.push(Task::done(Message::ToggleDiffViewer));
+                // Auto-load changed files for the right sidebar
+                if let Some(task) = self.load_diff_files_task() {
+                    self.diff_loading = true;
+                    tasks.push(task);
                 }
 
                 // Load chat history if not already loaded
@@ -952,8 +954,9 @@ impl App {
                     self.diff_revert_target = None;
                 } else if self.show_fuzzy_finder {
                     self.show_fuzzy_finder = false;
-                } else if self.diff_visible {
-                    self.diff_visible = false;
+                } else if self.diff_selected_file.is_some() {
+                    self.diff_selected_file = None;
+                    self.diff_content = None;
                 } else if self.show_delete_workspace.is_some() {
                     self.show_delete_workspace = None;
                 } else if self.show_relink_repo.is_some() {
@@ -1201,66 +1204,35 @@ impl App {
                 }
             }
 
-            // --- Diff Viewer ---
-            Message::ToggleDiffViewer => {
-                let Some(ws_id) = self.selected_workspace.clone() else {
-                    return Task::none();
-                };
-
-                if self.diff_visible {
-                    self.diff_visible = false;
-                    return Task::none();
+            // --- Right sidebar / Diff ---
+            Message::ToggleRightSidebar => {
+                self.right_sidebar_visible = !self.right_sidebar_visible;
+                // Auto-load changed files when opening if empty
+                if self.right_sidebar_visible
+                    && self.diff_files.is_empty()
+                    && let Some(task) = self.load_diff_files_task()
+                {
+                    self.diff_loading = true;
+                    return task;
                 }
-
-                let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
-                let Some(ws) = ws else {
-                    return Task::none();
-                };
-                let Some(worktree_path) = ws.worktree_path.clone() else {
-                    self.diff_error = Some("Workspace has no worktree (archived?)".into());
-                    self.diff_visible = true;
-                    return Task::none();
-                };
-
-                self.diff_visible = true;
-                self.diff_loading = true;
-                self.diff_error = None;
+            }
+            Message::SetRightSidebarTab(tab) => {
+                self.right_sidebar_tab = tab;
+            }
+            Message::DiffClearSelection => {
+                self.diff_selected_file = None;
+                self.diff_content = None;
+            }
+            Message::DiffRefresh => {
                 self.diff_files.clear();
                 self.diff_selected_file = None;
                 self.diff_content = None;
-
-                let repo = self
-                    .repositories
-                    .iter()
-                    .find(|r| r.id == ws.repository_id)
-                    .cloned();
-                let Some(repo) = repo else {
-                    return Task::none();
-                };
-
-                return Task::perform(
-                    async move {
-                        let base_branch = git::default_branch(&repo.path)
-                            .await
-                            .map_err(|e| e.to_string())?;
-                        let mb = diff::merge_base(&worktree_path, "HEAD", &base_branch)
-                            .await
-                            .map_err(|e| e.to_string())?;
-                        let files = diff::changed_files(&worktree_path, &mb)
-                            .await
-                            .map_err(|e| e.to_string())?;
-                        Ok((files, mb))
-                    },
-                    Message::DiffFilesLoaded,
-                );
-            }
-            Message::DiffRefresh => {
-                // Re-trigger the same load as ToggleDiffViewer but without toggling
-                if !self.diff_visible {
-                    return Task::none();
+                self.diff_error = None;
+                self.diff_merge_base = None;
+                if let Some(task) = self.load_diff_files_task() {
+                    self.diff_loading = true;
+                    return task;
                 }
-                self.diff_visible = false; // toggle off, then back on
-                return Task::done(Message::ToggleDiffViewer);
             }
             Message::DiffFilesLoaded(Ok((files, merge_base))) => {
                 self.diff_loading = false;
@@ -1720,6 +1692,35 @@ impl App {
         }
     }
 
+    /// Build an async task that loads changed files for the currently selected workspace.
+    /// Returns `None` if no workspace is selected or the workspace has no worktree.
+    fn load_diff_files_task(&self) -> Option<Task<Message>> {
+        let ws_id = self.selected_workspace.as_ref()?;
+        let ws = self.workspaces.iter().find(|w| w.id == *ws_id)?;
+        let worktree_path = ws.worktree_path.clone()?;
+        let repo = self
+            .repositories
+            .iter()
+            .find(|r| r.id == ws.repository_id)?;
+        let repo_path = repo.path.clone();
+
+        Some(Task::perform(
+            async move {
+                let base_branch = git::default_branch(&repo_path)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                let mb = diff::merge_base(&worktree_path, "HEAD", &base_branch)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                let files = diff::changed_files(&worktree_path, &mb)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok((files, mb))
+            },
+            Message::DiffFilesLoaded,
+        ))
+    }
+
     fn fuzzy_filtered_workspaces(&self) -> impl Iterator<Item = &Workspace> {
         let query = self.fuzzy_query.to_lowercase();
         self.workspaces.iter().filter(move |ws| {
@@ -1766,16 +1767,6 @@ impl App {
             (&[] as &[ChatMessage], &[] as &[Vec<markdown::Item>], "")
         };
 
-        let diff_state = DiffViewState {
-            visible: self.diff_visible,
-            files: &self.diff_files,
-            selected_file: self.diff_selected_file.as_deref(),
-            content: self.diff_content.as_ref(),
-            view_mode: self.diff_view_mode,
-            loading: self.diff_loading,
-            error: self.diff_error.as_deref(),
-        };
-
         let (term_tabs, active_term) = if let Some(ws_id) = &self.selected_workspace {
             let tabs = self
                 .terminal_tabs
@@ -1796,14 +1787,44 @@ impl App {
             &self.chat_input,
             streaming,
             md_items,
-            &diff_state,
+            &self.diff_files,
+            self.diff_selected_file.as_deref(),
+            self.diff_content.as_ref(),
+            self.diff_view_mode,
+            self.diff_loading,
+            self.diff_error.as_deref(),
             &self.terminals,
             term_tabs,
             active_term,
             self.terminal_panel_visible,
         ));
 
-        let base: Element<'_, Message> = layout.into();
+        // Right sidebar
+        if self.right_sidebar_visible {
+            layout = layout.push(ui::view_right_sidebar(
+                self.right_sidebar_tab,
+                &self.diff_files,
+                self.diff_selected_file.as_deref(),
+                self.diff_view_mode,
+                self.diff_loading,
+            ));
+        }
+
+        // Wrap in Column with status bar at bottom
+        let base: Element<'_, Message> = iced::widget::Column::new()
+            .push(
+                iced::widget::container(layout)
+                    .width(iced::Fill)
+                    .height(iced::Fill),
+            )
+            .push(ui::view_status_bar(
+                self.sidebar_visible,
+                self.terminal_panel_visible,
+                self.right_sidebar_visible,
+            ))
+            .width(iced::Fill)
+            .height(iced::Fill)
+            .into();
 
         // Icon picker layered on top of repo settings modal
         if self.show_icon_picker && self.show_repo_settings.is_some() {
@@ -1913,7 +1934,7 @@ impl App {
                         return Some(Message::ToggleFuzzyFinder);
                     }
                     Key::Character(c) if c.as_ref() == "d" && modifiers.command() => {
-                        return Some(Message::ToggleDiffViewer);
+                        return Some(Message::ToggleRightSidebar);
                     }
                     Key::Character(c) if c.as_ref() == "`" && modifiers.command() => {
                         return Some(Message::TerminalTogglePanel);

--- a/src/app.rs
+++ b/src/app.rs
@@ -144,6 +144,14 @@ pub struct App {
     terminal_tabs: HashMap<String, Vec<TerminalTab>>,
     active_terminal_tab: HashMap<String, u64>,
     terminal_panel_visible: bool,
+
+    // Panel sizing & drag state
+    sidebar_width: f32,
+    right_sidebar_width: f32,
+    terminal_height: f32,
+    dragging_divider: Option<crate::message::DividerDrag>,
+    drag_cursor_initialized: bool,
+    last_cursor_position: iced::Point,
 }
 
 fn claudette_home() -> PathBuf {
@@ -208,6 +216,12 @@ impl App {
             terminal_tabs: HashMap::new(),
             active_terminal_tab: HashMap::new(),
             terminal_panel_visible: true,
+            sidebar_width: ui::style::SIDEBAR_WIDTH,
+            right_sidebar_width: ui::style::RIGHT_SIDEBAR_WIDTH,
+            terminal_height: 300.0,
+            dragging_divider: None,
+            drag_cursor_initialized: false,
+            last_cursor_position: iced::Point::ORIGIN,
         };
 
         let load_task = Task::perform(
@@ -1572,6 +1586,46 @@ impl App {
                     }
                 }
             }
+
+            // --- Panel resizing ---
+            Message::DividerDragStart(divider) => {
+                self.dragging_divider = Some(divider);
+                self.drag_cursor_initialized = false;
+            }
+            Message::DividerDragUpdate(x, y) => {
+                if self.dragging_divider.is_none() {
+                    // Not dragging — just track position for when a drag starts
+                    self.last_cursor_position = iced::Point::new(x, y);
+                    return Task::none();
+                }
+                if !self.drag_cursor_initialized {
+                    self.last_cursor_position = iced::Point::new(x, y);
+                    self.drag_cursor_initialized = true;
+                    return Task::none();
+                }
+
+                let dx = x - self.last_cursor_position.x;
+                let dy = y - self.last_cursor_position.y;
+                self.last_cursor_position = iced::Point::new(x, y);
+
+                if let Some(divider) = self.dragging_divider {
+                    match divider {
+                        crate::message::DividerDrag::LeftSidebar => {
+                            self.sidebar_width = (self.sidebar_width + dx).clamp(150.0, 500.0);
+                        }
+                        crate::message::DividerDrag::RightSidebar => {
+                            self.right_sidebar_width =
+                                (self.right_sidebar_width - dx).clamp(150.0, 500.0);
+                        }
+                        crate::message::DividerDrag::Terminal => {
+                            self.terminal_height = (self.terminal_height - dy).clamp(100.0, 800.0);
+                        }
+                    }
+                }
+            }
+            Message::DividerDragEnd => {
+                self.dragging_divider = None;
+            }
         }
         Task::none()
     }
@@ -1742,6 +1796,10 @@ impl App {
                 self.selected_workspace.as_deref(),
                 &self.sidebar_filter,
                 &self.repo_collapsed,
+                self.sidebar_width,
+            ));
+            layout = layout.push(ui::divider::vertical_divider(
+                crate::message::DividerDrag::LeftSidebar,
             ));
         }
 
@@ -1797,16 +1855,21 @@ impl App {
             term_tabs,
             active_term,
             self.terminal_panel_visible,
+            self.terminal_height,
         ));
 
         // Right sidebar
         if self.right_sidebar_visible {
+            layout = layout.push(ui::divider::vertical_divider(
+                crate::message::DividerDrag::RightSidebar,
+            ));
             layout = layout.push(ui::view_right_sidebar(
                 self.right_sidebar_tab,
                 &self.diff_files,
                 self.diff_selected_file.as_deref(),
                 self.diff_view_mode,
                 self.diff_loading,
+                self.right_sidebar_width,
             ));
         }
 
@@ -1922,30 +1985,32 @@ impl App {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let keyboard_sub = event::listen_with(|event, _status, _id| {
-            if let iced::Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) =
-                &event
-            {
+        let input_sub = event::listen_with(|event, _status, _id| match &event {
+            iced::Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. }) => {
                 match key {
                     Key::Character(c) if c.as_ref() == "b" && modifiers.command() => {
-                        return Some(Message::ToggleSidebar);
+                        Some(Message::ToggleSidebar)
                     }
                     Key::Character(c) if c.as_ref() == "k" && modifiers.command() => {
-                        return Some(Message::ToggleFuzzyFinder);
+                        Some(Message::ToggleFuzzyFinder)
                     }
                     Key::Character(c) if c.as_ref() == "d" && modifiers.command() => {
-                        return Some(Message::ToggleRightSidebar);
+                        Some(Message::ToggleRightSidebar)
                     }
                     Key::Character(c) if c.as_ref() == "`" && modifiers.command() => {
-                        return Some(Message::TerminalTogglePanel);
+                        Some(Message::TerminalTogglePanel)
                     }
-                    Key::Named(keyboard::key::Named::Escape) => {
-                        return Some(Message::EscapePressed);
-                    }
-                    _ => {}
+                    Key::Named(keyboard::key::Named::Escape) => Some(Message::EscapePressed),
+                    _ => None,
                 }
             }
-            None
+            iced::Event::Mouse(iced::mouse::Event::CursorMoved { position }) => {
+                Some(Message::DividerDragUpdate(position.x, position.y))
+            }
+            iced::Event::Mouse(iced::mouse::Event::ButtonReleased(iced::mouse::Button::Left)) => {
+                Some(Message::DividerDragEnd)
+            }
+            _ => None,
         });
 
         // Agent streaming subscriptions — one per active agent
@@ -1968,7 +2033,7 @@ impl App {
             .map(|term| term.subscription().map(Message::TerminalEvent))
             .collect();
 
-        let mut subs = vec![keyboard_sub];
+        let mut subs = vec![input_sub];
         subs.extend(agent_subs);
         subs.extend(terminal_subs);
         Subscription::batch(subs)

--- a/src/app.rs
+++ b/src/app.rs
@@ -301,6 +301,14 @@ impl App {
                             move |result| Message::TerminalTabsLoaded(ws_id, result)
                         },
                     ));
+                } else if self
+                    .terminal_tabs
+                    .get(&id)
+                    .map(|t| t.is_empty())
+                    .unwrap_or(false)
+                {
+                    // Already loaded but empty — ensure at least 1 terminal exists
+                    tasks.push(Task::done(Message::TerminalCreate(id.clone())));
                 }
 
                 if !tasks.is_empty() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,8 +14,10 @@ use crate::agent::{self, StreamEvent};
 use crate::db::Database;
 use crate::message::{Message, SidebarFilter};
 use crate::model::diff::{DiffFile, DiffViewMode, DiffViewState, FileDiff};
-use crate::model::{AgentStatus, ChatMessage, ChatRole, Repository, Workspace, WorkspaceStatus};
-use crate::{diff, git, ui};
+use crate::model::{
+    AgentStatus, ChatMessage, ChatRole, Repository, TerminalTab, Workspace, WorkspaceStatus,
+};
+use crate::{diff, git, terminal, ui};
 
 /// Subscription data for an agent stream — hashes only by ws_id for dedup.
 #[derive(Clone)]
@@ -133,6 +135,12 @@ pub struct App {
     diff_error: Option<String>,
     diff_revert_target: Option<String>,
     diff_merge_base: Option<String>,
+
+    // Terminal state
+    terminals: HashMap<u64, iced_term::Terminal>,
+    terminal_tabs: HashMap<String, Vec<TerminalTab>>,
+    active_terminal_tab: HashMap<String, u64>,
+    terminal_panel_visible: bool,
 }
 
 fn claudette_home() -> PathBuf {
@@ -192,6 +200,10 @@ impl App {
             diff_error: None,
             diff_revert_target: None,
             diff_merge_base: None,
+            terminals: HashMap::new(),
+            terminal_tabs: HashMap::new(),
+            active_terminal_tab: HashMap::new(),
+            terminal_panel_visible: true,
         };
 
         let load_task = Task::perform(
@@ -227,43 +239,56 @@ impl App {
                 self.chat_input.clear();
 
                 // Reset diff state when switching workspaces
-                if self.diff_visible {
+                let was_diff_visible = self.diff_visible;
+                if was_diff_visible {
                     self.diff_files.clear();
                     self.diff_selected_file = None;
                     self.diff_content = None;
                     self.diff_error = None;
                     self.diff_merge_base = None;
                     self.diff_revert_target = None;
-                    // Set diff_visible to false so ToggleDiffViewer will re-open
-                    // and reload diff data for the new workspace
                     self.diff_visible = false;
-                    let mut tasks = vec![];
-                    if !self.chat_messages.contains_key(&id) {
-                        let db_path = self.db_path.clone();
-                        let ws_id = id.clone();
-                        tasks.push(Task::perform(
-                            async move {
-                                let db = Database::open(&db_path).map_err(|e| e.to_string())?;
-                                db.list_chat_messages(&ws_id).map_err(|e| e.to_string())
-                            },
-                            move |result| Message::ChatHistoryLoaded(id, result),
-                        ));
-                    }
+                }
+
+                let mut tasks = vec![];
+
+                if was_diff_visible {
                     tasks.push(Task::done(Message::ToggleDiffViewer));
-                    return Task::batch(tasks);
                 }
 
                 // Load chat history if not already loaded
                 if !self.chat_messages.contains_key(&id) {
                     let db_path = self.db_path.clone();
                     let ws_id = id.clone();
-                    return Task::perform(
+                    let ws_id_cb = id.clone();
+                    tasks.push(Task::perform(
                         async move {
                             let db = Database::open(&db_path).map_err(|e| e.to_string())?;
                             db.list_chat_messages(&ws_id).map_err(|e| e.to_string())
                         },
-                        move |result| Message::ChatHistoryLoaded(id, result),
-                    );
+                        move |result| Message::ChatHistoryLoaded(ws_id_cb, result),
+                    ));
+                }
+
+                // Lazily load terminal tabs if not already loaded
+                if !self.terminal_tabs.contains_key(&id) {
+                    let db_path = self.db_path.clone();
+                    let ws_id = id.clone();
+                    tasks.push(Task::perform(
+                        async move {
+                            let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                            db.list_terminal_tabs_by_workspace(&ws_id)
+                                .map_err(|e| e.to_string())
+                        },
+                        {
+                            let ws_id = id.clone();
+                            move |result| Message::TerminalTabsLoaded(ws_id, result)
+                        },
+                    ));
+                }
+
+                if !tasks.is_empty() {
+                    return Task::batch(tasks);
                 }
             }
             Message::ToggleRepoCollapsed(id) => {
@@ -563,8 +588,9 @@ impl App {
             Message::WorkspaceCreated(Ok(ws)) => {
                 let ws_id = ws.id.clone();
                 self.workspaces.push(ws);
-                self.selected_workspace = Some(ws_id);
+                self.selected_workspace = Some(ws_id.clone());
                 self.show_create_workspace = None;
+                return Task::done(Message::TerminalCreate(ws_id));
             }
             Message::WorkspaceCreated(Err(msg)) => {
                 self.create_workspace_error = Some(msg);
@@ -572,6 +598,14 @@ impl App {
 
             // --- Archive ---
             Message::ArchiveWorkspace(ws_id) => {
+                // Destroy all terminals for this workspace
+                if let Some(tabs) = self.terminal_tabs.remove(&ws_id) {
+                    for tab in &tabs {
+                        self.terminals.remove(&(tab.id as u64));
+                    }
+                }
+                self.active_terminal_tab.remove(&ws_id);
+
                 // Stop agent first if running
                 if self.agents.contains_key(&ws_id) {
                     let pid = self.agents[&ws_id].handle.pid;
@@ -671,6 +705,7 @@ impl App {
                     ws.worktree_path = Some(wt_path);
                     ws.agent_status = AgentStatus::Idle;
                 }
+                return Task::done(Message::TerminalCreate(ws_id));
             }
             Message::WorkspaceRestored(Err(e)) => {
                 eprintln!("Failed to restore workspace: {e}");
@@ -729,6 +764,12 @@ impl App {
                 self.workspaces.retain(|w| w.id != ws_id);
                 self.chat_messages.remove(&ws_id);
                 self.markdown_cache.remove(&ws_id);
+                if let Some(tabs) = self.terminal_tabs.remove(&ws_id) {
+                    for tab in &tabs {
+                        self.terminals.remove(&(tab.id as u64));
+                    }
+                }
+                self.active_terminal_tab.remove(&ws_id);
                 if self.selected_workspace.as_deref() == Some(&ws_id) {
                     self.selected_workspace = None;
                 }
@@ -1341,6 +1382,224 @@ impl App {
             Message::DiffFileReverted(Err(e)) => {
                 self.diff_error = Some(format!("Failed to revert: {e}"));
             }
+
+            // --- Terminal ---
+            Message::TerminalCreate(ws_id) => {
+                let ws = self.workspaces.iter().find(|w| w.id == ws_id);
+                let Some(wt_path) = ws.and_then(|w| w.worktree_path.as_deref()) else {
+                    return Task::none();
+                };
+
+                let id = terminal::next_terminal_id();
+                match terminal::create_terminal(id, std::path::Path::new(wt_path)) {
+                    Ok(term) => {
+                        self.terminals.insert(id, term);
+                        let sort_order = self
+                            .terminal_tabs
+                            .get(&ws_id)
+                            .map(|tabs| tabs.len() as i32)
+                            .unwrap_or(0);
+                        let tab = TerminalTab {
+                            id: id as i64,
+                            workspace_id: ws_id.clone(),
+                            title: format!("Terminal {}", sort_order + 1),
+                            is_script_output: false,
+                            sort_order,
+                            created_at: String::new(),
+                        };
+                        self.terminal_tabs
+                            .entry(ws_id.clone())
+                            .or_default()
+                            .push(tab.clone());
+                        self.active_terminal_tab.insert(ws_id.clone(), id);
+
+                        let db_path = self.db_path.clone();
+                        return Task::perform(
+                            async move {
+                                let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                                db.insert_terminal_tab(&tab).map_err(|e| e.to_string())?;
+                                Ok((ws_id, tab))
+                            },
+                            Message::TerminalCreated,
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to create terminal: {e}");
+                    }
+                }
+            }
+            Message::TerminalCreated(Ok(_)) => {}
+            Message::TerminalCreated(Err(e)) => {
+                eprintln!("Failed to persist terminal tab: {e}");
+            }
+
+            Message::TerminalClose(terminal_id) => {
+                self.terminals.remove(&terminal_id);
+                let tab_id = terminal_id as i64;
+                let mut affected_ws = None;
+                for (ws_id, tabs) in &mut self.terminal_tabs {
+                    if let Some(pos) = tabs.iter().position(|t| t.id == tab_id) {
+                        tabs.remove(pos);
+                        affected_ws = Some(ws_id.clone());
+                        break;
+                    }
+                }
+                if let Some(ws_id) = &affected_ws
+                    && self.active_terminal_tab.get(ws_id) == Some(&terminal_id)
+                {
+                    let new_active = self
+                        .terminal_tabs
+                        .get(ws_id)
+                        .and_then(|tabs| tabs.first())
+                        .map(|t| t.id as u64);
+                    if let Some(id) = new_active {
+                        self.active_terminal_tab.insert(ws_id.clone(), id);
+                    } else {
+                        self.active_terminal_tab.remove(ws_id);
+                    }
+                }
+
+                // Auto-recreate if last terminal was closed
+                if let Some(ws_id) = &affected_ws {
+                    let is_empty = self
+                        .terminal_tabs
+                        .get(ws_id)
+                        .map(|t| t.is_empty())
+                        .unwrap_or(true);
+                    if is_empty {
+                        let ws_id = ws_id.clone();
+                        let db_path = self.db_path.clone();
+                        return Task::batch([
+                            Task::perform(
+                                async move {
+                                    let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                                    db.delete_terminal_tab(tab_id).map_err(|e| e.to_string())?;
+                                    Ok(tab_id)
+                                },
+                                Message::TerminalClosed,
+                            ),
+                            Task::done(Message::TerminalCreate(ws_id)),
+                        ]);
+                    }
+                }
+
+                let db_path = self.db_path.clone();
+                return Task::perform(
+                    async move {
+                        let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                        db.delete_terminal_tab(tab_id).map_err(|e| e.to_string())?;
+                        Ok(tab_id)
+                    },
+                    Message::TerminalClosed,
+                );
+            }
+            Message::TerminalClosed(Ok(_)) => {}
+            Message::TerminalClosed(Err(e)) => {
+                eprintln!("Failed to delete terminal tab: {e}");
+            }
+
+            Message::TerminalSelectTab(terminal_id) => {
+                if let Some(ws_id) = &self.selected_workspace {
+                    self.active_terminal_tab.insert(ws_id.clone(), terminal_id);
+                }
+            }
+
+            Message::TerminalTogglePanel => {
+                self.terminal_panel_visible = !self.terminal_panel_visible;
+            }
+
+            Message::TerminalEvent(event) => {
+                let iced_term::Event::BackendCall(id, cmd) = event;
+                if let Some(term) = self.terminals.get_mut(&id) {
+                    let action = term.handle(iced_term::Command::ProxyToBackend(cmd));
+                    match action {
+                        iced_term::actions::Action::Shutdown => {
+                            return Task::done(Message::TerminalClose(id));
+                        }
+                        iced_term::actions::Action::ChangeTitle(title) => {
+                            for tabs in self.terminal_tabs.values_mut() {
+                                if let Some(tab) = tabs.iter_mut().find(|t| t.id == id as i64) {
+                                    tab.title = title;
+                                    break;
+                                }
+                            }
+                        }
+                        iced_term::actions::Action::Ignore => {}
+                    }
+                }
+            }
+
+            Message::TerminalTabsLoaded(ws_id, Ok(tabs)) => {
+                let ws = self.workspaces.iter().find(|w| w.id == ws_id);
+                if let Some(wt_path) = ws.and_then(|w| w.worktree_path.as_deref()) {
+                    let mut first_id = None;
+                    for tab in &tabs {
+                        let id = tab.id as u64;
+                        if !self.terminals.contains_key(&id)
+                            && let Ok(term) =
+                                terminal::create_terminal(id, std::path::Path::new(wt_path))
+                        {
+                            self.terminals.insert(id, term);
+                        }
+                        if first_id.is_none() {
+                            first_id = Some(id);
+                        }
+                    }
+                    if let Some(id) = first_id {
+                        self.active_terminal_tab.entry(ws_id.clone()).or_insert(id);
+                    }
+                }
+                self.terminal_tabs.insert(ws_id, tabs);
+            }
+            Message::TerminalTabsLoaded(_ws_id, Err(e)) => {
+                eprintln!("Failed to load terminal tabs: {e}");
+            }
+
+            Message::ScriptOutputCreate(ws_id, command) => {
+                let ws = self.workspaces.iter().find(|w| w.id == ws_id);
+                let Some(wt_path) = ws.and_then(|w| w.worktree_path.as_deref()) else {
+                    return Task::none();
+                };
+
+                let id = terminal::next_terminal_id();
+                match terminal::create_script_terminal(id, std::path::Path::new(wt_path), &command)
+                {
+                    Ok(term) => {
+                        self.terminals.insert(id, term);
+                        let sort_order = self
+                            .terminal_tabs
+                            .get(&ws_id)
+                            .map(|tabs| tabs.len() as i32)
+                            .unwrap_or(0);
+                        let tab = TerminalTab {
+                            id: id as i64,
+                            workspace_id: ws_id.clone(),
+                            title: command,
+                            is_script_output: true,
+                            sort_order,
+                            created_at: String::new(),
+                        };
+                        self.terminal_tabs
+                            .entry(ws_id.clone())
+                            .or_default()
+                            .push(tab.clone());
+                        self.active_terminal_tab.insert(ws_id.clone(), id);
+
+                        let db_path = self.db_path.clone();
+                        return Task::perform(
+                            async move {
+                                let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                                db.insert_terminal_tab(&tab).map_err(|e| e.to_string())?;
+                                Ok((ws_id, tab))
+                            },
+                            Message::TerminalCreated,
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to create script terminal: {e}");
+                    }
+                }
+            }
         }
         Task::none()
     }
@@ -1517,6 +1776,18 @@ impl App {
             error: self.diff_error.as_deref(),
         };
 
+        let (term_tabs, active_term) = if let Some(ws_id) = &self.selected_workspace {
+            let tabs = self
+                .terminal_tabs
+                .get(ws_id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            let active = self.active_terminal_tab.get(ws_id).copied();
+            (tabs, active)
+        } else {
+            (&[] as &[TerminalTab], None)
+        };
+
         layout = layout.push(ui::view_main_content(
             &self.repositories,
             &self.workspaces,
@@ -1526,6 +1797,10 @@ impl App {
             streaming,
             md_items,
             &diff_state,
+            &self.terminals,
+            term_tabs,
+            active_term,
+            self.terminal_panel_visible,
         ));
 
         let base: Element<'_, Message> = layout.into();
@@ -1640,6 +1915,9 @@ impl App {
                     Key::Character(c) if c.as_ref() == "d" && modifiers.command() => {
                         return Some(Message::ToggleDiffViewer);
                     }
+                    Key::Character(c) if c.as_ref() == "`" && modifiers.command() => {
+                        return Some(Message::TerminalTogglePanel);
+                    }
                     Key::Named(keyboard::key::Named::Escape) => {
                         return Some(Message::EscapePressed);
                     }
@@ -1662,8 +1940,16 @@ impl App {
             })
             .collect();
 
+        // Terminal subscriptions — one per live terminal instance
+        let terminal_subs: Vec<Subscription<Message>> = self
+            .terminals
+            .values()
+            .map(|term| term.subscription().map(Message::TerminalEvent))
+            .collect();
+
         let mut subs = vec![keyboard_sub];
         subs.extend(agent_subs);
+        subs.extend(terminal_subs);
         Subscription::batch(subs)
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -370,6 +370,14 @@ impl Database {
         Ok(())
     }
 
+    pub fn max_terminal_tab_id(&self) -> Result<i64, rusqlite::Error> {
+        self.conn.query_row(
+            "SELECT COALESCE(MAX(id), 0) FROM terminal_tabs",
+            [],
+            |row| row.get(0),
+        )
+    }
+
     pub fn list_terminal_tabs_by_workspace(
         &self,
         workspace_id: &str,

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use rusqlite::{Connection, params};
 
-use crate::model::{ChatMessage, ChatRole, Repository, Workspace, WorkspaceStatus};
+use crate::model::{ChatMessage, ChatRole, Repository, TerminalTab, Workspace, WorkspaceStatus};
 
 pub struct Database {
     conn: Connection,
@@ -94,6 +94,24 @@ impl Database {
                  );
 
                  PRAGMA user_version = 3;",
+            )?;
+        }
+
+        if version < 4 {
+            self.conn.execute_batch(
+                "CREATE TABLE terminal_tabs (
+                    id               INTEGER PRIMARY KEY,
+                    workspace_id     TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                    title            TEXT NOT NULL DEFAULT 'Terminal',
+                    is_script_output INTEGER NOT NULL DEFAULT 0,
+                    sort_order       INTEGER NOT NULL DEFAULT 0,
+                    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE INDEX idx_terminal_tabs_workspace
+                    ON terminal_tabs(workspace_id, sort_order);
+
+                PRAGMA user_version = 4;",
             )?;
         }
 
@@ -331,6 +349,72 @@ impl Database {
         self.conn.execute(
             "DELETE FROM chat_messages WHERE workspace_id = ?1",
             params![workspace_id],
+        )?;
+        Ok(())
+    }
+
+    // --- Terminal Tabs ---
+
+    pub fn insert_terminal_tab(&self, tab: &TerminalTab) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT INTO terminal_tabs (id, workspace_id, title, is_script_output, sort_order)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                tab.id,
+                tab.workspace_id,
+                tab.title,
+                tab.is_script_output as i32,
+                tab.sort_order,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_terminal_tabs_by_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Vec<TerminalTab>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, title, is_script_output, sort_order, created_at
+             FROM terminal_tabs WHERE workspace_id = ?1 ORDER BY sort_order, id",
+        )?;
+        let rows = stmt.query_map(params![workspace_id], |row| {
+            let is_script: i32 = row.get(3)?;
+            Ok(TerminalTab {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                title: row.get(2)?,
+                is_script_output: is_script != 0,
+                sort_order: row.get(4)?,
+                created_at: row.get(5)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn delete_terminal_tab(&self, id: i64) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute("DELETE FROM terminal_tabs WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn delete_terminal_tabs_for_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM terminal_tabs WHERE workspace_id = ?1",
+            params![workspace_id],
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn update_terminal_tab_title(&self, id: i64, title: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE terminal_tabs SET title = ?1 WHERE id = ?2",
+            params![title, id],
         )?;
         Ok(())
     }
@@ -629,5 +713,88 @@ mod tests {
         db.set_app_setting("key1", "value2").unwrap();
         let val = db.get_app_setting("key1").unwrap();
         assert_eq!(val.as_deref(), Some("value2"));
+    }
+
+    // --- Terminal tab tests ---
+
+    fn make_terminal_tab(id: i64, ws_id: &str, title: &str) -> TerminalTab {
+        TerminalTab {
+            id,
+            workspace_id: ws_id.into(),
+            title: title.into(),
+            is_script_output: false,
+            sort_order: 0,
+            created_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_insert_and_list_terminal_tabs() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
+            .unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(2, "w1", "Terminal 2"))
+            .unwrap();
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert_eq!(tabs.len(), 2);
+        assert_eq!(tabs[0].title, "Terminal 1");
+        assert_eq!(tabs[1].title, "Terminal 2");
+    }
+
+    #[test]
+    fn test_terminal_tabs_filtered_by_workspace() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "feature"))
+            .unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "T1"))
+            .unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(2, "w2", "T2"))
+            .unwrap();
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0].title, "T1");
+    }
+
+    #[test]
+    fn test_delete_terminal_tab() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
+            .unwrap();
+        db.delete_terminal_tab(1).unwrap();
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert!(tabs.is_empty());
+    }
+
+    #[test]
+    fn test_terminal_tabs_cascade_on_workspace_delete() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
+            .unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(2, "w1", "Terminal 2"))
+            .unwrap();
+        db.delete_workspace("w1").unwrap();
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert!(tabs.is_empty());
+    }
+
+    #[test]
+    fn test_terminal_tab_script_output_flag() {
+        let db = setup_db_with_workspace();
+        let mut tab = make_terminal_tab(1, "w1", "npm run dev");
+        tab.is_script_output = true;
+        db.insert_terminal_tab(&tab).unwrap();
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert!(tabs[0].is_script_output);
+    }
+
+    #[test]
+    fn test_update_terminal_tab_title() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
+            .unwrap();
+        db.update_terminal_tab_title(1, "My Custom Terminal")
+            .unwrap();
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert_eq!(tabs[0].title, "My Custom Terminal");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod icons;
 mod message;
 mod model;
 mod names;
+mod terminal;
 mod ui;
 
 use app::App;

--- a/src/message.rs
+++ b/src/message.rs
@@ -15,6 +15,13 @@ pub enum RightSidebarTab {
     Changes,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DividerDrag {
+    LeftSidebar,
+    RightSidebar,
+    Terminal,
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     // Sidebar
@@ -146,4 +153,9 @@ pub enum Message {
     // Script output (foundation for §4.7)
     #[allow(dead_code)]
     ScriptOutputCreate(String, String), // workspace_id, command
+
+    // --- Panel resizing ---
+    DividerDragStart(DividerDrag),
+    DividerDragUpdate(f32, f32), // cursor_x, cursor_y
+    DividerDragEnd,
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
 use crate::agent::StreamEvent;
 use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
-use crate::model::{ChatMessage, Repository, Workspace};
+use crate::model::{ChatMessage, Repository, TerminalTab, Workspace};
 
 #[derive(Debug, Clone)]
 pub enum SidebarFilter {
@@ -124,4 +124,18 @@ pub enum Message {
     DiffConfirmRevert,
     DiffCancelRevert,
     DiffFileReverted(Result<String, String>), // Ok(file_path)
+
+    // --- Terminal ---
+    TerminalCreate(String),                                 // workspace_id
+    TerminalCreated(Result<(String, TerminalTab), String>), // Ok((ws_id, tab))
+    TerminalClose(u64),                                     // terminal_id
+    TerminalClosed(Result<i64, String>),                    // Ok(tab_id)
+    TerminalSelectTab(u64),                                 // terminal_id
+    TerminalTogglePanel,                                    // Ctrl/Cmd+`
+    TerminalEvent(iced_term::Event),                        // event from backend
+    TerminalTabsLoaded(String, Result<Vec<TerminalTab>, String>), // ws_id, tabs
+
+    // Script output (foundation for §4.7)
+    #[allow(dead_code)]
+    ScriptOutputCreate(String, String), // workspace_id, command
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -9,6 +9,12 @@ pub enum SidebarFilter {
     Archived,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RightSidebarTab {
+    AllFiles,
+    Changes,
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     // Sidebar
@@ -113,8 +119,10 @@ pub enum Message {
     // --- Markdown link ---
     ChatLinkClicked(String), // URL
 
-    // --- Diff viewer ---
-    ToggleDiffViewer,
+    // --- Right sidebar / Diff ---
+    ToggleRightSidebar,
+    SetRightSidebarTab(RightSidebarTab),
+    DiffClearSelection,
     DiffRefresh,
     DiffFilesLoaded(Result<(Vec<DiffFile>, String), String>), // Ok((files, merge_base))
     DiffSelectFile(String),                                   // file path

--- a/src/model/diff.rs
+++ b/src/model/diff.rs
@@ -50,14 +50,3 @@ pub struct DiffLine {
     pub old_line_number: Option<u32>,
     pub new_line_number: Option<u32>,
 }
-
-/// Bundled read-only diff state for passing to view functions.
-pub struct DiffViewState<'a> {
-    pub visible: bool,
-    pub files: &'a [DiffFile],
-    pub selected_file: Option<&'a str>,
-    pub content: Option<&'a FileDiff>,
-    pub view_mode: DiffViewMode,
-    pub loading: bool,
-    pub error: Option<&'a str>,
-}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,8 +1,10 @@
 mod chat_message;
 pub mod diff;
 mod repository;
+mod terminal_tab;
 mod workspace;
 
 pub use chat_message::{ChatMessage, ChatRole};
 pub use repository::Repository;
+pub use terminal_tab::TerminalTab;
 pub use workspace::{AgentStatus, Workspace, WorkspaceStatus};

--- a/src/model/terminal_tab.rs
+++ b/src/model/terminal_tab.rs
@@ -1,0 +1,12 @@
+/// Metadata for a terminal tab. The actual terminal emulator state
+/// (iced_term::Terminal, PTY process) is ephemeral and stored on App.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct TerminalTab {
+    pub id: i64,
+    pub workspace_id: String,
+    pub title: String,
+    pub is_script_output: bool,
+    pub sort_order: i32,
+    pub created_at: String,
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -6,6 +6,12 @@ use iced_term::{ColorPalette, Terminal};
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Seed the ID counter so it starts above any existing DB IDs.
+/// Call once at startup with the max terminal_tab id from the database.
+pub fn seed_next_id(max_existing: u64) {
+    NEXT_ID.store(max_existing + 1, Ordering::Relaxed);
+}
+
 /// Generate a unique terminal ID (monotonically increasing).
 pub fn next_terminal_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::Relaxed)

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use iced_term::settings::{BackendSettings, FontSettings, Settings, ThemeSettings};
+use iced_term::{ColorPalette, Terminal};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Generate a unique terminal ID (monotonically increasing).
+pub fn next_terminal_id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Create an interactive shell terminal in the given working directory.
+pub fn create_terminal(id: u64, working_dir: &Path) -> std::io::Result<Terminal> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+    let settings = Settings {
+        font: FontSettings::default(),
+        theme: terminal_theme(),
+        backend: BackendSettings {
+            program: shell,
+            args: vec![],
+            env: Default::default(),
+            working_directory: Some(working_dir.to_path_buf()),
+        },
+    };
+    Terminal::new(id, settings)
+}
+
+/// Create a terminal that runs a specific command (for script output tabs).
+pub fn create_script_terminal(
+    id: u64,
+    working_dir: &Path,
+    command: &str,
+) -> std::io::Result<Terminal> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+    let settings = Settings {
+        font: FontSettings::default(),
+        theme: terminal_theme(),
+        backend: BackendSettings {
+            program: shell,
+            args: vec!["-c".to_string(), command.to_string()],
+            env: Default::default(),
+            working_directory: Some(working_dir.to_path_buf()),
+        },
+    };
+    Terminal::new(id, settings)
+}
+
+fn terminal_theme() -> ThemeSettings {
+    ThemeSettings::new(Box::new(ColorPalette {
+        foreground: "#e6e6ea".to_string(),
+        background: "#14141a".to_string(),
+        black: "#14141a".to_string(),
+        red: "#e64d4d".to_string(),
+        green: "#33cc4d".to_string(),
+        yellow: "#e6b333".to_string(),
+        blue: "#6b9fb5".to_string(),
+        magenta: "#aa759f".to_string(),
+        cyan: "#75b5aa".to_string(),
+        white: "#e6e6ea".to_string(),
+        bright_black: "#6b6b6b".to_string(),
+        bright_red: "#ff6666".to_string(),
+        bright_green: "#66ff80".to_string(),
+        bright_yellow: "#ffcc66".to_string(),
+        bright_blue: "#82b8c8".to_string(),
+        bright_magenta: "#c28cb8".to_string(),
+        bright_cyan: "#93d3c3".to_string(),
+        bright_white: "#f8f8f8".to_string(),
+        bright_foreground: None,
+        dim_foreground: "#828482".to_string(),
+        dim_black: "#0f0f0f".to_string(),
+        dim_red: "#712b2b".to_string(),
+        dim_green: "#5f6f3a".to_string(),
+        dim_yellow: "#a17e4d".to_string(),
+        dim_blue: "#456877".to_string(),
+        dim_magenta: "#704d68".to_string(),
+        dim_cyan: "#4d7770".to_string(),
+        dim_white: "#8e8e8e".to_string(),
+    }))
+}

--- a/src/ui/diff_file_tree.rs
+++ b/src/ui/diff_file_tree.rs
@@ -124,7 +124,7 @@ pub fn view_diff_file_tree<'a>(
     ];
 
     container(content)
-        .width(Length::Fixed(style::DIFF_FILE_TREE_WIDTH))
+        .width(Fill)
         .height(Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(Background::Color(style::SIDEBAR_BG)),

--- a/src/ui/diff_viewer.rs
+++ b/src/ui/diff_viewer.rs
@@ -1,31 +1,57 @@
-use iced::widget::{Space, column, container, row, text};
+use iced::widget::{Space, button, column, container, row, text};
 use iced::{Background, Border, Element, Fill, Theme};
 
 use crate::message::Message;
 use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
-use crate::ui::{diff_content, diff_file_tree, style};
+use crate::ui::{diff_content, style};
 
-pub fn view_diff_viewer<'a>(
-    files: &'a [DiffFile],
-    selected_file: Option<&str>,
+/// Renders the diff content panel (no file tree — that lives in the right sidebar).
+/// Shows a thin header with the selected file path and a back button.
+pub fn view_diff_content_panel<'a>(
+    files: &[DiffFile],
+    selected_file: Option<&'a str>,
     content: Option<&'a FileDiff>,
     view_mode: DiffViewMode,
     loading: bool,
     error: Option<&'a str>,
 ) -> Element<'a, Message> {
-    // File tree on the left
-    let file_tree = diff_file_tree::view_diff_file_tree(files, selected_file, view_mode);
+    // Header with file path and back button
+    let file_label = selected_file.unwrap_or("No file selected");
+    let header = container(
+        row![
+            button(text("\u{2190}").size(14).color(style::MUTED))
+                .on_press(Message::DiffClearSelection)
+                .style(|theme: &Theme, status| {
+                    let mut s = button::text(theme, status);
+                    s.border = Border {
+                        radius: 4.0.into(),
+                        ..s.border
+                    };
+                    s
+                })
+                .padding([2, 8]),
+            text(file_label).size(13).color(style::TEXT),
+            Space::new().width(Fill),
+        ]
+        .align_y(iced::Alignment::Center)
+        .spacing(8)
+        .padding([6, 12]),
+    )
+    .width(Fill)
+    .style(|_theme: &Theme| container::Style {
+        background: Some(Background::Color(style::CHAT_HEADER_BG)),
+        ..Default::default()
+    });
 
-    // Divider
-    let divider = container(column![])
-        .width(1)
-        .height(Fill)
+    let header_divider = container(column![])
+        .height(1)
+        .width(Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(Background::Color(style::DIVIDER)),
             ..Default::default()
         });
 
-    // Content area on the right
+    // Content area
     let content_area: Element<'_, Message> = if let Some(err) = error {
         container(
             column![
@@ -50,47 +76,7 @@ pub fn view_diff_viewer<'a>(
         diff_content::view_diff_placeholder("Select a file to view changes")
     };
 
-    // Header with close button
-    let header = container(
-        row![
-            text("Diff Viewer").size(14).color(style::TEXT),
-            Space::new().width(Fill),
-            iced::widget::button(text("\u{2715}").size(14).color(style::MUTED))
-                .on_press(Message::ToggleDiffViewer)
-                .style(|theme: &Theme, status| {
-                    let mut s = iced::widget::button::text(theme, status);
-                    s.border = Border {
-                        radius: 4.0.into(),
-                        ..s.border
-                    };
-                    s
-                })
-                .padding([2, 8]),
-        ]
-        .align_y(iced::Alignment::Center)
-        .padding([6, 12]),
-    )
-    .width(Fill)
-    .style(|_theme: &Theme| container::Style {
-        background: Some(Background::Color(style::CHAT_HEADER_BG)),
-        border: Border {
-            width: 0.0,
-            ..Default::default()
-        },
-        ..Default::default()
-    });
-
-    let header_divider = container(column![])
-        .height(1)
-        .width(Fill)
-        .style(|_theme: &Theme| container::Style {
-            background: Some(Background::Color(style::DIVIDER)),
-            ..Default::default()
-        });
-
-    let body = row![file_tree, divider, content_area];
-
-    column![header, header_divider, body]
+    column![header, header_divider, content_area]
         .width(Fill)
         .height(Fill)
         .into()

--- a/src/ui/divider.rs
+++ b/src/ui/divider.rs
@@ -1,0 +1,41 @@
+use iced::widget::{Space, container, mouse_area};
+use iced::{Background, Border, Element, Length, Theme};
+
+use crate::message::{DividerDrag, Message};
+use crate::ui::style;
+
+/// A vertical divider (between side panels) — draggable horizontally.
+pub fn vertical_divider(drag_target: DividerDrag) -> Element<'static, Message> {
+    let handle = container(Space::new())
+        .width(Length::Fixed(5.0))
+        .height(Length::Fill)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(Background::Color(style::DIVIDER)),
+            ..Default::default()
+        });
+
+    mouse_area(handle)
+        .on_press(Message::DividerDragStart(drag_target))
+        .interaction(iced::mouse::Interaction::ResizingHorizontally)
+        .into()
+}
+
+/// A horizontal divider (between main content and terminal) — draggable vertically.
+pub fn horizontal_divider(drag_target: DividerDrag) -> Element<'static, Message> {
+    let handle = container(Space::new())
+        .width(Length::Fill)
+        .height(Length::Fixed(5.0))
+        .style(|_theme: &Theme| container::Style {
+            background: Some(Background::Color(style::DIVIDER)),
+            border: Border {
+                width: 0.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+    mouse_area(handle)
+        .on_press(Message::DividerDragStart(drag_target))
+        .interaction(iced::mouse::Interaction::ResizingVertically)
+        .into()
+}

--- a/src/ui/main_content.rs
+++ b/src/ui/main_content.rs
@@ -1,10 +1,13 @@
-use iced::widget::{Space, center, column, container, markdown, text};
+use std::collections::HashMap;
+
+use iced::widget::{Column, Space, center, column, container, markdown, text};
 use iced::{Element, Fill};
+use iced_term::Terminal;
 
 use crate::message::Message;
 use crate::model::diff::DiffViewState;
-use crate::model::{AgentStatus, ChatMessage, Repository, Workspace};
-use crate::ui::{chat_panel, diff_viewer, style};
+use crate::model::{AgentStatus, ChatMessage, Repository, TerminalTab, Workspace};
+use crate::ui::{chat_panel, diff_viewer, style, terminal_panel};
 
 #[allow(clippy::too_many_arguments)]
 pub fn view_main_content<'a>(
@@ -16,6 +19,10 @@ pub fn view_main_content<'a>(
     streaming_text: &'a str,
     markdown_items: &'a [Vec<markdown::Item>],
     diff: &DiffViewState<'a>,
+    terminals: &'a HashMap<u64, Terminal>,
+    terminal_tabs: &[TerminalTab],
+    active_terminal_tab: Option<u64>,
+    terminal_panel_visible: bool,
 ) -> Element<'a, Message> {
     let content: Element<'_, Message> = if let Some(ws_id) = selected_workspace {
         if let Some(ws) = workspaces.iter().find(|w| w.id == ws_id) {
@@ -30,7 +37,7 @@ pub fn view_main_content<'a>(
                 )
             } else {
                 let is_running = ws.agent_status == AgentStatus::Running;
-                chat_panel::view_chat_panel(
+                let chat = chat_panel::view_chat_panel(
                     ws,
                     repositories,
                     chat_messages,
@@ -38,7 +45,22 @@ pub fn view_main_content<'a>(
                     streaming_text,
                     markdown_items,
                     is_running,
-                )
+                );
+
+                let terminal = terminal_panel::view_terminal_panel(
+                    terminals,
+                    terminal_tabs,
+                    active_terminal_tab,
+                    terminal_panel_visible,
+                    ws_id,
+                );
+
+                Column::new()
+                    .push(container(chat).width(Fill).height(Fill))
+                    .push(terminal)
+                    .width(Fill)
+                    .height(Fill)
+                    .into()
             }
         } else {
             center(text("Workspace not found").size(16).color(style::FAINT)).into()

--- a/src/ui/main_content.rs
+++ b/src/ui/main_content.rs
@@ -4,10 +4,10 @@ use iced::widget::{Column, Space, center, column, container, markdown, text};
 use iced::{Element, Fill};
 use iced_term::Terminal;
 
-use crate::message::Message;
+use crate::message::{DividerDrag, Message};
 use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
 use crate::model::{AgentStatus, ChatMessage, Repository, TerminalTab, Workspace};
-use crate::ui::{chat_panel, diff_viewer, style, terminal_panel};
+use crate::ui::{chat_panel, diff_viewer, divider, style, terminal_panel};
 
 #[allow(clippy::too_many_arguments)]
 pub fn view_main_content<'a>(
@@ -18,7 +18,7 @@ pub fn view_main_content<'a>(
     chat_input: &str,
     streaming_text: &'a str,
     markdown_items: &'a [Vec<markdown::Item>],
-    // Diff state (individual fields, no DiffViewState)
+    // Diff state
     diff_files: &'a [DiffFile],
     diff_selected_file: Option<&'a str>,
     diff_content: Option<&'a FileDiff>,
@@ -30,6 +30,7 @@ pub fn view_main_content<'a>(
     terminal_tabs: &[TerminalTab],
     active_terminal_tab: Option<u64>,
     terminal_panel_visible: bool,
+    terminal_height: f32,
 ) -> Element<'a, Message> {
     let content: Element<'_, Message> = if let Some(ws_id) = selected_workspace {
         if let Some(ws) = workspaces.iter().find(|w| w.id == ws_id) {
@@ -62,14 +63,22 @@ pub fn view_main_content<'a>(
                 active_terminal_tab,
                 terminal_panel_visible,
                 ws_id,
+                terminal_height,
             );
 
-            Column::new()
+            let mut col = Column::new()
                 .push(container(top_content).width(Fill).height(Fill))
-                .push(terminal)
                 .width(Fill)
-                .height(Fill)
-                .into()
+                .height(Fill);
+
+            // Add horizontal divider + terminal if terminal is visible and has tabs
+            if terminal_panel_visible && !terminal_tabs.is_empty() {
+                col = col
+                    .push(divider::horizontal_divider(DividerDrag::Terminal))
+                    .push(terminal);
+            }
+
+            col.into()
         } else {
             center(text("Workspace not found").size(16).color(style::FAINT)).into()
         }

--- a/src/ui/main_content.rs
+++ b/src/ui/main_content.rs
@@ -5,7 +5,7 @@ use iced::{Element, Fill};
 use iced_term::Terminal;
 
 use crate::message::Message;
-use crate::model::diff::DiffViewState;
+use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
 use crate::model::{AgentStatus, ChatMessage, Repository, TerminalTab, Workspace};
 use crate::ui::{chat_panel, diff_viewer, style, terminal_panel};
 
@@ -18,7 +18,14 @@ pub fn view_main_content<'a>(
     chat_input: &str,
     streaming_text: &'a str,
     markdown_items: &'a [Vec<markdown::Item>],
-    diff: &DiffViewState<'a>,
+    // Diff state (individual fields, no DiffViewState)
+    diff_files: &'a [DiffFile],
+    diff_selected_file: Option<&'a str>,
+    diff_content: Option<&'a FileDiff>,
+    diff_view_mode: DiffViewMode,
+    diff_loading: bool,
+    diff_error: Option<&'a str>,
+    // Terminal state
     terminals: &'a HashMap<u64, Terminal>,
     terminal_tabs: &[TerminalTab],
     active_terminal_tab: Option<u64>,
@@ -26,18 +33,19 @@ pub fn view_main_content<'a>(
 ) -> Element<'a, Message> {
     let content: Element<'_, Message> = if let Some(ws_id) = selected_workspace {
         if let Some(ws) = workspaces.iter().find(|w| w.id == ws_id) {
-            if diff.visible {
-                diff_viewer::view_diff_viewer(
-                    diff.files,
-                    diff.selected_file,
-                    diff.content,
-                    diff.view_mode,
-                    diff.loading,
-                    diff.error,
+            // Decide top content: diff content or chat
+            let top_content: Element<'_, Message> = if diff_selected_file.is_some() {
+                diff_viewer::view_diff_content_panel(
+                    diff_files,
+                    diff_selected_file,
+                    diff_content,
+                    diff_view_mode,
+                    diff_loading,
+                    diff_error,
                 )
             } else {
                 let is_running = ws.agent_status == AgentStatus::Running;
-                let chat = chat_panel::view_chat_panel(
+                chat_panel::view_chat_panel(
                     ws,
                     repositories,
                     chat_messages,
@@ -45,23 +53,23 @@ pub fn view_main_content<'a>(
                     streaming_text,
                     markdown_items,
                     is_running,
-                );
+                )
+            };
 
-                let terminal = terminal_panel::view_terminal_panel(
-                    terminals,
-                    terminal_tabs,
-                    active_terminal_tab,
-                    terminal_panel_visible,
-                    ws_id,
-                );
+            let terminal = terminal_panel::view_terminal_panel(
+                terminals,
+                terminal_tabs,
+                active_terminal_tab,
+                terminal_panel_visible,
+                ws_id,
+            );
 
-                Column::new()
-                    .push(container(chat).width(Fill).height(Fill))
-                    .push(terminal)
-                    .width(Fill)
-                    .height(Fill)
-                    .into()
-            }
+            Column::new()
+                .push(container(top_content).width(Fill).height(Fill))
+                .push(terminal)
+                .width(Fill)
+                .height(Fill)
+                .into()
         } else {
             center(text("Workspace not found").size(16).color(style::FAINT)).into()
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ mod main_content;
 mod modal;
 mod sidebar;
 pub mod style;
+pub mod terminal_panel;
 
 pub use fuzzy_finder::view_fuzzy_finder;
 pub use icon_picker::view_icon_picker;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,7 +6,9 @@ mod fuzzy_finder;
 mod icon_picker;
 mod main_content;
 mod modal;
+mod right_sidebar;
 mod sidebar;
+mod status_bar;
 pub mod style;
 pub mod terminal_panel;
 
@@ -18,4 +20,6 @@ pub use modal::{
     view_delete_workspace_modal, view_relink_repo_modal, view_repo_settings_modal,
     view_revert_file_modal,
 };
+pub use right_sidebar::view_right_sidebar;
 pub use sidebar::view_sidebar;
+pub use status_bar::view_status_bar;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod chat_panel;
 mod diff_content;
 mod diff_file_tree;
 pub mod diff_viewer;
+pub mod divider;
 mod fuzzy_finder;
 mod icon_picker;
 mod main_content;

--- a/src/ui/right_sidebar.rs
+++ b/src/ui/right_sidebar.rs
@@ -11,6 +11,7 @@ pub fn view_right_sidebar<'a>(
     selected_file: Option<&str>,
     view_mode: DiffViewMode,
     loading: bool,
+    width: f32,
 ) -> Element<'a, Message> {
     let tab_bar = view_tab_bar(active_tab);
 
@@ -37,24 +38,14 @@ pub fn view_right_sidebar<'a>(
 
     let content = column![tab_bar, tab_divider, tab_content];
 
-    // Left border divider
-    let divider = container(column![])
-        .width(1)
-        .height(Fill)
-        .style(|_theme: &Theme| container::Style {
-            background: Some(Background::Color(style::DIVIDER)),
-            ..Default::default()
-        });
-
-    let sidebar = container(content)
-        .width(Length::Fixed(style::RIGHT_SIDEBAR_WIDTH - 1.0))
+    container(content)
+        .width(Length::Fixed(width))
         .height(Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(Background::Color(style::SIDEBAR_BG)),
             ..Default::default()
-        });
-
-    row![divider, sidebar].into()
+        })
+        .into()
 }
 
 fn view_tab_bar(active_tab: RightSidebarTab) -> Element<'static, Message> {

--- a/src/ui/right_sidebar.rs
+++ b/src/ui/right_sidebar.rs
@@ -1,0 +1,106 @@
+use iced::widget::{Space, button, center, column, container, row, text};
+use iced::{Background, Border, Element, Fill, Length, Theme};
+
+use crate::message::{Message, RightSidebarTab};
+use crate::model::diff::{DiffFile, DiffViewMode};
+use crate::ui::{diff_file_tree, style};
+
+pub fn view_right_sidebar<'a>(
+    active_tab: RightSidebarTab,
+    diff_files: &'a [DiffFile],
+    selected_file: Option<&str>,
+    view_mode: DiffViewMode,
+    loading: bool,
+) -> Element<'a, Message> {
+    let tab_bar = view_tab_bar(active_tab);
+
+    let tab_divider = container(column![])
+        .height(1)
+        .width(Fill)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(Background::Color(style::DIVIDER)),
+            ..Default::default()
+        });
+
+    let tab_content: Element<'_, Message> = match active_tab {
+        RightSidebarTab::Changes => {
+            if loading {
+                center(text("Loading changes...").size(13).color(style::MUTED)).into()
+            } else {
+                diff_file_tree::view_diff_file_tree(diff_files, selected_file, view_mode)
+            }
+        }
+        RightSidebarTab::AllFiles => {
+            center(text("Coming soon").size(13).color(style::FAINT)).into()
+        }
+    };
+
+    let content = column![tab_bar, tab_divider, tab_content];
+
+    // Left border divider
+    let divider = container(column![])
+        .width(1)
+        .height(Fill)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(Background::Color(style::DIVIDER)),
+            ..Default::default()
+        });
+
+    let sidebar = container(content)
+        .width(Length::Fixed(style::RIGHT_SIDEBAR_WIDTH - 1.0))
+        .height(Fill)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(Background::Color(style::SIDEBAR_BG)),
+            ..Default::default()
+        });
+
+    row![divider, sidebar].into()
+}
+
+fn view_tab_bar(active_tab: RightSidebarTab) -> Element<'static, Message> {
+    let all_files_btn = tab_button(
+        "All Files",
+        active_tab == RightSidebarTab::AllFiles,
+        Message::SetRightSidebarTab(RightSidebarTab::AllFiles),
+    );
+
+    let changes_btn = tab_button(
+        "Changes",
+        active_tab == RightSidebarTab::Changes,
+        Message::SetRightSidebarTab(RightSidebarTab::Changes),
+    );
+
+    container(
+        row![all_files_btn, changes_btn, Space::new().width(Fill)]
+            .spacing(2)
+            .align_y(iced::Alignment::Center)
+            .padding([4, 8]),
+    )
+    .width(Fill)
+    .into()
+}
+
+fn tab_button(label: &str, is_active: bool, message: Message) -> Element<'static, Message> {
+    let label = label.to_string();
+    button(text(label).size(12))
+        .on_press(message)
+        .padding([4, 10])
+        .style(move |_theme: &Theme, _status| button::Style {
+            background: if is_active {
+                Some(Background::Color(style::FILTER_ACTIVE_BG))
+            } else {
+                None
+            },
+            text_color: if is_active {
+                style::FILTER_ACTIVE
+            } else {
+                style::MUTED
+            },
+            border: Border {
+                radius: 4.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .into()
+}

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -14,6 +14,7 @@ pub fn view_sidebar<'a>(
     selected_workspace: Option<&str>,
     filter: &'a SidebarFilter,
     repo_collapsed: &HashMap<String, bool>,
+    width: f32,
 ) -> Element<'a, Message> {
     let mut content = Column::new().spacing(4).padding([12, 0]);
 
@@ -109,7 +110,7 @@ pub fn view_sidebar<'a>(
     );
 
     container(scrollable(content).height(Fill))
-        .width(style::SIDEBAR_WIDTH)
+        .width(width)
         .height(Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(Background::Color(style::SIDEBAR_BG)),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -26,18 +26,21 @@ pub fn view_status_bar(
             Message::ToggleRightSidebar,
         ),
     ]
-    .spacing(2)
+    .spacing(4)
     .align_y(iced::Alignment::Center);
 
-    let bar = row![Space::new().width(Fill), icons].padding([0, 8]);
+    let bar = row![Space::new().width(Fill), icons]
+        .align_y(iced::Alignment::Center)
+        .padding([0, 6]);
 
     container(bar)
         .width(Fill)
         .height(style::STATUS_BAR_HEIGHT)
+        .center_y(Fill)
         .style(|_theme: &Theme| container::Style {
             background: Some(Background::Color(style::STATUS_BAR_BG)),
             border: Border {
-                width: 1.0,
+                width: 0.0,
                 color: style::DIVIDER,
                 radius: 0.0.into(),
             },
@@ -88,20 +91,16 @@ fn panel_toggle_icon(
         }
     };
 
-    button(
-        container(icon)
-            .padding(2)
-            .style(|_theme: &Theme| container::Style {
-                border: Border {
-                    width: 1.0,
-                    color: style::TOGGLE_ICON_BORDER,
-                    radius: 2.0.into(),
-                },
-                ..Default::default()
-            }),
-    )
+    button(container(icon).style(|_theme: &Theme| container::Style {
+        border: Border {
+            width: 1.0,
+            color: style::TOGGLE_ICON_BORDER,
+            radius: 2.0.into(),
+        },
+        ..Default::default()
+    }))
     .on_press(message)
-    .padding(2)
+    .padding([2, 3])
     .style(|_theme: &Theme, _status| button::Style {
         background: None,
         text_color: Color::TRANSPARENT,

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,0 +1,126 @@
+use iced::widget::{Space, button, container, row};
+use iced::{Background, Border, Color, Element, Fill, Length, Theme};
+
+use crate::message::Message;
+use crate::ui::style;
+
+pub fn view_status_bar(
+    left_sidebar_visible: bool,
+    terminal_visible: bool,
+    right_sidebar_visible: bool,
+) -> Element<'static, Message> {
+    let icons = row![
+        panel_toggle_icon(
+            PanelLayout::Left,
+            left_sidebar_visible,
+            Message::ToggleSidebar,
+        ),
+        panel_toggle_icon(
+            PanelLayout::Bottom,
+            terminal_visible,
+            Message::TerminalTogglePanel,
+        ),
+        panel_toggle_icon(
+            PanelLayout::Right,
+            right_sidebar_visible,
+            Message::ToggleRightSidebar,
+        ),
+    ]
+    .spacing(2)
+    .align_y(iced::Alignment::Center);
+
+    let bar = row![Space::new().width(Fill), icons].padding([0, 8]);
+
+    container(bar)
+        .width(Fill)
+        .height(style::STATUS_BAR_HEIGHT)
+        .style(|_theme: &Theme| container::Style {
+            background: Some(Background::Color(style::STATUS_BAR_BG)),
+            border: Border {
+                width: 1.0,
+                color: style::DIVIDER,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+enum PanelLayout {
+    Left,
+    Bottom,
+    Right,
+}
+
+/// Builds a small ~18x14 icon using nested containers to mimic VS Code panel toggles.
+/// The highlighted portion indicates which panel the icon controls.
+fn panel_toggle_icon(
+    layout: PanelLayout,
+    is_active: bool,
+    message: Message,
+) -> Element<'static, Message> {
+    let active_color = if is_active {
+        style::TOGGLE_ICON_ACTIVE
+    } else {
+        style::TOGGLE_ICON_INACTIVE
+    };
+    let inactive_color = style::TOGGLE_ICON_INACTIVE;
+
+    let icon: Element<'static, Message> = match layout {
+        PanelLayout::Left => {
+            // Left portion highlighted: [##|    ]
+            let left = colored_block(active_color, 5.0, 10.0);
+            let right = colored_block(inactive_color, 11.0, 10.0);
+            row![left, right].spacing(1).into()
+        }
+        PanelLayout::Bottom => {
+            // Bottom portion highlighted: [      ]
+            //                             [######]
+            let top = colored_block(inactive_color, 17.0, 5.0);
+            let bottom = colored_block(active_color, 17.0, 4.0);
+            iced::widget::column![top, bottom].spacing(1).into()
+        }
+        PanelLayout::Right => {
+            // Right portion highlighted: [    |##]
+            let left = colored_block(inactive_color, 11.0, 10.0);
+            let right = colored_block(active_color, 5.0, 10.0);
+            row![left, right].spacing(1).into()
+        }
+    };
+
+    button(
+        container(icon)
+            .padding(2)
+            .style(|_theme: &Theme| container::Style {
+                border: Border {
+                    width: 1.0,
+                    color: style::TOGGLE_ICON_BORDER,
+                    radius: 2.0.into(),
+                },
+                ..Default::default()
+            }),
+    )
+    .on_press(message)
+    .padding(2)
+    .style(|_theme: &Theme, _status| button::Style {
+        background: None,
+        text_color: Color::TRANSPARENT,
+        ..Default::default()
+    })
+    .into()
+}
+
+fn colored_block(color: Color, width: f32, height: f32) -> Element<'static, Message> {
+    container(Space::new())
+        .width(Length::Fixed(width))
+        .height(Length::Fixed(height))
+        .style(move |_theme: &Theme| container::Style {
+            background: Some(Background::Color(color)),
+            border: Border {
+                radius: 1.0.into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .into()
+}

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -36,7 +36,7 @@ pub fn view_status_bar(
     container(bar)
         .width(Fill)
         .height(style::STATUS_BAR_HEIGHT)
-        .center_y(Fill)
+        .center_y(style::STATUS_BAR_HEIGHT)
         .style(|_theme: &Theme| container::Style {
             background: Some(Background::Color(style::STATUS_BAR_BG)),
             border: Border {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -66,6 +66,11 @@ pub const CHAT_INPUT_BG: Color = Color::from_rgb(0.12, 0.12, 0.14);
 pub const CHAT_INPUT_BORDER: Color = Color::from_rgb(0.22, 0.22, 0.26);
 pub const CHAT_HEADER_BG: Color = Color::from_rgb(0.1, 0.1, 0.12);
 
+// Terminal
+pub const TERMINAL_TAB_BG: Color = Color::from_rgb(0.12, 0.12, 0.14);
+pub const TERMINAL_TAB_ACTIVE_BG: Color = Color::from_rgb(0.18, 0.18, 0.22);
+pub const TERMINAL_TAB_BORDER: Color = Color::from_rgb(0.2, 0.2, 0.24);
+
 use iced::{Background, Border, Theme};
 
 pub fn tooltip_style(_theme: &Theme) -> iced::widget::container::Style {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -56,15 +56,22 @@ pub const FILE_STATUS_MODIFIED: Color = Color::from_rgb(0.8, 0.7, 0.2);
 pub const FILE_STATUS_DELETED: Color = Color::from_rgb(0.8, 0.3, 0.3);
 pub const FILE_STATUS_RENAMED: Color = Color::from_rgb(0.4, 0.6, 0.9);
 
-// Diff layout
-pub const DIFF_FILE_TREE_WIDTH: f32 = 250.0;
-
 // Chat
 pub const CHAT_USER_BG: Color = Color::from_rgba(1.0, 1.0, 1.0, 0.06);
 pub const CHAT_SYSTEM_BG: Color = Color::from_rgba(0.9, 0.7, 0.2, 0.08);
 pub const CHAT_INPUT_BG: Color = Color::from_rgb(0.12, 0.12, 0.14);
 pub const CHAT_INPUT_BORDER: Color = Color::from_rgb(0.22, 0.22, 0.26);
 pub const CHAT_HEADER_BG: Color = Color::from_rgb(0.1, 0.1, 0.12);
+
+// Right sidebar
+pub const RIGHT_SIDEBAR_WIDTH: f32 = 250.0;
+
+// Status bar
+pub const STATUS_BAR_HEIGHT: f32 = 24.0;
+pub const STATUS_BAR_BG: Color = Color::from_rgb(0.08, 0.08, 0.10);
+pub const TOGGLE_ICON_ACTIVE: Color = Color::from_rgba(1.0, 1.0, 1.0, 0.25);
+pub const TOGGLE_ICON_INACTIVE: Color = Color::from_rgba(1.0, 1.0, 1.0, 0.08);
+pub const TOGGLE_ICON_BORDER: Color = Color::from_rgba(1.0, 1.0, 1.0, 0.15);
 
 // Terminal
 pub const TERMINAL_TAB_BG: Color = Color::from_rgb(0.12, 0.12, 0.14);

--- a/src/ui/terminal_panel.rs
+++ b/src/ui/terminal_panel.rs
@@ -18,8 +18,12 @@ pub fn view_terminal_panel<'a>(
     panel_visible: bool,
     workspace_id: &str,
 ) -> Element<'a, Message> {
-    if tabs.is_empty() || !panel_visible {
+    if tabs.is_empty() {
         return Space::new().into();
+    }
+
+    if !panel_visible {
+        return view_collapsed_bar();
     }
 
     let tab_bar = view_tab_bar(tabs, active_tab_id, workspace_id);
@@ -147,6 +151,41 @@ fn view_tab_bar<'a>(
             background: Some(Background::Color(style::TERMINAL_TAB_BG)),
             border: Border {
                 width: 0.0,
+                color: style::TERMINAL_TAB_BORDER,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+fn view_collapsed_bar<'a>() -> Element<'a, Message> {
+    let restore_btn = button(
+        row![text("Terminal").size(12), text("\u{25B2}").size(10)]
+            .spacing(6)
+            .align_y(iced::Alignment::Center),
+    )
+    .on_press(Message::TerminalTogglePanel)
+    .padding([4, 10])
+    .style(|_theme, _status| button::Style {
+        background: None,
+        text_color: style::MUTED,
+        ..Default::default()
+    });
+
+    let bar = Row::new()
+        .push(restore_btn)
+        .push(Space::new().width(Fill))
+        .align_y(iced::Alignment::Center)
+        .height(TAB_BAR_HEIGHT)
+        .width(Fill);
+
+    container(bar)
+        .width(Fill)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(style::TERMINAL_TAB_BG)),
+            border: Border {
+                width: 1.0,
                 color: style::TERMINAL_TAB_BORDER,
                 radius: 0.0.into(),
             },

--- a/src/ui/terminal_panel.rs
+++ b/src/ui/terminal_panel.rs
@@ -23,7 +23,7 @@ pub fn view_terminal_panel<'a>(
     }
 
     if !panel_visible {
-        return view_collapsed_bar();
+        return Space::new().into();
     }
 
     let tab_bar = view_tab_bar(tabs, active_tab_id, workspace_id);
@@ -151,41 +151,6 @@ fn view_tab_bar<'a>(
             background: Some(Background::Color(style::TERMINAL_TAB_BG)),
             border: Border {
                 width: 0.0,
-                color: style::TERMINAL_TAB_BORDER,
-                radius: 0.0.into(),
-            },
-            ..Default::default()
-        })
-        .into()
-}
-
-fn view_collapsed_bar<'a>() -> Element<'a, Message> {
-    let restore_btn = button(
-        row![text("Terminal").size(12), text("\u{25B2}").size(10)]
-            .spacing(6)
-            .align_y(iced::Alignment::Center),
-    )
-    .on_press(Message::TerminalTogglePanel)
-    .padding([4, 10])
-    .style(|_theme, _status| button::Style {
-        background: None,
-        text_color: style::MUTED,
-        ..Default::default()
-    });
-
-    let bar = Row::new()
-        .push(restore_btn)
-        .push(Space::new().width(Fill))
-        .align_y(iced::Alignment::Center)
-        .height(TAB_BAR_HEIGHT)
-        .width(Fill);
-
-    container(bar)
-        .width(Fill)
-        .style(|_theme| container::Style {
-            background: Some(Background::Color(style::TERMINAL_TAB_BG)),
-            border: Border {
-                width: 1.0,
                 color: style::TERMINAL_TAB_BORDER,
                 radius: 0.0.into(),
             },

--- a/src/ui/terminal_panel.rs
+++ b/src/ui/terminal_panel.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+
+use iced::widget::{Column, Row, Space, button, container, row, text};
+use iced::{Background, Border, Element, Fill};
+use iced_term::{Terminal, TerminalView};
+
+use crate::message::Message;
+use crate::model::TerminalTab;
+use crate::ui::style;
+
+const TERMINAL_PANEL_HEIGHT: f32 = 300.0;
+const TAB_BAR_HEIGHT: f32 = 32.0;
+
+pub fn view_terminal_panel<'a>(
+    terminals: &'a HashMap<u64, Terminal>,
+    tabs: &[TerminalTab],
+    active_tab_id: Option<u64>,
+    panel_visible: bool,
+    workspace_id: &str,
+) -> Element<'a, Message> {
+    if tabs.is_empty() || !panel_visible {
+        return Space::new().into();
+    }
+
+    let tab_bar = view_tab_bar(tabs, active_tab_id, workspace_id);
+
+    let terminal_content: Element<'_, Message> = if let Some(active_id) = active_tab_id {
+        if let Some(term) = terminals.get(&active_id) {
+            TerminalView::show(term).map(Message::TerminalEvent)
+        } else {
+            container(text("Terminal initializing...").color(style::MUTED))
+                .center(Fill)
+                .into()
+        }
+    } else {
+        container(text("No terminal selected").color(style::MUTED))
+            .center(Fill)
+            .into()
+    };
+
+    let content = Column::new().push(tab_bar).push(
+        container(terminal_content)
+            .width(Fill)
+            .height(TERMINAL_PANEL_HEIGHT - TAB_BAR_HEIGHT),
+    );
+
+    container(content)
+        .width(Fill)
+        .height(TERMINAL_PANEL_HEIGHT)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(style::TERMINAL_TAB_BG)),
+            border: Border {
+                width: 1.0,
+                color: style::TERMINAL_TAB_BORDER,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+}
+
+fn view_tab_bar<'a>(
+    tabs: &[TerminalTab],
+    active_tab_id: Option<u64>,
+    workspace_id: &str,
+) -> Element<'a, Message> {
+    let mut tab_row = Row::new().spacing(1);
+
+    for tab in tabs {
+        let is_active = active_tab_id == Some(tab.id as u64);
+        let label = if tab.is_script_output {
+            format!("\u{25B6} {}", tab.title)
+        } else {
+            tab.title.clone()
+        };
+
+        let tab_label = text(label).size(12);
+        let close_btn = button(text("\u{00D7}").size(12))
+            .on_press(Message::TerminalClose(tab.id as u64))
+            .padding([0, 4])
+            .style(|_theme, _status| button::Style {
+                background: None,
+                text_color: style::MUTED,
+                ..Default::default()
+            });
+
+        let tab_content = row![tab_label, close_btn]
+            .spacing(6)
+            .align_y(iced::Alignment::Center);
+
+        let bg = if is_active {
+            style::TERMINAL_TAB_ACTIVE_BG
+        } else {
+            style::TERMINAL_TAB_BG
+        };
+
+        let tab_btn = button(tab_content)
+            .on_press(Message::TerminalSelectTab(tab.id as u64))
+            .padding([4, 10])
+            .style(move |_theme, _status| button::Style {
+                background: Some(Background::Color(bg)),
+                text_color: if is_active { style::TEXT } else { style::MUTED },
+                border: Border {
+                    width: 0.0,
+                    color: style::TERMINAL_TAB_BORDER,
+                    radius: 4.0.into(),
+                },
+                ..Default::default()
+            });
+
+        tab_row = tab_row.push(tab_btn);
+    }
+
+    // "+" button to add a new terminal tab
+    let ws_id = workspace_id.to_string();
+    let add_btn = button(text("+").size(12))
+        .on_press(Message::TerminalCreate(ws_id))
+        .padding([4, 8])
+        .style(|_theme, _status| button::Style {
+            background: None,
+            text_color: style::MUTED,
+            ..Default::default()
+        });
+
+    // Toggle button to hide the panel
+    let toggle_btn = button(text("\u{2014}").size(12))
+        .on_press(Message::TerminalTogglePanel)
+        .padding([4, 8])
+        .style(|_theme, _status| button::Style {
+            background: None,
+            text_color: style::MUTED,
+            ..Default::default()
+        });
+
+    let bar = Row::new()
+        .push(tab_row)
+        .push(add_btn)
+        .push(Space::new().width(Fill))
+        .push(toggle_btn)
+        .align_y(iced::Alignment::Center)
+        .height(TAB_BAR_HEIGHT)
+        .width(Fill);
+
+    container(bar)
+        .width(Fill)
+        .style(|_theme| container::Style {
+            background: Some(Background::Color(style::TERMINAL_TAB_BG)),
+            border: Border {
+                width: 0.0,
+                color: style::TERMINAL_TAB_BORDER,
+                radius: 0.0.into(),
+            },
+            ..Default::default()
+        })
+        .into()
+}

--- a/src/ui/terminal_panel.rs
+++ b/src/ui/terminal_panel.rs
@@ -8,7 +8,6 @@ use crate::message::Message;
 use crate::model::TerminalTab;
 use crate::ui::style;
 
-const TERMINAL_PANEL_HEIGHT: f32 = 300.0;
 const TAB_BAR_HEIGHT: f32 = 32.0;
 
 pub fn view_terminal_panel<'a>(
@@ -17,6 +16,7 @@ pub fn view_terminal_panel<'a>(
     active_tab_id: Option<u64>,
     panel_visible: bool,
     workspace_id: &str,
+    panel_height: f32,
 ) -> Element<'a, Message> {
     if tabs.is_empty() {
         return Space::new().into();
@@ -45,12 +45,12 @@ pub fn view_terminal_panel<'a>(
     let content = Column::new().push(tab_bar).push(
         container(terminal_content)
             .width(Fill)
-            .height(TERMINAL_PANEL_HEIGHT - TAB_BAR_HEIGHT),
+            .height(panel_height - TAB_BAR_HEIGHT),
     );
 
     container(content)
         .width(Fill)
-        .height(TERMINAL_PANEL_HEIGHT)
+        .height(panel_height)
         .style(|_theme| container::Style {
             background: Some(Background::Color(style::TERMINAL_TAB_BG)),
             border: Border {


### PR DESCRIPTION
## Summary

- Adds integrated terminal emulation (PRD §4.4) using `iced_term` 0.7 / `alacritty_terminal` backend
- Each workspace gets a terminal panel below the chat area with PTY sessions running in the worktree directory
- Supports multiple terminal tabs per workspace with add/close/select controls and script output tabs
- Ensures at least one terminal always exists per workspace (auto-recreates on last close)
- Wires terminal lifecycle into workspace create/archive/delete/restore and adds `Cmd+`` ` `` toggle shortcut

## Changes

- **Dependencies**: `iced_term = "0.7"`, Iced `canvas` + `advanced` features
- **Data layer**: `TerminalTab` model, DB migration v3 (`terminal_tabs` table with CASCADE), 5 CRUD methods, 6 new tests
- **Terminal service** (`src/terminal.rs`): PTY creation for interactive shells and script commands, theme config
- **Messages** (`src/message.rs`): 8 terminal message variants + `ScriptOutputCreate`
- **App state** (`src/app.rs`): Terminal HashMap, tab tracking, update handlers, subscriptions, keyboard shortcut
- **UI** (`src/ui/terminal_panel.rs`): Tab bar with close/add/minimize buttons, `TerminalView` widget rendering
- **Main content** (`src/ui/main_content.rs`): Terminal panel integrated below chat in vertical layout

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features` — zero warnings
- [x] `cargo test --all-features` — 71 tests pass (6 new terminal tab DB tests)
- [ ] Manual: create workspace → terminal panel visible → type commands → output renders
- [ ] Manual: create additional tabs → switch tabs → close tabs → last close auto-recreates
- [ ] Manual: archive workspace → terminals cleaned up; restore → terminal recreated
- [ ] Manual: `Cmd+`` ` `` toggles terminal panel visibility