### PR TITLE
chore: add MIT license for open source release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "claudette"
 version = "0.5.3"
 edition = "2024"
 description = "Claude's missing better half — a companion tool for Claude Code"
+license = "MIT"
 
 [lib]
 path = "src/lib.rs"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Utensils
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -232,3 +232,7 @@ All traffic is encrypted with TLS. The local app pins the server's certificate f
 - The backend (`src/`) is a library crate consumed by the Tauri binary (`src-tauri/`).
 - See `CLAUDE.md` for detailed architecture and contribution guidelines.
 - See `docs/tauri-migration-tdd.md` for the technical design document.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/src-server/Cargo.toml
+++ b/src-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "claudette-server"
 version = "0.5.3"
 edition = "2024"
 description = "Headless Claudette backend for remote access"
+license = "MIT"
 
 [[bin]]
 name = "claudette-server"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "claudette-tauri"
 version = "0.5.3"
 edition = "2024"
+license = "MIT"
 
 [dependencies]
 claudette = { path = ".." }

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ui",
   "private": true,
+  "license": "MIT",
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds the MIT license file (`LICENSE`) at the project root, copyright 2026 Utensils
- Sets `license = "MIT"` in all three Cargo.toml files (root, src-tauri, src-server) for crate metadata consistency
- Sets `"license": "MIT"` in the frontend `package.json`

## Test Steps

1. Verify the `LICENSE` file exists at the repository root and contains the full MIT license text
2. Confirm `license = "MIT"` is present in `Cargo.toml`, `src-tauri/Cargo.toml`, and `src-server/Cargo.toml`
3. Confirm `"license": "MIT"` is present in `src/ui/package.json`
4. Run `cargo metadata --format-version 1 | jq '.packages[] | select(.name | startswith("claudette")) | {name, license}'` to verify Cargo picks up the license field

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)

> No tests or documentation changes needed — this is a metadata-only change adding the license file and SPDX identifiers.