### PR TITLE
fix: resolve claude CLI path for GUI-launched apps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3"
 rusqlite = { version = "0.34", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync"] }
+tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync", "rt"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 open = "5"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.94"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.94"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -314,72 +314,123 @@ pub fn build_claude_args(
 // Claude CLI path resolution
 // ---------------------------------------------------------------------------
 
-/// Resolve the full path to the `claude` CLI binary.
+/// Resolve the full path to the `claude` CLI binary (async-safe).
 ///
 /// GUI apps on macOS (and some Linux desktop environments) don't inherit the
 /// user's shell PATH, so a bare `Command::new("claude")` fails with ENOENT.
 /// We check well-known install locations first, then fall back to asking the
 /// user's login shell for its PATH (cached for the lifetime of the process).
-fn resolve_claude_path() -> OsString {
+///
+/// The login-shell probe uses `std::process::Command` (blocking), so we run
+/// the entire resolution inside `spawn_blocking` on first call and cache the
+/// result in a `OnceLock` for subsequent calls.
+async fn resolve_claude_path() -> OsString {
     static RESOLVED: OnceLock<OsString> = OnceLock::new();
-    RESOLVED
-        .get_or_init(|| {
-            // 1. Well-known install locations.
-            if let Some(home) = dirs::home_dir() {
-                let candidates = [
-                    home.join(".local/bin/claude"),
-                    home.join(".claude/local/claude"),
-                ];
-                for p in &candidates {
-                    if p.is_file() {
-                        return p.clone().into_os_string();
-                    }
-                }
-            }
+    if let Some(cached) = RESOLVED.get() {
+        return cached.clone();
+    }
+    let resolved = tokio::task::spawn_blocking(|| {
+        resolve_claude_path_inner(dirs::home_dir(), login_shell_path(), |p| p.is_file())
+    })
+    .await
+    .unwrap_or_else(|_| OsString::from("claude"));
+    // Another task may have raced us — that's fine, OnceLock deduplicates.
+    let _ = RESOLVED.set(resolved.clone());
+    resolved
+}
 
-            // System-wide locations (macOS + Linux).
-            let system_candidates = [
-                PathBuf::from("/usr/local/bin/claude"),
-                PathBuf::from("/opt/homebrew/bin/claude"), // macOS Homebrew
-            ];
-            for p in &system_candidates {
-                if p.is_file() {
-                    return p.clone().into_os_string();
-                }
+/// Pure, testable search logic — no filesystem or process side effects.
+///
+/// `home` is the user's home directory (if available), `shell_path` is the
+/// colon-separated PATH obtained from the login shell (if available), and
+/// `exists` is a predicate that returns true if the given path points to an
+/// existing file.
+fn resolve_claude_path_inner(
+    home: Option<PathBuf>,
+    shell_path: Option<OsString>,
+    exists: impl Fn(&Path) -> bool,
+) -> OsString {
+    // 1. Well-known install locations under $HOME.
+    if let Some(home) = home {
+        let candidates = [
+            home.join(".local/bin/claude"),
+            home.join(".claude/local/claude"),
+        ];
+        for p in &candidates {
+            if exists(p) {
+                return p.clone().into_os_string();
             }
+        }
+    }
 
-            // 2. Ask the login shell for its PATH and search there.
-            if let Some(shell_path) = login_shell_path() {
-                for dir in std::env::split_paths(&shell_path) {
-                    let candidate = dir.join("claude");
-                    if candidate.is_file() {
-                        return candidate.into_os_string();
-                    }
-                }
+    // System-wide locations (macOS + Linux).
+    let system_candidates = [
+        PathBuf::from("/usr/local/bin/claude"),
+        PathBuf::from("/opt/homebrew/bin/claude"), // macOS Homebrew
+    ];
+    for p in &system_candidates {
+        if exists(p) {
+            return p.clone().into_os_string();
+        }
+    }
+
+    // 2. Search directories from the login shell's PATH.
+    if let Some(shell_path) = shell_path {
+        for dir in std::env::split_paths(&shell_path) {
+            let candidate = dir.join("claude");
+            if exists(&candidate) {
+                return candidate.into_os_string();
             }
+        }
+    }
 
-            // 3. Last resort — bare name, will rely on the process PATH.
-            OsString::from("claude")
-        })
-        .clone()
+    // 3. Last resort — bare name, will rely on the process PATH.
+    OsString::from("claude")
 }
 
 /// Get the PATH as seen by the user's login shell.
 ///
-/// Runs `$SHELL -l -c 'echo $PATH'` to pick up profile/rc files that
-/// desktop-launched apps don't source. Returns `None` on platforms where
-/// `$SHELL` isn't set (shouldn't happen on macOS/Linux in practice).
+/// Runs `$SHELL -l -c 'printf "%s\n" "$PATH"'` to pick up profile/rc files
+/// that desktop-launched apps don't source. For fish shells, uses
+/// `string join :` to convert fish's space-separated list to colon-separated.
+///
+/// If the shell prints startup output (motd, banner, etc.), only the last
+/// non-empty line is used as the PATH value.
+///
+/// Returns `None` if `$SHELL` is unset or not an absolute path.
 fn login_shell_path() -> Option<OsString> {
     let shell = std::env::var("SHELL").ok()?;
+
+    // Validate: must be an absolute path.
+    if !shell.starts_with('/') {
+        return None;
+    }
+
+    // Fish treats $PATH as a list and prints space-separated entries.
+    // Convert to colon-separated so std::env::split_paths works correctly.
+    let is_fish = shell.ends_with("/fish");
+    let cmd_arg = if is_fish {
+        r#"printf '%s\n' (string join : $PATH)"#
+    } else {
+        r#"printf '%s\n' "$PATH""#
+    };
+
     let output = std::process::Command::new(&shell)
-        .args(["-l", "-c", "echo $PATH"])
+        .args(["-l", "-c", cmd_arg])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
         .output()
         .ok()?;
+
     if output.status.success() {
-        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Take the last non-empty line to skip any startup banner output.
+        let path = stdout
+            .lines()
+            .rev()
+            .find(|line| !line.trim().is_empty())
+            .map(|line| line.trim().to_string())?;
         if !path.is_empty() {
             return Some(OsString::from(path));
         }
@@ -412,7 +463,7 @@ pub async fn run_turn(
         settings,
     );
 
-    let mut cmd = Command::new(resolve_claude_path());
+    let mut cmd = Command::new(resolve_claude_path().await);
     cmd.args(&args)
         .current_dir(working_dir)
         .stdin(std::process::Stdio::null())
@@ -567,7 +618,7 @@ pub async fn generate_branch_name(
     // Truncate prompt to keep the Haiku call fast and cheap.
     let truncated: String = prompt_text.chars().take(200).collect();
 
-    let mut cmd = Command::new(resolve_claude_path());
+    let mut cmd = Command::new(resolve_claude_path().await);
     cmd.stdin(std::process::Stdio::null());
     // Run in the user's worktree so the CLI loads *their* project context.
     cmd.current_dir(worktree_path);
@@ -1378,5 +1429,82 @@ mod tests {
         };
         let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
         assert!(!args.contains(&"--chrome".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_claude_path_inner tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_prefers_home_local_bin() {
+        let home = PathBuf::from("/home/user");
+        let expected = home.join(".local/bin/claude");
+        let result = resolve_claude_path_inner(Some(home.clone()), None, |p| p == expected);
+        assert_eq!(result, expected.into_os_string());
+    }
+
+    #[test]
+    fn test_resolve_prefers_home_claude_local() {
+        let home = PathBuf::from("/home/user");
+        let expected = home.join(".claude/local/claude");
+        let result = resolve_claude_path_inner(Some(home.clone()), None, |p| p == expected);
+        assert_eq!(result, expected.into_os_string());
+    }
+
+    #[test]
+    fn test_resolve_prefers_home_over_system() {
+        let home = PathBuf::from("/home/user");
+        let home_path = home.join(".local/bin/claude");
+        let result = resolve_claude_path_inner(Some(home), None, |p| {
+            p == home_path || p == Path::new("/usr/local/bin/claude")
+        });
+        assert_eq!(result, home_path.into_os_string());
+    }
+
+    #[test]
+    fn test_resolve_falls_back_to_system() {
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_path_inner(Some(home), None, |p| {
+            p == Path::new("/usr/local/bin/claude")
+        });
+        assert_eq!(result, OsString::from("/usr/local/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_falls_back_to_homebrew() {
+        let result =
+            resolve_claude_path_inner(None, None, |p| p == Path::new("/opt/homebrew/bin/claude"));
+        assert_eq!(result, OsString::from("/opt/homebrew/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_searches_shell_path() {
+        let shell_path = OsString::from("/custom/bin:/another/bin");
+        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
+            p == Path::new("/another/bin/claude")
+        });
+        assert_eq!(result, OsString::from("/another/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_prefers_system_over_shell_path() {
+        let shell_path = OsString::from("/custom/bin");
+        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
+            p == Path::new("/usr/local/bin/claude") || p == Path::new("/custom/bin/claude")
+        });
+        assert_eq!(result, OsString::from("/usr/local/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_bare_fallback() {
+        let result = resolve_claude_path_inner(None, None, |_| false);
+        assert_eq!(result, OsString::from("claude"));
+    }
+
+    #[test]
+    fn test_resolve_no_home_still_checks_system() {
+        let result =
+            resolve_claude_path_inner(None, None, |p| p == Path::new("/usr/local/bin/claude"));
+        assert_eq!(result, OsString::from("/usr/local/bin/claude"));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
-use std::path::Path;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -308,6 +310,83 @@ pub fn build_claude_args(
     args
 }
 
+// ---------------------------------------------------------------------------
+// Claude CLI path resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve the full path to the `claude` CLI binary.
+///
+/// GUI apps on macOS (and some Linux desktop environments) don't inherit the
+/// user's shell PATH, so a bare `Command::new("claude")` fails with ENOENT.
+/// We check well-known install locations first, then fall back to asking the
+/// user's login shell for its PATH (cached for the lifetime of the process).
+fn resolve_claude_path() -> OsString {
+    static RESOLVED: OnceLock<OsString> = OnceLock::new();
+    RESOLVED
+        .get_or_init(|| {
+            // 1. Well-known install locations.
+            if let Some(home) = dirs::home_dir() {
+                let candidates = [
+                    home.join(".local/bin/claude"),
+                    home.join(".claude/local/claude"),
+                ];
+                for p in &candidates {
+                    if p.is_file() {
+                        return p.clone().into_os_string();
+                    }
+                }
+            }
+
+            // System-wide locations (macOS + Linux).
+            let system_candidates = [
+                PathBuf::from("/usr/local/bin/claude"),
+                PathBuf::from("/opt/homebrew/bin/claude"), // macOS Homebrew
+            ];
+            for p in &system_candidates {
+                if p.is_file() {
+                    return p.clone().into_os_string();
+                }
+            }
+
+            // 2. Ask the login shell for its PATH and search there.
+            if let Some(shell_path) = login_shell_path() {
+                for dir in std::env::split_paths(&shell_path) {
+                    let candidate = dir.join("claude");
+                    if candidate.is_file() {
+                        return candidate.into_os_string();
+                    }
+                }
+            }
+
+            // 3. Last resort — bare name, will rely on the process PATH.
+            OsString::from("claude")
+        })
+        .clone()
+}
+
+/// Get the PATH as seen by the user's login shell.
+///
+/// Runs `$SHELL -l -c 'echo $PATH'` to pick up profile/rc files that
+/// desktop-launched apps don't source. Returns `None` on platforms where
+/// `$SHELL` isn't set (shouldn't happen on macOS/Linux in practice).
+fn login_shell_path() -> Option<OsString> {
+    let shell = std::env::var("SHELL").ok()?;
+    let output = std::process::Command::new(&shell)
+        .args(["-l", "-c", "echo $PATH"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if output.status.success() {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Some(OsString::from(path));
+        }
+    }
+    None
+}
+
 /// Run a single agent turn by spawning `claude -p` with the given prompt.
 ///
 /// For the first turn, uses `--session-id` to establish the session.
@@ -333,7 +412,7 @@ pub async fn run_turn(
         settings,
     );
 
-    let mut cmd = Command::new("claude");
+    let mut cmd = Command::new(resolve_claude_path());
     cmd.args(&args)
         .current_dir(working_dir)
         .stdin(std::process::Stdio::null())
@@ -488,7 +567,7 @@ pub async fn generate_branch_name(
     // Truncate prompt to keep the Haiku call fast and cheap.
     let truncated: String = prompt_text.chars().take(200).collect();
 
-    let mut cmd = Command::new("claude");
+    let mut cmd = Command::new(resolve_claude_path());
     cmd.stdin(std::process::Stdio::null());
     // Run in the user's worktree so the CLI loads *their* project context.
     cmd.current_dir(worktree_path);

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -318,35 +318,38 @@ pub fn build_claude_args(
 ///
 /// GUI apps on macOS (and some Linux desktop environments) don't inherit the
 /// user's shell PATH, so a bare `Command::new("claude")` fails with ENOENT.
-/// We check well-known install locations first, then fall back to asking the
-/// user's login shell for its PATH (cached for the lifetime of the process).
+/// We first check the current process PATH, then ask the user's login shell
+/// for its PATH, then try well-known install locations, and finally fall back
+/// to a bare `claude` command.
 ///
-/// The login-shell probe uses `std::process::Command` (blocking), so we run
-/// the entire resolution inside `spawn_blocking` on first call and cache the
-/// result in a `OnceLock` for subsequent calls. A 5-second timeout guards
-/// against broken or hanging shell init scripts.
+/// Successful absolute-path resolutions are cached in a `OnceLock` for the
+/// lifetime of the process. The bare `"claude"` fallback is NOT cached, so
+/// subsequent calls can retry resolution if the environment improves (e.g.,
+/// a slow shell probe that timed out on first call).
+///
+/// The login-shell probe uses `std::process::Command` (blocking) with a
+/// 5-second timeout that kills the subprocess on expiry. We run the entire
+/// resolution inside `spawn_blocking` to avoid stalling async workers.
 async fn resolve_claude_path() -> OsString {
     static RESOLVED: OnceLock<OsString> = OnceLock::new();
     if let Some(cached) = RESOLVED.get() {
         return cached.clone();
     }
-    let resolved = tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        tokio::task::spawn_blocking(|| {
-            resolve_claude_path_inner(
-                dirs::home_dir(),
-                std::env::var_os("PATH"),
-                login_shell_path,
-                is_executable_file,
-            )
-        }),
-    )
+    let resolved = tokio::task::spawn_blocking(|| {
+        resolve_claude_path_inner(
+            dirs::home_dir(),
+            std::env::var_os("PATH"),
+            login_shell_path,
+            is_executable_file,
+        )
+    })
     .await
-    .ok() // timeout elapsed → None
-    .and_then(|r| r.ok()) // spawn_blocking JoinError → None
-    .unwrap_or_else(|| OsString::from("claude"));
-    // Another task may have raced us — that's fine, OnceLock deduplicates.
-    let _ = RESOLVED.set(resolved.clone());
+    .unwrap_or_else(|_| OsString::from("claude"));
+    // Only cache absolute paths — the bare "claude" fallback should allow
+    // retries on subsequent calls in case the environment improves.
+    if Path::new(&resolved).is_absolute() {
+        let _ = RESOLVED.set(resolved.clone());
+    }
     resolved
 }
 
@@ -455,6 +458,9 @@ fn search_path_dirs(path: &std::ffi::OsStr, exists: &impl Fn(&Path) -> bool) -> 
 /// If the shell prints startup output (motd, banner, etc.), only the last
 /// non-empty line is used as the PATH value.
 ///
+/// A 5-second timeout kills the subprocess if the shell init hangs (nvm,
+/// pyenv, etc.), preventing leaked processes.
+///
 /// Returns `None` if `$SHELL` is unset or not an absolute path.
 fn login_shell_path() -> Option<OsString> {
     let shell = std::env::var("SHELL").ok()?;
@@ -473,27 +479,53 @@ fn login_shell_path() -> Option<OsString> {
         r#"printf '%s\n' "$PATH""#
     };
 
-    let output = std::process::Command::new(&shell)
+    let mut child = std::process::Command::new(&shell)
         .args(["-l", "-c", cmd_arg])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
-        .output()
+        .spawn()
         .ok()?;
 
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        // Take the last non-empty line to skip any startup banner output.
-        let path = stdout
-            .lines()
-            .rev()
-            .find(|line| !line.trim().is_empty())
-            .map(|line| line.trim().to_string())?;
-        if !path.is_empty() {
-            return Some(OsString::from(path));
+    // Wait up to 5 seconds. If the shell init hangs (nvm, pyenv, etc.),
+    // kill the subprocess to avoid leaking a stuck process.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(_) => break None,
         }
+    };
+
+    let status = status?;
+    if !status.success() {
+        return None;
     }
-    None
+
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        use std::io::Read;
+        let _ = out.read_to_string(&mut stdout);
+    }
+    // Take the last non-empty line to skip any startup banner output.
+    let path = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.trim().to_string())?;
+    if path.is_empty() {
+        None
+    } else {
+        Some(OsString::from(path))
+    }
 }
 
 /// Run a single agent turn by spawning `claude -p` with the given prompt.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -323,17 +323,28 @@ pub fn build_claude_args(
 ///
 /// The login-shell probe uses `std::process::Command` (blocking), so we run
 /// the entire resolution inside `spawn_blocking` on first call and cache the
-/// result in a `OnceLock` for subsequent calls.
+/// result in a `OnceLock` for subsequent calls. A 5-second timeout guards
+/// against broken or hanging shell init scripts.
 async fn resolve_claude_path() -> OsString {
     static RESOLVED: OnceLock<OsString> = OnceLock::new();
     if let Some(cached) = RESOLVED.get() {
         return cached.clone();
     }
-    let resolved = tokio::task::spawn_blocking(|| {
-        resolve_claude_path_inner(dirs::home_dir(), login_shell_path(), is_executable_file)
-    })
+    let resolved = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio::task::spawn_blocking(|| {
+            resolve_claude_path_inner(
+                dirs::home_dir(),
+                std::env::var_os("PATH"),
+                login_shell_path,
+                is_executable_file,
+            )
+        }),
+    )
     .await
-    .unwrap_or_else(|_| OsString::from("claude"));
+    .ok() // timeout elapsed → None
+    .and_then(|r| r.ok()) // spawn_blocking JoinError → None
+    .unwrap_or_else(|| OsString::from("claude"));
     // Another task may have raced us — that's fine, OnceLock deduplicates.
     let _ = RESOLVED.set(resolved.clone());
     resolved
@@ -358,56 +369,81 @@ fn is_executable_file(path: &Path) -> bool {
 
 /// Pure, testable search logic — no filesystem or process side effects.
 ///
-/// `home` is the user's home directory (if available), `shell_path` is the
-/// colon-separated PATH obtained from the login shell (if available), and
-/// `exists` is a predicate that returns true if the given path points to an
-/// existing file.
+/// Resolution order respects the user's configured PATH first, then falls
+/// back to progressively more expensive probes:
+///
+/// 1. Process PATH (cheap — honours shims, asdf, mise, Nix profiles, etc.)
+/// 2. Login shell PATH (deferred — only runs if #1 missed, handles GUI launch)
+/// 3. Well-known install locations (static fallback paths)
+/// 4. Bare `"claude"` (absolute last resort)
+///
+/// All PATH searches skip non-absolute entries to prevent repo-local execution.
+/// The `shell_path_probe` closure is called lazily so we don't pay the
+/// shell-spawn cost when the process PATH already found claude.
 fn resolve_claude_path_inner(
     home: Option<PathBuf>,
-    shell_path: Option<OsString>,
+    process_path: Option<OsString>,
+    shell_path_probe: impl FnOnce() -> Option<OsString>,
     exists: impl Fn(&Path) -> bool,
 ) -> OsString {
-    // 1. Well-known install locations under $HOME.
-    if let Some(home) = home {
-        let candidates = [
-            home.join(".local/bin/claude"),
-            home.join(".claude/local/claude"),
-        ];
-        for p in &candidates {
-            if exists(p) {
-                return p.clone().into_os_string();
-            }
-        }
+    // 1. Search the process PATH first. This respects the user's configured
+    //    environment, including shims (asdf, mise, Nix, pnpm, etc.).
+    //    Skip non-absolute entries (e.g. "." or "") to avoid resolving a
+    //    repo-local `claude` binary relative to the working directory.
+    if let Some(process_path) = process_path
+        && let Some(found) = search_path_dirs(&process_path, &exists)
+    {
+        return found;
     }
 
-    // System-wide locations (macOS + Linux).
-    let system_candidates = [
+    // 2. Probe the login shell's PATH. GUI-launched apps on macOS don't
+    //    inherit the user's shell PATH, so this catches the common case
+    //    where process PATH is empty/minimal. Deferred to here so we don't
+    //    pay the shell-spawn cost when process PATH already found claude.
+    if let Some(shell_path) = shell_path_probe()
+        && let Some(found) = search_path_dirs(&shell_path, &exists)
+    {
+        return found;
+    }
+
+    // 3. Well-known install locations as static fallbacks.
+    let mut fallback_candidates: Vec<PathBuf> = Vec::new();
+    if let Some(ref home) = home {
+        fallback_candidates.extend([
+            home.join(".local/bin/claude"),
+            home.join(".claude/local/claude"),
+            home.join(".nix-profile/bin/claude"), // Nix single-user
+        ]);
+    }
+    fallback_candidates.extend([
         PathBuf::from("/usr/local/bin/claude"),
         PathBuf::from("/opt/homebrew/bin/claude"), // macOS Homebrew
-    ];
-    for p in &system_candidates {
+        PathBuf::from("/run/current-system/sw/bin/claude"), // NixOS system
+        PathBuf::from("/nix/var/nix/profiles/default/bin/claude"), // Nix multi-user
+    ]);
+    for p in &fallback_candidates {
         if exists(p) {
             return p.clone().into_os_string();
         }
     }
 
-    // 2. Search directories from the login shell's PATH.
-    //    Skip non-absolute entries (e.g. "." or "") to avoid resolving a
-    //    repo-local `claude` binary relative to the working directory.
-    if let Some(shell_path) = shell_path {
-        for dir in std::env::split_paths(&shell_path) {
-            if !dir.is_absolute() {
-                continue;
-            }
-            let candidate = dir.join("claude");
-            if exists(&candidate) {
-                return candidate.into_os_string();
-            }
+    // 4. Nothing found — bare name as absolute last resort.
+    OsString::from("claude")
+}
+
+/// Search colon-separated PATH directories for a `claude` binary.
+/// Skips non-absolute entries to prevent repo-local execution.
+fn search_path_dirs(path: &std::ffi::OsStr, exists: &impl Fn(&Path) -> bool) -> Option<OsString> {
+    for dir in std::env::split_paths(path) {
+        if !dir.is_absolute() {
+            continue;
+        }
+        let candidate = dir.join("claude");
+        if exists(&candidate) {
+            return Some(candidate.into_os_string());
         }
     }
-
-    // 3. Last resort — bare name, will rely on the process PATH.
-    OsString::from("claude")
+    None
 }
 
 /// Get the PATH as seen by the user's login shell.
@@ -1461,36 +1497,77 @@ mod tests {
     // resolve_claude_path_inner tests
     // -----------------------------------------------------------------------
 
+    // Helper: no shell probe (returns None).
+    fn no_shell() -> Option<OsString> {
+        None
+    }
+
     #[test]
-    fn test_resolve_prefers_home_local_bin() {
+    fn test_resolve_process_path_wins() {
+        // Process PATH is checked first and should win over everything.
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_path_inner(
+            Some(home.clone()),
+            Some(OsString::from("/custom/bin")),
+            no_shell,
+            |p| {
+                p == Path::new("/custom/bin/claude")
+                    || p == home.join(".local/bin/claude")
+                    || p == Path::new("/usr/local/bin/claude")
+            },
+        );
+        assert_eq!(result, OsString::from("/custom/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_shell_path_before_well_known() {
+        // When process PATH misses, shell probe runs before well-known paths.
+        let shell_path = OsString::from("/shell/bin");
+        let result = resolve_claude_path_inner(
+            None,
+            None, // empty process PATH
+            || Some(shell_path),
+            |p| p == Path::new("/shell/bin/claude") || p == Path::new("/usr/local/bin/claude"),
+        );
+        assert_eq!(result, OsString::from("/shell/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_shell_probe_deferred() {
+        // Shell probe should NOT run if process PATH already found claude.
+        let probed = std::sync::atomic::AtomicBool::new(false);
+        let result = resolve_claude_path_inner(
+            None,
+            Some(OsString::from("/good/bin")),
+            || {
+                probed.store(true, std::sync::atomic::Ordering::SeqCst);
+                Some(OsString::from("/shell/bin"))
+            },
+            |p| p == Path::new("/good/bin/claude") || p == Path::new("/shell/bin/claude"),
+        );
+        assert_eq!(result, OsString::from("/good/bin/claude"));
+        assert!(!probed.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_resolve_falls_back_to_well_known_home() {
         let home = PathBuf::from("/home/user");
         let expected = home.join(".local/bin/claude");
-        let result = resolve_claude_path_inner(Some(home.clone()), None, |p| p == expected);
+        let result = resolve_claude_path_inner(Some(home), None, no_shell, |p| p == expected);
         assert_eq!(result, expected.into_os_string());
     }
 
     #[test]
-    fn test_resolve_prefers_home_claude_local() {
+    fn test_resolve_falls_back_to_claude_local() {
         let home = PathBuf::from("/home/user");
         let expected = home.join(".claude/local/claude");
-        let result = resolve_claude_path_inner(Some(home.clone()), None, |p| p == expected);
+        let result = resolve_claude_path_inner(Some(home), None, no_shell, |p| p == expected);
         assert_eq!(result, expected.into_os_string());
-    }
-
-    #[test]
-    fn test_resolve_prefers_home_over_system() {
-        let home = PathBuf::from("/home/user");
-        let home_path = home.join(".local/bin/claude");
-        let result = resolve_claude_path_inner(Some(home), None, |p| {
-            p == home_path || p == Path::new("/usr/local/bin/claude")
-        });
-        assert_eq!(result, home_path.into_os_string());
     }
 
     #[test]
     fn test_resolve_falls_back_to_system() {
-        let home = PathBuf::from("/home/user");
-        let result = resolve_claude_path_inner(Some(home), None, |p| {
+        let result = resolve_claude_path_inner(None, None, no_shell, |p| {
             p == Path::new("/usr/local/bin/claude")
         });
         assert_eq!(result, OsString::from("/usr/local/bin/claude"));
@@ -1498,76 +1575,93 @@ mod tests {
 
     #[test]
     fn test_resolve_falls_back_to_homebrew() {
-        let result =
-            resolve_claude_path_inner(None, None, |p| p == Path::new("/opt/homebrew/bin/claude"));
+        let result = resolve_claude_path_inner(None, None, no_shell, |p| {
+            p == Path::new("/opt/homebrew/bin/claude")
+        });
         assert_eq!(result, OsString::from("/opt/homebrew/bin/claude"));
     }
 
     #[test]
-    fn test_resolve_searches_shell_path() {
-        let shell_path = OsString::from("/custom/bin:/another/bin");
-        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
-            p == Path::new("/another/bin/claude")
-        });
-        assert_eq!(result, OsString::from("/another/bin/claude"));
+    fn test_resolve_finds_nix_profile() {
+        let home = PathBuf::from("/home/user");
+        let expected = home.join(".nix-profile/bin/claude");
+        let result = resolve_claude_path_inner(Some(home), None, no_shell, |p| p == expected);
+        assert_eq!(result, expected.into_os_string());
     }
 
     #[test]
-    fn test_resolve_prefers_system_over_shell_path() {
-        let shell_path = OsString::from("/custom/bin");
-        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
-            p == Path::new("/usr/local/bin/claude") || p == Path::new("/custom/bin/claude")
+    fn test_resolve_finds_nixos_system() {
+        let result = resolve_claude_path_inner(None, None, no_shell, |p| {
+            p == Path::new("/run/current-system/sw/bin/claude")
         });
-        assert_eq!(result, OsString::from("/usr/local/bin/claude"));
+        assert_eq!(result, OsString::from("/run/current-system/sw/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_home_before_system_in_fallbacks() {
+        // Within the well-known fallbacks, home paths are checked before system.
+        let home = PathBuf::from("/home/user");
+        let home_path = home.join(".local/bin/claude");
+        let result = resolve_claude_path_inner(Some(home), None, no_shell, |p| {
+            p == home_path || p == Path::new("/usr/local/bin/claude")
+        });
+        assert_eq!(result, home_path.into_os_string());
     }
 
     #[test]
     fn test_resolve_bare_fallback() {
-        let result = resolve_claude_path_inner(None, None, |_| false);
+        let result = resolve_claude_path_inner(None, None, no_shell, |_| false);
         assert_eq!(result, OsString::from("claude"));
     }
 
     #[test]
-    fn test_resolve_no_home_still_checks_system() {
-        let result =
-            resolve_claude_path_inner(None, None, |p| p == Path::new("/usr/local/bin/claude"));
-        assert_eq!(result, OsString::from("/usr/local/bin/claude"));
-    }
-
-    #[test]
-    fn test_resolve_skips_relative_path_entries() {
-        // A PATH containing "." or relative dirs should not match — prevents
-        // executing a repo-local `claude` binary.
-        let shell_path = OsString::from(".:/relative/bin:/abs/bin");
-        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
-            // Everything "exists" — only absolute entries should be checked.
-            p == Path::new("./claude")
-                || p == Path::new("relative/bin/claude")
-                || p == Path::new("/abs/bin/claude")
-        });
+    fn test_resolve_skips_relative_in_process_path() {
+        let result = resolve_claude_path_inner(
+            None,
+            Some(OsString::from(".:/relative/bin:/abs/bin")),
+            no_shell,
+            |p| {
+                p == Path::new("./claude")
+                    || p == Path::new("relative/bin/claude")
+                    || p == Path::new("/abs/bin/claude")
+            },
+        );
         assert_eq!(result, OsString::from("/abs/bin/claude"));
     }
 
     #[test]
     fn test_resolve_skips_empty_path_entry() {
-        // Empty segments in PATH (e.g. "/good/bin::") resolve to "." — must be
-        // skipped because they are not absolute.
-        let shell_path = OsString::from(":/good/bin:");
-        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
-            p == Path::new("/good/bin/claude")
-        });
+        let result =
+            resolve_claude_path_inner(None, Some(OsString::from(":/good/bin:")), no_shell, |p| {
+                p == Path::new("/good/bin/claude")
+            });
         assert_eq!(result, OsString::from("/good/bin/claude"));
     }
 
     #[test]
     fn test_resolve_all_relative_falls_through_to_bare() {
-        // If the shell PATH contains only relative entries and no well-known
-        // locations exist, fall through to the bare "claude" fallback.
-        let shell_path = OsString::from(".:./bin:relative");
-        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
-            // Only "exists" for relative candidates — system paths don't exist.
-            !p.is_absolute()
-        });
+        let result = resolve_claude_path_inner(
+            None,
+            Some(OsString::from(".:./bin:relative")),
+            no_shell,
+            |p| !p.is_absolute(),
+        );
         assert_eq!(result, OsString::from("claude"));
+    }
+
+    #[test]
+    fn test_search_path_dirs_skips_relative() {
+        let path = OsString::from(".:/tmp/evil:/good/bin");
+        let result = search_path_dirs(path.as_os_str(), &|p| {
+            p == Path::new("/tmp/evil/claude") || p == Path::new("/good/bin/claude")
+        });
+        assert_eq!(result, Some(OsString::from("/tmp/evil/claude")));
+    }
+
+    #[test]
+    fn test_search_path_dirs_returns_none_for_all_relative() {
+        let path = OsString::from(".:relative:./bin");
+        let result = search_path_dirs(path.as_os_str(), &|_| true);
+        assert_eq!(result, None);
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -330,13 +330,30 @@ async fn resolve_claude_path() -> OsString {
         return cached.clone();
     }
     let resolved = tokio::task::spawn_blocking(|| {
-        resolve_claude_path_inner(dirs::home_dir(), login_shell_path(), |p| p.is_file())
+        resolve_claude_path_inner(dirs::home_dir(), login_shell_path(), is_executable_file)
     })
     .await
     .unwrap_or_else(|_| OsString::from("claude"));
     // Another task may have raced us — that's fine, OnceLock deduplicates.
     let _ = RESOLVED.set(resolved.clone());
     resolved
+}
+
+/// Check that a path is a regular file with execute permission.
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.is_file()
+        && path
+            .metadata()
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+/// Check that a path is a regular file (non-Unix fallback).
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 /// Pure, testable search logic — no filesystem or process side effects.
@@ -375,8 +392,13 @@ fn resolve_claude_path_inner(
     }
 
     // 2. Search directories from the login shell's PATH.
+    //    Skip non-absolute entries (e.g. "." or "") to avoid resolving a
+    //    repo-local `claude` binary relative to the working directory.
     if let Some(shell_path) = shell_path {
         for dir in std::env::split_paths(&shell_path) {
+            if !dir.is_absolute() {
+                continue;
+            }
             let candidate = dir.join("claude");
             if exists(&candidate) {
                 return candidate.into_os_string();
@@ -463,7 +485,8 @@ pub async fn run_turn(
         settings,
     );
 
-    let mut cmd = Command::new(resolve_claude_path().await);
+    let claude_path = resolve_claude_path().await;
+    let mut cmd = Command::new(&claude_path);
     cmd.args(&args)
         .current_dir(working_dir)
         .stdin(std::process::Stdio::null())
@@ -484,7 +507,7 @@ pub async fn run_turn(
 
     let mut child = cmd
         .spawn()
-        .map_err(|e| format!("Failed to spawn claude: {e}"))?;
+        .map_err(|e| format!("Failed to spawn claude at {:?}: {e}", claude_path))?;
 
     let pid = child
         .id()
@@ -618,7 +641,8 @@ pub async fn generate_branch_name(
     // Truncate prompt to keep the Haiku call fast and cheap.
     let truncated: String = prompt_text.chars().take(200).collect();
 
-    let mut cmd = Command::new(resolve_claude_path().await);
+    let claude_path = resolve_claude_path().await;
+    let mut cmd = Command::new(&claude_path);
     cmd.stdin(std::process::Stdio::null());
     // Run in the user's worktree so the CLI loads *their* project context.
     cmd.current_dir(worktree_path);
@@ -658,10 +682,12 @@ pub async fn generate_branch_name(
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
-    let output = cmd
-        .output()
-        .await
-        .map_err(|e| format!("Failed to spawn claude for branch name: {e}"))?;
+    let output = cmd.output().await.map_err(|e| {
+        format!(
+            "Failed to spawn claude at {:?} for branch name: {e}",
+            claude_path
+        )
+    })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1506,5 +1532,42 @@ mod tests {
         let result =
             resolve_claude_path_inner(None, None, |p| p == Path::new("/usr/local/bin/claude"));
         assert_eq!(result, OsString::from("/usr/local/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_skips_relative_path_entries() {
+        // A PATH containing "." or relative dirs should not match — prevents
+        // executing a repo-local `claude` binary.
+        let shell_path = OsString::from(".:/relative/bin:/abs/bin");
+        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
+            // Everything "exists" — only absolute entries should be checked.
+            p == Path::new("./claude")
+                || p == Path::new("relative/bin/claude")
+                || p == Path::new("/abs/bin/claude")
+        });
+        assert_eq!(result, OsString::from("/abs/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_skips_empty_path_entry() {
+        // Empty segments in PATH (e.g. "/good/bin::") resolve to "." — must be
+        // skipped because they are not absolute.
+        let shell_path = OsString::from(":/good/bin:");
+        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
+            p == Path::new("/good/bin/claude")
+        });
+        assert_eq!(result, OsString::from("/good/bin/claude"));
+    }
+
+    #[test]
+    fn test_resolve_all_relative_falls_through_to_bare() {
+        // If the shell PATH contains only relative entries and no well-known
+        // locations exist, fall through to the bare "claude" fallback.
+        let shell_path = OsString::from(".:./bin:relative");
+        let result = resolve_claude_path_inner(None, Some(shell_path), |p| {
+            // Only "exists" for relative candidates — system paths don't exist.
+            !p.is_absolute()
+        });
+        assert_eq!(result, OsString::from("claude"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes `Failed to spawn claude: No such file or directory` when Claudette is launched from Finder/Dock, where the GUI process doesn't inherit the user's shell PATH.

Based on the work by @ogreface in #173 — all original commits are cherry-picked with authorship preserved.

### Resolution order
1. **Process PATH** (cheap — honours shims, asdf, mise, Nix profiles, etc.)
2. **Login shell PATH** (deferred — only probed if #1 missed, handles GUI launch)
3. **Well-known fallback paths** (~/.local/bin, ~/.claude/local, ~/.nix-profile/bin, /usr/local/bin, /opt/homebrew/bin, Nix system paths)
4. **Bare `claude`** (absolute last resort)

### Additional hardening (on top of #173)
- 5-second timeout on login shell probe to prevent hanging on broken shell init
- Shell probe deferred until process PATH misses (no cost when PATH works)
- Process PATH searched with relative-entry filtering before bare fallback
- Nix install paths added (~/.nix-profile/bin, /run/current-system/sw/bin, /nix/var/nix/profiles/default/bin)
- PATH precedence preserved — user's configured PATH wins over hard-coded locations
- 18 unit tests covering priority order, deferred probe, relative-entry rejection, fallbacks

### Review findings addressed
- Copilot: blocking shell probe, fish shell handling, relative PATH entries, error messages, test coverage
- Greptile: blocking subprocess in async context, fish PATH parsing
- Codex: deferred shell probe, PATH precedence over hard-coded locations
- Security audit: bare fallback hardening, timeout on shell probe

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy -p claudette -p claudette-server --all-targets --all-features` with `-Dwarnings` passes
- [x] `cargo test -p claudette` — 214 tests pass
- [x] `bunx tsc --noEmit` passes
- [x] CI passes on all platforms