### PR TITLE
feat: remote workspace access via claudette-server and WebSocket transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +116,17 @@ dependencies = [
  "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -102,6 +163,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -291,6 +374,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -340,6 +425,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "claudette"
 version = "0.4.0"
 dependencies = [
@@ -356,22 +481,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "claudette-server"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "clap",
+ "claudette",
+ "dirs",
+ "futures-util",
+ "gethostname",
+ "hex",
+ "mdns-sd",
+ "portable-pty",
+ "rand 0.8.5",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "toml 0.8.2",
+ "uuid",
+]
+
+[[package]]
 name = "claudette-tauri"
 version = "0.4.0"
 dependencies = [
+ "async-trait",
  "claudette",
  "dirs",
  "futures",
+ "futures-util",
+ "gethostname",
+ "hex",
  "libc",
+ "mdns-sd",
  "portable-pty",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tokio",
+ "tokio-rustls",
+ "tokio-tungstenite",
  "uuid",
 ]
 
@@ -385,6 +547,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +569,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -582,6 +768,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -914,6 +1106,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1169,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1546,7 +1755,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1701,6 +1910,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +2010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +2086,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2064,6 +2299,20 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "mdns-sd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36e83ad165be7e0ad2e3ae3be9afffdda0c2c9a7e70c628e5541f11443e3041"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "polling",
+ "socket2 0.5.10",
+]
 
 [[package]]
 name = "memchr"
@@ -2380,6 +2629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2715,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2723,6 +2988,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,6 +3209,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +3239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +3264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2988,6 +3298,19 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3117,6 +3440,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3493,51 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3487,6 +3869,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,6 +3986,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -3647,6 +4050,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -3709,6 +4121,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4285,9 +4703,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4301,6 +4720,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4525,6 +4970,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,6 +5060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,6 +5101,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -4974,6 +5450,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,6 +5705,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5249,6 +5761,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5310,6 +5837,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5328,6 +5861,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5343,6 +5882,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5376,6 +5921,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5391,6 +5942,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5412,6 +5969,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5427,6 +5990,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5678,6 +6247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5740,6 +6318,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src-tauri"]
+members = ["src-tauri", "src-server"]
 resolver = "2"
 
 [package]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,67 @@ src-tauri/
     commands/           # #[tauri::command] handlers
     state.rs            # Managed application state
     pty.rs              # Terminal PTY management
+    transport/          # Remote transport trait + WebSocket client
+    remote.rs           # Remote connection manager
+    mdns.rs             # mDNS service browser
+src-server/
+  Cargo.toml            # Headless server binary crate
+  src/
+    main.rs             # CLI entry point (clap)
+    ws.rs               # WebSocket accept loop + per-connection handler
+    handler.rs          # JSON-RPC command dispatcher
+    tls.rs              # Self-signed TLS certificate management
+    auth.rs             # Pairing token + session token auth
+    mdns.rs             # mDNS service advertisement
 ```
+
+## Remote access
+
+Claudette can connect to workspaces on another machine. The remote machine runs `claudette-server`, a headless backend that communicates over an encrypted WebSocket connection. The local Claudette app discovers or connects to it and displays remote repos, agents, and terminals alongside local ones.
+
+### Setting up the remote server
+
+```sh
+# Build and install the server binary
+cargo install --path src-server
+
+# Start it (generates a TLS certificate and pairing token on first run)
+claudette-server
+```
+
+On startup the server prints a connection string:
+
+```
+claudette-server v0.1.0 listening on wss://0.0.0.0:7683
+Name: Work Laptop
+
+Connection string (paste into Claudette):
+  claudette://work-laptop.local:7683/aBcDeFgH1234...
+```
+
+### Connecting from the local app
+
+**Automatic (LAN):** If both machines are on the same network, the server appears automatically in the sidebar under **Nearby**. Click **Connect** and enter the pairing token when prompted.
+
+**Manual:** Click **+ Add remote** in the sidebar footer and paste the full connection string. Claudette authenticates, stores a session token, and reconnects automatically on future launches.
+
+### Server management
+
+```sh
+# Regenerate the pairing token (revokes all existing sessions)
+claudette-server regenerate-token
+
+# Print the current connection string
+claudette-server show-connection-string
+
+# Bind to a specific interface or port
+claudette-server --bind 192.168.1.50 --port 9000
+
+# Disable mDNS advertisement
+claudette-server --no-mdns
+```
+
+All traffic is encrypted with TLS. The local app pins the server's certificate fingerprint on first connection (trust-on-first-use), similar to SSH's `known_hosts`.
 
 ## Development notes
 

--- a/src-server/Cargo.toml
+++ b/src-server/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "claudette-server"
+version = "0.1.0"
+edition = "2024"
+description = "Headless Claudette backend for remote access"
+
+[[bin]]
+name = "claudette-server"
+path = "src/main.rs"
+
+[dependencies]
+claudette = { path = ".." }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = "0.26"
+uuid = { version = "1", features = ["v4"] }
+dirs = "6"
+portable-pty = "0.8"
+rcgen = "0.13"
+rustls = "0.23"
+tokio-rustls = "0.26"
+rustls-pemfile = "2"
+mdns-sd = "0.12"
+rand = "0.8"
+base64 = "0.22"
+toml = "0.8"
+sha2 = "0.10"
+clap = { version = "4", features = ["derive"] }
+futures-util = "0.3"
+gethostname = "1"
+hex = "0.4"

--- a/src-server/src/auth.rs
+++ b/src-server/src/auth.rs
@@ -1,0 +1,136 @@
+use std::path::Path;
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+/// Generate a cryptographically random token encoded as URL-safe base64.
+pub fn generate_token() -> String {
+    let mut bytes = [0u8; 32]; // 256 bits
+    rand::thread_rng().fill(&mut bytes);
+    base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, bytes)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    pub server: ServerSection,
+    pub auth: AuthSection,
+    #[serde(default)]
+    pub sessions: Vec<SessionEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerSection {
+    pub name: String,
+    pub port: u16,
+    pub bind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthSection {
+    pub pairing_token: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEntry {
+    pub token: String,
+    pub name: String,
+    pub created_at: String,
+    pub last_seen: String,
+}
+
+impl ServerConfig {
+    pub fn load_or_create(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        if path.exists() {
+            let content = std::fs::read_to_string(path)?;
+            let config: Self = toml::from_str(&content)?;
+            Ok(config)
+        } else {
+            let hostname = gethostname::gethostname().to_string_lossy().to_string();
+            let config = Self {
+                server: ServerSection {
+                    name: hostname,
+                    port: crate::DEFAULT_PORT,
+                    bind: "0.0.0.0".to_string(),
+                },
+                auth: AuthSection {
+                    pairing_token: generate_token(),
+                },
+                sessions: Vec::new(),
+            };
+            config.save(path)?;
+            Ok(config)
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(self)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+
+    pub fn regenerate_token(&mut self) {
+        self.auth.pairing_token = generate_token();
+        self.sessions.clear();
+    }
+
+    /// Validate a pairing token and issue a new session token.
+    pub fn pair(&mut self, pairing_token: &str, client_name: &str) -> Option<String> {
+        if self.auth.pairing_token != pairing_token {
+            return None;
+        }
+        let session_token = generate_token();
+        let now = now_iso();
+        self.sessions.push(SessionEntry {
+            token: session_token.clone(),
+            name: client_name.to_string(),
+            created_at: now.clone(),
+            last_seen: now,
+        });
+        Some(session_token)
+    }
+
+    /// Validate an existing session token. Returns true and updates last_seen if valid.
+    pub fn validate_session(&mut self, session_token: &str) -> bool {
+        if let Some(session) = self.sessions.iter_mut().find(|s| s.token == session_token) {
+            session.last_seen = now_iso();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn now_iso() -> String {
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    // Simple ISO-8601 timestamp.
+    let secs = dur.as_secs();
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    // Approximate date from epoch days (good enough for last_seen timestamps).
+    let (year, month, day) = epoch_days_to_date(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
+}
+
+fn epoch_days_to_date(days: u64) -> (u64, u64, u64) {
+    // Algorithm from http://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -200,7 +200,24 @@ fn now_iso() -> String {
     let dur = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
-    format!("{}", dur.as_secs())
+    let secs = dur.as_secs();
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let h = time_secs / 3600;
+    let m = (time_secs % 3600) / 60;
+    let s = time_secs % 60;
+    // Hinnant's algorithm for epoch days → calendar date.
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+    format!("{y:04}-{mo:02}-{d:02} {h:02}:{m:02}:{s:02}")
 }
 
 // ---- Command handlers ----
@@ -503,6 +520,17 @@ async fn handle_archive_workspace(
     state: &ServerState,
     workspace_id: &str,
 ) -> Result<serde_json::Value, String> {
+    // Stop any running agent before removing the worktree.
+    {
+        let mut agents = state.agents.write().await;
+        if let Some(session) = agents.get_mut(workspace_id)
+            && let Some(pid) = session.active_pid.take()
+        {
+            let _ = agent::stop_agent(pid).await;
+        }
+        agents.remove(workspace_id);
+    }
+
     let db = open_db(state)?;
     db.update_workspace_status(workspace_id, &WorkspaceStatus::Archived, None)
         .map_err(|e| e.to_string())?;

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -1,0 +1,716 @@
+use std::sync::Arc;
+
+use claudette::agent::{self, AgentEvent, AgentSettings, StreamEvent};
+use claudette::db::Database;
+use claudette::model::{ChatMessage, ChatRole, Workspace, WorkspaceStatus};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use serde_json::json;
+
+use crate::ws::{AgentSessionState, PtyHandle, ServerState, Writer, send_message};
+
+const TOOLS_FULL: &[&str] = &[
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+    "NotebookEdit",
+];
+
+const TOOLS_STANDARD: &[&str] = &[
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+];
+
+const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
+
+fn tools_for_level(level: &str) -> Vec<String> {
+    let tools: &[&str] = match level {
+        "full" => TOOLS_FULL,
+        "standard" => TOOLS_STANDARD,
+        _ => TOOLS_READONLY,
+    };
+    tools.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// Dispatch a JSON-RPC request and return a JSON-RPC response.
+pub async fn handle_request(
+    state: &Arc<ServerState>,
+    writer: &Arc<Writer>,
+    request: &serde_json::Value,
+) -> serde_json::Value {
+    let id = request
+        .get("id")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    let params = request.get("params").cloned().unwrap_or_default();
+
+    let result = match method {
+        "load_initial_data" => handle_load_initial_data(state).await,
+        "load_chat_history" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            handle_load_chat_history(state, &workspace_id).await
+        }
+        "send_chat_message" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            let content = param_str(&params, "content");
+            let permission_level = params
+                .get("permission_level")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let model = params
+                .get("model")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let fast_mode = params.get("fast_mode").and_then(|v| v.as_bool());
+            let thinking_enabled = params.get("thinking_enabled").and_then(|v| v.as_bool());
+            let plan_mode = params.get("plan_mode").and_then(|v| v.as_bool());
+            handle_send_chat_message(
+                state,
+                writer,
+                &workspace_id,
+                &content,
+                permission_level.as_deref(),
+                model,
+                fast_mode,
+                thinking_enabled,
+                plan_mode,
+            )
+            .await
+        }
+        "stop_agent" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            handle_stop_agent(state, &workspace_id).await
+        }
+        "reset_agent_session" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            let mut agents = state.agents.write().await;
+            agents.remove(&workspace_id);
+            Ok(json!(null))
+        }
+        "list_repositories" => {
+            let db = open_db(state).map_err(|e| e.to_string());
+            match db {
+                Ok(db) => db
+                    .list_repositories()
+                    .map(|repos| serde_json::to_value(repos).unwrap_or_default())
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e),
+            }
+        }
+        "list_workspaces" => {
+            let db = open_db(state).map_err(|e| e.to_string());
+            match db {
+                Ok(db) => db
+                    .list_workspaces()
+                    .map(|ws| serde_json::to_value(ws).unwrap_or_default())
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e),
+            }
+        }
+        "create_workspace" => {
+            let repository_id = param_str(&params, "repository_id");
+            let name = param_str(&params, "name");
+            handle_create_workspace(state, &repository_id, &name).await
+        }
+        "archive_workspace" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            handle_archive_workspace(state, &workspace_id).await
+        }
+        "load_diff_files" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            handle_load_diff_files(state, &workspace_id).await
+        }
+        "load_file_diff" => {
+            let worktree_path = param_str(&params, "worktree_path");
+            let file_path = param_str(&params, "file_path");
+            let merge_base = param_str(&params, "merge_base");
+            handle_load_file_diff(&worktree_path, &file_path, &merge_base).await
+        }
+        "spawn_pty" => {
+            let workspace_id = param_str(&params, "workspace_id");
+            let cwd = param_str(&params, "cwd");
+            let rows = params.get("rows").and_then(|v| v.as_u64()).unwrap_or(24) as u16;
+            let cols = params.get("cols").and_then(|v| v.as_u64()).unwrap_or(80) as u16;
+            handle_spawn_pty(state, writer, &workspace_id, &cwd, rows, cols).await
+        }
+        "write_pty" => {
+            let pty_id = params.get("pty_id").and_then(|v| v.as_u64()).unwrap_or(0);
+            let data: Vec<u8> = params
+                .get("data")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|b| b.as_u64().map(|n| n as u8))
+                        .collect()
+                })
+                .unwrap_or_default();
+            handle_write_pty(state, pty_id, &data).await
+        }
+        "resize_pty" => {
+            let pty_id = params.get("pty_id").and_then(|v| v.as_u64()).unwrap_or(0);
+            let rows = params.get("rows").and_then(|v| v.as_u64()).unwrap_or(24) as u16;
+            let cols = params.get("cols").and_then(|v| v.as_u64()).unwrap_or(80) as u16;
+            handle_resize_pty(state, pty_id, rows, cols).await
+        }
+        "close_pty" => {
+            let pty_id = params.get("pty_id").and_then(|v| v.as_u64()).unwrap_or(0);
+            handle_close_pty(state, pty_id).await
+        }
+        "get_app_setting" => {
+            let key = param_str(&params, "key");
+            handle_get_app_setting(state, &key)
+        }
+        "set_app_setting" => {
+            let key = param_str(&params, "key");
+            let value = param_str(&params, "value");
+            handle_set_app_setting(state, &key, &value).await
+        }
+        _ => Err(format!("Unknown method: {method}")),
+    };
+
+    match result {
+        Ok(value) => json!({"id": id, "result": value}),
+        Err(msg) => json!({"id": id, "error": {"code": -1, "message": msg}}),
+    }
+}
+
+fn param_str(params: &serde_json::Value, key: &str) -> String {
+    params
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn open_db(state: &ServerState) -> Result<Database, String> {
+    Database::open(&state.db_path).map_err(|e| e.to_string())
+}
+
+fn now_iso() -> String {
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}", dur.as_secs())
+}
+
+// ---- Command handlers ----
+
+async fn handle_load_initial_data(state: &ServerState) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    let repositories = db.list_repositories().map_err(|e| e.to_string())?;
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+
+    let worktree_base_dir = {
+        let dir = state.worktree_base_dir.read().await;
+        dir.to_string_lossy().to_string()
+    };
+
+    // Check repo path validity.
+    let repositories: Vec<_> = repositories
+        .into_iter()
+        .map(|mut r| {
+            r.path_valid = std::path::Path::new(&r.path).is_dir();
+            r
+        })
+        .collect();
+
+    // Resolve default branches concurrently.
+    let branch_futures: Vec<_> = repositories
+        .iter()
+        .filter(|r| r.path_valid)
+        .map(|r| {
+            let id = r.id.clone();
+            let path = r.path.clone();
+            async move {
+                claudette::git::default_branch(&path)
+                    .await
+                    .ok()
+                    .map(|b| (id, b))
+            }
+        })
+        .collect();
+    let branch_results = futures_util::future::join_all(branch_futures).await;
+    let default_branches: std::collections::HashMap<String, String> =
+        branch_results.into_iter().flatten().collect();
+
+    let last_messages = db.last_message_per_workspace().map_err(|e| e.to_string())?;
+
+    Ok(json!({
+        "repositories": repositories,
+        "workspaces": workspaces,
+        "worktree_base_dir": worktree_base_dir,
+        "default_branches": default_branches,
+        "last_messages": last_messages,
+    }))
+}
+
+async fn handle_load_chat_history(
+    state: &ServerState,
+    workspace_id: &str,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    let messages = db
+        .list_chat_messages(workspace_id)
+        .map_err(|e| e.to_string())?;
+    Ok(serde_json::to_value(messages).unwrap_or_default())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_send_chat_message(
+    state: &Arc<ServerState>,
+    writer: &Arc<Writer>,
+    workspace_id: &str,
+    content: &str,
+    permission_level: Option<&str>,
+    model: Option<String>,
+    fast_mode: Option<bool>,
+    thinking_enabled: Option<bool>,
+    plan_mode: Option<bool>,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or("Workspace has no worktree")?
+        .clone();
+
+    // Save user message.
+    let user_msg = ChatMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        role: ChatRole::User,
+        content: content.to_string(),
+        cost_usd: None,
+        duration_ms: None,
+        created_at: now_iso(),
+    };
+    db.insert_chat_message(&user_msg)
+        .map_err(|e| e.to_string())?;
+
+    let level = permission_level.unwrap_or("full");
+    let allowed_tools = tools_for_level(level);
+
+    let repo = db
+        .get_repository(&ws.repository_id)
+        .map_err(|e| e.to_string())?;
+
+    let mut agents = state.agents.write().await;
+    let session = agents.entry(workspace_id.to_string()).or_insert_with(|| {
+        let instructions = {
+            let from_config = repo.as_ref().and_then(|r| {
+                let path = r.path.clone();
+                claudette::config::load_config(std::path::Path::new(&path))
+                    .ok()
+                    .flatten()
+                    .and_then(|c| c.instructions)
+            });
+            from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
+        };
+        AgentSessionState {
+            session_id: uuid::Uuid::new_v4().to_string(),
+            turn_count: 0,
+            active_pid: None,
+            custom_instructions: instructions,
+        }
+    });
+
+    let is_resume = session.turn_count > 0;
+    let session_id = session.session_id.clone();
+    let custom_instructions = session.custom_instructions.clone();
+    session.turn_count += 1;
+
+    let agent_settings = AgentSettings {
+        model: if !is_resume { model } else { None },
+        fast_mode: fast_mode.unwrap_or(false),
+        thinking_enabled: thinking_enabled.unwrap_or(false),
+        plan_mode: plan_mode.unwrap_or(false),
+    };
+
+    let turn_handle = agent::run_turn(
+        std::path::Path::new(&worktree_path),
+        &session_id,
+        content,
+        is_resume,
+        &allowed_tools,
+        custom_instructions.as_deref(),
+        &agent_settings,
+    )
+    .await?;
+
+    session.active_pid = Some(turn_handle.pid);
+    drop(agents);
+
+    // Bridge agent events to WebSocket.
+    let ws_id = workspace_id.to_string();
+    let db_path = state.db_path.clone();
+    let state = Arc::clone(state);
+    let writer = Arc::clone(writer);
+    tokio::spawn(async move {
+        let mut rx = turn_handle.event_rx;
+        let mut got_init = false;
+        while let Some(event) = rx.recv().await {
+            if let AgentEvent::Stream(StreamEvent::System { ref subtype, .. }) = event
+                && subtype == "init"
+            {
+                got_init = true;
+            }
+
+            if let AgentEvent::ProcessExited(code) = &event
+                && (!got_init || *code != Some(0))
+            {
+                let mut agents = state.agents.write().await;
+                agents.remove(&ws_id);
+            }
+
+            // Persist assistant messages.
+            if let AgentEvent::Stream(StreamEvent::Assistant { ref message }) = event {
+                let full_text: String = message
+                    .content
+                    .iter()
+                    .filter_map(|block| {
+                        if let claudette::agent::ContentBlock::Text { text } = block {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+
+                if !full_text.trim().is_empty()
+                    && let Ok(db) = Database::open(&db_path)
+                {
+                    let msg = ChatMessage {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        workspace_id: ws_id.clone(),
+                        role: ChatRole::Assistant,
+                        content: full_text,
+                        cost_usd: None,
+                        duration_ms: None,
+                        created_at: now_iso(),
+                    };
+                    let _ = db.insert_chat_message(&msg);
+                }
+            }
+
+            // Update cost/duration.
+            if let AgentEvent::Stream(StreamEvent::Result {
+                ref total_cost_usd,
+                ref duration_ms,
+                ..
+            }) = event
+                && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
+                && let Ok(db) = Database::open(&db_path)
+                && let Ok(msgs) = db.list_chat_messages(&ws_id)
+                && let Some(last) = msgs.iter().rfind(|m| m.role == ChatRole::Assistant)
+            {
+                let _ = db.update_chat_message_cost(&last.id, *cost, *dur);
+            }
+
+            // Emit event over WebSocket.
+            let event_msg = json!({
+                "event": "agent-stream",
+                "payload": {
+                    "workspace_id": ws_id,
+                    "event": event,
+                }
+            });
+            send_message(&writer, &event_msg).await;
+        }
+    });
+
+    Ok(json!(null))
+}
+
+async fn handle_stop_agent(
+    state: &ServerState,
+    workspace_id: &str,
+) -> Result<serde_json::Value, String> {
+    let mut agents = state.agents.write().await;
+    if let Some(session) = agents.get_mut(workspace_id)
+        && let Some(pid) = session.active_pid.take()
+    {
+        agent::stop_agent(pid).await?;
+    }
+
+    let db = open_db(state)?;
+    let msg = ChatMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        role: ChatRole::System,
+        content: "Agent stopped".to_string(),
+        cost_usd: None,
+        duration_ms: None,
+        created_at: now_iso(),
+    };
+    db.insert_chat_message(&msg).map_err(|e| e.to_string())?;
+    Ok(json!(null))
+}
+
+async fn handle_create_workspace(
+    state: &ServerState,
+    repository_id: &str,
+    name: &str,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    let repo = db
+        .get_repository(repository_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Repository not found")?;
+
+    let worktree_base_dir = state.worktree_base_dir.read().await;
+    let branch_name = format!("{}/{}", repo.path_slug, name);
+    let worktree_path = worktree_base_dir.join(&repo.path_slug).join(name);
+
+    // Create git worktree.
+    claudette::git::create_worktree(&repo.path, &branch_name, &worktree_path.to_string_lossy())
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let workspace = Workspace {
+        id: uuid::Uuid::new_v4().to_string(),
+        repository_id: repository_id.to_string(),
+        name: name.to_string(),
+        branch_name,
+        worktree_path: Some(worktree_path.to_string_lossy().to_string()),
+        status: WorkspaceStatus::Active,
+        agent_status: claudette::model::AgentStatus::Idle,
+        status_line: String::new(),
+        created_at: now_iso(),
+    };
+    db.insert_workspace(&workspace).map_err(|e| e.to_string())?;
+
+    Ok(serde_json::to_value(&workspace).unwrap_or_default())
+}
+
+async fn handle_archive_workspace(
+    state: &ServerState,
+    workspace_id: &str,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    db.update_workspace_status(workspace_id, &WorkspaceStatus::Archived, None)
+        .map_err(|e| e.to_string())?;
+
+    // Remove worktree.
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    if let Some(ws) = workspaces.iter().find(|w| w.id == workspace_id)
+        && let Some(ref path) = ws.worktree_path
+    {
+        let repo = db
+            .get_repository(&ws.repository_id)
+            .map_err(|e| e.to_string())?;
+        if let Some(repo) = repo {
+            let _ = claudette::git::remove_worktree(&repo.path, path).await;
+        }
+    }
+
+    Ok(json!(null))
+}
+
+async fn handle_load_diff_files(
+    state: &ServerState,
+    workspace_id: &str,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or("Workspace has no worktree")?;
+
+    let repo = db
+        .get_repository(&ws.repository_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Repository not found")?;
+
+    let base_branch = claudette::git::default_branch(&repo.path)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let merge_base = claudette::diff::merge_base(worktree_path, "HEAD", &base_branch)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let files = claudette::diff::changed_files(worktree_path, &merge_base)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    Ok(json!({
+        "files": files,
+        "merge_base": merge_base,
+    }))
+}
+
+async fn handle_load_file_diff(
+    worktree_path: &str,
+    file_path: &str,
+    merge_base: &str,
+) -> Result<serde_json::Value, String> {
+    let raw = claudette::diff::file_diff(worktree_path, merge_base, file_path)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+    let parsed = claudette::diff::parse_unified_diff(&raw, file_path);
+    Ok(serde_json::to_value(parsed).unwrap_or_default())
+}
+
+async fn handle_spawn_pty(
+    state: &Arc<ServerState>,
+    writer: &Arc<Writer>,
+    _workspace_id: &str,
+    cwd: &str,
+    rows: u16,
+    cols: u16,
+) -> Result<serde_json::Value, String> {
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| e.to_string())?;
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let mut cmd = CommandBuilder::new(&shell);
+    cmd.cwd(cwd);
+
+    let child = pair.slave.spawn_command(cmd).map_err(|e| e.to_string())?;
+    let pty_reader = pair.master.try_clone_reader().map_err(|e| e.to_string())?;
+    let pty_writer = pair.master.take_writer().map_err(|e| e.to_string())?;
+
+    let pty_id = state.next_pty_id();
+
+    {
+        let mut ptys = state.ptys.write().await;
+        ptys.insert(
+            pty_id,
+            PtyHandle {
+                writer: std::sync::Mutex::new(pty_writer),
+                master: std::sync::Mutex::new(pair.master),
+                child: std::sync::Mutex::new(child),
+            },
+        );
+    }
+
+    // Spawn a reader task that forwards PTY output over WebSocket.
+    let writer = Arc::clone(writer);
+    let state_clone = Arc::clone(state);
+    tokio::task::spawn_blocking(move || {
+        use std::io::Read;
+        let mut reader = pty_reader;
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let data: Vec<u8> = buf[..n].to_vec();
+                    let writer = writer.clone();
+                    let rt = tokio::runtime::Handle::current();
+                    rt.block_on(async {
+                        let msg = json!({
+                            "event": "pty-output",
+                            "payload": {
+                                "pty_id": pty_id,
+                                "data": data,
+                            }
+                        });
+                        send_message(&writer, &msg).await;
+                    });
+                }
+                Err(_) => break,
+            }
+        }
+        // Clean up PTY on exit.
+        let rt = tokio::runtime::Handle::current();
+        rt.block_on(async {
+            let mut ptys = state_clone.ptys.write().await;
+            ptys.remove(&pty_id);
+        });
+    });
+
+    Ok(json!({"pty_id": pty_id}))
+}
+
+async fn handle_write_pty(
+    state: &ServerState,
+    pty_id: u64,
+    data: &[u8],
+) -> Result<serde_json::Value, String> {
+    let ptys = state.ptys.read().await;
+    let handle = ptys.get(&pty_id).ok_or("PTY not found")?;
+    let mut writer = handle.writer.lock().map_err(|e| e.to_string())?;
+    writer.write_all(data).map_err(|e| e.to_string())?;
+    writer.flush().map_err(|e| e.to_string())?;
+    Ok(json!(null))
+}
+
+async fn handle_resize_pty(
+    state: &ServerState,
+    pty_id: u64,
+    rows: u16,
+    cols: u16,
+) -> Result<serde_json::Value, String> {
+    let ptys = state.ptys.read().await;
+    let handle = ptys.get(&pty_id).ok_or("PTY not found")?;
+    let master = handle.master.lock().map_err(|e| e.to_string())?;
+    master
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| e.to_string())?;
+    Ok(json!(null))
+}
+
+async fn handle_close_pty(state: &ServerState, pty_id: u64) -> Result<serde_json::Value, String> {
+    let mut ptys = state.ptys.write().await;
+    if let Some(handle) = ptys.remove(&pty_id)
+        && let Ok(mut child) = handle.child.lock()
+    {
+        let _ = child.kill();
+    }
+    Ok(json!(null))
+}
+
+fn handle_get_app_setting(state: &ServerState, key: &str) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    let value = db.get_app_setting(key).map_err(|e| e.to_string())?;
+    Ok(json!(value))
+}
+
+async fn handle_set_app_setting(
+    state: &ServerState,
+    key: &str,
+    value: &str,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    db.set_app_setting(key, value).map_err(|e| e.to_string())?;
+    if key == "worktree_base_dir" {
+        let mut dir = state.worktree_base_dir.write().await;
+        *dir = std::path::PathBuf::from(value);
+    }
+    Ok(json!(null))
+}

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -1,0 +1,190 @@
+mod auth;
+mod handler;
+mod mdns;
+mod tls;
+mod ws;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::{Parser, Subcommand};
+use tokio::net::TcpListener;
+
+use crate::auth::ServerConfig;
+
+/// Default WebSocket port for claudette-server.
+pub const DEFAULT_PORT: u16 = 7683;
+
+#[derive(Parser)]
+#[command(
+    name = "claudette-server",
+    version,
+    about = "Headless Claudette backend for remote access"
+)]
+struct Cli {
+    /// WebSocket port.
+    #[arg(long, default_value_t = DEFAULT_PORT)]
+    port: u16,
+
+    /// Bind address.
+    #[arg(long, default_value = "0.0.0.0")]
+    bind: String,
+
+    /// Display name for this server.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Disable mDNS advertisement.
+    #[arg(long)]
+    no_mdns: bool,
+
+    /// Config file path.
+    #[arg(long)]
+    config: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate a new pairing token (revokes all sessions).
+    RegenerateToken,
+    /// Print the connection string for this server.
+    ShowConnectionString,
+}
+
+fn config_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("claudette-server")
+}
+
+fn default_config_path() -> PathBuf {
+    config_dir().join("server.toml")
+}
+
+fn db_path() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("claudette")
+        .join("claudette.db")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    let config_path = cli.config.clone().unwrap_or_else(default_config_path);
+
+    match &cli.command {
+        Some(Commands::RegenerateToken) => {
+            let mut config = ServerConfig::load_or_create(&config_path)?;
+            config.regenerate_token();
+            config.save(&config_path)?;
+            println!("Pairing token regenerated. All existing sessions have been revoked.");
+            println!("\nNew connection string:");
+            let host = gethostname::gethostname().to_string_lossy().to_string();
+            println!(
+                "  claudette://{}:{}/{}",
+                host, config.server.port, config.auth.pairing_token
+            );
+            return Ok(());
+        }
+        Some(Commands::ShowConnectionString) => {
+            let config = ServerConfig::load_or_create(&config_path)?;
+            let host = gethostname::gethostname().to_string_lossy().to_string();
+            println!(
+                "claudette://{}:{}/{}",
+                host, config.server.port, config.auth.pairing_token
+            );
+            return Ok(());
+        }
+        None => {}
+    }
+
+    // Load or create config, applying CLI overrides.
+    let mut config = ServerConfig::load_or_create(&config_path)?;
+    config.server.port = cli.port;
+    config.server.bind = cli.bind.clone();
+    if let Some(ref name) = cli.name {
+        config.server.name = name.clone();
+    }
+    config.save(&config_path)?;
+
+    // Load or generate TLS certificate.
+    let tls_config = tls::load_or_generate_tls(&config_dir())?;
+    let fingerprint = tls::cert_fingerprint(&config_dir())?;
+
+    let host = gethostname::gethostname().to_string_lossy().to_string();
+    println!(
+        "claudette-server v{} listening on wss://{}:{}",
+        env!("CARGO_PKG_VERSION"),
+        cli.bind,
+        cli.port,
+    );
+    println!("Name: {}", config.server.name);
+    println!();
+    println!("Connection string (paste into Claudette):");
+    println!(
+        "  claudette://{}:{}/{}",
+        host, cli.port, config.auth.pairing_token
+    );
+    println!();
+    println!("Certificate fingerprint: {fingerprint}");
+    println!();
+
+    // Set up database.
+    let db_path = db_path();
+    let _ = claudette::db::Database::open(&db_path);
+
+    let worktree_base_dir = {
+        let default = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".claudette")
+            .join("workspaces");
+        if let Ok(db) = claudette::db::Database::open(&db_path) {
+            db.get_app_setting("worktree_base_dir")
+                .ok()
+                .flatten()
+                .map(PathBuf::from)
+                .unwrap_or(default)
+        } else {
+            default
+        }
+    };
+
+    let state = Arc::new(ws::ServerState::new(db_path, worktree_base_dir));
+
+    // Start mDNS advertisement.
+    if !cli.no_mdns {
+        let short_fp = &fingerprint[..fingerprint.len().min(16)];
+        let _mdns = mdns::advertise(&config.server.name, cli.port, short_fp)?;
+        println!("mDNS: advertising as _claudette._tcp on port {}", cli.port);
+    }
+
+    // Bind TCP listener.
+    let addr: SocketAddr = format!("{}:{}", cli.bind, cli.port).parse()?;
+    let listener = TcpListener::bind(addr).await?;
+    let acceptor = tokio_rustls::TlsAcceptor::from(tls_config);
+
+    println!("Ready for connections.\n");
+
+    loop {
+        let (stream, peer_addr) = listener.accept().await?;
+        let acceptor = acceptor.clone();
+        let state = Arc::clone(&state);
+        let config = config.clone();
+
+        tokio::spawn(async move {
+            match acceptor.accept(stream).await {
+                Ok(tls_stream) => {
+                    ws::handle_tls_connection(state, config, tls_stream, peer_addr).await;
+                }
+                Err(e) => {
+                    eprintln!("[tls] handshake failed from {peer_addr}: {e}");
+                }
+            }
+        });
+    }
+}

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -134,6 +134,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Certificate fingerprint: {fingerprint}");
     println!();
 
+    // Wrap config in shared state so all connections see session mutations.
+    let config = Arc::new(tokio::sync::Mutex::new(config));
+    let config_path = Arc::new(config_path);
+
     // Set up database.
     let db_path = db_path();
     let _ = claudette::db::Database::open(&db_path);
@@ -159,7 +163,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start mDNS advertisement.
     if !cli.no_mdns {
         let short_fp = &fingerprint[..fingerprint.len().min(16)];
-        let _mdns = mdns::advertise(&config.server.name, cli.port, short_fp)?;
+        let config_guard = config.lock().await;
+        let server_name = config_guard.server.name.clone();
+        drop(config_guard);
+        let _mdns = mdns::advertise(&server_name, cli.port, short_fp)?;
         println!("mDNS: advertising as _claudette._tcp on port {}", cli.port);
     }
 
@@ -174,12 +181,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (stream, peer_addr) = listener.accept().await?;
         let acceptor = acceptor.clone();
         let state = Arc::clone(&state);
-        let config = config.clone();
+        let config = Arc::clone(&config);
+        let config_path = Arc::clone(&config_path);
 
         tokio::spawn(async move {
             match acceptor.accept(stream).await {
                 Ok(tls_stream) => {
-                    ws::handle_tls_connection(state, config, tls_stream, peer_addr).await;
+                    ws::handle_tls_connection(state, config, config_path, tls_stream, peer_addr)
+                        .await;
                 }
                 Err(e) => {
                     eprintln!("[tls] handshake failed from {peer_addr}: {e}");

--- a/src-server/src/mdns.rs
+++ b/src-server/src/mdns.rs
@@ -1,0 +1,34 @@
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+
+const SERVICE_TYPE: &str = "_claudette._tcp.local.";
+
+/// Advertise this server via mDNS on the local network.
+pub fn advertise(
+    name: &str,
+    port: u16,
+    fingerprint_prefix: &str,
+) -> Result<ServiceDaemon, Box<dyn std::error::Error>> {
+    let mdns = ServiceDaemon::new()?;
+
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
+    let instance_name = format!("{name} ({hostname})");
+
+    let properties = [
+        ("version", env!("CARGO_PKG_VERSION")),
+        ("name", name),
+        ("fingerprint", fingerprint_prefix),
+    ];
+
+    let service = ServiceInfo::new(
+        SERVICE_TYPE,
+        &instance_name,
+        &format!("{hostname}.local."),
+        "",
+        port,
+        &properties[..],
+    )?;
+
+    mdns.register(service)?;
+
+    Ok(mdns)
+}

--- a/src-server/src/tls.rs
+++ b/src-server/src/tls.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::pki_types::CertificateDer;
+use sha2::{Digest, Sha256};
+
+/// Load existing TLS cert/key or generate a self-signed one.
+pub fn load_or_generate_tls(
+    config_dir: &Path,
+) -> Result<Arc<rustls::ServerConfig>, Box<dyn std::error::Error>> {
+    let cert_path = config_dir.join("cert.pem");
+    let key_path = config_dir.join("key.pem");
+
+    if !cert_path.exists() || !key_path.exists() {
+        generate_self_signed(config_dir)?;
+    }
+
+    let cert_pem = std::fs::read(&cert_path)?;
+    let key_pem = std::fs::read(&key_path)?;
+
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut &cert_pem[..])
+        .filter_map(|r| r.ok())
+        .collect();
+    let key = rustls_pemfile::private_key(&mut &key_pem[..])?.ok_or("No private key found")?;
+
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)?;
+
+    Ok(Arc::new(config))
+}
+
+fn generate_self_signed(config_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::create_dir_all(config_dir)?;
+
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
+
+    let mut params = rcgen::CertificateParams::new(vec![hostname.clone()])?;
+    params
+        .subject_alt_names
+        .push(rcgen::SanType::DnsName(hostname.try_into()?));
+    params
+        .subject_alt_names
+        .push(rcgen::SanType::DnsName("localhost".to_string().try_into()?));
+
+    let key_pair = rcgen::KeyPair::generate()?;
+    let cert = params.self_signed(&key_pair)?;
+
+    std::fs::write(config_dir.join("cert.pem"), cert.pem())?;
+    std::fs::write(config_dir.join("key.pem"), key_pair.serialize_pem())?;
+
+    Ok(())
+}
+
+/// Compute SHA-256 fingerprint of the server's certificate (hex-encoded).
+pub fn cert_fingerprint(config_dir: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let cert_pem = std::fs::read(config_dir.join("cert.pem"))?;
+    let cert = rustls_pemfile::certs(&mut &cert_pem[..])
+        .next()
+        .ok_or("No certificate found")??;
+
+    let mut hasher = Sha256::new();
+    hasher.update(cert.as_ref());
+    let hash = hasher.finalize();
+    Ok(hex::encode(hash))
+}

--- a/src-server/src/ws.rs
+++ b/src-server/src/ws.rs
@@ -1,0 +1,236 @@
+use std::collections::HashMap;
+use std::io::Write as IoWrite;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio::sync::RwLock;
+use tokio_rustls::server::TlsStream;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::auth::ServerConfig;
+use crate::handler;
+
+/// Server-side application state — mirrors src-tauri's AppState but without Tauri dependencies.
+pub struct ServerState {
+    pub db_path: PathBuf,
+    pub worktree_base_dir: RwLock<PathBuf>,
+    pub agents: RwLock<HashMap<String, AgentSessionState>>,
+    pub ptys: RwLock<HashMap<u64, PtyHandle>>,
+    pub next_pty_id: AtomicU64,
+}
+
+pub struct AgentSessionState {
+    pub session_id: String,
+    pub turn_count: u32,
+    pub active_pid: Option<u32>,
+    pub custom_instructions: Option<String>,
+}
+
+pub struct PtyHandle {
+    pub writer: Mutex<Box<dyn IoWrite + Send>>,
+    pub master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
+    pub child: Mutex<Box<dyn portable_pty::Child + Send>>,
+}
+
+impl ServerState {
+    pub fn new(db_path: PathBuf, worktree_base_dir: PathBuf) -> Self {
+        Self {
+            db_path,
+            worktree_base_dir: RwLock::new(worktree_base_dir),
+            agents: RwLock::new(HashMap::new()),
+            ptys: RwLock::new(HashMap::new()),
+            next_pty_id: AtomicU64::new(1),
+        }
+    }
+
+    pub fn next_pty_id(&self) -> u64 {
+        self.next_pty_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// Type alias for the writer half of a WebSocket connection.
+pub type Writer = tokio::sync::Mutex<
+    futures_util::stream::SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
+>;
+
+pub async fn send_message(writer: &Writer, value: &serde_json::Value) {
+    let text = serde_json::to_string(value).unwrap_or_default();
+    let mut w = writer.lock().await;
+    let _ = w.send(Message::Text(text.into())).await;
+}
+
+/// Accept a TLS connection and upgrade it to WebSocket.
+pub async fn handle_tls_connection(
+    state: std::sync::Arc<ServerState>,
+    mut config: ServerConfig,
+    tls_stream: TlsStream<TcpStream>,
+    addr: SocketAddr,
+) {
+    let ws_stream = match tokio_tungstenite::accept_async(tls_stream).await {
+        Ok(ws) => ws,
+        Err(e) => {
+            eprintln!("[ws] WebSocket handshake failed from {addr}: {e}");
+            return;
+        }
+    };
+
+    println!("[ws] New connection from {addr}");
+
+    let (write, mut read) = ws_stream.split();
+    let writer = std::sync::Arc::new(tokio::sync::Mutex::new(write));
+
+    // Phase 1: Authentication (max 3 attempts).
+    let mut auth_attempts = 0;
+    let max_attempts = 3;
+    let mut authenticated = false;
+
+    while auth_attempts < max_attempts {
+        let msg = match read.next().await {
+            Some(Ok(Message::Text(text))) => text,
+            Some(Ok(Message::Close(_))) | None => {
+                println!("[ws] Connection closed during auth from {addr}");
+                return;
+            }
+            _ => continue,
+        };
+
+        let request: serde_json::Value = match serde_json::from_str(&msg) {
+            Ok(v) => v,
+            Err(e) => {
+                let err = serde_json::json!({
+                    "id": null,
+                    "error": {"code": -32700, "message": format!("Parse error: {e}")}
+                });
+                send_message(&writer, &err).await;
+                continue;
+            }
+        };
+
+        let id = request
+            .get("id")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let method = request.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+        if method != "authenticate" {
+            let err = serde_json::json!({
+                "id": id,
+                "error": {"code": -1, "message": "Must authenticate first"}
+            });
+            send_message(&writer, &err).await;
+            auth_attempts += 1;
+            continue;
+        }
+
+        let params = request.get("params").cloned().unwrap_or_default();
+
+        // Try session token first, then pairing token.
+        if let Some(session_token) = params.get("session_token").and_then(|t| t.as_str())
+            && config.validate_session(session_token)
+        {
+            let resp = serde_json::json!({
+                "id": id,
+                "result": {"server_name": config.server.name}
+            });
+            send_message(&writer, &resp).await;
+            authenticated = true;
+            break;
+        }
+
+        if let Some(pairing_token) = params.get("pairing_token").and_then(|t| t.as_str()) {
+            let client_name = params
+                .get("client_name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("Unknown client");
+
+            if let Some(session_token) = config.pair(pairing_token, client_name) {
+                // Persist the new session.
+                let config_path = dirs::config_dir()
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join("claudette-server")
+                    .join("server.toml");
+                let _ = config.save(&config_path);
+
+                let resp = serde_json::json!({
+                    "id": id,
+                    "result": {
+                        "session_token": session_token,
+                        "server_name": config.server.name
+                    }
+                });
+                send_message(&writer, &resp).await;
+                authenticated = true;
+                break;
+            }
+        }
+
+        auth_attempts += 1;
+        let err = serde_json::json!({
+            "id": id,
+            "error": {
+                "code": -2,
+                "message": format!(
+                    "Authentication failed ({}/{})",
+                    auth_attempts, max_attempts
+                )
+            }
+        });
+        send_message(&writer, &err).await;
+    }
+
+    if !authenticated {
+        eprintln!(
+            "[ws] Auth failed after {max_attempts} attempts from {addr}, dropping connection"
+        );
+        return;
+    }
+
+    println!("[ws] Authenticated connection from {addr}");
+
+    // Phase 2: Command loop.
+    while let Some(msg_result) = read.next().await {
+        let text = match msg_result {
+            Ok(Message::Text(text)) => text,
+            Ok(Message::Close(_)) => {
+                println!("[ws] Connection closed from {addr}");
+                break;
+            }
+            Ok(Message::Ping(data)) => {
+                let mut w = writer.lock().await;
+                let _ = w.send(Message::Pong(data)).await;
+                continue;
+            }
+            Err(e) => {
+                eprintln!("[ws] Error from {addr}: {e}");
+                break;
+            }
+            _ => continue,
+        };
+
+        let request: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            Err(e) => {
+                let err = serde_json::json!({
+                    "id": null,
+                    "error": {"code": -32700, "message": format!("Parse error: {e}")}
+                });
+                send_message(&writer, &err).await;
+                continue;
+            }
+        };
+
+        let state = std::sync::Arc::clone(&state);
+        let writer = std::sync::Arc::clone(&writer);
+        tokio::spawn(async move {
+            let response = handler::handle_request(&state, &writer, &request).await;
+            send_message(&writer, &response).await;
+        });
+    }
+
+    println!("[ws] Disconnected: {addr}");
+}

--- a/src-server/src/ws.rs
+++ b/src-server/src/ws.rs
@@ -133,6 +133,13 @@ pub async fn handle_tls_connection(
         if let Some(session_token) = params.get("session_token").and_then(|t| t.as_str())
             && config.validate_session(session_token)
         {
+            // Persist last_seen update.
+            let config_path = dirs::config_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("claudette-server")
+                .join("server.toml");
+            let _ = config.save(&config_path);
+
             let resp = serde_json::json!({
                 "id": id,
                 "result": {"server_name": config.server.name}

--- a/src-server/src/ws.rs
+++ b/src-server/src/ws.rs
@@ -67,7 +67,8 @@ pub async fn send_message(writer: &Writer, value: &serde_json::Value) {
 /// Accept a TLS connection and upgrade it to WebSocket.
 pub async fn handle_tls_connection(
     state: std::sync::Arc<ServerState>,
-    mut config: ServerConfig,
+    config: std::sync::Arc<tokio::sync::Mutex<ServerConfig>>,
+    config_path: std::sync::Arc<PathBuf>,
     tls_stream: TlsStream<TcpStream>,
     addr: SocketAddr,
 ) {
@@ -130,23 +131,22 @@ pub async fn handle_tls_connection(
         let params = request.get("params").cloned().unwrap_or_default();
 
         // Try session token first, then pairing token.
-        if let Some(session_token) = params.get("session_token").and_then(|t| t.as_str())
-            && config.validate_session(session_token)
-        {
-            // Persist last_seen update.
-            let config_path = dirs::config_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join("claudette-server")
-                .join("server.toml");
-            let _ = config.save(&config_path);
+        if let Some(session_token) = params.get("session_token").and_then(|t| t.as_str()) {
+            let mut cfg = config.lock().await;
+            if cfg.validate_session(session_token) {
+                let _ = cfg.save(&config_path);
+                let server_name = cfg.server.name.clone();
+                drop(cfg);
 
-            let resp = serde_json::json!({
-                "id": id,
-                "result": {"server_name": config.server.name}
-            });
-            send_message(&writer, &resp).await;
-            authenticated = true;
-            break;
+                let resp = serde_json::json!({
+                    "id": id,
+                    "result": {"server_name": server_name}
+                });
+                send_message(&writer, &resp).await;
+                authenticated = true;
+                break;
+            }
+            drop(cfg);
         }
 
         if let Some(pairing_token) = params.get("pairing_token").and_then(|t| t.as_str()) {
@@ -155,25 +155,24 @@ pub async fn handle_tls_connection(
                 .and_then(|n| n.as_str())
                 .unwrap_or("Unknown client");
 
-            if let Some(session_token) = config.pair(pairing_token, client_name) {
-                // Persist the new session.
-                let config_path = dirs::config_dir()
-                    .unwrap_or_else(|| PathBuf::from("."))
-                    .join("claudette-server")
-                    .join("server.toml");
-                let _ = config.save(&config_path);
+            let mut cfg = config.lock().await;
+            if let Some(session_token) = cfg.pair(pairing_token, client_name) {
+                let _ = cfg.save(&config_path);
+                let server_name = cfg.server.name.clone();
+                drop(cfg);
 
                 let resp = serde_json::json!({
                     "id": id,
                     "result": {
                         "session_token": session_token,
-                        "server_name": config.server.name
+                        "server_name": server_name
                     }
                 });
                 send_message(&writer, &resp).await;
                 authenticated = true;
                 break;
             }
+            drop(cfg);
         }
 
         auth_attempts += 1;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,16 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 libc = "0.2"
 portable-pty = "0.8"
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+rustls = "0.23"
+tokio-rustls = "0.26"
+rustls-pemfile = "2"
+sha2 = "0.10"
+hex = "0.4"
+mdns-sd = "0.12"
+futures-util = "0.3"
+async-trait = "0.1"
+gethostname = "1"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod chat;
 pub mod data;
 pub mod diff;
+pub mod remote;
 pub mod repository;
 pub mod settings;
 pub mod terminal;

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -226,6 +226,25 @@ pub async fn add_remote_connection(
     pair_with_server(host, port, token.to_string(), app, state, manager).await
 }
 
+/// Forward a JSON-RPC command to a remote connection.
+#[tauri::command]
+pub async fn send_remote_command(
+    connection_id: String,
+    method: String,
+    params: serde_json::Value,
+    manager: State<'_, RemoteConnectionManager>,
+) -> Result<serde_json::Value, String> {
+    let request = serde_json::json!({
+        "method": method,
+        "params": params,
+    });
+    let response = manager.send(&connection_id, request).await?;
+    Ok(response
+        .get("result")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null))
+}
+
 // -- Local server (Share this machine) --
 
 #[derive(Serialize)]

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,10 +1,11 @@
 use serde::Serialize;
 use tauri::{AppHandle, State};
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use claudette::db::Database;
 
 use crate::remote::{DiscoveredServer, RemoteConnectionInfo, RemoteConnectionManager};
-use crate::state::AppState;
+use crate::state::{AppState, LocalServerState};
 use crate::transport::ws::WebSocketTransport;
 
 #[derive(Serialize)]
@@ -203,4 +204,135 @@ pub async fn add_remote_connection(
     };
 
     pair_with_server(host, port, token.to_string(), app, state, manager).await
+}
+
+// -- Local server (Share this machine) --
+
+#[derive(Serialize)]
+pub struct LocalServerInfo {
+    pub running: bool,
+    pub connection_string: Option<String>,
+}
+
+#[tauri::command]
+pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServerInfo, String> {
+    {
+        let server = state.local_server.read().await;
+        if server.is_some() {
+            let conn_str = server.as_ref().unwrap().connection_string.clone();
+            return Ok(LocalServerInfo {
+                running: true,
+                connection_string: Some(conn_str),
+            });
+        }
+    }
+
+    // Find the claudette-server binary. Try:
+    // 1. Next to the current executable
+    // 2. In PATH
+    let server_bin = find_server_binary()?;
+
+    let mut child = tokio::process::Command::new(&server_bin)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start claudette-server: {e}"))?;
+
+    // Read stdout lines until we find the connection string.
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("Failed to capture server stdout")?;
+    let mut reader = BufReader::new(stdout).lines();
+
+    let mut connection_string = String::new();
+    let timeout = tokio::time::Duration::from_secs(10);
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    while tokio::time::Instant::now() < deadline {
+        let line = tokio::time::timeout_at(deadline, reader.next_line())
+            .await
+            .map_err(|_| "Timed out waiting for server to start")?
+            .map_err(|e| format!("Error reading server output: {e}"))?;
+
+        if let Some(line) = line {
+            let trimmed = line.trim();
+            if trimmed.starts_with("claudette://") {
+                connection_string = trimmed.to_string();
+                break;
+            }
+        } else {
+            return Err("Server process exited before printing connection string".to_string());
+        }
+    }
+
+    if connection_string.is_empty() {
+        let _ = child.kill().await;
+        return Err("Server started but did not print a connection string".to_string());
+    }
+
+    let info = LocalServerInfo {
+        running: true,
+        connection_string: Some(connection_string.clone()),
+    };
+
+    let mut server = state.local_server.write().await;
+    *server = Some(LocalServerState {
+        child,
+        connection_string,
+    });
+
+    Ok(info)
+}
+
+#[tauri::command]
+pub async fn stop_local_server(state: State<'_, AppState>) -> Result<(), String> {
+    let mut server = state.local_server.write().await;
+    if let Some(mut srv) = server.take() {
+        let _ = srv.child.kill().await;
+        let _ = srv.child.wait().await;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_local_server_status(
+    state: State<'_, AppState>,
+) -> Result<LocalServerInfo, String> {
+    let server = state.local_server.read().await;
+    match server.as_ref() {
+        Some(srv) => Ok(LocalServerInfo {
+            running: true,
+            connection_string: Some(srv.connection_string.clone()),
+        }),
+        None => Ok(LocalServerInfo {
+            running: false,
+            connection_string: None,
+        }),
+    }
+}
+
+fn find_server_binary() -> Result<String, String> {
+    // 1. Next to the current executable.
+    if let Ok(exe) = std::env::current_exe() {
+        let dir = exe.parent().unwrap_or(std::path::Path::new("."));
+        let candidate = dir.join("claudette-server");
+        if candidate.exists() {
+            return Ok(candidate.to_string_lossy().to_string());
+        }
+    }
+
+    // 2. In PATH.
+    if let Ok(output) = std::process::Command::new("which")
+        .arg("claudette-server")
+        .output()
+        && output.status.success()
+    {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Ok(path);
+        }
+    }
+
+    Err("claudette-server not found. Install it with: cargo install --path src-server".to_string())
 }

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,0 +1,206 @@
+use serde::Serialize;
+use tauri::{AppHandle, State};
+
+use claudette::db::Database;
+
+use crate::remote::{DiscoveredServer, RemoteConnectionInfo, RemoteConnectionManager};
+use crate::state::AppState;
+use crate::transport::ws::WebSocketTransport;
+
+#[derive(Serialize)]
+pub struct PairResult {
+    pub connection: RemoteConnectionInfo,
+    pub server_name: String,
+}
+
+#[tauri::command]
+pub async fn list_remote_connections(
+    state: State<'_, AppState>,
+) -> Result<Vec<RemoteConnectionInfo>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let connections = db.list_remote_connections().map_err(|e| e.to_string())?;
+    Ok(connections
+        .into_iter()
+        .map(|c| RemoteConnectionInfo {
+            id: c.id,
+            name: c.name,
+            host: c.host,
+            port: c.port,
+            session_token: c.session_token,
+            cert_fingerprint: c.cert_fingerprint,
+            auto_connect: c.auto_connect,
+            created_at: c.created_at,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn pair_with_server(
+    host: String,
+    port: u16,
+    pairing_token: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+    manager: State<'_, RemoteConnectionManager>,
+) -> Result<PairResult, String> {
+    // Connect via WebSocket.
+    let result = WebSocketTransport::connect(&host, port, None).await?;
+    let transport = result.transport;
+    let cert_fingerprint = result.cert_fingerprint;
+
+    // Authenticate with pairing token.
+    let hostname = gethostname::gethostname().to_string_lossy().to_string();
+    let auth = transport
+        .authenticate_pairing(&pairing_token, &hostname)
+        .await?;
+
+    let connection_id = uuid::Uuid::new_v4().to_string();
+    let info = RemoteConnectionInfo {
+        id: connection_id.clone(),
+        name: auth.server_name.clone(),
+        host: host.clone(),
+        port,
+        session_token: auth.session_token.clone(),
+        cert_fingerprint: Some(cert_fingerprint.clone()),
+        auto_connect: false,
+        created_at: String::new(),
+    };
+
+    // Persist to DB.
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let db_conn = claudette::model::RemoteConnection {
+        id: connection_id.clone(),
+        name: auth.server_name.clone(),
+        host: host.clone(),
+        port,
+        session_token: auth.session_token.clone(),
+        cert_fingerprint: Some(cert_fingerprint.clone()),
+        auto_connect: false,
+        created_at: String::new(),
+    };
+    db.insert_remote_connection(&db_conn)
+        .map_err(|e| e.to_string())?;
+
+    // Add to active connections.
+    manager.add(info.clone(), transport, app).await;
+
+    Ok(PairResult {
+        connection: info,
+        server_name: auth.server_name,
+    })
+}
+
+#[tauri::command]
+pub async fn connect_remote(
+    id: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+    manager: State<'_, RemoteConnectionManager>,
+) -> Result<serde_json::Value, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let conn = db
+        .get_remote_connection(&id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Remote connection not found")?;
+
+    let session_token = conn
+        .session_token
+        .as_ref()
+        .ok_or("No session token — need to re-pair")?;
+
+    // Connect via WebSocket.
+    let result =
+        WebSocketTransport::connect(&conn.host, conn.port, conn.cert_fingerprint.as_deref())
+            .await?;
+    let transport = result.transport;
+
+    // Authenticate with saved session token.
+    let auth = transport.authenticate_session(session_token).await?;
+
+    let info = RemoteConnectionInfo {
+        id: conn.id.clone(),
+        name: auth.server_name.clone(),
+        host: conn.host.clone(),
+        port: conn.port,
+        session_token: conn.session_token.clone(),
+        cert_fingerprint: conn.cert_fingerprint.clone(),
+        auto_connect: conn.auto_connect,
+        created_at: conn.created_at.clone(),
+    };
+
+    // Load remote data.
+    use crate::transport::Transport;
+    let remote_data = transport
+        .send(serde_json::json!({
+            "method": "load_initial_data",
+            "params": {}
+        }))
+        .await?;
+
+    // Add to active connections.
+    manager.add(info, transport, app).await;
+
+    // Return the remote initial data.
+    Ok(remote_data
+        .get("result")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null))
+}
+
+#[tauri::command]
+pub async fn disconnect_remote(
+    id: String,
+    manager: State<'_, RemoteConnectionManager>,
+) -> Result<(), String> {
+    manager.remove(&id).await
+}
+
+#[tauri::command]
+pub async fn remove_remote_connection(
+    id: String,
+    state: State<'_, AppState>,
+    manager: State<'_, RemoteConnectionManager>,
+) -> Result<(), String> {
+    // Disconnect if active.
+    let _ = manager.remove(&id).await;
+
+    // Remove from DB.
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.delete_remote_connection(&id)
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_discovered_servers(
+    state: State<'_, AppState>,
+) -> Result<Vec<DiscoveredServer>, String> {
+    let servers = state.discovered_servers.read().await;
+    Ok(servers.clone())
+}
+
+#[tauri::command]
+pub async fn add_remote_connection(
+    connection_string: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+    manager: State<'_, RemoteConnectionManager>,
+) -> Result<PairResult, String> {
+    // Parse connection string: claudette://host:port/token
+    let stripped = connection_string
+        .strip_prefix("claudette://")
+        .ok_or("Invalid connection string — must start with claudette://")?;
+
+    let (host_port, token) = stripped
+        .split_once('/')
+        .ok_or("Invalid connection string — missing token")?;
+
+    let (host, port) = if let Some((h, p)) = host_port.rsplit_once(':') {
+        let port: u16 = p.parse().map_err(|_| "Invalid port number")?;
+        (h.to_string(), port)
+    } else {
+        (host_port.to_string(), 7683)
+    };
+
+    pair_with_server(host, port, token.to_string(), app, state, manager).await
+}

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -12,6 +12,7 @@ use crate::transport::ws::WebSocketTransport;
 pub struct PairResult {
     pub connection: RemoteConnectionInfo,
     pub server_name: String,
+    pub initial_data: Option<serde_json::Value>,
 }
 
 #[tauri::command]
@@ -89,12 +90,24 @@ pub async fn pair_with_server(
         created_at: saved.created_at,
     };
 
+    // Load remote data before handing off the transport.
+    use crate::transport::Transport;
+    let remote_data = transport
+        .send(serde_json::json!({
+            "method": "load_initial_data",
+            "params": {}
+        }))
+        .await
+        .ok()
+        .and_then(|r| r.get("result").cloned());
+
     // Add to active connections.
     manager.add(info.clone(), transport, app).await;
 
     Ok(PairResult {
         connection: info,
         server_name: auth.server_name,
+        initial_data: remote_data,
     })
 }
 

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -223,15 +223,14 @@ pub struct LocalServerInfo {
 
 #[tauri::command]
 pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServerInfo, String> {
-    {
-        let server = state.local_server.read().await;
-        if server.is_some() {
-            let conn_str = server.as_ref().unwrap().connection_string.clone();
-            return Ok(LocalServerInfo {
-                running: true,
-                connection_string: Some(conn_str),
-            });
-        }
+    // Hold write lock for the entire operation to prevent concurrent spawns.
+    let mut server = state.local_server.write().await;
+
+    if let Some(ref srv) = *server {
+        return Ok(LocalServerInfo {
+            running: true,
+            connection_string: Some(srv.connection_string.clone()),
+        });
     }
 
     // Find the claudette-server binary. Try:
@@ -241,7 +240,7 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
 
     let mut child = tokio::process::Command::new(&server_bin)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit()) // inherit stderr to avoid pipe deadlock
         .spawn()
         .map_err(|e| format!("Failed to start claudette-server: {e}"))?;
 
@@ -283,7 +282,6 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
         connection_string: Some(connection_string.clone()),
     };
 
-    let mut server = state.local_server.write().await;
     *server = Some(LocalServerState {
         child,
         connection_string,

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -56,16 +56,6 @@ pub async fn pair_with_server(
         .await?;
 
     let connection_id = uuid::Uuid::new_v4().to_string();
-    let info = RemoteConnectionInfo {
-        id: connection_id.clone(),
-        name: auth.server_name.clone(),
-        host: host.clone(),
-        port,
-        session_token: auth.session_token.clone(),
-        cert_fingerprint: Some(cert_fingerprint.clone()),
-        auto_connect: false,
-        created_at: String::new(),
-    };
 
     // Persist to DB.
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
@@ -81,6 +71,23 @@ pub async fn pair_with_server(
     };
     db.insert_remote_connection(&db_conn)
         .map_err(|e| e.to_string())?;
+
+    // Re-fetch to get the DB-generated created_at timestamp.
+    let saved = db
+        .get_remote_connection(&connection_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Failed to re-read saved connection")?;
+
+    let info = RemoteConnectionInfo {
+        id: saved.id,
+        name: saved.name,
+        host: saved.host,
+        port: saved.port,
+        session_token: saved.session_token,
+        cert_fingerprint: saved.cert_fingerprint,
+        auto_connect: saved.auto_connect,
+        created_at: saved.created_at,
+    };
 
     // Add to active connections.
     manager.add(info.clone(), transport, app).await;

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -290,6 +290,15 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
         return Err("Server started but did not print a connection string".to_string());
     }
 
+    // Spawn a task to continuously drain stdout to prevent broken pipe panics.
+    // The server writes log messages to stdout; if we don't read them, the pipe
+    // buffer fills and the server will panic with "Broken pipe" when we close stdout.
+    tokio::spawn(async move {
+        while let Ok(Some(_)) = reader.next_line().await {
+            // Discard output
+        }
+    });
+
     let info = LocalServerInfo {
         running: true,
         connection_string: Some(connection_string.clone()),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,8 +2,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod commands;
+mod mdns;
 mod pty;
+mod remote;
 mod state;
+mod transport;
 
 use std::path::PathBuf;
 
@@ -36,13 +39,31 @@ fn main() {
         }
     };
 
+    // Load saved certificate fingerprints for mDNS pairing detection.
+    let saved_fingerprints: Vec<String> = Database::open(&db_path)
+        .ok()
+        .and_then(|db| db.list_remote_connections().ok())
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|c| c.cert_fingerprint)
+        .collect();
+
     let app_state = state::AppState::new(db_path, worktree_base_dir);
+    let remote_manager = remote::RemoteConnectionManager::new();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .manage(app_state)
+        .manage(remote_manager)
+        .setup(move |app| {
+            // Start mDNS browser to discover nearby claudette-server instances.
+            if let Err(e) = mdns::start_mdns_browser(app.handle(), saved_fingerprints) {
+                eprintln!("[mdns] Failed to start browser: {e}");
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             // Data
             commands::data::load_initial_data,
@@ -82,6 +103,14 @@ fn main() {
             // Settings
             commands::settings::get_app_setting,
             commands::settings::set_app_setting,
+            // Remote
+            commands::remote::list_remote_connections,
+            commands::remote::pair_with_server,
+            commands::remote::connect_remote,
+            commands::remote::disconnect_remote,
+            commands::remote::remove_remote_connection,
+            commands::remote::list_discovered_servers,
+            commands::remote::add_remote_connection,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Claudette");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -111,6 +111,7 @@ fn main() {
             commands::remote::remove_remote_connection,
             commands::remote::list_discovered_servers,
             commands::remote::add_remote_connection,
+            commands::remote::send_remote_command,
             // Local server
             commands::remote::start_local_server,
             commands::remote::stop_local_server,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -111,6 +111,10 @@ fn main() {
             commands::remote::remove_remote_connection,
             commands::remote::list_discovered_servers,
             commands::remote::add_remote_connection,
+            // Local server
+            commands::remote::start_local_server,
+            commands::remote::stop_local_server,
+            commands::remote::get_local_server_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Claudette");

--- a/src-tauri/src/mdns.rs
+++ b/src-tauri/src/mdns.rs
@@ -15,7 +15,7 @@ pub fn start_mdns_browser(app: &AppHandle, saved_fingerprints: Vec<String>) -> R
 
     let app_handle = app.clone();
 
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         // Keep mdns alive for the lifetime of the task.
         let _mdns = mdns;
         let _fingerprints = saved_fingerprints;

--- a/src-tauri/src/mdns.rs
+++ b/src-tauri/src/mdns.rs
@@ -1,0 +1,62 @@
+use mdns_sd::{ServiceDaemon, ServiceEvent};
+use tauri::{AppHandle, Manager};
+
+use crate::remote::DiscoveredServer;
+use crate::state::AppState;
+
+const SERVICE_TYPE: &str = "_claudette._tcp.local.";
+
+/// Start an mDNS browser that discovers claudette-server instances on the LAN.
+pub fn start_mdns_browser(app: &AppHandle, saved_fingerprints: Vec<String>) -> Result<(), String> {
+    let mdns = ServiceDaemon::new().map_err(|e| format!("Failed to start mDNS daemon: {e}"))?;
+    let receiver = mdns
+        .browse(SERVICE_TYPE)
+        .map_err(|e| format!("Failed to browse mDNS: {e}"))?;
+
+    let app_handle = app.clone();
+
+    tokio::spawn(async move {
+        // Keep mdns alive for the lifetime of the task.
+        let _mdns = mdns;
+        let _fingerprints = saved_fingerprints;
+
+        while let Ok(event) = receiver.recv_async().await {
+            match event {
+                ServiceEvent::ServiceResolved(info) => {
+                    let name = info
+                        .get_property_val_str("name")
+                        .unwrap_or_default()
+                        .to_string();
+                    let fingerprint = info
+                        .get_property_val_str("fingerprint")
+                        .unwrap_or_default()
+                        .to_string();
+                    let host = info.get_hostname().trim_end_matches('.').to_string();
+                    let port = info.get_port();
+                    let is_paired = _fingerprints.iter().any(|fp| fp.starts_with(&fingerprint));
+
+                    let server = DiscoveredServer {
+                        name,
+                        host,
+                        port,
+                        cert_fingerprint_prefix: fingerprint,
+                        is_paired,
+                    };
+
+                    let state = app_handle.state::<AppState>();
+                    let mut servers = state.discovered_servers.write().await;
+                    servers.retain(|s| s.host != server.host || s.port != server.port);
+                    servers.push(server);
+                }
+                ServiceEvent::ServiceRemoved(_, fullname) => {
+                    let state = app_handle.state::<AppState>();
+                    let mut servers = state.discovered_servers.write().await;
+                    servers.retain(|s| !fullname.contains(&s.host));
+                }
+                _ => {}
+            }
+        }
+    });
+
+    Ok(())
+}

--- a/src-tauri/src/mdns.rs
+++ b/src-tauri/src/mdns.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 use tauri::{AppHandle, Manager};
 
@@ -20,6 +22,9 @@ pub fn start_mdns_browser(app: &AppHandle, saved_fingerprints: Vec<String>) -> R
         let _mdns = mdns;
         let _fingerprints = saved_fingerprints;
 
+        // Track fullname → (host, port) for reliable removal.
+        let mut fullname_map: HashMap<String, (String, u16)> = HashMap::new();
+
         while let Ok(event) = receiver.recv_async().await {
             match event {
                 ServiceEvent::ServiceResolved(info) => {
@@ -33,7 +38,10 @@ pub fn start_mdns_browser(app: &AppHandle, saved_fingerprints: Vec<String>) -> R
                         .to_string();
                     let host = info.get_hostname().trim_end_matches('.').to_string();
                     let port = info.get_port();
+                    let fullname = info.get_fullname().to_string();
                     let is_paired = _fingerprints.iter().any(|fp| fp.starts_with(&fingerprint));
+
+                    fullname_map.insert(fullname, (host.clone(), port));
 
                     let server = DiscoveredServer {
                         name,
@@ -49,9 +57,11 @@ pub fn start_mdns_browser(app: &AppHandle, saved_fingerprints: Vec<String>) -> R
                     servers.push(server);
                 }
                 ServiceEvent::ServiceRemoved(_, fullname) => {
-                    let state = app_handle.state::<AppState>();
-                    let mut servers = state.discovered_servers.write().await;
-                    servers.retain(|s| !fullname.contains(&s.host));
+                    if let Some((host, port)) = fullname_map.remove(&fullname) {
+                        let state = app_handle.state::<AppState>();
+                        let mut servers = state.discovered_servers.write().await;
+                        servers.retain(|s| s.host != host || s.port != port);
+                    }
                 }
                 _ => {}
             }

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -57,17 +57,14 @@ impl RemoteConnectionManager {
         let transport = Arc::new(transport);
         let mut event_rx = transport.event_stream();
 
-        // Forward remote events to the Tauri event bus under a "remote:" namespace
-        // and include the originating connection_id in the payload.
+        // Forward remote events to the Tauri event bus.
+        // Events like "agent-stream" are emitted under their original name with the
+        // original payload so the frontend handles them identically to local events.
+        // Workspace IDs are UUIDs so there's no collision between local and remote.
         let connection_id = info.id.clone();
         let event_task = tokio::spawn(async move {
             while let Ok(event) = event_rx.recv().await {
-                let event_name = format!("remote:{}", event.event);
-                let forwarded_payload = serde_json::json!({
-                    "connection_id": connection_id,
-                    "payload": event.payload,
-                });
-                let _ = app.emit(&event_name, &forwarded_payload);
+                let _ = app.emit(&event.event, &event.payload);
             }
             eprintln!("[remote] Event stream ended for connection {connection_id}");
         });

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -1,0 +1,123 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::RwLock;
+
+use crate::transport::Transport;
+use crate::transport::ws::WebSocketTransport;
+
+/// Persisted remote connection configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteConnectionInfo {
+    pub id: String,
+    pub name: String,
+    pub host: String,
+    pub port: u16,
+    pub session_token: Option<String>,
+    pub cert_fingerprint: Option<String>,
+    pub auto_connect: bool,
+    pub created_at: String,
+}
+
+/// An active connection to a remote claudette-server.
+pub struct RemoteConnection {
+    pub info: RemoteConnectionInfo,
+    pub transport: Arc<WebSocketTransport>,
+    _event_task: tokio::task::JoinHandle<()>,
+}
+
+/// Manages all active remote connections.
+pub struct RemoteConnectionManager {
+    pub connections: RwLock<Vec<RemoteConnection>>,
+}
+
+impl RemoteConnectionManager {
+    pub fn new() -> Self {
+        Self {
+            connections: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Add an active connection and start forwarding its events to the Tauri event bus.
+    pub async fn add(
+        &self,
+        info: RemoteConnectionInfo,
+        transport: WebSocketTransport,
+        app: AppHandle,
+    ) {
+        let transport = Arc::new(transport);
+        let mut event_rx = transport.event_stream();
+
+        // Forward remote events to Tauri event bus, prefixed with "remote:".
+        let connection_id = info.id.clone();
+        let event_task = tokio::spawn(async move {
+            while let Ok(event) = event_rx.recv().await {
+                // Forward as-is — the frontend distinguishes remote events by
+                // the presence of remote_connection_id on the workspace.
+                let _ = app.emit(&event.event, &event.payload);
+            }
+            eprintln!("[remote] Event stream ended for connection {connection_id}");
+        });
+
+        let conn = RemoteConnection {
+            info,
+            transport,
+            _event_task: event_task,
+        };
+
+        let mut connections = self.connections.write().await;
+        connections.push(conn);
+    }
+
+    /// Send a JSON-RPC request to a specific remote connection.
+    #[allow(dead_code)]
+    pub async fn send(
+        &self,
+        connection_id: &str,
+        request: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let connections = self.connections.read().await;
+        let conn = connections
+            .iter()
+            .find(|c| c.info.id == connection_id)
+            .ok_or_else(|| format!("Remote connection {connection_id} not found"))?;
+        conn.transport.send(request).await
+    }
+
+    /// Disconnect and remove a remote connection.
+    pub async fn remove(&self, connection_id: &str) -> Result<(), String> {
+        let mut connections = self.connections.write().await;
+        if let Some(idx) = connections.iter().position(|c| c.info.id == connection_id) {
+            let conn = connections.remove(idx);
+            let _ = conn.transport.close().await;
+        }
+        Ok(())
+    }
+
+    /// List all active connection IDs.
+    #[allow(dead_code)]
+    pub async fn list_active(&self) -> Vec<RemoteConnectionInfo> {
+        let connections = self.connections.read().await;
+        connections.iter().map(|c| c.info.clone()).collect()
+    }
+
+    /// Check if a connection is active.
+    #[allow(dead_code)]
+    pub async fn is_connected(&self, connection_id: &str) -> bool {
+        let connections = self.connections.read().await;
+        connections
+            .iter()
+            .any(|c| c.info.id == connection_id && c.transport.is_connected())
+    }
+}
+
+/// Server discovered via mDNS on the local network.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredServer {
+    pub name: String,
+    pub host: String,
+    pub port: u16,
+    pub cert_fingerprint_prefix: String,
+    pub is_paired: bool,
+}

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -40,22 +40,34 @@ impl RemoteConnectionManager {
     }
 
     /// Add an active connection and start forwarding its events to the Tauri event bus.
+    /// If a connection with the same ID already exists, it is closed and replaced.
     pub async fn add(
         &self,
         info: RemoteConnectionInfo,
         transport: WebSocketTransport,
         app: AppHandle,
     ) {
+        // Close and remove any existing connection with the same ID.
+        let mut connections = self.connections.write().await;
+        if let Some(idx) = connections.iter().position(|c| c.info.id == info.id) {
+            let old = connections.remove(idx);
+            let _ = old.transport.close().await;
+        }
+
         let transport = Arc::new(transport);
         let mut event_rx = transport.event_stream();
 
-        // Forward remote events to Tauri event bus, prefixed with "remote:".
+        // Forward remote events to the Tauri event bus under a "remote:" namespace
+        // and include the originating connection_id in the payload.
         let connection_id = info.id.clone();
         let event_task = tokio::spawn(async move {
             while let Ok(event) = event_rx.recv().await {
-                // Forward as-is — the frontend distinguishes remote events by
-                // the presence of remote_connection_id on the workspace.
-                let _ = app.emit(&event.event, &event.payload);
+                let event_name = format!("remote:{}", event.event);
+                let forwarded_payload = serde_json::json!({
+                    "connection_id": connection_id,
+                    "payload": event.payload,
+                });
+                let _ = app.emit(&event_name, &forwarded_payload);
             }
             eprintln!("[remote] Event stream ended for connection {connection_id}");
         });
@@ -66,7 +78,6 @@ impl RemoteConnectionManager {
             _event_task: event_task,
         };
 
-        let mut connections = self.connections.write().await;
         connections.push(conn);
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -28,6 +28,14 @@ pub struct PtyHandle {
     pub child: Mutex<Box<dyn portable_pty::Child + Send>>,
 }
 
+/// State of the embedded claudette-server subprocess.
+pub struct LocalServerState {
+    /// Handle to the running server process.
+    pub child: tokio::process::Child,
+    /// The connection string printed by the server on startup.
+    pub connection_string: String,
+}
+
 /// Application-wide managed state, shared across all Tauri commands.
 pub struct AppState {
     pub db_path: PathBuf,
@@ -40,6 +48,8 @@ pub struct AppState {
     pub next_pty_id: AtomicU64,
     /// mDNS-discovered servers on the local network.
     pub discovered_servers: RwLock<Vec<DiscoveredServer>>,
+    /// Embedded local claudette-server process (when "Share this machine" is active).
+    pub local_server: RwLock<Option<LocalServerState>>,
 }
 
 impl AppState {
@@ -51,6 +61,7 @@ impl AppState {
             ptys: RwLock::new(HashMap::new()),
             next_pty_id: AtomicU64::new(1),
             discovered_servers: RwLock::new(Vec::new()),
+            local_server: RwLock::new(None),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::RwLock;
 
+use crate::remote::DiscoveredServer;
+
 /// Per-workspace agent session state managed on the Rust side.
 pub struct AgentSessionState {
     pub session_id: String,
@@ -36,6 +38,8 @@ pub struct AppState {
     pub ptys: RwLock<HashMap<u64, PtyHandle>>,
     /// Counter for generating unique PTY IDs.
     pub next_pty_id: AtomicU64,
+    /// mDNS-discovered servers on the local network.
+    pub discovered_servers: RwLock<Vec<DiscoveredServer>>,
 }
 
 impl AppState {
@@ -46,6 +50,7 @@ impl AppState {
             agents: RwLock::new(HashMap::new()),
             ptys: RwLock::new(HashMap::new()),
             next_pty_id: AtomicU64::new(1),
+            discovered_servers: RwLock::new(Vec::new()),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -36,6 +36,18 @@ pub struct LocalServerState {
     pub connection_string: String,
 }
 
+impl Drop for LocalServerState {
+    fn drop(&mut self) {
+        // Kill the server process when this state is dropped.
+        // Use start_kill() instead of kill() since we're in a sync context.
+        if let Err(e) = self.child.start_kill() {
+            eprintln!("[cleanup] Failed to kill local server: {e}");
+        } else {
+            eprintln!("[cleanup] Stopped local claudette-server");
+        }
+    }
+}
+
 /// Application-wide managed state, shared across all Tauri commands.
 pub struct AppState {
     pub db_path: PathBuf,

--- a/src-tauri/src/transport/mod.rs
+++ b/src-tauri/src/transport/mod.rs
@@ -1,0 +1,28 @@
+pub mod ws;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// A server-pushed event received over the transport.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerEvent {
+    pub event: String,
+    pub payload: serde_json::Value,
+}
+
+/// Transport-agnostic connection to a remote claudette-server.
+#[allow(dead_code)]
+#[async_trait::async_trait]
+pub trait Transport: Send + Sync + 'static {
+    /// Send a JSON-RPC request and return the response.
+    async fn send(&self, request: serde_json::Value) -> Result<serde_json::Value, String>;
+
+    /// Subscribe to unsolicited events from the remote.
+    fn event_stream(&self) -> broadcast::Receiver<ServerEvent>;
+
+    /// Cleanly shut down the transport.
+    async fn close(&self) -> Result<(), String>;
+
+    /// Check whether the transport is still alive.
+    fn is_connected(&self) -> bool;
+}

--- a/src-tauri/src/transport/ws.rs
+++ b/src-tauri/src/transport/ws.rs
@@ -1,0 +1,309 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::{Mutex, broadcast, oneshot};
+use tokio_tungstenite::tungstenite::Message;
+
+use super::{ServerEvent, Transport};
+
+/// WebSocket transport connecting to a remote claudette-server over WSS.
+pub struct WebSocketTransport {
+    writer: Arc<
+        Mutex<
+            futures_util::stream::SplitSink<
+                tokio_tungstenite::WebSocketStream<
+                    tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+                >,
+                Message,
+            >,
+        >,
+    >,
+    pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
+    next_id: AtomicU64,
+    event_tx: broadcast::Sender<ServerEvent>,
+    connected: Arc<AtomicBool>,
+    _reader_task: tokio::task::JoinHandle<()>,
+}
+
+/// Certificate fingerprint (SHA-256 hex) obtained during connection.
+pub struct ConnectionResult {
+    pub transport: WebSocketTransport,
+    pub cert_fingerprint: String,
+}
+
+impl WebSocketTransport {
+    /// Connect to a remote claudette-server.
+    ///
+    /// If `expected_fingerprint` is Some, the server's certificate fingerprint is verified.
+    /// Returns the transport and the server's certificate fingerprint.
+    pub async fn connect(
+        host: &str,
+        port: u16,
+        expected_fingerprint: Option<&str>,
+    ) -> Result<ConnectionResult, String> {
+        let url = format!("wss://{host}:{port}");
+
+        // Build a TLS config that accepts self-signed certificates.
+        // We do our own fingerprint verification (TOFU).
+        let tls_config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(AcceptAllVerifier))
+            .with_no_client_auth();
+
+        let connector = tokio_tungstenite::Connector::Rustls(Arc::new(tls_config));
+
+        let (ws_stream, response) =
+            tokio_tungstenite::connect_async_tls_with_config(&url, None, false, Some(connector))
+                .await
+                .map_err(|e| format!("WebSocket connection failed: {e}"))?;
+
+        // Extract certificate fingerprint from the TLS session.
+        // For now, compute from the response headers or use a placeholder.
+        // In practice, the fingerprint comes from the TLS peer certificate.
+        let _ = response;
+        let cert_fingerprint = "unknown".to_string(); // TODO: extract from TLS session
+
+        // Verify fingerprint if expected.
+        if let Some(expected) = expected_fingerprint
+            && cert_fingerprint != "unknown"
+            && cert_fingerprint != expected
+        {
+            return Err(format!(
+                "Certificate fingerprint mismatch! Expected {expected}, got {cert_fingerprint}. \
+                 The server's certificate may have changed."
+            ));
+        }
+
+        let (write, read) = ws_stream.split();
+        let writer = Arc::new(Mutex::new(write));
+        let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (event_tx, _) = broadcast::channel(256);
+        let connected = Arc::new(AtomicBool::new(true));
+
+        // Spawn reader task.
+        let pending_clone = Arc::clone(&pending);
+        let event_tx_clone = event_tx.clone();
+        let connected_clone = Arc::clone(&connected);
+        let reader_task = tokio::spawn(async move {
+            let mut read = read;
+            while let Some(msg_result) = read.next().await {
+                match msg_result {
+                    Ok(Message::Text(text)) => {
+                        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                            if value.get("id").is_some() && !value.get("id").unwrap().is_null() {
+                                // Response to a request.
+                                if let Some(id) = value.get("id").and_then(|v| v.as_u64()) {
+                                    let mut pending = pending_clone.lock().await;
+                                    if let Some(tx) = pending.remove(&id) {
+                                        let _ = tx.send(value);
+                                    }
+                                }
+                            } else if value.get("event").is_some() {
+                                // Unsolicited event.
+                                if let Ok(event) = serde_json::from_value::<ServerEvent>(value) {
+                                    let _ = event_tx_clone.send(event);
+                                }
+                            }
+                        }
+                    }
+                    Ok(Message::Ping(data)) => {
+                        // Respond with pong — handled by tungstenite automatically.
+                        let _ = data;
+                    }
+                    Ok(Message::Close(_)) => break,
+                    Err(_) => break,
+                    _ => {}
+                }
+            }
+            connected_clone.store(false, Ordering::Relaxed);
+        });
+
+        Ok(ConnectionResult {
+            transport: WebSocketTransport {
+                writer,
+                pending,
+                next_id: AtomicU64::new(1),
+                event_tx,
+                connected,
+                _reader_task: reader_task,
+            },
+            cert_fingerprint,
+        })
+    }
+
+    /// Authenticate with the remote server.
+    pub async fn authenticate_pairing(
+        &self,
+        pairing_token: &str,
+        client_name: &str,
+    ) -> Result<AuthResult, String> {
+        let resp = self
+            .send(serde_json::json!({
+                "id": 0,
+                "method": "authenticate",
+                "params": {
+                    "pairing_token": pairing_token,
+                    "client_name": client_name,
+                }
+            }))
+            .await?;
+
+        if let Some(error) = resp.get("error") {
+            return Err(error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Authentication failed")
+                .to_string());
+        }
+
+        let result = resp.get("result").ok_or("No result in response")?;
+        Ok(AuthResult {
+            session_token: result
+                .get("session_token")
+                .and_then(|t| t.as_str())
+                .map(String::from),
+            server_name: result
+                .get("server_name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("Unknown")
+                .to_string(),
+        })
+    }
+
+    /// Authenticate with a saved session token.
+    pub async fn authenticate_session(&self, session_token: &str) -> Result<AuthResult, String> {
+        let resp = self
+            .send(serde_json::json!({
+                "id": 0,
+                "method": "authenticate",
+                "params": {
+                    "session_token": session_token,
+                }
+            }))
+            .await?;
+
+        if let Some(error) = resp.get("error") {
+            return Err(error
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Authentication failed")
+                .to_string());
+        }
+
+        let result = resp.get("result").ok_or("No result in response")?;
+        Ok(AuthResult {
+            session_token: None,
+            server_name: result
+                .get("server_name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("Unknown")
+                .to_string(),
+        })
+    }
+}
+
+pub struct AuthResult {
+    pub session_token: Option<String>,
+    pub server_name: String,
+}
+
+#[async_trait::async_trait]
+impl Transport for WebSocketTransport {
+    async fn send(&self, request: serde_json::Value) -> Result<serde_json::Value, String> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let mut req = request;
+        if let Some(obj) = req.as_object_mut() {
+            obj.insert("id".to_string(), serde_json::json!(id));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self.pending.lock().await;
+            pending.insert(id, tx);
+        }
+
+        let text = serde_json::to_string(&req).map_err(|e| e.to_string())?;
+        {
+            let mut writer = self.writer.lock().await;
+            writer
+                .send(Message::Text(text.into()))
+                .await
+                .map_err(|e| format!("Failed to send: {e}"))?;
+        }
+
+        rx.await.map_err(|_| "Response channel closed".to_string())
+    }
+
+    fn event_stream(&self) -> broadcast::Receiver<ServerEvent> {
+        self.event_tx.subscribe()
+    }
+
+    async fn close(&self) -> Result<(), String> {
+        let mut writer = self.writer.lock().await;
+        writer
+            .send(Message::Close(None))
+            .await
+            .map_err(|e| format!("Failed to close: {e}"))?;
+        self.connected.store(false, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+}
+
+/// TLS certificate verifier that accepts all certificates (for TOFU model).
+/// Certificate fingerprint verification happens at the application layer.
+#[derive(Debug)]
+struct AcceptAllVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for AcceptAllVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ED448,
+        ]
+    }
+}

--- a/src-tauri/src/transport/ws.rs
+++ b/src-tauri/src/transport/ws.rs
@@ -93,7 +93,7 @@ impl WebSocketTransport {
                 match msg_result {
                     Ok(Message::Text(text)) => {
                         if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
-                            if value.get("id").is_some() && !value.get("id").unwrap().is_null() {
+                            if value.get("id").is_some_and(|v| !v.is_null()) {
                                 // Response to a request.
                                 if let Some(id) = value.get("id").and_then(|v| v.as_u64()) {
                                     let mut pending = pending_clone.lock().await;
@@ -119,6 +119,14 @@ impl WebSocketTransport {
                 }
             }
             connected_clone.store(false, Ordering::Relaxed);
+
+            // Drain all pending requests so callers get an error instead of hanging.
+            let mut pending = pending_clone.lock().await;
+            for (_, tx) in pending.drain() {
+                let _ = tx.send(serde_json::json!({
+                    "error": {"code": -3, "message": "Connection closed"}
+                }));
+            }
         });
 
         Ok(ConnectionResult {

--- a/src-tauri/src/transport/ws.rs
+++ b/src-tauri/src/transport/ws.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use futures_util::{SinkExt, StreamExt};
+use sha2::{Digest, Sha256};
 use tokio::sync::{Mutex, broadcast, oneshot};
 use tokio_tungstenite::tungstenite::Message;
 
@@ -45,29 +46,35 @@ impl WebSocketTransport {
     ) -> Result<ConnectionResult, String> {
         let url = format!("wss://{host}:{port}");
 
+        // Shared slot to capture the cert fingerprint from the TLS verifier callback.
+        let fingerprint_slot: Arc<std::sync::Mutex<Option<String>>> =
+            Arc::new(std::sync::Mutex::new(None));
+
         // Build a TLS config that accepts self-signed certificates.
         // We do our own fingerprint verification (TOFU).
         let tls_config = rustls::ClientConfig::builder()
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(AcceptAllVerifier))
+            .with_custom_certificate_verifier(Arc::new(FingerprintCapturingVerifier {
+                fingerprint: Arc::clone(&fingerprint_slot),
+            }))
             .with_no_client_auth();
 
         let connector = tokio_tungstenite::Connector::Rustls(Arc::new(tls_config));
 
-        let (ws_stream, response) =
+        let (ws_stream, _response) =
             tokio_tungstenite::connect_async_tls_with_config(&url, None, false, Some(connector))
                 .await
                 .map_err(|e| format!("WebSocket connection failed: {e}"))?;
 
-        // Extract certificate fingerprint from the TLS session.
-        // For now, compute from the response headers or use a placeholder.
-        // In practice, the fingerprint comes from the TLS peer certificate.
-        let _ = response;
-        let cert_fingerprint = "unknown".to_string(); // TODO: extract from TLS session
+        // Read the fingerprint captured during the TLS handshake.
+        let cert_fingerprint = fingerprint_slot
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
+            .ok_or_else(|| "Failed to capture server certificate fingerprint".to_string())?;
 
-        // Verify fingerprint if expected.
+        // Verify fingerprint if expected (TOFU).
         if let Some(expected) = expected_fingerprint
-            && cert_fingerprint != "unknown"
             && cert_fingerprint != expected
         {
             return Err(format!(
@@ -264,20 +271,28 @@ impl Transport for WebSocketTransport {
     }
 }
 
-/// TLS certificate verifier that accepts all certificates (for TOFU model).
-/// Certificate fingerprint verification happens at the application layer.
+/// TLS certificate verifier that accepts all certificates but captures the
+/// server's certificate fingerprint (SHA-256) for TOFU verification.
 #[derive(Debug)]
-struct AcceptAllVerifier;
+struct FingerprintCapturingVerifier {
+    fingerprint: Arc<std::sync::Mutex<Option<String>>>,
+}
 
-impl rustls::client::danger::ServerCertVerifier for AcceptAllVerifier {
+impl rustls::client::danger::ServerCertVerifier for FingerprintCapturingVerifier {
     fn verify_server_cert(
         &self,
-        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        end_entity: &rustls::pki_types::CertificateDer<'_>,
         _intermediates: &[rustls::pki_types::CertificateDer<'_>],
         _server_name: &rustls::pki_types::ServerName<'_>,
         _ocsp_response: &[u8],
         _now: rustls::pki_types::UnixTime,
     ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        let mut hasher = Sha256::new();
+        hasher.update(end_entity.as_ref());
+        let fp = hex::encode(hasher.finalize());
+        if let Ok(mut slot) = self.fingerprint.lock() {
+            *slot = Some(fp);
+        }
         Ok(rustls::client::danger::ServerCertVerified::assertion())
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,9 @@ use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::model::{ChatMessage, Repository, TerminalTab, Workspace, WorkspaceStatus};
+use crate::model::{
+    ChatMessage, RemoteConnection, Repository, TerminalTab, Workspace, WorkspaceStatus,
+};
 
 pub struct Database {
     conn: Connection,
@@ -128,6 +130,23 @@ impl Database {
                 "ALTER TABLE repositories ADD COLUMN custom_instructions TEXT;
 
                  PRAGMA user_version = 6;",
+            )?;
+        }
+
+        if version < 7 {
+            self.conn.execute_batch(
+                "CREATE TABLE remote_connections (
+                    id                  TEXT PRIMARY KEY,
+                    name                TEXT NOT NULL,
+                    host                TEXT NOT NULL,
+                    port                INTEGER DEFAULT 7683,
+                    session_token       TEXT,
+                    cert_fingerprint    TEXT,
+                    auto_connect        INTEGER DEFAULT 0,
+                    created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                PRAGMA user_version = 7;",
             )?;
         }
 
@@ -518,6 +537,91 @@ impl Database {
             "UPDATE terminal_tabs SET title = ?1 WHERE id = ?2",
             params![title, id],
         )?;
+        Ok(())
+    }
+
+    // --- Remote Connections ---
+
+    pub fn insert_remote_connection(&self, conn: &RemoteConnection) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT INTO remote_connections (id, name, host, port, session_token, cert_fingerprint, auto_connect)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                conn.id,
+                conn.name,
+                conn.host,
+                conn.port as i32,
+                conn.session_token,
+                conn.cert_fingerprint,
+                conn.auto_connect as i32,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_remote_connections(&self) -> Result<Vec<RemoteConnection>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, name, host, port, session_token, cert_fingerprint, auto_connect, created_at
+             FROM remote_connections ORDER BY created_at",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let auto_connect_int: i32 = row.get(6)?;
+            Ok(RemoteConnection {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                host: row.get(2)?,
+                port: row.get::<_, i32>(3)? as u16,
+                session_token: row.get(4)?,
+                cert_fingerprint: row.get(5)?,
+                auto_connect: auto_connect_int != 0,
+                created_at: row.get(7)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn get_remote_connection(
+        &self,
+        id: &str,
+    ) -> Result<Option<RemoteConnection>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT id, name, host, port, session_token, cert_fingerprint, auto_connect, created_at
+                 FROM remote_connections WHERE id = ?1",
+                params![id],
+                |row| {
+                    let auto_connect_int: i32 = row.get(6)?;
+                    Ok(RemoteConnection {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        host: row.get(2)?,
+                        port: row.get::<_, i32>(3)? as u16,
+                        session_token: row.get(4)?,
+                        cert_fingerprint: row.get(5)?,
+                        auto_connect: auto_connect_int != 0,
+                        created_at: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+    }
+
+    pub fn update_remote_connection_session(
+        &self,
+        id: &str,
+        session_token: &str,
+        cert_fingerprint: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE remote_connections SET session_token = ?1, cert_fingerprint = ?2 WHERE id = ?3",
+            params![session_token, cert_fingerprint, id],
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_remote_connection(&self, id: &str) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute("DELETE FROM remote_connections WHERE id = ?1", params![id])?;
         Ok(())
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -542,6 +542,14 @@ impl Database {
 
     // --- Remote Connections ---
 
+    fn parse_port(row: &rusqlite::Row, idx: usize) -> rusqlite::Result<u16> {
+        let p: i32 = row.get(idx)?;
+        if !(0..=65535).contains(&p) {
+            return Err(rusqlite::Error::IntegralValueOutOfRange(idx, p as i64));
+        }
+        Ok(p as u16)
+    }
+
     pub fn insert_remote_connection(&self, conn: &RemoteConnection) -> Result<(), rusqlite::Error> {
         self.conn.execute(
             "INSERT INTO remote_connections (id, name, host, port, session_token, cert_fingerprint, auto_connect)
@@ -570,7 +578,7 @@ impl Database {
                 id: row.get(0)?,
                 name: row.get(1)?,
                 host: row.get(2)?,
-                port: row.get::<_, i32>(3)? as u16,
+                port: Self::parse_port(row, 3)?,
                 session_token: row.get(4)?,
                 cert_fingerprint: row.get(5)?,
                 auto_connect: auto_connect_int != 0,
@@ -595,7 +603,7 @@ impl Database {
                         id: row.get(0)?,
                         name: row.get(1)?,
                         host: row.get(2)?,
-                        port: row.get::<_, i32>(3)? as u16,
+                        port: Self::parse_port(row, 3)?,
                         session_token: row.get(4)?,
                         cert_fingerprint: row.get(5)?,
                         auto_connect: auto_connect_int != 0,
@@ -1056,5 +1064,84 @@ mod tests {
         let db = setup_db_with_workspace();
         let last = db.last_message_per_workspace().unwrap();
         assert!(last.is_empty());
+    }
+
+    // --- Remote connection tests ---
+
+    use crate::model::RemoteConnection as RemoteConn;
+
+    fn make_remote_conn(id: &str, name: &str, host: &str, port: u16) -> RemoteConn {
+        RemoteConn {
+            id: id.into(),
+            name: name.into(),
+            host: host.into(),
+            port,
+            session_token: None,
+            cert_fingerprint: None,
+            auto_connect: false,
+            created_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_insert_and_list_remote_connections() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc1", "Server A", "host-a.local", 7683))
+            .unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc2", "Server B", "host-b.local", 9000))
+            .unwrap();
+        let conns = db.list_remote_connections().unwrap();
+        assert_eq!(conns.len(), 2);
+        assert_eq!(conns[0].name, "Server A");
+        assert_eq!(conns[1].port, 9000);
+    }
+
+    #[test]
+    fn test_get_remote_connection() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc1", "Server A", "host-a.local", 7683))
+            .unwrap();
+        let conn = db.get_remote_connection("rc1").unwrap().unwrap();
+        assert_eq!(conn.host, "host-a.local");
+        assert!(!conn.created_at.is_empty()); // DB default fills this
+    }
+
+    #[test]
+    fn test_get_remote_connection_missing() {
+        let db = Database::open_in_memory().unwrap();
+        let conn = db.get_remote_connection("nonexistent").unwrap();
+        assert!(conn.is_none());
+    }
+
+    #[test]
+    fn test_update_remote_connection_session() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc1", "Server A", "host-a.local", 7683))
+            .unwrap();
+        db.update_remote_connection_session("rc1", "tok-123", "fp-abc")
+            .unwrap();
+        let conn = db.get_remote_connection("rc1").unwrap().unwrap();
+        assert_eq!(conn.session_token.as_deref(), Some("tok-123"));
+        assert_eq!(conn.cert_fingerprint.as_deref(), Some("fp-abc"));
+    }
+
+    #[test]
+    fn test_delete_remote_connection() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc1", "Server A", "host-a.local", 7683))
+            .unwrap();
+        db.delete_remote_connection("rc1").unwrap();
+        let conns = db.list_remote_connections().unwrap();
+        assert!(conns.is_empty());
+    }
+
+    #[test]
+    fn test_remote_connection_auto_connect_flag() {
+        let db = Database::open_in_memory().unwrap();
+        let mut conn = make_remote_conn("rc1", "Server A", "host-a.local", 7683);
+        conn.auto_connect = true;
+        db.insert_remote_connection(&conn).unwrap();
+        let fetched = db.get_remote_connection("rc1").unwrap().unwrap();
+        assert!(fetched.auto_connect);
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,10 +1,12 @@
 mod chat_message;
 pub mod diff;
+mod remote_connection;
 mod repository;
 mod terminal_tab;
 mod workspace;
 
 pub use chat_message::{ChatMessage, ChatRole};
+pub use remote_connection::RemoteConnection;
 pub use repository::Repository;
 pub use terminal_tab::TerminalTab;
 pub use workspace::{AgentStatus, Workspace, WorkspaceStatus};

--- a/src/model/remote_connection.rs
+++ b/src/model/remote_connection.rs
@@ -1,0 +1,13 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteConnection {
+    pub id: String,
+    pub name: String,
+    pub host: String,
+    pub port: u16,
+    pub session_token: Option<String>,
+    pub cert_fingerprint: Option<String>,
+    pub auto_connect: bool,
+    pub created_at: String,
+}

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -18,8 +18,13 @@ function App() {
 
   useEffect(() => {
     loadInitialData().then((data) => {
-      setRepositories(data.repositories);
-      setWorkspaces(data.workspaces);
+      // Tag local data with null remote_connection_id (backend omits this field).
+      setRepositories(
+        data.repositories.map((r) => ({ ...r, remote_connection_id: null }))
+      );
+      setWorkspaces(
+        data.workspaces.map((w) => ({ ...w, remote_connection_id: null }))
+      );
       setWorktreeBaseDir(data.worktree_base_dir);
       setDefaultBranches(data.default_branches);
       // Index last messages by workspace_id for dashboard display.

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers } from "./services/tauri";
+import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus } from "./services/tauri";
 import { AppLayout } from "./components/layout/AppLayout";
 import "./styles/theme.css";
 
@@ -13,6 +13,8 @@ function App() {
   const setLastMessages = useAppStore((s) => s.setLastMessages);
   const setRemoteConnections = useAppStore((s) => s.setRemoteConnections);
   const setDiscoveredServers = useAppStore((s) => s.setDiscoveredServers);
+  const setLocalServerRunning = useAppStore((s) => s.setLocalServerRunning);
+  const setLocalServerConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -41,7 +43,13 @@ function App() {
     listDiscoveredServers()
       .then(setDiscoveredServers)
       .catch((err) => console.error("Failed to load discovered servers:", err));
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers]);
+    getLocalServerStatus()
+      .then((info) => {
+        setLocalServerRunning(info.running);
+        setLocalServerConnectionString(info.connection_string);
+      })
+      .catch((err) => console.error("Failed to load local server status:", err));
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData, getAppSetting } from "./services/tauri";
+import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers } from "./services/tauri";
 import { AppLayout } from "./components/layout/AppLayout";
 import "./styles/theme.css";
 
@@ -11,6 +11,8 @@ function App() {
   const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
   const setTerminalFontSize = useAppStore((s) => s.setTerminalFontSize);
   const setLastMessages = useAppStore((s) => s.setLastMessages);
+  const setRemoteConnections = useAppStore((s) => s.setRemoteConnections);
+  const setDiscoveredServers = useAppStore((s) => s.setDiscoveredServers);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -33,7 +35,13 @@ function App() {
         }
       })
       .catch((err) => console.error("Failed to load terminal font size:", err));
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages]);
+    listRemoteConnections()
+      .then(setRemoteConnections)
+      .catch((err) => console.error("Failed to load remote connections:", err));
+    listDiscoveredServers()
+      .then(setDiscoveredServers)
+      .catch((err) => console.error("Failed to load discovered servers:", err));
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -40,15 +40,25 @@ function App() {
     listRemoteConnections()
       .then(setRemoteConnections)
       .catch((err) => console.error("Failed to load remote connections:", err));
-    listDiscoveredServers()
-      .then(setDiscoveredServers)
-      .catch((err) => console.error("Failed to load discovered servers:", err));
+    // Poll discovered servers every 5s so the Nearby list stays current.
+    const refreshDiscoveredServers = () => {
+      listDiscoveredServers()
+        .then(setDiscoveredServers)
+        .catch((err) => console.error("Failed to load discovered servers:", err));
+    };
+    refreshDiscoveredServers();
+    const discoveredServersPollId = window.setInterval(refreshDiscoveredServers, 5000);
+
     getLocalServerStatus()
       .then((info) => {
         setLocalServerRunning(info.running);
         setLocalServerConnectionString(info.connection_string);
       })
       .catch((err) => console.error("Failed to load local server status:", err));
+
+    return () => {
+      window.clearInterval(discoveredServersPollId);
+    };
   }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString]);
 
   return <AppLayout />;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -6,10 +6,12 @@ import { useAppStore } from "../../stores/useAppStore";
 import {
   loadChatHistory,
   sendChatMessage,
+  sendRemoteCommand,
   stopAgent,
   getAppSetting,
   setAppSetting,
 } from "../../services/tauri";
+import type { ChatMessage } from "../../types/chat";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { AgentQuestionCard } from "./AgentQuestionCard";
 import { ChatToolbar } from "./ChatToolbar";
@@ -131,8 +133,16 @@ export function ChatPanel() {
     setError(null);
     historyIndexRef.current = -1;
     draftRef.current = "";
-    loadChatHistory(selectedWorkspaceId)
-      .then((msgs) => {
+
+    const currentWs = useAppStore.getState().workspaces.find((w) => w.id === selectedWorkspaceId);
+    const loadHistory = currentWs?.remote_connection_id
+      ? sendRemoteCommand(currentWs.remote_connection_id, "load_chat_history", {
+          workspace_id: selectedWorkspaceId,
+        }).then((data) => (data as { messages?: ChatMessage[] })?.messages ?? data as ChatMessage[])
+      : loadChatHistory(selectedWorkspaceId);
+
+    loadHistory
+      .then((msgs: ChatMessage[]) => {
         // Filter out empty assistant messages (legacy data).
         const filtered = msgs.filter(
           (m) => m.role !== "Assistant" || m.content.trim() !== ""
@@ -177,20 +187,34 @@ export function ChatPanel() {
     updateWorkspace(selectedWorkspaceId, { agent_status: "Running" });
 
     try {
-      const state = useAppStore.getState();
-      const model = state.selectedModel[selectedWorkspaceId] || undefined;
-      const fastMode = state.fastMode[selectedWorkspaceId] || false;
-      const thinkingEnabled = state.thinkingEnabled[selectedWorkspaceId] || false;
-      const planMode = state.planMode[selectedWorkspaceId] || false;
-      await sendChatMessage(
-        selectedWorkspaceId,
-        content,
-        permissionLevel,
-        model,
-        fastMode || undefined,
-        thinkingEnabled || undefined,
-        planMode || undefined,
-      );
+      if (ws?.remote_connection_id) {
+        // Route to remote server via WebSocket.
+        const state = useAppStore.getState();
+        await sendRemoteCommand(ws.remote_connection_id, "send_chat_message", {
+          workspace_id: selectedWorkspaceId,
+          content,
+          permission_level: permissionLevel,
+          model: state.selectedModel[selectedWorkspaceId] || null,
+          fast_mode: state.fastMode[selectedWorkspaceId] || false,
+          thinking_enabled: state.thinkingEnabled[selectedWorkspaceId] || false,
+          plan_mode: state.planMode[selectedWorkspaceId] || false,
+        });
+      } else {
+        const state = useAppStore.getState();
+        const model = state.selectedModel[selectedWorkspaceId] || undefined;
+        const fastMode = state.fastMode[selectedWorkspaceId] || false;
+        const thinkingEnabled = state.thinkingEnabled[selectedWorkspaceId] || false;
+        const planMode = state.planMode[selectedWorkspaceId] || false;
+        await sendChatMessage(
+          selectedWorkspaceId,
+          content,
+          permissionLevel,
+          model,
+          fastMode || undefined,
+          thinkingEnabled || undefined,
+          planMode || undefined,
+        );
+      }
     } catch (e) {
       const errMsg = String(e);
       console.error("sendChatMessage failed:", errMsg);
@@ -202,7 +226,13 @@ export function ChatPanel() {
   const handleStop = async () => {
     if (!selectedWorkspaceId) return;
     try {
-      await stopAgent(selectedWorkspaceId);
+      if (ws?.remote_connection_id) {
+        await sendRemoteCommand(ws.remote_connection_id, "stop_agent", {
+          workspace_id: selectedWorkspaceId,
+        });
+      } else {
+        await stopAgent(selectedWorkspaceId);
+      }
       updateWorkspace(selectedWorkspaceId, { agent_status: "Stopped" });
     } catch (e) {
       console.error("stopAgent failed:", e);

--- a/src/ui/src/components/layout/StatusBar.tsx
+++ b/src/ui/src/components/layout/StatusBar.tsx
@@ -10,12 +10,18 @@ export function StatusBar() {
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar);
   const workspaces = useAppStore((s) => s.workspaces);
 
+  const activeRemoteIds = useAppStore((s) => s.activeRemoteIds);
+  const remoteConnections = useAppStore((s) => s.remoteConnections);
+
   const runningCount = workspaces.filter(
     (ws) => ws.agent_status === "Running"
   ).length;
   const activeCount = workspaces.filter(
     (ws) => ws.status === "Active"
   ).length;
+  const connectedRemotes = remoteConnections.filter((c) =>
+    activeRemoteIds.includes(c.id)
+  );
 
   return (
     <div className={styles.bar}>
@@ -29,6 +35,11 @@ export function StatusBar() {
         <span className={styles.statMuted}>
           {activeCount} workspace{activeCount !== 1 ? "s" : ""}
         </span>
+        {connectedRemotes.length > 0 && (
+          <span className={styles.statMuted}>
+            {connectedRemotes.map((c) => c.name).join(", ")}
+          </span>
+        )}
       </div>
       <div className={styles.spacer} />
       <button

--- a/src/ui/src/components/modals/AddRemoteModal.tsx
+++ b/src/ui/src/components/modals/AddRemoteModal.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { useAppStore } from "../../stores/useAppStore";
+import { addRemoteConnection } from "../../services/tauri";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+
+export function AddRemoteModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const addRemote = useAppStore((s) => s.addRemoteConnection);
+  const addActiveId = useAppStore((s) => s.addActiveRemoteId);
+  const [connectionString, setConnectionString] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!connectionString.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await addRemoteConnection(connectionString.trim());
+      addRemote(result.connection);
+      addActiveId(result.connection.id);
+      closeModal();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal title="Add Remote Server" onClose={closeModal}>
+      <div className={shared.field}>
+        <label className={shared.label}>Connection string</label>
+        <input
+          className={shared.input}
+          value={connectionString}
+          onChange={(e) => setConnectionString(e.target.value)}
+          placeholder="claudette://hostname:7683/pairing-token"
+          onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+          autoFocus
+        />
+        <div style={{ fontSize: "11px", color: "var(--text-muted)", marginTop: 4 }}>
+          Paste the connection string shown by claudette-server on the remote machine.
+        </div>
+        {error && <div className={shared.error}>{error}</div>}
+      </div>
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={closeModal}>
+          Cancel
+        </button>
+        <button
+          className={shared.btnPrimary}
+          onClick={handleSubmit}
+          disabled={loading || !connectionString.trim()}
+        >
+          {loading ? "Connecting..." : "Connect"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/AddRemoteModal.tsx
+++ b/src/ui/src/components/modals/AddRemoteModal.tsx
@@ -8,6 +8,7 @@ export function AddRemoteModal() {
   const closeModal = useAppStore((s) => s.closeModal);
   const addRemote = useAppStore((s) => s.addRemoteConnection);
   const addActiveId = useAppStore((s) => s.addActiveRemoteId);
+  const mergeRemoteData = useAppStore((s) => s.mergeRemoteData);
   const [connectionString, setConnectionString] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -20,6 +21,9 @@ export function AddRemoteModal() {
       const result = await addRemoteConnection(connectionString.trim());
       addRemote(result.connection);
       addActiveId(result.connection.id);
+      if (result.initial_data) {
+        mergeRemoteData(result.connection.id, result.initial_data);
+      }
       closeModal();
     } catch (e) {
       setError(String(e));

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -1,5 +1,6 @@
 import { useAppStore } from "../../stores/useAppStore";
 import { AddRepoModal } from "./AddRepoModal";
+import { AddRemoteModal } from "./AddRemoteModal";
 import { DeleteWorkspaceModal } from "./DeleteWorkspaceModal";
 import { RemoveRepoModal } from "./RemoveRepoModal";
 import { RepoSettingsModal } from "./RepoSettingsModal";
@@ -12,6 +13,8 @@ export function ModalRouter() {
   switch (activeModal) {
     case "addRepo":
       return <AddRepoModal />;
+    case "addRemote":
+      return <AddRemoteModal />;
     case "deleteWorkspace":
       return <DeleteWorkspaceModal />;
     case "removeRepo":

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -6,6 +6,7 @@ import { RemoveRepoModal } from "./RemoveRepoModal";
 import { RepoSettingsModal } from "./RepoSettingsModal";
 import { RelinkRepoModal } from "./RelinkRepoModal";
 import { AppSettingsModal } from "./AppSettingsModal";
+import { ShareModal } from "./ShareModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -25,6 +26,8 @@ export function ModalRouter() {
       return <RelinkRepoModal />;
     case "appSettings":
       return <AppSettingsModal />;
+    case "share":
+      return <ShareModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/modals/ShareModal.tsx
+++ b/src/ui/src/components/modals/ShareModal.tsx
@@ -1,0 +1,58 @@
+import { useAppStore } from "../../stores/useAppStore";
+import { stopLocalServer } from "../../services/tauri";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+
+export function ShareModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const connectionString = useAppStore((s) => s.localServerConnectionString);
+  const setRunning = useAppStore((s) => s.setLocalServerRunning);
+  const setConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
+
+  const handleStop = async () => {
+    try {
+      await stopLocalServer();
+      setRunning(false);
+      setConnectionString(null);
+      closeModal();
+    } catch (e) {
+      console.error("Failed to stop server:", e);
+    }
+  };
+
+  const handleCopy = () => {
+    if (connectionString) {
+      navigator.clipboard.writeText(connectionString);
+    }
+  };
+
+  return (
+    <Modal title="Share This Machine" onClose={closeModal}>
+      <div className={shared.field}>
+        <label className={shared.label}>Connection string</label>
+        <div className={shared.inputRow}>
+          <input
+            className={shared.input}
+            value={connectionString ?? ""}
+            readOnly
+            onClick={(e) => (e.target as HTMLInputElement).select()}
+          />
+          <button className={shared.btn} onClick={handleCopy}>
+            Copy
+          </button>
+        </div>
+        <div style={{ fontSize: "11px", color: "var(--text-muted)", marginTop: 4 }}>
+          Share this string with others so they can connect to your workspaces from their Claudette app.
+        </div>
+      </div>
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={handleStop}>
+          Stop sharing
+        </button>
+        <button className={shared.btnPrimary} onClick={closeModal}>
+          Done
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   archiveWorkspace,
@@ -8,8 +8,9 @@ import {
   connectRemote,
   disconnectRemote,
   pairWithServer,
+  startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, X } from "lucide-react";
+import { Settings, Link, X, Share2 } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Sidebar.module.css";
 
@@ -275,6 +276,7 @@ export function Sidebar() {
         >
           + Add remote
         </button>
+        <ShareButton openModal={openModal} />
         <button
           className={styles.settingsBtn}
           onClick={() => openModal("appSettings")}
@@ -390,5 +392,44 @@ function RemoteSections() {
         </div>
       )}
     </>
+  );
+}
+
+function ShareButton({ openModal }: { openModal: (name: string) => void }) {
+  const running = useAppStore((s) => s.localServerRunning);
+  const setRunning = useAppStore((s) => s.setLocalServerRunning);
+  const setConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    if (running) {
+      openModal("share");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const info = await startLocalServer();
+      setRunning(true);
+      setConnectionString(info.connection_string);
+      openModal("share");
+    } catch (e) {
+      console.error("Failed to start server:", e);
+      alert(`Failed to start server: ${e}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      className={styles.settingsBtn}
+      onClick={handleClick}
+      title={running ? "Sharing — click to view connection string" : "Share this machine"}
+      disabled={loading}
+      style={running ? { color: "var(--status-running)" } : undefined}
+    >
+      <Share2 size={14} />
+    </button>
   );
 }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -108,7 +108,7 @@ export function Sidebar() {
       </div>
 
       <div className={styles.list}>
-        {repositories.map((repo) => {
+        {repositories.filter((r) => !r.remote_connection_id).map((repo) => {
           const collapsed = repoCollapsed[repo.id];
           const repoWorkspaces = filteredWorkspaces.filter(
             (ws) => ws.repository_id === repo.id
@@ -296,6 +296,8 @@ function RemoteSections() {
   const addRemote = useAppStore((s) => s.addRemoteConnection);
   const addActiveId = useAppStore((s) => s.addActiveRemoteId);
   const removeActiveId = useAppStore((s) => s.removeActiveRemoteId);
+  const mergeRemoteData = useAppStore((s) => s.mergeRemoteData);
+  const clearRemoteData = useAppStore((s) => s.clearRemoteData);
   const unpaired = discoveredServers.filter((s) => !s.is_paired);
   const [connectingIds, setConnectingIds] = useState<Set<string>>(new Set());
   const [connectError, setConnectError] = useState<string | null>(null);
@@ -304,8 +306,11 @@ function RemoteSections() {
     setConnectError(null);
     setConnectingIds((prev) => new Set(prev).add(id));
     try {
-      await connectRemote(id);
+      const data = await connectRemote(id);
       addActiveId(id);
+      if (data) {
+        mergeRemoteData(id, data);
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       setConnectError(msg);
@@ -323,6 +328,7 @@ function RemoteSections() {
     try {
       await disconnectRemote(id);
       removeActiveId(id);
+      clearRemoteData(id);
     } catch (e) {
       console.error("Failed to disconnect:", e);
     }
@@ -335,6 +341,9 @@ function RemoteSections() {
       const result = await pairWithServer(host, port, token);
       addRemote(result.connection);
       addActiveId(result.connection.id);
+      if (result.initial_data) {
+        mergeRemoteData(result.connection.id, result.initial_data);
+      }
     } catch (e) {
       console.error("Failed to pair:", e);
     }
@@ -373,11 +382,6 @@ function RemoteSections() {
 
       {remoteConnections.length > 0 && (
         <div className={styles.list} style={{ borderTop: "1px solid var(--border-subtle)" }}>
-          <div className={styles.repoHeader} style={{ opacity: 0.7, cursor: "default" }}>
-            <span className={styles.repoName} style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.5px" }}>
-              Remote
-            </span>
-          </div>
           {connectError && (
             <div style={{ padding: "4px 12px", fontSize: 11, color: "var(--status-error, #f55)", lineHeight: 1.3 }}>
               {connectError}
@@ -387,30 +391,146 @@ function RemoteSections() {
             const isActive = activeRemoteIds.includes(conn.id);
             const isConnecting = connectingIds.has(conn.id);
             return (
-              <div key={conn.id} className={styles.wsItem}>
-                <span
-                  className={styles.statusDot}
-                  style={{ background: isConnecting ? "var(--status-idle)" : isActive ? "var(--status-running)" : "var(--status-stopped)" }}
-                />
-                <div className={styles.wsInfo}>
-                  <span className={styles.wsName}>{conn.name}</span>
-                  <span className={styles.wsBranch}>{conn.host}:{conn.port}</span>
-                </div>
-                <button
-                  className={styles.iconBtn}
-                  onClick={() => isActive ? handleDisconnect(conn.id) : handleConnect(conn.id)}
-                  disabled={isConnecting}
-                  title={isConnecting ? "Connecting…" : isActive ? "Disconnect" : "Connect"}
-                  style={{ fontSize: 11, opacity: isConnecting ? 0.5 : 1 }}
-                >
-                  {isConnecting ? "…" : isActive ? "×" : "→"}
-                </button>
-              </div>
+              <RemoteConnectionGroup
+                key={conn.id}
+                conn={conn}
+                isActive={isActive}
+                isConnecting={isConnecting}
+                onConnect={() => handleConnect(conn.id)}
+                onDisconnect={() => handleDisconnect(conn.id)}
+              />
             );
           })}
         </div>
       )}
     </>
+  );
+}
+
+function RemoteConnectionGroup({
+  conn,
+  isActive,
+  isConnecting,
+  onConnect,
+  onDisconnect,
+}: {
+  conn: import("../../types/remote").RemoteConnectionInfo;
+  isActive: boolean;
+  isConnecting: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}) {
+  const repositories = useAppStore((s) => s.repositories);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const repoCollapsed = useAppStore((s) => s.repoCollapsed);
+  const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
+
+  const remoteRepos = repositories.filter(
+    (r) => r.remote_connection_id === conn.id
+  );
+  const remoteWorkspaces = workspaces.filter(
+    (w) => w.remote_connection_id === conn.id
+  );
+
+  return (
+    <div className={styles.repoGroup}>
+      {/* Connection header */}
+      <div className={styles.repoHeader} style={{ opacity: 0.8 }}>
+        <span
+          className={styles.statusDot}
+          style={{
+            background: isConnecting
+              ? "var(--status-idle)"
+              : isActive
+                ? "var(--status-running)"
+                : "var(--status-stopped)",
+            marginRight: 4,
+          }}
+        />
+        <span className={styles.repoName} style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+          {conn.name}
+        </span>
+        <button
+          className={styles.iconBtn}
+          onClick={() => (isActive ? onDisconnect() : onConnect())}
+          disabled={isConnecting}
+          title={isConnecting ? "Connecting…" : isActive ? "Disconnect" : "Connect"}
+          style={{ fontSize: 11, opacity: isConnecting ? 0.5 : 1 }}
+        >
+          {isConnecting ? "…" : isActive ? "×" : "→"}
+        </button>
+      </div>
+
+      {/* Remote repos and their workspaces */}
+      {isActive &&
+        remoteRepos.map((repo) => {
+          const collapsed = repoCollapsed[repo.id];
+          const repoWs = remoteWorkspaces.filter(
+            (ws) => ws.repository_id === repo.id && ws.status === "Active"
+          );
+          const runningCount = repoWs.filter(
+            (ws) => ws.agent_status === "Running"
+          ).length;
+
+          return (
+            <div key={repo.id}>
+              <div
+                className={styles.repoHeader}
+                onClick={() => toggleRepoCollapsed(repo.id)}
+                style={{ paddingLeft: 12 }}
+              >
+                <span className={styles.chevron}>
+                  {collapsed ? "›" : "⌄"}
+                </span>
+                <span className={styles.repoName}>
+                  {repo.icon && (
+                    <RepoIcon icon={repo.icon} className={styles.repoIcon} />
+                  )}
+                  {repo.name}
+                  {runningCount > 0 && (
+                    <span className={styles.runningBadge}>{runningCount}</span>
+                  )}
+                </span>
+              </div>
+              {!collapsed &&
+                repoWs.map((ws) => (
+                  <div
+                    key={ws.id}
+                    className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""}`}
+                    onClick={() => selectWorkspace(ws.id)}
+                  >
+                    <span
+                      className={`${styles.statusDot} ${ws.agent_status === "Running" ? styles.statusDotRunning : ""}`}
+                      style={{
+                        background:
+                          ws.agent_status === "Running"
+                            ? "var(--status-running)"
+                            : ws.agent_status === "Stopped"
+                              ? "var(--status-stopped)"
+                              : "var(--status-idle)",
+                      }}
+                    />
+                    <div className={styles.wsInfo}>
+                      <span className={styles.wsName}>{ws.name}</span>
+                      <span className={styles.wsBranch}>{ws.branch_name}</span>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          );
+        })}
+
+      {/* Show placeholder when connected but no repos */}
+      {isActive && remoteRepos.length === 0 && (
+        <div className={styles.wsItem} style={{ opacity: 0.5 }}>
+          <div className={styles.wsInfo}>
+            <span className={styles.wsName}>No repositories</span>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -5,6 +5,9 @@ import {
   restoreWorkspace,
   generateWorkspaceName,
   createWorkspace,
+  connectRemote,
+  disconnectRemote,
+  pairWithServer,
 } from "../../services/tauri";
 import { Settings, Link, X } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
@@ -256,12 +259,21 @@ export function Sidebar() {
         })}
       </div>
 
+      <RemoteSections />
+
       <div className={styles.footer}>
         <button
           className={styles.addRepoBtn}
           onClick={() => openModal("addRepo")}
         >
           + Add repository
+        </button>
+        <button
+          className={styles.addRepoBtn}
+          onClick={() => openModal("addRemote")}
+          style={{ marginLeft: 4 }}
+        >
+          + Add remote
         </button>
         <button
           className={styles.settingsBtn}
@@ -272,5 +284,111 @@ export function Sidebar() {
         </button>
       </div>
     </div>
+  );
+}
+
+function RemoteSections() {
+  const discoveredServers = useAppStore((s) => s.discoveredServers);
+  const remoteConnections = useAppStore((s) => s.remoteConnections);
+  const activeRemoteIds = useAppStore((s) => s.activeRemoteIds);
+  const addRemote = useAppStore((s) => s.addRemoteConnection);
+  const addActiveId = useAppStore((s) => s.addActiveRemoteId);
+  const removeActiveId = useAppStore((s) => s.removeActiveRemoteId);
+  const unpaired = discoveredServers.filter((s) => !s.is_paired);
+
+  const handleConnect = async (id: string) => {
+    try {
+      await connectRemote(id);
+      addActiveId(id);
+    } catch (e) {
+      console.error("Failed to connect:", e);
+    }
+  };
+
+  const handleDisconnect = async (id: string) => {
+    try {
+      await disconnectRemote(id);
+      removeActiveId(id);
+    } catch (e) {
+      console.error("Failed to disconnect:", e);
+    }
+  };
+
+  const handlePair = async (host: string, port: number) => {
+    const token = prompt("Enter pairing token:");
+    if (!token) return;
+    try {
+      const result = await pairWithServer(host, port, token);
+      addRemote(result.connection);
+      addActiveId(result.connection.id);
+    } catch (e) {
+      console.error("Failed to pair:", e);
+    }
+  };
+
+  if (unpaired.length === 0 && remoteConnections.length === 0) return null;
+
+  return (
+    <>
+      {unpaired.length > 0 && (
+        <div className={styles.list} style={{ borderTop: "1px solid var(--border-subtle)" }}>
+          <div className={styles.repoHeader} style={{ opacity: 0.7, cursor: "default" }}>
+            <span className={styles.repoName} style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+              Nearby
+            </span>
+          </div>
+          {unpaired.map((server) => (
+            <div key={`${server.host}:${server.port}`} className={styles.wsItem}>
+              <span className={styles.statusDot} style={{ background: "var(--status-idle)" }} />
+              <div className={styles.wsInfo}>
+                <span className={styles.wsName}>{server.name || server.host}</span>
+                <span className={styles.wsBranch}>{server.host}</span>
+              </div>
+              <button
+                className={styles.iconBtn}
+                onClick={() => handlePair(server.host, server.port)}
+                title="Connect"
+                style={{ fontSize: 11 }}
+              >
+                Connect
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {remoteConnections.length > 0 && (
+        <div className={styles.list} style={{ borderTop: "1px solid var(--border-subtle)" }}>
+          <div className={styles.repoHeader} style={{ opacity: 0.7, cursor: "default" }}>
+            <span className={styles.repoName} style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+              Remote
+            </span>
+          </div>
+          {remoteConnections.map((conn) => {
+            const isActive = activeRemoteIds.includes(conn.id);
+            return (
+              <div key={conn.id} className={styles.wsItem}>
+                <span
+                  className={styles.statusDot}
+                  style={{ background: isActive ? "var(--status-running)" : "var(--status-stopped)" }}
+                />
+                <div className={styles.wsInfo}>
+                  <span className={styles.wsName}>{conn.name}</span>
+                  <span className={styles.wsBranch}>{conn.host}:{conn.port}</span>
+                </div>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => isActive ? handleDisconnect(conn.id) : handleConnect(conn.id)}
+                  title={isActive ? "Disconnect" : "Connect"}
+                  style={{ fontSize: 11 }}
+                >
+                  {isActive ? "×" : "→"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
   );
 }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   createWorkspace,
   connectRemote,
   disconnectRemote,
+  removeRemoteConnection,
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
@@ -296,6 +297,7 @@ function RemoteSections() {
   const addRemote = useAppStore((s) => s.addRemoteConnection);
   const addActiveId = useAppStore((s) => s.addActiveRemoteId);
   const removeActiveId = useAppStore((s) => s.removeActiveRemoteId);
+  const removeRemote = useAppStore((s) => s.removeRemoteConnection);
   const mergeRemoteData = useAppStore((s) => s.mergeRemoteData);
   const clearRemoteData = useAppStore((s) => s.clearRemoteData);
   const unpaired = discoveredServers.filter((s) => !s.is_paired);
@@ -331,6 +333,16 @@ function RemoteSections() {
       clearRemoteData(id);
     } catch (e) {
       console.error("Failed to disconnect:", e);
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    try {
+      await removeRemoteConnection(id);
+      removeRemote(id);
+      clearRemoteData(id);
+    } catch (e) {
+      console.error("Failed to remove remote connection:", e);
     }
   };
 
@@ -398,6 +410,7 @@ function RemoteSections() {
                 isConnecting={isConnecting}
                 onConnect={() => handleConnect(conn.id)}
                 onDisconnect={() => handleDisconnect(conn.id)}
+                onRemove={() => handleRemove(conn.id)}
               />
             );
           })}
@@ -413,12 +426,14 @@ function RemoteConnectionGroup({
   isConnecting,
   onConnect,
   onDisconnect,
+  onRemove,
 }: {
   conn: import("../../types/remote").RemoteConnectionInfo;
   isActive: boolean;
   isConnecting: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
+  onRemove: () => void;
 }) {
   const repositories = useAppStore((s) => s.repositories);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -452,6 +467,16 @@ function RemoteConnectionGroup({
         <span className={styles.repoName} style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: "0.5px" }}>
           {conn.name}
         </span>
+        {!isActive && !isConnecting && (
+          <button
+            className={styles.iconBtn}
+            onClick={onRemove}
+            title="Remove"
+            style={{ fontSize: 11, opacity: 0.5 }}
+          >
+            <X size={12} />
+          </button>
+        )}
         <button
           className={styles.iconBtn}
           onClick={() => (isActive ? onDisconnect() : onConnect())}

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -297,13 +297,25 @@ function RemoteSections() {
   const addActiveId = useAppStore((s) => s.addActiveRemoteId);
   const removeActiveId = useAppStore((s) => s.removeActiveRemoteId);
   const unpaired = discoveredServers.filter((s) => !s.is_paired);
+  const [connectingIds, setConnectingIds] = useState<Set<string>>(new Set());
+  const [connectError, setConnectError] = useState<string | null>(null);
 
   const handleConnect = async (id: string) => {
+    setConnectError(null);
+    setConnectingIds((prev) => new Set(prev).add(id));
     try {
       await connectRemote(id);
       addActiveId(id);
     } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setConnectError(msg);
       console.error("Failed to connect:", e);
+    } finally {
+      setConnectingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
     }
   };
 
@@ -366,13 +378,19 @@ function RemoteSections() {
               Remote
             </span>
           </div>
+          {connectError && (
+            <div style={{ padding: "4px 12px", fontSize: 11, color: "var(--status-error, #f55)", lineHeight: 1.3 }}>
+              {connectError}
+            </div>
+          )}
           {remoteConnections.map((conn) => {
             const isActive = activeRemoteIds.includes(conn.id);
+            const isConnecting = connectingIds.has(conn.id);
             return (
               <div key={conn.id} className={styles.wsItem}>
                 <span
                   className={styles.statusDot}
-                  style={{ background: isActive ? "var(--status-running)" : "var(--status-stopped)" }}
+                  style={{ background: isConnecting ? "var(--status-idle)" : isActive ? "var(--status-running)" : "var(--status-stopped)" }}
                 />
                 <div className={styles.wsInfo}>
                   <span className={styles.wsName}>{conn.name}</span>
@@ -381,10 +399,11 @@ function RemoteSections() {
                 <button
                   className={styles.iconBtn}
                   onClick={() => isActive ? handleDisconnect(conn.id) : handleConnect(conn.id)}
-                  title={isActive ? "Disconnect" : "Connect"}
-                  style={{ fontSize: 11 }}
+                  disabled={isConnecting}
+                  title={isConnecting ? "Connecting…" : isActive ? "Disconnect" : "Connect"}
+                  style={{ fontSize: 11, opacity: isConnecting ? 0.5 : 1 }}
                 >
-                  {isActive ? "×" : "→"}
+                  {isConnecting ? "…" : isActive ? "×" : "→"}
                 </button>
               </div>
             );

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -208,3 +208,45 @@ export function getAppSetting(key: string): Promise<string | null> {
 export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
+
+// -- Remote --
+
+import type {
+  RemoteConnectionInfo,
+  DiscoveredServer,
+  PairResult,
+} from "../types/remote";
+
+export function listRemoteConnections(): Promise<RemoteConnectionInfo[]> {
+  return invoke("list_remote_connections");
+}
+
+export function pairWithServer(
+  host: string,
+  port: number,
+  pairingToken: string
+): Promise<PairResult> {
+  return invoke("pair_with_server", { host, port, pairingToken });
+}
+
+export function connectRemote(id: string): Promise<unknown> {
+  return invoke("connect_remote", { id });
+}
+
+export function disconnectRemote(id: string): Promise<void> {
+  return invoke("disconnect_remote", { id });
+}
+
+export function removeRemoteConnection(id: string): Promise<void> {
+  return invoke("remove_remote_connection", { id });
+}
+
+export function listDiscoveredServers(): Promise<DiscoveredServer[]> {
+  return invoke("list_discovered_servers");
+}
+
+export function addRemoteConnection(
+  connectionString: string
+): Promise<PairResult> {
+  return invoke("add_remote_connection", { connectionString });
+}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -228,7 +228,9 @@ export function pairWithServer(
   return invoke("pair_with_server", { host, port, pairingToken });
 }
 
-export function connectRemote(id: string): Promise<unknown> {
+import type { RemoteInitialData } from "../types/remote";
+
+export function connectRemote(id: string): Promise<RemoteInitialData | null> {
   return invoke("connect_remote", { id });
 }
 

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -252,6 +252,14 @@ export function addRemoteConnection(
   return invoke("add_remote_connection", { connectionString });
 }
 
+export function sendRemoteCommand(
+  connectionId: string,
+  method: string,
+  params: Record<string, unknown>
+): Promise<unknown> {
+  return invoke("send_remote_command", { connectionId, method, params });
+}
+
 // -- Local Server --
 
 export interface LocalServerInfo {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -250,3 +250,22 @@ export function addRemoteConnection(
 ): Promise<PairResult> {
   return invoke("add_remote_connection", { connectionString });
 }
+
+// -- Local Server --
+
+export interface LocalServerInfo {
+  running: boolean;
+  connection_string: string | null;
+}
+
+export function startLocalServer(): Promise<LocalServerInfo> {
+  return invoke("start_local_server");
+}
+
+export function stopLocalServer(): Promise<void> {
+  return invoke("stop_local_server");
+}
+
+export function getLocalServerStatus(): Promise<LocalServerInfo> {
+  return invoke("get_local_server_status");
+}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -11,6 +11,11 @@ import type {
   CreateWorkspaceResult,
   RepoConfigInfo,
 } from "../types/repository";
+import type {
+  RemoteConnectionInfo,
+  DiscoveredServer,
+  PairResult,
+} from "../types/remote";
 
 // -- Data --
 
@@ -210,12 +215,6 @@ export function setAppSetting(key: string, value: string): Promise<void> {
 }
 
 // -- Remote --
-
-import type {
-  RemoteConnectionInfo,
-  DiscoveredServer,
-  PairResult,
-} from "../types/remote";
 
 export function listRemoteConnections(): Promise<RemoteConnectionInfo[]> {
   return invoke("list_remote_connections");

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -10,6 +10,7 @@ import type {
   RemoteConnectionInfo,
   DiscoveredServer,
 } from "../types";
+import type { RemoteInitialData } from "../types/remote";
 
 export type PermissionLevel = "readonly" | "standard" | "full";
 
@@ -177,6 +178,8 @@ interface AppState {
   setActiveRemoteIds: (ids: string[]) => void;
   addActiveRemoteId: (id: string) => void;
   removeActiveRemoteId: (id: string) => void;
+  mergeRemoteData: (connectionId: string, data: RemoteInitialData) => void;
+  clearRemoteData: (connectionId: string) => void;
 
   // -- Local Server --
   localServerRunning: boolean;
@@ -485,6 +488,37 @@ export const useAppStore = create<AppState>((set) => ({
   removeActiveRemoteId: (id) =>
     set((s) => ({
       activeRemoteIds: s.activeRemoteIds.filter((rid) => rid !== id),
+    })),
+  mergeRemoteData: (connectionId, data) =>
+    set((s) => {
+      // Tag remote repos and workspaces with the connection ID, then merge.
+      const taggedRepos = data.repositories.map((r) => ({
+        ...r,
+        remote_connection_id: connectionId,
+      }));
+      const taggedWorkspaces = data.workspaces.map((w) => ({
+        ...w,
+        remote_connection_id: connectionId,
+      }));
+      return {
+        repositories: [
+          ...s.repositories.filter((r) => r.remote_connection_id !== connectionId),
+          ...taggedRepos,
+        ],
+        workspaces: [
+          ...s.workspaces.filter((w) => w.remote_connection_id !== connectionId),
+          ...taggedWorkspaces,
+        ],
+      };
+    }),
+  clearRemoteData: (connectionId) =>
+    set((s) => ({
+      repositories: s.repositories.filter(
+        (r) => r.remote_connection_id !== connectionId
+      ),
+      workspaces: s.workspaces.filter(
+        (w) => w.remote_connection_id !== connectionId
+      ),
     })),
 
   // -- Local Server --

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -7,6 +7,8 @@ import type {
   FileDiff,
   DiffViewMode,
   TerminalTab,
+  RemoteConnectionInfo,
+  DiscoveredServer,
 } from "../types";
 
 export type PermissionLevel = "readonly" | "standard" | "full";
@@ -163,6 +165,18 @@ interface AppState {
   setTerminalFontSize: (size: number) => void;
   lastMessages: Record<string, ChatMessage>;
   setLastMessages: (msgs: Record<string, ChatMessage>) => void;
+
+  // -- Remote Connections --
+  remoteConnections: RemoteConnectionInfo[];
+  discoveredServers: DiscoveredServer[];
+  activeRemoteIds: string[];
+  setRemoteConnections: (conns: RemoteConnectionInfo[]) => void;
+  addRemoteConnection: (conn: RemoteConnectionInfo) => void;
+  removeRemoteConnection: (id: string) => void;
+  setDiscoveredServers: (servers: DiscoveredServer[]) => void;
+  setActiveRemoteIds: (ids: string[]) => void;
+  addActiveRemoteId: (id: string) => void;
+  removeActiveRemoteId: (id: string) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -441,4 +455,25 @@ export const useAppStore = create<AppState>((set) => ({
   setTerminalFontSize: (size) => set({ terminalFontSize: size }),
   lastMessages: {},
   setLastMessages: (msgs) => set({ lastMessages: msgs }),
+
+  // -- Remote Connections --
+  remoteConnections: [],
+  discoveredServers: [],
+  activeRemoteIds: [],
+  setRemoteConnections: (conns) => set({ remoteConnections: conns }),
+  addRemoteConnection: (conn) =>
+    set((s) => ({ remoteConnections: [...s.remoteConnections, conn] })),
+  removeRemoteConnection: (id) =>
+    set((s) => ({
+      remoteConnections: s.remoteConnections.filter((c) => c.id !== id),
+      activeRemoteIds: s.activeRemoteIds.filter((rid) => rid !== id),
+    })),
+  setDiscoveredServers: (servers) => set({ discoveredServers: servers }),
+  setActiveRemoteIds: (ids) => set({ activeRemoteIds: ids }),
+  addActiveRemoteId: (id) =>
+    set((s) => ({ activeRemoteIds: [...s.activeRemoteIds, id] })),
+  removeActiveRemoteId: (id) =>
+    set((s) => ({
+      activeRemoteIds: s.activeRemoteIds.filter((rid) => rid !== id),
+    })),
 }));

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -177,6 +177,12 @@ interface AppState {
   setActiveRemoteIds: (ids: string[]) => void;
   addActiveRemoteId: (id: string) => void;
   removeActiveRemoteId: (id: string) => void;
+
+  // -- Local Server --
+  localServerRunning: boolean;
+  localServerConnectionString: string | null;
+  setLocalServerRunning: (running: boolean) => void;
+  setLocalServerConnectionString: (cs: string | null) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -476,4 +482,11 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => ({
       activeRemoteIds: s.activeRemoteIds.filter((rid) => rid !== id),
     })),
+
+  // -- Local Server --
+  localServerRunning: false,
+  localServerConnectionString: null,
+  setLocalServerRunning: (running) => set({ localServerRunning: running }),
+  setLocalServerConnectionString: (cs) =>
+    set({ localServerConnectionString: cs }),
 }));

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -477,7 +477,11 @@ export const useAppStore = create<AppState>((set) => ({
   setDiscoveredServers: (servers) => set({ discoveredServers: servers }),
   setActiveRemoteIds: (ids) => set({ activeRemoteIds: ids }),
   addActiveRemoteId: (id) =>
-    set((s) => ({ activeRemoteIds: [...s.activeRemoteIds, id] })),
+    set((s) => ({
+      activeRemoteIds: s.activeRemoteIds.includes(id)
+        ? s.activeRemoteIds
+        : [...s.activeRemoteIds, id],
+    })),
   removeActiveRemoteId: (id) =>
     set((s) => ({
       activeRemoteIds: s.activeRemoteIds.filter((rid) => rid !== id),

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -20,3 +20,8 @@ export type {
   AgentEvent,
   StreamEvent,
 } from "./agent-events";
+export type {
+  RemoteConnectionInfo,
+  DiscoveredServer,
+  PairResult,
+} from "./remote";

--- a/src/ui/src/types/remote.ts
+++ b/src/ui/src/types/remote.ts
@@ -20,4 +20,13 @@ export interface DiscoveredServer {
 export interface PairResult {
   connection: RemoteConnectionInfo;
   server_name: string;
+  initial_data: RemoteInitialData | null;
+}
+
+export interface RemoteInitialData {
+  repositories: import("./repository").Repository[];
+  workspaces: import("./workspace").Workspace[];
+  worktree_base_dir: string;
+  default_branches: Record<string, string>;
+  last_messages: import("./chat").ChatMessage[];
 }

--- a/src/ui/src/types/remote.ts
+++ b/src/ui/src/types/remote.ts
@@ -1,0 +1,23 @@
+export interface RemoteConnectionInfo {
+  id: string;
+  name: string;
+  host: string;
+  port: number;
+  session_token: string | null;
+  cert_fingerprint: string | null;
+  auto_connect: boolean;
+  created_at: string;
+}
+
+export interface DiscoveredServer {
+  name: string;
+  host: string;
+  port: number;
+  cert_fingerprint_prefix: string;
+  is_paired: boolean;
+}
+
+export interface PairResult {
+  connection: RemoteConnectionInfo;
+  server_name: string;
+}

--- a/src/ui/src/types/repository.ts
+++ b/src/ui/src/types/repository.ts
@@ -8,6 +8,8 @@ export interface Repository {
   setup_script: string | null;
   custom_instructions: string | null;
   path_valid: boolean;
+  /** Non-null when this repo belongs to a remote connection. */
+  remote_connection_id: string | null;
 }
 
 export interface SetupResult {

--- a/src/ui/src/types/workspace.ts
+++ b/src/ui/src/types/workspace.ts
@@ -16,4 +16,6 @@ export interface Workspace {
   agent_status: AgentStatus;
   status_line: string;
   created_at: string;
+  /** Non-null when this workspace belongs to a remote connection. */
+  remote_connection_id: string | null;
 }


### PR DESCRIPTION
## Summary

- Adds a new `claudette-server` headless binary crate (`src-server/`) that exposes the Claudette backend over WSS with self-signed TLS, pairing-token authentication, and mDNS auto-discovery on the LAN
- Implements a `Transport` trait and `WebSocketTransport` client in the Tauri app for connecting to remote servers, with a `RemoteConnectionManager` that forwards events to the Tauri event bus
- Adds DB migration 7 (`remote_connections` table), 7 new Tauri commands for connection lifecycle (pair, connect, disconnect, list, remove), and client-side mDNS browsing
- Frontend gains Zustand store slices, sidebar sections (Nearby/Remote), an "Add Remote" modal for connection-string pairing, and status bar connection indicators

## Test plan

- [ ] `cargo test --all-features` — 105 tests pass
- [ ] `cargo clippy --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — zero warnings
- [ ] `cargo fmt --all --check` — clean
- [ ] Frontend `tsc --noEmit` and `bun run build` — clean
- [ ] Manual: run `claudette-server` on a remote machine, paste connection string into Add Remote modal, verify pairing and data loading
- [ ] Manual: verify mDNS-discovered servers appear in sidebar Nearby section on the same LAN