### PR TITLE
fix: terminal tabs persist across tab switches (#71)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -20,10 +20,17 @@ pub async fn create_terminal_tab(
         .map_err(|e| e.to_string())?;
     let sort_order = existing.len() as i32;
 
+    // Find the lowest unused terminal number to avoid title collisions.
+    let mut n = 1;
+    let used_titles: Vec<_> = existing.iter().map(|t| t.title.as_str()).collect();
+    while used_titles.contains(&format!("Terminal {n}").as_str()) {
+        n += 1;
+    }
+
     let tab = TerminalTab {
         id: new_id,
         workspace_id,
-        title: format!("Terminal {}", existing.len() + 1),
+        title: format!("Terminal {n}"),
         is_script_output: false,
         sort_order,
         created_at: now_iso(),

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -23,7 +23,7 @@ pub async fn create_terminal_tab(
     let tab = TerminalTab {
         id: new_id,
         workspace_id,
-        title: format!("Terminal {new_id}"),
+        title: format!("Terminal {}", existing.len() + 1),
         is_script_output: false,
         sort_order,
         created_at: now_iso(),

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -126,35 +126,55 @@ export function TerminalPanel() {
     const worktreePath = ws.worktree_path!;
 
     (async () => {
-      const ptyId = await spawnPty(worktreePath);
-      const inst = instancesRef.current.get(currentTabId);
-      if (!inst) {
-        closePty(ptyId);
-        return;
-      }
-      inst.ptyId = ptyId;
-
-      const unlistenFn = await listen<PtyOutputPayload>(
-        "pty-output",
-        (event) => {
-          if (event.payload.pty_id === ptyId) {
-            term.write(new Uint8Array(event.payload.data));
-          }
+      try {
+        const ptyId = await spawnPty(worktreePath);
+        // Re-check: instance may have been removed during await.
+        const inst = instancesRef.current.get(currentTabId);
+        if (!inst) {
+          closePty(ptyId);
+          return;
         }
-      );
-      inst.unlisten = unlistenFn;
+        inst.ptyId = ptyId;
 
-      term.onData((data) => {
-        const bytes = Array.from(new TextEncoder().encode(data));
-        writePty(ptyId, bytes);
-      });
+        const unlistenFn = await listen<PtyOutputPayload>(
+          "pty-output",
+          (event) => {
+            if (event.payload.pty_id === ptyId) {
+              term.write(new Uint8Array(event.payload.data));
+            }
+          }
+        );
+        // Re-check again: instance may have been removed during listen await.
+        const stillExists = instancesRef.current.get(currentTabId);
+        if (!stillExists || stillExists !== inst) {
+          unlistenFn();
+          closePty(ptyId);
+          return;
+        }
+        inst.unlisten = unlistenFn;
 
-      term.onResize(({ cols, rows }) => {
-        resizePty(ptyId, cols, rows);
-      });
+        term.onData((data) => {
+          const bytes = Array.from(new TextEncoder().encode(data));
+          writePty(ptyId, bytes);
+        });
 
-      fit.fit();
-      resizePty(ptyId, term.cols, term.rows);
+        term.onResize(({ cols, rows }) => {
+          resizePty(ptyId, cols, rows);
+        });
+
+        fit.fit();
+        resizePty(ptyId, term.cols, term.rows);
+      } catch (e) {
+        // Setup failed — clean up the orphaned instance.
+        console.error("Failed to initialize terminal:", e);
+        const inst = instancesRef.current.get(currentTabId);
+        if (inst) {
+          inst.resizeObserver.disconnect();
+          inst.term.dispose();
+          inst.container.remove();
+          instancesRef.current.delete(currentTabId);
+        }
+      }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTerminalTabId, ws?.worktree_path]);
@@ -187,6 +207,7 @@ export function TerminalPanel() {
         inst.term.dispose();
         if (inst.unlisten) inst.unlisten();
         if (inst.ptyId >= 0) closePty(inst.ptyId);
+        inst.container.remove();
       }
       instancesRef.current.clear();
     };

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -21,6 +21,15 @@ interface PtyOutputPayload {
   data: number[];
 }
 
+interface TermInstance {
+  term: Terminal;
+  fit: FitAddon;
+  ptyId: number;
+  unlisten: (() => void) | null;
+  container: HTMLDivElement;
+  resizeObserver: ResizeObserver;
+}
+
 export function TerminalPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -34,10 +43,9 @@ export function TerminalPanel() {
   const terminalFontSize = useAppStore((s) => s.terminalFontSize);
 
   const autoCreatedRef = useRef<string | null>(null);
-  const termRef = useRef<HTMLDivElement>(null);
-  const xtermRef = useRef<Terminal | null>(null);
-  const fitRef = useRef<FitAddon | null>(null);
-  const ptyIdRef = useRef<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Map of tab ID → terminal instance. Persists across tab switches.
+  const instancesRef = useRef<Map<number, TermInstance>>(new Map());
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const tabs = selectedWorkspaceId
@@ -71,9 +79,21 @@ export function TerminalPanel() {
     activeTerminalTabId,
   ]);
 
-  // Initialize xterm and PTY
+  // Create a terminal instance for a tab if it doesn't exist yet.
   useEffect(() => {
-    if (!termRef.current || !ws?.worktree_path || !activeTerminalTabId) return;
+    if (
+      !containerRef.current ||
+      !ws?.worktree_path ||
+      !activeTerminalTabId ||
+      instancesRef.current.has(activeTerminalTabId)
+    ) {
+      return;
+    }
+
+    const tabContainer = document.createElement("div");
+    tabContainer.style.height = "100%";
+    tabContainer.style.width = "100%";
+    containerRef.current.appendChild(tabContainer);
 
     const term = new Terminal({
       fontSize: terminalFontSize,
@@ -88,69 +108,89 @@ export function TerminalPanel() {
     const links = new WebLinksAddon();
     term.loadAddon(fit);
     term.loadAddon(links);
-    term.open(termRef.current);
+    term.open(tabContainer);
     fit.fit();
 
-    xtermRef.current = term;
-    fitRef.current = fit;
+    const instance: TermInstance = {
+      term,
+      fit,
+      ptyId: -1,
+      unlisten: null,
+      container: tabContainer,
+      resizeObserver: new ResizeObserver(() => fit.fit()),
+    };
+    instance.resizeObserver.observe(tabContainer);
+    instancesRef.current.set(activeTerminalTabId, instance);
 
-    let ptyId: number | null = null;
-    let unlisten: (() => void) | null = null;
+    const currentTabId = activeTerminalTabId;
+    const worktreePath = ws.worktree_path!;
 
     (async () => {
-      ptyId = await spawnPty(ws.worktree_path!);
-      ptyIdRef.current = ptyId;
+      const ptyId = await spawnPty(worktreePath);
+      const inst = instancesRef.current.get(currentTabId);
+      if (!inst) {
+        closePty(ptyId);
+        return;
+      }
+      inst.ptyId = ptyId;
 
-      const currentPtyId = ptyId;
       const unlistenFn = await listen<PtyOutputPayload>(
         "pty-output",
         (event) => {
-          if (event.payload.pty_id === currentPtyId) {
+          if (event.payload.pty_id === ptyId) {
             term.write(new Uint8Array(event.payload.data));
           }
         }
       );
-      unlisten = unlistenFn;
+      inst.unlisten = unlistenFn;
 
       term.onData((data) => {
         const bytes = Array.from(new TextEncoder().encode(data));
-        writePty(currentPtyId, bytes);
+        writePty(ptyId, bytes);
       });
 
       term.onResize(({ cols, rows }) => {
-        resizePty(currentPtyId, cols, rows);
+        resizePty(ptyId, cols, rows);
       });
 
-      // Initial resize after PTY is ready
       fit.fit();
-      resizePty(currentPtyId, term.cols, term.rows);
+      resizePty(ptyId, term.cols, term.rows);
     })();
-
-    const resizeObserver = new ResizeObserver(() => {
-      fit.fit();
-    });
-    resizeObserver.observe(termRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-      term.dispose();
-      xtermRef.current = null;
-      fitRef.current = null;
-      if (unlisten) unlisten();
-      if (ptyId !== null) {
-        closePty(ptyId);
-        ptyIdRef.current = null;
-      }
-    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTerminalTabId, ws?.worktree_path]);
 
-  // Update font size without destroying the terminal/PTY.
+  // Show/hide terminal containers based on active tab.
   useEffect(() => {
-    if (xtermRef.current) {
-      xtermRef.current.options.fontSize = terminalFontSize;
-      fitRef.current?.fit();
+    for (const [tabId, inst] of instancesRef.current) {
+      const isActive = tabId === activeTerminalTabId;
+      inst.container.style.display = isActive ? "block" : "none";
+      if (isActive) {
+        inst.fit.fit();
+        inst.term.focus();
+      }
+    }
+  }, [activeTerminalTabId]);
+
+  // Update font size on all instances without destroying them.
+  useEffect(() => {
+    for (const inst of instancesRef.current.values()) {
+      inst.term.options.fontSize = terminalFontSize;
+      inst.fit.fit();
     }
   }, [terminalFontSize]);
+
+  // Cleanup all instances on workspace change.
+  useEffect(() => {
+    return () => {
+      for (const inst of instancesRef.current.values()) {
+        inst.resizeObserver.disconnect();
+        inst.term.dispose();
+        if (inst.unlisten) inst.unlisten();
+        if (inst.ptyId >= 0) closePty(inst.ptyId);
+      }
+      instancesRef.current.clear();
+    };
+  }, [selectedWorkspaceId]);
 
   const handleCreateTab = useCallback(async () => {
     if (!selectedWorkspaceId) return;
@@ -165,6 +205,16 @@ export function TerminalPanel() {
   const handleCloseTab = useCallback(
     async (tabId: number) => {
       if (!selectedWorkspaceId) return;
+      // Destroy the instance for this tab.
+      const inst = instancesRef.current.get(tabId);
+      if (inst) {
+        inst.resizeObserver.disconnect();
+        inst.term.dispose();
+        if (inst.unlisten) inst.unlisten();
+        if (inst.ptyId >= 0) closePty(inst.ptyId);
+        inst.container.remove();
+        instancesRef.current.delete(tabId);
+      }
       try {
         await deleteTerminalTab(tabId);
         removeTerminalTab(selectedWorkspaceId, tabId);
@@ -204,7 +254,7 @@ export function TerminalPanel() {
           −
         </button>
       </div>
-      <div className={styles.termContainer} ref={termRef} />
+      <div className={styles.termContainer} ref={containerRef} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fix terminal tabs resetting when switching between them. Previously, switching tabs destroyed the PTY and xterm instance, killing any running process.

## Changes

- **`TerminalPanel.tsx`**: Replaced single-instance model with a persistent `Map<tabId, TermInstance>`. Each tab gets its own xterm + PTY + DOM container. Switching tabs toggles `display: none/block` instead of teardown/rebuild. Instances are only destroyed on explicit tab close or workspace switch.
- **`src-tauri/src/commands/terminal.rs`**: Tab titles now based on existing tab count (`Terminal 1`, `Terminal 2`) instead of global auto-increment ID, so numbering stays sequential after deletions.

## Root cause

The terminal initialization `useEffect` had `activeTerminalTabId` as a dependency. Every tab switch triggered cleanup (dispose xterm, close PTY, kill shell) followed by a fresh spawn. The new architecture keeps all tab instances alive in a ref map.

Fixes #71

## Test plan

- [ ] Open Terminal 1, run a long command (e.g., `top`)
- [ ] Open Terminal 2
- [ ] Switch back to Terminal 1 → process still running, output preserved
- [ ] Switch to Terminal 2 → process still running
- [ ] Close Terminal 1 → only Terminal 1's PTY is killed
- [ ] Create new tab after deleting one → numbered sequentially (not skipping)
- [ ] Change font size in settings → all tabs update without restart
- [ ] Switch workspaces → old workspace terminals cleaned up