### PR TITLE
feat: interactive popup for agent AskUserQuestion tool calls

### DIFF
--- a/src/ui/src/components/chat/AgentQuestionCard.module.css
+++ b/src/ui/src/components/chat/AgentQuestionCard.module.css
@@ -1,0 +1,147 @@
+.card {
+  border: 1px solid var(--sidebar-border);
+  border-radius: 8px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.questionBlock {
+  margin-bottom: 12px;
+}
+
+.header {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.question {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.option {
+  padding: 10px 12px;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.4;
+  transition: border-color 0.15s;
+}
+
+.option:hover {
+  border-color: var(--text-dim);
+  background: var(--hover-bg);
+}
+
+.optionLabel {
+  font-weight: 500;
+}
+
+.optionSelected {
+  border-color: var(--status-running);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.confirmBtn {
+  display: block;
+  width: 100%;
+  margin-bottom: 12px;
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.confirmBtn:hover {
+  background: var(--hover-bg);
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--divider);
+}
+
+.freeformRow {
+  display: flex;
+  gap: 8px;
+}
+
+.freeformInput {
+  flex: 1;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  resize: none;
+  min-height: 36px;
+}
+
+.freeformInput:focus {
+  border-color: var(--text-dim);
+}
+
+.freeformInput::placeholder {
+  color: var(--text-dim);
+}
+
+.submitBtn {
+  background: var(--selected-bg);
+  border: 1px solid var(--divider);
+  color: var(--text-primary);
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  align-self: flex-end;
+}
+
+.submitBtn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.submitBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/ui/src/components/chat/AgentQuestionCard.tsx
+++ b/src/ui/src/components/chat/AgentQuestionCard.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import type { AgentQuestion } from "../../stores/useAppStore";
+import styles from "./AgentQuestionCard.module.css";
+
+interface AgentQuestionCardProps {
+  question: AgentQuestion;
+  onRespond: (response: string) => void;
+}
+
+export function AgentQuestionCard({
+  question,
+  onRespond,
+}: AgentQuestionCardProps) {
+  const isSingleQuestion = question.questions.length === 1;
+
+  const [selections, setSelections] = useState<Record<number, Set<number>>>(
+    () => Object.fromEntries(question.questions.map((_, i) => [i, new Set()]))
+  );
+  const [freeform, setFreeform] = useState("");
+
+  const toggleSelection = (qIdx: number, optIdx: number, multi: boolean) => {
+    if (isSingleQuestion && !multi) {
+      // Single question, single select — respond immediately
+      const opt = question.questions[qIdx].options[optIdx];
+      if (opt) onRespond(opt.label);
+      return;
+    }
+
+    setSelections((prev) => {
+      const current = prev[qIdx] ?? new Set();
+      const next = new Set(multi ? current : []);
+      if (next.has(optIdx)) {
+        next.delete(optIdx);
+      } else {
+        next.add(optIdx);
+      }
+      return { ...prev, [qIdx]: next };
+    });
+  };
+
+  const handleSubmitSelections = () => {
+    const parts: string[] = [];
+    for (let i = 0; i < question.questions.length; i++) {
+      const q = question.questions[i];
+      const selected = selections[i] ?? new Set();
+      const chosen = [...selected].map((idx) => q.options[idx]?.label).filter(Boolean);
+      if (chosen.length > 0) {
+        if (question.questions.length > 1) {
+          parts.push(`${q.question}: ${chosen.join(", ")}`);
+        } else {
+          parts.push(chosen.join(", "));
+        }
+      }
+    }
+    if (parts.length > 0) {
+      onRespond(parts.join("\n"));
+    }
+  };
+
+  const handleSubmitFreeform = () => {
+    const text = freeform.trim();
+    if (text) {
+      onRespond(text);
+    }
+  };
+
+  const hasSelections = Object.values(selections).some((s) => s.size > 0);
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.label}>Agent Question</div>
+
+      {question.questions.map((q, qIdx) => (
+        <div key={qIdx} className={styles.questionBlock}>
+          {q.header && <div className={styles.header}>{q.header}</div>}
+          <div className={styles.question}>{q.question}</div>
+          {q.options.length > 0 && (
+            <div className={styles.options}>
+              {q.options.map((opt, optIdx) => {
+                const isSelected = selections[qIdx]?.has(optIdx) ?? false;
+                return (
+                  <button
+                    key={optIdx}
+                    className={`${styles.option} ${isSelected ? styles.optionSelected : ""}`}
+                    onClick={() =>
+                      toggleSelection(qIdx, optIdx, q.multiSelect ?? false)
+                    }
+                  >
+                    <span className={styles.optionLabel}>{opt.label}</span>
+                    {opt.description && (
+                      <span className={styles.optionDesc}>{opt.description}</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {!isSingleQuestion && hasSelections && (
+        <button className={styles.confirmBtn} onClick={handleSubmitSelections}>
+          Submit answers
+        </button>
+      )}
+
+      <div className={styles.divider}>Or type your response below</div>
+
+      <div className={styles.freeformRow}>
+        <textarea
+          className={styles.freeformInput}
+          value={freeform}
+          onChange={(e) => setFreeform(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSubmitFreeform();
+            }
+          }}
+          placeholder="Type a response..."
+          rows={1}
+        />
+        <button
+          className={styles.submitBtn}
+          onClick={handleSubmitFreeform}
+          disabled={!freeform.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -10,6 +10,7 @@ import {
   setAppSetting,
 } from "../../services/tauri";
 import { useAgentStream } from "../../hooks/useAgentStream";
+import { AgentQuestionCard } from "./AgentQuestionCard";
 import styles from "./ChatPanel.module.css";
 
 export function ChatPanel() {
@@ -54,7 +55,11 @@ export function ChatPanel() {
       : "readonly"
   );
   const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
+  const agentQuestion = useAppStore((s) => s.agentQuestion);
+  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
   const isRunning = ws?.agent_status === "Running";
+  const pendingQuestion =
+    agentQuestion?.workspaceId === selectedWorkspaceId ? agentQuestion : null;
 
   // Load persisted permission level when workspace changes.
   useEffect(() => {
@@ -98,8 +103,8 @@ export function ChatPanel() {
 
   if (!ws) return null;
 
-  const handleSend = async () => {
-    const content = chatInput.trim();
+  const handleSend = async (messageOverride?: string) => {
+    const content = (messageOverride ?? chatInput).trim();
     if (!content || !selectedWorkspaceId) return;
 
     setError(null);
@@ -305,8 +310,18 @@ export function ChatPanel() {
               </div>
             )}
 
-            {isRunning && !streaming && (
+            {isRunning && !streaming && !pendingQuestion && (
               <div className={styles.processing}>Processing...</div>
+            )}
+
+            {pendingQuestion && (
+              <AgentQuestionCard
+                question={pendingQuestion}
+                onRespond={(response) => {
+                  setAgentQuestion(null);
+                  handleSend(response);
+                }}
+              />
             )}
           </>
         )}
@@ -324,7 +339,7 @@ export function ChatPanel() {
         />
         <button
           className={styles.sendBtn}
-          onClick={handleSend}
+          onClick={() => handleSend()}
           disabled={!chatInput.trim()}
         >
           Send

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -1,7 +1,63 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
+import type { AgentQuestionItem } from "../stores/useAppStore";
 import type { AgentStreamPayload } from "../types/agent-events";
+
+const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
+
+/**
+ * Parse AskUserQuestion tool input JSON into question items.
+ * Supports two formats:
+ * - Single: { question: "...", options: [...] }
+ * - Multi:  { questions: [{ header?, question, options, multiSelect? }] }
+ *
+ * Options can be strings or objects with label/description fields.
+ */
+function parseAskUserQuestion(
+  parsed: Record<string, unknown>
+): AgentQuestionItem[] {
+  // Multi-question format
+  if (Array.isArray(parsed.questions)) {
+    return parsed.questions.map((q: Record<string, unknown>) => ({
+      header: typeof q.header === "string" ? q.header : undefined,
+      question: typeof q.question === "string" ? q.question : "",
+      options: parseOptions(q.options),
+      multiSelect: q.multiSelect === true,
+    }));
+  }
+
+  // Single-question format
+  if (typeof parsed.question === "string") {
+    return [
+      {
+        question: parsed.question,
+        options: parseOptions(parsed.options),
+        multiSelect: false,
+      },
+    ];
+  }
+
+  return [];
+}
+
+function parseOptions(
+  raw: unknown
+): Array<{ label: string; description?: string }> {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((opt: unknown) => {
+    if (typeof opt === "string") return { label: opt };
+    if (typeof opt === "object" && opt !== null) {
+      const o = opt as Record<string, unknown>;
+      return {
+        label: typeof o.label === "string" ? o.label : String(o.label ?? ""),
+        description:
+          typeof o.description === "string" ? o.description : undefined,
+      };
+    }
+    return { label: String(opt) };
+  });
+}
 
 export function useAgentStream() {
   const appendStreamingContent = useAppStore((s) => s.appendStreamingContent);
@@ -9,7 +65,17 @@ export function useAgentStream() {
   const addChatMessage = useAppStore((s) => s.addChatMessage);
   const addToolActivity = useAppStore((s) => s.addToolActivity);
   const updateToolActivity = useAppStore((s) => s.updateToolActivity);
+  const appendToolActivityInput = useAppStore(
+    (s) => s.appendToolActivityInput
+  );
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
+  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
+
+  // Map content block index → { toolUseId, toolName } for the current turn.
+  // Reset on process exit.
+  const blockToolMapRef = useRef<
+    Record<number, { toolUseId: string; toolName: string }>
+  >({});
 
   useEffect(() => {
     const unlisten = listen<AgentStreamPayload>("agent-stream", (event) => {
@@ -18,6 +84,12 @@ export function useAgentStream() {
       if ("ProcessExited" in agentEvent) {
         updateWorkspace(wsId, { agent_status: "Idle" });
         setStreamingContent(wsId, "");
+        blockToolMapRef.current = {};
+        // Clear pending question for this workspace
+        const currentQuestion = useAppStore.getState().agentQuestion;
+        if (currentQuestion?.workspaceId === wsId) {
+          setAgentQuestion(null);
+        }
         return;
       }
 
@@ -41,7 +113,28 @@ export function useAgentStream() {
                     delta.type === "input_json_delta" &&
                     delta.partial_json
                   ) {
-                    // Append to the last tool activity's input
+                    const entry = blockToolMapRef.current[inner.index];
+                    if (entry) {
+                      appendToolActivityInput(
+                        wsId,
+                        entry.toolUseId,
+                        delta.partial_json
+                      );
+                    }
+                  }
+                  if (
+                    "type" in delta &&
+                    delta.type === "tool_use_delta" &&
+                    delta.partial_json
+                  ) {
+                    const entry = blockToolMapRef.current[inner.index];
+                    if (entry) {
+                      appendToolActivityInput(
+                        wsId,
+                        entry.toolUseId,
+                        delta.partial_json
+                      );
+                    }
                   }
                   break;
                 }
@@ -51,6 +144,10 @@ export function useAgentStream() {
                     "type" in inner.content_block &&
                     inner.content_block.type === "tool_use"
                   ) {
+                    blockToolMapRef.current[inner.index] = {
+                      toolUseId: inner.content_block.id,
+                      toolName: inner.content_block.name,
+                    };
                     addToolActivity(wsId, {
                       toolUseId: inner.content_block.id,
                       toolName: inner.content_block.name,
@@ -58,6 +155,33 @@ export function useAgentStream() {
                       resultText: "",
                       collapsed: true,
                     });
+                  }
+                  break;
+                }
+                case "content_block_stop": {
+                  const entry = blockToolMapRef.current[inner.index];
+                  if (entry?.toolName === ASK_USER_QUESTION_TOOL) {
+                    // Read accumulated input JSON from the tool activity
+                    const activities =
+                      useAppStore.getState().toolActivities[wsId] || [];
+                    const activity = activities.find(
+                      (a) => a.toolUseId === entry.toolUseId
+                    );
+                    if (activity?.inputJson) {
+                      try {
+                        const parsed = JSON.parse(activity.inputJson);
+                        const questions = parseAskUserQuestion(parsed);
+                        if (questions.length > 0) {
+                          setAgentQuestion({
+                            workspaceId: wsId,
+                            toolUseId: entry.toolUseId,
+                            questions,
+                          });
+                        }
+                      } catch {
+                        // Malformed JSON — ignore, question won't show
+                      }
+                    }
                   }
                   break;
                 }
@@ -119,6 +243,8 @@ export function useAgentStream() {
     addChatMessage,
     addToolActivity,
     updateToolActivity,
+    appendToolActivityInput,
     updateWorkspace,
+    setAgentQuestion,
   ]);
 }

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -19,6 +19,19 @@ export interface ToolActivity {
   collapsed: boolean;
 }
 
+export interface AgentQuestionItem {
+  header?: string;
+  question: string;
+  options: Array<{ label: string; description?: string }>;
+  multiSelect?: boolean;
+}
+
+export interface AgentQuestion {
+  workspaceId: string;
+  toolUseId: string;
+  questions: AgentQuestionItem[];
+}
+
 interface AppState {
   // -- Repositories --
   repositories: Repository[];
@@ -54,6 +67,15 @@ interface AppState {
     updates: Partial<ToolActivity>
   ) => void;
   toggleToolActivityCollapsed: (wsId: string, index: number) => void;
+  appendToolActivityInput: (
+    wsId: string,
+    toolUseId: string,
+    partialJson: string
+  ) => void;
+
+  // -- Agent Questions --
+  agentQuestion: AgentQuestion | null;
+  setAgentQuestion: (q: AgentQuestion | null) => void;
 
   // -- Permissions --
   permissionLevel: Record<string, PermissionLevel>;
@@ -209,6 +231,21 @@ export const useAppStore = create<AppState>((set) => ({
         ),
       },
     })),
+  appendToolActivityInput: (wsId, toolUseId, partialJson) =>
+    set((s) => ({
+      toolActivities: {
+        ...s.toolActivities,
+        [wsId]: (s.toolActivities[wsId] || []).map((a) =>
+          a.toolUseId === toolUseId
+            ? { ...a, inputJson: a.inputJson + partialJson }
+            : a
+        ),
+      },
+    })),
+
+  // -- Agent Questions --
+  agentQuestion: null,
+  setAgentQuestion: (q) => set({ agentQuestion: q }),
 
   // -- Permissions --
   permissionLevel: {},


### PR DESCRIPTION
## Summary
- Detects `AskUserQuestion` tool invocations in the agent stream and renders them as interactive option cards instead of raw text output
- Supports single-question (click to respond immediately) and multi-question formats with optional headers, multi-select, and a free-form text fallback
- Adds `appendToolActivityInput` to the Zustand store to accumulate streamed JSON input for tool blocks, enabling parsing at `content_block_stop`
- Restores the question popup UX from the pre-Tauri Iced version

## Test plan
- [ ] Start an agent session and trigger a prompt that causes Claude to call `AskUserQuestion`
- [ ] Verify single-question mode: clicking an option sends the response immediately
- [ ] Verify multi-question mode: selections accumulate, "Submit answers" button sends all
- [ ] Verify free-form text input works as an alternative to clicking options
- [ ] Verify question card clears on process exit