### PR TITLE
fix(ci): use PR with auto-merge for Nix FOD hash updates

### DIFF
--- a/.github/workflows/update-frontend-hash.yml
+++ b/.github/workflows/update-frontend-hash.yml
@@ -8,8 +8,8 @@ name: Nix
 # claudette-server) use crane, which takes source as a regular input
 # with no hardcoded output hash.
 #
-# The path filter also prevents an infinite loop — the auto-commit
-# only touches flake.nix, not src/ui/.
+# The path filter also prevents an infinite loop — the squash-merged
+# PR only touches flake.nix, not src/ui/.
 #
 # NOTE: if `nix flake update` bumps the bun package version, the
 # hashes will also drift.  Add 'flake.lock' to the paths list below
@@ -27,6 +27,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   hash-linux:
@@ -132,16 +133,36 @@ jobs:
           perl -i -pe "s|\Q$CURRENT_LINUX\E|$NEW_LINUX|" flake.nix
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push
+      - name: Create or update PR
         if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="chore/update-frontend-fod-hashes"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add flake.nix
-          git diff --cached --quiet && exit 0
-          git stash
-          git pull --rebase origin main
-          git stash pop
+
+          # Close any stale hash-update PR from a previous run
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr close "$EXISTING_PR" --delete-branch || true
+          fi
+
+          git checkout -b "$BRANCH"
           git add flake.nix
           git commit -m "chore(nix): update frontend FOD hashes"
-          git push
+          git push --force-with-lease origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --title "chore(nix): update frontend FOD hashes" \
+            --body "$(cat <<'EOF'
+          Automated update of the Nix frontend fixed-output derivation hashes.
+
+          Triggered by changes to `src/ui/` on `main`. Auto-merges once required status checks pass.
+          EOF
+          )" \
+            --head "$BRANCH" \
+            --base main)
+
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

- The Nix `update-frontend-hash` workflow was pushing directly to `main`, which is rejected by the branch ruleset requiring `Format` and `Test` status checks to pass
- Changed the workflow to create a PR (`chore/update-frontend-fod-hashes`) with auto-merge enabled instead of direct push
- Added `pull-requests: write` permission so the workflow can create PRs and enable auto-merge
- Stale hash-update PRs from previous runs are closed before creating a new one

Also enabled auto-merge on the repository (was previously disabled).

## Test plan

- [ ] Merge this PR
- [ ] Push a change to `src/ui/` on `main` to trigger the Nix workflow
- [ ] Verify the workflow creates a PR instead of pushing directly
- [ ] Verify the PR auto-merges after CI passes