### PR TITLE
feat: add sidebar/terminal resize + workspace actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +201,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -339,10 +366,20 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -443,6 +480,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -773,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +838,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "fdeflate"
@@ -825,6 +894,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1107,6 +1182,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,7 +1581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1600,6 +1696,20 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2005,6 +2115,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,7 +2139,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2082,6 +2202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2267,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2334,6 +2464,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
 
 [[package]]
 name = "phf"
@@ -2548,7 +2689,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2560,6 +2701,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2696,10 +2850,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -3738,7 +3913,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -3783,6 +3958,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4027,6 +4217,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4295,10 +4499,21 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -4621,6 +4836,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,6 +5006,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5279,6 +5570,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5348,6 +5657,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "yoke"
@@ -5451,3 +5777,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,6 +8,7 @@ claudette = { path = ".." }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "time", "process"] }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -176,7 +176,9 @@ pub async fn open_workspace_in_terminal(worktree_path: String) -> Result<(), Str
     #[cfg(target_os = "linux")]
     {
         // Try common Linux terminal emulators
-        let xterm_cmd = format!("cd '{}' && exec bash", worktree_path);
+        // For xterm: escape single quotes by replacing ' with '\''
+        let xterm_escaped = worktree_path.replace('\'', r"'\''");
+        let xterm_cmd = format!("cd '{}' && exec bash", xterm_escaped);
         let terminals: Vec<(&str, Vec<&str>)> = vec![
             (
                 "gnome-terminal",
@@ -220,12 +222,15 @@ pub async fn open_workspace_in_terminal(worktree_path: String) -> Result<(), Str
     #[cfg(target_os = "macos")]
     {
         // Use AppleScript to open Terminal.app
+        // Escape both single quotes and backslashes for AppleScript string within shell command
+        let escaped = worktree_path.replace('\\', r"\\").replace('\'', r"'\''");
+
         let script = format!(
             r#"tell application "Terminal"
                 activate
-                do script "cd '{}'"
+                do script "cd '{}'; exec bash"
             end tell"#,
-            worktree_path.replace('\'', "'\\''")
+            escaped
         );
 
         tokio::process::Command::new("osascript")

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -169,6 +169,80 @@ pub async fn refresh_branches(state: State<'_, AppState>) -> Result<Vec<(String,
     Ok(updates)
 }
 
+#[tauri::command]
+pub async fn open_workspace_in_terminal(worktree_path: String) -> Result<(), String> {
+    eprintln!("Opening terminal for path: {}", worktree_path);
+
+    #[cfg(target_os = "linux")]
+    {
+        // Try common Linux terminal emulators
+        let xterm_cmd = format!("cd '{}' && exec bash", worktree_path);
+        let terminals: Vec<(&str, Vec<&str>)> = vec![
+            (
+                "gnome-terminal",
+                vec!["--working-directory", &worktree_path],
+            ),
+            ("konsole", vec!["--workdir", &worktree_path]),
+            (
+                "xfce4-terminal",
+                vec!["--working-directory", &worktree_path],
+            ),
+            ("xterm", vec!["-e", "bash", "-c", &xterm_cmd]),
+            ("alacritty", vec!["--working-directory", &worktree_path]),
+            ("kitty", vec!["--directory", &worktree_path]),
+        ];
+
+        let mut errors = Vec::new();
+        for (terminal, args) in &terminals {
+            let mut cmd = tokio::process::Command::new(terminal);
+            for arg in args {
+                cmd.arg(arg);
+            }
+
+            match cmd.spawn() {
+                Ok(_) => {
+                    eprintln!("Successfully launched {} with args: {:?}", terminal, args);
+                    return Ok(());
+                }
+                Err(e) => {
+                    eprintln!("Failed to launch {}: {}", terminal, e);
+                    errors.push(format!("{}: {}", terminal, e));
+                }
+            }
+        }
+
+        Err(format!(
+            "No terminal emulator found. Tried: {}",
+            errors.join(", ")
+        ))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // Use AppleScript to open Terminal.app
+        let script = format!(
+            r#"tell application "Terminal"
+                activate
+                do script "cd '{}'"
+            end tell"#,
+            worktree_path.replace('\'', "'\\''")
+        );
+
+        tokio::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .spawn()
+            .map_err(|e| format!("Failed to open terminal: {}", e))?;
+
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err("Unsupported platform".to_string())
+    }
+}
+
 fn now_iso() -> String {
     let dur = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             // Data
@@ -57,6 +58,7 @@ fn main() {
             commands::workspace::delete_workspace,
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
+            commands::workspace::open_workspace_in_terminal,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::send_chat_message,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,21 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "capabilities": [
+        {
+          "identifier": "main-capability",
+          "description": "Main application permissions",
+          "windows": ["main"],
+          "permissions": [
+            "core:default",
+            "dialog:default",
+            "shell:default",
+            "clipboard-manager:allow-write-text",
+            "clipboard-manager:allow-read-text"
+          ]
+        }
+      ]
     }
   },
   "bundle": {

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,10 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ui",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -145,6 +147,8 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.6.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../services/tauri";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { AgentQuestionCard } from "./AgentQuestionCard";
+import { WorkspaceActions } from "./WorkspaceActions";
 import styles from "./ChatPanel.module.css";
 
 export function ChatPanel() {
@@ -201,6 +202,10 @@ export function ChatPanel() {
           {repo && <span className={styles.repoName}>{repo.name}</span>}
         </div>
         <div className={styles.headerRight}>
+          <WorkspaceActions
+            worktreePath={ws.worktree_path}
+            disabled={isRunning}
+          />
           <select
             className={styles.permissionSelect}
             value={permissionLevel}

--- a/src/ui/src/components/chat/WorkspaceActions.module.css
+++ b/src/ui/src/components/chat/WorkspaceActions.module.css
@@ -1,0 +1,23 @@
+.select {
+  appearance: none;
+  background: var(--chat-input-bg)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23808089'/%3E%3C/svg%3E")
+    no-repeat right 6px center;
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  color: var(--text-muted);
+  color-scheme: dark;
+  font-size: 11px;
+  padding: 2px 20px 2px 6px;
+  cursor: pointer;
+  outline: none;
+}
+
+.select:hover:not(:disabled) {
+  border-color: var(--text-dim);
+}
+
+.select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/ui/src/components/chat/WorkspaceActions.tsx
+++ b/src/ui/src/components/chat/WorkspaceActions.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { openWorkspaceInTerminal } from "../../services/tauri";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import styles from "./WorkspaceActions.module.css";
+
+interface WorkspaceActionsProps {
+  worktreePath: string | null;
+  disabled?: boolean;
+}
+
+export function WorkspaceActions({
+  worktreePath,
+  disabled = false,
+}: WorkspaceActionsProps) {
+  const [value, setValue] = useState("");
+
+  const handleAction = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const action = e.target.value;
+    setValue(""); // Reset to placeholder
+
+    if (!worktreePath) {
+      console.error("No worktree path available");
+      return;
+    }
+
+    switch (action) {
+      case "open-terminal":
+        try {
+          await openWorkspaceInTerminal(worktreePath);
+        } catch (err) {
+          console.error("Failed to open terminal:", err);
+          alert(`Failed to open terminal: ${err}`);
+        }
+        break;
+      case "copy-path":
+        try {
+          await writeText(worktreePath);
+          console.log("Path copied:", worktreePath);
+        } catch (err) {
+          console.error("Failed to copy path:", err);
+          alert(`Failed to copy path: ${err}`);
+        }
+        break;
+    }
+  };
+
+  return (
+    <select
+      className={styles.select}
+      onChange={handleAction}
+      disabled={disabled || !worktreePath}
+      title="Workspace actions"
+      aria-label="Workspace actions"
+      value={value}
+    >
+      <option value="" disabled>
+        Actions
+      </option>
+      <option value="open-terminal">Open in Terminal</option>
+      <option value="copy-path">Copy Path</option>
+    </select>
+  );
+}

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -57,8 +57,6 @@ export function AppLayout() {
             <ResizeHandle
               direction="horizontal"
               onResize={handleLeftResize}
-              minSize={150}
-              maxSize={600}
             />
           </>
         )}
@@ -81,8 +79,6 @@ export function AppLayout() {
               <ResizeHandle
                 direction="vertical"
                 onResize={handleTerminalResize}
-                minSize={100}
-                maxSize={800}
               />
               <div
                 className={styles.terminal}
@@ -98,8 +94,6 @@ export function AppLayout() {
             <ResizeHandle
               direction="horizontal"
               onResize={handleRightResize}
-              minSize={150}
-              maxSize={600}
             />
             <div
               className={styles.rightSidebar}

--- a/src/ui/src/components/layout/ResizeHandle.tsx
+++ b/src/ui/src/components/layout/ResizeHandle.tsx
@@ -11,12 +11,9 @@ interface ResizeHandleProps {
 export function ResizeHandle({
   direction,
   onResize,
-  minSize = 150,
-  maxSize = 600,
 }: ResizeHandleProps) {
   const isDraggingRef = useRef(false);
   const startPosRef = useRef(0);
-  const startSizeRef = useRef(0);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -52,7 +49,7 @@ export function ResizeHandle({
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [direction, onResize, minSize, maxSize]);
+  }, [direction, onResize]);
 
   return (
     <div

--- a/src/ui/src/components/layout/ResizeHandle.tsx
+++ b/src/ui/src/components/layout/ResizeHandle.tsx
@@ -4,8 +4,6 @@ import styles from "./ResizeHandle.module.css";
 interface ResizeHandleProps {
   direction: "horizontal" | "vertical";
   onResize: (delta: number) => void;
-  minSize?: number;
-  maxSize?: number;
 }
 
 export function ResizeHandle({

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -71,6 +71,10 @@ export function refreshBranches(): Promise<[string, string][]> {
   return invoke("refresh_branches");
 }
 
+export function openWorkspaceInTerminal(worktreePath: string): Promise<void> {
+  return invoke("open_workspace_in_terminal", { worktreePath });
+}
+
 // -- Chat --
 
 export function loadChatHistory(workspaceId: string): Promise<ChatMessage[]> {


### PR DESCRIPTION
## Summary
- Added resizable sidebars (left, right) and terminal panel
- Added workspace actions dropdown for opening workspace in terminal or copying path to clipboard

## Changes

### Resize Functionality
- Created reusable `ResizeHandle` component for horizontal and vertical resizing
- Added resize handles to left sidebar, right sidebar, and terminal panel
- Min/max constraints: 150-600px for sidebars, 100-800px for terminal
- Visual feedback with cursor changes and accent color on hover

### Workspace Actions
- Added `WorkspaceActions` dropdown in ChatPanel header (next to permissions selector)
- **Open in Terminal**: Opens workspace directory in system default terminal
  - Linux: Supports gnome-terminal, konsole, xfce4-terminal, xterm, alacritty, kitty
  - macOS: Uses AppleScript to open Terminal.app
- **Copy Path**: Copies worktree path to clipboard using Tauri clipboard plugin

### Implementation Details
- Added `tauri-plugin-clipboard-manager` for reliable clipboard access
- Added clipboard permissions to Tauri capabilities
- Improved terminal launcher error handling with detailed logging
- Matched styling for workspace actions to existing permission selector

## Test Plan
- [x] Resize left sidebar (repos/workspaces)
- [x] Resize right sidebar (changed files)
- [x] Resize terminal panel height
- [x] Open workspace in terminal (Linux verified)
- [x] Copy workspace path to clipboard (with permissions)
- [x] TypeScript strict checks pass
- [x] Rust clippy with zero warnings
- [x] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)