### PR TITLE
feat: show repo/branch info in chat header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ version = "0.1.0"
 dependencies = [
  "claudette",
  "dirs",
+ "futures",
  "libc",
  "portable-pty",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-clipboard-manager = "2"
+futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "time", "process"] }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -39,15 +39,18 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         })
         .collect();
 
-    // Resolve default branch for each valid repo (best-effort).
-    let mut default_branches = HashMap::new();
-    for repo in &repositories {
-        if repo.path_valid
-            && let Ok(branch) = git::default_branch(&repo.path).await
-        {
-            default_branches.insert(repo.id.clone(), branch);
-        }
-    }
+    // Resolve default branch for each valid repo concurrently (best-effort).
+    let branch_futures: Vec<_> = repositories
+        .iter()
+        .filter(|r| r.path_valid)
+        .map(|r| {
+            let id = r.id.clone();
+            let path = r.path.clone();
+            async move { git::default_branch(&path).await.ok().map(|b| (id, b)) }
+        })
+        .collect();
+    let branch_results = futures::future::join_all(branch_futures).await;
+    let default_branches: HashMap<String, String> = branch_results.into_iter().flatten().collect();
 
     Ok(InitialData {
         repositories,

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 use tauri::State;
 
 use claudette::db::Database;
+use claudette::git;
 use claudette::model::{Repository, Workspace};
 
 use crate::state::AppState;
@@ -11,6 +14,8 @@ pub struct InitialData {
     pub repositories: Vec<Repository>,
     pub workspaces: Vec<Workspace>,
     pub worktree_base_dir: String,
+    /// Maps repo ID → default branch name (e.g., "main", "master").
+    pub default_branches: HashMap<String, String>,
 }
 
 #[tauri::command]
@@ -26,7 +31,7 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
     };
 
     // Check which repo paths are still valid on disk.
-    let repositories = repositories
+    let repositories: Vec<Repository> = repositories
         .into_iter()
         .map(|mut r| {
             r.path_valid = std::path::Path::new(&r.path).is_dir();
@@ -34,9 +39,20 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         })
         .collect();
 
+    // Resolve default branch for each valid repo (best-effort).
+    let mut default_branches = HashMap::new();
+    for repo in &repositories {
+        if repo.path_valid
+            && let Ok(branch) = git::default_branch(&repo.path).await
+        {
+            default_branches.insert(repo.id.clone(), branch);
+        }
+    }
+
     Ok(InitialData {
         repositories,
         workspaces,
         worktree_base_dir,
+        default_branches,
     })
 }

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -156,6 +156,25 @@ pub async fn get_repo_config(
     }
 }
 
+/// Get the default branch for a repository (e.g., "main" or "master").
+#[tauri::command]
+pub async fn get_default_branch(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<Option<String>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let repo = repos
+        .iter()
+        .find(|r| r.id == repo_id)
+        .ok_or("Repository not found")?;
+
+    match git::default_branch(&repo.path).await {
+        Ok(branch) => Ok(Some(branch)),
+        Err(_) => Ok(None),
+    }
+}
+
 fn slug_from_path(path: &str) -> String {
     Path::new(path)
         .file_name()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
             commands::repository::relink_repository,
             commands::repository::remove_repository,
             commands::repository::get_repo_config,
+            commands::repository::get_default_branch,
             // Workspace
             commands::workspace::create_workspace,
             commands::workspace::archive_workspace,

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -8,14 +8,16 @@ function App() {
   const setRepositories = useAppStore((s) => s.setRepositories);
   const setWorkspaces = useAppStore((s) => s.setWorkspaces);
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
+  const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
 
   useEffect(() => {
     loadInitialData().then((data) => {
       setRepositories(data.repositories);
       setWorkspaces(data.workspaces);
       setWorktreeBaseDir(data.worktree_base_dir);
+      setDefaultBranches(data.default_branches);
     });
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -25,14 +25,45 @@
   gap: 8px;
 }
 
-.wsName {
-  font-weight: 600;
-  font-size: 14px;
+.branchInfo {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  font-family: monospace;
+  min-width: 0;
 }
 
 .repoName {
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.branchSep {
+  color: var(--text-faint);
+}
+
+.branchIcon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.branchName {
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.branchArrow {
+  color: var(--text-faint);
+  flex-shrink: 0;
+}
+
+.baseBranch {
   color: var(--text-dim);
-  font-size: 12px;
+  white-space: nowrap;
 }
 
 .permissionSelect {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -54,6 +54,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .branchArrow {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { GitBranch } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   loadChatHistory,
@@ -41,6 +42,8 @@ export function ChatPanel() {
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const repo = repositories.find((r) => r.id === ws?.repository_id);
+  const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
+  const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
   const messages = selectedWorkspaceId
     ? chatMessages[selectedWorkspaceId] || []
     : [];
@@ -206,8 +209,20 @@ export function ChatPanel() {
     <div className={styles.panel}>
       <div className={styles.header}>
         <div className={styles.headerLeft}>
-          <span className={styles.wsName}>{ws.name}</span>
-          {repo && <span className={styles.repoName}>{repo.name}</span>}
+          {repo && (
+            <span className={styles.branchInfo}>
+              <span className={styles.repoName}>{repo.name}</span>
+              <span className={styles.branchSep}>/</span>
+              <GitBranch size={12} className={styles.branchIcon} />
+              <span className={styles.branchName}>{ws.branch_name}</span>
+              {defaultBranch && (
+                <>
+                  <span className={styles.branchArrow}>{'>'}</span>
+                  <span className={styles.baseBranch}>{defaultBranch}</span>
+                </>
+              )}
+            </span>
+          )}
         </div>
         <div className={styles.headerRight}>
           <WorkspaceActions

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -40,9 +40,10 @@ export function ChatPanel() {
 
   useAgentStream();
 
+  const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
+
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const repo = repositories.find((r) => r.id === ws?.repository_id);
-  const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
   const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
   const messages = selectedWorkspaceId
     ? chatMessages[selectedWorkspaceId] || []
@@ -209,7 +210,7 @@ export function ChatPanel() {
     <div className={styles.panel}>
       <div className={styles.header}>
         <div className={styles.headerLeft}>
-          {repo && (
+          {repo ? (
             <span className={styles.branchInfo}>
               <span className={styles.repoName}>{repo.name}</span>
               <span className={styles.branchSep}>/</span>
@@ -222,6 +223,8 @@ export function ChatPanel() {
                 </>
               )}
             </span>
+          ) : (
+            <span className={styles.repoName}>{ws.name}</span>
           )}
         </div>
         <div className={styles.headerRight}>

--- a/src/ui/src/components/modals/AddRepoModal.tsx
+++ b/src/ui/src/components/modals/AddRepoModal.tsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../stores/useAppStore";
-import { addRepository } from "../../services/tauri";
+import { addRepository, getDefaultBranch } from "../../services/tauri";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
 export function AddRepoModal() {
   const closeModal = useAppStore((s) => s.closeModal);
   const addRepo = useAppStore((s) => s.addRepository);
+  const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
+  const defaultBranches = useAppStore((s) => s.defaultBranches);
   const [path, setPath] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -31,6 +33,12 @@ export function AddRepoModal() {
     try {
       const repo = await addRepository(path.trim());
       addRepo(repo);
+      // Fetch default branch for the new repo.
+      getDefaultBranch(repo.id).then((branch) => {
+        if (branch) {
+          setDefaultBranches({ ...defaultBranches, [repo.id]: branch });
+        }
+      });
       closeModal();
     } catch (e) {
       setError(String(e));

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -18,6 +18,7 @@ export interface InitialData {
   repositories: Repository[];
   workspaces: Workspace[];
   worktree_base_dir: string;
+  default_branches: Record<string, string>;
 }
 
 export function loadInitialData(): Promise<InitialData> {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -52,6 +52,10 @@ export function getRepoConfig(repoId: string): Promise<RepoConfigInfo> {
   return invoke("get_repo_config", { repoId });
 }
 
+export function getDefaultBranch(repoId: string): Promise<string | null> {
+  return invoke("get_default_branch", { repoId });
+}
+
 // -- Workspace --
 
 export function createWorkspace(

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -145,6 +145,8 @@ interface AppState {
   // -- Settings --
   worktreeBaseDir: string;
   setWorktreeBaseDir: (dir: string) => void;
+  defaultBranches: Record<string, string>;
+  setDefaultBranches: (branches: Record<string, string>) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -392,4 +394,6 @@ export const useAppStore = create<AppState>((set) => ({
   // -- Settings --
   worktreeBaseDir: "",
   setWorktreeBaseDir: (dir) => set({ worktreeBaseDir: dir }),
+  defaultBranches: {},
+  setDefaultBranches: (branches) => set({ defaultBranches: branches }),
 }));


### PR DESCRIPTION
## Summary

Replace the redundant workspace name + repo name in the chat header with useful git branch context:

```
Claudette / 🔀 claudette/my-workspace > main
```

Shows `repo-name / branch-name > default-branch`, giving immediate visibility into what branch you're on and where it branched from.

## Changes

- **`src-tauri/src/commands/data.rs`**: `load_initial_data` now resolves the default branch (main/master) for each repo and returns it in `default_branches` map
- **`src/ui/src/stores/useAppStore.ts`**: New `defaultBranches` state
- **`src/ui/src/App.tsx`**: Stores default branches on initial load
- **`src/ui/src/services/tauri.ts`**: `InitialData` type includes `default_branches`
- **`src/ui/src/components/chat/ChatPanel.tsx`**: Header shows repo/branch > base-branch with git branch icon (lucide-react)
- **`ChatPanel.module.css`**: Monospace branch info styling with truncation

## Test plan

- [ ] Header shows `repo / branch > main` for an active workspace
- [ ] Branch name truncates with ellipsis if too long
- [ ] Default branch is absent gracefully (no arrow shown) if git lookup fails
- [ ] Header updates when branch changes (via existing branch refresh polling)