### PR TITLE
fix(ci): use npx for tauri icon generation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -121,7 +121,7 @@ jobs:
         run: cd src/ui && bun install --frozen-lockfile
 
       - name: Generate icons
-        run: bunx @tauri-apps/cli icon assets/logo.png
+        run: npx @tauri-apps/cli icon assets/logo.png
 
       - name: Build and upload desktop app
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
bunx doesn't resolve scoped `@tauri-apps/cli` correctly on CI — falls through to a .NET assembly lookup. Switch to npx.