### PR TITLE
fix: kill embedded server process on app exit to prevent port conflicts

### DIFF
--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -288,6 +288,10 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
             .spawn()
             .map_err(|e| format!("Failed to start embedded server: {e}"))?;
 
+        // Capture PID eagerly — child.id() returns None after the process is
+        // reaped, and we need the PID for synchronous cleanup on app exit.
+        let pid = child.id().ok_or("Failed to get server process PID")?;
+
         let stdout = child
             .stdout
             .take()
@@ -360,6 +364,7 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
 
         *server = Some(LocalServerState {
             child,
+            pid,
             connection_string,
         });
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -362,16 +362,36 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("error while building Claudette")
         .run(|_app, _event| {
-            // Show the window when the dock icon is clicked (macOS reopen).
-            #[cfg(target_os = "macos")]
-            if let tauri::RunEvent::Reopen { .. } = _event {
-                if let Some(window) = _app.get_webview_window("main") {
-                    let _ = window.unminimize();
-                    let _ = window.show();
-                    let _ = window.set_focus();
+            match _event {
+                // Show the window when the dock icon is clicked (macOS reopen).
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen { .. } => {
+                    if let Some(window) = _app.get_webview_window("main") {
+                        let _ = window.unminimize();
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                    }
+                    // Navigate to session needing attention, if any.
+                    tray::navigate_to_attention(_app);
                 }
-                // Navigate to session needing attention, if any.
-                tray::navigate_to_attention(_app);
+                // Kill the embedded server process (if we spawned one) before
+                // the tokio runtime tears down. Using synchronous POSIX kill
+                // ensures the child is dead before our process exits, preventing
+                // the "Address already in use" error on next launch.
+                tauri::RunEvent::Exit => {
+                    let app_state = _app.state::<state::AppState>();
+                    // try_write avoids blocking if another thread holds the lock
+                    // during shutdown — in that case Drop will still fire.
+                    // Dropping `srv` triggers LocalServerState::drop which
+                    // calls kill_process_sync(pid). Taking it out of the
+                    // Option ensures cleanup runs exactly once.
+                    if let Ok(mut guard) = app_state.local_server.try_write()
+                        && let Some(srv) = guard.take()
+                    {
+                        drop(srv);
+                    }
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -64,19 +64,76 @@ pub struct PtyHandle {
 pub struct LocalServerState {
     /// Handle to the running server process.
     pub child: tokio::process::Child,
+    /// The PID captured at spawn time for reliable synchronous cleanup.
+    /// `tokio::process::Child::id()` returns `None` after the child is reaped,
+    /// so we store the PID eagerly.
+    pub pid: u32,
     /// The connection string printed by the server on startup.
     pub connection_string: String,
 }
 
 impl Drop for LocalServerState {
     fn drop(&mut self) {
-        // Kill the server process when this state is dropped.
-        // Use start_kill() instead of kill() since we're in a sync context.
-        if let Err(e) = self.child.start_kill() {
-            eprintln!("[cleanup] Failed to kill local server: {e}");
-        } else {
-            eprintln!("[cleanup] Stopped local claudette-server");
+        // Best-effort tokio-level kill (may fail if runtime is gone).
+        let _ = self.child.start_kill();
+        // Synchronous POSIX kill — works even during process teardown when the
+        // tokio runtime is no longer available.
+        kill_process_sync(self.pid);
+    }
+}
+
+/// Synchronously send SIGKILL to a process and wait for it to exit.
+///
+/// This is safe to call from `Drop` impls and the `RunEvent::Exit` handler
+/// where async code cannot run. Uses raw libc calls so it does not depend on
+/// the tokio runtime.
+pub fn kill_process_sync(pid: u32) {
+    #[cfg(unix)]
+    {
+        use std::time::{Duration, Instant};
+        let pid = pid as i32;
+        // SAFETY: libc::kill with SIGKILL is a standard POSIX call.
+        // A pid of 0 would signal our own process group — guard against it.
+        if pid <= 0 {
+            return;
         }
+
+        // First try SIGTERM for a graceful shutdown.
+        // SAFETY: pid is a valid positive i32.
+        let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
+        if ret != 0 {
+            // Process already gone — nothing to do.
+            eprintln!("[cleanup] Server process {pid} already exited");
+            return;
+        }
+
+        // Give the server up to 500ms to exit gracefully.
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            // SAFETY: waitpid with WNOHANG is a standard POSIX call.
+            let mut status: libc::c_int = 0;
+            let ret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if ret == pid || ret == -1 {
+                eprintln!("[cleanup] Stopped local claudette-server (pid {pid})");
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        // Graceful shutdown timed out — force kill.
+        // SAFETY: pid is a valid positive i32.
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+
+        // Reap the zombie so the PID is released to the OS.
+        // SAFETY: waitpid is a standard POSIX call.
+        unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+        eprintln!("[cleanup] Force-killed local claudette-server (pid {pid})");
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        // On non-Unix, fall through to tokio's start_kill() in the Drop impl.
     }
 }
 
@@ -120,5 +177,103 @@ impl AppState {
 
     pub fn next_pty_id(&self) -> u64 {
         self.next_pty_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::*;
+
+    /// Helper: spawn a long-running `sleep` process and return its PID.
+    fn spawn_sleep() -> (tokio::process::Child, u32) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let mut child = tokio::process::Command::new("sleep")
+                .arg("3600")
+                .kill_on_drop(true)
+                .spawn()
+                .expect("failed to spawn sleep");
+            let pid = child.id().expect("missing pid");
+            // Detach stdout/stderr ownership so kill_on_drop doesn't race.
+            let _ = child.stdout.take();
+            let _ = child.stderr.take();
+            (child, pid)
+        })
+    }
+
+    /// Returns true if the given PID is still alive.
+    fn is_alive(pid: u32) -> bool {
+        // kill(pid, 0) checks existence without sending a signal.
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+
+    #[test]
+    fn kill_process_sync_terminates_running_process() {
+        let (child, pid) = spawn_sleep();
+        assert!(is_alive(pid), "process should be alive after spawn");
+
+        // Forget the tokio child so kill_on_drop doesn't interfere.
+        std::mem::forget(child);
+
+        kill_process_sync(pid);
+
+        // Give the OS a moment to update process table.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !is_alive(pid),
+            "process should be dead after kill_process_sync"
+        );
+    }
+
+    #[test]
+    fn kill_process_sync_noop_for_dead_process() {
+        let (child, pid) = spawn_sleep();
+        std::mem::forget(child);
+
+        // Kill it once.
+        kill_process_sync(pid);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(!is_alive(pid));
+
+        // Calling again on a dead PID should not panic.
+        kill_process_sync(pid);
+    }
+
+    #[test]
+    fn kill_process_sync_noop_for_zero_pid() {
+        // pid 0 would signal our own process group — must be a no-op.
+        kill_process_sync(0);
+    }
+
+    #[test]
+    fn local_server_state_drop_kills_child() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (child, pid) = rt.block_on(async {
+            let mut child = tokio::process::Command::new("sleep")
+                .arg("3600")
+                .kill_on_drop(true)
+                .spawn()
+                .expect("failed to spawn sleep");
+            let pid = child.id().expect("missing pid");
+            let _ = child.stdout.take();
+            let _ = child.stderr.take();
+            (child, pid)
+        });
+        assert!(is_alive(pid));
+
+        let state = LocalServerState {
+            child,
+            pid,
+            connection_string: String::new(),
+        };
+        // Dropping the state should kill the process.
+        drop(state);
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !is_alive(pid),
+            "child should be dead after LocalServerState is dropped"
+        );
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -74,6 +74,13 @@ pub struct LocalServerState {
 
 impl Drop for LocalServerState {
     fn drop(&mut self) {
+        // If tokio can still reach the child, check whether it already exited
+        // (e.g. crash, external kill). If so, skip the PID-based cleanup to
+        // avoid signaling a recycled PID that now belongs to another process.
+        if let Ok(Some(_status)) = self.child.try_wait() {
+            eprintln!("[cleanup] Server process already exited");
+            return;
+        }
         // Best-effort tokio-level kill (may fail if runtime is gone).
         let _ = self.child.start_kill();
         // Synchronous POSIX kill — works even during process teardown when the
@@ -113,9 +120,18 @@ pub fn kill_process_sync(pid: u32) {
             // SAFETY: waitpid with WNOHANG is a standard POSIX call.
             let mut status: libc::c_int = 0;
             let ret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
-            if ret == pid || ret == -1 {
+            if ret == pid {
                 eprintln!("[cleanup] Stopped local claudette-server (pid {pid})");
                 return;
+            }
+            if ret == -1 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::ECHILD) {
+                    // No such child — already reaped.
+                    eprintln!("[cleanup] Stopped local claudette-server (pid {pid})");
+                    return;
+                }
+                // EINTR or other transient error — retry.
             }
             std::thread::sleep(Duration::from_millis(10));
         }
@@ -124,9 +140,22 @@ pub fn kill_process_sync(pid: u32) {
         // SAFETY: pid is a valid positive i32.
         unsafe { libc::kill(pid, libc::SIGKILL) };
 
-        // Reap the zombie so the PID is released to the OS.
-        // SAFETY: waitpid is a standard POSIX call.
-        unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+        // Reap the zombie so the PID is released to the OS. Loop to handle
+        // EINTR — only stop when waitpid returns the pid or ECHILD.
+        loop {
+            // SAFETY: waitpid is a standard POSIX call.
+            let ret = unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
+            if ret == pid {
+                break;
+            }
+            if ret == -1 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(libc::EINTR) {
+                    break; // ECHILD or unexpected error — stop.
+                }
+                // EINTR — retry waitpid.
+            }
+        }
         eprintln!("[cleanup] Force-killed local claudette-server (pid {pid})");
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -89,81 +89,93 @@ impl Drop for LocalServerState {
     }
 }
 
-/// Synchronously send SIGKILL to a process and wait for it to exit.
+/// Synchronously try to terminate a process and wait for it to exit.
 ///
-/// This is safe to call from `Drop` impls and the `RunEvent::Exit` handler
-/// where async code cannot run. Uses raw libc calls so it does not depend on
-/// the tokio runtime.
+/// On Unix, this first sends `SIGTERM` and allows a short grace period for
+/// graceful shutdown. If the process does not exit in time, it escalates to
+/// `SIGKILL` and reaps the process. This is safe to call from `Drop` impls
+/// and the `RunEvent::Exit` handler where async code cannot run. Uses raw
+/// libc calls so it does not depend on the tokio runtime.
 pub fn kill_process_sync(pid: u32) {
-    #[cfg(unix)]
-    {
-        use std::time::{Duration, Instant};
-        let pid = pid as i32;
-        // SAFETY: libc::kill with SIGKILL is a standard POSIX call.
-        // A pid of 0 would signal our own process group — guard against it.
-        if pid <= 0 {
-            return;
-        }
+    use std::time::{Duration, Instant};
+    let pid = pid as i32;
+    // A pid of 0 would signal our own process group — guard against it.
+    if pid <= 0 {
+        return;
+    }
 
-        // First try SIGTERM for a graceful shutdown.
-        // SAFETY: pid is a valid positive i32.
-        let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
-        if ret != 0 {
-            // Process already gone — nothing to do.
+    // First try SIGTERM for a graceful shutdown.
+    // SAFETY: pid is a valid positive i32.
+    let ret = unsafe { libc::kill(pid, libc::SIGTERM) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) {
             eprintln!("[cleanup] Server process {pid} already exited");
+        } else {
+            eprintln!("[cleanup] Failed to send SIGTERM to server process {pid}: {err}");
+        }
+        return;
+    }
+
+    // Give the server up to 500ms to exit gracefully.
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        // SAFETY: waitpid with WNOHANG is a standard POSIX call.
+        let mut status: libc::c_int = 0;
+        let ret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if ret == pid {
+            eprintln!("[cleanup] Stopped local claudette-server (pid {pid})");
             return;
         }
-
-        // Give the server up to 500ms to exit gracefully.
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while Instant::now() < deadline {
-            // SAFETY: waitpid with WNOHANG is a standard POSIX call.
-            let mut status: libc::c_int = 0;
-            let ret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
-            if ret == pid {
+        if ret == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ECHILD) {
+                // No such child — already reaped.
                 eprintln!("[cleanup] Stopped local claudette-server (pid {pid})");
                 return;
             }
-            if ret == -1 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() == Some(libc::ECHILD) {
-                    // No such child — already reaped.
-                    eprintln!("[cleanup] Stopped local claudette-server (pid {pid})");
+            // EINTR or other transient error — retry.
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // Graceful shutdown timed out — force kill.
+    // SAFETY: pid is a valid positive i32.
+    unsafe { libc::kill(pid, libc::SIGKILL) };
+
+    // Try to reap the process without blocking indefinitely. If it does not
+    // become waitable in time (e.g. stuck in uninterruptible sleep), give up
+    // so app shutdown cannot hang forever.
+    let reap_deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < reap_deadline {
+        let mut status: libc::c_int = 0;
+        // SAFETY: waitpid with WNOHANG is a standard POSIX call.
+        let ret = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if ret == pid {
+            eprintln!("[cleanup] Force-killed local claudette-server (pid {pid})");
+            return;
+        }
+        if ret == -1 {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::ECHILD) => {
+                    eprintln!("[cleanup] Force-killed local claudette-server (pid {pid})");
                     return;
                 }
-                // EINTR or other transient error — retry.
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-
-        // Graceful shutdown timed out — force kill.
-        // SAFETY: pid is a valid positive i32.
-        unsafe { libc::kill(pid, libc::SIGKILL) };
-
-        // Reap the zombie so the PID is released to the OS. Loop to handle
-        // EINTR — only stop when waitpid returns the pid or ECHILD.
-        loop {
-            // SAFETY: waitpid is a standard POSIX call.
-            let ret = unsafe { libc::waitpid(pid, std::ptr::null_mut(), 0) };
-            if ret == pid {
-                break;
-            }
-            if ret == -1 {
-                let err = std::io::Error::last_os_error();
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    break; // ECHILD or unexpected error — stop.
+                Some(libc::EINTR) => {} // Retry.
+                _ => {
+                    eprintln!(
+                        "[cleanup] Sent SIGKILL to claudette-server (pid {pid}) but could not reap: {err}"
+                    );
+                    return;
                 }
-                // EINTR — retry waitpid.
             }
         }
-        eprintln!("[cleanup] Force-killed local claudette-server (pid {pid})");
+        std::thread::sleep(Duration::from_millis(10));
     }
-
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        // On non-Unix, fall through to tokio's start_kill() in the Drop impl.
-    }
+    eprintln!(
+        "[cleanup] Sent SIGKILL to claudette-server (pid {pid}) but timed out waiting to reap"
+    );
 }
 
 /// Application-wide managed state, shared across all Tauri commands.
@@ -218,15 +230,12 @@ mod tests {
     fn spawn_sleep() -> (tokio::process::Child, u32) {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let mut child = tokio::process::Command::new("sleep")
+            let child = tokio::process::Command::new("sleep")
                 .arg("3600")
                 .kill_on_drop(true)
                 .spawn()
                 .expect("failed to spawn sleep");
             let pid = child.id().expect("missing pid");
-            // Detach stdout/stderr ownership so kill_on_drop doesn't race.
-            let _ = child.stdout.take();
-            let _ = child.stderr.take();
             (child, pid)
         })
     }
@@ -279,14 +288,12 @@ mod tests {
     fn local_server_state_drop_kills_child() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let (child, pid) = rt.block_on(async {
-            let mut child = tokio::process::Command::new("sleep")
+            let child = tokio::process::Command::new("sleep")
                 .arg("3600")
                 .kill_on_drop(true)
                 .spawn()
                 .expect("failed to spawn sleep");
             let pid = child.id().expect("missing pid");
-            let _ = child.stdout.take();
-            let _ = child.stderr.take();
             (child, pid)
         });
         assert!(is_alive(pid));


### PR DESCRIPTION
## Summary

- The embedded `claudette-server` spawned via "Share this machine" was not reliably killed when the desktop app exited, leaving the port occupied and causing "Address already in use (os error 48)" on next launch
- Root cause: `LocalServerState::Drop` called `start_kill()` which is async fire-and-forget — the parent process could exit before the signal was delivered, orphaning the server
- Fix: store the child PID eagerly at spawn time and use synchronous POSIX `kill(2)` + `waitpid(2)` via libc, both in the `Drop` impl and a new `RunEvent::Exit` handler
- Guards against PID reuse (checks `try_wait()` before signaling) and EINTR on `waitpid`

## Test plan

- [x] 4 new regression tests in `state::tests` (all pass):
  - `kill_process_sync_terminates_running_process` — spawns `sleep 3600`, kills it, verifies dead
  - `kill_process_sync_noop_for_dead_process` — idempotent on already-dead PID
  - `kill_process_sync_noop_for_zero_pid` — no-op for pid 0 (would signal own process group)
  - `local_server_state_drop_kills_child` — full `LocalServerState` drop path
- [x] `cargo clippy --workspace --all-targets --all-features` with `RUSTFLAGS="-Dwarnings"` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --all-features` — 64/64 pass
- [x] Manual verification: start server from app, quit app, relaunch — no port conflict