### PR TITLE
fix: rename branch from worktree path to avoid checked-out error

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -168,7 +168,7 @@ pub async fn send_chat_message(
     drop(agents);
 
     // Capture rename context before the bridge spawn.
-    let rename_repo_path = repo.as_ref().map(|r| r.path.clone());
+    let has_repo = repo.is_some();
     let rename_old_branch = ws.branch_name.clone();
     let rename_old_name = ws.name.clone();
     let rename_prompt = content.clone();
@@ -181,7 +181,7 @@ pub async fn send_chat_message(
     tokio::spawn(async move {
         // On the first turn, spawn a background task to auto-rename the branch
         // using Haiku. This runs concurrently and does not block the event loop.
-        if !is_resume && rename_repo_path.is_some() {
+        if !is_resume && has_repo {
             let ws_id2 = ws_id.clone();
             let wt_path2 = wt_path.clone();
             let old_branch2 = rename_old_branch.clone();

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -181,9 +181,8 @@ pub async fn send_chat_message(
     tokio::spawn(async move {
         // On the first turn, spawn a background task to auto-rename the branch
         // using Haiku. This runs concurrently and does not block the event loop.
-        if !is_resume && let Some(ref repo_path) = rename_repo_path {
+        if !is_resume && rename_repo_path.is_some() {
             let ws_id2 = ws_id.clone();
-            let repo_path2 = repo_path.clone();
             let wt_path2 = wt_path.clone();
             let old_branch2 = rename_old_branch.clone();
             let old_name2 = rename_old_name.clone();
@@ -193,7 +192,6 @@ pub async fn send_chat_message(
             tokio::spawn(async move {
                 try_auto_rename(
                     &ws_id2,
-                    &repo_path2,
                     &wt_path2,
                     &old_name2,
                     &old_branch2,
@@ -545,10 +543,8 @@ pub async fn load_completed_turns(
 
 /// Background task: generate a descriptive branch name via Haiku and rename
 /// the workspace's branch + DB record. All failures are non-fatal.
-#[allow(clippy::too_many_arguments)]
 async fn try_auto_rename(
     ws_id: &str,
-    repo_path: &str,
     worktree_path: &str,
     old_name: &str,
     old_branch: &str,
@@ -581,7 +577,7 @@ async fn try_auto_rename(
         match db.rename_workspace(ws_id, candidate, &new_branch) {
             Ok(()) => {
                 // DB updated — now rename the git branch.
-                if let Err(e) = git::rename_branch(repo_path, old_branch, &new_branch).await {
+                if let Err(e) = git::rename_branch(worktree_path, old_branch, &new_branch).await {
                     let msg = e.to_string();
                     eprintln!("[rename] Git branch rename failed: {e} — rolling back DB");
                     let _ = db.rename_workspace(ws_id, old_name, old_branch);

--- a/src/git.rs
+++ b/src/git.rs
@@ -459,6 +459,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_rename_branch_checked_out_in_worktree() {
+        let dir = setup_temp_repo().await;
+        let repo_path = dir.path().to_str().unwrap();
+
+        // Create a worktree which checks out the branch.
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().to_str().unwrap();
+        create_worktree(repo_path, "claudette/feature", wt_path)
+            .await
+            .unwrap();
+
+        // Renaming from the worktree (where the branch is checked out) should work.
+        rename_branch(wt_path, "claudette/feature", "claudette/renamed")
+            .await
+            .unwrap();
+
+        let branches = list_branches(repo_path).await.unwrap();
+        assert!(!branches.contains(&"claudette/feature".to_string()));
+        assert!(branches.contains(&"claudette/renamed".to_string()));
+
+        // Clean up worktree before temp dirs are dropped.
+        remove_worktree(repo_path, wt_path, true).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_rename_branch_conflict() {
         let dir = setup_temp_repo().await;
         let path = dir.path().to_str().unwrap();

--- a/src/git.rs
+++ b/src/git.rs
@@ -263,12 +263,10 @@ pub async fn restore_to_commit(worktree_path: &str, commit_hash: &str) -> Result
 }
 
 /// Rename a branch. The worktree's HEAD follows automatically.
-pub async fn rename_branch(
-    repo_path: &str,
-    old_name: &str,
-    new_name: &str,
-) -> Result<(), GitError> {
-    run_git(repo_path, &["branch", "-m", old_name, new_name]).await?;
+/// `path` can be a repo root or a worktree — when the branch is checked
+/// out in a linked worktree, pass the worktree path to avoid errors.
+pub async fn rename_branch(path: &str, old_name: &str, new_name: &str) -> Result<(), GitError> {
+    run_git(path, &["branch", "-m", old_name, new_name]).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Run `git branch -m` from the workspace's worktree path instead of `repo_path`, fixing "cannot rename branch checked out at..." errors that occur because workspace branches are always checked out in their linked worktree
- Remove the now-unused `repo_path` parameter from `try_auto_rename()`
- Add test coverage for renaming a branch that is currently checked out in a worktree

## Test plan
- [x] `cargo test --all-features` — 173 tests pass including new `test_rename_branch_checked_out_in_worktree`
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo fmt --all --check` — clean