### PR TITLE
feat: setup scripts for workspace creation (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ version = "0.1.0"
 dependencies = [
  "claudette",
  "dirs",
+ "libc",
  "portable-pty",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["sync", "time", "process"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
+libc = "0.2"
 portable-pty = "0.8"
 
 [build-dependencies]

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -130,7 +130,14 @@ pub async fn get_repo_config(
         .find(|r| r.id == repo_id)
         .ok_or("Repository not found")?;
 
-    match config::load_config(Path::new(&repo.path)) {
+    // Run sync file I/O off the async runtime thread.
+    let repo_path = repo.path.clone();
+    let config_result =
+        tokio::task::spawn_blocking(move || config::load_config(Path::new(&repo_path)))
+            .await
+            .map_err(|e| format!("Config load task failed: {e}"))?;
+
+    match config_result {
         Ok(Some(cfg)) => Ok(RepoConfigInfo {
             has_config_file: true,
             setup_script: cfg.scripts.and_then(|s| s.setup),

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -1,12 +1,21 @@
 use std::path::Path;
 
+use serde::Serialize;
 use tauri::State;
 
+use claudette::config;
 use claudette::db::Database;
 use claudette::git;
 use claudette::model::Repository;
 
 use crate::state::AppState;
+
+#[derive(Serialize)]
+pub struct RepoConfigInfo {
+    pub has_config_file: bool,
+    pub setup_script: Option<String>,
+    pub parse_error: Option<String>,
+}
 
 #[tauri::command]
 pub async fn add_repository(
@@ -32,6 +41,7 @@ pub async fn add_repository(
         path_slug,
         icon: None,
         created_at: now_iso(),
+        setup_script: None,
         path_valid: true,
     };
 
@@ -46,12 +56,15 @@ pub async fn update_repository_settings(
     id: String,
     name: String,
     icon: Option<String>,
+    setup_script: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.update_repository_name(&id, &name)
         .map_err(|e| e.to_string())?;
     db.update_repository_icon(&id, icon.as_deref())
+        .map_err(|e| e.to_string())?;
+    db.update_repository_setup_script(&id, setup_script.as_deref())
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -102,6 +115,38 @@ pub async fn remove_repository(id: String, state: State<'_, AppState>) -> Result
     db.delete_repository(&id).map_err(|e| e.to_string())?;
 
     Ok(())
+}
+
+/// Read .claudette.json config for a registered repository (by ID).
+#[tauri::command]
+pub async fn get_repo_config(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<RepoConfigInfo, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let repo = repos
+        .iter()
+        .find(|r| r.id == repo_id)
+        .ok_or("Repository not found")?;
+
+    match config::load_config(Path::new(&repo.path)) {
+        Ok(Some(cfg)) => Ok(RepoConfigInfo {
+            has_config_file: true,
+            setup_script: cfg.scripts.and_then(|s| s.setup),
+            parse_error: None,
+        }),
+        Ok(None) => Ok(RepoConfigInfo {
+            has_config_file: false,
+            setup_script: None,
+            parse_error: None,
+        }),
+        Err(e) => Ok(RepoConfigInfo {
+            has_config_file: true,
+            setup_script: None,
+            parse_error: Some(e),
+        }),
+    }
 }
 
 fn slug_from_path(path: &str) -> String {

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -131,13 +131,15 @@ async fn resolve_and_run_setup(
         }
     };
 
-    // 2. Execute the script.
+    // 2. Execute the script in its own process group so we can kill the
+    //    entire tree on timeout (prevents orphan grandchild processes).
     let mut child = match TokioCommand::new("sh")
         .arg("-c")
         .arg(&script)
         .current_dir(worktree_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        .process_group(0)
         .spawn()
     {
         Ok(c) => c,
@@ -153,18 +155,33 @@ async fn resolve_and_run_setup(
         }
     };
 
-    // 3. Wait with 5-minute timeout.
+    let pid = child.id();
+
+    // 3. Read stdout/stderr concurrently with waiting to avoid pipe buffer
+    //    deadlocks (OS pipe buffers are ~64KB — scripts like `npm install`
+    //    easily exceed that).
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    let stdout_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut out) = stdout_handle {
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut out, &mut buf).await;
+        }
+        buf
+    });
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut err) = stderr_handle {
+            let _ = tokio::io::AsyncReadExt::read_to_end(&mut err, &mut buf).await;
+        }
+        buf
+    });
+
     match tokio::time::timeout(Duration::from_secs(300), child.wait()).await {
         Ok(Ok(status)) => {
-            // Process finished — read any remaining output from pipes.
-            let mut stdout_buf = Vec::new();
-            let mut stderr_buf = Vec::new();
-            if let Some(mut out) = child.stdout.take() {
-                let _ = tokio::io::AsyncReadExt::read_to_end(&mut out, &mut stdout_buf).await;
-            }
-            if let Some(mut err) = child.stderr.take() {
-                let _ = tokio::io::AsyncReadExt::read_to_end(&mut err, &mut stderr_buf).await;
-            }
+            let stdout_buf = stdout_task.await.unwrap_or_default();
+            let stderr_buf = stderr_task.await.unwrap_or_default();
             let stdout = String::from_utf8_lossy(&stdout_buf);
             let stderr = String::from_utf8_lossy(&stderr_buf);
             let combined = if stderr.is_empty() {
@@ -193,8 +210,14 @@ async fn resolve_and_run_setup(
             timed_out: false,
         }),
         Err(_) => {
-            // Timeout — explicitly kill the child process.
+            // Timeout — kill the entire process group, then reap the child.
+            if let Some(pgid) = pid {
+                unsafe {
+                    libc::kill(-(pgid as i32), libc::SIGKILL);
+                }
+            }
             let _ = child.kill().await;
+            let _ = child.wait().await; // reap to avoid zombie
             Some(SetupResult {
                 source: source.to_string(),
                 script,

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,7 +1,11 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
+use serde::Serialize;
 use tauri::State;
+use tokio::process::Command as TokioCommand;
 
+use claudette::config;
 use claudette::db::Database;
 use claudette::git;
 use claudette::model::{AgentStatus, Workspace, WorkspaceStatus};
@@ -9,12 +13,28 @@ use claudette::names::NameGenerator;
 
 use crate::state::AppState;
 
+#[derive(Serialize, Clone)]
+pub struct SetupResult {
+    pub source: String,
+    pub script: String,
+    pub output: String,
+    pub exit_code: Option<i32>,
+    pub success: bool,
+    pub timed_out: bool,
+}
+
+#[derive(Serialize)]
+pub struct CreateWorkspaceResult {
+    pub workspace: Workspace,
+    pub setup_result: Option<SetupResult>,
+}
+
 #[tauri::command]
 pub async fn create_workspace(
     repo_id: String,
     name: String,
     state: State<'_, AppState>,
-) -> Result<Workspace, String> {
+) -> Result<CreateWorkspaceResult, String> {
     // Validate workspace name.
     let forbidden = ['/', '\\', ':', '?', '*', '[', ' ', '~', '.'];
     if name.is_empty() || name.chars().any(|c| forbidden.contains(&c)) || name.ends_with(".lock") {
@@ -28,12 +48,16 @@ pub async fn create_workspace(
         .find(|r| r.id == repo_id)
         .ok_or("Repository not found")?;
 
+    // Capture setup script info before moving repo fields.
+    let repo_path = repo.path.clone();
+    let settings_setup_script = repo.setup_script.clone();
+
     let branch_name = format!("claudette/{name}");
     let worktree_base = state.worktree_base_dir.read().await;
     let worktree_path: PathBuf = worktree_base.join(&repo.path_slug).join(&name);
     let worktree_path_str = worktree_path.to_string_lossy().to_string();
 
-    let actual_path = git::create_worktree(&repo.path, &branch_name, &worktree_path_str)
+    let actual_path = git::create_worktree(&repo_path, &branch_name, &worktree_path_str)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -42,7 +66,7 @@ pub async fn create_workspace(
         repository_id: repo_id,
         name,
         branch_name,
-        worktree_path: Some(actual_path),
+        worktree_path: Some(actual_path.clone()),
         status: WorkspaceStatus::Active,
         agent_status: AgentStatus::Idle,
         status_line: String::new(),
@@ -51,7 +75,136 @@ pub async fn create_workspace(
 
     db.insert_workspace(&ws).map_err(|e| e.to_string())?;
 
-    Ok(ws)
+    // Resolve and execute setup script.
+    let setup_result = resolve_and_run_setup(
+        Path::new(&repo_path),
+        Path::new(&actual_path),
+        settings_setup_script.as_deref(),
+    )
+    .await;
+
+    Ok(CreateWorkspaceResult {
+        workspace: ws,
+        setup_result,
+    })
+}
+
+/// Resolve the setup script from .claudette.json or settings fallback, then execute it.
+async fn resolve_and_run_setup(
+    repo_path: &Path,
+    worktree_path: &Path,
+    settings_script: Option<&str>,
+) -> Option<SetupResult> {
+    // 1. Check .claudette.json
+    let (script, source) = match config::load_config(repo_path) {
+        Ok(Some(cfg)) => {
+            if let Some(setup) = cfg.scripts.and_then(|s| s.setup) {
+                (setup, "repo")
+            } else if let Some(fallback) = settings_script {
+                (fallback.to_string(), "settings")
+            } else {
+                return None;
+            }
+        }
+        Ok(None) => {
+            if let Some(fallback) = settings_script {
+                (fallback.to_string(), "settings")
+            } else {
+                return None;
+            }
+        }
+        Err(parse_err) => {
+            // Malformed .claudette.json — warn but fall back to settings script.
+            eprintln!("[setup] {parse_err}");
+            if let Some(fallback) = settings_script {
+                (fallback.to_string(), "settings")
+            } else {
+                return Some(SetupResult {
+                    source: "repo".to_string(),
+                    script: String::new(),
+                    output: parse_err,
+                    exit_code: None,
+                    success: false,
+                    timed_out: false,
+                });
+            }
+        }
+    };
+
+    // 2. Execute the script.
+    let mut child = match TokioCommand::new("sh")
+        .arg("-c")
+        .arg(&script)
+        .current_dir(worktree_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return Some(SetupResult {
+                source: source.to_string(),
+                script,
+                output: format!("Failed to spawn script: {e}"),
+                exit_code: None,
+                success: false,
+                timed_out: false,
+            });
+        }
+    };
+
+    // 3. Wait with 5-minute timeout.
+    match tokio::time::timeout(Duration::from_secs(300), child.wait()).await {
+        Ok(Ok(status)) => {
+            // Process finished — read any remaining output from pipes.
+            let mut stdout_buf = Vec::new();
+            let mut stderr_buf = Vec::new();
+            if let Some(mut out) = child.stdout.take() {
+                let _ = tokio::io::AsyncReadExt::read_to_end(&mut out, &mut stdout_buf).await;
+            }
+            if let Some(mut err) = child.stderr.take() {
+                let _ = tokio::io::AsyncReadExt::read_to_end(&mut err, &mut stderr_buf).await;
+            }
+            let stdout = String::from_utf8_lossy(&stdout_buf);
+            let stderr = String::from_utf8_lossy(&stderr_buf);
+            let combined = if stderr.is_empty() {
+                stdout.to_string()
+            } else if stdout.is_empty() {
+                stderr.to_string()
+            } else {
+                format!("{stdout}\n{stderr}")
+            };
+            let code = status.code();
+            Some(SetupResult {
+                source: source.to_string(),
+                script,
+                output: combined,
+                exit_code: code,
+                success: code == Some(0),
+                timed_out: false,
+            })
+        }
+        Ok(Err(e)) => Some(SetupResult {
+            source: source.to_string(),
+            script,
+            output: format!("Script execution error: {e}"),
+            exit_code: None,
+            success: false,
+            timed_out: false,
+        }),
+        Err(_) => {
+            // Timeout — explicitly kill the child process.
+            let _ = child.kill().await;
+            Some(SetupResult {
+                source: source.to_string(),
+                script,
+                output: "Setup script timed out after 5 minutes".to_string(),
+                exit_code: None,
+                success: false,
+                timed_out: true,
+            })
+        }
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,6 +51,7 @@ fn main() {
             commands::repository::update_repository_settings,
             commands::repository::relink_repository,
             commands::repository::remove_repository,
+            commands::repository::get_repo_config,
             // Workspace
             commands::workspace::create_workspace,
             commands::workspace::archive_workspace,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,107 @@
+use std::path::Path;
+
+use serde::Deserialize;
+
+const CONFIG_FILE_NAME: &str = ".claudette.json";
+
+/// Top-level structure of a `.claudette.json` file.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ClaudetteConfig {
+    #[serde(default)]
+    pub scripts: Option<Scripts>,
+}
+
+/// Script definitions within `.claudette.json`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Scripts {
+    #[serde(default)]
+    pub setup: Option<String>,
+}
+
+/// Load and parse `.claudette.json` from the given directory.
+///
+/// Returns `Ok(None)` if the file doesn't exist (not an error).
+/// Returns `Err` with a user-visible message if the file exists but is malformed.
+pub fn load_config(repo_path: &Path) -> Result<Option<ClaudetteConfig>, String> {
+    let config_path = repo_path.join(CONFIG_FILE_NAME);
+
+    let contents = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("Failed to read {CONFIG_FILE_NAME}: {e}")),
+    };
+
+    let config: ClaudetteConfig = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse {CONFIG_FILE_NAME}: {e}"))?;
+
+    Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_valid_config_with_setup() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            r#"{"scripts": {"setup": "mise trust && mise install"}}"#,
+        )
+        .unwrap();
+
+        let config = load_config(dir.path()).unwrap().unwrap();
+        assert_eq!(
+            config.scripts.unwrap().setup.unwrap(),
+            "mise trust && mise install"
+        );
+    }
+
+    #[test]
+    fn test_valid_config_without_scripts_key() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE_NAME), r#"{}"#).unwrap();
+
+        let config = load_config(dir.path()).unwrap().unwrap();
+        assert!(config.scripts.is_none());
+    }
+
+    #[test]
+    fn test_valid_config_scripts_without_setup() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE_NAME), r#"{"scripts": {}}"#).unwrap();
+
+        let config = load_config(dir.path()).unwrap().unwrap();
+        assert!(config.scripts.unwrap().setup.is_none());
+    }
+
+    #[test]
+    fn test_unknown_keys_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            r#"{"scripts": {"setup": "echo hi", "deploy": "echo deploy"}, "version": 2, "extra": true}"#,
+        )
+        .unwrap();
+
+        let config = load_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.scripts.unwrap().setup.unwrap(), "echo hi");
+    }
+
+    #[test]
+    fn test_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE_NAME), "not valid json {{{").unwrap();
+
+        let err = load_config(dir.path()).unwrap_err();
+        assert!(err.contains("Failed to parse .claudette.json"));
+    }
+
+    #[test]
+    fn test_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = load_config(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -115,6 +115,14 @@ impl Database {
             )?;
         }
 
+        if version < 5 {
+            self.conn.execute_batch(
+                "ALTER TABLE repositories ADD COLUMN setup_script TEXT;
+
+                 PRAGMA user_version = 5;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -130,7 +138,8 @@ impl Database {
 
     pub fn list_repositories(&self) -> Result<Vec<Repository>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, path, name, icon, path_slug, created_at FROM repositories ORDER BY name",
+            "SELECT id, path, name, icon, path_slug, created_at, setup_script
+             FROM repositories ORDER BY name",
         )?;
         let rows = stmt.query_map([], |row| {
             Ok(Repository {
@@ -140,6 +149,7 @@ impl Database {
                 icon: row.get(3)?,
                 path_slug: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
                 created_at: row.get(5)?,
+                setup_script: row.get(6)?,
                 path_valid: true, // validated after load
             })
         })?;
@@ -178,6 +188,18 @@ impl Database {
         self.conn.execute(
             "UPDATE repositories SET icon = ?1 WHERE id = ?2",
             params![icon, id],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_repository_setup_script(
+        &self,
+        id: &str,
+        script: Option<&str>,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE repositories SET setup_script = ?1 WHERE id = ?2",
+            params![script, id],
         )?;
         Ok(())
     }
@@ -441,6 +463,7 @@ mod tests {
             path_slug: name.into(),
             icon: None,
             created_at: String::new(),
+            setup_script: None,
             path_valid: true,
         }
     }
@@ -688,6 +711,7 @@ mod tests {
             path_slug: "my-project".into(),
             icon: None,
             created_at: String::new(),
+            setup_script: None,
             path_valid: true,
         };
         db.insert_repository(&repo).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod config;
 pub mod db;
 pub mod diff;
 pub mod git;

--- a/src/model/repository.rs
+++ b/src/model/repository.rs
@@ -12,6 +12,8 @@ pub struct Repository {
     /// Lucide icon name (e.g. "rocket", "code"). None means use default icon.
     pub icon: Option<String>,
     pub created_at: String,
+    /// Per-user setup script configured in the Settings UI. None means no script.
+    pub setup_script: Option<String>,
     /// Runtime-only: whether the repo path still exists on disk. Not persisted.
     pub path_valid: bool,
 }

--- a/src/ui/src/components/modals/RepoSettingsModal.tsx
+++ b/src/ui/src/components/modals/RepoSettingsModal.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAppStore } from "../../stores/useAppStore";
-import { updateRepositorySettings } from "../../services/tauri";
+import { updateRepositorySettings, getRepoConfig } from "../../services/tauri";
+import type { RepoConfigInfo } from "../../types/repository";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
@@ -16,18 +17,37 @@ export function RepoSettingsModal() {
 
   const [name, setName] = useState(repo?.name ?? "");
   const [icon, setIcon] = useState(repo?.icon ?? "");
+  const [setupScript, setSetupScript] = useState(repo?.setup_script ?? "");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const [repoConfig, setRepoConfig] = useState<RepoConfigInfo | null>(null);
+
+  useEffect(() => {
+    if (repoId) {
+      getRepoConfig(repoId)
+        .then(setRepoConfig)
+        .catch(() => setRepoConfig(null));
+    }
+  }, [repoId]);
+
   if (!repo) return null;
+
+  const repoScriptOverrides =
+    repoConfig?.has_config_file && repoConfig.setup_script != null;
 
   const handleSave = async () => {
     setLoading(true);
     setError(null);
     try {
       const iconValue = icon.trim() || null;
-      await updateRepositorySettings(repoId, name.trim(), iconValue);
-      updateRepo(repoId, { name: name.trim(), icon: iconValue });
+      const scriptValue = setupScript.trim() || null;
+      await updateRepositorySettings(repoId, name.trim(), iconValue, scriptValue);
+      updateRepo(repoId, {
+        name: name.trim(),
+        icon: iconValue,
+        setup_script: scriptValue,
+      });
       closeModal();
     } catch (e) {
       setError(String(e));
@@ -55,6 +75,72 @@ export function RepoSettingsModal() {
           onChange={(e) => setIcon(e.target.value)}
           placeholder="e.g. rocket, code, bug"
         />
+      </div>
+
+      <div
+        style={{
+          borderTop: "1px solid var(--divider)",
+          marginTop: 16,
+          paddingTop: 12,
+        }}
+      >
+        <label className={shared.label}>Setup Script</label>
+        {repoConfig?.parse_error && (
+          <div className={shared.error} style={{ marginBottom: 8 }}>
+            {repoConfig.parse_error}
+          </div>
+        )}
+        {repoScriptOverrides && (
+          <div className={shared.hint} style={{ marginBottom: 8 }}>
+            This repo includes a <code>.claudette.json</code> that defines a
+            setup script. Repo-level scripts take precedence over your personal
+            setup script.
+          </div>
+        )}
+        {repoConfig?.has_config_file && repoConfig.setup_script && (
+          <div style={{ marginBottom: 8 }}>
+            <div
+              className={shared.label}
+              style={{ fontSize: 11, marginBottom: 2 }}
+            >
+              From .claudette.json (read-only):
+            </div>
+            <pre
+              style={{
+                background: "var(--chat-input-bg)",
+                border: "1px solid var(--divider)",
+                borderRadius: 4,
+                padding: "6px 8px",
+                fontSize: 12,
+                color: "var(--text-dim)",
+                margin: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {repoConfig.setup_script}
+            </pre>
+          </div>
+        )}
+        <div className={shared.label} style={{ fontSize: 11, marginBottom: 2 }}>
+          Personal setup script{repoScriptOverrides ? " (overridden)" : ""}:
+        </div>
+        <textarea
+          className={shared.input}
+          value={setupScript}
+          onChange={(e) => setSetupScript(e.target.value)}
+          placeholder="e.g. mise trust && mise install"
+          rows={3}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 12,
+            resize: "vertical",
+            opacity: repoScriptOverrides ? 0.5 : 1,
+          }}
+        />
+        <div className={shared.hint}>
+          Runs automatically when a new workspace is created.
+        </div>
       </div>
 
       <div

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -29,9 +29,15 @@ export function Sidebar() {
     creatingRef.current = true;
     try {
       const name = await generateWorkspaceName();
-      const ws = await createWorkspace(repoId, name);
-      addWorkspace(ws);
-      selectWorkspace(ws.id);
+      const result = await createWorkspace(repoId, name);
+      addWorkspace(result.workspace);
+      selectWorkspace(result.workspace.id);
+      if (result.setup_result && !result.setup_result.success) {
+        console.warn("Setup script failed:", result.setup_result.output);
+        alert(
+          `Setup script failed (source: ${result.setup_result.source}):\n${result.setup_result.output}`
+        );
+      }
     } catch (e) {
       console.error("Failed to create workspace:", e);
     } finally {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ export function Sidebar() {
   const repoCollapsed = useAppStore((s) => s.repoCollapsed);
   const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
+  const addChatMessage = useAppStore((s) => s.addChatMessage);
   const openModal = useAppStore((s) => s.openModal);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
 
@@ -32,11 +33,19 @@ export function Sidebar() {
       const result = await createWorkspace(repoId, name);
       addWorkspace(result.workspace);
       selectWorkspace(result.workspace.id);
-      if (result.setup_result && !result.setup_result.success) {
-        console.warn("Setup script failed:", result.setup_result.output);
-        alert(
-          `Setup script failed (source: ${result.setup_result.source}):\n${result.setup_result.output}`
-        );
+      if (result.setup_result) {
+        const sr = result.setup_result;
+        const label = sr.source === "repo" ? ".claudette.json" : "settings";
+        const status = sr.success ? "completed" : sr.timed_out ? "timed out" : "failed";
+        addChatMessage(result.workspace.id, {
+          id: crypto.randomUUID(),
+          workspace_id: result.workspace.id,
+          role: "System",
+          content: `Setup script (${label}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
+          cost_usd: null,
+          duration_ms: null,
+          created_at: new Date().toISOString(),
+        });
       }
     } catch (e) {
       console.error("Failed to create workspace:", e);

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -7,6 +7,10 @@ import type {
   FileDiff,
   TerminalTab,
 } from "../types";
+import type {
+  CreateWorkspaceResult,
+  RepoConfigInfo,
+} from "../types/repository";
 
 // -- Data --
 
@@ -29,9 +33,10 @@ export function addRepository(path: string): Promise<Repository> {
 export function updateRepositorySettings(
   id: string,
   name: string,
-  icon: string | null
+  icon: string | null,
+  setupScript: string | null
 ): Promise<void> {
-  return invoke("update_repository_settings", { id, name, icon });
+  return invoke("update_repository_settings", { id, name, icon, setupScript });
 }
 
 export function relinkRepository(id: string, path: string): Promise<void> {
@@ -42,12 +47,16 @@ export function removeRepository(id: string): Promise<void> {
   return invoke("remove_repository", { id });
 }
 
+export function getRepoConfig(repoId: string): Promise<RepoConfigInfo> {
+  return invoke("get_repo_config", { repoId });
+}
+
 // -- Workspace --
 
 export function createWorkspace(
   repoId: string,
   name: string
-): Promise<Workspace> {
+): Promise<CreateWorkspaceResult> {
   return invoke("create_workspace", { repoId, name });
 }
 

--- a/src/ui/src/types/repository.ts
+++ b/src/ui/src/types/repository.ts
@@ -5,5 +5,26 @@ export interface Repository {
   path_slug: string;
   icon: string | null;
   created_at: string;
+  setup_script: string | null;
   path_valid: boolean;
+}
+
+export interface SetupResult {
+  source: string;
+  script: string;
+  output: string;
+  exit_code: number | null;
+  success: boolean;
+  timed_out: boolean;
+}
+
+export interface CreateWorkspaceResult {
+  workspace: import("./workspace").Workspace;
+  setup_result: SetupResult | null;
+}
+
+export interface RepoConfigInfo {
+  has_config_file: boolean;
+  setup_script: string | null;
+  parse_error: string | null;
 }


### PR DESCRIPTION
## Summary

- Add per-repo setup scripts that run automatically when a workspace is created
- Scripts can come from `.claudette.json` (repo-level, team-shared) or Settings UI (personal)
- `.claudette.json` takes precedence when both exist

## Changes

### Backend
- **`src/config.rs`** — New module: parses `.claudette.json` from repo root. Handles missing files, malformed JSON, unknown keys. 6 unit tests.
- **`src/db.rs`** — Migration 5: adds `setup_script` column to repositories table. New `update_repository_setup_script` method.
- **`src/model/repository.rs`** — `setup_script: Option<String>` field
- **`src-tauri/src/commands/workspace.rs`** — `create_workspace` now resolves setup script (.claudette.json > settings > none), executes with `sh -c`, 5-min timeout with explicit `child.kill()`, captures stdout/stderr. Returns `CreateWorkspaceResult` with `SetupResult`.
- **`src-tauri/src/commands/repository.rs`** — `update_repository_settings` extended with `setup_script` param. New `get_repo_config` command (validates repo ID against DB).

### Frontend
- **`src/ui/src/types/repository.ts`** — `SetupResult`, `CreateWorkspaceResult`, `RepoConfigInfo` types
- **`src/ui/src/services/tauri.ts`** — `getRepoConfig`, updated `updateRepositorySettings` and `createWorkspace` signatures
- **`RepoSettingsModal`** — Setup script textarea, `.claudette.json` read-only display with precedence note, parse error display
- **`Sidebar`** — Handles `CreateWorkspaceResult`, alerts on setup script failure

## Implementation follows
- `docs/setup-scripts-tdd.md` (merged in #52)

## Test plan
- [ ] `.claudette.json` with `scripts.setup` → runs on workspace creation
- [ ] Settings UI script → runs when no `.claudette.json`
- [ ] Both present → `.claudette.json` takes precedence
- [ ] Malformed `.claudette.json` → warning shown, falls back to settings
- [ ] No script configured → nothing runs
- [ ] Script failure (non-zero exit) → alert shown, workspace still created
- [ ] Script timeout → workspace still created with timeout warning
- [ ] Repo Settings modal shows `.claudette.json` indicator and override note

Closes #50