### PR TITLE
feat: braille spinner and elapsed timer in agent chat

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -219,20 +219,24 @@
 }
 
 .processing {
-  color: var(--text-muted);
-  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 8px 12px;
-  animation: pulse 1.5s ease-in-out infinite;
+  font-size: 13px;
 }
 
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 0.5;
-  }
-  50% {
-    opacity: 1;
-  }
+.spinner {
+  font-size: 16px;
+  color: var(--status-running);
+  width: 16px;
+  text-align: center;
+}
+
+.elapsed {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
 }
 
 .toolActivities {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { GitBranch } from "lucide-react";
@@ -69,6 +69,36 @@ export function ChatPanel() {
   const isRunning = ws?.agent_status === "Running";
   const pendingQuestion =
     agentQuestion?.workspaceId === selectedWorkspaceId ? agentQuestion : null;
+
+  // Spinner and elapsed timer for running agent.
+  const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  const [spinnerIdx, setSpinnerIdx] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+  const startTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isRunning) {
+      startTimeRef.current = null;
+      return;
+    }
+    if (!startTimeRef.current) {
+      startTimeRef.current = Date.now();
+    }
+    const interval = setInterval(() => {
+      setSpinnerIdx((i) => (i + 1) % SPINNER_FRAMES.length);
+      if (startTimeRef.current) {
+        setElapsed(Math.floor((Date.now() - startTimeRef.current) / 1000));
+      }
+    }, 80);
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  const formatElapsed = useCallback((secs: number) => {
+    if (secs < 60) return `${secs}s`;
+    const m = Math.floor(secs / 60);
+    const s = secs % 60;
+    return `${m}m ${s}s`;
+  }, []);
 
   // Load persisted permission level when workspace changes.
   useEffect(() => {
@@ -399,8 +429,11 @@ export function ChatPanel() {
               </div>
             )}
 
-            {isRunning && !streaming && !pendingQuestion && (
-              <div className={styles.processing}>Processing...</div>
+            {isRunning && !pendingQuestion && (
+              <div className={styles.processing}>
+                <span className={styles.spinner}>{SPINNER_FRAMES[spinnerIdx]}</span>
+                <span className={styles.elapsed}>{formatElapsed(elapsed)}</span>
+              </div>
             )}
 
             {pendingQuestion && (

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -15,6 +15,8 @@ import { AgentQuestionCard } from "./AgentQuestionCard";
 import { WorkspaceActions } from "./WorkspaceActions";
 import styles from "./ChatPanel.module.css";
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 export function ChatPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -71,7 +73,6 @@ export function ChatPanel() {
     agentQuestion?.workspaceId === selectedWorkspaceId ? agentQuestion : null;
 
   // Spinner and elapsed timer for running agent.
-  const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
   const [spinnerIdx, setSpinnerIdx] = useState(0);
   const [elapsed, setElapsed] = useState(0);
   const startTimeRef = useRef<number | null>(null);
@@ -83,11 +84,14 @@ export function ChatPanel() {
     }
     if (!startTimeRef.current) {
       startTimeRef.current = Date.now();
+      setElapsed(0);
+      setSpinnerIdx(0);
     }
     const interval = setInterval(() => {
       setSpinnerIdx((i) => (i + 1) % SPINNER_FRAMES.length);
       if (startTimeRef.current) {
-        setElapsed(Math.floor((Date.now() - startTimeRef.current) / 1000));
+        const newElapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+        setElapsed((prev) => (prev === newElapsed ? prev : newElapsed));
       }
     }, 80);
     return () => clearInterval(interval);
@@ -430,8 +434,12 @@ export function ChatPanel() {
             )}
 
             {isRunning && !pendingQuestion && (
-              <div className={styles.processing}>
-                <span className={styles.spinner}>{SPINNER_FRAMES[spinnerIdx]}</span>
+              <div
+                className={styles.processing}
+                role="status"
+                aria-label={`Processing, ${formatElapsed(elapsed)} elapsed`}
+              >
+                <span className={styles.spinner} aria-hidden="true">{SPINNER_FRAMES[spinnerIdx]}</span>
                 <span className={styles.elapsed}>{formatElapsed(elapsed)}</span>
               </div>
             )}


### PR DESCRIPTION
## Summary

Replace the static "Processing..." text with a braille spinner animation and elapsed timer while the agent is working, matching the Claude Code CLI experience.

## Changes

- **`ChatPanel.tsx`**: Braille spinner (`⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`) cycling at 80ms with elapsed time counter (`12s`, `1m 34s`). Visible during both processing pauses and alongside streaming content. Timer starts when agent status changes to Running.
- **`ChatPanel.module.css`**: Spinner in green (`--status-running`), timer in dim text with `tabular-nums` for stable digit width. Replaces the old pulse animation.

## Test plan

- [ ] Send a prompt — spinner and timer appear immediately
- [ ] Timer counts up accurately (seconds, then minutes + seconds)
- [ ] Spinner visible alongside streaming text and tool activities
- [ ] Timer resets on each new prompt
- [ ] Spinner stops when agent completes or is stopped