### PR TITLE
feat: create remote workspaces from sidebar

### DIFF
--- a/.claude/projects/-home-eben-Claudette/memory/feedback_no_generated_by.md
+++ b/.claude/projects/-home-eben-Claudette/memory/feedback_no_generated_by.md
@@ -1,0 +1,11 @@
+---
+name: No attribution lines in commits or PRs
+description: Never add Co-Authored-By lines to commits or "Generated with" lines to PR descriptions
+type: feedback
+---
+
+Do not add Co-Authored-By lines to git commits or "Generated with [Claude Code]" lines to pull request descriptions.
+
+**Why:** User explicitly does not want these attribution markers in their work.
+
+**How to apply:** When creating commits, omit any Co-Authored-By trailer. When creating PRs, omit any "Generated with" or bot attribution footer.

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -89,6 +89,19 @@
   color: var(--text-muted);
 }
 
+.remoteBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--accent-primary);
+  background: rgba(var(--accent-primary-rgb), 0.1);
+  border-radius: 4px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+
 .statusIndicator {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useState } from "react";
-import { GitBranch, Layers } from "lucide-react";
+import { GitBranch, Layers, Globe } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Dashboard.module.css";
@@ -51,6 +51,7 @@ function WorkspaceCard({
   repo,
   baseBranch,
   lastMsg,
+  remoteName,
   onClick,
   index,
 }: {
@@ -58,6 +59,7 @@ function WorkspaceCard({
   repo: { name: string; icon: string | null } | undefined;
   baseBranch: string | undefined;
   lastMsg: { role: string; content: string } | undefined;
+  remoteName: string | undefined;
   onClick: () => void;
   index: number;
 }) {
@@ -99,6 +101,12 @@ function WorkspaceCard({
             <RepoIcon icon={repo.icon} size={14} className={styles.repoIcon} />
           )}
           {repo?.name ?? "Unknown"}
+          {remoteName && (
+            <span className={styles.remoteBadge}>
+              <Globe size={10} />
+              {remoteName}
+            </span>
+          )}
         </span>
         <span className={styles.statusIndicator}>
           <span className={styles.statusLabel} style={{ color: statusColor }}>
@@ -147,11 +155,17 @@ export function Dashboard() {
   const workspaces = useAppStore((s) => s.workspaces);
   const lastMessages = useAppStore((s) => s.lastMessages);
   const defaultBranches = useAppStore((s) => s.defaultBranches);
+  const remoteConnections = useAppStore((s) => s.remoteConnections);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
 
   const repoMap = useMemo(
     () => new Map(repositories.map((r) => [r.id, r])),
     [repositories]
+  );
+
+  const remoteNameMap = useMemo(
+    () => new Map(remoteConnections.map((c) => [c.id, c.name])),
+    [remoteConnections]
   );
 
   const activeWorkspaces = workspaces.filter((ws) => ws.status === "Active");
@@ -193,6 +207,7 @@ export function Dashboard() {
               repo={repo}
               baseBranch={repo ? defaultBranches[repo.id] : undefined}
               lastMsg={lastMessages[ws.id]}
+              remoteName={ws.remote_connection_id ? remoteNameMap.get(ws.remote_connection_id) : undefined}
               onClick={() => selectWorkspace(ws.id)}
               index={i}
             />

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -456,7 +456,7 @@ function RemoteConnectionGroup({
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const repoCollapsed = useAppStore((s) => s.repoCollapsed);
   const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
-  const creatingRef = useRef(false);
+  const creatingRef = useRef<Set<string>>(new Set());
 
   const remoteRepos = repositories.filter(
     (r) => r.remote_connection_id === conn.id
@@ -466,21 +466,27 @@ function RemoteConnectionGroup({
   );
 
   const handleCreateWorkspace = async (repoId: string) => {
-    if (creatingRef.current) return;
-    creatingRef.current = true;
+    if (creatingRef.current.has(repoId)) return;
+    creatingRef.current.add(repoId);
     try {
       const name = await generateWorkspaceName();
       const result = await sendRemoteCommand(conn.id, "create_workspace", {
         repository_id: repoId,
         name,
-      }) as import("../../types/workspace").Workspace;
-      const ws = { ...result, remote_connection_id: conn.id };
+      });
+      if (result === null || typeof result !== "object" || !("id" in result)) {
+        throw new Error("Remote server returned an invalid workspace");
+      }
+      const ws: import("../../types/workspace").Workspace = {
+        ...(result as Omit<import("../../types/workspace").Workspace, "remote_connection_id">),
+        remote_connection_id: conn.id,
+      };
       addWorkspace(ws);
       selectWorkspace(ws.id);
     } catch (e) {
       console.error("Failed to create remote workspace:", e);
     } finally {
-      creatingRef.current = false;
+      creatingRef.current.delete(repoId);
     }
   };
 

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   connectRemote,
   disconnectRemote,
   removeRemoteConnection,
+  sendRemoteCommand,
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
@@ -452,8 +453,10 @@ function RemoteConnectionGroup({
   const workspaces = useAppStore((s) => s.workspaces);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const addWorkspace = useAppStore((s) => s.addWorkspace);
   const repoCollapsed = useAppStore((s) => s.repoCollapsed);
   const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
+  const creatingRef = useRef(false);
 
   const remoteRepos = repositories.filter(
     (r) => r.remote_connection_id === conn.id
@@ -461,6 +464,25 @@ function RemoteConnectionGroup({
   const remoteWorkspaces = workspaces.filter(
     (w) => w.remote_connection_id === conn.id
   );
+
+  const handleCreateWorkspace = async (repoId: string) => {
+    if (creatingRef.current) return;
+    creatingRef.current = true;
+    try {
+      const name = await generateWorkspaceName();
+      const result = await sendRemoteCommand(conn.id, "create_workspace", {
+        repository_id: repoId,
+        name,
+      }) as import("../../types/workspace").Workspace;
+      const ws = { ...result, remote_connection_id: conn.id };
+      addWorkspace(ws);
+      selectWorkspace(ws.id);
+    } catch (e) {
+      console.error("Failed to create remote workspace:", e);
+    } finally {
+      creatingRef.current = false;
+    }
+  };
 
   return (
     <div className={styles.repoGroup}>
@@ -531,6 +553,16 @@ function RemoteConnectionGroup({
                     <span className={styles.runningBadge}>{runningCount}</span>
                   )}
                 </span>
+                <button
+                  className={styles.iconBtn}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCreateWorkspace(repo.id);
+                  }}
+                  title="New workspace"
+                >
+                  +
+                </button>
               </div>
               {!collapsed &&
                 repoWs.map((ws) => (


### PR DESCRIPTION
## Summary
- Adds a "+" button on remote repo headers to create new workspaces on the remote server
- Routes workspace creation through `sendRemoteCommand` JSON-RPC to the remote `claudette-server`
- Tags the returned workspace with `remote_connection_id` so it appears under the correct remote connection in the sidebar

## Test plan
- [ ] Connect to a remote claudette-server
- [ ] Verify "+" button appears on remote repo headers
- [ ] Click "+" and confirm a new workspace is created on the remote server
- [ ] Verify the new workspace appears in the sidebar under the correct remote repo
- [ ] Verify the new workspace is selected after creation
- [ ] Verify local workspace creation still works unchanged