### PR TITLE
feat: @-mention file references in chat input

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -47,6 +47,9 @@ pub async fn handle_request(
                 .get("effort")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let mentioned_files: Option<Vec<String>> = params
+                .get("mentioned_files")
+                .and_then(|v| serde_json::from_value(v.clone()).ok());
             handle_send_chat_message(
                 state,
                 writer,
@@ -58,6 +61,7 @@ pub async fn handle_request(
                 thinking_enabled,
                 plan_mode,
                 effort,
+                mentioned_files,
             )
             .await
         }
@@ -303,6 +307,7 @@ async fn handle_send_chat_message(
     thinking_enabled: Option<bool>,
     plan_mode: Option<bool>,
     effort: Option<String>,
+    mentioned_files: Option<Vec<String>>,
 ) -> Result<serde_json::Value, String> {
     let db = open_db(state)?;
 
@@ -371,10 +376,18 @@ async fn handle_send_chat_message(
         effort,
     };
 
+    // Expand @-file mentions into inline file content for the agent prompt.
+    let prompt = claudette::file_expand::expand_file_mentions(
+        std::path::Path::new(&worktree_path),
+        content,
+        mentioned_files.as_deref().unwrap_or(&[]),
+    )
+    .await;
+
     let turn_handle = agent::run_turn(
         std::path::Path::new(&worktree_path),
         &session_id,
-        content,
+        &prompt,
         is_resume,
         &allowed_tools,
         custom_instructions.as_deref(),

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-plugin-notification = "2"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["sync", "time", "process"] }
+tokio = { version = "1", features = ["sync", "time", "process", "fs"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 libc = "0.2"

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -35,6 +35,7 @@ pub async fn load_chat_history(
 pub async fn send_chat_message(
     workspace_id: String,
     content: String,
+    mentioned_files: Option<Vec<String>>,
     permission_level: Option<String>,
     model: Option<String>,
     fast_mode: Option<bool>,
@@ -155,11 +156,19 @@ pub async fn send_chat_message(
         effort,
     };
 
+    // Expand @-file mentions into inline file content for the agent prompt.
+    let prompt = claudette::file_expand::expand_file_mentions(
+        std::path::Path::new(&worktree_path),
+        &content,
+        mentioned_files.as_deref().unwrap_or(&[]),
+    )
+    .await;
+
     // Spawn the agent turn.
     let turn_handle = agent::run_turn(
         std::path::Path::new(&worktree_path),
         &session_id,
-        &content,
+        &prompt,
         is_resume,
         &allowed_tools,
         custom_instructions.as_deref(),

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,0 +1,168 @@
+use serde::Serialize;
+use tauri::State;
+use tokio::process::Command;
+
+use claudette::db::Database;
+
+use crate::state::AppState;
+
+const MAX_FILES: usize = 10_000;
+const MAX_FILE_SIZE: u64 = 100 * 1024; // 100 KB
+
+#[derive(Clone, Serialize)]
+pub struct FileEntry {
+    pub path: String,
+    pub is_directory: bool,
+}
+
+#[derive(Clone, Serialize)]
+pub struct FileContent {
+    pub path: String,
+    pub content: Option<String>,
+    pub is_binary: bool,
+    pub size_bytes: u64,
+    pub truncated: bool,
+}
+
+/// List files in a workspace's worktree using `git ls-files`.
+///
+/// Returns tracked files plus untracked-but-not-ignored files, capped at 10,000
+/// entries. Paths are relative to the worktree root.
+#[tauri::command]
+pub async fn list_workspace_files(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<FileEntry>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or("Workspace has no worktree")?;
+
+    let output = Command::new("git")
+        .args(["-C", worktree_path])
+        .args(["ls-files", "--cached", "--others", "--exclude-standard"])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run git ls-files: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git ls-files failed: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Collect file entries and extract unique directory paths.
+    let mut dirs = std::collections::BTreeSet::new();
+    let mut entries: Vec<FileEntry> = stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .take(MAX_FILES)
+        .map(|line| {
+            // Extract all parent directories from the file path.
+            let mut pos = 0;
+            while let Some(slash) = line[pos..].find('/') {
+                let dir_end = pos + slash;
+                dirs.insert(line[..=dir_end].to_string());
+                pos = dir_end + 1;
+            }
+            FileEntry {
+                path: line.to_string(),
+                is_directory: false,
+            }
+        })
+        .collect();
+
+    // Prepend directory entries (sorted alphabetically by BTreeSet).
+    let dir_entries: Vec<FileEntry> = dirs
+        .into_iter()
+        .map(|path| FileEntry {
+            path,
+            is_directory: true,
+        })
+        .collect();
+    entries.splice(0..0, dir_entries);
+
+    Ok(entries)
+}
+
+/// Read a file from a workspace's worktree.
+///
+/// Validates that the resolved path stays within the worktree (path traversal
+/// protection). Detects binary files by scanning the first 8 KB for null bytes.
+/// Truncates content at 100 KB.
+#[tauri::command]
+pub async fn read_workspace_file(
+    workspace_id: String,
+    relative_path: String,
+    state: State<'_, AppState>,
+) -> Result<FileContent, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or("Workspace has no worktree")?;
+
+    // Path traversal protection: canonicalize both paths and verify containment.
+    let worktree_canonical = tokio::fs::canonicalize(worktree_path)
+        .await
+        .map_err(|e| format!("Failed to resolve worktree path: {e}"))?;
+    let joined = std::path::Path::new(worktree_path).join(&relative_path);
+    let file_canonical = tokio::fs::canonicalize(&joined)
+        .await
+        .map_err(|e| format!("File not found: {e}"))?;
+
+    if !file_canonical.starts_with(&worktree_canonical) {
+        return Err("Path traversal denied: path escapes worktree".to_string());
+    }
+
+    let metadata = tokio::fs::metadata(&file_canonical)
+        .await
+        .map_err(|e| format!("Cannot read file metadata: {e}"))?;
+    let size_bytes = metadata.len();
+
+    // Read file bytes (cap read at MAX_FILE_SIZE + 1 to detect truncation).
+    let raw = tokio::fs::read(&file_canonical)
+        .await
+        .map_err(|e| format!("Failed to read file: {e}"))?;
+
+    // Binary detection: check first 8 KB for null bytes.
+    let check_len = raw.len().min(8192);
+    if raw[..check_len].contains(&0) {
+        return Ok(FileContent {
+            path: relative_path,
+            content: None,
+            is_binary: true,
+            size_bytes,
+            truncated: false,
+        });
+    }
+
+    let truncated = raw.len() as u64 > MAX_FILE_SIZE;
+    let usable = if truncated {
+        &raw[..MAX_FILE_SIZE as usize]
+    } else {
+        &raw[..]
+    };
+
+    let text = String::from_utf8_lossy(usable).into_owned();
+
+    Ok(FileContent {
+        path: relative_path,
+        content: Some(text),
+        is_binary: false,
+        size_bytes,
+        truncated,
+    })
+}

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -3,11 +3,11 @@ use tauri::State;
 use tokio::process::Command;
 
 use claudette::db::Database;
+use claudette::file_expand;
 
 use crate::state::AppState;
 
 const MAX_FILES: usize = 10_000;
-const MAX_FILE_SIZE: u64 = 100 * 1024; // 100 KB
 
 #[derive(Clone, Serialize)]
 pub struct FileEntry {
@@ -94,9 +94,8 @@ pub async fn list_workspace_files(
 
 /// Read a file from a workspace's worktree.
 ///
-/// Validates that the resolved path stays within the worktree (path traversal
-/// protection). Detects binary files by scanning the first 8 KB for null bytes.
-/// Truncates content at 100 KB.
+/// Delegates to the shared `read_worktree_file` helper for path-traversal
+/// protection, binary detection, and 100 KB truncation.
 #[tauri::command]
 pub async fn read_workspace_file(
     workspace_id: String,
@@ -114,55 +113,15 @@ pub async fn read_workspace_file(
         .as_ref()
         .ok_or("Workspace has no worktree")?;
 
-    // Path traversal protection: canonicalize both paths and verify containment.
-    let worktree_canonical = tokio::fs::canonicalize(worktree_path)
+    let read = file_expand::read_worktree_file(std::path::Path::new(worktree_path), &relative_path)
         .await
-        .map_err(|e| format!("Failed to resolve worktree path: {e}"))?;
-    let joined = std::path::Path::new(worktree_path).join(&relative_path);
-    let file_canonical = tokio::fs::canonicalize(&joined)
-        .await
-        .map_err(|e| format!("File not found: {e}"))?;
-
-    if !file_canonical.starts_with(&worktree_canonical) {
-        return Err("Path traversal denied: path escapes worktree".to_string());
-    }
-
-    let metadata = tokio::fs::metadata(&file_canonical)
-        .await
-        .map_err(|e| format!("Cannot read file metadata: {e}"))?;
-    let size_bytes = metadata.len();
-
-    // Read file bytes (cap read at MAX_FILE_SIZE + 1 to detect truncation).
-    let raw = tokio::fs::read(&file_canonical)
-        .await
-        .map_err(|e| format!("Failed to read file: {e}"))?;
-
-    // Binary detection: check first 8 KB for null bytes.
-    let check_len = raw.len().min(8192);
-    if raw[..check_len].contains(&0) {
-        return Ok(FileContent {
-            path: relative_path,
-            content: None,
-            is_binary: true,
-            size_bytes,
-            truncated: false,
-        });
-    }
-
-    let truncated = raw.len() as u64 > MAX_FILE_SIZE;
-    let usable = if truncated {
-        &raw[..MAX_FILE_SIZE as usize]
-    } else {
-        &raw[..]
-    };
-
-    let text = String::from_utf8_lossy(usable).into_owned();
+        .ok_or("File not found or path escapes worktree")?;
 
     Ok(FileContent {
         path: relative_path,
-        content: Some(text),
-        is_binary: false,
-        size_bytes,
-        truncated,
+        content: read.content,
+        is_binary: read.is_binary,
+        size_bytes: read.size_bytes,
+        truncated: read.truncated,
     })
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod data;
 #[cfg(debug_assertions)]
 pub mod debug;
 pub mod diff;
+pub mod files;
 pub mod plan;
 pub mod remote;
 pub mod repository;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -237,6 +237,9 @@ fn main() {
             // Slash commands
             commands::slash_commands::list_slash_commands,
             commands::slash_commands::record_slash_command_usage,
+            // Files
+            commands::files::list_workspace_files,
+            commands::files::read_workspace_file,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::send_chat_message,

--- a/src/file_expand.rs
+++ b/src/file_expand.rs
@@ -1,0 +1,163 @@
+use std::path::Path;
+
+const MAX_FILE_SIZE: usize = 100 * 1024; // 100 KB
+
+/// Expand @-file mentions into `<referenced-file>` XML blocks prepended to the
+/// prompt.
+///
+/// For each relative path in `mentioned_files`, reads the file from
+/// `worktree_path` with path-traversal protection, binary detection, and 100 KB
+/// truncation. Unreadable, binary, or missing files are silently skipped.
+pub async fn expand_file_mentions(
+    worktree_path: &Path,
+    content: &str,
+    mentioned_files: &[String],
+) -> String {
+    if mentioned_files.is_empty() {
+        return content.to_string();
+    }
+
+    let worktree_canonical = match tokio::fs::canonicalize(worktree_path).await {
+        Ok(p) => p,
+        Err(_) => return content.to_string(),
+    };
+
+    let mut blocks = Vec::new();
+
+    for relative_path in mentioned_files {
+        let joined = worktree_path.join(relative_path);
+
+        // Path traversal protection.
+        let file_canonical = match tokio::fs::canonicalize(&joined).await {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if !file_canonical.starts_with(&worktree_canonical) {
+            continue;
+        }
+
+        // Read file bytes.
+        let raw = match tokio::fs::read(&file_canonical).await {
+            Ok(bytes) => bytes,
+            Err(_) => continue,
+        };
+
+        // Binary detection: check first 8 KB for null bytes.
+        let check_len = raw.len().min(8192);
+        if raw[..check_len].contains(&0) {
+            continue;
+        }
+
+        let truncated = raw.len() > MAX_FILE_SIZE;
+        let usable = if truncated {
+            &raw[..MAX_FILE_SIZE]
+        } else {
+            &raw[..]
+        };
+        let text = String::from_utf8_lossy(usable);
+
+        let mut block =
+            format!("<referenced-file path=\"{relative_path}\">\n{text}\n</referenced-file>");
+        if truncated {
+            block.push_str(&format!(
+                "\n(Note: file truncated at 100KB, total size {} bytes)",
+                raw.len()
+            ));
+        }
+        blocks.push(block);
+    }
+
+    if blocks.is_empty() {
+        return content.to_string();
+    }
+
+    format!("{}\n\n{content}", blocks.join("\n\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_expand_empty_mentions() {
+        let dir = TempDir::new().unwrap();
+        let result = expand_file_mentions(dir.path(), "hello", &[]).await;
+        assert_eq!(result, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_expand_single_file() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("foo.txt"), "file content").unwrap();
+
+        let result = expand_file_mentions(dir.path(), "fix this", &["foo.txt".to_string()]).await;
+
+        assert!(result.contains("<referenced-file path=\"foo.txt\">"));
+        assert!(result.contains("file content"));
+        assert!(result.ends_with("fix this"));
+    }
+
+    #[tokio::test]
+    async fn test_expand_missing_file_skipped() {
+        let dir = TempDir::new().unwrap();
+
+        let result =
+            expand_file_mentions(dir.path(), "hello", &["nonexistent.txt".to_string()]).await;
+
+        assert_eq!(result, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_expand_path_traversal_blocked() {
+        let dir = TempDir::new().unwrap();
+
+        let result =
+            expand_file_mentions(dir.path(), "hello", &["../../etc/passwd".to_string()]).await;
+
+        assert_eq!(result, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_expand_binary_file_skipped() {
+        let dir = TempDir::new().unwrap();
+        let mut data = vec![0u8; 100];
+        data[50] = 0; // null byte
+        fs::write(dir.path().join("binary.bin"), &data).unwrap();
+
+        let result = expand_file_mentions(dir.path(), "hello", &["binary.bin".to_string()]).await;
+
+        assert_eq!(result, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_expand_multiple_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("a.txt"), "aaa").unwrap();
+        fs::write(dir.path().join("b.txt"), "bbb").unwrap();
+
+        let result = expand_file_mentions(
+            dir.path(),
+            "fix both",
+            &["a.txt".to_string(), "b.txt".to_string()],
+        )
+        .await;
+
+        assert!(result.contains("<referenced-file path=\"a.txt\">"));
+        assert!(result.contains("<referenced-file path=\"b.txt\">"));
+        assert!(result.ends_with("fix both"));
+    }
+
+    #[tokio::test]
+    async fn test_expand_truncates_large_file() {
+        let dir = TempDir::new().unwrap();
+        let data = "x".repeat(200 * 1024); // 200KB
+        fs::write(dir.path().join("big.txt"), &data).unwrap();
+
+        let result = expand_file_mentions(dir.path(), "check", &["big.txt".to_string()]).await;
+
+        assert!(result.contains("(Note: file truncated at 100KB"));
+        assert!(result.contains("total size 204800 bytes"));
+    }
+}

--- a/src/file_expand.rs
+++ b/src/file_expand.rs
@@ -2,6 +2,13 @@ use std::path::{Path, PathBuf};
 
 const MAX_FILE_SIZE: usize = 100 * 1024; // 100 KB
 
+fn escape_xml_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 /// Result of reading a file from a worktree with safety checks applied.
 pub struct SafeFileRead {
     pub content: Option<String>,
@@ -42,7 +49,13 @@ async fn read_checked(path: &PathBuf) -> Option<SafeFileRead> {
     let metadata = tokio::fs::metadata(path).await.ok()?;
     let size_bytes = metadata.len();
 
-    let raw = tokio::fs::read(path).await.ok()?;
+    // Read at most MAX_FILE_SIZE + 1 bytes to detect truncation without
+    // buffering the entire file for large inputs.
+    use tokio::io::AsyncReadExt;
+    let file = tokio::fs::File::open(path).await.ok()?;
+    let read_limit = (MAX_FILE_SIZE + 1) as u64;
+    let mut raw = Vec::with_capacity(read_limit.min(size_bytes + 1) as usize);
+    file.take(read_limit).read_to_end(&mut raw).await.ok()?;
 
     // Binary detection: check first 8 KB for null bytes.
     let check_len = raw.len().min(8192);
@@ -104,8 +117,9 @@ pub async fn expand_file_mentions(
             None => continue, // binary
         };
 
+        let escaped_path = escape_xml_attr(relative_path);
         let mut block =
-            format!("<referenced-file path=\"{relative_path}\">\n{text}\n</referenced-file>");
+            format!("<referenced-file path=\"{escaped_path}\">\n{text}\n</referenced-file>");
         if read.truncated {
             block.push_str(&format!(
                 "\n(Note: file truncated at 100KB, total size {} bytes)",

--- a/src/file_expand.rs
+++ b/src/file_expand.rs
@@ -1,6 +1,75 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const MAX_FILE_SIZE: usize = 100 * 1024; // 100 KB
+
+/// Result of reading a file from a worktree with safety checks applied.
+pub struct SafeFileRead {
+    pub content: Option<String>,
+    pub is_binary: bool,
+    pub size_bytes: u64,
+    pub truncated: bool,
+}
+
+/// Read a file from a worktree with path-traversal protection, binary
+/// detection, and 100 KB truncation.
+///
+/// Returns `None` if the file is missing, the path escapes the worktree, or
+/// the worktree path itself cannot be resolved.
+pub async fn read_worktree_file(worktree_path: &Path, relative_path: &str) -> Option<SafeFileRead> {
+    let worktree_canonical = tokio::fs::canonicalize(worktree_path).await.ok()?;
+    resolve_and_read(&worktree_canonical, worktree_path, relative_path).await
+}
+
+/// Inner helper: resolve a relative path against the worktree, validate
+/// containment, read with binary/truncation checks.
+async fn resolve_and_read(
+    worktree_canonical: &Path,
+    worktree_path: &Path,
+    relative_path: &str,
+) -> Option<SafeFileRead> {
+    let joined = worktree_path.join(relative_path);
+    let file_canonical = tokio::fs::canonicalize(&joined).await.ok()?;
+
+    if !file_canonical.starts_with(worktree_canonical) {
+        return None;
+    }
+
+    read_checked(&file_canonical).await
+}
+
+/// Read a canonical path with binary detection and size truncation.
+async fn read_checked(path: &PathBuf) -> Option<SafeFileRead> {
+    let metadata = tokio::fs::metadata(path).await.ok()?;
+    let size_bytes = metadata.len();
+
+    let raw = tokio::fs::read(path).await.ok()?;
+
+    // Binary detection: check first 8 KB for null bytes.
+    let check_len = raw.len().min(8192);
+    if raw[..check_len].contains(&0) {
+        return Some(SafeFileRead {
+            content: None,
+            is_binary: true,
+            size_bytes,
+            truncated: false,
+        });
+    }
+
+    let truncated = raw.len() > MAX_FILE_SIZE;
+    let usable = if truncated {
+        &raw[..MAX_FILE_SIZE]
+    } else {
+        &raw[..]
+    };
+    let text = String::from_utf8_lossy(usable).into_owned();
+
+    Some(SafeFileRead {
+        content: Some(text),
+        is_binary: false,
+        size_bytes,
+        truncated,
+    })
+}
 
 /// Expand @-file mentions into `<referenced-file>` XML blocks prepended to the
 /// prompt.
@@ -25,43 +94,22 @@ pub async fn expand_file_mentions(
     let mut blocks = Vec::new();
 
     for relative_path in mentioned_files {
-        let joined = worktree_path.join(relative_path);
-
-        // Path traversal protection.
-        let file_canonical = match tokio::fs::canonicalize(&joined).await {
-            Ok(p) => p,
-            Err(_) => continue,
-        };
-        if !file_canonical.starts_with(&worktree_canonical) {
-            continue;
-        }
-
-        // Read file bytes.
-        let raw = match tokio::fs::read(&file_canonical).await {
-            Ok(bytes) => bytes,
-            Err(_) => continue,
+        let read = match resolve_and_read(&worktree_canonical, worktree_path, relative_path).await {
+            Some(r) => r,
+            None => continue,
         };
 
-        // Binary detection: check first 8 KB for null bytes.
-        let check_len = raw.len().min(8192);
-        if raw[..check_len].contains(&0) {
-            continue;
-        }
-
-        let truncated = raw.len() > MAX_FILE_SIZE;
-        let usable = if truncated {
-            &raw[..MAX_FILE_SIZE]
-        } else {
-            &raw[..]
+        let text = match read.content {
+            Some(t) => t,
+            None => continue, // binary
         };
-        let text = String::from_utf8_lossy(usable);
 
         let mut block =
             format!("<referenced-file path=\"{relative_path}\">\n{text}\n</referenced-file>");
-        if truncated {
+        if read.truncated {
             block.push_str(&format!(
                 "\n(Note: file truncated at 100KB, total size {} bytes)",
-                raw.len()
+                read.size_bytes
             ));
         }
         blocks.push(block);
@@ -79,6 +127,43 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_read_worktree_file_success() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("hello.txt"), "world").unwrap();
+
+        let result = read_worktree_file(dir.path(), "hello.txt").await.unwrap();
+        assert_eq!(result.content.unwrap(), "world");
+        assert!(!result.is_binary);
+        assert!(!result.truncated);
+    }
+
+    #[tokio::test]
+    async fn test_read_worktree_file_missing() {
+        let dir = TempDir::new().unwrap();
+        assert!(read_worktree_file(dir.path(), "nope.txt").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_read_worktree_file_traversal() {
+        let dir = TempDir::new().unwrap();
+        assert!(
+            read_worktree_file(dir.path(), "../../etc/passwd")
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_worktree_file_binary() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("bin"), b"\x00\x01\x02").unwrap();
+
+        let result = read_worktree_file(dir.path(), "bin").await.unwrap();
+        assert!(result.is_binary);
+        assert!(result.content.is_none());
+    }
 
     #[tokio::test]
     async fn test_expand_empty_mentions() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod config;
 pub mod db;
 pub mod diff;
+pub mod file_expand;
 pub mod git;
 pub mod model;
 pub mod names;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -20,7 +20,6 @@ import {
   getAppSetting,
   setAppSetting,
   listWorkspaceFiles,
-  readWorkspaceFile,
 } from "../../services/tauri";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
 import type { SlashCommand, FileEntry } from "../../services/tauri";
@@ -485,12 +484,10 @@ export function ChatPanel() {
 
     setError(null);
 
-    // Expand @-file references into inline file content blocks.
-    const expandedContent = await expandFileMentions(
-      trimmed,
-      selectedWorkspaceId,
-      mentionedFiles,
-    );
+    // Convert mentioned files set to array for the backend.
+    const mentionedFilesArray = mentionedFiles?.size
+      ? [...mentionedFiles]
+      : undefined;
 
     // Push to prompt history.
     const history = (historyRef.current[selectedWorkspaceId] ??= []);
@@ -515,7 +512,8 @@ export function ChatPanel() {
         const state = useAppStore.getState();
         await sendRemoteCommand(ws.remote_connection_id, "send_chat_message", {
           workspace_id: selectedWorkspaceId,
-          content: expandedContent,
+          content: trimmed,
+          mentioned_files: mentionedFilesArray,
           permission_level: permissionLevel,
           model: state.selectedModel[selectedWorkspaceId] || null,
           fast_mode: state.fastMode[selectedWorkspaceId] || false,
@@ -532,7 +530,8 @@ export function ChatPanel() {
         const effort = state.effortLevel[selectedWorkspaceId] || undefined;
         await sendChatMessage(
           selectedWorkspaceId,
-          expandedContent,
+          trimmed,
+          mentionedFilesArray,
           permissionLevel,
           model,
           fastMode || undefined,
@@ -1128,36 +1127,6 @@ function extractMentionQuery(text: string, cursorPos: number): string | null {
   // If query contains whitespace, the mention is "closed".
   if (/\s/.test(query)) return null;
   return query;
-}
-
-/** Expand @-file references into <referenced-file> blocks prepended to the prompt. */
-async function expandFileMentions(
-  content: string,
-  workspaceId: string,
-  mentionedFiles?: Set<string>,
-): Promise<string> {
-  if (!mentionedFiles || mentionedFiles.size === 0) return content;
-
-  const paths = [...mentionedFiles];
-  const results = await Promise.allSettled(
-    paths.map((p) => readWorkspaceFile(workspaceId, p)),
-  );
-
-  const blocks: string[] = [];
-  for (let i = 0; i < paths.length; i++) {
-    const result = results[i];
-    if (result.status === "fulfilled" && result.value.content) {
-      const fc = result.value;
-      let block = `<referenced-file path="${paths[i]}">\n${fc.content}\n</referenced-file>`;
-      if (fc.truncated) {
-        block += `\n(Note: file truncated at 100KB, total size ${fc.size_bytes} bytes)`;
-      }
-      blocks.push(block);
-    }
-  }
-
-  if (blocks.length === 0) return content;
-  return blocks.join("\n\n") + "\n\n" + content;
 }
 
 // Separate component for input area to prevent full ChatPanel re-renders on every keystroke

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -33,7 +33,7 @@ import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { HeaderMenu } from "./HeaderMenu";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
-import { FileMentionPicker, fuzzyMatchFiles, type FileMatchResult } from "./FileMentionPicker";
+import { FileMentionPicker, fuzzyMatchFiles } from "./FileMentionPicker";
 import { checkpointHasFileChanges, clearAllHasFileChanges, buildRollbackMap } from "../../utils/checkpointUtils";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { debugChat } from "../../utils/chatDebug";

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -19,9 +19,11 @@ import {
   stopAgent,
   getAppSetting,
   setAppSetting,
+  listWorkspaceFiles,
+  readWorkspaceFile,
 } from "../../services/tauri";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
-import type { SlashCommand } from "../../services/tauri";
+import type { SlashCommand, FileEntry } from "../../services/tauri";
 import type { ChatMessage } from "../../types/chat";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { extractToolSummary } from "../../hooks/toolSummary";
@@ -31,6 +33,7 @@ import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { HeaderMenu } from "./HeaderMenu";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
+import { FileMentionPicker, fuzzyMatchFiles, type FileMatchResult } from "./FileMentionPicker";
 import { checkpointHasFileChanges, clearAllHasFileChanges, buildRollbackMap } from "../../utils/checkpointUtils";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { debugChat } from "../../utils/chatDebug";
@@ -449,7 +452,7 @@ export function ChatPanel() {
   ]);
 
   // Auto-dispatch queued message when agent becomes idle.
-  const handleSendRef = useRef<((content: string) => void) | null>(null);
+  const handleSendRef = useRef<((content: string, mentionedFiles?: Set<string>) => void) | null>(null);
   useEffect(() => {
     if (isRunning || !selectedWorkspaceId || !queuedMessage) return;
     // Agent just finished — dispatch the queued message.
@@ -461,7 +464,7 @@ export function ChatPanel() {
 
   if (!ws) return null;
 
-  const handleSend = async (content: string) => {
+  const handleSend = async (content: string, mentionedFiles?: Set<string>) => {
     const trimmed = content.trim();
     if (!trimmed || !selectedWorkspaceId) return;
 
@@ -481,6 +484,13 @@ export function ChatPanel() {
     }
 
     setError(null);
+
+    // Expand @-file references into inline file content blocks.
+    const expandedContent = await expandFileMentions(
+      trimmed,
+      selectedWorkspaceId,
+      mentionedFiles,
+    );
 
     // Push to prompt history.
     const history = (historyRef.current[selectedWorkspaceId] ??= []);
@@ -505,7 +515,7 @@ export function ChatPanel() {
         const state = useAppStore.getState();
         await sendRemoteCommand(ws.remote_connection_id, "send_chat_message", {
           workspace_id: selectedWorkspaceId,
-          content: trimmed,
+          content: expandedContent,
           permission_level: permissionLevel,
           model: state.selectedModel[selectedWorkspaceId] || null,
           fast_mode: state.fastMode[selectedWorkspaceId] || false,
@@ -522,7 +532,7 @@ export function ChatPanel() {
         const effort = state.effortLevel[selectedWorkspaceId] || undefined;
         await sendChatMessage(
           selectedWorkspaceId,
-          trimmed,
+          expandedContent,
           permissionLevel,
           model,
           fastMode || undefined,
@@ -1107,6 +1117,49 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
   );
 });
 
+/** Extract the @-query based on cursor position in the textarea. */
+function extractMentionQuery(text: string, cursorPos: number): string | null {
+  const before = text.slice(0, cursorPos);
+  const atIndex = before.lastIndexOf("@");
+  if (atIndex === -1) return null;
+  // The @ must be at start of input or preceded by whitespace.
+  if (atIndex > 0 && !/\s/.test(before[atIndex - 1])) return null;
+  const query = before.slice(atIndex + 1);
+  // If query contains whitespace, the mention is "closed".
+  if (/\s/.test(query)) return null;
+  return query;
+}
+
+/** Expand @-file references into <referenced-file> blocks prepended to the prompt. */
+async function expandFileMentions(
+  content: string,
+  workspaceId: string,
+  mentionedFiles?: Set<string>,
+): Promise<string> {
+  if (!mentionedFiles || mentionedFiles.size === 0) return content;
+
+  const paths = [...mentionedFiles];
+  const results = await Promise.allSettled(
+    paths.map((p) => readWorkspaceFile(workspaceId, p)),
+  );
+
+  const blocks: string[] = [];
+  for (let i = 0; i < paths.length; i++) {
+    const result = results[i];
+    if (result.status === "fulfilled" && result.value.content) {
+      const fc = result.value;
+      let block = `<referenced-file path="${paths[i]}">\n${fc.content}\n</referenced-file>`;
+      if (fc.truncated) {
+        block += `\n(Note: file truncated at 100KB, total size ${fc.size_bytes} bytes)`;
+      }
+      blocks.push(block);
+    }
+  }
+
+  if (blocks.length === 0) return content;
+  return blocks.join("\n\n") + "\n\n" + content;
+}
+
 // Separate component for input area to prevent full ChatPanel re-renders on every keystroke
 function ChatInputArea({
   onSend,
@@ -1117,7 +1170,7 @@ function ChatInputArea({
   historyIndexRef,
   draftRef,
 }: {
-  onSend: (content: string) => Promise<void>;
+  onSend: (content: string, mentionedFiles?: Set<string>) => Promise<void>;
   isRunning: boolean;
   selectedWorkspaceId: string;
   projectPath: string | undefined;
@@ -1126,10 +1179,17 @@ function ChatInputArea({
   draftRef: React.MutableRefObject<string>;
 }) {
   const [chatInput, setChatInput] = useState("");
+  const [cursorPos, setCursorPos] = useState(0);
   const [slashPickerIndex, setSlashPickerIndex] = useState(0);
   const [slashPickerDismissed, setSlashPickerDismissed] = useState(false);
   const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
+  const [filePickerIndex, setFilePickerIndex] = useState(0);
+  const [filePickerDismissed, setFilePickerDismissed] = useState(false);
+  const [workspaceFiles, setWorkspaceFiles] = useState<FileEntry[]>([]);
+  const [filesLoaded, setFilesLoaded] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const filesCache = useRef<Record<string, FileEntry[]>>({});
+  const mentionedFilesRef = useRef<Set<string>>(new Set());
 
   // Per-workspace draft storage: save input when switching away,
   // restore when switching back.
@@ -1143,6 +1203,10 @@ function ChatInputArea({
       // Restore draft for the workspace we're entering.
       setChatInput(draftsRef.current[selectedWorkspaceId] ?? "");
       prevWorkspaceRef.current = selectedWorkspaceId;
+      // Reset file picker state for new workspace.
+      setFilesLoaded(false);
+      setWorkspaceFiles([]);
+      mentionedFilesRef.current = new Set();
     }
   }, [selectedWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1199,6 +1263,72 @@ function ChatInputArea({
     setSlashPickerDismissed(false);
   }, [slashQuery]);
 
+  // --- File mention picker ---
+
+  const loadFiles = useCallback(async () => {
+    if (filesCache.current[selectedWorkspaceId]) {
+      setWorkspaceFiles(filesCache.current[selectedWorkspaceId]);
+      setFilesLoaded(true);
+      return;
+    }
+    try {
+      const files = await listWorkspaceFiles(selectedWorkspaceId);
+      filesCache.current[selectedWorkspaceId] = files;
+      setWorkspaceFiles(files);
+      setFilesLoaded(true);
+    } catch (e) {
+      console.error("Failed to load workspace files:", e);
+    }
+  }, [selectedWorkspaceId]);
+
+  const mentionQuery = extractMentionQuery(chatInput, cursorPos);
+  const mentionResults = useMemo(
+    () => (mentionQuery === null ? [] : fuzzyMatchFiles(workspaceFiles, mentionQuery)),
+    [workspaceFiles, mentionQuery],
+  );
+  const showFilePicker =
+    mentionQuery !== null && mentionResults.length > 0 && !filePickerDismissed && filesLoaded;
+
+  // Lazy-load file list on first @ trigger.
+  useEffect(() => {
+    if (mentionQuery !== null && !filesLoaded) {
+      loadFiles();
+    }
+  }, [mentionQuery, filesLoaded, loadFiles]);
+
+  // Reset picker index when query changes.
+  useEffect(() => {
+    setFilePickerIndex(0);
+    setFilePickerDismissed(false);
+  }, [mentionQuery]);
+
+  const insertFileMention = useCallback(
+    (file: FileEntry) => {
+      const before = chatInput.slice(0, cursorPos);
+      const atIndex = before.lastIndexOf("@");
+      const after = chatInput.slice(cursorPos);
+      const mention = `@${file.path}`;
+      // Directories: no trailing space so the user can keep narrowing.
+      // Files: add a trailing space to close the mention.
+      const suffix = file.is_directory ? "" : " ";
+      const newText = before.slice(0, atIndex) + mention + suffix + after;
+      setChatInput(newText);
+      const newCursor = atIndex + mention.length + suffix.length;
+      setCursorPos(newCursor);
+      if (!file.is_directory) {
+        mentionedFilesRef.current.add(file.path);
+      }
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (ta) {
+          ta.selectionStart = ta.selectionEnd = newCursor;
+          ta.focus();
+        }
+      });
+    },
+    [chatInput, cursorPos],
+  );
+
   // Auto-resize textarea based on content
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -1211,8 +1341,12 @@ function ChatInputArea({
   }, [chatInput]);
 
   const handleSend = () => {
-    onSend(chatInput);
+    const files = mentionedFilesRef.current.size > 0
+      ? new Set(mentionedFilesRef.current)
+      : undefined;
+    onSend(chatInput, files);
     setChatInput("");
+    mentionedFilesRef.current = new Set();
   };
 
   const planMode = useAppStore(
@@ -1226,6 +1360,37 @@ function ChatInputArea({
       e.preventDefault();
       setPlanMode(selectedWorkspaceId, !planMode);
       return;
+    }
+
+    // File mention picker navigation (takes priority over slash picker)
+    if (showFilePicker) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFilePickerIndex((i) => Math.min(i + 1, mentionResults.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFilePickerIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const result = mentionResults[filePickerIndex];
+        if (result) insertFileMention(result.file);
+        return;
+      }
+      if (e.key === "Tab" && !e.shiftKey) {
+        e.preventDefault();
+        const result = mentionResults[filePickerIndex];
+        if (result) insertFileMention(result.file);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setFilePickerDismissed(true);
+        return;
+      }
     }
 
     // Slash command picker navigation
@@ -1302,6 +1467,14 @@ function ChatInputArea({
 
   return (
     <div className={styles.inputArea}>
+      {showFilePicker && (
+        <FileMentionPicker
+          results={mentionResults}
+          selectedIndex={filePickerIndex}
+          onSelect={insertFileMention}
+          onHover={setFilePickerIndex}
+        />
+      )}
       {showSlashPicker && (
         <SlashCommandPicker
           commands={slashResults}
@@ -1320,7 +1493,13 @@ function ChatInputArea({
         ref={textareaRef}
         className={styles.input}
         value={chatInput}
-        onChange={(e) => setChatInput(e.target.value)}
+        onChange={(e) => {
+          setChatInput(e.target.value);
+          setCursorPos(e.target.selectionStart ?? 0);
+        }}
+        onSelect={(e) => {
+          setCursorPos((e.target as HTMLTextAreaElement).selectionStart ?? 0);
+        }}
         onKeyDown={handleKeyDown}
         placeholder={isRunning ? "Type to queue a message..." : "Send a message..."}
       />

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -32,7 +32,7 @@ import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { HeaderMenu } from "./HeaderMenu";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
-import { FileMentionPicker, fuzzyMatchFiles } from "./FileMentionPicker";
+import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
 import { checkpointHasFileChanges, clearAllHasFileChanges, buildRollbackMap } from "../../utils/checkpointUtils";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { debugChat } from "../../utils/chatDebug";
@@ -455,10 +455,11 @@ export function ChatPanel() {
   useEffect(() => {
     if (isRunning || !selectedWorkspaceId || !queuedMessage) return;
     // Agent just finished — dispatch the queued message.
-    const content = queuedMessage;
+    const { content, mentionedFiles } = queuedMessage;
     clearQueuedMessage(selectedWorkspaceId);
+    const filesSet = mentionedFiles?.length ? new Set(mentionedFiles) : undefined;
     // Use a microtask to avoid calling handleSend during render.
-    queueMicrotask(() => handleSendRef.current?.(content));
+    queueMicrotask(() => handleSendRef.current?.(content, filesSet));
   }, [isRunning, selectedWorkspaceId, queuedMessage, clearQueuedMessage]);
 
   if (!ws) return null;
@@ -467,11 +468,16 @@ export function ChatPanel() {
     const trimmed = content.trim();
     if (!trimmed || !selectedWorkspaceId) return;
 
+    // Convert mentioned files set to array for the backend.
+    const mentionedFilesArray = mentionedFiles?.size
+      ? [...mentionedFiles]
+      : undefined;
+
     // If the agent is running, queue the message instead of interrupting.
     // The user can press Escape to stop the agent if they want to interrupt.
     // Queued messages are auto-sent when the current turn finishes.
     if (isRunning) {
-      setQueuedMessage(selectedWorkspaceId, trimmed);
+      setQueuedMessage(selectedWorkspaceId, trimmed, mentionedFilesArray);
       return;
     }
 
@@ -483,11 +489,6 @@ export function ChatPanel() {
     }
 
     setError(null);
-
-    // Convert mentioned files set to array for the backend.
-    const mentionedFilesArray = mentionedFiles?.size
-      ? [...mentionedFiles]
-      : undefined;
 
     // Push to prompt history.
     const history = (historyRef.current[selectedWorkspaceId] ??= []);
@@ -725,7 +726,7 @@ export function ChatPanel() {
             {queuedMessage && selectedWorkspaceId && (
               <div className={styles.queuedMessage}>
                 <span className={styles.queuedLabel}>Queued</span>
-                <span className={styles.queuedContent}>{queuedMessage}</span>
+                <span className={styles.queuedContent}>{queuedMessage.content}</span>
                 <button
                   className={styles.queuedCancel}
                   onClick={() => clearQueuedMessage(selectedWorkspaceId)}
@@ -1252,7 +1253,7 @@ function ChatInputArea({
 
   const mentionQuery = extractMentionQuery(chatInput, cursorPos);
   const mentionResults = useMemo(
-    () => (mentionQuery === null ? [] : fuzzyMatchFiles(workspaceFiles, mentionQuery)),
+    () => (mentionQuery === null ? [] : matchFiles(workspaceFiles, mentionQuery)),
     [workspaceFiles, mentionQuery],
   );
   const showFilePicker =
@@ -1310,9 +1311,15 @@ function ChatInputArea({
   }, [chatInput]);
 
   const handleSend = () => {
-    const files = mentionedFilesRef.current.size > 0
-      ? new Set(mentionedFilesRef.current)
-      : undefined;
+    // Only include files whose @path tokens are still in the text, so that
+    // removed references don't get expanded.
+    const activeFiles = new Set<string>();
+    for (const path of mentionedFilesRef.current) {
+      if (chatInput.includes(`@${path}`)) {
+        activeFiles.add(path);
+      }
+    }
+    const files = activeFiles.size > 0 ? activeFiles : undefined;
     onSend(chatInput, files);
     setChatInput("");
     mentionedFilesRef.current = new Set();

--- a/src/ui/src/components/chat/FileMentionPicker.module.css
+++ b/src/ui/src/components/chat/FileMentionPicker.module.css
@@ -1,0 +1,65 @@
+.picker {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: 8px;
+  padding: 4px;
+  z-index: 100;
+  max-height: 400px;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+}
+
+.item:hover {
+  background: var(--hover-bg);
+}
+
+.itemSelected {
+  background: var(--selected-bg);
+}
+
+.itemSelected:hover {
+  background: var(--selected-bg);
+}
+
+.atSign {
+  color: var(--text-dim);
+  margin-right: 2px;
+  flex-shrink: 0;
+}
+
+.pathText {
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.highlight {
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.dirBadge {
+  margin-left: auto;
+  padding-left: 8px;
+  color: var(--text-dim);
+  font-size: 11px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}

--- a/src/ui/src/components/chat/FileMentionPicker.tsx
+++ b/src/ui/src/components/chat/FileMentionPicker.tsx
@@ -1,0 +1,113 @@
+import type { FileEntry } from "../../services/tauri";
+import styles from "./FileMentionPicker.module.css";
+
+const MAX_RESULTS = 50;
+
+export interface FileMatchResult {
+  file: FileEntry;
+  matchStart: number;
+  matchEnd: number;
+}
+
+interface FileMentionPickerProps {
+  results: FileMatchResult[];
+  selectedIndex: number;
+  onSelect: (file: FileEntry) => void;
+  onHover: (index: number) => void;
+}
+
+export function FileMentionPicker({
+  results,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: FileMentionPickerProps) {
+  if (results.length === 0) return null;
+
+  return (
+    <div className={styles.picker} role="listbox">
+      {results.map(({ file, matchStart, matchEnd }, i) => {
+        const pre = file.path.slice(0, matchStart);
+        const matched = file.path.slice(matchStart, matchEnd);
+        const post = file.path.slice(matchEnd);
+
+        return (
+          <div
+            key={file.path}
+            role="option"
+            aria-selected={i === selectedIndex}
+            className={`${styles.item} ${i === selectedIndex ? styles.itemSelected : ""}`}
+            onClick={() => onSelect(file)}
+            onMouseEnter={() => onHover(i)}
+          >
+            <span className={styles.atSign}>@</span>
+            <span className={styles.pathText}>
+              {pre}
+              <span className={styles.highlight}>{matched}</span>
+              {post}
+            </span>
+            {file.is_directory && <span className={styles.dirBadge}>dir</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function fuzzyMatchFiles(
+  files: FileEntry[],
+  query: string,
+): FileMatchResult[] {
+  if (!query) {
+    return files.slice(0, MAX_RESULTS).map((file) => ({
+      file,
+      matchStart: 0,
+      matchEnd: 0,
+    }));
+  }
+
+  const q = query.toLowerCase();
+  const scored: { file: FileEntry; score: number; matchStart: number; matchEnd: number }[] = [];
+
+  for (const file of files) {
+    const pathLower = file.path.toLowerCase();
+    const filename = pathLower.split("/").pop() ?? pathLower;
+    const filenameOffset = file.path.length - filename.length;
+
+    // Priority 1: substring match in filename
+    const fnIdx = filename.indexOf(q);
+    if (fnIdx >= 0) {
+      const score = 100 + (q.length / filename.length) * 50;
+      // Boost directories so they sort before files at equal relevance
+      const dirBoost = file.is_directory ? 0.5 : 0;
+      scored.push({
+        file,
+        score: score + dirBoost,
+        matchStart: filenameOffset + fnIdx,
+        matchEnd: filenameOffset + fnIdx + q.length,
+      });
+      continue;
+    }
+
+    // Priority 2: substring match in full path
+    const pathIdx = pathLower.indexOf(q);
+    if (pathIdx >= 0) {
+      const score = 50 + (q.length / pathLower.length) * 25;
+      const dirBoost = file.is_directory ? 0.5 : 0;
+      scored.push({
+        file,
+        score: score + dirBoost,
+        matchStart: pathIdx,
+        matchEnd: pathIdx + q.length,
+      });
+      continue;
+    }
+
+    // No fuzzy fallback — only substring matches
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_RESULTS)
+    .map(({ file, matchStart, matchEnd }) => ({ file, matchStart, matchEnd }));
+}

--- a/src/ui/src/components/chat/FileMentionPicker.tsx
+++ b/src/ui/src/components/chat/FileMentionPicker.tsx
@@ -54,7 +54,7 @@ export function FileMentionPicker({
   );
 }
 
-export function fuzzyMatchFiles(
+export function matchFiles(
   files: FileEntry[],
   query: string,
 ): FileMatchResult[] {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -147,6 +147,34 @@ export function recordSlashCommandUsage(
   });
 }
 
+// -- File Mentions --
+
+export interface FileEntry {
+  path: string;
+  is_directory: boolean;
+}
+
+export interface FileContent {
+  path: string;
+  content: string | null;
+  is_binary: boolean;
+  size_bytes: number;
+  truncated: boolean;
+}
+
+export function listWorkspaceFiles(
+  workspaceId: string,
+): Promise<FileEntry[]> {
+  return invoke("list_workspace_files", { workspaceId });
+}
+
+export function readWorkspaceFile(
+  workspaceId: string,
+  relativePath: string,
+): Promise<FileContent> {
+  return invoke("read_workspace_file", { workspaceId, relativePath });
+}
+
 // -- Chat --
 
 export function loadChatHistory(workspaceId: string): Promise<ChatMessage[]> {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -184,6 +184,7 @@ export function loadChatHistory(workspaceId: string): Promise<ChatMessage[]> {
 export function sendChatMessage(
   workspaceId: string,
   content: string,
+  mentionedFiles?: string[],
   permissionLevel?: string,
   model?: string,
   fastMode?: boolean,
@@ -194,6 +195,7 @@ export function sendChatMessage(
   return invoke("send_chat_message", {
     workspaceId,
     content,
+    mentionedFiles: mentionedFiles ?? null,
     permissionLevel: permissionLevel ?? null,
     model: model ?? null,
     fastMode: fastMode ?? null,

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -154,25 +154,10 @@ export interface FileEntry {
   is_directory: boolean;
 }
 
-export interface FileContent {
-  path: string;
-  content: string | null;
-  is_binary: boolean;
-  size_bytes: number;
-  truncated: boolean;
-}
-
 export function listWorkspaceFiles(
   workspaceId: string,
 ): Promise<FileEntry[]> {
   return invoke("list_workspace_files", { workspaceId });
-}
-
-export function readWorkspaceFile(
-  workspaceId: string,
-  relativePath: string,
-): Promise<FileContent> {
-  return invoke("read_workspace_file", { workspaceId, relativePath });
 }
 
 // -- Chat --

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -117,8 +117,8 @@ interface AppState {
   clearPlanApproval: (wsId: string) => void;
 
   // -- Queued Messages (sent while agent is running, dispatched when idle) --
-  queuedMessages: Record<string, string>;
-  setQueuedMessage: (wsId: string, content: string) => void;
+  queuedMessages: Record<string, { content: string; mentionedFiles?: string[] }>;
+  setQueuedMessage: (wsId: string, content: string, mentionedFiles?: string[]) => void;
   clearQueuedMessage: (wsId: string) => void;
 
   // -- Checkpoints --
@@ -528,9 +528,9 @@ export const useAppStore = create<AppState>((set) => ({
 
   // -- Queued Messages --
   queuedMessages: {},
-  setQueuedMessage: (wsId, content) =>
+  setQueuedMessage: (wsId, content, mentionedFiles) =>
     set((s) => ({
-      queuedMessages: { ...s.queuedMessages, [wsId]: content },
+      queuedMessages: { ...s.queuedMessages, [wsId]: { content, mentionedFiles } },
     })),
   clearQueuedMessage: (wsId) =>
     set((s) => {


### PR DESCRIPTION
## Summary

Adds an autocomplete file picker triggered by `@` in the chat textarea, mirroring Claude Code CLI's `@filename` syntax. Users can reference specific files from the workspace's git worktree, and file contents are expanded inline before sending to the agent.

- **Backend**: Two new Tauri commands (`list_workspace_files`, `read_workspace_file`) using `git ls-files` with path traversal protection, binary detection, and 100KB size cap
- **Frontend**: `FileMentionPicker` component with substring matching, match highlighting, directory browsing, and cursor-aware `@` detection that works anywhere in the text
- **Prompt expansion**: Referenced files are wrapped in `<referenced-file>` XML blocks and prepended to the prompt; only files inserted via the picker are expanded (no false positives from `@` in natural text)

```mermaid
sequenceDiagram
    participant User
    participant ChatInputArea
    participant FileMentionPicker
    participant Tauri Backend
    participant Agent

    User->>ChatInputArea: Types "@par"
    ChatInputArea->>Tauri Backend: listWorkspaceFiles()
    Tauri Backend-->>ChatInputArea: FileEntry[] (git ls-files)
    ChatInputArea->>FileMentionPicker: fuzzyMatchFiles(files, "par")
    FileMentionPicker-->>User: Shows filtered results with highlights
    User->>ChatInputArea: Selects file (Enter/Tab/click)
    ChatInputArea->>ChatInputArea: Inserts @path/to/file
    User->>ChatInputArea: Sends message
    ChatInputArea->>Tauri Backend: readWorkspaceFile() for each @-ref
    Tauri Backend-->>ChatInputArea: FileContent (with traversal check)
    ChatInputArea->>Agent: Expanded prompt with <referenced-file> blocks
```

## Complexity Notes

- **Cursor position tracking**: Unlike slash commands (triggered at start of input), `@` can appear anywhere. The `extractMentionQuery()` function walks backwards from cursor position to find the active `@` trigger, requiring `onSelect` and `onChange` handlers to keep `cursorPos` in sync.
- **Directory handling**: Directories are derived server-side from `git ls-files` output (no separate git command). Selecting a directory inserts `@dir/` without trailing space, keeping the picker open for further narrowing.
- **False positive prevention**: A `mentionedFilesRef` tracks which files were inserted via the picker. Only those paths get expanded during prompt construction — typing `@someone` in natural text won't trigger file reads.

## Test Steps

1. Run `cargo tauri dev` to start the app
2. Open a workspace with files
3. Type `@` in the chat input — verify the file picker appears with file and directory entries
4. Type `@parse` — verify only files/paths containing "parse" appear, with the match highlighted
5. Select a file with Enter/Tab/click — verify `@path/to/file ` is inserted with trailing space
6. Type `@src/` — verify directory entries appear; select one and verify the picker stays open for further narrowing
7. Send a message with `@` references — verify the agent receives expanded file contents
8. Type `@../../etc/passwd` and send — verify the backend rejects path traversal

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)

Closes #133