### PR TITLE
docs: add Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ claudette-server --no-mdns
 
 All traffic is encrypted with TLS. The local app pins the server's certificate fingerprint on first connection (trust-on-first-use), similar to SSH's `known_hosts`.
 
+## Community
+
+Join us on [Discord](https://discord.gg/Ks9Ghnem) to ask questions, share feedback, and connect with other Claudette users.
+
 ## Contributing
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) to get started. All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Adds the Discord server invite link (https://discord.gg/Ks9Ghnem) to the project:

- **README.md**: New "Community" section with Discord link, placed above Contributing
- **gh-pages site** (pushed directly to `gh-pages` branch in [9ec3b24](https://github.com/utensils/Claudette/commit/9ec3b24)): Discord link added to the nav bar, CTA section, and footer

## Test Steps

1. Verify the README renders correctly on the PR's "Files changed" tab — the Discord link should appear in its own "Community" section
2. Check the live site at the GitHub Pages URL — Discord should appear in the top nav, the bottom CTA buttons, and the footer links
3. Click the Discord link to confirm it resolves to the correct server

## Checklist

- [ ] Documentation updated (if applicable)