### PR TITLE
feat: implement MCP configuration detection and --mcp-config injection

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -378,6 +378,7 @@ async fn handle_send_chat_message(
         plan_mode: plan_mode.unwrap_or(false),
         effort,
         chrome_enabled: chrome_enabled.unwrap_or(false),
+        mcp_config: None,
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -240,6 +240,35 @@ pub async fn send_chat_message(
     session.needs_attention = false;
     session.attention_kind = None;
 
+    // Load repository MCP configs for injection on first turn.
+    let mcp_config = if !is_resume {
+        let db_rows = db
+            .list_repository_mcp_servers(&ws.repository_id)
+            .unwrap_or_default();
+        if db_rows.is_empty() {
+            None
+        } else {
+            let mcp_servers: Vec<claudette::mcp::McpServer> = db_rows
+                .iter()
+                .filter_map(|row| {
+                    let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
+                    Some(claudette::mcp::McpServer {
+                        name: row.name.clone(),
+                        config,
+                        source: claudette::mcp::McpSource::UserProjectConfig,
+                    })
+                })
+                .collect();
+            if mcp_servers.is_empty() {
+                None
+            } else {
+                Some(claudette::mcp::serialize_for_cli(&mcp_servers))
+            }
+        }
+    } else {
+        None
+    };
+
     // Build agent settings from frontend params.
     let agent_settings = AgentSettings {
         model: if !is_resume { model } else { None },
@@ -248,6 +277,7 @@ pub async fn send_chat_message(
         plan_mode: plan_mode.unwrap_or(false),
         effort,
         chrome_enabled: chrome_enabled.unwrap_or(false),
+        mcp_config,
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -252,10 +252,13 @@ pub async fn send_chat_message(
                 .iter()
                 .filter_map(|row| {
                     let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
+                    let source: claudette::mcp::McpSource =
+                        serde_json::from_str(&format!("\"{}\"", row.source))
+                            .unwrap_or(claudette::mcp::McpSource::UserProjectConfig);
                     Some(claudette::mcp::McpServer {
                         name: row.name.clone(),
                         config,
-                        source: claudette::mcp::McpSource::UserProjectConfig,
+                        source,
                     })
                 })
                 .collect();

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,0 +1,82 @@
+use tauri::State;
+
+use claudette::db::{Database, RepositoryMcpServer};
+use claudette::mcp::{self, McpServer};
+
+use crate::state::AppState;
+
+/// Detect non-portable MCP servers for a repository.
+#[tauri::command]
+pub async fn detect_mcp_servers(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<McpServer>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repo = db
+        .get_repository(&repo_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Repository not found")?;
+
+    let repo_path = std::path::Path::new(&repo.path);
+    tokio::task::spawn_blocking({
+        let path = repo_path.to_path_buf();
+        move || mcp::detect_mcp_servers(&path)
+    })
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Save selected MCP servers for a repository (replaces any existing).
+#[tauri::command]
+pub async fn save_repository_mcps(
+    repo_id: String,
+    servers: Vec<McpServer>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    let rows: Vec<RepositoryMcpServer> = servers
+        .into_iter()
+        .map(|s| {
+            // Validate config is valid JSON before storing.
+            let config_json = serde_json::to_string(&s.config)
+                .map_err(|e| format!("Invalid config JSON for {}: {e}", s.name))?;
+            Ok(RepositoryMcpServer {
+                id: uuid::Uuid::new_v4().to_string(),
+                repository_id: repo_id.clone(),
+                name: s.name,
+                config_json,
+                source: serde_json::to_string(&s.source)
+                    .unwrap_or_default()
+                    .trim_matches('"')
+                    .to_string(),
+                created_at: String::new(), // DB default
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    db.replace_repository_mcp_servers(&repo_id, &rows)
+        .map_err(|e| e.to_string())
+}
+
+/// Load saved MCP servers for a repository.
+#[tauri::command]
+pub async fn load_repository_mcps(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<RepositoryMcpServer>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.list_repository_mcp_servers(&repo_id)
+        .map_err(|e| e.to_string())
+}
+
+/// Delete a single MCP server from a repository's saved config.
+#[tauri::command]
+pub async fn delete_repository_mcp(
+    server_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.delete_repository_mcp_server(&server_id)
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod data;
 pub mod debug;
 pub mod diff;
 pub mod files;
+pub mod mcp;
 pub mod plan;
 pub mod remote;
 pub mod repository;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -321,6 +321,11 @@ fn main() {
             commands::shell::setup_shell_integration,
             commands::shell::apply_shell_integration,
             commands::shell::open_in_editor,
+            // MCP
+            commands::mcp::detect_mcp_servers,
+            commands::mcp::save_repository_mcps,
+            commands::mcp::load_repository_mcps,
+            commands::mcp::delete_repository_mcp,
             // Apps
             commands::apps::detect_installed_apps,
             commands::apps::open_workspace_in_app,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -213,6 +213,9 @@ pub struct AgentSettings {
     /// Enable Chrome browser mode via `--chrome`. Session-level: only applied
     /// on the first turn.
     pub chrome_enabled: bool,
+    /// MCP config JSON string for `--mcp-config`. Session-level: only applied
+    /// on the first turn.
+    pub mcp_config: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +262,13 @@ pub fn build_claude_args(
     // Chrome is session-level — only set on the first turn.
     if !is_resume && settings.chrome_enabled {
         args.push("--chrome".to_string());
+    }
+
+    // MCP config is session-level — only inject on the first turn.
+    // Resumed sessions inherit MCP servers from the initial turn.
+    if !is_resume && let Some(ref mcp_json) = settings.mcp_config {
+        args.push("--mcp-config".to_string());
+        args.push(mcp_json.clone());
     }
 
     // Permission mode must be set on every turn — each `claude` invocation is

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1636,6 +1636,34 @@ mod tests {
         assert!(!args.contains(&"--chrome".to_string()));
     }
 
+    #[test]
+    fn test_build_args_with_mcp_config() {
+        let settings = AgentSettings {
+            mcp_config: Some(r#"{"mcpServers":{"s":{"type":"stdio","command":"x"}}}"#.to_string()),
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
+        let idx = args.iter().position(|a| a == "--mcp-config").unwrap();
+        assert!(args[idx + 1].contains("mcpServers"));
+    }
+
+    #[test]
+    fn test_build_args_mcp_config_skipped_on_resume() {
+        let settings = AgentSettings {
+            mcp_config: Some(r#"{"mcpServers":{}}"#.to_string()),
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
+        assert!(!args.contains(&"--mcp-config".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_mcp_config_none_omitted() {
+        let settings = AgentSettings::default();
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
+        assert!(!args.contains(&"--mcp-config".to_string()));
+    }
+
     // -----------------------------------------------------------------------
     // resolve_claude_path_inner tests
     // -----------------------------------------------------------------------

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension, params};
 
+use serde::{Deserialize, Serialize};
+
 use crate::model::{
     Attachment, ChatMessage, CheckpointFile, CompletedTurnData, ConversationCheckpoint,
     RemoteConnection, Repository, TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
@@ -20,6 +22,17 @@ fn row_to_attachment(row: &rusqlite::Row) -> rusqlite::Result<Attachment> {
         height: row.get(6)?,
         created_at: row.get(8)?,
     })
+}
+
+/// A saved MCP server configuration for a repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepositoryMcpServer {
+    pub id: String,
+    pub repository_id: String,
+    pub name: String,
+    pub config_json: String,
+    pub source: String,
+    pub created_at: String,
 }
 
 pub struct Database {
@@ -299,6 +312,22 @@ impl Database {
                     ON attachments(message_id);
 
                 PRAGMA user_version = 16;",
+            )?;
+        }
+
+        if version < 17 {
+            self.conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS repository_mcp_servers (
+                    id              TEXT PRIMARY KEY,
+                    repository_id   TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+                    name            TEXT NOT NULL,
+                    config_json     TEXT NOT NULL,
+                    source          TEXT NOT NULL,
+                    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(repository_id, name)
+                );
+
+                PRAGMA user_version = 17;",
             )?;
         }
 
@@ -1307,6 +1336,67 @@ impl Database {
             map.insert(name, count);
         }
         Ok(map)
+    }
+
+    // --- Repository MCP Servers ---
+
+    /// List all saved MCP servers for a repository.
+    pub fn list_repository_mcp_servers(
+        &self,
+        repository_id: &str,
+    ) -> Result<Vec<RepositoryMcpServer>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repository_id, name, config_json, source, created_at
+             FROM repository_mcp_servers
+             WHERE repository_id = ?1
+             ORDER BY name",
+        )?;
+        let rows = stmt.query_map(params![repository_id], |row| {
+            Ok(RepositoryMcpServer {
+                id: row.get(0)?,
+                repository_id: row.get(1)?,
+                name: row.get(2)?,
+                config_json: row.get(3)?,
+                source: row.get(4)?,
+                created_at: row.get(5)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Replace all MCP servers for a repository atomically (delete + re-insert).
+    pub fn replace_repository_mcp_servers(
+        &self,
+        repository_id: &str,
+        servers: &[RepositoryMcpServer],
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM repository_mcp_servers WHERE repository_id = ?1",
+            params![repository_id],
+        )?;
+        for server in servers {
+            self.conn.execute(
+                "INSERT INTO repository_mcp_servers (id, repository_id, name, config_json, source)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    server.id,
+                    server.repository_id,
+                    server.name,
+                    server.config_json,
+                    server.source,
+                ],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Delete a single MCP server by ID.
+    pub fn delete_repository_mcp_server(&self, id: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM repository_mcp_servers WHERE id = ?1",
+            params![id],
+        )?;
+        Ok(())
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1370,12 +1370,13 @@ impl Database {
         repository_id: &str,
         servers: &[RepositoryMcpServer],
     ) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
             "DELETE FROM repository_mcp_servers WHERE repository_id = ?1",
             params![repository_id],
         )?;
         for server in servers {
-            self.conn.execute(
+            tx.execute(
                 "INSERT INTO repository_mcp_servers (id, repository_id, name, config_json, source)
                  VALUES (?1, ?2, ?3, ?4, ?5)",
                 params![
@@ -1387,7 +1388,7 @@ impl Database {
                 ],
             )?;
         }
-        Ok(())
+        tx.commit()
     }
 
     /// Delete a single MCP server by ID.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod diff;
 pub mod file_expand;
 pub mod git;
+pub mod mcp;
 pub mod model;
 pub mod names;
 pub mod permissions;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,345 @@
+//! MCP (Model Context Protocol) server detection and serialization.
+//!
+//! Detects non-portable MCP configurations that won't be automatically
+//! available inside git worktrees:
+//!
+//! 1. Project-scoped MCPs in `~/.claude.json` (keyed by absolute repo path)
+//! 2. MCPs in gitignored `{repo}/.claude.json`
+//!
+//! Committed `.mcp.json` and global user MCPs are auto-available and NOT
+//! detected here.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// A detected MCP server with its full configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServer {
+    /// Server name (key in the mcpServers object).
+    pub name: String,
+    /// Full server configuration (passed through to --mcp-config).
+    pub config: serde_json::Value,
+    /// Where this config was found.
+    pub source: McpSource,
+}
+
+/// Where the MCP server configuration was detected from.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpSource {
+    /// Project-scoped entry in ~/.claude.json
+    UserProjectConfig,
+    /// Gitignored .claude.json at repo root
+    RepoLocalConfig,
+}
+
+/// Detect non-portable MCP servers for the given repository path.
+///
+/// Scans two locations:
+/// 1. `~/.claude.json` → `projects[repo_path].mcpServers`
+/// 2. `{repo_path}/.claude.json` (only if gitignored)
+///
+/// Returns an empty Vec if no non-portable MCPs are found.
+pub fn detect_mcp_servers(repo_path: &Path) -> Vec<McpServer> {
+    let mut servers = Vec::new();
+
+    if let Some(user_servers) = detect_user_project_mcps(repo_path) {
+        servers.extend(user_servers);
+    }
+
+    if let Some(local_servers) = detect_repo_local_mcps(repo_path) {
+        servers.extend(local_servers);
+    }
+
+    servers
+}
+
+/// Serialize selected MCP servers into the JSON format expected by
+/// `--mcp-config`.
+///
+/// Produces: `{"mcpServers":{"name":{...config...}}}`
+pub fn serialize_for_cli(servers: &[McpServer]) -> String {
+    let mut mcp_servers = serde_json::Map::new();
+    for server in servers {
+        mcp_servers.insert(server.name.clone(), server.config.clone());
+    }
+    let wrapper = serde_json::json!({ "mcpServers": mcp_servers });
+    wrapper.to_string()
+}
+
+/// Parse project-scoped MCPs from `~/.claude.json`.
+///
+/// Claude Code stores per-project configs at:
+///   `projects["/absolute/path/to/repo"].mcpServers`
+fn detect_user_project_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
+    let home = dirs::home_dir()?;
+    let config_path = home.join(".claude.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let root: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let repo_key = repo_path.to_string_lossy();
+    let mcp_servers = root
+        .get("projects")?
+        .get(repo_key.as_ref())?
+        .get("mcpServers")?
+        .as_object()?;
+
+    let servers = mcp_servers
+        .iter()
+        .map(|(name, config)| McpServer {
+            name: name.clone(),
+            config: config.clone(),
+            source: McpSource::UserProjectConfig,
+        })
+        .collect();
+
+    Some(servers)
+}
+
+/// Parse MCPs from `{repo}/.claude.json`, but only if it's explicitly
+/// gitignored.
+fn detect_repo_local_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
+    let config_path = repo_path.join(".claude.json");
+    if !config_path.exists() {
+        return None;
+    }
+
+    // Only include if the file is explicitly gitignored. An untracked but
+    // not-ignored .claude.json should not be picked up.
+    if !is_gitignored(repo_path, ".claude.json") {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let root: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let mcp_servers = root.get("mcpServers")?.as_object()?;
+
+    let servers = mcp_servers
+        .iter()
+        .map(|(name, config)| McpServer {
+            name: name.clone(),
+            config: config.clone(),
+            source: McpSource::RepoLocalConfig,
+        })
+        .collect();
+
+    Some(servers)
+}
+
+/// Check if a file is explicitly gitignored (returns true if ignored).
+fn is_gitignored(repo_path: &Path, file: &str) -> bool {
+    std::process::Command::new("git")
+        .args(["check-ignore", "-q", file])
+        .current_dir(repo_path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper: create a temporary git repo with .gitignore containing .claude.json.
+    fn setup_git_repo_with_gitignored_claude_json(mcp_json: &str) -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path();
+
+        // Init git repo
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(repo)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+
+        // Create .gitignore that ignores .claude.json
+        fs::write(repo.join(".gitignore"), ".claude.json\n").unwrap();
+
+        // Create .claude.json with MCP content
+        fs::write(repo.join(".claude.json"), mcp_json).unwrap();
+
+        // Stage and commit .gitignore so git is functional
+        std::process::Command::new("git")
+            .args(["add", ".gitignore"])
+            .current_dir(repo)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init", "--allow-empty"])
+            .current_dir(repo)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+
+        dir
+    }
+
+    #[test]
+    fn test_detect_repo_local_mcps_with_gitignored_file() {
+        let dir = setup_git_repo_with_gitignored_claude_json(
+            r#"{
+                "mcpServers": {
+                    "my-server": {
+                        "type": "stdio",
+                        "command": "npx",
+                        "args": ["-y", "@example/mcp"]
+                    }
+                }
+            }"#,
+        );
+
+        let servers = detect_repo_local_mcps(dir.path()).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "my-server");
+        assert_eq!(servers[0].source, McpSource::RepoLocalConfig);
+        assert_eq!(servers[0].config["command"], "npx");
+    }
+
+    #[test]
+    fn test_detect_repo_local_mcps_not_gitignored() {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path();
+
+        // Init git repo WITHOUT .gitignore
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(repo)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+
+        // Create .claude.json but it's NOT ignored
+        fs::write(
+            repo.join(".claude.json"),
+            r#"{"mcpServers":{"s":{"type":"stdio","command":"x"}}}"#,
+        )
+        .unwrap();
+
+        let result = detect_repo_local_mcps(repo);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_repo_local_mcps_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let result = detect_repo_local_mcps(dir.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_repo_local_mcps_malformed_json() {
+        let dir = setup_git_repo_with_gitignored_claude_json("not valid json {{{");
+        let result = detect_repo_local_mcps(dir.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_repo_local_mcps_no_mcp_servers_key() {
+        let dir = setup_git_repo_with_gitignored_claude_json(r#"{"customInstructions": "hello"}"#);
+        let result = detect_repo_local_mcps(dir.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_repo_local_mcps_multiple_servers() {
+        let dir = setup_git_repo_with_gitignored_claude_json(
+            r#"{
+                "mcpServers": {
+                    "server-a": {"type": "stdio", "command": "a"},
+                    "server-b": {"type": "http", "url": "https://example.com"}
+                }
+            }"#,
+        );
+
+        let servers = detect_repo_local_mcps(dir.path()).unwrap();
+        assert_eq!(servers.len(), 2);
+        let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"server-a"));
+        assert!(names.contains(&"server-b"));
+    }
+
+    #[test]
+    fn test_serialize_for_cli_empty() {
+        let json = serialize_for_cli(&[]);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["mcpServers"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_serialize_for_cli_single_server() {
+        let servers = vec![McpServer {
+            name: "test-server".to_string(),
+            config: serde_json::json!({"type": "stdio", "command": "echo"}),
+            source: McpSource::UserProjectConfig,
+        }];
+        let json = serialize_for_cli(&servers);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["mcpServers"]["test-server"]["command"], "echo");
+    }
+
+    #[test]
+    fn test_serialize_for_cli_multiple_servers() {
+        let servers = vec![
+            McpServer {
+                name: "a".to_string(),
+                config: serde_json::json!({"type": "stdio", "command": "cmd-a"}),
+                source: McpSource::UserProjectConfig,
+            },
+            McpServer {
+                name: "b".to_string(),
+                config: serde_json::json!({"type": "http", "url": "https://b.example.com"}),
+                source: McpSource::RepoLocalConfig,
+            },
+        ];
+        let json = serialize_for_cli(&servers);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let mcp = parsed["mcpServers"].as_object().unwrap();
+        assert_eq!(mcp.len(), 2);
+        assert_eq!(mcp["a"]["command"], "cmd-a");
+        assert_eq!(mcp["b"]["url"], "https://b.example.com");
+    }
+
+    #[test]
+    fn test_serialize_for_cli_preserves_env_vars() {
+        let servers = vec![McpServer {
+            name: "s".to_string(),
+            config: serde_json::json!({
+                "type": "http",
+                "url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer ${TOKEN}"}
+            }),
+            source: McpSource::UserProjectConfig,
+        }];
+        let json = serialize_for_cli(&servers);
+        assert!(json.contains("${TOKEN}"));
+    }
+
+    #[test]
+    fn test_is_gitignored_true() {
+        let dir = setup_git_repo_with_gitignored_claude_json("{}");
+        assert!(is_gitignored(dir.path(), ".claude.json"));
+    }
+
+    #[test]
+    fn test_is_gitignored_false_not_ignored() {
+        let dir = TempDir::new().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(!is_gitignored(dir.path(), ".claude.json"));
+    }
+}

--- a/src/ui/src/components/modals/AddRepoModal.tsx
+++ b/src/ui/src/components/modals/AddRepoModal.tsx
@@ -2,11 +2,13 @@ import { useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../stores/useAppStore";
 import { addRepository, getDefaultBranch } from "../../services/tauri";
+import { detectMcpServers } from "../../services/mcp";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
 export function AddRepoModal() {
   const closeModal = useAppStore((s) => s.closeModal);
+  const openModal = useAppStore((s) => s.openModal);
   const addRepo = useAppStore((s) => s.addRepository);
   const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
   const defaultBranches = useAppStore((s) => s.defaultBranches);
@@ -39,6 +41,17 @@ export function AddRepoModal() {
           setDefaultBranches({ ...defaultBranches, [repo.id]: branch });
         }
       });
+      // Detect non-portable MCP servers. If found, open selection modal;
+      // otherwise just close.
+      try {
+        const mcps = await detectMcpServers(repo.id);
+        if (mcps.length > 0) {
+          openModal("mcpSelection", { repoId: repo.id });
+          return;
+        }
+      } catch {
+        // MCP detection is best-effort — don't block repo addition.
+      }
       closeModal();
     } catch (e) {
       setError(String(e));

--- a/src/ui/src/components/modals/McpSelectionModal.module.css
+++ b/src/ui/src/components/modals/McpSelectionModal.module.css
@@ -1,0 +1,82 @@
+.loading {
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 16px 0;
+  text-align: center;
+}
+
+.description {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.serverList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.serverRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.serverRow:hover {
+  background: var(--hover-bg);
+}
+
+.serverRow input[type="checkbox"] {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.serverInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.serverHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.serverName {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--selected-bg);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.source {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.serverDetail {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/ui/src/components/modals/McpSelectionModal.tsx
+++ b/src/ui/src/components/modals/McpSelectionModal.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useState } from "react";
+import { useAppStore } from "../../stores/useAppStore";
+import {
+  detectMcpServers,
+  loadRepositoryMcps,
+  saveRepositoryMcps,
+} from "../../services/mcp";
+import type { McpServer } from "../../types/mcp";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+import styles from "./McpSelectionModal.module.css";
+
+const SOURCE_LABELS: Record<string, string> = {
+  user_project_config: "~/.claude.json",
+  repo_local_config: ".claude.json",
+};
+
+/** Infer transport type from the config object for display. */
+function getTransportType(config: Record<string, unknown>): string {
+  if (config.url) {
+    const url = String(config.url);
+    if (url.includes("/sse") || config.type === "sse") return "sse";
+    return "http";
+  }
+  if (config.command) return "stdio";
+  if (config.type) return String(config.type);
+  return "unknown";
+}
+
+/** Get a one-line summary of the config for display. */
+function getConfigSummary(config: Record<string, unknown>): string {
+  if (config.command) {
+    const args = Array.isArray(config.args) ? config.args.join(" ") : "";
+    return `${config.command} ${args}`.trim();
+  }
+  if (config.url) return String(config.url);
+  return "";
+}
+
+export function McpSelectionModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const modalData = useAppStore((s) => s.modalData);
+  const repoId = modalData.repoId as string;
+
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!repoId) return;
+    setLoading(true);
+
+    // Load both detected and already-saved servers, then merge.
+    // Already-saved servers stay selected; newly detected ones are also
+    // pre-selected (opt-out default).
+    Promise.all([detectMcpServers(repoId), loadRepositoryMcps(repoId)])
+      .then(([detected, saved]) => {
+        const savedNames = new Set(saved.map((s) => s.name));
+
+        // Build merged list: start with detected servers, then add any
+        // saved servers that were NOT re-detected (source may have changed).
+        const merged = new Map<string, McpServer>();
+        for (const s of detected) {
+          merged.set(s.name, s);
+        }
+        for (const s of saved) {
+          if (!merged.has(s.name)) {
+            let config: Record<string, unknown> = {};
+            try {
+              config = JSON.parse(s.config_json);
+            } catch {
+              /* ignore */
+            }
+            merged.set(s.name, {
+              name: s.name,
+              config,
+              source: s.source as McpServer["source"],
+            });
+          }
+        }
+
+        const all = Array.from(merged.values());
+        setServers(all);
+        // Pre-select everything: already-saved + newly detected.
+        setSelected(new Set(all.map((s) => s.name)));
+
+        // If nothing to show and nothing was saved, close automatically
+        // (first-time add-repo with no MCPs).
+        if (all.length === 0 && savedNames.size === 0) {
+          closeModal();
+        }
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, [repoId, closeModal]);
+
+  const toggleServer = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const selectedServers = servers.filter((s) => selected.has(s.name));
+      await saveRepositoryMcps(repoId, selectedServers);
+      closeModal();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Modal title="MCP Servers" onClose={closeModal}>
+        <div className={styles.loading}>Detecting MCP servers...</div>
+      </Modal>
+    );
+  }
+
+  if (servers.length === 0) {
+    return (
+      <Modal title="MCP Servers" onClose={closeModal}>
+        <p className={styles.description}>
+          No non-portable MCP servers detected for this repository.
+        </p>
+        <div className={shared.actions}>
+          <button className={shared.btn} onClick={closeModal}>
+            Close
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal title="MCP Servers Detected" onClose={closeModal}>
+      <p className={styles.description}>
+        These MCP servers are configured for this project but won't be
+        automatically available in workspaces. Select which to include:
+      </p>
+
+      <div className={styles.serverList}>
+        {servers.map((server) => (
+          <label key={server.name} className={styles.serverRow}>
+            <input
+              type="checkbox"
+              checked={selected.has(server.name)}
+              onChange={() => toggleServer(server.name)}
+            />
+            <div className={styles.serverInfo}>
+              <div className={styles.serverHeader}>
+                <span className={styles.serverName}>{server.name}</span>
+                <span className={styles.badge}>
+                  {getTransportType(server.config)}
+                </span>
+                <span className={styles.source}>
+                  {SOURCE_LABELS[server.source] ?? server.source}
+                </span>
+              </div>
+              <div className={styles.serverDetail}>
+                {getConfigSummary(server.config)}
+              </div>
+            </div>
+          </label>
+        ))}
+      </div>
+
+      {error && <div className={shared.error}>{error}</div>}
+
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={closeModal}>
+          Skip
+        </button>
+        <button
+          className={shared.btnPrimary}
+          onClick={handleSave}
+          disabled={saving || selected.size === 0}
+        >
+          {saving ? "Saving..." : "Save Selections"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/McpSelectionModal.tsx
+++ b/src/ui/src/components/modals/McpSelectionModal.tsx
@@ -184,7 +184,7 @@ export function McpSelectionModal() {
         <button
           className={shared.btnPrimary}
           onClick={handleSave}
-          disabled={saving || selected.size === 0}
+          disabled={saving}
         >
           {saving ? "Saving..." : "Save Selections"}
         </button>

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -7,6 +7,7 @@ import { RelinkRepoModal } from "./RelinkRepoModal";
 import { RollbackModal } from "./RollbackModal";
 import { ShareModal } from "./ShareModal";
 import { ConfirmSetupScriptModal } from "./ConfirmSetupScriptModal";
+import { McpSelectionModal } from "./McpSelectionModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -28,6 +29,8 @@ export function ModalRouter() {
       return <ShareModal />;
     case "confirmSetupScript":
       return <ConfirmSetupScriptModal />;
+    case "mcpSelection":
+      return <McpSelectionModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -517,6 +517,71 @@
   text-decoration: underline;
 }
 
+/* ── MCP server list ── */
+
+.mcpList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mcpRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+.mcpRow:hover {
+  background: var(--hover-bg);
+}
+
+.mcpInfo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.mcpName {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.mcpBadge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--selected-bg);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.mcpSource {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.mcpRemoveBtn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.mcpRemoveBtn:hover {
+  background: rgba(204, 51, 51, 0.15);
+  color: var(--status-stopped);
+}
+
 /* ── Placeholder ── */
 
 .placeholder {

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -341,9 +341,14 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
                   <button
                     className={styles.mcpRemoveBtn}
                     title="Remove this MCP server"
+                    aria-label={`Remove MCP server ${server.name}`}
                     onClick={async () => {
-                      await deleteRepositoryMcp(server.id);
-                      refreshMcpServers();
+                      try {
+                        await deleteRepositoryMcp(server.id);
+                        refreshMcpServers();
+                      } catch (e) {
+                        setError(String(e));
+                      }
                     }}
                   >
                     ×

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { updateRepositorySettings, getRepoConfig } from "../../../services/tauri";
+import {
+  loadRepositoryMcps,
+  deleteRepositoryMcp,
+} from "../../../services/mcp";
 import type { RepoConfigInfo } from "../../../types/repository";
+import type { SavedMcpServer } from "../../../types/mcp";
 import { RepoIcon } from "../../shared/RepoIcon";
 import { IconPicker } from "../../modals/IconPicker";
 import styles from "../Settings.module.css";
@@ -12,6 +17,7 @@ interface RepoSettingsProps {
 
 export function RepoSettings({ repoId }: RepoSettingsProps) {
   const openModal = useAppStore((s) => s.openModal);
+  const activeModal = useAppStore((s) => s.activeModal);
   const updateRepo = useAppStore((s) => s.updateRepository);
   const repositories = useAppStore((s) => s.repositories);
 
@@ -29,6 +35,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [repoConfig, setRepoConfig] = useState<RepoConfigInfo | null>(null);
+  const [mcpServers, setMcpServers] = useState<SavedMcpServer[]>([]);
   const iconPopoverRef = useRef<HTMLDivElement>(null);
 
   // Reset local state only when switching to a different repo
@@ -48,6 +55,25 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
       .then(setRepoConfig)
       .catch(() => setRepoConfig(null));
   }, [repoId]);
+
+  const refreshMcpServers = useCallback(() => {
+    loadRepositoryMcps(repoId)
+      .then(setMcpServers)
+      .catch(() => setMcpServers([]));
+  }, [repoId]);
+
+  useEffect(() => {
+    refreshMcpServers();
+  }, [refreshMcpServers]);
+
+  // Refresh MCP list when the selection modal closes (user may have saved new MCPs).
+  const prevModal = useRef(activeModal);
+  useEffect(() => {
+    if (prevModal.current === "mcpSelection" && activeModal === null) {
+      refreshMcpServers();
+    }
+    prevModal.current = activeModal;
+  }, [activeModal, refreshMcpServers]);
 
   // Close icon picker on click outside
   useEffect(() => {
@@ -273,6 +299,68 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           placeholder="Add your preferences here. The agent will be told to prioritize these instructions over its default instructions."
           rows={3}
         />
+      </div>
+
+      <div className={styles.fieldGroup}>
+        <div className={styles.fieldLabel}>MCP servers</div>
+        <div className={styles.fieldHint} style={{ marginBottom: 12 }}>
+          Non-portable MCP servers injected into agent sessions via{" "}
+          <code>--mcp-config</code>. These are servers from your user config or
+          gitignored repo config that aren't automatically available in
+          worktrees.
+        </div>
+        {mcpServers.length === 0 ? (
+          <div className={styles.fieldHint}>
+            No MCP servers configured for this repository.
+          </div>
+        ) : (
+          <div className={styles.mcpList}>
+            {mcpServers.map((server) => {
+              let transport = "unknown";
+              try {
+                const cfg = JSON.parse(server.config_json);
+                if (cfg.command) transport = "stdio";
+                else if (cfg.url) transport = "http";
+                if (cfg.type) transport = cfg.type;
+              } catch {
+                /* ignore parse errors */
+              }
+              const sourceLabel =
+                server.source === "user_project_config"
+                  ? "~/.claude.json"
+                  : server.source === "repo_local_config"
+                    ? ".claude.json"
+                    : server.source;
+              return (
+                <div key={server.id} className={styles.mcpRow}>
+                  <div className={styles.mcpInfo}>
+                    <span className={styles.mcpName}>{server.name}</span>
+                    <span className={styles.mcpBadge}>{transport}</span>
+                    <span className={styles.mcpSource}>{sourceLabel}</span>
+                  </div>
+                  <button
+                    className={styles.mcpRemoveBtn}
+                    title="Remove this MCP server"
+                    onClick={async () => {
+                      await deleteRepositoryMcp(server.id);
+                      refreshMcpServers();
+                    }}
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <div style={{ marginTop: 8 }}>
+          <button
+            className={styles.iconBtn}
+            onClick={() => openModal("mcpSelection", { repoId })}
+          >
+            Re-detect &amp; add servers
+          </button>
+        </div>
       </div>
 
       <div className={styles.dangerZone}>

--- a/src/ui/src/services/mcp.ts
+++ b/src/ui/src/services/mcp.ts
@@ -1,0 +1,23 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { McpServer, SavedMcpServer } from "../types/mcp";
+
+export function detectMcpServers(repoId: string): Promise<McpServer[]> {
+  return invoke("detect_mcp_servers", { repoId });
+}
+
+export function saveRepositoryMcps(
+  repoId: string,
+  servers: McpServer[],
+): Promise<void> {
+  return invoke("save_repository_mcps", { repoId, servers });
+}
+
+export function loadRepositoryMcps(
+  repoId: string,
+): Promise<SavedMcpServer[]> {
+  return invoke("load_repository_mcps", { repoId });
+}
+
+export function deleteRepositoryMcp(serverId: string): Promise<void> {
+  return invoke("delete_repository_mcp", { serverId });
+}

--- a/src/ui/src/types/mcp.ts
+++ b/src/ui/src/types/mcp.ts
@@ -1,0 +1,19 @@
+/** Where the MCP server configuration was detected from. */
+export type McpSource = "user_project_config" | "repo_local_config";
+
+/** A detected MCP server (returned by detect_mcp_servers). */
+export interface McpServer {
+  name: string;
+  config: Record<string, unknown>;
+  source: McpSource;
+}
+
+/** A saved MCP server row from the database (returned by load_repository_mcps). */
+export interface SavedMcpServer {
+  id: string;
+  repository_id: string;
+  name: string;
+  config_json: string;
+  source: string;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

- Detect non-portable MCP servers (user project-scoped in `~/.claude.json`, gitignored repo `.claude.json`) when adding a repository
- Store selected MCP configs in SQLite (`repository_mcp_servers` table, migration v15)
- Inject stored MCPs at agent spawn time via `--mcp-config` flag on first turn
- Manage MCP selections in repo settings: view, remove, and re-detect servers

### New files
- `src/mcp.rs` — detection module with 11 unit tests
- `src-tauri/src/commands/mcp.rs` — 4 Tauri commands (detect, save, load, delete)
- `src/ui/src/components/modals/McpSelectionModal.tsx` — selection modal (add-repo + re-detect flows)
- `src/ui/src/types/mcp.ts`, `src/ui/src/services/mcp.ts` — frontend types and service wrappers

### Modified files
- `src/agent.rs` — `mcp_config` on `AgentSettings`, `--mcp-config` in `build_claude_args()`
- `src/db.rs` — migration v15 + CRUD for `repository_mcp_servers`
- `src-tauri/src/commands/chat.rs` — load MCPs from DB on first turn
- `src/ui/src/components/settings/sections/RepoSettings.tsx` — MCP management section
- `AddRepoModal.tsx`, `ModalRouter.tsx` — modal integration

Implements TDD from #175. Closes #170.

## Test plan

- [ ] Add a repo that has project-scoped MCPs in `~/.claude.json` — verify modal appears
- [ ] Add a repo with no non-portable MCPs — verify modal does NOT appear
- [ ] Add a repo with gitignored `.claude.json` containing MCPs — verify detection
- [ ] Select MCPs, create workspace, send message — verify agent has MCP access
- [ ] Skip MCPs — verify agent spawns without `--mcp-config`
- [ ] Open repo settings — verify saved MCPs listed with remove buttons
- [ ] Click "Re-detect & add servers" — verify modal merges detected + saved
- [ ] Remove an MCP from settings — verify next agent session doesn't include it
- [ ] `cargo test --all-features` passes (206 tests)
- [ ] `cargo clippy` clean, `cargo fmt` clean, `bunx tsc --noEmit` clean