### PR TITLE
fix: use wildcard tool permissions for full level on remote server

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -8,18 +8,6 @@ use serde_json::json;
 
 use crate::ws::{AgentSessionState, PtyHandle, ServerState, Writer, send_message};
 
-const TOOLS_FULL: &[&str] = &[
-    "Bash",
-    "Read",
-    "Write",
-    "Edit",
-    "Glob",
-    "Grep",
-    "WebSearch",
-    "WebFetch",
-    "NotebookEdit",
-];
-
 const TOOLS_STANDARD: &[&str] = &[
     "Read",
     "Write",
@@ -32,9 +20,11 @@ const TOOLS_STANDARD: &[&str] = &[
 
 const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
 
+/// Map a permission level name to the list of tools to pre-approve.
+/// "full" returns a wildcard pattern to allow all tools including MCP tools.
 fn tools_for_level(level: &str) -> Vec<String> {
     let tools: &[&str] = match level {
-        "full" => TOOLS_FULL,
+        "full" => return vec!["*".to_string()],
         "standard" => TOOLS_STANDARD,
         _ => TOOLS_READONLY,
     };

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -20,8 +20,10 @@ const TOOLS_STANDARD: &[&str] = &[
 
 const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
 
-/// Map a permission level name to the list of tools to pre-approve.
-/// "full" returns a wildcard pattern to allow all tools including MCP tools.
+/// Map a permission level name to the tools to pre-approve.
+/// "full" returns the wildcard sentinel `["*"]`, which `build_claude_args`
+/// interprets as `--permission-mode bypassPermissions` (skips all permission
+/// checks, including for MCP tools).
 fn tools_for_level(level: &str) -> Vec<String> {
     let tools: &[&str] = match level {
         "full" => return vec!["*".to_string()],


### PR DESCRIPTION
## Summary
- The server's `tools_for_level("full")` was returning an explicit tool list (`Bash`, `Read`, `Write`, etc.) which excluded MCP tools and didn't trigger `bypassPermissions` mode in `build_claude_args`
- Changed to return `["*"]` (wildcard), matching the local Tauri command behavior from #105/#106
- This triggers `--permission-mode bypassPermissions` on the remote server, eliminating tool approval prompts for full permission level

## Test plan
- [ ] Connect to a remote claudette-server
- [ ] Open a remote workspace with full permission level
- [ ] Send a prompt that uses tools — verify no permission approval is required
- [ ] Verify standard and readonly permission levels still restrict tools as expected