### PR TITLE
fix(ci): stage flake.nix before git pull --rebase in Nix hash workflow

### DIFF
--- a/.github/workflows/update-frontend-hash.yml
+++ b/.github/workflows/update-frontend-hash.yml
@@ -142,5 +142,6 @@ jobs:
           git stash
           git pull --rebase origin main
           git stash pop
+          git add flake.nix
           git commit -m "chore(nix): update frontend FOD hashes"
           git push

--- a/.github/workflows/update-frontend-hash.yml
+++ b/.github/workflows/update-frontend-hash.yml
@@ -137,8 +137,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin main
           git add flake.nix
           git diff --cached --quiet && exit 0
+          git stash
+          git pull --rebase origin main
+          git stash pop
           git commit -m "chore(nix): update frontend FOD hashes"
           git push


### PR DESCRIPTION
## Summary

- The Nix FOD hash update workflow fails because `git pull --rebase origin main` runs before `git add flake.nix`, but `flake.nix` was already modified by the hash update step
- Git refuses to rebase with unstaged changes: `error: cannot pull with rebase: You have unstaged changes`
- Fix: stage first, check for no-op early, stash/pull --rebase/pop so the rebase works cleanly

## Test plan

- [ ] Nix workflow succeeds on next `src/ui/` change pushed to main