### PR TITLE
feat: add repository removal with confirmation modal and full cleanup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -114,6 +114,7 @@ pub struct App {
 
     // Remove repository confirmation
     show_remove_repository: Option<String>, // Some(repo_id)
+    remove_repo_error: Option<String>,
 
     // Fuzzy finder
     show_fuzzy_finder: bool,
@@ -204,6 +205,7 @@ impl App {
             worktree_base_dir: claudette_home().join("workspaces"),
             show_delete_workspace: None,
             show_remove_repository: None,
+            remove_repo_error: None,
             show_fuzzy_finder: false,
             fuzzy_query: String::new(),
             fuzzy_selected_index: 0,
@@ -438,15 +440,17 @@ impl App {
             Message::ShowRemoveRepository(repo_id) => {
                 // Close settings modal if the user clicked "Remove" from there
                 self.show_repo_settings = None;
+                self.remove_repo_error = None;
                 self.show_remove_repository = Some(repo_id);
             }
             Message::HideRemoveRepository => {
                 self.show_remove_repository = None;
             }
             Message::ConfirmRemoveRepository => {
-                let Some(repo_id) = self.show_remove_repository.take() else {
+                let Some(repo_id) = self.show_remove_repository.clone() else {
                     return Task::none();
                 };
+                self.remove_repo_error = None;
 
                 // Stop all running agents for this repo's workspaces
                 let ws_ids: Vec<String> = self
@@ -495,6 +499,9 @@ impl App {
                 );
             }
             Message::RepositoryRemoved(Ok(repo_id)) => {
+                // Dismiss confirmation modal
+                self.show_remove_repository = None;
+
                 // Collect workspace IDs before removing them
                 let ws_ids: Vec<String> = self
                     .workspaces
@@ -502,6 +509,16 @@ impl App {
                     .filter(|w| w.repository_id == repo_id)
                     .map(|w| w.id.clone())
                     .collect();
+
+                // Drain any agents (catches late spawns that arrived after Confirm)
+                for ws_id in &ws_ids {
+                    if let Some(state) = self.agents.remove(ws_id) {
+                        let pid = state.handle.pid;
+                        tokio::spawn(async move {
+                            let _ = agent::stop_agent(pid).await;
+                        });
+                    }
+                }
 
                 // Clean up per-workspace in-memory state
                 for ws_id in &ws_ids {
@@ -529,6 +546,7 @@ impl App {
             }
             Message::RepositoryRemoved(Err(e)) => {
                 eprintln!("Failed to remove repository: {e}");
+                self.remove_repo_error = Some(format!("Failed to remove repository: {e}"));
             }
 
             // --- Re-link Repository ---
@@ -2033,7 +2051,13 @@ impl App {
                 .iter()
                 .filter(|w| w.repository_id == *repo_id && w.status == WorkspaceStatus::Archived)
                 .count();
-            return ui::view_remove_repo_modal(base, repo_name, active_count, archived_count);
+            return ui::view_remove_repo_modal(
+                base,
+                repo_name,
+                active_count,
+                archived_count,
+                self.remove_repo_error.as_ref(),
+            );
         }
 
         if let Some(ws_id) = &self.show_delete_workspace {

--- a/src/app.rs
+++ b/src/app.rs
@@ -112,6 +112,9 @@ pub struct App {
     // Delete workspace confirmation
     show_delete_workspace: Option<String>, // Some(ws_id)
 
+    // Remove repository confirmation
+    show_remove_repository: Option<String>, // Some(repo_id)
+
     // Fuzzy finder
     show_fuzzy_finder: bool,
     fuzzy_query: String,
@@ -200,6 +203,7 @@ impl App {
             app_settings_error: None,
             worktree_base_dir: claudette_home().join("workspaces"),
             show_delete_workspace: None,
+            show_remove_repository: None,
             show_fuzzy_finder: false,
             fuzzy_query: String::new(),
             fuzzy_selected_index: 0,
@@ -430,11 +434,59 @@ impl App {
                 self.add_repo_error = Some(msg);
             }
 
-            // --- Remove Repository ---
-            Message::RemoveRepository(repo_id) => {
+            // --- Remove Repository (with confirmation) ---
+            Message::ShowRemoveRepository(repo_id) => {
+                // Close settings modal if the user clicked "Remove" from there
+                self.show_repo_settings = None;
+                self.show_remove_repository = Some(repo_id);
+            }
+            Message::HideRemoveRepository => {
+                self.show_remove_repository = None;
+            }
+            Message::ConfirmRemoveRepository => {
+                let Some(repo_id) = self.show_remove_repository.take() else {
+                    return Task::none();
+                };
+
+                // Stop all running agents for this repo's workspaces
+                let ws_ids: Vec<String> = self
+                    .workspaces
+                    .iter()
+                    .filter(|w| w.repository_id == repo_id)
+                    .map(|w| w.id.clone())
+                    .collect();
+
+                for ws_id in &ws_ids {
+                    if let Some(state) = self.agents.remove(ws_id) {
+                        let pid = state.handle.pid;
+                        tokio::spawn(async move {
+                            let _ = agent::stop_agent(pid).await;
+                        });
+                    }
+                }
+
+                // Collect worktree paths and repo path for async cleanup
+                let worktree_paths: Vec<String> = self
+                    .workspaces
+                    .iter()
+                    .filter(|w| w.repository_id == repo_id)
+                    .filter_map(|w| w.worktree_path.clone())
+                    .collect();
+
+                let repo = self.repositories.iter().find(|r| r.id == repo_id).cloned();
+                let Some(repo) = repo else {
+                    return Task::none();
+                };
                 let db_path = self.db_path.clone();
+                let repo_path = repo.path.clone();
+
                 return Task::perform(
                     async move {
+                        // Remove all worktree directories
+                        for wt_path in &worktree_paths {
+                            crate::git::remove_worktree(&repo_path, wt_path).await.ok();
+                        }
+                        // Delete from DB (cascades to workspaces, chat_messages, terminal_tabs)
                         let db = Database::open(&db_path).map_err(|e| e.to_string())?;
                         db.delete_repository(&repo_id).map_err(|e| e.to_string())?;
                         Ok(repo_id)
@@ -443,8 +495,32 @@ impl App {
                 );
             }
             Message::RepositoryRemoved(Ok(repo_id)) => {
-                self.repositories.retain(|r| r.id != repo_id);
+                // Collect workspace IDs before removing them
+                let ws_ids: Vec<String> = self
+                    .workspaces
+                    .iter()
+                    .filter(|w| w.repository_id == repo_id)
+                    .map(|w| w.id.clone())
+                    .collect();
+
+                // Clean up per-workspace in-memory state
+                for ws_id in &ws_ids {
+                    self.chat_messages.remove(ws_id);
+                    self.markdown_cache.remove(ws_id);
+                    if let Some(tabs) = self.terminal_tabs.remove(ws_id) {
+                        for tab in &tabs {
+                            self.terminals.remove(&(tab.id as u64));
+                        }
+                    }
+                    self.active_terminal_tab.remove(ws_id);
+                }
+
+                // Remove workspaces and repository
                 self.workspaces.retain(|w| w.repository_id != repo_id);
+                self.repositories.retain(|r| r.id != repo_id);
+                self.repo_collapsed.remove(&repo_id);
+
+                // Clear selection if it pointed to a removed workspace
                 if let Some(sel) = &self.selected_workspace
                     && !self.workspaces.iter().any(|w| w.id == *sel)
                 {
@@ -997,6 +1073,8 @@ impl App {
                     self.diff_content = None;
                 } else if self.show_delete_workspace.is_some() {
                     self.show_delete_workspace = None;
+                } else if self.show_remove_repository.is_some() {
+                    self.show_remove_repository = None;
                 } else if self.show_relink_repo.is_some() {
                     self.show_relink_repo = None;
                 } else if self.show_create_workspace.is_some() {
@@ -1041,6 +1119,15 @@ impl App {
                 );
             }
             Message::AgentSpawned(Ok((ws_id, handle))) => {
+                // Guard: if the workspace was removed while spawning, kill the orphan
+                if !self.workspaces.iter().any(|w| w.id == ws_id) {
+                    let pid = handle.pid;
+                    tokio::spawn(async move {
+                        let _ = agent::stop_agent(pid).await;
+                    });
+                    return Task::none();
+                }
+
                 // Add system message
                 let sys_msg = ChatMessage {
                     id: uuid::Uuid::new_v4().to_string(),
@@ -1883,8 +1970,10 @@ impl App {
 
         // Icon picker layered on top of repo settings modal
         if self.show_icon_picker && self.show_repo_settings.is_some() {
+            let repo_id = self.show_repo_settings.as_deref().unwrap_or("");
             let repo_settings_base = ui::view_repo_settings_modal(
                 base,
+                repo_id,
                 &self.repo_settings_name_input,
                 self.repo_settings_icon_input.as_deref(),
                 self.repo_settings_error.as_ref(),
@@ -1894,8 +1983,10 @@ impl App {
         }
 
         if self.show_repo_settings.is_some() {
+            let repo_id = self.show_repo_settings.as_deref().unwrap_or("");
             return ui::view_repo_settings_modal(
                 base,
+                repo_id,
                 &self.repo_settings_name_input,
                 self.repo_settings_icon_input.as_deref(),
                 self.repo_settings_error.as_ref(),
@@ -1923,6 +2014,26 @@ impl App {
 
         if let Some(file_path) = &self.diff_revert_target {
             return ui::view_revert_file_modal(base, file_path);
+        }
+
+        if let Some(repo_id) = &self.show_remove_repository {
+            let repo_name = self
+                .repositories
+                .iter()
+                .find(|r| r.id == *repo_id)
+                .map(|r| r.name.as_str())
+                .unwrap_or("this repository");
+            let active_count = self
+                .workspaces
+                .iter()
+                .filter(|w| w.repository_id == *repo_id && w.status == WorkspaceStatus::Active)
+                .count();
+            let archived_count = self
+                .workspaces
+                .iter()
+                .filter(|w| w.repository_id == *repo_id && w.status == WorkspaceStatus::Archived)
+                .count();
+            return ui::view_remove_repo_modal(base, repo_name, active_count, archived_count);
         }
 
         if let Some(ws_id) = &self.show_delete_workspace {

--- a/src/message.rs
+++ b/src/message.rs
@@ -59,10 +59,12 @@ pub enum Message {
     IconPickerQueryChanged(String),
     SelectIcon(Option<String>), // icon name or None to clear
 
-    // Repository management
-    RemoveRepository(String),                  // repo_id
+    // Repository removal (with confirmation)
+    ShowRemoveRepository(String), // repo_id — opens confirmation modal
+    HideRemoveRepository,         // cancel
+    ConfirmRemoveRepository,      // user confirmed — proceed with cleanup
     RepositoryRemoved(Result<String, String>), // Ok(repo_id)
-    ShowRelinkRepo(String),                    // repo_id
+    ShowRelinkRepo(String),       // repo_id
     HideRelinkRepo,
     RelinkRepoPathChanged(String),
     BrowseRelinkPath,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,8 +18,8 @@ pub use icon_picker::view_icon_picker;
 pub use main_content::view_main_content;
 pub use modal::{
     view_add_repo_modal, view_app_settings_modal, view_create_workspace_modal,
-    view_delete_workspace_modal, view_relink_repo_modal, view_repo_settings_modal,
-    view_revert_file_modal,
+    view_delete_workspace_modal, view_relink_repo_modal, view_remove_repo_modal,
+    view_repo_settings_modal, view_revert_file_modal,
 };
 pub use right_sidebar::view_right_sidebar;
 pub use sidebar::view_sidebar;

--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -248,6 +248,7 @@ pub fn view_remove_repo_modal<'a>(
     repo_name: &str,
     active_count: usize,
     archived_count: usize,
+    error: Option<&String>,
 ) -> Element<'a, Message> {
     let mut content = column![
         text("Remove Repository").size(20),
@@ -275,6 +276,10 @@ pub fn view_remove_repo_modal<'a>(
             ));
         }
         content = content.push(text(impact).size(13).color(style::ERROR));
+    }
+
+    if let Some(err) = error {
+        content = content.push(text(err.clone()).size(14).color(style::ERROR));
     }
 
     content = content.push(

--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -243,6 +243,76 @@ pub fn view_delete_workspace_modal<'a>(
     )
 }
 
+pub fn view_remove_repo_modal<'a>(
+    base: Element<'a, Message>,
+    repo_name: &str,
+    active_count: usize,
+    archived_count: usize,
+) -> Element<'a, Message> {
+    let mut content = column![
+        text("Remove Repository").size(20),
+        text(format!("Are you sure you want to remove \"{repo_name}\"?"))
+            .size(14)
+            .color(style::DIM),
+        text(
+            "This will NOT delete the repository from disk — it only unregisters it from Claudette."
+        )
+        .size(13)
+        .color(style::DIM),
+    ]
+    .spacing(12);
+
+    if active_count > 0 || archived_count > 0 {
+        let mut impact = String::from("This will permanently destroy:");
+        if active_count > 0 {
+            impact.push_str(&format!(
+                "\n  \u{2022} {active_count} active workspace(s) (agents will be stopped)"
+            ));
+        }
+        if archived_count > 0 {
+            impact.push_str(&format!(
+                "\n  \u{2022} {archived_count} archived workspace(s) and their chat history"
+            ));
+        }
+        content = content.push(text(impact).size(13).color(style::ERROR));
+    }
+
+    content = content.push(
+        row![
+            button(text("Cancel").size(14))
+                .on_press(Message::HideRemoveRepository)
+                .style(|theme: &Theme, status| {
+                    let mut s = button::secondary(theme, status);
+                    s.border = Border {
+                        radius: 4.0.into(),
+                        ..s.border
+                    };
+                    s
+                })
+                .padding([8, 16]),
+            Space::new().width(8),
+            button(text("Remove").size(14).color(style::ERROR))
+                .on_press(Message::ConfirmRemoveRepository)
+                .style(|theme: &Theme, status| {
+                    let mut s = button::secondary(theme, status);
+                    s.border = Border {
+                        radius: 4.0.into(),
+                        ..s.border
+                    };
+                    s
+                })
+                .padding([8, 16]),
+        ]
+        .align_y(iced::Alignment::Center),
+    );
+
+    modal_backdrop(
+        base,
+        modal_card(content.into()),
+        Message::HideRemoveRepository,
+    )
+}
+
 pub fn view_relink_repo_modal<'a>(
     base: Element<'a, Message>,
     repo_name: &str,
@@ -361,6 +431,7 @@ pub fn view_revert_file_modal<'a>(
 
 pub fn view_repo_settings_modal<'a>(
     base: Element<'a, Message>,
+    repo_id: &str,
     name_input: &str,
     icon_input: Option<&'a str>,
     error: Option<&String>,
@@ -423,6 +494,45 @@ pub fn view_repo_settings_modal<'a>(
     if let Some(err) = error {
         content = content.push(text(err.clone()).size(14).color(style::ERROR));
     }
+
+    // Danger zone — remove repository
+    let repo_id_owned = repo_id.to_string();
+    content = content.push(Space::new().height(4));
+    content = content.push(
+        container(
+            row![
+                column![
+                    text("Remove Repository").size(14),
+                    text("Unregister this repository and delete all its workspaces")
+                        .size(12)
+                        .color(style::DIM),
+                ]
+                .spacing(2),
+                Space::new().width(Fill),
+                button(text("Remove").size(14).color(style::ERROR))
+                    .on_press(Message::ShowRemoveRepository(repo_id_owned))
+                    .style(|theme: &Theme, status| {
+                        let mut s = button::secondary(theme, status);
+                        s.border = Border {
+                            radius: 4.0.into(),
+                            ..s.border
+                        };
+                        s
+                    })
+                    .padding([6, 12]),
+            ]
+            .align_y(iced::Alignment::Center),
+        )
+        .padding(12)
+        .style(|_theme: &Theme| container::Style {
+            border: Border {
+                radius: 4.0.into(),
+                width: 1.0,
+                color: style::MODAL_BORDER,
+            },
+            ..Default::default()
+        }),
+    );
 
     content = content.push(
         row![

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -296,7 +296,7 @@ fn view_repo_group<'a>(
             .push(
                 tooltip(
                     button(text("\u{2715}").size(12).color(style::MUTED))
-                        .on_press(Message::RemoveRepository(repo_id_for_remove))
+                        .on_press(Message::ShowRemoveRepository(repo_id_for_remove))
                         .style(|theme: &Theme, status| {
                             let mut s = button::text(theme, status);
                             if matches!(status, button::Status::Hovered) {
@@ -425,7 +425,7 @@ fn view_workspace_entry<'a>(
     } else {
         row![
             tooltip(
-                button(text("\u{2193}").size(11).color(style::MUTED))
+                button(text("\u{2611}").size(11).color(style::MUTED))
                     .on_press(Message::ArchiveWorkspace(ws_id.clone()))
                     .style(|theme: &Theme, status| {
                         let mut s = button::text(theme, status);


### PR DESCRIPTION
## Summary

- Adds a proper "Remove Repository" feature with confirmation modal, accessible via the gear (settings) icon on any repo
- Replaces the previous unsafe immediate-delete that was hidden behind invalid-path repos only
- Confirmation modal shows impact: count of active/archived workspaces that will be destroyed, with clear messaging that the source repo is NOT deleted from disk
- Full cleanup on confirm: stops running agents, removes git worktrees, cascades DB delete, purges all in-memory state (chat messages, markdown cache, terminals, tabs)
- Guards `AgentSpawned` against orphaned processes when a repo is removed during an in-flight agent spawn
- Sidebar `✕` button for invalid-path repos now also goes through confirmation
- Changes the archive workspace icon from a down-arrow to a ballot box with check (☑)

Closes no specific issue — this was a gap in the PRD (section 3.1 mentions adding repos but not removing them).

## Test plan

- [x] Open gear icon on a valid repo — see "Remove Repository" danger zone at bottom of settings modal
- [x] Click "Remove" — confirmation modal appears with workspace counts
- [x] Click "Cancel" — modal closes, nothing changed
- [x] Click "Remove" on confirmation — repo disappears, workspaces gone, agents stopped
- [ ] For invalid-path repo: sidebar `✕` button also shows confirmation modal
- [x] Escape key dismisses both modals
- [x] Source repo directory remains untouched on disk
- [x] Archive button now shows ☑ instead of ↓