### PR TITLE
feat: highlight chat input with dashed border when plan mode is active

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -863,6 +863,16 @@
   color: var(--text-faint);
 }
 
+.inputPlanMode {
+  border: 2px dashed rgba(var(--accent-primary-rgb), 0.5);
+  background: rgba(var(--accent-primary-rgb), 0.04);
+}
+
+.inputPlanMode:focus {
+  border-color: rgba(var(--accent-primary-rgb), 0.6);
+  box-shadow: 0 0 0 3px rgba(var(--accent-primary-rgb), 0.12);
+}
+
 .sendBtn {
   background: transparent;
   border: 1px solid rgba(var(--accent-primary-rgb), 0.2);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1469,7 +1469,7 @@ function ChatInputArea({
       )}
       <textarea
         ref={textareaRef}
-        className={`${styles.input} ${planMode ? styles.inputPlanMode : ""}`}
+        className={`${styles.input}${planMode ? ` ${styles.inputPlanMode}` : ""}`}
         value={chatInput}
         onChange={(e) => {
           setChatInput(e.target.value);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1469,7 +1469,7 @@ function ChatInputArea({
       )}
       <textarea
         ref={textareaRef}
-        className={styles.input}
+        className={`${styles.input} ${planMode ? styles.inputPlanMode : ""}`}
         value={chatInput}
         onChange={(e) => {
           setChatInput(e.target.value);


### PR DESCRIPTION
## Summary

Adds a visual indicator to the chat textarea when plan mode is enabled. The input border changes from a solid gray `1px solid` to a `2px dashed` teal accent border with a subtle teal background tint, making it immediately clear that the user is composing in plan mode.

- New `.inputPlanMode` CSS class with dashed border and faint teal background
- Conditional className applied to textarea based on existing Zustand `planMode` state

## Test Steps

1. Run `cargo tauri dev`
2. Select a workspace with an active agent session
3. Observe the chat input has its normal solid gray border
4. Press **Shift+Tab** (or click the **Plan** chip in the toolbar) to enable plan mode
5. Verify the input border changes to a **dashed teal** line with a subtle teal background tint
6. Click into the textarea — verify the focus glow is teal-accented
7. Press **Shift+Tab** again to disable plan mode
8. Verify the input returns to its normal solid gray border with smooth transition

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)