### PR TITLE
fix: use remote-tracking refs for merge-base diff calculations

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -45,18 +45,40 @@ pub async fn validate_repo(path: &str) -> Result<(), GitError> {
 }
 
 pub async fn default_branch(repo_path: &str) -> Result<String, GitError> {
-    // Try symbolic-ref of origin/HEAD first
+    // Try symbolic-ref of origin/HEAD first (returns e.g. "origin/main")
     if let Ok(remote_head) = run_git(
         repo_path,
         &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
     )
     .await
-        && let Some(branch) = remote_head.strip_prefix("origin/")
     {
-        return Ok(branch.to_string());
+        let trimmed = remote_head.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
     }
 
-    // Fall back to checking if main or master exists
+    // Fall back to checking if remote-tracking main or master exists
+    if run_git(
+        repo_path,
+        &["rev-parse", "--verify", "refs/remotes/origin/main"],
+    )
+    .await
+    .is_ok()
+    {
+        return Ok("origin/main".into());
+    }
+    if run_git(
+        repo_path,
+        &["rev-parse", "--verify", "refs/remotes/origin/master"],
+    )
+    .await
+    .is_ok()
+    {
+        return Ok("origin/master".into());
+    }
+
+    // Last resort: local branches (no remote configured)
     if run_git(repo_path, &["rev-parse", "--verify", "refs/heads/main"])
         .await
         .is_ok()

--- a/src/git.rs
+++ b/src/git.rs
@@ -45,37 +45,55 @@ pub async fn validate_repo(path: &str) -> Result<(), GitError> {
 }
 
 pub async fn default_branch(repo_path: &str) -> Result<String, GitError> {
-    // Try symbolic-ref of origin/HEAD first (returns e.g. "origin/main")
+    // Resolve the primary remote name (usually "origin", but could be "upstream"
+    // in fork-and-PR workflows). Falls back to "origin" if no remote exists.
+    let remote = run_git(repo_path, &["remote"])
+        .await
+        .ok()
+        .and_then(|out| out.lines().next().map(|l| l.to_string()))
+        .unwrap_or_else(|| "origin".to_string());
+
+    // Try symbolic-ref of <remote>/HEAD first (returns e.g. "origin/main")
     if let Ok(remote_head) = run_git(
         repo_path,
-        &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+        &[
+            "symbolic-ref",
+            &format!("refs/remotes/{remote}/HEAD"),
+            "--short",
+        ],
     )
     .await
+        && !remote_head.is_empty()
     {
-        let trimmed = remote_head.trim();
-        if !trimmed.is_empty() {
-            return Ok(trimmed.to_string());
-        }
+        return Ok(remote_head);
     }
 
     // Fall back to checking if remote-tracking main or master exists
     if run_git(
         repo_path,
-        &["rev-parse", "--verify", "refs/remotes/origin/main"],
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("refs/remotes/{remote}/main"),
+        ],
     )
     .await
     .is_ok()
     {
-        return Ok("origin/main".into());
+        return Ok(format!("{remote}/main"));
     }
     if run_git(
         repo_path,
-        &["rev-parse", "--verify", "refs/remotes/origin/master"],
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("refs/remotes/{remote}/master"),
+        ],
     )
     .await
     .is_ok()
     {
-        return Ok("origin/master".into());
+        return Ok(format!("{remote}/master"));
     }
 
     // Last resort: local branches (no remote configured)

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -417,7 +417,7 @@ export function ChatPanel() {
               {defaultBranch && (
                 <>
                   <span className={styles.branchArrow}>{'>'}</span>
-                  <span className={styles.baseBranch}>{defaultBranch}</span>
+                  <span className={styles.baseBranch}>{defaultBranch.replace(/^origin\//, '')}</span>
                 </>
               )}
             </span>

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -124,7 +124,7 @@ const WorkspaceCard = memo(function WorkspaceCard({
         {baseBranch && (
           <>
             <span className={styles.arrow}>{">"}</span>
-            <span className={styles.baseBranch}>{baseBranch}</span>
+            <span className={styles.baseBranch}>{baseBranch.replace(/^origin\//, '')}</span>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- `default_branch()` now resolves to `origin/main` (remote-tracking ref) instead of the local `main` branch, which becomes stale in worktrees since `git fetch` doesn't update local branch refs
- Fixes workspaces showing inflated changed-file counts (e.g. 74 files instead of 16) when local `main` is behind `origin/main`
- UI display strips the `origin/` prefix so branch labels still show `main`

## Test plan
- [ ] Open a workspace where local `main` is behind `origin/main` — changed files should match `git diff origin/main...HEAD`
- [ ] Verify branch label in chat header and dashboard cards still shows `main` (not `origin/main`)
- [ ] Create a new worktree — should branch from `origin/main`
- [ ] Test with a repo that has no remote configured — should fall back to local `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)