### PR TITLE
fix: rewrite agent pane with per-turn process spawning

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -39,6 +39,9 @@ pub enum StreamEvent {
         duration_ms: Option<i64>,
     },
 
+    #[serde(rename = "user")]
+    User { message: UserEventMessage },
+
     #[serde(other)]
     Unknown,
 }
@@ -50,7 +53,11 @@ pub enum InnerStreamEvent {
     MessageStart {},
 
     #[serde(rename = "content_block_start")]
-    ContentBlockStart { index: usize },
+    ContentBlockStart {
+        index: usize,
+        #[serde(default)]
+        content_block: Option<StartContentBlock>,
+    },
 
     #[serde(rename = "content_block_delta")]
     ContentBlockDelta { index: usize, delta: Delta },
@@ -78,6 +85,48 @@ pub enum Delta {
     ToolUse {
         #[serde(default)]
         partial_json: Option<String>,
+    },
+
+    #[serde(rename = "input_json_delta")]
+    InputJson {
+        #[serde(default)]
+        partial_json: Option<String>,
+    },
+
+    #[serde(other)]
+    Unknown,
+}
+
+/// Content block info from `content_block_start` events.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum StartContentBlock {
+    #[serde(rename = "tool_use")]
+    ToolUse { id: String, name: String },
+
+    #[serde(rename = "text")]
+    Text {},
+
+    #[serde(other)]
+    Unknown,
+}
+
+/// Message payload from `user` type events (tool results fed back to the model).
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserEventMessage {
+    #[serde(default)]
+    pub content: Vec<UserContentBlock>,
+}
+
+/// Content block within a `user` event message.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum UserContentBlock {
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        #[serde(default)]
+        content: serde_json::Value,
     },
 
     #[serde(other)]
@@ -326,7 +375,7 @@ mod tests {
         let event = parse_stream_line(line).unwrap();
         match event {
             StreamEvent::Stream { event } => match event {
-                InnerStreamEvent::ContentBlockStart { index } => assert_eq!(index, 0),
+                InnerStreamEvent::ContentBlockStart { index, .. } => assert_eq!(index, 0),
                 _ => panic!("Expected ContentBlockStart"),
             },
             _ => panic!("Expected Stream event"),
@@ -480,8 +529,28 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_unknown_delta_type() {
+    fn test_parse_input_json_delta() {
         let line = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => match event {
+                InnerStreamEvent::ContentBlockDelta { delta, .. } => {
+                    assert!(matches!(
+                        delta,
+                        Delta::InputJson {
+                            partial_json: Some(_)
+                        }
+                    ));
+                }
+                _ => panic!("Expected ContentBlockDelta"),
+            },
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_unknown_delta_type() {
+        let line = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"some_future_delta","data":123}}}"#;
         let event = parse_stream_line(line).unwrap();
         match event {
             StreamEvent::Stream { event } => match event {
@@ -514,10 +583,25 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_user_event_as_unknown() {
+    fn test_parse_user_event_with_tool_result() {
         let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_01","content":"ok"}]}}"#;
         let event = parse_stream_line(line).unwrap();
-        assert!(matches!(event, StreamEvent::Unknown));
+        match event {
+            StreamEvent::User { message } => {
+                assert_eq!(message.content.len(), 1);
+                match &message.content[0] {
+                    UserContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                    } => {
+                        assert_eq!(tool_use_id, "tu_01");
+                        assert_eq!(content.as_str().unwrap(), "ok");
+                    }
+                    _ => panic!("Expected ToolResult"),
+                }
+            }
+            _ => panic!("Expected User event"),
+        }
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use serde::Deserialize;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 
@@ -38,6 +38,9 @@ pub enum StreamEvent {
         #[serde(default)]
         duration_ms: Option<i64>,
     },
+
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -54,6 +57,9 @@ pub enum InnerStreamEvent {
 
     #[serde(rename = "content_block_stop")]
     ContentBlockStop { index: usize },
+
+    #[serde(rename = "message_delta")]
+    MessageDelta {},
 
     #[serde(rename = "message_stop")]
     MessageStop {},
@@ -102,34 +108,63 @@ pub fn parse_stream_line(line: &str) -> Result<StreamEvent, serde_json::Error> {
 }
 
 // ---------------------------------------------------------------------------
-// Agent process manager
+// Agent events — wrapper for all events from a turn
 // ---------------------------------------------------------------------------
 
-/// Result of spawning an agent process — individual parts for flexible storage.
-pub struct SpawnedAgent {
-    pub stdin_tx: mpsc::Sender<String>,
-    pub event_rx: mpsc::Receiver<StreamEvent>,
-    pub session_id: String,
+/// Events emitted by an agent turn (stream events + process lifecycle).
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    /// A parsed stream event from stdout.
+    Stream(StreamEvent),
+    /// The agent process has exited.
+    ProcessExited(Option<i32>),
+}
+
+// ---------------------------------------------------------------------------
+// Per-turn agent process
+// ---------------------------------------------------------------------------
+
+/// Handle for an active agent turn — holds the event receiver and process ID.
+pub struct TurnHandle {
+    pub event_rx: mpsc::Receiver<AgentEvent>,
     pub pid: u32,
 }
 
-/// Spawn a Claude Code CLI process with bidirectional JSON streaming.
-pub async fn spawn_agent(working_dir: &Path, session_id: &str) -> Result<SpawnedAgent, String> {
+/// Run a single agent turn by spawning `claude -p` with the given prompt.
+///
+/// For the first turn, uses `--session-id` to establish the session.
+/// For subsequent turns, uses `--resume` to continue the conversation.
+pub async fn run_turn(
+    working_dir: &Path,
+    session_id: &str,
+    prompt: &str,
+    is_resume: bool,
+) -> Result<TurnHandle, String> {
+    let mut args = vec![
+        "--print".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+        "--include-partial-messages".to_string(),
+    ];
+
+    if is_resume {
+        args.push("--resume".to_string());
+        args.push(session_id.to_string());
+    } else {
+        args.push("--session-id".to_string());
+        args.push(session_id.to_string());
+    }
+
+    // Prompt as positional argument
+    args.push(prompt.to_string());
+
     let mut child = Command::new("claude")
-        .args([
-            "--print",
-            "--output-format",
-            "stream-json",
-            "--input-format",
-            "stream-json",
-            "--verbose",
-            "--session-id",
-            session_id,
-        ])
+        .args(&args)
         .current_dir(working_dir)
-        .stdin(std::process::Stdio::piped())
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("Failed to spawn claude: {e}"))?;
 
@@ -137,34 +172,19 @@ pub async fn spawn_agent(working_dir: &Path, session_id: &str) -> Result<Spawned
         .id()
         .ok_or_else(|| "Process exited immediately".to_string())?;
 
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| "Failed to capture stdin".to_string())?;
     let stdout = child
         .stdout
         .take()
         .ok_or_else(|| "Failed to capture stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture stderr".to_string())?;
 
-    // Stdin writer task
-    let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
-    tokio::spawn(async move {
-        let mut stdin = stdin;
-        while let Some(msg) = stdin_rx.recv().await {
-            if stdin.write_all(msg.as_bytes()).await.is_err() {
-                break;
-            }
-            if stdin.write_all(b"\n").await.is_err() {
-                break;
-            }
-            if stdin.flush().await.is_err() {
-                break;
-            }
-        }
-    });
+    let (event_tx, event_rx) = mpsc::channel::<AgentEvent>(128);
 
-    // Stdout reader task
-    let (event_tx, event_rx) = mpsc::channel::<StreamEvent>(128);
+    // Stdout reader task — parse stream-json events
+    let tx_stdout = event_tx.clone();
     tokio::spawn(async move {
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
@@ -174,7 +194,7 @@ pub async fn spawn_agent(working_dir: &Path, session_id: &str) -> Result<Spawned
             }
             match parse_stream_line(&line) {
                 Ok(event) => {
-                    if event_tx.send(event).await.is_err() {
+                    if tx_stdout.send(AgentEvent::Stream(event)).await.is_err() {
                         break;
                     }
                 }
@@ -185,34 +205,25 @@ pub async fn spawn_agent(working_dir: &Path, session_id: &str) -> Result<Spawned
         }
     });
 
-    // Wait for process exit in background, let the event channel close naturally
+    // Stderr reader task — log stderr lines
     tokio::spawn(async move {
-        let _ = child.wait().await;
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if !line.trim().is_empty() {
+                eprintln!("[agent stderr] {line}");
+            }
+        }
     });
 
-    Ok(SpawnedAgent {
-        stdin_tx,
-        event_rx,
-        session_id: session_id.to_string(),
-        pid,
-    })
-}
+    // Process exit watcher — sends ProcessExited when the child terminates
+    let tx_exit = event_tx;
+    tokio::spawn(async move {
+        let status = child.wait().await.ok().and_then(|s| s.code());
+        let _ = tx_exit.send(AgentEvent::ProcessExited(status)).await;
+    });
 
-/// Send a user message to the agent via its stdin channel.
-pub async fn send_user_message(
-    stdin_tx: &mpsc::Sender<String>,
-    content: &str,
-) -> Result<(), String> {
-    let msg = serde_json::json!({
-        "type": "user",
-        "content": content,
-    })
-    .to_string();
-
-    stdin_tx
-        .send(msg)
-        .await
-        .map_err(|e| format!("Failed to send message: {e}"))
+    Ok(TurnHandle { event_rx, pid })
 }
 
 /// Stop an agent process by killing it.
@@ -292,6 +303,18 @@ mod tests {
         match event {
             StreamEvent::Stream { event } => {
                 assert!(matches!(event, InnerStreamEvent::MessageStop {}));
+            }
+            _ => panic!("Expected Stream event"),
+        }
+    }
+
+    #[test]
+    fn test_parse_message_delta() {
+        let line = r#"{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{}}}"#;
+        let event = parse_stream_line(line).unwrap();
+        match event {
+            StreamEvent::Stream { event } => {
+                assert!(matches!(event, InnerStreamEvent::MessageDelta {}));
             }
             _ => panic!("Expected Stream event"),
         }
@@ -488,6 +511,13 @@ mod tests {
     fn test_parse_invalid_json_returns_error() {
         let result = parse_stream_line("not json at all");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_user_event_as_unknown() {
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_01","content":"ok"}]}}"#;
+        let event = parse_stream_line(line).unwrap();
+        assert!(matches!(event, StreamEvent::Unknown));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1359,6 +1359,8 @@ impl App {
             Message::ChatInputChanged(text) => {
                 self.terminal_focused = false;
                 self.handle_chat_input_changed(text);
+                // Focus chat input to unfocus terminal
+                return iced::widget::operation::focus(ui::chat_panel::chat_input_id());
             }
             Message::ChatSend => {
                 return self.handle_chat_send();
@@ -1584,7 +1586,10 @@ impl App {
                     }
                 }
             }
-            Message::TerminalCreated(Ok(_)) => {}
+            Message::TerminalCreated(Ok(_)) => {
+                // Unfocus terminal by focusing chat input — terminals default to is_focused: true
+                return iced::widget::operation::focus(iced::widget::Id::new("chat_input"));
+            }
             Message::TerminalCreated(Err(e)) => {
                 eprintln!("Failed to persist terminal tab: {e}");
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,81 @@ pub struct ActiveTurn {
     pub pid: u32,
 }
 
+/// A single tool use activity tracked during an agent turn.
+#[derive(Debug, Clone)]
+pub struct ToolActivity {
+    pub tool_use_id: String,
+    pub tool_name: String,
+    pub input_json: String,
+    pub result_text: String,
+    pub collapsed: bool,
+}
+
+impl ToolActivity {
+    /// Returns a short summary derived from the tool name and input JSON.
+    pub fn summary(&self) -> String {
+        let desc = self.extract_description();
+        if desc.is_empty() {
+            self.tool_name.clone()
+        } else {
+            format!("{} {}", self.tool_name, desc)
+        }
+    }
+
+    fn extract_description(&self) -> String {
+        if self.input_json.is_empty() {
+            return String::new();
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(&self.input_json) else {
+            return String::new();
+        };
+        let obj = val.as_object();
+        match self.tool_name.as_str() {
+            "Read" => obj
+                .and_then(|o| o.get("file_path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            "Edit" | "Write" => obj
+                .and_then(|o| o.get("file_path"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            "Bash" => obj
+                .and_then(|o| o.get("command"))
+                .and_then(|v| v.as_str())
+                .map(|s| truncate_str(s, 80))
+                .unwrap_or_default(),
+            "Grep" => obj
+                .and_then(|o| o.get("pattern"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            "Glob" => obj
+                .and_then(|o| o.get("pattern"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            _ => {
+                let s = self.input_json.chars().take(80).collect::<String>();
+                if self.input_json.len() > 80 {
+                    format!("{s}...")
+                } else {
+                    s
+                }
+            }
+        }
+    }
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max])
+    }
+}
+
 /// Per-workspace agent session stored on App.
 struct AgentSession {
     session_id: String,
@@ -69,6 +144,10 @@ struct AgentSession {
     active_turn: Option<ActiveTurn>,
     streaming_content: String,
     turn_started_at: Option<std::time::Instant>,
+    /// Tool activities accumulated during the current turn.
+    tool_activities: Vec<ToolActivity>,
+    /// Maps content_block index to tool_activities index for in-progress tool uses.
+    active_tool_blocks: HashMap<usize, usize>,
 }
 
 pub struct App {
@@ -1132,6 +1211,8 @@ impl App {
                         active_turn: None,
                         streaming_content: String::new(),
                         turn_started_at: None,
+                        tool_activities: Vec::new(),
+                        active_tool_blocks: HashMap::new(),
                     },
                 );
 
@@ -1754,6 +1835,13 @@ impl App {
             Message::DividerDragEnd => {
                 self.dragging_divider = None;
             }
+            Message::ToggleToolActivity(ws_id, idx) => {
+                if let Some(state) = self.agents.get_mut(&ws_id)
+                    && let Some(activity) = state.tool_activities.get_mut(idx)
+                {
+                    activity.collapsed = !activity.collapsed;
+                }
+            }
             Message::Tick => {
                 // No-op: the tick just triggers a view refresh for the processing timer
             }
@@ -1763,6 +1851,58 @@ impl App {
 
     fn handle_stream_event(&mut self, ws_id: &str, event: StreamEvent) -> Task<Message> {
         match event {
+            // --- Tool use tracking: content_block_start with tool_use ---
+            StreamEvent::Stream {
+                event:
+                    agent::InnerStreamEvent::ContentBlockStart {
+                        index,
+                        content_block: Some(agent::StartContentBlock::ToolUse { id, name }),
+                    },
+            } => {
+                if let Some(state) = self.agents.get_mut(ws_id) {
+                    let activity = ToolActivity {
+                        tool_use_id: id,
+                        tool_name: name,
+                        input_json: String::new(),
+                        result_text: String::new(),
+                        collapsed: true,
+                    };
+                    let idx = state.tool_activities.len();
+                    state.tool_activities.push(activity);
+                    state.active_tool_blocks.insert(index, idx);
+                }
+            }
+
+            // --- Tool use tracking: accumulate input JSON ---
+            StreamEvent::Stream {
+                event:
+                    agent::InnerStreamEvent::ContentBlockDelta {
+                        index,
+                        delta:
+                            agent::Delta::InputJson {
+                                partial_json: Some(json),
+                            },
+                    },
+            }
+            | StreamEvent::Stream {
+                event:
+                    agent::InnerStreamEvent::ContentBlockDelta {
+                        index,
+                        delta:
+                            agent::Delta::ToolUse {
+                                partial_json: Some(json),
+                            },
+                    },
+            } => {
+                if let Some(state) = self.agents.get_mut(ws_id)
+                    && let Some(&activity_idx) = state.active_tool_blocks.get(&index)
+                    && let Some(activity) = state.tool_activities.get_mut(activity_idx)
+                {
+                    activity.input_json.push_str(&json);
+                }
+            }
+
+            // --- Streaming text delta ---
             StreamEvent::Stream {
                 event:
                     agent::InnerStreamEvent::ContentBlockDelta {
@@ -1774,36 +1914,53 @@ impl App {
                     state.streaming_content.push_str(&text);
                 }
             }
+
+            // --- Tool result from user event ---
+            StreamEvent::User { message } => {
+                if let Some(state) = self.agents.get_mut(ws_id) {
+                    for block in message.content {
+                        if let agent::UserContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                        } = block
+                        {
+                            // Find the matching tool activity by ID
+                            if let Some(activity) = state
+                                .tool_activities
+                                .iter_mut()
+                                .rev()
+                                .find(|a| a.tool_use_id == tool_use_id)
+                            {
+                                activity.result_text = match &content {
+                                    serde_json::Value::String(s) => s.clone(),
+                                    serde_json::Value::Null => String::new(),
+                                    other => other.to_string(),
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+
+            // --- Complete assistant message ---
             StreamEvent::Assistant { message } => {
-                // Complete assistant message — persist and add to chat
                 let mut text_parts = Vec::new();
-                let mut tool_names = Vec::new();
 
                 for block in &message.content {
-                    match block {
-                        agent::ContentBlock::Text { text } => text_parts.push(text.as_str()),
-                        agent::ContentBlock::ToolUse { name, .. } => tool_names.push(name.as_str()),
-                        _ => {}
+                    if let agent::ContentBlock::Text { text } = block {
+                        text_parts.push(text.as_str());
                     }
                 }
 
-                let mut full_text = text_parts.join("\n");
-
-                if !tool_names.is_empty() {
-                    let tool_info = format!("[Used: {}]", tool_names.join(", "));
-                    if full_text.is_empty() {
-                        full_text = tool_info;
-                    } else {
-                        full_text = format!("{full_text}\n\n{tool_info}");
-                    }
-                }
+                let full_text = text_parts.join("\n");
 
                 // Clear streaming content
                 if let Some(state) = self.agents.get_mut(ws_id) {
                     state.streaming_content.clear();
+                    state.active_tool_blocks.clear();
                 }
 
-                // Skip completely empty messages (no text, no tools)
+                // Skip completely empty messages (no text)
                 if full_text.is_empty() {
                     return Task::none();
                 }
@@ -1859,13 +2016,15 @@ impl App {
                     );
                 }
 
-                // Clear streaming
+                // Clear streaming and tool activities on completion
                 if let Some(state) = self.agents.get_mut(ws_id) {
                     state.streaming_content.clear();
+                    state.tool_activities.clear();
+                    state.active_tool_blocks.clear();
                 }
             }
             _ => {
-                // Other events (system init, message_start, etc.) — ignored for now
+                // Other events (system init, message_start/stop, etc.) — ignored
             }
         }
         Task::none()
@@ -1939,7 +2098,7 @@ impl App {
         }
 
         // Get chat data for selected workspace
-        let (msgs, md_items, streaming, turn_elapsed) =
+        let (msgs, md_items, streaming, turn_elapsed, tool_activities) =
             if let Some(ws_id) = &self.selected_workspace {
                 let msgs = self
                     .chat_messages
@@ -1954,13 +2113,15 @@ impl App {
                 let session = self.agents.get(ws_id);
                 let streaming = session.map(|s| s.streaming_content.as_str()).unwrap_or("");
                 let elapsed = session.and_then(|s| s.turn_started_at).map(|t| t.elapsed());
-                (msgs, md, streaming, elapsed)
+                let tools = session.map(|s| s.tool_activities.as_slice()).unwrap_or(&[]);
+                (msgs, md, streaming, elapsed, tools)
             } else {
                 (
                     &[] as &[ChatMessage],
                     &[] as &[Vec<markdown::Item>],
                     "",
                     None,
+                    &[] as &[ToolActivity],
                 )
             };
 
@@ -1985,6 +2146,7 @@ impl App {
             streaming,
             md_items,
             turn_elapsed,
+            tool_activities,
             &self.diff_files,
             self.diff_selected_file.as_deref(),
             self.diff_content.as_ref(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use iced::widget::{Row, markdown};
 use iced::{Element, Subscription, Task, Theme};
 use tokio::sync::Mutex;
 
-use crate::agent::{self, StreamEvent};
+use crate::agent::{self, AgentEvent, StreamEvent};
 use crate::db::Database;
 use crate::message::{Message, SidebarFilter};
 use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
@@ -21,11 +21,11 @@ use crate::model::{
 };
 use crate::{diff, git, terminal, ui};
 
-/// Subscription data for an agent stream — hashes only by ws_id for dedup.
+/// Subscription data for an agent turn stream — hashes only by ws_id for dedup.
 #[derive(Clone)]
 struct AgentSubData {
     ws_id: String,
-    event_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<StreamEvent>>>>,
+    event_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<AgentEvent>>>>,
 }
 
 impl Hash for AgentSubData {
@@ -40,31 +40,35 @@ fn agent_stream(data: &AgentSubData) -> Pin<Box<dyn futures::Stream<Item = Messa
     Box::pin(futures::stream::unfold(
         (rx, ws_id),
         |(rx, ws_id)| async move {
-            // Take receiver out so we don't hold the mutex across recv().await
             let mut receiver = rx.lock().await.take()?;
             let event = receiver.recv().await;
-            // Put receiver back for the next iteration
             *rx.lock().await = Some(receiver);
             let event = event?;
-            Some((Message::AgentStreamEvent(ws_id.clone(), event), (rx, ws_id)))
+            let msg = match event {
+                AgentEvent::Stream(stream_event) => {
+                    Message::AgentStreamEvent(ws_id.clone(), stream_event)
+                }
+                AgentEvent::ProcessExited(code) => Message::AgentProcessExited(ws_id.clone(), code),
+            };
+            Some((msg, (rx, ws_id)))
         },
     ))
 }
 
-/// Handle returned when an agent is spawned — stored on App for communication.
+/// Active turn handle — stored on AgentSession while a turn is in progress.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
-pub struct AgentHandle {
-    pub stdin_tx: tokio::sync::mpsc::Sender<String>,
-    pub event_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<StreamEvent>>>>,
-    pub session_id: String,
+pub struct ActiveTurn {
+    pub event_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<AgentEvent>>>>,
     pub pid: u32,
 }
 
-/// Per-workspace agent state stored on App.
-struct AgentState {
-    handle: AgentHandle,
+/// Per-workspace agent session stored on App.
+struct AgentSession {
+    session_id: String,
+    turn_count: u32,
+    active_turn: Option<ActiveTurn>,
     streaming_content: String,
+    turn_started_at: Option<std::time::Instant>,
 }
 
 pub struct App {
@@ -121,8 +125,8 @@ pub struct App {
     fuzzy_query: String,
     fuzzy_selected_index: usize,
 
-    // Agent state per workspace
-    agents: HashMap<String, AgentState>,
+    // Agent sessions per workspace
+    agents: HashMap<String, AgentSession>,
 
     // Chat state
     chat_messages: HashMap<String, Vec<ChatMessage>>,
@@ -331,9 +335,21 @@ impl App {
                     tasks.push(Task::done(Message::TerminalCreate(id.clone())));
                 }
 
-                if !tasks.is_empty() {
-                    return Task::batch(tasks);
+                // Auto-start agent session if not already active
+                if !self.agents.contains_key(&id)
+                    && let Some(ws) = self.workspaces.iter().find(|w| w.id == id)
+                    && ws.worktree_path.is_some()
+                    && ws.status == WorkspaceStatus::Active
+                {
+                    tasks.push(Task::done(Message::AgentStart(id.clone())));
                 }
+
+                // Focus chat input to unfocus terminal's default is_focused state
+                tasks.push(iced::widget::operation::focus(iced::widget::Id::new(
+                    "chat_input",
+                )));
+
+                return Task::batch(tasks);
             }
             Message::ToggleRepoCollapsed(id) => {
                 let collapsed = self.repo_collapsed.entry(id).or_insert(false);
@@ -461,11 +477,8 @@ impl App {
                     .collect();
 
                 for ws_id in &ws_ids {
-                    if let Some(state) = self.agents.remove(ws_id) {
-                        let pid = state.handle.pid;
-                        tokio::spawn(async move {
-                            let _ = agent::stop_agent(pid).await;
-                        });
+                    if let Some(session) = self.agents.remove(ws_id) {
+                        self.kill_active_turn(session.active_turn);
                     }
                 }
 
@@ -512,11 +525,8 @@ impl App {
 
                 // Drain any agents (catches late spawns that arrived after Confirm)
                 for ws_id in &ws_ids {
-                    if let Some(state) = self.agents.remove(ws_id) {
-                        let pid = state.handle.pid;
-                        tokio::spawn(async move {
-                            let _ = agent::stop_agent(pid).await;
-                        });
+                    if let Some(session) = self.agents.remove(ws_id) {
+                        self.kill_active_turn(session.active_turn);
                     }
                 }
 
@@ -738,16 +748,12 @@ impl App {
                 }
                 self.active_terminal_tab.remove(&ws_id);
 
-                // Stop agent first if running
-                if self.agents.contains_key(&ws_id) {
-                    let pid = self.agents[&ws_id].handle.pid;
-                    self.agents.remove(&ws_id);
+                // Stop agent session if active
+                if let Some(session) = self.agents.remove(&ws_id) {
+                    self.kill_active_turn(session.active_turn);
                     if let Some(ws) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
                         ws.agent_status = AgentStatus::Idle;
                     }
-                    tokio::spawn(async move {
-                        let _ = agent::stop_agent(pid).await;
-                    });
                 }
 
                 let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
@@ -857,12 +863,9 @@ impl App {
                     return Task::none();
                 };
 
-                // Stop agent if running
-                if let Some(state) = self.agents.remove(&ws_id) {
-                    let pid = state.handle.pid;
-                    tokio::spawn(async move {
-                        let _ = agent::stop_agent(pid).await;
-                    });
+                // Stop agent session if active
+                if let Some(session) = self.agents.remove(&ws_id) {
+                    self.kill_active_turn(session.active_turn);
                 }
 
                 let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
@@ -1104,67 +1107,52 @@ impl App {
 
             // --- Agent Lifecycle ---
             Message::AgentStart(ws_id) => {
-                let ws = self.workspaces.iter().find(|w| w.id == ws_id).cloned();
+                // Don't start if session already exists
+                if self.agents.contains_key(&ws_id) {
+                    return Task::none();
+                }
+                let ws = self.workspaces.iter().find(|w| w.id == ws_id);
                 let Some(ws) = ws else {
                     return Task::none();
                 };
-                let Some(worktree_path) = ws.worktree_path.clone() else {
+                if ws.worktree_path.is_none() {
                     return Task::none();
-                };
+                }
 
                 if let Some(w) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
                     w.agent_status = AgentStatus::Running;
                 }
 
                 let session_id = uuid::Uuid::new_v4().to_string();
-
-                return Task::perform(
-                    async move {
-                        let spawned =
-                            agent::spawn_agent(std::path::Path::new(&worktree_path), &session_id)
-                                .await?;
-
-                        let handle = AgentHandle {
-                            stdin_tx: spawned.stdin_tx,
-                            event_rx: Arc::new(Mutex::new(Some(spawned.event_rx))),
-                            session_id: spawned.session_id,
-                            pid: spawned.pid,
-                        };
-
-                        Ok((ws_id, handle))
+                self.agents.insert(
+                    ws_id.clone(),
+                    AgentSession {
+                        session_id,
+                        turn_count: 0,
+                        active_turn: None,
+                        streaming_content: String::new(),
+                        turn_started_at: None,
                     },
-                    Message::AgentSpawned,
                 );
-            }
-            Message::AgentSpawned(Ok((ws_id, handle))) => {
-                // Guard: if the workspace was removed while spawning, kill the orphan
-                if !self.workspaces.iter().any(|w| w.id == ws_id) {
-                    let pid = handle.pid;
-                    tokio::spawn(async move {
-                        let _ = agent::stop_agent(pid).await;
-                    });
-                    return Task::none();
-                }
 
                 // Add system message
                 let sys_msg = ChatMessage {
                     id: uuid::Uuid::new_v4().to_string(),
                     workspace_id: ws_id.clone(),
                     role: ChatRole::System,
-                    content: "Agent started".into(),
+                    content: "Agent session started".into(),
                     cost_usd: None,
                     duration_ms: None,
                     created_at: String::new(),
                 };
                 self.chat_messages
-                    .entry(ws_id.clone())
+                    .entry(ws_id)
                     .or_default()
                     .push(sys_msg.clone());
-                self.rebuild_markdown_cache(&ws_id);
+                self.rebuild_markdown_cache(&sys_msg.workspace_id);
 
-                // Persist system message
                 let db_path = self.db_path.clone();
-                let persist_task = Task::perform(
+                return Task::perform(
                     async move {
                         let db = Database::open(&db_path).map_err(|e| e.to_string())?;
                         db.insert_chat_message(&sys_msg)
@@ -1173,35 +1161,23 @@ impl App {
                     },
                     Message::ChatMessageSaved,
                 );
-
-                self.agents.insert(
-                    ws_id,
-                    AgentState {
-                        handle,
-                        streaming_content: String::new(),
-                    },
-                );
-
-                return persist_task;
             }
-            Message::AgentSpawned(Err(e)) => {
-                eprintln!("Failed to spawn agent: {e}");
-                // Reset any workspaces still marked as Running back to Error
-                let running: Vec<_> = self
-                    .workspaces
-                    .iter()
-                    .filter(|w| matches!(w.agent_status, AgentStatus::Running))
-                    .map(|w| w.id.clone())
-                    .collect();
-                for ws_id in &running {
-                    if let Some(ws) = self.workspaces.iter_mut().find(|w| &w.id == ws_id) {
-                        ws.agent_status = AgentStatus::Error(e.clone());
-                    }
+            Message::AgentTurnStarted(Ok((ws_id, turn))) => {
+                if let Some(session) = self.agents.get_mut(&ws_id) {
+                    session.active_turn = Some(turn);
+                    session.turn_count += 1;
+                    session.turn_started_at = Some(std::time::Instant::now());
+                }
+            }
+            Message::AgentTurnStarted(Err(e)) => {
+                eprintln!("Failed to start agent turn: {e}");
+                // Find the workspace that was trying to start a turn and show error
+                if let Some(ws_id) = self.selected_workspace.clone() {
                     let sys_msg = ChatMessage {
                         id: uuid::Uuid::new_v4().to_string(),
                         workspace_id: ws_id.clone(),
                         role: ChatRole::System,
-                        content: format!("Failed to start agent: {e}"),
+                        content: format!("Failed to send message: {e}"),
                         cost_usd: None,
                         duration_ms: None,
                         created_at: String::new(),
@@ -1210,13 +1186,12 @@ impl App {
                         .entry(ws_id.clone())
                         .or_default()
                         .push(sys_msg);
-                    self.rebuild_markdown_cache(ws_id);
+                    self.rebuild_markdown_cache(&ws_id);
                 }
             }
 
             Message::AgentStop(ws_id) => {
-                if let Some(state) = self.agents.remove(&ws_id) {
-                    let pid = state.handle.pid;
+                if let Some(session) = self.agents.remove(&ws_id) {
                     if let Some(ws) = self.workspaces.iter_mut().find(|w| w.id == ws_id) {
                         ws.agent_status = AgentStatus::Idle;
                     }
@@ -1237,21 +1212,29 @@ impl App {
                         .push(sys_msg.clone());
                     self.rebuild_markdown_cache(&ws_id);
 
+                    let mut tasks = vec![];
+
+                    // Kill active turn process if any
+                    if let Some(turn) = session.active_turn {
+                        let pid = turn.pid;
+                        tasks.push(Task::perform(
+                            async move { agent::stop_agent(pid).await },
+                            move |result| Message::AgentStopped(result.map(|()| ws_id.clone())),
+                        ));
+                    }
+
                     let db_path = self.db_path.clone();
-                    return Task::batch([
-                        Task::perform(async move { agent::stop_agent(pid).await }, move |result| {
-                            Message::AgentStopped(result.map(|()| ws_id.clone()))
-                        }),
-                        Task::perform(
-                            async move {
-                                let db = Database::open(&db_path).map_err(|e| e.to_string())?;
-                                db.insert_chat_message(&sys_msg)
-                                    .map_err(|e| e.to_string())?;
-                                Ok(sys_msg)
-                            },
-                            Message::ChatMessageSaved,
-                        ),
-                    ]);
+                    tasks.push(Task::perform(
+                        async move {
+                            let db = Database::open(&db_path).map_err(|e| e.to_string())?;
+                            db.insert_chat_message(&sys_msg)
+                                .map_err(|e| e.to_string())?;
+                            Ok(sys_msg)
+                        },
+                        Message::ChatMessageSaved,
+                    ));
+
+                    return Task::batch(tasks);
                 }
             }
             Message::AgentStopped(Ok(_ws_id)) => {
@@ -1264,6 +1247,31 @@ impl App {
             // --- Agent Stream Events ---
             Message::AgentStreamEvent(ws_id, event) => {
                 return self.handle_stream_event(&ws_id, event);
+            }
+            Message::AgentProcessExited(ws_id, exit_code) => {
+                if let Some(session) = self.agents.get_mut(&ws_id) {
+                    session.active_turn = None;
+                    session.streaming_content.clear();
+                    session.turn_started_at = None;
+                }
+                if let Some(code) = exit_code
+                    && code != 0
+                {
+                    let sys_msg = ChatMessage {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        workspace_id: ws_id.clone(),
+                        role: ChatRole::System,
+                        content: format!("Agent process exited with code {code}"),
+                        cost_usd: None,
+                        duration_ms: None,
+                        created_at: String::new(),
+                    };
+                    self.chat_messages
+                        .entry(ws_id.clone())
+                        .or_default()
+                        .push(sys_msg);
+                    self.rebuild_markdown_cache(&ws_id);
+                }
             }
 
             // --- Chat ---
@@ -1746,6 +1754,9 @@ impl App {
             Message::DividerDragEnd => {
                 self.dragging_divider = None;
             }
+            Message::Tick => {
+                // No-op: the tick just triggers a view refresh for the processing timer
+            }
         }
         Task::none()
     }
@@ -1765,19 +1776,36 @@ impl App {
             }
             StreamEvent::Assistant { message } => {
                 // Complete assistant message — persist and add to chat
-                let full_text: String = message
-                    .content
-                    .iter()
-                    .filter_map(|block| match block {
-                        agent::ContentBlock::Text { text } => Some(text.as_str()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                let mut text_parts = Vec::new();
+                let mut tool_names = Vec::new();
+
+                for block in &message.content {
+                    match block {
+                        agent::ContentBlock::Text { text } => text_parts.push(text.as_str()),
+                        agent::ContentBlock::ToolUse { name, .. } => tool_names.push(name.as_str()),
+                        _ => {}
+                    }
+                }
+
+                let mut full_text = text_parts.join("\n");
+
+                if !tool_names.is_empty() {
+                    let tool_info = format!("[Used: {}]", tool_names.join(", "));
+                    if full_text.is_empty() {
+                        full_text = tool_info;
+                    } else {
+                        full_text = format!("{full_text}\n\n{tool_info}");
+                    }
+                }
 
                 // Clear streaming content
                 if let Some(state) = self.agents.get_mut(ws_id) {
                     state.streaming_content.clear();
+                }
+
+                // Skip completely empty messages (no text, no tools)
+                if full_text.is_empty() {
+                    return Task::none();
                 }
 
                 let assistant_msg = ChatMessage {
@@ -1843,6 +1871,16 @@ impl App {
         Task::none()
     }
 
+    /// Kill an active turn's process in the background, if present.
+    fn kill_active_turn(&self, turn: Option<ActiveTurn>) {
+        if let Some(turn) = turn {
+            let pid = turn.pid;
+            tokio::spawn(async move {
+                let _ = agent::stop_agent(pid).await;
+            });
+        }
+    }
+
     /// Build an async task that loads changed files for the currently selected workspace.
     /// Returns `None` if no workspace is selected or the workspace has no worktree.
     fn load_diff_files_task(&self) -> Option<Task<Message>> {
@@ -1901,26 +1939,30 @@ impl App {
         }
 
         // Get chat data for selected workspace
-        let (msgs, md_items, streaming) = if let Some(ws_id) = &self.selected_workspace {
-            let msgs = self
-                .chat_messages
-                .get(ws_id)
-                .map(|v| v.as_slice())
-                .unwrap_or(&[]);
-            let md = self
-                .markdown_cache
-                .get(ws_id)
-                .map(|v| v.as_slice())
-                .unwrap_or(&[]);
-            let streaming = self
-                .agents
-                .get(ws_id)
-                .map(|s| s.streaming_content.as_str())
-                .unwrap_or("");
-            (msgs, md, streaming)
-        } else {
-            (&[] as &[ChatMessage], &[] as &[Vec<markdown::Item>], "")
-        };
+        let (msgs, md_items, streaming, turn_elapsed) =
+            if let Some(ws_id) = &self.selected_workspace {
+                let msgs = self
+                    .chat_messages
+                    .get(ws_id)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
+                let md = self
+                    .markdown_cache
+                    .get(ws_id)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
+                let session = self.agents.get(ws_id);
+                let streaming = session.map(|s| s.streaming_content.as_str()).unwrap_or("");
+                let elapsed = session.and_then(|s| s.turn_started_at).map(|t| t.elapsed());
+                (msgs, md, streaming, elapsed)
+            } else {
+                (
+                    &[] as &[ChatMessage],
+                    &[] as &[Vec<markdown::Item>],
+                    "",
+                    None,
+                )
+            };
 
         let (term_tabs, active_term) = if let Some(ws_id) = &self.selected_workspace {
             let tabs = self
@@ -1942,6 +1984,7 @@ impl App {
             &self.chat_input,
             streaming,
             md_items,
+            turn_elapsed,
             &self.diff_files,
             self.diff_selected_file.as_deref(),
             self.diff_content.as_ref(),
@@ -2151,16 +2194,17 @@ impl App {
             _ => None,
         });
 
-        // Agent streaming subscriptions — one per active agent
+        // Agent streaming subscriptions — one per active turn
         let agent_subs: Vec<Subscription<Message>> = self
             .agents
             .iter()
-            .map(|(ws_id, state)| {
+            .filter_map(|(ws_id, session)| {
+                let turn = session.active_turn.as_ref()?;
                 let data = AgentSubData {
                     ws_id: ws_id.clone(),
-                    event_rx: state.handle.event_rx.clone(),
+                    event_rx: turn.event_rx.clone(),
                 };
-                Subscription::run_with(data, agent_stream)
+                Some(Subscription::run_with(data, agent_stream))
             })
             .collect();
 
@@ -2174,6 +2218,15 @@ impl App {
         let mut subs = vec![input_sub];
         subs.extend(agent_subs);
         subs.extend(terminal_subs);
+
+        // Tick subscription for processing indicator timer (10Hz when any turn is active)
+        let has_active_turn = self.agents.values().any(|s| s.turn_started_at.is_some());
+        if has_active_turn {
+            subs.push(
+                iced::time::every(std::time::Duration::from_millis(100)).map(|_| Message::Tick),
+            );
+        }
+
         Subscription::batch(subs)
     }
 

--- a/src/app/chat.rs
+++ b/src/app/chat.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
 use iced::Task;
 use iced::widget::markdown;
 
 use crate::agent;
+use crate::app::ActiveTurn;
 use crate::db::Database;
 use crate::message::Message;
 use crate::model::{ChatMessage, ChatRole};
@@ -23,12 +28,28 @@ impl App {
         if content.is_empty() {
             return Task::none();
         }
-        if !self.agents.contains_key(&ws_id) {
+        let Some(session) = self.agents.get(&ws_id) else {
+            return Task::none();
+        };
+        // Don't send if a turn is already in progress
+        if session.active_turn.is_some() {
             return Task::none();
         }
+        let session_id = session.session_id.clone();
+        let is_resume = session.turn_count > 0;
         self.chat_input.clear();
         self.chat_history_index = None;
         self.chat_history_draft.clear();
+
+        // Get worktree path for spawning the turn
+        let worktree_path = self
+            .workspaces
+            .iter()
+            .find(|w| w.id == ws_id)
+            .and_then(|w| w.worktree_path.clone());
+        let Some(worktree_path) = worktree_path else {
+            return Task::none();
+        };
 
         // Create user message
         let user_msg = ChatMessage {
@@ -47,17 +68,27 @@ impl App {
             .push(user_msg.clone());
         self.rebuild_markdown_cache(&ws_id);
 
-        // Send to agent via stdin
+        // Spawn per-turn agent process
         let mut tasks = vec![];
-        if let Some(state) = self.agents.get(&ws_id) {
-            let stdin_tx = state.handle.stdin_tx.clone();
-            tasks.push(Task::perform(
-                async move {
-                    agent::send_user_message(&stdin_tx, &content).await.ok();
-                },
-                |()| Message::Noop,
-            ));
-        }
+        tasks.push(Task::perform(
+            async move {
+                let turn_handle = agent::run_turn(
+                    std::path::Path::new(&worktree_path),
+                    &session_id,
+                    &content,
+                    is_resume,
+                )
+                .await?;
+
+                let active_turn = ActiveTurn {
+                    event_rx: Arc::new(Mutex::new(Some(turn_handle.event_rx))),
+                    pid: turn_handle.pid,
+                };
+
+                Ok((ws_id.clone(), active_turn))
+            },
+            Message::AgentTurnStarted,
+        ));
 
         // Persist user message
         let db_path = self.db_path.clone();

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
 use crate::agent::StreamEvent;
+use crate::app::ActiveTurn;
 use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
 use crate::model::{ChatMessage, Repository, TerminalTab, Workspace};
 
@@ -116,11 +117,12 @@ pub enum Message {
     EscapePressed,
 
     // --- Agent lifecycle ---
-    AgentStart(String), // workspace_id
-    AgentStop(String),  // workspace_id
-    AgentSpawned(Result<(String, crate::app::AgentHandle), String>), // Ok((ws_id, handle))
-    AgentStopped(Result<String, String>), // Ok(ws_id)
-    AgentStreamEvent(String, StreamEvent), // workspace_id, event
+    AgentStart(String),                                     // workspace_id
+    AgentStop(String),                                      // workspace_id
+    AgentTurnStarted(Result<(String, ActiveTurn), String>), // Ok((ws_id, turn))
+    AgentStopped(Result<String, String>),                   // Ok(ws_id)
+    AgentStreamEvent(String, StreamEvent),                  // workspace_id, event
+    AgentProcessExited(String, Option<i32>),                // workspace_id, exit_code
 
     // --- Chat ---
     ChatInputChanged(String),
@@ -166,4 +168,7 @@ pub enum Message {
     DividerDragStart(DividerDrag),
     DividerDragUpdate(f32, f32), // cursor_x, cursor_y
     DividerDragEnd,
+
+    // --- Timer tick for processing indicator ---
+    Tick,
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -169,6 +169,9 @@ pub enum Message {
     DividerDragUpdate(f32, f32), // cursor_x, cursor_y
     DividerDragEnd,
 
+    // --- Tool activity ---
+    ToggleToolActivity(String, usize), // (workspace_id, activity_index)
+
     // --- Timer tick for processing indicator ---
     Tick,
 }

--- a/src/ui/chat_panel.rs
+++ b/src/ui/chat_panel.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use iced::widget::{Space, button, column, container, markdown, row, scrollable, text, text_input};
 use iced::{Background, Border, Element, Fill, Length, Theme};
 
@@ -11,6 +13,7 @@ pub fn chat_input_id() -> iced::widget::Id {
 }
 
 /// Renders the full chat panel for a selected workspace.
+#[allow(clippy::too_many_arguments)]
 pub fn view_chat_panel<'a>(
     ws: &'a Workspace,
     repositories: &'a [Repository],
@@ -19,6 +22,7 @@ pub fn view_chat_panel<'a>(
     streaming_text: &'a str,
     markdown_items: &'a [Vec<markdown::Item>],
     is_agent_running: bool,
+    turn_elapsed: Option<Duration>,
 ) -> Element<'a, Message> {
     let repo_name = repositories
         .iter()
@@ -110,6 +114,11 @@ pub fn view_chat_panel<'a>(
     // Streaming content (agent is currently responding)
     if !streaming_text.is_empty() {
         messages_col = messages_col.push(view_streaming_indicator(streaming_text));
+    }
+
+    // Processing indicator (turn is active)
+    if let Some(elapsed) = turn_elapsed {
+        messages_col = messages_col.push(view_processing_indicator(elapsed));
     }
 
     let chat_area = scrollable(messages_col)
@@ -246,4 +255,30 @@ fn view_streaming_indicator(content: &str) -> Element<'_, Message> {
     .padding([10, 14])
     .width(Fill)
     .into()
+}
+
+fn view_processing_indicator(elapsed: Duration) -> Element<'static, Message> {
+    const BRAILLE_FRAMES: &[&str] = &[
+        "\u{280B}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283C}", "\u{2834}", "\u{2826}",
+        "\u{2827}", "\u{2807}", "\u{280F}",
+    ];
+
+    let total_tenths = (elapsed.as_millis() / 100) as u64;
+    let frame_idx = (total_tenths as usize) % BRAILLE_FRAMES.len();
+    let spinner = BRAILLE_FRAMES[frame_idx];
+
+    let total_secs = elapsed.as_secs();
+    let tenths = (elapsed.as_millis() / 100 % 10) as u64;
+    let minutes = total_secs / 60;
+    let secs = total_secs % 60;
+    let time_str = if minutes > 0 {
+        format!("{spinner} {minutes}m, {secs}.{tenths}s")
+    } else {
+        format!("{spinner} {secs}.{tenths}s")
+    };
+
+    container(text(time_str).size(13).color(style::STATUS_RUNNING))
+        .padding([6, 14])
+        .width(Fill)
+        .into()
 }

--- a/src/ui/chat_panel.rs
+++ b/src/ui/chat_panel.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use iced::widget::{Space, button, column, container, markdown, row, scrollable, text, text_input};
 use iced::{Background, Border, Element, Fill, Length, Theme};
 
+use crate::app::ToolActivity;
 use crate::message::Message;
 use crate::model::{ChatMessage, ChatRole, Repository, Workspace};
 use crate::ui::style;
@@ -23,6 +24,7 @@ pub fn view_chat_panel<'a>(
     markdown_items: &'a [Vec<markdown::Item>],
     is_agent_running: bool,
     turn_elapsed: Option<Duration>,
+    tool_activities: &'a [ToolActivity],
 ) -> Element<'a, Message> {
     let repo_name = repositories
         .iter()
@@ -109,6 +111,11 @@ pub fn view_chat_panel<'a>(
             ChatRole::System => view_system_message(&msg.content),
         };
         messages_col = messages_col.push(bubble);
+    }
+
+    // Tool activities (shown during active turn)
+    if !tool_activities.is_empty() {
+        messages_col = messages_col.push(view_tool_activities(tool_activities, &ws.id));
     }
 
     // Streaming content (agent is currently responding)
@@ -281,4 +288,68 @@ fn view_processing_indicator(elapsed: Duration) -> Element<'static, Message> {
         .padding([6, 14])
         .width(Fill)
         .into()
+}
+
+fn view_tool_activities<'a>(
+    activities: &'a [ToolActivity],
+    ws_id: &'a str,
+) -> Element<'a, Message> {
+    let mut col = column![].spacing(2);
+
+    for (i, activity) in activities.iter().enumerate() {
+        let arrow = if activity.collapsed {
+            "\u{25B8}"
+        } else {
+            "\u{25BE}"
+        }; // ▸ or ▾
+        let summary = activity.summary();
+        let header_text = format!("{arrow} {summary}");
+
+        let ws_id_owned = ws_id.to_string();
+        let header_btn = button(text(header_text).size(12).color(style::DIM))
+            .on_press(Message::ToggleToolActivity(ws_id_owned, i))
+            .style(|theme: &Theme, status| {
+                let mut s = button::text(theme, status);
+                s.text_color = style::DIM;
+                s
+            })
+            .padding([2, 4]);
+
+        if activity.collapsed {
+            col = col.push(header_btn);
+        } else {
+            let result_preview = if activity.result_text.is_empty() {
+                "...".to_string()
+            } else {
+                // Show first few lines, truncated
+                activity
+                    .result_text
+                    .lines()
+                    .take(8)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+
+            let detail = container(
+                text(result_preview)
+                    .size(11)
+                    .color(style::FAINT)
+                    .font(iced::Font::MONOSPACE),
+            )
+            .padding([4, 8])
+            .width(Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(Background::Color(style::CHAT_SYSTEM_BG)),
+                border: Border {
+                    radius: 4.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+
+            col = col.push(column![header_btn, detail].spacing(2));
+        }
+    }
+
+    container(col).padding([4, 14]).width(Fill).into()
 }

--- a/src/ui/main_content.rs
+++ b/src/ui/main_content.rs
@@ -5,6 +5,7 @@ use iced::widget::{Column, Space, center, column, container, markdown, text};
 use iced::{Element, Fill};
 use iced_term::Terminal;
 
+use crate::app::ToolActivity;
 use crate::message::{DividerDrag, Message};
 use crate::model::diff::{DiffFile, DiffViewMode, FileDiff};
 use crate::model::{AgentStatus, ChatMessage, Repository, TerminalTab, Workspace};
@@ -20,6 +21,7 @@ pub fn view_main_content<'a>(
     streaming_text: &'a str,
     markdown_items: &'a [Vec<markdown::Item>],
     turn_elapsed: Option<Duration>,
+    tool_activities: &'a [ToolActivity],
     // Diff state
     diff_files: &'a [DiffFile],
     diff_selected_file: Option<&'a str>,
@@ -57,6 +59,7 @@ pub fn view_main_content<'a>(
                     markdown_items,
                     is_running,
                     turn_elapsed,
+                    tool_activities,
                 )
             };
 

--- a/src/ui/main_content.rs
+++ b/src/ui/main_content.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use iced::widget::{Column, Space, center, column, container, markdown, text};
 use iced::{Element, Fill};
@@ -18,6 +19,7 @@ pub fn view_main_content<'a>(
     chat_input: &str,
     streaming_text: &'a str,
     markdown_items: &'a [Vec<markdown::Item>],
+    turn_elapsed: Option<Duration>,
     // Diff state
     diff_files: &'a [DiffFile],
     diff_selected_file: Option<&'a str>,
@@ -54,6 +56,7 @@ pub fn view_main_content<'a>(
                     streaming_text,
                     markdown_items,
                     is_running,
+                    turn_elapsed,
                 )
             };
 


### PR DESCRIPTION
## Summary

- Replaces the broken long-lived agent process model with per-turn spawning of `claude -p --output-format stream-json`, using `--resume SESSION_ID` for multi-turn continuity
- Agent sessions now auto-start when selecting an active workspace with a worktree
- Shows tool use activity in chat bubbles (tool names instead of empty messages) and adds a processing indicator with spinner and elapsed timer
- Fixes chat input focus bleeding keystrokes into the terminal
- Handles unknown CLI stream event types (e.g. `user` tool result echoes) gracefully via `#[serde(other)]`

## Test plan
- [x] All 79 tests pass
- [x] Zero clippy warnings
- [x] Manual: select a workspace, verify agent session starts automatically
- [x] Manual: send a message, verify streaming response with tool use visibility
- [x] Manual: verify processing spinner and timer appear during agent turns
- [x] Manual: verify typing in chat input does not bleed into terminal
- [ ] Allow selecting content in the agent pane