### PR TITLE
feat: replace sidebar status dot with braille spinner for running workspaces

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -49,7 +49,7 @@ import { useStickyScroll } from "../../hooks/useStickyScroll";
 import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 
-import { SPINNER_FRAMES } from "../../utils/spinnerFrames";
+import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../../utils/spinnerFrames";
 
 /**
  * Lazily renders a PDF first-page thumbnail.
@@ -222,7 +222,7 @@ export function ChatPanel() {
         const newElapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
         setElapsed((prev) => (prev === newElapsed ? prev : newElapsed));
       }
-    }, 80);
+    }, SPINNER_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [isRunning]);
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -49,7 +49,7 @@ import { useStickyScroll } from "../../hooks/useStickyScroll";
 import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+import { SPINNER_FRAMES } from "../../utils/spinnerFrames";
 
 /**
  * Lazily renders a PDF first-page thumbnail.

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -236,10 +236,18 @@
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
+  margin: 0 4px;
 }
 
-.statusDotRunning {
-  animation: pulse-dot 2s ease-in-out infinite;
+.statusSpinner {
+  font-size: 14px;
+  width: 14px;
+  text-align: center;
+  font-family: var(--font-mono);
+  color: var(--accent-primary);
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 3px rgba(var(--accent-primary-rgb), 0.4));
+  line-height: 1;
 }
 
 .wsActions {
@@ -269,8 +277,10 @@
 .badgeDone,
 .badgePlan,
 .badgeAsk {
+  width: 14px;
   flex-shrink: 0;
   display: inline-flex;
+  justify-content: center;
   animation: pulse-badge 2s ease-in-out infinite;
 }
 

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../services/tauri";
 import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
+import { useSpinnerFrame } from "../../hooks/useSpinnerFrame";
 import styles from "./Sidebar.module.css";
 
 
@@ -48,6 +49,12 @@ export const Sidebar = memo(function Sidebar() {
   const didDragRef = useRef(false);
   const DRAG_THRESHOLD = 5; // px before drag activates
   const workspaceTerminalCommands = useAppStore((s) => s.workspaceTerminalCommands);
+
+  const anyRunning = useMemo(
+    () => workspaces.some((ws) => ws.agent_status === "Running"),
+    [workspaces],
+  );
+  const spinnerChar = useSpinnerFrame(anyRunning);
 
   const creatingRef = useRef(false);
 
@@ -356,16 +363,18 @@ export const Sidebar = memo(function Sidebar() {
                       <span className={styles.badgeAsk} title="Question requires attention" aria-label="Question requires attention" role="img">
                         <BadgeQuestionMark size={14} />
                       </span>
+                    ) : ws.agent_status === "Running" ? (
+                      <span className={styles.statusSpinner} aria-hidden="true">
+                        {spinnerChar}
+                      </span>
                     ) : (
                       <span
-                        className={`${styles.statusDot} ${ws.agent_status === "Running" ? styles.statusDotRunning : ""}`}
+                        className={styles.statusDot}
                         style={{
                           background:
-                            ws.agent_status === "Running"
-                              ? "var(--status-running)"
-                              : ws.agent_status === "Stopped"
-                                ? "var(--status-stopped)"
-                                : "var(--status-idle)",
+                            ws.agent_status === "Stopped"
+                              ? "var(--status-stopped)"
+                              : "var(--status-idle)",
                         }}
                       />
                     )}
@@ -647,6 +656,9 @@ function RemoteConnectionGroup({
     (w) => w.remote_connection_id === conn.id
   );
 
+  const anyRunning = remoteWorkspaces.some((ws) => ws.agent_status === "Running");
+  const spinnerChar = useSpinnerFrame(anyRunning);
+
   const handleCreateWorkspace = async (repoId: string) => {
     if (creatingRef.current.has(repoId)) return;
     creatingRef.current.add(repoId);
@@ -779,17 +791,21 @@ function RemoteConnectionGroup({
                     className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""}`}
                     onClick={() => selectWorkspace(ws.id)}
                   >
-                    <span
-                      className={`${styles.statusDot} ${ws.agent_status === "Running" ? styles.statusDotRunning : ""}`}
-                      style={{
-                        background:
-                          ws.agent_status === "Running"
-                            ? "var(--status-running)"
-                            : ws.agent_status === "Stopped"
+                    {ws.agent_status === "Running" ? (
+                      <span className={styles.statusSpinner} aria-hidden="true">
+                        {spinnerChar}
+                      </span>
+                    ) : (
+                      <span
+                        className={styles.statusDot}
+                        style={{
+                          background:
+                            ws.agent_status === "Stopped"
                               ? "var(--status-stopped)"
                               : "var(--status-idle)",
-                      }}
-                    />
+                        }}
+                      />
+                    )}
                     <div className={styles.wsInfo}>
                       <span className={styles.wsName}>{ws.name}</span>
                       <span className={styles.wsBranch}>{ws.branch_name}</span>

--- a/src/ui/src/hooks/useSpinnerFrame.ts
+++ b/src/ui/src/hooks/useSpinnerFrame.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../utils/spinnerFrames";
+
+/**
+ * Returns the current Braille spinner character.
+ * When `active` is false, no interval runs and the returned value is the first frame.
+ */
+export function useSpinnerFrame(active: boolean): string {
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    if (!active) {
+      setIdx(0);
+      return;
+    }
+    const interval = setInterval(() => {
+      setIdx((i) => (i + 1) % SPINNER_FRAMES.length);
+    }, SPINNER_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [active]);
+
+  return SPINNER_FRAMES[idx];
+}

--- a/src/ui/src/utils/spinnerFrames.ts
+++ b/src/ui/src/utils/spinnerFrames.ts
@@ -1,0 +1,2 @@
+export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+export const SPINNER_INTERVAL_MS = 80;


### PR DESCRIPTION
## Summary

Replaces the subtle pulsing colored dot in the sidebar workspace list with the same animated braille character spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) used in the chat pane, making it immediately obvious when a workspace has an active agent.

- Extracts `SPINNER_FRAMES` into a shared constant (`utils/spinnerFrames.ts`) used by both ChatPanel and Sidebar
- Adds `useSpinnerFrame` hook that runs a single 80ms interval shared across all workspace items
- Normalizes all indicator widths (dot, spinner, badges) to 14px so workspace names align regardless of which icon is shown

## Complexity Notes

The `useSpinnerFrame` hook is called once per component that needs it (`Sidebar` and `RemoteConnectionGroup`), producing a single shared frame value for all workspace items within that scope. This means the sidebar re-renders at 80ms only when at least one workspace is running — no interval fires when all workspaces are idle.

## Test Steps

1. Run `cargo tauri dev`
2. Open the sidebar with multiple workspaces
3. Start an agent in one workspace — verify the braille spinner appears next to it instead of a pulsing dot
4. Confirm idle and stopped workspaces still show the small colored dot
5. Verify all workspace names are horizontally aligned regardless of indicator type (dot, spinner, or badge)
6. Check the chat pane spinner still works identically
7. Stop the agent — verify the spinner reverts to the idle dot

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)