### PR TITLE
ci(nix): add workflow_dispatch trigger for manual runs

### DIFF
--- a/.github/workflows/update-frontend-hash.yml
+++ b/.github/workflows/update-frontend-hash.yml
@@ -20,6 +20,7 @@ on:
     branches: [main]
     paths:
       - 'src/ui/**'
+  workflow_dispatch:
 
 concurrency:
   group: update-frontend-hash


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Nix hash update workflow so it can be manually triggered from the Actions tab or via `gh workflow run`

## Test plan

- [ ] Merge this PR
- [ ] Run `gh workflow run update-frontend-hash.yml` to trigger manually
- [ ] Verify the workflow creates a PR with auto-merge