### PR TITLE
fix: return branch-safe slug from generate_workspace_name

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -35,9 +35,13 @@ pub async fn create_workspace(
     name: String,
     state: State<'_, AppState>,
 ) -> Result<CreateWorkspaceResult, String> {
-    // Validate workspace name.
-    let forbidden = ['/', '\\', ':', '?', '*', '[', ' ', '~', '.'];
-    if name.is_empty() || name.chars().any(|c| forbidden.contains(&c)) || name.ends_with(".lock") {
+    // Validate workspace name: must be ASCII alphanumeric + hyphens only (branch-safe).
+    if name.is_empty()
+        || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        || name.starts_with('-')
+        || name.ends_with('-')
+        || name.ends_with(".lock")
+    {
         return Err(format!("Invalid workspace name: '{name}'"));
     }
 
@@ -318,9 +322,28 @@ pub async fn delete_workspace(id: String, state: State<'_, AppState>) -> Result<
     Ok(())
 }
 
+#[derive(Serialize)]
+pub struct GeneratedWorkspaceName {
+    /// Safe for branch names and file paths
+    pub slug: String,
+    /// Fun display version (may contain emojis/special chars for easter eggs)
+    pub display: String,
+    /// Optional easter egg message
+    pub message: Option<String>,
+}
+
 #[tauri::command]
-pub fn generate_workspace_name() -> String {
-    NameGenerator::new().generate().display
+pub fn generate_workspace_name() -> GeneratedWorkspaceName {
+    let generated = NameGenerator::new().generate();
+    let message = match &generated.easter_egg {
+        Some(claudette::names::EasterEgg::Message(msg)) => Some(msg.clone()),
+        _ => None,
+    };
+    GeneratedWorkspaceName {
+        slug: generated.slug(),
+        display: generated.display,
+        message,
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -40,7 +40,6 @@ pub async fn create_workspace(
         || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
         || name.starts_with('-')
         || name.ends_with('-')
-        || name.ends_with(".lock")
     {
         return Err(format!("Invalid workspace name: '{name}'"));
     }

--- a/src/names/mod.rs
+++ b/src/names/mod.rs
@@ -36,6 +36,13 @@ pub struct GeneratedName {
     pub easter_egg: Option<EasterEgg>,
 }
 
+impl GeneratedName {
+    /// Branch-safe name: always "{adjective}-{plant}", no special characters.
+    pub fn slug(&self) -> String {
+        format!("{}-{}", self.adjective, self.plant)
+    }
+}
+
 impl NameGenerator {
     pub fn new() -> Self {
         let mut this = Self {
@@ -214,6 +221,13 @@ mod tests {
         let name = namer.generate();
         assert!(!name.display.is_empty());
         assert!(name.display.contains('-') || name.easter_egg.is_some());
+        // slug is always branch-safe regardless of easter eggs
+        assert!(name.slug().contains('-'));
+        assert!(
+            name.slug()
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-')
+        );
     }
 
     #[test]
@@ -261,5 +275,14 @@ mod tests {
         let namer = NameGenerator::new();
         let name = namer.build_name("calm", "daisy");
         assert!(name.easter_egg.is_none());
+    }
+
+    #[test]
+    fn slug_is_safe_even_for_easter_eggs() {
+        let namer = NameGenerator::new();
+        let name = namer.build_name("wild", "fern");
+        assert_eq!(name.slug(), "wild-fern");
+        // display has the fun emoji version
+        assert!(name.display.contains('\u{1f33f}'));
     }
 }

--- a/src/names/mod.rs
+++ b/src/names/mod.rs
@@ -37,7 +37,8 @@ pub struct GeneratedName {
 }
 
 impl GeneratedName {
-    /// Branch-safe name: always "{adjective}-{plant}", no special characters.
+    /// Branch-safe name: always "{adjective}-{plant}".
+    /// Safe because ADJECTIVES and PLANTS word lists are lowercase ASCII only.
     pub fn slug(&self) -> String {
         format!("{}-{}", self.adjective, self.plant)
     }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -38,10 +38,21 @@ export function Sidebar() {
     if (creatingRef.current) return;
     creatingRef.current = true;
     try {
-      const name = await generateWorkspaceName();
-      const result = await createWorkspace(repoId, name);
+      const generated = await generateWorkspaceName();
+      const result = await createWorkspace(repoId, generated.slug);
       addWorkspace(result.workspace);
       selectWorkspace(result.workspace.id);
+      if (generated.message) {
+        addChatMessage(result.workspace.id, {
+          id: crypto.randomUUID(),
+          workspace_id: result.workspace.id,
+          role: "System",
+          content: generated.message,
+          cost_usd: null,
+          duration_ms: null,
+          created_at: new Date().toISOString(),
+        });
+      }
       if (result.setup_result) {
         const sr = result.setup_result;
         const label = sr.source === "repo" ? ".claudette.json" : "settings";

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -90,7 +90,13 @@ export function deleteWorkspace(id: string): Promise<void> {
   return invoke("delete_workspace", { id });
 }
 
-export function generateWorkspaceName(): Promise<string> {
+export interface GeneratedWorkspaceName {
+  slug: string;
+  display: string;
+  message: string | null;
+}
+
+export function generateWorkspaceName(): Promise<GeneratedWorkspaceName> {
   return invoke("generate_workspace_name");
 }
 


### PR DESCRIPTION
## Summary

`generate_workspace_name` was returning the `display` field from `GeneratedName`, which for easter eggs like `EasterEgg::Custom` can contain emojis and special characters (e.g., `🌿 w·i·l·d·f·e·r·n 🌿`). This value flows directly into `create_workspace` where it becomes the git branch name (`claudette/{name}`), causing branch creation to fail.

**Changes:**
- Added `slug()` method to `GeneratedName` — always returns `"{adjective}-{plant}"`, guaranteed branch-safe
- `generate_workspace_name` Tauri command now returns a `GeneratedWorkspaceName` struct with `slug`, `display`, and optional `message` fields
- Frontend uses `slug` for workspace creation; easter egg messages are shown as system chat messages
- Hardened `create_workspace` validation to require ASCII alphanumeric + hyphens only (defense-in-depth)

Closes #46

## Test Steps

1. Run `cargo test --all-features` — all 126 tests pass, including the new `slug_is_safe_even_for_easter_eggs` test
2. Run `cargo clippy --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — zero warnings
3. Run `cargo fmt --all --check` — clean
4. Run `bunx tsc --noEmit` in `src/ui` — clean
5. To verify the fix manually: in `src/names/mod.rs` tests, `build_name("wild", "fern")` returns slug `"wild-fern"` while `display` contains the emoji version

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)