### PR TITLE
feat: dashboard navigation and shared repo icons

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -32,9 +32,14 @@
   border-radius: 4px;
 }
 
-.dashboardBtn:hover {
+.dashboardBtn:hover:not(:disabled) {
   color: var(--text-primary);
   background: var(--hover-bg);
+}
+
+.dashboardBtn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }
 
 .headerRight {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -17,6 +17,24 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.dashboardBtn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  border-radius: 4px;
+}
+
+.dashboardBtn:hover {
+  color: var(--text-primary);
+  background: var(--hover-bg);
 }
 
 .headerRight {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -247,9 +247,11 @@ export function ChatPanel() {
         <div className={styles.headerLeft}>
           <button
             className={styles.dashboardBtn}
-            onClick={() => selectWorkspace(null)}
-            title="Back to dashboard"
+            onClick={() => !isRunning && selectWorkspace(null)}
+            title={isRunning ? "Stop the agent before navigating away" : "Back to dashboard"}
+            aria-label="Back to dashboard"
             type="button"
+            disabled={isRunning}
           >
             <LayoutDashboard size={14} />
           </button>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { GitBranch } from "lucide-react";
+import { GitBranch, LayoutDashboard } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   loadChatHistory,
@@ -43,6 +43,7 @@ export function ChatPanel() {
   useAgentStream();
 
   const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const repo = repositories.find((r) => r.id === ws?.repository_id);
@@ -244,6 +245,14 @@ export function ChatPanel() {
     <div className={styles.panel}>
       <div className={styles.header}>
         <div className={styles.headerLeft}>
+          <button
+            className={styles.dashboardBtn}
+            onClick={() => selectWorkspace(null)}
+            title="Back to dashboard"
+            type="button"
+          >
+            <LayoutDashboard size={14} />
+          </button>
           {repo ? (
             <span className={styles.branchInfo}>
               <span className={styles.repoName}>{repo.name}</span>

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -48,8 +48,16 @@
 }
 
 .repoName {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-weight: 600;
   font-size: 14px;
+}
+
+.repoIcon {
+  flex-shrink: 0;
+  color: var(--text-muted);
 }
 
 .statusDot {

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { GitBranch } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
+import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Dashboard.module.css";
 
 /** Strip markdown syntax for a clean one-line preview. */
@@ -71,7 +72,13 @@ export function Dashboard() {
             >
               <div className={styles.cardHeader}>
                 <span className={styles.repoName}>
-                  {repo?.icon && `${repo.icon} `}
+                  {repo?.icon && (
+                    <RepoIcon
+                      icon={repo.icon}
+                      size={14}
+                      className={styles.repoIcon}
+                    />
+                  )}
                   {repo?.name ?? "Unknown"}
                 </span>
                 <span

--- a/src/ui/src/components/shared/RepoIcon.tsx
+++ b/src/ui/src/components/shared/RepoIcon.tsx
@@ -1,0 +1,23 @@
+import { icons } from "lucide-react";
+
+interface RepoIconProps {
+  icon: string;
+  size?: number;
+  className?: string;
+}
+
+export function RepoIcon({ icon, size = 14, className }: RepoIconProps) {
+  const pascalName = icon
+    .trim()
+    .toLowerCase()
+    .split("-")
+    .filter(Boolean)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join("");
+  const LucideIcon = icons[pascalName as keyof typeof icons];
+
+  if (LucideIcon) {
+    return <LucideIcon size={size} className={className} />;
+  }
+  return <span className={className}>{icon}</span>;
+}

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -6,24 +6,10 @@ import {
   generateWorkspaceName,
   createWorkspace,
 } from "../../services/tauri";
-import { Settings, Link, X, icons } from "lucide-react";
+import { Settings, Link, X } from "lucide-react";
+import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Sidebar.module.css";
 
-function RepoIcon({ icon }: { icon: string }) {
-  const pascalName = icon
-    .trim()
-    .toLowerCase()
-    .split("-")
-    .filter(Boolean)
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-    .join("");
-  const LucideIcon = icons[pascalName as keyof typeof icons];
-
-  if (LucideIcon) {
-    return <LucideIcon size={14} className={styles.repoIcon} />;
-  }
-  return <span className={styles.repoIcon}>{icon}</span>;
-}
 
 export function Sidebar() {
   const repositories = useAppStore((s) => s.repositories);
@@ -134,7 +120,7 @@ export function Sidebar() {
                   {collapsed ? "›" : "⌄"}
                 </span>
                 <span className={styles.repoName}>
-                  {repo.icon && <RepoIcon icon={repo.icon} />}
+                  {repo.icon && <RepoIcon icon={repo.icon} className={styles.repoIcon} />}
                   {repo.name}
                 </span>
                 {!repo.path_valid && (


### PR DESCRIPTION
## Summary

- Add a dashboard navigation button to the chat header so users can return to the workspace overview
- Extract `RepoIcon` into a shared component and fix dashboard to render proper Lucide icons

## Changes

- **`ChatPanel.tsx`**: Dashboard button (LayoutDashboard icon) to the left of the branch info. Calls `selectWorkspace(null)` to deselect and return to dashboard.
- **`components/shared/RepoIcon.tsx`**: New shared component — converts icon name strings (e.g., "rocket") to Lucide React components, with text fallback for non-Lucide values.
- **`Sidebar.tsx`**: Uses shared `RepoIcon` instead of local duplicate.
- **`Dashboard.tsx`**: Uses shared `RepoIcon` — icons now render as actual Lucide SVGs instead of raw text like "rocket".

## Test plan

- [ ] Click dashboard icon in chat header → returns to workspace dashboard
- [ ] Dashboard shows proper Lucide icons for repos that have them set
- [ ] Repos without icons show no icon (no empty space)
- [ ] Sidebar icons still render correctly after refactor
- [ ] Dashboard icon has hover state and tooltip