### PR TITLE
feat(ui): comprehensive UI/UX overhaul with brand identity and polish

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use claudette::agent::{self, AgentEvent, StreamEvent};
+use claudette::agent::{self, AgentEvent, AgentSettings, StreamEvent};
 use claudette::db::Database;
 use claudette::model::{ChatMessage, ChatRole};
 
@@ -58,10 +58,15 @@ pub async fn load_chat_history(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn send_chat_message(
     workspace_id: String,
     content: String,
     permission_level: Option<String>,
+    model: Option<String>,
+    fast_mode: Option<bool>,
+    thinking_enabled: Option<bool>,
+    plan_mode: Option<bool>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -133,6 +138,14 @@ pub async fn send_chat_message(
     let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
 
+    // Build agent settings from frontend params.
+    let agent_settings = AgentSettings {
+        model: if !is_resume { model } else { None },
+        fast_mode: fast_mode.unwrap_or(false),
+        thinking_enabled: thinking_enabled.unwrap_or(false),
+        plan_mode: plan_mode.unwrap_or(false),
+    };
+
     // Spawn the agent turn.
     let turn_handle = agent::run_turn(
         std::path::Path::new(&worktree_path),
@@ -141,6 +154,7 @@ pub async fn send_chat_message(
         is_resume,
         &allowed_tools,
         custom_instructions.as_deref(),
+        &agent_settings,
     )
     .await?;
 
@@ -248,6 +262,16 @@ pub async fn stop_agent(workspace_id: String, state: State<'_, AppState>) -> Res
     };
     db.insert_chat_message(&msg).map_err(|e| e.to_string())?;
 
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn reset_agent_session(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let mut agents = state.agents.write().await;
+    agents.remove(&workspace_id);
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -65,6 +65,7 @@ fn main() {
             commands::chat::load_chat_history,
             commands::chat::send_chat_message,
             commands::chat::stop_agent,
+            commands::chat::reset_agent_session,
             // Diff
             commands::diff::load_diff_files,
             commands::diff::load_file_diff,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -170,6 +170,25 @@ pub enum AgentEvent {
 }
 
 // ---------------------------------------------------------------------------
+// Per-turn agent settings
+// ---------------------------------------------------------------------------
+
+/// Per-turn settings that control CLI flags for the agent subprocess.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AgentSettings {
+    /// Model alias (e.g. "opus", "sonnet") or full model ID. Session-level: only
+    /// applied on the first turn.
+    pub model: Option<String>,
+    /// Enable fast mode via `--settings`.
+    pub fast_mode: bool,
+    /// Enable extended thinking via `--settings`.
+    pub thinking_enabled: bool,
+    /// Start session in plan permission mode. Session-level: only applied on
+    /// the first turn.
+    pub plan_mode: bool,
+}
+
+// ---------------------------------------------------------------------------
 // Per-turn agent process
 // ---------------------------------------------------------------------------
 
@@ -186,6 +205,7 @@ pub fn build_claude_args(
     is_resume: bool,
     allowed_tools: &[String],
     custom_instructions: Option<&str>,
+    settings: &AgentSettings,
 ) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
@@ -194,6 +214,34 @@ pub fn build_claude_args(
         "--verbose".to_string(),
         "--include-partial-messages".to_string(),
     ];
+
+    // Session-level flags — only on first turn.
+    if !is_resume {
+        if let Some(ref model) = settings.model {
+            args.push("--model".to_string());
+            args.push(model.clone());
+        }
+        if settings.plan_mode {
+            args.push("--permission-mode".to_string());
+            args.push("plan".to_string());
+        }
+    }
+
+    // Per-turn settings via --settings JSON.
+    if settings.fast_mode || settings.thinking_enabled {
+        let mut obj = serde_json::Map::new();
+        if settings.fast_mode {
+            obj.insert("fastMode".to_string(), serde_json::Value::Bool(true));
+        }
+        if settings.thinking_enabled {
+            obj.insert(
+                "alwaysThinkingEnabled".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        args.push("--settings".to_string());
+        args.push(serde_json::Value::Object(obj).to_string());
+    }
 
     if !allowed_tools.is_empty() {
         args.push("--allowedTools".to_string());
@@ -236,6 +284,7 @@ pub async fn run_turn(
     is_resume: bool,
     allowed_tools: &[String],
     custom_instructions: Option<&str>,
+    settings: &AgentSettings,
 ) -> Result<TurnHandle, String> {
     let args = build_claude_args(
         session_id,
@@ -243,6 +292,7 @@ pub async fn run_turn(
         is_resume,
         allowed_tools,
         custom_instructions,
+        settings,
     );
 
     let mut cmd = Command::new("claude");
@@ -669,7 +719,14 @@ mod tests {
 
     #[test]
     fn test_build_args_first_turn_no_tools() {
-        let args = build_claude_args("sess-1", "hello", false, &[], None);
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            false,
+            &[],
+            None,
+            &AgentSettings::default(),
+        );
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"--session-id".to_string()));
         assert!(args.contains(&"sess-1".to_string()));
@@ -681,7 +738,14 @@ mod tests {
 
     #[test]
     fn test_build_args_resume() {
-        let args = build_claude_args("sess-1", "continue", true, &[], None);
+        let args = build_claude_args(
+            "sess-1",
+            "continue",
+            true,
+            &[],
+            None,
+            &AgentSettings::default(),
+        );
         assert!(args.contains(&"--resume".to_string()));
         assert!(!args.contains(&"--session-id".to_string()));
     }
@@ -689,14 +753,28 @@ mod tests {
     #[test]
     fn test_build_args_with_allowed_tools() {
         let tools = vec!["Bash".to_string(), "Read".to_string(), "Edit".to_string()];
-        let args = build_claude_args("sess-1", "hello", false, &tools, None);
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            false,
+            &tools,
+            None,
+            &AgentSettings::default(),
+        );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         assert_eq!(args[idx + 1], "Bash,Read,Edit");
     }
 
     #[test]
     fn test_build_args_with_custom_instructions() {
-        let args = build_claude_args("sess-1", "hello", false, &[], Some("Always use TypeScript"));
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            false,
+            &[],
+            Some("Always use TypeScript"),
+            &AgentSettings::default(),
+        );
         let idx = args
             .iter()
             .position(|a| a == "--append-system-prompt")
@@ -706,20 +784,122 @@ mod tests {
 
     #[test]
     fn test_build_args_empty_instructions_skipped() {
-        let args = build_claude_args("sess-1", "hello", false, &[], Some(""));
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            false,
+            &[],
+            Some(""),
+            &AgentSettings::default(),
+        );
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
     #[test]
     fn test_build_args_whitespace_instructions_skipped() {
-        let args = build_claude_args("sess-1", "hello", false, &[], Some("   "));
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            false,
+            &[],
+            Some("   "),
+            &AgentSettings::default(),
+        );
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
 
     #[test]
     fn test_build_args_resume_skips_instructions() {
-        let args = build_claude_args("sess-1", "hello", true, &[], Some("Always use TypeScript"));
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            true,
+            &[],
+            Some("Always use TypeScript"),
+            &AgentSettings::default(),
+        );
         assert!(!args.contains(&"--append-system-prompt".to_string()));
         assert!(args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_with_model() {
+        let settings = AgentSettings {
+            model: Some("opus".to_string()),
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let idx = args.iter().position(|a| a == "--model").unwrap();
+        assert_eq!(args[idx + 1], "opus");
+    }
+
+    #[test]
+    fn test_build_args_model_skipped_on_resume() {
+        let settings = AgentSettings {
+            model: Some("opus".to_string()),
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        assert!(!args.contains(&"--model".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_plan_mode() {
+        let settings = AgentSettings {
+            plan_mode: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let idx = args.iter().position(|a| a == "--permission-mode").unwrap();
+        assert_eq!(args[idx + 1], "plan");
+    }
+
+    #[test]
+    fn test_build_args_plan_mode_skipped_on_resume() {
+        let settings = AgentSettings {
+            plan_mode: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        assert!(!args.contains(&"--permission-mode".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_with_settings_json() {
+        let settings = AgentSettings {
+            fast_mode: true,
+            thinking_enabled: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let idx = args.iter().position(|a| a == "--settings").unwrap();
+        let json: serde_json::Value = serde_json::from_str(&args[idx + 1]).unwrap();
+        assert_eq!(json["fastMode"], true);
+        assert_eq!(json["alwaysThinkingEnabled"], true);
+    }
+
+    #[test]
+    fn test_build_args_fast_mode_only() {
+        let settings = AgentSettings {
+            fast_mode: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let idx = args.iter().position(|a| a == "--settings").unwrap();
+        let json: serde_json::Value = serde_json::from_str(&args[idx + 1]).unwrap();
+        assert_eq!(json["fastMode"], true);
+        assert!(json.get("alwaysThinkingEnabled").is_none());
+    }
+
+    #[test]
+    fn test_build_args_settings_on_resume() {
+        let settings = AgentSettings {
+            fast_mode: true,
+            thinking_enabled: true,
+            ..Default::default()
+        };
+        // --settings should still be passed on resume (per-turn flag)
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        assert!(args.contains(&"--settings".to_string()));
     }
 }

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ui</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <title>Claudette</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/ui/src/components/chat/AgentQuestionCard.module.css
+++ b/src/ui/src/components/chat/AgentQuestionCard.module.css
@@ -1,15 +1,18 @@
 .card {
-  border: 1px solid var(--sidebar-border);
+  border: 1px solid rgba(0, 229, 204, 0.2);
   border-radius: 8px;
   padding: 16px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--accent-bg);
+  animation: fadeInUp 0.25s ease both;
 }
 
 .label {
   font-size: 11px;
   font-weight: 600;
-  color: var(--text-muted);
+  color: var(--accent-dim);
   margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .questionBlock {
@@ -48,12 +51,12 @@
   color: var(--text-primary);
   font-size: 13px;
   line-height: 1.4;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
 }
 
 .option:hover {
-  border-color: var(--text-dim);
-  background: var(--hover-bg);
+  border-color: var(--accent-dim);
+  background: var(--accent-bg);
 }
 
 .optionLabel {
@@ -61,8 +64,8 @@
 }
 
 .optionSelected {
-  border-color: var(--status-running);
-  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--accent-primary);
+  background: var(--accent-bg);
 }
 
 .confirmBtn {
@@ -70,16 +73,18 @@
   width: 100%;
   margin-bottom: 12px;
   padding: 8px 14px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid var(--divider);
+  background: var(--accent-bg-strong);
+  border: 1px solid rgba(0, 229, 204, 0.2);
   border-radius: 6px;
-  color: var(--text-primary);
+  color: var(--accent-primary);
   font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
+  transition: background var(--transition-fast);
 }
 
 .confirmBtn:hover {
-  background: var(--hover-bg);
+  background: rgba(0, 229, 204, 0.2);
 }
 
 .divider {
@@ -116,10 +121,12 @@
   outline: none;
   resize: none;
   min-height: 36px;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
 }
 
 .freeformInput:focus {
-  border-color: var(--text-dim);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(0, 229, 204, 0.1);
 }
 
 .freeformInput::placeholder {
@@ -127,18 +134,20 @@
 }
 
 .submitBtn {
-  background: var(--selected-bg);
-  border: 1px solid var(--divider);
-  color: var(--text-primary);
+  background: var(--accent-bg-strong);
+  border: 1px solid rgba(0, 229, 204, 0.2);
+  color: var(--accent-primary);
   padding: 8px 14px;
   border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
+  font-weight: 500;
   align-self: flex-end;
+  transition: background var(--transition-fast);
 }
 
 .submitBtn:hover:not(:disabled) {
-  background: var(--hover-bg);
+  background: rgba(0, 229, 204, 0.2);
 }
 
 .submitBtn:disabled {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -53,7 +53,7 @@
   align-items: center;
   gap: 4px;
   font-size: 13px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   min-width: 0;
 }
 
@@ -336,7 +336,7 @@
 }
 
 .toolChevron {
-  font-family: monospace;
+  font-family: var(--font-mono);
   width: 10px;
 }
 
@@ -348,7 +348,7 @@
 
 .toolSummary {
   color: var(--text-dim);
-  font-family: monospace;
+  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -363,7 +363,7 @@
 .toolContent {
   padding: 8px;
   font-size: 11px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   color: var(--text-dim);
   max-height: 200px;
   overflow-y: auto;

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -25,16 +25,17 @@
   border: none;
   color: var(--text-dim);
   cursor: pointer;
-  padding: 2px;
+  padding: 4px;
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  border-radius: 4px;
+  border-radius: 6px;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .dashboardBtn:hover:not(:disabled) {
-  color: var(--text-primary);
-  background: var(--hover-bg);
+  color: var(--accent-primary);
+  background: var(--accent-bg);
 }
 
 .dashboardBtn:disabled {
@@ -104,6 +105,7 @@
   padding: 2px 20px 2px 6px;
   cursor: pointer;
   outline: none;
+  transition: border-color var(--transition-fast);
 }
 
 .permissionSelect:hover:not(:disabled) {
@@ -128,19 +130,22 @@
   border-radius: 4px;
   cursor: pointer;
   font-size: 11px;
+  transition: background var(--transition-fast);
 }
 
 .stopBtn:hover {
-  background: rgba(204, 51, 51, 0.15);
+  background: rgba(240, 72, 72, 0.15);
 }
 
+/* Messages area */
 .messages {
   flex: 1;
   overflow-y: auto;
-  padding: 16px;
+  padding: 16px 20px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 4px;
+  scroll-behavior: smooth;
 }
 
 .empty {
@@ -148,31 +153,40 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted);
+  color: var(--text-dim);
+  font-size: 14px;
 }
 
 .errorBanner {
-  background: rgba(204, 51, 51, 0.15);
-  border: 1px solid var(--status-stopped);
+  background: rgba(240, 72, 72, 0.1);
+  border: 1px solid rgba(240, 72, 72, 0.3);
   border-radius: 6px;
   padding: 8px 12px;
   font-size: 12px;
   color: var(--status-stopped);
   white-space: pre-wrap;
   word-break: break-word;
+  animation: fadeInUp 0.2s ease;
 }
 
+/* Message bubbles */
 .message {
-  padding: 8px 12px;
-  border-radius: 6px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  animation: fadeInUp 0.2s ease both;
+  max-width: 100%;
 }
 
 .role_User {
   background: var(--chat-user-bg);
+  border-left: 3px solid var(--text-faint);
+  margin-left: 32px;
 }
 
 .role_Assistant {
   background: transparent;
+  border-left: 3px solid var(--accent-primary);
+  padding-left: 14px;
 }
 
 .role_System {
@@ -180,6 +194,11 @@
   text-align: center;
   font-size: 12px;
   color: var(--text-muted);
+  border-left: none;
+  border-radius: 20px;
+  padding: 6px 16px;
+  align-self: center;
+  max-width: 80%;
 }
 
 .roleLabel {
@@ -187,28 +206,37 @@
   font-weight: 600;
   color: var(--text-muted);
   margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.role_Assistant .roleLabel {
+  color: var(--accent-dim);
 }
 
 .content {
   font-size: 13px;
-  line-height: 1.6;
+  line-height: 1.65;
   word-break: break-word;
 }
 
 .content pre {
   background: rgba(255, 255, 255, 0.04);
-  border-radius: 4px;
-  padding: 8px 12px;
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 10px 14px;
   overflow-x: auto;
   font-size: 12px;
+  font-family: var(--font-mono);
   margin: 8px 0;
 }
 
 .content code {
   background: rgba(255, 255, 255, 0.06);
-  padding: 1px 4px;
-  border-radius: 3px;
+  padding: 2px 5px;
+  border-radius: 4px;
   font-size: 12px;
+  font-family: var(--font-mono);
 }
 
 .content pre code {
@@ -226,46 +254,60 @@
   padding-left: 20px;
 }
 
+.content a {
+  color: var(--accent-primary);
+  text-decoration: none;
+}
+
+.content a:hover {
+  text-decoration: underline;
+}
+
 .cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--accent-primary);
+  margin-left: 2px;
+  vertical-align: text-bottom;
   animation: blink 1s step-end infinite;
-  color: var(--text-primary);
 }
 
 @keyframes blink {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
 }
 
+/* Processing indicator */
 .processing {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 8px 14px;
   font-size: 13px;
+  animation: fadeIn 0.2s ease;
 }
 
 .spinner {
   font-size: 16px;
-  color: var(--status-running);
+  color: var(--accent-primary);
   width: 16px;
   text-align: center;
+  font-family: var(--font-mono);
 }
 
 .elapsed {
   color: var(--text-dim);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
 }
 
+/* Tool activity cards */
 .toolActivities {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
 }
 
 .turnSummary {
@@ -273,6 +315,12 @@
   border-radius: 6px;
   margin: 4px 0;
   cursor: pointer;
+  transition: border-color var(--transition-fast);
+  overflow: hidden;
+}
+
+.turnSummary:hover {
+  border-color: var(--text-faint);
 }
 
 .turnHeader {
@@ -280,8 +328,9 @@
   align-items: center;
   gap: 6px;
   padding: 8px 12px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.03);
   font-size: 12px;
+  transition: background var(--transition-fast);
 }
 
 .turnSummary:hover > .turnHeader {
@@ -313,8 +362,13 @@
 
 .toolActivity {
   border: 1px solid var(--divider);
-  border-radius: 4px;
+  border-radius: 6px;
   overflow: hidden;
+  transition: border-color var(--transition-fast);
+}
+
+.toolActivity:hover {
+  border-color: var(--text-faint);
 }
 
 .toolHeader {
@@ -322,13 +376,14 @@
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 4px 8px;
-  background: rgba(255, 255, 255, 0.03);
+  padding: 5px 10px;
+  background: rgba(255, 255, 255, 0.02);
   border: none;
   color: var(--text-muted);
   cursor: pointer;
   font-size: 12px;
   text-align: left;
+  transition: background var(--transition-fast);
 }
 
 .toolHeader:hover {
@@ -338,11 +393,13 @@
 .toolChevron {
   font-family: var(--font-mono);
   width: 10px;
+  color: var(--text-faint);
+  transition: transform var(--transition-fast);
 }
 
 .toolName {
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--accent-dim);
   flex-shrink: 0;
 }
 
@@ -353,15 +410,16 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+  font-size: 11px;
 }
 
 .toolSummary::before {
-  content: "— ";
+  content: "  ";
   color: var(--text-faint);
 }
 
 .toolContent {
-  padding: 8px;
+  padding: 10px 12px;
   font-size: 11px;
   font-family: var(--font-mono);
   color: var(--text-dim);
@@ -371,54 +429,66 @@
   word-break: break-all;
   margin: 0;
   border-top: 1px solid var(--divider);
+  background: rgba(0, 0, 0, 0.15);
 }
 
+/* Input area */
 .inputArea {
   display: flex;
   gap: 8px;
   padding: 12px 16px;
   border-top: 1px solid var(--sidebar-border);
+  background: var(--chat-header-bg);
 }
 
 .input {
   flex: 1;
   background: var(--chat-input-bg);
   border: 1px solid var(--divider);
-  border-radius: 6px;
-  padding: 8px 12px;
+  border-radius: 8px;
+  padding: 10px 14px;
   color: var(--text-primary);
   font-size: 13px;
   font-family: inherit;
   outline: none;
   resize: none;
-  min-height: 36px;
+  min-height: 40px;
   max-height: 120px;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
 }
 
 .input:focus {
-  border-color: var(--text-dim);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px rgba(0, 229, 204, 0.1), var(--accent-glow);
 }
 
 .input::placeholder {
-  color: var(--text-dim);
+  color: var(--text-faint);
 }
 
 .sendBtn {
-  background: var(--selected-bg);
-  border: 1px solid var(--divider);
-  color: var(--text-primary);
-  padding: 8px 16px;
-  border-radius: 6px;
+  background: var(--accent-bg-strong);
+  border: 1px solid rgba(0, 229, 204, 0.2);
+  color: var(--accent-primary);
+  padding: 8px 18px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 13px;
+  font-weight: 500;
   align-self: flex-end;
+  transition: background var(--transition-fast), transform var(--transition-fast);
 }
 
 .sendBtn:hover:not(:disabled) {
-  background: var(--hover-bg);
+  background: var(--accent-bg-strong);
+  transform: translateY(-1px);
+}
+
+.sendBtn:active:not(:disabled) {
+  transform: translateY(0);
 }
 
 .sendBtn:disabled {
-  opacity: 0.4;
+  opacity: 0.3;
   cursor: not-allowed;
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -435,10 +435,19 @@
 /* Input area */
 .inputArea {
   display: flex;
-  gap: 8px;
+  flex-direction: column;
+  gap: 0;
   padding: 12px 16px;
   border-top: 1px solid var(--sidebar-border);
   background: var(--chat-header-bg);
+}
+
+.inputControls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 4px;
 }
 
 .input {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -439,7 +439,7 @@ export function ChatPanel() {
                 <div className={styles.roleLabel}>Claude</div>
                 <div className={styles.content}>
                   <Markdown remarkPlugins={[remarkGfm]}>{streaming}</Markdown>
-                  <span className={styles.cursor}>|</span>
+                  <span className={styles.cursor} />
                 </div>
               </div>
             )}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../services/tauri";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { AgentQuestionCard } from "./AgentQuestionCard";
+import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
 import styles from "./ChatPanel.module.css";
 
@@ -176,7 +177,20 @@ export function ChatPanel() {
     updateWorkspace(selectedWorkspaceId, { agent_status: "Running" });
 
     try {
-      await sendChatMessage(selectedWorkspaceId, content, permissionLevel);
+      const state = useAppStore.getState();
+      const model = state.selectedModel[selectedWorkspaceId] || undefined;
+      const fastMode = state.fastMode[selectedWorkspaceId] || false;
+      const thinkingEnabled = state.thinkingEnabled[selectedWorkspaceId] || false;
+      const planMode = state.planMode[selectedWorkspaceId] || false;
+      await sendChatMessage(
+        selectedWorkspaceId,
+        content,
+        permissionLevel,
+        model,
+        fastMode || undefined,
+        thinkingEnabled || undefined,
+        planMode || undefined,
+      );
     } catch (e) {
       const errMsg = String(e);
       console.error("sendChatMessage failed:", errMsg);
@@ -478,13 +492,19 @@ export function ChatPanel() {
           placeholder="Send a message..."
           rows={1}
         />
-        <button
-          className={styles.sendBtn}
-          onClick={() => handleSend()}
-          disabled={!chatInput.trim()}
-        >
-          Send
-        </button>
+        <div className={styles.inputControls}>
+          <ChatToolbar
+            workspaceId={selectedWorkspaceId!}
+            disabled={isRunning}
+          />
+          <button
+            className={styles.sendBtn}
+            onClick={() => handleSend()}
+            disabled={!chatInput.trim()}
+          >
+            Send
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/ui/src/components/chat/ChatToolbar.module.css
+++ b/src/ui/src/components/chat/ChatToolbar.module.css
@@ -1,7 +1,7 @@
 .toolbar {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   padding: 4px 0;
 }
 
@@ -10,14 +10,14 @@
   align-items: center;
   gap: 4px;
   padding: 3px 8px;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 6px;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--text-dim);
   font-size: 12px;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .chip:hover:not(:disabled) {
@@ -26,19 +26,20 @@
 }
 
 .chip:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: default;
 }
 
 .chipActive {
   background: var(--toolbar-active);
   color: var(--toolbar-active-text);
+  border-color: rgba(0, 229, 204, 0.15);
 }
 
 .chipActive:hover:not(:disabled) {
   background: var(--toolbar-active);
   color: var(--toolbar-active-text);
-  filter: brightness(1.1);
+  filter: brightness(1.15);
 }
 
 .chipLabel {

--- a/src/ui/src/components/chat/ChatToolbar.module.css
+++ b/src/ui/src/components/chat/ChatToolbar.module.css
@@ -3,6 +3,7 @@
   align-items: center;
   gap: 2px;
   padding: 4px 0;
+  position: relative;
 }
 
 .chip {

--- a/src/ui/src/components/chat/ChatToolbar.module.css
+++ b/src/ui/src/components/chat/ChatToolbar.module.css
@@ -1,0 +1,47 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.chip:hover:not(:disabled) {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.chip:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.chipActive {
+  background: var(--toolbar-active);
+  color: var(--toolbar-active-text);
+}
+
+.chipActive:hover:not(:disabled) {
+  background: var(--toolbar-active);
+  color: var(--toolbar-active-text);
+  filter: brightness(1.1);
+}
+
+.chipLabel {
+  font-size: 12px;
+  line-height: 1;
+}

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Sparkles, Zap, Brain, BookOpen } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import { resetAgentSession, setAppSetting, getAppSetting } from "../../services/tauri";
+import { ModelSelector, MODELS } from "./ModelSelector";
+import styles from "./ChatToolbar.module.css";
+
+interface ChatToolbarProps {
+  workspaceId: string;
+  disabled: boolean;
+}
+
+export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId] ?? "opus");
+  const fastMode = useAppStore((s) => s.fastMode[workspaceId] ?? false);
+  const thinkingEnabled = useAppStore((s) => s.thinkingEnabled[workspaceId] ?? false);
+  const planMode = useAppStore((s) => s.planMode[workspaceId] ?? false);
+  const modelSelectorOpen = useAppStore((s) => s.modelSelectorOpen);
+  const setSelectedModel = useAppStore((s) => s.setSelectedModel);
+  const setFastMode = useAppStore((s) => s.setFastMode);
+  const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
+  const setPlanMode = useAppStore((s) => s.setPlanMode);
+  const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
+
+  const modelChipRef = useRef<HTMLButtonElement>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Load persisted settings on mount / workspace change.
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const [model, fast, thinking] = await Promise.all([
+        getAppSetting(`model:${workspaceId}`),
+        getAppSetting(`fast_mode:${workspaceId}`),
+        getAppSetting(`thinking_enabled:${workspaceId}`),
+      ]);
+      if (cancelled) return;
+      if (model) setSelectedModel(workspaceId, model);
+      if (fast === "true") setFastMode(workspaceId, true);
+      if (thinking === "true") setThinkingEnabled(workspaceId, true);
+      setLoaded(true);
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [workspaceId, setSelectedModel, setFastMode, setThinkingEnabled]);
+
+  const handleModelSelect = useCallback(
+    async (model: string) => {
+      if (model !== selectedModel) {
+        setSelectedModel(workspaceId, model);
+        await setAppSetting(`model:${workspaceId}`, model);
+        // Model is session-level — reset session so next turn uses the new model.
+        await resetAgentSession(workspaceId);
+      }
+      setModelSelectorOpen(false);
+    },
+    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen]
+  );
+
+  const toggleFast = useCallback(async () => {
+    const next = !fastMode;
+    setFastMode(workspaceId, next);
+    await setAppSetting(`fast_mode:${workspaceId}`, String(next));
+  }, [workspaceId, fastMode, setFastMode]);
+
+  const toggleThinking = useCallback(async () => {
+    const next = !thinkingEnabled;
+    setThinkingEnabled(workspaceId, next);
+    await setAppSetting(`thinking_enabled:${workspaceId}`, String(next));
+  }, [workspaceId, thinkingEnabled, setThinkingEnabled]);
+
+  const togglePlan = useCallback(() => {
+    setPlanMode(workspaceId, !planMode);
+  }, [workspaceId, planMode, setPlanMode]);
+
+  // Keyboard shortcuts.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.metaKey && e.key === "t") {
+        e.preventDefault();
+        if (!disabled) toggleThinking();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [disabled, toggleThinking]);
+
+  const modelLabel =
+    MODELS.find((m) => m.id === selectedModel)?.label ?? selectedModel;
+
+  if (!loaded) return null;
+
+  return (
+    <div className={styles.toolbar}>
+      <button
+        ref={modelChipRef}
+        className={`${styles.chip}`}
+        onClick={() => setModelSelectorOpen(!modelSelectorOpen)}
+        disabled={disabled}
+        title="Change model"
+      >
+        <Sparkles size={14} />
+        <span className={styles.chipLabel}>{modelLabel}</span>
+      </button>
+
+      <button
+        className={`${styles.chip} ${fastMode ? styles.chipActive : ""}`}
+        onClick={toggleFast}
+        disabled={disabled}
+        title="Enable fast mode (uses extra credits)"
+        aria-pressed={fastMode}
+      >
+        <Zap size={14} />
+      </button>
+
+      <button
+        className={`${styles.chip} ${thinkingEnabled ? styles.chipActive : ""}`}
+        onClick={toggleThinking}
+        disabled={disabled}
+        title={`${thinkingEnabled ? "Disable" : "Enable"} thinking`}
+        aria-pressed={thinkingEnabled}
+      >
+        <Brain size={14} />
+        <span className={styles.chipLabel}>Thinking</span>
+      </button>
+
+      <button
+        className={`${styles.chip} ${planMode ? styles.chipActive : ""}`}
+        onClick={togglePlan}
+        disabled={disabled}
+        title={`${planMode ? "Disable" : "Enable"} plan mode`}
+        aria-pressed={planMode}
+      >
+        <BookOpen size={14} />
+        <span className={styles.chipLabel}>Plan</span>
+      </button>
+
+      {modelSelectorOpen && (
+        <ModelSelector
+          anchorRef={modelChipRef}
+          selected={selectedModel}
+          onSelect={handleModelSelect}
+          onClose={() => setModelSelectorOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/ModelSelector.module.css
+++ b/src/ui/src/components/chat/ModelSelector.module.css
@@ -9,21 +9,23 @@
   bottom: 100%;
   left: 0;
   margin-bottom: 4px;
-  min-width: 200px;
+  min-width: 210px;
   background: var(--sidebar-bg);
-  border: 1px solid var(--divider);
+  border: 1px solid var(--sidebar-border);
   border-radius: 8px;
   padding: 4px;
   z-index: 100;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
+  animation: scaleIn 0.12s ease;
 }
 
 .groupLabel {
   padding: 6px 8px 2px;
-  font-size: 11px;
+  font-size: 10px;
+  font-weight: 600;
   color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.06em;
 }
 
 .item {
@@ -39,6 +41,7 @@
   font-size: 13px;
   cursor: pointer;
   text-align: left;
+  transition: background var(--transition-fast);
 }
 
 .item:hover {
@@ -46,20 +49,20 @@
 }
 
 .itemSelected {
-  color: var(--toolbar-active-text);
+  color: var(--accent-primary);
 }
 
 .dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--status-running);
+  background: var(--accent-primary);
   flex-shrink: 0;
 }
 
 .check {
   margin-left: auto;
-  color: var(--toolbar-active-text);
+  color: var(--accent-primary);
   font-size: 14px;
 }
 
@@ -67,4 +70,5 @@
   margin-left: auto;
   color: var(--text-dim);
   font-size: 11px;
+  font-family: var(--font-mono);
 }

--- a/src/ui/src/components/chat/ModelSelector.module.css
+++ b/src/ui/src/components/chat/ModelSelector.module.css
@@ -1,0 +1,70 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+}
+
+.dropdown {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 4px;
+  min-width: 200px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  padding: 4px;
+  z-index: 100;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.groupLabel {
+  padding: 6px 8px 2px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.item:hover {
+  background: var(--hover-bg);
+}
+
+.itemSelected {
+  color: var(--toolbar-active-text);
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--status-running);
+  flex-shrink: 0;
+}
+
+.check {
+  margin-left: auto;
+  color: var(--toolbar-active-text);
+  font-size: 14px;
+}
+
+.shortcut {
+  margin-left: auto;
+  color: var(--text-dim);
+  font-size: 11px;
+}

--- a/src/ui/src/components/chat/ModelSelector.tsx
+++ b/src/ui/src/components/chat/ModelSelector.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, type RefObject } from "react";
+import styles from "./ModelSelector.module.css";
+
+export const MODELS = [
+  { id: "opus", label: "Opus 4.6 1M", group: "Claude Code" },
+  { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code" },
+  { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code" },
+  { id: "haiku", label: "Haiku 4.5", group: "Claude Code" },
+] as const;
+
+interface ModelSelectorProps {
+  anchorRef: RefObject<HTMLButtonElement | null>;
+  selected: string;
+  onSelect: (model: string) => void;
+  onClose: () => void;
+}
+
+export function ModelSelector({
+  selected,
+  onSelect,
+  onClose,
+}: ModelSelectorProps) {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Group models.
+  const groups = new Map<string, typeof MODELS[number][]>();
+  for (const model of MODELS) {
+    const list = groups.get(model.group) ?? [];
+    list.push(model);
+    groups.set(model.group, list);
+  }
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose} />
+      <div ref={dropdownRef} className={styles.dropdown}>
+        {[...groups.entries()].map(([group, models]) => (
+          <div key={group}>
+            <div className={styles.groupLabel}>{group}</div>
+            {models.map((model) => (
+              <button
+                key={model.id}
+                className={`${styles.item} ${model.id === selected ? styles.itemSelected : ""}`}
+                onClick={() => onSelect(model.id)}
+              >
+                <span className={styles.dot} />
+                {model.label}
+                {model.id === selected && <span className={styles.check}>✓</span>}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/ui/src/components/chat/WorkspaceActions.module.css
+++ b/src/ui/src/components/chat/WorkspaceActions.module.css
@@ -11,6 +11,7 @@
   padding: 2px 20px 2px 6px;
   cursor: pointer;
   outline: none;
+  transition: border-color var(--transition-fast);
 }
 
 .select:hover:not(:disabled) {

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -26,7 +26,7 @@
 }
 
 .fileName {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 13px;
 }
 
@@ -45,7 +45,7 @@
 }
 
 .diffTable {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
 }

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  animation: fadeIn 0.15s ease;
 }
 
 .header {
@@ -19,10 +20,14 @@
   color: var(--text-muted);
   cursor: pointer;
   font-size: 13px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .backBtn:hover {
-  color: var(--text-primary);
+  color: var(--accent-primary);
+  background: var(--accent-bg);
 }
 
 .fileName {
@@ -51,16 +56,19 @@
 }
 
 .hunkHeader {
-  background: rgba(102, 153, 230, 0.1);
+  background: rgba(100, 160, 240, 0.08);
   color: var(--diff-hunk-header);
-  padding: 2px 12px;
+  padding: 4px 12px;
   font-size: 12px;
+  border-top: 1px solid rgba(100, 160, 240, 0.1);
+  border-bottom: 1px solid rgba(100, 160, 240, 0.1);
 }
 
 .line {
   display: flex;
   min-height: 20px;
   padding: 0 4px;
+  transition: background var(--transition-fast);
 }
 
 .lineAdded {
@@ -78,6 +86,7 @@
   color: var(--diff-line-number);
   flex-shrink: 0;
   user-select: none;
+  border-right: 1px solid var(--divider);
 }
 
 .linePrefix {
@@ -89,14 +98,17 @@
 
 .lineAdded .linePrefix {
   color: var(--diff-added-text);
+  font-weight: 600;
 }
 
 .lineRemoved .linePrefix {
   color: var(--diff-removed-text);
+  font-weight: 600;
 }
 
 .lineContent {
   flex: 1;
   white-space: pre;
   overflow-x: auto;
+  padding-left: 4px;
 }

--- a/src/ui/src/components/fuzzy-finder/FuzzyFinder.module.css
+++ b/src/ui/src/components/fuzzy-finder/FuzzyFinder.module.css
@@ -1,22 +1,26 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
   display: flex;
   justify-content: center;
   padding-top: 80px;
   z-index: 100;
+  animation: fadeIn 0.1s ease;
 }
 
 .card {
   background: var(--app-bg);
   border: 1px solid var(--sidebar-border);
-  border-radius: var(--border-radius);
-  width: 500px;
+  border-radius: 10px;
+  width: 520px;
   max-height: 400px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  animation: scaleIn 0.15s ease;
 }
 
 .input {
@@ -24,9 +28,10 @@
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--divider);
-  padding: 12px 16px;
+  padding: 14px 18px;
   color: var(--text-primary);
   font-size: 14px;
+  font-family: var(--font-sans);
   outline: none;
 }
 
@@ -41,16 +46,17 @@
 }
 
 .empty {
-  padding: 16px;
+  padding: 20px;
   text-align: center;
-  color: var(--text-muted);
+  color: var(--text-dim);
   font-size: 13px;
 }
 
 .result {
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: 8px 14px;
+  border-radius: 6px;
   cursor: pointer;
+  transition: background var(--transition-fast);
 }
 
 .result:hover {
@@ -70,4 +76,5 @@
   font-size: 12px;
   color: var(--text-dim);
   margin-top: 2px;
+  font-family: var(--font-mono);
 }

--- a/src/ui/src/components/layout/AppLayout.module.css
+++ b/src/ui/src/components/layout/AppLayout.module.css
@@ -50,6 +50,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-muted);
+  color: var(--text-dim);
   font-size: 14px;
 }

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -1,16 +1,24 @@
 .dashboard {
   height: 100%;
   overflow-y: auto;
-  padding: 24px;
+  padding: 28px 32px;
 }
 
 .header {
-  font-size: 14px;
+  font-size: 11px;
   font-weight: 600;
-  color: var(--text-muted);
+  color: var(--text-dim);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-bottom: 16px;
+  letter-spacing: 0.08em;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.headerCount {
+  color: var(--accent-primary);
+  font-variant-numeric: tabular-nums;
 }
 
 .grid {
@@ -19,9 +27,11 @@
   gap: 12px;
 }
 
+/* Workspace card */
 .card {
-  background: rgba(255, 255, 255, 0.03);
+  background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--divider);
+  border-left: 3px solid var(--status-idle);
   border-radius: 8px;
   padding: 14px 16px;
   cursor: pointer;
@@ -29,16 +39,35 @@
   color: var(--text-primary);
   font-family: inherit;
   font-size: 13px;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    transform var(--transition-normal),
+    box-shadow var(--transition-normal),
+    border-color var(--transition-normal),
+    background var(--transition-normal);
   display: flex;
   flex-direction: column;
   gap: 8px;
   width: 100%;
+  position: relative;
 }
 
 .card:hover {
-  background: var(--hover-bg);
-  border-color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--text-faint);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card-hover);
+}
+
+.cardRunning {
+  border-left-color: var(--status-running);
+}
+
+.cardStopped {
+  border-left-color: var(--status-stopped);
+}
+
+.cardIdle {
+  border-left-color: var(--status-idle);
 }
 
 .cardHeader {
@@ -60,11 +89,28 @@
   color: var(--text-muted);
 }
 
+.statusIndicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .statusDot {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.statusDotRunning {
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+.statusLabel {
+  font-size: 11px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
 }
 
 .branchLine {
@@ -117,6 +163,7 @@
   font-style: italic;
 }
 
+/* Empty state */
 .empty {
   height: 100%;
   display: flex;
@@ -124,11 +171,37 @@
   align-items: center;
   justify-content: center;
   color: var(--text-muted);
-  font-size: 14px;
-  gap: 4px;
+  gap: 12px;
+  animation: fadeIn 0.4s ease;
+}
+
+.emptyIcon {
+  color: var(--accent-primary);
+  opacity: 0.4;
+  margin-bottom: 4px;
+}
+
+.emptyTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
 .hint {
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: 13px;
+  max-width: 320px;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.hintKey {
+  display: inline-block;
+  background: var(--hover-bg);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
 }

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -71,7 +71,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-muted);
 }

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { GitBranch } from "lucide-react";
+import { useMemo, useEffect, useState, useCallback } from "react";
+import { GitBranch, Layers } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Dashboard.module.css";
@@ -21,6 +21,127 @@ function stripMarkdown(s: string): string {
     .trim();
 }
 
+function formatElapsed(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}m ${s}s`;
+}
+
+function useElapsed(isRunning: boolean): number {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!isRunning) {
+      setElapsed(0);
+      return;
+    }
+    const start = Date.now();
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - start) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isRunning]);
+
+  return elapsed;
+}
+
+function WorkspaceCard({
+  ws,
+  repo,
+  baseBranch,
+  lastMsg,
+  onClick,
+  index,
+}: {
+  ws: { id: string; branch_name: string; agent_status: string | { Error: string } };
+  repo: { name: string; icon: string | null } | undefined;
+  baseBranch: string | undefined;
+  lastMsg: { role: string; content: string } | undefined;
+  onClick: () => void;
+  index: number;
+}) {
+  const isRunning = ws.agent_status === "Running";
+  const elapsed = useElapsed(isRunning);
+
+  const statusColor =
+    isRunning
+      ? "var(--status-running)"
+      : ws.agent_status === "Stopped" || typeof ws.agent_status !== "string"
+        ? "var(--status-stopped)"
+        : "var(--status-idle)";
+
+  const cardClass = [
+    styles.card,
+    isRunning
+      ? styles.cardRunning
+      : ws.agent_status === "Stopped" || typeof ws.agent_status !== "string"
+        ? styles.cardStopped
+        : styles.cardIdle,
+  ].join(" ");
+
+  const statusText = isRunning
+    ? formatElapsed(elapsed)
+    : typeof ws.agent_status === "string"
+      ? ws.agent_status
+      : "Error";
+
+  return (
+    <button
+      type="button"
+      className={cardClass}
+      onClick={onClick}
+      style={{ animationDelay: `${index * 0.04}s` }}
+    >
+      <div className={styles.cardHeader}>
+        <span className={styles.repoName}>
+          {repo?.icon && (
+            <RepoIcon icon={repo.icon} size={14} className={styles.repoIcon} />
+          )}
+          {repo?.name ?? "Unknown"}
+        </span>
+        <span className={styles.statusIndicator}>
+          <span className={styles.statusLabel} style={{ color: statusColor }}>
+            {statusText}
+          </span>
+          <span
+            className={`${styles.statusDot} ${isRunning ? styles.statusDotRunning : ""}`}
+            style={{ background: statusColor }}
+          />
+        </span>
+      </div>
+      <div className={styles.branchLine}>
+        <GitBranch size={11} />
+        <span className={styles.branch}>{ws.branch_name}</span>
+        {baseBranch && (
+          <>
+            <span className={styles.arrow}>{">"}</span>
+            <span className={styles.baseBranch}>{baseBranch}</span>
+          </>
+        )}
+      </div>
+      {lastMsg ? (
+        <div className={styles.lastMessage}>
+          <span className={styles.msgRole}>
+            {lastMsg.role === "User"
+              ? "You"
+              : lastMsg.role === "Assistant"
+                ? "Claude"
+                : "System"}
+            :
+          </span>{" "}
+          <span className={styles.msgContent}>
+            {stripMarkdown(lastMsg.content).slice(0, 120)}
+            {lastMsg.content.length > 120 ? "..." : ""}
+          </span>
+        </div>
+      ) : (
+        <div className={styles.noMessages}>No messages yet</div>
+      )}
+    </button>
+  );
+}
+
 export function Dashboard() {
   const repositories = useAppStore((s) => s.repositories);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -38,83 +159,43 @@ export function Dashboard() {
   if (activeWorkspaces.length === 0) {
     return (
       <div className={styles.empty}>
-        <p>No active workspaces</p>
+        <Layers size={40} className={styles.emptyIcon} />
+        <span className={styles.emptyTitle}>No active workspaces</span>
         <p className={styles.hint}>
-          Create a workspace from a repository in the sidebar
+          Create a workspace from a repository in the sidebar, or press{" "}
+          <kbd className={styles.hintKey}>+</kbd> next to a repo name.
         </p>
       </div>
     );
   }
 
+  const runningCount = activeWorkspaces.filter(
+    (ws) => ws.agent_status === "Running"
+  ).length;
+
   return (
     <div className={styles.dashboard}>
-      <div className={styles.header}>Active Workspaces</div>
+      <div className={styles.header}>
+        Active Workspaces
+        {runningCount > 0 && (
+          <span className={styles.headerCount}>
+            {runningCount} running
+          </span>
+        )}
+      </div>
       <div className={styles.grid}>
-        {activeWorkspaces.map((ws) => {
+        {activeWorkspaces.map((ws, i) => {
           const repo = repoMap.get(ws.repository_id);
-          const lastMsg = lastMessages[ws.id];
-          const baseBranch = repo ? defaultBranches[repo.id] : undefined;
-
-          const statusColor =
-            ws.agent_status === "Running"
-              ? "var(--status-running)"
-              : ws.agent_status === "Stopped" ||
-                  typeof ws.agent_status !== "string"
-                ? "var(--status-stopped)"
-                : "var(--status-idle)";
-
           return (
-            <button
+            <WorkspaceCard
               key={ws.id}
-              type="button"
-              className={styles.card}
+              ws={ws}
+              repo={repo}
+              baseBranch={repo ? defaultBranches[repo.id] : undefined}
+              lastMsg={lastMessages[ws.id]}
               onClick={() => selectWorkspace(ws.id)}
-            >
-              <div className={styles.cardHeader}>
-                <span className={styles.repoName}>
-                  {repo?.icon && (
-                    <RepoIcon
-                      icon={repo.icon}
-                      size={14}
-                      className={styles.repoIcon}
-                    />
-                  )}
-                  {repo?.name ?? "Unknown"}
-                </span>
-                <span
-                  className={styles.statusDot}
-                  style={{ background: statusColor }}
-                />
-              </div>
-              <div className={styles.branchLine}>
-                <GitBranch size={11} />
-                <span className={styles.branch}>{ws.branch_name}</span>
-                {baseBranch && (
-                  <>
-                    <span className={styles.arrow}>{">"}</span>
-                    <span className={styles.baseBranch}>{baseBranch}</span>
-                  </>
-                )}
-              </div>
-              {lastMsg ? (
-                <div className={styles.lastMessage}>
-                  <span className={styles.msgRole}>
-                    {lastMsg.role === "User"
-                      ? "You"
-                      : lastMsg.role === "Assistant"
-                        ? "Claude"
-                        : "System"}
-                    :
-                  </span>{" "}
-                  <span className={styles.msgContent}>
-                    {stripMarkdown(lastMsg.content).slice(0, 120)}
-                    {lastMsg.content.length > 120 ? "..." : ""}
-                  </span>
-                </div>
-              ) : (
-                <div className={styles.noMessages}>No messages yet</div>
-              )}
-            </button>
+              index={i}
+            />
           );
         })}
       </div>

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState, useCallback } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { GitBranch, Layers } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { RepoIcon } from "../shared/RepoIcon";

--- a/src/ui/src/components/layout/ResizeHandle.module.css
+++ b/src/ui/src/components/layout/ResizeHandle.module.css
@@ -2,6 +2,7 @@
   position: relative;
   background: transparent;
   z-index: 10;
+  transition: background var(--transition-fast);
 }
 
 .horizontal {

--- a/src/ui/src/components/layout/StatusBar.module.css
+++ b/src/ui/src/components/layout/StatusBar.module.css
@@ -1,11 +1,39 @@
 .bar {
   display: flex;
   align-items: center;
-  height: 24px;
-  padding: 0 8px;
+  height: 26px;
+  padding: 0 10px;
   background: var(--sidebar-bg);
   border-top: 1px solid var(--sidebar-border);
-  gap: 4px;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.stats {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.statRunning {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--accent-primary);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.statDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+.statMuted {
+  color: var(--text-dim);
 }
 
 .spacer {
@@ -14,19 +42,22 @@
 
 .toggle {
   background: none;
-  border: 1px solid var(--divider);
+  border: 1px solid transparent;
   color: var(--text-dim);
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 3px;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 4px;
   cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .toggle:hover {
   background: var(--hover-bg);
+  color: var(--text-muted);
 }
 
 .toggle.active {
-  color: var(--text-primary);
-  background: var(--selected-bg);
+  color: var(--accent-primary);
+  background: var(--accent-bg);
+  border-color: rgba(0, 229, 204, 0.1);
 }

--- a/src/ui/src/components/layout/StatusBar.tsx
+++ b/src/ui/src/components/layout/StatusBar.tsx
@@ -8,28 +8,47 @@ export function StatusBar() {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar);
+  const workspaces = useAppStore((s) => s.workspaces);
+
+  const runningCount = workspaces.filter(
+    (ws) => ws.agent_status === "Running"
+  ).length;
+  const activeCount = workspaces.filter(
+    (ws) => ws.status === "Active"
+  ).length;
 
   return (
     <div className={styles.bar}>
+      <div className={styles.stats}>
+        {runningCount > 0 && (
+          <span className={styles.statRunning}>
+            <span className={styles.statDot} />
+            {runningCount} running
+          </span>
+        )}
+        <span className={styles.statMuted}>
+          {activeCount} workspace{activeCount !== 1 ? "s" : ""}
+        </span>
+      </div>
       <div className={styles.spacer} />
       <button
         className={`${styles.toggle} ${sidebarVisible ? styles.active : ""}`}
         onClick={toggleSidebar}
-        title="Toggle sidebar"
+        title="Toggle sidebar (⌘B)"
       >
         sidebar
       </button>
       <button
         className={`${styles.toggle} ${terminalPanelVisible ? styles.active : ""}`}
         onClick={toggleTerminalPanel}
-        title="Toggle terminal"
+        title="Toggle terminal (⌘`)"
       >
         terminal
       </button>
       <button
         className={`${styles.toggle} ${rightSidebarVisible ? styles.active : ""}`}
         onClick={toggleRightSidebar}
-        title="Toggle changes"
+        title="Toggle changes (⌘D)"
       >
         changes
       </button>

--- a/src/ui/src/components/modals/Modal.module.css
+++ b/src/ui/src/components/modals/Modal.module.css
@@ -1,20 +1,24 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 100;
+  animation: fadeIn 0.15s ease;
 }
 
 .card {
   background: var(--app-bg);
   border: 1px solid var(--sidebar-border);
-  border-radius: var(--border-radius);
+  border-radius: 10px;
   width: 420px;
   max-height: 80vh;
   overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+  animation: scaleIn 0.2s ease;
 }
 
 .header {

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -58,7 +58,7 @@
   border-radius: 4px;
   cursor: pointer;
   font-size: 12px;
-  font-family: monospace;
+  font-family: var(--font-mono);
 }
 
 .file:hover {

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -13,9 +13,11 @@
 }
 
 .title {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
-  color: var(--text-muted);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .controls {
@@ -31,10 +33,12 @@
   border-radius: 3px;
   cursor: pointer;
   font-size: 14px;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .modeBtn:hover {
   background: var(--hover-bg);
+  color: var(--text-muted);
 }
 
 .list {
@@ -46,7 +50,7 @@
 .empty {
   padding: 16px;
   text-align: center;
-  color: var(--text-muted);
+  color: var(--text-dim);
   font-size: 12px;
 }
 
@@ -54,11 +58,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 5px 8px;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 12px;
   font-family: var(--font-mono);
+  transition: background var(--transition-fast);
 }
 
 .file:hover {
@@ -74,6 +79,7 @@
   width: 14px;
   text-align: center;
   flex-shrink: 0;
+  font-size: 11px;
 }
 
 .path {

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -68,7 +68,7 @@
   font-size: 10px;
   color: var(--text-dim);
   width: 12px;
-  font-family: monospace;
+  font-family: var(--font-mono);
 }
 
 .repoName {

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -5,15 +5,15 @@
 }
 
 .header {
-  padding: 12px 16px 8px;
+  padding: 14px 16px 8px;
 }
 
 .title {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  color: var(--text-muted);
-  letter-spacing: 0.5px;
+  color: var(--text-dim);
+  letter-spacing: 0.08em;
 }
 
 .filters {
@@ -27,18 +27,20 @@
   border: none;
   color: var(--text-dim);
   font-size: 12px;
-  padding: 2px 8px;
+  padding: 3px 8px;
   border-radius: 4px;
   cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .filterBtn:hover {
   background: var(--hover-bg);
+  color: var(--text-muted);
 }
 
 .filterActive {
-  color: var(--text-primary);
-  background: var(--selected-bg);
+  color: var(--accent-primary);
+  background: var(--accent-bg);
 }
 
 .list {
@@ -54,10 +56,11 @@
 .repoHeader {
   display: flex;
   align-items: center;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 5px 8px;
+  border-radius: 6px;
   cursor: pointer;
   gap: 6px;
+  transition: background var(--transition-fast);
 }
 
 .repoHeader:hover {
@@ -69,12 +72,16 @@
   color: var(--text-dim);
   width: 12px;
   font-family: var(--font-mono);
+  transition: transform var(--transition-fast);
 }
 
 .repoName {
   flex: 1;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .iconBtn {
@@ -85,9 +92,10 @@
   padding: 2px 4px;
   line-height: 1;
   opacity: 0;
-  transition: opacity 0.1s;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
   display: flex;
   align-items: center;
+  border-radius: 4px;
 }
 
 .repoHeader:hover .iconBtn,
@@ -96,7 +104,8 @@
 }
 
 .iconBtn:hover {
-  color: var(--text-primary);
+  color: var(--accent-primary);
+  background: var(--accent-bg);
 }
 
 .invalidBadge {
@@ -106,19 +115,33 @@
 }
 
 .repoIcon {
-  margin-right: 4px;
+  margin-right: 2px;
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
 }
 
+/* Running count badge next to repo name */
+.runningBadge {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent-primary);
+  background: var(--accent-bg);
+  padding: 0 5px;
+  border-radius: 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Workspace items */
 .wsItem {
   display: flex;
   align-items: center;
   padding: 6px 8px 6px 28px;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
   gap: 8px;
+  position: relative;
+  transition: background var(--transition-fast);
 }
 
 .wsItem:hover {
@@ -129,11 +152,26 @@
   background: var(--selected-bg);
 }
 
+.wsSelected::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--accent-primary);
+}
+
 .statusDot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.statusDotRunning {
+  animation: pulse-dot 2s ease-in-out infinite;
 }
 
 .wsActions {
@@ -163,6 +201,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-family: var(--font-mono);
 }
 
 .footer {
@@ -181,10 +220,11 @@
   padding: 4px 0;
   flex: 1;
   text-align: left;
+  transition: color var(--transition-fast);
 }
 
 .addRepoBtn:hover {
-  color: var(--text-primary);
+  color: var(--accent-primary);
 }
 
 .settingsBtn {
@@ -195,8 +235,11 @@
   padding: 4px;
   display: flex;
   align-items: center;
+  border-radius: 4px;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .settingsBtn:hover {
-  color: var(--text-primary);
+  color: var(--accent-primary);
+  background: var(--accent-bg);
 }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -109,6 +109,9 @@ export function Sidebar() {
           const repoWorkspaces = filteredWorkspaces.filter(
             (ws) => ws.repository_id === repo.id
           );
+          const runningCount = repoWorkspaces.filter(
+            (ws) => ws.agent_status === "Running"
+          ).length;
 
           return (
             <div key={repo.id} className={styles.repoGroup}>
@@ -122,6 +125,9 @@ export function Sidebar() {
                 <span className={styles.repoName}>
                   {repo.icon && <RepoIcon icon={repo.icon} className={styles.repoIcon} />}
                   {repo.name}
+                  {runningCount > 0 && (
+                    <span className={styles.runningBadge}>{runningCount}</span>
+                  )}
                 </span>
                 {!repo.path_valid && (
                   <span className={styles.invalidBadge}>!</span>
@@ -189,7 +195,7 @@ export function Sidebar() {
                     onClick={() => selectWorkspace(ws.id)}
                   >
                     <span
-                      className={styles.statusDot}
+                      className={`${styles.statusDot} ${ws.agent_status === "Running" ? styles.statusDotRunning : ""}`}
                       style={{
                         background:
                           ws.agent_status === "Running"

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -24,19 +24,25 @@
   cursor: pointer;
   font-size: 12px;
   color: var(--text-dim);
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .tab:hover {
   background: var(--hover-bg);
+  color: var(--text-muted);
 }
 
 .tabActive {
-  background: var(--terminal-tab-active-bg);
   color: var(--text-primary);
+  border-bottom-color: var(--accent-primary);
+  background: transparent;
 }
 
 .tabTitle {
   white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 
 .tabClose {
@@ -47,10 +53,13 @@
   font-size: 14px;
   line-height: 1;
   padding: 0 2px;
+  border-radius: 3px;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .tabClose:hover {
   color: var(--text-primary);
+  background: var(--hover-bg);
 }
 
 .addTab {
@@ -60,10 +69,12 @@
   cursor: pointer;
   font-size: 16px;
   padding: 0 6px;
+  border-radius: 4px;
+  transition: color var(--transition-fast);
 }
 
 .addTab:hover {
-  color: var(--text-primary);
+  color: var(--accent-primary);
 }
 
 .spacer {
@@ -77,6 +88,7 @@
   cursor: pointer;
   font-size: 18px;
   padding: 0 6px;
+  transition: color var(--transition-fast);
 }
 
 .hideBtn:hover {
@@ -86,5 +98,5 @@
 .termContainer {
   flex: 1;
   overflow: hidden;
-  background: #121216;
+  background: var(--app-bg);
 }

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -72,6 +72,7 @@ export function useAgentStream() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
   const finalizeTurn = useAppStore((s) => s.finalizeTurn);
+  const setPlanMode = useAppStore((s) => s.setPlanMode);
 
   // Map content block index → { toolUseId, toolName } for the current turn.
   // Reset on process exit.
@@ -162,6 +163,12 @@ export function useAgentStream() {
                       collapsed: true,
                       summary: "",
                     });
+                    // Detect plan mode changes from agent tool calls.
+                    if (inner.content_block.name === "EnterPlanMode") {
+                      setPlanMode(wsId, true);
+                    } else if (inner.content_block.name === "ExitPlanMode") {
+                      setPlanMode(wsId, false);
+                    }
                   }
                   break;
                 }
@@ -273,5 +280,6 @@ export function useAgentStream() {
     updateWorkspace,
     setAgentQuestion,
     finalizeTurn,
+    setPlanMode,
   ]);
 }

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -106,17 +106,29 @@ export function loadChatHistory(workspaceId: string): Promise<ChatMessage[]> {
 export function sendChatMessage(
   workspaceId: string,
   content: string,
-  permissionLevel?: string
+  permissionLevel?: string,
+  model?: string,
+  fastMode?: boolean,
+  thinkingEnabled?: boolean,
+  planMode?: boolean
 ): Promise<void> {
   return invoke("send_chat_message", {
     workspaceId,
     content,
     permissionLevel: permissionLevel ?? null,
+    model: model ?? null,
+    fastMode: fastMode ?? null,
+    thinkingEnabled: thinkingEnabled ?? null,
+    planMode: planMode ?? null,
   });
 }
 
 export function stopAgent(workspaceId: string): Promise<void> {
   return invoke("stop_agent", { workspaceId });
+}
+
+export function resetAgentSession(workspaceId: string): Promise<void> {
+  return invoke("reset_agent_session", { workspaceId });
 }
 
 // -- Diff --

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -92,6 +92,18 @@ interface AppState {
   permissionLevel: Record<string, PermissionLevel>;
   setPermissionLevel: (wsId: string, level: PermissionLevel) => void;
 
+  // -- Toolbar --
+  selectedModel: Record<string, string>;
+  fastMode: Record<string, boolean>;
+  thinkingEnabled: Record<string, boolean>;
+  planMode: Record<string, boolean>;
+  modelSelectorOpen: boolean;
+  setSelectedModel: (wsId: string, model: string) => void;
+  setFastMode: (wsId: string, enabled: boolean) => void;
+  setThinkingEnabled: (wsId: string, enabled: boolean) => void;
+  setPlanMode: (wsId: string, enabled: boolean) => void;
+  setModelSelectorOpen: (open: boolean) => void;
+
   // -- Diff --
   diffFiles: DiffFile[];
   diffMergeBase: string | null;
@@ -306,6 +318,30 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => ({
       permissionLevel: { ...s.permissionLevel, [wsId]: level },
     })),
+
+  // -- Toolbar --
+  selectedModel: {},
+  fastMode: {},
+  thinkingEnabled: {},
+  planMode: {},
+  modelSelectorOpen: false,
+  setSelectedModel: (wsId, model) =>
+    set((s) => ({
+      selectedModel: { ...s.selectedModel, [wsId]: model },
+    })),
+  setFastMode: (wsId, enabled) =>
+    set((s) => ({
+      fastMode: { ...s.fastMode, [wsId]: enabled },
+    })),
+  setThinkingEnabled: (wsId, enabled) =>
+    set((s) => ({
+      thinkingEnabled: { ...s.thinkingEnabled, [wsId]: enabled },
+    })),
+  setPlanMode: (wsId, enabled) =>
+    set((s) => ({
+      planMode: { ...s.planMode, [wsId]: enabled },
+    })),
+  setModelSelectorOpen: (open) => set({ modelSelectorOpen: open }),
 
   // -- Diff --
   diffFiles: [],

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -49,8 +49,8 @@
   --terminal-tab-active-bg: rgb(38, 38, 48);
 
   /* Toolbar */
-  --toolbar-active: rgba(180, 130, 50, 0.25);
-  --toolbar-active-text: rgb(196, 160, 80);
+  --toolbar-active: rgba(0, 229, 204, 0.12);
+  --toolbar-active-text: var(--accent-primary);
 
   /* General */
   --app-bg: rgb(14, 14, 18);

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -1,48 +1,71 @@
 :root {
+  /* Brand accent — Claudette teal */
+  --accent-primary: #00e5cc;
+  --accent-primary-rgb: 0, 229, 204;
+  --accent-dim: #00b3a0;
+  --accent-bg: rgba(0, 229, 204, 0.08);
+  --accent-bg-strong: rgba(0, 229, 204, 0.15);
+  --accent-glow: 0 0 12px rgba(0, 229, 204, 0.25);
+
   /* Sidebar */
-  --sidebar-bg: rgb(26, 26, 31);
-  --sidebar-border: rgb(46, 46, 56);
+  --sidebar-bg: rgb(22, 22, 28);
+  --sidebar-border: rgb(40, 40, 50);
   --sidebar-width: 260px;
 
   /* Text */
-  --text-primary: rgb(230, 230, 235);
-  --text-muted: rgb(128, 128, 137);
-  --text-dim: rgb(115, 115, 128);
-  --text-faint: rgb(102, 102, 115);
-  --text-separator: rgb(89, 89, 102);
+  --text-primary: rgb(235, 235, 240);
+  --text-muted: rgb(140, 140, 150);
+  --text-dim: rgb(110, 110, 125);
+  --text-faint: rgb(85, 85, 100);
+  --text-separator: rgb(65, 65, 80);
 
   /* Interactive */
-  --hover-bg: rgba(255, 255, 255, 0.05);
+  --hover-bg: rgba(255, 255, 255, 0.06);
   --hover-bg-subtle: rgba(255, 255, 255, 0.04);
-  --selected-bg: rgba(255, 255, 255, 0.08);
-  --divider: rgb(51, 51, 61);
+  --selected-bg: rgba(0, 229, 204, 0.1);
+  --divider: rgb(42, 42, 54);
 
   /* Agent status */
-  --status-running: rgb(51, 204, 77);
-  --status-idle: rgb(128, 128, 128);
-  --status-stopped: rgb(204, 51, 51);
+  --status-running: #00e5cc;
+  --status-idle: rgb(110, 110, 120);
+  --status-stopped: #f04848;
 
   /* Diff */
-  --diff-added-bg: rgba(0, 128, 0, 0.15);
-  --diff-removed-bg: rgba(128, 0, 0, 0.15);
-  --diff-added-text: rgb(102, 230, 102);
-  --diff-removed-text: rgb(230, 102, 102);
-  --diff-hunk-header: rgb(102, 153, 230);
-  --diff-line-number: rgb(102, 102, 115);
+  --diff-added-bg: rgba(0, 180, 80, 0.12);
+  --diff-removed-bg: rgba(220, 40, 40, 0.12);
+  --diff-added-text: rgb(80, 220, 120);
+  --diff-removed-text: rgb(240, 100, 100);
+  --diff-hunk-header: rgb(100, 160, 240);
+  --diff-line-number: rgb(85, 85, 100);
 
   /* Chat */
-  --chat-user-bg: rgba(255, 255, 255, 0.06);
+  --chat-user-bg: rgba(255, 255, 255, 0.05);
   --chat-system-bg: rgba(230, 179, 51, 0.08);
-  --chat-input-bg: rgb(31, 31, 36);
-  --chat-header-bg: rgb(26, 26, 31);
+  --chat-input-bg: rgb(26, 26, 33);
+  --chat-header-bg: rgb(22, 22, 28);
 
   /* Terminal */
-  --terminal-tab-bg: rgb(31, 31, 36);
-  --terminal-tab-active-bg: rgb(46, 46, 56);
+  --terminal-tab-bg: rgb(26, 26, 33);
+  --terminal-tab-active-bg: rgb(38, 38, 48);
 
   /* General */
-  --app-bg: rgb(18, 18, 22);
+  --app-bg: rgb(14, 14, 18);
   --border-radius: 8px;
+
+  /* Elevation / shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+  --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(0, 229, 204, 0.15);
+
+  /* Typography */
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", monospace;
+
+  /* Transitions */
+  --transition-fast: 0.12s ease;
+  --transition-normal: 0.2s ease;
+  --transition-slow: 0.3s ease;
 }
 
 * {
@@ -59,11 +82,25 @@ body,
   overflow: hidden;
   background: var(--app-bg);
   color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-sans);
   font-size: 13px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
+/* Selection */
+::selection {
+  background: rgba(0, 229, 204, 0.3);
+  color: var(--text-primary);
+}
+
+/* Focus ring */
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(0, 229, 204, 0.5);
+}
+
+/* Scrollbars */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -74,10 +111,80 @@ body,
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.08);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(0, 229, 204, 0.25);
+}
+
+/* Global keyframes */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes pulse-glow {
+  0%, 100% {
+    box-shadow: 0 0 4px rgba(0, 229, 204, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 10px rgba(0, 229, 204, 0.7);
+  }
+}
+
+@keyframes pulse-dot {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(1.3);
+  }
+}
+
+@keyframes slideInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideInRight {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -48,6 +48,10 @@
   --terminal-tab-bg: rgb(26, 26, 33);
   --terminal-tab-active-bg: rgb(38, 38, 48);
 
+  /* Toolbar */
+  --toolbar-active: rgba(180, 130, 50, 0.25);
+  --toolbar-active-text: rgb(196, 160, 80);
+
   /* General */
   --app-bg: rgb(14, 14, 18);
   --border-radius: 8px;


### PR DESCRIPTION
## Summary

Comprehensive visual redesign of the Claudette frontend, transforming it from a generic dark-theme developer tool into a distinctive, engaging mission-control interface.

### Theme System
- **Brand accent**: Teal (#00e5cc) threads through every interactive element
- **Typography**: Inter (sans) + JetBrains Mono (mono) replace system fonts
- **Design tokens**: CSS variables for shadows, transitions, and elevation
- **Global animations**: fadeInUp, pulse-glow, scaleIn keyframes
- **Polish**: Accent-tinted scrollbars, ::selection color, :focus-visible rings

### Chat Panel
- Message differentiation: accent left border for Claude, indented user messages, centered system pills
- Input: accent focus glow with box-shadow ring, tinted send button
- Tool activities: accent-colored tool names, smoother expand/collapse
- Streaming cursor: slim 2px accent bar instead of pipe character
- Message entrance animations

### Dashboard
- Status-colored left borders on workspace cards (teal/red/gray)
- Running agents: pulsing dot + live elapsed time counter
- Card hover: translateY lift with accent shadow
- Staggered entrance animations
- Improved empty state with icon and keyboard hint

### Sidebar
- Active workspace: accent left bar indicator
- Running count badges per repository
- Pulsing status dots for running agents
- Accent hover states on all interactive elements

### Global Polish
- Status bar: running agent count with pulsing dot, workspace stats
- Terminal: accent underline for active tab
- Diff viewer: hunk header borders, line number gutter, fade-in
- Modals & fuzzy finder: backdrop blur, scale-in animation
- All components: consistent transition timing via CSS variables

## Test plan
- [ ] Verify fonts load correctly (Inter + JetBrains Mono)
- [ ] Check dashboard cards show correct status borders and pulsing dots
- [ ] Verify chat input focus glow and send button styling
- [ ] Test message entrance animations in chat
- [ ] Confirm sidebar active indicator and running badges
- [ ] Test modal/fuzzy finder backdrop blur and animations
- [ ] Verify terminal tab accent underline
- [ ] Check diff viewer hunk header styling
- [ ] Ensure status bar shows running count
- [ ] Test all keyboard shortcuts still work
- [ ] Verify no TypeScript errors (tsc --noEmit passes)