### PR TITLE
fix(ui): replace ambiguous X icons with Archive and Trash2 in sidebar

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -133,6 +133,15 @@
   background: var(--accent-bg);
 }
 
+.iconBtnDanger {
+  color: var(--status-stopped);
+}
+
+.iconBtnDanger:hover {
+  color: var(--status-stopped);
+  background: rgba(255, 80, 80, 0.15);
+}
+
 .invalidBadge {
   color: var(--status-stopped);
   font-weight: bold;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, Share2, Plus, Globe, Archive, Trash2 } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2 } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Sidebar.module.css";
 

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe } from "lucide-react";
+import { Settings, Link, Share2, Plus, Globe, Archive, Trash2 } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import styles from "./Sidebar.module.css";
 
@@ -389,7 +389,7 @@ export function Sidebar() {
                           }}
                           title="Archive"
                         >
-                          <X size={12} />
+                          <Archive size={12} />
                         </button>
                       ) : (
                         <>
@@ -404,7 +404,7 @@ export function Sidebar() {
                             ↺
                           </button>
                           <button
-                            className={styles.iconBtn}
+                            className={`${styles.iconBtn} ${styles.iconBtnDanger}`}
                             onClick={(e) => {
                               e.stopPropagation();
                               openModal("deleteWorkspace", {
@@ -414,7 +414,7 @@ export function Sidebar() {
                             }}
                             title="Delete"
                           >
-                            <X size={12} />
+                            <Trash2 size={12} />
                           </button>
                         </>
                       )}
@@ -779,7 +779,7 @@ function RemoteConnectionGroup({
                         }}
                         title="Archive"
                       >
-                        <X size={12} />
+                        <Archive size={12} />
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

- Replace the small `X` icon on workspace archive buttons with the Lucide `Archive` icon, making the action immediately recognizable
- Replace the `X` icon on workspace delete buttons with the Lucide `Trash2` icon styled in red, clearly communicating the destructive nature of the action
- Add `.iconBtnDanger` CSS class for red-styled danger buttons in the sidebar

## Test Steps

1. Run `cargo tauri dev` to launch the app
2. In the sidebar, hover over an **active** workspace — verify the archive button shows a box-with-arrow (Archive) icon instead of an X
3. Archive a workspace, then hover over the archived workspace — verify:
   - The restore button still shows `↺`
   - The delete button shows a red trash can icon (`Trash2`) instead of an X
   - The trash icon has a red tint on hover with a subtle red background
4. Repeat for remote workspaces if available

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)