### PR TITLE
refactor: replace git-commit checkpoints with SQLite file snapshots

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -9,6 +9,7 @@ use claudette::git;
 use claudette::model::{
     ChatMessage, ChatRole, CompletedTurnData, ConversationCheckpoint, TurnToolActivity,
 };
+use claudette::snapshot;
 
 use crate::state::{AgentSessionState, AppState};
 
@@ -437,33 +438,36 @@ pub async fn send_chat_message(
                     .map(|cp| cp.turn_index + 1)
                     .unwrap_or(0);
 
-                let commit_hash =
-                    match git::create_checkpoint_commit(&wt_path, &format!("Turn {turn_index}"))
-                        .await
-                    {
-                        Ok(hash) => Some(hash),
-                        Err(e) => {
-                            eprintln!(
-                                "[chat] Checkpoint commit failed for {ws_id}: {e} \
-                             — checkpoint will be recorded without file restore capability"
-                            );
-                            None
-                        }
-                    };
-
                 let checkpoint = ConversationCheckpoint {
                     id: uuid::Uuid::new_v4().to_string(),
                     workspace_id: ws_id.clone(),
                     message_id: anchor_msg_id.to_string(),
-                    commit_hash,
+                    commit_hash: None,
+                    has_file_state: false, // Updated after snapshot succeeds
                     turn_index,
                     message_count: 0, // Updated by frontend after finalizeTurn
                     created_at: now_iso(),
                 };
                 if db.insert_checkpoint(&checkpoint).is_ok() {
+                    // Snapshot worktree files into SQLite.
+                    let has_files =
+                        match snapshot::save_snapshot(&db_path, &checkpoint.id, &wt_path).await {
+                            Ok(()) => true,
+                            Err(e) => {
+                                eprintln!(
+                                    "[chat] Snapshot failed for {ws_id}: {e} \
+                                 — checkpoint recorded without file restore capability"
+                                );
+                                false
+                            }
+                        };
+
+                    // Emit with up-to-date has_file_state so frontend knows.
+                    let mut cp_payload = checkpoint.clone();
+                    cp_payload.has_file_state = has_files;
                     let payload = serde_json::json!({
                         "workspace_id": &ws_id,
-                        "checkpoint": &checkpoint,
+                        "checkpoint": &cp_payload,
                     });
                     let _ = app.emit("checkpoint-created", &payload);
                 }
@@ -570,10 +574,10 @@ pub async fn rollback_to_checkpoint(
         return Err("Checkpoint does not belong to this workspace".into());
     }
 
-    // Attempt file restore BEFORE any destructive DB writes so that a git
+    // Attempt file restore BEFORE any destructive DB writes so that a
     // failure does not leave the DB truncated while the frontend still shows
     // the full conversation.
-    if restore_files && let Some(ref commit_hash) = checkpoint.commit_hash {
+    if restore_files {
         let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
         let ws = workspaces
             .iter()
@@ -583,9 +587,18 @@ pub async fn rollback_to_checkpoint(
             .worktree_path
             .as_ref()
             .ok_or("Workspace has no worktree")?;
-        git::restore_to_commit(wt, commit_hash)
-            .await
-            .map_err(|e| e.to_string())?;
+
+        if checkpoint.has_file_state {
+            // New path: restore from SQLite snapshot.
+            snapshot::restore_snapshot(&state.db_path, &checkpoint_id, wt)
+                .await
+                .map_err(|e| e.to_string())?;
+        } else if let Some(ref commit_hash) = checkpoint.commit_hash {
+            // Legacy path: restore from git commit.
+            git::restore_to_commit(wt, commit_hash)
+                .await
+                .map_err(|e| e.to_string())?;
+        }
     }
 
     // Now perform the destructive DB writes — safe because the risky git

--- a/src/db.rs
+++ b/src/db.rs
@@ -37,7 +37,7 @@ impl Database {
     }
 
     /// Execute raw SQL. Intended for test setup only.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn execute_batch(&self, sql: &str) -> Result<(), rusqlite::Error> {
         self.conn.execute_batch(sql)
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::model::{
-    ChatMessage, CompletedTurnData, ConversationCheckpoint, RemoteConnection, Repository,
-    TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
+    ChatMessage, CheckpointFile, CompletedTurnData, ConversationCheckpoint, RemoteConnection,
+    Repository, TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
 };
 
 pub struct Database {
@@ -34,6 +34,12 @@ impl Database {
         let db = Self { conn };
         db.migrate()?;
         Ok(db)
+    }
+
+    /// Execute raw SQL. Intended for test setup only.
+    #[allow(dead_code)]
+    pub fn execute_batch(&self, sql: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute_batch(sql)
     }
 
     fn migrate(&self) -> Result<(), rusqlite::Error> {
@@ -239,6 +245,24 @@ impl Database {
             self.conn.execute_batch(
                 "ALTER TABLE repositories ADD COLUMN branch_rename_preferences TEXT;
                  PRAGMA user_version = 14;",
+            )?;
+        }
+
+        if version < 15 {
+            self.conn.execute_batch(
+                "CREATE TABLE checkpoint_files (
+                    id              TEXT PRIMARY KEY,
+                    checkpoint_id   TEXT NOT NULL REFERENCES conversation_checkpoints(id) ON DELETE CASCADE,
+                    file_path       TEXT NOT NULL,
+                    content         BLOB,
+                    file_mode       INTEGER NOT NULL DEFAULT 33188,
+                    UNIQUE(checkpoint_id, file_path)
+                );
+
+                CREATE INDEX idx_checkpoint_files_checkpoint
+                    ON checkpoint_files(checkpoint_id);
+
+                PRAGMA user_version = 15;",
             )?;
         }
 
@@ -674,20 +698,27 @@ impl Database {
             workspace_id: row.get(1)?,
             message_id: row.get(2)?,
             commit_hash: row.get(3)?,
-            turn_index: row.get(4)?,
-            message_count: row.get(5)?,
-            created_at: row.get(6)?,
+            has_file_state: row.get(4)?,
+            turn_index: row.get(5)?,
+            message_count: row.get(6)?,
+            created_at: row.get(7)?,
         })
     }
+
+    /// SQL column list for checkpoint queries, including a subquery for has_file_state.
+    const CHECKPOINT_COLS: &str = "id, workspace_id, message_id, commit_hash, \
+         EXISTS(SELECT 1 FROM checkpoint_files WHERE checkpoint_id = conversation_checkpoints.id) AS has_file_state, \
+         turn_index, message_count, created_at";
 
     pub fn list_checkpoints(
         &self,
         workspace_id: &str,
     ) -> Result<Vec<ConversationCheckpoint>, rusqlite::Error> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, workspace_id, message_id, commit_hash, turn_index, message_count, created_at
-             FROM conversation_checkpoints WHERE workspace_id = ?1 ORDER BY turn_index",
-        )?;
+        let sql = format!(
+            "SELECT {} FROM conversation_checkpoints WHERE workspace_id = ?1 ORDER BY turn_index",
+            Self::CHECKPOINT_COLS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(params![workspace_id], Self::parse_checkpoint_row)?;
         rows.collect()
     }
@@ -696,13 +727,12 @@ impl Database {
         &self,
         id: &str,
     ) -> Result<Option<ConversationCheckpoint>, rusqlite::Error> {
+        let sql = format!(
+            "SELECT {} FROM conversation_checkpoints WHERE id = ?1",
+            Self::CHECKPOINT_COLS
+        );
         self.conn
-            .query_row(
-                "SELECT id, workspace_id, message_id, commit_hash, turn_index, message_count, created_at
-                 FROM conversation_checkpoints WHERE id = ?1",
-                params![id],
-                Self::parse_checkpoint_row,
-            )
+            .query_row(&sql, params![id], Self::parse_checkpoint_row)
             .optional()
     }
 
@@ -710,16 +740,13 @@ impl Database {
         &self,
         workspace_id: &str,
     ) -> Result<Option<ConversationCheckpoint>, rusqlite::Error> {
+        let sql = format!(
+            "SELECT {} FROM conversation_checkpoints \
+             WHERE workspace_id = ?1 ORDER BY turn_index DESC LIMIT 1",
+            Self::CHECKPOINT_COLS
+        );
         self.conn
-            .query_row(
-                "SELECT id, workspace_id, message_id, commit_hash, turn_index, message_count, created_at
-                 FROM conversation_checkpoints
-                 WHERE workspace_id = ?1
-                 ORDER BY turn_index DESC
-                 LIMIT 1",
-                params![workspace_id],
-                Self::parse_checkpoint_row,
-            )
+            .query_row(&sql, params![workspace_id], Self::parse_checkpoint_row)
             .optional()
     }
 
@@ -733,6 +760,57 @@ impl Database {
             params![workspace_id, turn_index],
         )?;
         Ok(deleted)
+    }
+
+    // --- Checkpoint Files ---
+
+    pub fn insert_checkpoint_files(&self, files: &[CheckpointFile]) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO checkpoint_files (id, checkpoint_id, file_path, content, file_mode)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for f in files {
+                stmt.execute(params![
+                    f.id,
+                    f.checkpoint_id,
+                    f.file_path,
+                    f.content,
+                    f.file_mode,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_checkpoint_files(
+        &self,
+        checkpoint_id: &str,
+    ) -> Result<Vec<CheckpointFile>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, checkpoint_id, file_path, content, file_mode
+             FROM checkpoint_files WHERE checkpoint_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![checkpoint_id], |row| {
+            Ok(CheckpointFile {
+                id: row.get(0)?,
+                checkpoint_id: row.get(1)?,
+                file_path: row.get(2)?,
+                content: row.get(3)?,
+                file_mode: row.get(4)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn has_checkpoint_files(&self, checkpoint_id: &str) -> Result<bool, rusqlite::Error> {
+        self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM checkpoint_files WHERE checkpoint_id = ?1)",
+            params![checkpoint_id],
+            |row| row.get(0),
+        )
     }
 
     // --- Turn Tool Activities ---
@@ -1763,6 +1841,7 @@ mod tests {
             workspace_id: ws_id.into(),
             message_id: msg_id.into(),
             commit_hash: Some(format!("abc{turn}")),
+            has_file_state: false,
             turn_index: turn,
             message_count: 1,
             created_at: String::new(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -213,32 +213,6 @@ pub async fn branch_delete(repo_path: &str, branch: &str) -> Result<(), GitError
     Ok(())
 }
 
-/// Create a checkpoint commit in a worktree, staging all changes first.
-/// If there are no changes to commit, returns the current HEAD hash.
-/// On commit failure (hooks, missing config, etc.) unstages changes so
-/// the worktree is not left in a surprising half-staged state.
-pub async fn create_checkpoint_commit(
-    worktree_path: &str,
-    message: &str,
-) -> Result<String, GitError> {
-    // Stage all changes (including untracked files).
-    run_git(worktree_path, &["add", "-A"]).await?;
-
-    // Check if there are staged changes.
-    let status = run_git(worktree_path, &["status", "--porcelain"]).await?;
-    if !status.is_empty() {
-        let commit_msg = format!("[checkpoint] {message}");
-        if let Err(e) = run_git(worktree_path, &["commit", "-m", &commit_msg]).await {
-            // Unstage so the worktree isn't left with everything added.
-            let _ = run_git(worktree_path, &["reset"]).await;
-            return Err(e);
-        }
-    }
-
-    // Return current HEAD hash regardless.
-    run_git(worktree_path, &["rev-parse", "HEAD"]).await
-}
-
 /// Hard-reset a worktree to a specific commit and clean untracked files.
 pub async fn restore_to_commit(worktree_path: &str, commit_hash: &str) -> Result<(), GitError> {
     run_git(worktree_path, &["reset", "--hard", commit_hash]).await?;
@@ -293,49 +267,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_checkpoint_commit_with_changes() {
-        let dir = setup_temp_repo().await;
-        let path = dir.path().to_str().unwrap();
-
-        // Create a new file.
-        std::fs::write(dir.path().join("file.txt"), "hello").unwrap();
-
-        let hash = create_checkpoint_commit(path, "Turn 0").await.unwrap();
-        assert!(!hash.is_empty());
-
-        // Verify the commit message.
-        let log = run_git(path, &["log", "-1", "--format=%s"]).await.unwrap();
-        assert_eq!(log, "[checkpoint] Turn 0");
-    }
-
-    #[tokio::test]
-    async fn test_create_checkpoint_commit_no_changes() {
-        let dir = setup_temp_repo().await;
-        let path = dir.path().to_str().unwrap();
-
-        let head_before = run_git(path, &["rev-parse", "HEAD"]).await.unwrap();
-        let hash = create_checkpoint_commit(path, "Turn 0").await.unwrap();
-
-        // No new commit should be created — hash should match HEAD.
-        assert_eq!(hash, head_before);
-    }
-
-    #[tokio::test]
     async fn test_restore_to_commit() {
         let dir = setup_temp_repo().await;
         let path = dir.path().to_str().unwrap();
         let file = dir.path().join("data.txt");
 
-        // First checkpoint.
+        // Create a commit with known content.
         std::fs::write(&file, "version 1").unwrap();
-        let hash1 = create_checkpoint_commit(path, "Turn 0").await.unwrap();
+        run_git(path, &["add", "-A"]).await.unwrap();
+        run_git(path, &["commit", "-m", "v1"]).await.unwrap();
+        let hash1 = run_git(path, &["rev-parse", "HEAD"]).await.unwrap();
 
-        // Second checkpoint.
+        // Create another commit.
         std::fs::write(&file, "version 2").unwrap();
-        let _hash2 = create_checkpoint_commit(path, "Turn 1").await.unwrap();
+        run_git(path, &["add", "-A"]).await.unwrap();
+        run_git(path, &["commit", "-m", "v2"]).await.unwrap();
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "version 2");
 
-        // Restore to first checkpoint.
+        // Restore to first commit.
         restore_to_commit(path, &hash1).await.unwrap();
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "version 1");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod model;
 pub mod names;
 pub mod permissions;
 pub mod slash_commands;
+pub mod snapshot;

--- a/src/model/checkpoint.rs
+++ b/src/model/checkpoint.rs
@@ -6,9 +6,22 @@ pub struct ConversationCheckpoint {
     pub workspace_id: String,
     pub message_id: String,
     pub commit_hash: Option<String>,
+    /// Whether this checkpoint has file snapshot data in the `checkpoint_files`
+    /// table. When true, rollback restores files from SQLite instead of git.
+    pub has_file_state: bool,
     pub turn_index: i32,
     pub message_count: i32,
     pub created_at: String,
+}
+
+/// A single file captured in a checkpoint snapshot.
+#[derive(Debug, Clone)]
+pub struct CheckpointFile {
+    pub id: String,
+    pub checkpoint_id: String,
+    pub file_path: String,
+    pub content: Option<Vec<u8>>,
+    pub file_mode: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,7 +7,7 @@ mod terminal_tab;
 mod workspace;
 
 pub use chat_message::{ChatMessage, ChatRole};
-pub use checkpoint::{CompletedTurnData, ConversationCheckpoint, TurnToolActivity};
+pub use checkpoint::{CheckpointFile, CompletedTurnData, ConversationCheckpoint, TurnToolActivity};
 pub use remote_connection::RemoteConnection;
 pub use repository::Repository;
 pub use terminal_tab::TerminalTab;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -72,7 +72,9 @@ async fn list_worktree_files(worktree_path: &str) -> Result<Vec<String>, Snapsho
 }
 
 /// Collect all files from a worktree for snapshotting.
-/// Skips files larger than `MAX_SNAPSHOT_FILE_SIZE`.
+/// Skips symlinks, files larger than `MAX_SNAPSHOT_FILE_SIZE`, and
+/// anything that isn't a regular file. Uses `symlink_metadata` to
+/// avoid following symlinks.
 pub async fn collect_worktree_files(
     worktree_path: &str,
 ) -> Result<Vec<(String, Vec<u8>, u32)>, SnapshotError> {
@@ -83,13 +85,15 @@ pub async fn collect_worktree_files(
     for rel_path in paths {
         let full_path = base.join(&rel_path);
 
-        let metadata = match tokio::fs::metadata(&full_path).await {
+        // Use symlink_metadata to avoid following symlinks — we skip
+        // symlinks entirely rather than snapshotting their targets.
+        let metadata = match tokio::fs::symlink_metadata(&full_path).await {
             Ok(m) => m,
             Err(_) => continue, // file may have been deleted between ls-files and read
         };
 
         if !metadata.is_file() {
-            continue;
+            continue; // skip symlinks, directories, and other non-regular files
         }
 
         if metadata.len() > MAX_SNAPSHOT_FILE_SIZE {
@@ -162,7 +166,7 @@ pub async fn restore_snapshot(
     // Write snapshot files to disk.
     for f in &snapshot_files {
         // Guard against path traversal from corrupted DB rows.
-        if f.file_path.contains("..") {
+        if f.file_path.contains("..") || Path::new(&f.file_path).is_absolute() {
             continue;
         }
         let full_path = base.join(&f.file_path);
@@ -187,13 +191,23 @@ pub async fn restore_snapshot(
         }
     }
 
-    // Delete files on disk that aren't in the snapshot.
+    // Delete files on disk that aren't in the snapshot — but preserve
+    // files that were skipped during save (large files, symlinks) so
+    // restore doesn't cause data loss for content we never captured.
     let current_files = list_worktree_files(worktree_path).await?;
     for rel_path in &current_files {
-        if !snapshot_paths.contains(rel_path.as_str()) {
-            let full_path = base.join(rel_path);
-            let _ = tokio::fs::remove_file(&full_path).await;
+        if snapshot_paths.contains(rel_path.as_str()) {
+            continue;
         }
+        let full_path = base.join(rel_path);
+        // Preserve files that would have been skipped during save
+        // (symlinks and large files) so restore doesn't cause data loss.
+        if let Ok(meta) = tokio::fs::symlink_metadata(&full_path).await
+            && (!meta.is_file() || meta.len() > MAX_SNAPSHOT_FILE_SIZE)
+        {
+            continue;
+        }
+        let _ = tokio::fs::remove_file(&full_path).await;
     }
 
     // Clean up empty directories (best-effort, bottom-up).

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -150,6 +150,7 @@ pub async fn restore_snapshot(
 ) -> Result<(), SnapshotError> {
     let db = crate::db::Database::open(db_path).map_err(|e| SnapshotError::Db(e.to_string()))?;
     let snapshot_files = db.get_checkpoint_files(checkpoint_id)?;
+    drop(db); // Release connection before async I/O.
     let base = Path::new(worktree_path);
 
     // Build set of snapshot paths for deletion pass.
@@ -160,6 +161,10 @@ pub async fn restore_snapshot(
 
     // Write snapshot files to disk.
     for f in &snapshot_files {
+        // Guard against path traversal from corrupted DB rows.
+        if f.file_path.contains("..") {
+            continue;
+        }
         let full_path = base.join(&f.file_path);
         match &f.content {
             Some(content) => {
@@ -227,30 +232,24 @@ async fn clean_empty_dirs(root: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use tempfile::TempDir;
     use tokio::process::Command;
 
-    async fn setup_test_repo() -> PathBuf {
-        let dir = tempfile::tempdir().unwrap().keep();
+    async fn setup_test_repo() -> TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().to_str().unwrap();
         Command::new("git")
-            .args(["init", dir.to_str().unwrap()])
-            .output()
-            .await
-            .unwrap();
-        // Configure git user for commits
-        Command::new("git")
-            .args([
-                "-C",
-                dir.to_str().unwrap(),
-                "config",
-                "user.email",
-                "test@test.com",
-            ])
+            .args(["init", path])
             .output()
             .await
             .unwrap();
         Command::new("git")
-            .args(["-C", dir.to_str().unwrap(), "config", "user.name", "Test"])
+            .args(["-C", path, "config", "user.email", "test@test.com"])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", path, "config", "user.name", "Test"])
             .output()
             .await
             .unwrap();
@@ -260,10 +259,10 @@ mod tests {
     #[tokio::test]
     async fn test_collect_worktree_files() {
         let dir = setup_test_repo().await;
-        let dir_str = dir.to_str().unwrap();
+        let dir_str = dir.path().to_str().unwrap();
 
         // Create tracked file
-        tokio::fs::write(dir.join("hello.txt"), b"hello")
+        tokio::fs::write(dir.path().join("hello.txt"), b"hello")
             .await
             .unwrap();
         Command::new("git")
@@ -273,15 +272,15 @@ mod tests {
             .unwrap();
 
         // Create untracked (but not ignored) file
-        tokio::fs::write(dir.join("world.txt"), b"world")
+        tokio::fs::write(dir.path().join("world.txt"), b"world")
             .await
             .unwrap();
 
         // Create gitignored file
-        tokio::fs::write(dir.join(".gitignore"), "ignored.txt\n")
+        tokio::fs::write(dir.path().join(".gitignore"), "ignored.txt\n")
             .await
             .unwrap();
-        tokio::fs::write(dir.join("ignored.txt"), b"secret")
+        tokio::fs::write(dir.path().join("ignored.txt"), b"secret")
             .await
             .unwrap();
 
@@ -292,23 +291,21 @@ mod tests {
         assert!(paths.contains(&"world.txt"));
         assert!(paths.contains(&".gitignore"));
         assert!(!paths.contains(&"ignored.txt"));
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]
     async fn test_collect_skips_large_files() {
         let dir = setup_test_repo().await;
-        let dir_str = dir.to_str().unwrap();
+        let dir_str = dir.path().to_str().unwrap();
 
         // Create a small file
-        tokio::fs::write(dir.join("small.txt"), b"small")
+        tokio::fs::write(dir.path().join("small.txt"), b"small")
             .await
             .unwrap();
 
         // Create a file larger than MAX_SNAPSHOT_FILE_SIZE
         let large = vec![0u8; (MAX_SNAPSHOT_FILE_SIZE + 1) as usize];
-        tokio::fs::write(dir.join("large.bin"), &large)
+        tokio::fs::write(dir.path().join("large.bin"), &large)
             .await
             .unwrap();
 
@@ -317,8 +314,6 @@ mod tests {
 
         assert!(paths.contains(&"small.txt"));
         assert!(!paths.contains(&"large.bin"));
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     const TEST_SEED_SQL: &str = "\
@@ -331,19 +326,21 @@ mod tests {
     #[tokio::test]
     async fn test_save_and_restore_roundtrip() {
         let dir = setup_test_repo().await;
-        let dir_str = dir.to_str().unwrap();
+        let dir_str = dir.path().to_str().unwrap();
 
         // Create initial files
-        tokio::fs::write(dir.join("a.txt"), b"content-a")
+        tokio::fs::write(dir.path().join("a.txt"), b"content-a")
             .await
             .unwrap();
-        tokio::fs::create_dir_all(dir.join("sub")).await.unwrap();
-        tokio::fs::write(dir.join("sub/b.txt"), b"content-b")
+        tokio::fs::create_dir_all(dir.path().join("sub"))
+            .await
+            .unwrap();
+        tokio::fs::write(dir.path().join("sub/b.txt"), b"content-b")
             .await
             .unwrap();
 
         // Save snapshot to DB
-        let db_path = dir.join("test.db");
+        let db_path = dir.path().join("test.db");
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 
@@ -353,60 +350,88 @@ mod tests {
         assert!(db.has_checkpoint_files("cp1").unwrap());
 
         // Modify worktree: change a file, add a new one, delete one
-        tokio::fs::write(dir.join("a.txt"), b"modified")
+        tokio::fs::write(dir.path().join("a.txt"), b"modified")
             .await
             .unwrap();
-        tokio::fs::write(dir.join("new.txt"), b"new-file")
+        tokio::fs::write(dir.path().join("new.txt"), b"new-file")
             .await
             .unwrap();
-        tokio::fs::remove_file(dir.join("sub/b.txt")).await.unwrap();
+        tokio::fs::remove_file(dir.path().join("sub/b.txt"))
+            .await
+            .unwrap();
 
         // Restore snapshot
         restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
 
         // Verify original state is restored
-        let a_content = tokio::fs::read_to_string(dir.join("a.txt")).await.unwrap();
+        let a_content = tokio::fs::read_to_string(dir.path().join("a.txt"))
+            .await
+            .unwrap();
         assert_eq!(a_content, "content-a");
 
-        let b_content = tokio::fs::read_to_string(dir.join("sub/b.txt"))
+        let b_content = tokio::fs::read_to_string(dir.path().join("sub/b.txt"))
             .await
             .unwrap();
         assert_eq!(b_content, "content-b");
 
         // new.txt should be deleted
-        assert!(!dir.join("new.txt").exists());
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
+        assert!(!dir.path().join("new.txt").exists());
     }
 
     #[tokio::test]
     async fn test_restore_deletes_extra_files() {
         let dir = setup_test_repo().await;
-        let dir_str = dir.to_str().unwrap();
+        let dir_str = dir.path().to_str().unwrap();
 
         // Create one file and snapshot
-        tokio::fs::write(dir.join("keep.txt"), b"keep")
+        tokio::fs::write(dir.path().join("keep.txt"), b"keep")
             .await
             .unwrap();
 
-        let db_path = dir.join("test.db");
+        let db_path = dir.path().join("test.db");
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 
         save_snapshot(&db_path, "cp1", dir_str).await.unwrap();
 
         // Add extra file after snapshot
-        tokio::fs::write(dir.join("extra.txt"), b"extra")
+        tokio::fs::write(dir.path().join("extra.txt"), b"extra")
             .await
             .unwrap();
-        assert!(dir.join("extra.txt").exists());
+        assert!(dir.path().join("extra.txt").exists());
 
         // Restore should remove extra.txt
         restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
-        assert!(!dir.join("extra.txt").exists());
-        assert!(dir.join("keep.txt").exists());
+        assert!(!dir.path().join("extra.txt").exists());
+        assert!(dir.path().join("keep.txt").exists());
+    }
 
-        let _ = tokio::fs::remove_dir_all(&dir).await;
+    #[tokio::test]
+    async fn test_restore_empty_snapshot_deletes_all_files() {
+        let dir = setup_test_repo().await;
+        let dir_str = dir.path().to_str().unwrap();
+
+        // Create a file before snapshotting
+        tokio::fs::write(dir.path().join("exists.txt"), b"hello")
+            .await
+            .unwrap();
+
+        let db_path = dir.path().join("test.db");
+        let db = crate::db::Database::open(&db_path).unwrap();
+        db.execute_batch(TEST_SEED_SQL).unwrap();
+
+        // Insert checkpoint with no files (empty snapshot).
+        // save_snapshot is NOT called — cp1 has zero checkpoint_files rows.
+
+        // Add a second file after the "snapshot" point
+        tokio::fs::write(dir.path().join("also.txt"), b"world")
+            .await
+            .unwrap();
+
+        // Restoring an empty snapshot should delete all tracked files.
+        restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+        assert!(!dir.path().join("exists.txt").exists());
+        assert!(!dir.path().join("also.txt").exists());
     }
 
     #[cfg(unix)]
@@ -415,35 +440,35 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = setup_test_repo().await;
-        let dir_str = dir.to_str().unwrap();
+        let dir_str = dir.path().to_str().unwrap();
 
         // Create an executable file
-        tokio::fs::write(dir.join("script.sh"), b"#!/bin/sh\necho hi")
+        tokio::fs::write(dir.path().join("script.sh"), b"#!/bin/sh\necho hi")
             .await
             .unwrap();
         let perms = std::fs::Permissions::from_mode(0o100755);
-        tokio::fs::set_permissions(dir.join("script.sh"), perms)
+        tokio::fs::set_permissions(dir.path().join("script.sh"), perms)
             .await
             .unwrap();
 
-        let db_path = dir.join("test.db");
+        let db_path = dir.path().join("test.db");
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 
         save_snapshot(&db_path, "cp1", dir_str).await.unwrap();
 
         // Overwrite with non-executable
-        tokio::fs::write(dir.join("script.sh"), b"changed")
+        tokio::fs::write(dir.path().join("script.sh"), b"changed")
             .await
             .unwrap();
 
         // Restore should bring back executable permission
         restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
 
-        let metadata = tokio::fs::metadata(dir.join("script.sh")).await.unwrap();
+        let metadata = tokio::fs::metadata(dir.path().join("script.sh"))
+            .await
+            .unwrap();
         let mode = metadata.permissions().mode();
         assert_eq!(mode & 0o111, 0o111, "executable bits should be preserved");
-
-        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -170,6 +170,19 @@ pub async fn restore_snapshot(
             continue;
         }
         let full_path = base.join(&f.file_path);
+
+        // If the target path currently exists as a symlink or directory,
+        // remove it first. A symlink would cause writes to follow it
+        // (potentially outside the worktree), and a directory would cause
+        // tokio::fs::write to fail with "is a directory".
+        if let Ok(meta) = tokio::fs::symlink_metadata(&full_path).await {
+            if meta.is_symlink() {
+                let _ = tokio::fs::remove_file(&full_path).await;
+            } else if meta.is_dir() {
+                let _ = tokio::fs::remove_dir_all(&full_path).await;
+            }
+        }
+
         match &f.content {
             Some(content) => {
                 if let Some(parent) = full_path.parent() {
@@ -226,7 +239,12 @@ async fn clean_empty_dirs(root: &Path) {
     let mut subdirs = Vec::new();
     while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
-        if path.is_dir() {
+        // Use symlink_metadata to avoid following symlinks into
+        // directories outside the worktree.
+        let is_real_dir = tokio::fs::symlink_metadata(&path)
+            .await
+            .is_ok_and(|m| m.is_dir());
+        if is_real_dir {
             // Skip .git directory
             if path.file_name().is_some_and(|n| n == ".git") {
                 continue;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,449 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::path::Path;
+
+use tokio::process::Command;
+
+use crate::model::CheckpointFile;
+
+/// Maximum file size to include in a snapshot (10 MB).
+const MAX_SNAPSHOT_FILE_SIZE: u64 = 10 * 1024 * 1024;
+
+#[derive(Debug)]
+pub enum SnapshotError {
+    Io(String),
+    Db(String),
+    Git(String),
+}
+
+impl fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(msg) => write!(f, "Snapshot IO error: {msg}"),
+            Self::Db(msg) => write!(f, "Snapshot DB error: {msg}"),
+            Self::Git(msg) => write!(f, "Snapshot git error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SnapshotError {}
+
+impl From<rusqlite::Error> for SnapshotError {
+    fn from(e: rusqlite::Error) -> Self {
+        Self::Db(e.to_string())
+    }
+}
+
+impl From<std::io::Error> for SnapshotError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}
+
+/// Enumerate all files in a worktree that git tracks or would track
+/// (respects .gitignore). Returns NUL-separated paths.
+async fn list_worktree_files(worktree_path: &str) -> Result<Vec<String>, SnapshotError> {
+    let output = Command::new("git")
+        .args(["-C", worktree_path])
+        .args([
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ])
+        .output()
+        .await
+        .map_err(|e| SnapshotError::Git(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(SnapshotError::Git(stderr));
+    }
+
+    let paths: Vec<String> = output
+        .stdout
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect();
+
+    Ok(paths)
+}
+
+/// Collect all files from a worktree for snapshotting.
+/// Skips files larger than `MAX_SNAPSHOT_FILE_SIZE`.
+pub async fn collect_worktree_files(
+    worktree_path: &str,
+) -> Result<Vec<(String, Vec<u8>, u32)>, SnapshotError> {
+    let paths = list_worktree_files(worktree_path).await?;
+    let base = Path::new(worktree_path);
+    let mut files = Vec::with_capacity(paths.len());
+
+    for rel_path in paths {
+        let full_path = base.join(&rel_path);
+
+        let metadata = match tokio::fs::metadata(&full_path).await {
+            Ok(m) => m,
+            Err(_) => continue, // file may have been deleted between ls-files and read
+        };
+
+        if !metadata.is_file() {
+            continue;
+        }
+
+        if metadata.len() > MAX_SNAPSHOT_FILE_SIZE {
+            continue;
+        }
+
+        let content = match tokio::fs::read(&full_path).await {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        #[cfg(unix)]
+        let mode = {
+            use std::os::unix::fs::PermissionsExt;
+            metadata.permissions().mode()
+        };
+        #[cfg(not(unix))]
+        let mode = 33188u32; // 0o100644
+
+        files.push((rel_path, content, mode));
+    }
+
+    Ok(files)
+}
+
+/// Snapshot all worktree files into the `checkpoint_files` table.
+/// Opens its own DB connection so it can be called from async contexts
+/// without holding a non-Send `Database` across await points.
+pub async fn save_snapshot(
+    db_path: &Path,
+    checkpoint_id: &str,
+    worktree_path: &str,
+) -> Result<(), SnapshotError> {
+    let collected = collect_worktree_files(worktree_path).await?;
+
+    let files: Vec<CheckpointFile> = collected
+        .into_iter()
+        .map(|(path, content, mode)| CheckpointFile {
+            id: uuid::Uuid::new_v4().to_string(),
+            checkpoint_id: checkpoint_id.to_string(),
+            file_path: path,
+            content: Some(content),
+            file_mode: mode,
+        })
+        .collect();
+
+    let db = crate::db::Database::open(db_path).map_err(|e| SnapshotError::Db(e.to_string()))?;
+    db.insert_checkpoint_files(&files)?;
+    Ok(())
+}
+
+/// Restore a worktree to the exact state captured in a checkpoint snapshot.
+/// Opens its own DB connection for the same Send-safety reason as `save_snapshot`.
+pub async fn restore_snapshot(
+    db_path: &Path,
+    checkpoint_id: &str,
+    worktree_path: &str,
+) -> Result<(), SnapshotError> {
+    let db = crate::db::Database::open(db_path).map_err(|e| SnapshotError::Db(e.to_string()))?;
+    let snapshot_files = db.get_checkpoint_files(checkpoint_id)?;
+    let base = Path::new(worktree_path);
+
+    // Build set of snapshot paths for deletion pass.
+    let snapshot_paths: HashSet<&str> = snapshot_files
+        .iter()
+        .map(|f| f.file_path.as_str())
+        .collect();
+
+    // Write snapshot files to disk.
+    for f in &snapshot_files {
+        let full_path = base.join(&f.file_path);
+        match &f.content {
+            Some(content) => {
+                if let Some(parent) = full_path.parent() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+                tokio::fs::write(&full_path, content).await?;
+
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let perms = std::fs::Permissions::from_mode(f.file_mode);
+                    tokio::fs::set_permissions(&full_path, perms).await?;
+                }
+            }
+            None => {
+                // Tombstone: delete the file if it exists.
+                let _ = tokio::fs::remove_file(&full_path).await;
+            }
+        }
+    }
+
+    // Delete files on disk that aren't in the snapshot.
+    let current_files = list_worktree_files(worktree_path).await?;
+    for rel_path in &current_files {
+        if !snapshot_paths.contains(rel_path.as_str()) {
+            let full_path = base.join(rel_path);
+            let _ = tokio::fs::remove_file(&full_path).await;
+        }
+    }
+
+    // Clean up empty directories (best-effort, bottom-up).
+    // Re-list to find dirs that may now be empty.
+    clean_empty_dirs(base).await;
+
+    Ok(())
+}
+
+/// Recursively remove empty directories under `root`, bottom-up.
+async fn clean_empty_dirs(root: &Path) {
+    let Ok(mut entries) = tokio::fs::read_dir(root).await else {
+        return;
+    };
+
+    let mut subdirs = Vec::new();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip .git directory
+            if path.file_name().is_some_and(|n| n == ".git") {
+                continue;
+            }
+            subdirs.push(path);
+        }
+    }
+
+    for dir in subdirs {
+        // Recurse first so leaf dirs are cleaned first.
+        Box::pin(clean_empty_dirs(&dir)).await;
+        // Try to remove — succeeds only if empty.
+        let _ = tokio::fs::remove_dir(&dir).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tokio::process::Command;
+
+    async fn setup_test_repo() -> PathBuf {
+        let dir = tempfile::tempdir().unwrap().keep();
+        Command::new("git")
+            .args(["init", dir.to_str().unwrap()])
+            .output()
+            .await
+            .unwrap();
+        // Configure git user for commits
+        Command::new("git")
+            .args([
+                "-C",
+                dir.to_str().unwrap(),
+                "config",
+                "user.email",
+                "test@test.com",
+            ])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", dir.to_str().unwrap(), "config", "user.name", "Test"])
+            .output()
+            .await
+            .unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn test_collect_worktree_files() {
+        let dir = setup_test_repo().await;
+        let dir_str = dir.to_str().unwrap();
+
+        // Create tracked file
+        tokio::fs::write(dir.join("hello.txt"), b"hello")
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", dir_str, "add", "hello.txt"])
+            .output()
+            .await
+            .unwrap();
+
+        // Create untracked (but not ignored) file
+        tokio::fs::write(dir.join("world.txt"), b"world")
+            .await
+            .unwrap();
+
+        // Create gitignored file
+        tokio::fs::write(dir.join(".gitignore"), "ignored.txt\n")
+            .await
+            .unwrap();
+        tokio::fs::write(dir.join("ignored.txt"), b"secret")
+            .await
+            .unwrap();
+
+        let files = collect_worktree_files(dir_str).await.unwrap();
+        let paths: Vec<&str> = files.iter().map(|(p, _, _)| p.as_str()).collect();
+
+        assert!(paths.contains(&"hello.txt"));
+        assert!(paths.contains(&"world.txt"));
+        assert!(paths.contains(&".gitignore"));
+        assert!(!paths.contains(&"ignored.txt"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn test_collect_skips_large_files() {
+        let dir = setup_test_repo().await;
+        let dir_str = dir.to_str().unwrap();
+
+        // Create a small file
+        tokio::fs::write(dir.join("small.txt"), b"small")
+            .await
+            .unwrap();
+
+        // Create a file larger than MAX_SNAPSHOT_FILE_SIZE
+        let large = vec![0u8; (MAX_SNAPSHOT_FILE_SIZE + 1) as usize];
+        tokio::fs::write(dir.join("large.bin"), &large)
+            .await
+            .unwrap();
+
+        let files = collect_worktree_files(dir_str).await.unwrap();
+        let paths: Vec<&str> = files.iter().map(|(p, _, _)| p.as_str()).collect();
+
+        assert!(paths.contains(&"small.txt"));
+        assert!(!paths.contains(&"large.bin"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    const TEST_SEED_SQL: &str = "\
+        INSERT INTO repositories (id, name, path) VALUES ('r1', 'test-repo', '/tmp/test'); \
+        INSERT INTO workspaces (id, repository_id, name, branch_name, status) \
+        VALUES ('ws1', 'r1', 'test', 'main', 'active'); \
+        INSERT INTO conversation_checkpoints (id, workspace_id, message_id, turn_index, message_count) \
+        VALUES ('cp1', 'ws1', 'm1', 0, 0);";
+
+    #[tokio::test]
+    async fn test_save_and_restore_roundtrip() {
+        let dir = setup_test_repo().await;
+        let dir_str = dir.to_str().unwrap();
+
+        // Create initial files
+        tokio::fs::write(dir.join("a.txt"), b"content-a")
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(dir.join("sub")).await.unwrap();
+        tokio::fs::write(dir.join("sub/b.txt"), b"content-b")
+            .await
+            .unwrap();
+
+        // Save snapshot to DB
+        let db_path = dir.join("test.db");
+        let db = crate::db::Database::open(&db_path).unwrap();
+        db.execute_batch(TEST_SEED_SQL).unwrap();
+
+        save_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+
+        // Verify files were saved
+        assert!(db.has_checkpoint_files("cp1").unwrap());
+
+        // Modify worktree: change a file, add a new one, delete one
+        tokio::fs::write(dir.join("a.txt"), b"modified")
+            .await
+            .unwrap();
+        tokio::fs::write(dir.join("new.txt"), b"new-file")
+            .await
+            .unwrap();
+        tokio::fs::remove_file(dir.join("sub/b.txt")).await.unwrap();
+
+        // Restore snapshot
+        restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+
+        // Verify original state is restored
+        let a_content = tokio::fs::read_to_string(dir.join("a.txt")).await.unwrap();
+        assert_eq!(a_content, "content-a");
+
+        let b_content = tokio::fs::read_to_string(dir.join("sub/b.txt"))
+            .await
+            .unwrap();
+        assert_eq!(b_content, "content-b");
+
+        // new.txt should be deleted
+        assert!(!dir.join("new.txt").exists());
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn test_restore_deletes_extra_files() {
+        let dir = setup_test_repo().await;
+        let dir_str = dir.to_str().unwrap();
+
+        // Create one file and snapshot
+        tokio::fs::write(dir.join("keep.txt"), b"keep")
+            .await
+            .unwrap();
+
+        let db_path = dir.join("test.db");
+        let db = crate::db::Database::open(&db_path).unwrap();
+        db.execute_batch(TEST_SEED_SQL).unwrap();
+
+        save_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+
+        // Add extra file after snapshot
+        tokio::fs::write(dir.join("extra.txt"), b"extra")
+            .await
+            .unwrap();
+        assert!(dir.join("extra.txt").exists());
+
+        // Restore should remove extra.txt
+        restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+        assert!(!dir.join("extra.txt").exists());
+        assert!(dir.join("keep.txt").exists());
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_restore_preserves_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = setup_test_repo().await;
+        let dir_str = dir.to_str().unwrap();
+
+        // Create an executable file
+        tokio::fs::write(dir.join("script.sh"), b"#!/bin/sh\necho hi")
+            .await
+            .unwrap();
+        let perms = std::fs::Permissions::from_mode(0o100755);
+        tokio::fs::set_permissions(dir.join("script.sh"), perms)
+            .await
+            .unwrap();
+
+        let db_path = dir.join("test.db");
+        let db = crate::db::Database::open(&db_path).unwrap();
+        db.execute_batch(TEST_SEED_SQL).unwrap();
+
+        save_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+
+        // Overwrite with non-executable
+        tokio::fs::write(dir.join("script.sh"), b"changed")
+            .await
+            .unwrap();
+
+        // Restore should bring back executable permission
+        restore_snapshot(&db_path, "cp1", dir_str).await.unwrap();
+
+        let metadata = tokio::fs::metadata(dir.join("script.sh")).await.unwrap();
+        let mode = metadata.permissions().mode();
+        assert_eq!(mode & 0o111, 0o111, "executable bits should be preserved");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+}

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -382,6 +382,7 @@ function makeCheckpoint(
     workspace_id: wsId,
     message_id: messageId,
     commit_hash: `hash-${turnIndex}`,
+    has_file_state: false,
     turn_index: turnIndex,
     message_count: 1,
     created_at: "",

--- a/src/ui/src/types/checkpoint.ts
+++ b/src/ui/src/types/checkpoint.ts
@@ -3,6 +3,7 @@ export interface ConversationCheckpoint {
   workspace_id: string;
   message_id: string;
   commit_hash: string | null;
+  has_file_state: boolean;
   turn_index: number;
   message_count: number;
   created_at: string;

--- a/src/ui/src/utils/checkpointUtils.test.ts
+++ b/src/ui/src/utils/checkpointUtils.test.ts
@@ -7,12 +7,14 @@ function cp(
   id: string,
   commitHash: string | null,
   turnIndex: number,
+  hasFileState = false,
 ): ConversationCheckpoint {
   return {
     id,
     workspace_id: "ws",
     message_id: `m-${id}`,
     commit_hash: commitHash,
+    has_file_state: hasFileState,
     turn_index: turnIndex,
     message_count: 1,
     created_at: "",
@@ -74,6 +76,24 @@ describe("checkpointHasFileChanges", () => {
     ];
     expect(checkpointHasFileChanges(target, all)).toBe(false);
   });
+
+  it("returns true when has_file_state is true (SQLite snapshot)", () => {
+    const target = cp("cp1", null, 0, true);
+    const all = [cp("cp1", null, 0, true), cp("cp2", null, 1, true)];
+    expect(checkpointHasFileChanges(target, all)).toBe(true);
+  });
+
+  it("returns true when has_file_state is true even with no commit_hash", () => {
+    const target = cp("cp1", null, 0, true);
+    const all = [cp("cp1", null, 0, true)];
+    expect(checkpointHasFileChanges(target, all)).toBe(true);
+  });
+
+  it("returns false when neither has_file_state nor commit_hash", () => {
+    const target = cp("cp1", null, 0, false);
+    const all = [cp("cp1", null, 0, false)];
+    expect(checkpointHasFileChanges(target, all)).toBe(false);
+  });
 });
 
 describe("clearAllHasFileChanges", () => {
@@ -118,6 +138,27 @@ describe("clearAllHasFileChanges", () => {
       cp("cp2", "aaa", 1),
       cp("cp3", "aaa", 2),
     ])).toBe(true);
+  });
+
+  it("returns true when checkpoints have has_file_state (SQLite snapshots)", () => {
+    expect(clearAllHasFileChanges([
+      cp("cp1", null, 0, true),
+      cp("cp2", null, 1, true),
+    ])).toBe(true);
+  });
+
+  it("returns true with mix of snapshot and legacy checkpoints", () => {
+    expect(clearAllHasFileChanges([
+      cp("cp1", "aaa", 0, false),
+      cp("cp2", null, 1, true),
+    ])).toBe(true);
+  });
+
+  it("returns false when no checkpoints have file state or commit hash", () => {
+    expect(clearAllHasFileChanges([
+      cp("cp1", null, 0, false),
+      cp("cp2", null, 1, false),
+    ])).toBe(false);
   });
 });
 

--- a/src/ui/src/utils/checkpointUtils.ts
+++ b/src/ui/src/utils/checkpointUtils.ts
@@ -3,36 +3,34 @@ import type { ChatMessage } from "../types/chat";
 
 /**
  * Determine whether rolling back to a given checkpoint could involve
- * restoring file changes. Returns false only when the checkpoint has no
- * commit hash, or when a later checkpoint confirms the same hash (meaning
- * no files changed between the two). When the target is the latest
- * checkpoint we conservatively return true since the worktree may have
- * drifted after that checkpoint was created.
+ * restoring file changes. New checkpoints use `has_file_state` (SQLite
+ * snapshots). Legacy checkpoints fall back to comparing `commit_hash`
+ * values.
  */
 export function checkpointHasFileChanges(
   checkpoint: ConversationCheckpoint,
   allCheckpoints: ConversationCheckpoint[],
 ): boolean {
+  // New snapshots: has_file_state is authoritative.
+  if (checkpoint.has_file_state) return true;
+  // Legacy: fall back to commit_hash comparison.
   if (!checkpoint.commit_hash) return false;
   if (allCheckpoints.length === 0) return false;
   const latest = allCheckpoints[allCheckpoints.length - 1];
-  // If this IS the latest checkpoint we can't be sure files haven't
-  // drifted — conservatively offer restore.
   if (checkpoint.id === latest.id) return true;
   return checkpoint.commit_hash !== latest.commit_hash;
 }
 
 /**
  * Determine whether clearing the entire conversation could involve
- * restoring file changes. Returns true when any checkpoint has a non-null
- * commit hash — meaning the agent edited files at some point. A clear-all
- * rolls back to before the first turn, so even a single file-editing turn
- * needs the restore checkbox.
+ * restoring file changes. Returns true when any checkpoint has file state
+ * (snapshot or legacy commit hash) — meaning the agent edited files at
+ * some point.
  */
 export function clearAllHasFileChanges(
   checkpoints: ConversationCheckpoint[],
 ): boolean {
-  return checkpoints.some((c) => c.commit_hash !== null);
+  return checkpoints.some((c) => c.has_file_state || c.commit_hash !== null);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces `[checkpoint] Turn N` git commits with SQLite-stored file snapshots, eliminating checkpoint noise in PRs and git history while unifying all session state in the database.

- **New `snapshot.rs` module** — collects worktree files (via `git ls-files`, respecting `.gitignore`), saves them to a new `checkpoint_files` table, and restores worktrees from snapshots
- **Migration v15** adds `checkpoint_files` table with `ON DELETE CASCADE` from `conversation_checkpoints`
- **Dual-path rollback** — new checkpoints restore from SQLite; old checkpoints with `commit_hash` fall back to `git reset --hard` for backward compatibility
- **Computed `has_file_state` field** on `ConversationCheckpoint` (via SQL subquery) replaces the `commit_hash` comparison heuristic on the frontend

```mermaid
flowchart TD
    A[Agent turn completes] --> B[Collect worktree files]
    B --> C[Insert checkpoint record]
    C --> D[Save files to checkpoint_files table]
    D --> E[Emit checkpoint-created event]

    F[User clicks Rollback] --> G{has_file_state?}
    G -->|Yes| H[Restore from SQLite snapshot]
    G -->|No| I{commit_hash?}
    I -->|Yes| J[Legacy: git reset --hard]
    I -->|No| K[No file restore]
```

## Complexity Notes

- **`save_snapshot` and `restore_snapshot` take `&Path` (db_path)** instead of `&Database` because `rusqlite::Connection` is not `Send`. Each call opens a fresh connection, matching the project's existing pattern for Tauri commands.
- **`has_file_state` is computed, not stored** — uses `EXISTS(SELECT 1 FROM checkpoint_files ...)` subquery in every checkpoint query. This avoids stale state but adds a minor query cost per checkpoint row. For typical workloads (< 50 checkpoints) this is negligible.
- **File size cap of 10 MB** — files exceeding this are silently skipped during snapshot and preserved (not deleted) during restore.
- **Symlinks are skipped** — uses `symlink_metadata` to detect symlinks without following them; symlinks are neither snapshotted nor deleted during restore.
- **Path traversal guard** — rejects file paths containing `..` or absolute paths during restore.

## Test Steps

1. `cargo test --all-features` — all 195 tests pass (6 new snapshot tests)
2. `cargo clippy --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — zero warnings
3. `cd src/ui && bun x tsc --noEmit` — typecheck passes
4. `cd src/ui && bun test` — 54 pass, 2 pre-existing failures (unrelated dependency issues)
5. **Manual verification:**
   - `cargo tauri dev` → create workspace → run agent → check `git log` for absence of `[checkpoint]` commits
   - Click rollback on a user message → check "Also restore files" checkbox → verify files restored correctly
   - Verify old checkpoints (created before this change) still restore via git fallback

## Checklist

- [x] Tests added/updated (6 Rust snapshot tests, 6 TypeScript checkpoint util tests)
- [x] Backward compatibility preserved (dual-path rollback)
- [x] `clear_conversation` unchanged (still uses git merge-base restore)

Closes #145