### PR TITLE
feat: discover project-level skills in slash command picker

### DIFF
--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -47,9 +47,10 @@ pub fn discover_slash_commands(project_path: Option<&Path>) -> Vec<SlashCommand>
     collect_commands_from_dir(&claude_dir.join("commands"), "user", &mut commands);
     collect_skills_from_dir(&claude_dir.join("skills"), "user", &mut commands);
 
-    // Project-level commands (highest priority).
+    // Project-level commands and skills (highest priority).
     if let Some(project) = project_path {
         collect_commands_from_dir(&project.join(".claude/commands"), "project", &mut commands);
+        collect_skills_from_dir(&project.join(".claude/skills"), "project", &mut commands);
     }
 
     // Sort by name for consistent ordering.
@@ -343,6 +344,26 @@ mod tests {
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].name, "deploy");
         assert_eq!(commands[0].description, "Deploy the app to production.");
+        assert_eq!(commands[0].source, "project");
+    }
+
+    #[test]
+    fn test_project_skills() {
+        let project = tempfile::tempdir().unwrap();
+        let skills_dir = project.path().join(".claude/skills/my-project-skill");
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(
+            skills_dir.join("SKILL.md"),
+            "---\ndescription: Project-specific debugging skill\n---\n",
+        )
+        .unwrap();
+
+        let mut commands = Vec::new();
+        collect_skills_from_dir(&project.path().join(".claude/skills"), "project", &mut commands);
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "my-project-skill");
+        assert_eq!(commands[0].description, "Project-specific debugging skill");
         assert_eq!(commands[0].source, "project");
     }
 }


### PR DESCRIPTION
## Summary
Enables project-level skills (like `/claudette-debug`) to appear in the slash command picker.

## Problem
The slash command discovery system was only discovering:
- Plugin commands and skills (from `~/.claude/plugins/`)
- User-level commands and skills (from `~/.claude/commands` and `~/.claude/skills`)
- **Project-level commands only** (from `.claude/commands`)

Project-level skills from `.claude/skills/` were not being discovered, so the new `claudette-debug` skill wouldn't show up in the picker.

## Solution
Added `collect_skills_from_dir` call for the project path in `discover_slash_commands`, mirroring the existing pattern for user-level discovery.

## Changes
- `src/slash_commands.rs`: Added project-level skills discovery
- Added test `test_project_skills` to verify the functionality

## Test Plan
- [x] All 134 backend tests pass (including new test)
- [x] Zero clippy warnings
- [x] TypeScript type check passes
- [ ] Manual testing: Run app in dev mode, type `/` in chat, verify `/claudette-debug` appears in picker

## Context
This supports the new debugging infrastructure documented in `CLAUDE.md` lines 118-139.