### PR TITLE
feat: agent completion notifications with visual badge and audio alert

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -193,6 +193,30 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.notificationBadge {
+  color: var(--accent-primary);
+  font-size: 16px;
+  line-height: 1;
+  animation: pulse-badge 2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+.wsUnread {
+  font-weight: 600;
+}
+
+@keyframes pulse-badge {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 .wsBranch {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -29,6 +29,8 @@ export function Sidebar() {
   const addChatMessage = useAppStore((s) => s.addChatMessage);
   const openModal = useAppStore((s) => s.openModal);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
+  const unreadCompletions = useAppStore((s) => s.unreadCompletions);
+  const clearUnreadCompletion = useAppStore((s) => s.clearUnreadCompletion);
 
   const creatingRef = useRef(false);
 
@@ -193,11 +195,18 @@ export function Sidebar() {
               </div>
 
               {!collapsed &&
-                repoWorkspaces.map((ws) => (
+                repoWorkspaces.map((ws) => {
+                  const hasUnread = unreadCompletions.has(ws.id);
+                  return (
                   <div
                     key={ws.id}
-                    className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""}`}
-                    onClick={() => selectWorkspace(ws.id)}
+                    className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""} ${hasUnread ? styles.wsUnread : ""}`}
+                    onClick={() => {
+                      selectWorkspace(ws.id);
+                      if (hasUnread) {
+                        clearUnreadCompletion(ws.id);
+                      }
+                    }}
                   >
                     <span
                       className={`${styles.statusDot} ${ws.agent_status === "Running" ? styles.statusDotRunning : ""}`}
@@ -211,7 +220,10 @@ export function Sidebar() {
                       }}
                     />
                     <div className={styles.wsInfo}>
-                      <span className={styles.wsName}>{ws.name}</span>
+                      <span className={styles.wsName}>
+                        {ws.name}
+                        {hasUnread && <span className={styles.notificationBadge}>●</span>}
+                      </span>
                       <span className={styles.wsBranch}>{ws.branch_name}</span>
                     </div>
                     <div className={styles.wsActions}>
@@ -255,7 +267,8 @@ export function Sidebar() {
                       )}
                     </div>
                   </div>
-                ))}
+                  );
+                })}
             </div>
           );
         })}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -97,6 +97,25 @@ export function useAgentStream() {
         if (currentQuestion?.workspaceId === wsId) {
           setAgentQuestion(null);
         }
+
+        // Notification: mark workspace as unread if not currently selected
+        const { selectedWorkspaceId, markWorkspaceAsUnread } = useAppStore.getState();
+        if (wsId !== selectedWorkspaceId) {
+          markWorkspaceAsUnread(wsId);
+        }
+
+        // Audio notification: play terminal bell sound
+        console.log('[useAgentStream] Agent completed, playing audio notification for workspace:', wsId);
+        try {
+          const audio = new Audio('data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2/LDciUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmwhBTGH0fPTgjMGHm7A7+OZSA0PVqzn77BdGAg+ltryxnMkBSp+zPLaizsIGGS57OihUBELTKXh8bllHAU2jdXyz4IzBh1qwO/mnEoPEFWs5++vXRgIPpbZ8sR0IwUpfszy2Ys7CBhkueznolARDEul4fG5ZRwFN43V8s+CMwYcacDv5pxKDxBVrOfvrl0YCD6W2fLEdCMFKX7M8tmLOwgYZLns6KJQEQxLpeHxuWUcBTeN1fLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLaizsIGGS57OiiUBEMS6Xh8bllHAU3jdXyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEA==');
+          audio.volume = 0.5;
+          audio.play().catch((err) => {
+            console.error('[useAgentStream] Failed to play audio notification:', err);
+          });
+        } catch (err) {
+          console.error('[useAgentStream] Error creating audio:', err);
+        }
+
         return;
       }
 

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -105,7 +105,6 @@ export function useAgentStream() {
         }
 
         // Audio notification: play terminal bell sound
-        console.log('[useAgentStream] Agent completed, playing audio notification for workspace:', wsId);
         try {
           const audio = new Audio('data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2/LDciUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmwhBTGH0fPTgjMGHm7A7+OZSA0PVqzn77BdGAg+ltryxnMkBSp+zPLaizsIGGS57OihUBELTKXh8bllHAU2jdXyz4IzBh1qwO/mnEoPEFWs5++vXRgIPpbZ8sR0IwUpfszy2Ys7CBhkueznolARDEul4fG5ZRwFN43V8s+CMwYcacDv5pxKDxBVrOfvrl0YCD6W2fLEdCMFKX7M8tmLOwgYZLns6KJQEQxLpeHxuWUcBTeN1fLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLaizsIGGS57OiiUBEMS6Xh8bllHAU3jdXyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEFWs5++uXRgIPpbZ8sR0IwUpfszy2Ys7CBhkuezooleRDBIp+DwumQcBTOP1PLPgjMGHGnA7+acSg8QVazn765dGAg+ltnyw3MkBSl+zPLZizsIGGS57OmiUBEMSaXh8bhlHAU2jdTyz4IzBhxpwO/mnEoPEA==');
           audio.volume = 0.5;

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -89,6 +89,11 @@ interface AppState {
   agentQuestion: AgentQuestion | null;
   setAgentQuestion: (q: AgentQuestion | null) => void;
 
+  // -- Notifications --
+  unreadCompletions: Set<string>; // workspace IDs with unread completions
+  markWorkspaceAsUnread: (wsId: string) => void;
+  clearUnreadCompletion: (wsId: string) => void;
+
   // -- Permissions --
   permissionLevel: Record<string, PermissionLevel>;
   setPermissionLevel: (wsId: string, level: PermissionLevel) => void;
@@ -330,6 +335,21 @@ export const useAppStore = create<AppState>((set) => ({
   // -- Agent Questions --
   agentQuestion: null,
   setAgentQuestion: (q) => set({ agentQuestion: q }),
+
+  // -- Notifications --
+  unreadCompletions: new Set<string>(),
+  markWorkspaceAsUnread: (wsId) =>
+    set((s) => {
+      const newSet = new Set(s.unreadCompletions);
+      newSet.add(wsId);
+      return { unreadCompletions: newSet };
+    }),
+  clearUnreadCompletion: (wsId) =>
+    set((s) => {
+      const newSet = new Set(s.unreadCompletions);
+      newSet.delete(wsId);
+      return { unreadCompletions: newSet };
+    }),
 
   // -- Permissions --
   permissionLevel: {},

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -222,11 +222,16 @@ export const useAppStore = create<AppState>((set) => ({
       ),
     })),
   removeWorkspace: (id) =>
-    set((s) => ({
-      workspaces: s.workspaces.filter((w) => w.id !== id),
-      selectedWorkspaceId:
-        s.selectedWorkspaceId === id ? null : s.selectedWorkspaceId,
-    })),
+    set((s) => {
+      const newUnreadCompletions = new Set(s.unreadCompletions);
+      newUnreadCompletions.delete(id);
+      return {
+        workspaces: s.workspaces.filter((w) => w.id !== id),
+        selectedWorkspaceId:
+          s.selectedWorkspaceId === id ? null : s.selectedWorkspaceId,
+        unreadCompletions: newUnreadCompletions,
+      };
+    }),
   selectWorkspace: (id) => set({ selectedWorkspaceId: id }),
 
   // -- Chat --


### PR DESCRIPTION
## Summary
- Added visual notification badge (pulsing ●) in sidebar for workspaces with completed agent responses
- Added audio notification (terminal bell sound) that plays when any agent completes
- Audio plays for all completions regardless of which workspace is focused
- Visual badge only shows for non-selected workspaces and clears when selected

## Implementation
- Added `unreadCompletions` Set to Zustand store to track workspaces with unread completions
- Modified `useAgentStream` hook to mark workspaces and play audio on `ProcessExited` event
- Updated `Sidebar` component to display pulsing badge and clear on selection
- Added CSS animations for badge pulse effect
- Included debug logging to help diagnose audio playback issues

## Test plan
- [ ] Visual badge appears on sidebar workspace when agent completes (for non-selected workspaces)
- [ ] Badge clears when workspace is selected
- [ ] Audio notification plays when agent completes (even for currently focused workspace)
- [ ] Check browser console for debug logs if audio doesn't play
- [ ] Test with multiple workspaces to ensure notifications work correctly