### PR TITLE
fix: skip updater checks in dev mode

### DIFF
--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -80,8 +80,11 @@ export function useAutoUpdater() {
     setUpdateDismissed(true);
   }, [setUpdateDismissed]);
 
-  // Periodic update checks.
+  // Periodic update checks — disabled in dev mode where the updater endpoint
+  // won't have matching artifacts and relaunch() can't restart the dev server.
   useEffect(() => {
+    if (import.meta.env.DEV) return;
+
     checkForUpdate();
     const intervalId = window.setInterval(checkForUpdate, CHECK_INTERVAL_MS);
     return () => window.clearInterval(intervalId);


### PR DESCRIPTION
## Summary

- Skip auto-updater checks entirely when running in dev mode (`cargo tauri dev`)
- The updater always found a spurious "update" because the dev build version never matches the latest GitHub release, and `relaunch()` cannot restart the dev server process
- Adds a single `import.meta.env.DEV` guard in the periodic check `useEffect` — the banner never appears in dev builds since `updateAvailable` is never set to `true`

Closes #147

## Test Steps

1. Run `cargo tauri dev`
2. Verify the updater banner does **not** appear on startup
3. Confirm the app otherwise functions normally (agent chat, terminal, etc.)
4. Run `cd src/ui && bun x tsc --noEmit` — no type errors
5. Run `cd src/ui && bun run build` — production build succeeds (updater code is included, just not triggered in dev)

## Checklist

- [x] Tests added/updated (no new tests needed — this is a dev-mode-only guard on existing behavior; all 180 existing tests pass)
- [ ] Documentation updated (if applicable)