### PR TITLE
ci: replace deprecated macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,7 +85,7 @@ jobs:
             rust-target: aarch64-apple-darwin
             bundles: dmg
             label: macos-aarch64
-          - platform: macos-13
+          - platform: macos-15-intel
             rust-target: x86_64-apple-darwin
             bundles: dmg
             label: macos-x86_64


### PR DESCRIPTION
## Summary

- Replace `macos-13` with `macos-15-intel` in the release build matrix for `macos-x86_64`
- The `macos-13` runner image was removed by GitHub Actions, causing release builds to fail with `The configuration 'macos-13-us-default' is not supported`
- `macos-15-intel` is the last x86_64 macOS runner GitHub will offer (available until August 2027)

## Test Steps

1. Verify the workflow YAML is valid: `gh workflow view release-please.yml`
2. Trigger a release (or manually run the build job) and confirm the `macos-x86_64` job starts and completes on `macos-15-intel`
3. Verify the built DMG artifact is uploaded to the release

## Checklist
- [x] No code changes — CI config only
- [ ] Verified runner starts successfully on next release