### PR TITLE
fix: add macOS updater artifacts and check-for-updates button

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,11 +68,11 @@ jobs:
         include:
           - platform: macos-latest
             rust-target: aarch64-apple-darwin
-            bundles: dmg
+            bundles: app,dmg
             label: macos-aarch64
           - platform: macos-15-intel
             rust-target: x86_64-apple-darwin
-            bundles: dmg
+            bundles: app,dmg
             label: macos-x86_64
           - platform: ubuntu-22.04
             rust-target: x86_64-unknown-linux-gnu

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -1,17 +1,22 @@
 import { useEffect, useState } from "react";
 import { FolderOpen } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "../../../stores/useAppStore";
 import { getAppSetting, setAppSetting } from "../../../services/tauri";
+import { checkForUpdate } from "../../../hooks/useAutoUpdater";
 import styles from "../Settings.module.css";
 
 export function GeneralSettings() {
   const worktreeBaseDir = useAppStore((s) => s.worktreeBaseDir);
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
+  const updateAvailable = useAppStore((s) => s.updateAvailable);
 
   const [path, setPath] = useState(worktreeBaseDir);
   const [trayEnabled, setTrayEnabled] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [appVersion, setAppVersion] = useState("");
+  const [checkState, setCheckState] = useState<"idle" | "checking" | "up-to-date">("idle");
 
   useEffect(() => {
     setPath(worktreeBaseDir);
@@ -22,6 +27,30 @@ export function GeneralSettings() {
       .then((val) => setTrayEnabled(val !== "false"))
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => {});
+  }, []);
+
+  // Auto-reset "up to date" message after 4 seconds.
+  useEffect(() => {
+    if (checkState !== "up-to-date") return;
+    const timer = setTimeout(() => setCheckState("idle"), 4000);
+    return () => clearTimeout(timer);
+  }, [checkState]);
+
+  // If an update becomes available (e.g. from the banner), reset to idle.
+  useEffect(() => {
+    if (updateAvailable) setCheckState("idle");
+  }, [updateAvailable]);
+
+  const handleCheckForUpdates = async () => {
+    setCheckState("checking");
+    const found = await checkForUpdate();
+    if (!found) {
+      setCheckState("up-to-date");
+    }
+  };
 
   const handlePathBlur = async () => {
     const trimmed = path.trim();
@@ -53,6 +82,28 @@ export function GeneralSettings() {
       <h2 className={styles.sectionTitle}>General</h2>
 
       {error && <div className={styles.error}>{error}</div>}
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>App version</div>
+          <div className={styles.settingDescription}>
+            {appVersion ? `v${appVersion}` : "\u2026"}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.iconBtn}
+            onClick={handleCheckForUpdates}
+            disabled={checkState === "checking"}
+          >
+            {checkState === "checking"
+              ? "Checking\u2026"
+              : checkState === "up-to-date"
+                ? "Up to date"
+                : "Check for Updates"}
+          </button>
+        </div>
+      </div>
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -45,10 +45,14 @@ export function GeneralSettings() {
   }, [updateAvailable]);
 
   const handleCheckForUpdates = async () => {
+    setError(null);
     setCheckState("checking");
-    const found = await checkForUpdate();
-    if (!found) {
+    const result = await checkForUpdate();
+    if (result === "up-to-date") {
       setCheckState("up-to-date");
+    } else if (result === "error") {
+      setCheckState("idle");
+      setError("Update check failed. Please try again later.");
     }
   };
 

--- a/src/ui/src/hooks/useAutoUpdater.test.ts
+++ b/src/ui/src/hooks/useAutoUpdater.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks (vi.hoisted runs before vi.mock factories) ────────────────
+const { mockCheck, mockSetUpdateAvailable } = vi.hoisted(() => ({
+  mockCheck: vi.fn(),
+  mockSetUpdateAvailable: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: mockCheck,
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: vi.fn(),
+}));
+
+vi.mock("../stores/useAppStore", () => ({
+  useAppStore: Object.assign(() => null, {
+    getState: () => ({
+      setUpdateAvailable: mockSetUpdateAvailable,
+      updateDownloading: false,
+      workspaces: [],
+    }),
+  }),
+}));
+
+// ── Import under test (after mocks) ─────────────────────────────────
+import { checkForUpdate } from "./useAutoUpdater";
+
+describe("checkForUpdate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns "available" and sets store when an update exists', async () => {
+    mockCheck.mockResolvedValue({ version: "2.0.0" });
+
+    const result = await checkForUpdate();
+
+    expect(result).toBe("available");
+    expect(mockSetUpdateAvailable).toHaveBeenCalledWith(true, "2.0.0");
+  });
+
+  it('returns "up-to-date" and clears store when no update exists', async () => {
+    mockCheck.mockResolvedValue(null);
+
+    const result = await checkForUpdate();
+
+    expect(result).toBe("up-to-date");
+    expect(mockSetUpdateAvailable).toHaveBeenCalledWith(false, null);
+  });
+
+  it('returns "error" and does not touch store when check throws', async () => {
+    mockCheck.mockRejectedValue(new Error("network failure"));
+
+    const result = await checkForUpdate();
+
+    expect(result).toBe("error");
+    expect(mockSetUpdateAvailable).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -1,37 +1,41 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useCallback } from "react";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { useAppStore } from "../stores/useAppStore";
 
 const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
-export function useAutoUpdater() {
-  const updateRef = useRef<Update | null>(null);
+// Module-level storage so both the hook and external callers (e.g. Settings)
+// share the same Update handle.
+let pendingUpdate: Update | null = null;
 
-  const setUpdateAvailable = useAppStore((s) => s.setUpdateAvailable);
+/** Check the updater endpoint and update Zustand state. Returns true if an update is available. */
+export async function checkForUpdate(): Promise<boolean> {
+  try {
+    const update = await check();
+    if (update) {
+      pendingUpdate = update;
+      useAppStore.getState().setUpdateAvailable(true, update.version);
+      return true;
+    } else {
+      pendingUpdate = null;
+      useAppStore.getState().setUpdateAvailable(false, null);
+      return false;
+    }
+  } catch (e) {
+    console.error("[updater] Check failed:", e);
+    return false;
+  }
+}
+
+export function useAutoUpdater() {
   const setUpdateDismissed = useAppStore((s) => s.setUpdateDismissed);
   const setUpdateInstallWhenIdle = useAppStore((s) => s.setUpdateInstallWhenIdle);
   const setUpdateDownloading = useAppStore((s) => s.setUpdateDownloading);
   const setUpdateProgress = useAppStore((s) => s.setUpdateProgress);
 
-  const checkForUpdate = useCallback(async () => {
-    try {
-      const update = await check();
-      if (update) {
-        updateRef.current = update;
-        setUpdateAvailable(true, update.version);
-      } else {
-        // No update available — clear any stale state (e.g. release withdrawn).
-        updateRef.current = null;
-        setUpdateAvailable(false, null);
-      }
-    } catch (e) {
-      console.error("[updater] Check failed:", e);
-    }
-  }, [setUpdateAvailable]);
-
   const installNow = useCallback(async () => {
-    const update = updateRef.current;
+    const update = pendingUpdate;
     if (!update) return;
     if (useAppStore.getState().updateDownloading) return;
 
@@ -62,7 +66,7 @@ export function useAutoUpdater() {
       // Re-check to get a fresh Update instance after failure
       checkForUpdate();
     }
-  }, [setUpdateDownloading, setUpdateProgress, checkForUpdate]);
+  }, [setUpdateDownloading, setUpdateProgress]);
 
   const installWhenIdle = useCallback(() => {
     const hasRunning = useAppStore.getState().workspaces.some(
@@ -88,7 +92,7 @@ export function useAutoUpdater() {
     checkForUpdate();
     const intervalId = window.setInterval(checkForUpdate, CHECK_INTERVAL_MS);
     return () => window.clearInterval(intervalId);
-  }, [checkForUpdate]);
+  }, []);
 
   // Install when idle: watch for all agents to stop running.
   const updateInstallWhenIdle = useAppStore((s) => s.updateInstallWhenIdle);

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -9,22 +9,24 @@ const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 // share the same Update handle.
 let pendingUpdate: Update | null = null;
 
-/** Check the updater endpoint and update Zustand state. Returns true if an update is available. */
-export async function checkForUpdate(): Promise<boolean> {
+export type UpdateCheckResult = "available" | "up-to-date" | "error";
+
+/** Check the updater endpoint and update Zustand state. */
+export async function checkForUpdate(): Promise<UpdateCheckResult> {
   try {
     const update = await check();
     if (update) {
       pendingUpdate = update;
       useAppStore.getState().setUpdateAvailable(true, update.version);
-      return true;
+      return "available";
     } else {
       pendingUpdate = null;
       useAppStore.getState().setUpdateAvailable(false, null);
-      return false;
+      return "up-to-date";
     }
   } catch (e) {
     console.error("[updater] Check failed:", e);
-    return false;
+    return "error";
   }
 }
 


### PR DESCRIPTION
## Summary

- **Fix macOS auto-updater**: The CI only built `dmg` bundles for macOS, so `createUpdaterArtifacts` never generated the `.app.tar.gz` + `.sig` files the Tauri updater needs. The published `latest.json` for v0.10.0 contains zero macOS platform entries — only Linux. Adding the `app` bundle type alongside `dmg` fixes this.
- **Add "Check for Updates" to General Settings**: Extracts `checkForUpdate` from the `useAutoUpdater` hook into a standalone exported function and adds a version display + manual update check button to the General Settings page.

## Complexity Notes

The `useAutoUpdater` refactoring moves the `Update` object from a React `useRef` to a module-level variable. This is safe because exactly one hook instance exists (in `AppLayout`), and it enables the Settings component to trigger update checks without prop drilling or context wiring.

## Test Steps

1. **CI fix** (verified on next release):
   - After merging, trigger a release via `workflow_dispatch` or let release-please create one
   - Verify the GitHub release assets include `*.app.tar.gz` and `*.app.tar.gz.sig` files for both architectures
   - Download `latest.json` from the release and confirm `darwin-aarch64` and `darwin-x86_64` keys are present
2. **UI**:
   - Run `cargo tauri dev`, open Settings > General
   - Verify the app version is displayed (e.g. `v0.10.0`)
   - Click "Check for Updates" — button should show "Checking..." then "Up to date" (in dev mode, no release matches)
   - The "Up to date" text auto-resets to "Check for Updates" after 4 seconds

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)