### PR TITLE
feat: tool call summaries and rollup

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -134,7 +134,9 @@ pub async fn send_chat_message(
         let mut got_init = false;
         while let Some(event) = rx.recv().await {
             // Track whether the CLI initialized successfully.
-            if let AgentEvent::Stream(StreamEvent::System { .. }) = &event {
+            if let AgentEvent::Stream(StreamEvent::System { subtype, .. }) = &event
+                && subtype == "init"
+            {
                 got_init = true;
             }
 
@@ -187,7 +189,7 @@ pub async fn send_chat_message(
                 && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
                 && let Ok(db) = Database::open(&db_path)
                 && let Ok(msgs) = db.list_chat_messages(&ws_id)
-                && let Some(last) = msgs.last()
+                && let Some(last) = msgs.iter().rfind(|m| m.role == ChatRole::Assistant)
             {
                 let _ = db.update_chat_message_cost(&last.id, *cost, *dur);
             }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::{self, AgentEvent, StreamEvent};
 use claudette::db::Database;
@@ -131,7 +131,22 @@ pub async fn send_chat_message(
     let db_path = state.db_path.clone();
     tokio::spawn(async move {
         let mut rx = turn_handle.event_rx;
+        let mut got_init = false;
         while let Some(event) = rx.recv().await {
+            // Track whether the CLI initialized successfully.
+            if let AgentEvent::Stream(StreamEvent::System { .. }) = &event {
+                got_init = true;
+            }
+
+            // If the process exits without ever initializing, reset the session
+            // so the next attempt starts fresh instead of trying --resume.
+            if let AgentEvent::ProcessExited(code) = &event
+                && (!got_init || *code != Some(0))
+            {
+                let app_state = app.state::<AppState>();
+                let mut agents = app_state.agents.write().await;
+                agents.remove(&ws_id);
+            }
             // Persist assistant messages to DB on completion.
             if let AgentEvent::Stream(StreamEvent::Assistant { ref message }) = event {
                 let full_text: String = message
@@ -147,7 +162,9 @@ pub async fn send_chat_message(
                     .collect::<Vec<_>>()
                     .join("");
 
-                if let Ok(db) = Database::open(&db_path) {
+                if !full_text.trim().is_empty()
+                    && let Ok(db) = Database::open(&db_path)
+                {
                     let msg = ChatMessage {
                         id: uuid::Uuid::new_v4().to_string(),
                         workspace_id: ws_id.clone(),

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -208,6 +208,53 @@
   gap: 4px;
 }
 
+.turnSummary {
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 4px;
+}
+
+.turnHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  text-align: left;
+}
+
+.turnHeader:hover {
+  background: var(--hover-bg);
+}
+
+.turnLabel {
+  color: var(--text-dim);
+}
+
+.turnActivities {
+  border-top: 1px solid var(--divider);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.turnActivities .toolActivity {
+  border: none;
+  border-radius: 0;
+}
+
+.turnActivities .toolHeader {
+  padding: 2px 8px;
+  cursor: default;
+}
+
 .toolActivity {
   border: 1px solid var(--divider);
   border-radius: 4px;
@@ -240,6 +287,21 @@
 .toolName {
   font-weight: 500;
   color: var(--text-primary);
+  flex-shrink: 0;
+}
+
+.toolSummary {
+  color: var(--text-dim);
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.toolSummary::before {
+  content: "— ";
+  color: var(--text-faint);
 }
 
 .toolContent {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -210,31 +210,27 @@
 
 .turnSummary {
   border: 1px solid var(--divider);
-  border-radius: 4px;
-  overflow: hidden;
-  margin-bottom: 4px;
+  border-radius: 6px;
+  margin: 4px 0;
+  cursor: pointer;
 }
 
 .turnHeader {
   display: flex;
   align-items: center;
   gap: 6px;
-  width: 100%;
-  padding: 6px 8px;
-  background: rgba(255, 255, 255, 0.03);
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.04);
   font-size: 12px;
-  text-align: left;
 }
 
-.turnHeader:hover {
+.turnSummary:hover > .turnHeader {
   background: var(--hover-bg);
 }
 
 .turnLabel {
-  color: var(--text-dim);
+  color: var(--text-primary);
+  font-weight: 500;
 }
 
 .turnActivities {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -291,10 +291,19 @@ export function ChatPanel() {
               <div
                 key={turn.id}
                 className={styles.turnSummary}
+                role="button"
+                tabIndex={0}
                 onClick={() =>
                   selectedWorkspaceId &&
                   toggleCompletedTurn(selectedWorkspaceId, ti)
                 }
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    selectedWorkspaceId &&
+                      toggleCompletedTurn(selectedWorkspaceId, ti);
+                  }
+                }}
               >
                 <div className={styles.turnHeader}>
                   <span className={styles.toolChevron}>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -47,15 +47,19 @@ export function ChatPanel() {
   const streaming = selectedWorkspaceId
     ? streamingContent[selectedWorkspaceId] || ""
     : "";
+  const completedTurnsMap = useAppStore((s) => s.completedTurns);
+  const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
+  const completedTurns = selectedWorkspaceId
+    ? completedTurnsMap[selectedWorkspaceId] ?? []
+    : [];
   const activities = selectedWorkspaceId
     ? toolActivities[selectedWorkspaceId] || []
     : [];
-  const permissionLevel = useAppStore((s) =>
-    selectedWorkspaceId
-      ? s.permissionLevel[selectedWorkspaceId] || "full"
-      : "readonly"
-  );
+  const permissionLevelMap = useAppStore((s) => s.permissionLevel);
   const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
+  const permissionLevel = selectedWorkspaceId
+    ? permissionLevelMap[selectedWorkspaceId] ?? "full"
+    : "full";
   const agentQuestion = useAppStore((s) => s.agentQuestion);
   const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
   const isRunning = ws?.agent_status === "Running";
@@ -279,6 +283,49 @@ export function ChatPanel() {
               </div>
             ))}
 
+            {completedTurns.map((turn, ti) => (
+              <div key={turn.id} className={styles.turnSummary}>
+                <button
+                  className={styles.turnHeader}
+                  onClick={() =>
+                    selectedWorkspaceId &&
+                    toggleCompletedTurn(selectedWorkspaceId, ti)
+                  }
+                >
+                  <span className={styles.toolChevron}>
+                    {turn.collapsed ? ">" : "v"}
+                  </span>
+                  <span className={styles.turnLabel}>
+                    {turn.activities.length} tool call
+                    {turn.activities.length !== 1 ? "s" : ""}
+                    {turn.messageCount > 0 &&
+                      `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
+                  </span>
+                </button>
+                {!turn.collapsed && (
+                  <div className={styles.turnActivities}>
+                    {turn.activities.map((act) => (
+                      <div
+                        key={act.toolUseId}
+                        className={styles.toolActivity}
+                      >
+                        <div className={styles.toolHeader}>
+                          <span className={styles.toolName}>
+                            {act.toolName}
+                          </span>
+                          {act.summary && (
+                            <span className={styles.toolSummary}>
+                              {act.summary}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+
             {activities.length > 0 && (
               <div className={styles.toolActivities}>
                 {activities.map((act, i) => (
@@ -294,6 +341,11 @@ export function ChatPanel() {
                         {act.collapsed ? ">" : "v"}
                       </span>
                       <span className={styles.toolName}>{act.toolName}</span>
+                      {act.summary && (
+                        <span className={styles.toolSummary}>
+                          {act.summary}
+                        </span>
+                      )}
                     </button>
                     {!act.collapsed && (
                       <pre className={styles.toolContent}>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -93,8 +93,12 @@ export function ChatPanel() {
     draftRef.current = "";
     loadChatHistory(selectedWorkspaceId)
       .then((msgs) => {
-        setChatMessages(selectedWorkspaceId, msgs);
-        historyRef.current[selectedWorkspaceId] = msgs
+        // Filter out empty assistant messages (legacy data).
+        const filtered = msgs.filter(
+          (m) => m.role !== "Assistant" || m.content.trim() !== ""
+        );
+        setChatMessages(selectedWorkspaceId, filtered);
+        historyRef.current[selectedWorkspaceId] = filtered
           .filter((m) => m.role === "User")
           .map((m) => m.content);
       })
@@ -284,16 +288,17 @@ export function ChatPanel() {
             ))}
 
             {completedTurns.map((turn, ti) => (
-              <div key={turn.id} className={styles.turnSummary}>
-                <button
-                  className={styles.turnHeader}
-                  onClick={() =>
-                    selectedWorkspaceId &&
-                    toggleCompletedTurn(selectedWorkspaceId, ti)
-                  }
-                >
+              <div
+                key={turn.id}
+                className={styles.turnSummary}
+                onClick={() =>
+                  selectedWorkspaceId &&
+                  toggleCompletedTurn(selectedWorkspaceId, ti)
+                }
+              >
+                <div className={styles.turnHeader}>
                   <span className={styles.toolChevron}>
-                    {turn.collapsed ? ">" : "v"}
+                    {turn.collapsed ? "›" : "⌄"}
                   </span>
                   <span className={styles.turnLabel}>
                     {turn.activities.length} tool call
@@ -301,7 +306,7 @@ export function ChatPanel() {
                     {turn.messageCount > 0 &&
                       `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
                   </span>
-                </button>
+                </div>
                 {!turn.collapsed && (
                   <div className={styles.turnActivities}>
                     {turn.activities.map((act) => (

--- a/src/ui/src/components/layout/ErrorBoundary.tsx
+++ b/src/ui/src/components/layout/ErrorBoundary.tsx
@@ -65,6 +65,8 @@ export class ErrorBoundary extends Component<Props, State> {
               cursor: "pointer",
             }}
           >
+            {/* Only useful for transient render errors. If the error is caused
+                by corrupted store state, the same crash will recur immediately. */}
             Try Again
           </button>
         </div>

--- a/src/ui/src/components/layout/ErrorBoundary.tsx
+++ b/src/ui/src/components/layout/ErrorBoundary.tsx
@@ -1,0 +1,76 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("React error boundary caught:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            padding: 24,
+            color: "#e6e6eb",
+            background: "#121216",
+            height: "100%",
+            fontFamily: "monospace",
+            fontSize: 13,
+          }}
+        >
+          <h2 style={{ color: "#cc3333", marginBottom: 12 }}>
+            Something went wrong
+          </h2>
+          <pre style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+            {this.state.error.message}
+          </pre>
+          <pre
+            style={{
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              color: "#808089",
+              marginTop: 12,
+              fontSize: 11,
+            }}
+          >
+            {this.state.error.stack}
+          </pre>
+          <button
+            onClick={() => this.setState({ error: null })}
+            style={{
+              marginTop: 16,
+              padding: "6px 16px",
+              background: "rgba(255,255,255,0.1)",
+              border: "1px solid #333",
+              color: "#e6e6eb",
+              borderRadius: 4,
+              cursor: "pointer",
+            }}
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/ui/src/hooks/toolSummary.ts
+++ b/src/ui/src/hooks/toolSummary.ts
@@ -1,0 +1,56 @@
+/** Extract a short human-readable summary from a tool's input JSON. */
+export function extractToolSummary(
+  toolName: string,
+  inputJson: string
+): string {
+  try {
+    const input = JSON.parse(inputJson);
+
+    switch (toolName) {
+      case "Bash":
+        return truncate(input.command ?? input.description ?? "", 80);
+      case "Read":
+        return input.file_path ?? "";
+      case "Edit":
+        return input.file_path ?? "";
+      case "Write":
+        return input.file_path ?? "";
+      case "Glob":
+        return input.pattern ?? "";
+      case "Grep":
+        return input.pattern
+          ? `${input.pattern}${input.path ? ` in ${input.path}` : ""}`
+          : "";
+      case "WebFetch":
+        return input.url ?? "";
+      case "WebSearch":
+        return input.query ?? "";
+      case "NotebookEdit":
+        return input.notebook_path ?? "";
+      case "LSP":
+        return input.action ?? "";
+      case "TodoWrite":
+        return input.todos
+          ? `${(input.todos as unknown[]).length} items`
+          : "";
+      default:
+        // For unknown tools, try common field names.
+        return truncate(
+          input.command ??
+            input.file_path ??
+            input.path ??
+            input.query ??
+            input.url ??
+            "",
+          80
+        );
+    }
+  } catch {
+    return "";
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + "...";
+}

--- a/src/ui/src/hooks/toolSummary.ts
+++ b/src/ui/src/hooks/toolSummary.ts
@@ -19,7 +19,7 @@ export function extractToolSummary(
         return input.pattern ?? "";
       case "Grep":
         return input.pattern
-          ? `${input.pattern}${input.path ? ` in ${input.path}` : ""}`
+          ? truncate(`${input.pattern}${input.path ? ` in ${input.path}` : ""}`, 80)
           : "";
       case "WebFetch":
         return input.url ?? "";
@@ -30,8 +30,8 @@ export function extractToolSummary(
       case "LSP":
         return input.action ?? "";
       case "TodoWrite":
-        return input.todos
-          ? `${(input.todos as unknown[]).length} items`
+        return Array.isArray(input.todos)
+          ? `${input.todos.length} items`
           : "";
       default:
         // For unknown tools, try common field names.
@@ -52,5 +52,6 @@ export function extractToolSummary(
 
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
-  return s.slice(0, max) + "...";
+  if (max <= 3) return s.slice(0, max);
+  return s.slice(0, max - 3) + "...";
 }

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -214,9 +214,6 @@ export function useAgentStream() {
           }
           case "assistant": {
             // Full message received — it's already persisted by the backend.
-            turnMessageCountRef.current[wsId] =
-              (turnMessageCountRef.current[wsId] || 0) + 1;
-            // Build display text from content blocks.
             const text = streamEvent.message.content
               .filter(
                 (b): b is { type: "text"; text: string } => b.type === "text"
@@ -224,6 +221,8 @@ export function useAgentStream() {
               .map((b) => b.text)
               .join("");
             if (text) {
+              turnMessageCountRef.current[wsId] =
+                (turnMessageCountRef.current[wsId] || 0) + 1;
               addChatMessage(wsId, {
                 id: crypto.randomUUID(),
                 workspace_id: wsId,

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
 import type { AgentQuestionItem } from "../stores/useAppStore";
 import type { AgentStreamPayload } from "../types/agent-events";
+import { extractToolSummary } from "./toolSummary";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 
@@ -70,18 +71,23 @@ export function useAgentStream() {
   );
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
+  const finalizeTurn = useAppStore((s) => s.finalizeTurn);
 
   // Map content block index → { toolUseId, toolName } for the current turn.
   // Reset on process exit.
   const blockToolMapRef = useRef<
     Record<number, { toolUseId: string; toolName: string }>
   >({});
+  // Count assistant messages in the current turn for the summary.
+  const turnMessageCountRef = useRef<Record<string, number>>({});
 
   useEffect(() => {
     const unlisten = listen<AgentStreamPayload>("agent-stream", (event) => {
       const { workspace_id: wsId, event: agentEvent } = event.payload;
 
       if ("ProcessExited" in agentEvent) {
+        finalizeTurn(wsId, turnMessageCountRef.current[wsId] || 0);
+        turnMessageCountRef.current[wsId] = 0;
         updateWorkspace(wsId, { agent_status: "Idle" });
         setStreamingContent(wsId, "");
         blockToolMapRef.current = {};
@@ -154,33 +160,50 @@ export function useAgentStream() {
                       inputJson: "",
                       resultText: "",
                       collapsed: true,
+                      summary: "",
                     });
                   }
                   break;
                 }
                 case "content_block_stop": {
                   const entry = blockToolMapRef.current[inner.index];
-                  if (entry?.toolName === ASK_USER_QUESTION_TOOL) {
-                    // Read accumulated input JSON from the tool activity
-                    const activities =
-                      useAppStore.getState().toolActivities[wsId] || [];
-                    const activity = activities.find(
-                      (a) => a.toolUseId === entry.toolUseId
+                  if (!entry) break;
+
+                  // Read accumulated input JSON from the tool activity.
+                  const activities =
+                    useAppStore.getState().toolActivities[wsId] || [];
+                  const activity = activities.find(
+                    (a) => a.toolUseId === entry.toolUseId
+                  );
+
+                  // Extract a one-line summary from the tool input.
+                  if (activity?.inputJson) {
+                    const summary = extractToolSummary(
+                      entry.toolName,
+                      activity.inputJson
                     );
-                    if (activity?.inputJson) {
-                      try {
-                        const parsed = JSON.parse(activity.inputJson);
-                        const questions = parseAskUserQuestion(parsed);
-                        if (questions.length > 0) {
-                          setAgentQuestion({
-                            workspaceId: wsId,
-                            toolUseId: entry.toolUseId,
-                            questions,
-                          });
-                        }
-                      } catch {
-                        // Malformed JSON — ignore, question won't show
+                    if (summary) {
+                      updateToolActivity(wsId, entry.toolUseId, { summary });
+                    }
+                  }
+
+                  // Handle AskUserQuestion specifically.
+                  if (
+                    entry.toolName === ASK_USER_QUESTION_TOOL &&
+                    activity?.inputJson
+                  ) {
+                    try {
+                      const parsed = JSON.parse(activity.inputJson);
+                      const questions = parseAskUserQuestion(parsed);
+                      if (questions.length > 0) {
+                        setAgentQuestion({
+                          workspaceId: wsId,
+                          toolUseId: entry.toolUseId,
+                          questions,
+                        });
                       }
+                    } catch {
+                      // Malformed JSON — ignore, question won't show
                     }
                   }
                   break;
@@ -191,6 +214,8 @@ export function useAgentStream() {
           }
           case "assistant": {
             // Full message received — it's already persisted by the backend.
+            turnMessageCountRef.current[wsId] =
+              (turnMessageCountRef.current[wsId] || 0) + 1;
             // Build display text from content blocks.
             const text = streamEvent.message.content
               .filter(
@@ -246,5 +271,6 @@ export function useAgentStream() {
     appendToolActivityInput,
     updateWorkspace,
     setAgentQuestion,
+    finalizeTurn,
   ]);
 }

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -238,6 +238,8 @@ export function useAgentStream() {
             break;
           }
           case "result": {
+            finalizeTurn(wsId, turnMessageCountRef.current[wsId] || 0);
+            turnMessageCountRef.current[wsId] = 0;
             updateWorkspace(wsId, { agent_status: "Idle" });
             break;
           }

--- a/src/ui/src/main.tsx
+++ b/src/ui/src/main.tsx
@@ -1,9 +1,12 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { ErrorBoundary } from "./components/layout/ErrorBoundary";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
+  </StrictMode>
+);

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -17,6 +17,14 @@ export interface ToolActivity {
   inputJson: string;
   resultText: string;
   collapsed: boolean;
+  summary: string;
+}
+
+export interface CompletedTurn {
+  id: string;
+  activities: ToolActivity[];
+  messageCount: number;
+  collapsed: boolean;
 }
 
 export interface AgentQuestionItem {
@@ -54,6 +62,7 @@ interface AppState {
   chatInput: string;
   streamingContent: Record<string, string>;
   toolActivities: Record<string, ToolActivity[]>;
+  completedTurns: Record<string, CompletedTurn[]>;
   setChatMessages: (wsId: string, messages: ChatMessage[]) => void;
   addChatMessage: (wsId: string, message: ChatMessage) => void;
   setChatInput: (input: string) => void;
@@ -67,6 +76,8 @@ interface AppState {
     updates: Partial<ToolActivity>
   ) => void;
   toggleToolActivityCollapsed: (wsId: string, index: number) => void;
+  finalizeTurn: (wsId: string, messageCount: number) => void;
+  toggleCompletedTurn: (wsId: string, turnIndex: number) => void;
   appendToolActivityInput: (
     wsId: string,
     toolUseId: string,
@@ -179,6 +190,7 @@ export const useAppStore = create<AppState>((set) => ({
   chatInput: "",
   streamingContent: {},
   toolActivities: {},
+  completedTurns: {},
   setChatMessages: (wsId, messages) =>
     set((s) => ({
       chatMessages: { ...s.chatMessages, [wsId]: messages },
@@ -239,6 +251,33 @@ export const useAppStore = create<AppState>((set) => ({
           a.toolUseId === toolUseId
             ? { ...a, inputJson: a.inputJson + partialJson }
             : a
+        ),
+      },
+    })),
+  finalizeTurn: (wsId, messageCount) =>
+    set((s) => {
+      const activities = s.toolActivities[wsId] || [];
+      if (activities.length === 0) return {};
+      const turn: CompletedTurn = {
+        id: crypto.randomUUID(),
+        activities: activities.map((a) => ({ ...a, collapsed: true })),
+        messageCount,
+        collapsed: true,
+      };
+      return {
+        completedTurns: {
+          ...s.completedTurns,
+          [wsId]: [...(s.completedTurns[wsId] || []), turn],
+        },
+        toolActivities: { ...s.toolActivities, [wsId]: [] },
+      };
+    }),
+  toggleCompletedTurn: (wsId, turnIndex) =>
+    set((s) => ({
+      completedTurns: {
+        ...s.completedTurns,
+        [wsId]: (s.completedTurns[wsId] || []).map((t, i) =>
+          i === turnIndex ? { ...t, collapsed: !t.collapsed } : t
         ),
       },
     })),

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -260,7 +260,14 @@ export const useAppStore = create<AppState>((set) => ({
       if (activities.length === 0) return {};
       const turn: CompletedTurn = {
         id: crypto.randomUUID(),
-        activities: activities.map((a) => ({ ...a, collapsed: true })),
+        activities: activities.map((a) => ({
+          toolUseId: a.toolUseId,
+          toolName: a.toolName,
+          inputJson: "",
+          resultText: "",
+          collapsed: true,
+          summary: a.summary,
+        })),
         messageCount,
         collapsed: true,
       };


### PR DESCRIPTION
## Summary

- Show inline summaries next to tool names during agent execution (e.g., `Bash — git status`, `Read — src/main.rs`)
- Roll up completed turn tool calls into a collapsible summary showing "N tool calls, M messages"
- Clicking the summary expands to show individual tool calls with their summaries
- Skip persisting empty assistant messages (tool-only turns) to DB
- Filter out empty assistant messages from existing DB data on load
- Add React error boundary to catch and display rendering crashes
- Fix `is_error` field on CLI result events to surface agent errors in chat

## Changes

- **`src/ui/src/hooks/toolSummary.ts`**: New helper that extracts one-line summaries from tool input JSON per tool type (Bash→command, Read→path, Grep→pattern, etc.)
- **`src/ui/src/hooks/useAgentStream.ts`**: Extract summaries at `content_block_stop`, finalize turns on `result` event, track message count per turn
- **`src/ui/src/stores/useAppStore.ts`**: New `CompletedTurn` type, `completedTurns` state, `finalizeTurn`/`toggleCompletedTurn` actions, `summary` field on `ToolActivity`
- **`src/ui/src/components/chat/ChatPanel.tsx`**: Render completed turn summaries, show tool summaries inline, filter empty assistant messages
- **`src-tauri/src/commands/chat.rs`**: Skip persisting empty assistant messages, reset session on failed process exit
- **`src/ui/src/components/layout/ErrorBoundary.tsx`**: New error boundary component
- **`src/ui/src/main.tsx`**: Wrap app in error boundary

## Test plan

- [ ] Send a prompt that uses multiple tools — verify inline summaries appear (e.g., `Read — src/lib.rs`)
- [ ] After turn completes, verify tool calls collapse into "N tool calls, M messages" summary
- [ ] Click the summary to expand and see individual tool calls
- [ ] Verify no blank "Claude" messages appear after tool-only turns
- [ ] Force a rendering error to verify the error boundary catches and displays it