### PR TITLE
ci(release): add Discord notification on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,11 +36,16 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+            echo "DISCORD_WEBHOOK_URL secret is not set — skipping notification"
+            exit 0
+          fi
+
           # Extract text between first and second ## [ headers
           CHANGELOG=$(sed -n '/^## \[/{n; :loop; /^## \[/q; p; n; b loop}' CHANGELOG.md)
 
           # Strip commit hash links — clutter in Discord
-          CHANGELOG=$(echo "$CHANGELOG" | sed 's/ \[([a-f0-9]\{7,\}\](https:\/\/[^)]*))//g')
+          CHANGELOG=$(echo "$CHANGELOG" | sed 's/ (\[[a-f0-9]\{7,\}\](https:\/\/[^)]*))//g')
 
           # Trim leading/trailing blank lines
           CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba}')

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,8 +47,8 @@ jobs:
           # Strip commit hash links — clutter in Discord
           CHANGELOG=$(echo "$CHANGELOG" | sed 's/ (\[[a-f0-9]\{7,\}\](https:\/\/[^)]*))//g')
 
-          # Trim leading/trailing blank lines
-          CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba}')
+          # Trim leading blank lines
+          CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d')
 
           # Truncate to 1900 chars (leaving room for embed overhead)
           if [ ${#CHANGELOG} -gt 1900 ]; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,53 @@ jobs:
       - id: release
         uses: googleapis/release-please-action@v4
 
+  notify-discord:
+    name: Discord Release Notification
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract changelog and notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          # Extract text between first and second ## [ headers
+          CHANGELOG=$(sed -n '/^## \[/{n; :loop; /^## \[/q; p; n; b loop}' CHANGELOG.md)
+
+          # Strip commit hash links — clutter in Discord
+          CHANGELOG=$(echo "$CHANGELOG" | sed 's/ \[([a-f0-9]\{7,\}\](https:\/\/[^)]*))//g')
+
+          # Trim leading/trailing blank lines
+          CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba}')
+
+          # Truncate to 1900 chars (leaving room for embed overhead)
+          if [ ${#CHANGELOG} -gt 1900 ]; then
+            CHANGELOG="${CHANGELOG:0:1897}..."
+          fi
+
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${TAG_NAME}"
+
+          PAYLOAD=$(jq -n \
+            --arg title "Claudette ${TAG_NAME} Released" \
+            --arg url "$RELEASE_URL" \
+            --arg desc "$CHANGELOG" \
+            '{
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 5763719
+              }]
+            }')
+
+          curl -f -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"
+
   build:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'


### PR DESCRIPTION
## Summary

Adds a `notify-discord` job to the release-please workflow that posts the latest CHANGELOG section to Discord as a rich embed when a new release is created.

```mermaid
graph LR
    A[release-please] --> B[notify-discord]
    A --> C[build matrix]
```

The notification job runs **in parallel** with the build matrix, so Discord gets notified immediately rather than waiting for the ~20min multi-platform build.

**How it works:**
- Extracts the newest section from `CHANGELOG.md` using `sed`
- Strips noisy commit hash links to save space
- Truncates to 1900 chars (Discord embed limit headroom)
- Builds JSON payload safely with `jq` (avoids injection from special chars in changelog)
- POSTs a green-bordered embed with the version as a clickable link to the GitHub Release

**Requires:** A `DISCORD_WEBHOOK_URL` repository secret (Discord Server Settings → Integrations → Webhooks).

## Test Steps

1. Add the `DISCORD_WEBHOOK_URL` secret to the repo (Settings → Secrets and variables → Actions)
2. Merge this PR, then merge the next release-please PR
3. Verify the `notify-discord` job succeeds in the Actions tab
4. Confirm the embed appears in the Discord channel with correct version, changelog, and link

## Checklist

- [x] No code changes — CI workflow only
- [ ] `DISCORD_WEBHOOK_URL` secret added to repo before next release