### PR TITLE
feat(mcp): add MCP server supervision with persistent sessions and connectors UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,9 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "url",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -1125,6 +1127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1178,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -3565,7 +3579,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3603,9 +3617,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6138,6 +6152,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6682,6 +6708,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ futures = "0.3"
 rusqlite = { version = "0.34", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync", "rt"] }
+tokio = { version = "1", features = ["process", "fs", "io-util", "time", "sync", "rt", "net"] }
+url = "2"
 uuid = { version = "1", features = ["v4"] }
+which = "7"
 dirs = "6"
 open = "5"
 rand = "0.8"

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -371,6 +371,16 @@ async fn handle_send_chat_message(
     let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
 
+    // Load repository MCP configs for injection on EVERY turn. Each `claude
+    // --print` is an independent process — MCP connections are per-process and
+    // NOT restored from session state on `--resume`.
+    let mcp_config = {
+        let db_rows = db
+            .list_repository_mcp_servers(&ws.repository_id)
+            .unwrap_or_default();
+        claudette::mcp::cli_config_from_rows(&db_rows)
+    };
+
     let agent_settings = AgentSettings {
         model: if !is_resume { model } else { None },
         fast_mode: fast_mode.unwrap_or(false),
@@ -378,7 +388,7 @@ async fn handle_send_chat_message(
         plan_mode: plan_mode.unwrap_or(false),
         effort,
         chrome_enabled: chrome_enabled.unwrap_or(false),
-        mcp_config: None,
+        mcp_config,
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -347,7 +347,7 @@ pub async fn send_chat_message(
         // Drop lock before async process spawn.
         drop(agents);
 
-        let ps = start_persistent(
+        let (ps, final_sid) = match start_persistent(
             worktree_path.clone(),
             sid.clone(),
             is_resume,
@@ -355,13 +355,33 @@ pub async fn send_chat_message(
             custom_instructions.clone(),
             agent_settings.clone(),
         )
-        .await?;
+        .await
+        {
+            Ok(ps) => (ps, sid),
+            Err(e) if is_resume => {
+                // Resume failed (stale/corrupt session) — start fresh instead.
+                eprintln!("[chat] --resume failed ({e}), starting fresh session");
+                let fresh_sid = uuid::Uuid::new_v4().to_string();
+                let ps = start_persistent(
+                    worktree_path.clone(),
+                    fresh_sid.clone(),
+                    false,
+                    allowed_tools.clone(),
+                    custom_instructions.clone(),
+                    agent_settings.clone(),
+                )
+                .await?;
+                (ps, fresh_sid)
+            }
+            Err(e) => return Err(e),
+        };
         let handle = ps.send_turn(&prompt, &image_attachments).await?;
 
         agents = state.agents.write().await;
         let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
         session.persistent_session = Some(ps);
-        let _ = db.save_agent_session(&workspace_id, &sid, session.turn_count);
+        session.session_id = final_sid.clone();
+        let _ = db.save_agent_session(&workspace_id, &final_sid, session.turn_count);
         handle
     };
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -423,6 +423,7 @@ pub async fn send_chat_message(
     {
         let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
         session.active_pid = Some(spawned_pid);
+        let _ = db.save_agent_session(&workspace_id, &session.session_id, session.turn_count);
     }
     drop(agents);
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -316,20 +316,43 @@ pub async fn send_chat_message(
                 session.persistent_session = None;
                 drop(agents);
 
-                let ps = start_persistent(
+                let is_resume = saved_turn_count > 1;
+                let (ps, final_sid) = match start_persistent(
                     worktree_path.clone(),
                     saved_session_id.clone(),
-                    saved_turn_count > 1, // resume if we had prior turns
+                    is_resume,
                     allowed_tools.clone(),
                     custom_instructions.clone(),
                     agent_settings.clone(),
                 )
-                .await?;
+                .await
+                {
+                    Ok(ps) => (ps, saved_session_id.clone()),
+                    Err(e2) if is_resume => {
+                        eprintln!("[chat] --resume respawn failed ({e2}), starting fresh");
+                        let fresh = uuid::Uuid::new_v4().to_string();
+                        let ps = start_persistent(
+                            worktree_path.clone(),
+                            fresh.clone(),
+                            false,
+                            allowed_tools.clone(),
+                            custom_instructions.clone(),
+                            agent_settings.clone(),
+                        )
+                        .await?;
+                        (ps, fresh)
+                    }
+                    Err(e2) => {
+                        let _ = db.clear_agent_session(&workspace_id);
+                        return Err(e2);
+                    }
+                };
                 let handle = ps.send_turn(&prompt, &image_attachments).await?;
 
                 agents = state.agents.write().await;
                 let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
                 session.persistent_session = Some(ps);
+                session.session_id = final_sid;
                 handle
             }
         }
@@ -373,7 +396,18 @@ pub async fn send_chat_message(
                 .await?;
                 (ps, fresh_sid)
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                // Spawn failed entirely — clear stale session from DB so the
+                // next attempt doesn't try --resume with a dead session ID.
+                let _ = db.clear_agent_session(&workspace_id);
+                agents = state.agents.write().await;
+                if let Some(session) = agents.get_mut(&workspace_id) {
+                    session.turn_count = 0;
+                    session.session_id = String::new();
+                }
+                drop(agents);
+                return Err(e);
+            }
         };
         let handle = ps.send_turn(&prompt, &image_attachments).await?;
 
@@ -787,19 +821,25 @@ pub async fn stop_agent(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let mut agents = state.agents.write().await;
-    if let Some(session) = agents.get_mut(&workspace_id)
-        && let Some(pid) = session.active_pid.take()
-    {
-        // Clear persistent session so the next turn starts fresh.
+    if let Some(session) = agents.get_mut(&workspace_id) {
+        // Clear persistent session and reset session state so the next
+        // turn starts completely fresh (not --resume with a stale ID).
         session.persistent_session = None;
-        agent::stop_agent(pid).await?;
+        session.turn_count = 0;
+        session.session_id = String::new();
+        if let Some(pid) = session.active_pid.take() {
+            agent::stop_agent(pid).await?;
+        }
     }
     drop(agents);
+
+    // Clear persisted session from DB too.
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let _ = db.clear_agent_session(&workspace_id);
 
     crate::tray::rebuild_tray(&app);
 
     // Log stop message.
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let msg = ChatMessage {
         id: uuid::Uuid::new_v4().to_string(),
         workspace_id,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -524,6 +524,10 @@ pub async fn send_chat_message(
                     session.active_pid = None;
                 }
                 drop(agents);
+                // Rebuild tray so it reflects the idle state. Without this,
+                // the tray stays stuck on "Running" because the persistent
+                // process doesn't exit (only ProcessExited triggered rebuild).
+                crate::tray::rebuild_tray(&app);
             }
 
             if let AgentEvent::ProcessExited(_code) = &event {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,12 +1,15 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::{
-    self, AgentEvent, AgentSettings, ImageAttachment, InnerStreamEvent, StartContentBlock,
-    StreamEvent,
+    self, AgentEvent, AgentSettings, ImageAttachment, InnerStreamEvent, PersistentSession,
+    StartContentBlock, StreamEvent,
 };
 use claudette::db::Database;
 use claudette::git;
+use claudette::mcp_supervisor::McpSupervisor;
 use claudette::model::{
     Attachment, ChatMessage, ChatRole, CompletedTurnData, ConversationCheckpoint, TurnToolActivity,
 };
@@ -188,29 +191,7 @@ pub async fn send_chat_message(
             );
             e.to_string()
         })?;
-    let mcp_config = if db_rows.is_empty() {
-        None
-    } else {
-        let mcp_servers: Vec<claudette::mcp::McpServer> = db_rows
-            .iter()
-            .filter_map(|row| {
-                let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
-                let source: claudette::mcp::McpSource =
-                    serde_json::from_str(&format!("\"{}\"", row.source))
-                        .unwrap_or(claudette::mcp::McpSource::UserProjectConfig);
-                Some(claudette::mcp::McpServer {
-                    name: row.name.clone(),
-                    config,
-                    source,
-                })
-            })
-            .collect();
-        if mcp_servers.is_empty() {
-            None
-        } else {
-            Some(claudette::mcp::serialize_for_cli(&mcp_servers))
-        }
-    };
+    let mcp_config = claudette::mcp::cli_config_from_rows(&db_rows);
 
     // Get or create agent session. Custom instructions are resolved once on
     // the first turn and cached for the session lifetime.
@@ -241,6 +222,7 @@ pub async fn send_chat_message(
                 custom_instructions: instructions.clone(),
                 needs_attention: false,
                 attention_kind: None,
+                persistent_session: None,
             };
         }
 
@@ -251,26 +233,27 @@ pub async fn send_chat_message(
             custom_instructions: instructions,
             needs_attention: false,
             attention_kind: None,
+            persistent_session: None,
         }
     });
 
-    // If a previous turn is still running, stop it before starting a new one.
-    // This prevents overlapping processes for the same workspace.
-    if let Some(old_pid) = session.active_pid.take() {
+    // If a previous turn is still running and there's no persistent session,
+    // stop the stale process. With a persistent session, the process is shared
+    // and the CLI serializes turns internally.
+    if session.persistent_session.is_none()
+        && let Some(old_pid) = session.active_pid.take()
+    {
         eprintln!("[chat] Stopping stale process {old_pid} before new turn");
         drop(agents); // release lock while waiting
         let _ = agent::stop_agent(old_pid).await;
-        // Brief wait for process cleanup.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         agents = state.agents.write().await;
-        // Re-borrow session after re-acquiring lock.
         let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
         session.active_pid = None;
     }
     let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
 
-    let is_resume = session.turn_count > 0;
-    let session_id = session.session_id.clone();
+    let has_persistent = session.persistent_session.is_some();
     let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
     session.needs_attention = false;
@@ -278,7 +261,7 @@ pub async fn send_chat_message(
 
     // Build agent settings from frontend params.
     let agent_settings = AgentSettings {
-        model: if !is_resume { model } else { None },
+        model,
         fast_mode: fast_mode.unwrap_or(false),
         thinking_enabled: thinking_enabled.unwrap_or(false),
         plan_mode: plan_mode.unwrap_or(false),
@@ -295,26 +278,99 @@ pub async fn send_chat_message(
     )
     .await;
 
-    // Spawn the agent turn.
-    let turn_handle = agent::run_turn(
-        std::path::Path::new(&worktree_path),
-        &session_id,
-        &prompt,
-        is_resume,
-        &allowed_tools,
-        custom_instructions.as_deref(),
-        &agent_settings,
-        &image_attachments,
-    )
-    .await?;
+    // Use persistent session to keep MCP servers alive across turns.
+    // First turn or after restart: start a PersistentSession.
+    // Subsequent turns in same session: reuse the existing process via stdin.
+    let existing_persistent = session.persistent_session.clone();
+    let saved_session_id = session.session_id.clone();
+    let saved_turn_count = session.turn_count;
 
-    // Persist session state only after the subprocess spawned successfully.
-    // If run_turn fails (missing binary, spawn error), we avoid persisting a
-    // turn_count > 0 for a session Claude never initialized.
-    let _ = db.save_agent_session(&workspace_id, &session_id, session.turn_count);
+    // Helper: start a persistent session, using --resume for restored sessions.
+    let start_persistent = |worktree: String,
+                            sid: String,
+                            is_resume: bool,
+                            tools: Vec<String>,
+                            instructions: Option<String>,
+                            settings: AgentSettings| async move {
+        let ps = Arc::new(
+            PersistentSession::start(
+                std::path::Path::new(&worktree),
+                &sid,
+                is_resume,
+                &tools,
+                instructions.as_deref(),
+                &settings,
+            )
+            .await?,
+        );
+        Ok::<Arc<PersistentSession>, String>(ps)
+    };
+
+    let turn_handle = if let Some(ref ps) = existing_persistent {
+        // Reuse existing persistent process — send turn via stdin.
+        match ps.send_turn(&prompt, &image_attachments).await {
+            Ok(handle) => handle,
+            Err(e) => {
+                // Persistent session died — drop lock before async spawn to
+                // avoid blocking other workspaces during process startup.
+                eprintln!("[chat] Persistent session failed, respawning: {e}");
+                session.persistent_session = None;
+                drop(agents);
+
+                let ps = start_persistent(
+                    worktree_path.clone(),
+                    saved_session_id.clone(),
+                    saved_turn_count > 1, // resume if we had prior turns
+                    allowed_tools.clone(),
+                    custom_instructions.clone(),
+                    agent_settings.clone(),
+                )
+                .await?;
+                let handle = ps.send_turn(&prompt, &image_attachments).await?;
+
+                agents = state.agents.write().await;
+                let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
+                session.persistent_session = Some(ps);
+                handle
+            }
+        }
+    } else {
+        // No persistent session — start one. Use --resume if we have a saved
+        // session from the DB (app restart), fresh ID if brand new.
+        let is_resume = saved_turn_count > 1;
+        let sid = if is_resume {
+            saved_session_id.clone()
+        } else {
+            let fresh = uuid::Uuid::new_v4().to_string();
+            session.session_id = fresh.clone();
+            fresh
+        };
+        // Drop lock before async process spawn.
+        drop(agents);
+
+        let ps = start_persistent(
+            worktree_path.clone(),
+            sid.clone(),
+            is_resume,
+            allowed_tools.clone(),
+            custom_instructions.clone(),
+            agent_settings.clone(),
+        )
+        .await?;
+        let handle = ps.send_turn(&prompt, &image_attachments).await?;
+
+        agents = state.agents.write().await;
+        let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
+        session.persistent_session = Some(ps);
+        let _ = db.save_agent_session(&workspace_id, &sid, session.turn_count);
+        handle
+    };
 
     let spawned_pid = turn_handle.pid;
-    session.active_pid = Some(spawned_pid);
+    {
+        let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
+        session.active_pid = Some(spawned_pid);
+    }
     drop(agents);
 
     // Capture rename context before the bridge spawn.
@@ -333,10 +389,11 @@ pub async fn send_chat_message(
     let db_path = state.db_path.clone();
     let wt_path = worktree_path.clone();
     let user_msg_id = user_msg.id.clone();
+    let repo_id_for_mcp = ws.repository_id.clone();
     tokio::spawn(async move {
         // On the first turn, spawn a background task to auto-rename the branch
         // using Haiku. This runs concurrently and does not block the event loop.
-        if !is_resume && has_repo {
+        if !has_persistent && has_repo {
             let ws_id2 = ws_id.clone();
             let wt_path2 = wt_path.clone();
             let old_branch2 = rename_old_branch.clone();
@@ -362,6 +419,9 @@ pub async fn send_chat_message(
 
         let mut rx = turn_handle.event_rx;
         let mut got_init = false;
+        // MCP monitoring: map tool_use_id → tool_name for MCP error detection.
+        let mut mcp_tool_names: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
         // Track the last assistant message inserted in THIS turn. Falls back
         // to the user message ID for tool-only turns (AskUserQuestion, plan
         // approval) so that checkpoint creation isn't skipped entirely.
@@ -413,6 +473,59 @@ pub async fn send_chat_message(
                 }
             }
 
+            // MCP monitoring: track tool_use_id → tool_name for all MCP tool calls.
+            if let AgentEvent::Stream(StreamEvent::Stream {
+                event:
+                    InnerStreamEvent::ContentBlockStart {
+                        content_block: Some(StartContentBlock::ToolUse { id, name }),
+                        ..
+                    },
+            }) = &event
+                && claudette::mcp_supervisor::extract_mcp_server_name(name).is_some()
+            {
+                mcp_tool_names.insert(id.clone(), name.clone());
+            }
+
+            // MCP monitoring: check tool results for connection failure patterns.
+            if let AgentEvent::Stream(StreamEvent::User { message }) = &event {
+                for block in &message.content {
+                    if let claudette::agent::UserContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                    } = block
+                        && let Some(tool_name) = mcp_tool_names.get(tool_use_id)
+                    {
+                        let content_str = content.to_string();
+                        if claudette::mcp_supervisor::is_terminal_mcp_error(&content_str)
+                            && let Some(server_name) =
+                                claudette::mcp_supervisor::extract_mcp_server_name(tool_name)
+                        {
+                            let sv = app.state::<Arc<McpSupervisor>>();
+                            sv.report_tool_failure(&repo_id_for_mcp, server_name, &content_str)
+                                .await;
+                            if let Some(snapshot) = sv.get_status(&repo_id_for_mcp).await {
+                                let _ = app.emit("mcp-status-changed", &snapshot);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // When a persistent turn completes (Result event), clear active_pid
+            // so the workspace shows as idle. The persistent process stays alive
+            // for the next turn — only active_pid is cleared, not persistent_session.
+            if let AgentEvent::Stream(StreamEvent::Result { .. }) = &event {
+                let app_state = app.state::<AppState>();
+                let mut agents = app_state.agents.write().await;
+                if let Some(session) = agents.get_mut(&ws_id)
+                    && session.active_pid == Some(spawned_pid)
+                    && session.persistent_session.is_some()
+                {
+                    session.active_pid = None;
+                }
+                drop(agents);
+            }
+
             if let AgentEvent::ProcessExited(_code) = &event {
                 let app_state = app.state::<AppState>();
                 let mut agents = app_state.agents.write().await;
@@ -429,6 +542,9 @@ pub async fn send_chat_message(
                     // Only clear active_pid if it still matches the process that
                     // exited. A new turn may have already replaced it.
                     session.active_pid = None;
+                    // Process died — clear persistent session so the next turn
+                    // spawns a fresh one.
+                    session.persistent_session = None;
                 }
                 // Play notification sound + run command if the window is not focused.
                 // This runs on the Rust side so it works even when the webview
@@ -649,6 +765,8 @@ pub async fn stop_agent(
     if let Some(session) = agents.get_mut(&workspace_id)
         && let Some(pid) = session.active_pid.take()
     {
+        // Clear persistent session so the next turn starts fresh.
+        session.persistent_session = None;
         agent::stop_agent(pid).await?;
     }
     drop(agents);

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -253,7 +253,6 @@ pub async fn send_chat_message(
     }
     let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
 
-    let has_persistent = session.persistent_session.is_some();
     let custom_instructions = session.custom_instructions.clone();
     session.turn_count += 1;
     session.needs_attention = false;
@@ -392,8 +391,10 @@ pub async fn send_chat_message(
     let repo_id_for_mcp = ws.repository_id.clone();
     tokio::spawn(async move {
         // On the first turn, spawn a background task to auto-rename the branch
-        // using Haiku. This runs concurrently and does not block the event loop.
-        if !has_persistent && has_repo {
+        // using Haiku. Gate on turn count (not persistent_session) because
+        // persistent_session is in-memory only and is None after app restart
+        // even for resumed sessions.
+        if saved_turn_count <= 1 && has_repo {
             let ws_id2 = ws_id.clone();
             let wt_path2 = wt_path.clone();
             let old_branch2 = rename_old_branch.clone();

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -169,9 +169,16 @@ pub async fn ensure_and_validate_mcps(
         .collect();
 
     // Always replace — even with an empty vec — so removed servers are dropped.
-    let _ = db.replace_repository_mcp_servers(&repo_id, &rows);
+    if let Err(e) = db.replace_repository_mcp_servers(&repo_id, &rows) {
+        eprintln!("[mcp] Failed to persist MCP servers for {repo_id}: {e}");
+    }
 
-    let saved = db.list_repository_mcp_servers(&repo_id).unwrap_or_default();
+    let saved = db
+        .list_repository_mcp_servers(&repo_id)
+        .unwrap_or_else(|e| {
+            eprintln!("[mcp] Failed to reload MCP servers for {repo_id}: {e}");
+            Vec::new()
+        });
 
     // Initialize supervisor from persisted state (including empty, so stale
     // in-memory servers are cleared) and validate enabled servers.
@@ -241,21 +248,31 @@ pub async fn set_mcp_server_enabled(
 
     // Invalidate persistent sessions for all workspaces in this repo so the
     // next turn starts a fresh process with the updated MCP config.
-    // Kill the running process so it takes effect immediately.
-    let mut agents = state.agents.write().await;
+    // Collect PIDs under the lock, then drop it before awaiting stop_agent
+    // to avoid blocking other workspace commands during process shutdown.
     let workspaces = db.list_workspaces().unwrap_or_default();
     let repo_workspace_ids: Vec<String> = workspaces
         .iter()
         .filter(|w| w.repository_id == repo_id)
         .map(|w| w.id.clone())
         .collect();
-    for ws_id in &repo_workspace_ids {
-        if let Some(session) = agents.get_mut(ws_id) {
-            if let Some(pid) = session.active_pid.take() {
-                let _ = claudette::agent::stop_agent(pid).await;
+
+    let pids_to_stop = {
+        let mut agents = state.agents.write().await;
+        let mut pids = Vec::new();
+        for ws_id in &repo_workspace_ids {
+            if let Some(session) = agents.get_mut(ws_id) {
+                if let Some(pid) = session.active_pid.take() {
+                    pids.push(pid);
+                }
+                session.persistent_session = None;
             }
-            session.persistent_session = None;
         }
+        pids
+    };
+
+    for pid in pids_to_stop {
+        let _ = claudette::agent::stop_agent(pid).await;
     }
 
     Ok(())

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -135,7 +135,12 @@ pub async fn ensure_and_validate_mcps(
 
     // Merge with existing DB state: preserve enabled flags for known servers,
     // add new ones respecting ~/.claude.json disabledMcpServers.
-    let existing = db.list_repository_mcp_servers(&repo_id).unwrap_or_default();
+    let existing = db
+        .list_repository_mcp_servers(&repo_id)
+        .unwrap_or_else(|e| {
+            eprintln!("[mcp] Failed to load existing MCP servers for {repo_id}: {e}");
+            Vec::new()
+        });
     let existing_by_name: std::collections::HashMap<String, &RepositoryMcpServer> =
         existing.iter().map(|s| (s.name.clone(), s)).collect();
     let disabled_list = mcp::get_disabled_servers(repo_path);

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use tauri::State;
 
 use claudette::db::{Database, RepositoryMcpServer};
 use claudette::mcp::{self, McpServer};
+use claudette::mcp_supervisor::{McpServerStatus, McpStatusSnapshot, McpSupervisor};
 
 use crate::state::AppState;
 
@@ -27,6 +30,8 @@ pub async fn detect_mcp_servers(
 }
 
 /// Save selected MCP servers for a repository (replaces any existing).
+///
+/// Respects `~/.claude.json` `disabledMcpServers` for initial enabled state.
 #[tauri::command]
 pub async fn save_repository_mcps(
     repo_id: String,
@@ -35,12 +40,19 @@ pub async fn save_repository_mcps(
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
+    // Read disabled list from ~/.claude.json so initial enabled state matches.
+    let repo = db.get_repository(&repo_id).map_err(|e| e.to_string())?;
+    let disabled_list = repo
+        .as_ref()
+        .map(|r| mcp::get_disabled_servers(std::path::Path::new(&r.path)))
+        .unwrap_or_default();
+
     let rows: Vec<RepositoryMcpServer> = servers
         .into_iter()
         .map(|s| {
-            // Validate config is valid JSON before storing.
             let config_json = serde_json::to_string(&s.config)
                 .map_err(|e| format!("Invalid config JSON for {}: {e}", s.name))?;
+            let enabled = !disabled_list.contains(&s.name);
             Ok(RepositoryMcpServer {
                 id: uuid::Uuid::new_v4().to_string(),
                 repository_id: repo_id.clone(),
@@ -51,6 +63,7 @@ pub async fn save_repository_mcps(
                     .trim_matches('"')
                     .to_string(),
                 created_at: String::new(), // DB default
+                enabled,
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
@@ -79,4 +92,171 @@ pub async fn delete_repository_mcp(
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.delete_repository_mcp_server(&server_id)
         .map_err(|e| e.to_string())
+}
+
+/// Get MCP server status for a repository from the supervisor.
+#[tauri::command]
+pub async fn get_mcp_status(
+    repo_id: String,
+    supervisor: State<'_, Arc<McpSupervisor>>,
+) -> Result<Option<McpStatusSnapshot>, String> {
+    Ok(supervisor.get_status(&repo_id).await)
+}
+
+/// Detect, merge, initialize supervisor, and validate MCP servers for a repo.
+///
+/// Always re-detects from all sources and merges with existing DB state:
+/// - New servers are added (preserving disabled list from ~/.claude.json)
+/// - Removed servers are dropped
+/// - Existing servers keep their enabled state
+///
+/// Called when a workspace is selected or the connectors menu opens. Returns
+/// the validated status snapshot with connected/failed states.
+#[tauri::command]
+pub async fn ensure_and_validate_mcps(
+    repo_id: String,
+    state: State<'_, AppState>,
+    supervisor: State<'_, Arc<McpSupervisor>>,
+) -> Result<McpStatusSnapshot, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repo = db
+        .get_repository(&repo_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Repository not found")?;
+    let repo_path = std::path::Path::new(&repo.path);
+
+    // Always re-detect from all sources (user, project, plugins).
+    let detected = tokio::task::spawn_blocking({
+        let path = repo_path.to_path_buf();
+        move || mcp::detect_mcp_servers(&path)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    // Merge with existing DB state: preserve enabled flags for known servers,
+    // add new ones respecting ~/.claude.json disabledMcpServers.
+    let existing = db.list_repository_mcp_servers(&repo_id).unwrap_or_default();
+    let existing_by_name: std::collections::HashMap<String, &RepositoryMcpServer> =
+        existing.iter().map(|s| (s.name.clone(), s)).collect();
+    let disabled_list = mcp::get_disabled_servers(repo_path);
+
+    let rows: Vec<RepositoryMcpServer> = detected
+        .into_iter()
+        .map(|s| {
+            let config_json = serde_json::to_string(&s.config).unwrap_or_default();
+            // Preserve existing enabled state, or use disabled list for new servers.
+            let enabled = existing_by_name
+                .get(&s.name)
+                .map(|e| e.enabled)
+                .unwrap_or_else(|| !disabled_list.contains(&s.name));
+            let id = existing_by_name
+                .get(&s.name)
+                .map(|e| e.id.clone())
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            RepositoryMcpServer {
+                id,
+                repository_id: repo_id.clone(),
+                name: s.name,
+                config_json,
+                source: serde_json::to_string(&s.source)
+                    .unwrap_or_default()
+                    .trim_matches('"')
+                    .to_string(),
+                created_at: String::new(),
+                enabled,
+            }
+        })
+        .collect();
+
+    // Always replace — even with an empty vec — so removed servers are dropped.
+    let _ = db.replace_repository_mcp_servers(&repo_id, &rows);
+
+    let saved = db.list_repository_mcp_servers(&repo_id).unwrap_or_default();
+
+    // Initialize supervisor from persisted state (including empty, so stale
+    // in-memory servers are cleared) and validate enabled servers.
+    supervisor
+        .init_repo_with_enabled(&repo_id, mcp::rows_to_servers(&saved))
+        .await;
+    if !saved.is_empty() {
+        supervisor.validate_servers(&repo_id).await;
+    }
+
+    Ok(supervisor
+        .get_status(&repo_id)
+        .await
+        .unwrap_or(McpStatusSnapshot {
+            repository_id: repo_id,
+            servers: Vec::new(),
+        }))
+}
+
+/// Manually reconnect a specific MCP server.
+#[tauri::command]
+pub async fn reconnect_mcp_server(
+    repo_id: String,
+    server_name: String,
+    supervisor: State<'_, Arc<McpSupervisor>>,
+) -> Result<McpServerStatus, String> {
+    supervisor.reconnect_server(&repo_id, &server_name).await
+}
+
+/// Enable or disable a specific MCP server.
+///
+/// Persists to both our DB and `~/.claude.json` `disabledMcpServers` so the
+/// CLI respects the toggle for auto-discovered servers (global, project).
+/// Also invalidates any active persistent sessions for workspaces in this repo
+/// so the next turn starts a fresh process with the updated MCP config.
+#[tauri::command]
+pub async fn set_mcp_server_enabled(
+    server_id: String,
+    repo_id: String,
+    server_name: String,
+    enabled: bool,
+    state: State<'_, AppState>,
+    supervisor: State<'_, Arc<McpSupervisor>>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    // Persist enabled state in our DB.
+    db.set_mcp_server_enabled(&server_id, enabled)
+        .map_err(|e| e.to_string())?;
+
+    // Also write to ~/.claude.json disabledMcpServers so the CLI respects
+    // the toggle for auto-discovered servers (global, .mcp.json).
+    let repo = db.get_repository(&repo_id).map_err(|e| e.to_string())?;
+    if let Some(ref repo) = repo {
+        let repo_path = std::path::Path::new(&repo.path);
+        if let Err(e) =
+            claudette::mcp::set_server_disabled_in_config(repo_path, &server_name, !enabled)
+        {
+            eprintln!("[mcp] Failed to update ~/.claude.json: {e}");
+        }
+    }
+
+    // Update supervisor in-memory state.
+    supervisor
+        .set_server_enabled(&repo_id, &server_name, enabled)
+        .await;
+
+    // Invalidate persistent sessions for all workspaces in this repo so the
+    // next turn starts a fresh process with the updated MCP config.
+    // Kill the running process so it takes effect immediately.
+    let mut agents = state.agents.write().await;
+    let workspaces = db.list_workspaces().unwrap_or_default();
+    let repo_workspace_ids: Vec<String> = workspaces
+        .iter()
+        .filter(|w| w.repository_id == repo_id)
+        .map(|w| w.id.clone())
+        .collect();
+    for ws_id in &repo_workspace_ids {
+        if let Some(session) = agents.get_mut(ws_id) {
+            if let Some(pid) = session.active_pid.take() {
+                let _ = claudette::agent::stop_agent(pid).await;
+            }
+            session.persistent_session = None;
+        }
+    }
+
+    Ok(())
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,14 +1,16 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::Serialize;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 use tokio::process::Command as TokioCommand;
 
 use claudette::agent;
 use claudette::config;
 use claudette::db::Database;
 use claudette::git;
+use claudette::mcp_supervisor::McpSupervisor;
 use claudette::model::{AgentStatus, Workspace, WorkspaceStatus};
 use claudette::names::NameGenerator;
 
@@ -426,6 +428,7 @@ pub async fn delete_workspace(
     id: String,
     app: AppHandle,
     state: State<'_, AppState>,
+    supervisor: State<'_, Arc<McpSupervisor>>,
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
@@ -435,10 +438,12 @@ pub async fn delete_workspace(
         .find(|w| w.id == id)
         .ok_or("Workspace not found")?;
 
+    let repo_id = ws.repository_id.clone();
+
     let repos = db.list_repositories().map_err(|e| e.to_string())?;
     let repo = repos
         .iter()
-        .find(|r| r.id == ws.repository_id)
+        .find(|r| r.id == repo_id)
         .ok_or("Repository not found")?;
 
     // Stop any running agent and clear session so tray state stays consistent.
@@ -461,6 +466,14 @@ pub async fn delete_workspace(
 
     // Cascade deletes chat messages and terminal tabs.
     db.delete_workspace(&id).map_err(|e| e.to_string())?;
+
+    // If this was the last workspace for the repo, clean up MCP supervisor state
+    // and notify the frontend to clear the stale MCP status indicator.
+    let remaining = db.list_workspaces().unwrap_or_default();
+    if !remaining.iter().any(|w| w.repository_id == repo_id) {
+        supervisor.remove_repo(&repo_id).await;
+        let _ = app.emit("mcp-status-cleared", &repo_id);
+    }
 
     crate::tray::rebuild_tray(&app);
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -78,6 +78,7 @@ fn main() {
 
     let app_state = state::AppState::new(db_path, worktree_base_dir);
     let remote_manager = remote::RemoteConnectionManager::new();
+    let mcp_supervisor = std::sync::Arc::new(claudette::mcp_supervisor::McpSupervisor::new());
 
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
@@ -87,7 +88,8 @@ fn main() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
         .manage(app_state)
-        .manage(remote_manager);
+        .manage(remote_manager)
+        .manage(mcp_supervisor);
 
     // Custom app menu (macOS only): replace the default Quit item (which
     // calls NSApp.terminate() immediately) with one we can intercept to
@@ -326,6 +328,10 @@ fn main() {
             commands::mcp::save_repository_mcps,
             commands::mcp::load_repository_mcps,
             commands::mcp::delete_repository_mcp,
+            commands::mcp::get_mcp_status,
+            commands::mcp::ensure_and_validate_mcps,
+            commands::mcp::reconnect_mcp_server,
+            commands::mcp::set_mcp_server_enabled,
             // Apps
             commands::apps::detect_installed_apps,
             commands::apps::open_workspace_in_app,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
+use claudette::agent::PersistentSession;
 use parking_lot::Mutex as ParkingMutex;
 use tokio::sync::RwLock;
 
@@ -34,6 +35,10 @@ pub struct AgentSessionState {
     pub needs_attention: bool,
     /// What kind of input the agent needs, if any.
     pub attention_kind: Option<AttentionKind>,
+    /// Long-lived process that persists MCP servers across turns.
+    /// When present, subsequent turns write to this process's stdin instead of
+    /// spawning new processes.
+    pub persistent_session: Option<Arc<PersistentSession>>,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -432,6 +432,7 @@ mod tests {
             } else {
                 None
             },
+            persistent_session: None,
         }
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -546,4 +546,25 @@ mod tests {
         agents.insert("ws2".to_string(), session(Some(5678), true));
         assert!(has_running_agents(&agents));
     }
+
+    /// Regression: persistent session turn completes (active_pid cleared) but
+    /// persistent_session stays alive for the next turn. The tray must show
+    /// Idle, not Running. Before the fix, rebuild_tray was not called after
+    /// the Result event cleared active_pid, leaving the tray stuck on Running.
+    #[test]
+    fn test_tray_state_idle_after_persistent_turn_completes() {
+        let mut agents = HashMap::new();
+        // Simulate: persistent session exists, but active_pid was cleared
+        // when the Result event arrived (turn finished, process stays alive).
+        let mut s = session(None, false);
+        // persistent_session would be Some in real code, but the tray state
+        // computation only checks active_pid and needs_attention — the
+        // presence of persistent_session should NOT cause Running.
+        s.persistent_session = None; // compute_tray_state doesn't read this field
+        agents.insert("ws1".to_string(), s);
+        assert!(
+            matches!(compute_tray_state_from_agents(&agents), TrayState::Idle),
+            "tray should show Idle when active_pid is None, even with persistent sessions"
+        );
+    }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -546,25 +546,4 @@ mod tests {
         agents.insert("ws2".to_string(), session(Some(5678), true));
         assert!(has_running_agents(&agents));
     }
-
-    /// Regression: persistent session turn completes (active_pid cleared) but
-    /// persistent_session stays alive for the next turn. The tray must show
-    /// Idle, not Running. Before the fix, rebuild_tray was not called after
-    /// the Result event cleared active_pid, leaving the tray stuck on Running.
-    #[test]
-    fn test_tray_state_idle_after_persistent_turn_completes() {
-        let mut agents = HashMap::new();
-        // Simulate: persistent session exists, but active_pid was cleared
-        // when the Result event arrived (turn finished, process stays alive).
-        let mut s = session(None, false);
-        // persistent_session would be Some in real code, but the tray state
-        // computation only checks active_pid and needs_attention — the
-        // presence of persistent_session should NOT cause Running.
-        s.persistent_session = None; // compute_tray_state doesn't read this field
-        agents.insert("ws1".to_string(), s);
-        assert!(
-            matches!(compute_tray_state_from_agents(&agents), TrayState::Idle),
-            "tray should show Idle when active_pid is None, even with persistent sessions"
-        );
-    }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -989,7 +989,8 @@ fn build_persistent_args(
     }
     args.push(session_id.to_string());
 
-    if let Some(ref model) = settings.model {
+    // Model is session-level — only set on fresh sessions, not resumes.
+    if !is_resume && let Some(ref model) = settings.model {
         args.push("--model".to_string());
         args.push(model.clone());
     }
@@ -1032,13 +1033,13 @@ fn build_persistent_args(
     }
 
     if !bypass_permissions && !allowed_tools.is_empty() {
-        for tool in allowed_tools {
-            args.push("--allowedTools".to_string());
-            args.push(tool.clone());
-        }
+        args.push("--allowedTools".to_string());
+        args.push(allowed_tools.join(","));
     }
 
-    if let Some(instructions) = custom_instructions
+    // System prompt is session-level — only set on fresh sessions, not resumes.
+    if !is_resume
+        && let Some(instructions) = custom_instructions
         && !instructions.trim().is_empty()
     {
         args.push("--append-system-prompt".to_string());
@@ -2378,15 +2379,8 @@ mod tests {
         let settings = AgentSettings::default();
         let tools = vec!["Read".to_string(), "Bash".to_string()];
         let args = build_persistent_args("sess-1", false, &tools, None, &settings);
-        let tool_indices: Vec<usize> = args
-            .iter()
-            .enumerate()
-            .filter(|(_, a)| a.as_str() == "--allowedTools")
-            .map(|(i, _)| i)
-            .collect();
-        assert_eq!(tool_indices.len(), 2);
-        assert_eq!(args[tool_indices[0] + 1], "Read");
-        assert_eq!(args[tool_indices[1] + 1], "Bash");
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[idx + 1], "Read,Bash");
     }
 
     #[test]
@@ -2423,15 +2417,8 @@ mod tests {
         let mcp_idx = args.iter().position(|a| a == "--mcp-config").unwrap();
         assert!(args[mcp_idx + 1].contains("mcpServers"));
 
-        let tool_positions: Vec<usize> = args
-            .iter()
-            .enumerate()
-            .filter(|(_, a)| a.as_str() == "--allowedTools")
-            .map(|(i, _)| i)
-            .collect();
-        assert_eq!(tool_positions.len(), 2);
-        assert_eq!(args[tool_positions[0] + 1], "Bash");
-        assert_eq!(args[tool_positions[1] + 1], "Read");
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        assert_eq!(args[idx + 1], "Bash,Read");
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -756,6 +756,301 @@ pub async fn stop_agent(pid: u32) -> Result<(), String> {
 }
 
 // ---------------------------------------------------------------------------
+// Persistent session — long-lived process for multi-turn MCP retention
+// ---------------------------------------------------------------------------
+
+/// A persistent Claude CLI process that stays alive across turns.
+///
+/// Instead of spawning a new `claude --print` per turn (which kills MCP server
+/// subprocesses), this keeps a single process alive and sends turns via stdin
+/// using `--input-format stream-json`. MCP servers and their state (e.g.
+/// playwright browser) persist for the session lifetime.
+pub struct PersistentSession {
+    pid: u32,
+    stdin: tokio::sync::Mutex<tokio::process::ChildStdin>,
+    event_tx: tokio::sync::broadcast::Sender<AgentEvent>,
+}
+
+impl PersistentSession {
+    /// Start a new persistent session process.
+    ///
+    /// The process is spawned with `--input-format stream-json` and no prompt
+    /// argument. Turns are sent via [`send_turn`] which writes `SDKUserMessage`
+    /// lines to stdin.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start(
+        working_dir: &Path,
+        session_id: &str,
+        is_resume: bool,
+        allowed_tools: &[String],
+        custom_instructions: Option<&str>,
+        settings: &AgentSettings,
+    ) -> Result<Self, String> {
+        let args = build_persistent_args(
+            session_id,
+            is_resume,
+            allowed_tools,
+            custom_instructions,
+            settings,
+        );
+
+        let claude_path = resolve_claude_path().await;
+        let mut cmd = Command::new(&claude_path);
+        cmd.args(&args)
+            .current_dir(working_dir)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        // Strip OAuth tokens (same as run_turn).
+        if let Ok(key) = std::env::var("ANTHROPIC_API_KEY")
+            && !key.starts_with("sk-ant-api")
+        {
+            cmd.env_remove("ANTHROPIC_API_KEY");
+        }
+        cmd.env_remove("CLAUDECODE");
+        cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+        let mut child = cmd.spawn().map_err(|e| {
+            format!(
+                "Failed to spawn persistent session at {:?}: {e}",
+                claude_path
+            )
+        })?;
+
+        let pid = child
+            .id()
+            .ok_or_else(|| "Process exited immediately".to_string())?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Failed to capture stdin".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Failed to capture stdout".to_string())?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "Failed to capture stderr".to_string())?;
+
+        let (event_tx, _) = tokio::sync::broadcast::channel::<AgentEvent>(2048);
+
+        // Background stdout reader — runs for the session lifetime.
+        let tx = event_tx.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_stream_line(&line) {
+                    Ok(event) => {
+                        let _ = tx.send(AgentEvent::Stream(event));
+                    }
+                    Err(e) => {
+                        eprintln!("[persistent] Failed to parse: {e}\nLine: {line}");
+                    }
+                }
+            }
+        });
+
+        // Background stderr reader.
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.trim().is_empty() {
+                    eprintln!("[persistent stderr] {line}");
+                }
+            }
+        });
+
+        // Process exit watcher — broadcasts ProcessExited when the child dies.
+        // Owns the child handle; the process stays alive until it exits naturally
+        // (stdin closed) or is killed via stop_agent(pid).
+        let tx_exit = event_tx.clone();
+        tokio::spawn(async move {
+            let status = child.wait().await.ok().and_then(|s| s.code());
+            let _ = tx_exit.send(AgentEvent::ProcessExited(status));
+        });
+
+        Ok(Self {
+            pid,
+            stdin: tokio::sync::Mutex::new(stdin),
+            event_tx,
+        })
+    }
+
+    /// Send a turn's prompt and return a handle for receiving that turn's events.
+    ///
+    /// The returned `TurnHandle` receives events until a `Result` event (turn
+    /// complete) or `ProcessExited` (session died).
+    /// Send a new turn to the persistent process via stdin.
+    ///
+    /// # Single-turn invariant
+    ///
+    /// Only one turn may be in flight at a time. The CLI serializes turns
+    /// internally via `--input-format stream-json`, and the Tauri command
+    /// layer checks `agent_status == Running` before allowing a new send.
+    /// The returned `TurnHandle` forwards events until the first `Result`
+    /// event, which marks the turn as complete.
+    pub async fn send_turn(
+        &self,
+        prompt: &str,
+        attachments: &[ImageAttachment],
+    ) -> Result<TurnHandle, String> {
+        use tokio::io::AsyncWriteExt;
+
+        // Subscribe BEFORE writing to stdin to avoid a race where a fast turn
+        // emits events before the receiver exists (broadcast doesn't replay).
+        let mut broadcast_rx = self.event_tx.subscribe();
+
+        let message = build_stdin_message(prompt, attachments);
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(message.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write to persistent session: {e}"))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("Failed to write newline: {e}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| format!("Failed to flush stdin: {e}"))?;
+        drop(stdin); // Release lock so other code can check process state.
+        let (mpsc_tx, mpsc_rx) = mpsc::channel::<AgentEvent>(128);
+        tokio::spawn(async move {
+            loop {
+                match broadcast_rx.recv().await {
+                    Ok(event) => {
+                        let is_turn_end =
+                            matches!(&event, AgentEvent::Stream(StreamEvent::Result { .. }));
+                        let is_process_exit = matches!(&event, AgentEvent::ProcessExited(_));
+                        // Forward to per-turn channel.
+                        if mpsc_tx.send(event).await.is_err() {
+                            break;
+                        }
+                        if is_turn_end || is_process_exit {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        eprintln!("[persistent] Broadcast lagged by {n} events");
+                    }
+                }
+            }
+        });
+
+        Ok(TurnHandle {
+            event_rx: mpsc_rx,
+            pid: self.pid,
+        })
+    }
+
+    /// Get the process ID.
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
+/// Build CLI arguments for a persistent session (no prompt, with `--input-format stream-json`).
+///
+/// When `is_resume` is true, uses `--resume` to restore conversation history
+/// from a prior session. Otherwise uses `--session-id` for a fresh session.
+fn build_persistent_args(
+    session_id: &str,
+    is_resume: bool,
+    allowed_tools: &[String],
+    custom_instructions: Option<&str>,
+    settings: &AgentSettings,
+) -> Vec<String> {
+    let mut args = vec![
+        "--print".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--input-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+        "--include-partial-messages".to_string(),
+    ];
+
+    let bypass_permissions = allowed_tools.len() == 1 && allowed_tools[0] == "*";
+
+    if is_resume {
+        args.push("--resume".to_string());
+    } else {
+        args.push("--session-id".to_string());
+    }
+    args.push(session_id.to_string());
+
+    if let Some(ref model) = settings.model {
+        args.push("--model".to_string());
+        args.push(model.clone());
+    }
+
+    if settings.chrome_enabled {
+        args.push("--chrome".to_string());
+    }
+
+    if let Some(ref mcp_json) = settings.mcp_config {
+        args.push("--mcp-config".to_string());
+        args.push(mcp_json.clone());
+    }
+
+    if settings.plan_mode {
+        args.push("--permission-mode".to_string());
+        args.push("plan".to_string());
+    } else if bypass_permissions {
+        args.push("--permission-mode".to_string());
+        args.push("bypassPermissions".to_string());
+    }
+
+    if settings.fast_mode || settings.thinking_enabled {
+        let mut obj = serde_json::Map::new();
+        if settings.fast_mode {
+            obj.insert("fastMode".to_string(), serde_json::Value::Bool(true));
+        }
+        if settings.thinking_enabled {
+            obj.insert(
+                "alwaysThinkingEnabled".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        args.push("--settings".to_string());
+        args.push(serde_json::Value::Object(obj).to_string());
+    }
+
+    if let Some(ref effort) = settings.effort {
+        args.push("--effort".to_string());
+        args.push(effort.clone());
+    }
+
+    if !bypass_permissions && !allowed_tools.is_empty() {
+        for tool in allowed_tools {
+            args.push("--allowedTools".to_string());
+            args.push(tool.clone());
+        }
+    }
+
+    if let Some(instructions) = custom_instructions
+        && !instructions.trim().is_empty()
+    {
+        args.push("--append-system-prompt".to_string());
+        args.push(instructions.to_string());
+    }
+
+    // No prompt argument — prompts come via stdin as SDKUserMessage.
+
+    args
+}
+
+// ---------------------------------------------------------------------------
 // Branch name generation via Haiku
 // ---------------------------------------------------------------------------
 
@@ -2001,5 +2296,198 @@ mod tests {
         assert_eq!(content.len(), 3); // 1 text + 1 image + 1 document
         assert_eq!(content[1]["type"], "image");
         assert_eq!(content[2]["type"], "document");
+    }
+
+    // -- Persistent session args --
+
+    #[test]
+    fn test_build_persistent_args_includes_input_format() {
+        let settings = AgentSettings::default();
+        let args = build_persistent_args("sess-1", false, &[], None, &settings);
+        assert!(args.contains(&"--input-format".to_string()));
+        assert!(args.contains(&"stream-json".to_string()));
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn test_build_persistent_args_resume_mode() {
+        let settings = AgentSettings::default();
+        let args = build_persistent_args("old-session-id", true, &[], None, &settings);
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"old-session-id".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+    }
+
+    #[test]
+    fn test_build_persistent_args_includes_mcp_config() {
+        let settings = AgentSettings {
+            mcp_config: Some(r#"{"mcpServers":{"s":{"type":"stdio","command":"x"}}}"#.to_string()),
+            ..Default::default()
+        };
+        let args = build_persistent_args("sess-1", false, &[], None, &settings);
+        let idx = args.iter().position(|a| a == "--mcp-config").unwrap();
+        assert!(args[idx + 1].contains("mcpServers"));
+    }
+
+    #[test]
+    fn test_build_persistent_args_includes_model() {
+        let settings = AgentSettings {
+            model: Some("opus".to_string()),
+            ..Default::default()
+        };
+        let args = build_persistent_args("sess-1", false, &[], None, &settings);
+        let idx = args.iter().position(|a| a == "--model").unwrap();
+        assert_eq!(args[idx + 1], "opus");
+    }
+
+    #[test]
+    fn test_build_persistent_args_no_prompt_argument() {
+        let settings = AgentSettings::default();
+        let args = build_persistent_args("sess-1", false, &[], None, &settings);
+        // The last arg should be either a flag or flag value, not a bare prompt.
+        // Verify --print is present but no trailing prompt string.
+        assert!(args.contains(&"--print".to_string()));
+        assert!(args.contains(&"--output-format".to_string()));
+        // Verify no bare text that could be mistaken for a prompt (not a flag).
+        let non_flag_args: Vec<&String> = args
+            .iter()
+            .enumerate()
+            .filter(|(i, a)| !a.starts_with("--") && *i > 0 && !args[i - 1].starts_with("--"))
+            .map(|(_, a)| a)
+            .collect();
+        assert!(
+            non_flag_args.is_empty(),
+            "Found unexpected non-flag args: {non_flag_args:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_persistent_args_includes_custom_instructions() {
+        let settings = AgentSettings::default();
+        let args = build_persistent_args("sess-1", false, &[], Some("be concise"), &settings);
+        let idx = args
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .unwrap();
+        assert_eq!(args[idx + 1], "be concise");
+    }
+
+    #[test]
+    fn test_build_persistent_args_includes_allowed_tools() {
+        let settings = AgentSettings::default();
+        let tools = vec!["Read".to_string(), "Bash".to_string()];
+        let args = build_persistent_args("sess-1", false, &tools, None, &settings);
+        let tool_indices: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.as_str() == "--allowedTools")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(tool_indices.len(), 2);
+        assert_eq!(args[tool_indices[0] + 1], "Read");
+        assert_eq!(args[tool_indices[1] + 1], "Bash");
+    }
+
+    #[test]
+    fn test_build_persistent_args_bypass_permissions() {
+        let settings = AgentSettings::default();
+        let tools = vec!["*".to_string()];
+        let args = build_persistent_args("sess-1", false, &tools, None, &settings);
+        assert!(args.contains(&"bypassPermissions".to_string()));
+        // Should NOT have --allowedTools when bypassing.
+        assert!(!args.iter().any(|a| a == "--allowedTools"));
+    }
+
+    #[test]
+    fn test_build_persistent_args_empty_allowed_tools() {
+        let settings = AgentSettings::default();
+        let args = build_persistent_args("sess-1", false, &[], None, &settings);
+        // Empty allowed tools should not produce any --allowedTools flags.
+        assert!(!args.iter().any(|a| a == "--allowedTools"));
+        // And should not produce bypassPermissions either.
+        assert!(!args.contains(&"bypassPermissions".to_string()));
+    }
+
+    #[test]
+    fn test_build_persistent_args_mcp_with_allowed_tools() {
+        // Verify MCP config and allowed tools don't interfere with each other.
+        let settings = AgentSettings {
+            mcp_config: Some(r#"{"mcpServers":{"s":{"type":"stdio","command":"x"}}}"#.to_string()),
+            ..Default::default()
+        };
+        let tools = vec!["Bash".to_string(), "Read".to_string()];
+        let args = build_persistent_args("sess-1", false, &tools, None, &settings);
+
+        // Both should be present.
+        let mcp_idx = args.iter().position(|a| a == "--mcp-config").unwrap();
+        assert!(args[mcp_idx + 1].contains("mcpServers"));
+
+        let tool_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.as_str() == "--allowedTools")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(tool_positions.len(), 2);
+        assert_eq!(args[tool_positions[0] + 1], "Bash");
+        assert_eq!(args[tool_positions[1] + 1], "Read");
+    }
+
+    #[test]
+    fn test_build_persistent_args_all_flags_combined() {
+        // Kitchen-sink test: all settings at once.
+        let settings = AgentSettings {
+            model: Some("claude-opus-4-20250514".to_string()),
+            fast_mode: true,
+            thinking_enabled: true,
+            plan_mode: true,
+            effort: Some("high".to_string()),
+            chrome_enabled: true,
+            mcp_config: Some(r#"{"mcpServers":{}}"#.to_string()),
+        };
+        let args = build_persistent_args(
+            "sess-1",
+            false,
+            &["Bash".to_string()],
+            Some("Be concise"),
+            &settings,
+        );
+
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"claude-opus-4-20250514".to_string()));
+        assert!(args.contains(&"--chrome".to_string()));
+        assert!(args.contains(&"--mcp-config".to_string()));
+        assert!(args.contains(&"--effort".to_string()));
+        assert!(args.contains(&"high".to_string()));
+        assert!(args.contains(&"--append-system-prompt".to_string()));
+        assert!(args.contains(&"Be concise".to_string()));
+        // plan_mode takes precedence over allowedTools.
+        assert!(args.contains(&"plan".to_string()));
+        // --settings should contain fastMode and alwaysThinkingEnabled.
+        let settings_idx = args.iter().position(|a| a == "--settings").unwrap();
+        let settings_json: serde_json::Value =
+            serde_json::from_str(&args[settings_idx + 1]).unwrap();
+        assert_eq!(settings_json["fastMode"], true);
+        assert_eq!(settings_json["alwaysThinkingEnabled"], true);
+    }
+
+    #[test]
+    fn test_build_args_mcp_config_none_not_present() {
+        // When mcp_config is None, --mcp-config should not appear at all.
+        let settings = AgentSettings {
+            mcp_config: None,
+            ..Default::default()
+        };
+        let args = build_claude_args("sess-1", "hello", false, &[], None, &settings, false);
+        assert!(!args.iter().any(|a| a == "--mcp-config"));
+    }
+
+    #[test]
+    fn test_build_persistent_args_empty_custom_instructions_ignored() {
+        // Whitespace-only instructions should be treated as absent.
+        let settings = AgentSettings::default();
+        let args = build_persistent_args("sess-1", false, &[], Some("   "), &settings);
+        assert!(!args.iter().any(|a| a == "--append-system-prompt"));
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -33,6 +33,7 @@ pub struct RepositoryMcpServer {
     pub config_json: String,
     pub source: String,
     pub created_at: String,
+    pub enabled: bool,
 }
 
 pub struct Database {
@@ -328,6 +329,14 @@ impl Database {
                 );
 
                 PRAGMA user_version = 17;",
+            )?;
+        }
+
+        if version < 18 {
+            self.conn.execute_batch(
+                "ALTER TABLE repository_mcp_servers ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
+
+                PRAGMA user_version = 18;",
             )?;
         }
 
@@ -1346,12 +1355,13 @@ impl Database {
         repository_id: &str,
     ) -> Result<Vec<RepositoryMcpServer>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, repository_id, name, config_json, source, created_at
+            "SELECT id, repository_id, name, config_json, source, created_at, enabled
              FROM repository_mcp_servers
              WHERE repository_id = ?1
              ORDER BY name",
         )?;
         let rows = stmt.query_map(params![repository_id], |row| {
+            let enabled_int: i32 = row.get(6)?;
             Ok(RepositoryMcpServer {
                 id: row.get(0)?,
                 repository_id: row.get(1)?,
@@ -1359,6 +1369,7 @@ impl Database {
                 config_json: row.get(3)?,
                 source: row.get(4)?,
                 created_at: row.get(5)?,
+                enabled: enabled_int != 0,
             })
         })?;
         rows.collect()
@@ -1377,14 +1388,15 @@ impl Database {
         )?;
         for server in servers {
             tx.execute(
-                "INSERT INTO repository_mcp_servers (id, repository_id, name, config_json, source)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                "INSERT INTO repository_mcp_servers (id, repository_id, name, config_json, source, enabled)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
                 params![
                     server.id,
                     server.repository_id,
                     server.name,
                     server.config_json,
                     server.source,
+                    server.enabled as i32,
                 ],
             )?;
         }
@@ -1396,6 +1408,15 @@ impl Database {
         self.conn.execute(
             "DELETE FROM repository_mcp_servers WHERE id = ?1",
             params![id],
+        )?;
+        Ok(())
+    }
+
+    /// Update the enabled state of a single MCP server.
+    pub fn set_mcp_server_enabled(&self, id: &str, enabled: bool) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE repository_mcp_servers SET enabled = ?1 WHERE id = ?2",
+            params![enabled as i32, id],
         )?;
         Ok(())
     }
@@ -2432,5 +2453,162 @@ mod tests {
 
         let cp = db.get_checkpoint("cp1").unwrap().unwrap();
         assert_eq!(cp.message_count, 3);
+    }
+
+    // --- MCP server enabled field ---
+
+    fn make_mcp_server(id: &str, repo_id: &str, name: &str) -> RepositoryMcpServer {
+        RepositoryMcpServer {
+            id: id.into(),
+            repository_id: repo_id.into(),
+            name: name.into(),
+            config_json: r#"{"type":"stdio","command":"echo"}"#.into(),
+            source: "user_project_config".into(),
+            created_at: String::new(),
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn test_mcp_server_enabled_default_true() {
+        let db = setup_db_with_workspace();
+        let server = make_mcp_server("mcp1", "r1", "test-server");
+        db.replace_repository_mcp_servers("r1", &[server]).unwrap();
+
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert_eq!(servers.len(), 1);
+        assert!(servers[0].enabled);
+    }
+
+    #[test]
+    fn test_set_mcp_server_enabled() {
+        let db = setup_db_with_workspace();
+        let server = make_mcp_server("mcp1", "r1", "test-server");
+        db.replace_repository_mcp_servers("r1", &[server]).unwrap();
+
+        // Disable
+        db.set_mcp_server_enabled("mcp1", false).unwrap();
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert!(!servers[0].enabled);
+
+        // Re-enable
+        db.set_mcp_server_enabled("mcp1", true).unwrap();
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert!(servers[0].enabled);
+    }
+
+    #[test]
+    fn test_mcp_server_replace_preserves_enabled() {
+        let db = setup_db_with_workspace();
+        let mut server = make_mcp_server("mcp1", "r1", "test-server");
+        server.enabled = false;
+        db.replace_repository_mcp_servers("r1", &[server]).unwrap();
+
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert!(!servers[0].enabled);
+    }
+
+    #[test]
+    fn test_set_mcp_server_enabled_nonexistent_id() {
+        // Setting enabled on a nonexistent server ID should succeed silently
+        // (UPDATE on 0 rows is not an error in SQLite).
+        let db = setup_db_with_workspace();
+        let result = db.set_mcp_server_enabled("nonexistent-id", false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_list_mcp_servers_empty_repo() {
+        let db = setup_db_with_workspace();
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn test_mcp_server_replace_clears_old_servers() {
+        let db = setup_db_with_workspace();
+
+        // Insert two servers.
+        let servers = vec![
+            make_mcp_server("mcp1", "r1", "server-a"),
+            make_mcp_server("mcp2", "r1", "server-b"),
+        ];
+        db.replace_repository_mcp_servers("r1", &servers).unwrap();
+        assert_eq!(db.list_repository_mcp_servers("r1").unwrap().len(), 2);
+
+        // Replace with just one — the old ones should be gone.
+        let new_servers = vec![make_mcp_server("mcp3", "r1", "server-c")];
+        db.replace_repository_mcp_servers("r1", &new_servers)
+            .unwrap();
+        let result = db.list_repository_mcp_servers("r1").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "server-c");
+    }
+
+    #[test]
+    fn test_delete_mcp_server() {
+        let db = setup_db_with_workspace();
+        let servers = vec![
+            make_mcp_server("mcp1", "r1", "server-a"),
+            make_mcp_server("mcp2", "r1", "server-b"),
+        ];
+        db.replace_repository_mcp_servers("r1", &servers).unwrap();
+
+        db.delete_repository_mcp_server("mcp1").unwrap();
+        let result = db.list_repository_mcp_servers("r1").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "server-b");
+    }
+
+    #[test]
+    fn test_mcp_server_enabled_survives_roundtrip() {
+        // Insert with enabled=true, disable, verify after fresh list.
+        let db = setup_db_with_workspace();
+        let server = make_mcp_server("mcp1", "r1", "test-server");
+        db.replace_repository_mcp_servers("r1", &[server]).unwrap();
+
+        db.set_mcp_server_enabled("mcp1", false).unwrap();
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert!(!servers[0].enabled);
+
+        db.set_mcp_server_enabled("mcp1", true).unwrap();
+        let servers = db.list_repository_mcp_servers("r1").unwrap();
+        assert!(servers[0].enabled);
+    }
+
+    #[test]
+    fn test_mcp_servers_isolated_per_repo() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_repository(&make_repo("r2", "/tmp/repo2", "repo2"))
+            .unwrap();
+
+        let s1 = make_mcp_server("m1", "r1", "server-for-r1");
+        let s2 = make_mcp_server("m2", "r2", "server-for-r2");
+        db.replace_repository_mcp_servers("r1", &[s1]).unwrap();
+        db.replace_repository_mcp_servers("r2", &[s2]).unwrap();
+
+        let r1_servers = db.list_repository_mcp_servers("r1").unwrap();
+        let r2_servers = db.list_repository_mcp_servers("r2").unwrap();
+        assert_eq!(r1_servers.len(), 1);
+        assert_eq!(r1_servers[0].name, "server-for-r1");
+        assert_eq!(r2_servers.len(), 1);
+        assert_eq!(r2_servers[0].name, "server-for-r2");
+    }
+
+    #[test]
+    fn test_mcp_server_replace_with_empty_clears_all() {
+        let db = setup_db_with_workspace();
+        let servers = vec![
+            make_mcp_server("mcp1", "r1", "server-a"),
+            make_mcp_server("mcp2", "r1", "server-b"),
+        ];
+        db.replace_repository_mcp_servers("r1", &servers).unwrap();
+        assert_eq!(db.list_repository_mcp_servers("r1").unwrap().len(), 2);
+
+        // Replace with empty vec — should clear all.
+        db.replace_repository_mcp_servers("r1", &[]).unwrap();
+        assert!(db.list_repository_mcp_servers("r1").unwrap().is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod diff;
 pub mod file_expand;
 pub mod git;
 pub mod mcp;
+pub mod mcp_supervisor;
 pub mod model;
 pub mod names;
 pub mod permissions;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -110,8 +110,14 @@ pub fn rows_to_servers(rows: &[crate::db::RepositoryMcpServer]) -> Vec<(McpServe
     rows.iter()
         .filter_map(|row| {
             let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
-            let source: McpSource = serde_json::from_str(&format!("\"{}\"", row.source))
-                .unwrap_or(McpSource::UserProjectConfig);
+            let source = match row.source.as_str() {
+                "user_global_config" => McpSource::UserGlobalConfig,
+                "user_project_config" => McpSource::UserProjectConfig,
+                "project_mcp_json" => McpSource::ProjectMcpJson,
+                "repo_local_config" => McpSource::RepoLocalConfig,
+                "plugin" => McpSource::Plugin,
+                _ => McpSource::UserProjectConfig,
+            };
             Some((
                 McpServer {
                     name: row.name.clone(),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -231,8 +231,14 @@ pub fn set_server_disabled_in_config(
 
     // Atomic write: write to temp file then rename, so a crash mid-write
     // cannot truncate/corrupt the user's ~/.claude.json.
+    // On Windows, std::fs::rename does not overwrite an existing file,
+    // so we remove it first.
     let tmp_path = config_path.with_extension("json.tmp");
     std::fs::write(&tmp_path, &json_str).map_err(|e| format!("Write error: {e}"))?;
+    #[cfg(windows)]
+    if config_path.exists() {
+        std::fs::remove_file(&config_path).map_err(|e| format!("Remove error: {e}"))?;
+    }
     std::fs::rename(&tmp_path, &config_path).map_err(|e| format!("Rename error: {e}"))?;
 
     Ok(())

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1053,29 +1053,55 @@ mod tests {
         assert_eq!(names, sorted);
     }
 
-    /// Mutex to serialize tests that mutate the HOME env var. Rust tests run
-    /// in parallel, so without this, concurrent tests calling dirs::home_dir()
-    /// could see a temporarily overridden HOME.
+    /// Mutex to serialize tests that mutate home-related env vars. Rust tests
+    /// run in parallel, so without this, concurrent tests calling
+    /// dirs::home_dir() could see temporarily overridden values.
     static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Override all home-related env vars and restore on drop.
+    struct HomeEnvGuard {
+        home: Option<std::ffi::OsString>,
+        userprofile: Option<std::ffi::OsString>,
+    }
+
+    impl HomeEnvGuard {
+        fn override_with(path: &Path) -> Self {
+            let guard = Self {
+                home: std::env::var_os("HOME"),
+                userprofile: std::env::var_os("USERPROFILE"),
+            };
+            unsafe {
+                std::env::set_var("HOME", path);
+                std::env::set_var("USERPROFILE", path);
+            }
+            guard
+        }
+    }
+
+    impl Drop for HomeEnvGuard {
+        fn drop(&mut self) {
+            match &self.home {
+                Some(v) => unsafe { std::env::set_var("HOME", v) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+            match &self.userprofile {
+                Some(v) => unsafe { std::env::set_var("USERPROFILE", v) },
+                None => unsafe { std::env::remove_var("USERPROFILE") },
+            }
+        }
+    }
 
     #[test]
     fn test_detect_mcp_servers_empty_repo() {
         // Isolate from real home dir so user-global and plugin MCPs don't
-        // leak into the test. Override HOME to an empty temp directory.
+        // leak into the test. Override all home-related env vars for
+        // cross-platform determinism (HOME on Unix, USERPROFILE on Windows).
         let _guard = ENV_MUTEX.lock().unwrap();
         let home = TempDir::new().unwrap();
         let repo = TempDir::new().unwrap();
-
-        let orig_home = std::env::var_os("HOME");
-        unsafe { std::env::set_var("HOME", home.path()) };
+        let _home_env = HomeEnvGuard::override_with(home.path());
 
         let servers = detect_mcp_servers(repo.path());
-
-        // Restore before any assertions so panics don't leave env dirty.
-        match orig_home {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
 
         assert!(
             servers.is_empty(),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1053,15 +1053,19 @@ mod tests {
         assert_eq!(names, sorted);
     }
 
+    /// Mutex to serialize tests that mutate the HOME env var. Rust tests run
+    /// in parallel, so without this, concurrent tests calling dirs::home_dir()
+    /// could see a temporarily overridden HOME.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_detect_mcp_servers_empty_repo() {
         // Isolate from real home dir so user-global and plugin MCPs don't
         // leak into the test. Override HOME to an empty temp directory.
+        let _guard = ENV_MUTEX.lock().unwrap();
         let home = TempDir::new().unwrap();
         let repo = TempDir::new().unwrap();
 
-        // SAFETY: test binary runs single-threaded per test by default,
-        // and we restore immediately after the call.
         let orig_home = std::env::var_os("HOME");
         unsafe { std::env::set_var("HOME", home.path()) };
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -228,7 +228,12 @@ pub fn set_server_disabled_in_config(
 
     let json_str =
         serde_json::to_string_pretty(&root).map_err(|e| format!("Serialize error: {e}"))?;
-    std::fs::write(&config_path, json_str).map_err(|e| format!("Write error: {e}"))?;
+
+    // Atomic write: write to temp file then rename, so a crash mid-write
+    // cannot truncate/corrupt the user's ~/.claude.json.
+    let tmp_path = config_path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &json_str).map_err(|e| format!("Write error: {e}"))?;
+    std::fs::rename(&tmp_path, &config_path).map_err(|e| format!("Rename error: {e}"))?;
 
     Ok(())
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,13 +1,14 @@
 //! MCP (Model Context Protocol) server detection and serialization.
 //!
-//! Detects non-portable MCP configurations that won't be automatically
-//! available inside git worktrees:
+//! Detects MCP server configurations from all sources:
 //!
-//! 1. Project-scoped MCPs in `~/.claude.json` (keyed by absolute repo path)
-//! 2. MCPs in gitignored `{repo}/.claude.json`
+//! 1. User global MCPs in `~/.claude.json` → `mcpServers`
+//! 2. Project-scoped MCPs in `~/.claude.json` → `projects[repo_path].mcpServers`
+//! 3. Project committed `.mcp.json` at repo root
+//! 4. Gitignored `.claude.json` at repo root
 //!
-//! Committed `.mcp.json` and global user MCPs are auto-available and NOT
-//! detected here.
+//! Sources 1 and 3 are auto-discovered by the CLI in worktrees, but are
+//! detected here for UI display purposes (connectors menu, settings).
 
 use std::path::Path;
 
@@ -28,30 +29,63 @@ pub struct McpServer {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum McpSource {
-    /// Project-scoped entry in ~/.claude.json
+    /// User-global entry in ~/.claude.json → mcpServers
+    UserGlobalConfig,
+    /// Project-scoped entry in ~/.claude.json → projects[path].mcpServers
     UserProjectConfig,
+    /// Committed .mcp.json at repo root
+    ProjectMcpJson,
     /// Gitignored .claude.json at repo root
     RepoLocalConfig,
+    /// Claude Code plugin (always available)
+    Plugin,
 }
 
-/// Detect non-portable MCP servers for the given repository path.
+/// Detect MCP servers from all configuration sources for the given repository.
 ///
-/// Scans two locations:
-/// 1. `~/.claude.json` → `projects[repo_path].mcpServers`
-/// 2. `{repo_path}/.claude.json` (only if gitignored)
-///
-/// Returns an empty Vec if no non-portable MCPs are found.
+/// Scans four locations (later sources override earlier ones by name):
+/// 1. `~/.claude.json` → `mcpServers` (user global)
+/// 2. `~/.claude.json` → `projects[repo_path].mcpServers` (user project-scoped)
+/// 3. `{repo_path}/.mcp.json` → `mcpServers` (project committed)
+/// 4. `{repo_path}/.claude.json` (only if gitignored)
 pub fn detect_mcp_servers(repo_path: &Path) -> Vec<McpServer> {
-    let mut servers = Vec::new();
+    let mut by_name = std::collections::HashMap::<String, McpServer>::new();
 
-    if let Some(user_servers) = detect_user_project_mcps(repo_path) {
-        servers.extend(user_servers);
+    // 1. User global MCPs.
+    if let Some(servers) = detect_user_global_mcps() {
+        for s in servers {
+            by_name.insert(s.name.clone(), s);
+        }
     }
 
-    if let Some(local_servers) = detect_repo_local_mcps(repo_path) {
-        servers.extend(local_servers);
+    // 2. User project-scoped MCPs (override globals by name).
+    if let Some(servers) = detect_user_project_mcps(repo_path) {
+        for s in servers {
+            by_name.insert(s.name.clone(), s);
+        }
     }
 
+    // 3. Committed .mcp.json at repo root.
+    if let Some(servers) = detect_project_mcp_json(repo_path) {
+        for s in servers {
+            by_name.insert(s.name.clone(), s);
+        }
+    }
+
+    // 4. Gitignored .claude.json at repo root.
+    if let Some(servers) = detect_repo_local_mcps(repo_path) {
+        for s in servers {
+            by_name.insert(s.name.clone(), s);
+        }
+    }
+
+    // 5. Claude Code plugins (always available, don't override explicit configs).
+    for s in detect_plugin_mcps() {
+        by_name.entry(s.name.clone()).or_insert(s);
+    }
+
+    let mut servers: Vec<McpServer> = by_name.into_values().collect();
+    servers.sort_by(|a, b| a.name.cmp(&b.name));
     servers
 }
 
@@ -66,6 +100,137 @@ pub fn serialize_for_cli(servers: &[McpServer]) -> String {
     }
     let wrapper = serde_json::json!({ "mcpServers": mcp_servers });
     wrapper.to_string()
+}
+
+/// Convert saved DB rows into `McpServer` structs with their enabled flag.
+///
+/// Parses `config_json` and `source` from each row. Rows with invalid JSON
+/// are silently skipped.
+pub fn rows_to_servers(rows: &[crate::db::RepositoryMcpServer]) -> Vec<(McpServer, bool)> {
+    rows.iter()
+        .filter_map(|row| {
+            let config: serde_json::Value = serde_json::from_str(&row.config_json).ok()?;
+            let source: McpSource = serde_json::from_str(&format!("\"{}\"", row.source))
+                .unwrap_or(McpSource::UserProjectConfig);
+            Some((
+                McpServer {
+                    name: row.name.clone(),
+                    config,
+                    source,
+                },
+                row.enabled,
+            ))
+        })
+        .collect()
+}
+
+/// Build the `--mcp-config` CLI string from saved DB rows.
+///
+/// Only includes enabled servers. Returns `None` if no servers qualify.
+pub fn cli_config_from_rows(rows: &[crate::db::RepositoryMcpServer]) -> Option<String> {
+    let servers: Vec<McpServer> = rows_to_servers(rows)
+        .into_iter()
+        .filter(|(_, enabled)| *enabled)
+        .map(|(s, _)| s)
+        .collect();
+    if servers.is_empty() {
+        None
+    } else {
+        Some(serialize_for_cli(&servers))
+    }
+}
+
+/// Read the `disabledMcpServers` list from `~/.claude.json` project config.
+///
+/// Claude Code stores disabled servers at:
+///   `projects[repo_path].disabledMcpServers` as an array of server names.
+pub fn get_disabled_servers(repo_path: &Path) -> Vec<String> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let config_path = home.join(".claude.json");
+    let Ok(content) = std::fs::read_to_string(&config_path) else {
+        return Vec::new();
+    };
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return Vec::new();
+    };
+
+    let repo_key = repo_path.to_string_lossy();
+    root.get("projects")
+        .and_then(|p| p.get(repo_key.as_ref()))
+        .and_then(|proj| proj.get("disabledMcpServers"))
+        .and_then(|arr| arr.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Set a server's enabled/disabled state in `~/.claude.json` project config.
+///
+/// Matches Claude Code's behavior: disabled servers are tracked in
+/// `projects[repo_path].disabledMcpServers` as an array of names.
+pub fn set_server_disabled_in_config(
+    repo_path: &Path,
+    server_name: &str,
+    disabled: bool,
+) -> Result<(), String> {
+    let home = dirs::home_dir().ok_or("No home directory")?;
+    let config_path = home.join(".claude.json");
+
+    let mut root: serde_json::Value = if config_path.exists() {
+        let content =
+            std::fs::read_to_string(&config_path).map_err(|e| format!("Read error: {e}"))?;
+        serde_json::from_str(&content).map_err(|e| format!("Parse error: {e}"))?
+    } else {
+        serde_json::json!({})
+    };
+
+    let repo_key = repo_path.to_string_lossy().to_string();
+
+    // Ensure projects[repo_path] exists.
+    if root.get("projects").is_none() {
+        root["projects"] = serde_json::json!({});
+    }
+    if root["projects"].get(&repo_key).is_none() {
+        root["projects"][&repo_key] = serde_json::json!({});
+    }
+
+    let project = root["projects"][&repo_key]
+        .as_object_mut()
+        .ok_or("Bad project config")?;
+
+    let mut disabled_list: Vec<String> = project
+        .get("disabledMcpServers")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let already_disabled = disabled_list.contains(&server_name.to_string());
+
+    if disabled && !already_disabled {
+        disabled_list.push(server_name.to_string());
+    } else if !disabled && already_disabled {
+        disabled_list.retain(|n| n != server_name);
+    }
+
+    project.insert(
+        "disabledMcpServers".to_string(),
+        serde_json::json!(disabled_list),
+    );
+
+    let json_str =
+        serde_json::to_string_pretty(&root).map_err(|e| format!("Serialize error: {e}"))?;
+    std::fs::write(&config_path, json_str).map_err(|e| format!("Write error: {e}"))?;
+
+    Ok(())
 }
 
 /// Normalize an MCP config by ensuring it has a "type" field.
@@ -83,6 +248,143 @@ fn normalize_mcp_config(mut config: serde_json::Value) -> serde_json::Value {
         );
     }
     config
+}
+
+/// Parse user-global MCPs from `~/.claude.json` → `mcpServers`.
+fn detect_user_global_mcps() -> Option<Vec<McpServer>> {
+    let home = dirs::home_dir()?;
+    let config_path = home.join(".claude.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let root: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    let mcp_servers = root.get("mcpServers")?.as_object()?;
+
+    let servers = mcp_servers
+        .iter()
+        .map(|(name, config)| McpServer {
+            name: name.clone(),
+            config: normalize_mcp_config(config.clone()),
+            source: McpSource::UserGlobalConfig,
+        })
+        .collect();
+
+    Some(servers)
+}
+
+/// Parse committed `.mcp.json` at the repository root.
+fn detect_project_mcp_json(repo_path: &Path) -> Option<Vec<McpServer>> {
+    let config_path = repo_path.join(".mcp.json");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let root: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let mcp_servers = root.get("mcpServers")?.as_object()?;
+
+    let servers = mcp_servers
+        .iter()
+        .map(|(name, config)| McpServer {
+            name: name.clone(),
+            config: normalize_mcp_config(config.clone()),
+            source: McpSource::ProjectMcpJson,
+        })
+        .collect();
+
+    Some(servers)
+}
+
+/// Detect MCP servers from installed Claude Code plugins.
+///
+/// Plugins are installed at `~/.claude/plugins/cache/<marketplace>/<name>/<version>/`.
+/// Enabled plugins are listed in `~/.claude/settings.json` → `enabledPlugins`.
+/// Each plugin may have a `.mcp.json` defining MCP servers.
+fn detect_plugin_mcps() -> Vec<McpServer> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let claude_dir = home.join(".claude");
+
+    // Read enabled plugins from settings.json.
+    let settings_path = claude_dir.join("settings.json");
+    let enabled_plugins: std::collections::HashSet<String> =
+        std::fs::read_to_string(&settings_path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+            .and_then(|root| {
+                root.get("enabledPlugins")?.as_object().map(|obj| {
+                    obj.iter()
+                        .filter(|(_, v)| v.as_bool() == Some(true))
+                        .map(|(k, _)| k.clone())
+                        .collect()
+                })
+            })
+            .unwrap_or_default();
+
+    // Read installed plugins manifest.
+    let installed_path = claude_dir.join("plugins").join("installed_plugins.json");
+    let installed: serde_json::Value = std::fs::read_to_string(&installed_path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+        .unwrap_or_default();
+
+    let mut servers = Vec::new();
+
+    let Some(plugins) = installed.get("plugins").and_then(|p| p.as_object()) else {
+        return servers;
+    };
+
+    for (plugin_key, installs) in plugins {
+        // Only include enabled plugins.
+        if !enabled_plugins.contains(plugin_key) {
+            continue;
+        }
+
+        let Some(install_list) = installs.as_array() else {
+            continue;
+        };
+        for install in install_list {
+            let Some(install_path) = install.get("installPath").and_then(|p| p.as_str()) else {
+                continue;
+            };
+
+            let mcp_json_path = Path::new(install_path).join(".mcp.json");
+            let Ok(content) = std::fs::read_to_string(&mcp_json_path) else {
+                continue;
+            };
+            let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
+                continue;
+            };
+
+            // Plugin .mcp.json may use {"mcpServers": {...}} wrapper or bare {name: config}.
+            let mcp_obj = if let Some(inner) = root.get("mcpServers").and_then(|v| v.as_object()) {
+                inner.clone()
+            } else if let Some(obj) = root.as_object() {
+                // Bare format: top-level keys are server names.
+                obj.iter()
+                    .filter(|(k, v)| *k != "mcpServers" && v.is_object())
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            } else {
+                continue;
+            };
+
+            // Extract plugin display name from the key (e.g., "context7@claude-plugins-official" → "context7").
+            let plugin_name = plugin_key.split('@').next().unwrap_or(plugin_key);
+
+            for (name, config) in mcp_obj {
+                // Use plugin:name:name format for display, matching Claude Code.
+                let display_name = if name == plugin_name {
+                    format!("plugin:{plugin_name}")
+                } else {
+                    format!("plugin:{plugin_name}:{name}")
+                };
+                servers.push(McpServer {
+                    name: display_name,
+                    config: normalize_mcp_config(config),
+                    source: McpSource::Plugin,
+                });
+            }
+        }
+    }
+
+    servers
 }
 
 /// Parse project-scoped MCPs from `~/.claude.json`.
@@ -388,5 +690,700 @@ mod tests {
 
         assert_eq!(normalized["type"], "http");
         assert_eq!(normalized["url"], "https://example.com");
+    }
+
+    // -- set_server_disabled_in_config tests --
+
+    #[test]
+    fn test_set_server_disabled_creates_project_entry() {
+        let dir = TempDir::new().unwrap();
+        let config_path = dir.path().join(".claude.json");
+        fs::write(&config_path, "{}").unwrap();
+
+        // We can't easily test with real home dir, so test the JSON manipulation
+        // directly by simulating the logic.
+        let mut root: serde_json::Value = serde_json::json!({});
+        let repo_key = "/fake/repo";
+
+        // Ensure structure.
+        root["projects"] = serde_json::json!({});
+        root["projects"][repo_key] = serde_json::json!({});
+
+        let project = root["projects"][repo_key].as_object_mut().unwrap();
+        let disabled_list: Vec<String> = vec!["my-server".to_string()];
+        project.insert(
+            "disabledMcpServers".to_string(),
+            serde_json::json!(disabled_list),
+        );
+
+        let disabled = root["projects"][repo_key]["disabledMcpServers"]
+            .as_array()
+            .unwrap();
+        assert_eq!(disabled.len(), 1);
+        assert_eq!(disabled[0], "my-server");
+    }
+
+    #[test]
+    fn test_disabled_list_toggle_logic() {
+        // Simulate the toggle logic in set_server_disabled_in_config.
+        let mut list: Vec<String> = vec!["a".into(), "b".into()];
+
+        // Disable "c" (not in list).
+        let name = "c";
+        let disabled = true;
+        if disabled && !list.contains(&name.to_string()) {
+            list.push(name.to_string());
+        }
+        assert_eq!(list, vec!["a", "b", "c"]);
+
+        // Enable "b" (remove from list).
+        let name = "b";
+        let disabled = false;
+        if !disabled {
+            list.retain(|n| n != name);
+        }
+        assert_eq!(list, vec!["a", "c"]);
+
+        // Enable "x" (not in list, no-op).
+        let name = "x";
+        let disabled = false;
+        if !disabled {
+            list.retain(|n| n != name);
+        }
+        assert_eq!(list, vec!["a", "c"]);
+
+        // Disable "a" (already in list, no-op).
+        let name = "a";
+        let disabled = true;
+        if disabled && !list.contains(&name.to_string()) {
+            list.push(name.to_string());
+        }
+        assert_eq!(list, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn test_set_server_disabled_preserves_other_config() {
+        // Verify the JSON manipulation preserves existing config keys.
+        let mut root = serde_json::json!({
+            "apiKey": "sk-xxx",
+            "projects": {
+                "/my/repo": {
+                    "allowedTools": ["Bash", "Read"],
+                    "customInstructions": "be concise",
+                    "mcpServers": {
+                        "test": {"type": "stdio", "command": "echo"}
+                    }
+                }
+            },
+            "mcpServers": {
+                "global-server": {"type": "stdio", "command": "npx"}
+            }
+        });
+
+        let repo_key = "/my/repo";
+        let project = root["projects"][repo_key].as_object_mut().unwrap();
+        project.insert(
+            "disabledMcpServers".to_string(),
+            serde_json::json!(["some-server"]),
+        );
+
+        // Verify all other keys are preserved.
+        assert_eq!(root["apiKey"], "sk-xxx");
+        assert!(root["mcpServers"]["global-server"].is_object());
+        let proj = &root["projects"]["/my/repo"];
+        assert_eq!(proj["allowedTools"][0], "Bash");
+        assert_eq!(proj["customInstructions"], "be concise");
+        assert!(proj["mcpServers"]["test"].is_object());
+        assert_eq!(proj["disabledMcpServers"][0], "some-server");
+    }
+
+    #[test]
+    fn test_get_disabled_servers_parses_array() {
+        // Test the parsing logic directly.
+        let config = serde_json::json!({
+            "projects": {
+                "/my/repo": {
+                    "disabledMcpServers": ["server-a", "server-b"]
+                }
+            }
+        });
+
+        let repo_key = "/my/repo";
+        let disabled: Vec<String> = config
+            .get("projects")
+            .and_then(|p| p.get(repo_key))
+            .and_then(|proj| proj.get("disabledMcpServers"))
+            .and_then(|arr| arr.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        assert_eq!(disabled, vec!["server-a", "server-b"]);
+    }
+
+    #[test]
+    fn test_get_disabled_servers_missing_key() {
+        let config = serde_json::json!({
+            "projects": {
+                "/my/repo": {
+                    "allowedTools": ["Bash"]
+                }
+            }
+        });
+
+        let repo_key = "/my/repo";
+        let disabled: Vec<String> = config
+            .get("projects")
+            .and_then(|p| p.get(repo_key))
+            .and_then(|proj| proj.get("disabledMcpServers"))
+            .and_then(|arr| arr.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        assert!(disabled.is_empty());
+    }
+
+    #[test]
+    fn test_detect_project_mcp_json() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"ctx":{"type":"stdio","command":"npx","args":["-y","@upstash/context7-mcp"]}}}"#,
+        )
+        .unwrap();
+
+        let servers = detect_project_mcp_json(dir.path()).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "ctx");
+        assert_eq!(servers[0].source, McpSource::ProjectMcpJson);
+    }
+
+    #[test]
+    fn test_detect_project_mcp_json_missing_file() {
+        let dir = TempDir::new().unwrap();
+        assert!(detect_project_mcp_json(dir.path()).is_none());
+    }
+
+    // -- Plugin detection tests --
+
+    #[test]
+    fn test_plugin_mcp_json_bare_format() {
+        // Test parsing bare format: {"name": {config}} (no mcpServers wrapper).
+        let json = r#"{"my-server": {"command": "npx", "args": ["-y", "server"]}}"#;
+        let root: serde_json::Value = serde_json::from_str(json).unwrap();
+
+        // Simulate the bare format extraction.
+        let mcp_obj: serde_json::Map<String, serde_json::Value> = root
+            .as_object()
+            .unwrap()
+            .iter()
+            .filter(|(k, v)| *k != "mcpServers" && v.is_object())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        assert_eq!(mcp_obj.len(), 1);
+        assert!(mcp_obj.contains_key("my-server"));
+    }
+
+    #[test]
+    fn test_plugin_mcp_json_wrapped_format() {
+        // Test parsing wrapped format: {"mcpServers": {"name": {config}}}.
+        let json = r#"{"mcpServers": {"telegram": {"command": "bun", "args": ["start"]}}}"#;
+        let root: serde_json::Value = serde_json::from_str(json).unwrap();
+
+        let inner = root.get("mcpServers").and_then(|v| v.as_object()).unwrap();
+        assert_eq!(inner.len(), 1);
+        assert!(inner.contains_key("telegram"));
+    }
+
+    #[test]
+    fn test_plugin_display_name_same_as_plugin() {
+        // When server name matches plugin name → "plugin:name"
+        let plugin_key = "playwright@claude-plugins-official";
+        let plugin_name = plugin_key.split('@').next().unwrap();
+        let server_name = "playwright";
+        let display = if server_name == plugin_name {
+            format!("plugin:{plugin_name}")
+        } else {
+            format!("plugin:{plugin_name}:{server_name}")
+        };
+        assert_eq!(display, "plugin:playwright");
+    }
+
+    #[test]
+    fn test_plugin_display_name_different() {
+        // When server name differs → "plugin:pluginname:servername"
+        let plugin_key = "mytools@marketplace";
+        let plugin_name = plugin_key.split('@').next().unwrap();
+        let server_name = "database";
+        let display = if server_name == plugin_name {
+            format!("plugin:{plugin_name}")
+        } else {
+            format!("plugin:{plugin_name}:{server_name}")
+        };
+        assert_eq!(display, "plugin:mytools:database");
+    }
+
+    #[test]
+    fn test_detect_mcp_servers_does_not_override_explicit_with_plugin() {
+        // Plugin servers should NOT override explicit project/user configs.
+        // We can't easily test detect_mcp_servers with real files,
+        // but we verify the HashMap insertion logic: or_insert (not insert).
+        let mut by_name = std::collections::HashMap::<String, McpServer>::new();
+
+        // Simulate explicit config (inserted first).
+        by_name.insert(
+            "playwright".to_string(),
+            McpServer {
+                name: "playwright".to_string(),
+                config: serde_json::json!({"command": "explicit"}),
+                source: McpSource::ProjectMcpJson,
+            },
+        );
+
+        // Simulate plugin (should not override).
+        let plugin_server = McpServer {
+            name: "playwright".to_string(),
+            config: serde_json::json!({"command": "plugin"}),
+            source: McpSource::Plugin,
+        };
+        by_name
+            .entry(plugin_server.name.clone())
+            .or_insert(plugin_server);
+
+        assert_eq!(by_name["playwright"].source, McpSource::ProjectMcpJson);
+        assert_eq!(by_name["playwright"].config["command"], "explicit");
+    }
+
+    #[test]
+    fn test_mcp_source_plugin_serialization() {
+        let source = McpSource::Plugin;
+        let json = serde_json::to_string(&source).unwrap();
+        assert_eq!(json, "\"plugin\"");
+        let deserialized: McpSource = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, McpSource::Plugin);
+    }
+
+    // -- detect_mcp_servers full chain --
+
+    #[test]
+    fn test_detect_mcp_servers_combines_project_and_local() {
+        // Set up a repo with both .mcp.json (committed) and gitignored .claude.json.
+        let dir = setup_git_repo_with_gitignored_claude_json(
+            r#"{
+                "mcpServers": {
+                    "local-only": {"type": "stdio", "command": "local-cmd"}
+                }
+            }"#,
+        );
+
+        // Also add a .mcp.json (committed project config).
+        fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"committed-server":{"type":"stdio","command":"proj-cmd"}}}"#,
+        )
+        .unwrap();
+
+        let servers = detect_mcp_servers(dir.path());
+        let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+
+        // Both should be present (different names).
+        assert!(names.contains(&"local-only"));
+        assert!(names.contains(&"committed-server"));
+
+        // Verify sources.
+        let local = servers.iter().find(|s| s.name == "local-only").unwrap();
+        assert_eq!(local.source, McpSource::RepoLocalConfig);
+        let committed = servers
+            .iter()
+            .find(|s| s.name == "committed-server")
+            .unwrap();
+        assert_eq!(committed.source, McpSource::ProjectMcpJson);
+    }
+
+    #[test]
+    fn test_detect_mcp_servers_local_overrides_committed_by_name() {
+        // When .claude.json (gitignored) has same server name as .mcp.json,
+        // the local one wins (later source overrides earlier).
+        let dir = setup_git_repo_with_gitignored_claude_json(
+            r#"{
+                "mcpServers": {
+                    "shared-name": {"type": "stdio", "command": "local-version"}
+                }
+            }"#,
+        );
+
+        fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"shared-name":{"type":"stdio","command":"committed-version"}}}"#,
+        )
+        .unwrap();
+
+        let servers = detect_mcp_servers(dir.path());
+        let shared = servers.iter().find(|s| s.name == "shared-name").unwrap();
+
+        // .claude.json (source 4) overrides .mcp.json (source 3).
+        assert_eq!(shared.source, McpSource::RepoLocalConfig);
+        assert_eq!(shared.config["command"], "local-version");
+    }
+
+    #[test]
+    fn test_detect_mcp_servers_sorted_by_name() {
+        let dir = setup_git_repo_with_gitignored_claude_json(
+            r#"{
+                "mcpServers": {
+                    "zebra": {"type": "stdio", "command": "z"},
+                    "alpha": {"type": "stdio", "command": "a"},
+                    "middle": {"type": "stdio", "command": "m"}
+                }
+            }"#,
+        );
+
+        let servers = detect_mcp_servers(dir.path());
+        let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn test_detect_mcp_servers_empty_repo() {
+        // Isolate from real home dir so user-global and plugin MCPs don't
+        // leak into the test. Override HOME to an empty temp directory.
+        let home = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+
+        // SAFETY: test binary runs single-threaded per test by default,
+        // and we restore immediately after the call.
+        let orig_home = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let servers = detect_mcp_servers(repo.path());
+
+        // Restore before any assertions so panics don't leave env dirty.
+        match orig_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert!(
+            servers.is_empty(),
+            "expected no servers from empty repo + empty home, got {}",
+            servers.len()
+        );
+    }
+
+    // -- detect_project_mcp_json edge cases --
+
+    #[test]
+    fn test_detect_project_mcp_json_malformed_json() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".mcp.json"), "not valid json").unwrap();
+        assert!(detect_project_mcp_json(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_detect_project_mcp_json_empty_servers() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".mcp.json"), r#"{"mcpServers":{}}"#).unwrap();
+        let servers = detect_project_mcp_json(dir.path());
+        // Empty mcpServers object → Some with empty vec.
+        assert!(servers.is_some());
+        assert!(servers.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_detect_project_mcp_json_no_mcp_servers_key() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".mcp.json"), r#"{"other": "data"}"#).unwrap();
+        assert!(detect_project_mcp_json(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_detect_project_mcp_json_normalizes_config() {
+        let dir = TempDir::new().unwrap();
+        // Config without "type" field should get "stdio" added.
+        fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"my-srv":{"command":"npx","args":["-y","srv"]}}}"#,
+        )
+        .unwrap();
+
+        let servers = detect_project_mcp_json(dir.path()).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].config["type"], "stdio");
+        assert_eq!(servers[0].config["command"], "npx");
+    }
+
+    // -- detect_plugin_mcps with fixtures --
+
+    #[test]
+    fn test_detect_plugin_mcps_with_fixture_dir() {
+        // Create a realistic plugin directory structure.
+        let home_dir = TempDir::new().unwrap();
+        let claude_dir = home_dir.path().join(".claude");
+        let plugins_dir = claude_dir.join("plugins");
+        let cache_dir = plugins_dir
+            .join("cache")
+            .join("marketplace")
+            .join("test-plugin")
+            .join("1.0.0");
+        fs::create_dir_all(&cache_dir).unwrap();
+
+        // settings.json with enabled plugin.
+        fs::write(
+            claude_dir.join("settings.json"),
+            r#"{"enabledPlugins":{"test-plugin@marketplace":true}}"#,
+        )
+        .unwrap();
+
+        // installed_plugins.json.
+        let install_path = cache_dir.to_string_lossy().to_string();
+        fs::write(
+            plugins_dir.join("installed_plugins.json"),
+            serde_json::json!({
+                "plugins": {
+                    "test-plugin@marketplace": [{
+                        "installPath": install_path,
+                        "version": "1.0.0"
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        // Plugin's .mcp.json (wrapped format).
+        fs::write(
+            cache_dir.join(".mcp.json"),
+            r#"{"mcpServers":{"test-plugin":{"command":"node","args":["server.js"]}}}"#,
+        )
+        .unwrap();
+
+        // We can't call detect_plugin_mcps() directly because it reads from
+        // the real home dir. Instead, test the parsing logic in isolation by
+        // reading the files we just created and simulating the function.
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(claude_dir.join("settings.json")).unwrap())
+                .unwrap();
+        let enabled: std::collections::HashSet<String> = settings
+            .get("enabledPlugins")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter(|(_, v)| v.as_bool() == Some(true))
+                    .map(|(k, _)| k.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(enabled.contains("test-plugin@marketplace"));
+
+        let installed: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(plugins_dir.join("installed_plugins.json")).unwrap(),
+        )
+        .unwrap();
+        let plugins = installed
+            .get("plugins")
+            .and_then(|p| p.as_object())
+            .unwrap();
+
+        let mut servers = Vec::new();
+        for (plugin_key, installs) in plugins {
+            if !enabled.contains(plugin_key) {
+                continue;
+            }
+            for install in installs.as_array().unwrap() {
+                let ip = install.get("installPath").and_then(|p| p.as_str()).unwrap();
+                let content =
+                    fs::read_to_string(std::path::Path::new(ip).join(".mcp.json")).unwrap();
+                let root: serde_json::Value = serde_json::from_str(&content).unwrap();
+                let mcp_obj = root.get("mcpServers").and_then(|v| v.as_object()).unwrap();
+                let plugin_name = plugin_key.split('@').next().unwrap();
+                for (name, config) in mcp_obj {
+                    let display_name = if *name == plugin_name {
+                        format!("plugin:{plugin_name}")
+                    } else {
+                        format!("plugin:{plugin_name}:{name}")
+                    };
+                    servers.push(McpServer {
+                        name: display_name,
+                        config: normalize_mcp_config(config.clone()),
+                        source: McpSource::Plugin,
+                    });
+                }
+            }
+        }
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "plugin:test-plugin");
+        assert_eq!(servers[0].source, McpSource::Plugin);
+        assert_eq!(servers[0].config["type"], "stdio");
+        assert_eq!(servers[0].config["command"], "node");
+    }
+
+    #[test]
+    fn test_detect_plugin_mcps_bare_format_parsing() {
+        // Test that bare format (no mcpServers wrapper) is parsed correctly.
+        let json = r#"{"my-tool": {"command": "npx", "args": ["-y", "my-tool-server"]}}"#;
+        let root: serde_json::Value = serde_json::from_str(json).unwrap();
+
+        // Simulate the bare format fallback from detect_plugin_mcps.
+        let mcp_obj = if let Some(inner) = root.get("mcpServers").and_then(|v| v.as_object()) {
+            inner.clone()
+        } else if let Some(obj) = root.as_object() {
+            obj.iter()
+                .filter(|(k, v)| *k != "mcpServers" && v.is_object())
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        } else {
+            serde_json::Map::new()
+        };
+
+        assert_eq!(mcp_obj.len(), 1);
+        assert!(mcp_obj.contains_key("my-tool"));
+        assert_eq!(mcp_obj["my-tool"]["command"], "npx");
+    }
+
+    #[test]
+    fn test_detect_plugin_disabled_plugin_skipped() {
+        // Verify that disabled plugins in settings are not included.
+        let settings = serde_json::json!({
+            "enabledPlugins": {
+                "active@marketplace": true,
+                "disabled@marketplace": false
+            }
+        });
+
+        let enabled: std::collections::HashSet<String> = settings
+            .get("enabledPlugins")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .filter(|(_, v)| v.as_bool() == Some(true))
+                    .map(|(k, _)| k.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        assert!(enabled.contains("active@marketplace"));
+        assert!(!enabled.contains("disabled@marketplace"));
+        assert_eq!(enabled.len(), 1);
+    }
+
+    // -- normalize_mcp_config edge cases --
+
+    #[test]
+    fn test_normalize_mcp_config_with_url_type() {
+        // SSE config should keep its type.
+        let config = serde_json::json!({
+            "type": "sse",
+            "url": "https://example.com/sse"
+        });
+        let normalized = normalize_mcp_config(config);
+        assert_eq!(normalized["type"], "sse");
+    }
+
+    #[test]
+    fn test_normalize_mcp_config_non_object() {
+        // Non-object values should pass through unchanged.
+        let config = serde_json::json!("just a string");
+        let normalized = normalize_mcp_config(config.clone());
+        assert_eq!(normalized, config);
+    }
+
+    // -- McpSource serialization --
+
+    #[test]
+    fn test_mcp_source_all_variants_roundtrip() {
+        let sources = vec![
+            McpSource::UserGlobalConfig,
+            McpSource::UserProjectConfig,
+            McpSource::ProjectMcpJson,
+            McpSource::RepoLocalConfig,
+            McpSource::Plugin,
+        ];
+        let expected_strs = vec![
+            "user_global_config",
+            "user_project_config",
+            "project_mcp_json",
+            "repo_local_config",
+            "plugin",
+        ];
+        for (source, expected) in sources.into_iter().zip(expected_strs) {
+            let json = serde_json::to_string(&source).unwrap();
+            assert_eq!(json, format!("\"{expected}\""));
+            let deserialized: McpSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, source);
+        }
+    }
+
+    // -- rows_to_servers / cli_config_from_rows --
+
+    fn make_db_row(name: &str, source: &str, enabled: bool) -> crate::db::RepositoryMcpServer {
+        crate::db::RepositoryMcpServer {
+            id: format!("id-{name}"),
+            repository_id: "r1".to_string(),
+            name: name.to_string(),
+            config_json: format!(r#"{{"type":"stdio","command":"{name}"}}"#),
+            source: source.to_string(),
+            created_at: String::new(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn test_rows_to_servers_parses_correctly() {
+        let rows = vec![
+            make_db_row("srv-a", "user_project_config", true),
+            make_db_row("srv-b", "plugin", false),
+        ];
+        let result = rows_to_servers(&rows);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0.name, "srv-a");
+        assert!(result[0].1); // enabled
+        assert_eq!(result[0].0.source, McpSource::UserProjectConfig);
+        assert_eq!(result[1].0.name, "srv-b");
+        assert!(!result[1].1); // disabled
+        assert_eq!(result[1].0.source, McpSource::Plugin);
+    }
+
+    #[test]
+    fn test_rows_to_servers_skips_invalid_json() {
+        let mut row = make_db_row("bad", "user_project_config", true);
+        row.config_json = "not valid json".to_string();
+        let result = rows_to_servers(&[row]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_cli_config_from_rows_filters_disabled() {
+        let rows = vec![
+            make_db_row("enabled-srv", "user_project_config", true),
+            make_db_row("disabled-srv", "user_project_config", false),
+        ];
+        let config = cli_config_from_rows(&rows).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&config).unwrap();
+        let servers = parsed["mcpServers"].as_object().unwrap();
+        assert_eq!(servers.len(), 1);
+        assert!(servers.contains_key("enabled-srv"));
+        assert!(!servers.contains_key("disabled-srv"));
+    }
+
+    #[test]
+    fn test_cli_config_from_rows_all_disabled_returns_none() {
+        let rows = vec![make_db_row("srv", "user_project_config", false)];
+        assert!(cli_config_from_rows(&rows).is_none());
+    }
+
+    #[test]
+    fn test_cli_config_from_rows_empty_returns_none() {
+        assert!(cli_config_from_rows(&[]).is_none());
     }
 }

--- a/src/mcp_supervisor.rs
+++ b/src/mcp_supervisor.rs
@@ -198,14 +198,19 @@ pub async fn validate_remote_server(config: &serde_json::Value) -> Result<(), St
     let url: url::Url = url_str.parse().map_err(|e| format!("invalid URL: {e}"))?;
     let host = url.host_str().ok_or("URL missing host")?;
     let port = url.port_or_known_default().unwrap_or(443);
-    let addr = format!("{host}:{port}");
+    let display_addr = if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
 
     // TCP connect with 5-second timeout.
+    // Use (host, port) tuple so tokio resolves IPv6 addresses correctly.
     let timeout = Duration::from_secs(5);
-    match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(&addr)).await {
+    match tokio::time::timeout(timeout, tokio::net::TcpStream::connect((host, port))).await {
         Ok(Ok(_)) => Ok(()),
-        Ok(Err(e)) => Err(format!("TCP connect to {addr} failed: {e}")),
-        Err(_) => Err(format!("TCP connect to {addr} timed out after 5s")),
+        Ok(Err(e)) => Err(format!("TCP connect to {display_addr} failed: {e}")),
+        Err(_) => Err(format!("TCP connect to {display_addr} timed out after 5s")),
     }
 }
 
@@ -434,6 +439,10 @@ impl McpSupervisor {
 
         for (name, result) in results {
             if let Some(server) = repo.servers.get_mut(&name) {
+                // Server may have been disabled while validation was in flight.
+                if !server.enabled {
+                    continue;
+                }
                 match result {
                     Ok(()) => {
                         server.state = McpConnectionState::Connected;
@@ -517,6 +526,19 @@ impl McpSupervisor {
             .servers
             .get_mut(server_name)
             .ok_or("server not found")?;
+
+        // Server may have been disabled while validation was in flight.
+        if !server.enabled {
+            let status = McpServerStatus {
+                name: server.name.clone(),
+                transport: server.transport,
+                state: server.state,
+                enabled: server.enabled,
+                last_error: server.last_error.clone(),
+                failure_count: server.failure_count,
+            };
+            return Ok(status);
+        }
 
         match result {
             Ok(()) => {

--- a/src/mcp_supervisor.rs
+++ b/src/mcp_supervisor.rs
@@ -1,0 +1,1282 @@
+//! MCP server supervision: pre-validation, state tracking, and health monitoring.
+//!
+//! Claudette doesn't speak MCP protocol directly — it passes `--mcp-config` to
+//! the Claude CLI subprocess. This module provides a supervision layer that:
+//!
+//! 1. **Pre-validates** server availability before each agent session
+//! 2. **Tracks** per-server connection state via an explicit state machine
+//! 3. **Monitors** the agent event stream for MCP tool failures
+//! 4. **Broadcasts** status changes via `tokio::sync::watch` for UI updates
+//!
+//! The supervisor lives in the `claudette` library crate so both `src-tauri`
+//! (desktop) and `src-server` (headless) can share it.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::{RwLock, watch};
+
+use crate::mcp::McpServer;
+
+// ---------------------------------------------------------------------------
+// Constants (matching Claude Code's proven values)
+// ---------------------------------------------------------------------------
+
+/// Terminal error patterns from the Claude Code reference implementation.
+/// These indicate the MCP server connection is broken, not just a transient error.
+const TERMINAL_ERROR_PATTERNS: &[&str] = &[
+    "ECONNRESET",
+    "ETIMEDOUT",
+    "EPIPE",
+    "EHOSTUNREACH",
+    "ECONNREFUSED",
+    "Body Timeout Error",
+    "terminated",
+    "SSE stream disconnected",
+    "Failed to reconnect SSE stream",
+    "Connection closed",
+    "server disconnected",
+    "Maximum reconnection attempts",
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Connection state for a supervised MCP server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpConnectionState {
+    /// Server is reachable / command exists.
+    Connected,
+    /// Awaiting validation or reconnection.
+    Pending,
+    /// Validation or connection failed.
+    Failed,
+    /// Manually disabled by user.
+    Disabled,
+}
+
+/// Transport type derived from server config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpTransport {
+    Stdio,
+    Http,
+    Sse,
+}
+
+/// Full per-server supervision state (internal, includes config).
+#[derive(Debug, Clone, Serialize)]
+pub struct SupervisedServer {
+    pub name: String,
+    pub transport: McpTransport,
+    pub state: McpConnectionState,
+    pub config: serde_json::Value,
+    pub enabled: bool,
+    pub failure_count: u32,
+    pub last_error: Option<String>,
+}
+
+/// Lightweight status for events and frontend (no config blob).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpServerStatus {
+    pub name: String,
+    pub transport: McpTransport,
+    pub state: McpConnectionState,
+    pub enabled: bool,
+    pub last_error: Option<String>,
+    pub failure_count: u32,
+}
+
+/// Snapshot of all server states for a repository.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpStatusSnapshot {
+    pub repository_id: String,
+    pub servers: Vec<McpServerStatus>,
+}
+
+// ---------------------------------------------------------------------------
+// Backoff
+// ---------------------------------------------------------------------------
+
+/// Exponential backoff configuration.
+pub struct BackoffConfig {
+    pub base_ms: u64,
+    pub multiplier: f64,
+    pub max_ms: u64,
+    pub max_attempts: u32,
+}
+
+impl Default for BackoffConfig {
+    fn default() -> Self {
+        Self {
+            base_ms: 1000,
+            multiplier: 2.0,
+            max_ms: 30_000,
+            max_attempts: 5,
+        }
+    }
+}
+
+/// Calculate backoff delay for a given failure count.
+///
+/// Follows Claude Code's exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
+pub fn calculate_backoff(config: &BackoffConfig, failure_count: u32) -> Duration {
+    let delay_ms = (config.base_ms as f64 * config.multiplier.powi(failure_count as i32)) as u64;
+    Duration::from_millis(delay_ms.min(config.max_ms))
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/// Detect the transport type from a server config JSON value.
+pub fn detect_transport(config: &serde_json::Value) -> McpTransport {
+    if let Some(t) = config.get("type").and_then(|v| v.as_str()) {
+        match t {
+            "sse" => return McpTransport::Sse,
+            "http" => return McpTransport::Http,
+            "stdio" => return McpTransport::Stdio,
+            _ => {}
+        }
+    }
+    // Fallback heuristics: if it has a "command" field, it's stdio; if "url", it's http.
+    if config.get("command").is_some() {
+        McpTransport::Stdio
+    } else if config.get("url").is_some() {
+        McpTransport::Http
+    } else {
+        McpTransport::Stdio
+    }
+}
+
+/// Extract MCP server name from a tool name like `mcp__servername__toolname`.
+///
+/// Returns `None` if the tool name doesn't follow MCP naming convention.
+pub fn extract_mcp_server_name(tool_name: &str) -> Option<&str> {
+    let rest = tool_name.strip_prefix("mcp__")?;
+    let end = rest.find("__")?;
+    Some(&rest[..end])
+}
+
+/// Check if an error message indicates a terminal MCP connection failure.
+pub fn is_terminal_mcp_error(msg: &str) -> bool {
+    TERMINAL_ERROR_PATTERNS
+        .iter()
+        .any(|pattern| msg.contains(pattern))
+}
+
+// ---------------------------------------------------------------------------
+// Validation functions
+// ---------------------------------------------------------------------------
+
+/// Check if a stdio server's command exists and is executable.
+///
+/// Resolves the command from `PATH` using the `which` crate for
+/// cross-platform lookup (works on macOS, Linux, and Windows).
+pub async fn validate_stdio_server(config: &serde_json::Value) -> Result<(), String> {
+    let command = config
+        .get("command")
+        .and_then(|v| v.as_str())
+        .ok_or("stdio server config missing 'command' field")?;
+
+    which::which(command)
+        .map(|_| ())
+        .map_err(|_| format!("command not found in PATH: {command}"))
+}
+
+/// Health-check a remote server endpoint via TCP connect with timeout.
+pub async fn validate_remote_server(config: &serde_json::Value) -> Result<(), String> {
+    let url_str = config
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or("remote server config missing 'url' field")?;
+
+    // Parse host and port from the URL.
+    let url: url::Url = url_str.parse().map_err(|e| format!("invalid URL: {e}"))?;
+    let host = url.host_str().ok_or("URL missing host")?;
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addr = format!("{host}:{port}");
+
+    // TCP connect with 5-second timeout.
+    let timeout = Duration::from_secs(5);
+    match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(&addr)).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(format!("TCP connect to {addr} failed: {e}")),
+        Err(_) => Err(format!("TCP connect to {addr} timed out after 5s")),
+    }
+}
+
+/// Validate a server based on its transport type.
+async fn validate_server(
+    config: &serde_json::Value,
+    transport: McpTransport,
+) -> Result<(), String> {
+    match transport {
+        McpTransport::Stdio => validate_stdio_server(config).await,
+        McpTransport::Http | McpTransport::Sse => validate_remote_server(config).await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-repository state
+// ---------------------------------------------------------------------------
+
+struct RepoMcpState {
+    servers: HashMap<String, SupervisedServer>,
+    state_tx: watch::Sender<McpStatusSnapshot>,
+}
+
+impl RepoMcpState {
+    fn new(repository_id: &str) -> Self {
+        let initial = McpStatusSnapshot {
+            repository_id: repository_id.to_string(),
+            servers: Vec::new(),
+        };
+        let (state_tx, _) = watch::channel(initial);
+        Self {
+            servers: HashMap::new(),
+            state_tx,
+        }
+    }
+
+    /// Build and broadcast a status snapshot.
+    fn broadcast(&self, repository_id: &str) {
+        let servers: Vec<McpServerStatus> = self
+            .servers
+            .values()
+            .map(|s| McpServerStatus {
+                name: s.name.clone(),
+                transport: s.transport,
+                state: s.state,
+                enabled: s.enabled,
+                last_error: s.last_error.clone(),
+                failure_count: s.failure_count,
+            })
+            .collect();
+
+        let snapshot = McpStatusSnapshot {
+            repository_id: repository_id.to_string(),
+            servers,
+        };
+        // Ignore send error — means no receivers are listening.
+        let _ = self.state_tx.send(snapshot);
+    }
+
+    /// Get the current snapshot without broadcasting.
+    fn snapshot(&self, repository_id: &str) -> McpStatusSnapshot {
+        let servers: Vec<McpServerStatus> = self
+            .servers
+            .values()
+            .map(|s| McpServerStatus {
+                name: s.name.clone(),
+                transport: s.transport,
+                state: s.state,
+                enabled: s.enabled,
+                last_error: s.last_error.clone(),
+                failure_count: s.failure_count,
+            })
+            .collect();
+
+        McpStatusSnapshot {
+            repository_id: repository_id.to_string(),
+            servers,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// McpSupervisor
+// ---------------------------------------------------------------------------
+
+/// Top-level MCP server supervisor, one instance per application.
+///
+/// Manages per-repository server state, validation, and status broadcasting.
+pub struct McpSupervisor {
+    repos: RwLock<HashMap<String, RepoMcpState>>,
+}
+
+impl McpSupervisor {
+    pub fn new() -> Self {
+        Self {
+            repos: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Initialize supervision for a repository from its saved MCP servers.
+    ///
+    /// Idempotent: if the repo is already initialized, merges new servers
+    /// (adds missing, removes stale) without resetting existing state.
+    pub async fn init_repo(&self, repository_id: &str, servers: Vec<McpServer>) {
+        let mut repos = self.repos.write().await;
+        let repo = repos
+            .entry(repository_id.to_string())
+            .or_insert_with(|| RepoMcpState::new(repository_id));
+
+        // Build set of incoming server names.
+        let incoming_names: std::collections::HashSet<&str> =
+            servers.iter().map(|s| s.name.as_str()).collect();
+
+        // Remove servers no longer in the config.
+        repo.servers
+            .retain(|name, _| incoming_names.contains(name.as_str()));
+
+        // Add or update servers.
+        for server in servers {
+            let transport = detect_transport(&server.config);
+            repo.servers
+                .entry(server.name.clone())
+                .and_modify(|existing| {
+                    // Update config but keep current state.
+                    existing.config = server.config.clone();
+                    existing.transport = transport;
+                })
+                .or_insert(SupervisedServer {
+                    name: server.name,
+                    transport,
+                    state: McpConnectionState::Pending,
+                    config: server.config,
+                    enabled: true,
+                    failure_count: 0,
+                    last_error: None,
+                });
+        }
+
+        repo.broadcast(repository_id);
+    }
+
+    /// Initialize a repo with enabled state from DB rows.
+    ///
+    /// Like `init_repo` but also sets the `enabled` flag per server.
+    pub async fn init_repo_with_enabled(
+        &self,
+        repository_id: &str,
+        servers: Vec<(McpServer, bool)>,
+    ) {
+        let mut repos = self.repos.write().await;
+        let repo = repos
+            .entry(repository_id.to_string())
+            .or_insert_with(|| RepoMcpState::new(repository_id));
+
+        let incoming_names: std::collections::HashSet<&str> =
+            servers.iter().map(|(s, _)| s.name.as_str()).collect();
+
+        repo.servers
+            .retain(|name, _| incoming_names.contains(name.as_str()));
+
+        for (server, enabled) in servers {
+            let transport = detect_transport(&server.config);
+            repo.servers
+                .entry(server.name.clone())
+                .and_modify(|existing| {
+                    existing.config = server.config.clone();
+                    existing.transport = transport;
+                    existing.enabled = enabled;
+                })
+                .or_insert(SupervisedServer {
+                    name: server.name,
+                    transport,
+                    state: if enabled {
+                        McpConnectionState::Pending
+                    } else {
+                        McpConnectionState::Disabled
+                    },
+                    config: server.config,
+                    enabled,
+                    failure_count: 0,
+                    last_error: None,
+                });
+        }
+
+        repo.broadcast(repository_id);
+    }
+
+    /// Pre-validate all enabled servers for a repository.
+    ///
+    /// Transitions each server's state based on validation result:
+    /// - Success → Connected
+    /// - Failure → Failed (with error message)
+    /// - Disabled servers are skipped.
+    ///
+    /// Returns the updated status list.
+    pub async fn validate_servers(&self, repository_id: &str) -> Vec<McpServerStatus> {
+        // Collect servers to validate (snapshot under read lock).
+        let to_validate: Vec<(String, serde_json::Value, McpTransport)> = {
+            let repos = self.repos.read().await;
+            let Some(repo) = repos.get(repository_id) else {
+                return Vec::new();
+            };
+            repo.servers
+                .values()
+                .filter(|s| s.enabled)
+                .map(|s| (s.name.clone(), s.config.clone(), s.transport))
+                .collect()
+        };
+
+        // Validate concurrently (release lock during I/O).
+        let results: Vec<(String, Result<(), String>)> =
+            futures::future::join_all(to_validate.into_iter().map(|(name, config, transport)| {
+                let name = name.clone();
+                async move {
+                    let result = validate_server(&config, transport).await;
+                    (name, result)
+                }
+            }))
+            .await;
+
+        // Apply results under write lock.
+        let mut repos = self.repos.write().await;
+        let Some(repo) = repos.get_mut(repository_id) else {
+            return Vec::new();
+        };
+
+        for (name, result) in results {
+            if let Some(server) = repo.servers.get_mut(&name) {
+                match result {
+                    Ok(()) => {
+                        server.state = McpConnectionState::Connected;
+                        server.failure_count = 0;
+                        server.last_error = None;
+                    }
+                    Err(err) => {
+                        server.state = McpConnectionState::Failed;
+                        server.failure_count += 1;
+                        server.last_error = Some(err);
+                    }
+                }
+            }
+        }
+
+        let snapshot = repo.snapshot(repository_id);
+        repo.broadcast(repository_id);
+        snapshot.servers
+    }
+
+    /// Report a tool failure detected from the agent event stream.
+    ///
+    /// Transitions the named server to Failed state.
+    pub async fn report_tool_failure(&self, repository_id: &str, server_name: &str, error: &str) {
+        let mut repos = self.repos.write().await;
+        let Some(repo) = repos.get_mut(repository_id) else {
+            return;
+        };
+        let Some(server) = repo.servers.get_mut(server_name) else {
+            return;
+        };
+
+        if server.state == McpConnectionState::Connected {
+            server.state = McpConnectionState::Failed;
+            server.failure_count += 1;
+            server.last_error = Some(error.to_string());
+            repo.broadcast(repository_id);
+        }
+    }
+
+    /// Manually reconnect a specific server (re-validate).
+    ///
+    /// Returns the new state, or an error if the server doesn't exist or is disabled.
+    pub async fn reconnect_server(
+        &self,
+        repository_id: &str,
+        server_name: &str,
+    ) -> Result<McpServerStatus, String> {
+        // Read config under lock, then validate without lock held.
+        let (config, transport) = {
+            let repos = self.repos.read().await;
+            let repo = repos
+                .get(repository_id)
+                .ok_or("repository not supervised")?;
+            let server = repo.servers.get(server_name).ok_or("server not found")?;
+            if !server.enabled {
+                return Err("server is disabled".to_string());
+            }
+            (server.config.clone(), server.transport)
+        };
+
+        // Mark as pending during validation.
+        {
+            let mut repos = self.repos.write().await;
+            if let Some(repo) = repos.get_mut(repository_id)
+                && let Some(server) = repo.servers.get_mut(server_name)
+            {
+                server.state = McpConnectionState::Pending;
+                repo.broadcast(repository_id);
+            }
+        }
+
+        let result = validate_server(&config, transport).await;
+
+        // Apply result.
+        let mut repos = self.repos.write().await;
+        let repo = repos
+            .get_mut(repository_id)
+            .ok_or("repository not supervised")?;
+        let server = repo
+            .servers
+            .get_mut(server_name)
+            .ok_or("server not found")?;
+
+        match result {
+            Ok(()) => {
+                server.state = McpConnectionState::Connected;
+                server.failure_count = 0;
+                server.last_error = None;
+            }
+            Err(ref err) => {
+                server.state = McpConnectionState::Failed;
+                server.failure_count += 1;
+                server.last_error = Some(err.clone());
+            }
+        }
+
+        let status = McpServerStatus {
+            name: server.name.clone(),
+            transport: server.transport,
+            state: server.state,
+            enabled: server.enabled,
+            last_error: server.last_error.clone(),
+            failure_count: server.failure_count,
+        };
+        repo.broadcast(repository_id);
+
+        result.map(|()| status.clone()).or(Ok(status))
+    }
+
+    /// Enable or disable a specific server.
+    ///
+    /// Disabling transitions state to Disabled; enabling transitions to Pending.
+    pub async fn set_server_enabled(&self, repository_id: &str, server_name: &str, enabled: bool) {
+        let mut repos = self.repos.write().await;
+        let Some(repo) = repos.get_mut(repository_id) else {
+            return;
+        };
+        let Some(server) = repo.servers.get_mut(server_name) else {
+            return;
+        };
+
+        server.enabled = enabled;
+        if enabled {
+            // Re-enable: move to Pending so next validate picks it up.
+            if server.state == McpConnectionState::Disabled {
+                server.state = McpConnectionState::Pending;
+                server.failure_count = 0;
+                server.last_error = None;
+            }
+        } else {
+            server.state = McpConnectionState::Disabled;
+        }
+
+        repo.broadcast(repository_id);
+    }
+
+    /// Get current status snapshot for a repository.
+    pub async fn get_status(&self, repository_id: &str) -> Option<McpStatusSnapshot> {
+        let repos = self.repos.read().await;
+        repos.get(repository_id).map(|r| r.snapshot(repository_id))
+    }
+
+    /// Subscribe to status changes for a repository.
+    ///
+    /// Returns `None` if the repository is not supervised.
+    pub async fn subscribe(
+        &self,
+        repository_id: &str,
+    ) -> Option<watch::Receiver<McpStatusSnapshot>> {
+        let repos = self.repos.read().await;
+        repos.get(repository_id).map(|r| r.state_tx.subscribe())
+    }
+
+    /// Remove supervision for a repository.
+    pub async fn remove_repo(&self, repository_id: &str) {
+        let mut repos = self.repos.write().await;
+        repos.remove(repository_id);
+    }
+}
+
+impl Default for McpSupervisor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Backoff --
+
+    #[test]
+    fn test_backoff_calculation_exponential() {
+        let config = BackoffConfig::default();
+        assert_eq!(calculate_backoff(&config, 0), Duration::from_millis(1000));
+        assert_eq!(calculate_backoff(&config, 1), Duration::from_millis(2000));
+        assert_eq!(calculate_backoff(&config, 2), Duration::from_millis(4000));
+        assert_eq!(calculate_backoff(&config, 3), Duration::from_millis(8000));
+        assert_eq!(calculate_backoff(&config, 4), Duration::from_millis(16000));
+    }
+
+    #[test]
+    fn test_backoff_caps_at_max() {
+        let config = BackoffConfig::default();
+        // 2^5 * 1000 = 32000, capped to 30000
+        assert_eq!(calculate_backoff(&config, 5), Duration::from_millis(30000));
+        assert_eq!(calculate_backoff(&config, 10), Duration::from_millis(30000));
+    }
+
+    // -- Transport detection --
+
+    #[test]
+    fn test_detect_transport_stdio_explicit() {
+        let config = serde_json::json!({"type": "stdio", "command": "npx"});
+        assert_eq!(detect_transport(&config), McpTransport::Stdio);
+    }
+
+    #[test]
+    fn test_detect_transport_stdio_implicit() {
+        let config = serde_json::json!({"command": "npx", "args": ["-y", "server"]});
+        assert_eq!(detect_transport(&config), McpTransport::Stdio);
+    }
+
+    #[test]
+    fn test_detect_transport_http() {
+        let config = serde_json::json!({"type": "http", "url": "https://example.com"});
+        assert_eq!(detect_transport(&config), McpTransport::Http);
+    }
+
+    #[test]
+    fn test_detect_transport_sse() {
+        let config = serde_json::json!({"type": "sse", "url": "https://example.com/sse"});
+        assert_eq!(detect_transport(&config), McpTransport::Sse);
+    }
+
+    #[test]
+    fn test_detect_transport_url_fallback() {
+        let config = serde_json::json!({"url": "https://example.com"});
+        assert_eq!(detect_transport(&config), McpTransport::Http);
+    }
+
+    // -- Tool name parsing --
+
+    #[test]
+    fn test_extract_mcp_server_name_valid() {
+        assert_eq!(
+            extract_mcp_server_name("mcp__my_server__do_thing"),
+            Some("my_server")
+        );
+    }
+
+    #[test]
+    fn test_extract_mcp_server_name_with_plugin_prefix() {
+        assert_eq!(
+            extract_mcp_server_name("mcp__plugin_playwright_playwright__browser_click"),
+            Some("plugin_playwright_playwright")
+        );
+    }
+
+    #[test]
+    fn test_extract_mcp_server_name_not_mcp() {
+        assert_eq!(extract_mcp_server_name("Read"), None);
+        assert_eq!(extract_mcp_server_name("Bash"), None);
+    }
+
+    #[test]
+    fn test_extract_mcp_server_name_no_tool_part() {
+        assert_eq!(extract_mcp_server_name("mcp__server_only"), None);
+    }
+
+    // -- Terminal error detection --
+
+    #[test]
+    fn test_is_terminal_mcp_error_matches() {
+        assert!(is_terminal_mcp_error("Connection reset: ECONNRESET"));
+        assert!(is_terminal_mcp_error("ETIMEDOUT after 30s"));
+        assert!(is_terminal_mcp_error("write failed: EPIPE"));
+        assert!(is_terminal_mcp_error("ECONNREFUSED 127.0.0.1:8080"));
+        assert!(is_terminal_mcp_error("SSE stream disconnected"));
+        assert!(is_terminal_mcp_error("Connection closed by server"));
+    }
+
+    #[test]
+    fn test_is_terminal_mcp_error_non_terminal() {
+        assert!(!is_terminal_mcp_error("Invalid argument: foo"));
+        assert!(!is_terminal_mcp_error("Tool not found"));
+        assert!(!is_terminal_mcp_error("Permission denied"));
+    }
+
+    // -- Status snapshot serialization --
+
+    #[test]
+    fn test_status_snapshot_serialization_roundtrip() {
+        let snapshot = McpStatusSnapshot {
+            repository_id: "repo-1".to_string(),
+            servers: vec![
+                McpServerStatus {
+                    name: "server-a".to_string(),
+                    transport: McpTransport::Stdio,
+                    state: McpConnectionState::Connected,
+                    enabled: true,
+                    last_error: None,
+                    failure_count: 0,
+                },
+                McpServerStatus {
+                    name: "server-b".to_string(),
+                    transport: McpTransport::Http,
+                    state: McpConnectionState::Failed,
+                    enabled: true,
+                    last_error: Some("ECONNREFUSED".to_string()),
+                    failure_count: 2,
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let deserialized: McpStatusSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snapshot, deserialized);
+    }
+
+    // -- McpSupervisor --
+
+    fn make_test_server(name: &str, transport_type: &str) -> McpServer {
+        let config = match transport_type {
+            "stdio" => serde_json::json!({"type": "stdio", "command": "echo", "args": []}),
+            "http" => serde_json::json!({"type": "http", "url": "https://example.com"}),
+            "sse" => serde_json::json!({"type": "sse", "url": "https://example.com/sse"}),
+            _ => serde_json::json!({"type": "stdio", "command": "echo"}),
+        };
+        McpServer {
+            name: name.to_string(),
+            config,
+            source: crate::mcp::McpSource::UserProjectConfig,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_init_repo_creates_pending_servers() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo(
+                "repo-1",
+                vec![
+                    make_test_server("a", "stdio"),
+                    make_test_server("b", "http"),
+                ],
+            )
+            .await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        assert_eq!(status.servers.len(), 2);
+        for s in &status.servers {
+            assert_eq!(s.state, McpConnectionState::Pending);
+            assert!(s.enabled);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_init_repo_idempotent() {
+        let supervisor = McpSupervisor::new();
+        let servers = vec![make_test_server("a", "stdio")];
+
+        supervisor.init_repo("repo-1", servers.clone()).await;
+        // Second init should not duplicate.
+        supervisor.init_repo("repo-1", servers).await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        assert_eq!(status.servers.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_init_repo_removes_stale_servers() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo(
+                "repo-1",
+                vec![
+                    make_test_server("a", "stdio"),
+                    make_test_server("b", "http"),
+                ],
+            )
+            .await;
+
+        // Re-init with only server "a" — "b" should be removed.
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        assert_eq!(status.servers.len(), 1);
+        assert_eq!(status.servers[0].name, "a");
+    }
+
+    #[tokio::test]
+    async fn test_report_tool_failure_transitions_to_failed() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        // Manually set to Connected first.
+        {
+            let mut repos = supervisor.repos.write().await;
+            let repo = repos.get_mut("repo-1").unwrap();
+            repo.servers.get_mut("a").unwrap().state = McpConnectionState::Connected;
+        }
+
+        supervisor
+            .report_tool_failure("repo-1", "a", "ECONNRESET")
+            .await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        let server = status.servers.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(server.state, McpConnectionState::Failed);
+        assert_eq!(server.last_error.as_deref(), Some("ECONNRESET"));
+        assert_eq!(server.failure_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_set_server_enabled_disable() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        supervisor.set_server_enabled("repo-1", "a", false).await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        let server = status.servers.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(server.state, McpConnectionState::Disabled);
+        assert!(!server.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_set_server_enabled_reenable() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        supervisor.set_server_enabled("repo-1", "a", false).await;
+        supervisor.set_server_enabled("repo-1", "a", true).await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        let server = status.servers.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(server.state, McpConnectionState::Pending);
+        assert!(server.enabled);
+    }
+
+    #[tokio::test]
+    async fn test_watch_channel_broadcasts_changes() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        let mut rx = supervisor.subscribe("repo-1").await.unwrap();
+
+        // Mark current value as seen so `changed()` waits for the next update.
+        rx.borrow_and_update();
+
+        // Trigger a state change.
+        supervisor.set_server_enabled("repo-1", "a", false).await;
+
+        // Should receive the update.
+        rx.changed().await.unwrap();
+        let updated = rx.borrow().clone();
+        assert_eq!(updated.servers.len(), 1);
+        assert_eq!(updated.servers[0].state, McpConnectionState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn test_remove_repo() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        supervisor.remove_repo("repo-1").await;
+        assert!(supervisor.get_status("repo-1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_status_nonexistent_repo() {
+        let supervisor = McpSupervisor::new();
+        assert!(supervisor.get_status("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_validate_stdio_server_existing_command() {
+        // `echo` should exist on all Unix systems.
+        let config = serde_json::json!({"type": "stdio", "command": "echo"});
+        let result = validate_stdio_server(&config).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_stdio_server_missing_command() {
+        let config =
+            serde_json::json!({"type": "stdio", "command": "nonexistent_binary_xyz_12345"});
+        let result = validate_stdio_server(&config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("command not found"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_remote_server_unreachable() {
+        // Port 1 on localhost should be unreachable.
+        let config = serde_json::json!({"type": "http", "url": "http://127.0.0.1:1/mcp"});
+        let result = validate_remote_server(&config).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_disabled_server_errors() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        supervisor.set_server_enabled("repo-1", "a", false).await;
+
+        let result = supervisor.reconnect_server("repo-1", "a").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("disabled"));
+    }
+
+    // -- validate_servers --
+
+    #[tokio::test]
+    async fn test_validate_servers_mixed_results() {
+        let supervisor = McpSupervisor::new();
+        // "echo" exists, "nonexistent_binary_xyz_12345" does not.
+        supervisor
+            .init_repo(
+                "repo-1",
+                vec![
+                    make_test_server("good", "stdio"),     // command = "echo" → will pass
+                    McpServer {
+                        name: "bad".to_string(),
+                        config: serde_json::json!({"type": "stdio", "command": "nonexistent_binary_xyz_12345"}),
+                        source: crate::mcp::McpSource::UserProjectConfig,
+                    },
+                ],
+            )
+            .await;
+
+        let statuses = supervisor.validate_servers("repo-1").await;
+        assert_eq!(statuses.len(), 2);
+
+        let good = statuses.iter().find(|s| s.name == "good").unwrap();
+        assert_eq!(good.state, McpConnectionState::Connected);
+        assert!(good.last_error.is_none());
+        assert_eq!(good.failure_count, 0);
+
+        let bad = statuses.iter().find(|s| s.name == "bad").unwrap();
+        assert_eq!(bad.state, McpConnectionState::Failed);
+        assert!(bad.last_error.is_some());
+        assert!(bad.failure_count > 0);
+    }
+
+    #[tokio::test]
+    async fn test_validate_servers_skips_disabled() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        supervisor.set_server_enabled("repo-1", "a", false).await;
+
+        let statuses = supervisor.validate_servers("repo-1").await;
+        // Disabled server should stay disabled, not be validated.
+        let a = statuses.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(a.state, McpConnectionState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn test_validate_servers_nonexistent_repo() {
+        let supervisor = McpSupervisor::new();
+        let statuses = supervisor.validate_servers("nope").await;
+        assert!(statuses.is_empty());
+    }
+
+    // -- report_tool_failure edge cases --
+
+    #[tokio::test]
+    async fn test_report_tool_failure_only_from_connected() {
+        // report_tool_failure should only transition Connected → Failed.
+        // If server is Pending or Disabled, it should NOT change state.
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        // Server starts as Pending — failure report should be ignored.
+        supervisor
+            .report_tool_failure("repo-1", "a", "ECONNRESET")
+            .await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        let a = status.servers.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(a.state, McpConnectionState::Pending);
+        assert_eq!(a.failure_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_report_tool_failure_nonexistent_server() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        // Should not panic — just no-op.
+        supervisor
+            .report_tool_failure("repo-1", "nonexistent", "ECONNRESET")
+            .await;
+        supervisor
+            .report_tool_failure("no-repo", "a", "ECONNRESET")
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_report_tool_failure_increments_count() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        // Set to Connected.
+        {
+            let mut repos = supervisor.repos.write().await;
+            let repo = repos.get_mut("repo-1").unwrap();
+            repo.servers.get_mut("a").unwrap().state = McpConnectionState::Connected;
+        }
+
+        supervisor
+            .report_tool_failure("repo-1", "a", "ECONNRESET")
+            .await;
+
+        // After first failure it's now Failed, so second report should be no-op
+        // (only Connected → Failed transition triggers).
+        supervisor.report_tool_failure("repo-1", "a", "EPIPE").await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        let a = status.servers.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(a.failure_count, 1); // Not 2, because second was from Failed state
+        assert_eq!(a.last_error.as_deref(), Some("ECONNRESET"));
+    }
+
+    // -- reconnect state machine --
+
+    #[tokio::test]
+    async fn test_reconnect_transitions_failed_to_connected() {
+        let supervisor = McpSupervisor::new();
+        // Use "echo" which is a valid command.
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        // Set to Failed.
+        {
+            let mut repos = supervisor.repos.write().await;
+            let repo = repos.get_mut("repo-1").unwrap();
+            let s = repo.servers.get_mut("a").unwrap();
+            s.state = McpConnectionState::Failed;
+            s.failure_count = 3;
+            s.last_error = Some("previous error".to_string());
+        }
+
+        let result = supervisor.reconnect_server("repo-1", "a").await;
+        assert!(result.is_ok());
+
+        let status = result.unwrap();
+        assert_eq!(status.state, McpConnectionState::Connected);
+        assert_eq!(status.failure_count, 0);
+        assert!(status.last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_bad_server_stays_failed() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo(
+                "repo-1",
+                vec![McpServer {
+                    name: "bad".to_string(),
+                    config: serde_json::json!({"type": "stdio", "command": "nonexistent_binary_xyz_12345"}),
+                    source: crate::mcp::McpSource::UserProjectConfig,
+                }],
+            )
+            .await;
+
+        let result = supervisor.reconnect_server("repo-1", "bad").await;
+        // reconnect_server returns Ok with the status even on failure.
+        assert!(result.is_ok());
+        let status = result.unwrap();
+        assert_eq!(status.state, McpConnectionState::Failed);
+        assert!(status.failure_count > 0);
+        assert!(status.last_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_nonexistent_server_errors() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+
+        let result = supervisor.reconnect_server("repo-1", "nope").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_nonexistent_repo_errors() {
+        let supervisor = McpSupervisor::new();
+        let result = supervisor.reconnect_server("nope", "a").await;
+        assert!(result.is_err());
+    }
+
+    // -- get_status direct --
+
+    #[tokio::test]
+    async fn test_get_status_returns_all_servers() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo(
+                "repo-1",
+                vec![
+                    make_test_server("a", "stdio"),
+                    make_test_server("b", "http"),
+                    make_test_server("c", "sse"),
+                ],
+            )
+            .await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        assert_eq!(status.repository_id, "repo-1");
+        assert_eq!(status.servers.len(), 3);
+        // Each server should have correct transport.
+        let a = status.servers.iter().find(|s| s.name == "a").unwrap();
+        assert_eq!(a.transport, McpTransport::Stdio);
+        let b = status.servers.iter().find(|s| s.name == "b").unwrap();
+        assert_eq!(b.transport, McpTransport::Http);
+        let c = status.servers.iter().find(|s| s.name == "c").unwrap();
+        assert_eq!(c.transport, McpTransport::Sse);
+    }
+
+    // -- watch channel multiple repos --
+
+    #[tokio::test]
+    async fn test_watch_channel_independent_per_repo() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        supervisor
+            .init_repo("repo-2", vec![make_test_server("b", "stdio")])
+            .await;
+
+        let mut rx1 = supervisor.subscribe("repo-1").await.unwrap();
+        let mut rx2 = supervisor.subscribe("repo-2").await.unwrap();
+
+        rx1.borrow_and_update();
+        rx2.borrow_and_update();
+
+        // Change in repo-1 should not notify repo-2.
+        supervisor.set_server_enabled("repo-1", "a", false).await;
+
+        rx1.changed().await.unwrap();
+        let snap1 = rx1.borrow().clone();
+        assert_eq!(snap1.servers[0].state, McpConnectionState::Disabled);
+
+        // rx2 should not have changed.
+        assert!(rx2.has_changed().is_err() || !rx2.has_changed().unwrap_or(true));
+    }
+
+    // -- backoff with custom config --
+
+    #[test]
+    fn test_backoff_with_custom_config() {
+        let config = BackoffConfig {
+            base_ms: 500,
+            max_ms: 5000,
+            multiplier: 3.0,
+            max_attempts: 10,
+        };
+        assert_eq!(calculate_backoff(&config, 0), Duration::from_millis(500));
+        // 500 * 3^1 = 1500
+        assert_eq!(calculate_backoff(&config, 1), Duration::from_millis(1500));
+        // 500 * 3^2 = 4500
+        assert_eq!(calculate_backoff(&config, 2), Duration::from_millis(4500));
+        // 500 * 3^3 = 13500, capped to 5000
+        assert_eq!(calculate_backoff(&config, 3), Duration::from_millis(5000));
+    }
+
+    // -- validate_stdio_server edge cases --
+
+    #[tokio::test]
+    async fn test_validate_stdio_server_missing_command_field() {
+        let config = serde_json::json!({"type": "stdio"});
+        let result = validate_stdio_server(&config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing"));
+    }
+
+    // -- validate_remote_server edge cases --
+
+    #[tokio::test]
+    async fn test_validate_remote_server_missing_url() {
+        let config = serde_json::json!({"type": "http"});
+        let result = validate_remote_server(&config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_remote_server_invalid_url() {
+        let config = serde_json::json!({"type": "http", "url": "not-a-url"});
+        let result = validate_remote_server(&config).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_init_repo_with_enabled() {
+        let supervisor = McpSupervisor::new();
+        supervisor
+            .init_repo_with_enabled(
+                "repo-1",
+                vec![
+                    (make_test_server("a", "stdio"), true),
+                    (make_test_server("b", "http"), false),
+                ],
+            )
+            .await;
+
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        let a = status.servers.iter().find(|s| s.name == "a").unwrap();
+        let b = status.servers.iter().find(|s| s.name == "b").unwrap();
+        assert!(a.enabled);
+        assert_eq!(a.state, McpConnectionState::Pending);
+        assert!(!b.enabled);
+        assert_eq!(b.state, McpConnectionState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn test_init_repo_with_empty_clears_stale_servers() {
+        let supervisor = McpSupervisor::new();
+        // Start with servers.
+        supervisor
+            .init_repo("repo-1", vec![make_test_server("a", "stdio")])
+            .await;
+        assert_eq!(
+            supervisor.get_status("repo-1").await.unwrap().servers.len(),
+            1
+        );
+
+        // Re-init with empty list — stale servers should be cleared.
+        supervisor.init_repo_with_enabled("repo-1", vec![]).await;
+        let status = supervisor.get_status("repo-1").await.unwrap();
+        assert!(
+            status.servers.is_empty(),
+            "expected stale servers to be cleared"
+        );
+    }
+}

--- a/src/mcp_supervisor.rs
+++ b/src/mcp_supervisor.rs
@@ -742,12 +742,18 @@ mod tests {
 
     // -- McpSupervisor --
 
+    /// A real PATH-resolvable executable for validation tests.
+    /// `echo` is a shell built-in on Windows, so we use `cmd` there instead.
+    const TEST_COMMAND: &str = if cfg!(windows) { "cmd" } else { "echo" };
+
     fn make_test_server(name: &str, transport_type: &str) -> McpServer {
         let config = match transport_type {
-            "stdio" => serde_json::json!({"type": "stdio", "command": "echo", "args": []}),
+            "stdio" => {
+                serde_json::json!({"type": "stdio", "command": TEST_COMMAND, "args": []})
+            }
             "http" => serde_json::json!({"type": "http", "url": "https://example.com"}),
             "sse" => serde_json::json!({"type": "sse", "url": "https://example.com/sse"}),
-            _ => serde_json::json!({"type": "stdio", "command": "echo"}),
+            _ => serde_json::json!({"type": "stdio", "command": TEST_COMMAND}),
         };
         McpServer {
             name: name.to_string(),
@@ -910,8 +916,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_stdio_server_existing_command() {
-        // `echo` should exist on all Unix systems.
-        let config = serde_json::json!({"type": "stdio", "command": "echo"});
+        let config = serde_json::json!({"type": "stdio", "command": TEST_COMMAND});
         let result = validate_stdio_server(&config).await;
         assert!(result.is_ok());
     }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useAppStore } from "./stores/useAppStore";
 import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, clearAttention, detectInstalledApps } from "./services/tauri";
 import { applyTheme, loadAllThemes, findTheme } from "./utils/theme";
+import { useMcpStatus } from "./hooks/useMcpStatus";
 import { AppLayout } from "./components/layout/AppLayout";
 import type { CommandEvent } from "./types";
 import "./styles/theme.css";
@@ -21,6 +22,9 @@ function App() {
   const setCurrentThemeId = useAppStore((s) => s.setCurrentThemeId);
   const setDetectedApps = useAppStore((s) => s.setDetectedApps);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
+
+  // Listen for MCP supervisor status events from the Rust backend.
+  useMcpStatus();
 
   useEffect(() => {
     loadInitialData().then((data) => {

--- a/src/ui/src/components/chat/AttachMenu.module.css
+++ b/src/ui/src/components/chat/AttachMenu.module.css
@@ -89,6 +89,14 @@
   font: inherit;
 }
 
+button.serverInfo {
+  cursor: pointer;
+}
+
+button.serverInfo:hover .serverName {
+  text-decoration: underline;
+}
+
 .serverDot {
   width: 8px;
   height: 8px;

--- a/src/ui/src/components/chat/AttachMenu.module.css
+++ b/src/ui/src/components/chat/AttachMenu.module.css
@@ -1,0 +1,174 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+}
+
+.menu {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 6px;
+  min-width: 260px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: 10px;
+  padding: 4px;
+  z-index: 100;
+  box-shadow: var(--shadow-lg);
+  animation: scaleIn 0.12s ease;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.menuItem:hover {
+  background: var(--hover-bg);
+}
+
+.menuItem:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.menuIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.divider {
+  height: 1px;
+  background: var(--divider);
+  margin: 4px 0;
+}
+
+/* -- Server rows with toggle switches -- */
+
+.serverRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 10px;
+  border-radius: 7px;
+  transition: background var(--transition-fast);
+}
+
+.serverRow:hover {
+  background: var(--hover-bg);
+}
+
+.serverInfo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: default;
+  color: inherit;
+  font: inherit;
+}
+
+.serverDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.serverName {
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.serverNameDisabled {
+  color: var(--text-dim);
+}
+
+.reconnectHint {
+  font-size: 10px;
+  color: var(--status-stopped);
+  padding-left: 4px;
+  cursor: pointer;
+}
+
+/* -- iOS-style toggle switch -- */
+
+.toggle {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  background: var(--text-faint);
+  transition: background 0.2s ease;
+}
+
+.toggleOn {
+  background: var(--accent-primary);
+}
+
+.toggleKnob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.toggleOn .toggleKnob {
+  transform: translateX(16px);
+}
+
+/* -- Manage connectors link -- */
+
+.manageItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.manageItem:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}

--- a/src/ui/src/components/chat/AttachMenu.tsx
+++ b/src/ui/src/components/chat/AttachMenu.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Paperclip, Settings } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import {
+  loadRepositoryMcps,
+  ensureAndValidateMcps,
+  setMcpServerEnabled,
+  getMcpStatus,
+  reconnectMcpServer,
+} from "../../services/mcp";
+import type { SavedMcpServer, McpConnectionState } from "../../types/mcp";
+import { MCP_SOURCE_LABELS } from "../../types/mcp";
+import styles from "./AttachMenu.module.css";
+
+interface AttachMenuProps {
+  repoId: string | undefined;
+  onAttachFiles: () => void;
+  onClose: () => void;
+  isRemote: boolean;
+}
+
+function dotColor(state: McpConnectionState | undefined): string {
+  switch (state) {
+    case "connected":
+      return "var(--status-running)";
+    case "failed":
+      return "var(--status-stopped)";
+    case "disabled":
+      return "var(--text-faint)";
+    case "pending":
+    default:
+      return "var(--status-idle)";
+  }
+}
+
+export function AttachMenu({
+  repoId,
+  onAttachFiles,
+  onClose,
+  isRemote,
+}: AttachMenuProps) {
+  const mcpStatus = useAppStore((s) =>
+    repoId ? s.mcpStatus[repoId] : undefined,
+  );
+  const setMcpStatus = useAppStore((s) => s.setMcpStatus);
+  const openSettings = useAppStore((s) => s.openSettings);
+  const setSettingsSection = useAppStore((s) => s.setSettingsSection);
+
+  const [servers, setServers] = useState<SavedMcpServer[]>([]);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // On mount: auto-detect + validate, then load DB rows for toggle state.
+  // Chained (not parallel) so loadRepositoryMcps reads after ensure has written.
+  useEffect(() => {
+    if (!repoId) return;
+    const id = repoId;
+    ensureAndValidateMcps(id)
+      .then((snapshot) => {
+        setMcpStatus(id, snapshot);
+        return loadRepositoryMcps(id);
+      })
+      .then(setServers)
+      .catch(() => {});
+  }, [repoId, setMcpStatus]);
+
+  // Close on Escape.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const handleToggle = useCallback(
+    async (server: SavedMcpServer, enabled: boolean) => {
+      if (!repoId) return;
+      try {
+        await setMcpServerEnabled(server.id, repoId, server.name, enabled);
+        const [updatedServers, snap] = await Promise.all([
+          loadRepositoryMcps(repoId),
+          getMcpStatus(repoId),
+        ]);
+        setServers(updatedServers);
+        if (snap) setMcpStatus(repoId, snap);
+      } catch (err) {
+        console.error("Failed to toggle MCP server:", err);
+      }
+    },
+    [repoId, setMcpStatus],
+  );
+
+  const handleReconnect = useCallback(
+    async (serverName: string) => {
+      if (!repoId) return;
+      try {
+        await reconnectMcpServer(repoId, serverName);
+        const snap = await getMcpStatus(repoId);
+        if (snap) setMcpStatus(repoId, snap);
+      } catch (err) {
+        console.error("Failed to reconnect MCP server:", err);
+      }
+    },
+    [repoId, setMcpStatus],
+  );
+
+  const handleManage = useCallback(() => {
+    if (!repoId) return;
+    onClose();
+    openSettings();
+    setSettingsSection(`repo:${repoId}`);
+  }, [repoId, onClose, openSettings, setSettingsSection]);
+
+  const hasServers = servers.length > 0;
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose} />
+      <div ref={menuRef} className={styles.menu}>
+        {/* Attach files */}
+        <button
+          className={styles.menuItem}
+          onClick={onAttachFiles}
+          disabled={isRemote}
+          title={
+            isRemote
+              ? "Attachments not supported for remote workspaces"
+              : undefined
+          }
+        >
+          <span className={styles.menuIcon}>
+            <Paperclip size={14} />
+          </span>
+          Add files or images
+        </button>
+
+        {/* Connectors — servers grouped by source with toggle switches */}
+        {hasServers && (
+          <>
+            {(() => {
+              const groups = new Map<string, typeof servers>();
+              for (const s of servers) {
+                const list = groups.get(s.source) ?? [];
+                list.push(s);
+                groups.set(s.source, list);
+              }
+              return [...groups.entries()].map(([source, list]) => (
+                <div key={source}>
+                  <div className={styles.divider} />
+                  <div className={styles.groupLabel}>
+                    {MCP_SOURCE_LABELS[source] ?? source}
+                  </div>
+                  {list.map((server) => {
+                    const status = mcpStatus?.servers.find(
+                      (s) => s.name === server.name,
+                    );
+                    const stateColor = dotColor(status?.state);
+                    const isFailed = status?.state === "failed";
+
+                    return (
+                      <div key={server.id} className={styles.serverRow}>
+                        <button
+                          className={styles.serverInfo}
+                          onClick={() => {
+                            if (isFailed) {
+                              handleReconnect(server.name);
+                            }
+                          }}
+                          title={
+                            isFailed
+                              ? `Failed: ${status?.last_error ?? "unknown"} — click to reconnect`
+                              : undefined
+                          }
+                        >
+                          <span
+                            className={styles.serverDot}
+                            style={{ background: stateColor }}
+                          />
+                          <span
+                            className={`${styles.serverName} ${!server.enabled ? styles.serverNameDisabled : ""}`}
+                          >
+                            {server.name}
+                          </span>
+                          {isFailed && (
+                            <span className={styles.reconnectHint}>retry</span>
+                          )}
+                        </button>
+                        <button
+                          className={`${styles.toggle} ${server.enabled ? styles.toggleOn : ""}`}
+                          onClick={() => handleToggle(server, !server.enabled)}
+                          aria-label={`${server.enabled ? "Disable" : "Enable"} ${server.name}`}
+                          role="switch"
+                          aria-checked={server.enabled}
+                        >
+                          <span className={styles.toggleKnob} />
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ));
+            })()}
+          </>
+        )}
+
+        {/* Manage connectors — opens repo settings */}
+        {repoId && (
+          <>
+            <div className={styles.divider} />
+            <button className={styles.manageItem} onClick={handleManage}>
+              <span className={styles.menuIcon}>
+                <Settings size={13} />
+              </span>
+              Manage connectors
+            </button>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/ui/src/components/chat/AttachMenu.tsx
+++ b/src/ui/src/components/chat/AttachMenu.tsx
@@ -57,10 +57,11 @@ export function AttachMenu({
     ensureAndValidateMcps(id)
       .then((snapshot) => {
         setMcpStatus(id, snapshot);
-        return loadRepositoryMcps(id);
       })
-      .then(setServers)
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        loadRepositoryMcps(id).then(setServers).catch(() => {});
+      });
   }, [repoId, setMcpStatus]);
 
   // Close on Escape.
@@ -162,32 +163,37 @@ export function AttachMenu({
 
                     return (
                       <div key={server.id} className={styles.serverRow}>
-                        <button
-                          className={styles.serverInfo}
-                          onClick={() => {
-                            if (isFailed) {
-                              handleReconnect(server.name);
-                            }
-                          }}
-                          title={
-                            isFailed
-                              ? `Failed: ${status?.last_error ?? "unknown"} — click to reconnect`
-                              : undefined
-                          }
-                        >
-                          <span
-                            className={styles.serverDot}
-                            style={{ background: stateColor }}
-                          />
-                          <span
-                            className={`${styles.serverName} ${!server.enabled ? styles.serverNameDisabled : ""}`}
+                        {isFailed ? (
+                          <button
+                            type="button"
+                            className={styles.serverInfo}
+                            onClick={() => handleReconnect(server.name)}
+                            title={`Failed: ${status?.last_error ?? "unknown"} — click to reconnect`}
                           >
-                            {server.name}
-                          </span>
-                          {isFailed && (
+                            <span
+                              className={styles.serverDot}
+                              style={{ background: stateColor }}
+                            />
+                            <span
+                              className={`${styles.serverName} ${!server.enabled ? styles.serverNameDisabled : ""}`}
+                            >
+                              {server.name}
+                            </span>
                             <span className={styles.reconnectHint}>retry</span>
-                          )}
-                        </button>
+                          </button>
+                        ) : (
+                          <div className={styles.serverInfo}>
+                            <span
+                              className={styles.serverDot}
+                              style={{ background: stateColor }}
+                            />
+                            <span
+                              className={`${styles.serverName} ${!server.enabled ? styles.serverNameDisabled : ""}`}
+                            >
+                              {server.name}
+                            </span>
+                          </div>
+                        )}
                         <button
                           className={`${styles.toggle} ${server.enabled ? styles.toggleOn : ""}`}
                           onClick={() => handleToggle(server, !server.enabled)}

--- a/src/ui/src/components/chat/AttachMenu.tsx
+++ b/src/ui/src/components/chat/AttachMenu.tsx
@@ -8,7 +8,7 @@ import {
   getMcpStatus,
   reconnectMcpServer,
 } from "../../services/mcp";
-import type { SavedMcpServer, McpConnectionState } from "../../types/mcp";
+import type { SavedMcpServer, McpConnectionState, McpSource } from "../../types/mcp";
 import { MCP_SOURCE_LABELS } from "../../types/mcp";
 import styles from "./AttachMenu.module.css";
 
@@ -151,7 +151,7 @@ export function AttachMenu({
                 <div key={source}>
                   <div className={styles.divider} />
                   <div className={styles.groupLabel}>
-                    {MCP_SOURCE_LABELS[source] ?? source}
+                    {MCP_SOURCE_LABELS[source as McpSource] ?? source}
                   </div>
                   {list.map((server) => {
                     const status = mcpStatus?.servers.find(

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -1023,6 +1023,12 @@
   border-color: var(--text-dim);
 }
 
+.attachBtnActive {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-primary);
+  border-color: var(--text-dim);
+}
+
 /* -- Inline message images -- */
 
 .messageImages {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -38,6 +38,7 @@ import { ChatToolbar } from "./ChatToolbar";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { HeaderMenu } from "./HeaderMenu";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
+import { AttachMenu } from "./AttachMenu";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
 import { checkpointHasFileChanges, clearAllHasFileChanges, buildRollbackMap } from "../../utils/checkpointUtils";
 import { ThinkingBlock } from "./ThinkingBlock";
@@ -736,6 +737,7 @@ export function ChatPanel() {
         isRunning={isRunning}
         isRemote={!!ws?.remote_connection_id}
         selectedWorkspaceId={selectedWorkspaceId!}
+        repoId={repo?.id}
         projectPath={repo?.path}
         historyRef={historyRef}
         historyIndexRef={historyIndexRef}
@@ -1252,6 +1254,7 @@ function ChatInputArea({
   isRunning,
   isRemote,
   selectedWorkspaceId,
+  repoId,
   projectPath,
   historyRef,
   historyIndexRef,
@@ -1265,6 +1268,7 @@ function ChatInputArea({
   isRunning: boolean;
   isRemote: boolean;
   selectedWorkspaceId: string;
+  repoId: string | undefined;
   projectPath: string | undefined;
   historyRef: React.MutableRefObject<Record<string, string[]>>;
   historyIndexRef: React.MutableRefObject<number>;
@@ -1284,6 +1288,7 @@ function ChatInputArea({
   const mentionedFilesRef = useRef<Set<string>>(new Set());
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [dragActive, setDragActive] = useState(false);
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
 
   // Per-workspace draft storage: save input when switching away,
   // restore when switching back.
@@ -1829,14 +1834,26 @@ function ChatInputArea({
         placeholder={isRunning ? "Type to queue a message..." : "Send a message..."}
       />
       <div className={styles.inputControls}>
-        <button
-          className={styles.attachBtn}
-          onClick={handleAttachClick}
-          disabled={isRemote}
-          title={isRemote ? "Attachments not supported for remote workspaces" : "Add files or images"}
-        >
-          <Plus size={16} />
-        </button>
+        <div style={{ position: "relative" }}>
+          <button
+            className={`${styles.attachBtn} ${attachMenuOpen ? styles.attachBtnActive : ""}`}
+            onClick={() => setAttachMenuOpen((v) => !v)}
+            title="Add files or connectors"
+          >
+            <Plus size={16} />
+          </button>
+          {attachMenuOpen && (
+            <AttachMenu
+              repoId={repoId}
+              onAttachFiles={() => {
+                setAttachMenuOpen(false);
+                handleAttachClick();
+              }}
+              onClose={() => setAttachMenuOpen(false)}
+              isRemote={isRemote}
+            />
+          )}
+        </div>
         <ChatToolbar
           workspaceId={selectedWorkspaceId}
           disabled={isRunning}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -641,8 +641,6 @@ export function ChatPanel() {
 
       <ScrollContext.Provider value={scrollContextValue}>
         <div className={styles.messages} ref={messagesContainerRef}>
-          {error && <div className={styles.errorBanner}>{error}</div>}
-
           {messages.length === 0 && !hasStreaming ? (
             <div className={styles.empty}>
               Send a message to start a conversation
@@ -722,6 +720,8 @@ export function ChatPanel() {
                   </button>
                 </div>
               )}
+
+              {error && <div className={styles.errorBanner}>{error}</div>}
             </>
           )}
         </div>

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -582,6 +582,96 @@
   color: var(--status-stopped);
 }
 
+.mcpStatusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.mcpError {
+  font-size: 11px;
+  color: var(--status-stopped);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+.mcpActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.mcpReconnectBtn {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--sidebar-border);
+  background: none;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.mcpReconnectBtn:hover {
+  background: var(--accent-bg);
+}
+
+.mcpNameDisabled {
+  color: var(--text-dim);
+}
+
+/* Group label for MCP source sections */
+.mcpGroupLabel {
+  padding: 8px 8px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+}
+
+.mcpGroupLabel:not(:first-child) {
+  margin-top: 8px;
+  border-top: 1px solid var(--divider);
+  padding-top: 12px;
+}
+
+/* iOS-style toggle switch (matching AttachMenu) */
+.mcpToggle {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  background: var(--text-faint);
+  transition: background 0.2s ease;
+}
+
+.mcpToggleOn {
+  background: var(--accent-primary);
+}
+
+.mcpToggleKnob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.mcpToggleOn .mcpToggleKnob {
+  transform: translateX(16px);
+}
+
 /* ── Placeholder ── */
 
 .placeholder {

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -331,8 +331,8 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
       <div className={styles.fieldGroup}>
         <div className={styles.fieldLabel}>MCP servers</div>
         <div className={styles.fieldHint} style={{ marginBottom: 12 }}>
-          Servers injected into agent sessions. Toggle to enable or disable per
-          workspace.
+          Servers injected into agent sessions. Toggle to enable or disable for
+          this repository.
         </div>
         {mcpServers.length === 0 ? (
           <div className={styles.fieldHint}>

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -10,7 +10,7 @@ import {
   getMcpStatus,
 } from "../../../services/mcp";
 import type { RepoConfigInfo } from "../../../types/repository";
-import type { SavedMcpServer } from "../../../types/mcp";
+import type { SavedMcpServer, McpSource } from "../../../types/mcp";
 import { MCP_SOURCE_LABELS } from "../../../types/mcp";
 import { RepoIcon } from "../../shared/RepoIcon";
 import { IconPicker } from "../../modals/IconPicker";
@@ -352,7 +352,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
               return [...groups.entries()].map(([source, servers]) => (
                 <div key={source}>
                   <div className={styles.mcpGroupLabel}>
-                    {MCP_SOURCE_LABELS[source] ?? source}
+                    {MCP_SOURCE_LABELS[source as McpSource] ?? source}
                   </div>
                   {servers.map((server) => {
                     let transport = "unknown";

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -3,10 +3,15 @@ import { useAppStore } from "../../../stores/useAppStore";
 import { updateRepositorySettings, getRepoConfig } from "../../../services/tauri";
 import {
   loadRepositoryMcps,
-  deleteRepositoryMcp,
+  detectMcpServers,
+  saveRepositoryMcps,
+  reconnectMcpServer,
+  setMcpServerEnabled,
+  getMcpStatus,
 } from "../../../services/mcp";
 import type { RepoConfigInfo } from "../../../types/repository";
 import type { SavedMcpServer } from "../../../types/mcp";
+import { MCP_SOURCE_LABELS } from "../../../types/mcp";
 import { RepoIcon } from "../../shared/RepoIcon";
 import { IconPicker } from "../../modals/IconPicker";
 import styles from "../Settings.module.css";
@@ -20,8 +25,11 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const activeModal = useAppStore((s) => s.activeModal);
   const updateRepo = useAppStore((s) => s.updateRepository);
   const repositories = useAppStore((s) => s.repositories);
+  const mcpStatus = useAppStore((s) => s.mcpStatus);
+  const setMcpStatus = useAppStore((s) => s.setMcpStatus);
 
   const repo = repositories.find((r) => r.id === repoId);
+  const repoMcpStatus = mcpStatus[repoId];
 
   const [name, setName] = useState(repo?.name ?? "");
   const [icon, setIcon] = useState(repo?.icon ?? "");
@@ -63,8 +71,27 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   }, [repoId]);
 
   useEffect(() => {
-    refreshMcpServers();
-  }, [refreshMcpServers]);
+    // Load saved servers, and auto-detect + save if none exist yet.
+    loadRepositoryMcps(repoId)
+      .then(async (saved) => {
+        if (saved.length > 0) {
+          setMcpServers(saved);
+          return;
+        }
+        // No saved servers — auto-detect and save so they appear immediately.
+        try {
+          const detected = await detectMcpServers(repoId);
+          if (detected.length > 0) {
+            await saveRepositoryMcps(repoId, detected);
+            const updated = await loadRepositoryMcps(repoId);
+            setMcpServers(updated);
+          }
+        } catch {
+          // Detection failed — leave empty.
+        }
+      })
+      .catch(() => setMcpServers([]));
+  }, [repoId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Refresh MCP list when the selection modal closes (user may have saved new MCPs).
   const prevModal = useRef(activeModal);
@@ -304,67 +331,144 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
       <div className={styles.fieldGroup}>
         <div className={styles.fieldLabel}>MCP servers</div>
         <div className={styles.fieldHint} style={{ marginBottom: 12 }}>
-          Non-portable MCP servers injected into agent sessions via{" "}
-          <code>--mcp-config</code>. These are servers from your user config or
-          gitignored repo config that aren't automatically available in
-          worktrees.
+          Servers injected into agent sessions. Toggle to enable or disable per
+          workspace.
         </div>
         {mcpServers.length === 0 ? (
           <div className={styles.fieldHint}>
-            No MCP servers configured for this repository.
+            No MCP servers detected for this repository.
           </div>
         ) : (
           <div className={styles.mcpList}>
-            {mcpServers.map((server) => {
-              let transport = "unknown";
-              try {
-                const cfg = JSON.parse(server.config_json);
-                if (cfg.command) transport = "stdio";
-                else if (cfg.url) transport = "http";
-                if (cfg.type) transport = cfg.type;
-              } catch {
-                /* ignore parse errors */
+            {/* Group servers by source */}
+            {(() => {
+              const groups = new Map<string, typeof mcpServers>();
+              for (const server of mcpServers) {
+                const key = server.source;
+                const list = groups.get(key) ?? [];
+                list.push(server);
+                groups.set(key, list);
               }
-              const sourceLabel =
-                server.source === "user_project_config"
-                  ? "~/.claude.json"
-                  : server.source === "repo_local_config"
-                    ? ".claude.json"
-                    : server.source;
-              return (
-                <div key={server.id} className={styles.mcpRow}>
-                  <div className={styles.mcpInfo}>
-                    <span className={styles.mcpName}>{server.name}</span>
-                    <span className={styles.mcpBadge}>{transport}</span>
-                    <span className={styles.mcpSource}>{sourceLabel}</span>
+              return [...groups.entries()].map(([source, servers]) => (
+                <div key={source}>
+                  <div className={styles.mcpGroupLabel}>
+                    {MCP_SOURCE_LABELS[source] ?? source}
                   </div>
-                  <button
-                    className={styles.mcpRemoveBtn}
-                    title="Remove this MCP server"
-                    aria-label={`Remove MCP server ${server.name}`}
-                    onClick={async () => {
-                      try {
-                        await deleteRepositoryMcp(server.id);
-                        refreshMcpServers();
-                      } catch (e) {
-                        setError(String(e));
-                      }
-                    }}
-                  >
-                    ×
-                  </button>
+                  {servers.map((server) => {
+                    let transport = "unknown";
+                    try {
+                      const cfg = JSON.parse(server.config_json);
+                      if (cfg.command) transport = "stdio";
+                      else if (cfg.url) transport = "http";
+                      if (cfg.type) transport = cfg.type;
+                    } catch {
+                      /* ignore */
+                    }
+                    const serverStatus = repoMcpStatus?.servers.find(
+                      (s) => s.name === server.name,
+                    );
+                    const stateColor =
+                      serverStatus?.state === "connected"
+                        ? "var(--status-running)"
+                        : serverStatus?.state === "failed"
+                          ? "var(--status-stopped)"
+                          : serverStatus?.state === "disabled"
+                            ? "var(--text-faint)"
+                            : "var(--status-idle)";
+                    return (
+                      <div key={server.id} className={styles.mcpRow}>
+                        <div className={styles.mcpInfo}>
+                          <span
+                            className={styles.mcpStatusDot}
+                            style={{ background: stateColor }}
+                            title={serverStatus?.state ?? "pending"}
+                          />
+                          <span
+                            className={`${styles.mcpName} ${!server.enabled ? styles.mcpNameDisabled : ""}`}
+                          >
+                            {server.name}
+                          </span>
+                          <span className={styles.mcpBadge}>{transport}</span>
+                          {serverStatus?.last_error && (
+                            <span
+                              className={styles.mcpError}
+                              title={serverStatus.last_error}
+                            >
+                              {serverStatus.last_error.slice(0, 40)}
+                            </span>
+                          )}
+                        </div>
+                        <div className={styles.mcpActions}>
+                          {serverStatus?.state === "failed" && (
+                            <button
+                              className={styles.mcpReconnectBtn}
+                              onClick={async () => {
+                                try {
+                                  await reconnectMcpServer(repoId, server.name);
+                                  const snap = await getMcpStatus(repoId);
+                                  if (snap) setMcpStatus(repoId, snap);
+                                } catch (e) {
+                                  setError(String(e));
+                                }
+                              }}
+                            >
+                              Reconnect
+                            </button>
+                          )}
+                          <button
+                            className={`${styles.mcpToggle} ${server.enabled ? styles.mcpToggleOn : ""}`}
+                            onClick={async () => {
+                              try {
+                                await setMcpServerEnabled(
+                                  server.id,
+                                  repoId,
+                                  server.name,
+                                  !server.enabled,
+                                );
+                                refreshMcpServers();
+                                const snap = await getMcpStatus(repoId);
+                                if (snap) setMcpStatus(repoId, snap);
+                              } catch (err) {
+                                setError(String(err));
+                              }
+                            }}
+                            role="switch"
+                            aria-checked={server.enabled}
+                            aria-label={`${server.enabled ? "Disable" : "Enable"} ${server.name}`}
+                          >
+                            <span className={styles.mcpToggleKnob} />
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
-              );
-            })}
+              ));
+            })()}
           </div>
         )}
-        <div style={{ marginTop: 8 }}>
+        <div style={{ marginTop: 8, display: "flex", gap: 8 }}>
           <button
             className={styles.iconBtn}
             onClick={() => openModal("mcpSelection", { repoId })}
           >
             Re-detect &amp; add servers
           </button>
+          {mcpServers.length > 0 && (
+            <button
+              className={styles.iconBtn}
+              onClick={async () => {
+                try {
+                  const snap = await getMcpStatus(repoId);
+                  if (snap) setMcpStatus(repoId, snap);
+                } catch (e) {
+                  setError(String(e));
+                }
+              }}
+            >
+              Refresh status
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -176,6 +176,24 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* MCP server health indicator next to repo name */
+.mcpIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-left: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mcpDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 /* Keyboard shortcut badge shown on Cmd/Ctrl hold — absolutely positioned
    so it doesn't reflow the header when it appears/disappears. */
 .shortcutBadge {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -17,13 +17,44 @@ import {
 import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { useSpinnerFrame } from "../../hooks/useSpinnerFrame";
+import type { McpStatusSnapshot } from "../../types/mcp";
 import styles from "./Sidebar.module.css";
+
+/** Compact MCP status badge for the repo row: [dot] connected/enabled */
+function McpStatusBadge({ status }: { status: McpStatusSnapshot | undefined }) {
+  if (!status || status.servers.length === 0) return null;
+  const enabled = status.servers.filter((s) => s.enabled);
+  if (enabled.length === 0) return null;
+  const connected = enabled.filter((s) => s.state === "connected").length;
+  const total = enabled.length;
+  const hasFailed = enabled.some((s) => s.state === "failed");
+  const allConnected = connected === total;
+  return (
+    <span
+      className={styles.mcpIndicator}
+      title={`MCP: ${connected}/${total} connected`}
+    >
+      <span
+        className={styles.mcpDot}
+        style={{
+          background: allConnected
+            ? "var(--status-running)"
+            : hasFailed
+              ? "var(--status-stopped)"
+              : "var(--status-idle)",
+        }}
+      />
+      {connected}/{total}
+    </span>
+  );
+}
 
 
 export const Sidebar = memo(function Sidebar() {
   const repositories = useAppStore((s) => s.repositories);
   const workspaces = useAppStore((s) => s.workspaces);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const mcpStatus = useAppStore((s) => s.mcpStatus);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
   const sidebarFilter = useAppStore((s) => s.sidebarFilter);
   const setSidebarFilter = useAppStore((s) => s.setSidebarFilter);
@@ -273,6 +304,7 @@ export const Sidebar = memo(function Sidebar() {
                     <span className={styles.runningBadge}>{runningCount}</span>
                   )}
                 </span>
+                <McpStatusBadge status={mcpStatus[repo.id]} />
                 {!repo.path_valid && (
                   <span className={styles.invalidBadge}>!</span>
                 )}

--- a/src/ui/src/hooks/useMcpStatus.ts
+++ b/src/ui/src/hooks/useMcpStatus.ts
@@ -48,7 +48,9 @@ export function useMcpStatus() {
     if (!ws) return;
     const repoId = ws.repository_id;
 
-    // Skip if we already validated this repo.
+    // Skip if we already validated this repo during this session.
+    // This avoids re-running detection on every workspace switch within the
+    // same repo. The AttachMenu always re-detects on open for fresh state.
     if (lastRepoId.current === repoId) return;
     lastRepoId.current = repoId;
 

--- a/src/ui/src/hooks/useMcpStatus.ts
+++ b/src/ui/src/hooks/useMcpStatus.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { McpStatusSnapshot } from "../types/mcp";
+import { useAppStore } from "../stores/useAppStore";
+import { ensureAndValidateMcps } from "../services/mcp";
+
+/**
+ * Listen for "mcp-status-changed" events from the Rust MCP supervisor
+ * and update the Zustand store with the latest per-repository status.
+ *
+ * Also triggers MCP detection + validation when the active workspace changes.
+ */
+export function useMcpStatus() {
+  const setMcpStatus = useAppStore((s) => s.setMcpStatus);
+  const clearMcpStatus = useAppStore((s) => s.clearMcpStatus);
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const repositories = useAppStore((s) => s.repositories);
+  const lastRepoId = useRef<string | null>(null);
+
+  // Listen for supervisor status events.
+  useEffect(() => {
+    const unlisten = listen<McpStatusSnapshot>(
+      "mcp-status-changed",
+      (event) => {
+        setMcpStatus(event.payload.repository_id, event.payload);
+      },
+    );
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [setMcpStatus]);
+
+  // Listen for status cleared events (e.g. last workspace for a repo deleted).
+  useEffect(() => {
+    const unlisten = listen<string>("mcp-status-cleared", (event) => {
+      clearMcpStatus(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [clearMcpStatus]);
+
+  // When the selected workspace changes, ensure MCPs are detected + validated.
+  useEffect(() => {
+    if (!selectedWorkspaceId) return;
+    const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
+    if (!ws) return;
+    const repoId = ws.repository_id;
+
+    // Skip if we already validated this repo.
+    if (lastRepoId.current === repoId) return;
+    lastRepoId.current = repoId;
+
+    // Check repo exists.
+    if (!repositories.some((r) => r.id === repoId)) return;
+
+    ensureAndValidateMcps(repoId)
+      .then((snapshot) => setMcpStatus(repoId, snapshot))
+      .catch(() => {});
+  }, [selectedWorkspaceId, workspaces, repositories, setMcpStatus]);
+}

--- a/src/ui/src/services/mcp.ts
+++ b/src/ui/src/services/mcp.ts
@@ -1,5 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { McpServer, SavedMcpServer } from "../types/mcp";
+import type {
+  McpServer,
+  McpServerStatus,
+  McpStatusSnapshot,
+  SavedMcpServer,
+} from "../types/mcp";
 
 export function detectMcpServers(repoId: string): Promise<McpServer[]> {
   return invoke("detect_mcp_servers", { repoId });
@@ -20,4 +25,40 @@ export function loadRepositoryMcps(
 
 export function deleteRepositoryMcp(serverId: string): Promise<void> {
   return invoke("delete_repository_mcp", { serverId });
+}
+
+// -- Supervisor commands --
+
+export function getMcpStatus(
+  repoId: string,
+): Promise<McpStatusSnapshot | null> {
+  return invoke("get_mcp_status", { repoId });
+}
+
+/** Auto-detect, save, and validate MCP servers for a repo. Returns live status. */
+export function ensureAndValidateMcps(
+  repoId: string,
+): Promise<McpStatusSnapshot> {
+  return invoke("ensure_and_validate_mcps", { repoId });
+}
+
+export function reconnectMcpServer(
+  repoId: string,
+  serverName: string,
+): Promise<McpServerStatus> {
+  return invoke("reconnect_mcp_server", { repoId, serverName });
+}
+
+export function setMcpServerEnabled(
+  serverId: string,
+  repoId: string,
+  serverName: string,
+  enabled: boolean,
+): Promise<void> {
+  return invoke("set_mcp_server_enabled", {
+    serverId,
+    repoId,
+    serverName,
+    enabled,
+  });
 }

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -16,6 +16,7 @@ import type {
   DiscoveredServer,
   ConversationCheckpoint,
 } from "../types";
+import type { McpStatusSnapshot } from "../types/mcp";
 import type { RemoteInitialData } from "../types/remote";
 import type { DetectedApp } from "../types/apps";
 import type { ClaudeCodeUsage } from "../types/usage";
@@ -281,6 +282,11 @@ interface AppState {
   localServerConnectionString: string | null;
   setLocalServerRunning: (running: boolean) => void;
   setLocalServerConnectionString: (cs: string | null) => void;
+
+  // -- MCP Status (per-repository) --
+  mcpStatus: Record<string, McpStatusSnapshot>;
+  setMcpStatus: (repoId: string, snapshot: McpStatusSnapshot) => void;
+  clearMcpStatus: (repoId: string) => void;
 
   // -- Detected Apps --
   detectedApps: DetectedApp[];
@@ -904,6 +910,18 @@ export const useAppStore = create<AppState>((set) => ({
   setLocalServerRunning: (running) => set({ localServerRunning: running }),
   setLocalServerConnectionString: (cs) =>
     set({ localServerConnectionString: cs }),
+
+  // -- MCP Status --
+  mcpStatus: {},
+  setMcpStatus: (repoId, snapshot) =>
+    set((state) => ({
+      mcpStatus: { ...state.mcpStatus, [repoId]: snapshot },
+    })),
+  clearMcpStatus: (repoId) =>
+    set((state) => {
+      const { [repoId]: _, ...rest } = state.mcpStatus;
+      return { mcpStatus: rest };
+    }),
 
   // -- Detected Apps --
   detectedApps: [],

--- a/src/ui/src/types/mcp.ts
+++ b/src/ui/src/types/mcp.ts
@@ -1,5 +1,19 @@
 /** Where the MCP server configuration was detected from. */
-export type McpSource = "user_project_config" | "repo_local_config";
+export type McpSource =
+  | "user_global_config"
+  | "user_project_config"
+  | "project_mcp_json"
+  | "repo_local_config"
+  | "plugin";
+
+/** Human-readable labels for MCP source types (matching Claude Code's grouping). */
+export const MCP_SOURCE_LABELS: Record<string, string> = {
+  user_global_config: "User (~/.claude.json)",
+  user_project_config: "User project",
+  project_mcp_json: "Project (.mcp.json)",
+  repo_local_config: "Local (.claude.json)",
+  plugin: "Built-in (always available)",
+};
 
 /** A detected MCP server (returned by detect_mcp_servers). */
 export interface McpServer {
@@ -16,4 +30,33 @@ export interface SavedMcpServer {
   config_json: string;
   source: string;
   created_at: string;
+  enabled: boolean;
+}
+
+// -- Supervisor status types --
+
+/** Connection state tracked by the MCP supervisor. */
+export type McpConnectionState =
+  | "connected"
+  | "pending"
+  | "failed"
+  | "disabled";
+
+/** Transport type for an MCP server. */
+export type McpTransportType = "stdio" | "http" | "sse";
+
+/** Real-time status for a single supervised MCP server. */
+export interface McpServerStatus {
+  name: string;
+  transport: McpTransportType;
+  state: McpConnectionState;
+  enabled: boolean;
+  last_error: string | null;
+  failure_count: number;
+}
+
+/** Snapshot of all MCP server states for a repository. */
+export interface McpStatusSnapshot {
+  repository_id: string;
+  servers: McpServerStatus[];
 }

--- a/src/ui/src/types/mcp.ts
+++ b/src/ui/src/types/mcp.ts
@@ -7,7 +7,7 @@ export type McpSource =
   | "plugin";
 
 /** Human-readable labels for MCP source types (matching Claude Code's grouping). */
-export const MCP_SOURCE_LABELS: Record<string, string> = {
+export const MCP_SOURCE_LABELS: Record<McpSource, string> = {
   user_global_config: "User (~/.claude.json)",
   user_project_config: "User project",
   project_mcp_json: "Project (.mcp.json)",


### PR DESCRIPTION
## Problem

Each time Claudette sends a turn to the Claude CLI, it spawns a fresh `claude --print` process. MCP servers are initialized per-process — they connect on startup and die when the process exits. This means:

1. **MCP servers restart every turn**: A server that takes 5-10 seconds to initialize (OAuth handshake, database connection pool, browser launch) pays that cost on *every single message*, not just the first.
2. **No visibility into MCP state**: Users have no way to see which MCP servers are connected, failed, or available — they only discover problems when a tool call fails mid-conversation.
3. **No control over MCP servers**: Users can't toggle servers on/off from the chat interface. Disabling a server requires editing config files and restarting.
4. **Config scattered across 5 sources**: MCP servers can be defined in `~/.claude.json` (global), `~/.claude.json` (project-scoped), `.mcp.json` (committed), `.claude.json` (gitignored), and Claude Code plugins. Claudette only detected some of these.
5. **Toggle state not synced with CLI**: Disabling a server in Claudette's UI had no effect on the CLI's auto-discovery, so disabled servers would still appear in headless turns.

## Solution

### Persistent Sessions

Replace per-turn process spawning with a long-lived `claude --print --input-format stream-json --output-format stream-json` process per workspace. The process stays alive across turns, so MCP servers connect once and remain available. Subsequent turns are sent via stdin as JSON messages, and events are forwarded via a `tokio::sync::broadcast` channel scoped to each turn.

### MCP Supervisor (`src/mcp_supervisor.rs`)

A Rust-side supervision layer that tracks MCP server lifecycle:

- **State machine**: `Pending → Connected/Failed`, `Disabled ↔ Pending` — well-defined transitions prevent double-counting failures
- **Pre-validation**: Stdio servers checked via `which` (command exists in PATH), remote servers checked via TCP connect with 5s timeout
- **Health monitoring**: Agent event stream is monitored for MCP tool failures (`ECONNRESET`, `ETIMEDOUT`, `EPIPE`, etc.) — detected servers transition to Failed
- **Backoff config**: Exponential backoff matching Claude Code's parameters (1s base, 2x multiplier, 30s cap, 5 attempts)
- **Watch channel**: `tokio::sync::watch` broadcasts status changes to the frontend without polling

### Full Source Detection (`src/mcp.rs`)

Detects MCP servers from all 5 configuration sources, matching Claude Code's precedence:

1. `~/.claude.json` → `mcpServers` (user global)
2. `~/.claude.json` → `projects[path].mcpServers` (user project-scoped)
3. `{repo}/.mcp.json` → `mcpServers` (project committed)
4. `{repo}/.claude.json` (only if gitignored)
5. Claude Code plugins (`~/.claude/plugins/installed_plugins.json` + `enabledPlugins`)

Later sources override earlier ones by name; plugins use `or_insert` so they never override explicit configs.

### Bidirectional Toggle Sync

Toggling a server writes to both our SQLite DB and `~/.claude.json` → `projects[path].disabledMcpServers`, so the CLI respects the toggle for auto-discovered servers. The read-modify-write preserves all existing config keys.

### Connectors UI

- **AttachMenu**: The `+` button opens a popover with "Add files or images" plus a grouped connectors list with iOS-style toggle switches, status dots, and retry hints
- **McpStatusBadge**: Compact sidebar indicator showing connected/enabled count per repo (excludes disabled servers from the total)
- **RepoSettings**: Enhanced MCP section with source grouping and toggles
- **Auto-detection**: `ensureAndValidateMcps` runs when a workspace is selected or the connectors menu opens — always re-detects from all sources and merges with DB state

## Key Design Decisions

- **Pass `--mcp-config` every turn**: Each CLI invocation is independent — MCP connections are per-process and not restored from `--resume`. This matches the fix in #193.
- **Supervisor validates but doesn't gate**: The supervisor pre-validates servers for UI display, but all enabled servers are passed to `--mcp-config` regardless of validation state. The CLI handles its own connection logic.
- **Lock hygiene**: `validate_servers` collects configs under a read lock, releases it during async I/O, then re-acquires a write lock to apply results. Process spawn also drops the write lock to avoid blocking other workspaces.
- **Cleanup on last workspace delete**: Supervisor state and frontend status cleared when the last workspace for a repo is deleted, preventing stale indicators.

## Files Changed

| Area | Files | Description |
|------|-------|-------------|
| Supervisor | `src/mcp_supervisor.rs` (new) | State machine, backoff, validation, watch channel |
| Detection | `src/mcp.rs` | 5-source detection, helpers, `~/.claude.json` sync |
| Persistent sessions | `src/agent.rs` | `PersistentSession`, `build_persistent_args` |
| DB | `src/db.rs` | Migration v18 (`enabled` column), toggle method |
| Tauri commands | `src-tauri/src/commands/{mcp,chat,workspace}.rs` | Thin wrappers, session lifecycle, cleanup |
| Server | `src-server/src/handler.rs` | Use shared `cli_config_from_rows` helper |
| UI | `src/ui/src/components/chat/AttachMenu.tsx` (new) | Connectors popover |
| UI | `src/ui/src/components/sidebar/Sidebar.tsx` | `McpStatusBadge` component |
| UI | `src/ui/src/components/settings/sections/RepoSettings.tsx` | Enhanced MCP settings |
| UI | `src/ui/src/hooks/useMcpStatus.ts` (new) | Event listener + auto-validation |

## Test Plan

346 tests total (93 new), covering:

- [x] Supervisor state machine: init, idempotent re-init, stale server removal, enable/disable transitions
- [x] Validation: `validate_servers` with mixed success/failure, skips disabled, stdio/remote edge cases
- [x] Error handling: `report_tool_failure` only from Connected, no double-increment, nonexistent server/repo
- [x] Reconnect: Failed→Connected, bad server stays Failed, disabled server rejected
- [x] Watch channel: broadcasts per-repo, independent channels
- [x] Backoff: exponential growth, max cap, custom config
- [x] Detection: full chain with source precedence, local overrides committed, sorted output
- [x] `.mcp.json`: malformed JSON, empty servers, missing key, config normalization
- [x] Plugin detection: fixture parsing, bare/wrapped format, disabled plugins skipped
- [x] DB: enabled toggle, nonexistent ID, replace clears old, per-repo isolation
- [x] Persistent args: all flag combinations, empty tools, MCP + tools, resume mode
- [x] Helpers: `rows_to_servers`, `cli_config_from_rows` (filter, empty, invalid JSON)
- [x] `cargo clippy` — 0 warnings
- [x] `cargo fmt` — clean
- [x] `tsc --noEmit` — 0 errors
- [x] Manual: toggle servers in AttachMenu, verify status dots update
- [x] Manual: disable server, verify next turn doesn't use it
- [x] Manual: delete all workspaces, verify badge clears