### PR TITLE
feat: add Nix flake with devshell and build targets

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ src/ui/dist/
 
 # Tauri generated
 src-tauri/gen/
+src-tauri/icons/
+
+# Nix
+result
+result-*
+.direnv/
 
 # macOS
 .DS_Store

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,158 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1775236976,
+        "narHash": "sha256-gCgX+AXN7K1gAIEqcLcZHxmC+QoZcwn9m6Z9r2Az+N8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6c23998526351a53ce734f0ac84940da988ccef1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1775547409,
+        "narHash": "sha256-dNIhLmwrR7N78amgliAJvFx58RjrhDWorV9B9Kiayeo=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "a260dea172f86c7afa65cec0c6e6a9dd91530017",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775579569,
+        "narHash": "sha256-/m3yyS/EnXqoPGBJYVy4jTOsirdgsEZ3JdN2gGkBr14=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dfd9566f82a6e1d55c30f861879186440614696e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "devshell": "devshell",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775499626,
+        "narHash": "sha256-6PyDFl9fJu12xfdjgEiQKEVjX6/cdkN1DeKRLKwUz44=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "129f6167ab924c42fb16d4e3d1b31b6e725c7523",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,305 @@
+{
+  description = "Claudette — cross-platform desktop orchestrator for parallel Claude Code agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    devshell.url = "github:numtide/devshell";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
+
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        inputs.devshell.flakeModule
+        inputs.treefmt-nix.flakeModule
+      ];
+
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        {
+          pkgs,
+          system,
+          lib,
+          ...
+        }:
+        let
+          fenixPkgs = inputs.fenix.packages.${system};
+          rustToolchain = fenixPkgs.combine [
+            fenixPkgs.latest.cargo
+            fenixPkgs.latest.clippy
+            fenixPkgs.latest.rust-src
+            fenixPkgs.latest.rustc
+            fenixPkgs.latest.rustfmt
+          ];
+
+          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          # Version from workspace Cargo.toml — single source of truth
+          crateInfo = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
+          inherit (crateInfo) version;
+
+          commonMeta = {
+            homepage = "https://github.com/utensils/Claudette";
+            license = lib.licenses.mit;
+            platforms = lib.platforms.darwin ++ lib.platforms.linux;
+          };
+
+          # Frontend: FOD with network access for bun install + vite build.
+          # Update the hash when src/ui/bun.lock or package.json change:
+          #   nix build .#frontend 2>&1 | grep 'got:' | awk '{print $2}'
+          frontend = pkgs.stdenvNoCC.mkDerivation {
+            pname = "claudette-frontend";
+            inherit version;
+            src = ./src/ui;
+
+            nativeBuildInputs = [ pkgs.bun ];
+
+            outputHashMode = "recursive";
+            outputHashAlgo = "sha256";
+            outputHash = "sha256-B5jdCpB8PCOmBvptaigcRZRZSBBfQ4Tm6CaN+VMNvCI=";
+
+            buildPhase = ''
+              export HOME=$TMPDIR
+              bun install --frozen-lockfile
+              bun run build
+            '';
+
+            installPhase = ''
+              cp -r dist $out
+            '';
+          };
+
+          # Source filtering for Rust builds
+          src = lib.cleanSourceWith {
+            src = ./.;
+            filter =
+              path: type:
+              (craneLib.filterCargoSources path type)
+              || (builtins.match ".*src/ui/.*" path != null)
+              || (builtins.match ".*src-tauri/.*" path != null)
+              || (builtins.match ".*assets/.*" path != null);
+          };
+
+          # Platform-specific build dependencies
+          darwinBuildInputs = lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.apple-sdk_15
+            pkgs.libiconv
+          ];
+
+          linuxBuildInputs = lib.optionals pkgs.stdenv.isLinux [
+            pkgs.webkitgtk_4_1
+            pkgs.gtk3
+            pkgs.libsoup_3
+            pkgs.glib
+            pkgs.openssl
+            pkgs.glib-networking
+          ];
+
+          commonCraneArgs = {
+            inherit src;
+
+            strictDeps = true;
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pkgs.cmake
+              pkgs.perl
+            ]
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkgs.wrapGAppsHook4
+            ];
+
+            buildInputs = darwinBuildInputs ++ linuxBuildInputs;
+
+            # Sane deployment target — nixpkgs-unstable stdenv defaults to the
+            # SDK version (26.x) which aws-lc-sys rejects.
+            env = lib.optionalAttrs pkgs.stdenv.isDarwin {
+              MACOSX_DEPLOYMENT_TARGET = "11.0";
+            };
+          };
+
+          # Cargo deps — cached separately from source changes
+          cargoArtifacts = craneLib.buildDepsOnly (
+            commonCraneArgs
+            // {
+              # Tauri build.rs needs a frontend dir to exist
+              preBuild = ''
+                mkdir -p src/ui/dist
+                echo '<html></html>' > src/ui/dist/index.html
+              '';
+            }
+          );
+
+          # Tauri desktop app
+          claudette = craneLib.buildPackage (
+            commonCraneArgs
+            // {
+              inherit cargoArtifacts;
+              cargoExtraArgs = "-p claudette-tauri";
+
+              preBuild = ''
+                mkdir -p src/ui/dist
+                cp -r ${frontend}/* src/ui/dist/
+              '';
+
+              meta = commonMeta // {
+                description = "Cross-platform desktop orchestrator for parallel Claude Code agents";
+                mainProgram = "claudette-tauri";
+              };
+            }
+          );
+
+          # Headless server binary
+          claudette-server = craneLib.buildPackage (
+            commonCraneArgs
+            // {
+              inherit cargoArtifacts;
+              cargoExtraArgs = "-p claudette-server";
+
+              meta = commonMeta // {
+                description = "Headless Claudette backend for remote access";
+                mainProgram = "claudette-server";
+              };
+            }
+          );
+        in
+        {
+          # -- Packages ----------------------------------------------------------
+          packages = {
+            default = claudette;
+            inherit claudette claudette-server frontend;
+          };
+
+          # -- Checks ------------------------------------------------------------
+          checks = {
+            inherit claudette claudette-server;
+
+            clippy = craneLib.cargoClippy (
+              commonCraneArgs
+              // {
+                inherit cargoArtifacts;
+                cargoClippyExtraArgs = "--workspace --all-targets -- -D warnings";
+
+                preBuild = ''
+                  mkdir -p src/ui/dist
+                  echo '<html></html>' > src/ui/dist/index.html
+                '';
+              }
+            );
+
+            fmt = craneLib.cargoFmt { inherit src; };
+          };
+
+          # -- Dev shell ---------------------------------------------------------
+          devshells.default = {
+            name = "claudette";
+
+            packages = [
+              rustToolchain
+              pkgs.bun
+              pkgs.cargo-tauri
+              pkgs.pkg-config
+              pkgs.cmake
+              pkgs.perl
+            ]
+            ++ darwinBuildInputs
+            ++ linuxBuildInputs
+            ++ lib.optionals pkgs.stdenv.isLinux [
+              pkgs.wrapGAppsHook4
+            ];
+
+            env = [
+              {
+                name = "RUST_SRC_PATH";
+                value = "${fenixPkgs.latest.rust-src}/lib/rustlib/src/rust/library";
+              }
+            ]
+            ++ lib.optionals pkgs.stdenv.isDarwin [
+              {
+                # Use Apple's native clang — Nix's CC wrapper has SDK version
+                # mismatches (e.g. -mmacosx-version-min=26.4) that break aws-lc-sys
+                name = "CC";
+                value = "/usr/bin/cc";
+              }
+              {
+                name = "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER";
+                value = "/usr/bin/cc";
+              }
+              {
+                # Clear system CFLAGS that leak through direnv from nix-darwin
+                name = "CFLAGS";
+                value = "";
+              }
+              {
+                name = "CXXFLAGS";
+                value = "";
+              }
+            ];
+
+            commands = [
+              {
+                name = "dev";
+                command = "cargo tauri dev";
+                help = "Start Tauri dev mode with hot-reload";
+                category = "development";
+              }
+              {
+                name = "build-app";
+                command = "cargo tauri icon assets/logo.png && cargo tauri build";
+                help = "Build release app bundle (.app / .deb)";
+                category = "development";
+              }
+              {
+                name = "check";
+                command = ''
+                  mkdir -p src/ui/dist
+                  [ -f src/ui/dist/index.html ] || echo '<html></html>' > src/ui/dist/index.html
+                  cargo clippy --workspace --all-targets -- -D warnings && cd src/ui && bunx tsc --noEmit
+                '';
+                help = "Run clippy + TypeScript type checks";
+                category = "quality";
+              }
+              {
+                name = "fmt";
+                command = "cargo fmt --all && cd src/ui && bunx eslint --fix .";
+                help = "Format Rust and TypeScript code";
+                category = "quality";
+              }
+              {
+                name = "test";
+                command = "cargo test --workspace --all-features";
+                help = "Run all Rust tests";
+                category = "quality";
+              }
+            ];
+          };
+
+          # -- Formatting --------------------------------------------------------
+          treefmt = {
+            projectRootFile = "flake.nix";
+            programs.nixfmt.enable = true;
+            programs.rustfmt = {
+              enable = true;
+              package = rustToolchain;
+            };
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
 
       systems = [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-linux"
         "aarch64-darwin"
       ];
@@ -58,7 +57,11 @@
           commonMeta = {
             homepage = "https://github.com/utensils/Claudette";
             license = lib.licenses.mit;
-            platforms = lib.platforms.darwin ++ lib.platforms.linux;
+            platforms = [
+              "x86_64-linux"
+              "aarch64-linux"
+              "aarch64-darwin"
+            ];
           };
 
           # Frontend: FOD with network access for bun install + vite build.
@@ -86,13 +89,16 @@
             '';
           };
 
-          # Source filtering for Rust builds
+          # Cargo-only source: Cargo.toml, Cargo.lock, and *.rs files.
+          # Used by buildDepsOnly so UI/asset changes don't rebuild deps.
+          cargoSrc = craneLib.cleanCargoSource ./.;
+
+          # Full source: Cargo files + src-tauri config + assets (logo for tauri-codegen).
           src = lib.cleanSourceWith {
             src = ./.;
             filter =
               path: type:
               (craneLib.filterCargoSources path type)
-              || (builtins.match ".*src/ui/.*" path != null)
               || (builtins.match ".*src-tauri/.*" path != null)
               || (builtins.match ".*assets/.*" path != null);
           };
@@ -135,10 +141,14 @@
             };
           };
 
-          # Cargo deps — cached separately from source changes
+          # Cargo deps — cached separately from source changes.
+          # Uses cargoSrc (Cargo files + *.rs only) so UI/asset edits
+          # don't invalidate the dependency cache.
           cargoArtifacts = craneLib.buildDepsOnly (
             commonCraneArgs
             // {
+              src = cargoSrc;
+
               # Tauri build.rs needs a frontend dir to exist
               preBuild = ''
                 mkdir -p src/ui/dist
@@ -166,11 +176,15 @@
             }
           );
 
-          # Headless server binary
+          # Headless server binary — version from src-server/Cargo.toml
+          serverInfo = craneLib.crateNameFromCargoToml { cargoToml = ./src-server/Cargo.toml; };
+
           claudette-server = craneLib.buildPackage (
             commonCraneArgs
             // {
               inherit cargoArtifacts;
+              pname = serverInfo.pname;
+              version = serverInfo.version;
               cargoExtraArgs = "-p claudette-server";
 
               meta = commonMeta // {


### PR DESCRIPTION
## Summary

- Adds an optional Nix flake providing a complete dev environment via `nix develop` / `direnv allow`
- Dev shell includes nightly Rust (fenix), bun, cargo-tauri, pkg-config, cmake, and all platform deps
- `nix build` produces the Tauri desktop binary; `nix build .#claudette-server` produces the headless server
- Frontend built as a fixed-output derivation (bun + vite), injected into the Rust build via crane
- CI checks: clippy, cargo fmt, treefmt (nixfmt + rustfmt)
- Supports `x86_64-linux`, `aarch64-linux`, `aarch64-darwin` (x86_64-darwin excluded — deprecated by nixpkgs)

**Minimal impact**: only adds new files (`.envrc`, `flake.nix`, `flake.lock`) plus `.gitignore` entries. No existing source files modified.

### Darwin workarounds

- Devshell uses `/usr/bin/cc` instead of Nix's CC wrapper (SDK version mismatch causes `-mmacosx-version-min=26.4` which breaks `aws-lc-sys`)
- Nix builds set `MACOSX_DEPLOYMENT_TARGET=11.0` to override the stdenv default
- `CFLAGS`/`CXXFLAGS` cleared in devshell to prevent nix-darwin system env leaking via direnv

### Flake outputs

| Output | Description |
|---|---|
| `packages.claudette` | Tauri desktop app binary (crane) |
| `packages.claudette-server` | Headless server binary (crane) |
| `packages.frontend` | Vite frontend build (FOD) |
| `checks.{clippy,fmt,treefmt}` | Lint and format checks |
| `devShells.default` | Full dev environment with helper commands |
| `formatter` | treefmt (nixfmt + rustfmt) |

## Test plan

- [x] `nix flake check` passes on aarch64-darwin
- [x] `nix build` produces working `claudette-tauri` binary (27MB)
- [x] `nix build .#claudette-server` produces `claudette-server` binary (9.5MB)
- [x] `cargo tauri dev` works inside devshell
- [x] `cargo tauri build` produces `.app` and `.dmg` bundles inside devshell
- [ ] Verify on x86_64-linux