### PR TITLE
fix: pass MCP config on every turn, not just first turn

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -182,7 +182,10 @@ pub async fn send_chat_message(
     let db_rows = db
         .list_repository_mcp_servers(&ws.repository_id)
         .map_err(|e| {
-            eprintln!("[chat] Failed to load MCP servers for {}: {e}", ws.repository_id);
+            eprintln!(
+                "[chat] Failed to load MCP servers for {}: {e}",
+                ws.repository_id
+            );
             e.to_string()
         })?;
     let mcp_config = if db_rows.is_empty() {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -240,36 +240,33 @@ pub async fn send_chat_message(
     session.needs_attention = false;
     session.attention_kind = None;
 
-    // Load repository MCP configs for injection on first turn.
-    let mcp_config = if !is_resume {
-        let db_rows = db
-            .list_repository_mcp_servers(&ws.repository_id)
-            .unwrap_or_default();
-        if db_rows.is_empty() {
+    // Load repository MCP configs for injection on every turn.
+    // Each Claude CLI process is independent and needs the MCP config passed.
+    let db_rows = db
+        .list_repository_mcp_servers(&ws.repository_id)
+        .unwrap_or_default();
+    let mcp_config = if db_rows.is_empty() {
+        None
+    } else {
+        let mcp_servers: Vec<claudette::mcp::McpServer> = db_rows
+            .iter()
+            .filter_map(|row| {
+                let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
+                let source: claudette::mcp::McpSource =
+                    serde_json::from_str(&format!("\"{}\"", row.source))
+                        .unwrap_or(claudette::mcp::McpSource::UserProjectConfig);
+                Some(claudette::mcp::McpServer {
+                    name: row.name.clone(),
+                    config,
+                    source,
+                })
+            })
+            .collect();
+        if mcp_servers.is_empty() {
             None
         } else {
-            let mcp_servers: Vec<claudette::mcp::McpServer> = db_rows
-                .iter()
-                .filter_map(|row| {
-                    let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
-                    let source: claudette::mcp::McpSource =
-                        serde_json::from_str(&format!("\"{}\"", row.source))
-                            .unwrap_or(claudette::mcp::McpSource::UserProjectConfig);
-                    Some(claudette::mcp::McpServer {
-                        name: row.name.clone(),
-                        config,
-                        source,
-                    })
-                })
-                .collect();
-            if mcp_servers.is_empty() {
-                None
-            } else {
-                Some(claudette::mcp::serialize_for_cli(&mcp_servers))
-            }
+            Some(claudette::mcp::serialize_for_cli(&mcp_servers))
         }
-    } else {
-        None
     };
 
     // Build agent settings from frontend params.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -176,6 +176,39 @@ pub async fn send_chat_message(
         .get_repository(&ws.repository_id)
         .map_err(|e| e.to_string())?;
 
+    // Load repository MCP configs for injection on every turn.
+    // Each Claude CLI process is independent and needs the MCP config passed.
+    // This is done BEFORE acquiring the agents lock to avoid blocking other workspaces.
+    let db_rows = db
+        .list_repository_mcp_servers(&ws.repository_id)
+        .map_err(|e| {
+            eprintln!("[chat] Failed to load MCP servers for {}: {e}", ws.repository_id);
+            e.to_string()
+        })?;
+    let mcp_config = if db_rows.is_empty() {
+        None
+    } else {
+        let mcp_servers: Vec<claudette::mcp::McpServer> = db_rows
+            .iter()
+            .filter_map(|row| {
+                let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
+                let source: claudette::mcp::McpSource =
+                    serde_json::from_str(&format!("\"{}\"", row.source))
+                        .unwrap_or(claudette::mcp::McpSource::UserProjectConfig);
+                Some(claudette::mcp::McpServer {
+                    name: row.name.clone(),
+                    config,
+                    source,
+                })
+            })
+            .collect();
+        if mcp_servers.is_empty() {
+            None
+        } else {
+            Some(claudette::mcp::serialize_for_cli(&mcp_servers))
+        }
+    };
+
     // Get or create agent session. Custom instructions are resolved once on
     // the first turn and cached for the session lifetime.
     //
@@ -239,35 +272,6 @@ pub async fn send_chat_message(
     session.turn_count += 1;
     session.needs_attention = false;
     session.attention_kind = None;
-
-    // Load repository MCP configs for injection on every turn.
-    // Each Claude CLI process is independent and needs the MCP config passed.
-    let db_rows = db
-        .list_repository_mcp_servers(&ws.repository_id)
-        .unwrap_or_default();
-    let mcp_config = if db_rows.is_empty() {
-        None
-    } else {
-        let mcp_servers: Vec<claudette::mcp::McpServer> = db_rows
-            .iter()
-            .filter_map(|row| {
-                let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
-                let source: claudette::mcp::McpSource =
-                    serde_json::from_str(&format!("\"{}\"", row.source))
-                        .unwrap_or(claudette::mcp::McpSource::UserProjectConfig);
-                Some(claudette::mcp::McpServer {
-                    name: row.name.clone(),
-                    config,
-                    source,
-                })
-            })
-            .collect();
-        if mcp_servers.is_empty() {
-            None
-        } else {
-            Some(claudette::mcp::serialize_for_cli(&mcp_servers))
-        }
-    };
 
     // Build agent settings from frontend params.
     let agent_settings = AgentSettings {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -264,9 +264,9 @@ pub fn build_claude_args(
         args.push("--chrome".to_string());
     }
 
-    // MCP config is session-level — only inject on the first turn.
-    // Resumed sessions inherit MCP servers from the initial turn.
-    if !is_resume && let Some(ref mcp_json) = settings.mcp_config {
+    // MCP config must be set on every turn — each `claude` invocation is a fresh
+    // process that doesn't inherit MCP connections from previous turns.
+    if let Some(ref mcp_json) = settings.mcp_config {
         args.push("--mcp-config".to_string());
         args.push(mcp_json.clone());
     }
@@ -1648,13 +1648,15 @@ mod tests {
     }
 
     #[test]
-    fn test_build_args_mcp_config_skipped_on_resume() {
+    fn test_build_args_mcp_config_on_resume() {
         let settings = AgentSettings {
-            mcp_config: Some(r#"{"mcpServers":{}}"#.to_string()),
+            mcp_config: Some(r#"{"mcpServers":{"s":{"type":"stdio","command":"x"}}}"#.to_string()),
             ..Default::default()
         };
         let args = build_claude_args("sess-1", "hello", true, &[], None, &settings, false);
-        assert!(!args.contains(&"--mcp-config".to_string()));
+        // MCP config must be passed on every turn (including resume)
+        let idx = args.iter().position(|a| a == "--mcp-config").unwrap();
+        assert!(args[idx + 1].contains("mcpServers"));
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -213,8 +213,9 @@ pub struct AgentSettings {
     /// Enable Chrome browser mode via `--chrome`. Session-level: only applied
     /// on the first turn.
     pub chrome_enabled: bool,
-    /// MCP config JSON string for `--mcp-config`. Session-level: only applied
-    /// on the first turn.
+    /// MCP config JSON string for `--mcp-config`. Per-turn: applied on every
+    /// turn since each `claude` process is independent and doesn't inherit
+    /// MCP connections from previous turns.
     pub mcp_config: Option<String>,
 }
 


### PR DESCRIPTION
## Problem

MCP servers configured via `--mcp-config` were only available on the first prompt but disappeared on subsequent prompts in the same workspace.

## Root Cause

The code incorrectly treated `--mcp-config` as a session-level flag (like `--model` or `--chrome`), only passing it on the first turn:

```rust
// WRONG: Only passed on first turn
if !is_resume && let Some(ref mcp_json) = settings.mcp_config {
    args.push("--mcp-config".to_string());
    args.push(mcp_json.clone());
}
```

The assumption was that "resumed sessions inherit MCP servers from the initial turn." However, this is incorrect because **each `claude` invocation spawns a completely independent process** that doesn't inherit MCP connections.

## Solution

Changed `--mcp-config` to be a **per-turn flag** (like `--permission-mode`), passed on every turn:

```rust
// CORRECT: Passed on every turn
if let Some(ref mcp_json) = settings.mcp_config {
    args.push("--mcp-config".to_string());
    args.push(mcp_json.clone());
}
```

Also updated `chat.rs` to load repository MCP configs from the database on every turn, not just the first.

## Changes

- **`src/agent.rs`**: Remove `!is_resume` condition for `--mcp-config` flag
- **`src-tauri/src/commands/chat.rs`**: Load MCP configs on every turn
- **Tests**: Updated test to verify MCP config is passed on resume turns

## Testing

✅ All 248 tests pass  
✅ Updated test verifies MCP config is passed correctly on resumed turns

## Why This Fix Works

The Claude CLI's process lifecycle means each turn is a fresh start. Just like we pass `--permission-mode` on every turn, we must also pass `--mcp-config` on every turn to ensure MCP servers remain connected throughout the conversation.