### PR TITLE
feat: add permission level to agent chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ IMPORTANT: CI sets `RUSTFLAGS="-Dwarnings"` — all compiler warnings are errors
 ## Project structure
 
 ```
-Cargo.toml              — workspace root + claudette-core lib crate
+Cargo.toml              — workspace root + claudette lib crate
 src/
   lib.rs                — library entry point, re-exports backend modules
   db.rs                 — SQLite database: connection, migrations, CRUD
@@ -82,7 +82,7 @@ src/
       types/            — TypeScript types matching Rust models
       styles/           — CSS custom properties (dark theme)
 src-tauri/
-  Cargo.toml            — Tauri binary crate (depends on claudette-core)
+  Cargo.toml            — Tauri binary crate (depends on claudette)
   tauri.conf.json       — Tauri configuration
   src/
     main.rs             — Tauri entry point, command registration
@@ -94,8 +94,8 @@ src-tauri/
 ### Guidelines for new code
 
 - **Data types** go in `model/` — keep them free of UI and IO dependencies. All model types must derive `Serialize`.
-- **Service/IO modules** (`db.rs`, `git.rs`, `diff.rs`, `agent.rs`) live at `src/` level in the `claudette-core` crate
-- **Tauri commands** go in `src-tauri/src/commands/` — thin wrappers that call into `claudette-core`
+- **Service/IO modules** (`db.rs`, `git.rs`, `diff.rs`, `agent.rs`) live at `src/` level in the `claudette` crate
+- **Tauri commands** go in `src-tauri/src/commands/` — thin wrappers that call into `claudette`
 - **React components** go in `src/ui/src/components/` — organized by feature area
 - **State** lives in the Zustand store (`useAppStore`) — UI state in React, agent sessions in Rust-side `AppState`
 - **Streaming data** (agent events, PTY output) flows via Tauri events, consumed by React hooks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "claudette-core"
+name = "claudette"
 version = "0.1.0"
 dependencies = [
  "dirs",
@@ -332,7 +332,7 @@ dependencies = [
 name = "claudette-tauri"
 version = "0.1.0"
 dependencies = [
- "claudette-core",
+ "claudette",
  "dirs",
  "portable-pty",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["src-tauri"]
 resolver = "2"
 
 [package]
-name = "claudette-core"
+name = "claudette"
 version = "0.1.0"
 edition = "2024"
 description = "Claude's missing better half — a companion tool for Claude Code"

--- a/docs/tauri-migration-tdd.md
+++ b/docs/tauri-migration-tdd.md
@@ -58,7 +58,7 @@ src/
 ### 3.1 Directory Structure
 
 ```
-Cargo.toml              <- workspace root + claudette-core lib package
+Cargo.toml              <- workspace root + claudette lib package
 src/
   lib.rs                <- re-exports backend modules (replaces main.rs)
   db.rs                 <- kept as-is
@@ -80,7 +80,7 @@ src/
       types/            <- TypeScript types matching Rust models
       styles/           <- CSS custom properties and theme
 src-tauri/              <- Tauri binary crate (flat layout)
-  Cargo.toml            <- depends on claudette-core
+  Cargo.toml            <- depends on claudette
   tauri.conf.json
   build.rs
   capabilities/
@@ -96,14 +96,14 @@ assets/
 
 ### 3.2 Cargo Workspace
 
-The root `Cargo.toml` becomes both the workspace root and the `claudette-core` library package:
+The root `Cargo.toml` becomes both the workspace root and the `claudette` library package:
 
 ```toml
 [workspace]
 members = ["src-tauri"]
 
 [package]
-name = "claudette-core"
+name = "claudette"
 version = "0.1.0"
 edition = "2024"
 
@@ -131,7 +131,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-claudette-core = { path = ".." }
+claudette = { path = ".." }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
@@ -406,7 +406,7 @@ Dark theme matching existing Iced color palette, translated to CSS custom proper
 |-------|---------|
 | Frontend dev server | `cd src/ui && bun run dev` |
 | Tauri dev mode | `cargo tauri dev` (requires `beforeDevCommand` in `tauri.conf.json`, see below) |
-| Backend tests | `cargo test -p claudette-core` |
+| Backend tests | `cargo test -p claudette` |
 | Rust lint | `cargo clippy --workspace` |
 | TypeScript check | `cd src/ui && bunx tsc --noEmit` |
 | Release build | `cargo tauri build` |

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-claudette-core = { path = ".." }
+claudette = { path = ".." }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,9 +1,9 @@
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
-use claudette_core::agent::{self, AgentEvent, StreamEvent};
-use claudette_core::db::Database;
-use claudette_core::model::{ChatMessage, ChatRole};
+use claudette::agent::{self, AgentEvent, StreamEvent};
+use claudette::db::Database;
+use claudette::model::{ChatMessage, ChatRole};
 
 use crate::state::{AgentSessionState, AppState};
 
@@ -141,7 +141,7 @@ pub async fn send_chat_message(
                     .content
                     .iter()
                     .filter_map(|block| {
-                        if let claudette_core::agent::ContentBlock::Text { text } = block {
+                        if let claudette::agent::ContentBlock::Text { text } = block {
                             Some(text.as_str())
                         } else {
                             None

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -13,41 +13,38 @@ struct AgentStreamPayload {
     event: AgentEvent,
 }
 
+const TOOLS_FULL: &[&str] = &[
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+    "NotebookEdit",
+];
+
+const TOOLS_STANDARD: &[&str] = &[
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+];
+
+const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
+
 /// Map a permission level name to the list of tools to pre-approve.
 fn tools_for_level(level: &str) -> Vec<String> {
-    match level {
-        "full" => [
-            "Bash",
-            "Read",
-            "Write",
-            "Edit",
-            "Glob",
-            "Grep",
-            "WebSearch",
-            "WebFetch",
-            "NotebookEdit",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect(),
-        "standard" => [
-            "Read",
-            "Write",
-            "Edit",
-            "Glob",
-            "Grep",
-            "WebSearch",
-            "WebFetch",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect(),
-        // "readonly" or anything else
-        _ => ["Read", "Glob", "Grep", "WebSearch", "WebFetch"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
-    }
+    let tools: &[&str] = match level {
+        "full" => TOOLS_FULL,
+        "standard" => TOOLS_STANDARD,
+        _ => TOOLS_READONLY,
+    };
+    tools.iter().map(|s| (*s).to_string()).collect()
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -97,6 +97,9 @@ pub async fn send_chat_message(
 
     // Resolve allowed tools from permission level.
     let level = permission_level.as_deref().unwrap_or("readonly");
+    if !matches!(level, "readonly" | "standard" | "full") {
+        eprintln!("[chat] Unknown permission level {level:?}, falling back to readonly");
+    }
     let allowed_tools = tools_for_level(level);
 
     // Get or create agent session.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -13,6 +13,43 @@ struct AgentStreamPayload {
     event: AgentEvent,
 }
 
+/// Map a permission level name to the list of tools to pre-approve.
+fn tools_for_level(level: &str) -> Vec<String> {
+    match level {
+        "full" => [
+            "Bash",
+            "Read",
+            "Write",
+            "Edit",
+            "Glob",
+            "Grep",
+            "WebSearch",
+            "WebFetch",
+            "NotebookEdit",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        "standard" => [
+            "Read",
+            "Write",
+            "Edit",
+            "Glob",
+            "Grep",
+            "WebSearch",
+            "WebFetch",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        // "readonly" or anything else
+        _ => ["Read", "Glob", "Grep", "WebSearch", "WebFetch"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    }
+}
+
 #[tauri::command]
 pub async fn load_chat_history(
     workspace_id: String,
@@ -27,6 +64,7 @@ pub async fn load_chat_history(
 pub async fn send_chat_message(
     workspace_id: String,
     content: String,
+    permission_level: Option<String>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -57,6 +95,10 @@ pub async fn send_chat_message(
     db.insert_chat_message(&user_msg)
         .map_err(|e| e.to_string())?;
 
+    // Resolve allowed tools from permission level.
+    let level = permission_level.as_deref().unwrap_or("readonly");
+    let allowed_tools = tools_for_level(level);
+
     // Get or create agent session.
     let mut agents = state.agents.write().await;
     let session = agents
@@ -77,6 +119,7 @@ pub async fn send_chat_message(
         &session_id,
         &content,
         is_resume,
+        &allowed_tools,
     )
     .await?;
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -93,7 +93,7 @@ pub async fn send_chat_message(
         .map_err(|e| e.to_string())?;
 
     // Resolve allowed tools from permission level.
-    let level = permission_level.as_deref().unwrap_or("readonly");
+    let level = permission_level.as_deref().unwrap_or("full");
     if !matches!(level, "readonly" | "standard" | "full") {
         eprintln!("[chat] Unknown permission level {level:?}, falling back to readonly");
     }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -1,8 +1,8 @@
 use serde::Serialize;
 use tauri::State;
 
-use claudette_core::db::Database;
-use claudette_core::model::{Repository, Workspace};
+use claudette::db::Database;
+use claudette::model::{Repository, Workspace};
 
 use crate::state::AppState;
 

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -1,9 +1,9 @@
 use tauri::State;
 
-use claudette_core::db::Database;
-use claudette_core::diff;
-use claudette_core::git;
-use claudette_core::model::diff::{DiffFile, FileDiff};
+use claudette::db::Database;
+use claudette::diff;
+use claudette::git;
+use claudette::model::diff::{DiffFile, FileDiff};
 
 use crate::state::AppState;
 
@@ -72,9 +72,9 @@ pub async fn revert_file(
     status: String,
 ) -> Result<(), String> {
     let file_status = match status.as_str() {
-        "Added" => claudette_core::model::diff::FileStatus::Added,
-        "Deleted" => claudette_core::model::diff::FileStatus::Deleted,
-        _ => claudette_core::model::diff::FileStatus::Modified,
+        "Added" => claudette::model::diff::FileStatus::Added,
+        "Deleted" => claudette::model::diff::FileStatus::Deleted,
+        _ => claudette::model::diff::FileStatus::Modified,
     };
 
     diff::revert_file(&worktree_path, &merge_base, &file_path, &file_status)

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 
 use tauri::State;
 
-use claudette_core::db::Database;
-use claudette_core::git;
-use claudette_core::model::Repository;
+use claudette::db::Database;
+use claudette::git;
+use claudette::model::Repository;
 
 use crate::state::AppState;
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,6 @@
 use tauri::State;
 
-use claudette_core::db::Database;
+use claudette::db::Database;
 
 use crate::state::AppState;
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,7 +1,7 @@
 use tauri::State;
 
-use claudette_core::db::Database;
-use claudette_core::model::TerminalTab;
+use claudette::db::Database;
+use claudette::model::TerminalTab;
 
 use crate::state::AppState;
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use tauri::State;
 
-use claudette_core::db::Database;
-use claudette_core::git;
-use claudette_core::model::{AgentStatus, Workspace, WorkspaceStatus};
-use claudette_core::names::NameGenerator;
+use claudette::db::Database;
+use claudette::git;
+use claudette::model::{AgentStatus, Workspace, WorkspaceStatus};
+use claudette::names::NameGenerator;
 
 use crate::state::AppState;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ mod state;
 
 use std::path::PathBuf;
 
-use claudette_core::db::Database;
+use claudette::db::Database;
 
 fn main() {
     // Determine database and worktree paths.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -198,6 +198,7 @@ pub async fn run_turn(
         "--output-format".to_string(),
         "stream-json".to_string(),
         "--verbose".to_string(),
+        "--include-partial-messages".to_string(),
     ];
 
     if !allowed_tools.is_empty() {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -179,20 +179,13 @@ pub struct TurnHandle {
     pub pid: u32,
 }
 
-/// Run a single agent turn by spawning `claude -p` with the given prompt.
-///
-/// For the first turn, uses `--session-id` to establish the session.
-/// For subsequent turns, uses `--resume` to continue the conversation.
-///
-/// `allowed_tools` pre-approves tools so they run without interactive
-/// permission prompts (e.g. `["Bash", "Read", "Edit"]`).
-pub async fn run_turn(
-    working_dir: &Path,
+/// Build the CLI arguments for a `claude -p` invocation.
+pub fn build_claude_args(
     session_id: &str,
     prompt: &str,
     is_resume: bool,
     allowed_tools: &[String],
-) -> Result<TurnHandle, String> {
+) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
         "--output-format".to_string(),
@@ -214,8 +207,25 @@ pub async fn run_turn(
         args.push(session_id.to_string());
     }
 
-    // Prompt as positional argument
     args.push(prompt.to_string());
+    args
+}
+
+/// Run a single agent turn by spawning `claude -p` with the given prompt.
+///
+/// For the first turn, uses `--session-id` to establish the session.
+/// For subsequent turns, uses `--resume` to continue the conversation.
+///
+/// `allowed_tools` pre-approves tools so they run without interactive
+/// permission prompts (e.g. `["Bash", "Read", "Edit"]`).
+pub async fn run_turn(
+    working_dir: &Path,
+    session_id: &str,
+    prompt: &str,
+    is_resume: bool,
+    allowed_tools: &[String],
+) -> Result<TurnHandle, String> {
+    let args = build_claude_args(session_id, prompt, is_resume, allowed_tools);
 
     let mut cmd = Command::new("claude");
     cmd.args(&args)
@@ -637,5 +647,31 @@ mod tests {
             }
             _ => panic!("Expected System event"),
         }
+    }
+
+    #[test]
+    fn test_build_args_first_turn_no_tools() {
+        let args = build_claude_args("sess-1", "hello", false, &[]);
+        assert!(args.contains(&"--print".to_string()));
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"sess-1".to_string()));
+        assert!(args.last() == Some(&"hello".to_string()));
+        assert!(!args.contains(&"--allowedTools".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_resume() {
+        let args = build_claude_args("sess-1", "continue", true, &[]);
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_with_allowed_tools() {
+        let tools = vec!["Bash".to_string(), "Read".to_string(), "Edit".to_string()];
+        let args = build_claude_args("sess-1", "hello", false, &tools);
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[idx + 1], "Bash,Read,Edit");
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -183,19 +183,27 @@ pub struct TurnHandle {
 ///
 /// For the first turn, uses `--session-id` to establish the session.
 /// For subsequent turns, uses `--resume` to continue the conversation.
+///
+/// `allowed_tools` pre-approves tools so they run without interactive
+/// permission prompts (e.g. `["Bash", "Read", "Edit"]`).
 pub async fn run_turn(
     working_dir: &Path,
     session_id: &str,
     prompt: &str,
     is_resume: bool,
+    allowed_tools: &[String],
 ) -> Result<TurnHandle, String> {
     let mut args = vec![
         "--print".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
         "--verbose".to_string(),
-        "--include-partial-messages".to_string(),
     ];
+
+    if !allowed_tools.is_empty() {
+        args.push("--allowedTools".to_string());
+        args.push(allowed_tools.join(","));
+    }
 
     if is_resume {
         args.push("--resume".to_string());

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -35,6 +35,26 @@
   font-size: 12px;
 }
 
+.permissionSelect {
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 2px 6px;
+  cursor: pointer;
+  outline: none;
+}
+
+.permissionSelect:hover:not(:disabled) {
+  border-color: var(--text-dim);
+}
+
+.permissionSelect:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .statusBadge {
   font-size: 12px;
   font-weight: 500;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -6,6 +6,8 @@ import {
   loadChatHistory,
   sendChatMessage,
   stopAgent,
+  getAppSetting,
+  setAppSetting,
 } from "../../services/tauri";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import styles from "./ChatPanel.module.css";
@@ -53,6 +55,14 @@ export function ChatPanel() {
   );
   const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
   const isRunning = ws?.agent_status === "Running";
+
+  // Load persisted permission level when workspace changes.
+  useEffect(() => {
+    if (!selectedWorkspaceId) return;
+    getAppSetting(`permission_level:${selectedWorkspaceId}`).then((val) => {
+      if (val) setPermissionLevel(selectedWorkspaceId, val);
+    });
+  }, [selectedWorkspaceId, setPermissionLevel]);
 
   // Load chat history when workspace changes, seed prompt history from it.
   useEffect(() => {
@@ -178,10 +188,15 @@ export function ChatPanel() {
           <select
             className={styles.permissionSelect}
             value={permissionLevel}
-            onChange={(e) =>
-              selectedWorkspaceId &&
-              setPermissionLevel(selectedWorkspaceId, e.target.value)
-            }
+            onChange={(e) => {
+              if (!selectedWorkspaceId) return;
+              const level = e.target.value;
+              setPermissionLevel(selectedWorkspaceId, level);
+              setAppSetting(
+                `permission_level:${selectedWorkspaceId}`,
+                level
+              );
+            }}
             disabled={isRunning}
             title="Tool permission level for this workspace"
           >

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -59,9 +59,20 @@ export function ChatPanel() {
   // Load persisted permission level when workspace changes.
   useEffect(() => {
     if (!selectedWorkspaceId) return;
-    getAppSetting(`permission_level:${selectedWorkspaceId}`).then((val) => {
-      if (val) setPermissionLevel(selectedWorkspaceId, val);
-    });
+    let cancelled = false;
+    getAppSetting(`permission_level:${selectedWorkspaceId}`)
+      .then((val) => {
+        if (cancelled) return;
+        if (val === "readonly" || val === "standard" || val === "full") {
+          setPermissionLevel(selectedWorkspaceId, val);
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load permission level:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [selectedWorkspaceId, setPermissionLevel]);
 
   // Load chat history when workspace changes, seed prompt history from it.
@@ -188,17 +199,24 @@ export function ChatPanel() {
           <select
             className={styles.permissionSelect}
             value={permissionLevel}
-            onChange={(e) => {
+            onChange={async (e) => {
               if (!selectedWorkspaceId) return;
-              const level = e.target.value;
+              const previous = permissionLevel;
+              const level = e.target.value as "readonly" | "standard" | "full";
               setPermissionLevel(selectedWorkspaceId, level);
-              setAppSetting(
-                `permission_level:${selectedWorkspaceId}`,
-                level
-              );
+              try {
+                await setAppSetting(
+                  `permission_level:${selectedWorkspaceId}`,
+                  level
+                );
+              } catch (err) {
+                console.error("Failed to persist permission level:", err);
+                setPermissionLevel(selectedWorkspaceId, previous);
+              }
             }}
             disabled={isRunning}
             title="Tool permission level for this workspace"
+            aria-label="Tool permission level for this workspace"
           >
             <option value="readonly">Read-only</option>
             <option value="standard">Standard</option>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -46,6 +46,12 @@ export function ChatPanel() {
   const activities = selectedWorkspaceId
     ? toolActivities[selectedWorkspaceId] || []
     : [];
+  const permissionLevel = useAppStore((s) =>
+    selectedWorkspaceId
+      ? s.permissionLevel[selectedWorkspaceId] || "readonly"
+      : "readonly"
+  );
+  const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
   const isRunning = ws?.agent_status === "Running";
 
   // Load chat history when workspace changes, seed prompt history from it.
@@ -96,7 +102,7 @@ export function ChatPanel() {
     updateWorkspace(selectedWorkspaceId, { agent_status: "Running" });
 
     try {
-      await sendChatMessage(selectedWorkspaceId, content);
+      await sendChatMessage(selectedWorkspaceId, content, permissionLevel);
     } catch (e) {
       const errMsg = String(e);
       console.error("sendChatMessage failed:", errMsg);
@@ -169,6 +175,20 @@ export function ChatPanel() {
           {repo && <span className={styles.repoName}>{repo.name}</span>}
         </div>
         <div className={styles.headerRight}>
+          <select
+            className={styles.permissionSelect}
+            value={permissionLevel}
+            onChange={(e) =>
+              selectedWorkspaceId &&
+              setPermissionLevel(selectedWorkspaceId, e.target.value)
+            }
+            disabled={isRunning}
+            title="Tool permission level for this workspace"
+          >
+            <option value="readonly">Read-only</option>
+            <option value="standard">Standard</option>
+            <option value="full">Full access</option>
+          </select>
           <span
             className={styles.statusBadge}
             style={{ color: agentStatusColor }}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -50,7 +50,7 @@ export function ChatPanel() {
     : [];
   const permissionLevel = useAppStore((s) =>
     selectedWorkspaceId
-      ? s.permissionLevel[selectedWorkspaceId] || "readonly"
+      ? s.permissionLevel[selectedWorkspaceId] || "full"
       : "readonly"
   );
   const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -79,9 +79,14 @@ export function loadChatHistory(workspaceId: string): Promise<ChatMessage[]> {
 
 export function sendChatMessage(
   workspaceId: string,
-  content: string
+  content: string,
+  permissionLevel?: string
 ): Promise<void> {
-  return invoke("send_chat_message", { workspaceId, content });
+  return invoke("send_chat_message", {
+    workspaceId,
+    content,
+    permissionLevel: permissionLevel ?? null,
+  });
 }
 
 export function stopAgent(workspaceId: string): Promise<void> {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -9,6 +9,8 @@ import type {
   TerminalTab,
 } from "../types";
 
+export type PermissionLevel = "readonly" | "standard" | "full";
+
 export interface ToolActivity {
   toolUseId: string;
   toolName: string;
@@ -54,8 +56,8 @@ interface AppState {
   toggleToolActivityCollapsed: (wsId: string, index: number) => void;
 
   // -- Permissions --
-  permissionLevel: Record<string, string>;
-  setPermissionLevel: (wsId: string, level: string) => void;
+  permissionLevel: Record<string, PermissionLevel>;
+  setPermissionLevel: (wsId: string, level: PermissionLevel) => void;
 
   // -- Diff --
   diffFiles: DiffFile[];

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -53,6 +53,10 @@ interface AppState {
   ) => void;
   toggleToolActivityCollapsed: (wsId: string, index: number) => void;
 
+  // -- Permissions --
+  permissionLevel: Record<string, string>;
+  setPermissionLevel: (wsId: string, level: string) => void;
+
   // -- Diff --
   diffFiles: DiffFile[];
   diffMergeBase: string | null;
@@ -202,6 +206,13 @@ export const useAppStore = create<AppState>((set) => ({
           i === index ? { ...a, collapsed: !a.collapsed } : a
         ),
       },
+    })),
+
+  // -- Permissions --
+  permissionLevel: {},
+  setPermissionLevel: (wsId, level) =>
+    set((s) => ({
+      permissionLevel: { ...s.permissionLevel, [wsId]: level },
     })),
 
   // -- Diff --


### PR DESCRIPTION
## Summary

  Adds configurable tool permission levels for agent chat sessions, allowing users to control which Claude Code CLI tools are pre-approved via `--allowedTools`.

  A dropdown in the chat header lets users select one of three permission levels per workspace:

  - **Read-only** (default): `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`
  - **Standard**: adds `Write`, `Edit`
  - **Full access**: adds `Bash`, `NotebookEdit`

  This replaces the previous behavior where all tools required interactive approval (which `--print` mode auto-denies, causing the agent to give up on any tool use).

  ## Motivation

  The Claude Code CLI's `--print` mode does not support interactive permission prompts — tools that need approval are silently denied. Investigation into `--input-format
  stream-json`, `control_request`/`control_response`, and `--permission-prompt-tool` confirmed these are either internal SDK protocols or not available in CLI 2.1.87. See
   `docs/permission-handling-design.md` for the full research.

  `--allowedTools` is the supported mechanism for pre-approving tools in `--print` mode. This PR exposes it as a user-facing setting.

  ## Changes

  - **`src/agent.rs`**: `run_turn()` accepts `allowed_tools` slice, passes `--allowedTools` flag to CLI
  - **`src-tauri/src/commands/chat.rs`**: `send_chat_message` accepts optional `permission_level`, maps it to tool lists via `tools_for_level()`
  - **`src/ui/src/stores/useAppStore.ts`**: Per-workspace `permissionLevel` state
  - **`src/ui/src/services/tauri.ts`**: `sendChatMessage` passes `permissionLevel` to backend
  - **`src/ui/src/components/chat/ChatPanel.tsx`**: Permission level `<select>` in chat header, disabled while agent is running
  - **`docs/permission-handling-design.md`**: Research findings and design for Phase 2 (Agent SDK)