### PR TITLE
feat: sort slash command picker by usage frequency

### DIFF
--- a/src-tauri/src/commands/slash_commands.rs
+++ b/src-tauri/src/commands/slash_commands.rs
@@ -1,11 +1,39 @@
 use std::path::PathBuf;
 
+use tauri::State;
+
+use claudette::db::Database;
 use claudette::slash_commands::{self, SlashCommand};
+
+use crate::state::AppState;
 
 #[tauri::command]
 pub async fn list_slash_commands(
     project_path: Option<String>,
+    workspace_id: Option<String>,
+    state: State<'_, AppState>,
 ) -> Result<Vec<SlashCommand>, String> {
     let path = project_path.map(PathBuf::from);
-    Ok(slash_commands::discover_slash_commands(path.as_deref()))
+    let mut commands = slash_commands::discover_slash_commands(path.as_deref());
+
+    if let Some(ws_id) = workspace_id {
+        let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+        let usage = db
+            .get_slash_command_usage(&ws_id)
+            .map_err(|e| e.to_string())?;
+        slash_commands::sort_commands_by_usage(&mut commands, &usage);
+    }
+
+    Ok(commands)
+}
+
+#[tauri::command]
+pub async fn record_slash_command_usage(
+    workspace_id: String,
+    command_name: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.record_slash_command_usage(&workspace_id, &command_name)
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -84,6 +84,7 @@ fn main() {
             commands::workspace::open_workspace_in_terminal,
             // Slash commands
             commands::slash_commands::list_slash_commands,
+            commands::slash_commands::record_slash_command_usage,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::send_chat_message,

--- a/src/db.rs
+++ b/src/db.rs
@@ -150,6 +150,20 @@ impl Database {
             )?;
         }
 
+        if version < 8 {
+            self.conn.execute_batch(
+                "CREATE TABLE slash_command_usage (
+                    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                    command_name  TEXT NOT NULL,
+                    use_count     INTEGER NOT NULL DEFAULT 0,
+                    last_used_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (workspace_id, command_name)
+                );
+
+                PRAGMA user_version = 8;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -631,6 +645,41 @@ impl Database {
         self.conn
             .execute("DELETE FROM remote_connections WHERE id = ?1", params![id])?;
         Ok(())
+    }
+
+    // --- Slash Command Usage ---
+
+    pub fn record_slash_command_usage(
+        &self,
+        workspace_id: &str,
+        command_name: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT INTO slash_command_usage (workspace_id, command_name, use_count, last_used_at)
+             VALUES (?1, ?2, 1, datetime('now'))
+             ON CONFLICT (workspace_id, command_name)
+             DO UPDATE SET use_count = use_count + 1, last_used_at = datetime('now')",
+            params![workspace_id, command_name],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_slash_command_usage(
+        &self,
+        workspace_id: &str,
+    ) -> Result<std::collections::HashMap<String, i64>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT command_name, use_count FROM slash_command_usage WHERE workspace_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![workspace_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        let mut map = std::collections::HashMap::new();
+        for row in rows {
+            let (name, count) = row?;
+            map.insert(name, count);
+        }
+        Ok(map)
     }
 }
 
@@ -1143,5 +1192,72 @@ mod tests {
         db.insert_remote_connection(&conn).unwrap();
         let fetched = db.get_remote_connection("rc1").unwrap().unwrap();
         assert!(fetched.auto_connect);
+    }
+
+    #[test]
+    fn test_record_slash_command_usage_insert_and_increment() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/r1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "ws1"))
+            .unwrap();
+
+        // First use creates the row with count 1.
+        db.record_slash_command_usage("w1", "commit").unwrap();
+        let usage = db.get_slash_command_usage("w1").unwrap();
+        assert_eq!(usage.get("commit"), Some(&1));
+
+        // Second use increments to 2.
+        db.record_slash_command_usage("w1", "commit").unwrap();
+        let usage = db.get_slash_command_usage("w1").unwrap();
+        assert_eq!(usage.get("commit"), Some(&2));
+    }
+
+    #[test]
+    fn test_get_slash_command_usage_empty() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/r1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "ws1"))
+            .unwrap();
+
+        let usage = db.get_slash_command_usage("w1").unwrap();
+        assert!(usage.is_empty());
+    }
+
+    #[test]
+    fn test_slash_command_usage_per_workspace() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/r1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "ws1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "ws2"))
+            .unwrap();
+
+        db.record_slash_command_usage("w1", "commit").unwrap();
+        db.record_slash_command_usage("w1", "commit").unwrap();
+        db.record_slash_command_usage("w2", "commit").unwrap();
+
+        let usage_w1 = db.get_slash_command_usage("w1").unwrap();
+        let usage_w2 = db.get_slash_command_usage("w2").unwrap();
+        assert_eq!(usage_w1.get("commit"), Some(&2));
+        assert_eq!(usage_w2.get("commit"), Some(&1));
+    }
+
+    #[test]
+    fn test_slash_command_usage_cascade_delete() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/r1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "ws1"))
+            .unwrap();
+
+        db.record_slash_command_usage("w1", "commit").unwrap();
+        db.delete_workspace("w1").unwrap();
+
+        // After workspace deletion, usage rows should be gone.
+        let usage = db.get_slash_command_usage("w1").unwrap();
+        assert!(usage.is_empty());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -155,7 +155,7 @@ impl Database {
                 "CREATE TABLE slash_command_usage (
                     workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
                     command_name  TEXT NOT NULL,
-                    use_count     INTEGER NOT NULL DEFAULT 0,
+                    use_count     INTEGER NOT NULL DEFAULT 1,
                     last_used_at  TEXT NOT NULL DEFAULT (datetime('now')),
                     PRIMARY KEY (workspace_id, command_name)
                 );

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use serde::Serialize;
@@ -158,6 +159,15 @@ fn skip_frontmatter(contents: &str) -> &str {
     contents
 }
 
+/// Re-sort commands by usage frequency (descending), with unused commands sorted alphabetically.
+pub fn sort_commands_by_usage(commands: &mut [SlashCommand], usage: &HashMap<String, i64>) {
+    commands.sort_by(|a, b| {
+        let count_a = usage.get(&a.name).copied().unwrap_or(0);
+        let count_b = usage.get(&b.name).copied().unwrap_or(0);
+        count_b.cmp(&count_a).then_with(|| a.name.cmp(&b.name))
+    });
+}
+
 /// Insert or replace a command by name (higher priority sources replace lower).
 fn upsert_command(commands: &mut Vec<SlashCommand>, cmd: SlashCommand) {
     if let Some(existing) = commands.iter_mut().find(|c| c.name == cmd.name) {
@@ -261,6 +271,59 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].description, "User commit");
         assert_eq!(commands[0].source, "user");
+    }
+
+    #[test]
+    fn test_sort_commands_by_usage() {
+        let mut commands = vec![
+            SlashCommand {
+                name: "alpha".into(),
+                description: "".into(),
+                source: "user".into(),
+            },
+            SlashCommand {
+                name: "beta".into(),
+                description: "".into(),
+                source: "user".into(),
+            },
+            SlashCommand {
+                name: "gamma".into(),
+                description: "".into(),
+                source: "user".into(),
+            },
+        ];
+
+        let mut usage = HashMap::new();
+        usage.insert("gamma".to_string(), 5);
+        usage.insert("alpha".to_string(), 2);
+
+        sort_commands_by_usage(&mut commands, &usage);
+
+        assert_eq!(commands[0].name, "gamma"); // 5 uses
+        assert_eq!(commands[1].name, "alpha"); // 2 uses
+        assert_eq!(commands[2].name, "beta"); // 0 uses
+    }
+
+    #[test]
+    fn test_sort_commands_by_usage_alphabetical_tiebreaker() {
+        let mut commands = vec![
+            SlashCommand {
+                name: "zebra".into(),
+                description: "".into(),
+                source: "user".into(),
+            },
+            SlashCommand {
+                name: "apple".into(),
+                description: "".into(),
+                source: "user".into(),
+            },
+        ];
+
+        let usage = HashMap::new(); // no usage
+        sort_commands_by_usage(&mut commands, &usage);
+
+        assert_eq!(commands[0].name, "apple");
+        assert_eq!(commands[1].name, "zebra");
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import {
   loadChatHistory,
   listSlashCommands,
+  recordSlashCommandUsage,
   sendChatMessage,
   sendRemoteCommand,
   stopAgent,
@@ -515,11 +516,15 @@ function ChatInputArea({
   const [slashPickerDismissed, setSlashPickerDismissed] = useState(false);
   const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
 
-  useEffect(() => {
-    listSlashCommands(projectPath)
+  const refreshSlashCommands = useCallback(() => {
+    listSlashCommands(projectPath, selectedWorkspaceId)
       .then(setSlashCommands)
       .catch((e) => console.error("Failed to load slash commands:", e));
-  }, [projectPath]);
+  }, [projectPath, selectedWorkspaceId]);
+
+  useEffect(() => {
+    refreshSlashCommands();
+  }, [refreshSlashCommands]);
 
   const slashQuery = chatInput.startsWith("/") ? chatInput.slice(1) : null;
   const slashResults = useMemo(
@@ -557,6 +562,7 @@ function ChatInputArea({
         if (cmd) {
           onSend("/" + cmd.name);
           setChatInput("");
+          recordSlashCommandUsage(selectedWorkspaceId, cmd.name).then(refreshSlashCommands);
         }
         return;
       }
@@ -617,6 +623,7 @@ function ChatInputArea({
           onSelect={(cmd) => {
             onSend("/" + cmd.name);
             setChatInput("");
+            recordSlashCommandUsage(selectedWorkspaceId, cmd.name).then(refreshSlashCommands);
           }}
           onHover={setSlashPickerIndex}
         />

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -523,8 +523,16 @@ function ChatInputArea({
   }, [projectPath, selectedWorkspaceId]);
 
   useEffect(() => {
-    refreshSlashCommands();
-  }, [refreshSlashCommands]);
+    let cancelled = false;
+    listSlashCommands(projectPath, selectedWorkspaceId)
+      .then((cmds) => {
+        if (!cancelled) setSlashCommands(cmds);
+      })
+      .catch((e) => console.error("Failed to load slash commands:", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath, selectedWorkspaceId]);
 
   const slashQuery = chatInput.startsWith("/") ? chatInput.slice(1) : null;
   const slashResults = useMemo(

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -562,7 +562,9 @@ function ChatInputArea({
         if (cmd) {
           onSend("/" + cmd.name);
           setChatInput("");
-          recordSlashCommandUsage(selectedWorkspaceId, cmd.name).then(refreshSlashCommands);
+          recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
+            .then(refreshSlashCommands)
+            .catch((e) => console.error("Failed to record slash command usage:", e));
         }
         return;
       }
@@ -623,7 +625,9 @@ function ChatInputArea({
           onSelect={(cmd) => {
             onSend("/" + cmd.name);
             setChatInput("");
-            recordSlashCommandUsage(selectedWorkspaceId, cmd.name).then(refreshSlashCommands);
+            recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
+            .then(refreshSlashCommands)
+            .catch((e) => console.error("Failed to record slash command usage:", e));
           }}
           onHover={setSlashPickerIndex}
         />

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -111,10 +111,22 @@ export interface SlashCommand {
 }
 
 export function listSlashCommands(
-  projectPath?: string
+  projectPath?: string,
+  workspaceId?: string,
 ): Promise<SlashCommand[]> {
   return invoke("list_slash_commands", {
     projectPath: projectPath ?? null,
+    workspaceId: workspaceId ?? null,
+  });
+}
+
+export function recordSlashCommandUsage(
+  workspaceId: string,
+  commandName: string,
+): Promise<void> {
+  return invoke("record_slash_command_usage", {
+    workspaceId,
+    commandName,
   });
 }
 


### PR DESCRIPTION
## Summary

Tracks per-workspace slash command usage in SQLite and sorts the autocomplete picker by frequency (most-used first), with unused commands falling back to alphabetical order.

```mermaid
erDiagram
    workspaces ||--o{ slash_command_usage : "has usage"
    slash_command_usage {
        text workspace_id PK,FK
        text command_name PK
        int use_count
        text last_used_at
    }
```

**Changes:**
- **DB migration v8**: New `slash_command_usage` table with composite PK `(workspace_id, command_name)` and cascade delete on workspace removal
- **Backend**: `record_slash_command_usage` (UPSERT) and `get_slash_command_usage` DB methods; `sort_commands_by_usage` sorting function; extended `list_slash_commands` Tauri command with optional `workspace_id` param
- **Frontend**: Records usage on command send (Enter/click), refreshes picker sort order after each use

## Test Steps

1. Run `cargo test --all-features` — all 125 tests pass (6 new tests for usage tracking and sorting)
2. Run `cargo clippy --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — clean
3. Run `tsc --noEmit` in `src/ui` — clean
4. Launch the app with `cargo tauri dev`
5. Open a workspace and type `/` to see the picker — commands should be alphabetical initially
6. Select and send a command (e.g. `/commit`) via Enter or click
7. Type `/` again — the used command should now appear first
8. Use a different command — it should appear alongside the first, both sorted by frequency
9. Switch to a different workspace — picker should show alphabetical order (usage is per-workspace)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)