### PR TITLE
fix: use simple v* tag format for release-please

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to build (e.g., v0.2.0)"
+        description: "Release tag to build (e.g., v0.3.0)"
         required: true
         type: string
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
   ],
   "packages": {
     ".": {
+      "include-component-in-tag": false,
       "extra-files": [
         "src-tauri/Cargo.toml"
       ]


### PR DESCRIPTION
## Summary

The build-binaries workflow ([run #23881108957](https://github.com/utensils/Claudette/actions/runs/23881108957)) failed on all 3 platforms at the Checkout step. The root cause: release-please creates tags with a `claudette-` prefix (e.g., `claudette-v0.2.0`), but the workflow was manually dispatched with `v0.2.0` — a tag that doesn't exist.

This PR sets `include-component-in-tag: false` in the release-please config so future releases use the standard `v*` tag format (e.g., `v0.3.0`), which matches what the build workflow expects.

## Test Steps

1. Merge this PR and wait for the next release-please PR
2. Verify the release-please PR proposes a `v0.3.0` tag (not `claudette-v0.3.0`)
3. After the release is published, verify the build-binaries workflow triggers and the Checkout step succeeds

## Checklist

- [x] No tests needed (CI config change only)
- [x] No documentation changes needed