### PR TITLE
docs: add terminal theme properties to theming reference

### DIFF
--- a/site/src/content/docs/features/theming.mdx
+++ b/site/src/content/docs/features/theming.mdx
@@ -80,7 +80,7 @@ Each file must be valid JSON with the following structure:
 
 ## Color Properties Reference
 
-You can customize any of the following 43 CSS custom properties. Properties you don't specify will use the default theme's values.
+You can customize any of the following 47 CSS custom properties. Properties you don't specify will use the default theme's values.
 
 ### Scheme
 
@@ -120,8 +120,17 @@ You can customize any of the following 43 CSS custom properties. Properties you 
 | `chat-header-bg` | Chat panel header |
 | `chat-user-bg` | User message bubble background |
 | `chat-system-bg` | System message background |
-| `terminal-tab-bg` | Inactive terminal tab |
-| `terminal-tab-active-bg` | Active terminal tab |
+
+### Terminal
+
+| Property | Description |
+|----------|-------------|
+| `terminal-tab-bg` | Inactive terminal tab background |
+| `terminal-tab-active-bg` | Active terminal tab background |
+| `terminal-bg` | Terminal panel background color |
+| `terminal-fg` | Terminal text (foreground) color |
+| `terminal-cursor` | Terminal cursor color |
+| `terminal-selection` | Terminal text selection background |
 
 ### Interactive States
 
@@ -214,6 +223,10 @@ Here's a complete example based on the built-in Warm Ember theme:
     "chat-header-bg": "rgb(26, 22, 18)",
     "terminal-tab-bg": "rgb(30, 26, 20)",
     "terminal-tab-active-bg": "rgb(44, 38, 30)",
+    "terminal-bg": "rgb(18, 15, 12)",
+    "terminal-fg": "rgb(240, 232, 220)",
+    "terminal-cursor": "rgb(240, 232, 220)",
+    "terminal-selection": "rgba(240, 160, 80, 0.25)",
     "toolbar-active": "rgba(240, 160, 80, 0.12)",
     "toolbar-active-text": "#f0a050",
     "app-bg": "rgb(18, 15, 12)",


### PR DESCRIPTION
## Summary

Adds the 4 new terminal CSS custom properties introduced in #196 (`terminal-bg`, `terminal-fg`, `terminal-cursor`, `terminal-selection`) to the theming documentation.

Changes:
- Updated property count from 43 → 47
- Created a dedicated **Terminal** section in the Color Properties Reference, consolidating the existing `terminal-tab-*` properties with the 4 new ones (mirrors the `/* Terminal */` grouping in `theme.css`)
- Added the new properties to the Warm Ember example JSON with their actual values

## Test Steps

1. Preview the rendered `site/src/content/docs/features/theming.mdx` and verify:
   - The property count reads "47 CSS custom properties"
   - A new **Terminal** section appears between Backgrounds and Interactive States with 6 properties
   - The Warm Ember example JSON includes `terminal-bg`, `terminal-fg`, `terminal-cursor`, and `terminal-selection`
2. Count all property rows across all reference tables — should total 47

## Checklist

- [ ] Documentation updated