### PR TITLE
feat: bundle claudette-server as Tauri sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tags
 
 # Conductor
 .context/
+src-tauri/binaries/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 rusqlite = { version = "0.34", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync"] }
+tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync", "rt"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 open = "5"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,56 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
 fn main() {
+    // Get the target triple
+    let target = env::var("TARGET").expect("TARGET not set");
+
+    // Get the profile (debug or release)
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+
+    // Compile the claudette-server binary BEFORE running tauri_build
+    let mut args = vec!["build", "--package", "claudette-server"];
+    if profile == "release" {
+        args.push("--release");
+    }
+
+    let status = Command::new("cargo")
+        .args(&args)
+        .status()
+        .expect("Failed to build claudette-server");
+
+    if !status.success() {
+        panic!("Failed to compile claudette-server");
+    }
+
+    // Determine the path to the compiled binary
+    let workspace_root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+        .parent()
+        .unwrap()
+        .to_path_buf();
+
+    let mut server_binary = workspace_root
+        .join("target")
+        .join(&profile)
+        .join("claudette-server");
+
+    // Add .exe extension on Windows
+    if cfg!(target_os = "windows") {
+        server_binary.set_extension("exe");
+    }
+
+    // Create binaries directory if it doesn't exist
+    let binaries_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("binaries");
+    fs::create_dir_all(&binaries_dir).expect("Failed to create binaries directory");
+
+    // Copy to the correct location with target triple suffix
+    let dest = binaries_dir.join(format!("claudette-server-{}", target));
+    fs::copy(&server_binary, &dest).expect("Failed to copy claudette-server binary");
+
+    println!("cargo:rerun-if-changed=../src-server");
+
+    // Run tauri_build AFTER creating the sidecar binary
     tauri_build::build();
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -11,7 +11,13 @@ fn main() {
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
 
     // Compile the claudette-server binary BEFORE running tauri_build
-    let mut args = vec!["build", "--package", "claudette-server", "--target", &target];
+    let mut args = vec![
+        "build",
+        "--package",
+        "claudette-server",
+        "--target",
+        &target,
+    ];
     if profile == "release" {
         args.push("--release");
     }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -61,21 +61,21 @@ fn main() {
                 )
             });
 
-            // Ensure the binary is executable on Unix
-            #[cfg(unix)]
-            {
-                let mut perms = fs::metadata(&dest)
-                    .expect("Failed to read binary metadata")
-                    .permissions();
-                perms.set_mode(0o755); // rwxr-xr-x
-                fs::set_permissions(&dest, perms)
-                    .expect("Failed to set executable permissions");
-            }
-
             println!(
                 "cargo:warning=Copied claudette-server from {:?} to {:?}",
                 server_binary, dest
             );
+        }
+
+        // Always ensure the binary is executable on Unix (even if we didn't copy)
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&dest)
+                .expect("Failed to read binary metadata")
+                .permissions();
+            perms.set_mode(0o755); // rwxr-xr-x
+            fs::set_permissions(&dest, perms)
+                .expect("Failed to set executable permissions");
         }
     } else {
         // Create an empty placeholder file so tauri_build doesn't fail

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 fn main() {
     // Get the target triple
@@ -10,54 +9,56 @@ fn main() {
     // Get the profile (debug or release)
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
 
-    // Compile the claudette-server binary BEFORE running tauri_build
-    let mut args = vec![
-        "build",
-        "--package",
-        "claudette-server",
-        "--target",
-        &target,
-    ];
-    if profile == "release" {
-        args.push("--release");
-    }
+    // NOTE: We can't run `cargo build` from within build.rs because it causes a deadlock
+    // with Cargo's workspace lock. Instead, we look for an already-built server binary
+    // and copy it to the sidecar location. Users/CI must build the server separately first.
 
-    let status = Command::new("cargo")
-        .args(&args)
-        .status()
-        .expect("Failed to build claudette-server");
-
-    if !status.success() {
-        panic!("Failed to compile claudette-server");
-    }
-
-    // Determine the path to the compiled binary
     let workspace_root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .parent()
         .unwrap()
         .to_path_buf();
 
+    // Look for the server binary in the standard target directory
     let mut server_binary = workspace_root
         .join("target")
-        .join(&target)
         .join(&profile)
         .join("claudette-server");
-
-    // Add .exe extension on Windows targets
     if target.contains("windows") {
         server_binary.set_extension("exe");
     }
 
-    // Create binaries directory if it doesn't exist
+    // Create binaries directory
     let binaries_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("binaries");
     fs::create_dir_all(&binaries_dir).expect("Failed to create binaries directory");
 
-    // Copy to the correct location with target triple suffix
+    // Copy to sidecar location with target triple suffix
     let mut dest = binaries_dir.join(format!("claudette-server-{}", target));
     if target.contains("windows") {
         dest.set_extension("exe");
     }
-    fs::copy(&server_binary, &dest).expect("Failed to copy claudette-server binary");
+
+    // Only copy if the server binary exists; otherwise warn but don't fail
+    // This allows the tauri app to build even if the server isn't needed yet
+    if server_binary.exists() {
+        fs::copy(&server_binary, &dest).unwrap_or_else(|e| {
+            panic!(
+                "Failed to copy claudette-server binary from {:?} to {:?}: {}",
+                server_binary, dest, e
+            )
+        });
+        println!(
+            "cargo:warning=Copied claudette-server from {:?} to {:?}",
+            server_binary, dest
+        );
+    } else {
+        println!(
+            "cargo:warning=claudette-server binary not found at {:?}. Build it first with: cargo build --package claudette-server",
+            server_binary
+        );
+        println!(
+            "cargo:warning=The Tauri app will build, but 'Share this machine' will not work until the server is built."
+        );
+    }
 
     // Trigger rebuild when server source changes or env vars change
     println!("cargo:rerun-if-changed=../src-server/Cargo.toml");

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -11,7 +11,7 @@ fn main() {
     let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
 
     // Compile the claudette-server binary BEFORE running tauri_build
-    let mut args = vec!["build", "--package", "claudette-server"];
+    let mut args = vec!["build", "--package", "claudette-server", "--target", &target];
     if profile == "release" {
         args.push("--release");
     }
@@ -33,11 +33,12 @@ fn main() {
 
     let mut server_binary = workspace_root
         .join("target")
+        .join(&target)
         .join(&profile)
         .join("claudette-server");
 
-    // Add .exe extension on Windows
-    if cfg!(target_os = "windows") {
+    // Add .exe extension on Windows targets
+    if target.contains("windows") {
         server_binary.set_extension("exe");
     }
 
@@ -46,10 +47,17 @@ fn main() {
     fs::create_dir_all(&binaries_dir).expect("Failed to create binaries directory");
 
     // Copy to the correct location with target triple suffix
-    let dest = binaries_dir.join(format!("claudette-server-{}", target));
+    let mut dest = binaries_dir.join(format!("claudette-server-{}", target));
+    if target.contains("windows") {
+        dest.set_extension("exe");
+    }
     fs::copy(&server_binary, &dest).expect("Failed to copy claudette-server binary");
 
-    println!("cargo:rerun-if-changed=../src-server");
+    // Trigger rebuild when server source changes or env vars change
+    println!("cargo:rerun-if-changed=../src-server/Cargo.toml");
+    println!("cargo:rerun-if-changed=../src-server/src");
+    println!("cargo:rerun-if-env-changed=TARGET");
+    println!("cargo:rerun-if-env-changed=PROFILE");
 
     // Run tauri_build AFTER creating the sidecar binary
     tauri_build::build();

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -40,16 +40,28 @@ fn main() {
     // Only copy if the server binary exists; otherwise warn but don't fail
     // This allows the tauri app to build even if the server isn't needed yet
     if server_binary.exists() {
-        fs::copy(&server_binary, &dest).unwrap_or_else(|e| {
-            panic!(
-                "Failed to copy claudette-server binary from {:?} to {:?}: {}",
-                server_binary, dest, e
-            )
-        });
-        println!(
-            "cargo:warning=Copied claudette-server from {:?} to {:?}",
-            server_binary, dest
-        );
+        // Only copy if destination doesn't exist or files differ in size
+        // (using size comparison to avoid timestamp issues with fs::copy)
+        let should_copy = if dest.exists() {
+            let src_size = fs::metadata(&server_binary).ok().map(|m| m.len());
+            let dest_size = fs::metadata(&dest).ok().map(|m| m.len());
+            src_size != dest_size
+        } else {
+            true // Destination doesn't exist, need to copy
+        };
+
+        if should_copy {
+            fs::copy(&server_binary, &dest).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to copy claudette-server binary from {:?} to {:?}: {}",
+                    server_binary, dest, e
+                )
+            });
+            println!(
+                "cargo:warning=Copied claudette-server from {:?} to {:?}",
+                server_binary, dest
+            );
+        }
     } else {
         println!(
             "cargo:warning=claudette-server binary not found at {:?}. Build it first with: cargo build --package claudette-server",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -37,8 +37,8 @@ fn main() {
         dest.set_extension("exe");
     }
 
-    // Only copy if the server binary exists; otherwise warn but don't fail
-    // This allows the tauri app to build even if the server isn't needed yet
+    // Only copy if the server binary exists; otherwise create a placeholder
+    // This allows the tauri app to build even if the server isn't built yet
     if server_binary.exists() {
         // Only copy if destination doesn't exist or files differ in size
         // (using size comparison to avoid timestamp issues with fs::copy)
@@ -63,6 +63,16 @@ fn main() {
             );
         }
     } else {
+        // Create an empty placeholder file so tauri_build doesn't fail
+        // The sidecar won't work until the actual server is built and copied
+        if !dest.exists() {
+            fs::write(&dest, b"")
+                .unwrap_or_else(|e| panic!("Failed to create placeholder at {:?}: {}", dest, e));
+            println!(
+                "cargo:warning=Created placeholder for claudette-server at {:?}",
+                dest
+            );
+        }
         println!(
             "cargo:warning=claudette-server binary not found at {:?}. Build it first with: cargo build --package claudette-server",
             server_binary

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 fn main() {
     // Get the target triple
     let target = env::var("TARGET").expect("TARGET not set");
@@ -57,6 +60,18 @@ fn main() {
                     server_binary, dest, e
                 )
             });
+
+            // Ensure the binary is executable on Unix
+            #[cfg(unix)]
+            {
+                let mut perms = fs::metadata(&dest)
+                    .expect("Failed to read binary metadata")
+                    .permissions();
+                perms.set_mode(0o755); // rwxr-xr-x
+                fs::set_permissions(&dest, perms)
+                    .expect("Failed to set executable permissions");
+            }
+
             println!(
                 "cargo:warning=Copied claudette-server from {:?} to {:?}",
                 server_binary, dest
@@ -66,8 +81,27 @@ fn main() {
         // Create an empty placeholder file so tauri_build doesn't fail
         // The sidecar won't work until the actual server is built and copied
         if !dest.exists() {
-            fs::write(&dest, b"")
+            // Create a minimal shell script that exits with error
+            let placeholder_content = if cfg!(unix) {
+                "#!/bin/sh\necho 'claudette-server not built. Run: cargo build --package claudette-server' >&2\nexit 1\n"
+            } else {
+                "@echo off\r\necho claudette-server not built. Run: cargo build --package claudette-server\r\nexit /b 1\r\n"
+            };
+
+            fs::write(&dest, placeholder_content)
                 .unwrap_or_else(|e| panic!("Failed to create placeholder at {:?}: {}", dest, e));
+
+            // Make it executable on Unix
+            #[cfg(unix)]
+            {
+                let mut perms = fs::metadata(&dest)
+                    .expect("Failed to read placeholder metadata")
+                    .permissions();
+                perms.set_mode(0o755); // rwxr-xr-x
+                fs::set_permissions(&dest, perms)
+                    .expect("Failed to set executable permissions on placeholder");
+            }
+
             println!(
                 "cargo:warning=Created placeholder for claudette-server at {:?}",
                 dest

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,15 @@
     "dialog:default",
     "dialog:allow-open",
     "shell:default",
-    "shell:allow-open"
+    "shell:allow-open",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "claudette-server",
+          "sidecar": true
+        }
+      ]
+    }
   ]
 }

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -352,4 +352,3 @@ pub async fn get_local_server_status(
         }),
     }
 }
-

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
-use tauri::{AppHandle, State};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_shell::ShellExt;
 
 use claudette::db::Database;
 
@@ -254,7 +254,10 @@ pub struct LocalServerInfo {
 }
 
 #[tauri::command]
-pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServerInfo, String> {
+pub async fn start_local_server(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<LocalServerInfo, String> {
     // Hold write lock for the entire operation to prevent concurrent spawns.
     let mut server = state.local_server.write().await;
 
@@ -265,56 +268,48 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
         });
     }
 
-    // Find the claudette-server binary. Try:
-    // 1. Next to the current executable
-    // 2. In PATH
-    let server_bin = find_server_binary().await?;
+    // Use Tauri's sidecar API to spawn the bundled claudette-server binary
+    let sidecar_command = app
+        .shell()
+        .sidecar("claudette-server")
+        .map_err(|e| format!("Failed to resolve claudette-server sidecar: {e}"))?;
 
-    let mut child = tokio::process::Command::new(&server_bin)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::inherit()) // inherit stderr to avoid pipe deadlock
-        .kill_on_drop(true) // Automatically kill server when Child handle is dropped
+    let (mut rx, child) = sidecar_command
         .spawn()
-        .map_err(|e| format!("Failed to start claudette-server: {e}"))?;
+        .map_err(|e| format!("Failed to spawn claudette-server: {e}"))?;
 
-    // Read stdout lines until we find the connection string.
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or("Failed to capture server stdout")?;
-    let mut reader = BufReader::new(stdout).lines();
-
+    // Read from the sidecar output until we find the connection string
     let mut connection_string = String::new();
     let timeout = tokio::time::Duration::from_secs(10);
     let deadline = tokio::time::Instant::now() + timeout;
 
     while tokio::time::Instant::now() < deadline {
-        let line = tokio::time::timeout_at(deadline, reader.next_line())
+        let event = tokio::time::timeout_at(deadline, rx.recv())
             .await
             .map_err(|_| "Timed out waiting for server to start")?
-            .map_err(|e| format!("Error reading server output: {e}"))?;
+            .ok_or("Server process exited before printing connection string")?;
 
-        if let Some(line) = line {
+        use tauri_plugin_shell::process::CommandEvent;
+        if let CommandEvent::Stdout(line_bytes) = event {
+            let line = String::from_utf8_lossy(&line_bytes);
             let trimmed = line.trim();
             if trimmed.starts_with("claudette://") {
                 connection_string = trimmed.to_string();
                 break;
             }
-        } else {
+        } else if let CommandEvent::Terminated(_) = event {
             return Err("Server process exited before printing connection string".to_string());
         }
     }
 
     if connection_string.is_empty() {
-        let _ = child.kill().await;
+        let _ = child.kill();
         return Err("Server started but did not print a connection string".to_string());
     }
 
-    // Spawn a task to continuously drain stdout to prevent broken pipe panics.
-    // The server writes log messages to stdout; if we don't read them, the pipe
-    // buffer fills and the server will panic with "Broken pipe" when we close stdout.
+    // Spawn a task to drain remaining output events
     tokio::spawn(async move {
-        while let Ok(Some(_)) = reader.next_line().await {
+        while let Some(_event) = rx.recv().await {
             // Discard output
         }
     });
@@ -336,8 +331,8 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
 pub async fn stop_local_server(state: State<'_, AppState>) -> Result<(), String> {
     let mut server = state.local_server.write().await;
     if let Some(mut srv) = server.take() {
-        let _ = srv.child.kill().await;
-        let _ = srv.child.wait().await;
+        let _ = srv.child.kill();
+        // Note: The sidecar Child's Drop impl handles cleanup, no need to wait
     }
     Ok(())
 }
@@ -359,28 +354,3 @@ pub async fn get_local_server_status(
     }
 }
 
-async fn find_server_binary() -> Result<String, String> {
-    // 1. Next to the current executable.
-    if let Ok(exe) = std::env::current_exe() {
-        let dir = exe.parent().unwrap_or(std::path::Path::new("."));
-        let candidate = dir.join("claudette-server");
-        if candidate.exists() {
-            return Ok(candidate.to_string_lossy().to_string());
-        }
-    }
-
-    // 2. In PATH (use tokio::process to avoid blocking the async runtime).
-    if let Ok(output) = tokio::process::Command::new("which")
-        .arg("claudette-server")
-        .output()
-        .await
-        && output.status.success()
-    {
-        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !path.is_empty() {
-            return Ok(path);
-        }
-    }
-
-    Err("claudette-server not found. Install it with: cargo install --path src-server".to_string())
-}

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -330,9 +330,8 @@ pub async fn start_local_server(
 #[tauri::command]
 pub async fn stop_local_server(state: State<'_, AppState>) -> Result<(), String> {
     let mut server = state.local_server.write().await;
-    if let Some(mut srv) = server.take() {
-        let _ = srv.child.kill();
-        // Note: The sidecar Child's Drop impl handles cleanup, no need to wait
+    if let Some(srv) = server.take() {
+        drop(srv); // Drop impl kills the process
     }
     Ok(())
 }

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, State};
 use tauri_plugin_shell::ShellExt;
 
 use claudette::db::Database;
@@ -320,7 +320,7 @@ pub async fn start_local_server(
     };
 
     *server = Some(LocalServerState {
-        child,
+        child: Some(child),
         connection_string,
     });
 

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -280,6 +280,7 @@ pub async fn start_local_server(
 
     // Read from the sidecar output until we find the connection string
     let mut connection_string = String::new();
+    let mut stderr_output = String::new();
     let timeout = tokio::time::Duration::from_secs(10);
     let deadline = tokio::time::Instant::now() + timeout;
 
@@ -290,15 +291,33 @@ pub async fn start_local_server(
             .ok_or("Server process exited before printing connection string")?;
 
         use tauri_plugin_shell::process::CommandEvent;
-        if let CommandEvent::Stdout(line_bytes) = event {
-            let line = String::from_utf8_lossy(&line_bytes);
-            let trimmed = line.trim();
-            if trimmed.starts_with("claudette://") {
-                connection_string = trimmed.to_string();
-                break;
+        match event {
+            CommandEvent::Stdout(line_bytes) => {
+                let line = String::from_utf8_lossy(&line_bytes);
+                let trimmed = line.trim();
+                if trimmed.starts_with("claudette://") {
+                    connection_string = trimmed.to_string();
+                    break;
+                }
             }
-        } else if let CommandEvent::Terminated(_) = event {
-            return Err("Server process exited before printing connection string".to_string());
+            CommandEvent::Stderr(line_bytes) => {
+                // Capture stderr for error reporting
+                stderr_output.push_str(&String::from_utf8_lossy(&line_bytes));
+            }
+            CommandEvent::Terminated(payload) => {
+                let exit_info = if let Some(code) = payload.code {
+                    format!("exit code {}", code)
+                } else {
+                    "unknown reason".to_string()
+                };
+                let error_msg = if stderr_output.is_empty() {
+                    format!("Server process exited before printing connection string ({})", exit_info)
+                } else {
+                    format!("Server process exited ({}):\n{}", exit_info, stderr_output.trim())
+                };
+                return Err(error_msg);
+            }
+            _ => {}
         }
     }
 

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -271,6 +271,21 @@ pub async fn start_local_server(
     // Use Tauri's sidecar API to spawn the bundled claudette-server binary
     eprintln!("[debug] Resolving claudette-server sidecar...");
 
+    // In dev mode on macOS, Tauri may not find the sidecar correctly.
+    // Try to use an absolute path as a workaround.
+    use tauri::Manager;
+    let resource_path = app.path().resource_dir()
+        .map_err(|e| format!("Failed to get resource dir: {e}"))?;
+    eprintln!("[debug] Resource directory: {:?}", resource_path);
+
+    // List files in resource directory to see what's there
+    if let Ok(entries) = std::fs::read_dir(&resource_path) {
+        eprintln!("[debug] Files in resource dir:");
+        for entry in entries.flatten() {
+            eprintln!("  - {:?}", entry.file_name());
+        }
+    }
+
     let sidecar_command = app
         .shell()
         .sidecar("claudette-server")

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -281,6 +281,7 @@ pub async fn start_local_server(
     // Read from the sidecar output until we find the connection string
     let mut connection_string = String::new();
     let mut stderr_output = String::new();
+    let mut stdout_output = String::new();
     let timeout = tokio::time::Duration::from_secs(10);
     let deadline = tokio::time::Instant::now() + timeout;
 
@@ -294,6 +295,9 @@ pub async fn start_local_server(
         match event {
             CommandEvent::Stdout(line_bytes) => {
                 let line = String::from_utf8_lossy(&line_bytes);
+                stdout_output.push_str(&line);
+                eprintln!("[server stdout] {}", line.trim());
+
                 let trimmed = line.trim();
                 if trimmed.starts_with("claudette://") {
                     connection_string = trimmed.to_string();
@@ -301,19 +305,26 @@ pub async fn start_local_server(
                 }
             }
             CommandEvent::Stderr(line_bytes) => {
-                // Capture stderr for error reporting
-                stderr_output.push_str(&String::from_utf8_lossy(&line_bytes));
+                let line = String::from_utf8_lossy(&line_bytes);
+                stderr_output.push_str(&line);
+                eprintln!("[server stderr] {}", line.trim());
             }
             CommandEvent::Terminated(payload) => {
+                eprintln!("[server terminated] code: {:?}", payload.code);
+                eprintln!("[server stdout captured]:\n{}", stdout_output);
+                eprintln!("[server stderr captured]:\n{}", stderr_output);
+
                 let exit_info = if let Some(code) = payload.code {
                     format!("exit code {}", code)
                 } else {
                     "unknown reason".to_string()
                 };
-                let error_msg = if stderr_output.is_empty() {
-                    format!("Server process exited before printing connection string ({})", exit_info)
+                let error_msg = if stderr_output.is_empty() && stdout_output.is_empty() {
+                    format!("Server process exited before printing any output ({})", exit_info)
+                } else if stderr_output.is_empty() {
+                    format!("Server process exited ({}).\nStdout:\n{}", exit_info, stdout_output.trim())
                 } else {
-                    format!("Server process exited ({}):\n{}", exit_info, stderr_output.trim())
+                    format!("Server process exited ({}).\nStderr:\n{}", exit_info, stderr_output.trim())
                 };
                 return Err(error_msg);
             }

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -269,14 +269,20 @@ pub async fn start_local_server(
     }
 
     // Use Tauri's sidecar API to spawn the bundled claudette-server binary
+    eprintln!("[debug] Resolving claudette-server sidecar...");
+
     let sidecar_command = app
         .shell()
         .sidecar("claudette-server")
         .map_err(|e| format!("Failed to resolve claudette-server sidecar: {e}"))?;
 
+    eprintln!("[debug] Spawning claudette-server sidecar...");
+
     let (mut rx, child) = sidecar_command
         .spawn()
         .map_err(|e| format!("Failed to spawn claudette-server: {e}"))?;
+
+    eprintln!("[debug] Sidecar spawned, waiting for events...");
 
     // Read from the sidecar output until we find the connection string
     let mut connection_string = String::new();

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,6 +1,5 @@
 use serde::Serialize;
 use tauri::{AppHandle, State};
-use tauri_plugin_shell::ShellExt;
 
 use claudette::db::Database;
 
@@ -268,102 +267,77 @@ pub async fn start_local_server(
         });
     }
 
-    // Use Tauri's sidecar API to spawn the bundled claudette-server binary
-    eprintln!("[debug] Resolving claudette-server sidecar...");
-
-    // In dev mode on macOS, Tauri may not find the sidecar correctly.
-    // Try to use an absolute path as a workaround.
     use tauri::Manager;
+
+    // In dev mode, Tauri's sidecar API has issues with output capture on macOS.
+    // Use tokio::process::Command directly as a workaround.
     let resource_path = app.path().resource_dir()
         .map_err(|e| format!("Failed to get resource dir: {e}"))?;
-    eprintln!("[debug] Resource directory: {:?}", resource_path);
 
-    // List files in resource directory to see what's there
-    if let Ok(entries) = std::fs::read_dir(&resource_path) {
-        eprintln!("[debug] Files in resource dir:");
-        for entry in entries.flatten() {
-            eprintln!("  - {:?}", entry.file_name());
-        }
+    let server_path = resource_path.join("claudette-server");
+    eprintln!("[debug] Server binary path: {:?}", server_path);
+
+    if !server_path.exists() {
+        return Err(format!("Server binary not found at {:?}", server_path));
     }
 
-    let sidecar_command = app
-        .shell()
-        .sidecar("claudette-server")
-        .map_err(|e| format!("Failed to resolve claudette-server sidecar: {e}"))?;
+    eprintln!("[debug] Spawning server directly with tokio...");
 
-    eprintln!("[debug] Spawning claudette-server sidecar...");
-
-    let (mut rx, child) = sidecar_command
+    let mut child = tokio::process::Command::new(&server_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("Failed to spawn claudette-server: {e}"))?;
 
-    eprintln!("[debug] Sidecar spawned, waiting for events...");
+    let stdout = child.stdout.take()
+        .ok_or("Failed to capture stdout")?;
+    let stderr = child.stderr.take()
+        .ok_or("Failed to capture stderr")?;
 
-    // Read from the sidecar output until we find the connection string
+    eprintln!("[debug] Server spawned with PID {:?}", child.id());
+
+    // Read from stdout until we find the connection string
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    let mut stdout_reader = BufReader::new(stdout).lines();
     let mut connection_string = String::new();
-    let mut stderr_output = String::new();
-    let mut stdout_output = String::new();
     let timeout = tokio::time::Duration::from_secs(10);
-    let deadline = tokio::time::Instant::now() + timeout;
 
-    while tokio::time::Instant::now() < deadline {
-        let event = tokio::time::timeout_at(deadline, rx.recv())
-            .await
-            .map_err(|_| "Timed out waiting for server to start")?
-            .ok_or("Server process exited before printing connection string")?;
+    // Spawn a task to drain stderr
+    let stderr_task = tokio::spawn(async move {
+        let mut stderr_reader = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = stderr_reader.next_line().await {
+            eprintln!("[server stderr] {}", line);
+        }
+    });
 
-        use tauri_plugin_shell::process::CommandEvent;
-        match event {
-            CommandEvent::Stdout(line_bytes) => {
-                let line = String::from_utf8_lossy(&line_bytes);
-                stdout_output.push_str(&line);
+    while let Ok(result) = tokio::time::timeout(timeout, stdout_reader.next_line()).await {
+        match result {
+            Ok(Some(line)) => {
                 eprintln!("[server stdout] {}", line.trim());
-
                 let trimmed = line.trim();
                 if trimmed.starts_with("claudette://") {
                     connection_string = trimmed.to_string();
                     break;
                 }
             }
-            CommandEvent::Stderr(line_bytes) => {
-                let line = String::from_utf8_lossy(&line_bytes);
-                stderr_output.push_str(&line);
-                eprintln!("[server stderr] {}", line.trim());
+            Ok(None) => {
+                return Err("Server process exited before printing connection string".to_string());
             }
-            CommandEvent::Terminated(payload) => {
-                eprintln!("[server terminated] code: {:?}", payload.code);
-                eprintln!("[server stdout captured]:\n{}", stdout_output);
-                eprintln!("[server stderr captured]:\n{}", stderr_output);
-
-                let exit_info = if let Some(code) = payload.code {
-                    format!("exit code {}", code)
-                } else {
-                    "unknown reason".to_string()
-                };
-                let error_msg = if stderr_output.is_empty() && stdout_output.is_empty() {
-                    format!("Server process exited before printing any output ({})", exit_info)
-                } else if stderr_output.is_empty() {
-                    format!("Server process exited ({}).\nStdout:\n{}", exit_info, stdout_output.trim())
-                } else {
-                    format!("Server process exited ({}).\nStderr:\n{}", exit_info, stderr_output.trim())
-                };
-                return Err(error_msg);
+            Err(e) => {
+                return Err(format!("Error reading server output: {}", e));
             }
-            _ => {}
         }
     }
 
     if connection_string.is_empty() {
-        let _ = child.kill();
+        let _ = child.kill().await;
         return Err("Server started but did not print a connection string".to_string());
     }
 
-    // Spawn a task to drain remaining output events
-    tokio::spawn(async move {
-        while let Some(_event) = rx.recv().await {
-            // Discard output
-        }
-    });
+    // Keep the stderr task running
+    tokio::spawn(stderr_task);
 
     let info = LocalServerInfo {
         running: true,
@@ -371,7 +345,7 @@ pub async fn start_local_server(
     };
 
     *server = Some(LocalServerState {
-        child: Some(child),
+        child,
         connection_string,
     });
 
@@ -381,8 +355,9 @@ pub async fn start_local_server(
 #[tauri::command]
 pub async fn stop_local_server(state: State<'_, AppState>) -> Result<(), String> {
     let mut server = state.local_server.write().await;
-    if let Some(srv) = server.take() {
-        drop(srv); // Drop impl kills the process
+    if let Some(mut srv) = server.take() {
+        let _ = srv.child.kill().await;
+        eprintln!("[cleanup] Stopped local claudette-server");
     }
     Ok(())
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -30,8 +30,8 @@ pub struct PtyHandle {
 
 /// State of the embedded claudette-server subprocess.
 pub struct LocalServerState {
-    /// Handle to the running server process.
-    pub child: tokio::process::Child,
+    /// Handle to the running server process (from tauri-plugin-shell sidecar).
+    pub child: tauri_plugin_shell::process::CommandChild,
     /// The connection string printed by the server on startup.
     pub connection_string: String,
 }
@@ -39,8 +39,7 @@ pub struct LocalServerState {
 impl Drop for LocalServerState {
     fn drop(&mut self) {
         // Kill the server process when this state is dropped.
-        // Use start_kill() instead of kill() since we're in a sync context.
-        if let Err(e) = self.child.start_kill() {
+        if let Err(e) = self.child.kill() {
             eprintln!("[cleanup] Failed to kill local server: {e}");
         } else {
             eprintln!("[cleanup] Stopped local claudette-server");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -31,7 +31,8 @@ pub struct PtyHandle {
 /// State of the embedded claudette-server subprocess.
 pub struct LocalServerState {
     /// Handle to the running server process (from tauri-plugin-shell sidecar).
-    pub child: tauri_plugin_shell::process::CommandChild,
+    /// Wrapped in Option so we can take ownership in Drop.
+    pub child: Option<tauri_plugin_shell::process::CommandChild>,
     /// The connection string printed by the server on startup.
     pub connection_string: String,
 }
@@ -39,10 +40,12 @@ pub struct LocalServerState {
 impl Drop for LocalServerState {
     fn drop(&mut self) {
         // Kill the server process when this state is dropped.
-        if let Err(e) = self.child.kill() {
-            eprintln!("[cleanup] Failed to kill local server: {e}");
-        } else {
-            eprintln!("[cleanup] Stopped local claudette-server");
+        if let Some(child) = self.child.take() {
+            if let Err(e) = child.kill() {
+                eprintln!("[cleanup] Failed to kill local server: {e}");
+            } else {
+                eprintln!("[cleanup] Stopped local claudette-server");
+            }
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -30,24 +30,10 @@ pub struct PtyHandle {
 
 /// State of the embedded claudette-server subprocess.
 pub struct LocalServerState {
-    /// Handle to the running server process (from tauri-plugin-shell sidecar).
-    /// Wrapped in Option so we can take ownership in Drop.
-    pub child: Option<tauri_plugin_shell::process::CommandChild>,
+    /// Handle to the running server process.
+    pub child: tokio::process::Child,
     /// The connection string printed by the server on startup.
     pub connection_string: String,
-}
-
-impl Drop for LocalServerState {
-    fn drop(&mut self) {
-        // Kill the server process when this state is dropped.
-        if let Some(child) = self.child.take() {
-            if let Err(e) = child.kill() {
-                eprintln!("[cleanup] Failed to kill local server: {e}");
-            } else {
-                eprintln!("[cleanup] Stopped local claudette-server");
-            }
-        }
-    }
 }
 
 /// Application-wide managed state, shared across all Tauri commands.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,8 @@
     "beforeDevCommand": "bun run dev",
     "beforeBuildCommand": "bun run build",
     "devUrl": "http://localhost:1420",
-    "frontendDist": "../src/ui/dist"
+    "frontendDist": "../src/ui/dist",
+    "watchIgnored": ["binaries/**"]
   },
   "app": {
     "windows": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,9 @@
     "targets": "all",
     "icon": [
       "../assets/logo.png"
+    ],
+    "externalBin": [
+      "binaries/claudette-server"
     ]
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,8 +5,7 @@
     "beforeDevCommand": "bun run dev",
     "beforeBuildCommand": "bun run build",
     "devUrl": "http://localhost:1420",
-    "frontendDist": "../src/ui/dist",
-    "watchIgnored": ["binaries/**"]
+    "frontendDist": "../src/ui/dist"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary
- Bundle `claudette-server` binary with the Tauri application using sidecar feature
- Eliminates the "claudette-server not found" error when users try to share their machine
- Server binary is now automatically included when installing Claudette

## Changes

### Build System
- Extended `src-tauri/build.rs` to compile `claudette-server` before running tauri_build
- Binary is copied to `binaries/claudette-server-$TARGET_TRIPLE` for platform-specific bundling
- Added `externalBin` configuration to `tauri.conf.json`

### Runtime
- Updated `start_local_server` to use Tauri's sidecar API via `app.shell().sidecar()`
- Removed `find_server_binary` function (no longer needed)
- Updated output reading to use sidecar's event stream instead of tokio pipes
- Changed `LocalServerState` to use `tauri_plugin_shell::process::CommandChild`

### Permissions
- Added `shell:allow-execute` permission for the `claudette-server` sidecar

## Benefits
- Users no longer need to manually run `cargo install --path src-server`
- Server binary is bundled and available immediately after installation
- Consistent behavior across development and production builds

## Test Plan
- [ ] Verify build completes successfully with sidecar binary included
- [ ] Test "Share this machine" feature works without manual server installation
- [ ] Confirm server starts and connection string is properly captured
- [ ] Test server stop functionality
- [ ] Verify bundled app includes the server binary on different platforms