### PR TITLE
fix(chat): reliable sticky scroll with MutationObserver

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -172,8 +172,6 @@
 .message {
   max-width: 100%;
   animation: fadeInUp 0.15s ease both;
-  content-visibility: auto;
-  contain-intrinsic-size: auto none;
 }
 
 /* User messages — compact input blocks */
@@ -641,8 +639,6 @@
   transition: border-color var(--transition-fast);
   overflow: hidden;
   flex-shrink: 0;
-  content-visibility: auto;
-  contain-intrinsic-size: auto none;
 }
 
 .turnSummary:hover {

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -4,8 +4,9 @@ import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
  * Sticky-scroll hook: auto-scrolls to bottom when user is at the bottom of a
  * scrollable container, but stops when the user scrolls up.
  *
- * Tracks position via scroll events + ResizeObserver (catches content loads,
- * streaming growth, and window focus without external coordination).
+ * Tracks position via scroll events, ResizeObserver (container resizes), and
+ * MutationObserver (DOM changes like new messages, tool call expansion, and
+ * streaming content updates).
  *
  * Returns `isAtBottom` for rendering a "jump to bottom" indicator, plus
  * `scrollToBottom` and `handleContentChanged` helpers.
@@ -17,6 +18,29 @@ export function useStickyScroll(
   const isAtBottomRef = useRef(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const programmaticScrollRef = useRef(false);
+  const rafPendingRef = useRef(false);
+
+  /**
+   * Auto-scroll to bottom if the user is already there.
+   * Coalesced: at most one requestAnimationFrame callback per frame,
+   * preventing stacked RAFs from racing during fast streaming.
+   */
+  const handleContentChanged = useCallback(() => {
+    if (rafPendingRef.current) return;
+    rafPendingRef.current = true;
+    requestAnimationFrame(() => {
+      rafPendingRef.current = false;
+      if (!isAtBottomRef.current) return;
+      const el = containerRef.current;
+      if (el) {
+        const prev = el.scrollTop;
+        el.scrollTop = el.scrollHeight;
+        if (el.scrollTop !== prev) {
+          programmaticScrollRef.current = true;
+        }
+      }
+    });
+  }, [containerRef]);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -39,13 +63,29 @@ export function useStickyScroll(
       checkPosition();
     };
 
-    // ResizeObserver catches content height changes (message load, streaming
-    // growth, content-visibility recalc) that don't fire scroll events.
-    const resizeObserver = new ResizeObserver(() => checkPosition());
+    // ResizeObserver: catches container resizes (panel toggle, window resize).
+    const resizeObserver = new ResizeObserver(() => {
+      checkPosition();
+      handleContentChanged();
+    });
     resizeObserver.observe(el);
 
+    // MutationObserver: catches all DOM changes within the scroll container
+    // (new messages, tool call expansion/collapse, streaming content).
+    // This is critical — ResizeObserver only watches the container's border
+    // box, which doesn't change when children grow inside a flex:1 container.
+    const mutationObserver = new MutationObserver(() => handleContentChanged());
+    mutationObserver.observe(el, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
     // Re-check on window focus (content may arrive while app is backgrounded).
-    const onFocus = () => checkPosition();
+    const onFocus = () => {
+      checkPosition();
+      handleContentChanged();
+    };
 
     el.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("focus", onFocus);
@@ -53,8 +93,9 @@ export function useStickyScroll(
       el.removeEventListener("scroll", onScroll);
       window.removeEventListener("focus", onFocus);
       resizeObserver.disconnect();
+      mutationObserver.disconnect();
     };
-  }, [containerRef, threshold]);
+  }, [containerRef, threshold, handleContentChanged]);
 
   /** Programmatically scroll to bottom and re-enable auto-follow. */
   const scrollToBottom = useCallback(() => {
@@ -69,25 +110,6 @@ export function useStickyScroll(
       if (!containerRef.current) return;
       programmaticScrollRef.current = true;
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
-    });
-  }, [containerRef]);
-
-  /**
-   * Call when new content is added. Auto-scrolls only if the user is already
-   * at the bottom. The check is inside the RAF callback so a user scroll that
-   * fires between scheduling and execution correctly cancels the auto-scroll.
-   */
-  const handleContentChanged = useCallback(() => {
-    requestAnimationFrame(() => {
-      if (!isAtBottomRef.current) return;
-      const el = containerRef.current;
-      if (el) {
-        const prev = el.scrollTop;
-        el.scrollTop = el.scrollHeight;
-        if (el.scrollTop !== prev) {
-          programmaticScrollRef.current = true;
-        }
-      }
     });
   }, [containerRef]);
 

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -64,9 +64,14 @@ export function useStickyScroll(
     };
 
     // ResizeObserver: catches container resizes (panel toggle, window resize).
+    // Scroll first if pinned to bottom — prevents checkPosition() from
+    // flipping isAtBottomRef to false before auto-scroll can act on it.
     const resizeObserver = new ResizeObserver(() => {
+      if (isAtBottomRef.current) {
+        programmaticScrollRef.current = true;
+        el.scrollTop = el.scrollHeight;
+      }
       checkPosition();
-      handleContentChanged();
     });
     resizeObserver.observe(el);
 
@@ -105,7 +110,7 @@ export function useStickyScroll(
     el.scrollTop = el.scrollHeight;
     isAtBottomRef.current = true;
     setIsAtBottom(true);
-    // Second pass after layout settles (content-visibility recalc).
+    // Second pass after layout settles (React may flush a pending render).
     requestAnimationFrame(() => {
       if (!containerRef.current) return;
       programmaticScrollRef.current = true;


### PR DESCRIPTION
## Summary

- **Added MutationObserver** to `useStickyScroll` — detects all DOM changes in the scroll container (new messages, tool call expand/collapse, streaming content) instead of relying solely on ResizeObserver, which only watches the container's border box and never fires in a `flex:1` layout
- **Added RAF coalescing** — `handleContentChanged` now deduplicates to at most one `requestAnimationFrame` per frame, preventing stacked callbacks from racing during fast streaming
- **Removed `content-visibility: auto`** from `.message` and `.turnSummary` — this CSS optimization caused `scrollHeight` to collapse when React replaces streaming DOM nodes with persisted message nodes on agent finish, jumping the user to the top of the conversation

## Test plan

- [x] Chat auto-follows new messages during streaming
- [x] Scrolling up mid-conversation stays put (no yanking back to bottom)
- [x] Expanding/collapsing tool call summaries doesn't break scroll position
- [x] Agent finishing does not jump scroll to top of conversation
- [x] ScrollToBottomPill appears when scrolled up, clicking it works
- [x] TypeScript type check passes
- [x] Rust tests pass (192/192)
- [x] Clippy clean, rustfmt clean