### PR TITLE
fix(chat): default completed turns to collapsed

### DIFF
--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -173,6 +173,16 @@ describe("finalizeTurn afterMessageIndex", () => {
     expect(turns[0].id).toBe("cp-new");
   });
 
+  it("defaults completed turn to collapsed", () => {
+    addToolActivities();
+
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns).toHaveLength(1);
+    expect(turns[0].collapsed).toBe(true);
+  });
+
   it("records afterMessageIndex as current chatMessages length", () => {
     useAppStore.setState({
       chatMessages: {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -101,7 +101,7 @@ interface AppState {
   updateToolActivity: (
     wsId: string,
     toolUseId: string,
-    updates: Partial<ToolActivity>
+    updates: Partial<ToolActivity>,
   ) => void;
   toggleToolActivityCollapsed: (wsId: string, index: number) => void;
   finalizeTurn: (wsId: string, messageCount: number, turnId?: string) => void;
@@ -111,7 +111,7 @@ interface AppState {
   appendToolActivityInput: (
     wsId: string,
     toolUseId: string,
-    partialJson: string
+    partialJson: string,
   ) => void;
 
   // -- Agent Questions (per-workspace) --
@@ -148,7 +148,7 @@ interface AppState {
   rollbackConversation: (
     wsId: string,
     checkpointId: string,
-    messages: ChatMessage[]
+    messages: ChatMessage[],
   ) => void;
 
   // -- Notifications --
@@ -204,7 +204,7 @@ interface AppState {
   toggleTerminalPanel: () => void;
   setWorkspaceTerminalCommand: (
     wsId: string,
-    state: WorkspaceCommandState
+    state: WorkspaceCommandState,
   ) => void;
   updateTerminalTabPtyId: (tabId: number, ptyId: number) => void;
 
@@ -327,7 +327,7 @@ export const useAppStore = create<AppState>((set) => ({
   updateRepository: (id, updates) =>
     set((s) => ({
       repositories: s.repositories.map((r) =>
-        r.id === id ? { ...r, ...updates } : r
+        r.id === id ? { ...r, ...updates } : r,
       ),
     })),
   removeRepository: (id) =>
@@ -340,12 +340,11 @@ export const useAppStore = create<AppState>((set) => ({
   workspaces: [],
   selectedWorkspaceId: null,
   setWorkspaces: (workspaces) => set({ workspaces }),
-  addWorkspace: (ws) =>
-    set((s) => ({ workspaces: [...s.workspaces, ws] })),
+  addWorkspace: (ws) => set((s) => ({ workspaces: [...s.workspaces, ws] })),
   updateWorkspace: (id, updates) =>
     set((s) => ({
       workspaces: s.workspaces.map((w) =>
-        w.id === id ? { ...w, ...updates } : w
+        w.id === id ? { ...w, ...updates } : w,
       ),
     })),
   removeWorkspace: (id) =>
@@ -359,7 +358,8 @@ export const useAppStore = create<AppState>((set) => ({
         unreadCompletions: newUnreadCompletions,
       };
     }),
-  selectWorkspace: (id) => set({ selectedWorkspaceId: id, rightSidebarTab: "changes" }),
+  selectWorkspace: (id) =>
+    set({ selectedWorkspaceId: id, rightSidebarTab: "changes" }),
 
   // -- Chat --
   chatMessages: {},
@@ -434,7 +434,7 @@ export const useAppStore = create<AppState>((set) => ({
       toolActivities: {
         ...s.toolActivities,
         [wsId]: (s.toolActivities[wsId] || []).map((a) =>
-          a.toolUseId === toolUseId ? { ...a, ...updates } : a
+          a.toolUseId === toolUseId ? { ...a, ...updates } : a,
         ),
       },
     })),
@@ -443,7 +443,7 @@ export const useAppStore = create<AppState>((set) => ({
       toolActivities: {
         ...s.toolActivities,
         [wsId]: (s.toolActivities[wsId] || []).map((a, i) =>
-          i === index ? { ...a, collapsed: !a.collapsed } : a
+          i === index ? { ...a, collapsed: !a.collapsed } : a,
         ),
       },
     })),
@@ -454,7 +454,7 @@ export const useAppStore = create<AppState>((set) => ({
         [wsId]: (s.toolActivities[wsId] || []).map((a) =>
           a.toolUseId === toolUseId
             ? { ...a, inputJson: a.inputJson + partialJson }
-            : a
+            : a,
         ),
       },
     })),
@@ -466,7 +466,9 @@ export const useAppStore = create<AppState>((set) => ({
           wsId,
           messageCount,
           turnId: turnId ?? null,
-          existingCompletedTurnIds: (s.completedTurns[wsId] || []).map((turn) => turn.id),
+          existingCompletedTurnIds: (s.completedTurns[wsId] || []).map(
+            (turn) => turn.id,
+          ),
         });
         return {};
       }
@@ -481,7 +483,7 @@ export const useAppStore = create<AppState>((set) => ({
           summary: a.summary,
         })),
         messageCount,
-        collapsed: false,
+        collapsed: true,
         afterMessageIndex: (s.chatMessages[wsId] || []).length,
       };
       debugChat("store", "finalizeTurn", {
@@ -491,7 +493,9 @@ export const useAppStore = create<AppState>((set) => ({
         afterMessageIndex: turn.afterMessageIndex,
         toolCount: turn.activities.length,
         toolUseIds: turn.activities.map((activity) => activity.toolUseId),
-        existingCompletedTurnIds: (s.completedTurns[wsId] || []).map((existingTurn) => existingTurn.id),
+        existingCompletedTurnIds: (s.completedTurns[wsId] || []).map(
+          (existingTurn) => existingTurn.id,
+        ),
       });
       return {
         completedTurns: {
@@ -512,7 +516,10 @@ export const useAppStore = create<AppState>((set) => ({
         if (!existingTurn) return turn;
 
         const existingActivitiesById = new Map(
-          existingTurn.activities.map((activity) => [activity.toolUseId, activity])
+          existingTurn.activities.map((activity) => [
+            activity.toolUseId,
+            activity,
+          ]),
         );
 
         return {
@@ -529,7 +536,7 @@ export const useAppStore = create<AppState>((set) => ({
 
       const pendingTurns = existing.filter((turn) => !incomingIds.has(turn.id));
       const nextTurns = [...merged, ...pendingTurns].sort(
-        (a, b) => a.afterMessageIndex - b.afterMessageIndex
+        (a, b) => a.afterMessageIndex - b.afterMessageIndex,
       );
 
       debugChat("store", "hydrateCompletedTurns", {
@@ -563,7 +570,7 @@ export const useAppStore = create<AppState>((set) => ({
       completedTurns: {
         ...s.completedTurns,
         [wsId]: (s.completedTurns[wsId] || []).map((t, i) =>
-          i === turnIndex ? { ...t, collapsed: !t.collapsed } : t
+          i === turnIndex ? { ...t, collapsed: !t.collapsed } : t,
         ),
       },
     })),
@@ -625,7 +632,8 @@ export const useAppStore = create<AppState>((set) => ({
       const { [wsId]: _q, ...restQuestions } = s.agentQuestions;
       const { [wsId]: _p, ...restApprovals } = s.planApprovals;
       // Update lastMessages so workspace preview cards stay in sync.
-      const lastMsg = messages.length > 0 ? messages[messages.length - 1] : undefined;
+      const lastMsg =
+        messages.length > 0 ? messages[messages.length - 1] : undefined;
       const { [wsId]: _lm, ...restLastMessages } = s.lastMessages;
       const updatedLastMessages = lastMsg
         ? { ...s.lastMessages, [wsId]: lastMsg }
@@ -776,7 +784,7 @@ export const useAppStore = create<AppState>((set) => ({
       const newTabs: Record<string, TerminalTab[]> = {};
       for (const [wsId, tabs] of Object.entries(s.terminalTabs)) {
         newTabs[wsId] = tabs.map((tab) =>
-          tab.id === tabId ? { ...tab, pty_id: ptyId } : tab
+          tab.id === tabId ? { ...tab, pty_id: ptyId } : tab,
         );
       }
       return { terminalTabs: newTabs };
@@ -794,8 +802,7 @@ export const useAppStore = create<AppState>((set) => ({
   sidebarFilter: "all",
   repoCollapsed: {},
   fuzzyFinderOpen: false,
-  toggleSidebar: () =>
-    set((s) => ({ sidebarVisible: !s.sidebarVisible })),
+  toggleSidebar: () => set((s) => ({ sidebarVisible: !s.sidebarVisible })),
   toggleRightSidebar: () =>
     set((s) => ({ rightSidebarVisible: !s.rightSidebarVisible })),
   setRightSidebarTab: (tab) => set({ rightSidebarTab: tab }),
@@ -834,7 +841,8 @@ export const useAppStore = create<AppState>((set) => ({
   chatInputPrefill: null,
   setChatInputPrefill: (text) => set({ chatInputPrefill: text }),
   pendingAttachmentsPrefill: null,
-  setPendingAttachmentsPrefill: (atts) => set({ pendingAttachmentsPrefill: atts }),
+  setPendingAttachmentsPrefill: (atts) =>
+    set({ pendingAttachmentsPrefill: atts }),
 
   // -- Settings --
   worktreeBaseDir: "",
@@ -885,11 +893,15 @@ export const useAppStore = create<AppState>((set) => ({
       }));
       return {
         repositories: [
-          ...s.repositories.filter((r) => r.remote_connection_id !== connectionId),
+          ...s.repositories.filter(
+            (r) => r.remote_connection_id !== connectionId,
+          ),
           ...taggedRepos,
         ],
         workspaces: [
-          ...s.workspaces.filter((w) => w.remote_connection_id !== connectionId),
+          ...s.workspaces.filter(
+            (w) => w.remote_connection_id !== connectionId,
+          ),
           ...taggedWorkspaces,
         ],
       };
@@ -897,10 +909,10 @@ export const useAppStore = create<AppState>((set) => ({
   clearRemoteData: (connectionId) =>
     set((s) => ({
       repositories: s.repositories.filter(
-        (r) => r.remote_connection_id !== connectionId
+        (r) => r.remote_connection_id !== connectionId,
       ),
       workspaces: s.workspaces.filter(
-        (w) => w.remote_connection_id !== connectionId
+        (w) => w.remote_connection_id !== connectionId,
       ),
     })),
 
@@ -953,11 +965,14 @@ export const useAppStore = create<AppState>((set) => ({
     set((state) => ({
       updateAvailable: available,
       updateVersion: version,
-      updateDismissed: version === state.updateVersion ? state.updateDismissed : false,
+      updateDismissed:
+        version === state.updateVersion ? state.updateDismissed : false,
     })),
   setUpdateDismissed: (dismissed) => set({ updateDismissed: dismissed }),
-  setUpdateInstallWhenIdle: (enabled) => set({ updateInstallWhenIdle: enabled }),
-  setUpdateDownloading: (downloading) => set({ updateDownloading: downloading }),
+  setUpdateInstallWhenIdle: (enabled) =>
+    set({ updateInstallWhenIdle: enabled }),
+  setUpdateDownloading: (downloading) =>
+    set({ updateDownloading: downloading }),
   setUpdateProgress: (progress) => set({ updateProgress: progress }),
 }));
 

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -3,8 +3,20 @@ import { reconstructCompletedTurns } from "./reconstructTurns";
 import type { ChatMessage } from "../types/chat";
 import type { CompletedTurnData } from "../types/checkpoint";
 
-function makeMsg(id: string, role: "User" | "Assistant" = "Assistant"): ChatMessage {
-  return { id, workspace_id: "ws", role, content: "", cost_usd: null, duration_ms: null, created_at: "", thinking: null };
+function makeMsg(
+  id: string,
+  role: "User" | "Assistant" = "Assistant",
+): ChatMessage {
+  return {
+    id,
+    workspace_id: "ws",
+    role,
+    content: "",
+    cost_usd: null,
+    duration_ms: null,
+    created_at: "",
+    thinking: null,
+  };
 }
 
 function makeTurnData(
@@ -64,11 +76,16 @@ describe("reconstructCompletedTurns", () => {
   });
 
   it("keeps valid turns and drops invalid ones from mixed input", () => {
-    const messages = [makeMsg("m1", "User"), makeMsg("m2"), makeMsg("m3", "User"), makeMsg("m4")];
+    const messages = [
+      makeMsg("m1", "User"),
+      makeMsg("m2"),
+      makeMsg("m3", "User"),
+      makeMsg("m4"),
+    ];
     const turnData = [
-      makeTurnData("cp1", "m2", 3),       // valid — anchored to m2
-      makeTurnData("cp2", "orphaned", 2),  // invalid — message_id not in messages
-      makeTurnData("cp3", "m4", 1),        // valid — anchored to m4
+      makeTurnData("cp1", "m2", 3), // valid — anchored to m2
+      makeTurnData("cp2", "orphaned", 2), // invalid — message_id not in messages
+      makeTurnData("cp3", "m4", 1), // valid — anchored to m4
     ];
 
     const result = reconstructCompletedTurns(messages, turnData);
@@ -94,27 +111,31 @@ describe("reconstructCompletedTurns", () => {
 
   it("maps activity fields correctly", () => {
     const messages = [makeMsg("m1")];
-    const turnData: CompletedTurnData[] = [{
-      checkpoint_id: "cp1",
-      message_id: "m1",
-      turn_index: 0,
-      message_count: 5,
-      activities: [{
-        id: "act-1",
+    const turnData: CompletedTurnData[] = [
+      {
         checkpoint_id: "cp1",
-        tool_use_id: "tu-abc",
-        tool_name: "Bash",
-        input_json: '{"command":"ls"}',
-        result_text: "file.txt",
-        summary: "list files",
-        sort_order: 0,
-      }],
-    }];
+        message_id: "m1",
+        turn_index: 0,
+        message_count: 5,
+        activities: [
+          {
+            id: "act-1",
+            checkpoint_id: "cp1",
+            tool_use_id: "tu-abc",
+            tool_name: "Bash",
+            input_json: '{"command":"ls"}',
+            result_text: "file.txt",
+            summary: "list files",
+            sort_order: 0,
+          },
+        ],
+      },
+    ];
 
     const result = reconstructCompletedTurns(messages, turnData);
 
     expect(result[0].messageCount).toBe(5);
-    expect(result[0].collapsed).toBe(false);
+    expect(result[0].collapsed).toBe(true);
     const act = result[0].activities[0];
     expect(act.toolUseId).toBe("tu-abc");
     expect(act.toolName).toBe("Bash");

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -43,7 +43,7 @@ export function reconstructCompletedTurns(
           summary: a.summary,
         })),
         messageCount: td.message_count,
-        collapsed: false,
+        collapsed: true,
         afterMessageIndex,
       };
     });


### PR DESCRIPTION
## Summary
- Completed turn summaries now default to **collapsed** instead of expanded
- Fixes both `finalizeTurn` (live sessions) and `reconstructCompletedTurns` (reloaded sessions)
- Users can still click any turn summary to expand and view tool call details

Previously, when a session ended or was reloaded, the full tool call list would render expanded, pushing the agent's actual response out of view and requiring scrolling.

Relates to #183

## Test plan
- [x] Existing tests updated and passing
- [x] TypeScript type check clean
- [x] Rust clippy clean
- [x] Manual: start a session, let agent run several tool calls, verify turn summaries appear collapsed
- [x] Manual: reload a session from history, verify turns load collapsed
- [x] Manual: click a collapsed turn summary to expand — verify toggle still works