### PR TITLE
docs: add Code of Conduct and Contributing guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,102 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the Claudette project maintainers at **seancallan@gmail.com**. All reports will be reviewed and investigated promptly and fairly.
+
+When reporting, please include:
+
+- Your contact information (so we can follow up if needed)
+- Names (real, usernames, or pseudonyms) of any individuals involved, including witnesses
+- A description of what happened, including any relevant context, links, screenshots, or other supporting information
+- The date and approximate time of the incident
+- Whether the situation is ongoing
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident. Reports will be kept confidential to the extent possible, and details will only be shared with those who need to know in order to resolve the situation.
+
+If you feel your report has not been handled appropriately, or if a maintainer is the subject of the report, please contact **eben.goodman@gmail.com** directly.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+### 1. Warning
+
+- **Event:** A violation involving a single incident or series of incidents.
+- **Consequence:** A private, written warning from the Community Moderators.
+- **Repair:** Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+
+### 2. Temporarily Limited Activities
+
+- **Event:** A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+- **Consequence:** A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+- **Repair:** Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+
+### 3. Temporary Suspension
+
+- **Event:** A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+- **Consequence:** A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+- **Repair:** Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+
+### 4. Permanent Ban
+
+- **Event:** A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+- **Consequence:** Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+- **Repair:** There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 3.0, permanently available at <https://www.contributor-covenant.org/version/3/0/>.
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+For answers to common questions about Contributor Covenant, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are provided at <https://www.contributor-covenant.org/translations>. Additional enforcement and community guideline resources can be found at <https://www.contributor-covenant.org/resources>. The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to Claudette
+
+Thank you for your interest in contributing to Claudette! This guide will help you get started.
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant 3.0 Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to seancallan@gmail.com.
+
+## How to Contribute
+
+### Reporting Bugs
+
+Before filing a bug report, please check [existing issues](https://github.com/anthropics/claudette/issues) to avoid duplicates.
+
+When filing a bug report, include:
+
+- A clear, descriptive title
+- Steps to reproduce the issue
+- Expected behavior vs. actual behavior
+- Your OS and version (macOS or Linux)
+- Relevant logs or screenshots
+
+### Suggesting Features
+
+Feature suggestions are welcome! Please open an issue describing:
+
+- The problem your feature would solve
+- Your proposed solution
+- Any alternatives you've considered
+
+### Submitting Changes
+
+1. **Fork the repository** and create a feature branch from `main`.
+2. **Set up the development environment** — see the [README](README.md#prerequisites) for prerequisites.
+3. **Make your changes** following the guidelines below.
+4. **Test your changes** — run the full test and lint suite before submitting:
+   ```sh
+   cargo test --all-features
+   cargo clippy --workspace --all-targets
+   cargo fmt --all --check
+   cd src/ui && bunx tsc --noEmit
+   ```
+5. **Commit your changes** using [conventional commit](#commit-conventions) format.
+6. **Open a pull request** against `main` with a clear description of your changes.
+
+## Development Setup
+
+```sh
+# Clone your fork
+git clone https://github.com/<your-username>/claudette.git
+cd claudette
+
+# Install frontend dependencies
+cd src/ui && bun install && cd ../..
+
+# Run in development mode
+cargo tauri dev
+```
+
+## Commit Conventions
+
+This project uses **conventional commits**. Every commit message and PR title must follow this format:
+
+```
+<type>: <description>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`
+
+- Keep the header under 100 characters
+- Use the imperative mood ("add feature" not "added feature")
+- PR titles are validated by CI
+
+## Code Style
+
+### Rust
+
+- Edition 2024 — use modern idioms
+- Run `cargo fmt` before committing (CI enforces formatting)
+- Run `cargo clippy` with zero warnings (CI sets `RUSTFLAGS="-Dwarnings"`)
+
+### TypeScript
+
+- Strict mode enabled — no `any` types
+- Use `bun` as the package manager (not npm)
+
+## Architecture Overview
+
+Claudette is a Tauri 2 desktop app with a Rust backend and React/TypeScript frontend. See `CLAUDE.md` for the full architecture guide and the `docs/` directory for technical design documents.
+
+Key principles:
+
+- **Data types** go in `src/model/` — keep them free of UI and IO dependencies
+- **Service modules** (`db.rs`, `git.rs`, `agent.rs`) live at the `src/` level
+- **Tauri commands** go in `src-tauri/src/commands/` as thin wrappers
+- **React components** are organized by feature area in `src/ui/src/components/`
+- **State management** uses Zustand with domain slices
+
+## Pull Request Guidelines
+
+- Keep PRs focused — one feature or fix per PR
+- Include tests for new functionality where applicable
+- Update documentation if your change affects public behavior
+- Ensure CI passes before requesting review
+- Link related issues in the PR description
+
+## License
+
+By contributing to Claudette, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project adheres to the [Contributor Covenant 3.0 Code of Conduct](CODE_OF_C
 
 ### Reporting Bugs
 
-Before filing a bug report, please check [existing issues](https://github.com/anthropics/claudette/issues) to avoid duplicates.
+Before filing a bug report, please check [existing issues](https://github.com/utensils/Claudette/issues) to avoid duplicates.
 
 When filing a bug report, include:
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ claudette-server --no-mdns
 
 All traffic is encrypted with TLS. The local app pins the server's certificate fingerprint on first connection (trust-on-first-use), similar to SSH's `known_hosts`.
 
+## Contributing
+
+Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) to get started. All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Development notes
 
 - The project uses Rust edition 2024 and Bun as the frontend package manager.


### PR DESCRIPTION
## Summary

Adds community governance documents for the open source project:

- **CODE_OF_CONDUCT.md** — Contributor Covenant 3.0 adapted for Claudette, with project-specific reporting contacts and an enforcement ladder
- **CONTRIBUTING.md** — Contributor guide covering bug reports, feature requests, development setup, commit conventions, code style, and PR guidelines
- **README.md** — New "Contributing" section linking to both documents, placed above "Development notes"

## Test Steps

1. Verify `CODE_OF_CONDUCT.md` renders correctly on GitHub — check that bold text, headings, lists, and links all display properly
2. Verify `CONTRIBUTING.md` renders correctly — check that code blocks, links to README/LICENSE/CODE_OF_CONDUCT, and the commit convention examples display properly
3. Verify the new "Contributing" section in `README.md` links correctly to both documents
4. Confirm email addresses in the Code of Conduct match the intended maintainer contacts

## Checklist

- [ ] Documentation updated