### PR TITLE
feat: auto-rename git branch after first user prompt using Haiku

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -578,8 +578,16 @@ async fn try_auto_rename(
             Ok(()) => {
                 // DB updated — now rename the git branch.
                 if let Err(e) = git::rename_branch(repo_path, old_branch, &new_branch).await {
+                    let msg = e.to_string();
                     eprintln!("[rename] Git branch rename failed: {e} — rolling back DB");
                     let _ = db.rename_workspace(ws_id, old_name, old_branch);
+
+                    // If the target branch already exists, fall back to the next
+                    // candidate just like we do for DB unique constraint collisions.
+                    if msg.contains("already exists") {
+                        eprintln!("[rename] Branch {new_branch:?} collides, trying next");
+                        continue;
+                    }
                     return;
                 }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -167,12 +167,42 @@ pub async fn send_chat_message(
     session.active_pid = Some(turn_handle.pid);
     drop(agents);
 
+    // Capture rename context before the bridge spawn.
+    let rename_repo_path = repo.as_ref().map(|r| r.path.clone());
+    let rename_old_branch = ws.branch_name.clone();
+    let rename_old_name = ws.name.clone();
+    let rename_prompt = content.clone();
+
     // Bridge: read from mpsc receiver, emit Tauri events.
     let ws_id = workspace_id.clone();
     let db_path = state.db_path.clone();
     let wt_path = worktree_path.clone();
     let user_msg_id = user_msg.id.clone();
     tokio::spawn(async move {
+        // On the first turn, spawn a background task to auto-rename the branch
+        // using Haiku. This runs concurrently and does not block the event loop.
+        if !is_resume && let Some(ref repo_path) = rename_repo_path {
+            let ws_id2 = ws_id.clone();
+            let repo_path2 = repo_path.clone();
+            let old_branch2 = rename_old_branch.clone();
+            let old_name2 = rename_old_name.clone();
+            let prompt2 = rename_prompt.clone();
+            let db_path2 = db_path.clone();
+            let app2 = app.clone();
+            tokio::spawn(async move {
+                try_auto_rename(
+                    &ws_id2,
+                    &repo_path2,
+                    &old_name2,
+                    &old_branch2,
+                    &prompt2,
+                    &db_path2,
+                    &app2,
+                )
+                .await;
+            });
+        }
+
         let mut rx = turn_handle.event_rx;
         let mut got_init = false;
         // Track the last assistant message inserted in THIS turn. Falls back
@@ -509,6 +539,75 @@ pub async fn load_completed_turns(
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.list_completed_turns(&workspace_id)
         .map_err(|e| e.to_string())
+}
+
+/// Background task: generate a descriptive branch name via Haiku and rename
+/// the workspace's branch + DB record. All failures are non-fatal.
+async fn try_auto_rename(
+    ws_id: &str,
+    repo_path: &str,
+    old_name: &str,
+    old_branch: &str,
+    prompt: &str,
+    db_path: &std::path::Path,
+    app: &AppHandle,
+) {
+    // Ask Haiku for a branch name slug.
+    let slug = match agent::generate_branch_name(prompt).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[rename] Haiku branch name generation failed: {e}");
+            return;
+        }
+    };
+
+    // Try the slug, then slug-2, slug-3 on name collision.
+    let candidates = [slug.clone(), format!("{slug}-2"), format!("{slug}-3")];
+    for candidate in &candidates {
+        let new_branch = format!("claudette/{candidate}");
+
+        let db = match Database::open(db_path) {
+            Ok(db) => db,
+            Err(e) => {
+                eprintln!("[rename] Failed to open DB: {e}");
+                return;
+            }
+        };
+
+        match db.rename_workspace(ws_id, candidate, &new_branch) {
+            Ok(()) => {
+                // DB updated — now rename the git branch.
+                if let Err(e) = git::rename_branch(repo_path, old_branch, &new_branch).await {
+                    eprintln!("[rename] Git branch rename failed: {e} — rolling back DB");
+                    let _ = db.rename_workspace(ws_id, old_name, old_branch);
+                    return;
+                }
+
+                // Success — notify the frontend.
+                let payload = serde_json::json!({
+                    "workspace_id": ws_id,
+                    "name": candidate,
+                    "branch_name": new_branch,
+                });
+                let _ = app.emit("workspace-renamed", &payload);
+                eprintln!("[rename] Workspace {ws_id} renamed to {candidate} ({new_branch})");
+                return;
+            }
+            Err(e) => {
+                // Check if this is a unique constraint violation by inspecting
+                // the error message (rusqlite is not a direct dependency here).
+                let msg = e.to_string();
+                if msg.contains("UNIQUE constraint failed") {
+                    eprintln!("[rename] Name {candidate:?} collides, trying next");
+                    continue;
+                }
+                eprintln!("[rename] DB rename failed: {e}");
+                return;
+            }
+        }
+    }
+
+    eprintln!("[rename] All name candidates exhausted for workspace {ws_id}");
 }
 
 fn now_iso() -> String {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -184,6 +184,7 @@ pub async fn send_chat_message(
         if !is_resume && let Some(ref repo_path) = rename_repo_path {
             let ws_id2 = ws_id.clone();
             let repo_path2 = repo_path.clone();
+            let wt_path2 = wt_path.clone();
             let old_branch2 = rename_old_branch.clone();
             let old_name2 = rename_old_name.clone();
             let prompt2 = rename_prompt.clone();
@@ -193,6 +194,7 @@ pub async fn send_chat_message(
                 try_auto_rename(
                     &ws_id2,
                     &repo_path2,
+                    &wt_path2,
                     &old_name2,
                     &old_branch2,
                     &prompt2,
@@ -543,9 +545,11 @@ pub async fn load_completed_turns(
 
 /// Background task: generate a descriptive branch name via Haiku and rename
 /// the workspace's branch + DB record. All failures are non-fatal.
+#[allow(clippy::too_many_arguments)]
 async fn try_auto_rename(
     ws_id: &str,
     repo_path: &str,
+    worktree_path: &str,
     old_name: &str,
     old_branch: &str,
     prompt: &str,
@@ -553,7 +557,7 @@ async fn try_auto_rename(
     app: &AppHandle,
 ) {
     // Ask Haiku for a branch name slug.
-    let slug = match agent::generate_branch_name(prompt).await {
+    let slug = match agent::generate_branch_name(prompt, worktree_path).await {
         Ok(s) => s,
         Err(e) => {
             eprintln!("[rename] Haiku branch name generation failed: {e}");

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -442,7 +442,7 @@ pub fn sanitize_branch_name(raw: &str, max_len: usize) -> String {
     if trimmed.len() <= max_len {
         return trimmed.to_string();
     }
-    // Truncate at max_len but don't cut mid-word if there's a hyphen nearby.
+    // Truncate at `max_len` and drop any trailing hyphens introduced by the cut.
     let truncated = &trimmed[..max_len];
     truncated.trim_end_matches('-').to_string()
 }
@@ -454,6 +454,7 @@ pub async fn generate_branch_name(prompt_text: &str) -> Result<String, String> {
     let truncated: String = prompt_text.chars().take(200).collect();
 
     let mut cmd = Command::new("claude");
+    cmd.stdin(std::process::Stdio::null());
     cmd.args([
         "--print",
         "--output-format",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -404,6 +404,102 @@ pub async fn stop_agent(pid: u32) -> Result<(), String> {
 }
 
 // ---------------------------------------------------------------------------
+// Branch name generation via Haiku
+// ---------------------------------------------------------------------------
+
+/// Sanitize a string into a valid git branch slug: lowercase ASCII
+/// alphanumeric + hyphens, no leading/trailing hyphens, max `max_len` chars.
+pub fn sanitize_branch_name(raw: &str, max_len: usize) -> String {
+    let slug: String = raw
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    // Collapse consecutive hyphens.
+    let mut collapsed = String::with_capacity(slug.len());
+    let mut prev_hyphen = false;
+    for c in slug.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                collapsed.push(c);
+            }
+            prev_hyphen = true;
+        } else {
+            collapsed.push(c);
+            prev_hyphen = false;
+        }
+    }
+
+    // Trim leading/trailing hyphens, truncate.
+    let trimmed = collapsed.trim_matches('-');
+    if trimmed.len() <= max_len {
+        return trimmed.to_string();
+    }
+    // Truncate at max_len but don't cut mid-word if there's a hyphen nearby.
+    let truncated = &trimmed[..max_len];
+    truncated.trim_end_matches('-').to_string()
+}
+
+/// Call Claude Haiku to generate a short branch name slug from the user's
+/// first prompt. Returns a sanitized branch slug (e.g. `fix-login-timeout`).
+pub async fn generate_branch_name(prompt_text: &str) -> Result<String, String> {
+    // Truncate prompt to keep the Haiku call fast and cheap.
+    let truncated: String = prompt_text.chars().take(200).collect();
+
+    let mut cmd = Command::new("claude");
+    cmd.args([
+        "--print",
+        "--output-format",
+        "text",
+        "--model",
+        "claude-haiku-4-5",
+        "--max-turns",
+        "1",
+        "--append-system-prompt",
+        "You are a git branch name generator. Given the user's task description, \
+         output a single branch-safe slug: lowercase ASCII letters, numbers, and \
+         hyphens only. No spaces, no quotes, no explanation. Max 40 characters. \
+         Output ONLY the slug.",
+        &truncated,
+    ]);
+
+    // Strip env vars that interfere with subprocess auth — same as run_turn.
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY")
+        && !key.starts_with("sk-ant-api")
+    {
+        cmd.env_remove("ANTHROPIC_API_KEY");
+    }
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| format!("Failed to spawn claude for branch name: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Haiku branch name call failed: {stderr}"));
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let slug = sanitize_branch_name(&raw, 40);
+    if slug.is_empty() {
+        return Err(format!(
+            "Haiku returned empty or unsanitizable output: {raw:?}"
+        ));
+    }
+    Ok(slug)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -963,5 +1059,67 @@ mod tests {
         assert_eq!(args[pm_idx + 1], "plan");
         // Even with plan_mode, bypass tools should NOT pass --allowedTools
         assert!(!args.contains(&"--allowedTools".to_string()));
+    }
+
+    // --- Branch name sanitization tests ---
+
+    #[test]
+    fn test_sanitize_simple_slug() {
+        assert_eq!(sanitize_branch_name("fix-login-bug", 40), "fix-login-bug");
+    }
+
+    #[test]
+    fn test_sanitize_uppercase_and_spaces() {
+        assert_eq!(
+            sanitize_branch_name("Fix Login Timeout", 40),
+            "fix-login-timeout"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_special_characters() {
+        assert_eq!(
+            sanitize_branch_name("add CSV export!!", 40),
+            "add-csv-export"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_consecutive_hyphens() {
+        assert_eq!(
+            sanitize_branch_name("fix---multiple---hyphens", 40),
+            "fix-multiple-hyphens"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_leading_trailing_hyphens() {
+        assert_eq!(
+            sanitize_branch_name("--leading-and-trailing--", 40),
+            "leading-and-trailing"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_truncation() {
+        let long_input = "this-is-a-very-long-branch-name-that-exceeds-the-limit";
+        let result = sanitize_branch_name(long_input, 20);
+        assert!(result.len() <= 20);
+        assert!(!result.ends_with('-'));
+    }
+
+    #[test]
+    fn test_sanitize_empty_input() {
+        assert_eq!(sanitize_branch_name("", 40), "");
+    }
+
+    #[test]
+    fn test_sanitize_all_special_chars() {
+        assert_eq!(sanitize_branch_name("!@#$%", 40), "");
+    }
+
+    #[test]
+    fn test_sanitize_preserves_numbers() {
+        assert_eq!(sanitize_branch_name("fix-issue-42", 40), "fix-issue-42");
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -449,26 +449,34 @@ pub fn sanitize_branch_name(raw: &str, max_len: usize) -> String {
 
 /// Call Claude Haiku to generate a short branch name slug from the user's
 /// first prompt. Returns a sanitized branch slug (e.g. `fix-login-timeout`).
-pub async fn generate_branch_name(prompt_text: &str) -> Result<String, String> {
+/// `worktree_path` sets the subprocess CWD so the CLI picks up the correct
+/// project context (CLAUDE.md) for the user's workspace — not Claudette's own.
+pub async fn generate_branch_name(
+    prompt_text: &str,
+    worktree_path: &str,
+) -> Result<String, String> {
     // Truncate prompt to keep the Haiku call fast and cheap.
     let truncated: String = prompt_text.chars().take(200).collect();
 
     let mut cmd = Command::new("claude");
     cmd.stdin(std::process::Stdio::null());
+    // Run in the user's worktree so the CLI loads *their* project context.
+    cmd.current_dir(worktree_path);
+    let user_message = format!(
+        "Generate a short git branch name slug for the following task. \
+         Output ONLY the slug — no explanation, no markdown, no quotes. \
+         Lowercase letters, numbers, and hyphens only. Max 30 chars.\n\n\
+         Task: {truncated}"
+    );
     cmd.args([
         "--print",
         "--output-format",
         "text",
         "--model",
         "claude-haiku-4-5",
-        "--max-turns",
-        "1",
         "--append-system-prompt",
-        "You are a git branch name generator. Given the user's task description, \
-         output a single branch-safe slug: lowercase ASCII letters, numbers, and \
-         hyphens only. No spaces, no quotes, no explanation. Max 40 characters. \
-         Output ONLY the slug.",
-        &truncated,
+        "You are a branch name generator. Output ONLY a slug. Never answer the task itself.",
+        &user_message,
     ]);
 
     // Strip env vars that interfere with subprocess auth — same as run_turn.
@@ -491,7 +499,7 @@ pub async fn generate_branch_name(prompt_text: &str) -> Result<String, String> {
     }
 
     let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let slug = sanitize_branch_name(&raw, 40);
+    let slug = sanitize_branch_name(&raw, 30);
     if slug.is_empty() {
         return Err(format!(
             "Haiku returned empty or unsanitizable output: {raw:?}"

--- a/src/db.rs
+++ b/src/db.rs
@@ -493,10 +493,13 @@ impl Database {
         new_name: &str,
         new_branch_name: &str,
     ) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
+        let rows_affected = self.conn.execute(
             "UPDATE workspaces SET name = ?1, branch_name = ?2 WHERE id = ?3",
             params![new_name, new_branch_name, id],
         )?;
+        if rows_affected != 1 {
+            return Err(rusqlite::Error::StatementChangedRows(rows_affected));
+        }
         Ok(())
     }
 
@@ -1169,6 +1172,16 @@ mod tests {
             .unwrap();
         // Renaming w1 to "name-b" should fail (unique constraint).
         let result = db.rename_workspace("w1", "name-b", "claudette/name-b");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rename_workspace_nonexistent_id() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        // Renaming a workspace that doesn't exist should fail.
+        let result = db.rename_workspace("no-such-id", "new-name", "claudette/new-name");
         assert!(result.is_err());
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -484,6 +484,22 @@ impl Database {
         Ok(())
     }
 
+    /// Rename a workspace's name and branch. Relies on the
+    /// `UNIQUE(repository_id, name)` constraint — callers should handle
+    /// constraint-violation errors to retry with a suffix.
+    pub fn rename_workspace(
+        &self,
+        id: &str,
+        new_name: &str,
+        new_branch_name: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE workspaces SET name = ?1, branch_name = ?2 WHERE id = ?3",
+            params![new_name, new_branch_name, id],
+        )?;
+        Ok(())
+    }
+
     pub fn delete_workspace(&self, id: &str) -> Result<(), rusqlite::Error> {
         self.conn
             .execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
@@ -1126,6 +1142,34 @@ mod tests {
         let workspaces = db.list_workspaces().unwrap();
         assert_eq!(workspaces[0].status, WorkspaceStatus::Archived);
         assert!(workspaces[0].worktree_path.is_none());
+    }
+
+    #[test]
+    fn test_rename_workspace() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "old-name"))
+            .unwrap();
+        db.rename_workspace("w1", "new-name", "claudette/new-name")
+            .unwrap();
+        let workspaces = db.list_workspaces().unwrap();
+        assert_eq!(workspaces[0].name, "new-name");
+        assert_eq!(workspaces[0].branch_name, "claudette/new-name");
+    }
+
+    #[test]
+    fn test_rename_workspace_unique_conflict() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "name-a"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "name-b"))
+            .unwrap();
+        // Renaming w1 to "name-b" should fail (unique constraint).
+        let result = db.rename_workspace("w1", "name-b", "claudette/name-b");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -262,6 +262,16 @@ pub async fn restore_to_commit(worktree_path: &str, commit_hash: &str) -> Result
     Ok(())
 }
 
+/// Rename a branch. The worktree's HEAD follows automatically.
+pub async fn rename_branch(
+    repo_path: &str,
+    old_name: &str,
+    new_name: &str,
+) -> Result<(), GitError> {
+    run_git(repo_path, &["branch", "-m", old_name, new_name]).await?;
+    Ok(())
+}
+
 /// Get the current branch name for a worktree or repository.
 /// Returns an error if in a detached HEAD state.
 pub async fn current_branch(repo_path: &str) -> Result<String, GitError> {
@@ -425,5 +435,45 @@ mod tests {
             .await
             .unwrap();
         assert!(!branches.trim().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_rename_branch() {
+        let dir = setup_temp_repo().await;
+        let path = dir.path().to_str().unwrap();
+
+        // Create a feature branch.
+        run_git(path, &["checkout", "-b", "claudette/old-name"])
+            .await
+            .unwrap();
+        run_git(path, &["checkout", "main"]).await.unwrap();
+
+        rename_branch(path, "claudette/old-name", "claudette/new-name")
+            .await
+            .unwrap();
+
+        // Old branch should be gone, new branch should exist.
+        let branches = list_branches(path).await.unwrap();
+        assert!(!branches.contains(&"claudette/old-name".to_string()));
+        assert!(branches.contains(&"claudette/new-name".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_rename_branch_conflict() {
+        let dir = setup_temp_repo().await;
+        let path = dir.path().to_str().unwrap();
+
+        run_git(path, &["checkout", "-b", "branch-a"])
+            .await
+            .unwrap();
+        run_git(path, &["checkout", "main"]).await.unwrap();
+        run_git(path, &["checkout", "-b", "branch-b"])
+            .await
+            .unwrap();
+        run_git(path, &["checkout", "main"]).await.unwrap();
+
+        // Renaming branch-a to branch-b should fail (already exists).
+        let result = rename_branch(path, "branch-a", "branch-b").await;
+        assert!(result.is_err());
     }
 }

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ui",
@@ -8,6 +7,8 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
@@ -157,6 +158,10 @@
     "@tauri-apps/plugin-clipboard-manager": ["@tauri-apps/plugin-clipboard-manager@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.6.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -443,4 +443,22 @@ export function useAgentStream() {
       unlisten.then((fn) => fn());
     };
   }, [addCheckpoint, setChatMessages]);
+
+  // Listen for workspace-renamed events (auto-rename after first prompt).
+  useEffect(() => {
+    let active = true;
+    const unlisten = listen<{
+      workspace_id: string;
+      name: string;
+      branch_name: string;
+    }>("workspace-renamed", (event) => {
+      if (!active) return;
+      const { workspace_id: wsId, name, branch_name } = event.payload;
+      updateWorkspace(wsId, { name, branch_name });
+    });
+    return () => {
+      active = false;
+      unlisten.then((fn) => fn());
+    };
+  }, [updateWorkspace]);
 }


### PR DESCRIPTION
## Summary

Closes #123

After a workspace is created and the user sends their first prompt, a background Haiku call generates a descriptive branch name (e.g. `claudette/fix-login-timeout`) and renames the branch automatically — replacing the random `claudette/quirky-daisy` style names.

- **`src/agent.rs`**: Added `generate_branch_name()` (one-shot Haiku CLI call) and `sanitize_branch_name()` to produce clean branch slugs
- **`src/git.rs`**: Added `rename_branch()` wrapping `git branch -m`
- **`src/db.rs`**: Added `rename_workspace()` to update name + branch in SQLite
- **`src-tauri/src/commands/chat.rs`**: Added `try_auto_rename()` orchestrator, spawned as a detached background task on first turn — does not block chat streaming
- **`src/ui/src/hooks/useAgentStream.ts`**: Added `workspace-renamed` event listener that updates the Zustand store for reactive sidebar updates

```mermaid
sequenceDiagram
    participant User
    participant ChatPanel
    participant send_chat_message
    participant Bridge Task
    participant Haiku Task
    participant DB
    participant Git
    participant Frontend

    User->>ChatPanel: First prompt
    ChatPanel->>send_chat_message: invoke()
    send_chat_message->>Bridge Task: tokio::spawn (event loop)
    Bridge Task->>Haiku Task: tokio::spawn (detached)
    Bridge Task->>Frontend: agent-stream events (not blocked)
    Haiku Task->>Haiku Task: claude --model haiku (generate slug)
    Haiku Task->>DB: rename_workspace()
    Haiku Task->>Git: git branch -m
    Haiku Task->>Frontend: emit "workspace-renamed"
    Frontend->>Frontend: updateWorkspace() → sidebar re-renders
```

## Complexity Notes

- **Cross-crate boundary**: `rusqlite` is a dep of the `claudette` lib crate but not the `src-tauri` binary crate. The unique constraint collision check uses string matching on the error message (`"UNIQUE constraint failed"`) rather than matching the SQLite error code directly.
- **Non-fatal by design**: All rename failures (Haiku timeout, name collision exhaustion, git error) log a warning and keep the original random name. The chat flow is never interrupted.

## Test Steps

1. `cargo test --all-features` — 171 tests pass, including 13 new tests:
   - `test_rename_branch`, `test_rename_branch_conflict` (git)
   - `test_rename_workspace`, `test_rename_workspace_unique_conflict` (db)
   - 9 `test_sanitize_*` tests (branch name sanitization edge cases)
2. `cargo clippy --workspace --all-targets` — zero warnings with `RUSTFLAGS="-Dwarnings"`
3. `cargo fmt --all --check` — clean
4. `bunx tsc --noEmit` — clean
5. Manual: create a workspace → send first prompt → observe branch name update in sidebar within a few seconds

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)