### PR TITLE
feat(ui): add brain icon to thinking block header

### DIFF
--- a/src/ui/src/components/chat/ThinkingBlock.tsx
+++ b/src/ui/src/components/chat/ThinkingBlock.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Brain } from "lucide-react";
 import styles from "./ThinkingBlock.module.css";
 
 interface ThinkingBlockProps {
@@ -23,6 +24,7 @@ export function ThinkingBlock({ content, isStreaming }: ThinkingBlockProps) {
         <span className={`${styles.chevron} ${expanded ? styles.chevronExpanded : ""}`}>
           ›
         </span>
+        <Brain size={14} />
         <span className={styles.label}>{label}</span>
       </button>
       {expanded && (


### PR DESCRIPTION
## Summary

Adds the Brain Lucide icon to the `ThinkingBlock` component header, next to the "Thinking" / "Thinking…" label. This matches the existing pattern in `ChatToolbar` where the Brain icon appears next to the thinking toggle below the input.

The `.header` CSS already uses `display: flex` with `align-items: center` and `gap: 6px`, so the icon slots in with no styling changes.

## Test Steps

1. Run `cargo tauri dev` to start the app
2. Open a workspace and start an agent chat with extended thinking enabled
3. Observe the ThinkingBlock that appears while the agent thinks — it should now show a brain icon between the chevron and the "Thinking" label
4. Verify the icon color matches the label text (both inherit `var(--text-dim)`)
5. Click to expand/collapse the thinking block — icon should remain properly aligned

## Checklist

- [x] Tests added/updated (TypeScript type check passes, no runtime logic changed)
- [ ] Documentation updated (if applicable) — N/A