### PR TITLE
fix: always force-delete branch on archive/delete

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -456,8 +456,7 @@ pub async fn delete_workspace(
         let _ = git::remove_worktree(&repo.path, wt_path, true).await;
     }
 
-    // Best-effort branch delete. Force-deletes only if all unmerged commits
-    // are synthetic [checkpoint] commits; preserves branches with real work.
+    // Best-effort branch delete. Force-deletes even if unmerged commits exist.
     let _ = git::branch_delete(&repo.path, &ws.branch_name).await;
 
     // Cascade deletes chat messages and terminal tabs.

--- a/src/git.rs
+++ b/src/git.rs
@@ -204,7 +204,7 @@ pub async fn has_unmerged_commits(
 }
 
 /// Delete a branch. Tries safe `-d` first; falls back to force `-D`
-/// if the branch has unmerged commits.
+/// if `-d` fails.
 pub async fn branch_delete(repo_path: &str, branch: &str) -> Result<(), GitError> {
     if run_git(repo_path, &["branch", "-d", branch]).await.is_ok() {
         return Ok(());

--- a/src/git.rs
+++ b/src/git.rs
@@ -203,51 +203,14 @@ pub async fn has_unmerged_commits(
     Ok(count > 0)
 }
 
-/// Delete a branch. Tries safe `-d` first. If that fails (unmerged commits),
-/// checks whether all unmerged commits are synthetic `[checkpoint]` commits.
-/// Force-deletes only in that case; otherwise preserves real user work.
+/// Delete a branch. Tries safe `-d` first; falls back to force `-D`
+/// if the branch has unmerged commits.
 pub async fn branch_delete(repo_path: &str, branch: &str) -> Result<(), GitError> {
-    // Try safe delete first.
     if run_git(repo_path, &["branch", "-d", branch]).await.is_ok() {
         return Ok(());
     }
-
-    // Safe delete failed — check if only checkpoint commits are unmerged.
-    if has_only_checkpoint_commits(repo_path, branch).await {
-        run_git(repo_path, &["branch", "-D", branch]).await?;
-        return Ok(());
-    }
-
-    // Real unmerged work exists — leave the branch intact.
-    Err(GitError::CommandFailed(
-        "Branch has unmerged commits".into(),
-    ))
-}
-
-/// Returns true if every commit on `branch` that is not reachable from the
-/// default branch has a message starting with `[checkpoint]`.
-async fn has_only_checkpoint_commits(repo_path: &str, branch: &str) -> bool {
-    // Determine the default branch to compare against.
-    let base = match default_branch(repo_path).await {
-        Ok(b) => b,
-        Err(_) => return false,
-    };
-
-    let log = match run_git(
-        repo_path,
-        &["log", "--format=%s", &format!("{base}..{branch}")],
-    )
-    .await
-    {
-        Ok(output) => output,
-        Err(_) => return false,
-    };
-
-    if log.trim().is_empty() {
-        return true; // no ahead commits at all
-    }
-
-    log.lines().all(|line| line.starts_with("[checkpoint]"))
+    run_git(repo_path, &["branch", "-D", branch]).await?;
+    Ok(())
 }
 
 /// Create a checkpoint commit in a worktree, staging all changes first.
@@ -425,7 +388,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_branch_delete_preserves_branch_with_real_commits() {
+    async fn test_branch_delete_force_deletes_branch_with_real_commits() {
         let dir = setup_temp_repo().await;
         let path = dir.path().to_str().unwrap();
 
@@ -445,15 +408,14 @@ mod tests {
             .unwrap();
         run_git(path, &["checkout", "main"]).await.unwrap();
 
-        // Branch has a real commit — should NOT force-delete.
-        let result = branch_delete(path, "ws-branch").await;
-        assert!(result.is_err());
+        // Branch has real commits — should still force-delete.
+        branch_delete(path, "ws-branch").await.unwrap();
 
-        // Confirm branch still exists.
+        // Confirm branch is gone.
         let branches = run_git(path, &["branch", "--list", "ws-branch"])
             .await
             .unwrap();
-        assert!(!branches.trim().is_empty());
+        assert!(branches.trim().is_empty());
     }
 
     #[tokio::test]

--- a/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
+++ b/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
@@ -30,7 +30,7 @@ export function DeleteWorkspaceModal() {
     <Modal title="Delete Workspace" onClose={closeModal}>
       <div className={shared.warning}>
         Are you sure you want to delete <strong>{wsName}</strong>? The branch
-        will be kept if it has unmerged commits.
+        and any unmerged commits will be permanently deleted.
       </div>
       {error && <div className={shared.error}>{error}</div>}
       <div className={shared.actions}>

--- a/src/ui/src/components/settings/sections/GitSettings.tsx
+++ b/src/ui/src/components/settings/sections/GitSettings.tsx
@@ -139,8 +139,7 @@ export function GitSettings() {
               className={styles.settingDescription}
               style={{ color: "var(--status-stopped)", marginTop: 4 }}
             >
-              The branch will be permanently deleted, including any unmerged
-              commits
+              The branch will be permanently deleted, including any unmerged commits.
             </div>
           )}
         </div>

--- a/src/ui/src/components/settings/sections/GitSettings.tsx
+++ b/src/ui/src/components/settings/sections/GitSettings.tsx
@@ -139,8 +139,8 @@ export function GitSettings() {
               className={styles.settingDescription}
               style={{ color: "var(--status-stopped)", marginTop: 4 }}
             >
-              Branches with only checkpoint commits will be deleted; branches
-              with user commits are preserved
+              The branch will be permanently deleted, including any unmerged
+              commits
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Removes the checkpoint-only guard from `branch_delete()` — branches are now unconditionally force-deleted (`-D` fallback) when the user archives or deletes a workspace
- Previously, branches with real (non-checkpoint) commits were preserved even when "delete branch on archive" was enabled, making the setting confusing
- Updates the UI warning text to clearly state the branch will be permanently deleted including unmerged commits

## Test Steps

1. Create a workspace, make some real commits (not just checkpoints)
2. Enable **Settings → Git → Delete branch on archive**
3. Archive the workspace
4. Verify the branch is deleted (`git branch --list <branch-name>` returns empty)
5. Repeat with **Delete workspace** to verify that path also force-deletes

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)