### PR TITLE
fix: normalize MCP configs to include required 'type' field

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -371,7 +371,10 @@ mod tests {
 
         assert_eq!(normalized["type"], "stdio");
         assert_eq!(normalized["command"], "npx");
-        assert_eq!(normalized["args"], serde_json::json!(["-y", "@example/mcp-server"]));
+        assert_eq!(
+            normalized["args"],
+            serde_json::json!(["-y", "@example/mcp-server"])
+        );
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -68,6 +68,23 @@ pub fn serialize_for_cli(servers: &[McpServer]) -> String {
     wrapper.to_string()
 }
 
+/// Normalize an MCP config by ensuring it has a "type" field.
+///
+/// Claude Code's project-scoped configs don't include "type", but the
+/// Claude CLI `--mcp-config` flag requires it. This function adds
+/// `"type": "stdio"` if the field is missing.
+fn normalize_mcp_config(mut config: serde_json::Value) -> serde_json::Value {
+    if let Some(obj) = config.as_object_mut()
+        && !obj.contains_key("type")
+    {
+        obj.insert(
+            "type".to_string(),
+            serde_json::Value::String("stdio".to_string()),
+        );
+    }
+    config
+}
+
 /// Parse project-scoped MCPs from `~/.claude.json`.
 ///
 /// Claude Code stores per-project configs at:
@@ -89,7 +106,7 @@ fn detect_user_project_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
         .iter()
         .map(|(name, config)| McpServer {
             name: name.clone(),
-            config: config.clone(),
+            config: normalize_mcp_config(config.clone()),
             source: McpSource::UserProjectConfig,
         })
         .collect();
@@ -119,7 +136,7 @@ fn detect_repo_local_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
         .iter()
         .map(|(name, config)| McpServer {
             name: name.clone(),
-            config: config.clone(),
+            config: normalize_mcp_config(config.clone()),
             source: McpSource::RepoLocalConfig,
         })
         .collect();
@@ -341,5 +358,32 @@ mod tests {
             .status()
             .unwrap();
         assert!(!is_gitignored(dir.path(), ".claude.json"));
+    }
+
+    #[test]
+    fn test_normalize_mcp_config_adds_type_field() {
+        let config_without_type = serde_json::json!({
+            "command": "npx",
+            "args": ["-y", "@example/mcp-server"]
+        });
+
+        let normalized = normalize_mcp_config(config_without_type);
+
+        assert_eq!(normalized["type"], "stdio");
+        assert_eq!(normalized["command"], "npx");
+        assert_eq!(normalized["args"], serde_json::json!(["-y", "@example/mcp-server"]));
+    }
+
+    #[test]
+    fn test_normalize_mcp_config_preserves_existing_type() {
+        let config_with_type = serde_json::json!({
+            "type": "http",
+            "url": "https://example.com"
+        });
+
+        let normalized = normalize_mcp_config(config_with_type.clone());
+
+        assert_eq!(normalized["type"], "http");
+        assert_eq!(normalized["url"], "https://example.com");
     }
 }


### PR DESCRIPTION
## Summary

Fixes MCP server detection and injection by normalizing configs to include the required `"type"` field.

## Problem

Claude Code stores project-specific MCP configs in `~/.claude.json` using a nested format **without** a `"type"` field:
```json
{
  "command": "npx",
  "args": ["mcp-remote", "https://mcp.novu.co/"],
  "env": { "NOVU_API_KEY": "..." }
}
```

However, the Claude CLI `--mcp-config` flag **requires** each server config to have a `"type"` field:
```json
{
  "type": "stdio",
  "command": "npx",
  "args": ["mcp-remote", "https://mcp.novu.co/"],
  "env": { "NOVU_API_KEY": "..." }
}
```

When Claudette detected and stored these configs, it was storing them as-is without the `"type"` field, causing the Claude CLI to silently reject them. Users would see MCP servers configured in the database but they wouldn't be available to agents.

## Changes

- Add `normalize_mcp_config()` function to ensure all MCP configs have `"type": "stdio"` if missing
- Apply normalization in `detect_user_project_mcps()` and `detect_repo_local_mcps()`
- Add unit tests for normalization logic (preserves existing type, adds missing type)
- Use let-chain syntax to satisfy clippy

## Testing

```bash
cargo test --lib mcp::
# All 14 tests pass including 2 new normalization tests

cargo clippy --workspace --all-targets -- -D warnings
# Zero warnings
```

## Migration Note

Existing database records with missing `"type"` fields can be fixed with:
```sql
UPDATE repository_mcp_servers
SET config_json = json_insert(config_json, '$.type', 'stdio')
WHERE json_extract(config_json, '$.type') IS NULL;
```

This is safe to run idempotently and only affects records missing the field.

## Test Plan

- [x] Unit tests pass
- [x] Clippy passes with zero warnings
- [ ] Create new workspace in repo with project-scoped MCPs
- [ ] Verify MCP servers are injected via `--mcp-config`
- [ ] Verify MCP tools are available in agent session (e.g., `mcp__novu__*`)