### PR TITLE
feat: support image and PDF attachments in chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 name = "claudette"
 version = "0.8.0"
 dependencies = [
+ "base64 0.22.1",
  "dirs",
  "futures",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
+base64 = "0.22"
 futures = "0.3"
 rusqlite = { version = "0.34", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
             #   nix build .#frontend 2>&1 | grep 'got:' | awk '{print $2}'
             outputHash =
               if pkgs.stdenv.isDarwin then
-                "sha256-B5jdCpB8PCOmBvptaigcRZRZSBBfQ4Tm6CaN+VMNvCI="
+                "sha256-HpWPW+dgVuwwOn/m8APmZu4yKrJu217mWmP73AVT+Uk="
               else
                 "sha256-Zoht+jChNYNKQvNftpnu/o3lod+xXYQUzOupugrRDt8=";
 

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -396,6 +396,7 @@ async fn handle_send_chat_message(
         &allowed_tools,
         custom_instructions.as_deref(),
         &agent_settings,
+        &[], // Attachments not yet supported over remote transport
     )
     .await?;
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,17 +1,40 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::{
-    self, AgentEvent, AgentSettings, InnerStreamEvent, StartContentBlock, StreamEvent,
+    self, AgentEvent, AgentSettings, ImageAttachment, InnerStreamEvent, StartContentBlock,
+    StreamEvent,
 };
 use claudette::db::Database;
 use claudette::git;
 use claudette::model::{
-    ChatMessage, ChatRole, CompletedTurnData, ConversationCheckpoint, TurnToolActivity,
+    Attachment, ChatMessage, ChatRole, CompletedTurnData, ConversationCheckpoint, TurnToolActivity,
 };
 use claudette::snapshot;
+use claudette::{base64_decode, base64_encode};
 
 use crate::state::{AgentSessionState, AppState};
+
+/// Frontend-facing input for an image attachment (base64-encoded).
+#[derive(Clone, Deserialize)]
+pub struct AttachmentInput {
+    pub filename: String,
+    pub media_type: String,
+    pub data_base64: String,
+}
+
+/// Frontend-facing response for a stored attachment (base64-encoded data).
+#[derive(Clone, Serialize)]
+pub struct AttachmentResponse {
+    pub id: String,
+    pub message_id: String,
+    pub filename: String,
+    pub media_type: String,
+    pub data_base64: String,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub size_bytes: i64,
+}
 
 #[derive(Clone, Serialize)]
 struct AgentStreamPayload {
@@ -35,6 +58,7 @@ pub async fn load_chat_history(
 #[allow(clippy::too_many_arguments)]
 pub async fn send_chat_message(
     workspace_id: String,
+    message_id: Option<String>,
     content: String,
     mentioned_files: Option<Vec<String>>,
     permission_level: Option<String>,
@@ -44,6 +68,7 @@ pub async fn send_chat_message(
     plan_mode: Option<bool>,
     effort: Option<String>,
     chrome_enabled: Option<bool>,
+    attachments: Option<Vec<AttachmentInput>>,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -61,9 +86,10 @@ pub async fn send_chat_message(
         .ok_or("Workspace has no worktree")?
         .clone();
 
-    // Save user message to DB.
+    // Save user message to DB. Use the frontend-provided ID so optimistic
+    // UI state (attachments keyed by message ID) stays consistent.
     let user_msg = ChatMessage {
-        id: uuid::Uuid::new_v4().to_string(),
+        id: message_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
         workspace_id: workspace_id.clone(),
         role: ChatRole::User,
         content: content.clone(),
@@ -72,8 +98,70 @@ pub async fn send_chat_message(
         created_at: now_iso(),
         thinking: None,
     };
+    // Decode, validate, and persist attachments alongside the user message.
+    // Both inserts share a transaction so the message and its attachments are
+    // atomic — a failed attachment decode won't leave an orphaned message.
+    const ALLOWED_MIME: &[&str] = &[
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+    ];
+    const MAX_IMAGE_BYTES: usize = 3_932_160; // 3.75 MB
+    const MAX_PDF_BYTES: usize = 20_971_520; // 20 MB
+
+    let mut att_models: Vec<Attachment> = Vec::new();
+    let mut cli_atts: Vec<ImageAttachment> = Vec::new();
+
+    if let Some(ref inputs) = attachments {
+        for input in inputs {
+            if !ALLOWED_MIME.contains(&input.media_type.as_str()) {
+                return Err(format!("Unsupported attachment type: {}", input.media_type));
+            }
+            let data = base64_decode(&input.data_base64).map_err(|e| format!("Bad base64: {e}"))?;
+            let max = if input.media_type == "application/pdf" {
+                MAX_PDF_BYTES
+            } else {
+                MAX_IMAGE_BYTES
+            };
+            if data.len() > max {
+                return Err(format!(
+                    "Attachment too large: {} bytes (max {})",
+                    data.len(),
+                    max
+                ));
+            }
+            if input.media_type == "application/pdf" && !data.starts_with(b"%PDF-") {
+                return Err("Invalid PDF: missing %PDF- header".to_string());
+            }
+            let size_bytes = data.len() as i64;
+            att_models.push(Attachment {
+                id: uuid::Uuid::new_v4().to_string(),
+                message_id: user_msg.id.clone(),
+                filename: input.filename.clone(),
+                media_type: input.media_type.clone(),
+                width: None,
+                height: None,
+                size_bytes,
+                data,
+                created_at: now_iso(),
+            });
+            cli_atts.push(ImageAttachment {
+                media_type: input.media_type.clone(),
+                data_base64: input.data_base64.clone(),
+            });
+        }
+    }
+
+    // Atomic insert: message + attachments in one transaction.
     db.insert_chat_message(&user_msg)
         .map_err(|e| e.to_string())?;
+    if !att_models.is_empty() {
+        db.insert_attachments_batch(&att_models)
+            .map_err(|e| e.to_string())?;
+    }
+    let image_attachments = cli_atts;
 
     // Resolve allowed tools from permission level.
     let level = permission_level.as_deref().unwrap_or("full");
@@ -179,6 +267,7 @@ pub async fn send_chat_message(
         &allowed_tools,
         custom_instructions.as_deref(),
         &agent_settings,
+        &image_attachments,
     )
     .await?;
 
@@ -830,6 +919,142 @@ pub async fn clear_attention(
         crate::tray::rebuild_tray(&app);
     }
     Ok(())
+}
+
+/// Load attachment metadata for a workspace's chat history.
+///
+/// Images (< ~5 MB base64) include inline data for immediate rendering.
+/// Documents (PDFs, potentially 20+ MB) omit the body — use
+/// [`load_attachment_data`] to fetch on demand.
+#[tauri::command]
+pub async fn load_attachments_for_workspace(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<AttachmentResponse>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let messages = db
+        .list_chat_messages(&workspace_id)
+        .map_err(|e| e.to_string())?;
+    let message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+    let att_map = db
+        .list_attachments_for_messages(&message_ids)
+        .map_err(|e| e.to_string())?;
+
+    let mut result = Vec::new();
+    for (_, atts) in att_map {
+        for a in atts {
+            // Only inline base64 data for images — PDFs are too large to
+            // push through IPC eagerly and would stall the renderer.
+            let data_base64 = if a.media_type.starts_with("image/") {
+                base64_encode(&a.data)
+            } else {
+                String::new()
+            };
+            result.push(AttachmentResponse {
+                id: a.id,
+                message_id: a.message_id,
+                filename: a.filename,
+                media_type: a.media_type,
+                data_base64,
+                width: a.width,
+                height: a.height,
+                size_bytes: a.size_bytes,
+            });
+        }
+    }
+    Ok(result)
+}
+
+/// Fetch the full base64-encoded body of a single attachment by ID.
+/// Used for on-demand loading of large attachments (PDFs).
+#[tauri::command]
+pub async fn load_attachment_data(
+    attachment_id: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let att = db
+        .get_attachment(&attachment_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Attachment not found")?;
+    Ok(base64_encode(&att.data))
+}
+
+/// Read a file from disk and return it as base64 with metadata.
+/// Used by the frontend file picker — avoids needing the `plugin-fs` dependency.
+///
+/// Supported types: PNG, JPEG, GIF, WebP (images), PDF (documents).
+/// Images are capped at ~3.75 MB (encodes to ~5 MB base64).
+/// PDFs are capped at 20 MB (the Anthropic API raw-PDF limit).
+#[tauri::command]
+pub async fn read_file_as_base64(path: String) -> Result<AttachmentResponse, String> {
+    use std::path::Path;
+
+    const MAX_IMAGE_SIZE: usize = 3_932_160; // 3.75 MB
+    const MAX_PDF_SIZE: usize = 20_971_520; // 20 MB
+
+    let file_path = Path::new(&path);
+    let filename = file_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("attachment")
+        .to_string();
+
+    let ext = file_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    let media_type = match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "pdf" => "application/pdf",
+        other => return Err(format!("Unsupported file type: .{other}")),
+    }
+    .to_string();
+
+    let data = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read file: {e}"))?;
+
+    let size_bytes = data.len() as i64;
+
+    // Enforce size limits per content type.
+    if media_type == "application/pdf" {
+        if data.len() > MAX_PDF_SIZE {
+            return Err(format!(
+                "PDF too large: {:.1} MB (max {} MB)",
+                data.len() as f64 / 1_048_576.0,
+                MAX_PDF_SIZE / 1_048_576
+            ));
+        }
+        // Validate PDF magic bytes (%PDF-) to prevent session poisoning.
+        if !data.starts_with(b"%PDF-") {
+            return Err("Invalid PDF file: missing %PDF- header".to_string());
+        }
+    } else if data.len() > MAX_IMAGE_SIZE {
+        return Err(format!(
+            "Image too large: {:.1} MB (max {:.1} MB)",
+            data.len() as f64 / 1_048_576.0,
+            MAX_IMAGE_SIZE as f64 / 1_048_576.0
+        ));
+    }
+
+    let data_base64 = base64_encode(&data);
+
+    Ok(AttachmentResponse {
+        id: String::new(),
+        message_id: String::new(),
+        filename,
+        media_type,
+        data_base64,
+        width: None,
+        height: None,
+        size_bytes,
+    })
 }
 
 fn now_iso() -> String {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -281,6 +281,9 @@ fn main() {
             commands::files::read_workspace_file,
             // Chat
             commands::chat::load_chat_history,
+            commands::chat::load_attachments_for_workspace,
+            commands::chat::load_attachment_data,
+            commands::chat::read_file_as_base64,
             commands::chat::send_chat_message,
             commands::chat::stop_agent,
             commands::chat::reset_agent_session,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -184,6 +184,16 @@ pub enum AgentEvent {
 // Per-turn agent settings
 // ---------------------------------------------------------------------------
 
+/// An attachment (image or document) to send alongside the prompt via stream-json stdin.
+///
+/// Images use `"type": "image"` content blocks; PDFs use `"type": "document"`.
+/// The block type is determined by [`media_type`] in [`build_stdin_message`].
+#[derive(Debug, Clone)]
+pub struct ImageAttachment {
+    pub media_type: String,
+    pub data_base64: String,
+}
+
 /// Per-turn settings that control CLI flags for the agent subprocess.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentSettings {
@@ -216,6 +226,10 @@ pub struct TurnHandle {
 }
 
 /// Build the CLI arguments for a `claude -p` invocation.
+///
+/// When `has_attachments` is true, the prompt is omitted from the args and
+/// `--input-format stream-json` is added — the prompt + images are instead
+/// piped to stdin as an `SDKUserMessage` JSON line (see [`build_stdin_message`]).
 pub fn build_claude_args(
     session_id: &str,
     prompt: &str,
@@ -223,6 +237,7 @@ pub fn build_claude_args(
     allowed_tools: &[String],
     custom_instructions: Option<&str>,
     settings: &AgentSettings,
+    has_attachments: bool,
 ) -> Vec<String> {
     let mut args = vec![
         "--print".to_string(),
@@ -306,8 +321,58 @@ pub fn build_claude_args(
         args.push(session_id.to_string());
     }
 
-    args.push(prompt.to_string());
+    if has_attachments {
+        // When images are present, the prompt is sent via stdin as a structured
+        // SDKUserMessage (with content blocks). We add --input-format stream-json
+        // so the CLI reads from stdin instead of the positional arg.
+        args.push("--input-format".to_string());
+        args.push("stream-json".to_string());
+    } else {
+        args.push(prompt.to_string());
+    }
+
     args
+}
+
+/// Build a single-line JSON payload for stdin when using `--input-format stream-json`.
+///
+/// Produces an `SDKUserMessage` with content blocks: one text block for the
+/// prompt, then one `image` or `document` block per attachment (PDFs use the
+/// `document` block type; all other supported formats use `image`).
+pub fn build_stdin_message(prompt: &str, attachments: &[ImageAttachment]) -> String {
+    let mut content_blocks = Vec::new();
+
+    // Only add a text block if the prompt is non-empty — the API rejects
+    // empty text content blocks with "text content blocks must be non-empty".
+    if !prompt.trim().is_empty() {
+        content_blocks.push(serde_json::json!({"type": "text", "text": prompt}));
+    }
+
+    for att in attachments {
+        let block_type = if att.media_type == "application/pdf" {
+            "document"
+        } else {
+            "image"
+        };
+        content_blocks.push(serde_json::json!({
+            "type": block_type,
+            "source": {
+                "type": "base64",
+                "media_type": att.media_type,
+                "data": att.data_base64,
+            }
+        }));
+    }
+
+    serde_json::json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": content_blocks,
+        },
+        "parent_tool_use_id": null,
+    })
+    .to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -535,6 +600,7 @@ fn login_shell_path() -> Option<OsString> {
 ///
 /// `allowed_tools` pre-approves tools so they run without interactive
 /// permission prompts (e.g. `["Bash", "Read", "Edit"]`).
+#[allow(clippy::too_many_arguments)]
 pub async fn run_turn(
     working_dir: &Path,
     session_id: &str,
@@ -543,7 +609,9 @@ pub async fn run_turn(
     allowed_tools: &[String],
     custom_instructions: Option<&str>,
     settings: &AgentSettings,
+    attachments: &[ImageAttachment],
 ) -> Result<TurnHandle, String> {
+    let has_attachments = !attachments.is_empty();
     let args = build_claude_args(
         session_id,
         prompt,
@@ -551,15 +619,21 @@ pub async fn run_turn(
         allowed_tools,
         custom_instructions,
         settings,
+        has_attachments,
     );
 
     let claude_path = resolve_claude_path().await;
     let mut cmd = Command::new(&claude_path);
     cmd.args(&args)
         .current_dir(working_dir)
-        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+
+    if has_attachments {
+        cmd.stdin(std::process::Stdio::piped());
+    } else {
+        cmd.stdin(std::process::Stdio::null());
+    }
 
     // Strip OAuth tokens inherited from a parent Claude Code session — these
     // use the sk-ant-oat* prefix and are not valid for subprocess API calls.
@@ -580,6 +654,23 @@ pub async fn run_turn(
     let pid = child
         .id()
         .ok_or_else(|| "Process exited immediately".to_string())?;
+
+    // When images are present, pipe the prompt + image content blocks to stdin
+    // as a stream-json SDKUserMessage, then close stdin to signal EOF.
+    if has_attachments && let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        let payload = build_stdin_message(prompt, attachments);
+        stdin
+            .write_all(payload.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write image data to stdin: {e}"))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("Failed to write stdin newline: {e}"))?;
+        // Drop closes the pipe, signalling EOF to the child.
+        drop(stdin);
+    }
 
     let stdout = child
         .stdout
@@ -1147,6 +1238,7 @@ mod tests {
             &[],
             None,
             &AgentSettings::default(),
+            false,
         );
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"--session-id".to_string()));
@@ -1166,6 +1258,7 @@ mod tests {
             &[],
             None,
             &AgentSettings::default(),
+            false,
         );
         assert!(args.contains(&"--resume".to_string()));
         assert!(!args.contains(&"--session-id".to_string()));
@@ -1181,6 +1274,7 @@ mod tests {
             &tools,
             None,
             &AgentSettings::default(),
+            false,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         assert_eq!(args[idx + 1], "Bash,Read,Edit");
@@ -1195,6 +1289,7 @@ mod tests {
             &[],
             Some("Always use TypeScript"),
             &AgentSettings::default(),
+            false,
         );
         let idx = args
             .iter()
@@ -1212,6 +1307,7 @@ mod tests {
             &[],
             Some(""),
             &AgentSettings::default(),
+            false,
         );
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
@@ -1225,6 +1321,7 @@ mod tests {
             &[],
             Some("   "),
             &AgentSettings::default(),
+            false,
         );
         assert!(!args.contains(&"--append-system-prompt".to_string()));
     }
@@ -1238,6 +1335,7 @@ mod tests {
             &[],
             Some("Always use TypeScript"),
             &AgentSettings::default(),
+            false,
         );
         assert!(!args.contains(&"--append-system-prompt".to_string()));
         assert!(args.contains(&"--resume".to_string()));
@@ -1249,7 +1347,7 @@ mod tests {
             model: Some("opus".to_string()),
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         let idx = args.iter().position(|a| a == "--model").unwrap();
         assert_eq!(args[idx + 1], "opus");
     }
@@ -1260,7 +1358,7 @@ mod tests {
             model: Some("opus".to_string()),
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
         assert!(!args.contains(&"--model".to_string()));
     }
 
@@ -1270,7 +1368,7 @@ mod tests {
             plan_mode: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         let idx = args.iter().position(|a| a == "--permission-mode").unwrap();
         assert_eq!(args[idx + 1], "plan");
     }
@@ -1281,7 +1379,7 @@ mod tests {
             plan_mode: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
         // Permission mode must be set on every turn (per-process flag)
         let idx = args.iter().position(|a| a == "--permission-mode").unwrap();
         assert_eq!(args[idx + 1], "plan");
@@ -1294,7 +1392,7 @@ mod tests {
             thinking_enabled: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         let idx = args.iter().position(|a| a == "--settings").unwrap();
         let json: serde_json::Value = serde_json::from_str(&args[idx + 1]).unwrap();
         assert_eq!(json["fastMode"], true);
@@ -1307,7 +1405,7 @@ mod tests {
             fast_mode: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         let idx = args.iter().position(|a| a == "--settings").unwrap();
         let json: serde_json::Value = serde_json::from_str(&args[idx + 1]).unwrap();
         assert_eq!(json["fastMode"], true);
@@ -1322,7 +1420,7 @@ mod tests {
             ..Default::default()
         };
         // --settings should still be passed on resume (per-turn flag)
-        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
         assert!(args.contains(&"--settings".to_string()));
     }
 
@@ -1336,6 +1434,7 @@ mod tests {
             &tools,
             None,
             &AgentSettings::default(),
+            false,
         );
         // Should set permission-mode to bypassPermissions on first turn
         let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
@@ -1354,6 +1453,7 @@ mod tests {
             &tools,
             None,
             &AgentSettings::default(),
+            false,
         );
         // Permission mode must be set on every turn (per-process flag)
         let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
@@ -1369,7 +1469,7 @@ mod tests {
             plan_mode: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &tools, None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &tools, None, &settings, false);
         // Plan mode takes precedence over bypass
         let pm_idx = args.iter().position(|a| a == "--permission-mode").unwrap();
         assert_eq!(args[pm_idx + 1], "plan");
@@ -1445,7 +1545,7 @@ mod tests {
             effort: Some("high".to_string()),
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         let idx = args.iter().position(|a| a == "--effort").unwrap();
         assert_eq!(args[idx + 1], "high");
     }
@@ -1459,6 +1559,7 @@ mod tests {
             &[],
             None,
             &AgentSettings::default(),
+            false,
         );
         assert!(!args.contains(&"--effort".to_string()));
     }
@@ -1469,7 +1570,7 @@ mod tests {
             effort: Some("auto".to_string()),
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         // "auto" means let the CLI use its default — don't pass --effort
         assert!(!args.contains(&"--effort".to_string()));
     }
@@ -1480,7 +1581,7 @@ mod tests {
             effort: Some("low".to_string()),
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
         let idx = args.iter().position(|a| a == "--effort").unwrap();
         assert_eq!(args[idx + 1], "low");
     }
@@ -1493,7 +1594,7 @@ mod tests {
             effort: Some("max".to_string()),
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         // --effort is a standalone flag, separate from --settings JSON
         let effort_idx = args.iter().position(|a| a == "--effort").unwrap();
         assert_eq!(args[effort_idx + 1], "max");
@@ -1511,7 +1612,7 @@ mod tests {
             chrome_enabled: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
         assert!(args.contains(&"--chrome".to_string()));
     }
 
@@ -1521,7 +1622,7 @@ mod tests {
             chrome_enabled: true,
             ..Default::default()
         };
-        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings);
+        let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
         assert!(!args.contains(&"--chrome".to_string()));
     }
 
@@ -1695,5 +1796,169 @@ mod tests {
         let path = OsString::from(".:relative:./bin");
         let result = search_path_dirs(path.as_os_str(), &|_| true);
         assert_eq!(result, None);
+    }
+
+    // --- build_claude_args attachment tests ---
+
+    fn default_settings() -> AgentSettings {
+        AgentSettings::default()
+    }
+
+    #[test]
+    fn test_build_args_without_attachments_unchanged() {
+        let args = build_claude_args(
+            "sess-1",
+            "hello world",
+            false,
+            &["Bash".into(), "Read".into()],
+            None,
+            &default_settings(),
+            false,
+        );
+        // Prompt should be the last positional arg.
+        assert_eq!(args.last().unwrap(), "hello world");
+        // Should NOT have --input-format stream-json.
+        assert!(!args.contains(&"--input-format".to_string()));
+    }
+
+    #[test]
+    fn test_build_args_with_attachments_uses_stream_json() {
+        let args = build_claude_args(
+            "sess-1",
+            "describe this image",
+            false,
+            &["Bash".into()],
+            None,
+            &default_settings(),
+            true,
+        );
+        // Should have --input-format stream-json.
+        let idx = args
+            .iter()
+            .position(|a| a == "--input-format")
+            .expect("missing --input-format");
+        assert_eq!(args[idx + 1], "stream-json");
+        // Prompt should NOT be a positional arg.
+        assert_ne!(args.last().unwrap(), "describe this image");
+    }
+
+    #[test]
+    fn test_build_stdin_message_text_only() {
+        let msg = build_stdin_message("hello", &[]);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["type"], "user");
+        assert_eq!(parsed["parent_tool_use_id"], serde_json::Value::Null);
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "hello");
+    }
+
+    #[test]
+    fn test_build_stdin_message_empty_prompt_omits_text_block() {
+        let attachments = vec![ImageAttachment {
+            media_type: "image/png".into(),
+            data_base64: "data".into(),
+        }];
+        let msg = build_stdin_message("", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        // Should only have the image block, no empty text block.
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "image");
+    }
+
+    #[test]
+    fn test_build_stdin_message_whitespace_prompt_omits_text_block() {
+        let attachments = vec![ImageAttachment {
+            media_type: "image/png".into(),
+            data_base64: "data".into(),
+        }];
+        let msg = build_stdin_message("   ", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "image");
+    }
+
+    #[test]
+    fn test_build_stdin_message_with_image() {
+        let attachments = vec![ImageAttachment {
+            media_type: "image/png".into(),
+            data_base64: "iVBORw0KGgo=".into(),
+        }];
+        let msg = build_stdin_message("describe this", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "describe this");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["type"], "base64");
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+        assert_eq!(content[1]["source"]["data"], "iVBORw0KGgo=");
+    }
+
+    #[test]
+    fn test_build_stdin_message_multiple_images() {
+        let attachments = vec![
+            ImageAttachment {
+                media_type: "image/png".into(),
+                data_base64: "png_data".into(),
+            },
+            ImageAttachment {
+                media_type: "image/jpeg".into(),
+                data_base64: "jpg_data".into(),
+            },
+            ImageAttachment {
+                media_type: "image/webp".into(),
+                data_base64: "webp_data".into(),
+            },
+        ];
+        let msg = build_stdin_message("compare these", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 4); // 1 text + 3 images
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+        assert_eq!(content[2]["source"]["media_type"], "image/jpeg");
+        assert_eq!(content[3]["source"]["media_type"], "image/webp");
+    }
+
+    #[test]
+    fn test_build_stdin_message_pdf_uses_document_block() {
+        let attachments = vec![ImageAttachment {
+            media_type: "application/pdf".into(),
+            data_base64: "JVBERi0xLjQ=".into(),
+        }];
+        let msg = build_stdin_message("review this doc", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        // PDFs must use "document" type, not "image".
+        assert_eq!(content[1]["type"], "document");
+        assert_eq!(content[1]["source"]["type"], "base64");
+        assert_eq!(content[1]["source"]["media_type"], "application/pdf");
+        assert_eq!(content[1]["source"]["data"], "JVBERi0xLjQ=");
+    }
+
+    #[test]
+    fn test_build_stdin_message_mixed_images_and_pdf() {
+        let attachments = vec![
+            ImageAttachment {
+                media_type: "image/png".into(),
+                data_base64: "png_data".into(),
+            },
+            ImageAttachment {
+                media_type: "application/pdf".into(),
+                data_base64: "pdf_data".into(),
+            },
+        ];
+        let msg = build_stdin_message("here are files", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 3); // 1 text + 1 image + 1 document
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[2]["type"], "document");
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,9 +3,24 @@ use std::path::Path;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::model::{
-    ChatMessage, CheckpointFile, CompletedTurnData, ConversationCheckpoint, RemoteConnection,
-    Repository, TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
+    Attachment, ChatMessage, CheckpointFile, CompletedTurnData, ConversationCheckpoint,
+    RemoteConnection, Repository, TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
 };
+
+fn row_to_attachment(row: &rusqlite::Row) -> rusqlite::Result<Attachment> {
+    let data: Vec<u8> = row.get(4)?;
+    Ok(Attachment {
+        id: row.get(0)?,
+        message_id: row.get(1)?,
+        filename: row.get(2)?,
+        media_type: row.get(3)?,
+        size_bytes: row.get(7)?,
+        data,
+        width: row.get(5)?,
+        height: row.get(6)?,
+        created_at: row.get(8)?,
+    })
+}
 
 pub struct Database {
     conn: Connection,
@@ -263,6 +278,27 @@ impl Database {
                     ON checkpoint_files(checkpoint_id);
 
                 PRAGMA user_version = 15;",
+            )?;
+        }
+
+        if version < 16 {
+            self.conn.execute_batch(
+                "CREATE TABLE attachments (
+                    id           TEXT PRIMARY KEY,
+                    message_id   TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+                    filename     TEXT NOT NULL,
+                    media_type   TEXT NOT NULL,
+                    data         BLOB NOT NULL,
+                    width        INTEGER,
+                    height       INTEGER,
+                    size_bytes   INTEGER NOT NULL,
+                    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE INDEX idx_attachments_message
+                    ON attachments(message_id);
+
+                PRAGMA user_version = 16;",
             )?;
         }
 
@@ -672,6 +708,110 @@ impl Database {
             params![workspace_id],
         )?;
         Ok(())
+    }
+
+    // --- Attachments ---
+
+    pub fn insert_attachment(&self, att: &Attachment) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT INTO attachments (id, message_id, filename, media_type, data, width, height, size_bytes)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                att.id,
+                att.message_id,
+                att.filename,
+                att.media_type,
+                att.data,
+                att.width,
+                att.height,
+                att.size_bytes,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn insert_attachments_batch(
+        &self,
+        attachments: &[Attachment],
+    ) -> Result<(), rusqlite::Error> {
+        if attachments.is_empty() {
+            return Ok(());
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        for att in attachments {
+            tx.execute(
+                "INSERT INTO attachments (id, message_id, filename, media_type, data, width, height, size_bytes)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    att.id,
+                    att.message_id,
+                    att.filename,
+                    att.media_type,
+                    att.data,
+                    att.width,
+                    att.height,
+                    att.size_bytes,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn get_attachment(&self, id: &str) -> Result<Option<Attachment>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT id, message_id, filename, media_type, data, width, height, size_bytes, created_at
+                 FROM attachments WHERE id = ?1",
+                params![id],
+                row_to_attachment,
+            )
+            .optional()
+    }
+
+    pub fn list_attachments_for_message(
+        &self,
+        message_id: &str,
+    ) -> Result<Vec<Attachment>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, message_id, filename, media_type, data, width, height, size_bytes, created_at
+             FROM attachments WHERE message_id = ?1 ORDER BY created_at",
+        )?;
+        let rows = stmt.query_map(params![message_id], row_to_attachment)?;
+        rows.collect()
+    }
+
+    pub fn list_attachments_for_messages(
+        &self,
+        message_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<Attachment>>, rusqlite::Error> {
+        use std::collections::HashMap;
+
+        let mut result: HashMap<String, Vec<Attachment>> = HashMap::new();
+        if message_ids.is_empty() {
+            return Ok(result);
+        }
+
+        // Build a parameterised IN clause.
+        let placeholders: Vec<String> = (1..=message_ids.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "SELECT id, message_id, filename, media_type, data, width, height, size_bytes, created_at
+             FROM attachments WHERE message_id IN ({}) ORDER BY created_at",
+            placeholders.join(", ")
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::types::ToSql> = message_ids
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+        let rows = stmt.query_map(&*params, row_to_attachment)?;
+
+        for att in rows {
+            let att = att?;
+            result.entry(att.message_id.clone()).or_default().push(att);
+        }
+        Ok(result)
     }
 
     // --- Conversation Checkpoints ---
@@ -1173,7 +1313,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{AgentStatus, ChatRole, WorkspaceStatus};
+    use crate::model::{AgentStatus, Attachment, ChatRole, WorkspaceStatus};
 
     fn make_repo(id: &str, path: &str, name: &str) -> Repository {
         Repository {
@@ -1472,6 +1612,151 @@ mod tests {
         assert_eq!(msgs[0].role, ChatRole::User);
         assert_eq!(msgs[1].role, ChatRole::Assistant);
         assert_eq!(msgs[2].role, ChatRole::System);
+    }
+
+    // --- Attachment tests ---
+
+    fn make_attachment(id: &str, message_id: &str, filename: &str) -> Attachment {
+        Attachment {
+            id: id.into(),
+            message_id: message_id.into(),
+            filename: filename.into(),
+            media_type: "image/png".into(),
+            data: vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], // PNG header
+            width: Some(100),
+            height: Some(200),
+            size_bytes: 8,
+            created_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_insert_and_list_attachments() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "look at this"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a1", "m1", "screenshot.png"))
+            .unwrap();
+
+        let atts = db.list_attachments_for_message("m1").unwrap();
+        assert_eq!(atts.len(), 1);
+        assert_eq!(atts[0].id, "a1");
+        assert_eq!(atts[0].filename, "screenshot.png");
+        assert_eq!(atts[0].media_type, "image/png");
+        assert_eq!(
+            atts[0].data,
+            vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        );
+        assert_eq!(atts[0].width, Some(100));
+        assert_eq!(atts[0].height, Some(200));
+        assert_eq!(atts[0].size_bytes, 8);
+    }
+
+    #[test]
+    fn test_attachment_cascade_on_message_delete() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "img"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a1", "m1", "pic.png"))
+            .unwrap();
+
+        // Deleting all messages for the workspace should cascade to attachments.
+        db.delete_chat_messages_for_workspace("w1").unwrap();
+        let atts = db.list_attachments_for_message("m1").unwrap();
+        assert!(atts.is_empty());
+    }
+
+    #[test]
+    fn test_attachment_cascade_on_delete_messages_after() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a1", "m1", "first.png"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::User, "second"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a2", "m2", "second.png"))
+            .unwrap();
+
+        // Delete messages after m1 — m2 and its attachment should be gone.
+        db.delete_messages_after("w1", "m1").unwrap();
+
+        let atts_m1 = db.list_attachments_for_message("m1").unwrap();
+        assert_eq!(atts_m1.len(), 1, "first message attachment should survive");
+        let atts_m2 = db.list_attachments_for_message("m2").unwrap();
+        assert!(
+            atts_m2.is_empty(),
+            "second message attachment should be deleted"
+        );
+    }
+
+    #[test]
+    fn test_insert_attachments_batch() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "images"))
+            .unwrap();
+
+        let attachments = vec![
+            make_attachment("a1", "m1", "one.png"),
+            make_attachment("a2", "m1", "two.jpg"),
+            make_attachment("a3", "m1", "three.gif"),
+        ];
+        db.insert_attachments_batch(&attachments).unwrap();
+
+        let atts = db.list_attachments_for_message("m1").unwrap();
+        assert_eq!(atts.len(), 3);
+    }
+
+    #[test]
+    fn test_insert_attachments_batch_empty() {
+        let db = setup_db_with_workspace();
+        // Should be a no-op, not an error.
+        db.insert_attachments_batch(&[]).unwrap();
+    }
+
+    #[test]
+    fn test_get_attachment_by_id() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "hello"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a1", "m1", "doc.pdf"))
+            .unwrap();
+
+        let att = db.get_attachment("a1").unwrap().unwrap();
+        assert_eq!(att.filename, "doc.pdf");
+        assert_eq!(att.data.len(), 8); // PNG header bytes from make_attachment
+    }
+
+    #[test]
+    fn test_get_attachment_not_found() {
+        let db = setup_db_with_workspace();
+        let result = db.get_attachment("nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_list_attachments_for_messages_batch() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "msg1"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::User, "msg2"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m3", "w1", ChatRole::User, "msg3"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a1", "m1", "pic1.png"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a2", "m1", "pic2.png"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a3", "m2", "pic3.jpg"))
+            .unwrap();
+        // m3 has no attachments.
+
+        let ids = vec!["m1".into(), "m2".into(), "m3".into()];
+        let map = db.list_attachments_for_messages(&ids).unwrap();
+
+        assert_eq!(map.get("m1").map(|v| v.len()), Some(2));
+        assert_eq!(map.get("m2").map(|v| v.len()), Some(1));
+        assert!(!map.contains_key("m3"), "m3 should have no entry");
     }
 
     // --- Repository settings tests ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,13 @@ pub mod names;
 pub mod permissions;
 pub mod slash_commands;
 pub mod snapshot;
+
+use base64::Engine;
+
+pub fn base64_encode(data: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(data)
+}
+
+pub fn base64_decode(encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    base64::engine::general_purpose::STANDARD.decode(encoded)
+}

--- a/src/model/attachment.rs
+++ b/src/model/attachment.rs
@@ -1,0 +1,19 @@
+use serde::Serialize;
+
+/// An image or file attachment associated with a chat message.
+#[derive(Debug, Clone, Serialize)]
+pub struct Attachment {
+    pub id: String,
+    pub message_id: String,
+    pub filename: String,
+    pub media_type: String,
+    /// Raw file bytes. Skipped during default serialization to avoid
+    /// accidentally sending BLOBs over Tauri IPC — use `AttachmentResponse`
+    /// with base64-encoded data for frontend communication.
+    #[serde(skip)]
+    pub data: Vec<u8>,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub size_bytes: i64,
+    pub created_at: String,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,3 +1,4 @@
+mod attachment;
 mod chat_message;
 mod checkpoint;
 pub mod diff;
@@ -6,6 +7,7 @@ mod repository;
 mod terminal_tab;
 mod workspace;
 
+pub use attachment::Attachment;
 pub use chat_message::{ChatMessage, ChatRole};
 pub use checkpoint::{CheckpointFile, CompletedTurnData, ConversationCheckpoint, TurnToolActivity};
 pub use remote_connection::RemoteConnection;

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -15,6 +15,7 @@
         "@xterm/xterm": "^6.0.0",
         "ansi_up": "^6.0.6",
         "lucide-react": "^1.7.0",
+        "pdfjs-dist": "^5.6.205",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
@@ -115,6 +116,30 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.97", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.97", "@napi-rs/canvas-darwin-arm64": "0.1.97", "@napi-rs/canvas-darwin-x64": "0.1.97", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97", "@napi-rs/canvas-linux-arm64-gnu": "0.1.97", "@napi-rs/canvas-linux-arm64-musl": "0.1.97", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97", "@napi-rs/canvas-linux-x64-gnu": "0.1.97", "@napi-rs/canvas-linux-x64-musl": "0.1.97", "@napi-rs/canvas-win32-arm64-msvc": "0.1.97", "@napi-rs/canvas-win32-x64-msvc": "0.1.97" } }, "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.97", "", { "os": "android", "cpu": "arm64" }, "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.97", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.97", "", { "os": "darwin", "cpu": "x64" }, "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.97", "", { "os": "linux", "cpu": "arm" }, "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.97", "", { "os": "linux", "cpu": "none" }, "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.97", "", { "os": "linux", "cpu": "x64" }, "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.97", "", { "os": "linux", "cpu": "x64" }, "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.97", "", { "os": "win32", "cpu": "arm64" }, "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.97", "", { "os": "win32", "cpu": "x64" }, "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
 
@@ -574,6 +599,8 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "node-readable-to-web-readable-stream": ["node-readable-to-web-readable-stream@0.4.2", "", {}, "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ=="],
+
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
@@ -595,6 +622,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pdfjs-dist": ["pdfjs-dist@5.6.205", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.96", "node-readable-to-web-readable-stream": "^0.4.2" } }, "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -23,6 +23,7 @@
     "@xterm/xterm": "^6.0.0",
     "ansi_up": "^6.0.6",
     "lucide-react": "^1.7.0",
+    "pdfjs-dist": "^5.6.205",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -877,7 +877,6 @@
 .inputControls {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
   padding-top: 6px;
 }
@@ -928,7 +927,7 @@
   cursor: pointer;
   font-size: 13px;
   font-weight: 500;
-  align-self: flex-end;
+  margin-left: auto;
   transition: background var(--transition-fast), color var(--transition-fast),
               border-color var(--transition-fast);
 }
@@ -946,4 +945,110 @@
 .sendBtn:disabled {
   opacity: 0.25;
   cursor: not-allowed;
+}
+
+/* -- Attachment UI -- */
+
+.inputDragActive {
+  outline: 2px dashed var(--accent-primary);
+  outline-offset: -2px;
+  background: rgba(var(--accent-primary-rgb), 0.04);
+}
+
+.attachmentStrip {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0 8px;
+  overflow-x: auto;
+}
+
+.attachmentThumb {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--divider);
+  flex-shrink: 0;
+}
+
+.attachmentThumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.attachmentRemove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.attachmentRemove:hover {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.attachBtn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--divider);
+  color: var(--text-muted);
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  margin-right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  flex-shrink: 0;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.attachBtn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  border-color: var(--text-dim);
+}
+
+/* -- Inline message images -- */
+
+.messageImages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.messageImage {
+  max-width: 300px;
+  max-height: 300px;
+  border-radius: 8px;
+  border: 1px solid var(--divider);
+  object-fit: contain;
+  cursor: pointer;
+}
+
+.messagePdf {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--divider);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted);
+  font-size: 13px;
 }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,11 +1,13 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import { preprocessContent, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
-import { GitBranch, LayoutDashboard, RotateCcw } from "lucide-react";
+import { FileText, GitBranch, LayoutDashboard, Plus, RotateCcw, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
   loadChatHistory,
+  loadAttachmentsForWorkspace,
+  readFileAsBase64,
   listCheckpoints,
   loadCompletedTurns,
   listSlashCommands,
@@ -17,9 +19,17 @@ import {
   setAppSetting,
   listWorkspaceFiles,
 } from "../../services/tauri";
+import { open } from "@tauri-apps/plugin-dialog";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
 import type { SlashCommand, FileEntry } from "../../services/tauri";
-import type { ChatMessage } from "../../types/chat";
+import type { ChatMessage, ChatAttachment, AttachmentInput, PendingAttachment } from "../../types/chat";
+import { base64ToBytes } from "../../utils/base64";
+import {
+  SUPPORTED_DOCUMENT_TYPES,
+  SUPPORTED_ATTACHMENT_TYPES,
+  MAX_ATTACHMENTS,
+  maxSizeFor,
+} from "../../utils/attachmentValidation";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { extractToolSummary } from "../../hooks/toolSummary";
 import { AgentQuestionCard } from "./AgentQuestionCard";
@@ -40,6 +50,51 @@ import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/**
+ * Lazily renders a PDF first-page thumbnail.
+ *
+ * Accepts either `dataBase64` (optimistic/pre-loaded data) or `attachmentId`
+ * (fetches the body from the backend on demand). Shows a loading pill with
+ * the filename while the thumbnail generates.
+ */
+function PdfThumbnail({ dataBase64, attachmentId, filename, className }: {
+  dataBase64?: string;
+  attachmentId?: string;
+  filename: string;
+  className?: string;
+}) {
+  const [src, setSrc] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      let b64 = dataBase64;
+      // If no inline data, fetch on demand from the backend.
+      if (!b64 && attachmentId) {
+        const { loadAttachmentData } = await import("../../services/tauri");
+        b64 = await loadAttachmentData(attachmentId);
+      }
+      if (!b64 || cancelled) return;
+      const bytes = base64ToBytes(b64);
+      const { generatePdfThumbnail } = await import("../../utils/pdfThumbnail");
+      const url = await generatePdfThumbnail(bytes.buffer as ArrayBuffer, 300, attachmentId);
+      if (!cancelled) setSrc(url);
+    })().catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [dataBase64, attachmentId]);
+
+  if (!src) {
+    return (
+      <div className={styles.messagePdf}>
+        <FileText size={16} />
+        <span>{filename}</span>
+      </div>
+    );
+  }
+  return <img src={src} alt={filename} className={className} />;
+}
 
 /** Semantic colors for tool names — makes tool activity scannable at a glance. */
 const TOOL_COLORS: Record<string, string> = {
@@ -69,6 +124,7 @@ const ScrollContext = createContext<{
 // causing Object.is to return false and triggering unnecessary component re-renders.
 const EMPTY_COMPLETED_TURNS: CompletedTurn[] = [];
 const EMPTY_ACTIVITIES: ToolActivity[] = [];
+const EMPTY_ATTACHMENTS: ChatAttachment[] = [];
 
 export function ChatPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -239,6 +295,16 @@ export function ChatPanel() {
           .filter((m) => m.role === "User")
           .map((m) => m.content);
 
+        // Load attachments for this workspace's messages.
+        if (isLocal) {
+          loadAttachmentsForWorkspace(wsId)
+            .then((atts) => {
+              if (cancelled) return;
+              useAppStore.getState().setChatAttachments(wsId, atts);
+            })
+            .catch((e) => console.error("Failed to load attachments:", e));
+        }
+
         // Load persisted completed turns and reconstruct with correct positions.
         // Skip if the agent is currently running — the in-memory state from
         // finalizeTurn() is more current than the DB and must not be overwritten.
@@ -330,22 +396,30 @@ export function ChatPanel() {
   ]);
 
   // Auto-dispatch queued message when agent becomes idle.
-  const handleSendRef = useRef<((content: string, mentionedFiles?: Set<string>) => void) | null>(null);
+  const handleSendRef = useRef<((
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => void) | null>(null);
   useEffect(() => {
     if (isRunning || !selectedWorkspaceId || !queuedMessage) return;
     // Agent just finished — dispatch the queued message.
-    const { content, mentionedFiles } = queuedMessage;
+    const { content, mentionedFiles, attachments } = queuedMessage;
     clearQueuedMessage(selectedWorkspaceId);
     const filesSet = mentionedFiles?.length ? new Set(mentionedFiles) : undefined;
     // Use a microtask to avoid calling handleSend during render.
-    queueMicrotask(() => handleSendRef.current?.(content, filesSet));
+    queueMicrotask(() => handleSendRef.current?.(content, filesSet, attachments));
   }, [isRunning, selectedWorkspaceId, queuedMessage, clearQueuedMessage]);
 
   if (!ws) return null;
 
-  const handleSend = async (content: string, mentionedFiles?: Set<string>) => {
+  const handleSend = async (
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => {
     const trimmed = content.trim();
-    if (!trimmed || !selectedWorkspaceId) return;
+    if ((!trimmed && !attachments?.length) || !selectedWorkspaceId) return;
 
     // Convert mentioned files set to array for the backend.
     const mentionedFilesArray = mentionedFiles?.size
@@ -356,7 +430,12 @@ export function ChatPanel() {
     // The user can press Escape to stop the agent if they want to interrupt.
     // Queued messages are auto-sent when the current turn finishes.
     if (isRunning) {
-      setQueuedMessage(selectedWorkspaceId, trimmed, mentionedFilesArray);
+      setQueuedMessage(
+        selectedWorkspaceId,
+        trimmed,
+        mentionedFilesArray,
+        attachments,
+      );
       return;
     }
 
@@ -374,8 +453,9 @@ export function ChatPanel() {
     history.push(trimmed);
     historyIndexRef.current = -1;
     draftRef.current = "";
+    const optimisticMsgId = crypto.randomUUID();
     addChatMessage(selectedWorkspaceId, {
-      id: crypto.randomUUID(),
+      id: optimisticMsgId,
       workspace_id: selectedWorkspaceId,
       role: "User",
       content: trimmed,
@@ -384,6 +464,20 @@ export function ChatPanel() {
       created_at: new Date().toISOString(),
       thinking: null,
     });
+    // Add optimistic attachment data so images display immediately.
+    if (attachments?.length) {
+      const optimisticAtts = attachments.map((a) => ({
+        id: crypto.randomUUID(),
+        message_id: optimisticMsgId,
+        filename: a.filename,
+        media_type: a.media_type,
+        data_base64: a.data_base64,
+        width: null,
+        height: null,
+        size_bytes: Math.ceil(a.data_base64.length * 0.75),
+      }));
+      useAppStore.getState().addChatAttachments(selectedWorkspaceId, optimisticAtts);
+    }
     updateWorkspace(selectedWorkspaceId, { agent_status: "Running" });
     useAppStore.getState().clearUnreadCompletion(selectedWorkspaceId);
 
@@ -422,6 +516,8 @@ export function ChatPanel() {
           planMode || undefined,
           effort,
           chromeEnabled || undefined,
+          attachments,
+          optimisticMsgId,
         );
       }
     } catch (e) {
@@ -638,6 +734,7 @@ export function ChatPanel() {
       <ChatInputArea
         onSend={handleSend}
         isRunning={isRunning}
+        isRemote={!!ws?.remote_connection_id}
         selectedWorkspaceId={selectedWorkspaceId!}
         projectPath={repo?.path}
         historyRef={historyRef}
@@ -846,6 +943,20 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   const showThinkingBlocks = useAppStore(
     (s) => s.showThinkingBlocks[workspaceId] === true
   );
+  const chatAttachments = useAppStore(
+    (s) => s.chatAttachments[workspaceId] ?? EMPTY_ATTACHMENTS
+  );
+
+  // Pre-build a Map keyed by message_id for O(1) lookup in the render loop.
+  const attachmentsByMessage = useMemo(() => {
+    const map = new Map<string, ChatAttachment[]>();
+    for (const att of chatAttachments) {
+      const list = map.get(att.message_id);
+      if (list) list.push(att);
+      else map.set(att.message_id, [att]);
+    }
+    return map;
+  }, [chatAttachments]);
 
   // Build an index: afterMessageIndex → array of (turn, globalIndex) pairs.
   // Only recomputed when completedTurns changes, not on every streaming update.
@@ -938,6 +1049,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                     openModal("rollback", {
                       workspaceId,
                       checkpointId: cp ? cp.id : null,
+                      messageId: msg.id,
                       messagePreview: msg.content.slice(0, 100),
                       messageContent: msg.content,
                       hasFileChanges: cp
@@ -953,6 +1065,28 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
               <ThinkingBlock content={msg.thinking} isStreaming={false} />
             )}
             <div className={styles.content}>
+              {msg.role === "User" && attachmentsByMessage.has(msg.id) && (
+                <div className={styles.messageImages}>
+                  {attachmentsByMessage.get(msg.id)!.map((att) =>
+                    att.media_type === "application/pdf" ? (
+                      <PdfThumbnail
+                        key={att.id}
+                        dataBase64={att.data_base64 || undefined}
+                        attachmentId={att.id}
+                        filename={att.filename}
+                        className={styles.messageImage}
+                      />
+                    ) : (
+                      <img
+                        key={att.id}
+                        src={`data:${att.media_type};base64,${att.data_base64}`}
+                        alt={att.filename}
+                        className={styles.messageImage}
+                      />
+                    ),
+                  )}
+                </div>
+              )}
               {msg.role === "Assistant" ? (
                 <Markdown
                   remarkPlugins={REMARK_PLUGINS}
@@ -1099,17 +1233,37 @@ function extractMentionQuery(text: string, cursorPos: number): string | null {
 }
 
 // Separate component for input area to prevent full ChatPanel re-renders on every keystroke
+/** Convert a File/Blob to a base64 string (without the data: prefix). */
+function fileToBase64(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const base64 = result.split(",")[1] ?? "";
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
 function ChatInputArea({
   onSend,
   isRunning,
+  isRemote,
   selectedWorkspaceId,
   projectPath,
   historyRef,
   historyIndexRef,
   draftRef,
 }: {
-  onSend: (content: string, mentionedFiles?: Set<string>) => Promise<void>;
+  onSend: (
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => Promise<void>;
   isRunning: boolean;
+  isRemote: boolean;
   selectedWorkspaceId: string;
   projectPath: string | undefined;
   historyRef: React.MutableRefObject<Record<string, string[]>>;
@@ -1128,6 +1282,8 @@ function ChatInputArea({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const filesCache = useRef<Record<string, FileEntry[]>>({});
   const mentionedFilesRef = useRef<Set<string>>(new Set());
+  const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
+  const [dragActive, setDragActive] = useState(false);
 
   // Per-workspace draft storage: save input when switching away,
   // restore when switching back.
@@ -1141,10 +1297,17 @@ function ChatInputArea({
       // Restore draft for the workspace we're entering.
       setChatInput(draftsRef.current[selectedWorkspaceId] ?? "");
       prevWorkspaceRef.current = selectedWorkspaceId;
-      // Reset file picker state for new workspace.
+      // Reset file picker and attachment state for new workspace.
       setFilesLoaded(false);
       setWorkspaceFiles([]);
       mentionedFilesRef.current = new Set();
+      // Clear staged attachments so they don't leak across workspaces.
+      setPendingAttachments((prev) => {
+        for (const a of prev) {
+          if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
+        }
+        return [];
+      });
     }
   }, [selectedWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1278,6 +1441,192 @@ function ChatInputArea({
     textarea.style.height = `${textarea.scrollHeight}px`;
   }, [chatInput]);
 
+  // -- Attachment helpers --
+
+  const addAttachment = useCallback(async (file: Blob, filename: string) => {
+    if (isRemote) return; // Attachments not supported over remote transport
+    if (!SUPPORTED_ATTACHMENT_TYPES.has(file.type)) {
+      console.warn(`Unsupported file type: ${file.type}`);
+      return;
+    }
+    const isPdf = SUPPORTED_DOCUMENT_TYPES.has(file.type);
+    const sizeLimit = maxSizeFor(file.type);
+    if (file.size > sizeLimit) {
+      console.warn(
+        `File too large: ${(file.size / 1024 / 1024).toFixed(1)} MB (max ${(sizeLimit / 1024 / 1024).toFixed(1)} MB)`,
+      );
+      return;
+    }
+    const data_base64 = await fileToBase64(file);
+    // PDFs get a rendered first-page thumbnail; images use a blob URL.
+    let preview_url: string;
+    if (isPdf) {
+      const { generatePdfThumbnail } = await import("../../utils/pdfThumbnail");
+      preview_url = await generatePdfThumbnail(await file.arrayBuffer()).catch(() => "");
+    } else {
+      preview_url = URL.createObjectURL(file);
+    }
+    if (!preview_url) return; // PDF thumbnail generation failed
+    const att: PendingAttachment = {
+      id: crypto.randomUUID(),
+      filename,
+      media_type: file.type,
+      data_base64,
+      preview_url,
+      size_bytes: file.size,
+    };
+    setPendingAttachments((prev) => {
+      if (prev.length >= MAX_ATTACHMENTS) {
+        if (preview_url.startsWith("blob:")) URL.revokeObjectURL(preview_url);
+        return prev;
+      }
+      return [...prev, att];
+    });
+  }, [isRemote]);
+
+  const removeAttachment = useCallback((id: string) => {
+    setPendingAttachments((prev) => {
+      const att = prev.find((a) => a.id === id);
+      if (att?.preview_url.startsWith("blob:")) URL.revokeObjectURL(att.preview_url);
+      return prev.filter((a) => a.id !== id);
+    });
+  }, []);
+
+  // Track current attachments in a ref so the unmount cleanup always
+  // revokes the latest blob URLs (not the stale initial-render snapshot).
+  const pendingAttachmentsRef = useRef(pendingAttachments);
+  pendingAttachmentsRef.current = pendingAttachments;
+  useEffect(() => {
+    return () => {
+      for (const a of pendingAttachmentsRef.current) {
+        if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
+      }
+    };
+  }, []);
+
+  // Consume attachment prefill (e.g. from rollback) — convert the raw
+  // base64 data back into PendingAttachment objects with preview URLs.
+  const attachmentsPrefill = useAppStore((s) => s.pendingAttachmentsPrefill);
+  const setAttachmentsPrefill = useAppStore((s) => s.setPendingAttachmentsPrefill);
+  useEffect(() => {
+    if (!attachmentsPrefill || attachmentsPrefill.length === 0) return;
+    setAttachmentsPrefill(null);
+
+    (async () => {
+      for (const a of attachmentsPrefill) {
+        const bytes = base64ToBytes(a.data_base64);
+        const blob = new Blob([bytes], { type: a.media_type });
+        await addAttachment(blob, a.filename);
+      }
+    })().catch((e) => console.error("Failed to restore attachment prefill:", e));
+  }, [attachmentsPrefill, setAttachmentsPrefill, addAttachment]);
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      for (const item of items) {
+        if (SUPPORTED_ATTACHMENT_TYPES.has(item.type)) {
+          e.preventDefault();
+          const file = item.getAsFile();
+          if (file) {
+            const defaultName = item.type === "application/pdf"
+              ? "pasted-document.pdf"
+              : "pasted-image.png";
+            addAttachment(file, file.name || defaultName);
+          }
+          return; // Only handle first attachment
+        }
+      }
+      // If no supported items, let the default text paste proceed.
+    },
+    [addAttachment],
+  );
+
+  // Tauri intercepts native file drops before they reach the webview's HTML5
+  // drag events. Use Tauri's onDragDropEvent to handle file drops, and fall
+  // through to readFileAsBase64 (which validates type + size on the Rust side).
+  //
+  // The handler references addAttachment via a ref to avoid re-registering the
+  // listener when the callback identity changes — re-registration causes a race
+  // where the old listener's async cleanup hasn't fired yet and the same drop
+  // event is processed by both the old and new listeners, duplicating files.
+  const addAttachmentRef = useRef(addAttachment);
+  addAttachmentRef.current = addAttachment;
+
+  useEffect(() => {
+    if (isRemote) return;
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+
+    import("@tauri-apps/api/webview").then(({ getCurrentWebview }) => {
+      if (cancelled) return;
+      getCurrentWebview()
+        .onDragDropEvent((event) => {
+          if (cancelled) return;
+          if (event.payload.type === "enter" || event.payload.type === "over") {
+            setDragActive(true);
+          } else if (event.payload.type === "leave") {
+            setDragActive(false);
+          } else if (event.payload.type === "drop") {
+            setDragActive(false);
+            for (const filePath of event.payload.paths) {
+              readFileAsBase64(filePath)
+                .then((result) => {
+                  if (cancelled) return;
+                  const bytes = base64ToBytes(result.data_base64);
+                  const blob = new Blob([bytes], { type: result.media_type });
+                  addAttachmentRef.current(blob, result.filename);
+                })
+                .catch((err) =>
+                  console.warn("Skipped dropped file:", err),
+                );
+            }
+          }
+        })
+        .then((fn) => {
+          if (cancelled) {
+            fn(); // Already cleaned up — unlisten immediately
+          } else {
+            unlisten = fn;
+          }
+        });
+    }).catch((err) => {
+      console.warn("Failed to register drag-drop listener:", err);
+      setDragActive(false);
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [isRemote]); // Stable dep — no re-registration on callback changes
+
+  const handleAttachClick = useCallback(async () => {
+    const selected = await open({
+      multiple: true,
+      filters: [
+        {
+          name: "Images & Documents",
+          extensions: ["png", "jpg", "jpeg", "gif", "webp", "pdf"],
+        },
+      ],
+    });
+    if (!selected) return;
+    const paths = Array.isArray(selected) ? selected : [selected];
+    for (const filePath of paths) {
+      try {
+        const result = await readFileAsBase64(filePath);
+        const bytes = base64ToBytes(result.data_base64);
+        const blob = new Blob([bytes], { type: result.media_type });
+        await addAttachment(blob, result.filename);
+      } catch (err) {
+        console.error("Failed to read file:", err);
+      }
+    }
+  }, [addAttachment]);
+
   const handleSend = () => {
     // Only include files whose @path tokens are still in the text, so that
     // removed references don't get expanded.
@@ -1288,8 +1637,21 @@ function ChatInputArea({
       }
     }
     const files = activeFiles.size > 0 ? activeFiles : undefined;
-    onSend(chatInput, files);
+    const attachmentPayload =
+      pendingAttachments.length > 0
+        ? pendingAttachments.map((a) => ({
+            filename: a.filename,
+            media_type: a.media_type,
+            data_base64: a.data_base64,
+          }))
+        : undefined;
+    onSend(chatInput, files, attachmentPayload);
     setChatInput("");
+    // Revoke blob URLs to free memory (data: URLs don't need cleanup).
+    for (const a of pendingAttachments) {
+      if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
+    }
+    setPendingAttachments([]);
     mentionedFilesRef.current = new Set();
   };
 
@@ -1410,7 +1772,9 @@ function ChatInputArea({
   };
 
   return (
-    <div className={styles.inputArea}>
+    <div
+      className={`${styles.inputArea}${dragActive ? ` ${styles.inputDragActive}` : ""}`}
+    >
       {showFilePicker && (
         <FileMentionPicker
           results={mentionResults}
@@ -1433,6 +1797,22 @@ function ChatInputArea({
           onHover={setSlashPickerIndex}
         />
       )}
+      {pendingAttachments.length > 0 && (
+        <div className={styles.attachmentStrip}>
+          {pendingAttachments.map((att) => (
+            <div key={att.id} className={styles.attachmentThumb} title={att.filename}>
+              <img src={att.preview_url} alt={att.filename} />
+              <button
+                className={styles.attachmentRemove}
+                onClick={() => removeAttachment(att.id)}
+                title="Remove"
+              >
+                <X size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       <textarea
         ref={textareaRef}
         className={`${styles.input}${planMode ? ` ${styles.inputPlanMode}` : ""}`}
@@ -1445,9 +1825,18 @@ function ChatInputArea({
           setCursorPos((e.target as HTMLTextAreaElement).selectionStart ?? 0);
         }}
         onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
         placeholder={isRunning ? "Type to queue a message..." : "Send a message..."}
       />
       <div className={styles.inputControls}>
+        <button
+          className={styles.attachBtn}
+          onClick={handleAttachClick}
+          disabled={isRemote}
+          title={isRemote ? "Attachments not supported for remote workspaces" : "Add files or images"}
+        >
+          <Plus size={16} />
+        </button>
         <ChatToolbar
           workspaceId={selectedWorkspaceId}
           disabled={isRunning}
@@ -1455,7 +1844,7 @@ function ChatInputArea({
         <button
           className={styles.sendBtn}
           onClick={handleSend}
-          disabled={!chatInput.trim()}
+          disabled={!chatInput.trim() && pendingAttachments.length === 0}
         >
           Send
         </button>

--- a/src/ui/src/components/chat/attachments.test.ts
+++ b/src/ui/src/components/chat/attachments.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  SUPPORTED_IMAGE_TYPES,
+  SUPPORTED_DOCUMENT_TYPES,
+  SUPPORTED_ATTACHMENT_TYPES,
+  MAX_IMAGE_SIZE,
+  MAX_PDF_SIZE,
+  MAX_ATTACHMENTS,
+  maxSizeFor,
+} from "../../utils/attachmentValidation";
+
+function isSupported(mimeType: string): boolean {
+  return SUPPORTED_ATTACHMENT_TYPES.has(mimeType);
+}
+
+function isImage(mimeType: string): boolean {
+  return SUPPORTED_IMAGE_TYPES.has(mimeType);
+}
+
+function isDocument(mimeType: string): boolean {
+  return SUPPORTED_DOCUMENT_TYPES.has(mimeType);
+}
+
+function validateSize(mimeType: string, sizeBytes: number): boolean {
+  return sizeBytes <= maxSizeFor(mimeType);
+}
+
+/** Mirrors the content block type selection in build_stdin_message. */
+function contentBlockType(mimeType: string): "image" | "document" {
+  return mimeType === "application/pdf" ? "document" : "image";
+}
+
+describe("attachment type validation", () => {
+  it("accepts supported image types", () => {
+    expect(isSupported("image/png")).toBe(true);
+    expect(isSupported("image/jpeg")).toBe(true);
+    expect(isSupported("image/gif")).toBe(true);
+    expect(isSupported("image/webp")).toBe(true);
+  });
+
+  it("accepts PDF documents", () => {
+    expect(isSupported("application/pdf")).toBe(true);
+  });
+
+  it("rejects unsupported file types", () => {
+    expect(isSupported("image/svg+xml")).toBe(false);
+    expect(isSupported("text/plain")).toBe(false);
+    expect(isSupported("image/bmp")).toBe(false);
+    expect(isSupported("video/mp4")).toBe(false);
+    expect(isSupported("application/json")).toBe(false);
+    expect(isSupported("application/zip")).toBe(false);
+  });
+
+  it("classifies images vs documents", () => {
+    expect(isImage("image/png")).toBe(true);
+    expect(isDocument("image/png")).toBe(false);
+    expect(isImage("application/pdf")).toBe(false);
+    expect(isDocument("application/pdf")).toBe(true);
+  });
+});
+
+describe("attachment size validation", () => {
+  it("enforces image size limit at 3.75 MB", () => {
+    expect(validateSize("image/png", 1024)).toBe(true);
+    expect(validateSize("image/png", 3 * 1024 * 1024)).toBe(true);
+    expect(validateSize("image/png", MAX_IMAGE_SIZE)).toBe(true);
+    expect(validateSize("image/png", MAX_IMAGE_SIZE + 1)).toBe(false);
+    expect(validateSize("image/jpeg", 10 * 1024 * 1024)).toBe(false);
+  });
+
+  it("enforces PDF size limit at 20 MB", () => {
+    expect(validateSize("application/pdf", 5 * 1024 * 1024)).toBe(true);
+    expect(validateSize("application/pdf", 15 * 1024 * 1024)).toBe(true);
+    expect(validateSize("application/pdf", MAX_PDF_SIZE)).toBe(true);
+    expect(validateSize("application/pdf", MAX_PDF_SIZE + 1)).toBe(false);
+  });
+
+  it("applies correct limit per type", () => {
+    const size = 10 * 1024 * 1024; // 10 MB — valid for PDF, invalid for image
+    expect(validateSize("application/pdf", size)).toBe(true);
+    expect(validateSize("image/png", size)).toBe(false);
+  });
+});
+
+describe("attachment count limit", () => {
+  it("enforces max attachment count of 5", () => {
+    expect(MAX_ATTACHMENTS).toBe(5);
+    expect(4 < MAX_ATTACHMENTS).toBe(true);
+    expect(5 < MAX_ATTACHMENTS).toBe(false);
+  });
+});
+
+describe("content block type mapping", () => {
+  it("uses image blocks for image types", () => {
+    expect(contentBlockType("image/png")).toBe("image");
+    expect(contentBlockType("image/jpeg")).toBe("image");
+    expect(contentBlockType("image/gif")).toBe("image");
+    expect(contentBlockType("image/webp")).toBe("image");
+  });
+
+  it("uses document blocks for PDFs", () => {
+    expect(contentBlockType("application/pdf")).toBe("document");
+  });
+});
+
+describe("blob URL cleanup", () => {
+  it("identifies blob URLs that need revoking", () => {
+    const blobUrl = "blob:http://localhost/abc-123";
+    const dataUrl = "data:image/png;base64,iVBOR...";
+    expect(blobUrl.startsWith("blob:")).toBe(true);
+    expect(dataUrl.startsWith("blob:")).toBe(false);
+  });
+});
+
+describe("drag-drop deduplication", () => {
+  it("useEffect cleanup pattern prevents stale listeners", () => {
+    let cancelled = false;
+    const processed: string[] = [];
+
+    const processFile = (name: string) => {
+      if (cancelled) return;
+      processed.push(name);
+    };
+
+    processFile("file1.png");
+    expect(processed).toEqual(["file1.png"]);
+
+    cancelled = true;
+    processFile("file2.png");
+    expect(processed).toEqual(["file1.png"]);
+  });
+});

--- a/src/ui/src/components/modals/RollbackModal.tsx
+++ b/src/ui/src/components/modals/RollbackModal.tsx
@@ -5,6 +5,8 @@ import {
   clearConversation,
   loadDiffFiles,
   loadCompletedTurns,
+  loadAttachmentsForWorkspace,
+  loadAttachmentData,
 } from "../../services/tauri";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
 import { Modal } from "./Modal";
@@ -23,6 +25,7 @@ export function RollbackModal() {
 
   const workspaceId = modalData.workspaceId as string;
   const checkpointId = (modalData.checkpointId as string) ?? null;
+  const messageId = (modalData.messageId as string) ?? null;
   const messagePreview = modalData.messagePreview as string;
   const messageContent = (modalData.messageContent as string) ?? "";
   const hasFileChanges = modalData.hasFileChanges as boolean;
@@ -31,6 +34,15 @@ export function RollbackModal() {
   const handleRollback = async () => {
     setLoading(true);
     try {
+      // Capture the rolled-back message's attachments BEFORE the rollback
+      // deletes them from the DB (FK cascade). We'll prefill them into the
+      // input so the user can re-send with the same files.
+      const rolledBackAtts = messageId
+        ? (useAppStore.getState().chatAttachments[workspaceId] ?? []).filter(
+            (a) => a.message_id === messageId,
+          )
+        : [];
+
       const messages = isClearAll
         ? await clearConversation(workspaceId, restoreFiles)
         : await rollbackToCheckpoint(workspaceId, checkpointId, restoreFiles);
@@ -47,6 +59,32 @@ export function RollbackModal() {
       if (messageContent) {
         setChatInputPrefill(messageContent);
       }
+      // Prefill attachments from the rolled-back message so the user can
+      // re-send with the same files. For images the data is already in the
+      // store; for PDFs we need to fetch the body on demand.
+      if (rolledBackAtts.length > 0) {
+        const prefillAtts = await Promise.all(
+          rolledBackAtts.map(async (a) => {
+            let data = a.data_base64;
+            if (!data && a.id) {
+              data = await loadAttachmentData(a.id).catch(() => "");
+            }
+            return {
+              filename: a.filename,
+              media_type: a.media_type,
+              data_base64: data,
+            };
+          }),
+        );
+        useAppStore
+          .getState()
+          .setPendingAttachmentsPrefill(prefillAtts.filter((a) => a.data_base64));
+      }
+      // Reload attachments to reflect the rolled-back state (FK cascade
+      // deletes attachments for removed messages).
+      loadAttachmentsForWorkspace(workspaceId)
+        .then((atts) => useAppStore.getState().setChatAttachments(workspaceId, atts))
+        .catch((e) => console.error("Failed to reload attachments after rollback:", e));
       // Refresh the changed files view to reflect the rolled-back file state.
       clearDiff();
       loadDiffFiles(workspaceId)

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -3,6 +3,8 @@ import type {
   Repository,
   Workspace,
   ChatMessage,
+  ChatAttachment,
+  AttachmentInput,
   DiffFile,
   FileDiff,
   TerminalTab,
@@ -181,9 +183,12 @@ export function sendChatMessage(
   planMode?: boolean,
   effort?: string,
   chromeEnabled?: boolean,
+  attachments?: AttachmentInput[],
+  messageId?: string,
 ): Promise<void> {
   return invoke("send_chat_message", {
     workspaceId,
+    messageId: messageId ?? null,
     content,
     mentionedFiles: mentionedFiles ?? null,
     permissionLevel: permissionLevel ?? null,
@@ -193,7 +198,24 @@ export function sendChatMessage(
     planMode: planMode ?? null,
     effort: effort ?? null,
     chromeEnabled: chromeEnabled ?? null,
+    attachments: attachments ?? null,
   });
+}
+
+export function loadAttachmentsForWorkspace(
+  workspaceId: string,
+): Promise<ChatAttachment[]> {
+  return invoke("load_attachments_for_workspace", { workspaceId });
+}
+
+export function loadAttachmentData(
+  attachmentId: string,
+): Promise<string> {
+  return invoke("load_attachment_data", { attachmentId });
+}
+
+export function readFileAsBase64(path: string): Promise<ChatAttachment> {
+  return invoke("read_file_as_base64", { path });
 }
 
 export function stopAgent(workspaceId: string): Promise<void> {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -5,6 +5,8 @@ import type {
   Repository,
   Workspace,
   ChatMessage,
+  ChatAttachment,
+  AttachmentInput,
   DiffFile,
   FileDiff,
   DiffViewMode,
@@ -78,6 +80,9 @@ interface AppState {
 
   // -- Chat --
   chatMessages: Record<string, ChatMessage[]>;
+  chatAttachments: Record<string, ChatAttachment[]>;
+  setChatAttachments: (wsId: string, attachments: ChatAttachment[]) => void;
+  addChatAttachments: (wsId: string, attachments: ChatAttachment[]) => void;
   streamingContent: Record<string, string>;
   streamingThinking: Record<string, string>;
   showThinkingBlocks: Record<string, boolean>;
@@ -119,8 +124,20 @@ interface AppState {
   clearPlanApproval: (wsId: string) => void;
 
   // -- Queued Messages (sent while agent is running, dispatched when idle) --
-  queuedMessages: Record<string, { content: string; mentionedFiles?: string[] }>;
-  setQueuedMessage: (wsId: string, content: string, mentionedFiles?: string[]) => void;
+  queuedMessages: Record<
+    string,
+    {
+      content: string;
+      mentionedFiles?: string[];
+      attachments?: AttachmentInput[];
+    }
+  >;
+  setQueuedMessage: (
+    wsId: string,
+    content: string,
+    mentionedFiles?: string[],
+    attachments?: AttachmentInput[],
+  ) => void;
   clearQueuedMessage: (wsId: string) => void;
 
   // -- Checkpoints --
@@ -230,6 +247,8 @@ interface AppState {
   // -- Chat input prefill (e.g. after rollback) --
   chatInputPrefill: string | null;
   setChatInputPrefill: (text: string | null) => void;
+  pendingAttachmentsPrefill: AttachmentInput[] | null;
+  setPendingAttachmentsPrefill: (atts: AttachmentInput[] | null) => void;
 
   // -- Settings --
   worktreeBaseDir: string;
@@ -338,6 +357,18 @@ export const useAppStore = create<AppState>((set) => ({
 
   // -- Chat --
   chatMessages: {},
+  chatAttachments: {},
+  setChatAttachments: (wsId, attachments) =>
+    set((s) => ({
+      chatAttachments: { ...s.chatAttachments, [wsId]: attachments },
+    })),
+  addChatAttachments: (wsId, attachments) =>
+    set((s) => ({
+      chatAttachments: {
+        ...s.chatAttachments,
+        [wsId]: [...(s.chatAttachments[wsId] ?? []), ...attachments],
+      },
+    })),
   streamingContent: {},
   streamingThinking: {},
   showThinkingBlocks: {},
@@ -557,9 +588,12 @@ export const useAppStore = create<AppState>((set) => ({
 
   // -- Queued Messages --
   queuedMessages: {},
-  setQueuedMessage: (wsId, content, mentionedFiles) =>
+  setQueuedMessage: (wsId, content, mentionedFiles, attachments) =>
     set((s) => ({
-      queuedMessages: { ...s.queuedMessages, [wsId]: { content, mentionedFiles } },
+      queuedMessages: {
+        ...s.queuedMessages,
+        [wsId]: { content, mentionedFiles, attachments },
+      },
     })),
   clearQueuedMessage: (wsId) =>
     set((s) => {
@@ -793,6 +827,8 @@ export const useAppStore = create<AppState>((set) => ({
   // -- Chat input prefill (e.g. after rollback) --
   chatInputPrefill: null,
   setChatInputPrefill: (text) => set({ chatInputPrefill: text }),
+  pendingAttachmentsPrefill: null,
+  setPendingAttachmentsPrefill: (atts) => set({ pendingAttachmentsPrefill: atts }),
 
   // -- Settings --
   worktreeBaseDir: "",

--- a/src/ui/src/types/chat.ts
+++ b/src/ui/src/types/chat.ts
@@ -10,3 +10,32 @@ export interface ChatMessage {
   created_at: string;
   thinking: string | null;
 }
+
+/** A persisted image attachment returned from the backend (base64-encoded). */
+export interface ChatAttachment {
+  id: string;
+  message_id: string;
+  filename: string;
+  media_type: string;
+  data_base64: string;
+  width: number | null;
+  height: number | null;
+  size_bytes: number;
+}
+
+/** Payload shape for sending attachment data to the backend. */
+export interface AttachmentInput {
+  filename: string;
+  media_type: string;
+  data_base64: string;
+}
+
+/** A staged attachment in the frontend before the message is sent. */
+export interface PendingAttachment {
+  id: string;
+  filename: string;
+  media_type: string;
+  data_base64: string;
+  preview_url: string; // blob: URL for thumbnail display
+  size_bytes: number;
+}

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -4,7 +4,7 @@ export type {
   WorkspaceStatus,
   AgentStatus,
 } from "./workspace";
-export type { ChatMessage, ChatRole } from "./chat";
+export type { ChatMessage, ChatRole, ChatAttachment, AttachmentInput, PendingAttachment } from "./chat";
 export type {
   DiffFile,
   FileStatus,

--- a/src/ui/src/utils/attachmentValidation.ts
+++ b/src/ui/src/utils/attachmentValidation.ts
@@ -1,0 +1,30 @@
+/** Supported image MIME types for attachments. */
+export const SUPPORTED_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+/** Supported document MIME types. */
+export const SUPPORTED_DOCUMENT_TYPES = new Set(["application/pdf"]);
+
+/** All supported attachment MIME types (images + documents). */
+export const SUPPORTED_ATTACHMENT_TYPES = new Set([
+  ...SUPPORTED_IMAGE_TYPES,
+  ...SUPPORTED_DOCUMENT_TYPES,
+]);
+
+/** Max raw file size for an image attachment (3.75 MB -> ~5 MB base64). */
+export const MAX_IMAGE_SIZE = 3.75 * 1024 * 1024;
+
+/** Max raw file size for a PDF attachment (20 MB — Anthropic API limit). */
+export const MAX_PDF_SIZE = 20 * 1024 * 1024;
+
+/** Max number of attachments per message. */
+export const MAX_ATTACHMENTS = 5;
+
+/** Get the size limit for a given MIME type. */
+export function maxSizeFor(mimeType: string): number {
+  return SUPPORTED_DOCUMENT_TYPES.has(mimeType) ? MAX_PDF_SIZE : MAX_IMAGE_SIZE;
+}

--- a/src/ui/src/utils/base64.ts
+++ b/src/ui/src/utils/base64.ts
@@ -1,0 +1,9 @@
+/** Decode a base64 string to a Uint8Array backed by a plain ArrayBuffer. */
+export function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/ui/src/utils/pdfThumbnail.ts
+++ b/src/ui/src/utils/pdfThumbnail.ts
@@ -1,0 +1,60 @@
+/**
+ * Render the first page of a PDF to a PNG data URL thumbnail.
+ *
+ * pdfjs-dist is loaded lazily via dynamic import so the ~600 KB library
+ * is code-split into its own chunk and only fetched when a user first
+ * attaches a PDF.
+ *
+ * Results are cached by a caller-supplied key so repeated renders of the
+ * same PDF (e.g. re-renders of chat history) return instantly.
+ */
+
+let workerInitialized = false;
+
+const cache = new Map<string, string>();
+
+export async function generatePdfThumbnail(
+  data: ArrayBuffer,
+  maxSize = 128,
+  cacheKey?: string,
+): Promise<string> {
+  if (cacheKey) {
+    const cached = cache.get(cacheKey);
+    if (cached) return cached;
+  }
+
+  const pdfjsLib = await import("pdfjs-dist");
+  if (!workerInitialized) {
+    const workerUrl = (await import("pdfjs-dist/build/pdf.worker.min.mjs?url"))
+      .default;
+    pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl;
+    workerInitialized = true;
+  }
+
+  const pdf = await pdfjsLib.getDocument({ data }).promise;
+  const page = await pdf.getPage(1);
+
+  const viewport = page.getViewport({ scale: 1 });
+  const scale = maxSize / Math.max(viewport.width, viewport.height);
+  const scaled = page.getViewport({ scale });
+
+  const canvas = document.createElement("canvas");
+  canvas.width = scaled.width;
+  canvas.height = scaled.height;
+  const ctx = canvas.getContext("2d")!;
+
+  await page.render({ canvas, canvasContext: ctx, viewport: scaled }).promise;
+  const dataUrl = canvas.toDataURL("image/png");
+
+  // Release the pixel buffer immediately.
+  canvas.width = 0;
+  canvas.height = 0;
+
+  await pdf.destroy();
+
+  if (cacheKey) {
+    cache.set(cacheKey, dataUrl);
+  }
+
+  return dataUrl;
+}


### PR DESCRIPTION
## Summary

Closes #137. Adds Phase 1 attachment support: paste images (Cmd+V), drag-and-drop files, and a file picker button for PNG, JPEG, GIF, WebP images and PDF documents.

- **Database**: migration v16 adds `attachments` table with FK cascade from `chat_messages`
- **Agent**: switches to `--input-format stream-json` with image/document content blocks when attachments present; text-only path unchanged
- **Backend**: `send_chat_message` accepts attachments + message_id for optimistic UI; lazy attachment body loading for PDFs; magic byte validation
- **Frontend**: `+` button (Claude Desktop-inspired), clipboard paste, Tauri native drag-drop, thumbnail preview strip with rendered PDF first-page via pdfjs-dist (lazy-loaded, code-split), inline images in chat history, attachment restore on rollback
- **Code quality**: extracted `AttachmentInput` type, `base64ToBytes` utility, shared validation constants, `row_to_attachment` DB helper, O(1) attachment Map lookup, PDF thumbnail caching

## Test plan

- [ ] 231 Rust tests pass (`cargo test --all-features`)
- [ ] 127 Vitest tests pass (`cd src/ui && bun run test`)
- [ ] Zero clippy warnings (`cargo clippy --workspace --all-targets`)
- [ ] TypeScript clean (`cd src/ui && bunx tsc --noEmit`)
- [ ] Manual: paste image from clipboard -> thumbnail in strip -> send -> inline in history
- [ ] Manual: drag-drop PNG/PDF onto chat -> appears in strip
- [ ] Manual: click + button -> native file picker -> select image/PDF
- [ ] Manual: send PDF -> agent responds referencing document content
- [ ] Manual: send attachment-only message (no text) -> no API error
- [ ] Manual: rollback -> prompt + attachments restored to input
- [ ] Manual: switch workspaces -> staged attachments cleared
- [ ] Manual: remote workspace -> + button disabled with tooltip