### PR TITLE
feat: auto-detect installed apps for workspace actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,5 +41,8 @@ mac-notification-sys = "0.6"
 [features]
 devtools = ["tauri/devtools"]
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/default-apps.json
+++ b/src-tauri/default-apps.json
@@ -1,0 +1,157 @@
+{
+  "apps": [
+    {
+      "id": "vscode",
+      "name": "VS Code",
+      "category": "editor",
+      "bin_names": ["code"],
+      "mac_app_names": ["Visual Studio Code.app"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "cursor",
+      "name": "Cursor",
+      "category": "editor",
+      "bin_names": ["cursor"],
+      "mac_app_names": ["Cursor.app"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "zed",
+      "name": "Zed",
+      "category": "editor",
+      "bin_names": ["zed"],
+      "mac_app_names": ["Zed.app"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "sublime",
+      "name": "Sublime Text",
+      "category": "editor",
+      "bin_names": ["subl"],
+      "mac_app_names": ["Sublime Text.app"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "neovim",
+      "name": "Neovim",
+      "category": "editor",
+      "bin_names": ["nvim"],
+      "open_args": ["{}"],
+      "needs_terminal": true
+    },
+    {
+      "id": "vim",
+      "name": "Vim",
+      "category": "editor",
+      "bin_names": ["vim"],
+      "open_args": ["{}"],
+      "needs_terminal": true
+    },
+    {
+      "id": "helix",
+      "name": "Helix",
+      "category": "editor",
+      "bin_names": ["hx"],
+      "open_args": ["{}"],
+      "needs_terminal": true
+    },
+    {
+      "id": "emacs",
+      "name": "Emacs",
+      "category": "editor",
+      "bin_names": ["emacs"],
+      "mac_app_names": ["Emacs.app"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "alacritty",
+      "name": "Alacritty",
+      "category": "terminal",
+      "bin_names": ["alacritty"],
+      "mac_app_names": ["Alacritty.app"],
+      "open_args": ["--working-directory", "{}"]
+    },
+    {
+      "id": "kitty",
+      "name": "Kitty",
+      "category": "terminal",
+      "bin_names": ["kitty"],
+      "mac_app_names": ["kitty.app"],
+      "open_args": ["--directory", "{}"]
+    },
+    {
+      "id": "ghostty",
+      "name": "Ghostty",
+      "category": "terminal",
+      "bin_names": ["ghostty"],
+      "mac_app_names": ["Ghostty.app"],
+      "open_args": ["--working-directory={}"]
+    },
+    {
+      "id": "wezterm",
+      "name": "WezTerm",
+      "category": "terminal",
+      "bin_names": ["wezterm"],
+      "mac_app_names": ["WezTerm.app"],
+      "open_args": ["start", "--cwd", "{}"]
+    },
+    {
+      "id": "iterm2",
+      "name": "iTerm2",
+      "category": "terminal",
+      "mac_app_names": ["iTerm.app"],
+      "open_args": ["__applescript__"]
+    },
+    {
+      "id": "macos-terminal",
+      "name": "Terminal",
+      "category": "terminal",
+      "mac_app_names": ["__always__"],
+      "open_args": ["__applescript__"]
+    },
+    {
+      "id": "gnome-terminal",
+      "name": "GNOME Terminal",
+      "category": "terminal",
+      "bin_names": ["gnome-terminal"],
+      "open_args": ["--working-directory", "{}"]
+    },
+    {
+      "id": "konsole",
+      "name": "Konsole",
+      "category": "terminal",
+      "bin_names": ["konsole"],
+      "open_args": ["--workdir", "{}"]
+    },
+    {
+      "id": "xfce4-terminal",
+      "name": "Xfce Terminal",
+      "category": "terminal",
+      "bin_names": ["xfce4-terminal"],
+      "open_args": ["--working-directory", "{}"]
+    },
+    {
+      "id": "foot",
+      "name": "Foot",
+      "category": "terminal",
+      "bin_names": ["foot"],
+      "open_args": ["--working-directory", "{}"]
+    },
+    {
+      "id": "intellij",
+      "name": "IntelliJ IDEA",
+      "category": "ide",
+      "bin_names": ["idea"],
+      "mac_app_names": ["IntelliJ IDEA.app", "IntelliJ IDEA CE.app"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "xcode",
+      "name": "Xcode",
+      "category": "ide",
+      "mac_app_names": ["Xcode.app"],
+      "open_args": ["__open_a__"]
+    }
+  ]
+}

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -259,7 +259,16 @@ async fn open_applescript(app_id: &str, worktree_path: &str) -> Result<(), Strin
     set cmd to "cd " & quoted form of p & " && exec $SHELL"
     tell application "iTerm"
         activate
-        create window with default profile command cmd
+        if (count of windows) = 0 then
+            create window with default profile command cmd
+        else
+            tell current window
+                set newTab to (create tab with default profile)
+                tell current session of newTab
+                    write text cmd
+                end tell
+            end tell
+        end if
     end tell
 end run"#
         }
@@ -276,13 +285,30 @@ end run"#
         other => return Err(format!("No AppleScript handler for app '{other}'")),
     };
 
-    tokio::process::Command::new("osascript")
+    let mut child = tokio::process::Command::new("osascript")
         .arg("-e")
         .arg(script)
         .arg("--")
         .arg(worktree_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("Failed to run AppleScript for {app_id}: {e}"))?;
+
+    // Wait and capture output for debugging
+    let output = child.wait_with_output().await
+        .map_err(|e| format!("Failed to wait for osascript: {e}"))?;
+
+    if !output.status.success() {
+        eprintln!("[iTerm2 Debug] osascript failed with status: {:?}", output.status);
+        eprintln!("[iTerm2 Debug] stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("[iTerm2 Debug] stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return Err(format!("AppleScript failed: {}", String::from_utf8_lossy(&output.stderr)));
+    } else {
+        eprintln!("[iTerm2 Debug] osascript succeeded");
+        eprintln!("[iTerm2 Debug] stdout: {}", String::from_utf8_lossy(&output.stdout));
+    }
+
     Ok(())
 }
 
@@ -331,7 +357,16 @@ async fn open_tui_via_applescript(
     set cmd to item 1 of argv
     tell application "iTerm"
         activate
-        create window with default profile command cmd
+        if (count of windows) = 0 then
+            create window with default profile command cmd
+        else
+            tell current window
+                set newTab to (create tab with default profile)
+                tell current session of newTab
+                    write text cmd
+                end tell
+            end tell
+        end if
     end tell
 end run"#,
         )
@@ -353,6 +388,8 @@ end run"#,
         .arg(script)
         .arg("--")
         .arg(&full_cmd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .spawn()
         .map_err(|e| {
             format!(

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -1,0 +1,627 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::state::AppState;
+
+const DEFAULT_APPS_JSON: &str = include_str!("../../default-apps.json");
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AppCategory {
+    Editor,
+    Terminal,
+    Ide,
+}
+
+/// Entry in the user-editable apps.json config.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppEntry {
+    pub id: String,
+    pub name: String,
+    pub category: AppCategory,
+    #[serde(default)]
+    pub bin_names: Vec<String>,
+    #[serde(default)]
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    pub mac_app_names: Vec<String>,
+    pub open_args: Vec<String>,
+    #[serde(default)]
+    pub needs_terminal: bool,
+}
+
+/// The apps.json file structure.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppsConfig {
+    pub apps: Vec<AppEntry>,
+}
+
+/// App that passed detection (returned to frontend).
+#[derive(Debug, Clone, Serialize)]
+pub struct DetectedApp {
+    pub id: String,
+    pub name: String,
+    pub category: AppCategory,
+    /// The resolved binary path or .app bundle path.
+    pub detected_path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+/// Resolve the path to the user's apps.json config file.
+fn apps_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claudette").join("apps.json"))
+}
+
+/// Load and parse apps.json from the given path.
+/// If the file doesn't exist, write the embedded default and return it.
+/// If the file is malformed, log a warning and return the embedded default.
+fn load_apps_config_from(path: &Path) -> AppsConfig {
+    if path.exists() {
+        match std::fs::read_to_string(path) {
+            Ok(content) => match serde_json::from_str::<AppsConfig>(&content) {
+                Ok(config) => return config,
+                Err(e) => eprintln!("[apps] Failed to parse {}: {e}", path.display()),
+            },
+            Err(e) => eprintln!("[apps] Failed to read {}: {e}", path.display()),
+        }
+    } else {
+        // Write the default file for the user to discover and customize.
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(path, DEFAULT_APPS_JSON) {
+            eprintln!(
+                "[apps] Failed to write default config to {}: {e}",
+                path.display()
+            );
+        }
+    }
+    // Fallback: the embedded default always parses.
+    serde_json::from_str(DEFAULT_APPS_JSON).expect("embedded default-apps.json must be valid")
+}
+
+/// Public entry point — resolves ~/.claudette/apps.json and loads it.
+fn load_apps_config() -> AppsConfig {
+    match apps_config_path() {
+        Some(path) => load_apps_config_from(&path),
+        None => serde_json::from_str(DEFAULT_APPS_JSON)
+            .expect("embedded default-apps.json must be valid"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection logic
+// ---------------------------------------------------------------------------
+
+/// Well-known PATH prefixes that macOS GUI apps may not inherit.
+const EXTRA_PATH_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin", "/usr/local/sbin"];
+
+/// Build the list of directories to scan for binaries.
+fn build_path_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    for dir in EXTRA_PATH_DIRS {
+        dirs.push(PathBuf::from(dir));
+    }
+    if let Some(home) = dirs::home_dir() {
+        dirs.push(home.join(".local/bin"));
+    }
+
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            dirs.push(dir);
+        }
+    }
+
+    // Deduplicate while preserving order.
+    let mut seen = std::collections::HashSet::new();
+    dirs.retain(|d| seen.insert(d.clone()));
+    dirs
+}
+
+/// Check whether `name` exists as an executable in any of `path_dirs`.
+/// Returns the full path to the first match, or `None`.
+fn find_binary(name: &str, path_dirs: &[PathBuf]) -> Option<PathBuf> {
+    for dir in path_dirs {
+        let candidate = dir.join(name);
+        let Ok(meta) = std::fs::metadata(&candidate) else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        // On Unix, verify the executable bit is set.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if meta.permissions().mode() & 0o111 == 0 {
+                continue;
+            }
+        }
+        return Some(candidate);
+    }
+    None
+}
+
+/// Check whether a .app bundle exists in /Applications (macOS only).
+#[cfg(target_os = "macos")]
+fn find_mac_app(app_name: &str) -> Option<PathBuf> {
+    if app_name == "__always__" {
+        // Sentinel: always detected on macOS (e.g. Terminal.app).
+        return Some(PathBuf::from("/System/Applications/Utilities/Terminal.app"));
+    }
+    let path = PathBuf::from("/Applications").join(app_name);
+    if path.exists() { Some(path) } else { None }
+}
+
+/// Detect installed apps from the given config, searching the provided PATH dirs.
+/// This is the testable core — `detect_from_config` wraps it with the real PATH.
+fn detect_with_paths(config: &AppsConfig, path_dirs: &[PathBuf]) -> Vec<DetectedApp> {
+    let category_order = |c: &AppCategory| -> u8 {
+        match c {
+            AppCategory::Editor => 0,
+            AppCategory::Terminal => 1,
+            AppCategory::Ide => 2,
+        }
+    };
+
+    let mut detected: Vec<DetectedApp> = Vec::new();
+
+    for entry in &config.apps {
+        // Try bin_names first.
+        if let Some(bin_path) = entry
+            .bin_names
+            .iter()
+            .find_map(|name| find_binary(name, path_dirs))
+        {
+            detected.push(DetectedApp {
+                id: entry.id.clone(),
+                name: entry.name.clone(),
+                category: entry.category,
+                detected_path: bin_path.to_string_lossy().to_string(),
+            });
+            continue;
+        }
+
+        // Try mac_app_names (macOS only).
+        #[cfg(target_os = "macos")]
+        if let Some(app_path) = entry
+            .mac_app_names
+            .iter()
+            .find_map(|name| find_mac_app(name))
+        {
+            detected.push(DetectedApp {
+                id: entry.id.clone(),
+                name: entry.name.clone(),
+                category: entry.category,
+                detected_path: app_path.to_string_lossy().to_string(),
+            });
+            continue;
+        }
+    }
+
+    detected.sort_by(|a, b| {
+        category_order(&a.category)
+            .cmp(&category_order(&b.category))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    detected
+}
+
+/// Public detection entry point using the real system PATH.
+fn detect_from_config(config: &AppsConfig) -> Vec<DetectedApp> {
+    let path_dirs = build_path_dirs();
+    detect_with_paths(config, &path_dirs)
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn detect_installed_apps(state: State<'_, AppState>) -> Result<Vec<DetectedApp>, String> {
+    let apps = tokio::task::spawn_blocking(|| {
+        let config = load_apps_config();
+        detect_from_config(&config)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    // Cache for TUI editor terminal wrapping in open_workspace_in_app.
+    *state.detected_apps.write().await = apps.clone();
+    Ok(apps)
+}
+
+/// Launch an app using macOS `open -a` command.
+#[cfg(target_os = "macos")]
+async fn open_macos_app(app_name: &str, worktree_path: &str) -> Result<(), String> {
+    tokio::process::Command::new("open")
+        .args(["-a", app_name, worktree_path])
+        .spawn()
+        .map_err(|e| format!("Failed to launch {app_name}: {e}"))?;
+    Ok(())
+}
+
+/// Launch a terminal app via AppleScript (iTerm2, Terminal.app).
+#[cfg(target_os = "macos")]
+async fn open_applescript(app_id: &str, worktree_path: &str) -> Result<(), String> {
+    let escaped = worktree_path.replace('\\', r"\\").replace('\'', r"'\''");
+    let script = match app_id {
+        "iterm2" => format!(
+            r#"tell application "iTerm"
+    activate
+    create window with default profile command "cd '{escaped}' && exec $SHELL"
+end tell"#
+        ),
+        "macos-terminal" => format!(
+            r#"tell application "Terminal"
+    activate
+    do script "cd '{escaped}'"
+end tell"#
+        ),
+        other => return Err(format!("No AppleScript handler for app '{other}'")),
+    };
+
+    tokio::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .spawn()
+        .map_err(|e| format!("Failed to run AppleScript for {app_id}: {e}"))?;
+    Ok(())
+}
+
+/// Determine the exec-separator args for launching an editor inside a given terminal.
+fn terminal_exec_args(terminal_id: &str) -> &'static [&'static str] {
+    match terminal_id {
+        "alacritty" | "konsole" | "xfce4-terminal" => &["-e"],
+        "gnome-terminal" => &["--"],
+        // kitty, foot, wezterm, ghostty: just append the command directly.
+        _ => &[],
+    }
+}
+
+/// Launch a TUI editor (needs_terminal=true) inside the first detected terminal.
+async fn open_in_terminal(
+    editor_entry: &AppEntry,
+    editor_detected: &DetectedApp,
+    worktree_path: &str,
+    state: &State<'_, AppState>,
+) -> Result<(), String> {
+    let detected_apps = state.detected_apps.read().await;
+    let terminal = detected_apps
+        .iter()
+        .find(|a| a.category == AppCategory::Terminal)
+        .ok_or("No terminal emulator detected — cannot launch TUI editor")?
+        .clone();
+    drop(detected_apps);
+
+    // Reload config to get the terminal's open_args.
+    let config = load_apps_config();
+    let terminal_entry = config
+        .apps
+        .iter()
+        .find(|a| a.id == terminal.id)
+        .ok_or_else(|| format!("Terminal '{}' not found in config", terminal.id))?;
+
+    // Build: terminal_binary [terminal_open_args with {} -> path] [exec_separator] editor_binary .
+    let mut cmd = tokio::process::Command::new(&terminal.detected_path);
+
+    // Add terminal's open_args with path substitution.
+    for arg in &terminal_entry.open_args {
+        cmd.arg(arg.replace("{}", worktree_path));
+    }
+
+    // Add exec separator for this terminal.
+    for arg in terminal_exec_args(&terminal.id) {
+        cmd.arg(arg);
+    }
+
+    // Add the editor binary and "." (cwd is set by terminal's --working-directory).
+    cmd.arg(&editor_detected.detected_path);
+    cmd.arg(".");
+
+    cmd.spawn().map_err(|e| {
+        format!(
+            "Failed to launch {} in {}: {e}",
+            editor_entry.name, terminal.name
+        )
+    })?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn open_workspace_in_app(
+    app_id: String,
+    worktree_path: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    // Reload config each time so user edits take effect without restart.
+    let config = load_apps_config();
+    let entry = config
+        .apps
+        .iter()
+        .find(|a| a.id == app_id)
+        .ok_or_else(|| format!("App '{app_id}' not found in apps.json"))?
+        .clone();
+
+    // Handle AppleScript sentinel (iTerm2, Terminal.app).
+    #[cfg(target_os = "macos")]
+    if entry
+        .open_args
+        .first()
+        .is_some_and(|a| a == "__applescript__")
+    {
+        return open_applescript(&app_id, &worktree_path).await;
+    }
+
+    // Handle __open_a__ sentinel (Xcode).
+    #[cfg(target_os = "macos")]
+    if entry.open_args.first().is_some_and(|a| a == "__open_a__") {
+        return open_macos_app(&entry.name, &worktree_path).await;
+    }
+
+    // Look up the detected path for this app.
+    let detected_apps = state.detected_apps.read().await;
+    let detected = detected_apps
+        .iter()
+        .find(|a| a.id == app_id)
+        .ok_or_else(|| format!("App '{app_id}' not detected on this system"))?
+        .clone();
+    drop(detected_apps);
+
+    // Handle TUI editors that need a terminal host.
+    if entry.needs_terminal {
+        return open_in_terminal(&entry, &detected, &worktree_path, &state).await;
+    }
+
+    // Handle .app-only detection on macOS (CLI not in PATH).
+    #[cfg(target_os = "macos")]
+    if detected.detected_path.ends_with(".app") {
+        return open_macos_app(&entry.name, &worktree_path).await;
+    }
+
+    // Normal binary launch: substitute {} in open_args with the worktree path.
+    let args: Vec<String> = entry
+        .open_args
+        .iter()
+        .map(|a| a.replace("{}", &worktree_path))
+        .collect();
+
+    tokio::process::Command::new(&detected.detected_path)
+        .args(&args)
+        .spawn()
+        .map_err(|e| format!("Failed to launch {}: {e}", entry.name))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_config() {
+        let json = r#"{
+            "apps": [{
+                "id": "test-editor",
+                "name": "Test Editor",
+                "category": "editor",
+                "bin_names": ["testedit"],
+                "mac_app_names": ["Test Editor.app"],
+                "open_args": ["{}"],
+                "needs_terminal": false
+            }]
+        }"#;
+        let config: AppsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.apps.len(), 1);
+        assert_eq!(config.apps[0].id, "test-editor");
+        assert_eq!(config.apps[0].name, "Test Editor");
+        assert_eq!(config.apps[0].category, AppCategory::Editor);
+        assert_eq!(config.apps[0].bin_names, vec!["testedit"]);
+        assert_eq!(config.apps[0].open_args, vec!["{}"]);
+        assert!(!config.apps[0].needs_terminal);
+    }
+
+    #[test]
+    fn parse_optional_fields_use_defaults() {
+        let json = r#"{
+            "apps": [{
+                "id": "minimal",
+                "name": "Minimal",
+                "category": "terminal",
+                "open_args": ["--dir", "{}"]
+            }]
+        }"#;
+        let config: AppsConfig = serde_json::from_str(json).unwrap();
+        let app = &config.apps[0];
+        assert!(app.bin_names.is_empty());
+        assert!(app.mac_app_names.is_empty());
+        assert!(!app.needs_terminal);
+    }
+
+    #[test]
+    fn parse_malformed_json_is_err() {
+        let result = serde_json::from_str::<AppsConfig>("not valid json {{{");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_unknown_fields_ignored() {
+        let json = r#"{
+            "apps": [{
+                "id": "x",
+                "name": "X",
+                "category": "ide",
+                "open_args": ["{}"],
+                "future_field": true,
+                "another": 42
+            }],
+            "version": 99
+        }"#;
+        let config: AppsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.apps[0].id, "x");
+        assert_eq!(config.apps[0].category, AppCategory::Ide);
+    }
+
+    #[test]
+    fn parse_embedded_default_config() {
+        let config: AppsConfig =
+            serde_json::from_str(DEFAULT_APPS_JSON).expect("default-apps.json must parse");
+        assert!(config.apps.len() >= 15, "expected at least 15 default apps");
+        // Spot-check a few entries
+        assert!(config.apps.iter().any(|a| a.id == "vscode"));
+        assert!(config.apps.iter().any(|a| a.id == "ghostty"));
+        assert!(
+            config
+                .apps
+                .iter()
+                .any(|a| a.id == "neovim" && a.needs_terminal)
+        );
+    }
+
+    #[test]
+    fn load_apps_config_missing_file_returns_default() {
+        // Point at a path that definitely doesn't exist
+        let config = load_apps_config_from(Path::new("/tmp/claudette-test-nonexistent/apps.json"));
+        assert!(!config.apps.is_empty());
+    }
+
+    #[test]
+    fn load_apps_config_malformed_file_returns_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("apps.json");
+        std::fs::write(&path, "NOT JSON").unwrap();
+        let config = load_apps_config_from(&path);
+        assert!(!config.apps.is_empty());
+    }
+
+    #[test]
+    fn detect_finds_executable_in_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("myeditor");
+        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let config = AppsConfig {
+            apps: vec![AppEntry {
+                id: "myeditor".into(),
+                name: "My Editor".into(),
+                category: AppCategory::Editor,
+                bin_names: vec!["myeditor".into()],
+                mac_app_names: vec![],
+                open_args: vec!["{}".into()],
+                needs_terminal: false,
+            }],
+        };
+
+        let detected = detect_with_paths(&config, &[tmp.path().to_path_buf()]);
+        assert_eq!(detected.len(), 1);
+        assert_eq!(detected[0].id, "myeditor");
+        assert_eq!(detected[0].name, "My Editor");
+        assert_eq!(detected[0].category, AppCategory::Editor);
+        assert_eq!(detected[0].detected_path, bin.to_string_lossy().to_string());
+    }
+
+    #[test]
+    fn detect_skips_missing_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No binary created — the directory is empty.
+        let config = AppsConfig {
+            apps: vec![AppEntry {
+                id: "missing".into(),
+                name: "Missing App".into(),
+                category: AppCategory::Editor,
+                bin_names: vec!["nonexistent-binary".into()],
+                mac_app_names: vec![],
+                open_args: vec!["{}".into()],
+                needs_terminal: false,
+            }],
+        };
+
+        let detected = detect_with_paths(&config, &[tmp.path().to_path_buf()]);
+        assert!(detected.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_skips_non_executable_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("noexec");
+        std::fs::write(&bin, "data").unwrap();
+        // Permissions 0o644 — not executable.
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let config = AppsConfig {
+            apps: vec![AppEntry {
+                id: "noexec".into(),
+                name: "No Exec".into(),
+                category: AppCategory::Editor,
+                bin_names: vec!["noexec".into()],
+                mac_app_names: vec![],
+                open_args: vec!["{}".into()],
+                needs_terminal: false,
+            }],
+        };
+
+        let detected = detect_with_paths(&config, &[tmp.path().to_path_buf()]);
+        assert!(detected.is_empty());
+    }
+
+    #[test]
+    fn detect_sorted_by_category_then_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create two executables
+        for name in ["zterm", "aeditor"] {
+            let bin = tmp.path().join(name);
+            std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+
+        let config = AppsConfig {
+            apps: vec![
+                AppEntry {
+                    id: "zterm".into(),
+                    name: "Z Terminal".into(),
+                    category: AppCategory::Terminal,
+                    bin_names: vec!["zterm".into()],
+                    mac_app_names: vec![],
+                    open_args: vec!["{}".into()],
+                    needs_terminal: false,
+                },
+                AppEntry {
+                    id: "aeditor".into(),
+                    name: "A Editor".into(),
+                    category: AppCategory::Editor,
+                    bin_names: vec!["aeditor".into()],
+                    mac_app_names: vec![],
+                    open_args: vec!["{}".into()],
+                    needs_terminal: false,
+                },
+            ],
+        };
+
+        let detected = detect_with_paths(&config, &[tmp.path().to_path_buf()]);
+        assert_eq!(detected.len(), 2);
+        // Editors come before Terminals (category order: editor, terminal, ide)
+        assert_eq!(detected[0].id, "aeditor");
+        assert_eq!(detected[1].id, "zterm");
+    }
+}

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -296,17 +296,34 @@ end run"#
         .map_err(|e| format!("Failed to run AppleScript for {app_id}: {e}"))?;
 
     // Wait and capture output for debugging
-    let output = child.wait_with_output().await
+    let output = child
+        .wait_with_output()
+        .await
         .map_err(|e| format!("Failed to wait for osascript: {e}"))?;
 
     if !output.status.success() {
-        eprintln!("[iTerm2 Debug] osascript failed with status: {:?}", output.status);
-        eprintln!("[iTerm2 Debug] stdout: {}", String::from_utf8_lossy(&output.stdout));
-        eprintln!("[iTerm2 Debug] stderr: {}", String::from_utf8_lossy(&output.stderr));
-        return Err(format!("AppleScript failed: {}", String::from_utf8_lossy(&output.stderr)));
+        eprintln!(
+            "[iTerm2 Debug] osascript failed with status: {:?}",
+            output.status
+        );
+        eprintln!(
+            "[iTerm2 Debug] stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        eprintln!(
+            "[iTerm2 Debug] stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return Err(format!(
+            "AppleScript failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     } else {
         eprintln!("[iTerm2 Debug] osascript succeeded");
-        eprintln!("[iTerm2 Debug] stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!(
+            "[iTerm2 Debug] stdout: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
     }
 
     Ok(())

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -285,47 +285,15 @@ end run"#
         other => return Err(format!("No AppleScript handler for app '{other}'")),
     };
 
-    let mut child = tokio::process::Command::new("osascript")
+    tokio::process::Command::new("osascript")
         .arg("-e")
         .arg(script)
         .arg("--")
         .arg(worktree_path)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .spawn()
         .map_err(|e| format!("Failed to run AppleScript for {app_id}: {e}"))?;
-
-    // Wait and capture output for debugging
-    let output = child
-        .wait_with_output()
-        .await
-        .map_err(|e| format!("Failed to wait for osascript: {e}"))?;
-
-    if !output.status.success() {
-        eprintln!(
-            "[iTerm2 Debug] osascript failed with status: {:?}",
-            output.status
-        );
-        eprintln!(
-            "[iTerm2 Debug] stdout: {}",
-            String::from_utf8_lossy(&output.stdout)
-        );
-        eprintln!(
-            "[iTerm2 Debug] stderr: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        return Err(format!(
-            "AppleScript failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    } else {
-        eprintln!("[iTerm2 Debug] osascript succeeded");
-        eprintln!(
-            "[iTerm2 Debug] stdout: {}",
-            String::from_utf8_lossy(&output.stdout)
-        );
-    }
-
     Ok(())
 }
 

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -248,28 +248,39 @@ async fn open_macos_app(app_name: &str, worktree_path: &str) -> Result<(), Strin
 }
 
 /// Launch a terminal app via AppleScript (iTerm2, Terminal.app).
+/// Uses `on run argv` + `quoted form of` to pass the path as an argument,
+/// avoiding string interpolation and AppleScript injection risks.
 #[cfg(target_os = "macos")]
 async fn open_applescript(app_id: &str, worktree_path: &str) -> Result<(), String> {
-    let escaped = worktree_path.replace('\\', r"\\").replace('\'', r"'\''");
     let script = match app_id {
-        "iterm2" => format!(
-            r#"tell application "iTerm"
-    activate
-    create window with default profile command "cd '{escaped}' && exec $SHELL"
-end tell"#
-        ),
-        "macos-terminal" => format!(
-            r#"tell application "Terminal"
-    activate
-    do script "cd '{escaped}'"
-end tell"#
-        ),
+        "iterm2" => {
+            r#"on run argv
+    set p to item 1 of argv
+    set cmd to "cd " & quoted form of p & " && exec $SHELL"
+    tell application "iTerm"
+        activate
+        create window with default profile command cmd
+    end tell
+end run"#
+        }
+        "macos-terminal" => {
+            r#"on run argv
+    set p to item 1 of argv
+    set cmd to "cd " & quoted form of p
+    tell application "Terminal"
+        activate
+        do script cmd
+    end tell
+end run"#
+        }
         other => return Err(format!("No AppleScript handler for app '{other}'")),
     };
 
     tokio::process::Command::new("osascript")
         .arg("-e")
-        .arg(&script)
+        .arg(script)
+        .arg("--")
+        .arg(worktree_path)
         .spawn()
         .map_err(|e| format!("Failed to run AppleScript for {app_id}: {e}"))?;
     Ok(())
@@ -285,45 +296,124 @@ fn terminal_exec_args(terminal_id: &str) -> &'static [&'static str] {
     }
 }
 
-/// Launch a TUI editor (needs_terminal=true) inside the first detected terminal.
+/// Launch a TUI editor via AppleScript when only .app-bundle terminals are available (macOS).
+#[cfg(target_os = "macos")]
+async fn open_tui_via_applescript(
+    editor_entry: &AppEntry,
+    editor_detected: &DetectedApp,
+    worktree_path: &str,
+    terminal: &DetectedApp,
+) -> Result<(), String> {
+    // Build the shell command: cd '<path>' && <editor> <args>
+    // The editor's open_args may include flags; substitute {} with ".".
+    let mut editor_argv = vec![editor_detected.detected_path.clone()];
+    for arg in &editor_entry.open_args {
+        editor_argv.push(arg.replace("{}", "."));
+    }
+    let editor_cmd = editor_argv.join(" ");
+
+    let (app_name, script) = if terminal.id == "iterm2" {
+        (
+            "iTerm",
+            r#"on run argv
+    set p to item 1 of argv
+    set e to item 2 of argv
+    set cmd to "cd " & quoted form of p & " && " & e
+    tell application "iTerm"
+        activate
+        create window with default profile command cmd
+    end tell
+end run"#,
+        )
+    } else {
+        (
+            "Terminal",
+            r#"on run argv
+    set p to item 1 of argv
+    set e to item 2 of argv
+    set cmd to "cd " & quoted form of p & " && " & e
+    tell application "Terminal"
+        activate
+        do script cmd
+    end tell
+end run"#,
+        )
+    };
+
+    tokio::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .arg("--")
+        .arg(worktree_path)
+        .arg(&editor_cmd)
+        .spawn()
+        .map_err(|e| {
+            format!(
+                "Failed to launch {} in {app_name} via AppleScript: {e}",
+                editor_entry.name
+            )
+        })?;
+    Ok(())
+}
+
+/// Launch a TUI editor (needs_terminal=true) inside the best detected terminal.
+/// Prefers terminals detected via binary path; falls back to AppleScript on macOS
+/// when only .app-bundle terminals are available.
 async fn open_in_terminal(
     editor_entry: &AppEntry,
     editor_detected: &DetectedApp,
     worktree_path: &str,
     state: &State<'_, AppState>,
 ) -> Result<(), String> {
+    let config = load_apps_config();
+
     let detected_apps = state.detected_apps.read().await;
+
+    // Prefer a terminal detected via a real binary (not a .app bundle),
+    // because .app paths can't be passed to Command::new directly.
     let terminal = detected_apps
         .iter()
-        .find(|a| a.category == AppCategory::Terminal)
+        .filter(|a| a.category == AppCategory::Terminal)
+        .find(|a| !a.detected_path.ends_with(".app"))
+        .or_else(|| {
+            detected_apps
+                .iter()
+                .find(|a| a.category == AppCategory::Terminal)
+        })
         .ok_or("No terminal emulator detected — cannot launch TUI editor")?
         .clone();
     drop(detected_apps);
 
-    // Reload config to get the terminal's open_args.
-    let config = load_apps_config();
+    // If the terminal was detected via .app bundle, use AppleScript on macOS.
+    #[cfg(target_os = "macos")]
+    if terminal.detected_path.ends_with(".app") {
+        return open_tui_via_applescript(editor_entry, editor_detected, worktree_path, &terminal)
+            .await;
+    }
+
     let terminal_entry = config
         .apps
         .iter()
         .find(|a| a.id == terminal.id)
         .ok_or_else(|| format!("Terminal '{}' not found in config", terminal.id))?;
 
-    // Build: terminal_binary [terminal_open_args with {} -> path] [exec_separator] editor_binary .
+    // Build: terminal_binary [terminal_open_args with {} -> path] [exec_separator] editor_binary [editor_open_args]
     let mut cmd = tokio::process::Command::new(&terminal.detected_path);
 
-    // Add terminal's open_args with path substitution.
     for arg in &terminal_entry.open_args {
         cmd.arg(arg.replace("{}", worktree_path));
     }
 
-    // Add exec separator for this terminal.
     for arg in terminal_exec_args(&terminal.id) {
         cmd.arg(arg);
     }
 
-    // Add the editor binary and "." (cwd is set by terminal's --working-directory).
+    // Use the editor's configured open_args, substituting {} with "."
+    // (cwd is already set by the terminal's --working-directory flag).
     cmd.arg(&editor_detected.detected_path);
-    cmd.arg(".");
+    for arg in &editor_entry.open_args {
+        cmd.arg(arg.replace("{}", "."));
+    }
 
     cmd.spawn().map_err(|e| {
         format!(
@@ -359,10 +449,17 @@ pub async fn open_workspace_in_app(
         return open_applescript(&app_id, &worktree_path).await;
     }
 
-    // Handle __open_a__ sentinel (Xcode).
+    // Handle __open_a__ sentinel (Xcode) — look up detected_path to get the .app bundle.
     #[cfg(target_os = "macos")]
     if entry.open_args.first().is_some_and(|a| a == "__open_a__") {
-        return open_macos_app(&entry.name, &worktree_path).await;
+        let detected_apps = state.detected_apps.read().await;
+        let detected = detected_apps
+            .iter()
+            .find(|a| a.id == app_id)
+            .ok_or_else(|| format!("App '{app_id}' not detected on this system"))?;
+        let app_path = detected.detected_path.clone();
+        drop(detected_apps);
+        return open_macos_app(&app_path, &worktree_path).await;
     }
 
     // Look up the detected path for this app.
@@ -382,7 +479,7 @@ pub async fn open_workspace_in_app(
     // Handle .app-only detection on macOS (CLI not in PATH).
     #[cfg(target_os = "macos")]
     if detected.detected_path.ends_with(".app") {
-        return open_macos_app(&entry.name, &worktree_path).await;
+        return open_macos_app(&detected.detected_path, &worktree_path).await;
     }
 
     // Normal binary launch: substitute {} in open_args with the worktree path.

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -296,7 +296,16 @@ fn terminal_exec_args(terminal_id: &str) -> &'static [&'static str] {
     }
 }
 
+/// Shell-quote a string using single quotes (POSIX-safe).
+/// e.g. `hello world` → `'hello world'`, `it's` → `'it'\''s'`
+#[cfg(target_os = "macos")]
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 /// Launch a TUI editor via AppleScript when only .app-bundle terminals are available (macOS).
+/// Builds a fully shell-quoted command in Rust and passes it as a single argument
+/// to avoid injection risks from paths or args with special characters.
 #[cfg(target_os = "macos")]
 async fn open_tui_via_applescript(
     editor_entry: &AppEntry,
@@ -304,21 +313,22 @@ async fn open_tui_via_applescript(
     worktree_path: &str,
     terminal: &DetectedApp,
 ) -> Result<(), String> {
-    // Build the shell command: cd '<path>' && <editor> <args>
-    // The editor's open_args may include flags; substitute {} with ".".
-    let mut editor_argv = vec![editor_detected.detected_path.clone()];
+    // Build a properly shell-quoted command: cd '<path>' && '<editor>' '<arg1>' '<arg2>' ...
+    let mut editor_parts = vec![shell_quote(&editor_detected.detected_path)];
     for arg in &editor_entry.open_args {
-        editor_argv.push(arg.replace("{}", "."));
+        editor_parts.push(shell_quote(&arg.replace("{}", ".")));
     }
-    let editor_cmd = editor_argv.join(" ");
+    let full_cmd = format!(
+        "cd {} && {}",
+        shell_quote(worktree_path),
+        editor_parts.join(" ")
+    );
 
     let (app_name, script) = if terminal.id == "iterm2" {
         (
             "iTerm",
             r#"on run argv
-    set p to item 1 of argv
-    set e to item 2 of argv
-    set cmd to "cd " & quoted form of p & " && " & e
+    set cmd to item 1 of argv
     tell application "iTerm"
         activate
         create window with default profile command cmd
@@ -329,9 +339,7 @@ end run"#,
         (
             "Terminal",
             r#"on run argv
-    set p to item 1 of argv
-    set e to item 2 of argv
-    set cmd to "cd " & quoted form of p & " && " & e
+    set cmd to item 1 of argv
     tell application "Terminal"
         activate
         do script cmd
@@ -344,8 +352,7 @@ end run"#,
         .arg("-e")
         .arg(script)
         .arg("--")
-        .arg(worktree_path)
-        .arg(&editor_cmd)
+        .arg(&full_cmd)
         .spawn()
         .map_err(|e| {
             format!(
@@ -430,7 +437,9 @@ pub async fn open_workspace_in_app(
     worktree_path: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    // Reload config each time so user edits take effect without restart.
+    // Reload config each time so edits to open_args, needs_terminal, etc. take
+    // effect without restart.  Note: the *detected apps list* (which apps appear
+    // in the menu) is cached from startup; adding a new app requires restart.
     let config = load_apps_config();
     let entry = config
         .apps
@@ -587,8 +596,9 @@ mod tests {
 
     #[test]
     fn load_apps_config_missing_file_returns_default() {
-        // Point at a path that definitely doesn't exist
-        let config = load_apps_config_from(Path::new("/tmp/claudette-test-nonexistent/apps.json"));
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("apps.json");
+        let config = load_apps_config_from(&path);
         assert!(!config.apps.is_empty());
     }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod apps;
 pub mod chat;
 pub mod data;
 #[cfg(debug_assertions)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,9 @@ mod tray;
 
 use std::path::PathBuf;
 
-use tauri::{Emitter, Manager};
+#[cfg(target_os = "macos")]
+use tauri::Emitter;
+use tauri::Manager;
 
 use claudette::db::Database;
 
@@ -290,6 +292,9 @@ fn main() {
             commands::shell::setup_shell_integration,
             commands::shell::apply_shell_integration,
             commands::shell::open_in_editor,
+            // Apps
+            commands::apps::detect_installed_apps,
+            commands::apps::open_workspace_in_app,
             // Remote
             commands::remote::list_remote_connections,
             commands::remote::pair_with_server,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use parking_lot::Mutex as ParkingMutex;
 use tokio::sync::RwLock;
 
+use crate::commands::apps::DetectedApp;
 use crate::remote::DiscoveredServer;
 
 /// Re-export for use in tray module without direct tauri::tray import.
@@ -76,6 +77,8 @@ pub struct AppState {
     pub discovered_servers: RwLock<Vec<DiscoveredServer>>,
     /// Embedded local claudette-server process (when "Share this machine" is active).
     pub local_server: RwLock<Option<LocalServerState>>,
+    /// Detected apps cache (populated on startup, read by open_workspace_in_app for TUI wrapping).
+    pub detected_apps: RwLock<Vec<DetectedApp>>,
     /// System tray icon handle (None when tray is disabled).
     pub tray_handle: Mutex<Option<TrayIcon>>,
 }
@@ -90,6 +93,7 @@ impl AppState {
             next_pty_id: AtomicU64::new(1),
             discovered_servers: RwLock::new(Vec::new()),
             local_server: RwLock::new(None),
+            detected_apps: RwLock::new(Vec::new()),
             tray_handle: Mutex::new(None),
         }
     }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, clearAttention } from "./services/tauri";
+import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, clearAttention, detectInstalledApps } from "./services/tauri";
 import { applyTheme, loadAllThemes, findTheme } from "./utils/theme";
 import { AppLayout } from "./components/layout/AppLayout";
 import type { CommandEvent } from "./types";
@@ -19,6 +19,7 @@ function App() {
   const setLocalServerRunning = useAppStore((s) => s.setLocalServerRunning);
   const setLocalServerConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
   const setCurrentThemeId = useAppStore((s) => s.setCurrentThemeId);
+  const setDetectedApps = useAppStore((s) => s.setDetectedApps);
 
   useEffect(() => {
     loadInitialData().then((data) => {
@@ -72,6 +73,10 @@ function App() {
         setLocalServerConnectionString(info.connection_string);
       })
       .catch((err) => console.error("Failed to load local server status:", err));
+
+    detectInstalledApps()
+      .then(setDetectedApps)
+      .catch((err) => console.error("Failed to detect installed apps:", err));
 
     // Listen for terminal command events
     const setupCommandListeners = async () => {
@@ -148,7 +153,7 @@ function App() {
       unlistenTray.then((fn) => fn());
       unlistenSettings.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setDetectedApps]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/components/chat/HeaderMenu.module.css
+++ b/src/ui/src/components/chat/HeaderMenu.module.css
@@ -84,3 +84,12 @@
   color: var(--accent-primary);
   font-weight: 600;
 }
+
+.groupHeader {
+  font-size: 10px;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 6px 10px 2px;
+  pointer-events: none;
+}

--- a/src/ui/src/components/chat/HeaderMenu.tsx
+++ b/src/ui/src/components/chat/HeaderMenu.tsx
@@ -1,10 +1,11 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, Fragment } from "react";
 import { ChevronDown } from "lucide-react";
 import styles from "./HeaderMenu.module.css";
 
 interface MenuItem {
   value: string;
   label: string;
+  group?: string;
 }
 
 interface HeaderMenuProps {
@@ -66,19 +67,27 @@ export function HeaderMenu({
       </button>
       {open && (
         <div className={styles.menu}>
-          {items.map((item) => (
-            <button
-              key={item.value}
-              className={`${styles.item} ${item.value === value ? styles.itemActive : ""}`}
-              onClick={() => {
-                onSelect(item.value);
-                setOpen(false);
-              }}
-              type="button"
-            >
-              {item.label}
-            </button>
-          ))}
+          {items.map((item, i) => {
+            const showGroupHeader =
+              item.group && (i === 0 || items[i - 1].group !== item.group);
+            return (
+              <Fragment key={item.value}>
+                {showGroupHeader && (
+                  <div className={styles.groupHeader}>{item.group}</div>
+                )}
+                <button
+                  className={`${styles.item} ${item.value === value ? styles.itemActive : ""}`}
+                  onClick={() => {
+                    onSelect(item.value);
+                    setOpen(false);
+                  }}
+                  type="button"
+                >
+                  {item.label}
+                </button>
+              </Fragment>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/ui/src/components/chat/WorkspaceActions.tsx
+++ b/src/ui/src/components/chat/WorkspaceActions.tsx
@@ -1,5 +1,7 @@
-import { openWorkspaceInTerminal } from "../../services/tauri";
+import { useMemo } from "react";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { useAppStore } from "../../stores/useAppStore";
+import { openWorkspaceInApp } from "../../services/tauri";
 import { HeaderMenu } from "./HeaderMenu";
 
 interface WorkspaceActionsProps {
@@ -7,40 +9,67 @@ interface WorkspaceActionsProps {
   disabled?: boolean;
 }
 
-const ITEMS = [
-  { value: "open-terminal", label: "Open in Terminal" },
-  { value: "copy-path", label: "Copy Path" },
-];
+const CATEGORY_LABELS: Record<string, string> = {
+  editor: "Editors",
+  terminal: "Terminals",
+  ide: "IDEs",
+};
+
+const CATEGORY_ORDER = ["editor", "terminal", "ide"] as const;
 
 export function WorkspaceActions({
   worktreePath,
   disabled = false,
 }: WorkspaceActionsProps) {
+  const detectedApps = useAppStore((s) => s.detectedApps);
+
+  const items = useMemo(() => {
+    const menuItems: { value: string; label: string; group?: string }[] = [];
+
+    for (const category of CATEGORY_ORDER) {
+      const apps = detectedApps.filter((a) => a.category === category);
+      const groupLabel = CATEGORY_LABELS[category];
+      for (const app of apps) {
+        menuItems.push({
+          value: `open:${app.id}`,
+          label: `Open in ${app.name}`,
+          group: groupLabel,
+        });
+      }
+    }
+
+    menuItems.push({
+      value: "copy-path",
+      label: "Copy Path",
+      group: "Other",
+    });
+
+    return menuItems;
+  }, [detectedApps]);
+
   const handleSelect = async (action: string) => {
     if (!worktreePath) return;
 
-    switch (action) {
-      case "open-terminal":
-        try {
-          await openWorkspaceInTerminal(worktreePath);
-        } catch (err) {
-          console.error("Failed to open terminal:", err);
-        }
-        break;
-      case "copy-path":
-        try {
-          await writeText(worktreePath);
-        } catch (err) {
-          console.error("Failed to copy path:", err);
-        }
-        break;
+    if (action.startsWith("open:")) {
+      const appId = action.slice(5);
+      try {
+        await openWorkspaceInApp(appId, worktreePath);
+      } catch (err) {
+        console.error(`Failed to open in app ${appId}:`, err);
+      }
+    } else if (action === "copy-path") {
+      try {
+        await writeText(worktreePath);
+      } catch (err) {
+        console.error("Failed to copy path:", err);
+      }
     }
   };
 
   return (
     <HeaderMenu
       label="Actions"
-      items={ITEMS}
+      items={items}
       disabled={disabled || !worktreePath}
       title="Workspace actions"
       onSelect={handleSelect}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -16,6 +16,7 @@ import type {
   DiscoveredServer,
   PairResult,
 } from "../types/remote";
+import type { DetectedApp } from "../types/apps";
 
 // -- Data --
 
@@ -435,6 +436,16 @@ export function stopLocalServer(): Promise<void> {
 
 export function getLocalServerStatus(): Promise<LocalServerInfo> {
   return invoke("get_local_server_status");
+}
+
+// -- Apps --
+
+export function detectInstalledApps(): Promise<DetectedApp[]> {
+  return invoke("detect_installed_apps");
+}
+
+export function openWorkspaceInApp(appId: string, worktreePath: string): Promise<void> {
+  return invoke("open_workspace_in_app", { appId, worktreePath });
 }
 
 // -- Debug (dev builds only) --

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -15,6 +15,7 @@ import type {
   ConversationCheckpoint,
 } from "../types";
 import type { RemoteInitialData } from "../types/remote";
+import type { DetectedApp } from "../types/apps";
 
 export type PermissionLevel = "readonly" | "standard" | "full";
 
@@ -258,6 +259,10 @@ interface AppState {
   localServerConnectionString: string | null;
   setLocalServerRunning: (running: boolean) => void;
   setLocalServerConnectionString: (cs: string | null) => void;
+
+  // -- Detected Apps --
+  detectedApps: DetectedApp[];
+  setDetectedApps: (apps: DetectedApp[]) => void;
 
   // -- Updater --
   updateAvailable: boolean;
@@ -843,6 +848,10 @@ export const useAppStore = create<AppState>((set) => ({
   setLocalServerRunning: (running) => set({ localServerRunning: running }),
   setLocalServerConnectionString: (cs) =>
     set({ localServerConnectionString: cs }),
+
+  // -- Detected Apps --
+  detectedApps: [],
+  setDetectedApps: (apps) => set({ detectedApps: apps }),
 
   // -- Updater --
   updateAvailable: false,

--- a/src/ui/src/types/apps.ts
+++ b/src/ui/src/types/apps.ts
@@ -1,0 +1,8 @@
+export type AppCategory = "editor" | "terminal" | "ide";
+
+export interface DetectedApp {
+  id: string;
+  name: string;
+  category: AppCategory;
+  detected_path: string;
+}

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -31,3 +31,4 @@ export type {
   PairResult,
 } from "./remote";
 export type { ConversationCheckpoint } from "./checkpoint";
+export type { DetectedApp, AppCategory } from "./apps";


### PR DESCRIPTION
## Summary

Implements the auto-detect installed apps feature from the [TDD](https://github.com/utensils/Claudette/blob/main/docs/auto-detect-apps-tdd.md).

- **Config-driven app registry** at `~/.claudette/apps.json` with 20 default developer tools — users can add, remove, or modify entries without rebuilding
- **Binary detection** via `$PATH` scanning (with extra prefixes for macOS GUI apps) and executable bit verification on Linux
- **macOS .app bundle detection** in `/Applications`, with AppleScript handlers for iTerm2 and Terminal.app, and `open -a` fallback for apps without CLI wrappers
- **TUI editor wrapping** (`needs_terminal`) launches editors like Neovim/Vim/Helix inside the first detected terminal emulator
- **Grouped dropdown menu** with category headings (Editors, Terminals, IDEs) replaces the static 2-item workspace actions menu
- **11 unit tests** covering config parsing (valid, defaults, malformed, unknown fields, embedded default) and detection logic (finds executables, skips missing/non-executable, correct sort order)

### Files changed

| Area | Files |
|------|-------|
| **Rust backend** | `src-tauri/default-apps.json` (new), `src-tauri/src/commands/apps.rs` (new), `commands/mod.rs`, `state.rs`, `main.rs`, `Cargo.toml` |
| **Frontend types/services** | `types/apps.ts` (new), `types/index.ts`, `services/tauri.ts` |
| **Store/init** | `stores/useAppStore.ts`, `App.tsx` |
| **UI components** | `HeaderMenu.tsx`, `HeaderMenu.module.css`, `WorkspaceActions.tsx` |

Closes #115

## Test plan

- [ ] `cargo test --all-features` — 191 tests pass (includes 11 new apps tests)
- [ ] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets` — zero warnings
- [ ] `cargo fmt --all --check` — clean
- [ ] `cd src/ui && bunx tsc --noEmit` — clean
- [ ] Run `cargo tauri dev`, open a workspace, click "Actions" dropdown — detected apps appear grouped by category
- [ ] Click an editor entry → editor opens with workspace directory
- [ ] Click a terminal entry → terminal opens at workspace path
- [ ] "Copy Path" still works at the bottom of the menu
- [ ] Edit `~/.claudette/apps.json` to add a custom entry, restart app → new entry appears
- [ ] Delete `~/.claudette/apps.json`, restart → default file is recreated