### PR TITLE
fix: preserve terminal sessions when switching workspaces or tabs

### DIFF
--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -179,17 +179,19 @@ export function TerminalPanel() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTerminalTabId, ws?.worktree_path]);
 
-  // Show/hide terminal containers based on active tab.
+  // Show/hide terminal containers based on active tab and selected workspace.
   useEffect(() => {
+    const currentWorkspaceTabs = tabs.map((t) => t.id);
     for (const [tabId, inst] of instancesRef.current) {
-      const isActive = tabId === activeTerminalTabId;
+      const belongsToCurrentWorkspace = currentWorkspaceTabs.includes(tabId);
+      const isActive = tabId === activeTerminalTabId && belongsToCurrentWorkspace;
       inst.container.style.display = isActive ? "block" : "none";
       if (isActive) {
         inst.fit.fit();
         inst.term.focus();
       }
     }
-  }, [activeTerminalTabId]);
+  }, [activeTerminalTabId, tabs]);
 
   // Update font size on all instances without destroying them.
   useEffect(() => {
@@ -199,7 +201,7 @@ export function TerminalPanel() {
     }
   }, [terminalFontSize]);
 
-  // Cleanup all instances on workspace change.
+  // Cleanup all instances on component unmount only.
   useEffect(() => {
     return () => {
       for (const inst of instancesRef.current.values()) {
@@ -211,7 +213,7 @@ export function TerminalPanel() {
       }
       instancesRef.current.clear();
     };
-  }, [selectedWorkspaceId]);
+  }, []);
 
   const handleCreateTab = useCallback(async () => {
     if (!selectedWorkspaceId) return;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -48,9 +48,10 @@ export function TerminalPanel() {
   const instancesRef = useRef<Map<number, TermInstance>>(new Map());
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
-  const tabs = selectedWorkspaceId
-    ? terminalTabs[selectedWorkspaceId] || []
-    : [];
+  const tabs = useMemo(
+    () => (selectedWorkspaceId ? terminalTabs[selectedWorkspaceId] ?? [] : []),
+    [selectedWorkspaceId, terminalTabs]
+  );
 
   // Load terminal tabs on workspace change; auto-create one if none exist.
   useEffect(() => {
@@ -78,6 +79,15 @@ export function TerminalPanel() {
     addTerminalTab,
     activeTerminalTabId,
   ]);
+
+  // Ensure activeTerminalTabId belongs to the current workspace.
+  useEffect(() => {
+    if (!selectedWorkspaceId || tabs.length === 0) return;
+    const tabIds = tabs.map((t) => t.id);
+    if (activeTerminalTabId && !tabIds.includes(activeTerminalTabId)) {
+      setActiveTerminalTab(tabs[0].id);
+    }
+  }, [selectedWorkspaceId, tabs, activeTerminalTabId, setActiveTerminalTab]);
 
   // Create a terminal instance for a tab if it doesn't exist yet.
   useEffect(() => {
@@ -181,9 +191,9 @@ export function TerminalPanel() {
 
   // Show/hide terminal containers based on active tab and selected workspace.
   useEffect(() => {
-    const currentWorkspaceTabs = tabs.map((t) => t.id);
+    const currentWorkspaceTabIds = new Set(tabs.map((t) => t.id));
     for (const [tabId, inst] of instancesRef.current) {
-      const belongsToCurrentWorkspace = currentWorkspaceTabs.includes(tabId);
+      const belongsToCurrentWorkspace = currentWorkspaceTabIds.has(tabId);
       const isActive = tabId === activeTerminalTabId && belongsToCurrentWorkspace;
       inst.container.style.display = isActive ? "block" : "none";
       if (isActive) {
@@ -200,6 +210,23 @@ export function TerminalPanel() {
       inst.fit.fit();
     }
   }, [terminalFontSize]);
+
+  // Cleanup instances for tabs that no longer exist in any workspace.
+  useEffect(() => {
+    const allTabIds = new Set(
+      Object.values(terminalTabs).flatMap((tabs) => tabs.map((t) => t.id))
+    );
+    for (const [tabId, inst] of instancesRef.current) {
+      if (!allTabIds.has(tabId)) {
+        inst.resizeObserver.disconnect();
+        inst.term.dispose();
+        if (inst.unlisten) inst.unlisten();
+        if (inst.ptyId >= 0) closePty(inst.ptyId);
+        inst.container.remove();
+        instancesRef.current.delete(tabId);
+      }
+    }
+  }, [terminalTabs]);
 
   // Cleanup all instances on component unmount only.
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes #111 — terminal sessions are no longer killed when switching workspaces or tabs.

## Root Cause
The cleanup effect in `TerminalPanel.tsx` had `selectedWorkspaceId` as a dependency, causing it to run and destroy all PTY sessions whenever the workspace changed.

## Changes
- Changed cleanup effect dependency from `[selectedWorkspaceId]` to `[]` so cleanup only runs on component unmount
- Enhanced visibility logic to check workspace membership when showing/hiding terminals
- Terminal instances now persist across workspace and tab switches

## Test Plan
- [x] TypeScript type check passes
- [x] Frontend build succeeds  
- [x] Backend clippy passes with zero warnings
- [ ] Manual test: create multiple workspaces with long-running terminal commands
- [ ] Manual test: switch between workspaces — processes continue running
- [ ] Manual test: create multiple terminal tabs within a workspace
- [ ] Manual test: switch between tabs — background processes stay alive