### PR TITLE
fix: add end-of-options separator before branch names in git commands

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -59,7 +59,7 @@ async fn run_git(path: &str, args: &[&str]) -> Result<String, DiffError> {
 
 /// Get the merge base between two refs.
 pub async fn merge_base(repo_path: &str, branch: &str, base: &str) -> Result<String, DiffError> {
-    run_git(repo_path, &["merge-base", base, branch]).await
+    run_git(repo_path, &["merge-base", "--", base, branch]).await
 }
 
 /// List all changed files between merge base and current working tree.

--- a/src/git.rs
+++ b/src/git.rs
@@ -161,7 +161,11 @@ pub async fn restore_worktree(
     branch_name: &str,
     worktree_path: &str,
 ) -> Result<String, GitError> {
-    run_git(repo_path, &["worktree", "add", worktree_path, branch_name]).await?;
+    run_git(
+        repo_path,
+        &["worktree", "add", worktree_path, "--", branch_name],
+    )
+    .await?;
     let abs_path = std::path::Path::new(worktree_path)
         .canonicalize()
         .map_err(|e| GitError::CommandFailed(e.to_string()))?;
@@ -206,10 +210,13 @@ pub async fn has_unmerged_commits(
 /// Delete a branch. Tries safe `-d` first; falls back to force `-D`
 /// if `-d` fails.
 pub async fn branch_delete(repo_path: &str, branch: &str) -> Result<(), GitError> {
-    if run_git(repo_path, &["branch", "-d", branch]).await.is_ok() {
+    if run_git(repo_path, &["branch", "-d", "--", branch])
+        .await
+        .is_ok()
+    {
         return Ok(());
     }
-    run_git(repo_path, &["branch", "-D", branch]).await?;
+    run_git(repo_path, &["branch", "-D", "--", branch]).await?;
     Ok(())
 }
 
@@ -250,7 +257,7 @@ pub async fn restore_to_commit(worktree_path: &str, commit_hash: &str) -> Result
 /// `path` can be a repo root or a worktree — when the branch is checked
 /// out in a linked worktree, pass the worktree path to avoid errors.
 pub async fn rename_branch(path: &str, old_name: &str, new_name: &str) -> Result<(), GitError> {
-    run_git(path, &["branch", "-m", old_name, new_name]).await?;
+    run_git(path, &["branch", "-m", "--", old_name, new_name]).await?;
     Ok(())
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -426,6 +426,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_restore_worktree() {
+        let dir = setup_temp_repo().await;
+        let repo_path = dir.path().to_str().unwrap();
+
+        // Create a branch via create_worktree, then remove the worktree.
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().to_str().unwrap();
+        create_worktree(repo_path, "claudette/restore-test", wt_path)
+            .await
+            .unwrap();
+        remove_worktree(repo_path, wt_path, true).await.unwrap();
+
+        // Restore the worktree for the existing branch.
+        let wt_dir2 = tempfile::tempdir().unwrap();
+        let wt_path2 = wt_dir2.path().to_str().unwrap();
+        let abs = restore_worktree(repo_path, "claudette/restore-test", wt_path2)
+            .await
+            .unwrap();
+        assert!(!abs.is_empty());
+
+        // The restored worktree should be on the expected branch.
+        let branch = current_branch(wt_path2).await.unwrap();
+        assert_eq!(branch, "claudette/restore-test");
+
+        // Clean up.
+        remove_worktree(repo_path, wt_path2, true).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_rename_branch() {
         let dir = setup_temp_repo().await;
         let path = dir.path().to_str().unwrap();


### PR DESCRIPTION
## Summary

Adds `--` (POSIX end-of-options separator) before user-provided ref names in git command invocations across `src/git.rs` and `src/diff.rs`. This prevents ref arguments from being misinterpreted as git options.

**5 call sites updated:**
- `branch_delete` — both `-d` and `-D` paths
- `restore_worktree` — `worktree add` with existing branch
- `rename_branch` — `branch -m`
- `merge_base` — in `diff.rs`

**Call sites confirmed safe (unchanged):**
- `create_worktree` — `-b` flag consumes the next arg
- `has_unmerged_commits` / range format args — `base` from `default_branch()` is always safe
- `file_diff` / `revert_file` — already use `--`; merge_base result is a hex SHA

## Complexity Notes

While git's `check-ref-format` rules forbid branch names starting with `-`, the `--` separator is zero-cost defense-in-depth that protects against any edge cases with arbitrary ref names. Functions like `merge_base` accept arbitrary refs, not just branch names.

## Test Steps

1. Run `cargo test --all-features` — all 191 tests pass
2. Run `cargo clippy --workspace --all-targets` — clean
3. Run `cargo fmt --all --check` — clean
4. Verify existing branch operations (create workspace, delete workspace, rename workspace) work as before

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)