### PR TITLE
fix: allow all tool commands with full permission level

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -256,9 +256,9 @@ pub fn build_claude_args(
     // Add --allowedTools
     if !allowed_tools.is_empty() {
         if bypass_permissions {
-            // For bypass mode, explicitly allow Bash with all commands and all other tools
+            // For bypass mode, explicitly allow Bash and Edit with all patterns, plus all other tools
             args.push("--allowedTools".to_string());
-            args.push("Bash(*) *".to_string());
+            args.push("Bash(*) Edit(*) *".to_string());
         } else {
             args.push("--allowedTools".to_string());
             args.push(allowed_tools.join(","));
@@ -931,12 +931,12 @@ mod tests {
             None,
             &AgentSettings::default(),
         );
-        // Should set permission-mode on first turn
+        // Should set permission-mode to bypassPermissions on first turn
         let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
         assert_eq!(args[pm_idx + 1], "bypassPermissions");
-        // Should use wildcard allowedTools format
+        // Should use wildcard allowedTools format with explicit Bash and Edit patterns
         let at_idx = args.iter().position(|a| a == "--allowedTools").unwrap();
-        assert_eq!(args[at_idx + 1], "Bash(*) *");
+        assert_eq!(args[at_idx + 1], "Bash(*) Edit(*) *");
     }
 
     #[test]
@@ -952,9 +952,9 @@ mod tests {
         );
         // Permission mode is session-level, should not appear on resume
         assert!(!args.contains(&"--permission-mode".to_string()));
-        // But allowedTools should still be passed
+        // But allowedTools should still be passed with Bash and Edit patterns
         let at_idx = args.iter().position(|a| a == "--allowedTools").unwrap();
-        assert_eq!(args[at_idx + 1], "Bash(*) *");
+        assert_eq!(args[at_idx + 1], "Bash(*) Edit(*) *");
     }
 
     #[test]
@@ -968,8 +968,8 @@ mod tests {
         // Plan mode takes precedence over bypass
         let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
         assert_eq!(args[pm_idx + 1], "plan");
-        // Should still use wildcard allowedTools format
+        // Should still use wildcard allowedTools format with Bash and Edit patterns
         let at_idx = args.iter().position(|a| a == "--allowedTools").unwrap();
-        assert_eq!(args[at_idx + 1], "Bash(*) *");
+        assert_eq!(args[at_idx + 1], "Bash(*) Edit(*) *");
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -919,4 +919,57 @@ mod tests {
         let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
         assert!(args.contains(&"--settings".to_string()));
     }
+
+    #[test]
+    fn test_build_args_bypass_permissions_first_turn() {
+        let tools = vec!["*".to_string()];
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            false,
+            &tools,
+            None,
+            &AgentSettings::default(),
+        );
+        // Should set permission-mode on first turn
+        let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
+        assert_eq!(args[pm_idx + 1], "bypassPermissions");
+        // Should use wildcard allowedTools format
+        let at_idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[at_idx + 1], "Bash(*) *");
+    }
+
+    #[test]
+    fn test_build_args_bypass_permissions_resume() {
+        let tools = vec!["*".to_string()];
+        let args = build_claude_args(
+            "sess-1",
+            "hello",
+            true,
+            &tools,
+            None,
+            &AgentSettings::default(),
+        );
+        // Permission mode is session-level, should not appear on resume
+        assert!(!args.contains(&"--permission-mode".to_string()));
+        // But allowedTools should still be passed
+        let at_idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[at_idx + 1], "Bash(*) *");
+    }
+
+    #[test]
+    fn test_build_args_bypass_permissions_with_plan_mode() {
+        let tools = vec!["*".to_string()];
+        let settings = AgentSettings {
+            plan_mode: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &tools, None, &settings);
+        // Plan mode takes precedence over bypass
+        let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
+        assert_eq!(args[pm_idx + 1], "plan");
+        // Should still use wildcard allowedTools format
+        let at_idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[at_idx + 1], "Bash(*) *");
+    }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -253,10 +253,16 @@ pub fn build_claude_args(
         args.push(serde_json::Value::Object(obj).to_string());
     }
 
-    // Add --allowedTools only if not bypassing permissions
-    if !allowed_tools.is_empty() && !bypass_permissions {
-        args.push("--allowedTools".to_string());
-        args.push(allowed_tools.join(","));
+    // Add --allowedTools
+    if !allowed_tools.is_empty() {
+        if bypass_permissions {
+            // For bypass mode, explicitly allow Bash with all commands and all other tools
+            args.push("--allowedTools".to_string());
+            args.push("Bash(*) *".to_string());
+        } else {
+            args.push("--allowedTools".to_string());
+            args.push(allowed_tools.join(","));
+        }
     }
 
     // Only append custom instructions on the first turn — resumed sessions


### PR DESCRIPTION
## Summary
Updates full permission level to allow all Bash command patterns and MCP tools without permission prompts.

## Changes
- Modified `build_claude_args` to use `--allowedTools "Bash(*) *"` when in bypass mode
- `Bash(*)` allows Bash tool with any command pattern (e.g., `npx prisma generate`)
- `*` allows all other tools including MCP tools
- Combined with `--permission-mode bypassPermissions` for comprehensive permission bypass

## Test Plan
- [x] Verify MCP tools (e.g., `mcp__postgres_local__query`) work without prompts
- [x] Verify Bash commands with subcommands (e.g., `npx prisma generate`) work without prompts
- [x] Verify standard and read-only permission levels still restrict tools appropriately