### PR TITLE
feat: archive remote workspaces from sidebar

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -466,6 +466,7 @@ function RemoteConnectionGroup({
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
+  const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const repoCollapsed = useAppStore((s) => s.repoCollapsed);
   const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
   const creatingRef = useRef<Set<string>>(new Set());
@@ -499,6 +500,22 @@ function RemoteConnectionGroup({
       console.error("Failed to create remote workspace:", e);
     } finally {
       creatingRef.current.delete(repoId);
+    }
+  };
+
+  const handleArchive = async (wsId: string) => {
+    try {
+      await sendRemoteCommand(conn.id, "archive_workspace", {
+        workspace_id: wsId,
+      });
+      updateWorkspace(wsId, {
+        status: "Archived",
+        worktree_path: null,
+        agent_status: "Stopped",
+      });
+      if (selectedWorkspaceId === wsId) selectWorkspace(null);
+    } catch (e) {
+      console.error("Failed to archive remote workspace:", e);
     }
   };
 
@@ -603,6 +620,18 @@ function RemoteConnectionGroup({
                     <div className={styles.wsInfo}>
                       <span className={styles.wsName}>{ws.name}</span>
                       <span className={styles.wsBranch}>{ws.branch_name}</span>
+                    </div>
+                    <div className={styles.wsActions}>
+                      <button
+                        className={styles.iconBtn}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleArchive(ws.id);
+                        }}
+                        title="Archive"
+                      >
+                        <X size={12} />
+                      </button>
                     </div>
                   </div>
                 ))}

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -470,6 +470,7 @@ function RemoteConnectionGroup({
   const repoCollapsed = useAppStore((s) => s.repoCollapsed);
   const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
   const creatingRef = useRef<Set<string>>(new Set());
+  const archivingRef = useRef<Set<string>>(new Set());
 
   const remoteRepos = repositories.filter(
     (r) => r.remote_connection_id === conn.id
@@ -504,6 +505,8 @@ function RemoteConnectionGroup({
   };
 
   const handleArchive = async (wsId: string) => {
+    if (archivingRef.current.has(wsId)) return;
+    archivingRef.current.add(wsId);
     try {
       await sendRemoteCommand(conn.id, "archive_workspace", {
         workspace_id: wsId,
@@ -516,6 +519,8 @@ function RemoteConnectionGroup({
       if (selectedWorkspaceId === wsId) selectWorkspace(null);
     } catch (e) {
       console.error("Failed to archive remote workspace:", e);
+    } finally {
+      archivingRef.current.delete(wsId);
     }
   };
 


### PR DESCRIPTION
## Summary
- Adds archive (X) button on remote workspace items in the sidebar
- Routes `archive_workspace` command to the remote server via `sendRemoteCommand`
- Updates local store state on success (marks as Archived, clears worktree path, deselects if active)

## Test plan
- [ ] Connect to a remote server and expand a remote repo with workspaces
- [ ] Verify X button appears on remote workspace items
- [ ] Click X and confirm the workspace is archived on the remote server
- [ ] Verify it disappears from the active workspace list
- [ ] Verify local workspace archiving still works unchanged