### PR TITLE
feat: configurable terminal font size

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -18,12 +18,14 @@ function App() {
       setWorktreeBaseDir(data.worktree_base_dir);
       setDefaultBranches(data.default_branches);
     });
-    getAppSetting("terminal_font_size").then((val) => {
-      if (val) {
-        const size = parseInt(val, 10);
-        if (size >= 8 && size <= 24) setTerminalFontSize(size);
-      }
-    });
+    getAppSetting("terminal_font_size")
+      .then((val) => {
+        if (val) {
+          const size = parseInt(val, 10);
+          if (size >= 8 && size <= 24) setTerminalFontSize(size);
+        }
+      })
+      .catch((err) => console.error("Failed to load terminal font size:", err));
   }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize]);
 
   return <AppLayout />;

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData } from "./services/tauri";
+import { loadInitialData, getAppSetting } from "./services/tauri";
 import { AppLayout } from "./components/layout/AppLayout";
 import "./styles/theme.css";
 
@@ -9,6 +9,7 @@ function App() {
   const setWorkspaces = useAppStore((s) => s.setWorkspaces);
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
   const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
+  const setTerminalFontSize = useAppStore((s) => s.setTerminalFontSize);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -17,7 +18,13 @@ function App() {
       setWorktreeBaseDir(data.worktree_base_dir);
       setDefaultBranches(data.default_branches);
     });
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches]);
+    getAppSetting("terminal_font_size").then((val) => {
+      if (val) {
+        const size = parseInt(val, 10);
+        if (size >= 8 && size <= 24) setTerminalFontSize(size);
+      }
+    });
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/components/modals/AppSettingsModal.tsx
+++ b/src/ui/src/components/modals/AppSettingsModal.tsx
@@ -18,17 +18,21 @@ export function AppSettingsModal() {
 
   const handleSave = async () => {
     if (!path.trim()) return;
+
+    const size = parseInt(fontSize, 10);
+    if (isNaN(size) || size < 8 || size > 24) {
+      setError("Terminal font size must be between 8 and 24");
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
       await setAppSetting("worktree_base_dir", path.trim());
       setWorktreeBaseDir(path.trim());
 
-      const size = parseInt(fontSize, 10);
-      if (size >= 8 && size <= 24) {
-        await setAppSetting("terminal_font_size", String(size));
-        setTerminalFontSize(size);
-      }
+      await setAppSetting("terminal_font_size", String(size));
+      setTerminalFontSize(size);
 
       closeModal();
     } catch (e) {

--- a/src/ui/src/components/modals/AppSettingsModal.tsx
+++ b/src/ui/src/components/modals/AppSettingsModal.tsx
@@ -8,8 +8,11 @@ export function AppSettingsModal() {
   const closeModal = useAppStore((s) => s.closeModal);
   const worktreeBaseDir = useAppStore((s) => s.worktreeBaseDir);
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
+  const terminalFontSize = useAppStore((s) => s.terminalFontSize);
+  const setTerminalFontSize = useAppStore((s) => s.setTerminalFontSize);
 
   const [path, setPath] = useState(worktreeBaseDir);
+  const [fontSize, setFontSize] = useState(String(terminalFontSize));
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -20,6 +23,13 @@ export function AppSettingsModal() {
     try {
       await setAppSetting("worktree_base_dir", path.trim());
       setWorktreeBaseDir(path.trim());
+
+      const size = parseInt(fontSize, 10);
+      if (size >= 8 && size <= 24) {
+        await setAppSetting("terminal_font_size", String(size));
+        setTerminalFontSize(size);
+      }
+
       closeModal();
     } catch (e) {
       setError(String(e));
@@ -39,11 +49,38 @@ export function AppSettingsModal() {
           placeholder="~/.claudette/workspaces"
           autoFocus
         />
-        <div className={shared.hint}>
-          Default: ~/.claudette/workspaces
-        </div>
-        {error && <div className={shared.error}>{error}</div>}
+        <div className={shared.hint}>Default: ~/.claudette/workspaces</div>
       </div>
+
+      <div
+        style={{
+          borderTop: "1px solid var(--divider)",
+          marginTop: 16,
+          paddingTop: 12,
+        }}
+      >
+        <div
+          className={shared.label}
+          style={{ marginBottom: 8, fontWeight: 600 }}
+        >
+          Appearance
+        </div>
+        <div className={shared.field}>
+          <label className={shared.label}>Terminal Font Size</label>
+          <input
+            className={shared.input}
+            type="number"
+            min={8}
+            max={24}
+            value={fontSize}
+            onChange={(e) => setFontSize(e.target.value)}
+            style={{ width: 80 }}
+          />
+          <div className={shared.hint}>8–24px (default: 11)</div>
+        </div>
+      </div>
+
+      {error && <div className={shared.error}>{error}</div>}
       <div className={shared.actions}>
         <button className={shared.btn} onClick={closeModal}>
           Cancel

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -142,7 +142,15 @@ export function TerminalPanel() {
         ptyIdRef.current = null;
       }
     };
-  }, [activeTerminalTabId, ws?.worktree_path, terminalFontSize]);
+  }, [activeTerminalTabId, ws?.worktree_path]);
+
+  // Update font size without destroying the terminal/PTY.
+  useEffect(() => {
+    if (xtermRef.current) {
+      xtermRef.current.options.fontSize = terminalFontSize;
+      fitRef.current?.fit();
+    }
+  }, [terminalFontSize]);
 
   const handleCreateTab = useCallback(async () => {
     if (!selectedWorkspaceId) return;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -31,6 +31,7 @@ export function TerminalPanel() {
   const removeTerminalTab = useAppStore((s) => s.removeTerminalTab);
   const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
+  const terminalFontSize = useAppStore((s) => s.terminalFontSize);
 
   const autoCreatedRef = useRef<string | null>(null);
   const termRef = useRef<HTMLDivElement>(null);
@@ -75,7 +76,7 @@ export function TerminalPanel() {
     if (!termRef.current || !ws?.worktree_path || !activeTerminalTabId) return;
 
     const term = new Terminal({
-      fontSize: 13,
+      fontSize: terminalFontSize,
       fontFamily: "monospace",
       theme: {
         background: "#121216",
@@ -141,7 +142,7 @@ export function TerminalPanel() {
         ptyIdRef.current = null;
       }
     };
-  }, [activeTerminalTabId, ws?.worktree_path]);
+  }, [activeTerminalTabId, ws?.worktree_path, terminalFontSize]);
 
   const handleCreateTab = useCallback(async () => {
     if (!selectedWorkspaceId) return;

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -147,6 +147,8 @@ interface AppState {
   setWorktreeBaseDir: (dir: string) => void;
   defaultBranches: Record<string, string>;
   setDefaultBranches: (branches: Record<string, string>) => void;
+  terminalFontSize: number;
+  setTerminalFontSize: (size: number) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -396,4 +398,6 @@ export const useAppStore = create<AppState>((set) => ({
   setWorktreeBaseDir: (dir) => set({ worktreeBaseDir: dir }),
   defaultBranches: {},
   setDefaultBranches: (branches) => set({ defaultBranches: branches }),
+  terminalFontSize: 11,
+  setTerminalFontSize: (size) => set({ terminalFontSize: size }),
 }));


### PR DESCRIPTION
## Summary

Add a user-configurable terminal font size setting, persisted across app restarts.

## Changes

- **`AppSettingsModal`**: New "Appearance" section with terminal font size input (8–24px range, default 11)
- **`useAppStore`**: New `terminalFontSize` / `setTerminalFontSize` state
- **`App.tsx`**: Loads persisted `terminal_font_size` from `app_settings` on startup
- **`TerminalPanel.tsx`**: Uses store value for xterm.js `fontSize`; reinitializes terminal when font size changes

Setting is stored via the existing `app_settings` key-value table — no DB migration needed.

## Test plan

- [ ] Default font size is 11px on fresh install
- [ ] Change font size in Settings → terminal updates immediately
- [ ] Setting persists across app restart
- [ ] Values outside 8–24 range are rejected
- [ ] Existing terminals reinitialize with new size when changed