### PR TITLE
feat: add terminal command display via OSC 133 shell integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,8 +428,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -521,6 +523,7 @@ name = "claudette-tauri"
 version = "0.5.3"
 dependencies = [
  "async-trait",
+ "chrono",
  "claudette",
  "dirs",
  "futures",
@@ -529,6 +532,7 @@ dependencies = [
  "hex",
  "libc",
  "mdns-sd",
+ "parking_lot",
  "portable-pty",
  "rustls",
  "rustls-pemfile",
@@ -544,6 +548,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "urlencoding",
  "uuid",
 ]
 
@@ -5250,6 +5255,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,100 @@ src-server/
     mdns.rs             # mDNS service advertisement
 ```
 
+## Shell integration (optional)
+
+Claudette can track terminal commands and display them in the sidebar with status indicators (running, success, failure). This requires adding a snippet to your shell's RC file.
+
+### Zsh
+
+Add to `~/.zshrc`:
+
+```bash
+# Claudette shell integration
+if [[ -n "$CLAUDETTE_PTY" ]]; then
+    _claudette_precmd() {
+        local exit_code=$?
+        printf '\033]133;D;%s\007' "$exit_code"
+        printf '\033]133;A\007'
+        return $exit_code
+    }
+
+    _claudette_preexec() {
+        printf '\033]133;B\007'
+        local cmd_encoded=$(printf '%s' "$1" | jq -sRr @uri 2>/dev/null || printf '%s' "$1" | od -An -tx1 | tr ' ' '%' | tr -d '\n')
+        if [[ -n "$cmd_encoded" ]]; then
+            printf '\033]133;E;%s\007' "$cmd_encoded"
+        fi
+        printf '\033]133;C\007'
+    }
+
+    autoload -Uz add-zsh-hook
+    add-zsh-hook precmd _claudette_precmd
+    add-zsh-hook preexec _claudette_preexec
+fi
+```
+
+### Bash
+
+Add to `~/.bashrc`:
+
+```bash
+# Claudette shell integration
+if [[ -n "$CLAUDETTE_PTY" ]]; then
+    _claudette_prompt_start() {
+        printf '\033]133;A\007'
+    }
+
+    _claudette_prompt_cmd() {
+        local exit_code=$?
+        printf '\033]133;D;%s\007' "$exit_code"
+        _claudette_prompt_start
+        return $exit_code
+    }
+
+    _claudette_preexec() {
+        printf '\033]133;B\007'
+        local cmd_encoded=$(printf '%s' "$BASH_COMMAND" | jq -sRr @uri 2>/dev/null || echo "")
+        if [[ -n "$cmd_encoded" ]]; then
+            printf '\033]133;E;%s\007' "$cmd_encoded"
+        fi
+        printf '\033]133;C\007'
+    }
+
+    PROMPT_COMMAND="_claudette_prompt_cmd"
+    trap '_claudette_preexec' DEBUG
+fi
+```
+
+### Fish
+
+Add to `~/.config/fish/config.fish`:
+
+```fish
+# Claudette shell integration
+if test -n "$CLAUDETTE_PTY"
+    function __claudette_prompt_start --on-event fish_prompt
+        printf '\033]133;A\007'
+    end
+
+    function __claudette_preexec --on-event fish_preexec
+        printf '\033]133;B\007'
+        set cmd (string join ' ' $argv)
+        set cmd_encoded (string escape --style=url -- $cmd)
+        if test -n "$cmd_encoded"
+            printf '\033]133;E;%s\007' "$cmd_encoded"
+        end
+        printf '\033]133;C\007'
+    end
+
+    function __claudette_postexec --on-event fish_postexec
+        printf '\033]133;D;%s\007' $status
+    end
+end
+```
+
+After adding the snippet, restart your terminal or run `source ~/.zshrc` (or `~/.bashrc`/`~/.config/fish/config.fish`). Commands will now appear in the sidebar.
+
 ## Remote access
 
 Claudette can connect to workspaces on another machine. The remote machine runs `claudette-server`, a headless backend that communicates over an encrypted WebSocket connection. The local Claudette app discovers or connects to it and displays remote repos, agents, and terminals alongside local ones.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,9 @@ mdns-sd = "0.12"
 futures-util = "0.3"
 async-trait = "0.1"
 gethostname = "1"
+urlencoding = "2"
+parking_lot = "0.12"
+chrono = "0.4"
 
 [features]
 devtools = ["tauri/devtools"]

--- a/src-tauri/shell-integration.bash
+++ b/src-tauri/shell-integration.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Claudette shell integration for bash
+# This script enables command tracking and exit code reporting.
+
+_claudette_command_finished() {
+    local exit_code=$?
+    printf '\033]133;D;%s\007' "$exit_code"
+    return $exit_code
+}
+
+# Hook into bash prompt system
+if [[ -z "$PROMPT_COMMAND" ]]; then
+    PROMPT_COMMAND="_claudette_command_finished"
+else
+    PROMPT_COMMAND="${PROMPT_COMMAND%;}; _claudette_command_finished"
+fi
+
+# Emit A (prompt start) at the beginning of the prompt
+PS1='\[\033]133;A\007\]'"${PS1}"
+
+# PS0 is executed after command line is read, before execution
+# Bash doesn't let us emit B before user input, so we use an extended
+# format: OSC 133;E;command to send the command text explicitly
+# We also emit B and C for compatibility
+_claudette_ps0() {
+    # URL-encode the command to avoid issues with special characters
+    local cmd_encoded=$(printf '%s' "$BASH_COMMAND" | jq -sRr @uri 2>/dev/null || echo "")
+    printf '\033]133;B\007'
+    if [[ -n "$cmd_encoded" ]]; then
+        printf '\033]133;E;%s\007' "$cmd_encoded"
+    fi
+    printf '\033]133;C\007'
+}
+PS0='$(_claudette_ps0)'

--- a/src-tauri/shell-integration.fish
+++ b/src-tauri/shell-integration.fish
@@ -1,0 +1,22 @@
+# Claudette shell integration for fish
+# This script enables command tracking and exit code reporting.
+
+function __claudette_prompt_start --on-event fish_prompt
+    printf '\033]133;A\007'
+end
+
+# Emit B, explicit command text via E, and C in preexec
+# Fish provides the command in $argv
+function __claudette_preexec --on-event fish_preexec
+    printf '\033]133;B\007'
+    # URL-encode command to handle special characters
+    set cmd_encoded (string join ' ' $argv | jq -sRr @uri 2>/dev/null; or echo "")
+    if test -n "$cmd_encoded"
+        printf '\033]133;E;%s\007' "$cmd_encoded"
+    end
+    printf '\033]133;C\007'
+end
+
+function __claudette_postexec --on-event fish_postexec
+    printf '\033]133;D;%s\007' $status
+end

--- a/src-tauri/shell-integration.fish
+++ b/src-tauri/shell-integration.fish
@@ -9,8 +9,9 @@ end
 # Fish provides the command in $argv
 function __claudette_preexec --on-event fish_preexec
     printf '\033]133;B\007'
-    # URL-encode command to handle special characters
-    set cmd_encoded (string join ' ' $argv | jq -sRr @uri 2>/dev/null; or echo "")
+    # URL-encode command to handle special characters using fish built-in
+    set cmd (string join ' ' $argv)
+    set cmd_encoded (string escape --style=url -- $cmd)
     if test -n "$cmd_encoded"
         printf '\033]133;E;%s\007' "$cmd_encoded"
     end

--- a/src-tauri/shell-integration.zsh
+++ b/src-tauri/shell-integration.zsh
@@ -1,0 +1,22 @@
+# Claudette shell integration for zsh
+# This script enables command tracking and exit code reporting.
+
+_claudette_precmd() {
+    local exit_code=$?
+    printf '\033]133;D;%s\007' "$exit_code"
+    printf '\033]133;A\007'  # Prompt starts
+    return $exit_code
+}
+
+_claudette_preexec() {
+    printf '\033]133;C\007'  # Command output starts
+}
+
+# Add hooks
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _claudette_precmd
+add-zsh-hook preexec _claudette_preexec
+
+# Embed B marker (command start) at the END of the prompt
+# Use %{...%} to mark as non-printing for correct width calculation
+PS1="${PS1}"'%{$(printf "\033]133;B\007")%}'

--- a/src-tauri/shell-integration.zsh
+++ b/src-tauri/shell-integration.zsh
@@ -9,14 +9,19 @@ _claudette_precmd() {
 }
 
 _claudette_preexec() {
-    printf '\033]133;C\007'  # Command output starts
+    # Emit B marker (command input starts)
+    printf '\033]133;B\007'
+    # Emit explicit command text (zsh provides the command in $1)
+    # URL-encode to handle special characters
+    local cmd_encoded=$(printf '%s' "$1" | jq -sRr @uri 2>/dev/null || printf '%s' "$1" | od -An -tx1 | tr ' ' '%' | tr -d '\n')
+    if [[ -n "$cmd_encoded" ]]; then
+        printf '\033]133;E;%s\007' "$cmd_encoded"
+    fi
+    # Emit C marker (command output starts)
+    printf '\033]133;C\007'
 }
 
 # Add hooks
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _claudette_precmd
 add-zsh-hook preexec _claudette_preexec
-
-# Embed B marker (command start) at the END of the prompt
-# Use %{...%} to mark as non-printing for correct width calculation
-PS1="${PS1}"'%{$(printf "\033]133;B\007")%}'

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod plan;
 pub mod remote;
 pub mod repository;
 pub mod settings;
+pub mod shell;
 pub mod slash_commands;
 pub mod terminal;
 pub mod workspace;

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -53,7 +53,7 @@ fn generate_loader_code(shell_type: ShellType, script_path: &Path) -> String {
              # Auto-generated on {date}\n\
              # To disable, comment out or remove these lines\n\
              if [[ -n \"$CLAUDETTE_PTY\" ]]; then\n    \
-                 source {script_str}\n\
+                 source \"{script_str}\"\n\
              fi"
         ),
         ShellType::Fish => format!(
@@ -61,7 +61,7 @@ fn generate_loader_code(shell_type: ShellType, script_path: &Path) -> String {
              # Auto-generated on {date}\n\
              # To disable, comment out or remove these lines\n\
              if test -n \"$CLAUDETTE_PTY\"\n    \
-                 source {script_str}\n\
+                 source \"{script_str}\"\n\
              end"
         ),
         ShellType::Unknown => String::new(),
@@ -136,6 +136,27 @@ pub async fn setup_shell_integration() -> Result<SetupResult, String> {
 #[tauri::command]
 pub async fn apply_shell_integration(rc_path: String, loader_code: String) -> Result<(), String> {
     let path = PathBuf::from(&rc_path);
+
+    // Security: validate that the path is within home/config directory
+    let home_dir = dirs::home_dir().ok_or("Could not find home directory")?;
+    let config_dir = dirs::config_dir().ok_or("Could not find config directory")?;
+
+    let canonical_path = path.canonicalize().unwrap_or_else(|_| {
+        // If file doesn't exist yet, canonicalize the parent and append filename
+        path.parent()
+            .and_then(|p| p.canonicalize().ok())
+            .map(|p| p.join(path.file_name().unwrap_or_default()))
+            .unwrap_or_else(|| path.clone())
+    });
+
+    // Only allow writing to files under home or config directories
+    if !canonical_path.starts_with(&home_dir) && !canonical_path.starts_with(&config_dir) {
+        return Err(format!(
+            "Invalid RC path: must be within home ({}) or config ({}) directory",
+            home_dir.display(),
+            config_dir.display()
+        ));
+    }
 
     // Ensure parent directory exists (for fish config)
     if let Some(parent) = path.parent() {

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -1,0 +1,190 @@
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ShellType {
+    Bash,
+    Zsh,
+    Fish,
+    Unknown,
+}
+
+#[derive(Serialize)]
+pub struct SetupResult {
+    script_path: String,
+    rc_path: String,
+    loader_code: String,
+    already_integrated: bool,
+}
+
+fn detect_user_shell() -> (String, ShellType) {
+    // Try $SHELL environment variable first
+    if let Ok(shell) = std::env::var("SHELL") {
+        let shell_type = match shell.as_str() {
+            s if s.contains("bash") => ShellType::Bash,
+            s if s.contains("zsh") => ShellType::Zsh,
+            s if s.contains("fish") => ShellType::Fish,
+            _ => ShellType::Unknown,
+        };
+        return (shell, shell_type);
+    }
+
+    // Fallback: use system default
+    #[cfg(target_os = "macos")]
+    let default = ("/bin/zsh".to_string(), ShellType::Zsh);
+
+    #[cfg(target_os = "linux")]
+    let default = ("/bin/bash".to_string(), ShellType::Bash);
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let default = ("/bin/sh".to_string(), ShellType::Unknown);
+
+    default
+}
+
+fn generate_loader_code(shell_type: ShellType, script_path: &Path) -> String {
+    let script_str = script_path.to_string_lossy();
+    let date = chrono::Local::now().format("%Y-%m-%d");
+
+    match shell_type {
+        ShellType::Bash | ShellType::Zsh => format!(
+            "# Claudette shell integration\n\
+             # Auto-generated on {date}\n\
+             # To disable, comment out or remove these lines\n\
+             if [[ -n \"$CLAUDETTE_PTY\" ]]; then\n    \
+                 source {script_str}\n\
+             fi"
+        ),
+        ShellType::Fish => format!(
+            "# Claudette shell integration\n\
+             # Auto-generated on {date}\n\
+             # To disable, comment out or remove these lines\n\
+             if test -n \"$CLAUDETTE_PTY\"\n    \
+                 source {script_str}\n\
+             end"
+        ),
+        ShellType::Unknown => String::new(),
+    }
+}
+
+#[tauri::command]
+pub async fn setup_shell_integration() -> Result<SetupResult, String> {
+    let (_, shell_type) = detect_user_shell();
+
+    if shell_type == ShellType::Unknown {
+        return Err("Unsupported shell".to_string());
+    }
+
+    let config_dir = dirs::config_dir()
+        .ok_or("Could not find config directory")?
+        .join("claudette");
+
+    std::fs::create_dir_all(&config_dir)
+        .map_err(|e| format!("Failed to create config dir: {e}"))?;
+
+    // Write shell integration script
+    let script_content = match shell_type {
+        ShellType::Bash => include_str!("../../shell-integration.bash"),
+        ShellType::Zsh => include_str!("../../shell-integration.zsh"),
+        ShellType::Fish => include_str!("../../shell-integration.fish"),
+        ShellType::Unknown => return Err("Unsupported shell".to_string()),
+    };
+
+    let script_filename = match shell_type {
+        ShellType::Bash => "shell-integration.bash",
+        ShellType::Zsh => "shell-integration.zsh",
+        ShellType::Fish => "shell-integration.fish",
+        ShellType::Unknown => return Err("Unsupported shell".to_string()),
+    };
+
+    let script_path = config_dir.join(script_filename);
+
+    std::fs::write(&script_path, script_content)
+        .map_err(|e| format!("Failed to write integration script: {e}"))?;
+
+    // Determine RC file path
+    let rc_path = match shell_type {
+        ShellType::Bash => dirs::home_dir()
+            .ok_or("Could not find home directory")?
+            .join(".bashrc"),
+        ShellType::Zsh => dirs::home_dir()
+            .ok_or("Could not find home directory")?
+            .join(".zshrc"),
+        ShellType::Fish => dirs::config_dir()
+            .ok_or("Could not find config directory")?
+            .join("fish")
+            .join("config.fish"),
+        ShellType::Unknown => return Err("Unsupported shell".to_string()),
+    };
+
+    // Generate integration loader code
+    let loader_code = generate_loader_code(shell_type, &script_path);
+
+    // Check if already integrated
+    let existing_content = std::fs::read_to_string(&rc_path).unwrap_or_default();
+    let already_integrated = existing_content.contains("Claudette shell integration");
+
+    Ok(SetupResult {
+        script_path: script_path.to_string_lossy().to_string(),
+        rc_path: rc_path.to_string_lossy().to_string(),
+        loader_code,
+        already_integrated,
+    })
+}
+
+#[tauri::command]
+pub async fn apply_shell_integration(rc_path: String, loader_code: String) -> Result<(), String> {
+    let path = PathBuf::from(&rc_path);
+
+    // Ensure parent directory exists (for fish config)
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create parent directory: {e}"))?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&path)
+        .map_err(|e| format!("Failed to open RC file: {e}"))?;
+
+    use std::io::Write;
+    writeln!(file, "\n{loader_code}").map_err(|e| format!("Failed to write to RC file: {e}"))?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn open_in_editor(path: String) -> Result<(), String> {
+    // Open file in default editor using tauri-plugin-dialog
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = opener::open(&path) {
+            eprintln!("Failed to open file in editor: {e}");
+        }
+    });
+    Ok(())
+}
+
+mod opener {
+    use std::process::Command;
+
+    pub fn open(path: &str) -> std::io::Result<()> {
+        #[cfg(target_os = "macos")]
+        let cmd = Command::new("open").arg(path).spawn();
+
+        #[cfg(target_os = "linux")]
+        let cmd = Command::new("xdg-open").arg(path).spawn();
+
+        #[cfg(target_os = "windows")]
+        let cmd = Command::new("cmd").args(["/C", "start", "", path]).spawn();
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        let cmd = Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Unsupported platform",
+        ));
+
+        cmd.map(|_| ())
+    }
+}

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -18,7 +18,7 @@ pub struct SetupResult {
     already_integrated: bool,
 }
 
-fn detect_user_shell() -> (String, ShellType) {
+pub fn detect_user_shell() -> (String, ShellType) {
     // Try $SHELL environment variable first
     if let Ok(shell) = std::env::var("SHELL") {
         let shell_type = match shell.as_str() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 
 mod commands;
 mod mdns;
+mod osc133;
 mod pty;
 mod remote;
 mod state;
@@ -118,10 +119,15 @@ fn main() {
             pty::write_pty,
             pty::resize_pty,
             pty::close_pty,
+            pty::detect_shell,
             // Settings
             commands::settings::get_app_setting,
             commands::settings::set_app_setting,
             commands::settings::list_user_themes,
+            // Shell Integration
+            commands::shell::setup_shell_integration,
+            commands::shell::apply_shell_integration,
+            commands::shell::open_in_editor,
             // Remote
             commands::remote::list_remote_connections,
             commands::remote::pair_with_server,

--- a/src-tauri/src/osc133.rs
+++ b/src-tauri/src/osc133.rs
@@ -7,6 +7,8 @@ pub enum Osc133Event {
     CommandText { command: String }, // Extended: explicit command text
 }
 
+const MAX_OSC_PAYLOAD: usize = 4096; // Maximum OSC sequence payload length
+
 pub struct Osc133Parser {
     buffer: Vec<u8>,
     command_buffer: Vec<u8>,
@@ -79,6 +81,11 @@ impl Osc133Parser {
                     self.buffer.clear();
                 } else {
                     self.buffer.push(byte);
+                    // Prevent unbounded buffer growth from malformed OSC sequences
+                    if self.buffer.len() > MAX_OSC_PAYLOAD {
+                        self.in_osc = false;
+                        self.buffer.clear();
+                    }
                 }
             } else if byte == 0x1b {
                 self.buffer.push(byte);
@@ -117,8 +124,10 @@ impl Osc133Parser {
             self.tracking_command = false;
             Some(Osc133Event::CommandExecuted)
         } else if let Some(code_str) = s.strip_prefix("133;D;") {
-            let exit_code = code_str.trim().parse().unwrap_or(0);
-            Some(Osc133Event::CommandFinished { exit_code })
+            match code_str.trim().parse() {
+                Ok(exit_code) => Some(Osc133Event::CommandFinished { exit_code }),
+                Err(_) => None, // Ignore malformed exit codes
+            }
         } else if let Some(cmd_encoded) = s.strip_prefix("133;E;") {
             // Extended: explicit command text (URL-encoded)
             // When we receive explicit command text, stop tracking between B and C

--- a/src-tauri/src/osc133.rs
+++ b/src-tauri/src/osc133.rs
@@ -1,0 +1,247 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum Osc133Event {
+    PromptStart,
+    CommandStart,
+    CommandExecuted,
+    CommandFinished { exit_code: i32 },
+    CommandText { command: String }, // Extended: explicit command text
+}
+
+pub struct Osc133Parser {
+    buffer: Vec<u8>,
+    command_buffer: Vec<u8>,
+    in_osc: bool,
+    tracking_command: bool,
+}
+
+impl Osc133Parser {
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            command_buffer: Vec::new(),
+            in_osc: false,
+            tracking_command: false,
+        }
+    }
+
+    /// Feed bytes from PTY output, returns any detected OSC 133 events
+    pub fn feed(&mut self, data: &[u8]) -> Vec<Osc133Event> {
+        let mut events = Vec::new();
+
+        for &byte in data {
+            if self.in_osc {
+                // Look for BEL terminator
+                if byte == 0x07 {
+                    if let Some(event) = self.parse_osc133() {
+                        events.push(event);
+                    }
+                    self.in_osc = false;
+                    self.buffer.clear();
+                }
+                // Look for ESC \ terminator
+                else if self.buffer.last() == Some(&0x1b) && byte == b'\\' {
+                    self.buffer.pop(); // Remove ESC
+                    if let Some(event) = self.parse_osc133() {
+                        events.push(event);
+                    }
+                    self.in_osc = false;
+                    self.buffer.clear();
+                } else {
+                    self.buffer.push(byte);
+                }
+            } else if byte == 0x1b {
+                self.buffer.push(byte);
+            } else if !self.buffer.is_empty() {
+                // Check if we're starting an OSC sequence (ESC ])
+                if self.buffer == b"\x1b" && byte == b']' {
+                    self.in_osc = true;
+                    self.buffer.clear();
+                } else {
+                    // Not an OSC sequence, track as command text if needed
+                    if self.tracking_command && (0x20..0x7F).contains(&byte) {
+                        self.command_buffer.push(byte);
+                    }
+                    self.buffer.clear();
+                }
+            } else {
+                // Track printable characters between B and C markers
+                if self.tracking_command && (0x20..0x7F).contains(&byte) {
+                    self.command_buffer.push(byte);
+                }
+            }
+        }
+
+        events
+    }
+
+    fn parse_osc133(&mut self) -> Option<Osc133Event> {
+        let s = String::from_utf8_lossy(&self.buffer);
+
+        if s.starts_with("133;A") {
+            Some(Osc133Event::PromptStart)
+        } else if s.starts_with("133;B") {
+            // Command input starts - begin tracking
+            self.tracking_command = true;
+            self.command_buffer.clear();
+            Some(Osc133Event::CommandStart)
+        } else if s.starts_with("133;C") {
+            // Execution starts - stop tracking command text
+            self.tracking_command = false;
+            Some(Osc133Event::CommandExecuted)
+        } else if let Some(code_str) = s.strip_prefix("133;D;") {
+            let exit_code = code_str.trim().parse().unwrap_or(0);
+            Some(Osc133Event::CommandFinished { exit_code })
+        } else if let Some(cmd_encoded) = s.strip_prefix("133;E;") {
+            // Extended: explicit command text (URL-encoded)
+            let command = urlencoding::decode(cmd_encoded.trim())
+                .unwrap_or_default()
+                .to_string();
+            Some(Osc133Event::CommandText { command })
+        } else {
+            None
+        }
+    }
+
+    pub fn extract_command(&mut self) -> Option<String> {
+        if self.command_buffer.is_empty() {
+            return None;
+        }
+
+        let cmd = String::from_utf8_lossy(&self.command_buffer)
+            .trim()
+            .to_string();
+
+        self.command_buffer.clear();
+
+        if cmd.is_empty() { None } else { Some(cmd) }
+    }
+}
+
+impl Default for Osc133Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_sequence() {
+        let mut parser = Osc133Parser::new();
+
+        // Prompt start
+        let events = parser.feed(b"\x1b]133;A\x07");
+        assert_eq!(events, vec![Osc133Event::PromptStart]);
+
+        // Command start
+        let events = parser.feed(b"\x1b]133;B\x07");
+        assert_eq!(events, vec![Osc133Event::CommandStart]);
+
+        // User types command
+        parser.feed(b"npm run dev\r");
+
+        // Execution starts
+        let events = parser.feed(b"\x1b]133;C\x07");
+        assert_eq!(events, vec![Osc133Event::CommandExecuted]);
+        assert_eq!(parser.extract_command(), Some("npm run dev".to_string()));
+
+        // Command finishes with exit code 0
+        let events = parser.feed(b"\x1b]133;D;0\x07");
+        assert_eq!(events, vec![Osc133Event::CommandFinished { exit_code: 0 }]);
+    }
+
+    #[test]
+    fn test_exit_code_parsing() {
+        let mut parser = Osc133Parser::new();
+
+        let events = parser.feed(b"\x1b]133;D;127\x07");
+        assert_eq!(
+            events,
+            vec![Osc133Event::CommandFinished { exit_code: 127 }]
+        );
+    }
+
+    #[test]
+    fn test_esc_backslash_terminator() {
+        let mut parser = Osc133Parser::new();
+
+        // Use ESC \ instead of BEL
+        let events = parser.feed(b"\x1b]133;A\x1b\\");
+        assert_eq!(events, vec![Osc133Event::PromptStart]);
+    }
+
+    #[test]
+    fn test_multiline_command() {
+        let mut parser = Osc133Parser::new();
+
+        parser.feed(b"\x1b]133;B\x07");
+        parser.feed(b"for i in {1..10}; do\r\n");
+        parser.feed(b"  echo $i\r\n");
+        parser.feed(b"done\r");
+        parser.feed(b"\x1b]133;C\x07");
+
+        let cmd = parser.extract_command().unwrap();
+        assert!(cmd.contains("for i in"));
+        assert!(cmd.contains("echo"));
+        assert!(cmd.contains("done"));
+    }
+
+    #[test]
+    fn test_explicit_command_text() {
+        let mut parser = Osc133Parser::new();
+
+        // Bash/Fish style with explicit command via OSC 133;E
+        parser.feed(b"\x1b]133;B\x07");
+        let events = parser.feed(b"\x1b]133;E;npm%20run%20dev\x07");
+        assert_eq!(
+            events,
+            vec![Osc133Event::CommandText {
+                command: "npm run dev".to_string()
+            }]
+        );
+        parser.feed(b"\x1b]133;C\x07");
+        parser.feed(b"\x1b]133;D;0\x07");
+    }
+
+    #[test]
+    fn test_incremental_feed() {
+        let mut parser = Osc133Parser::new();
+
+        // Feed the sequence byte by byte
+        assert!(parser.feed(b"\x1b").is_empty());
+        assert!(parser.feed(b"]").is_empty());
+        assert!(parser.feed(b"1").is_empty());
+        assert!(parser.feed(b"3").is_empty());
+        assert!(parser.feed(b"3").is_empty());
+        assert!(parser.feed(b";").is_empty());
+        assert!(parser.feed(b"A").is_empty());
+        let events = parser.feed(b"\x07");
+        assert_eq!(events, vec![Osc133Event::PromptStart]);
+    }
+
+    #[test]
+    fn test_invalid_sequences_ignored() {
+        let mut parser = Osc133Parser::new();
+
+        // Invalid OSC code (not 133)
+        let events = parser.feed(b"\x1b]999;X\x07");
+        assert!(events.is_empty());
+
+        // Malformed sequence
+        let events = parser.feed(b"\x1b]133\x07");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_non_ascii_in_command() {
+        let mut parser = Osc133Parser::new();
+
+        parser.feed(b"\x1b]133;B\x07");
+        // Command with only printable ASCII should be captured
+        parser.feed(b"echo hello");
+        parser.feed(b"\x1b]133;C\x07");
+        assert_eq!(parser.extract_command(), Some("echo hello".to_string()));
+    }
+}

--- a/src-tauri/src/osc133.rs
+++ b/src-tauri/src/osc133.rs
@@ -12,6 +12,7 @@ pub struct Osc133Parser {
     command_buffer: Vec<u8>,
     in_osc: bool,
     tracking_command: bool,
+    in_escape: bool,
 }
 
 impl Osc133Parser {
@@ -21,6 +22,7 @@ impl Osc133Parser {
             command_buffer: Vec::new(),
             in_osc: false,
             tracking_command: false,
+            in_escape: false,
         }
     }
 
@@ -29,6 +31,35 @@ impl Osc133Parser {
         let mut events = Vec::new();
 
         for &byte in data {
+            // Handle escape sequences (don't track command text while in escape)
+            if self.in_escape {
+                self.buffer.push(byte);
+
+                // Check if we're starting an OSC sequence (ESC ])
+                if self.buffer == b"\x1b]" {
+                    self.in_osc = true;
+                    self.buffer.clear();
+                    self.in_escape = false;
+                }
+                // Check for CSI sequences (ESC [)
+                else if self.buffer.len() >= 2 && self.buffer[0] == 0x1b && self.buffer[1] == b'['
+                {
+                    // CSI parameter bytes: 0x30-0x3F (digits, semicolon, etc.)
+                    // CSI final byte: 0x40-0x7E (letters like H, J, K, m, etc.)
+                    // Skip [ itself and wait for the final byte
+                    if self.buffer.len() > 2 && (0x40..=0x7E).contains(&byte) {
+                        self.buffer.clear();
+                        self.in_escape = false;
+                    }
+                }
+                // Check for other escape sequences (ESC followed by single printable char)
+                else if self.buffer.len() == 2 && self.buffer[0] == 0x1b {
+                    self.buffer.clear();
+                    self.in_escape = false;
+                }
+                continue;
+            }
+
             if self.in_osc {
                 // Look for BEL terminator
                 if byte == 0x07 {
@@ -51,20 +82,9 @@ impl Osc133Parser {
                 }
             } else if byte == 0x1b {
                 self.buffer.push(byte);
-            } else if !self.buffer.is_empty() {
-                // Check if we're starting an OSC sequence (ESC ])
-                if self.buffer == b"\x1b" && byte == b']' {
-                    self.in_osc = true;
-                    self.buffer.clear();
-                } else {
-                    // Not an OSC sequence, track as command text if needed
-                    if self.tracking_command && (0x20..0x7F).contains(&byte) {
-                        self.command_buffer.push(byte);
-                    }
-                    self.buffer.clear();
-                }
+                self.in_escape = true;
             } else {
-                // Track printable characters between B and C markers
+                // Track printable characters between B and C markers (not in escape sequences)
                 if self.tracking_command && (0x20..0x7F).contains(&byte) {
                     self.command_buffer.push(byte);
                 }
@@ -243,5 +263,27 @@ mod tests {
         parser.feed(b"echo hello");
         parser.feed(b"\x1b]133;C\x07");
         assert_eq!(parser.extract_command(), Some("echo hello".to_string()));
+    }
+
+    #[test]
+    fn test_escape_sequences_filtered() {
+        let mut parser = Osc133Parser::new();
+
+        parser.feed(b"\x1b]133;B\x07");
+        // Command with ANSI escape sequences should filter them out
+        parser.feed(b"\x1b[K\x1b[?1h\x1b=\x1b[?2004hpnpm dev");
+        parser.feed(b"\x1b]133;C\x07");
+        assert_eq!(parser.extract_command(), Some("pnpm dev".to_string()));
+    }
+
+    #[test]
+    fn test_csi_sequences_filtered() {
+        let mut parser = Osc133Parser::new();
+
+        parser.feed(b"\x1b]133;B\x07");
+        // CSI sequences like cursor movement should be filtered
+        parser.feed(b"\x1b[2Jnpm run \x1b[31mbuild\x1b[0m");
+        parser.feed(b"\x1b]133;C\x07");
+        assert_eq!(parser.extract_command(), Some("npm run build".to_string()));
     }
 }

--- a/src-tauri/src/osc133.rs
+++ b/src-tauri/src/osc133.rs
@@ -85,8 +85,16 @@ impl Osc133Parser {
                 self.in_escape = true;
             } else {
                 // Track printable characters between B and C markers (not in escape sequences)
-                if self.tracking_command && (0x20..0x7F).contains(&byte) {
-                    self.command_buffer.push(byte);
+                if self.tracking_command {
+                    // Handle backspace/delete - remove last character from buffer
+                    if byte == 0x7F || byte == 0x08 {
+                        self.command_buffer.pop();
+                    }
+                    // Only add printable ASCII characters (space to ~, excluding DEL)
+                    else if (0x20..0x7F).contains(&byte) {
+                        self.command_buffer.push(byte);
+                    }
+                    // Ignore other control characters (newline, carriage return, etc.)
                 }
             }
         }
@@ -307,5 +315,28 @@ mod tests {
         parser.feed(b"\x1b]133;C\x07");
         // Should not extract duplicate command from B-C tracking
         assert_eq!(parser.extract_command(), None);
+    }
+
+    #[test]
+    fn test_backspace_handling() {
+        let mut parser = Osc133Parser::new();
+
+        parser.feed(b"\x1b]133;B\x07");
+        // User types "lss" then backspaces once to get "ls", then types " -l"
+        parser.feed(b"lss\x7F -l");
+        parser.feed(b"\x1b]133;C\x07");
+        assert_eq!(parser.extract_command(), Some("ls -l".to_string()));
+    }
+
+    #[test]
+    fn test_control_characters_ignored() {
+        let mut parser = Osc133Parser::new();
+
+        parser.feed(b"\x1b]133;B\x07");
+        // Command with carriage returns and newlines (from multiline input)
+        parser.feed(b"echo\rhello\n");
+        parser.feed(b"\x1b]133;C\x07");
+        // Should only capture printable characters
+        assert_eq!(parser.extract_command(), Some("echohello".to_string()));
     }
 }

--- a/src-tauri/src/osc133.rs
+++ b/src-tauri/src/osc133.rs
@@ -113,6 +113,9 @@ impl Osc133Parser {
             Some(Osc133Event::CommandFinished { exit_code })
         } else if let Some(cmd_encoded) = s.strip_prefix("133;E;") {
             // Extended: explicit command text (URL-encoded)
+            // When we receive explicit command text, stop tracking between B and C
+            self.tracking_command = false;
+            self.command_buffer.clear();
             let command = urlencoding::decode(cmd_encoded.trim())
                 .unwrap_or_default()
                 .to_string();
@@ -285,5 +288,24 @@ mod tests {
         parser.feed(b"\x1b[2Jnpm run \x1b[31mbuild\x1b[0m");
         parser.feed(b"\x1b]133;C\x07");
         assert_eq!(parser.extract_command(), Some("npm run build".to_string()));
+    }
+
+    #[test]
+    fn test_explicit_command_stops_tracking() {
+        let mut parser = Osc133Parser::new();
+
+        // Bash/Fish sends B, then some text, then E with explicit command, then C
+        parser.feed(b"\x1b]133;B\x07");
+        parser.feed(b"pnpm dev"); // This should be ignored once we get E
+        let events = parser.feed(b"\x1b]133;E;pnpm%20dev\x07");
+        assert_eq!(
+            events,
+            vec![Osc133Event::CommandText {
+                command: "pnpm dev".to_string()
+            }]
+        );
+        parser.feed(b"\x1b]133;C\x07");
+        // Should not extract duplicate command from B-C tracking
+        assert_eq!(parser.extract_command(), None);
     }
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,16 +1,65 @@
 use std::io::{Read, Write};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+use parking_lot::Mutex as ParkingMutex;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
+use crate::osc133::{Osc133Event, Osc133Parser};
 use crate::state::{AppState, PtyHandle};
 
 #[derive(Clone, Serialize)]
 struct PtyOutputPayload {
     pty_id: u64,
     data: Vec<u8>,
+}
+
+#[derive(Clone, Serialize)]
+struct CommandEvent {
+    pty_id: u64,
+    command: Option<String>,
+    exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum ShellType {
+    Bash,
+    Zsh,
+    Fish,
+    Unknown,
+}
+
+fn detect_user_shell() -> (String, ShellType) {
+    // Try $SHELL environment variable first
+    if let Ok(shell) = std::env::var("SHELL") {
+        let shell_type = match shell.as_str() {
+            s if s.contains("bash") => ShellType::Bash,
+            s if s.contains("zsh") => ShellType::Zsh,
+            s if s.contains("fish") => ShellType::Fish,
+            _ => ShellType::Unknown,
+        };
+        return (shell, shell_type);
+    }
+
+    // Fallback: use system default
+    #[cfg(target_os = "macos")]
+    let default = ("/bin/zsh".to_string(), ShellType::Zsh);
+
+    #[cfg(target_os = "linux")]
+    let default = ("/bin/bash".to_string(), ShellType::Bash);
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let default = ("/bin/sh".to_string(), ShellType::Unknown);
+
+    default
+}
+
+#[tauri::command]
+pub async fn detect_shell() -> Result<String, String> {
+    let (shell, _) = detect_user_shell();
+    Ok(shell)
 }
 
 #[tauri::command]
@@ -31,6 +80,9 @@ pub async fn spawn_pty(
 
     let mut cmd = CommandBuilder::new_default_prog();
     cmd.cwd(&working_dir);
+
+    // Set CLAUDETTE_PTY environment variable to enable shell integration
+    cmd.env("CLAUDETTE_PTY", "1");
 
     let child = pair
         .slave
@@ -53,20 +105,92 @@ pub async fn spawn_pty(
         .take_writer()
         .map_err(|e| format!("Failed to take PTY writer: {e}"))?;
 
+    // OSC 133 tracking state
+    let current_command = Arc::new(ParkingMutex::new(None));
+    let command_running = Arc::new(ParkingMutex::new(false));
+    let last_exit_code = Arc::new(ParkingMutex::new(None));
+
     // Background reader: reads PTY output and emits Tauri events.
     let emitter_app = app.clone();
     let reader_pty_id = pty_id;
+    let cmd_clone = current_command.clone();
+    let running_clone = command_running.clone();
+    let exit_clone = last_exit_code.clone();
+
     std::thread::spawn(move || {
         let mut buf = [0u8; 4096];
+        let mut parser = Osc133Parser::new();
+
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
+                    let data = &buf[..n];
+
+                    // Emit raw output for xterm.js
                     let payload = PtyOutputPayload {
                         pty_id: reader_pty_id,
-                        data: buf[..n].to_vec(),
+                        data: data.to_vec(),
                     };
                     let _ = emitter_app.emit("pty-output", &payload);
+
+                    // Parse OSC 133 sequences
+                    for event in parser.feed(data) {
+                        match event {
+                            Osc133Event::CommandStart => {
+                                // Will extract command from CommandText event or text between B and C
+                            }
+                            Osc133Event::CommandText { command } => {
+                                // Explicit command text (used by bash/fish via OSC 133;E)
+                                *cmd_clone.lock() = Some(command.clone());
+                                *running_clone.lock() = true;
+
+                                let _ = emitter_app.emit(
+                                    "pty-command-detected",
+                                    &CommandEvent {
+                                        pty_id: reader_pty_id,
+                                        command: Some(command),
+                                        exit_code: None,
+                                    },
+                                );
+                            }
+                            Osc133Event::CommandExecuted => {
+                                // Extract command text captured between B and C markers (zsh)
+                                if let Some(cmd) = parser.extract_command() {
+                                    *cmd_clone.lock() = Some(cmd.clone());
+                                    *running_clone.lock() = true;
+
+                                    let _ = emitter_app.emit(
+                                        "pty-command-detected",
+                                        &CommandEvent {
+                                            pty_id: reader_pty_id,
+                                            command: Some(cmd),
+                                            exit_code: None,
+                                        },
+                                    );
+                                }
+                            }
+                            Osc133Event::CommandFinished { exit_code } => {
+                                *running_clone.lock() = false;
+                                *exit_clone.lock() = Some(exit_code);
+
+                                let _ = emitter_app.emit(
+                                    "pty-command-stopped",
+                                    &CommandEvent {
+                                        pty_id: reader_pty_id,
+                                        command: cmd_clone.lock().clone(),
+                                        exit_code: Some(exit_code),
+                                    },
+                                );
+                            }
+                            Osc133Event::PromptStart => {
+                                // Prompt appeared - reset running state if still set
+                                if *running_clone.lock() {
+                                    *running_clone.lock() = false;
+                                }
+                            }
+                        }
+                    }
                 }
                 Err(_) => break,
             }
@@ -77,6 +201,9 @@ pub async fn spawn_pty(
         writer: Mutex::new(writer),
         master: Mutex::new(pair.master),
         child: Mutex::new(child),
+        current_command,
+        command_running,
+        last_exit_code,
     };
 
     state.ptys.write().await.insert(pty_id, handle);

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -152,8 +152,9 @@ pub async fn spawn_pty(
                             }
                             Osc133Event::PromptStart => {
                                 // Prompt appeared - reset running state if still set
-                                if *running_clone.lock() {
-                                    *running_clone.lock() = false;
+                                let mut running = running_clone.lock();
+                                if *running {
+                                    *running = false;
                                 }
                             }
                         }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -6,6 +6,7 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
+use crate::commands::shell::detect_user_shell;
 use crate::osc133::{Osc133Event, Osc133Parser};
 use crate::state::{AppState, PtyHandle};
 
@@ -20,40 +21,6 @@ struct CommandEvent {
     pty_id: u64,
     command: Option<String>,
     exit_code: Option<i32>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum ShellType {
-    Bash,
-    Zsh,
-    Fish,
-    Unknown,
-}
-
-fn detect_user_shell() -> (String, ShellType) {
-    // Try $SHELL environment variable first
-    if let Ok(shell) = std::env::var("SHELL") {
-        let shell_type = match shell.as_str() {
-            s if s.contains("bash") => ShellType::Bash,
-            s if s.contains("zsh") => ShellType::Zsh,
-            s if s.contains("fish") => ShellType::Fish,
-            _ => ShellType::Unknown,
-        };
-        return (shell, shell_type);
-    }
-
-    // Fallback: use system default
-    #[cfg(target_os = "macos")]
-    let default = ("/bin/zsh".to_string(), ShellType::Zsh);
-
-    #[cfg(target_os = "linux")]
-    let default = ("/bin/bash".to_string(), ShellType::Bash);
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    let default = ("/bin/sh".to_string(), ShellType::Unknown);
-
-    default
 }
 
 #[tauri::command]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
+use parking_lot::Mutex as ParkingMutex;
 use tokio::sync::RwLock;
 
 use crate::remote::DiscoveredServer;
@@ -26,6 +27,14 @@ pub struct PtyHandle {
     /// Master side — kept alive for resize operations.
     pub master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
     pub child: Mutex<Box<dyn portable_pty::Child + Send>>,
+
+    /// OSC 133 state tracking (kept for potential future use, e.g., PTY status queries)
+    #[allow(dead_code)]
+    pub current_command: Arc<ParkingMutex<Option<String>>>,
+    #[allow(dead_code)]
+    pub command_running: Arc<ParkingMutex<bool>>,
+    #[allow(dead_code)]
+    pub last_exit_code: Arc<ParkingMutex<Option<i32>>>,
 }
 
 /// State of the embedded claudette-server subprocess.

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -8,6 +8,8 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
@@ -157,6 +159,10 @@
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.6.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -123,16 +123,23 @@ function App() {
       };
     };
 
-    let unlistenCommandEvents: (() => void) | null = null;
-    setupCommandListeners().then((unlisten) => {
-      unlistenCommandEvents = unlisten;
+    let isActive = true;
+    const unlistenCommandEventsPromise = setupCommandListeners();
+
+    // If the promise resolves after cleanup, call unlisten immediately
+    unlistenCommandEventsPromise.then((unlisten) => {
+      if (!isActive) {
+        unlisten();
+      }
     });
 
     return () => {
+      isActive = false;
       window.clearInterval(discoveredServersPollId);
-      if (unlistenCommandEvents) {
-        unlistenCommandEvents();
-      }
+      // Clean up listeners when they're ready
+      void unlistenCommandEventsPromise.then((unlisten) => {
+        unlisten();
+      });
     };
   }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId]);
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "./stores/useAppStore";
 import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus } from "./services/tauri";
 import { applyTheme, loadAllThemes, findTheme } from "./utils/theme";
 import { AppLayout } from "./components/layout/AppLayout";
+import type { CommandEvent } from "./types";
 import "./styles/theme.css";
 
 function App() {
@@ -18,6 +20,8 @@ function App() {
   const setLocalServerRunning = useAppStore((s) => s.setLocalServerRunning);
   const setLocalServerConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
   const setCurrentThemeId = useAppStore((s) => s.setCurrentThemeId);
+  const setWorkspaceTerminalCommand = useAppStore((s) => s.setWorkspaceTerminalCommand);
+  const terminalTabs = useAppStore((s) => s.terminalTabs);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -77,8 +81,58 @@ function App() {
       })
       .catch((err) => console.error("Failed to load local server status:", err));
 
+    // Listen for terminal command events
+    const setupCommandListeners = async () => {
+      const unlistenCommandDetected = await listen<CommandEvent>("pty-command-detected", (event) => {
+        const { pty_id, command } = event.payload;
+
+        // Find the workspace that owns this PTY
+        for (const [wsId, tabs] of Object.entries(terminalTabs)) {
+          const tab = tabs.find((t) => t.pty_id === pty_id);
+          if (tab) {
+            setWorkspaceTerminalCommand(wsId, {
+              command: command || null,
+              isRunning: true,
+              exitCode: null,
+            });
+            break;
+          }
+        }
+      });
+
+      const unlistenCommandStopped = await listen<CommandEvent>("pty-command-stopped", (event) => {
+        const { pty_id, command, exit_code } = event.payload;
+
+        // Find the workspace that owns this PTY
+        for (const [wsId, tabs] of Object.entries(terminalTabs)) {
+          const tab = tabs.find((t) => t.pty_id === pty_id);
+          if (tab) {
+            setWorkspaceTerminalCommand(wsId, {
+              command: command || null,
+              isRunning: false,
+              exitCode: exit_code !== null && exit_code !== undefined ? exit_code : null,
+            });
+            break;
+          }
+        }
+      });
+
+      return () => {
+        unlistenCommandDetected();
+        unlistenCommandStopped();
+      };
+    };
+
+    let unlistenCommandEvents: (() => void) | null = null;
+    setupCommandListeners().then((unlisten) => {
+      unlistenCommandEvents = unlisten;
+    });
+
     return () => {
       window.clearInterval(discoveredServersPollId);
+      if (unlistenCommandEvents) {
+        unlistenCommandEvents();
+      }
     };
   }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId]);
 

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -20,8 +20,6 @@ function App() {
   const setLocalServerRunning = useAppStore((s) => s.setLocalServerRunning);
   const setLocalServerConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
   const setCurrentThemeId = useAppStore((s) => s.setCurrentThemeId);
-  const setWorkspaceTerminalCommand = useAppStore((s) => s.setWorkspaceTerminalCommand);
-  const terminalTabs = useAppStore((s) => s.terminalTabs);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -86,7 +84,8 @@ function App() {
       const unlistenCommandDetected = await listen<CommandEvent>("pty-command-detected", (event) => {
         const { pty_id, command } = event.payload;
 
-        // Find the workspace that owns this PTY
+        // Find the workspace that owns this PTY - use getState() to avoid stale closure
+        const { terminalTabs, setWorkspaceTerminalCommand } = useAppStore.getState();
         for (const [wsId, tabs] of Object.entries(terminalTabs)) {
           const tab = tabs.find((t) => t.pty_id === pty_id);
           if (tab) {
@@ -103,7 +102,8 @@ function App() {
       const unlistenCommandStopped = await listen<CommandEvent>("pty-command-stopped", (event) => {
         const { pty_id, command, exit_code } = event.payload;
 
-        // Find the workspace that owns this PTY
+        // Find the workspace that owns this PTY - use getState() to avoid stale closure
+        const { terminalTabs, setWorkspaceTerminalCommand } = useAppStore.getState();
         for (const [wsId, tabs] of Object.entries(terminalTabs)) {
           const tab = tabs.find((t) => t.pty_id === pty_id);
           if (tab) {

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -271,6 +271,56 @@
   font-family: var(--font-mono);
 }
 
+/* Terminal command display */
+.terminalCommand {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 2px;
+}
+
+.runningIcon {
+  color: var(--status-running);
+  animation: spin 2s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.successIcon {
+  color: var(--status-running);
+  flex-shrink: 0;
+}
+
+.errorIcon {
+  color: var(--status-stopped);
+  flex-shrink: 0;
+}
+
+.commandIcon {
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.commandText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .footer {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -45,6 +45,7 @@ export function Sidebar() {
   const didDragRef = useRef(false);
   const DRAG_THRESHOLD = 5; // px before drag activates
   const clearUnreadCompletion = useAppStore((s) => s.clearUnreadCompletion);
+  const workspaceTerminalCommands = useAppStore((s) => s.workspaceTerminalCommands);
 
   const creatingRef = useRef(false);
 
@@ -349,6 +350,32 @@ export function Sidebar() {
                         {hasUnread && <span className={styles.notificationBadge}>●</span>}
                       </span>
                       <span className={styles.wsBranch}>{ws.branch_name}</span>
+                      {(() => {
+                        const commandState = workspaceTerminalCommands[ws.id];
+                        if (!commandState?.command) return null;
+
+                        const truncateCommand = (cmd: string, maxLen: number) => {
+                          if (cmd.length <= maxLen) return cmd;
+                          return cmd.slice(0, maxLen - 3) + "...";
+                        };
+
+                        return (
+                          <div className={styles.terminalCommand}>
+                            {commandState.isRunning ? (
+                              <span className={styles.runningIcon} title="Running">⚙️</span>
+                            ) : commandState.exitCode === 0 ? (
+                              <span className={styles.successIcon} title="Exited successfully">✓</span>
+                            ) : commandState.exitCode !== null ? (
+                              <span className={styles.errorIcon} title={`Exit code: ${commandState.exitCode}`}>✗</span>
+                            ) : (
+                              <span className={styles.commandIcon}>▸</span>
+                            )}
+                            <span className={styles.commandText} title={commandState.command}>
+                              {truncateCommand(commandState.command, 40)}
+                            </span>
+                          </div>
+                        );
+                      })()}
                     </div>
                     <div className={styles.wsActions}>
                       {ws.status === "Active" ? (

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -41,6 +41,7 @@ export function TerminalPanel() {
   const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
   const terminalFontSize = useAppStore((s) => s.terminalFontSize);
+  const updateTerminalTabPtyId = useAppStore((s) => s.updateTerminalTabPtyId);
 
   const autoCreatedRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -145,6 +146,9 @@ export function TerminalPanel() {
           return;
         }
         inst.ptyId = ptyId;
+
+        // Store pty_id on the tab so we can map command events back to workspaces
+        updateTerminalTabPtyId(currentTabId, ptyId);
 
         const unlistenFn = await listen<PtyOutputPayload>(
           "pty-output",

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -9,6 +9,7 @@ import type {
   FileDiff,
   DiffViewMode,
   TerminalTab,
+  WorkspaceCommandState,
   RemoteConnectionInfo,
   DiscoveredServer,
   ConversationCheckpoint,
@@ -166,11 +167,17 @@ interface AppState {
   terminalTabs: Record<string, TerminalTab[]>;
   activeTerminalTabId: number | null;
   terminalPanelVisible: boolean;
+  workspaceTerminalCommands: Record<string, WorkspaceCommandState>;
   setTerminalTabs: (wsId: string, tabs: TerminalTab[]) => void;
   addTerminalTab: (wsId: string, tab: TerminalTab) => void;
   removeTerminalTab: (wsId: string, tabId: number) => void;
   setActiveTerminalTab: (id: number | null) => void;
   toggleTerminalPanel: () => void;
+  setWorkspaceTerminalCommand: (
+    wsId: string,
+    state: WorkspaceCommandState
+  ) => void;
+  updateTerminalTabPtyId: (tabId: number, ptyId: number) => void;
 
   // -- UI --
   metaKeyHeld: boolean;
@@ -627,6 +634,7 @@ export const useAppStore = create<AppState>((set) => ({
   terminalTabs: {},
   activeTerminalTabId: null,
   terminalPanelVisible: false,
+  workspaceTerminalCommands: {},
   setTerminalTabs: (wsId, tabs) =>
     set((s) => ({
       terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
@@ -654,6 +662,23 @@ export const useAppStore = create<AppState>((set) => ({
   setActiveTerminalTab: (id) => set({ activeTerminalTabId: id }),
   toggleTerminalPanel: () =>
     set((s) => ({ terminalPanelVisible: !s.terminalPanelVisible })),
+  setWorkspaceTerminalCommand: (wsId, state) =>
+    set((s) => ({
+      workspaceTerminalCommands: {
+        ...s.workspaceTerminalCommands,
+        [wsId]: state,
+      },
+    })),
+  updateTerminalTabPtyId: (tabId, ptyId) =>
+    set((s) => {
+      const newTabs: Record<string, TerminalTab[]> = {};
+      for (const [wsId, tabs] of Object.entries(s.terminalTabs)) {
+        newTabs[wsId] = tabs.map((tab) =>
+          tab.id === tabId ? { ...tab, pty_id: ptyId } : tab
+        );
+      }
+      return { terminalTabs: newTabs };
+    }),
 
   // -- UI --
   metaKeyHeld: false,

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -14,7 +14,12 @@ export type {
   DiffLine,
   DiffLineType,
 } from "./diff";
-export type { TerminalTab } from "./terminal";
+export type {
+  TerminalTab,
+  WorkspaceCommandState,
+  CommandEvent,
+  SetupResult,
+} from "./terminal";
 export type {
   AgentStreamPayload,
   AgentEvent,

--- a/src/ui/src/types/terminal.ts
+++ b/src/ui/src/types/terminal.ts
@@ -5,4 +5,24 @@ export interface TerminalTab {
   is_script_output: boolean;
   sort_order: number;
   created_at: string;
+  pty_id?: number;
+}
+
+export interface WorkspaceCommandState {
+  command: string | null;
+  isRunning: boolean;
+  exitCode: number | null;
+}
+
+export interface CommandEvent {
+  pty_id: number;
+  command: string | null;
+  exit_code: number | null;
+}
+
+export interface SetupResult {
+  script_path: string;
+  rc_path: string;
+  loader_code: string;
+  already_integrated: boolean;
 }


### PR DESCRIPTION
## Summary

Implements terminal command tracking in the sidebar using industry-standard OSC 133 escape sequences. Commands are displayed with visual indicators for running (spinning gear), success (checkmark), and failure (X with exit code).

## Backend Changes

- Add OSC 133 parser with comprehensive unit tests
- Integrate parser into PTY reader thread  
- Emit `pty-command-detected` and `pty-command-stopped` events
- Add shell detection and integration setup commands
- Create shell integration scripts for bash, zsh, and fish
- Set `CLAUDETTE_PTY=1` environment variable in spawned terminals

## Frontend Changes

- Add `WorkspaceCommandState` type and store slice
- Listen for command events and map PTY IDs to workspaces
- Display commands in sidebar with status icons:
  - ⚙️ Running (animated spin)
  - ✓ Success (exit code 0)
  - ✗ Failed (with exit code in tooltip)
- Add CSS animations for running commands
- Store PTY IDs on terminal tabs for event mapping

## Graceful Degradation

- When shell integration is not set up, sidebar shows nothing
- No prompts or warnings for missing integration
- Terminal functionality unchanged without integration
- Integration is completely optional

## Testing

- All backend tests pass (`cargo clippy` clean)
- TypeScript type check passes (`bunx tsc --noEmit`)
- OSC 133 parser has comprehensive unit tests

The feature enables users to see at a glance which workspaces have active processes (like dev servers) and whether recent commands succeeded or failed, without switching between workspaces.

Closes #121