### PR TITLE
fix: load diff files for remote workspaces

### DIFF
--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useAppStore } from "../../stores/useAppStore";
-import { loadDiffFiles } from "../../services/tauri";
+import { loadDiffFiles, sendRemoteCommand } from "../../services/tauri";
+import type { DiffFilesResult } from "../../services/tauri";
 import styles from "./RightSidebar.module.css";
 
 export function RightSidebar() {
@@ -17,18 +18,37 @@ export function RightSidebar() {
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = ws?.agent_status === "Running";
+  const isRemote = !!ws?.remote_connection_id;
   const prevIsRunning = useRef<boolean | undefined>(undefined);
+
+  // Load diff files for either local or remote workspace
+  const loadDiff = async (workspaceId: string) => {
+    if (!ws) return;
+
+    if (isRemote) {
+      const result = (await sendRemoteCommand(
+        ws.remote_connection_id!,
+        "load_diff_files",
+        { workspace_id: workspaceId }
+      )) as DiffFilesResult;
+      return result;
+    } else {
+      return await loadDiffFiles(workspaceId);
+    }
+  };
 
   useEffect(() => {
     if (!selectedWorkspaceId) return;
     setDiffLoading(true);
-    loadDiffFiles(selectedWorkspaceId)
-      .then(({ files, merge_base }) => {
-        setDiffFiles(files, merge_base);
+    loadDiff(selectedWorkspaceId)
+      .then((result) => {
+        if (result) {
+          setDiffFiles(result.files, result.merge_base);
+        }
         setDiffLoading(false);
       })
       .catch(() => setDiffLoading(false));
-  }, [selectedWorkspaceId, setDiffFiles, setDiffLoading]);
+  }, [selectedWorkspaceId, isRemote, setDiffFiles, setDiffLoading]);
 
   // Refresh diff files when agent stops running (after making changes)
   useEffect(() => {
@@ -40,15 +60,17 @@ export function RightSidebar() {
 
     // Debounce: wait a bit after agent stops to let file writes complete
     const timer = setTimeout(() => {
-      loadDiffFiles(selectedWorkspaceId)
-        .then(({ files, merge_base }) => {
-          setDiffFiles(files, merge_base);
+      loadDiff(selectedWorkspaceId)
+        .then((result) => {
+          if (result) {
+            setDiffFiles(result.files, result.merge_base);
+          }
         })
         .catch((e) => console.error("Failed to refresh diff files:", e));
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, setDiffFiles]);
+  }, [isRunning, selectedWorkspaceId, isRemote, setDiffFiles]);
 
   const statusLabel = (status: string | { Renamed: { from: string } }) => {
     if (typeof status === "string") {

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { loadDiffFiles, sendRemoteCommand } from "../../services/tauri";
 import type { DiffFilesResult } from "../../services/tauri";
@@ -22,20 +22,38 @@ export function RightSidebar() {
   const prevIsRunning = useRef<boolean | undefined>(undefined);
 
   // Load diff files for either local or remote workspace
-  const loadDiff = async (workspaceId: string) => {
-    if (!ws) return;
+  const loadDiff = useCallback(
+    async (workspaceId: string) => {
+      if (!ws) return;
 
-    if (isRemote) {
-      const result = (await sendRemoteCommand(
-        ws.remote_connection_id!,
-        "load_diff_files",
-        { workspace_id: workspaceId }
-      )) as DiffFilesResult;
-      return result;
-    } else {
-      return await loadDiffFiles(workspaceId);
-    }
-  };
+      if (isRemote) {
+        const connId = ws.remote_connection_id;
+        if (!connId) return;
+
+        const result = (await sendRemoteCommand(
+          connId,
+          "load_diff_files",
+          { workspace_id: workspaceId }
+        )) as DiffFilesResult;
+
+        // Validate response shape to prevent runtime errors
+        if (
+          !result ||
+          typeof result !== "object" ||
+          !Array.isArray(result.files) ||
+          typeof result.merge_base !== "string"
+        ) {
+          console.error("Invalid diff files response from remote:", result);
+          return;
+        }
+
+        return result;
+      } else {
+        return await loadDiffFiles(workspaceId);
+      }
+    },
+    [ws, isRemote]
+  );
 
   useEffect(() => {
     if (!selectedWorkspaceId) return;
@@ -48,7 +66,7 @@ export function RightSidebar() {
         setDiffLoading(false);
       })
       .catch(() => setDiffLoading(false));
-  }, [selectedWorkspaceId, isRemote, setDiffFiles, setDiffLoading]);
+  }, [selectedWorkspaceId, loadDiff, setDiffFiles, setDiffLoading]);
 
   // Refresh diff files when agent stops running (after making changes)
   useEffect(() => {
@@ -60,17 +78,22 @@ export function RightSidebar() {
 
     // Debounce: wait a bit after agent stops to let file writes complete
     const timer = setTimeout(() => {
+      setDiffLoading(true);
       loadDiff(selectedWorkspaceId)
         .then((result) => {
           if (result) {
             setDiffFiles(result.files, result.merge_base);
           }
+          setDiffLoading(false);
         })
-        .catch((e) => console.error("Failed to refresh diff files:", e));
+        .catch((e) => {
+          console.error("Failed to refresh diff files:", e);
+          setDiffLoading(false);
+        });
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [isRunning, selectedWorkspaceId, isRemote, setDiffFiles]);
+  }, [isRunning, selectedWorkspaceId, loadDiff, setDiffFiles, setDiffLoading]);
 
   const statusLabel = (status: string | { Renamed: { from: string } }) => {
     if (typeof status === "string") {


### PR DESCRIPTION
## Summary
- Fixed changed files sidebar not loading for remote workspaces
- Changed files now appear correctly when viewing remote workspaces connected via claudette-server

## Problem
The RightSidebar component was always calling the local `load_diff_files` Tauri command, which only works for local workspaces with local worktrees. For remote workspaces, the worktree exists on the remote server, not locally, so the command would fail silently.

## Solution
- Added detection for remote workspaces via the `remote_connection_id` field
- Created a `loadDiff` helper function that routes requests appropriately:
  - **Remote workspaces**: Uses `sendRemoteCommand` to call `load_diff_files` on the remote server
  - **Local workspaces**: Uses the existing local `loadDiffFiles` command
- Updated both initial load and auto-refresh on agent stop to use the new routing logic

## Changes
- Modified `RightSidebar.tsx` to detect remote vs local workspaces
- Imported `sendRemoteCommand` and `DiffFilesResult` type
- Added `isRemote` flag based on `ws.remote_connection_id`
- Created async `loadDiff` wrapper that dispatches to correct backend
- Updated useEffect dependencies to include `isRemote`

## Test Plan
- [x] TypeScript builds without errors
- [x] Verify changed files load for local workspaces (regression test)
- [x] Verify changed files load for remote workspaces (bug fix)
- [x] Confirm auto-refresh works after agent stops on remote workspace
- [x] Test switching between local and remote workspaces