### PR TITLE
feat: agent session UX — resume, plan mode, question dialogs

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -164,8 +164,10 @@ pub async fn send_chat_message(
 
             // If the process exits without ever initializing, reset the session
             // so the next attempt starts fresh instead of trying --resume.
-            if let AgentEvent::ProcessExited(code) = &event
-                && (!got_init || *code != Some(0))
+            // A non-zero exit AFTER successful init is normal (e.g. user stop,
+            // transient error) — the session is still valid for resumption.
+            if let AgentEvent::ProcessExited(_code) = &event
+                && !got_init
             {
                 let app_state = app.state::<AppState>();
                 let mut agents = app_state.agents.write().await;

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -84,6 +84,18 @@ pub async fn send_chat_message(
     // Session state is persisted to SQLite so that `--resume` survives app
     // restarts. The in-memory HashMap acts as a hot cache; on a cache miss we
     // restore from the database before falling back to creating a new session.
+    // Resolve custom instructions once — used for both restored and new sessions.
+    let instructions = {
+        let from_config = repo.as_ref().and_then(|r| {
+            let path = r.path.clone();
+            claudette::config::load_config(std::path::Path::new(&path))
+                .ok()
+                .flatten()
+                .and_then(|c| c.instructions)
+        });
+        from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
+    };
+
     let mut agents = state.agents.write().await;
     let session = agents.entry(workspace_id.clone()).or_insert_with(|| {
         // Try restoring a persisted session from the database first.
@@ -92,21 +104,10 @@ pub async fn send_chat_message(
                 session_id: sid,
                 turn_count: tc,
                 active_pid: None,
-                custom_instructions: None,
+                custom_instructions: instructions.clone(),
             };
         }
 
-        // First turn: resolve instructions from .claudette.json > repo settings.
-        let instructions = {
-            let from_config = repo.as_ref().and_then(|r| {
-                let path = r.path.clone();
-                claudette::config::load_config(std::path::Path::new(&path))
-                    .ok()
-                    .flatten()
-                    .and_then(|c| c.instructions)
-            });
-            from_config.or_else(|| repo.as_ref().and_then(|r| r.custom_instructions.clone()))
-        };
         AgentSessionState {
             session_id: uuid::Uuid::new_v4().to_string(),
             turn_count: 0,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -120,9 +120,6 @@ pub async fn send_chat_message(
     let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
 
-    // Persist updated session state to the database.
-    let _ = db.save_agent_session(&workspace_id, &session_id, session.turn_count);
-
     // Build agent settings from frontend params.
     let agent_settings = AgentSettings {
         model: if !is_resume { model } else { None },
@@ -142,6 +139,11 @@ pub async fn send_chat_message(
         &agent_settings,
     )
     .await?;
+
+    // Persist session state only after the subprocess spawned successfully.
+    // If run_turn fails (missing binary, spawn error), we avoid persisting a
+    // turn_count > 0 for a session Claude never initialized.
+    let _ = db.save_agent_session(&workspace_id, &session_id, session.turn_count);
 
     session.active_pid = Some(turn_handle.pid);
     drop(agents);

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -80,8 +80,22 @@ pub async fn send_chat_message(
 
     // Get or create agent session. Custom instructions are resolved once on
     // the first turn and cached for the session lifetime.
+    //
+    // Session state is persisted to SQLite so that `--resume` survives app
+    // restarts. The in-memory HashMap acts as a hot cache; on a cache miss we
+    // restore from the database before falling back to creating a new session.
     let mut agents = state.agents.write().await;
     let session = agents.entry(workspace_id.clone()).or_insert_with(|| {
+        // Try restoring a persisted session from the database first.
+        if let Ok(Some((sid, tc))) = db.get_agent_session(&workspace_id) {
+            return AgentSessionState {
+                session_id: sid,
+                turn_count: tc,
+                active_pid: None,
+                custom_instructions: None,
+            };
+        }
+
         // First turn: resolve instructions from .claudette.json > repo settings.
         let instructions = {
             let from_config = repo.as_ref().and_then(|r| {
@@ -105,6 +119,9 @@ pub async fn send_chat_message(
     let session_id = session.session_id.clone();
     let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
+
+    // Persist updated session state to the database.
+    let _ = db.save_agent_session(&workspace_id, &session_id, session.turn_count);
 
     // Build agent settings from frontend params.
     let agent_settings = AgentSettings {
@@ -151,6 +168,10 @@ pub async fn send_chat_message(
                 let app_state = app.state::<AppState>();
                 let mut agents = app_state.agents.write().await;
                 agents.remove(&ws_id);
+                // Also clear persisted session so restart doesn't try --resume.
+                if let Ok(db) = Database::open(&db_path) {
+                    let _ = db.clear_agent_session(&ws_id);
+                }
             }
             // Persist assistant messages to DB on completion.
             if let AgentEvent::Stream(StreamEvent::Assistant { ref message }) = event {
@@ -240,6 +261,11 @@ pub async fn reset_agent_session(
 ) -> Result<(), String> {
     let mut agents = state.agents.write().await;
     agents.remove(&workspace_id);
+
+    // Clear persisted session so the next turn starts fresh.
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.clear_agent_session(&workspace_id)
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod chat;
 pub mod data;
 pub mod diff;
+pub mod plan;
 pub mod remote;
 pub mod repository;
 pub mod settings;

--- a/src-tauri/src/commands/plan.rs
+++ b/src-tauri/src/commands/plan.rs
@@ -1,9 +1,18 @@
+use std::path::Path;
+
 /// Read a plan file from disk and return its content.
+///
+/// Only allows reading `.md` files whose canonicalized path lives inside a
+/// `.claude/plans/` directory, preventing directory-traversal attacks.
 #[tauri::command]
 pub async fn read_plan_file(path: String) -> Result<String, String> {
-    // Only allow reading .md files from .claude/plans/ directories for safety.
-    if !path.contains(".claude/plans/") || !path.ends_with(".md") {
+    let canonical =
+        std::fs::canonicalize(Path::new(&path)).map_err(|e| format!("Invalid plan path: {e}"))?;
+
+    let canonical_str = canonical.to_string_lossy();
+    if !canonical_str.contains(".claude/plans/") || !canonical_str.ends_with(".md") {
         return Err("Only .claude/plans/*.md files can be read".to_string());
     }
-    std::fs::read_to_string(&path).map_err(|e| format!("Failed to read plan file: {e}"))
+
+    std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read plan file: {e}"))
 }

--- a/src-tauri/src/commands/plan.rs
+++ b/src-tauri/src/commands/plan.rs
@@ -2,17 +2,29 @@ use std::path::Path;
 
 /// Read a plan file from disk and return its content.
 ///
-/// Only allows reading `.md` files whose canonicalized path lives inside a
-/// `.claude/plans/` directory, preventing directory-traversal attacks.
+/// Validates via path components that the canonicalized path contains a
+/// `.claude/plans/` directory and ends with `.md`.
 #[tauri::command]
 pub async fn read_plan_file(path: String) -> Result<String, String> {
-    let canonical =
-        std::fs::canonicalize(Path::new(&path)).map_err(|e| format!("Invalid plan path: {e}"))?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let canonical = std::fs::canonicalize(Path::new(&path))
+            .map_err(|e| format!("Invalid plan path: {e}"))?;
 
-    let canonical_str = canonical.to_string_lossy();
-    if !canonical_str.contains(".claude/plans/") || !canonical_str.ends_with(".md") {
-        return Err("Only .claude/plans/*.md files can be read".to_string());
-    }
+        // Validate via path components: must have consecutive .claude → plans segments.
+        let components: Vec<&str> = canonical
+            .components()
+            .filter_map(|c| c.as_os_str().to_str())
+            .collect();
+        let has_plans_dir = components
+            .windows(2)
+            .any(|w| w[0] == ".claude" && w[1] == "plans");
 
-    std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read plan file: {e}"))
+        if !has_plans_dir || canonical.extension().and_then(|e| e.to_str()) != Some("md") {
+            return Err("Only .claude/plans/*.md files can be read".to_string());
+        }
+
+        std::fs::read_to_string(&canonical).map_err(|e| format!("Failed to read plan file: {e}"))
+    })
+    .await
+    .map_err(|e| format!("Failed to read plan file: {e}"))?
 }

--- a/src-tauri/src/commands/plan.rs
+++ b/src-tauri/src/commands/plan.rs
@@ -1,0 +1,9 @@
+/// Read a plan file from disk and return its content.
+#[tauri::command]
+pub async fn read_plan_file(path: String) -> Result<String, String> {
+    // Only allow reading .md files from .claude/plans/ directories for safety.
+    if !path.contains(".claude/plans/") || !path.ends_with(".md") {
+        return Err("Only .claude/plans/*.md files can be read".to_string());
+    }
+    std::fs::read_to_string(&path).map_err(|e| format!("Failed to read plan file: {e}"))
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -90,6 +90,8 @@ fn main() {
             commands::chat::send_chat_message,
             commands::chat::stop_agent,
             commands::chat::reset_agent_session,
+            // Plan
+            commands::plan::read_plan_file,
             // Diff
             commands::diff::load_diff_files,
             commands::diff::load_file_diff,

--- a/src/db.rs
+++ b/src/db.rs
@@ -164,6 +164,15 @@ impl Database {
             )?;
         }
 
+        if version < 9 {
+            self.conn.execute_batch(
+                "ALTER TABLE workspaces ADD COLUMN session_id TEXT;
+                 ALTER TABLE workspaces ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0;
+
+                 PRAGMA user_version = 9;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -359,6 +368,48 @@ impl Database {
         self.conn.execute(
             "UPDATE workspaces SET status = ?1, worktree_path = ?2 WHERE id = ?3",
             params![status.as_str(), worktree_path, id],
+        )?;
+        Ok(())
+    }
+
+    /// Persist agent session state so it survives app restarts.
+    pub fn save_agent_session(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+        turn_count: u32,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE workspaces SET session_id = ?1, turn_count = ?2 WHERE id = ?3",
+            params![session_id, turn_count, workspace_id],
+        )?;
+        Ok(())
+    }
+
+    /// Load persisted agent session state. Returns `(session_id, turn_count)`.
+    pub fn get_agent_session(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<(String, u32)>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT session_id, turn_count FROM workspaces WHERE id = ?1",
+                params![workspace_id],
+                |row| {
+                    let sid: Option<String> = row.get(0)?;
+                    let tc: u32 = row.get(1)?;
+                    Ok(sid.map(|s| (s, tc)))
+                },
+            )
+            .optional()
+            .map(|opt| opt.flatten())
+    }
+
+    /// Clear persisted agent session (e.g. after a reset or failed init).
+    pub fn clear_agent_session(&self, workspace_id: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE workspaces SET session_id = NULL, turn_count = 0 WHERE id = ?1",
+            params![workspace_id],
         )?;
         Ok(())
     }
@@ -791,6 +842,48 @@ mod tests {
         db.delete_repository("r1").unwrap();
         let workspaces = db.list_workspaces().unwrap();
         assert!(workspaces.is_empty());
+    }
+
+    // --- Agent session persistence tests ---
+
+    #[test]
+    fn test_save_and_get_agent_session() {
+        let db = setup_db_with_workspace();
+        db.save_agent_session("w1", "sess-abc", 3).unwrap();
+        let result = db.get_agent_session("w1").unwrap();
+        assert_eq!(result, Some(("sess-abc".into(), 3)));
+    }
+
+    #[test]
+    fn test_get_agent_session_returns_none_when_no_session() {
+        let db = setup_db_with_workspace();
+        let result = db.get_agent_session("w1").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_agent_session_returns_none_for_missing_workspace() {
+        let db = Database::open_in_memory().unwrap();
+        let result = db.get_agent_session("nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_clear_agent_session() {
+        let db = setup_db_with_workspace();
+        db.save_agent_session("w1", "sess-abc", 5).unwrap();
+        db.clear_agent_session("w1").unwrap();
+        let result = db.get_agent_session("w1").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_save_agent_session_overwrites() {
+        let db = setup_db_with_workspace();
+        db.save_agent_session("w1", "sess-1", 1).unwrap();
+        db.save_agent_session("w1", "sess-2", 4).unwrap();
+        let result = db.get_agent_session("w1").unwrap();
+        assert_eq!(result, Some(("sess-2".into(), 4)));
     }
 
     // --- Chat message tests ---

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -35,6 +35,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
+        "vitest": "^4.1.4",
       },
     },
   },
@@ -149,6 +150,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
@@ -157,7 +160,11 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -203,6 +210,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.4", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.4", "", { "dependencies": { "@vitest/spy": "4.1.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.4", "", { "dependencies": { "@vitest/utils": "4.1.4", "pathe": "^2.0.3" } }, "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "@vitest/utils": "4.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
@@ -221,6 +242,8 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -236,6 +259,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001781", "", {}, "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -277,6 +302,8 @@
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -301,7 +328,11 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -439,6 +470,8 @@
 
     "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
@@ -537,6 +570,8 @@
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -552,6 +587,8 @@
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -597,9 +634,15 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -611,7 +654,13 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -655,9 +704,13 @@
 
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
+    "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
@@ -39,6 +41,7 @@
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -728,6 +728,21 @@
   line-height: 1.5;
 }
 
+.toolDetail {
+  padding: 6px 10px;
+  margin: 0;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  max-height: 150px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  line-height: 1.4;
+  border-top: 1px solid var(--divider);
+  background: var(--chat-input-bg);
+}
+
 /* Input area */
 .inputArea {
   position: relative;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -298,6 +298,13 @@ export function ChatPanel() {
     const trimmed = content.trim();
     if (!trimmed || !selectedWorkspaceId) return;
 
+    // Clear any pending agent question — the user is sending a new message
+    // (either an answer from the question card or a manual override).
+    const currentQ = useAppStore.getState().agentQuestion;
+    if (currentQ?.workspaceId === selectedWorkspaceId) {
+      setAgentQuestion(null);
+    }
+
     setError(null);
 
     // Push to prompt history.

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -474,31 +474,21 @@ export function ChatPanel() {
           </div>
         ) : (
           <>
-            {messages.map((msg) => (
-              <div
+            {messages.map((msg, idx) => (
+              <MessageWithTurns
                 key={msg.id}
-                className={`${styles.message} ${styles[`role_${msg.role}`]}`}
-              >
-                {msg.role === "User" && (
-                  <div className={styles.roleLabel}>You</div>
-                )}
-                <div className={styles.content}>
-                  {msg.role === "Assistant" ? (
-                    <Markdown
-                      remarkPlugins={REMARK_PLUGINS}
-                      rehypePlugins={REHYPE_PLUGINS}
-                    >
-                      {preprocessContent(msg.content)}
-                    </Markdown>
-                  ) : (
-                    msg.content
-                  )}
-                </div>
-              </div>
+                msg={msg}
+                idx={idx}
+                workspaceId={selectedWorkspaceId!}
+              />
             ))}
 
+            {/* Completed turns that came after all current messages */}
             {selectedWorkspaceId && (
-              <CompletedTurnsSection workspaceId={selectedWorkspaceId} />
+              <CompletedTurnsAfter
+                workspaceId={selectedWorkspaceId}
+                afterIndex={messages.length}
+              />
             )}
 
             {selectedWorkspaceId && hasStreaming && (
@@ -611,71 +601,156 @@ const StreamingMessage = memo(function StreamingMessage({
 });
 
 /**
- * Completed turns section — subscribes to completedTurns for this workspace only.
- * Isolated so it doesn't re-render on streaming or tool activity changes.
+ * Render a single completed turn summary (collapsible tool call list).
  */
-const CompletedTurnsSection = memo(function CompletedTurnsSection({
+function TurnSummary({
+  turn,
+  turnIndex,
   workspaceId,
 }: {
+  turn: CompletedTurn;
+  turnIndex: number;
   workspaceId: string;
 }) {
-  const completedTurns = useAppStore(
-    (s) => s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS
-  );
   const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
+  return (
+    <div
+      className={styles.turnSummary}
+      role="button"
+      tabIndex={0}
+      onClick={() => toggleCompletedTurn(workspaceId, turnIndex)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleCompletedTurn(workspaceId, turnIndex);
+        }
+      }}
+    >
+      <div className={styles.turnHeader}>
+        <span className={styles.toolChevron}>
+          {turn.collapsed ? "›" : "⌄"}
+        </span>
+        <span className={styles.turnLabel}>
+          {turn.activities.length} tool call
+          {turn.activities.length !== 1 ? "s" : ""}
+          {turn.messageCount > 0 &&
+            `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
+        </span>
+      </div>
+      {!turn.collapsed && (
+        <div className={styles.turnActivities}>
+          {turn.activities.map((act: ToolActivity) => (
+            <div key={act.toolUseId} className={styles.toolActivity}>
+              <div className={styles.toolHeader}>
+                <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
+                  {act.toolName}
+                </span>
+                {act.summary && (
+                  <span className={styles.toolSummary}>{act.summary}</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
-  if (completedTurns.length === 0) return null;
+/**
+ * A chat message preceded by any completed turns that belong at this position.
+ * Each completed turn records `afterMessageIndex` — the number of messages that
+ * existed when the turn finalized. Turns with afterMessageIndex === idx render
+ * just BEFORE message[idx].
+ */
+const MessageWithTurns = memo(function MessageWithTurns({
+  msg,
+  idx,
+  workspaceId,
+}: {
+  msg: ChatMessage;
+  idx: number;
+  workspaceId: string;
+}) {
+  const turnsHere = useAppStore(
+    (s) =>
+      (s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS).filter(
+        (t) => t.afterMessageIndex === idx
+      )
+  );
 
   return (
     <>
-      {completedTurns.map((turn: CompletedTurn, ti: number) => (
-        <div
-          key={turn.id}
-          className={styles.turnSummary}
-          role="button"
-          tabIndex={0}
-          onClick={() => toggleCompletedTurn(workspaceId, ti)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              toggleCompletedTurn(workspaceId, ti);
-            }
-          }}
-        >
-          <div className={styles.turnHeader}>
-            <span className={styles.toolChevron}>
-              {turn.collapsed ? "›" : "⌄"}
-            </span>
-            <span className={styles.turnLabel}>
-              {turn.activities.length} tool call
-              {turn.activities.length !== 1 ? "s" : ""}
-              {turn.messageCount > 0 &&
-                `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
-            </span>
-          </div>
-          {!turn.collapsed && (
-            <div className={styles.turnActivities}>
-              {turn.activities.map((act: ToolActivity) => (
-                <div
-                  key={act.toolUseId}
-                  className={styles.toolActivity}
-                >
-                  <div className={styles.toolHeader}>
-                    <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
-                      {act.toolName}
-                    </span>
-                    {act.summary && (
-                      <span className={styles.toolSummary}>
-                        {act.summary}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+      {turnsHere.map((turn) => {
+        const globalIdx = useAppStore
+          .getState()
+          .completedTurns[workspaceId]?.indexOf(turn) ?? 0;
+        return (
+          <TurnSummary
+            key={turn.id}
+            turn={turn}
+            turnIndex={globalIdx}
+            workspaceId={workspaceId}
+          />
+        );
+      })}
+      <div className={`${styles.message} ${styles[`role_${msg.role}`]}`}>
+        {msg.role === "User" && (
+          <div className={styles.roleLabel}>You</div>
+        )}
+        <div className={styles.content}>
+          {msg.role === "Assistant" ? (
+            <Markdown
+              remarkPlugins={REMARK_PLUGINS}
+              rehypePlugins={REHYPE_PLUGINS}
+            >
+              {preprocessContent(msg.content)}
+            </Markdown>
+          ) : (
+            msg.content
           )}
         </div>
-      ))}
+      </div>
+    </>
+  );
+});
+
+/**
+ * Completed turns that arrived after all current messages (e.g., a turn that
+ * finalized when no new messages followed it yet). Also catches any turns whose
+ * afterMessageIndex >= current message count.
+ */
+const CompletedTurnsAfter = memo(function CompletedTurnsAfter({
+  workspaceId,
+  afterIndex,
+}: {
+  workspaceId: string;
+  afterIndex: number;
+}) {
+  const turns = useAppStore(
+    (s) =>
+      (s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS).filter(
+        (t) => t.afterMessageIndex >= afterIndex
+      )
+  );
+
+  if (turns.length === 0) return null;
+
+  return (
+    <>
+      {turns.map((turn) => {
+        const globalIdx = useAppStore
+          .getState()
+          .completedTurns[workspaceId]?.indexOf(turn) ?? 0;
+        return (
+          <TurnSummary
+            key={turn.id}
+            turn={turn}
+            turnIndex={globalIdx}
+            workspaceId={workspaceId}
+          />
+        );
+      })}
     </>
   );
 });

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -510,6 +510,7 @@ export function ChatPanel() {
             {pendingPlan && (
               <PlanApprovalCard
                 approval={pendingPlan}
+                remoteConnectionId={ws?.remote_connection_id ?? undefined}
                 onRespond={(response) => {
                   if (selectedWorkspaceId) clearPlanApproval(selectedWorkspaceId);
                   handleSend(response);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, useMemo, useCallback } from "react";
+import React, { memo, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
@@ -195,11 +195,11 @@ export function ChatPanel() {
   const permissionLevel = selectedWorkspaceId
     ? permissionLevelMap[selectedWorkspaceId] ?? "full"
     : "full";
-  const agentQuestion = useAppStore((s) => s.agentQuestion);
-  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
+  const pendingQuestion = useAppStore(
+    (s) => (selectedWorkspaceId ? s.agentQuestions[selectedWorkspaceId] ?? null : null)
+  );
+  const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
   const isRunning = ws?.agent_status === "Running";
-  const pendingQuestion =
-    agentQuestion?.workspaceId === selectedWorkspaceId ? agentQuestion : null;
 
   // Spinner and elapsed timer for running agent.
   const [spinnerIdx, setSpinnerIdx] = useState(0);
@@ -300,9 +300,8 @@ export function ChatPanel() {
 
     // Clear any pending agent question — the user is sending a new message
     // (either an answer from the question card or a manual override).
-    const currentQ = useAppStore.getState().agentQuestion;
-    if (currentQ?.workspaceId === selectedWorkspaceId) {
-      setAgentQuestion(null);
+    if (selectedWorkspaceId) {
+      clearAgentQuestion(selectedWorkspaceId);
     }
 
     setError(null);
@@ -474,20 +473,10 @@ export function ChatPanel() {
           </div>
         ) : (
           <>
-            {messages.map((msg, idx) => (
-              <MessageWithTurns
-                key={msg.id}
-                msg={msg}
-                idx={idx}
-                workspaceId={selectedWorkspaceId!}
-              />
-            ))}
-
-            {/* Completed turns that came after all current messages */}
             {selectedWorkspaceId && (
-              <CompletedTurnsAfter
+              <MessagesWithTurns
+                messages={messages}
                 workspaceId={selectedWorkspaceId}
-                afterIndex={messages.length}
               />
             )}
 
@@ -506,7 +495,7 @@ export function ChatPanel() {
               <AgentQuestionCard
                 question={pendingQuestion}
                 onRespond={(response) => {
-                  setAgentQuestion(null);
+                  if (selectedWorkspaceId) clearAgentQuestion(selectedWorkspaceId);
                   handleSend(response);
                 }}
               />
@@ -605,30 +594,31 @@ const StreamingMessage = memo(function StreamingMessage({
  */
 function TurnSummary({
   turn,
-  turnIndex,
-  workspaceId,
+  collapsed,
+  onToggle,
 }: {
   turn: CompletedTurn;
   turnIndex: number;
   workspaceId: string;
+  collapsed: boolean;
+  onToggle: () => void;
 }) {
-  const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
   return (
     <div
       className={styles.turnSummary}
       role="button"
       tabIndex={0}
-      onClick={() => toggleCompletedTurn(workspaceId, turnIndex)}
+      onClick={onToggle}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          toggleCompletedTurn(workspaceId, turnIndex);
+          onToggle();
         }
       }}
     >
       <div className={styles.turnHeader}>
         <span className={styles.toolChevron}>
-          {turn.collapsed ? "›" : "⌄"}
+          {collapsed ? "›" : "⌄"}
         </span>
         <span className={styles.turnLabel}>
           {turn.activities.length} tool call
@@ -637,7 +627,7 @@ function TurnSummary({
             `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
         </span>
       </div>
-      {!turn.collapsed && (
+      {!collapsed && (
         <div className={styles.turnActivities}>
           {turn.activities.map((act: ToolActivity) => (
             <div key={act.toolUseId} className={styles.toolActivity}>
@@ -658,99 +648,86 @@ function TurnSummary({
 }
 
 /**
- * A chat message preceded by any completed turns that belong at this position.
- * Each completed turn records `afterMessageIndex` — the number of messages that
- * existed when the turn finalized. Turns with afterMessageIndex === idx render
- * just BEFORE message[idx].
+ * Renders all messages interleaved with completed turn summaries at the correct
+ * chronological position. Uses a single store subscription + useMemo to avoid
+ * per-message selectors and redundant re-renders during streaming.
  */
-const MessageWithTurns = memo(function MessageWithTurns({
-  msg,
-  idx,
+const MessagesWithTurns = memo(function MessagesWithTurns({
+  messages,
   workspaceId,
 }: {
-  msg: ChatMessage;
-  idx: number;
+  messages: ChatMessage[];
   workspaceId: string;
 }) {
-  const turnsHere = useAppStore(
-    (s) =>
-      (s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS).filter(
-        (t) => t.afterMessageIndex === idx
-      )
+  const completedTurns = useAppStore(
+    (s) => s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS
   );
+  const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
+
+  // Build an index: afterMessageIndex → array of (turn, globalIndex) pairs.
+  // Only recomputed when completedTurns changes, not on every streaming update.
+  const turnsByPosition = useMemo(() => {
+    const map: Record<number, Array<{ turn: CompletedTurn; globalIdx: number }>> = {};
+    completedTurns.forEach((turn, globalIdx) => {
+      const key = turn.afterMessageIndex;
+      (map[key] ??= []).push({ turn, globalIdx });
+    });
+    return map;
+  }, [completedTurns]);
+
+  const renderTurns = (position: number) => {
+    const entries = turnsByPosition[position];
+    if (!entries) return null;
+    return entries.map(({ turn, globalIdx }) => (
+      <TurnSummary
+        key={turn.id}
+        turn={turn}
+        turnIndex={globalIdx}
+        workspaceId={workspaceId}
+        collapsed={turn.collapsed}
+        onToggle={() => toggleCompletedTurn(workspaceId, globalIdx)}
+      />
+    ));
+  };
 
   return (
     <>
-      {turnsHere.map((turn) => {
-        const globalIdx = useAppStore
-          .getState()
-          .completedTurns[workspaceId]?.indexOf(turn) ?? 0;
-        return (
+      {messages.map((msg, idx) => (
+        <React.Fragment key={msg.id}>
+          {renderTurns(idx)}
+          <div className={`${styles.message} ${styles[`role_${msg.role}`]}`}>
+            {msg.role === "User" && (
+              <div className={styles.roleLabel}>You</div>
+            )}
+            <div className={styles.content}>
+              {msg.role === "Assistant" ? (
+                <Markdown
+                  remarkPlugins={REMARK_PLUGINS}
+                  rehypePlugins={REHYPE_PLUGINS}
+                >
+                  {preprocessContent(msg.content)}
+                </Markdown>
+              ) : (
+                msg.content
+              )}
+            </div>
+          </div>
+        </React.Fragment>
+      ))}
+      {/* Turns that finalized after or at the last message index */}
+      {completedTurns
+        .map((turn, globalIdx) => ({ turn, globalIdx }))
+        .filter(({ turn }) => turn.afterMessageIndex >= messages.length)
+        .map(({ turn, globalIdx }) => (
           <TurnSummary
             key={turn.id}
             turn={turn}
             turnIndex={globalIdx}
             workspaceId={workspaceId}
+            collapsed={turn.collapsed}
+            onToggle={() => toggleCompletedTurn(workspaceId, globalIdx)}
           />
-        );
-      })}
-      <div className={`${styles.message} ${styles[`role_${msg.role}`]}`}>
-        {msg.role === "User" && (
-          <div className={styles.roleLabel}>You</div>
-        )}
-        <div className={styles.content}>
-          {msg.role === "Assistant" ? (
-            <Markdown
-              remarkPlugins={REMARK_PLUGINS}
-              rehypePlugins={REHYPE_PLUGINS}
-            >
-              {preprocessContent(msg.content)}
-            </Markdown>
-          ) : (
-            msg.content
-          )}
-        </div>
-      </div>
-    </>
-  );
-});
-
-/**
- * Completed turns that arrived after all current messages (e.g., a turn that
- * finalized when no new messages followed it yet). Also catches any turns whose
- * afterMessageIndex >= current message count.
- */
-const CompletedTurnsAfter = memo(function CompletedTurnsAfter({
-  workspaceId,
-  afterIndex,
-}: {
-  workspaceId: string;
-  afterIndex: number;
-}) {
-  const turns = useAppStore(
-    (s) =>
-      (s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS).filter(
-        (t) => t.afterMessageIndex >= afterIndex
-      )
-  );
-
-  if (turns.length === 0) return null;
-
-  return (
-    <>
-      {turns.map((turn) => {
-        const globalIdx = useAppStore
-          .getState()
-          .completedTurns[workspaceId]?.indexOf(turn) ?? 0;
-        return (
-          <TurnSummary
-            key={turn.id}
-            turn={turn}
-            turnIndex={globalIdx}
-            workspaceId={workspaceId}
-          />
-        );
-      })}
+        ))}
     </>
   );
 });

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -814,7 +814,19 @@ function ChatInputArea({
     setChatInput("");
   };
 
+  const planMode = useAppStore(
+    (s) => s.planMode[selectedWorkspaceId] ?? false,
+  );
+  const setPlanMode = useAppStore((s) => s.setPlanMode);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Shift+Tab: toggle plan mode
+    if (e.key === "Tab" && e.shiftKey) {
+      e.preventDefault();
+      setPlanMode(selectedWorkspaceId, !planMode);
+      return;
+    }
+
     // Slash command picker navigation
     if (showSlashPicker) {
       if (e.key === "ArrowDown") {
@@ -839,7 +851,7 @@ function ChatInputArea({
         }
         return;
       }
-      if (e.key === "Tab") {
+      if (e.key === "Tab" && !e.shiftKey) {
         e.preventDefault();
         const cmd = slashResults[slashPickerIndex];
         if (cmd) {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -654,6 +654,12 @@ function TurnSummary({
                   <span className={styles.toolSummary}>{act.summary}</span>
                 )}
               </div>
+              {act.inputJson && (
+                <pre className={styles.toolDetail}>{act.inputJson}</pre>
+              )}
+              {act.resultText && (
+                <pre className={styles.toolDetail}>{act.resultText}</pre>
+              )}
             </div>
           ))}
         </div>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -615,8 +615,6 @@ function TurnSummary({
   onToggle,
 }: {
   turn: CompletedTurn;
-  turnIndex: number;
-  workspaceId: string;
   collapsed: boolean;
   onToggle: () => void;
 }) {
@@ -699,8 +697,6 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
       <TurnSummary
         key={turn.id}
         turn={turn}
-        turnIndex={globalIdx}
-        workspaceId={workspaceId}
         collapsed={turn.collapsed}
         onToggle={() => toggleCompletedTurn(workspaceId, globalIdx)}
       />
@@ -739,8 +735,6 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
           <TurnSummary
             key={turn.id}
             turn={turn}
-            turnIndex={globalIdx}
-            workspaceId={workspaceId}
             collapsed={turn.collapsed}
             onToggle={() => toggleCompletedTurn(workspaceId, globalIdx)}
           />

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -22,6 +22,7 @@ import type { SlashCommand } from "../../services/tauri";
 import type { ChatMessage } from "../../types/chat";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { AgentQuestionCard } from "./AgentQuestionCard";
+import { PlanApprovalCard } from "./PlanApprovalCard";
 import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { HeaderMenu } from "./HeaderMenu";
@@ -199,6 +200,10 @@ export function ChatPanel() {
     (s) => (selectedWorkspaceId ? s.agentQuestions[selectedWorkspaceId] ?? null : null)
   );
   const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
+  const pendingPlan = useAppStore(
+    (s) => (selectedWorkspaceId ? s.planApprovals[selectedWorkspaceId] ?? null : null)
+  );
+  const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
   const isRunning = ws?.agent_status === "Running";
 
   // Spinner and elapsed timer for running agent.
@@ -298,10 +303,11 @@ export function ChatPanel() {
     const trimmed = content.trim();
     if (!trimmed || !selectedWorkspaceId) return;
 
-    // Clear any pending agent question — the user is sending a new message
-    // (either an answer from the question card or a manual override).
+    // Clear any pending agent question or plan approval — the user is sending
+    // a new message (answer from a card or manual override).
     if (selectedWorkspaceId) {
       clearAgentQuestion(selectedWorkspaceId);
+      clearPlanApproval(selectedWorkspaceId);
     }
 
     setError(null);
@@ -501,7 +507,17 @@ export function ChatPanel() {
               />
             )}
 
-            {isRunning && !pendingQuestion && (
+            {pendingPlan && (
+              <PlanApprovalCard
+                approval={pendingPlan}
+                onRespond={(response) => {
+                  if (selectedWorkspaceId) clearPlanApproval(selectedWorkspaceId);
+                  handleSend(response);
+                }}
+              />
+            )}
+
+            {isRunning && !pendingQuestion && !pendingPlan && (
               <div
                 ref={processingRef}
                 className={styles.processing}

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -21,7 +21,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
-  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
+  const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
 
   const modelChipRef = useRef<HTMLButtonElement>(null);
   const [loaded, setLoaded] = useState(false);
@@ -52,11 +52,11 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
         await setAppSetting(`model:${workspaceId}`, model);
         // Model is session-level — reset session so next turn uses the new model.
         await resetAgentSession(workspaceId);
-        setAgentQuestion(null);
+        clearAgentQuestion(workspaceId);
       }
       setModelSelectorOpen(false);
     },
-    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen, setAgentQuestion]
+    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen, clearAgentQuestion]
   );
 
   const toggleFast = useCallback(async () => {

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -21,6 +21,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
+  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
 
   const modelChipRef = useRef<HTMLButtonElement>(null);
   const [loaded, setLoaded] = useState(false);
@@ -51,10 +52,11 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
         await setAppSetting(`model:${workspaceId}`, model);
         // Model is session-level — reset session so next turn uses the new model.
         await resetAgentSession(workspaceId);
+        setAgentQuestion(null);
       }
       setModelSelectorOpen(false);
     },
-    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen]
+    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen, setAgentQuestion]
   );
 
   const toggleFast = useCallback(async () => {

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -22,6 +22,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
   const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
+  const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
 
   const modelChipRef = useRef<HTMLButtonElement>(null);
   const [loaded, setLoaded] = useState(false);
@@ -53,10 +54,11 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
         // Model is session-level — reset session so next turn uses the new model.
         await resetAgentSession(workspaceId);
         clearAgentQuestion(workspaceId);
+        clearPlanApproval(workspaceId);
       }
       setModelSelectorOpen(false);
     },
-    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen, clearAgentQuestion]
+    [workspaceId, selectedModel, setSelectedModel, setModelSelectorOpen, clearAgentQuestion, clearPlanApproval]
   );
 
   const toggleFast = useCallback(async () => {

--- a/src/ui/src/components/chat/PlanApprovalCard.module.css
+++ b/src/ui/src/components/chat/PlanApprovalCard.module.css
@@ -1,0 +1,151 @@
+/* Plan approval card — shares visual language with AgentQuestionCard */
+.card {
+  background: linear-gradient(
+    135deg,
+    rgba(var(--accent-primary-rgb), 0.06) 0%,
+    rgba(var(--accent-primary-rgb), 0.02) 100%
+  );
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.15);
+  border-left: 3px solid var(--accent-primary);
+  border-radius: 0 10px 10px 0;
+  padding: 18px 20px;
+  margin: 12px 0;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2),
+              inset 0 1px 0 rgba(var(--accent-primary-rgb), 0.06);
+  animation: fadeInUp 0.2s ease both;
+}
+
+.label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent-primary);
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.description {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  margin-bottom: 14px;
+}
+
+.planLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  margin-bottom: 14px;
+  background: var(--hover-bg-subtle);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  color: var(--accent-primary);
+  font-size: 13px;
+  font-family: var(--font-mono, monospace);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  text-decoration: none;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.planLink:hover {
+  border-color: rgba(var(--accent-primary-rgb), 0.3);
+  background: rgba(var(--accent-primary-rgb), 0.05);
+}
+
+.planContent {
+  background: var(--hover-bg-subtle);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 14px;
+  max-height: 300px;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  font-family: var(--font-mono, monospace);
+}
+
+.permissions {
+  margin-bottom: 14px;
+}
+
+.permLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 6px;
+}
+
+.permList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.permItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 4px 8px;
+  background: var(--hover-bg-subtle);
+  border-radius: 4px;
+}
+
+.permTool {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.approveBtn {
+  flex: 1;
+  padding: 10px 14px;
+  background: rgba(var(--accent-primary-rgb), 0.1);
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.25);
+  border-radius: 8px;
+  color: var(--accent-primary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.approveBtn:hover {
+  background: rgba(var(--accent-primary-rgb), 0.18);
+}
+
+.denyBtn {
+  padding: 10px 14px;
+  background: transparent;
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.denyBtn:hover {
+  background: rgba(255, 100, 100, 0.06);
+  color: var(--text-primary);
+}

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
 import type { PlanApproval } from "../../stores/useAppStore";
-import { readPlanFile } from "../../services/tauri";
+import { readPlanFile, sendRemoteCommand } from "../../services/tauri";
 import styles from "./PlanApprovalCard.module.css";
 
 interface PlanApprovalCardProps {
   approval: PlanApproval;
   onRespond: (response: string) => void;
+  remoteConnectionId?: string;
 }
 
 export function PlanApprovalCard({
   approval,
   onRespond,
+  remoteConnectionId,
 }: PlanApprovalCardProps) {
   const [planContent, setPlanContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -24,7 +26,14 @@ export function PlanApprovalCard({
     if (!approval.planFilePath) return;
     setLoading(true);
     try {
-      const content = await readPlanFile(approval.planFilePath);
+      let content: string;
+      if (remoteConnectionId) {
+        content = (await sendRemoteCommand(remoteConnectionId, "read_plan_file", {
+          path: approval.planFilePath,
+        })) as string;
+      } else {
+        content = await readPlanFile(approval.planFilePath);
+      }
       setPlanContent(content);
       setExpanded(true);
     } catch (e) {

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import type { PlanApproval } from "../../stores/useAppStore";
+import { readPlanFile } from "../../services/tauri";
+import styles from "./PlanApprovalCard.module.css";
+
+interface PlanApprovalCardProps {
+  approval: PlanApproval;
+  onRespond: (response: string) => void;
+}
+
+export function PlanApprovalCard({
+  approval,
+  onRespond,
+}: PlanApprovalCardProps) {
+  const [planContent, setPlanContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const handleViewPlan = async () => {
+    if (planContent !== null) {
+      setExpanded(!expanded);
+      return;
+    }
+    if (!approval.planFilePath) return;
+    setLoading(true);
+    try {
+      const content = await readPlanFile(approval.planFilePath);
+      setPlanContent(content);
+      setExpanded(true);
+    } catch (e) {
+      console.error("Failed to read plan file:", e);
+      setPlanContent("(Failed to read plan file)");
+      setExpanded(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.label}>Plan Ready for Approval</div>
+
+      <div className={styles.description}>
+        The agent has written a plan and is requesting approval to proceed with
+        implementation.
+      </div>
+
+      {approval.planFilePath && (
+        <button
+          className={styles.planLink}
+          onClick={handleViewPlan}
+          disabled={loading}
+        >
+          {loading ? "Loading..." : expanded ? "Hide plan" : "View plan"}
+          {" \u2014 "}
+          {approval.planFilePath.split("/").slice(-2).join("/")}
+        </button>
+      )}
+
+      {expanded && planContent && (
+        <div className={styles.planContent}>{planContent}</div>
+      )}
+
+      {approval.allowedPrompts.length > 0 && (
+        <div className={styles.permissions}>
+          <div className={styles.permLabel}>Requested permissions</div>
+          <div className={styles.permList}>
+            {approval.allowedPrompts.map((p, i) => (
+              <div key={i} className={styles.permItem}>
+                <span className={styles.permTool}>{p.tool}</span>
+                <span>{p.prompt}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.actions}>
+        <button
+          className={styles.approveBtn}
+          onClick={() => onRespond("Plan approved. Proceed with implementation.")}
+        >
+          Approve plan
+        </button>
+        <button
+          className={styles.denyBtn}
+          onClick={() => onRespond("Plan denied. Please revise the approach.")}
+        >
+          Deny
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -62,6 +62,7 @@ export function CommandPalette() {
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const setFastMode = useAppStore((s) => s.setFastMode);
   const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
+  const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
 
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -149,6 +150,7 @@ export function CommandPalette() {
         stopAgent: (wsId: string) => stopAgent(wsId),
         resetAgentSession: (wsId: string) => resetAgentSession(wsId),
         clearAgentQuestion: (wsId: string) => clearAgentQuestion(wsId),
+        clearPlanApproval: (wsId: string) => clearPlanApproval(wsId),
         updateWorkspace: (id: string, updates: Record<string, unknown>) => updateWorkspace(id, updates),
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -61,7 +61,7 @@ export function CommandPalette() {
   const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const setFastMode = useAppStore((s) => s.setFastMode);
-  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
+  const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
 
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -148,7 +148,7 @@ export function CommandPalette() {
         persistSetting: (key: string, value: string) => setAppSetting(key, value).catch(console.error),
         stopAgent: (wsId: string) => stopAgent(wsId),
         resetAgentSession: (wsId: string) => resetAgentSession(wsId),
-        setAgentQuestion: (q: null) => setAgentQuestion(q),
+        clearAgentQuestion: (wsId: string) => clearAgentQuestion(wsId),
         updateWorkspace: (id: string, updates: Record<string, unknown>) => updateWorkspace(id, updates),
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -61,6 +61,7 @@ export function CommandPalette() {
   const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const setFastMode = useAppStore((s) => s.setFastMode);
+  const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
 
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -147,6 +148,7 @@ export function CommandPalette() {
         persistSetting: (key: string, value: string) => setAppSetting(key, value).catch(console.error),
         stopAgent: (wsId: string) => stopAgent(wsId),
         resetAgentSession: (wsId: string) => resetAgentSession(wsId),
+        setAgentQuestion: (q: null) => setAgentQuestion(q),
         updateWorkspace: (id: string, updates: Record<string, unknown>) => updateWorkspace(id, updates),
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ui/src/components/command-palette/commands.ts
+++ b/src/ui/src/components/command-palette/commands.ts
@@ -84,7 +84,7 @@ export interface CommandContext {
   persistSetting: (key: string, value: string) => void;
   stopAgent: (wsId: string) => Promise<void>;
   resetAgentSession: (wsId: string) => Promise<void>;
-  setAgentQuestion: (q: null) => void;
+  clearAgentQuestion: (wsId: string) => void;
   updateWorkspace: (id: string, updates: Record<string, unknown>) => void;
 }
 
@@ -198,7 +198,7 @@ export function buildCommands(ctx: CommandContext): Command[] {
       category: "agent",
       icon: RotateCcw,
       keywords: ["restart", "new", "clear"],
-      execute: () => { ctx.resetAgentSession(wsId); ctx.setAgentQuestion(null); ctx.close(); },
+      execute: () => { ctx.resetAgentSession(wsId); ctx.clearAgentQuestion(wsId); ctx.close(); },
     });
   }
 

--- a/src/ui/src/components/command-palette/commands.ts
+++ b/src/ui/src/components/command-palette/commands.ts
@@ -84,6 +84,7 @@ export interface CommandContext {
   persistSetting: (key: string, value: string) => void;
   stopAgent: (wsId: string) => Promise<void>;
   resetAgentSession: (wsId: string) => Promise<void>;
+  setAgentQuestion: (q: null) => void;
   updateWorkspace: (id: string, updates: Record<string, unknown>) => void;
 }
 
@@ -197,7 +198,7 @@ export function buildCommands(ctx: CommandContext): Command[] {
       category: "agent",
       icon: RotateCcw,
       keywords: ["restart", "new", "clear"],
-      execute: () => { ctx.resetAgentSession(wsId); ctx.close(); },
+      execute: () => { ctx.resetAgentSession(wsId); ctx.setAgentQuestion(null); ctx.close(); },
     });
   }
 

--- a/src/ui/src/components/command-palette/commands.ts
+++ b/src/ui/src/components/command-palette/commands.ts
@@ -85,6 +85,7 @@ export interface CommandContext {
   stopAgent: (wsId: string) => Promise<void>;
   resetAgentSession: (wsId: string) => Promise<void>;
   clearAgentQuestion: (wsId: string) => void;
+  clearPlanApproval: (wsId: string) => void;
   updateWorkspace: (id: string, updates: Record<string, unknown>) => void;
 }
 
@@ -198,7 +199,7 @@ export function buildCommands(ctx: CommandContext): Command[] {
       category: "agent",
       icon: RotateCcw,
       keywords: ["restart", "new", "clear"],
-      execute: () => { ctx.resetAgentSession(wsId); ctx.clearAgentQuestion(wsId); ctx.close(); },
+      execute: () => { ctx.resetAgentSession(wsId); ctx.clearAgentQuestion(wsId); ctx.clearPlanApproval(wsId); ctx.close(); },
     });
   }
 

--- a/src/ui/src/hooks/parseAgentQuestion.test.ts
+++ b/src/ui/src/hooks/parseAgentQuestion.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { parseAskUserQuestion, parseOptions } from "./parseAgentQuestion";
+
+describe("parseOptions", () => {
+  it("returns empty array for non-array input", () => {
+    expect(parseOptions(undefined)).toEqual([]);
+    expect(parseOptions(null)).toEqual([]);
+    expect(parseOptions("not an array")).toEqual([]);
+  });
+
+  it("wraps string options into { label } objects", () => {
+    expect(parseOptions(["A", "B"])).toEqual([
+      { label: "A" },
+      { label: "B" },
+    ]);
+  });
+
+  it("preserves label and description from object options", () => {
+    const opts = [
+      { label: "Nix", description: "Declarative builds" },
+      { label: "Docker" },
+    ];
+    expect(parseOptions(opts)).toEqual([
+      { label: "Nix", description: "Declarative builds" },
+      { label: "Docker", description: undefined },
+    ]);
+  });
+
+  it("stringifies non-string, non-object values", () => {
+    expect(parseOptions([42, true])).toEqual([
+      { label: "42" },
+      { label: "true" },
+    ]);
+  });
+});
+
+describe("parseAskUserQuestion", () => {
+  it("parses single-question format", () => {
+    const input = {
+      question: "Pick a color",
+      options: ["Red", "Blue"],
+    };
+    const result = parseAskUserQuestion(input);
+    expect(result).toEqual([
+      {
+        question: "Pick a color",
+        options: [{ label: "Red" }, { label: "Blue" }],
+        multiSelect: false,
+      },
+    ]);
+  });
+
+  it("parses multi-question format", () => {
+    const input = {
+      questions: [
+        {
+          header: "Deployment",
+          question: "How do you deploy?",
+          options: [{ label: "Nix", description: "Reproducible" }],
+          multiSelect: false,
+        },
+        {
+          question: "Testing?",
+          options: ["Unit", "Integration"],
+          multiSelect: true,
+        },
+      ],
+    };
+    const result = parseAskUserQuestion(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].header).toBe("Deployment");
+    expect(result[0].question).toBe("How do you deploy?");
+    expect(result[0].options).toEqual([
+      { label: "Nix", description: "Reproducible" },
+    ]);
+    expect(result[1].multiSelect).toBe(true);
+    expect(result[1].header).toBeUndefined();
+  });
+
+  it("returns empty array for unrecognized format", () => {
+    expect(parseAskUserQuestion({})).toEqual([]);
+    expect(parseAskUserQuestion({ random: "data" })).toEqual([]);
+  });
+
+  it("handles missing options gracefully", () => {
+    const result = parseAskUserQuestion({ question: "No options here" });
+    expect(result).toEqual([
+      { question: "No options here", options: [], multiSelect: false },
+    ]);
+  });
+});

--- a/src/ui/src/hooks/parseAgentQuestion.ts
+++ b/src/ui/src/hooks/parseAgentQuestion.ts
@@ -1,0 +1,54 @@
+import type { AgentQuestionItem } from "../stores/useAppStore";
+
+/**
+ * Parse AskUserQuestion tool input JSON into question items.
+ * Supports two formats:
+ * - Single: { question: "...", options: [...] }
+ * - Multi:  { questions: [{ header?, question, options, multiSelect? }] }
+ *
+ * Options can be strings or objects with label/description fields.
+ */
+export function parseAskUserQuestion(
+  parsed: Record<string, unknown>
+): AgentQuestionItem[] {
+  // Multi-question format
+  if (Array.isArray(parsed.questions)) {
+    return parsed.questions.map((q: Record<string, unknown>) => ({
+      header: typeof q.header === "string" ? q.header : undefined,
+      question: typeof q.question === "string" ? q.question : "",
+      options: parseOptions(q.options),
+      multiSelect: q.multiSelect === true,
+    }));
+  }
+
+  // Single-question format
+  if (typeof parsed.question === "string") {
+    return [
+      {
+        question: parsed.question,
+        options: parseOptions(parsed.options),
+        multiSelect: false,
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function parseOptions(
+  raw: unknown
+): Array<{ label: string; description?: string }> {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((opt: unknown) => {
+    if (typeof opt === "string") return { label: opt };
+    if (typeof opt === "object" && opt !== null) {
+      const o = opt as Record<string, unknown>;
+      return {
+        label: typeof o.label === "string" ? o.label : String(o.label ?? ""),
+        description:
+          typeof o.description === "string" ? o.description : undefined,
+      };
+    }
+    return { label: String(opt) };
+  });
+}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -1,64 +1,11 @@
 import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
-import type { AgentQuestionItem } from "../stores/useAppStore";
 import type { AgentStreamPayload } from "../types/agent-events";
 import { extractToolSummary } from "./toolSummary";
+import { parseAskUserQuestion } from "./parseAgentQuestion";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
-
-/**
- * Parse AskUserQuestion tool input JSON into question items.
- * Supports two formats:
- * - Single: { question: "...", options: [...] }
- * - Multi:  { questions: [{ header?, question, options, multiSelect? }] }
- *
- * Options can be strings or objects with label/description fields.
- */
-function parseAskUserQuestion(
-  parsed: Record<string, unknown>
-): AgentQuestionItem[] {
-  // Multi-question format
-  if (Array.isArray(parsed.questions)) {
-    return parsed.questions.map((q: Record<string, unknown>) => ({
-      header: typeof q.header === "string" ? q.header : undefined,
-      question: typeof q.question === "string" ? q.question : "",
-      options: parseOptions(q.options),
-      multiSelect: q.multiSelect === true,
-    }));
-  }
-
-  // Single-question format
-  if (typeof parsed.question === "string") {
-    return [
-      {
-        question: parsed.question,
-        options: parseOptions(parsed.options),
-        multiSelect: false,
-      },
-    ];
-  }
-
-  return [];
-}
-
-function parseOptions(
-  raw: unknown
-): Array<{ label: string; description?: string }> {
-  if (!Array.isArray(raw)) return [];
-  return raw.map((opt: unknown) => {
-    if (typeof opt === "string") return { label: opt };
-    if (typeof opt === "object" && opt !== null) {
-      const o = opt as Record<string, unknown>;
-      return {
-        label: typeof o.label === "string" ? o.label : String(o.label ?? ""),
-        description:
-          typeof o.description === "string" ? o.description : undefined,
-      };
-    }
-    return { label: String(opt) };
-  });
-}
 
 export function useAgentStream() {
   const appendStreamingContent = useAppStore((s) => s.appendStreamingContent);
@@ -92,11 +39,10 @@ export function useAgentStream() {
         updateWorkspace(wsId, { agent_status: "Idle" });
         setStreamingContent(wsId, "");
         blockToolMapRef.current = {};
-        // Clear pending question for this workspace
-        const currentQuestion = useAppStore.getState().agentQuestion;
-        if (currentQuestion?.workspaceId === wsId) {
-          setAgentQuestion(null);
-        }
+        // NOTE: Do NOT clear agentQuestion here. In --print mode the CLI
+        // exits immediately after emitting AskUserQuestion, so ProcessExited
+        // fires before the user has a chance to answer. The question is
+        // cleared when the user responds (onRespond) or sends a new message.
 
         // Notification: mark workspace as unread if not currently selected
         const { selectedWorkspaceId, markWorkspaceAsUnread } = useAppStore.getState();

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -191,26 +191,20 @@ export function useAgentStream() {
                       } catch { /* ignore */ }
                     }
 
-                    // Try to extract plan file path from recent messages.
+                    // Extract absolute plan file path from recent messages or
+                    // streaming content. Only match absolute paths (leading /).
+                    const planPathRe = /(\/[^\s)]+\/\.claude\/plans\/[^\s)]+\.md)/;
                     const messages = useAppStore.getState().chatMessages[wsId] || [];
                     let planFilePath: string | null = null;
                     for (let i = messages.length - 1; i >= Math.max(0, messages.length - 5); i--) {
-                      const match = messages[i].content.match(/\.claude\/plans\/[^\s)]+\.md/);
-                      if (match) {
-                        // Reconstruct full path — the match may be a relative or full path.
-                        planFilePath = match[0].startsWith("/") ? match[0] : null;
-                        // Also try extracting from a broader pattern.
-                        const fullMatch = messages[i].content.match(/(\/[^\s)]+\.claude\/plans\/[^\s)]+\.md)/);
-                        if (fullMatch) planFilePath = fullMatch[1];
-                        break;
-                      }
+                      const m = messages[i].content.match(planPathRe);
+                      if (m) { planFilePath = m[1]; break; }
                     }
 
-                    // Also check streaming content for the plan path.
                     if (!planFilePath) {
                       const streaming = useAppStore.getState().streamingContent[wsId] || "";
-                      const streamMatch = streaming.match(/(\/[^\s)]+\.claude\/plans\/[^\s)]+\.md)/);
-                      if (streamMatch) planFilePath = streamMatch[1];
+                      const m = streaming.match(planPathRe);
+                      if (m) planFilePath = m[1];
                     }
 
                     setPlanApproval({

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -18,6 +18,7 @@ export function useAgentStream() {
   );
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
+  const setPlanApproval = useAppStore((s) => s.setPlanApproval);
   const finalizeTurn = useAppStore((s) => s.finalizeTurn);
   const setPlanMode = useAppStore((s) => s.setPlanMode);
 
@@ -177,6 +178,48 @@ export function useAgentStream() {
                       // Malformed JSON — ignore, question won't show
                     }
                   }
+
+                  // Handle ExitPlanMode — show approval card.
+                  if (entry.toolName === "ExitPlanMode") {
+                    let allowedPrompts: Array<{ tool: string; prompt: string }> = [];
+                    if (activity?.inputJson) {
+                      try {
+                        const parsed = JSON.parse(activity.inputJson);
+                        if (Array.isArray(parsed.allowedPrompts)) {
+                          allowedPrompts = parsed.allowedPrompts;
+                        }
+                      } catch { /* ignore */ }
+                    }
+
+                    // Try to extract plan file path from recent messages.
+                    const messages = useAppStore.getState().chatMessages[wsId] || [];
+                    let planFilePath: string | null = null;
+                    for (let i = messages.length - 1; i >= Math.max(0, messages.length - 5); i--) {
+                      const match = messages[i].content.match(/\.claude\/plans\/[^\s)]+\.md/);
+                      if (match) {
+                        // Reconstruct full path — the match may be a relative or full path.
+                        planFilePath = match[0].startsWith("/") ? match[0] : null;
+                        // Also try extracting from a broader pattern.
+                        const fullMatch = messages[i].content.match(/(\/[^\s)]+\.claude\/plans\/[^\s)]+\.md)/);
+                        if (fullMatch) planFilePath = fullMatch[1];
+                        break;
+                      }
+                    }
+
+                    // Also check streaming content for the plan path.
+                    if (!planFilePath) {
+                      const streaming = useAppStore.getState().streamingContent[wsId] || "";
+                      const streamMatch = streaming.match(/(\/[^\s)]+\.claude\/plans\/[^\s)]+\.md)/);
+                      if (streamMatch) planFilePath = streamMatch[1];
+                    }
+
+                    setPlanApproval({
+                      workspaceId: wsId,
+                      toolUseId: entry.toolUseId,
+                      planFilePath,
+                      allowedPrompts,
+                    });
+                  }
                   break;
                 }
               }
@@ -243,6 +286,7 @@ export function useAgentStream() {
     appendToolActivityInput,
     updateWorkspace,
     setAgentQuestion,
+    setPlanApproval,
     finalizeTurn,
     setPlanMode,
   ]);

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -29,6 +29,8 @@ export function useAgentStream() {
   >({});
   // Count assistant messages in the current turn for the summary.
   const turnMessageCountRef = useRef<Record<string, number>>({});
+  // Plan file path extracted from EnterPlanMode tool results, keyed by wsId.
+  const planFilePathRef = useRef<Record<string, string>>({});
 
   useEffect(() => {
     const unlisten = listen<AgentStreamPayload>("agent-stream", (event) => {
@@ -191,20 +193,34 @@ export function useAgentStream() {
                       } catch { /* ignore */ }
                     }
 
-                    // Extract absolute plan file path from recent messages or
-                    // streaming content. Only match absolute paths (leading /).
-                    const planPathRe = /(\/[^\s)]+\/\.claude\/plans\/[^\s)]+\.md)/;
+                    // Extract absolute plan file path from ALL messages (the
+                    // path is typically mentioned when entering plan mode,
+                    // which may be many messages back). Search newest-first.
+                    const planPathRe = /(\/[^\s)"`]+\/\.claude\/plans\/[^\s)"`]+\.md)/;
                     const messages = useAppStore.getState().chatMessages[wsId] || [];
                     let planFilePath: string | null = null;
-                    for (let i = messages.length - 1; i >= Math.max(0, messages.length - 5); i--) {
+                    for (let i = messages.length - 1; i >= 0; i--) {
                       const m = messages[i].content.match(planPathRe);
                       if (m) { planFilePath = m[1]; break; }
                     }
 
+                    // Also check current streaming content and tool activity
+                    // input (the plan path may appear in tool results).
                     if (!planFilePath) {
                       const streaming = useAppStore.getState().streamingContent[wsId] || "";
                       const m = streaming.match(planPathRe);
                       if (m) planFilePath = m[1];
+                    }
+                    if (!planFilePath) {
+                      const allActivities = useAppStore.getState().toolActivities[wsId] || [];
+                      for (const act of allActivities) {
+                        const m = (act.inputJson + act.resultText).match(planPathRe);
+                        if (m) { planFilePath = m[1]; break; }
+                      }
+                    }
+                    // Fall back to cached path from EnterPlanMode tool result.
+                    if (!planFilePath && planFilePathRef.current[wsId]) {
+                      planFilePath = planFilePathRef.current[wsId];
                     }
 
                     setPlanApproval({
@@ -251,15 +267,21 @@ export function useAgentStream() {
             break;
           }
           case "user": {
-            // Tool results — update matching tool activities
+            // Tool results — update matching tool activities and extract
+            // plan file path from EnterPlanMode results.
+            const planPathRe = /(\/[^\s)"`]+\/\.claude\/plans\/[^\s)"`]+\.md)/;
             for (const block of streamEvent.message.content) {
               if (block.type === "tool_result") {
+                const text =
+                  typeof block.content === "string"
+                    ? block.content
+                    : JSON.stringify(block.content);
                 updateToolActivity(wsId, block.tool_use_id, {
-                  resultText:
-                    typeof block.content === "string"
-                      ? block.content
-                      : JSON.stringify(block.content),
+                  resultText: text,
                 });
+                // Capture plan file path from tool results (e.g. EnterPlanMode).
+                const pm = text.match(planPathRe);
+                if (pm) planFilePathRef.current[wsId] = pm[1];
               }
             }
             break;

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -170,6 +170,12 @@ export function resetAgentSession(workspaceId: string): Promise<void> {
   return invoke("reset_agent_session", { workspaceId });
 }
 
+// -- Plan --
+
+export function readPlanFile(path: string): Promise<string> {
+  return invoke("read_plan_file", { path });
+}
+
 // -- Diff --
 
 export interface DiffFilesResult {

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -34,29 +34,31 @@ function addToolActivities(wsId: string = WS_ID) {
   });
 }
 
-describe("agentQuestion lifecycle", () => {
+describe("agentQuestion lifecycle (per-workspace)", () => {
   beforeEach(() => {
     useAppStore.setState({
-      agentQuestion: null,
+      agentQuestions: {},
       toolActivities: {},
       completedTurns: {},
       chatMessages: {},
     });
   });
 
-  it("setAgentQuestion stores and retrieves the question", () => {
+  it("setAgentQuestion stores question keyed by workspace", () => {
     const q = makeQuestion();
     useAppStore.getState().setAgentQuestion(q);
-    expect(useAppStore.getState().agentQuestion).toEqual(q);
+    expect(useAppStore.getState().agentQuestions[WS_ID]).toEqual(q);
   });
 
-  it("setAgentQuestion(null) clears the question", () => {
-    useAppStore.getState().setAgentQuestion(makeQuestion());
-    useAppStore.getState().setAgentQuestion(null);
-    expect(useAppStore.getState().agentQuestion).toBeNull();
+  it("clearAgentQuestion removes question for that workspace only", () => {
+    useAppStore.getState().setAgentQuestion(makeQuestion(WS_ID));
+    useAppStore.getState().setAgentQuestion(makeQuestion("other-ws"));
+    useAppStore.getState().clearAgentQuestion(WS_ID);
+    expect(useAppStore.getState().agentQuestions[WS_ID]).toBeUndefined();
+    expect(useAppStore.getState().agentQuestions["other-ws"]).toBeDefined();
   });
 
-  it("finalizeTurn does NOT clear agentQuestion", () => {
+  it("finalizeTurn does NOT clear agentQuestions", () => {
     const q = makeQuestion();
     useAppStore.getState().setAgentQuestion(q);
     addToolActivities();
@@ -65,7 +67,7 @@ describe("agentQuestion lifecycle", () => {
 
     expect(useAppStore.getState().toolActivities[WS_ID]).toEqual([]);
     expect(useAppStore.getState().completedTurns[WS_ID]).toHaveLength(1);
-    expect(useAppStore.getState().agentQuestion).toEqual(q);
+    expect(useAppStore.getState().agentQuestions[WS_ID]).toEqual(q);
   });
 
   it("agentQuestion persists across multiple finalizeTurn calls", () => {
@@ -75,16 +77,17 @@ describe("agentQuestion lifecycle", () => {
     useAppStore.getState().finalizeTurn(WS_ID, 0);
     useAppStore.getState().finalizeTurn(WS_ID, 0);
 
-    expect(useAppStore.getState().agentQuestion).toEqual(q);
+    expect(useAppStore.getState().agentQuestions[WS_ID]).toEqual(q);
   });
 
-  it("question is scoped to workspace", () => {
-    const q = makeQuestion("other-workspace");
-    useAppStore.getState().setAgentQuestion(q);
+  it("questions are isolated per workspace", () => {
+    const qa = makeQuestion("ws-a");
+    const qb = makeQuestion("ws-b");
+    useAppStore.getState().setAgentQuestion(qa);
+    useAppStore.getState().setAgentQuestion(qb);
 
-    const stored = useAppStore.getState().agentQuestion;
-    expect(stored?.workspaceId).toBe("other-workspace");
-    expect(stored?.workspaceId).not.toBe(WS_ID);
+    expect(useAppStore.getState().agentQuestions["ws-a"]).toEqual(qa);
+    expect(useAppStore.getState().agentQuestions["ws-b"]).toEqual(qb);
   });
 });
 
@@ -98,7 +101,6 @@ describe("finalizeTurn afterMessageIndex", () => {
   });
 
   it("records afterMessageIndex as current chatMessages length", () => {
-    // Simulate 2 messages already in the chat.
     useAppStore.setState({
       chatMessages: {
         [WS_ID]: [
@@ -125,14 +127,12 @@ describe("finalizeTurn afterMessageIndex", () => {
   });
 
   it("successive turns get increasing afterMessageIndex", () => {
-    // Turn 1: finalize with 1 message
     useAppStore.setState({
       chatMessages: { [WS_ID]: [{ id: "m1", workspace_id: WS_ID, role: "Assistant", content: "a", cost_usd: null, duration_ms: null, created_at: "" }] },
     });
     addToolActivities();
     useAppStore.getState().finalizeTurn(WS_ID, 1);
 
-    // Turn 2: add user + assistant messages, then finalize with new tools
     useAppStore.setState({
       chatMessages: {
         [WS_ID]: [

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -17,13 +17,30 @@ function makeQuestion(wsId: string = WS_ID): AgentQuestion {
   };
 }
 
+function addToolActivities(wsId: string = WS_ID) {
+  useAppStore.setState({
+    toolActivities: {
+      [wsId]: [
+        {
+          toolUseId: "tool-1",
+          toolName: "AskUserQuestion",
+          inputJson: "{}",
+          resultText: "",
+          collapsed: true,
+          summary: "",
+        },
+      ],
+    },
+  });
+}
+
 describe("agentQuestion lifecycle", () => {
   beforeEach(() => {
-    // Reset store between tests.
     useAppStore.setState({
       agentQuestion: null,
       toolActivities: {},
       completedTurns: {},
+      chatMessages: {},
     });
   });
 
@@ -40,32 +57,14 @@ describe("agentQuestion lifecycle", () => {
   });
 
   it("finalizeTurn does NOT clear agentQuestion", () => {
-    // Set up a pending question and some tool activities.
     const q = makeQuestion();
     useAppStore.getState().setAgentQuestion(q);
-    useAppStore.setState({
-      toolActivities: {
-        [WS_ID]: [
-          {
-            toolUseId: "tool-1",
-            toolName: "AskUserQuestion",
-            inputJson: "{}",
-            resultText: "",
-            collapsed: true,
-            summary: "",
-          },
-        ],
-      },
-    });
+    addToolActivities();
 
-    // Finalize the turn — this is what "result" event triggers.
     useAppStore.getState().finalizeTurn(WS_ID, 1);
 
-    // Tool activities should be cleared and moved to completedTurns.
     expect(useAppStore.getState().toolActivities[WS_ID]).toEqual([]);
     expect(useAppStore.getState().completedTurns[WS_ID]).toHaveLength(1);
-
-    // But the question must survive — it's awaiting user input.
     expect(useAppStore.getState().agentQuestion).toEqual(q);
   });
 
@@ -73,7 +72,6 @@ describe("agentQuestion lifecycle", () => {
     const q = makeQuestion();
     useAppStore.getState().setAgentQuestion(q);
 
-    // Simulate ProcessExited calling finalizeTurn again (idempotent).
     useAppStore.getState().finalizeTurn(WS_ID, 0);
     useAppStore.getState().finalizeTurn(WS_ID, 0);
 
@@ -84,9 +82,72 @@ describe("agentQuestion lifecycle", () => {
     const q = makeQuestion("other-workspace");
     useAppStore.getState().setAgentQuestion(q);
 
-    // Question for a different workspace should not be visible for WS_ID.
     const stored = useAppStore.getState().agentQuestion;
     expect(stored?.workspaceId).toBe("other-workspace");
     expect(stored?.workspaceId).not.toBe(WS_ID);
+  });
+});
+
+describe("finalizeTurn afterMessageIndex", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      toolActivities: {},
+      completedTurns: {},
+      chatMessages: {},
+    });
+  });
+
+  it("records afterMessageIndex as current chatMessages length", () => {
+    // Simulate 2 messages already in the chat.
+    useAppStore.setState({
+      chatMessages: {
+        [WS_ID]: [
+          { id: "m1", workspace_id: WS_ID, role: "User", content: "hi", cost_usd: null, duration_ms: null, created_at: "" },
+          { id: "m2", workspace_id: WS_ID, role: "Assistant", content: "hello", cost_usd: null, duration_ms: null, created_at: "" },
+        ],
+      },
+    });
+    addToolActivities();
+
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns).toHaveLength(1);
+    expect(turns[0].afterMessageIndex).toBe(2);
+  });
+
+  it("records 0 when no messages exist", () => {
+    addToolActivities();
+    useAppStore.getState().finalizeTurn(WS_ID, 0);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns[0].afterMessageIndex).toBe(0);
+  });
+
+  it("successive turns get increasing afterMessageIndex", () => {
+    // Turn 1: finalize with 1 message
+    useAppStore.setState({
+      chatMessages: { [WS_ID]: [{ id: "m1", workspace_id: WS_ID, role: "Assistant", content: "a", cost_usd: null, duration_ms: null, created_at: "" }] },
+    });
+    addToolActivities();
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    // Turn 2: add user + assistant messages, then finalize with new tools
+    useAppStore.setState({
+      chatMessages: {
+        [WS_ID]: [
+          { id: "m1", workspace_id: WS_ID, role: "Assistant", content: "a", cost_usd: null, duration_ms: null, created_at: "" },
+          { id: "m2", workspace_id: WS_ID, role: "User", content: "b", cost_usd: null, duration_ms: null, created_at: "" },
+          { id: "m3", workspace_id: WS_ID, role: "Assistant", content: "c", cost_usd: null, duration_ms: null, created_at: "" },
+        ],
+      },
+    });
+    addToolActivities();
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns).toHaveLength(2);
+    expect(turns[0].afterMessageIndex).toBe(1);
+    expect(turns[1].afterMessageIndex).toBe(3);
   });
 });

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "./useAppStore";
+import type { AgentQuestion } from "./useAppStore";
+
+const WS_ID = "test-workspace";
+
+function makeQuestion(wsId: string = WS_ID): AgentQuestion {
+  return {
+    workspaceId: wsId,
+    toolUseId: "tool-1",
+    questions: [
+      {
+        question: "Pick a framework",
+        options: [{ label: "React" }, { label: "Vue" }],
+      },
+    ],
+  };
+}
+
+describe("agentQuestion lifecycle", () => {
+  beforeEach(() => {
+    // Reset store between tests.
+    useAppStore.setState({
+      agentQuestion: null,
+      toolActivities: {},
+      completedTurns: {},
+    });
+  });
+
+  it("setAgentQuestion stores and retrieves the question", () => {
+    const q = makeQuestion();
+    useAppStore.getState().setAgentQuestion(q);
+    expect(useAppStore.getState().agentQuestion).toEqual(q);
+  });
+
+  it("setAgentQuestion(null) clears the question", () => {
+    useAppStore.getState().setAgentQuestion(makeQuestion());
+    useAppStore.getState().setAgentQuestion(null);
+    expect(useAppStore.getState().agentQuestion).toBeNull();
+  });
+
+  it("finalizeTurn does NOT clear agentQuestion", () => {
+    // Set up a pending question and some tool activities.
+    const q = makeQuestion();
+    useAppStore.getState().setAgentQuestion(q);
+    useAppStore.setState({
+      toolActivities: {
+        [WS_ID]: [
+          {
+            toolUseId: "tool-1",
+            toolName: "AskUserQuestion",
+            inputJson: "{}",
+            resultText: "",
+            collapsed: true,
+            summary: "",
+          },
+        ],
+      },
+    });
+
+    // Finalize the turn — this is what "result" event triggers.
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    // Tool activities should be cleared and moved to completedTurns.
+    expect(useAppStore.getState().toolActivities[WS_ID]).toEqual([]);
+    expect(useAppStore.getState().completedTurns[WS_ID]).toHaveLength(1);
+
+    // But the question must survive — it's awaiting user input.
+    expect(useAppStore.getState().agentQuestion).toEqual(q);
+  });
+
+  it("agentQuestion persists across multiple finalizeTurn calls", () => {
+    const q = makeQuestion();
+    useAppStore.getState().setAgentQuestion(q);
+
+    // Simulate ProcessExited calling finalizeTurn again (idempotent).
+    useAppStore.getState().finalizeTurn(WS_ID, 0);
+    useAppStore.getState().finalizeTurn(WS_ID, 0);
+
+    expect(useAppStore.getState().agentQuestion).toEqual(q);
+  });
+
+  it("question is scoped to workspace", () => {
+    const q = makeQuestion("other-workspace");
+    useAppStore.getState().setAgentQuestion(q);
+
+    // Question for a different workspace should not be visible for WS_ID.
+    const stored = useAppStore.getState().agentQuestion;
+    expect(stored?.workspaceId).toBe("other-workspace");
+    expect(stored?.workspaceId).not.toBe(WS_ID);
+  });
+});

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -89,9 +89,10 @@ interface AppState {
     partialJson: string
   ) => void;
 
-  // -- Agent Questions --
-  agentQuestion: AgentQuestion | null;
-  setAgentQuestion: (q: AgentQuestion | null) => void;
+  // -- Agent Questions (per-workspace) --
+  agentQuestions: Record<string, AgentQuestion>;
+  setAgentQuestion: (q: AgentQuestion) => void;
+  clearAgentQuestion: (wsId: string) => void;
 
   // -- Notifications --
   unreadCompletions: Set<string>; // workspace IDs with unread completions
@@ -346,9 +347,17 @@ export const useAppStore = create<AppState>((set) => ({
       },
     })),
 
-  // -- Agent Questions --
-  agentQuestion: null,
-  setAgentQuestion: (q) => set({ agentQuestion: q }),
+  // -- Agent Questions (per-workspace) --
+  agentQuestions: {},
+  setAgentQuestion: (q) =>
+    set((s) => ({
+      agentQuestions: { ...s.agentQuestions, [q.workspaceId]: q },
+    })),
+  clearAgentQuestion: (wsId) =>
+    set((s) => {
+      const { [wsId]: _, ...rest } = s.agentQuestions;
+      return { agentQuestions: rest };
+    }),
 
   // -- Notifications --
   unreadCompletions: new Set<string>(),

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -29,6 +29,9 @@ export interface CompletedTurn {
   activities: ToolActivity[];
   messageCount: number;
   collapsed: boolean;
+  /** Index into chatMessages at the time of finalization — used to render
+   *  the turn summary at the correct chronological position. */
+  afterMessageIndex: number;
 }
 
 export interface AgentQuestionItem {
@@ -323,6 +326,7 @@ export const useAppStore = create<AppState>((set) => ({
         })),
         messageCount,
         collapsed: false,
+        afterMessageIndex: (s.chatMessages[wsId] || []).length,
       };
       return {
         completedTurns: {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -47,6 +47,13 @@ export interface AgentQuestion {
   questions: AgentQuestionItem[];
 }
 
+export interface PlanApproval {
+  workspaceId: string;
+  toolUseId: string;
+  planFilePath: string | null;
+  allowedPrompts: Array<{ tool: string; prompt: string }>;
+}
+
 interface AppState {
   // -- Repositories --
   repositories: Repository[];
@@ -93,6 +100,11 @@ interface AppState {
   agentQuestions: Record<string, AgentQuestion>;
   setAgentQuestion: (q: AgentQuestion) => void;
   clearAgentQuestion: (wsId: string) => void;
+
+  // -- Plan Approvals (per-workspace) --
+  planApprovals: Record<string, PlanApproval>;
+  setPlanApproval: (p: PlanApproval) => void;
+  clearPlanApproval: (wsId: string) => void;
 
   // -- Notifications --
   unreadCompletions: Set<string>; // workspace IDs with unread completions
@@ -357,6 +369,18 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => {
       const { [wsId]: _, ...rest } = s.agentQuestions;
       return { agentQuestions: rest };
+    }),
+
+  // -- Plan Approvals (per-workspace) --
+  planApprovals: {},
+  setPlanApproval: (p) =>
+    set((s) => ({
+      planApprovals: { ...s.planApprovals, [p.workspaceId]: p },
+    })),
+  clearPlanApproval: (wsId) =>
+    set((s) => {
+      const { [wsId]: _, ...rest } = s.planApprovals;
+      return { planApprovals: rest };
     }),
 
   // -- Notifications --

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -332,8 +332,8 @@ export const useAppStore = create<AppState>((set) => ({
         activities: activities.map((a) => ({
           toolUseId: a.toolUseId,
           toolName: a.toolName,
-          inputJson: "",
-          resultText: "",
+          inputJson: a.inputJson,
+          resultText: a.resultText,
           collapsed: true,
           summary: a.summary,
         })),


### PR DESCRIPTION
## Summary

- **Session persistence**: Persist agent session_id and turn_count to SQLite so `--resume` survives app restarts (migration 9)
- **Shift+Tab plan mode**: Toggle plan mode directly from chat input via Shift+Tab
- **AskUserQuestion fix**: Preserve question dialog after CLI process exit — the dialog was being cleared before the user could answer
- **Completed turns interleaving**: Tool call summaries now render at the correct chronological position in the chat stream instead of piling up at the bottom
- **Plan approval card**: When the agent calls ExitPlanMode, show an approval UI with inline plan viewer, requested permissions, and approve/deny buttons
- **Per-workspace state**: agentQuestions and planApprovals are now keyed by workspace ID to prevent cross-workspace clobbering
- **Codex review fixes**: Delayed session persistence until spawn succeeds, canonicalized plan paths to prevent directory traversal, routed remote plan reads through sendRemoteCommand

## Test plan

- [x] 138 Rust tests pass (`cargo test --all-features`)
- [x] 16 frontend tests pass (`bun run test`) — new vitest setup with parseAgentQuestion and store lifecycle tests
- [x] Zero clippy warnings, zero TS errors
- [x] Frontend builds successfully
- [x] Manual: verify session resume across app restart
- [x] Manual: verify AskUserQuestion persists until answered
- [x] Manual: verify plan approval card appears on ExitPlanMode
- [x] Manual: verify plan file viewer reads and displays content