### PR TITLE
feat: implement MCP configuration detection and workspace integration

### DIFF
--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,7 +1,10 @@
 //! Tauri commands for MCP configuration detection and management
 
 use claudette::db::Database;
-use claudette::mcp::{detect_mcp_servers as detect_mcp, write_workspace_mcp_config, McpServer};
+use claudette::mcp::{
+    detect_mcp_servers as detect_mcp, parse_mcp_config, write_workspace_mcp_config, McpScope,
+    McpServer,
+};
 use std::path::PathBuf;
 use tauri::State;
 
@@ -58,8 +61,6 @@ pub async fn read_workspace_mcps(
     workspace_id: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<McpServer>, String> {
-    use claudette::mcp::McpScope;
-
     // Get workspace worktree path
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
@@ -76,37 +77,7 @@ pub async fn read_workspace_mcps(
     let worktree_path = PathBuf::from(&worktree_path);
     let config_path = worktree_path.join(".claude.json");
 
-    // Parse .claude.json in worktree (use Local scope since it's workspace-specific)
-    if !config_path.exists() {
-        return Ok(Vec::new());
-    }
-
-    let content = tokio::fs::read_to_string(&config_path)
-        .await
-        .map_err(|e| format!("Failed to read .claude.json: {}", e))?;
-
-    #[derive(serde::Deserialize)]
-    struct ClaudeConfig {
-        #[serde(rename = "mcpServers")]
-        #[serde(default)]
-        mcp_servers: Option<std::collections::HashMap<String, claudette::mcp::McpServerConfig>>,
-    }
-
-    let config: ClaudeConfig = serde_json::from_str(&content)
-        .map_err(|e| format!("Malformed .claude.json: {}", e))?;
-
-    let Some(mcp_servers) = config.mcp_servers else {
-        return Ok(Vec::new());
-    };
-
-    let mut servers = Vec::new();
-    for (name, config) in mcp_servers {
-        servers.push(McpServer {
-            name,
-            config,
-            scope: McpScope::Local,
-        });
-    }
-
-    Ok(servers)
+    // Use the shared parsing function from claudette::mcp
+    // (use Local scope since it's workspace-specific)
+    parse_mcp_config(&config_path, McpScope::Local).await
 }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -2,8 +2,8 @@
 
 use claudette::db::Database;
 use claudette::mcp::{
-    detect_mcp_servers as detect_mcp, parse_mcp_config, write_workspace_mcp_config, McpScope,
-    McpServer,
+    McpScope, McpServer, detect_mcp_servers as detect_mcp, parse_mcp_config,
+    write_workspace_mcp_config,
 };
 use std::path::PathBuf;
 use tauri::State;

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,0 +1,112 @@
+//! Tauri commands for MCP configuration detection and management
+
+use claudette::db::Database;
+use claudette::mcp::{detect_mcp_servers as detect_mcp, write_workspace_mcp_config, McpServer};
+use std::path::PathBuf;
+use tauri::State;
+
+use crate::state::AppState;
+
+/// Detect all MCP servers for a repository
+#[tauri::command]
+pub async fn detect_mcp_servers(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<McpServer>, String> {
+    // Get repository path from database
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repo = db
+        .get_repository(&repo_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Repository not found: {}", repo_id))?;
+
+    let repo_path = PathBuf::from(&repo.path);
+
+    // Detect MCP servers
+    detect_mcp(&repo_path).await
+}
+
+/// Write MCP configuration to workspace .claude.json
+#[tauri::command]
+pub async fn configure_workspace_mcps(
+    workspace_id: String,
+    servers: Vec<McpServer>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    // Get workspace worktree path from database
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+
+    let workspace = workspaces
+        .into_iter()
+        .find(|ws| ws.id == workspace_id)
+        .ok_or_else(|| format!("Workspace not found: {}", workspace_id))?;
+
+    let worktree_path = workspace
+        .worktree_path
+        .ok_or_else(|| format!("Workspace {} has no worktree path", workspace_id))?;
+
+    let worktree_path = PathBuf::from(&worktree_path);
+
+    // Write MCP configuration
+    write_workspace_mcp_config(&worktree_path, &servers).await
+}
+
+/// Read workspace .claude.json MCP configuration
+#[tauri::command]
+pub async fn read_workspace_mcps(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<McpServer>, String> {
+    use claudette::mcp::McpScope;
+
+    // Get workspace worktree path
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+
+    let workspace = workspaces
+        .into_iter()
+        .find(|ws| ws.id == workspace_id)
+        .ok_or_else(|| format!("Workspace not found: {}", workspace_id))?;
+
+    let worktree_path = workspace
+        .worktree_path
+        .ok_or_else(|| format!("Workspace {} has no worktree path", workspace_id))?;
+
+    let worktree_path = PathBuf::from(&worktree_path);
+    let config_path = worktree_path.join(".claude.json");
+
+    // Parse .claude.json in worktree (use Local scope since it's workspace-specific)
+    if !config_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = tokio::fs::read_to_string(&config_path)
+        .await
+        .map_err(|e| format!("Failed to read .claude.json: {}", e))?;
+
+    #[derive(serde::Deserialize)]
+    struct ClaudeConfig {
+        #[serde(rename = "mcpServers")]
+        #[serde(default)]
+        mcp_servers: Option<std::collections::HashMap<String, claudette::mcp::McpServerConfig>>,
+    }
+
+    let config: ClaudeConfig = serde_json::from_str(&content)
+        .map_err(|e| format!("Malformed .claude.json: {}", e))?;
+
+    let Some(mcp_servers) = config.mcp_servers else {
+        return Ok(Vec::new());
+    };
+
+    let mut servers = Vec::new();
+    for (name, config) in mcp_servers {
+        servers.push(McpServer {
+            name,
+            config,
+            scope: McpScope::Local,
+        });
+    }
+
+    Ok(servers)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod data;
 pub mod debug;
 pub mod diff;
 pub mod files;
+pub mod mcp;
 pub mod plan;
 pub mod remote;
 pub mod repository;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -252,6 +252,10 @@ fn main() {
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
             commands::workspace::open_workspace_in_terminal,
+            // MCP
+            commands::mcp::detect_mcp_servers,
+            commands::mcp::configure_workspace_mcps,
+            commands::mcp::read_workspace_mcps,
             // Slash commands
             commands::slash_commands::list_slash_commands,
             commands::slash_commands::record_slash_command_usage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod diff;
 pub mod file_expand;
 pub mod git;
+pub mod mcp;
 pub mod model;
 pub mod names;
 pub mod permissions;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -70,6 +70,36 @@ struct ClaudeConfig {
     other: HashMap<String, serde_json::Value>,
 }
 
+/// Structure for parsing Claude Code's ~/.claude.json with nested project configs
+#[derive(Debug, Deserialize)]
+struct ClaudeCodeConfig {
+    #[serde(default)]
+    projects: HashMap<String, ProjectConfig>,
+
+    #[serde(flatten)]
+    _other: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectConfig {
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: Option<HashMap<String, McpServerConfigNested>>,
+
+    #[serde(flatten)]
+    _other: HashMap<String, serde_json::Value>,
+}
+
+/// Nested MCP config format (used in Claude Code's project-specific configs)
+/// This is slightly different from the standard format - it doesn't have a "type" field
+#[derive(Debug, Deserialize)]
+struct McpServerConfigNested {
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    url: Option<String>,
+    headers: Option<HashMap<String, String>>,
+}
+
 /// Detect all MCP servers from user, project, and local scopes.
 ///
 /// Precedence order (highest to lowest):
@@ -88,12 +118,22 @@ pub async fn detect_mcp_servers(repo_path: &Path) -> Result<Vec<McpServer>, Stri
     let mut seen_names = HashMap::new();
 
     // 1. Read user scope (~/.claude.json)
+    // First try to read project-specific MCP servers from Claude Code's nested format
     if let Some(home_dir) = dirs::home_dir() {
         let user_config_path = home_dir.join(".claude.json");
-        if let Ok(servers) = parse_mcp_config(&user_config_path, McpScope::User).await {
+        if let Ok(servers) = parse_claude_code_project_mcps(&user_config_path, repo_path).await {
             for server in servers {
                 seen_names.insert(server.name.clone(), server.scope);
                 all_servers.push(server);
+            }
+        }
+        // Also try to read from top-level mcpServers (standard format)
+        if let Ok(servers) = parse_mcp_config(&user_config_path, McpScope::User).await {
+            for server in servers {
+                if !seen_names.contains_key(&server.name) {
+                    seen_names.insert(server.name.clone(), server.scope);
+                    all_servers.push(server);
+                }
             }
         }
     }
@@ -131,6 +171,66 @@ pub async fn detect_mcp_servers(repo_path: &Path) -> Result<Vec<McpServer>, Stri
     }
 
     Ok(all_servers)
+}
+
+/// Parse Claude Code's project-specific MCP servers from ~/.claude.json
+/// Claude Code stores per-project MCPs in: .projects["/path/to/repo"].mcpServers
+async fn parse_claude_code_project_mcps(
+    config_path: &Path,
+    repo_path: &Path,
+) -> Result<Vec<McpServer>, String> {
+    if !config_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = fs::read_to_string(config_path)
+        .await
+        .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
+
+    let config: ClaudeCodeConfig = serde_json::from_str(&content).map_err(|e| {
+        format!("Malformed JSON in {}: {}", config_path.display(), e)
+    })?;
+
+    // Look for project-specific MCPs using the repo path as key
+    let repo_path_str = repo_path.to_string_lossy().to_string();
+    let Some(project_config) = config.projects.get(&repo_path_str) else {
+        return Ok(Vec::new());
+    };
+
+    let Some(mcp_servers) = &project_config.mcp_servers else {
+        return Ok(Vec::new());
+    };
+
+    let mut servers = Vec::new();
+    for (name, nested_config) in mcp_servers {
+        // Convert nested format to standard McpServerConfig
+        let config = if let Some(command) = &nested_config.command {
+            // Stdio server
+            McpServerConfig::Stdio {
+                command: command.clone(),
+                args: nested_config.args.clone().unwrap_or_default(),
+                env: nested_config.env.clone().unwrap_or_default(),
+            }
+        } else if let Some(url) = &nested_config.url {
+            // HTTP server
+            McpServerConfig::Http {
+                url: url.clone(),
+                headers: nested_config.headers.clone().unwrap_or_default(),
+                oauth: None,
+            }
+        } else {
+            // Invalid config - skip
+            continue;
+        };
+
+        servers.push(McpServer {
+            name: name.clone(),
+            config,
+            scope: McpScope::Project, // Claude Code project-specific = Project scope
+        });
+    }
+
+    Ok(servers)
 }
 
 /// Parse a single .claude.json or .mcp.json file

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -187,9 +187,8 @@ async fn parse_claude_code_project_mcps(
         .await
         .map_err(|e| format!("Failed to read {}: {}", config_path.display(), e))?;
 
-    let config: ClaudeCodeConfig = serde_json::from_str(&content).map_err(|e| {
-        format!("Malformed JSON in {}: {}", config_path.display(), e)
-    })?;
+    let config: ClaudeCodeConfig = serde_json::from_str(&content)
+        .map_err(|e| format!("Malformed JSON in {}: {}", config_path.display(), e))?;
 
     // Look for project-specific MCPs using the repo path as key
     let repo_path_str = repo_path.to_string_lossy().to_string();
@@ -247,13 +246,8 @@ pub async fn parse_mcp_config(path: &Path, scope: McpScope) -> Result<Vec<McpSer
         .await
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-    let config: ClaudeConfig = serde_json::from_str(&content).map_err(|e| {
-        format!(
-            "Malformed JSON in {}: {}",
-            path.display(),
-            e
-        )
-    })?;
+    let config: ClaudeConfig = serde_json::from_str(&content)
+        .map_err(|e| format!("Malformed JSON in {}: {}", path.display(), e))?;
 
     let Some(mcp_servers) = config.mcp_servers else {
         // No mcpServers section is valid
@@ -294,9 +288,8 @@ pub async fn write_workspace_mcp_config(
             .await
             .map_err(|e| format!("Failed to read existing .claude.json: {}", e))?;
 
-        serde_json::from_str(&content).map_err(|e| {
-            format!("Existing .claude.json is malformed: {}", e)
-        })?
+        serde_json::from_str(&content)
+            .map_err(|e| format!("Existing .claude.json is malformed: {}", e))?
     } else {
         ClaudeConfig {
             mcp_servers: None,
@@ -420,9 +413,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join(".claude.json");
 
-        fs::write(&config_path, "{ invalid json }")
-            .await
-            .unwrap();
+        fs::write(&config_path, "{ invalid json }").await.unwrap();
 
         let result = parse_mcp_config(&config_path, McpScope::User).await;
         assert!(result.is_err());
@@ -494,10 +485,7 @@ mod tests {
         let content = fs::read_to_string(&config_path).await.unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
 
-        assert_eq!(
-            parsed["customInstructions"],
-            "Always use TypeScript"
-        );
+        assert_eq!(parsed["customInstructions"], "Always use TypeScript");
         assert!(parsed["mcpServers"]["new-server"].is_object());
         assert!(parsed["mcpServers"]["old-server"].is_null());
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -179,7 +179,7 @@ async fn parse_claude_code_project_mcps(
     config_path: &Path,
     repo_path: &Path,
 ) -> Result<Vec<McpServer>, String> {
-    if !config_path.exists() {
+    if !tokio::fs::try_exists(config_path).await.unwrap_or(false) {
         return Ok(Vec::new());
     }
 
@@ -234,9 +234,12 @@ async fn parse_claude_code_project_mcps(
 }
 
 /// Parse a single .claude.json or .mcp.json file
-async fn parse_mcp_config(path: &Path, scope: McpScope) -> Result<Vec<McpServer>, String> {
+///
+/// This is a public function that can be used by other modules to read MCP
+/// configurations from .claude.json files.
+pub async fn parse_mcp_config(path: &Path, scope: McpScope) -> Result<Vec<McpServer>, String> {
     // Missing files are not errors
-    if !path.exists() {
+    if !tokio::fs::try_exists(path).await.unwrap_or(false) {
         return Ok(Vec::new());
     }
 
@@ -286,7 +289,7 @@ pub async fn write_workspace_mcp_config(
     let config_path = worktree_path.join(".claude.json");
 
     // Read existing config or create new one
-    let mut config: ClaudeConfig = if config_path.exists() {
+    let mut config: ClaudeConfig = if tokio::fs::try_exists(&config_path).await.unwrap_or(false) {
         let content = fs::read_to_string(&config_path)
             .await
             .map_err(|e| format!("Failed to read existing .claude.json: {}", e))?;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,401 @@
+//! MCP (Model Context Protocol) configuration detection and management.
+//!
+//! This module handles:
+//! - Detection of MCP servers from user/project/local scopes
+//! - Writing workspace-specific .claude.json configurations
+//! - Parsing and validating MCP server configurations
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::fs;
+
+/// Represents a detected MCP server configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServer {
+    pub name: String,
+    pub config: McpServerConfig,
+    pub scope: McpScope,
+}
+
+/// MCP server configuration based on transport type
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum McpServerConfig {
+    #[serde(rename = "stdio")]
+    Stdio {
+        command: String,
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        env: HashMap<String, String>,
+    },
+    #[serde(rename = "http")]
+    Http {
+        url: String,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        headers: HashMap<String, String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        oauth: Option<OAuthConfig>,
+    },
+    #[serde(rename = "sse")]
+    Sse { url: String },
+}
+
+/// OAuth configuration for HTTP MCP servers
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "authServerMetadataUrl")]
+    pub auth_server_metadata_url: Option<String>,
+}
+
+/// Scope of an MCP configuration
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum McpScope {
+    User,    // ~/.claude.json (global)
+    Project, // .mcp.json (project root)
+    Local,   // .claude.json (worktree root, workspace-local config)
+}
+
+/// Internal structure for parsing .claude.json and .mcp.json files
+#[derive(Debug, Deserialize, Serialize)]
+struct ClaudeConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "mcpServers")]
+    mcp_servers: Option<HashMap<String, McpServerConfig>>,
+
+    // Preserve other fields without parsing them
+    #[serde(flatten)]
+    other: HashMap<String, serde_json::Value>,
+}
+
+/// Detect all MCP servers from user, project, and local scopes.
+///
+/// Precedence order (highest to lowest):
+/// 1. Local scope (.claude.json in repo root)
+/// 2. Project scope (.mcp.json in repo root)
+/// 3. User scope (~/.claude.json global)
+///
+/// # Arguments
+/// * `repo_path` - Path to the repository root
+///
+/// # Returns
+/// A vector of all detected MCP servers with their scope information.
+/// Missing or malformed config files are skipped (not errors).
+pub async fn detect_mcp_servers(repo_path: &Path) -> Result<Vec<McpServer>, String> {
+    let mut all_servers = Vec::new();
+    let mut seen_names = HashMap::new();
+
+    // 1. Read user scope (~/.claude.json)
+    if let Some(home_dir) = dirs::home_dir() {
+        let user_config_path = home_dir.join(".claude.json");
+        if let Ok(servers) = parse_mcp_config(&user_config_path, McpScope::User).await {
+            for server in servers {
+                seen_names.insert(server.name.clone(), server.scope);
+                all_servers.push(server);
+            }
+        }
+    }
+
+    // 2. Read project scope (.mcp.json in repo root)
+    let project_config_path = repo_path.join(".mcp.json");
+    if let Ok(servers) = parse_mcp_config(&project_config_path, McpScope::Project).await {
+        for server in servers {
+            // Higher precedence overrides lower precedence with same name
+            if let Some(&existing_scope) = seen_names.get(&server.name) {
+                if server.scope > existing_scope {
+                    // Remove lower precedence server
+                    all_servers.retain(|s| s.name != server.name);
+                    seen_names.insert(server.name.clone(), server.scope);
+                    all_servers.push(server);
+                }
+            } else {
+                seen_names.insert(server.name.clone(), server.scope);
+                all_servers.push(server);
+            }
+        }
+    }
+
+    // 3. Read local scope (.claude.json in repo root)
+    let local_config_path = repo_path.join(".claude.json");
+    if let Ok(servers) = parse_mcp_config(&local_config_path, McpScope::Local).await {
+        for server in servers {
+            // Highest precedence always wins
+            if seen_names.contains_key(&server.name) {
+                all_servers.retain(|s| s.name != server.name);
+            }
+            seen_names.insert(server.name.clone(), server.scope);
+            all_servers.push(server);
+        }
+    }
+
+    Ok(all_servers)
+}
+
+/// Parse a single .claude.json or .mcp.json file
+async fn parse_mcp_config(path: &Path, scope: McpScope) -> Result<Vec<McpServer>, String> {
+    // Missing files are not errors
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = fs::read_to_string(path)
+        .await
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+    let config: ClaudeConfig = serde_json::from_str(&content).map_err(|e| {
+        format!(
+            "Malformed JSON in {}: {}",
+            path.display(),
+            e
+        )
+    })?;
+
+    let Some(mcp_servers) = config.mcp_servers else {
+        // No mcpServers section is valid
+        return Ok(Vec::new());
+    };
+
+    let mut servers = Vec::new();
+    for (name, config) in mcp_servers {
+        servers.push(McpServer {
+            name,
+            config,
+            scope,
+        });
+    }
+
+    Ok(servers)
+}
+
+/// Write MCP servers to workspace .claude.json
+///
+/// # Behavior
+/// - Creates .claude.json if it doesn't exist
+/// - Merges into existing .claude.json, preserving non-MCP fields
+/// - Pretty-prints with 2-space indentation (matches Claude CLI format)
+///
+/// # Arguments
+/// * `worktree_path` - Path to workspace worktree root
+/// * `servers` - MCP servers to write
+pub async fn write_workspace_mcp_config(
+    worktree_path: &Path,
+    servers: &[McpServer],
+) -> Result<(), String> {
+    let config_path = worktree_path.join(".claude.json");
+
+    // Read existing config or create new one
+    let mut config: ClaudeConfig = if config_path.exists() {
+        let content = fs::read_to_string(&config_path)
+            .await
+            .map_err(|e| format!("Failed to read existing .claude.json: {}", e))?;
+
+        serde_json::from_str(&content).map_err(|e| {
+            format!("Existing .claude.json is malformed: {}", e)
+        })?
+    } else {
+        ClaudeConfig {
+            mcp_servers: None,
+            other: HashMap::new(),
+        }
+    };
+
+    // Build mcpServers map from input servers
+    let mut mcp_servers = HashMap::new();
+    for server in servers {
+        mcp_servers.insert(server.name.clone(), server.config.clone());
+    }
+
+    config.mcp_servers = if mcp_servers.is_empty() {
+        None
+    } else {
+        Some(mcp_servers)
+    };
+
+    // Serialize with pretty printing
+    let json = serde_json::to_string_pretty(&config)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
+
+    // Write to file
+    fs::write(&config_path, json)
+        .await
+        .map_err(|e| format!("Failed to write .claude.json: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_parse_stdio_server() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".claude.json");
+
+        let config_content = r#"{
+            "mcpServers": {
+                "filesystem": {
+                    "type": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+                    "env": {}
+                }
+            }
+        }"#;
+
+        fs::write(&config_path, config_content).await.unwrap();
+
+        let servers = parse_mcp_config(&config_path, McpScope::User)
+            .await
+            .unwrap();
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "filesystem");
+        assert_eq!(servers[0].scope, McpScope::User);
+
+        match &servers[0].config {
+            McpServerConfig::Stdio { command, args, .. } => {
+                assert_eq!(command, "npx");
+                assert_eq!(args.len(), 2);
+            }
+            _ => panic!("Expected stdio config"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_http_server() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".claude.json");
+
+        let config_content = r#"{
+            "mcpServers": {
+                "github": {
+                    "type": "http",
+                    "url": "https://mcp.github.com/api",
+                    "headers": {
+                        "Authorization": "Bearer token"
+                    }
+                }
+            }
+        }"#;
+
+        fs::write(&config_path, config_content).await.unwrap();
+
+        let servers = parse_mcp_config(&config_path, McpScope::Project)
+            .await
+            .unwrap();
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "github");
+
+        match &servers[0].config {
+            McpServerConfig::Http { url, headers, .. } => {
+                assert_eq!(url, "https://mcp.github.com/api");
+                assert_eq!(headers.get("Authorization").unwrap(), "Bearer token");
+            }
+            _ => panic!("Expected http config"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_missing_file_returns_empty() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("nonexistent.json");
+
+        let servers = parse_mcp_config(&config_path, McpScope::User)
+            .await
+            .unwrap();
+
+        assert_eq!(servers.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_malformed_json_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".claude.json");
+
+        fs::write(&config_path, "{ invalid json }")
+            .await
+            .unwrap();
+
+        let result = parse_mcp_config(&config_path, McpScope::User).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Malformed JSON"));
+    }
+
+    #[tokio::test]
+    async fn test_write_new_config() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let servers = vec![McpServer {
+            name: "test-server".to_string(),
+            config: McpServerConfig::Stdio {
+                command: "node".to_string(),
+                args: vec!["server.js".to_string()],
+                env: HashMap::new(),
+            },
+            scope: McpScope::Local,
+        }];
+
+        write_workspace_mcp_config(temp_dir.path(), &servers)
+            .await
+            .unwrap();
+
+        let config_path = temp_dir.path().join(".claude.json");
+        assert!(config_path.exists());
+
+        let content = fs::read_to_string(&config_path).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert!(parsed["mcpServers"]["test-server"].is_object());
+    }
+
+    #[tokio::test]
+    async fn test_merge_preserves_other_fields() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(".claude.json");
+
+        // Write initial config with custom instructions
+        let initial = r#"{
+            "customInstructions": "Always use TypeScript",
+            "mcpServers": {
+                "old-server": {
+                    "type": "stdio",
+                    "command": "old",
+                    "args": []
+                }
+            }
+        }"#;
+
+        fs::write(&config_path, initial).await.unwrap();
+
+        // Write new MCP config
+        let servers = vec![McpServer {
+            name: "new-server".to_string(),
+            config: McpServerConfig::Http {
+                url: "https://example.com".to_string(),
+                headers: HashMap::new(),
+                oauth: None,
+            },
+            scope: McpScope::Local,
+        }];
+
+        write_workspace_mcp_config(temp_dir.path(), &servers)
+            .await
+            .unwrap();
+
+        // Verify custom instructions preserved
+        let content = fs::read_to_string(&config_path).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(
+            parsed["customInstructions"],
+            "Always use TypeScript"
+        );
+        assert!(parsed["mcpServers"]["new-server"].is_object());
+        assert!(parsed["mcpServers"]["old-server"].is_null());
+    }
+}

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -6,6 +6,7 @@ import shared from "./shared.module.css";
 
 export function ConfirmSetupScriptModal() {
   const closeModal = useAppStore((s) => s.closeModal);
+  const openModal = useAppStore((s) => s.openModal);
   const modalData = useAppStore((s) => s.modalData);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
   const [loading, setLoading] = useState(false);
@@ -13,6 +14,7 @@ export function ConfirmSetupScriptModal() {
   const workspaceId = modalData.workspaceId as string;
   const script = modalData.script as string;
   const source = modalData.source as string;
+  const repoId = modalData.repoId as string | undefined;
 
   const handleRun = async () => {
     setLoading(true);
@@ -37,6 +39,10 @@ export function ConfirmSetupScriptModal() {
         });
       }
       closeModal();
+      // Open MCP modal after setup script completes
+      if (repoId) {
+        openModal("mcpSelection", { workspaceId, repoId });
+      }
     } catch (e) {
       addChatMessage(workspaceId, {
         id: crypto.randomUUID(),
@@ -49,6 +55,18 @@ export function ConfirmSetupScriptModal() {
         thinking: null,
       });
       closeModal();
+      // Open MCP modal even if setup script fails
+      if (repoId) {
+        openModal("mcpSelection", { workspaceId, repoId });
+      }
+    }
+  };
+
+  const handleSkip = () => {
+    closeModal();
+    // Open MCP modal when user skips setup script
+    if (repoId) {
+      openModal("mcpSelection", { workspaceId, repoId });
     }
   };
 
@@ -81,7 +99,7 @@ export function ConfirmSetupScriptModal() {
         </pre>
       </div>
       <div className={shared.actions}>
-        <button className={shared.btn} onClick={closeModal}>
+        <button className={shared.btn} onClick={handleSkip}>
           Skip
         </button>
         <button

--- a/src/ui/src/components/modals/McpSelectionModal.tsx
+++ b/src/ui/src/components/modals/McpSelectionModal.tsx
@@ -17,13 +17,18 @@ export function McpSelectionModal() {
   const workspaceId = modalData.workspaceId as string;
   const repoId = modalData.repoId as string;
 
+  console.log('[MCP Modal] Component rendered! workspaceId:', workspaceId, 'repoId:', repoId);
+
   useEffect(() => {
+    console.log('[MCP Modal] Mounted, detecting servers for repo:', repoId);
     detectMcpServers(repoId)
       .then((detected) => {
+        console.log('[MCP Modal] Detected servers:', detected);
         setServers(detected);
         setLoading(false);
       })
       .catch((err) => {
+        console.error('[MCP Modal] Detection error:', err);
         setError(`Failed to detect MCP servers: ${err}`);
         setLoading(false);
       });

--- a/src/ui/src/components/modals/McpSelectionModal.tsx
+++ b/src/ui/src/components/modals/McpSelectionModal.tsx
@@ -1,0 +1,197 @@
+import { useState, useEffect } from 'react';
+import { useAppStore } from '../../stores/useAppStore';
+import { detectMcpServers, configureWorkspaceMcps } from '../../services/mcp';
+import type { McpServer } from '../../types/mcp';
+import { Modal } from './Modal';
+import shared from './shared.module.css';
+
+export function McpSelectionModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const modalData = useAppStore((s) => s.modalData);
+  const [loading, setLoading] = useState(true);
+  const [configuring, setConfiguring] = useState(false);
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const workspaceId = modalData.workspaceId as string;
+  const repoId = modalData.repoId as string;
+
+  useEffect(() => {
+    detectMcpServers(repoId)
+      .then((detected) => {
+        setServers(detected);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(`Failed to detect MCP servers: ${err}`);
+        setLoading(false);
+      });
+  }, [repoId]);
+
+  const toggleServer = (name: string) => {
+    const newSelected = new Set(selectedNames);
+    if (newSelected.has(name)) {
+      newSelected.delete(name);
+    } else {
+      newSelected.add(name);
+    }
+    setSelectedNames(newSelected);
+  };
+
+  const handleConfigure = async () => {
+    const selectedServers = servers.filter((s) => selectedNames.has(s.name));
+    if (selectedServers.length === 0) {
+      closeModal();
+      return;
+    }
+
+    setConfiguring(true);
+    try {
+      await configureWorkspaceMcps(workspaceId, selectedServers);
+      closeModal();
+    } catch (err) {
+      setError(`Failed to configure MCP servers: ${err}`);
+      setConfiguring(false);
+    }
+  };
+
+  const getScopeLabel = (scope: string) => {
+    switch (scope) {
+      case 'user':
+        return 'user (global)';
+      case 'project':
+        return 'project';
+      case 'local':
+        return 'local';
+      default:
+        return scope;
+    }
+  };
+
+  const getConfigPreview = (server: McpServer): string => {
+    switch (server.config.type) {
+      case 'stdio':
+        return `Command: ${server.config.command} ${server.config.args.join(' ')}`;
+      case 'http':
+        return `URL: ${server.config.url}`;
+      case 'sse':
+        return `URL: ${server.config.url}`;
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <Modal title="Configure MCP Servers for Workspace" onClose={closeModal}>
+      {loading && (
+        <div className={shared.field}>
+          <p>Detecting MCP servers...</p>
+        </div>
+      )}
+
+      {error && (
+        <div className={shared.warning}>
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && servers.length === 0 && (
+        <div className={shared.field}>
+          <p>No MCP servers detected in user, project, or local configurations.</p>
+          <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginTop: '8px' }}>
+            You can configure MCP servers in:
+            <br />
+            • <code>~/.claude.json</code> (user scope)
+            <br />
+            • <code>.mcp.json</code> (project scope)
+            <br />
+            • <code>.claude.json</code> (local scope)
+          </p>
+        </div>
+      )}
+
+      {!loading && !error && servers.length > 0 && (
+        <div className={shared.field}>
+          <label className={shared.label}>
+            Select which MCP servers to enable for this workspace:
+          </label>
+          <div
+            style={{
+              border: '1px solid var(--divider)',
+              borderRadius: 6,
+              maxHeight: 300,
+              overflow: 'auto',
+            }}
+          >
+            {servers.map((server) => (
+              <div
+                key={`${server.scope}-${server.name}`}
+                style={{
+                  padding: '12px',
+                  borderBottom: '1px solid var(--divider)',
+                  cursor: 'pointer',
+                  background: selectedNames.has(server.name)
+                    ? 'var(--chat-input-bg)'
+                    : 'transparent',
+                }}
+                onClick={() => toggleServer(server.name)}
+              >
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
+                  <input
+                    type="checkbox"
+                    checked={selectedNames.has(server.name)}
+                    onChange={() => toggleServer(server.name)}
+                    style={{ marginTop: '2px', cursor: 'pointer' }}
+                  />
+                  <div style={{ flex: 1 }}>
+                    <div style={{ fontWeight: 500, marginBottom: '4px' }}>
+                      {server.name}{' '}
+                      <span
+                        style={{
+                          fontSize: '12px',
+                          color: 'var(--text-secondary)',
+                          fontWeight: 'normal',
+                        }}
+                      >
+                        ({server.config.type}, {getScopeLabel(server.scope)})
+                      </span>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: '12px',
+                        color: 'var(--text-secondary)',
+                        fontFamily: 'monospace',
+                      }}
+                    >
+                      {getConfigPreview(server)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={closeModal} disabled={configuring}>
+          Skip
+        </button>
+        {servers.length > 0 && (
+          <button
+            className={shared.btnPrimary}
+            onClick={handleConfigure}
+            disabled={configuring || selectedNames.size === 0}
+          >
+            {configuring
+              ? 'Configuring...'
+              : selectedNames.size === 0
+                ? 'Select Servers'
+                : `Configure ${selectedNames.size} Server${selectedNames.size > 1 ? 's' : ''}`}
+          </button>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -7,6 +7,7 @@ import { RelinkRepoModal } from "./RelinkRepoModal";
 import { RollbackModal } from "./RollbackModal";
 import { ShareModal } from "./ShareModal";
 import { ConfirmSetupScriptModal } from "./ConfirmSetupScriptModal";
+import { McpSelectionModal } from "./McpSelectionModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -28,6 +29,8 @@ export function ModalRouter() {
       return <ShareModal />;
     case "confirmSetupScript":
       return <ConfirmSetupScriptModal />;
+    case "mcpSelection":
+      return <McpSelectionModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -52,12 +52,15 @@ export const Sidebar = memo(function Sidebar() {
   const creatingRef = useRef(false);
 
   const handleCreateWorkspace = useCallback(async (repoId: string) => {
+    console.log('[Workspace] Creating workspace for repo:', repoId);
     if (creatingRef.current) return;
     creatingRef.current = true;
     try {
       const generated = await generateWorkspaceName();
+      console.log('[Workspace] Generated name:', generated);
       // Always skip setup initially — we'll prompt for confirmation if needed.
       const result = await createWorkspace(repoId, generated.slug, true);
+      console.log('[Workspace] Workspace created:', result);
       addWorkspace(result.workspace);
       selectWorkspace(result.workspace.id);
       if (generated.message) {
@@ -72,31 +75,37 @@ export const Sidebar = memo(function Sidebar() {
           thinking: null,
         });
       }
-      // Check for MCP servers and prompt user to configure them.
-      try {
-        openModal("mcpSelection", {
-          workspaceId: result.workspace.id,
-          repoId,
-        });
-      } catch {
-        // Error opening MCP modal - continue with setup script check.
-      }
 
       // Check if a setup script exists and prompt user to review it.
+      let hasSetupScript = false;
       try {
         const config = await getRepoConfig(repoId);
         const repo = useAppStore.getState().repositories.find((r) => r.id === repoId);
         const script = config.setup_script ?? repo?.setup_script;
         const source = config.setup_script ? "repo" : "settings";
         if (script) {
+          hasSetupScript = true;
           openModal("confirmSetupScript", {
             workspaceId: result.workspace.id,
+            repoId,
             script,
             source,
           });
         }
       } catch {
         // No config or error reading it — no setup script to run.
+      }
+
+      // If there's no setup script, show MCP configuration modal.
+      // TODO: Chain modals properly so MCP shows after setup script completes.
+      if (!hasSetupScript) {
+        console.log('[MCP] Opening MCP selection modal for workspace:', result.workspace.id, 'repo:', repoId);
+        openModal("mcpSelection", {
+          workspaceId: result.workspace.id,
+          repoId,
+        });
+      } else {
+        console.log('[MCP] Skipping MCP modal due to setup script');
       }
     } catch (e) {
       console.error("Failed to create workspace:", e);

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -52,15 +52,12 @@ export const Sidebar = memo(function Sidebar() {
   const creatingRef = useRef(false);
 
   const handleCreateWorkspace = useCallback(async (repoId: string) => {
-    console.log('[Workspace] Creating workspace for repo:', repoId);
     if (creatingRef.current) return;
     creatingRef.current = true;
     try {
       const generated = await generateWorkspaceName();
-      console.log('[Workspace] Generated name:', generated);
       // Always skip setup initially — we'll prompt for confirmation if needed.
       const result = await createWorkspace(repoId, generated.slug, true);
-      console.log('[Workspace] Workspace created:', result);
       addWorkspace(result.workspace);
       selectWorkspace(result.workspace.id);
       if (generated.message) {
@@ -99,16 +96,11 @@ export const Sidebar = memo(function Sidebar() {
       // If there's no setup script, show MCP configuration modal.
       // TODO: Chain modals properly so MCP shows after setup script completes.
       if (!hasSetupScript) {
-        console.log('[MCP] Opening MCP selection modal for workspace:', result.workspace.id, 'repo:', repoId);
         openModal("mcpSelection", {
           workspaceId: result.workspace.id,
           repoId,
         });
-      } else {
-        console.log('[MCP] Skipping MCP modal due to setup script');
       }
-    } catch (e) {
-      console.error("Failed to create workspace:", e);
     } finally {
       creatingRef.current = false;
     }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -72,6 +72,16 @@ export const Sidebar = memo(function Sidebar() {
           thinking: null,
         });
       }
+      // Check for MCP servers and prompt user to configure them.
+      try {
+        openModal("mcpSelection", {
+          workspaceId: result.workspace.id,
+          repoId,
+        });
+      } catch {
+        // Error opening MCP modal - continue with setup script check.
+      }
+
       // Check if a setup script exists and prompt user to review it.
       try {
         const config = await getRepoConfig(repoId);

--- a/src/ui/src/services/mcp.ts
+++ b/src/ui/src/services/mcp.ts
@@ -1,0 +1,27 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { McpServer } from '../types/mcp';
+
+/**
+ * Detect all MCP servers configured for a repository
+ * Reads from user (~/.claude.json), project (.mcp.json), and local (.claude.json) scopes
+ */
+export async function detectMcpServers(repoId: string): Promise<McpServer[]> {
+  return invoke<McpServer[]>('detect_mcp_servers', { repoId });
+}
+
+/**
+ * Write selected MCP servers to workspace .claude.json
+ */
+export async function configureWorkspaceMcps(
+  workspaceId: string,
+  servers: McpServer[]
+): Promise<void> {
+  return invoke('configure_workspace_mcps', { workspaceId, servers });
+}
+
+/**
+ * Read MCP configuration from workspace .claude.json
+ */
+export async function readWorkspaceMcps(workspaceId: string): Promise<McpServer[]> {
+  return invoke<McpServer[]>('read_workspace_mcps', { workspaceId });
+}

--- a/src/ui/src/types/mcp.ts
+++ b/src/ui/src/types/mcp.ts
@@ -1,0 +1,38 @@
+// MCP (Model Context Protocol) server configuration types
+// These match the Rust types in src/mcp.rs
+
+export type McpScope = 'user' | 'project' | 'local';
+
+export interface McpServer {
+  name: string;
+  config: McpServerConfig;
+  scope: McpScope;
+}
+
+export type McpServerConfig =
+  | McpServerConfigStdio
+  | McpServerConfigHttp
+  | McpServerConfigSse;
+
+export interface McpServerConfigStdio {
+  type: 'stdio';
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpServerConfigHttp {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+  oauth?: OAuthConfig;
+}
+
+export interface McpServerConfigSse {
+  type: 'sse';
+  url: string;
+}
+
+export interface OAuthConfig {
+  authServerMetadataUrl?: string;
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 and Phase 2 from the MCP detection TDD (docs/mcp-detection-tdd.md), enabling users to detect and configure MCP servers when creating workspaces.

## Changes

### Backend (Rust)

**New Module: `src/mcp.rs`**
- `McpServer`, `McpServerConfig`, `McpScope` types for MCP configuration
- `detect_mcp_servers()` - Reads from user (~/.claude.json), project (.mcp.json), and local (.claude.json) scopes
- `write_workspace_mcp_config()` - Writes selected MCP servers to workspace .claude.json
- Handles precedence: Local > Project > User
- Preserves non-MCP fields when merging configs
- 6 unit tests covering parsing, merging, and error handling

**New Tauri Commands: `src-tauri/src/commands/mcp.rs`**
- `detect_mcp_servers(repo_id)` - Detect all MCP servers for a repository
- `configure_workspace_mcps(workspace_id, servers)` - Write MCP config to workspace
- `read_workspace_mcps(workspace_id)` - Read workspace MCP configuration

### Frontend (TypeScript/React)

**New Types: `src/ui/src/types/mcp.ts`**
- TypeScript types matching Rust MCP structures
- Supports stdio, http, and sse server types

**New Services: `src/ui/src/services/mcp.ts`**
- Service functions wrapping Tauri commands
- Typed async functions for MCP detection and configuration

**New Component: `src/ui/src/components/modals/McpSelectionModal.tsx`**
- Displays detected MCP servers with scope (user/project/local) and type
- Multi-select interface for choosing servers to enable
- Shows command/URL preview for each server
- Handles loading, error, and empty states
- Skip or configure workflow

**Integration: `src/ui/src/components/sidebar/Sidebar.tsx`**
- MCP selection modal opens after workspace creation
- User can skip or configure selected servers
- Flows into existing setup script confirmation

## Implementation Details

### Design Decisions
- **File-based storage**: MCP configs live in `.claude.json` files, not database
- **Workspace isolation**: Each workspace gets its own `.claude.json` in worktree root
- **Read-only global configs**: Never modifies `~/.claude.json` or `.mcp.json`
- **TOCTOU prevention**: Passes resolved `McpServer` objects to avoid race conditions
- **Post-creation write**: `.claude.json` written only after workspace creation succeeds

### Precedence Handling
When the same MCP server name exists in multiple scopes:
1. **Local scope** (.claude.json in repo) - highest precedence
2. **Project scope** (.mcp.json in repo)
3. **User scope** (~/.claude.json) - lowest precedence

### Config Merging
- Reads existing `.claude.json` if present
- Preserves all non-MCP fields (e.g., `customInstructions`)
- Updates only `mcpServers` section
- Pretty-prints with 2-space indentation (matches Claude CLI format)

## Testing

### Unit Tests
```bash
cargo test --all-features --lib mcp::
```

All 6 tests pass:
- ✅ Parse stdio server configuration
- ✅ Parse http server configuration
- ✅ Missing file returns empty list
- ✅ Malformed JSON returns error
- ✅ Write new .claude.json file
- ✅ Merge preserves other fields

### Type Checking
```bash
cargo clippy --workspace --all-targets  # Zero warnings
cd src/ui && bunx tsc --noEmit          # Zero errors
cd src/ui && bun run build              # Successful build
```

## Screenshots

_TODO: Add screenshots of MCP selection modal in action_

## Next Steps (Future PRs)

- **Phase 3**: MCP management UI for existing workspaces
- **Phase 4**: Advanced features (templates, health checks, env var resolution)

## Related

- Closes #170
- Implements docs/mcp-detection-tdd.md (Phase 1 & 2)

## Test Plan

Manual testing checklist:
- [ ] Create workspace with no MCP configs → modal shows "no servers detected"
- [ ] Create workspace with MCP configs → modal shows detected servers
- [ ] Select MCP servers and configure → `.claude.json` written correctly
- [ ] Skip MCP selection → no `.claude.json` created
- [ ] Verify precedence: local overrides project overrides user
- [ ] Verify merge preserves existing `.claude.json` fields
- [ ] Verify Claude agent can read workspace `.claude.json`