### PR TITLE
fix(ci): chain build jobs into release-please workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,8 +1,6 @@
 name: Build & Publish Binaries
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -42,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -86,7 +84,7 @@ jobs:
           # APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: ${{ github.event.release.tag_name || inputs.tag }}
-          releaseName: ${{ github.event.release.name || '' }}
-          releaseId: ${{ github.event.release.id || '' }}
+          tagName: ${{ inputs.tag }}
+          releaseName: ""
+          releaseId: ""
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,9 +8,92 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   release-please:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
+
+  build:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            rust-target: aarch64-apple-darwin
+            bundles: dmg
+            label: macos-aarch64
+          - platform: macos-13
+            rust-target: x86_64-apple-darwin
+            bundles: dmg
+            label: macos-x86_64
+          - platform: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-gnu
+            bundles: appimage,deb
+            label: linux-x86_64
+
+    name: Build (${{ matrix.label }})
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+          targets: ${{ matrix.rust-target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.label }}
+
+      - name: Install Linux system dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        run: cd src/ui && bun install --frozen-lockfile
+
+      - name: Build and upload binaries
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS code signing — uncomment and populate secrets when ready:
+          # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # APPLE_ID: ${{ secrets.APPLE_ID }}
+          # APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: ${{ needs.release-please.outputs.tag_name }}
+          releaseName: ${{ needs.release-please.outputs.tag_name }}
+          releaseId: ""
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}


### PR DESCRIPTION
## Summary

- **Root cause**: `build-binaries.yml` triggered on `release: types: [published]`, but GitHub Actions [does not fire workflow events from actions taken by `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). Since release-please uses `GITHUB_TOKEN` to create the release, the event was silently dropped.
- **Fix**: Move the build matrix into `release-please.yml` as a downstream job conditioned on `releases_created == 'true'`, bypassing the cross-workflow trigger entirely.
- **Cleanup**: Strip the dead `release` trigger from `build-binaries.yml`, keeping it as a `workflow_dispatch`-only workflow for manual/ad-hoc builds.

```mermaid
flowchart LR
    A[Push to main] --> B[release-please job]
    B -->|releases_created=true| C[Build matrix: macOS arm64, macOS x86, Linux x86]
    B -->|releases_created=false| D[Skip build]
    C --> E[Upload binaries to GitHub Release]
```

## Complexity Notes

The `tauri-action@v0` `releaseId` is passed as `""` in both the release-please build job and the manual workflow. The action resolves the release from the tag name when no ID is provided, so this is safe.

## Test Steps

1. Merge this PR, then push a non-release commit to `main` — verify the release-please workflow runs but the build job is **skipped** (shows as grey/skipped in Actions)
2. When the next release-please PR is merged, confirm the build matrix jobs fire and attach binaries to the GitHub Release
3. Trigger `build-binaries.yml` manually via Actions → "Run workflow" with a valid tag (e.g., `v0.3.0`) to verify the manual path still works

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)