### PR TITLE
feat: workspace dashboard with last message preview

### DIFF
--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -5,7 +5,7 @@ use tauri::State;
 
 use claudette::db::Database;
 use claudette::git;
-use claudette::model::{Repository, Workspace};
+use claudette::model::{ChatMessage, Repository, Workspace};
 
 use crate::state::AppState;
 
@@ -16,6 +16,8 @@ pub struct InitialData {
     pub worktree_base_dir: String,
     /// Maps repo ID → default branch name (e.g., "main", "master").
     pub default_branches: HashMap<String, String>,
+    /// Most recent chat message per workspace (for dashboard display).
+    pub last_messages: Vec<ChatMessage>,
 }
 
 #[tauri::command]
@@ -52,10 +54,13 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
     let branch_results = futures::future::join_all(branch_futures).await;
     let default_branches: HashMap<String, String> = branch_results.into_iter().flatten().collect();
 
+    let last_messages = db.last_message_per_workspace().unwrap_or_default();
+
     Ok(InitialData {
         repositories,
         workspaces,
         worktree_base_dir,
         default_branches,
+        last_messages,
     })
 }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -54,7 +54,7 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
     let branch_results = futures::future::join_all(branch_futures).await;
     let default_branches: HashMap<String, String> = branch_results.into_iter().flatten().collect();
 
-    let last_messages = db.last_message_per_workspace().unwrap_or_default();
+    let last_messages = db.last_message_per_workspace().map_err(|e| e.to_string())?;
 
     Ok(InitialData {
         repositories,

--- a/src/db.rs
+++ b/src/db.rs
@@ -363,6 +363,32 @@ impl Database {
         Ok(())
     }
 
+    /// Get the most recent chat message for each workspace (for dashboard display).
+    pub fn last_message_per_workspace(&self) -> Result<Vec<ChatMessage>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT m.id, m.workspace_id, m.role, m.content, m.cost_usd, m.duration_ms, m.created_at
+             FROM chat_messages m
+             INNER JOIN (
+                 SELECT workspace_id, MAX(created_at) as max_created
+                 FROM chat_messages
+                 GROUP BY workspace_id
+             ) latest ON m.workspace_id = latest.workspace_id AND m.created_at = latest.max_created",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let role_str: String = row.get(2)?;
+            Ok(ChatMessage {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                role: role_str.parse().unwrap(),
+                content: row.get(3)?,
+                cost_usd: row.get(4)?,
+                duration_ms: row.get(5)?,
+                created_at: row.get(6)?,
+            })
+        })?;
+        rows.collect()
+    }
+
     #[allow(dead_code)]
     pub fn delete_chat_messages_for_workspace(
         &self,

--- a/src/db.rs
+++ b/src/db.rs
@@ -364,15 +364,18 @@ impl Database {
     }
 
     /// Get the most recent chat message for each workspace (for dashboard display).
+    /// Uses a correlated subquery with rowid tie-breaking to guarantee exactly
+    /// one row per workspace even when multiple messages share the same timestamp.
     pub fn last_message_per_workspace(&self) -> Result<Vec<ChatMessage>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
             "SELECT m.id, m.workspace_id, m.role, m.content, m.cost_usd, m.duration_ms, m.created_at
              FROM chat_messages m
-             INNER JOIN (
-                 SELECT workspace_id, MAX(created_at) as max_created
-                 FROM chat_messages
-                 GROUP BY workspace_id
-             ) latest ON m.workspace_id = latest.workspace_id AND m.created_at = latest.max_created",
+             WHERE m.rowid = (
+                 SELECT rowid FROM chat_messages c2
+                 WHERE c2.workspace_id = m.workspace_id
+                 ORDER BY c2.created_at DESC, c2.rowid DESC
+                 LIMIT 1
+             )",
         )?;
         let rows = stmt.query_map([], |row| {
             let role_str: String = row.get(2)?;
@@ -854,5 +857,55 @@ mod tests {
             .unwrap();
         let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
         assert_eq!(tabs[0].title, "My Custom Terminal");
+    }
+
+    #[test]
+    fn test_last_message_per_workspace() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "feature"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "second"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            "m3",
+            "w2",
+            ChatRole::User,
+            "other workspace",
+        ))
+        .unwrap();
+
+        let last = db.last_message_per_workspace().unwrap();
+        assert_eq!(last.len(), 2);
+
+        let w1_msg = last.iter().find(|m| m.workspace_id == "w1").unwrap();
+        assert_eq!(w1_msg.content, "second");
+
+        let w2_msg = last.iter().find(|m| m.workspace_id == "w2").unwrap();
+        assert_eq!(w2_msg.content, "other workspace");
+    }
+
+    #[test]
+    fn test_last_message_per_workspace_same_timestamp() {
+        let db = setup_db_with_workspace();
+        // Insert two messages with identical timestamps — the later rowid should win.
+        let mut m1 = make_chat_msg("m1", "w1", ChatRole::User, "first");
+        m1.created_at = "2026-01-01 00:00:00".into();
+        let mut m2 = make_chat_msg("m2", "w1", ChatRole::Assistant, "second");
+        m2.created_at = "2026-01-01 00:00:00".into();
+        db.insert_chat_message(&m1).unwrap();
+        db.insert_chat_message(&m2).unwrap();
+
+        let last = db.last_message_per_workspace().unwrap();
+        assert_eq!(last.len(), 1);
+        assert_eq!(last[0].content, "second");
+    }
+
+    #[test]
+    fn test_last_message_empty_when_no_messages() {
+        let db = setup_db_with_workspace();
+        let last = db.last_message_per_workspace().unwrap();
+        assert!(last.is_empty());
     }
 }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -10,6 +10,7 @@ function App() {
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
   const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
   const setTerminalFontSize = useAppStore((s) => s.setTerminalFontSize);
+  const setLastMessages = useAppStore((s) => s.setLastMessages);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -17,6 +18,12 @@ function App() {
       setWorkspaces(data.workspaces);
       setWorktreeBaseDir(data.worktree_base_dir);
       setDefaultBranches(data.default_branches);
+      // Index last messages by workspace_id for dashboard display.
+      const msgMap: Record<string, (typeof data.last_messages)[0]> = {};
+      for (const msg of data.last_messages) {
+        msgMap[msg.workspace_id] = msg;
+      }
+      setLastMessages(msgMap);
     });
     getAppSetting("terminal_font_size")
       .then((val) => {
@@ -26,7 +33,7 @@ function App() {
         }
       })
       .catch((err) => console.error("Failed to load terminal font size:", err));
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { DiffViewer } from "../diff/DiffViewer";
 import { TerminalPanel } from "../terminal/TerminalPanel";
 import { RightSidebar } from "../right-sidebar/RightSidebar";
 import { FuzzyFinder } from "../fuzzy-finder/FuzzyFinder";
+import { Dashboard } from "./Dashboard";
 import { StatusBar } from "./StatusBar";
 import { ModalRouter } from "../modals/ModalRouter";
 import { ResizeHandle } from "./ResizeHandle";
@@ -69,9 +70,7 @@ export function AppLayout() {
                 <ChatPanel />
               )
             ) : (
-              <div className={styles.empty}>
-                <p>Select a workspace to get started</p>
-              </div>
+              <Dashboard />
             )}
           </div>
           {terminalPanelVisible && selectedWorkspaceId && (

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -1,0 +1,126 @@
+.dashboard {
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.header {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 16px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  padding: 14px 16px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 13px;
+  transition: border-color 0.15s, background 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.card:hover {
+  background: var(--hover-bg);
+  border-color: var(--text-dim);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.repoName {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.statusDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.branchLine {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.branch {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.arrow {
+  color: var(--text-faint);
+  flex-shrink: 0;
+}
+
+.baseBranch {
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.lastMessage {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-dim);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.msgRole {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.msgContent {
+  color: var(--text-dim);
+}
+
+.noMessages {
+  font-size: 12px;
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.empty {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 14px;
+  gap: 4px;
+}
+
+.hint {
+  color: var(--text-dim);
+  font-size: 12px;
+}

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,6 +1,24 @@
+import { useMemo } from "react";
 import { GitBranch } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import styles from "./Dashboard.module.css";
+
+/** Strip markdown syntax for a clean one-line preview. */
+function stripMarkdown(s: string): string {
+  return s
+    .replace(/```[\s\S]*?```/g, "[code]")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\n+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 export function Dashboard() {
   const repositories = useAppStore((s) => s.repositories);
@@ -8,6 +26,11 @@ export function Dashboard() {
   const lastMessages = useAppStore((s) => s.lastMessages);
   const defaultBranches = useAppStore((s) => s.defaultBranches);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+
+  const repoMap = useMemo(
+    () => new Map(repositories.map((r) => [r.id, r])),
+    [repositories]
+  );
 
   const activeWorkspaces = workspaces.filter((ws) => ws.status === "Active");
 
@@ -27,13 +50,22 @@ export function Dashboard() {
       <div className={styles.header}>Active Workspaces</div>
       <div className={styles.grid}>
         {activeWorkspaces.map((ws) => {
-          const repo = repositories.find((r) => r.id === ws.repository_id);
+          const repo = repoMap.get(ws.repository_id);
           const lastMsg = lastMessages[ws.id];
           const baseBranch = repo ? defaultBranches[repo.id] : undefined;
+
+          const statusColor =
+            ws.agent_status === "Running"
+              ? "var(--status-running)"
+              : ws.agent_status === "Stopped" ||
+                  typeof ws.agent_status !== "string"
+                ? "var(--status-stopped)"
+                : "var(--status-idle)";
 
           return (
             <button
               key={ws.id}
+              type="button"
               className={styles.card}
               onClick={() => selectWorkspace(ws.id)}
             >
@@ -44,12 +76,7 @@ export function Dashboard() {
                 </span>
                 <span
                   className={styles.statusDot}
-                  style={{
-                    background:
-                      ws.agent_status === "Running"
-                        ? "var(--status-running)"
-                        : "var(--status-idle)",
-                  }}
+                  style={{ background: statusColor }}
                 />
               </div>
               <div className={styles.branchLine}>
@@ -73,7 +100,7 @@ export function Dashboard() {
                     :
                   </span>{" "}
                   <span className={styles.msgContent}>
-                    {lastMsg.content.slice(0, 120)}
+                    {stripMarkdown(lastMsg.content).slice(0, 120)}
                     {lastMsg.content.length > 120 ? "..." : ""}
                   </span>
                 </div>

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,0 +1,89 @@
+import { GitBranch } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import styles from "./Dashboard.module.css";
+
+export function Dashboard() {
+  const repositories = useAppStore((s) => s.repositories);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const lastMessages = useAppStore((s) => s.lastMessages);
+  const defaultBranches = useAppStore((s) => s.defaultBranches);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+
+  const activeWorkspaces = workspaces.filter((ws) => ws.status === "Active");
+
+  if (activeWorkspaces.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <p>No active workspaces</p>
+        <p className={styles.hint}>
+          Create a workspace from a repository in the sidebar
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.dashboard}>
+      <div className={styles.header}>Active Workspaces</div>
+      <div className={styles.grid}>
+        {activeWorkspaces.map((ws) => {
+          const repo = repositories.find((r) => r.id === ws.repository_id);
+          const lastMsg = lastMessages[ws.id];
+          const baseBranch = repo ? defaultBranches[repo.id] : undefined;
+
+          return (
+            <button
+              key={ws.id}
+              className={styles.card}
+              onClick={() => selectWorkspace(ws.id)}
+            >
+              <div className={styles.cardHeader}>
+                <span className={styles.repoName}>
+                  {repo?.icon && `${repo.icon} `}
+                  {repo?.name ?? "Unknown"}
+                </span>
+                <span
+                  className={styles.statusDot}
+                  style={{
+                    background:
+                      ws.agent_status === "Running"
+                        ? "var(--status-running)"
+                        : "var(--status-idle)",
+                  }}
+                />
+              </div>
+              <div className={styles.branchLine}>
+                <GitBranch size={11} />
+                <span className={styles.branch}>{ws.branch_name}</span>
+                {baseBranch && (
+                  <>
+                    <span className={styles.arrow}>{">"}</span>
+                    <span className={styles.baseBranch}>{baseBranch}</span>
+                  </>
+                )}
+              </div>
+              {lastMsg ? (
+                <div className={styles.lastMessage}>
+                  <span className={styles.msgRole}>
+                    {lastMsg.role === "User"
+                      ? "You"
+                      : lastMsg.role === "Assistant"
+                        ? "Claude"
+                        : "System"}
+                    :
+                  </span>{" "}
+                  <span className={styles.msgContent}>
+                    {lastMsg.content.slice(0, 120)}
+                    {lastMsg.content.length > 120 ? "..." : ""}
+                  </span>
+                </div>
+              ) : (
+                <div className={styles.noMessages}>No messages yet</div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -19,6 +19,7 @@ export interface InitialData {
   workspaces: Workspace[];
   worktree_base_dir: string;
   default_branches: Record<string, string>;
+  last_messages: ChatMessage[];
 }
 
 export function loadInitialData(): Promise<InitialData> {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -207,6 +207,7 @@ export const useAppStore = create<AppState>((set) => ({
         ...s.chatMessages,
         [wsId]: [...(s.chatMessages[wsId] || []), message],
       },
+      lastMessages: { ...s.lastMessages, [wsId]: message },
     })),
   setChatInput: (input) => set({ chatInput: input }),
   setStreamingContent: (wsId, content) =>

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -149,6 +149,8 @@ interface AppState {
   setDefaultBranches: (branches: Record<string, string>) => void;
   terminalFontSize: number;
   setTerminalFontSize: (size: number) => void;
+  lastMessages: Record<string, ChatMessage>;
+  setLastMessages: (msgs: Record<string, ChatMessage>) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -400,4 +402,6 @@ export const useAppStore = create<AppState>((set) => ({
   setDefaultBranches: (branches) => set({ defaultBranches: branches }),
   terminalFontSize: 11,
   setTerminalFontSize: (size) => set({ terminalFontSize: size }),
+  lastMessages: {},
+  setLastMessages: (msgs) => set({ lastMessages: msgs }),
 }));


### PR DESCRIPTION
## Summary

Replace the "Select a workspace to get started" empty state with a dashboard showing all active workspaces as cards. Each card shows where you left off, making it easy to pick up work across multiple workspaces.

## Dashboard cards show

- Repo name with icon and agent status dot (green = running)
- Branch → base branch with git icon
- Last message preview: who said what (truncated to 120 chars, 2 lines max)
- Click to open the workspace

If no active workspaces exist, shows "No active workspaces" with a hint.

## Changes

- **`src/db.rs`**: New `last_message_per_workspace()` query — single SQL query using `GROUP BY` + `MAX(created_at)` to get the most recent chat message per workspace
- **`src-tauri/src/commands/data.rs`**: `InitialData` includes `last_messages` — loaded at startup, no extra round-trip
- **`src/ui/src/stores/useAppStore.ts`**: `lastMessages` state indexed by workspace ID
- **`src/ui/src/App.tsx`**: Indexes last messages on load
- **`src/ui/src/components/layout/Dashboard.tsx`**: New dashboard component with responsive card grid
- **`src/ui/src/components/layout/AppLayout.tsx`**: Renders Dashboard instead of empty state

## Test plan

- [ ] Launch app with active workspaces → dashboard shows cards
- [ ] Cards show repo name, branch info, and last message preview
- [ ] Click card → opens workspace chat
- [ ] Workspace with no messages → shows "No messages yet"
- [ ] No active workspaces → shows empty state with hint
- [ ] Running agent → green status dot on card