### PR TITLE
fix: lowercase base path to match GitHub Pages serving path

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,7 +3,7 @@ import starlight from '@astrojs/starlight';
 
 export default defineConfig({
   site: 'https://utensils.github.io',
-  base: '/Claudette',
+  base: '/claudette',
   integrations: [
     starlight({
       title: 'Claudette',


### PR DESCRIPTION
## Summary

The GitHub Pages site is completely broken — HTML loads but all CSS, JS, images, and internal navigation links return 404.

**Root cause:** `base: '/Claudette'` (uppercase C) in `site/astro.config.mjs`, but GitHub Pages serves project sites at `/<repo-name>/` using the lowercase repo name `claudette`. GitHub Pages paths are case-sensitive, so every asset reference and link generated by Astro misses.

**Fix:** `base: '/Claudette'` → `base: '/claudette'`

| Asset type | Before (404) | After (200) |
|-----------|-------------|-------------|
| CSS | `/Claudette/_astro/index.*.css` | `/claudette/_astro/index.*.css` |
| JS | `/Claudette/_astro/page.*.js` | `/claudette/_astro/page.*.js` |
| Images | `/Claudette/mascot.png` | `/claudette/mascot.png` |
| Nav links | `/Claudette/getting-started/installation/` | `/claudette/getting-started/installation/` |

## Test Steps

1. After merge, wait for the "Deploy Docs" workflow to complete
2. Visit https://utensils.io/claudette/ — confirm the page renders with full styling
3. Click any sidebar link (e.g. "Installation") — confirm navigation works (no 404)
4. Open DevTools Network tab — confirm no 404s for CSS/JS/image assets

## Checklist
- [x] Site builds successfully with `bun run build`
- [x] Built HTML confirmed to reference `/claudette/` (lowercase) paths
- [x] All existing tests pass