### PR TITLE
fix: show no changes when workspace is on base branch

### DIFF
--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -40,7 +40,19 @@ pub async fn load_diff_files(
         .await
         .map_err(|e| e.to_string())?;
 
-    let merge_base = diff::merge_base(worktree_path, "HEAD", &base_branch)
+    let current_branch = git::current_branch(worktree_path)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // If we're on the base branch, there are no changes to show
+    if current_branch == base_branch {
+        return Ok(DiffFilesResult {
+            files: vec![],
+            merge_base: String::new(),
+        });
+    }
+
+    let merge_base = diff::merge_base(worktree_path, &current_branch, &base_branch)
         .await
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -40,15 +40,24 @@ pub async fn load_diff_files(
         .await
         .map_err(|e| e.to_string())?;
 
-    let current_branch = git::current_branch(worktree_path)
-        .await
-        .map_err(|e| e.to_string())?;
+    // Handle detached HEAD: fall back to "HEAD" for diff calculation
+    let current_branch = match git::current_branch(worktree_path).await {
+        Ok(branch) => branch,
+        Err(e) => {
+            let err = e.to_string();
+            if err.to_lowercase().contains("detached") {
+                "HEAD".to_string()
+            } else {
+                return Err(err);
+            }
+        }
+    };
 
     // If we're on the base branch, there are no changes to show
     if current_branch == base_branch {
         return Ok(DiffFilesResult {
             files: vec![],
-            merge_base: String::new(),
+            merge_base: base_branch.clone(),
         });
     }
 

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -53,8 +53,11 @@ pub async fn load_diff_files(
         }
     };
 
+    eprintln!("[DEBUG load_diff_files] workspace_id={}, base_branch='{}', current_branch='{}'", workspace_id, base_branch, current_branch);
+
     // If we're on the base branch, there are no changes to show
     if current_branch == base_branch {
+        eprintln!("[DEBUG load_diff_files] On base branch, returning empty");
         return Ok(DiffFilesResult {
             files: vec![],
             merge_base: base_branch.clone(),
@@ -65,9 +68,13 @@ pub async fn load_diff_files(
         .await
         .map_err(|e| e.to_string())?;
 
+    eprintln!("[DEBUG load_diff_files] merge_base='{}'", merge_base);
+
     let files = diff::changed_files(worktree_path, &merge_base)
         .await
         .map_err(|e| e.to_string())?;
+
+    eprintln!("[DEBUG load_diff_files] found {} files", files.len());
 
     Ok(DiffFilesResult { files, merge_base })
 }


### PR DESCRIPTION
## Summary

- Fix changed files sidebar showing incorrect file count when workspace is on base branch
- Get actual current branch instead of using "HEAD" literal in merge-base calculation  
- Return empty changes list when current branch equals base branch

## Problem

When creating a new workspace on the main branch (or any base branch), the changed files sidebar incorrectly showed 82+ files. This included all uncommitted and untracked files in the working tree.

**Root cause**: The code was using the string literal "HEAD" in the merge-base calculation:
```rust
let merge_base = diff::merge_base(worktree_path, "HEAD", &base_branch).await?;
```

When you're ON the main branch:
- `merge_base("HEAD", "main")` returns the current commit
- `diff::changed_files(current_commit)` then shows ALL working tree changes
- This included build artifacts, node_modules, etc. that aren't tracked

## Solution

1. Get the actual current branch name with `git::current_branch()`
2. Compare current branch to base branch
3. If they match, return empty (no changes to show)
4. Otherwise, calculate merge-base using actual branch names

## Test Plan

- [x] Create new workspace on main branch → shows "No changes"
- [x] Create workspace on feature branch → shows only changes vs main
- [x] Switch existing workspace to main → refreshes to show "No changes"
- [x] Clippy passes with no warnings

## Before/After

**Before**: New workspace on main shows 82 files (all uncommitted/untracked)  
**After**: New workspace on main shows "No changes" correctly