### PR TITLE
ci: add Codecov test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test -p claudette -p claudette-server --all-features
+      - name: Run tests with coverage
+        run: cargo llvm-cov -p claudette -p claudette-server --all-features --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: utensils/claudette
+          files: lcov.info
+          fail_ci_if_error: false
 
   frontend:
     name: Frontend

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ debug/
 *.pdb
 **/mutants.out*/
 
+# Coverage
+lcov.info
+*.profraw
+*.profdata
+
 # Node / Frontend
 node_modules/
 src/ui/dist/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 <p align="center">Claude's missing better half — a companion tool for Claude Code usage.</p>
 
+<p align="center">
+  <a href="https://codecov.io/gh/utensils/claudette"><img src="https://codecov.io/gh/utensils/claudette/graph/badge.svg" alt="codecov"/></a>
+</p>
+
 Claudette is a cross-platform desktop application built with [Tauri 2](https://tauri.app) (Rust backend) and React/TypeScript (frontend). It provides a lightweight interface for managing and orchestrating Claude Code sessions, similar in spirit to [Conductor.build](https://conductor.build) but with a focused feature set.
 
 ## Prerequisites

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+  require_changes: true

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           rustToolchain = fenixPkgs.combine [
             fenixPkgs.latest.cargo
             fenixPkgs.latest.clippy
+            fenixPkgs.latest.llvm-tools-preview
             fenixPkgs.latest.rust-src
             fenixPkgs.latest.rustc
             fenixPkgs.latest.rustfmt
@@ -289,6 +290,7 @@
               pkgs.pkg-config
               pkgs.cmake
               pkgs.perl
+              pkgs.cargo-llvm-cov
             ]
             ++ darwinBuildInputs
             ++ linuxBuildInputs
@@ -443,9 +445,24 @@
                 category = "quality";
               }
               {
-                name = "test";
+                name = "run-tests";
                 command = "cargo test --workspace --all-features";
                 help = "Run all Rust tests";
+                category = "quality";
+              }
+              {
+                name = "coverage";
+                command = ''
+                  mkdir -p src/ui/dist
+                  [ -f src/ui/dist/index.html ] || echo '<html></html>' > src/ui/dist/index.html
+                  cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+                  cargo llvm-cov report --html
+                  cargo llvm-cov report
+                  echo ""
+                  echo "lcov:  lcov.info"
+                  echo "html:  target/llvm-cov/html/index.html"
+                '';
+                help = "Run tests with coverage (terminal summary + lcov + HTML report)";
                 category = "quality";
               }
             ];


### PR DESCRIPTION
## Summary

- Replace `cargo test` with `cargo llvm-cov` in CI for LLVM instrumented coverage, uploading lcov reports to Codecov via `codecov-action@v5`
- Add `codecov.yml` with `informational: true` on both project and patch status — coverage reports on PRs but never blocks merging
- Add `cargo-llvm-cov` and `llvm-tools-preview` to the Nix devshell/fenix toolchain, with a `coverage` helper that outputs terminal summary, lcov, and HTML report

## Test plan

- [ ] CI passes: test job generates coverage and uploads to Codecov
- [ ] Codecov PR comment appears as informational (no blocking check)
- [ ] `nix develop` provides `cargo-llvm-cov` in PATH
- [ ] `coverage` devshell command generates `lcov.info`, HTML report, and prints summary
- [ ] Codecov badge renders in README