### PR TITLE
feat: slash command autocomplete picker with dynamic discovery

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,5 +4,6 @@ pub mod diff;
 pub mod remote;
 pub mod repository;
 pub mod settings;
+pub mod slash_commands;
 pub mod terminal;
 pub mod workspace;

--- a/src-tauri/src/commands/slash_commands.rs
+++ b/src-tauri/src/commands/slash_commands.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use claudette::slash_commands::{self, SlashCommand};
+
+#[tauri::command]
+pub async fn list_slash_commands(
+    project_path: Option<String>,
+) -> Result<Vec<SlashCommand>, String> {
+    let path = project_path.map(PathBuf::from);
+    Ok(slash_commands::discover_slash_commands(path.as_deref()))
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -82,6 +82,8 @@ fn main() {
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
             commands::workspace::open_workspace_in_terminal,
+            // Slash commands
+            commands::slash_commands::list_slash_commands,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::send_chat_message,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod diff;
 pub mod git;
 pub mod model;
 pub mod names;
+pub mod slash_commands;

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Serialize;
 
@@ -100,7 +100,7 @@ fn collect_skills_from_dir(dir: &Path, source: &str, commands: &mut Vec<SlashCom
 }
 
 /// Parse a `.md` command file into a `SlashCommand`.
-fn parse_command_file(path: &PathBuf, source: &str) -> Option<SlashCommand> {
+fn parse_command_file(path: &Path, source: &str) -> Option<SlashCommand> {
     let name = path.file_stem()?.to_string_lossy().into_owned();
     let contents = std::fs::read_to_string(path).ok()?;
     let description = parse_description(&contents);

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -1,0 +1,285 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// A discovered slash command or skill.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SlashCommand {
+    pub name: String,
+    pub description: String,
+    /// Where the command was found: "user", "project", or "plugin".
+    pub source: String,
+}
+
+/// Discover all available slash commands by scanning known Claude Code directories.
+///
+/// Commands are deduplicated by name with priority: project > user > plugin.
+pub fn discover_slash_commands(project_path: Option<&Path>) -> Vec<SlashCommand> {
+    let mut commands: Vec<SlashCommand> = Vec::new();
+
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return commands,
+    };
+
+    let claude_dir = home.join(".claude");
+
+    // Plugin commands and skills (lowest priority — collected first, deduped later).
+    let marketplaces = claude_dir.join("plugins/marketplaces");
+    if let Ok(entries) = std::fs::read_dir(&marketplaces) {
+        for marketplace in entries.flatten() {
+            let plugins_dir = marketplace.path().join("plugins");
+            if let Ok(plugins) = std::fs::read_dir(&plugins_dir) {
+                for plugin in plugins.flatten() {
+                    collect_commands_from_dir(
+                        &plugin.path().join("commands"),
+                        "plugin",
+                        &mut commands,
+                    );
+                    collect_skills_from_dir(&plugin.path().join("skills"), "plugin", &mut commands);
+                }
+            }
+        }
+    }
+
+    // User-level commands and skills (medium priority).
+    collect_commands_from_dir(&claude_dir.join("commands"), "user", &mut commands);
+    collect_skills_from_dir(&claude_dir.join("skills"), "user", &mut commands);
+
+    // Project-level commands (highest priority).
+    if let Some(project) = project_path {
+        collect_commands_from_dir(&project.join(".claude/commands"), "project", &mut commands);
+    }
+
+    // Sort by name for consistent ordering.
+    commands.sort_by(|a, b| a.name.cmp(&b.name));
+    commands
+}
+
+/// Scan a directory of `*.md` command files.
+fn collect_commands_from_dir(dir: &Path, source: &str, commands: &mut Vec<SlashCommand>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "md")
+            && let Some(cmd) = parse_command_file(&path, source)
+        {
+            upsert_command(commands, cmd);
+        }
+    }
+}
+
+/// Scan a directory of skill subdirectories, each containing `SKILL.md`.
+fn collect_skills_from_dir(dir: &Path, source: &str, commands: &mut Vec<SlashCommand>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let skill_file = entry.path().join("SKILL.md");
+        if skill_file.is_file() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Ok(contents) = std::fs::read_to_string(&skill_file) {
+                let description = parse_description(&contents);
+                upsert_command(
+                    commands,
+                    SlashCommand {
+                        name,
+                        description,
+                        source: source.to_string(),
+                    },
+                );
+            }
+        }
+    }
+}
+
+/// Parse a `.md` command file into a `SlashCommand`.
+fn parse_command_file(path: &PathBuf, source: &str) -> Option<SlashCommand> {
+    let name = path.file_stem()?.to_string_lossy().into_owned();
+    let contents = std::fs::read_to_string(path).ok()?;
+    let description = parse_description(&contents);
+    Some(SlashCommand {
+        name,
+        description,
+        source: source.to_string(),
+    })
+}
+
+/// Extract a description from file contents.
+///
+/// Checks for YAML frontmatter `description:` field first, then falls back
+/// to the first non-empty line of the body.
+fn parse_description(contents: &str) -> String {
+    if contents.starts_with("---\n") || contents.starts_with("---\r\n") {
+        // Find the closing `---`.
+        if let Some(end) = contents[3..].find("\n---") {
+            let frontmatter = &contents[3..3 + end];
+            for line in frontmatter.lines() {
+                let trimmed = line.trim();
+                if let Some(rest) = trimmed.strip_prefix("description:") {
+                    let desc = rest.trim().trim_matches('"').trim_matches('\'');
+                    if !desc.is_empty() {
+                        return desc.to_string();
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: first non-empty line of the file body (skip frontmatter if present).
+    let body = skip_frontmatter(contents);
+    for line in body.lines() {
+        let trimmed = line.trim().trim_start_matches('#').trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+
+    String::new()
+}
+
+/// Skip YAML frontmatter if present, returning the body text.
+fn skip_frontmatter(contents: &str) -> &str {
+    if (contents.starts_with("---\n") || contents.starts_with("---\r\n"))
+        && let Some(end) = contents[3..].find("\n---")
+    {
+        let after = 3 + end + 4; // skip past "\n---"
+        if after < contents.len() {
+            return &contents[after..];
+        }
+        return "";
+    }
+    contents
+}
+
+/// Insert or replace a command by name (higher priority sources replace lower).
+fn upsert_command(commands: &mut Vec<SlashCommand>, cmd: SlashCommand) {
+    if let Some(existing) = commands.iter_mut().find(|c| c.name == cmd.name) {
+        *existing = cmd;
+    } else {
+        commands.push(cmd);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_parse_description_with_frontmatter() {
+        let contents =
+            "---\ndescription: Create a git commit\nallowed-tools: Bash\n---\n\nBody text";
+        assert_eq!(parse_description(contents), "Create a git commit");
+    }
+
+    #[test]
+    fn test_parse_description_quoted_frontmatter() {
+        let contents = "---\ndescription: \"Build apps with Claude API\"\n---\n\nBody";
+        assert_eq!(parse_description(contents), "Build apps with Claude API");
+    }
+
+    #[test]
+    fn test_parse_description_no_frontmatter() {
+        let contents = "Review all uncommitted changes and create a commit.\n\n## Steps\n...";
+        assert_eq!(
+            parse_description(contents),
+            "Review all uncommitted changes and create a commit."
+        );
+    }
+
+    #[test]
+    fn test_parse_description_heading_first_line() {
+        let contents = "# My Command\n\nDoes stuff.";
+        assert_eq!(parse_description(contents), "My Command");
+    }
+
+    #[test]
+    fn test_parse_description_empty() {
+        assert_eq!(parse_description(""), String::new());
+    }
+
+    #[test]
+    fn test_discover_from_temp_dirs() {
+        let home = tempfile::tempdir().unwrap();
+        let claude_dir = home.path().join(".claude");
+
+        // Create user commands.
+        let cmds_dir = claude_dir.join("commands");
+        fs::create_dir_all(&cmds_dir).unwrap();
+        fs::write(
+            cmds_dir.join("my-cmd.md"),
+            "---\ndescription: My custom command\n---\n",
+        )
+        .unwrap();
+
+        // Create user skill.
+        let skill_dir = claude_dir.join("skills/my-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: A test skill\n---\n",
+        )
+        .unwrap();
+
+        // We can't easily override home_dir, so test the helper functions directly.
+        let mut commands = Vec::new();
+        collect_commands_from_dir(&cmds_dir, "user", &mut commands);
+        collect_skills_from_dir(&claude_dir.join("skills"), "user", &mut commands);
+
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].name, "my-cmd");
+        assert_eq!(commands[0].description, "My custom command");
+        assert_eq!(commands[0].source, "user");
+        assert_eq!(commands[1].name, "my-skill");
+        assert_eq!(commands[1].description, "A test skill");
+    }
+
+    #[test]
+    fn test_upsert_replaces_by_name() {
+        let mut commands = vec![SlashCommand {
+            name: "commit".into(),
+            description: "Plugin commit".into(),
+            source: "plugin".into(),
+        }];
+
+        upsert_command(
+            &mut commands,
+            SlashCommand {
+                name: "commit".into(),
+                description: "User commit".into(),
+                source: "user".into(),
+            },
+        );
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].description, "User commit");
+        assert_eq!(commands[0].source, "user");
+    }
+
+    #[test]
+    fn test_project_commands() {
+        let project = tempfile::tempdir().unwrap();
+        let cmds_dir = project.path().join(".claude/commands");
+        fs::create_dir_all(&cmds_dir).unwrap();
+        fs::write(
+            cmds_dir.join("deploy.md"),
+            "Deploy the app to production.\n",
+        )
+        .unwrap();
+
+        let mut commands = Vec::new();
+        collect_commands_from_dir(&cmds_dir, "project", &mut commands);
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "deploy");
+        assert_eq!(commands[0].description, "Deploy the app to production.");
+        assert_eq!(commands[0].source, "project");
+    }
+}

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -434,6 +434,7 @@
 
 /* Input area */
 .inputArea {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -512,6 +512,7 @@ function ChatInputArea({
 }) {
   const [chatInput, setChatInput] = useState("");
   const [slashPickerIndex, setSlashPickerIndex] = useState(0);
+  const [slashPickerDismissed, setSlashPickerDismissed] = useState(false);
   const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
 
   useEffect(() => {
@@ -525,10 +526,11 @@ function ChatInputArea({
     () => (slashQuery === null ? [] : filterSlashCommands(slashCommands, slashQuery)),
     [slashCommands, slashQuery],
   );
-  const showSlashPicker = slashQuery !== null && slashResults.length > 0;
+  const showSlashPicker = slashQuery !== null && slashResults.length > 0 && !slashPickerDismissed;
 
   useEffect(() => {
     setSlashPickerIndex(0);
+    setSlashPickerDismissed(false);
   }, [slashQuery]);
 
   const handleSend = () => {
@@ -562,14 +564,14 @@ function ChatInputArea({
         e.preventDefault();
         const cmd = slashResults[slashPickerIndex];
         if (cmd) {
-          onSend("/" + cmd.name);
-          setChatInput("");
+          setChatInput("/" + cmd.name + " ");
+          setSlashPickerDismissed(true);
         }
         return;
       }
       if (e.key === "Escape") {
         e.preventDefault();
-        setChatInput("");
+        setSlashPickerDismissed(true);
         return;
       }
     }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,21 +1,24 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { GitBranch, LayoutDashboard } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   loadChatHistory,
+  listSlashCommands,
   sendChatMessage,
   sendRemoteCommand,
   stopAgent,
   getAppSetting,
   setAppSetting,
 } from "../../services/tauri";
+import type { SlashCommand } from "../../services/tauri";
 import type { ChatMessage } from "../../types/chat";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { AgentQuestionCard } from "./AgentQuestionCard";
 import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
+import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import styles from "./ChatPanel.module.css";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -480,6 +483,7 @@ export function ChatPanel() {
         onSend={handleSend}
         isRunning={isRunning}
         selectedWorkspaceId={selectedWorkspaceId!}
+        projectPath={repo?.path}
         historyRef={historyRef}
         historyIndexRef={historyIndexRef}
         draftRef={draftRef}
@@ -493,6 +497,7 @@ function ChatInputArea({
   onSend,
   isRunning,
   selectedWorkspaceId,
+  projectPath,
   historyRef,
   historyIndexRef,
   draftRef,
@@ -500,11 +505,31 @@ function ChatInputArea({
   onSend: (content: string) => Promise<void>;
   isRunning: boolean;
   selectedWorkspaceId: string;
+  projectPath: string | undefined;
   historyRef: React.MutableRefObject<Record<string, string[]>>;
   historyIndexRef: React.MutableRefObject<number>;
   draftRef: React.MutableRefObject<string>;
 }) {
   const [chatInput, setChatInput] = useState("");
+  const [slashPickerIndex, setSlashPickerIndex] = useState(0);
+  const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
+
+  useEffect(() => {
+    listSlashCommands(projectPath)
+      .then(setSlashCommands)
+      .catch((e) => console.error("Failed to load slash commands:", e));
+  }, [projectPath]);
+
+  const slashQuery = chatInput.startsWith("/") ? chatInput.slice(1) : null;
+  const slashResults = useMemo(
+    () => (slashQuery === null ? [] : filterSlashCommands(slashCommands, slashQuery)),
+    [slashCommands, slashQuery],
+  );
+  const showSlashPicker = slashQuery !== null && slashResults.length > 0;
+
+  useEffect(() => {
+    setSlashPickerIndex(0);
+  }, [slashQuery]);
 
   const handleSend = () => {
     onSend(chatInput);
@@ -512,6 +537,43 @@ function ChatInputArea({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Slash command picker navigation
+    if (showSlashPicker) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSlashPickerIndex((i) => Math.min(i + 1, slashResults.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSlashPickerIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const cmd = slashResults[slashPickerIndex];
+        if (cmd) {
+          onSend("/" + cmd.name);
+          setChatInput("");
+        }
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const cmd = slashResults[slashPickerIndex];
+        if (cmd) {
+          onSend("/" + cmd.name);
+          setChatInput("");
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setChatInput("");
+        return;
+      }
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -546,6 +608,17 @@ function ChatInputArea({
 
   return (
     <div className={styles.inputArea}>
+      {showSlashPicker && (
+        <SlashCommandPicker
+          commands={slashResults}
+          selectedIndex={slashPickerIndex}
+          onSelect={(cmd) => {
+            onSend("/" + cmd.name);
+            setChatInput("");
+          }}
+          onHover={setSlashPickerIndex}
+        />
+      )}
       <textarea
         className={styles.input}
         value={chatInput}

--- a/src/ui/src/components/chat/SlashCommandPicker.module.css
+++ b/src/ui/src/components/chat/SlashCommandPicker.module.css
@@ -1,0 +1,59 @@
+.picker {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: 8px;
+  padding: 4px;
+  z-index: 100;
+  max-height: 300px;
+  overflow-y: auto;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.item:hover {
+  background: var(--hover-bg);
+}
+
+.itemSelected {
+  background: var(--selected-bg);
+}
+
+.itemSelected:hover {
+  background: var(--selected-bg);
+}
+
+.commandSlash {
+  color: var(--text-dim);
+  margin-right: 2px;
+  font-size: 13px;
+}
+
+.commandName {
+  color: var(--accent-primary);
+  font-family: var(--font-mono, monospace);
+  font-weight: 500;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.commandDesc {
+  color: var(--text-dim);
+  font-size: 12px;
+  margin-left: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/ui/src/components/chat/SlashCommandPicker.tsx
+++ b/src/ui/src/components/chat/SlashCommandPicker.tsx
@@ -1,0 +1,40 @@
+import type { SlashCommand } from "../../services/tauri";
+import styles from "./SlashCommandPicker.module.css";
+
+interface SlashCommandPickerProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  onSelect: (command: SlashCommand) => void;
+  onHover: (index: number) => void;
+}
+
+export function SlashCommandPicker({
+  commands,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: SlashCommandPickerProps) {
+  if (commands.length === 0) return null;
+
+  return (
+    <div className={styles.picker}>
+      {commands.map((cmd, i) => (
+        <div
+          key={cmd.name}
+          className={`${styles.item} ${i === selectedIndex ? styles.itemSelected : ""}`}
+          onClick={() => onSelect(cmd)}
+          onMouseEnter={() => onHover(i)}
+        >
+          <span className={styles.commandSlash}>/</span>
+          <span className={styles.commandName}>{cmd.name}</span>
+          <span className={styles.commandDesc}>{cmd.description}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function filterSlashCommands(commands: SlashCommand[], query: string): SlashCommand[] {
+  const q = query.toLowerCase();
+  return commands.filter((cmd) => cmd.name.includes(q));
+}

--- a/src/ui/src/components/chat/SlashCommandPicker.tsx
+++ b/src/ui/src/components/chat/SlashCommandPicker.tsx
@@ -17,10 +17,12 @@ export function SlashCommandPicker({
   if (commands.length === 0) return null;
 
   return (
-    <div className={styles.picker}>
+    <div className={styles.picker} role="listbox">
       {commands.map((cmd, i) => (
         <div
           key={cmd.name}
+          role="option"
+          aria-selected={i === selectedIndex}
           className={`${styles.item} ${i === selectedIndex ? styles.itemSelected : ""}`}
           onClick={() => onSelect(cmd)}
           onMouseEnter={() => onHover(i)}
@@ -36,5 +38,5 @@ export function SlashCommandPicker({
 
 export function filterSlashCommands(commands: SlashCommand[], query: string): SlashCommand[] {
   const q = query.toLowerCase();
-  return commands.filter((cmd) => cmd.name.includes(q));
+  return commands.filter((cmd) => cmd.name.toLowerCase().includes(q));
 }

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -102,6 +102,22 @@ export function openWorkspaceInTerminal(worktreePath: string): Promise<void> {
   return invoke("open_workspace_in_terminal", { worktreePath });
 }
 
+// -- Slash Commands --
+
+export interface SlashCommand {
+  name: string;
+  description: string;
+  source: string;
+}
+
+export function listSlashCommands(
+  projectPath?: string
+): Promise<SlashCommand[]> {
+  return invoke("list_slash_commands", {
+    projectPath: projectPath ?? null,
+  });
+}
+
 // -- Chat --
 
 export function loadChatHistory(workspaceId: string): Promise<ChatMessage[]> {


### PR DESCRIPTION
## Summary

Adds a slash command autocomplete picker that appears when the user types `/` in the chat input. Commands are **dynamically discovered** from the filesystem rather than hardcoded, supporting:

- **User commands**: `~/.claude/commands/*.md`
- **User skills**: `~/.claude/skills/*/SKILL.md`
- **Plugin commands/skills**: `~/.claude/plugins/marketplaces/*/plugins/*/commands/*.md` and `skills/*/SKILL.md`
- **Project commands**: `{repo}/.claude/commands/*.md`

Commands are deduplicated with priority: project > user > plugin. Descriptions are parsed from YAML frontmatter or the first non-empty line.

```mermaid
sequenceDiagram
    participant UI as ChatInputArea
    participant Tauri as list_slash_commands
    participant FS as Filesystem

    UI->>Tauri: listSlashCommands(projectPath)
    Tauri->>FS: Scan ~/.claude/commands, skills, plugins
    FS-->>Tauri: Vec<SlashCommand>
    Tauri-->>UI: [{name, description, source}]
    UI->>UI: Filter by typed query, show popup
```

## Complexity Notes

- The `parse_description` function handles two formats: YAML frontmatter (`description:` field) and plain markdown (first non-empty line). User-level commands like `commit-changes.md` don't use frontmatter, while plugin commands do.
- Priority-based deduplication relies on collection order: plugins are collected first, then user commands overwrite them, then project commands overwrite those.

## Test Steps

1. Run `cargo test --all-features` — all 119 tests pass including 7 new slash command tests
2. Run `cargo tauri dev` and open a workspace
3. Type `/` in the chat input — all discovered commands should appear in a popup above the input
4. Type `/com` — should filter to commands containing "com" (e.g., `commit-changes`)
5. Use Arrow Up/Down to navigate, Enter to select and send
6. Press Escape to dismiss the picker
7. Type normal text (not starting with `/`) — no picker should appear
8. Arrow Up/Down for history navigation should still work when picker is closed
9. Add a custom command at `~/.claude/commands/test-cmd.md` and verify it appears in the picker

## Checklist

- [x] Tests added/updated (7 unit tests for discovery logic)
- [ ] Documentation updated (if applicable)