### PR TITLE
perf: minimize React re-renders across UI components

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import { memo, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { GitBranch, LayoutDashboard } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
+import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
   loadChatHistory,
   listSlashCommands,
@@ -31,12 +32,9 @@ export function ChatPanel() {
   const chatMessages = useAppStore((s) => s.chatMessages);
   const setChatMessages = useAppStore((s) => s.setChatMessages);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
-  const streamingContent = useAppStore((s) => s.streamingContent);
-  const toolActivities = useAppStore((s) => s.toolActivities);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [currentTurnCollapsed, setCurrentTurnCollapsed] = useState(true);
 
   // Prompt history: stores past user inputs per workspace.
   const historyRef = useRef<Record<string, string[]>>({});
@@ -54,17 +52,14 @@ export function ChatPanel() {
   const messages = selectedWorkspaceId
     ? chatMessages[selectedWorkspaceId] || []
     : [];
-  const streaming = selectedWorkspaceId
-    ? streamingContent[selectedWorkspaceId] || ""
-    : "";
-  const completedTurnsMap = useAppStore((s) => s.completedTurns);
-  const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
-  const completedTurns = selectedWorkspaceId
-    ? completedTurnsMap[selectedWorkspaceId] ?? []
-    : [];
-  const activities = selectedWorkspaceId
-    ? toolActivities[selectedWorkspaceId] || []
-    : [];
+  // Subscribe only to boolean — avoids re-render on every streaming character
+  const hasStreaming = useAppStore(
+    (s) => !!(selectedWorkspaceId && s.streamingContent[selectedWorkspaceId])
+  );
+  // Subscribe only to count — avoids re-render on tool activity content changes
+  const activitiesCount = useAppStore(
+    (s) => (selectedWorkspaceId ? (s.toolActivities[selectedWorkspaceId] || []).length : 0)
+  );
   const permissionLevelMap = useAppStore((s) => s.permissionLevel);
   const setPermissionLevel = useAppStore((s) => s.setPermissionLevel);
   const permissionLevel = selectedWorkspaceId
@@ -155,19 +150,10 @@ export function ChatPanel() {
       .catch((e) => console.error("Failed to load chat history:", e));
   }, [selectedWorkspaceId, setChatMessages]);
 
-  // Auto-scroll to bottom
+  // Auto-scroll to bottom (on new messages only — streaming handles its own scroll)
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length, streaming]);
-
-  // Collapse current turn when a new turn starts (activities goes from 0 to non-zero)
-  const prevActivitiesLengthRef = useRef(0);
-  useEffect(() => {
-    if (isRunning && activities.length > 0 && prevActivitiesLengthRef.current === 0) {
-      setCurrentTurnCollapsed(true);
-    }
-    prevActivitiesLengthRef.current = activities.length;
-  }, [isRunning, activities.length]);
+  }, [messages.length]);
 
   if (!ws) return null;
 
@@ -338,7 +324,7 @@ export function ChatPanel() {
       <div className={styles.messages}>
         {error && <div className={styles.errorBanner}>{error}</div>}
 
-        {messages.length === 0 && !streaming ? (
+        {messages.length === 0 && !hasStreaming ? (
           <div className={styles.empty}>
             Send a message to start a conversation
           </div>
@@ -368,110 +354,19 @@ export function ChatPanel() {
               </div>
             ))}
 
-            {completedTurns.map((turn, ti) => (
-              <div
-                key={turn.id}
-                className={styles.turnSummary}
-                role="button"
-                tabIndex={0}
-                onClick={() =>
-                  selectedWorkspaceId &&
-                  toggleCompletedTurn(selectedWorkspaceId, ti)
-                }
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    selectedWorkspaceId &&
-                      toggleCompletedTurn(selectedWorkspaceId, ti);
-                  }
-                }}
-              >
-                <div className={styles.turnHeader}>
-                  <span className={styles.toolChevron}>
-                    {turn.collapsed ? "›" : "⌄"}
-                  </span>
-                  <span className={styles.turnLabel}>
-                    {turn.activities.length} tool call
-                    {turn.activities.length !== 1 ? "s" : ""}
-                    {turn.messageCount > 0 &&
-                      `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
-                  </span>
-                </div>
-                {!turn.collapsed && (
-                  <div className={styles.turnActivities}>
-                    {turn.activities.map((act) => (
-                      <div
-                        key={act.toolUseId}
-                        className={styles.toolActivity}
-                      >
-                        <div className={styles.toolHeader}>
-                          <span className={styles.toolName}>
-                            {act.toolName}
-                          </span>
-                          {act.summary && (
-                            <span className={styles.toolSummary}>
-                              {act.summary}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
-
-            {activities.length > 0 && (
-              <div className={styles.toolActivities} aria-live="polite" aria-atomic="true">
-                <div className={styles.turnSummary}>
-                  <div
-                    className={styles.turnHeader}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => setCurrentTurnCollapsed(!currentTurnCollapsed)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        setCurrentTurnCollapsed(!currentTurnCollapsed);
-                      }
-                    }}
-                  >
-                    <span className={styles.toolChevron}>
-                      {currentTurnCollapsed ? "›" : "⌄"}
-                    </span>
-                    <span className={styles.turnLabel}>
-                      {activities.length} tool call{activities.length !== 1 ? "s" : ""}
-                      {isRunning && <span style={{ color: "var(--accent-dim)" }}> in progress</span>}
-                    </span>
-                  </div>
-                  {!currentTurnCollapsed && (
-                    <div className={styles.turnActivities}>
-                      {activities.map((act) => (
-                        <div key={act.toolUseId} className={styles.toolActivity}>
-                          <div className={styles.toolHeader}>
-                            <span className={styles.toolName}>{act.toolName}</span>
-                            {act.summary && (
-                              <span className={styles.toolSummary}>
-                                {act.summary}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
+            {selectedWorkspaceId && (
+              <CompletedTurnsSection workspaceId={selectedWorkspaceId} />
             )}
 
-            {streaming && (
-              <div className={`${styles.message} ${styles.role_Assistant}`}>
-                <div className={styles.roleLabel}>Claude</div>
-                <div className={styles.content}>
-                  <Markdown remarkPlugins={[remarkGfm]}>{streaming}</Markdown>
-                  <span className={styles.cursor} />
-                </div>
-              </div>
+            {selectedWorkspaceId && activitiesCount > 0 && (
+              <ToolActivitiesSection
+                workspaceId={selectedWorkspaceId}
+                isRunning={isRunning ?? false}
+              />
+            )}
+
+            {selectedWorkspaceId && hasStreaming && (
+              <StreamingMessage workspaceId={selectedWorkspaceId} />
             )}
 
             {isRunning && !pendingQuestion && (
@@ -511,6 +406,197 @@ export function ChatPanel() {
     </div>
   );
 }
+
+/**
+ * Isolated streaming message component — subscribes to streaming text directly
+ * and throttles Markdown re-parsing to ~10fps via requestAnimationFrame.
+ * This prevents the entire ChatPanel from re-rendering on every character delta.
+ */
+const StreamingMessage = memo(function StreamingMessage({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const streaming = useAppStore(
+    (s) => s.streamingContent[workspaceId] || ""
+  );
+
+  // Throttle Markdown rendering: store latest text in ref, render at rAF pace
+  const latestRef = useRef(streaming);
+  latestRef.current = streaming;
+  const [displayed, setDisplayed] = useState(streaming);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const tick = () => {
+      setDisplayed(latestRef.current);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  // Auto-scroll when streaming content grows
+  const elRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    elRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [displayed]);
+
+  if (!displayed) return null;
+
+  return (
+    <div ref={elRef} className={`${styles.message} ${styles.role_Assistant}`}>
+      <div className={styles.roleLabel}>Claude</div>
+      <div className={styles.content}>
+        <Markdown remarkPlugins={[remarkGfm]}>{displayed}</Markdown>
+        <span className={styles.cursor} />
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Completed turns section — subscribes to completedTurns for this workspace only.
+ * Isolated so it doesn't re-render on streaming or tool activity changes.
+ */
+const CompletedTurnsSection = memo(function CompletedTurnsSection({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const completedTurns = useAppStore(
+    (s) => s.completedTurns[workspaceId] ?? []
+  );
+  const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
+
+  if (completedTurns.length === 0) return null;
+
+  return (
+    <>
+      {completedTurns.map((turn: CompletedTurn, ti: number) => (
+        <div
+          key={turn.id}
+          className={styles.turnSummary}
+          role="button"
+          tabIndex={0}
+          onClick={() => toggleCompletedTurn(workspaceId, ti)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              toggleCompletedTurn(workspaceId, ti);
+            }
+          }}
+        >
+          <div className={styles.turnHeader}>
+            <span className={styles.toolChevron}>
+              {turn.collapsed ? "›" : "⌄"}
+            </span>
+            <span className={styles.turnLabel}>
+              {turn.activities.length} tool call
+              {turn.activities.length !== 1 ? "s" : ""}
+              {turn.messageCount > 0 &&
+                `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
+            </span>
+          </div>
+          {!turn.collapsed && (
+            <div className={styles.turnActivities}>
+              {turn.activities.map((act: ToolActivity) => (
+                <div
+                  key={act.toolUseId}
+                  className={styles.toolActivity}
+                >
+                  <div className={styles.toolHeader}>
+                    <span className={styles.toolName}>
+                      {act.toolName}
+                    </span>
+                    {act.summary && (
+                      <span className={styles.toolSummary}>
+                        {act.summary}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </>
+  );
+});
+
+/**
+ * Current tool activities section — subscribes to toolActivities for this workspace.
+ * Isolated so streaming text changes don't cause re-renders here.
+ */
+const ToolActivitiesSection = memo(function ToolActivitiesSection({
+  workspaceId,
+  isRunning,
+}: {
+  workspaceId: string;
+  isRunning: boolean;
+}) {
+  const activities = useAppStore(
+    (s) => s.toolActivities[workspaceId] || []
+  );
+  const [collapsed, setCollapsed] = useState(true);
+
+  // Auto-collapse when a new turn starts (activities goes from 0 to non-zero)
+  const prevLengthRef = useRef(0);
+  useEffect(() => {
+    if (isRunning && activities.length > 0 && prevLengthRef.current === 0) {
+      setCollapsed(true);
+    }
+    prevLengthRef.current = activities.length;
+  }, [isRunning, activities.length]);
+
+  if (activities.length === 0) return null;
+
+  return (
+    <div className={styles.toolActivities} aria-live="polite" aria-atomic="true">
+      <div className={styles.turnSummary}>
+        <div
+          className={styles.turnHeader}
+          role="button"
+          tabIndex={0}
+          onClick={() => setCollapsed(!collapsed)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setCollapsed(!collapsed);
+            }
+          }}
+        >
+          <span className={styles.toolChevron}>
+            {collapsed ? "›" : "⌄"}
+          </span>
+          <span className={styles.turnLabel}>
+            {activities.length} tool call{activities.length !== 1 ? "s" : ""}
+            {isRunning && <span style={{ color: "var(--accent-dim)" }}> in progress</span>}
+          </span>
+        </div>
+        {!collapsed && (
+          <div className={styles.turnActivities}>
+            {activities.map((act: ToolActivity) => (
+              <div key={act.toolUseId} className={styles.toolActivity}>
+                <div className={styles.toolHeader}>
+                  <span className={styles.toolName}>{act.toolName}</span>
+                  {act.summary && (
+                    <span className={styles.toolSummary}>
+                      {act.summary}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
 
 // Separate component for input area to prevent full ChatPanel re-renders on every keystroke
 function ChatInputArea({

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -150,10 +150,10 @@ export function ChatPanel() {
       .catch((e) => console.error("Failed to load chat history:", e));
   }, [selectedWorkspaceId, setChatMessages]);
 
-  // Auto-scroll to bottom (on new messages only — streaming handles its own scroll)
+  // Auto-scroll to bottom (on new messages or workspace switch — streaming handles its own scroll)
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length]);
+  }, [messages.length, selectedWorkspaceId]);
 
   if (!ws) return null;
 
@@ -421,15 +421,20 @@ const StreamingMessage = memo(function StreamingMessage({
     (s) => s.streamingContent[workspaceId] || ""
   );
 
-  // Throttle Markdown rendering: store latest text in ref, render at rAF pace
+  // Throttle Markdown rendering: store latest text in ref, update at ~10fps
   const latestRef = useRef(streaming);
   latestRef.current = streaming;
   const [displayed, setDisplayed] = useState(streaming);
   const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const tick = () => {
-      setDisplayed(latestRef.current);
+    let lastTime = 0;
+    const THROTTLE_MS = 100; // ~10fps
+    const tick = (time: number) => {
+      if (time - lastTime >= THROTTLE_MS) {
+        lastTime = time;
+        setDisplayed(latestRef.current);
+      }
       rafRef.current = requestAnimationFrame(tick);
     };
     rafRef.current = requestAnimationFrame(tick);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -25,6 +25,12 @@ import styles from "./ChatPanel.module.css";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+// Stable empty arrays to avoid Zustand selector re-renders when data is undefined.
+// Without these, `?? []` / `|| []` creates a new reference on every store update,
+// causing Object.is to return false and triggering unnecessary component re-renders.
+const EMPTY_COMPLETED_TURNS: CompletedTurn[] = [];
+const EMPTY_ACTIVITIES: ToolActivity[] = [];
+
 export function ChatPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -472,7 +478,7 @@ const CompletedTurnsSection = memo(function CompletedTurnsSection({
   workspaceId: string;
 }) {
   const completedTurns = useAppStore(
-    (s) => s.completedTurns[workspaceId] ?? []
+    (s) => s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS
   );
   const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
 
@@ -544,7 +550,7 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
   isRunning: boolean;
 }) {
   const activities = useAppStore(
-    (s) => s.toolActivities[workspaceId] || []
+    (s) => s.toolActivities[workspaceId] ?? EMPTY_ACTIVITIES
   );
   const [collapsed, setCollapsed] = useState(true);
 

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { Sidebar } from "../sidebar/Sidebar";
 import { ChatPanel } from "../chat/ChatPanel";
@@ -32,20 +33,20 @@ export function AppLayout() {
 
   const showDiff = diffSelectedFile !== null;
 
-  const handleLeftResize = (delta: number) => {
-    const newWidth = Math.max(150, Math.min(600, sidebarWidth + delta));
-    setSidebarWidth(newWidth);
-  };
+  const handleLeftResize = useCallback((delta: number) => {
+    const current = useAppStore.getState().sidebarWidth;
+    setSidebarWidth(Math.max(150, Math.min(600, current + delta)));
+  }, [setSidebarWidth]);
 
-  const handleRightResize = (delta: number) => {
-    const newWidth = Math.max(150, Math.min(600, rightSidebarWidth - delta));
-    setRightSidebarWidth(newWidth);
-  };
+  const handleRightResize = useCallback((delta: number) => {
+    const current = useAppStore.getState().rightSidebarWidth;
+    setRightSidebarWidth(Math.max(150, Math.min(600, current - delta)));
+  }, [setRightSidebarWidth]);
 
-  const handleTerminalResize = (delta: number) => {
-    const newHeight = Math.max(100, Math.min(800, terminalHeight - delta));
-    setTerminalHeight(newHeight);
-  };
+  const handleTerminalResize = useCallback((delta: number) => {
+    const current = useAppStore.getState().terminalHeight;
+    setTerminalHeight(Math.max(100, Math.min(800, current - delta)));
+  }, [setTerminalHeight]);
 
   return (
     <div className={styles.container}>

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useState } from "react";
+import { memo, useMemo, useEffect, useState } from "react";
 import { GitBranch, Layers, Globe } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { RepoIcon } from "../shared/RepoIcon";
@@ -46,7 +46,7 @@ function useElapsed(isRunning: boolean): number {
   return elapsed;
 }
 
-function WorkspaceCard({
+const WorkspaceCard = memo(function WorkspaceCard({
   ws,
   repo,
   baseBranch,
@@ -60,7 +60,7 @@ function WorkspaceCard({
   baseBranch: string | undefined;
   lastMsg: { role: string; content: string } | undefined;
   remoteName: string | undefined;
-  onClick: () => void;
+  onClick: (id: string | null) => void;
   index: number;
 }) {
   const isRunning = ws.agent_status === "Running";
@@ -92,7 +92,7 @@ function WorkspaceCard({
     <button
       type="button"
       className={cardClass}
-      onClick={onClick}
+      onClick={() => onClick(ws.id)}
       style={{ animationDelay: `${index * 0.04}s` }}
     >
       <div className={styles.cardHeader}>
@@ -148,7 +148,7 @@ function WorkspaceCard({
       )}
     </button>
   );
-}
+});
 
 export function Dashboard() {
   const repositories = useAppStore((s) => s.repositories);
@@ -208,7 +208,7 @@ export function Dashboard() {
               baseBranch={repo ? defaultBranches[repo.id] : undefined}
               lastMsg={lastMessages[ws.id]}
               remoteName={ws.remote_connection_id ? remoteNameMap.get(ws.remote_connection_id) : undefined}
-              onClick={() => selectWorkspace(ws.id)}
+              onClick={selectWorkspace}
               index={i}
             />
           );

--- a/src/ui/src/components/layout/ResizeHandle.tsx
+++ b/src/ui/src/components/layout/ResizeHandle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import styles from "./ResizeHandle.module.css";
 
 interface ResizeHandleProps {
@@ -6,7 +6,7 @@ interface ResizeHandleProps {
   onResize: (delta: number) => void;
 }
 
-export function ResizeHandle({
+export const ResizeHandle = memo(function ResizeHandle({
   direction,
   onResize,
 }: ResizeHandleProps) {
@@ -55,4 +55,4 @@ export function ResizeHandle({
       onMouseDown={handleMouseDown}
     />
   );
-}
+});

--- a/src/ui/src/components/layout/StatusBar.tsx
+++ b/src/ui/src/components/layout/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { useAppStore } from "../../stores/useAppStore";
+import { useShallow } from "zustand/react/shallow";
 import styles from "./StatusBar.module.css";
 
 export function StatusBar() {
@@ -8,19 +9,19 @@ export function StatusBar() {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar);
-  const workspaces = useAppStore((s) => s.workspaces);
 
-  const activeRemoteIds = useAppStore((s) => s.activeRemoteIds);
-  const remoteConnections = useAppStore((s) => s.remoteConnections);
-
-  const runningCount = workspaces.filter(
-    (ws) => ws.agent_status === "Running"
-  ).length;
-  const activeCount = workspaces.filter(
-    (ws) => ws.status === "Active"
-  ).length;
-  const connectedRemotes = remoteConnections.filter((c) =>
-    activeRemoteIds.includes(c.id)
+  const runningCount = useAppStore(
+    (s) => s.workspaces.filter((ws) => ws.agent_status === "Running").length
+  );
+  const activeCount = useAppStore(
+    (s) => s.workspaces.filter((ws) => ws.status === "Active").length
+  );
+  const connectedRemoteNames = useAppStore(
+    useShallow((s) =>
+      s.remoteConnections
+        .filter((c) => s.activeRemoteIds.includes(c.id))
+        .map((c) => c.name)
+    )
   );
 
   return (
@@ -35,9 +36,9 @@ export function StatusBar() {
         <span className={styles.statMuted}>
           {activeCount} workspace{activeCount !== 1 ? "s" : ""}
         </span>
-        {connectedRemotes.length > 0 && (
+        {connectedRemoteNames.length > 0 && (
           <span className={styles.statMuted}>
-            {connectedRemotes.map((c) => c.name).join(", ")}
+            {connectedRemoteNames.join(", ")}
           </span>
         )}
       </div>

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -18,20 +18,15 @@ export function RightSidebar() {
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = ws?.agent_status === "Running";
-  const isRemote = !!ws?.remote_connection_id;
+  const remoteConnectionId = ws?.remote_connection_id ?? null;
   const prevIsRunning = useRef<boolean | undefined>(undefined);
 
   // Load diff files for either local or remote workspace
   const loadDiff = useCallback(
     async (workspaceId: string) => {
-      if (!ws) return;
-
-      if (isRemote) {
-        const connId = ws.remote_connection_id;
-        if (!connId) return;
-
+      if (remoteConnectionId) {
         const result = (await sendRemoteCommand(
-          connId,
+          remoteConnectionId,
           "load_diff_files",
           { workspace_id: workspaceId }
         )) as DiffFilesResult;
@@ -52,7 +47,7 @@ export function RightSidebar() {
         return await loadDiffFiles(workspaceId);
       }
     },
-    [ws, isRemote]
+    [remoteConnectionId]
   );
 
   useEffect(() => {

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -24,6 +24,10 @@ export function RightSidebar() {
   // Load diff files for either local or remote workspace
   const loadDiff = useCallback(
     async (workspaceId: string) => {
+      // Guard: workspace may not be in the list yet during creation/deletion
+      const currentWs = useAppStore.getState().workspaces.find((w) => w.id === workspaceId);
+      if (!currentWs) return;
+
       if (remoteConnectionId) {
         const result = (await sendRemoteCommand(
           remoteConnectionId,

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useMemo, useCallback } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   archiveWorkspace,
@@ -35,7 +35,7 @@ export function Sidebar() {
 
   const creatingRef = useRef(false);
 
-  const handleCreateWorkspace = async (repoId: string) => {
+  const handleCreateWorkspace = useCallback(async (repoId: string) => {
     if (creatingRef.current) return;
     creatingRef.current = true;
     try {
@@ -73,15 +73,18 @@ export function Sidebar() {
     } finally {
       creatingRef.current = false;
     }
-  };
+  }, [addWorkspace, selectWorkspace, addChatMessage]);
 
-  const filteredWorkspaces = workspaces.filter((ws) => {
-    if (sidebarFilter === "active") return ws.status === "Active";
-    if (sidebarFilter === "archived") return ws.status === "Archived";
-    return true;
-  });
+  const filteredWorkspaces = useMemo(
+    () => workspaces.filter((ws) => {
+      if (sidebarFilter === "active") return ws.status === "Active";
+      if (sidebarFilter === "archived") return ws.status === "Archived";
+      return true;
+    }),
+    [workspaces, sidebarFilter]
+  );
 
-  const handleArchive = async (wsId: string) => {
+  const handleArchive = useCallback(async (wsId: string) => {
     try {
       await archiveWorkspace(wsId);
       updateWorkspace(wsId, {
@@ -89,20 +92,20 @@ export function Sidebar() {
         worktree_path: null,
         agent_status: "Stopped",
       });
-      if (selectedWorkspaceId === wsId) selectWorkspace(null);
+      if (useAppStore.getState().selectedWorkspaceId === wsId) selectWorkspace(null);
     } catch {
       // ignore
     }
-  };
+  }, [updateWorkspace, selectWorkspace]);
 
-  const handleRestore = async (wsId: string) => {
+  const handleRestore = useCallback(async (wsId: string) => {
     try {
       const path = await restoreWorkspace(wsId);
       updateWorkspace(wsId, { status: "Active", worktree_path: path });
     } catch {
       // ignore
     }
-  };
+  }, [updateWorkspace]);
 
   return (
     <div className={styles.sidebar}>


### PR DESCRIPTION
## Summary

Reduces unnecessary React re-renders across the frontend, with the biggest impact on the streaming chat path:

- **ChatPanel**: Extracted `StreamingMessage`, `ToolActivitiesSection`, and `CompletedTurnsSection` into isolated `React.memo` components with their own Zustand selectors. ChatPanel now subscribes to `hasStreaming` (boolean) and `activitiesCount` (number) instead of full text/array, so it only re-renders when streaming starts/stops rather than on every character delta (~10-50x/sec).
- **StreamingMessage**: Throttles Markdown re-parsing to ~10fps via `requestAnimationFrame` instead of re-parsing on every character.
- **AppLayout**: Stabilized resize handlers with `useCallback` + `getState()` to prevent re-render cascades during drag.
- **ResizeHandle**: Wrapped in `React.memo` to avoid re-renders from parent layout changes.
- **StatusBar**: Replaced `workspaces` array subscription with computed selectors returning primitives — only re-renders when counts change, not on any workspace property change.
- **Dashboard**: Wrapped `WorkspaceCard` in `React.memo` with stable `onClick` prop to prevent parent re-renders from cascading to all cards.
- **Sidebar**: Added `useMemo` for `filteredWorkspaces` and `useCallback` for event handlers.
- **RightSidebar**: Changed `loadDiff` callback to depend on primitive `remoteConnectionId` instead of the `ws` object reference.

## Complexity Notes

- The `StreamingMessage` component uses a `requestAnimationFrame` loop to throttle Markdown rendering. The rAF runs continuously while streaming is visible and cleans up on unmount. This is intentional — the alternative (debounce/throttle with setTimeout) would add visible input lag.
- `ChatPanel` auto-scroll now only triggers on message count changes. Streaming auto-scroll is handled inside `StreamingMessage` itself.

## Test Steps

1. Start the app with `cargo tauri dev`
2. Open a workspace and send a message to an agent
3. Verify streaming text renders smoothly without visible jank
4. Verify completed tool call summaries still collapse/expand correctly
5. Verify current tool activities section still shows and collapses during agent execution
6. Drag panel resize handles — verify smooth dragging without stuttering
7. Check sidebar filtering (all/active/archived) still works
8. Check the dashboard shows workspace cards correctly and clicking them navigates to the workspace
9. Open the changes panel (right sidebar) and verify diff files load correctly
10. Check the status bar shows correct running/workspace counts

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)