### PR TITLE
refactor: extract shared permissions module for local and remote

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -8,30 +8,7 @@ use serde_json::json;
 
 use crate::ws::{AgentSessionState, PtyHandle, ServerState, Writer, send_message};
 
-const TOOLS_STANDARD: &[&str] = &[
-    "Read",
-    "Write",
-    "Edit",
-    "Glob",
-    "Grep",
-    "WebSearch",
-    "WebFetch",
-];
-
-const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
-
-/// Map a permission level name to the tools to pre-approve.
-/// "full" returns the wildcard sentinel `["*"]`, which `build_claude_args`
-/// interprets as `--permission-mode bypassPermissions` (skips all permission
-/// checks, including for MCP tools).
-fn tools_for_level(level: &str) -> Vec<String> {
-    let tools: &[&str] = match level {
-        "full" => return vec!["*".to_string()],
-        "standard" => TOOLS_STANDARD,
-        _ => TOOLS_READONLY,
-    };
-    tools.iter().map(|s| (*s).to_string()).collect()
-}
+use claudette::permissions::tools_for_level;
 
 /// Dispatch a JSON-RPC request and return a JSON-RPC response.
 pub async fn handle_request(

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -13,32 +13,7 @@ struct AgentStreamPayload {
     event: AgentEvent,
 }
 
-const TOOLS_STANDARD: &[&str] = &[
-    "Read",
-    "Write",
-    "Edit",
-    "Glob",
-    "Grep",
-    "WebSearch",
-    "WebFetch",
-];
-
-const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
-
-/// Map a permission level name to the list of tools to pre-approve.
-/// "full" returns a wildcard pattern to allow all tools including MCP tools.
-///
-/// Note: Permission level is a session-level setting. Changing the permission
-/// level mid-session will not affect the running agent — the user must reset
-/// the agent session for the new permission level to take effect.
-fn tools_for_level(level: &str) -> Vec<String> {
-    let tools: &[&str] = match level {
-        "full" => return vec!["*".to_string()], // Wildcard = allow all tools
-        "standard" => TOOLS_STANDARD,
-        _ => TOOLS_READONLY,
-    };
-    tools.iter().map(|s| (*s).to_string()).collect()
-}
+use claudette::permissions::tools_for_level;
 
 #[tauri::command]
 pub async fn load_chat_history(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod diff;
 pub mod git;
 pub mod model;
 pub mod names;
+pub mod permissions;
 pub mod slash_commands;

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,0 +1,55 @@
+const TOOLS_STANDARD: &[&str] = &[
+    "Read",
+    "Write",
+    "Edit",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+];
+
+const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
+
+/// Map a permission level name to the tools to pre-approve.
+/// "full" returns the wildcard sentinel `["*"]`, which `build_claude_args`
+/// interprets as `--permission-mode bypassPermissions` (skips all permission
+/// checks, including for MCP tools).
+pub fn tools_for_level(level: &str) -> Vec<String> {
+    let tools: &[&str] = match level {
+        "full" => return vec!["*".to_string()],
+        "standard" => TOOLS_STANDARD,
+        _ => TOOLS_READONLY,
+    };
+    tools.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_returns_wildcard() {
+        assert_eq!(tools_for_level("full"), vec!["*"]);
+    }
+
+    #[test]
+    fn standard_excludes_bash() {
+        let tools = tools_for_level("standard");
+        assert!(tools.contains(&"Read".to_string()));
+        assert!(!tools.contains(&"Bash".to_string()));
+    }
+
+    #[test]
+    fn readonly_is_restrictive() {
+        let tools = tools_for_level("readonly");
+        assert!(tools.contains(&"Read".to_string()));
+        assert!(!tools.contains(&"Write".to_string()));
+        assert!(!tools.contains(&"Edit".to_string()));
+        assert!(!tools.contains(&"Bash".to_string()));
+    }
+
+    #[test]
+    fn unknown_level_defaults_to_readonly() {
+        assert_eq!(tools_for_level("unknown"), tools_for_level("readonly"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts `tools_for_level` and tool constants into `claudette::permissions` in the shared library crate
- Both `src-tauri/src/commands/chat.rs` and `src-server/src/handler.rs` now import from the single source of truth
- Eliminates the duplication that caused #107 (server had stale tool list while local had wildcard)
- Adds unit tests for all permission levels

## Test plan
- [ ] `cargo test --all-features` passes (133 tests including new permissions tests)
- [ ] Local workspaces: full/standard/readonly permission levels work as before
- [ ] Remote workspaces: full/standard/readonly permission levels match local behavior