### PR TITLE
feat: add --chrome flag support for browser automation

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -47,6 +47,7 @@ pub async fn handle_request(
                 .get("effort")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let chrome_enabled = params.get("chrome_enabled").and_then(|v| v.as_bool());
             let mentioned_files: Option<Vec<String>> = params
                 .get("mentioned_files")
                 .and_then(|v| serde_json::from_value(v.clone()).ok());
@@ -61,6 +62,7 @@ pub async fn handle_request(
                 thinking_enabled,
                 plan_mode,
                 effort,
+                chrome_enabled,
                 mentioned_files,
             )
             .await
@@ -307,6 +309,7 @@ async fn handle_send_chat_message(
     thinking_enabled: Option<bool>,
     plan_mode: Option<bool>,
     effort: Option<String>,
+    chrome_enabled: Option<bool>,
     mentioned_files: Option<Vec<String>>,
 ) -> Result<serde_json::Value, String> {
     let db = open_db(state)?;
@@ -374,6 +377,7 @@ async fn handle_send_chat_message(
         thinking_enabled: thinking_enabled.unwrap_or(false),
         plan_mode: plan_mode.unwrap_or(false),
         effort,
+        chrome_enabled: chrome_enabled.unwrap_or(false),
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -42,6 +42,7 @@ pub async fn send_chat_message(
     thinking_enabled: Option<bool>,
     plan_mode: Option<bool>,
     effort: Option<String>,
+    chrome_enabled: Option<bool>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -154,6 +155,7 @@ pub async fn send_chat_message(
         thinking_enabled: thinking_enabled.unwrap_or(false),
         plan_mode: plan_mode.unwrap_or(false),
         effort,
+        chrome_enabled: chrome_enabled.unwrap_or(false),
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -198,6 +198,9 @@ pub struct AgentSettings {
     /// Effort level for adaptive reasoning (`low`, `medium`, `high`, `max`).
     /// `max` is Opus 4.6 only. Applied on every turn via `--effort`.
     pub effort: Option<String>,
+    /// Enable Chrome browser mode via `--chrome`. Session-level: only applied
+    /// on the first turn.
+    pub chrome_enabled: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +237,11 @@ pub fn build_claude_args(
     if !is_resume && let Some(ref model) = settings.model {
         args.push("--model".to_string());
         args.push(model.clone());
+    }
+
+    // Chrome is session-level — only set on the first turn.
+    if !is_resume && settings.chrome_enabled {
+        args.push("--chrome".to_string());
     }
 
     // Permission mode must be set on every turn — each `claude` invocation is
@@ -1271,5 +1279,25 @@ mod tests {
         assert_eq!(json["alwaysThinkingEnabled"], true);
         // effort should NOT be in the --settings JSON
         assert!(json.get("effort").is_none());
+    }
+
+    #[test]
+    fn test_build_args_with_chrome() {
+        let settings = AgentSettings {
+            chrome_enabled: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        assert!(args.contains(&"--chrome".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_chrome_skipped_on_resume() {
+        let settings = AgentSettings {
+            chrome_enabled: true,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        assert!(!args.contains(&"--chrome".to_string()));
     }
 }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -504,6 +504,7 @@ export function ChatPanel() {
           thinking_enabled: state.thinkingEnabled[selectedWorkspaceId] || false,
           plan_mode: state.planMode[selectedWorkspaceId] || false,
           effort: state.effortLevel[selectedWorkspaceId] || null,
+          chrome_enabled: state.chromeEnabled[selectedWorkspaceId] || false,
         });
       } else {
         const state = useAppStore.getState();
@@ -512,6 +513,7 @@ export function ChatPanel() {
         const thinkingEnabled = state.thinkingEnabled[selectedWorkspaceId] || false;
         const planMode = state.planMode[selectedWorkspaceId] || false;
         const effort = state.effortLevel[selectedWorkspaceId] || undefined;
+        const chromeEnabled = state.chromeEnabled[selectedWorkspaceId] || false;
         await sendChatMessage(
           selectedWorkspaceId,
           trimmed,
@@ -522,6 +524,7 @@ export function ChatPanel() {
           thinkingEnabled || undefined,
           planMode || undefined,
           effort,
+          chromeEnabled || undefined,
         );
       }
     } catch (e) {

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Sparkles, Zap, Brain, BookOpen, Gauge, Eye, EyeOff } from "lucide-react";
+import { Sparkles, Zap, Brain, BookOpen, Gauge, Eye, EyeOff, Globe } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { resetAgentSession, setAppSetting, getAppSetting } from "../../services/tauri";
 import { ModelSelector, MODELS } from "./ModelSelector";
@@ -20,6 +20,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const thinkingEnabled = useAppStore((s) => s.thinkingEnabled[workspaceId] ?? false);
   const planMode = useAppStore((s) => s.planMode[workspaceId] ?? false);
   const effortLevel = useAppStore((s) => s.effortLevel[workspaceId] ?? "auto");
+  const chromeEnabled = useAppStore((s) => s.chromeEnabled[workspaceId] ?? false);
   const modelSelectorOpen = useAppStore((s) => s.modelSelectorOpen);
   const setSelectedModel = useAppStore((s) => s.setSelectedModel);
   const setFastMode = useAppStore((s) => s.setFastMode);
@@ -27,6 +28,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const showThinkingBlocks = useAppStore((s) => s.showThinkingBlocks[workspaceId] === true);
   const setEffortLevel = useAppStore((s) => s.setEffortLevel);
+  const setChromeEnabled = useAppStore((s) => s.setChromeEnabled);
   const setShowThinkingBlocks = useAppStore((s) => s.setShowThinkingBlocks);
   const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
   const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
@@ -41,18 +43,20 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   useEffect(() => {
     let cancelled = false;
     async function load() {
-      const [model, fast, thinking, effort, showThinking, defModel, defFast, defThinking, defPlan, defEffort, defShowThinking] = await Promise.all([
+      const [model, fast, thinking, effort, showThinking, chrome, defModel, defFast, defThinking, defPlan, defEffort, defShowThinking, defChrome] = await Promise.all([
         getAppSetting(`model:${workspaceId}`),
         getAppSetting(`fast_mode:${workspaceId}`),
         getAppSetting(`thinking_enabled:${workspaceId}`),
         getAppSetting(`effort_level:${workspaceId}`),
         getAppSetting(`show_thinking:${workspaceId}`),
+        getAppSetting(`chrome_enabled:${workspaceId}`),
         getAppSetting("default_model"),
         getAppSetting("default_fast_mode"),
         getAppSetting("default_thinking"),
         getAppSetting("default_plan_mode"),
         getAppSetting("default_effort"),
         getAppSetting("default_show_thinking"),
+        getAppSetting("default_chrome"),
       ]);
       if (cancelled) return;
       const loadedModel = model ?? defModel ?? "opus";
@@ -75,11 +79,12 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
         setEffortLevel(workspaceId, normalized);
       }
       setShowThinkingBlocks(workspaceId, showThinking === "true" || (!showThinking && defShowThinking === "true"));
+      setChromeEnabled(workspaceId, chrome === "true" || (!chrome && defChrome === "true"));
       setLoaded(true);
     }
     load();
     return () => { cancelled = true; };
-  }, [workspaceId, setSelectedModel, setFastMode, setThinkingEnabled, setPlanMode, setEffortLevel, setShowThinkingBlocks]);
+  }, [workspaceId, setSelectedModel, setFastMode, setThinkingEnabled, setPlanMode, setEffortLevel, setShowThinkingBlocks, setChromeEnabled]);
 
   const handleModelSelect = useCallback(
     async (model: string) => {
@@ -136,6 +141,16 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const togglePlan = useCallback(() => {
     setPlanMode(workspaceId, !planMode);
   }, [workspaceId, planMode, setPlanMode]);
+
+  const toggleChrome = useCallback(async () => {
+    const next = !chromeEnabled;
+    setChromeEnabled(workspaceId, next);
+    await setAppSetting(`chrome_enabled:${workspaceId}`, String(next));
+    // Chrome is session-level — reset session so the next turn picks up the change.
+    await resetAgentSession(workspaceId);
+    clearAgentQuestion(workspaceId);
+    clearPlanApproval(workspaceId);
+  }, [workspaceId, chromeEnabled, setChromeEnabled, clearAgentQuestion, clearPlanApproval]);
 
   // Keyboard shortcuts.
   useEffect(() => {
@@ -222,6 +237,17 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
         <BookOpen size={14} />
         <span className={styles.chipLabel}>Plan</span>
         <kbd className={`shortcut-badge ${metaKeyHeld ? "shortcut-badge-visible" : ""}`} aria-hidden="true">⇧Tab</kbd>
+      </button>
+
+      <button
+        className={`${styles.chip} ${chromeEnabled ? styles.chipActive : ""}`}
+        onClick={toggleChrome}
+        disabled={disabled}
+        title={`${chromeEnabled ? "Disable" : "Enable"} Chrome browser mode`}
+        aria-pressed={chromeEnabled}
+      >
+        <Globe size={14} />
+        <span className={styles.chipLabel}>Chrome</span>
       </button>
 
       {modelSelectorOpen && (

--- a/src/ui/src/components/settings/sections/ModelSettings.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.tsx
@@ -9,6 +9,7 @@ export function ModelSettings() {
   const [defaultThinking, setDefaultThinking] = useState(false);
   const [defaultPlanMode, setDefaultPlanMode] = useState(false);
   const [defaultFastMode, setDefaultFastMode] = useState(false);
+  const [defaultChrome, setDefaultChrome] = useState(false);
   const [defaultEffort, setDefaultEffort] = useState("auto");
   const [defaultShowThinking, setDefaultShowThinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -25,6 +26,9 @@ export function ModelSettings() {
       .catch(() => {});
     getAppSetting("default_fast_mode")
       .then((val) => setDefaultFastMode(val === "true"))
+      .catch(() => {});
+    getAppSetting("default_chrome")
+      .then((val) => setDefaultChrome(val === "true"))
       .catch(() => {});
     getAppSetting("default_effort")
       .then((val) => { if (val) setDefaultEffort(val); })
@@ -210,6 +214,27 @@ export function ModelSettings() {
             aria-label="Default to fast mode"
             data-checked={defaultFastMode}
             onClick={handleToggle(defaultFastMode, setDefaultFastMode, "default_fast_mode")}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Use Claude Code with Chrome</div>
+          <div className={styles.settingDescription}>
+            Allow Claude Code to control your Chrome browser. To use this feature, first install the Claude Code Chrome extension.
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={defaultChrome}
+            aria-label="Use Claude Code with Chrome"
+            data-checked={defaultChrome}
+            onClick={handleToggle(defaultChrome, setDefaultChrome, "default_chrome")}
           >
             <div className={styles.toggleKnob} />
           </button>

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -179,6 +179,7 @@ export function sendChatMessage(
   thinkingEnabled?: boolean,
   planMode?: boolean,
   effort?: string,
+  chromeEnabled?: boolean,
 ): Promise<void> {
   return invoke("send_chat_message", {
     workspaceId,
@@ -190,6 +191,7 @@ export function sendChatMessage(
     thinkingEnabled: thinkingEnabled ?? null,
     planMode: planMode ?? null,
     effort: effort ?? null,
+    chromeEnabled: chromeEnabled ?? null,
   });
 }
 

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -147,12 +147,14 @@ interface AppState {
   thinkingEnabled: Record<string, boolean>;
   planMode: Record<string, boolean>;
   effortLevel: Record<string, string>;
+  chromeEnabled: Record<string, boolean>;
   modelSelectorOpen: boolean;
   setSelectedModel: (wsId: string, model: string) => void;
   setFastMode: (wsId: string, enabled: boolean) => void;
   setThinkingEnabled: (wsId: string, enabled: boolean) => void;
   setPlanMode: (wsId: string, enabled: boolean) => void;
   setEffortLevel: (wsId: string, level: string) => void;
+  setChromeEnabled: (wsId: string, enabled: boolean) => void;
   setModelSelectorOpen: (open: boolean) => void;
 
   // -- Diff --
@@ -625,6 +627,7 @@ export const useAppStore = create<AppState>((set) => ({
   thinkingEnabled: {},
   planMode: {},
   effortLevel: {},
+  chromeEnabled: {},
   modelSelectorOpen: false,
   setSelectedModel: (wsId, model) =>
     set((s) => ({
@@ -645,6 +648,10 @@ export const useAppStore = create<AppState>((set) => ({
   setEffortLevel: (wsId, level) =>
     set((s) => ({
       effortLevel: { ...s.effortLevel, [wsId]: level },
+    })),
+  setChromeEnabled: (wsId, enabled) =>
+    set((s) => ({
+      chromeEnabled: { ...s.chromeEnabled, [wsId]: enabled },
     })),
   setModelSelectorOpen: (open) => set({ modelSelectorOpen: open }),
 


### PR DESCRIPTION
## Summary

- Adds configurable `--chrome` flag support for Claude Code's Chrome browser integration
- Global default toggle in **Settings > Model** ("Use Claude Code with Chrome")
- Per-workspace override toggle in the **chat toolbar** (Globe icon + "Chrome" label)
- `--chrome` is session-level: only passed on the first CLI turn, toggling resets the session

<img width="1274" height="406" alt="image" src="https://github.com/user-attachments/assets/f60b9857-241c-47be-97ac-76380a47b93b" />

<img width="1932" height="342" alt="image" src="https://github.com/user-attachments/assets/294b7627-5f31-4c94-aa01-c1f34d5fd08b" />

## Complexity Notes

- Chrome is **session-level** (like `--model`), not per-turn (like `--effort`). Toggling mid-session calls `resetAgentSession()` to ensure the next turn starts fresh with `--chrome` in the CLI args. This mirrors the existing model-change behavior.

## Test Steps

1. Run `cargo test --all-features` — verify `test_build_args_with_chrome` and `test_build_args_chrome_skipped_on_resume` pass (194 total)
2. Run `cargo clippy --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — zero warnings
3. Run `bunx tsc --noEmit` from `src/ui` — clean compile
4. Launch the app (`cargo tauri dev`):
   - Open **Settings > Model** → verify "Use Claude Code with Chrome" toggle appears at the bottom with description text
   - Toggle it on/off → verify it persists across settings reopens
   - In a workspace, verify the **Chrome** chip appears in the chat toolbar
   - Toggle Chrome on → verify the agent session resets
   - Send a message with Chrome enabled → check stderr logs for `--chrome` in the CLI args

## Checklist

- [x] Tests added/updated (2 new unit tests for `build_claude_args`)
- [x] Full stack wired: Rust → Tauri command → TypeScript service → Zustand store → React components