### PR TITLE
ci: add release build workflow for macOS and Linux binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,90 @@
+name: Build & Publish Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build (e.g., v0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            rust-target: aarch64-apple-darwin
+            bundles: dmg
+            label: macos-aarch64
+          - platform: macos-13
+            rust-target: x86_64-apple-darwin
+            bundles: dmg
+            label: macos-x86_64
+          - platform: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-gnu
+            bundles: appimage,deb
+            label: linux-x86_64
+
+    name: Build (${{ matrix.label }})
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+          targets: ${{ matrix.rust-target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.label }}
+
+      - name: Install Linux system dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        run: cd src/ui && bun install --frozen-lockfile
+
+      - name: Build and upload binaries
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS code signing — uncomment and populate secrets when ready:
+          # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # APPLE_ID: ${{ secrets.APPLE_ID }}
+          # APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: ${{ github.event.release.tag_name || inputs.tag }}
+          releaseName: ${{ github.event.release.name || inputs.tag }}
+          releaseId: ${{ github.event.release.id || '' }}
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -59,7 +61,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
+            libayatana-appindicator3-dev \
             librsvg2-dev \
             patchelf \
             libgtk-3-dev \
@@ -85,6 +87,6 @@ jobs:
           # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ github.event.release.tag_name || inputs.tag }}
-          releaseName: ${{ github.event.release.name || inputs.tag }}
+          releaseName: ${{ github.event.release.name || '' }}
           releaseId: ${{ github.event.release.id || '' }}
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,9 @@ rand = "0.8"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [profile.release]
 strip = true
-lto = true
+lto = "thin"
 codegen-units = 1
 opt-level = "s"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,10 @@
     { "type": "chore", "section": "Miscellaneous", "hidden": true }
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": [
+        "src-tauri/Cargo.toml"
+      ]
+    }
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,5 @@
 {
   "productName": "Claudette",
-  "version": "0.1.0",
   "identifier": "com.claudette.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Adds automated binary builds when release-please creates a GitHub release. Three changes:

- **New workflow** (`.github/workflows/build-binaries.yml`): Triggered on `release: published`, builds Tauri desktop binaries across a 3-target matrix (macOS ARM, macOS Intel, Linux x86_64) and uploads DMG/AppImage/deb artifacts to the GitHub release. Also supports `workflow_dispatch` for manual re-runs.
- **Version sync** (`src-tauri/tauri.conf.json`): Removed hardcoded version — Tauri 2 falls back to reading it from `src-tauri/Cargo.toml`, which release-please bumps automatically.
- **Release profile** (`Cargo.toml`): Added `[profile.release]` with `strip`, `lto`, `codegen-units = 1`, and `opt-level = "s"` to keep binaries under the 30 MB target.

macOS code signing env vars are structured but commented out, ready to enable when certificates are provisioned.

```mermaid
flowchart LR
    A[Push to main] --> B[release-please.yml]
    B --> C[Creates GitHub Release]
    C --> D[build-binaries.yml]
    D --> E[macOS ARM DMG]
    D --> F[macOS Intel DMG]
    D --> G[Linux AppImage + deb]
    E & F & G --> H[Uploaded to Release]
```

## Test Steps

1. Verify CI passes on this PR (fmt, clippy, test — no changes to Rust source code)
2. After merge, trigger a release-please PR and merge it
3. Confirm the `Build & Publish Binaries` workflow runs with 3 matrix jobs
4. Verify DMG artifacts appear on the GitHub release for both macOS architectures
5. Verify AppImage and .deb artifacts appear for Linux
6. Alternatively, use `workflow_dispatch` on the workflow with a tag to test manually

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)