### PR TITLE
feat: per-repo custom instructions for agent chat

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -99,6 +99,20 @@ pub async fn send_chat_message(
     }
     let allowed_tools = tools_for_level(level);
 
+    // Resolve custom instructions: .claudette.json > repo settings > none.
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let repo = repos.iter().find(|r| r.id == ws.repository_id);
+    let custom_instructions = {
+        let from_config = repo
+            .and_then(|r| {
+                claudette::config::load_config(std::path::Path::new(&r.path))
+                    .ok()
+                    .flatten()
+            })
+            .and_then(|c| c.instructions);
+        from_config.or_else(|| repo.and_then(|r| r.custom_instructions.clone()))
+    };
+
     // Get or create agent session.
     let mut agents = state.agents.write().await;
     let session = agents
@@ -120,6 +134,7 @@ pub async fn send_chat_message(
         &content,
         is_resume,
         &allowed_tools,
+        custom_instructions.as_deref(),
     )
     .await?;
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -100,31 +100,37 @@ pub async fn send_chat_message(
     let allowed_tools = tools_for_level(level);
 
     // Resolve custom instructions: .claudette.json > repo settings > none.
-    let repos = db.list_repositories().map_err(|e| e.to_string())?;
-    let repo = repos.iter().find(|r| r.id == ws.repository_id);
-    let custom_instructions = {
-        let from_config = repo
-            .and_then(|r| {
-                claudette::config::load_config(std::path::Path::new(&r.path))
+    // Only resolved on the first turn — cached in the session for subsequent turns.
+    let repo = db
+        .get_repository(&ws.repository_id)
+        .map_err(|e| e.to_string())?;
+
+    // Get or create agent session. Custom instructions are resolved once on
+    // the first turn and cached for the session lifetime.
+    let mut agents = state.agents.write().await;
+    let session = agents.entry(workspace_id.clone()).or_insert_with(|| {
+        // First turn: resolve instructions from .claudette.json > repo settings.
+        let instructions = {
+            let from_config = repo.as_ref().and_then(|r| {
+                let path = r.path.clone();
+                claudette::config::load_config(std::path::Path::new(&path))
                     .ok()
                     .flatten()
-            })
-            .and_then(|c| c.instructions);
-        from_config.or_else(|| repo.and_then(|r| r.custom_instructions.clone()))
-    };
-
-    // Get or create agent session.
-    let mut agents = state.agents.write().await;
-    let session = agents
-        .entry(workspace_id.clone())
-        .or_insert_with(|| AgentSessionState {
+                    .and_then(|c| c.instructions)
+            });
+            from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
+        };
+        AgentSessionState {
             session_id: uuid::Uuid::new_v4().to_string(),
             turn_count: 0,
             active_pid: None,
-        });
+            custom_instructions: instructions,
+        }
+    });
 
     let is_resume = session.turn_count > 0;
     let session_id = session.session_id.clone();
+    let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
 
     // Spawn the agent turn.

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -14,6 +14,7 @@ use crate::state::AppState;
 pub struct RepoConfigInfo {
     pub has_config_file: bool,
     pub setup_script: Option<String>,
+    pub instructions: Option<String>,
     pub parse_error: Option<String>,
 }
 
@@ -42,6 +43,7 @@ pub async fn add_repository(
         icon: None,
         created_at: now_iso(),
         setup_script: None,
+        custom_instructions: None,
         path_valid: true,
     };
 
@@ -57,6 +59,7 @@ pub async fn update_repository_settings(
     name: String,
     icon: Option<String>,
     setup_script: Option<String>,
+    custom_instructions: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
@@ -65,6 +68,8 @@ pub async fn update_repository_settings(
     db.update_repository_icon(&id, icon.as_deref())
         .map_err(|e| e.to_string())?;
     db.update_repository_setup_script(&id, setup_script.as_deref())
+        .map_err(|e| e.to_string())?;
+    db.update_repository_custom_instructions(&id, custom_instructions.as_deref())
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -141,16 +146,19 @@ pub async fn get_repo_config(
         Ok(Some(cfg)) => Ok(RepoConfigInfo {
             has_config_file: true,
             setup_script: cfg.scripts.and_then(|s| s.setup),
+            instructions: cfg.instructions,
             parse_error: None,
         }),
         Ok(None) => Ok(RepoConfigInfo {
             has_config_file: false,
             setup_script: None,
+            instructions: None,
             parse_error: None,
         }),
         Err(e) => Ok(RepoConfigInfo {
             has_config_file: true,
             setup_script: None,
+            instructions: None,
             parse_error: Some(e),
         }),
     }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -11,6 +11,8 @@ pub struct AgentSessionState {
     pub turn_count: u32,
     /// PID of the currently running agent process, if any.
     pub active_pid: Option<u32>,
+    /// Cached custom instructions resolved on first turn.
+    pub custom_instructions: Option<String>,
 }
 
 /// Handle to an active PTY process.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -185,6 +185,7 @@ pub fn build_claude_args(
     prompt: &str,
     is_resume: bool,
     allowed_tools: &[String],
+    custom_instructions: Option<&str>,
 ) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
@@ -197,6 +198,13 @@ pub fn build_claude_args(
     if !allowed_tools.is_empty() {
         args.push("--allowedTools".to_string());
         args.push(allowed_tools.join(","));
+    }
+
+    if let Some(instructions) = custom_instructions
+        && !instructions.is_empty()
+    {
+        args.push("--append-system-prompt".to_string());
+        args.push(instructions.to_string());
     }
 
     if is_resume {
@@ -224,8 +232,15 @@ pub async fn run_turn(
     prompt: &str,
     is_resume: bool,
     allowed_tools: &[String],
+    custom_instructions: Option<&str>,
 ) -> Result<TurnHandle, String> {
-    let args = build_claude_args(session_id, prompt, is_resume, allowed_tools);
+    let args = build_claude_args(
+        session_id,
+        prompt,
+        is_resume,
+        allowed_tools,
+        custom_instructions,
+    );
 
     let mut cmd = Command::new("claude");
     cmd.args(&args)
@@ -651,18 +666,19 @@ mod tests {
 
     #[test]
     fn test_build_args_first_turn_no_tools() {
-        let args = build_claude_args("sess-1", "hello", false, &[]);
+        let args = build_claude_args("sess-1", "hello", false, &[], None);
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"--session-id".to_string()));
         assert!(args.contains(&"sess-1".to_string()));
         assert!(args.last() == Some(&"hello".to_string()));
         assert!(!args.contains(&"--allowedTools".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
     #[test]
     fn test_build_args_resume() {
-        let args = build_claude_args("sess-1", "continue", true, &[]);
+        let args = build_claude_args("sess-1", "continue", true, &[], None);
         assert!(args.contains(&"--resume".to_string()));
         assert!(!args.contains(&"--session-id".to_string()));
     }
@@ -670,8 +686,24 @@ mod tests {
     #[test]
     fn test_build_args_with_allowed_tools() {
         let tools = vec!["Bash".to_string(), "Read".to_string(), "Edit".to_string()];
-        let args = build_claude_args("sess-1", "hello", false, &tools);
+        let args = build_claude_args("sess-1", "hello", false, &tools, None);
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         assert_eq!(args[idx + 1], "Bash,Read,Edit");
+    }
+
+    #[test]
+    fn test_build_args_with_custom_instructions() {
+        let args = build_claude_args("sess-1", "hello", false, &[], Some("Always use TypeScript"));
+        let idx = args
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .unwrap();
+        assert_eq!(args[idx + 1], "Always use TypeScript");
+    }
+
+    #[test]
+    fn test_build_args_empty_instructions_skipped() {
+        let args = build_claude_args("sess-1", "hello", false, &[], Some(""));
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -200,8 +200,11 @@ pub fn build_claude_args(
         args.push(allowed_tools.join(","));
     }
 
-    if let Some(instructions) = custom_instructions
-        && !instructions.is_empty()
+    // Only append custom instructions on the first turn — resumed sessions
+    // already have the system prompt set from the initial turn.
+    if !is_resume
+        && let Some(instructions) = custom_instructions
+        && !instructions.trim().is_empty()
     {
         args.push("--append-system-prompt".to_string());
         args.push(instructions.to_string());
@@ -705,5 +708,18 @@ mod tests {
     fn test_build_args_empty_instructions_skipped() {
         let args = build_claude_args("sess-1", "hello", false, &[], Some(""));
         assert!(!args.contains(&"--append-system-prompt".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_whitespace_instructions_skipped() {
+        let args = build_claude_args("sess-1", "hello", false, &[], Some("   "));
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_resume_skips_instructions() {
+        let args = build_claude_args("sess-1", "hello", true, &[], Some("Always use TypeScript"));
+        assert!(!args.contains(&"--append-system-prompt".to_string()));
+        assert!(args.contains(&"--resume".to_string()));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,9 @@ const CONFIG_FILE_NAME: &str = ".claudette.json";
 pub struct ClaudetteConfig {
     #[serde(default)]
     pub scripts: Option<Scripts>,
+    /// Custom instructions appended to the agent's system prompt.
+    #[serde(default)]
+    pub instructions: Option<String>,
 }
 
 /// Script definitions within `.claudette.json`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,34 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_config_with_instructions() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            r#"{"instructions": "Always use TypeScript"}"#,
+        )
+        .unwrap();
+
+        let config = load_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.instructions.unwrap(), "Always use TypeScript");
+        assert!(config.scripts.is_none());
+    }
+
+    #[test]
+    fn test_valid_config_with_instructions_and_scripts() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE_NAME),
+            r#"{"instructions": "Use Rust", "scripts": {"setup": "cargo build"}}"#,
+        )
+        .unwrap();
+
+        let config = load_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.instructions.unwrap(), "Use Rust");
+        assert_eq!(config.scripts.unwrap().setup.unwrap(), "cargo build");
+    }
+
+    #[test]
     fn test_malformed_json() {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join(CONFIG_FILE_NAME), "not valid json {{{").unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -123,6 +123,14 @@ impl Database {
             )?;
         }
 
+        if version < 6 {
+            self.conn.execute_batch(
+                "ALTER TABLE repositories ADD COLUMN custom_instructions TEXT;
+
+                 PRAGMA user_version = 6;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -138,7 +146,7 @@ impl Database {
 
     pub fn list_repositories(&self) -> Result<Vec<Repository>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, path, name, icon, path_slug, created_at, setup_script
+            "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions
              FROM repositories ORDER BY name",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -150,6 +158,7 @@ impl Database {
                 path_slug: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
                 created_at: row.get(5)?,
                 setup_script: row.get(6)?,
+                custom_instructions: row.get(7)?,
                 path_valid: true, // validated after load
             })
         })?;
@@ -200,6 +209,18 @@ impl Database {
         self.conn.execute(
             "UPDATE repositories SET setup_script = ?1 WHERE id = ?2",
             params![script, id],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_repository_custom_instructions(
+        &self,
+        id: &str,
+        instructions: Option<&str>,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE repositories SET custom_instructions = ?1 WHERE id = ?2",
+            params![instructions, id],
         )?;
         Ok(())
     }
@@ -493,6 +514,7 @@ mod tests {
             icon: None,
             created_at: String::new(),
             setup_script: None,
+            custom_instructions: None,
             path_valid: true,
         }
     }
@@ -741,6 +763,7 @@ mod tests {
             icon: None,
             created_at: String::new(),
             setup_script: None,
+            custom_instructions: None,
             path_valid: true,
         };
         db.insert_repository(&repo).unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::model::{ChatMessage, Repository, TerminalTab, Workspace, WorkspaceStatus};
 
@@ -163,6 +163,28 @@ impl Database {
             })
         })?;
         rows.collect()
+    }
+
+    pub fn get_repository(&self, id: &str) -> Result<Option<Repository>, rusqlite::Error> {
+        self.conn.query_row(
+            "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions
+             FROM repositories WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(Repository {
+                    id: row.get(0)?,
+                    path: row.get(1)?,
+                    name: row.get(2)?,
+                    icon: row.get(3)?,
+                    path_slug: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+                    created_at: row.get(5)?,
+                    setup_script: row.get(6)?,
+                    custom_instructions: row.get(7)?,
+                    path_valid: true,
+                })
+            },
+        )
+        .optional()
     }
 
     pub fn update_repository_path(&self, id: &str, path: &str) -> Result<(), rusqlite::Error> {

--- a/src/model/repository.rs
+++ b/src/model/repository.rs
@@ -14,6 +14,8 @@ pub struct Repository {
     pub created_at: String,
     /// Per-user setup script configured in the Settings UI. None means no script.
     pub setup_script: Option<String>,
+    /// Custom instructions appended to the agent's system prompt for every chat.
+    pub custom_instructions: Option<String>,
     /// Runtime-only: whether the repo path still exists on disk. Not persisted.
     pub path_valid: bool,
 }

--- a/src/ui/src/components/modals/RepoSettingsModal.tsx
+++ b/src/ui/src/components/modals/RepoSettingsModal.tsx
@@ -19,6 +19,9 @@ export function RepoSettingsModal() {
   const [name, setName] = useState(repo?.name ?? "");
   const [icon, setIcon] = useState(repo?.icon ?? "");
   const [setupScript, setSetupScript] = useState(repo?.setup_script ?? "");
+  const [customInstructions, setCustomInstructions] = useState(
+    repo?.custom_instructions ?? ""
+  );
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -43,11 +46,19 @@ export function RepoSettingsModal() {
     try {
       const iconValue = icon.trim() || null;
       const scriptValue = setupScript.trim() || null;
-      await updateRepositorySettings(repoId, name.trim(), iconValue, scriptValue);
+      const instructionsValue = customInstructions.trim() || null;
+      await updateRepositorySettings(
+        repoId,
+        name.trim(),
+        iconValue,
+        scriptValue,
+        instructionsValue
+      );
       updateRepo(repoId, {
         name: name.trim(),
         icon: iconValue,
         setup_script: scriptValue,
+        custom_instructions: instructionsValue,
       });
       closeModal();
     } catch (e) {
@@ -136,6 +147,33 @@ export function RepoSettingsModal() {
         />
         <div className={shared.hint}>
           Runs automatically when a new workspace is created.
+        </div>
+      </div>
+
+      <div
+        style={{
+          borderTop: "1px solid var(--divider)",
+          marginTop: 16,
+          paddingTop: 12,
+        }}
+      >
+        <label className={shared.label}>Custom Instructions</label>
+        <textarea
+          className={shared.input}
+          value={customInstructions}
+          onChange={(e) => setCustomInstructions(e.target.value)}
+          placeholder="e.g. Always use TypeScript. Prefer functional components."
+          rows={4}
+          style={{
+            fontFamily: "monospace",
+            fontSize: 12,
+            resize: "vertical",
+          }}
+        />
+        <div className={shared.hint}>
+          Appended to the agent's system prompt at the start of every chat.
+          Can also be set in <code>.claudette.json</code> (repo-level takes
+          precedence).
         </div>
       </div>
 

--- a/src/ui/src/components/modals/RepoSettingsModal.tsx
+++ b/src/ui/src/components/modals/RepoSettingsModal.tsx
@@ -39,6 +39,8 @@ export function RepoSettingsModal() {
 
   const repoScriptOverrides =
     repoConfig?.has_config_file && repoConfig.setup_script != null;
+  const repoInstructionsOverrides =
+    repoConfig?.has_config_file && repoConfig.instructions != null;
 
   const handleSave = async () => {
     setLoading(true);
@@ -158,6 +160,41 @@ export function RepoSettingsModal() {
         }}
       >
         <label className={shared.label}>Custom Instructions</label>
+        {repoInstructionsOverrides && (
+          <div className={shared.hint} style={{ marginBottom: 8 }}>
+            This repo includes a <code>.claudette.json</code> that defines
+            custom instructions. Repo-level instructions take precedence over
+            your personal instructions.
+          </div>
+        )}
+        {repoConfig?.has_config_file && repoConfig.instructions && (
+          <div style={{ marginBottom: 8 }}>
+            <div
+              className={shared.label}
+              style={{ fontSize: 11, marginBottom: 2 }}
+            >
+              From .claudette.json (read-only):
+            </div>
+            <pre
+              style={{
+                background: "var(--chat-input-bg)",
+                border: "1px solid var(--divider)",
+                borderRadius: 4,
+                padding: "6px 8px",
+                fontSize: 12,
+                color: "var(--text-dim)",
+                margin: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {repoConfig.instructions}
+            </pre>
+          </div>
+        )}
+        <div className={shared.label} style={{ fontSize: 11, marginBottom: 2 }}>
+          Personal instructions{repoInstructionsOverrides ? " (overridden)" : ""}:
+        </div>
         <textarea
           className={shared.input}
           value={customInstructions}
@@ -168,12 +205,11 @@ export function RepoSettingsModal() {
             fontFamily: "monospace",
             fontSize: 12,
             resize: "vertical",
+            opacity: repoInstructionsOverrides ? 0.5 : 1,
           }}
         />
         <div className={shared.hint}>
           Appended to the agent's system prompt at the start of every chat.
-          Can also be set in <code>.claudette.json</code> (repo-level takes
-          precedence).
         </div>
       </div>
 

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -36,9 +36,16 @@ export function updateRepositorySettings(
   id: string,
   name: string,
   icon: string | null,
-  setupScript: string | null
+  setupScript: string | null,
+  customInstructions: string | null
 ): Promise<void> {
-  return invoke("update_repository_settings", { id, name, icon, setupScript });
+  return invoke("update_repository_settings", {
+    id,
+    name,
+    icon,
+    setupScript,
+    customInstructions,
+  });
 }
 
 export function relinkRepository(id: string, path: string): Promise<void> {

--- a/src/ui/src/types/repository.ts
+++ b/src/ui/src/types/repository.ts
@@ -6,6 +6,7 @@ export interface Repository {
   icon: string | null;
   created_at: string;
   setup_script: string | null;
+  custom_instructions: string | null;
   path_valid: boolean;
 }
 

--- a/src/ui/src/types/repository.ts
+++ b/src/ui/src/types/repository.ts
@@ -27,5 +27,6 @@ export interface CreateWorkspaceResult {
 export interface RepoConfigInfo {
   has_config_file: boolean;
   setup_script: string | null;
+  instructions: string | null;
   parse_error: string | null;
 }


### PR DESCRIPTION
## Summary

Add per-repo custom instructions that are appended to the agent's system prompt at the start of every chat. Supports both personal settings (UI) and team-shared settings (`.claudette.json`).

## How it works

Instructions are resolved with the same precedence as setup scripts:
```
1. .claudette.json "instructions" field  ← repo-level, team-shared
2. Repo Settings UI                       ← personal
3. No instructions                        ← nothing appended
```

Passed to the Claude CLI via `--append-system-prompt`, which adds to the default system prompt without replacing it.

## Example `.claudette.json`

```json
{
  "instructions": "Always use TypeScript. Prefer functional React components. Follow the existing code style.",
  "scripts": {
    "setup": "mise trust && mise install"
  }
}
```

## Changes

### Backend
- **`src/db.rs`**: Migration 6 adds `custom_instructions` column to repositories
- **`src/config.rs`**: `.claudette.json` schema extended with `instructions` field
- **`src/agent.rs`**: `build_claude_args` / `run_turn` accept `custom_instructions`, pass `--append-system-prompt` to CLI. 2 new tests.
- **`src-tauri/src/commands/chat.rs`**: Resolves instructions (`.claudette.json` > settings > none) before spawning agent
- **`src-tauri/src/commands/repository.rs`**: `update_repository_settings` and `get_repo_config` extended with instructions

### Frontend
- **`src/ui/src/types/repository.ts`**: `custom_instructions` field on `Repository`
- **`src/ui/src/services/tauri.ts`**: `updateRepositorySettings` passes `customInstructions`
- **`src/ui/src/components/modals/RepoSettingsModal.tsx`**: "Custom Instructions" textarea with `.claudette.json` precedence note

## Test plan

- [ ] Set instructions in Repo Settings → agent receives them (visible in `--verbose` output)
- [ ] Set instructions in `.claudette.json` → takes precedence over settings
- [ ] No instructions set → `--append-system-prompt` flag is not passed
- [ ] Empty instructions → treated as no instructions
- [ ] Instructions persist across app restarts
- [ ] Existing tests pass (94 total including 2 new)