### PR TITLE
fix(terminal): overhaul lifecycle, keybindings, and focus flow

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -235,3 +235,134 @@ pub async fn close_pty(pty_id: u64, state: State<'_, AppState>) -> Result<(), St
     }
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Smoke tests
+//
+// The Tauri-wrapped `spawn_pty` / `write_pty` / `close_pty` commands require
+// an `AppHandle` and `State<AppState>` which are awkward to wire up in unit
+// tests. These tests exercise the exact `portable_pty` integration used by
+// `spawn_pty` (open master/slave, spawn_command, try_clone_reader,
+// take_writer, kill child) against `/bin/sh`, so a regression in the PTY
+// bring-up path gets caught in CI even without a full Tauri harness.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+    use std::io::Read;
+    use std::time::{Duration, Instant};
+
+    fn open_sh() -> (
+        Box<dyn portable_pty::MasterPty + Send>,
+        Box<dyn portable_pty::Child + Send>,
+        Box<dyn Read + Send>,
+    ) {
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty should succeed");
+
+        // A short-lived `sh` command that prints a known string and exits. We
+        // avoid an interactive shell so the test can't hang on a missing rc
+        // file or waiting for a prompt.
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.args(["-c", "printf claudette-pty-ok"]);
+        cmd.env("CLAUDETTE_PTY", "1");
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .expect("spawn_command should succeed");
+
+        drop(pair.slave);
+
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .expect("try_clone_reader should succeed");
+
+        (pair.master, child, reader)
+    }
+
+    /// Drain the reader with a wall-clock deadline so the test cannot hang
+    /// even if the PTY somehow stays open forever.
+    fn read_with_deadline(mut reader: Box<dyn Read + Send>, deadline: Duration) -> Vec<u8> {
+        let end = Instant::now() + deadline;
+        let mut out = Vec::with_capacity(64);
+        let mut buf = [0u8; 256];
+        while Instant::now() < end {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&buf[..n]),
+                Err(_) => break,
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn pty_spawn_emits_expected_output() {
+        let (master, mut child, reader) = open_sh();
+
+        // Read until the child prints its payload and closes the PTY.
+        let bytes = read_with_deadline(reader, Duration::from_secs(5));
+
+        // The child exits on its own; make sure we reap it rather than leave
+        // a zombie hanging around.
+        let _ = child.wait();
+        drop(master);
+
+        let s = String::from_utf8_lossy(&bytes);
+        assert!(
+            s.contains("claudette-pty-ok"),
+            "expected PTY output to contain marker, got: {s:?}"
+        );
+    }
+
+    #[test]
+    fn pty_child_kill_terminates_process() {
+        // Spawn a shell that would run indefinitely, then kill it the same
+        // way `close_pty` does (`child.kill()` on the boxed portable_pty
+        // Child). Verifies the kill path works against a live PTY child.
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty should succeed");
+
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.args(["-c", "sleep 30"]);
+
+        let mut child = pair
+            .slave
+            .spawn_command(cmd)
+            .expect("spawn_command should succeed");
+        drop(pair.slave);
+
+        let pid = child
+            .process_id()
+            .expect("child should expose a pid on unix");
+
+        // SAFETY: kill(pid, 0) is a standard existence check.
+        let alive_before = unsafe { libc::kill(pid as i32, 0) == 0 };
+        assert!(alive_before, "child should be alive before kill");
+
+        child.kill().expect("kill should succeed");
+        let _ = child.wait();
+
+        // Give the OS a moment to update the process table.
+        std::thread::sleep(Duration::from_millis(50));
+        let alive_after = unsafe { libc::kill(pid as i32, 0) == 0 };
+        assert!(!alive_after, "child should be dead after kill");
+    }
+}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1820,6 +1820,10 @@ function ChatInputArea({
       )}
       <textarea
         ref={textareaRef}
+        // data-chat-input is the stable selector used by the global focus
+        // shortcuts (Cmd+` and Cmd+0) in useKeyboardShortcuts.ts to move
+        // focus into the prompt from anywhere in the app.
+        data-chat-input
         className={`${styles.input}${planMode ? ` ${styles.inputPlanMode}` : ""}`}
         value={chatInput}
         onChange={(e) => {

--- a/src/ui/src/components/layout/AppLayout.module.css
+++ b/src/ui/src/components/layout/AppLayout.module.css
@@ -64,3 +64,12 @@
   color: var(--text-dim);
   font-size: 14px;
 }
+
+/*
+  Used to hide the terminal panel + its resize handle without unmounting them.
+  Unmounting would destroy xterm instances and kill PTY children; we want
+  the shells to keep running while the panel is collapsed.
+*/
+.hidden {
+  display: none !important;
+}

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -102,21 +102,31 @@ export function AppLayout() {
                   <Dashboard />
                 )}
               </div>
-              {terminalPanelVisible && selectedWorkspaceId && (
-                <>
-                  <ResizeHandle
-                    direction="vertical"
-                    targetRef={mainRef}
-                    cssVar="--terminal-h"
-                    min={100}
-                    max={800}
-                    invert
-                    onResizeEnd={handleTerminalResizeEnd}
-                  />
-                  <div className={styles.terminal}>
-                    <TerminalPanel />
-                  </div>
-                </>
+              {/*
+                Always mount the terminal panel when a workspace is selected;
+                drive visibility via a CSS class. Unmounting on collapse would
+                dispose every xterm instance and kill every PTY child —
+                toggling the panel must NOT destroy running shells.
+                The ResizeHandle has no state worth preserving and is only
+                useful when the panel is visible, so we conditionally render it.
+              */}
+              {selectedWorkspaceId && terminalPanelVisible && (
+                <ResizeHandle
+                  direction="vertical"
+                  targetRef={mainRef}
+                  cssVar="--terminal-h"
+                  min={100}
+                  max={800}
+                  invert
+                  onResizeEnd={handleTerminalResizeEnd}
+                />
+              )}
+              {selectedWorkspaceId && (
+                <div
+                  className={`${styles.terminal} ${terminalPanelVisible ? "" : styles.hidden}`}
+                >
+                  <TerminalPanel />
+                </div>
               )}
             </div>
             {rightSidebarVisible && selectedWorkspaceId && (

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -99,4 +99,51 @@
   flex: 1;
   overflow: hidden;
   background: var(--terminal-bg);
+  position: relative;
+}
+
+.spawnError {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--error-bg, rgba(180, 60, 60, 0.18));
+  border: 1px solid var(--error-border, rgba(180, 60, 60, 0.55));
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.spawnErrorTitle {
+  font-weight: 600;
+}
+
+.spawnErrorMessage {
+  opacity: 0.85;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.spawnErrorRetry {
+  margin-top: 2px;
+  padding: 4px 10px;
+  background: var(--accent-primary);
+  color: var(--bg-primary, #000);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  transition: opacity var(--transition-fast);
+}
+
+.spawnErrorRetry:hover {
+  opacity: 0.85;
 }

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -52,6 +52,19 @@ function safeFitRaw(container: HTMLElement, fit: FitAddon) {
   if (container.clientHeight > 0 && container.clientWidth > 0) fit.fit();
 }
 
+// `closePty` is a Tauri invoke that returns a Promise<void>. Teardown
+// paths don't await it (we don't want close to block tab-switching or
+// unmount), so we need a centralized error sink; otherwise a failed close
+// would surface as an unhandled promise rejection in the webview console.
+// Failures here are best-effort by design — if the backend has already
+// dropped the PTY (e.g. child exited, state race), there's nothing more
+// we can do from the frontend.
+function closePtyBestEffort(ptyId: number) {
+  void closePty(ptyId).catch((err) => {
+    console.error(`Failed to close PTY ${ptyId} during teardown:`, err);
+  });
+}
+
 export const TerminalPanel = memo(function TerminalPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -109,7 +122,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
     inst.resizeObserver.disconnect();
     inst.term.dispose();
     if (inst.unlisten) inst.unlisten();
-    if (inst.ptyId >= 0) closePty(inst.ptyId);
+    if (inst.ptyId >= 0) closePtyBestEffort(inst.ptyId);
     inst.container.remove();
     instancesRef.current.delete(tabId);
   }, []);
@@ -152,9 +165,14 @@ export const TerminalPanel = memo(function TerminalPanel() {
     listTerminalTabs(wsId).then(async (t) => {
       if (t.length > 0) {
         setTerminalTabs(wsId, t);
-        // Only initialize this workspace's active tab if it has none.
+        // Initialize this workspace's active tab if it has none, OR if the
+        // stored active id is stale (the tab was deleted elsewhere — e.g.
+        // another app instance, or a DB cascade we weren't notified of).
+        // Otherwise the visibility effect would show no tab at all.
         const currentActive = useAppStore.getState().activeTerminalTabId[wsId];
-        if (currentActive == null) {
+        const activeStillValid =
+          currentActive != null && t.some((tab) => tab.id === currentActive);
+        if (!activeStillValid) {
           setActiveTerminalTab(wsId, t[0].id);
         }
       } else if (autoCreatedRef.current !== wsId) {
@@ -255,7 +273,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
           const ptyId = await spawnPty(worktreePath);
           const inst = instancesRef.current.get(tabId);
           if (!inst) {
-            closePty(ptyId);
+            closePtyBestEffort(ptyId);
             return;
           }
           inst.ptyId = ptyId;
@@ -273,7 +291,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
           const stillExists = instancesRef.current.get(tabId);
           if (!stillExists || stillExists !== inst) {
             unlistenFn();
-            closePty(ptyId);
+            closePtyBestEffort(ptyId);
             return;
           }
           inst.unlisten = unlistenFn;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -14,6 +14,11 @@ import {
   resizePty,
   closePty,
 } from "../../services/tauri";
+import { cycleTabId, terminalKeyAction } from "./terminalShortcuts";
+import {
+  focusActiveTerminal,
+  focusChatPrompt,
+} from "../../utils/focusTargets";
 import "@xterm/xterm/css/xterm.css";
 import styles from "./TerminalPanel.module.css";
 
@@ -30,174 +35,284 @@ interface TermInstance {
   container: HTMLDivElement;
   resizeObserver: ResizeObserver;
   fitTimer: ReturnType<typeof setTimeout> | null;
+  workspaceId: string;
+  worktreePath: string;
+}
+
+// Fit xterm only when its container has real dimensions. A hidden container
+// (display: none on the panel, or an inactive tab) has clientHeight === 0,
+// and calling fit() against it throws inside xterm.
+function safeFit(inst: TermInstance) {
+  if (inst.container.clientHeight > 0 && inst.container.clientWidth > 0) {
+    inst.fit.fit();
+  }
+}
+
+function safeFitRaw(container: HTMLElement, fit: FitAddon) {
+  if (container.clientHeight > 0 && container.clientWidth > 0) fit.fit();
 }
 
 export const TerminalPanel = memo(function TerminalPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
   const terminalTabs = useAppStore((s) => s.terminalTabs);
-  const activeTerminalTabId = useAppStore((s) => s.activeTerminalTabId);
+  // Workspace-scoped active tab. Read through the selector so each workspace
+  // preserves its own active tab independently.
+  const activeTerminalTabId = useAppStore((s) =>
+    s.selectedWorkspaceId ? s.activeTerminalTabId[s.selectedWorkspaceId] ?? null : null,
+  );
   const setTerminalTabs = useAppStore((s) => s.setTerminalTabs);
   const addTerminalTab = useAppStore((s) => s.addTerminalTab);
   const removeTerminalTab = useAppStore((s) => s.removeTerminalTab);
   const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
+  const terminalPanelVisible = useAppStore((s) => s.terminalPanelVisible);
   const terminalFontSize = useAppStore((s) => s.terminalFontSize);
   const currentThemeId = useAppStore((s) => s.currentThemeId);
   const updateTerminalTabPtyId = useAppStore((s) => s.updateTerminalTabPtyId);
 
   const autoCreatedRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  // Map of tab ID → terminal instance. Persists across tab switches.
+  // Map of tab ID → terminal instance. Persists across tab switches AND
+  // across terminal-panel collapse/restore (the panel no longer unmounts).
   const instancesRef = useRef<Map<number, TermInstance>>(new Map());
+  // Per-tab spawn-error messages; UI-only, ephemeral — not persisted.
+  const [spawnErrors, setSpawnErrors] = useState<Record<number, string>>({});
+
+  // Keep a live ref to the tabs-by-workspace map so the stable xterm key
+  // handler can read the latest value without being re-created per render.
+  const terminalTabsRef = useRef(terminalTabs);
+  useEffect(() => {
+    terminalTabsRef.current = terminalTabs;
+  }, [terminalTabs]);
+  const selectedWorkspaceIdRef = useRef(selectedWorkspaceId);
+  useEffect(() => {
+    selectedWorkspaceIdRef.current = selectedWorkspaceId;
+  }, [selectedWorkspaceId]);
+  const activeTerminalTabIdRef = useRef(activeTerminalTabId);
+  useEffect(() => {
+    activeTerminalTabIdRef.current = activeTerminalTabId;
+  }, [activeTerminalTabId]);
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const tabs = useMemo(
     () => (selectedWorkspaceId ? terminalTabs[selectedWorkspaceId] ?? [] : []),
-    [selectedWorkspaceId, terminalTabs]
+    [selectedWorkspaceId, terminalTabs],
   );
 
-  // Load terminal tabs on workspace change; auto-create one if none exist.
+  // Destroy a single instance: dispose xterm, unlisten, close PTY, detach DOM.
+  // Used by per-tab close AND by the tabs-no-longer-exist cleanup effect.
+  const destroyInstance = useCallback((tabId: number) => {
+    const inst = instancesRef.current.get(tabId);
+    if (!inst) return;
+    if (inst.fitTimer) clearTimeout(inst.fitTimer);
+    inst.resizeObserver.disconnect();
+    inst.term.dispose();
+    if (inst.unlisten) inst.unlisten();
+    if (inst.ptyId >= 0) closePty(inst.ptyId);
+    inst.container.remove();
+    instancesRef.current.delete(tabId);
+  }, []);
+
+  const handleCreateTab = useCallback(async () => {
+    const wsId = selectedWorkspaceIdRef.current;
+    if (!wsId) return;
+    try {
+      const tab = await createTerminalTab(wsId);
+      addTerminalTab(wsId, tab);
+    } catch (err) {
+      console.error("Failed to create terminal tab:", err);
+    }
+  }, [addTerminalTab]);
+
+  const cycleActiveTab = useCallback(
+    (offset: 1 | -1) => {
+      const wsId = selectedWorkspaceIdRef.current;
+      if (!wsId) return;
+      const wsTabs = terminalTabsRef.current[wsId] ?? [];
+      const tabIds = wsTabs.map((t) => t.id);
+      const nextId = cycleTabId(tabIds, activeTerminalTabIdRef.current, offset);
+      if (nextId !== null) setActiveTerminalTab(wsId, nextId);
+    },
+    [setActiveTerminalTab],
+  );
+
+  // Load terminal tabs on workspace change. Only auto-create when the
+  // workspace has zero tabs, and only set an active tab when the workspace
+  // doesn't already have one — respect prior selection within each workspace.
   useEffect(() => {
     if (!selectedWorkspaceId) return;
-    listTerminalTabs(selectedWorkspaceId).then(async (t) => {
+    const wsId = selectedWorkspaceId;
+    listTerminalTabs(wsId).then(async (t) => {
       if (t.length > 0) {
-        setTerminalTabs(selectedWorkspaceId, t);
-        if (!activeTerminalTabId) {
-          setActiveTerminalTab(t[0].id);
+        setTerminalTabs(wsId, t);
+        // Only initialize this workspace's active tab if it has none.
+        const currentActive = useAppStore.getState().activeTerminalTabId[wsId];
+        if (currentActive == null) {
+          setActiveTerminalTab(wsId, t[0].id);
         }
-      } else if (autoCreatedRef.current !== selectedWorkspaceId) {
-        autoCreatedRef.current = selectedWorkspaceId;
+      } else if (autoCreatedRef.current !== wsId) {
+        autoCreatedRef.current = wsId;
         try {
-          const tab = await createTerminalTab(selectedWorkspaceId);
-          addTerminalTab(selectedWorkspaceId, tab);
+          const tab = await createTerminalTab(wsId);
+          addTerminalTab(wsId, tab);
         } catch {
           autoCreatedRef.current = null;
         }
       }
     });
-  }, [
-    selectedWorkspaceId,
-    setTerminalTabs,
-    setActiveTerminalTab,
-    addTerminalTab,
-    activeTerminalTabId,
-  ]);
+  }, [selectedWorkspaceId, setTerminalTabs, setActiveTerminalTab, addTerminalTab]);
 
-  // Ensure activeTerminalTabId belongs to the current workspace.
-  useEffect(() => {
-    if (!selectedWorkspaceId || tabs.length === 0) return;
-    const tabIds = tabs.map((t) => t.id);
-    if (activeTerminalTabId && !tabIds.includes(activeTerminalTabId)) {
-      setActiveTerminalTab(tabs[0].id);
-    }
-  }, [selectedWorkspaceId, tabs, activeTerminalTabId, setActiveTerminalTab]);
+  // Create the xterm instance for the active tab, spawn the PTY, wire I/O.
+  // Extracted as a function so we can re-run it from the spawn-error Retry
+  // button without tearing down and recreating the whole component.
+  const initializeTab = useCallback(
+    (tabId: number, worktreePath: string, workspaceId: string) => {
+      if (!containerRef.current) return;
+      if (instancesRef.current.has(tabId)) return;
 
-  // Create a terminal instance for a tab if it doesn't exist yet.
-  useEffect(() => {
-    if (
-      !containerRef.current ||
-      !ws?.worktree_path ||
-      !activeTerminalTabId ||
-      instancesRef.current.has(activeTerminalTabId)
-    ) {
-      return;
-    }
+      const tabContainer = document.createElement("div");
+      tabContainer.style.height = "100%";
+      tabContainer.style.width = "100%";
+      containerRef.current.appendChild(tabContainer);
 
-    const tabContainer = document.createElement("div");
-    tabContainer.style.height = "100%";
-    tabContainer.style.width = "100%";
-    containerRef.current.appendChild(tabContainer);
+      const term = new Terminal({
+        fontSize: terminalFontSize,
+        fontFamily: "monospace",
+        theme: getTerminalTheme(),
+      });
+      const fit = new FitAddon();
+      const links = new WebLinksAddon();
+      term.loadAddon(fit);
+      term.loadAddon(links);
 
-    const term = new Terminal({
-      fontSize: terminalFontSize,
-      fontFamily: "monospace",
-      theme: getTerminalTheme(),
-    });
-    const fit = new FitAddon();
-    const links = new WebLinksAddon();
-    term.loadAddon(fit);
-    term.loadAddon(links);
-    term.open(tabContainer);
-    fit.fit();
-
-    const instance: TermInstance = {
-      term,
-      fit,
-      ptyId: -1,
-      unlisten: null,
-      container: tabContainer,
-      fitTimer: null,
-      resizeObserver: new ResizeObserver(() => {
-        if (instance.fitTimer) clearTimeout(instance.fitTimer);
-        instance.fitTimer = setTimeout(() => fit.fit(), 150);
-      }),
-    };
-    instance.resizeObserver.observe(tabContainer);
-    instancesRef.current.set(activeTerminalTabId, instance);
-
-    const currentTabId = activeTerminalTabId;
-    const worktreePath = ws.worktree_path!;
-
-    (async () => {
-      try {
-        const ptyId = await spawnPty(worktreePath);
-        // Re-check: instance may have been removed during await.
-        const inst = instancesRef.current.get(currentTabId);
-        if (!inst) {
-          closePty(ptyId);
-          return;
+      // Intercept terminal-scoped hotkeys BEFORE xterm forwards the key to
+      // the PTY. Returning false from this handler tells xterm not to send
+      // bytes, and stopImmediatePropagation prevents the window-level
+      // handler in useKeyboardShortcuts.ts from ALSO firing (which would
+      // otherwise cycle workspaces on Cmd+Shift+[/]).
+      term.attachCustomKeyEventHandler((ev) => {
+        const action = terminalKeyAction(ev);
+        if (!action) return true;
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        if (action.kind === "cycle") {
+          cycleActiveTab(action.direction === "next" ? 1 : -1);
+        } else if (action.kind === "new-tab") {
+          void handleCreateTab();
+        } else if (action.kind === "toggle-panel") {
+          // Cmd+` — hide panel and move focus to the chat prompt. The
+          // shells keep running (the panel is CSS-hidden, not unmounted).
+          useAppStore.getState().toggleTerminalPanel();
+          requestAnimationFrame(() => {
+            const visible = useAppStore.getState().terminalPanelVisible;
+            if (visible) focusActiveTerminal();
+            else focusChatPrompt();
+          });
+        } else if (action.kind === "focus-chat") {
+          // Cmd+0 — focus the chat prompt; leave the terminal visible.
+          focusChatPrompt();
         }
-        inst.ptyId = ptyId;
+        return false;
+      });
 
-        // Store pty_id on the tab so we can map command events back to workspaces
-        updateTerminalTabPtyId(currentTabId, ptyId);
+      term.open(tabContainer);
+      safeFitRaw(tabContainer, fit);
 
-        const unlistenFn = await listen<PtyOutputPayload>(
-          "pty-output",
-          (event) => {
-            if (event.payload.pty_id === ptyId) {
-              term.write(new Uint8Array(event.payload.data));
-            }
+      const instance: TermInstance = {
+        term,
+        fit,
+        ptyId: -1,
+        unlisten: null,
+        container: tabContainer,
+        fitTimer: null,
+        workspaceId,
+        worktreePath,
+        // The observer debounces resizes to 150ms and skips fits when the
+        // container has no real dimensions (e.g. the panel is hidden).
+        resizeObserver: new ResizeObserver(() => {
+          if (instance.fitTimer) clearTimeout(instance.fitTimer);
+          instance.fitTimer = setTimeout(() => safeFit(instance), 150);
+        }),
+      };
+      instance.resizeObserver.observe(tabContainer);
+      instancesRef.current.set(tabId, instance);
+
+      (async () => {
+        try {
+          const ptyId = await spawnPty(worktreePath);
+          const inst = instancesRef.current.get(tabId);
+          if (!inst) {
+            closePty(ptyId);
+            return;
           }
-        );
-        // Re-check again: instance may have been removed during listen await.
-        const stillExists = instancesRef.current.get(currentTabId);
-        if (!stillExists || stillExists !== inst) {
-          unlistenFn();
-          closePty(ptyId);
-          return;
+          inst.ptyId = ptyId;
+
+          updateTerminalTabPtyId(tabId, ptyId);
+
+          const unlistenFn = await listen<PtyOutputPayload>(
+            "pty-output",
+            (event) => {
+              if (event.payload.pty_id === ptyId) {
+                term.write(new Uint8Array(event.payload.data));
+              }
+            },
+          );
+          const stillExists = instancesRef.current.get(tabId);
+          if (!stillExists || stillExists !== inst) {
+            unlistenFn();
+            closePty(ptyId);
+            return;
+          }
+          inst.unlisten = unlistenFn;
+
+          term.onData((data) => {
+            const bytes = Array.from(new TextEncoder().encode(data));
+            writePty(ptyId, bytes);
+          });
+
+          term.onResize(({ cols, rows }) => {
+            resizePty(ptyId, cols, rows);
+          });
+
+          safeFit(inst);
+          resizePty(ptyId, term.cols, term.rows);
+        } catch (e) {
+          // Keep the tab around (don't delete the user's tab just because
+          // spawn failed); surface the error inline with a Retry button.
+          console.error("Failed to initialize terminal:", e);
+          destroyInstance(tabId);
+          setSpawnErrors((prev) => ({
+            ...prev,
+            [tabId]: e instanceof Error ? e.message : String(e),
+          }));
         }
-        inst.unlisten = unlistenFn;
+      })();
+    },
+    [
+      cycleActiveTab,
+      destroyInstance,
+      handleCreateTab,
+      terminalFontSize,
+      updateTerminalTabPtyId,
+    ],
+  );
 
-        term.onData((data) => {
-          const bytes = Array.from(new TextEncoder().encode(data));
-          writePty(ptyId, bytes);
-        });
-
-        term.onResize(({ cols, rows }) => {
-          resizePty(ptyId, cols, rows);
-        });
-
-        fit.fit();
-        resizePty(ptyId, term.cols, term.rows);
-      } catch (e) {
-        // Setup failed — clean up the orphaned instance.
-        console.error("Failed to initialize terminal:", e);
-        const inst = instancesRef.current.get(currentTabId);
-        if (inst) {
-          if (inst.fitTimer) clearTimeout(inst.fitTimer);
-          inst.resizeObserver.disconnect();
-          inst.term.dispose();
-          inst.container.remove();
-          instancesRef.current.delete(currentTabId);
-        }
-      }
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTerminalTabId, ws?.worktree_path]);
+  // Spawn instances as tabs become active. Unlike before, this does NOT run
+  // when the panel is toggled (the panel doesn't unmount anymore), so the
+  // xterm + PTY only get set up once per tab, and survive collapse/restore.
+  useEffect(() => {
+    if (!containerRef.current || !ws?.worktree_path || !activeTerminalTabId) return;
+    if (instancesRef.current.has(activeTerminalTabId)) return;
+    // Don't re-spawn tabs that have an active spawn error banner — the user
+    // must click Retry, which clears the error and calls us again.
+    if (spawnErrors[activeTerminalTabId]) return;
+    initializeTab(activeTerminalTabId, ws.worktree_path, ws.id);
+  }, [activeTerminalTabId, ws?.worktree_path, ws?.id, initializeTab, spawnErrors]);
 
   // Show/hide terminal containers based on active tab and selected workspace.
+  // Instances for non-current workspaces stay in the DOM (display: none) so
+  // their shells keep running while the user is elsewhere in the app.
   useEffect(() => {
     const currentWorkspaceTabIds = new Set(tabs.map((t) => t.id));
     for (const [tabId, inst] of instancesRef.current) {
@@ -205,17 +320,35 @@ export const TerminalPanel = memo(function TerminalPanel() {
       const isActive = tabId === activeTerminalTabId && belongsToCurrentWorkspace;
       inst.container.style.display = isActive ? "block" : "none";
       if (isActive) {
-        inst.fit.fit();
+        safeFit(inst);
         inst.term.focus();
       }
     }
   }, [activeTerminalTabId, tabs]);
 
+  // Re-fit the active instance when the panel transitions hidden → visible.
+  // xterm doesn't know the container grew from 0×0 to real dimensions, so
+  // without this the terminal keeps its old (possibly 80×24) geometry.
+  useEffect(() => {
+    if (!terminalPanelVisible || !activeTerminalTabId) return;
+    const inst = instancesRef.current.get(activeTerminalTabId);
+    if (!inst) return;
+    // Run after layout so clientHeight reflects the restored panel.
+    const id = requestAnimationFrame(() => {
+      safeFit(inst);
+      if (inst.ptyId >= 0) {
+        resizePty(inst.ptyId, inst.term.cols, inst.term.rows);
+      }
+      inst.term.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [terminalPanelVisible, activeTerminalTabId]);
+
   // Update font size on all instances without destroying them.
   useEffect(() => {
     for (const inst of instancesRef.current.values()) {
       inst.term.options.fontSize = terminalFontSize;
-      inst.fit.fit();
+      safeFit(inst);
     }
   }, [terminalFontSize]);
 
@@ -227,70 +360,68 @@ export const TerminalPanel = memo(function TerminalPanel() {
     }
   }, [currentThemeId]);
 
-  // Cleanup instances for tabs that no longer exist in any workspace.
+  // Cleanup instances for tabs that no longer exist in any workspace. This
+  // covers BOTH per-tab close (removeTerminalTab) AND workspace deletion
+  // (removeWorkspace / removeRepository in the store drops the workspace's
+  // `terminalTabs` entry, which removes all its tab ids from this set).
   useEffect(() => {
     const allTabIds = new Set(
-      Object.values(terminalTabs).flatMap((tabs) => tabs.map((t) => t.id))
+      Object.values(terminalTabs).flatMap((wsTabs) => wsTabs.map((t) => t.id)),
     );
-    for (const [tabId, inst] of instancesRef.current) {
-      if (!allTabIds.has(tabId)) {
-        if (inst.fitTimer) clearTimeout(inst.fitTimer);
-        inst.resizeObserver.disconnect();
-        inst.term.dispose();
-        if (inst.unlisten) inst.unlisten();
-        if (inst.ptyId >= 0) closePty(inst.ptyId);
-        inst.container.remove();
-        instancesRef.current.delete(tabId);
-      }
+    // Snapshot keys — destroyInstance mutates the map.
+    for (const tabId of [...instancesRef.current.keys()]) {
+      if (!allTabIds.has(tabId)) destroyInstance(tabId);
     }
-  }, [terminalTabs]);
+    // Also clear any spawn-error entries for tabs that have disappeared.
+    setSpawnErrors((prev) => {
+      const next: Record<number, string> = {};
+      let changed = false;
+      for (const [idStr, msg] of Object.entries(prev)) {
+        const id = Number(idStr);
+        if (allTabIds.has(id)) next[id] = msg;
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [terminalTabs, destroyInstance]);
 
-  // Cleanup all instances on component unmount only.
+  // Cleanup all instances on component unmount only. Snapshot the keys first
+  // because `destroyInstance` mutates the map during iteration.
   useEffect(() => {
+    const instances = instancesRef.current;
     return () => {
-      for (const inst of instancesRef.current.values()) {
-        if (inst.fitTimer) clearTimeout(inst.fitTimer);
-        inst.resizeObserver.disconnect();
-        inst.term.dispose();
-        if (inst.unlisten) inst.unlisten();
-        if (inst.ptyId >= 0) closePty(inst.ptyId);
-        inst.container.remove();
-      }
-      instancesRef.current.clear();
+      for (const tabId of [...instances.keys()]) destroyInstance(tabId);
+      instances.clear();
     };
-  }, []);
-
-  const handleCreateTab = useCallback(async () => {
-    if (!selectedWorkspaceId) return;
-    try {
-      const tab = await createTerminalTab(selectedWorkspaceId);
-      addTerminalTab(selectedWorkspaceId, tab);
-    } catch {
-      // ignore
-    }
-  }, [selectedWorkspaceId, addTerminalTab]);
+  }, [destroyInstance]);
 
   const handleCloseTab = useCallback(
     async (tabId: number) => {
       if (!selectedWorkspaceId) return;
-      // Destroy the instance for this tab.
-      const inst = instancesRef.current.get(tabId);
-      if (inst) {
-        inst.resizeObserver.disconnect();
-        inst.term.dispose();
-        if (inst.unlisten) inst.unlisten();
-        if (inst.ptyId >= 0) closePty(inst.ptyId);
-        inst.container.remove();
-        instancesRef.current.delete(tabId);
-      }
+      destroyInstance(tabId);
       try {
         await deleteTerminalTab(tabId);
         removeTerminalTab(selectedWorkspaceId, tabId);
-      } catch {
-        // ignore
+      } catch (err) {
+        console.error("Failed to close terminal tab:", err);
       }
     },
-    [selectedWorkspaceId, removeTerminalTab]
+    [selectedWorkspaceId, removeTerminalTab, destroyInstance],
+  );
+
+  const handleRetrySpawn = useCallback(
+    (tabId: number) => {
+      if (!ws?.worktree_path || !selectedWorkspaceId) return;
+      setSpawnErrors((prev) => {
+        const { [tabId]: _removed, ...rest } = prev;
+        return rest;
+      });
+      // Call directly; the spawn effect will also re-run because
+      // `spawnErrors[tabId]` just cleared, but initializeTab is idempotent
+      // (it bails if an instance already exists).
+      initializeTab(tabId, ws.worktree_path, selectedWorkspaceId);
+    },
+    [ws?.worktree_path, selectedWorkspaceId, initializeTab],
   );
 
   return (
@@ -300,7 +431,9 @@ export const TerminalPanel = memo(function TerminalPanel() {
           <div
             key={tab.id}
             className={`${styles.tab} ${activeTerminalTabId === tab.id ? styles.tabActive : ""}`}
-            onClick={() => setActiveTerminalTab(tab.id)}
+            onClick={() =>
+              selectedWorkspaceId && setActiveTerminalTab(selectedWorkspaceId, tab.id)
+            }
           >
             <span className={styles.tabTitle}>{tab.title}</span>
             <button
@@ -322,7 +455,23 @@ export const TerminalPanel = memo(function TerminalPanel() {
           −
         </button>
       </div>
-      <div className={styles.termContainer} ref={containerRef} />
+      <div className={styles.termContainer} ref={containerRef}>
+        {activeTerminalTabId !== null && spawnErrors[activeTerminalTabId] && (
+          <div className={styles.spawnError} role="alert">
+            <div className={styles.spawnErrorTitle}>Failed to start shell</div>
+            <div className={styles.spawnErrorMessage}>
+              {spawnErrors[activeTerminalTabId]}
+            </div>
+            <button
+              className={styles.spawnErrorRetry}
+              onClick={() => handleRetrySpawn(activeTerminalTabId)}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 });
+

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -137,11 +137,17 @@ export const TerminalPanel = memo(function TerminalPanel() {
     [setActiveTerminalTab],
   );
 
-  // Load terminal tabs on workspace change. Only auto-create when the
-  // workspace has zero tabs, and only set an active tab when the workspace
-  // doesn't already have one — respect prior selection within each workspace.
+  // Load terminal tabs on workspace change — but ONLY while the panel is
+  // visible. Skipping this while hidden preserves two important properties:
+  //   1. Selecting a workspace the user explicitly collapsed the panel on
+  //      doesn't auto-create a tab, which would flip terminalPanelVisible
+  //      back to true via addTerminalTab and reopen the panel uninvited.
+  //   2. DB-backed tab creation (and future remote-workspace failures) is
+  //      deferred until the user actually wants a terminal.
+  // When the user later opens the panel, this effect re-runs (terminalPanel-
+  // Visible is in its deps) and bootstraps the workspace's tabs on demand.
   useEffect(() => {
-    if (!selectedWorkspaceId) return;
+    if (!selectedWorkspaceId || !terminalPanelVisible) return;
     const wsId = selectedWorkspaceId;
     listTerminalTabs(wsId).then(async (t) => {
       if (t.length > 0) {
@@ -161,7 +167,13 @@ export const TerminalPanel = memo(function TerminalPanel() {
         }
       }
     });
-  }, [selectedWorkspaceId, setTerminalTabs, setActiveTerminalTab, addTerminalTab]);
+  }, [
+    selectedWorkspaceId,
+    terminalPanelVisible,
+    setTerminalTabs,
+    setActiveTerminalTab,
+    addTerminalTab,
+  ]);
 
   // Create the xterm instance for the active tab, spawn the PTY, wire I/O.
   // Extracted as a function so we can re-run it from the spawn-error Retry

--- a/src/ui/src/components/terminal/terminalShortcuts.test.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.test.ts
@@ -102,16 +102,30 @@ describe("terminalKeyAction", () => {
       .toEqual({ kind: "cycle", direction: "next" });
   });
 
-  it("recognizes Cmd+T as new-tab (upper and lower case)", () => {
+  it("recognizes Cmd+T (macOS) as new-tab (upper and lower case)", () => {
     expect(terminalKeyAction(mk({ key: "t", metaKey: true })))
       .toEqual({ kind: "new-tab" });
     expect(terminalKeyAction(mk({ key: "T", metaKey: true })))
       .toEqual({ kind: "new-tab" });
   });
 
-  it("does NOT treat Cmd+Shift+T as new-tab (Shift must be absent)", () => {
-    // Leaves Cmd+Shift+T available for other future bindings and avoids
-    // double-firing with the cycle handler.
+  it("recognizes Ctrl+Shift+T (Linux/Windows) as new-tab", () => {
+    expect(terminalKeyAction(mk({ key: "t", ctrlKey: true, shiftKey: true })))
+      .toEqual({ kind: "new-tab" });
+    expect(terminalKeyAction(mk({ key: "T", ctrlKey: true, shiftKey: true })))
+      .toEqual({ kind: "new-tab" });
+  });
+
+  it("does NOT intercept bare Ctrl+T — readline uses it for transpose-chars", () => {
+    // This is the regression Codex caught. Hijacking Ctrl+T would break a
+    // standard shell shortcut inside the terminal.
+    expect(terminalKeyAction(mk({ key: "t", ctrlKey: true }))).toBeNull();
+    expect(terminalKeyAction(mk({ key: "T", ctrlKey: true }))).toBeNull();
+  });
+
+  it("does NOT treat Cmd+Shift+T as new-tab on macOS (that's a Linux combo)", () => {
+    // On macOS users type Cmd+T; Cmd+Shift+T would leak the "reopen closed tab"
+    // muscle memory from browsers — keep it available for future use.
     expect(terminalKeyAction(mk({ key: "T", metaKey: true, shiftKey: true })))
       .toBeNull();
   });

--- a/src/ui/src/components/terminal/terminalShortcuts.test.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { cycleTabId, terminalKeyAction } from "./terminalShortcuts";
+
+describe("cycleTabId", () => {
+  it("returns null for an empty list", () => {
+    expect(cycleTabId([], null, 1)).toBeNull();
+    expect(cycleTabId([], 5, -1)).toBeNull();
+  });
+
+  it("returns the sole id for a single-tab list (no-op)", () => {
+    expect(cycleTabId([7], 7, 1)).toBe(7);
+    expect(cycleTabId([7], 7, -1)).toBe(7);
+    expect(cycleTabId([7], null, 1)).toBe(7);
+  });
+
+  it("advances forward with wrap-around", () => {
+    expect(cycleTabId([1, 2, 3], 1, 1)).toBe(2);
+    expect(cycleTabId([1, 2, 3], 2, 1)).toBe(3);
+    expect(cycleTabId([1, 2, 3], 3, 1)).toBe(1);
+  });
+
+  it("advances backward with wrap-around", () => {
+    expect(cycleTabId([1, 2, 3], 1, -1)).toBe(3);
+    expect(cycleTabId([1, 2, 3], 2, -1)).toBe(1);
+    expect(cycleTabId([1, 2, 3], 3, -1)).toBe(2);
+  });
+
+  it("when activeId is null, starts from index 0", () => {
+    expect(cycleTabId([1, 2, 3], null, 1)).toBe(2);
+    expect(cycleTabId([1, 2, 3], null, -1)).toBe(3);
+  });
+
+  it("when activeId is not in the list, treats cursor as index 0", () => {
+    expect(cycleTabId([10, 20, 30], 999, 1)).toBe(20);
+    expect(cycleTabId([10, 20, 30], 999, -1)).toBe(30);
+  });
+});
+
+// Minimal KeyboardEvent-like object so we can exercise the action logic
+// without a DOM. Fields match what `terminalKeyAction` reads.
+type KeyInit = {
+  type?: string;
+  key?: string;
+  code?: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+};
+
+function mk(init: KeyInit): KeyboardEvent {
+  return {
+    type: init.type ?? "keydown",
+    key: init.key ?? "",
+    code: init.code ?? "",
+    metaKey: init.metaKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    shiftKey: init.shiftKey ?? false,
+  } as unknown as KeyboardEvent;
+}
+
+describe("terminalKeyAction", () => {
+  it("returns null for events without a modifier", () => {
+    expect(terminalKeyAction(mk({ key: "t" }))).toBeNull();
+    expect(terminalKeyAction(mk({ key: "]", shiftKey: true }))).toBeNull();
+  });
+
+  it("returns null for non-keydown events", () => {
+    expect(
+      terminalKeyAction(mk({ type: "keyup", key: "t", metaKey: true })),
+    ).toBeNull();
+  });
+
+  it("returns null for unrelated keys", () => {
+    expect(terminalKeyAction(mk({ key: "a", metaKey: true }))).toBeNull();
+    expect(terminalKeyAction(mk({ key: "Enter", metaKey: true }))).toBeNull();
+  });
+
+  it("recognizes Cmd+Shift+[ (prev tab) via key and via code", () => {
+    expect(terminalKeyAction(mk({ key: "[", metaKey: true, shiftKey: true })))
+      .toEqual({ kind: "cycle", direction: "prev" });
+    expect(terminalKeyAction(mk({ key: "{", metaKey: true, shiftKey: true })))
+      .toEqual({ kind: "cycle", direction: "prev" });
+    expect(
+      terminalKeyAction(mk({ code: "BracketLeft", metaKey: true, shiftKey: true })),
+    ).toEqual({ kind: "cycle", direction: "prev" });
+  });
+
+  it("recognizes Cmd+Shift+] (next tab) via key and via code", () => {
+    expect(terminalKeyAction(mk({ key: "]", metaKey: true, shiftKey: true })))
+      .toEqual({ kind: "cycle", direction: "next" });
+    expect(terminalKeyAction(mk({ key: "}", metaKey: true, shiftKey: true })))
+      .toEqual({ kind: "cycle", direction: "next" });
+    expect(
+      terminalKeyAction(mk({ code: "BracketRight", metaKey: true, shiftKey: true })),
+    ).toEqual({ kind: "cycle", direction: "next" });
+  });
+
+  it("recognizes Ctrl+Shift+[/] for Linux/Windows", () => {
+    expect(terminalKeyAction(mk({ key: "[", ctrlKey: true, shiftKey: true })))
+      .toEqual({ kind: "cycle", direction: "prev" });
+    expect(terminalKeyAction(mk({ key: "]", ctrlKey: true, shiftKey: true })))
+      .toEqual({ kind: "cycle", direction: "next" });
+  });
+
+  it("recognizes Cmd+T as new-tab (upper and lower case)", () => {
+    expect(terminalKeyAction(mk({ key: "t", metaKey: true })))
+      .toEqual({ kind: "new-tab" });
+    expect(terminalKeyAction(mk({ key: "T", metaKey: true })))
+      .toEqual({ kind: "new-tab" });
+  });
+
+  it("does NOT treat Cmd+Shift+T as new-tab (Shift must be absent)", () => {
+    // Leaves Cmd+Shift+T available for other future bindings and avoids
+    // double-firing with the cycle handler.
+    expect(terminalKeyAction(mk({ key: "T", metaKey: true, shiftKey: true })))
+      .toBeNull();
+  });
+
+  it("recognizes Cmd+` as toggle-panel (so xterm doesn't forward the backtick)", () => {
+    expect(terminalKeyAction(mk({ key: "`", metaKey: true })))
+      .toEqual({ kind: "toggle-panel" });
+    expect(terminalKeyAction(mk({ key: "`", ctrlKey: true })))
+      .toEqual({ kind: "toggle-panel" });
+  });
+
+  it("does NOT treat Cmd+Shift+` as toggle-panel (Shift must be absent)", () => {
+    expect(
+      terminalKeyAction(mk({ key: "`", metaKey: true, shiftKey: true })),
+    ).toBeNull();
+  });
+
+  it("recognizes Cmd+0 as focus-chat", () => {
+    expect(terminalKeyAction(mk({ key: "0", metaKey: true })))
+      .toEqual({ kind: "focus-chat" });
+    expect(terminalKeyAction(mk({ key: "0", ctrlKey: true })))
+      .toEqual({ kind: "focus-chat" });
+  });
+
+  it("does NOT treat Cmd+Shift+0 as focus-chat", () => {
+    expect(
+      terminalKeyAction(mk({ key: "0", metaKey: true, shiftKey: true })),
+    ).toBeNull();
+  });
+});

--- a/src/ui/src/components/terminal/terminalShortcuts.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure helpers for terminal-scoped keyboard shortcuts.
+ *
+ * Kept free of xterm.js / React imports so they can be unit-tested in
+ * isolation. The xterm `attachCustomKeyEventHandler` call in TerminalPanel.tsx
+ * delegates to `terminalKeyAction` to decide whether a key event should be
+ * intercepted, and which of these cycle helpers to call.
+ */
+
+/**
+ * Returns the id of the tab at `currentIndex + offset` with wrap-around.
+ *
+ * - Returns `null` for empty lists.
+ * - Returns the sole tab's id (no-op) for single-tab lists.
+ * - If `activeId` is not in `tabIds`, treats the first tab as the cursor so
+ *   Cmd+Shift+] still does something sensible.
+ */
+export function cycleTabId(
+  tabIds: readonly number[],
+  activeId: number | null,
+  offset: 1 | -1,
+): number | null {
+  if (tabIds.length === 0) return null;
+  if (tabIds.length === 1) return tabIds[0];
+  const idx = activeId === null ? 0 : tabIds.indexOf(activeId);
+  const from = idx < 0 ? 0 : idx;
+  const next = (from + offset + tabIds.length) % tabIds.length;
+  return tabIds[next];
+}
+
+/**
+ * Discriminated result of evaluating a keyboard event for a terminal-scoped
+ * shortcut. `null` means the event is not a shortcut we care about — xterm
+ * should forward the key to the PTY as normal.
+ *
+ * `toggle-panel` and `focus-chat` are special: they exist only so xterm
+ * doesn't send the key to the PTY (e.g. so Cmd+` doesn't end up as a
+ * literal backtick in the shell). The actual toggle/focus behavior is
+ * shared with the window-level handler in `useKeyboardShortcuts.ts`.
+ */
+export type TerminalKeyAction =
+  | { kind: "cycle"; direction: "prev" | "next" }
+  | { kind: "new-tab" }
+  | { kind: "toggle-panel" }
+  | { kind: "focus-chat" }
+  | null;
+
+/**
+ * Decide whether a keyboard event should trigger a terminal-scoped action.
+ *
+ * The xterm handler uses the result to call `preventDefault()`,
+ * `stopImmediatePropagation()`, and `return false` so that:
+ * - xterm does not send bytes to the PTY (e.g. "t" for Cmd+T)
+ * - the window-level shortcut listener in `useKeyboardShortcuts.ts` does not
+ *   also fire (e.g. Cmd+Shift+[/] would otherwise cycle workspaces)
+ *
+ * We intentionally shadow the global Cmd+Shift+[/] workspace-cycle when the
+ * terminal has focus — this is the behavior the issue specifies.
+ */
+export function terminalKeyAction(ev: KeyboardEvent): TerminalKeyAction {
+  if (ev.type !== "keydown") return null;
+  const mod = ev.metaKey || ev.ctrlKey;
+  if (!mod) return null;
+
+  // Cmd+Shift+[ / Cmd+Shift+] — prev/next terminal tab.
+  // The bracketed-key surface is messy across layouts and Shift state
+  // (`[`/`]` vs. `{`/`}` vs. `Bracket*` codes), so accept all spellings.
+  if (ev.shiftKey) {
+    const prev = ev.key === "[" || ev.key === "{" || ev.code === "BracketLeft";
+    const next = ev.key === "]" || ev.key === "}" || ev.code === "BracketRight";
+    if (prev) return { kind: "cycle", direction: "prev" };
+    if (next) return { kind: "cycle", direction: "next" };
+  }
+
+  // Cmd+T — new terminal tab. Require no Shift so Cmd+Shift+T stays available
+  // for anything we might want it to mean later.
+  if (!ev.shiftKey && (ev.key === "t" || ev.key === "T")) {
+    return { kind: "new-tab" };
+  }
+
+  // Cmd+` — toggle terminal panel (and move focus). Intercepted so xterm
+  // doesn't send a literal backtick to the shell.
+  if (!ev.shiftKey && ev.key === "`") {
+    return { kind: "toggle-panel" };
+  }
+
+  // Cmd+0 — focus the chat prompt without touching panel visibility.
+  if (!ev.shiftKey && ev.key === "0") {
+    return { kind: "focus-chat" };
+  }
+
+  return null;
+}

--- a/src/ui/src/components/terminal/terminalShortcuts.ts
+++ b/src/ui/src/components/terminal/terminalShortcuts.ts
@@ -72,9 +72,16 @@ export function terminalKeyAction(ev: KeyboardEvent): TerminalKeyAction {
     if (next) return { kind: "cycle", direction: "next" };
   }
 
-  // Cmd+T — new terminal tab. Require no Shift so Cmd+Shift+T stays available
-  // for anything we might want it to mean later.
-  if (!ev.shiftKey && (ev.key === "t" || ev.key === "T")) {
+  // New-tab: Cmd+T on macOS, Ctrl+Shift+T on Linux/Windows (browser
+  // convention). We specifically do NOT intercept bare Ctrl+T because that
+  // is readline's `transpose-chars` binding — hijacking it would break a
+  // standard shell shortcut inside the terminal. Meta+T (macOS) is safe
+  // because Cmd-keys never reach the shell.
+  const isT = ev.key === "t" || ev.key === "T";
+  if (isT && ev.metaKey && !ev.ctrlKey && !ev.shiftKey) {
+    return { kind: "new-tab" };
+  }
+  if (isT && ev.ctrlKey && ev.shiftKey && !ev.metaKey) {
     return { kind: "new-tab" };
   }
 

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,11 @@
 import { useEffect } from "react";
 import { useAppStore } from "../stores/useAppStore";
 import { stopAgent, sendRemoteCommand } from "../services/tauri";
+import {
+  focusActiveTerminal,
+  focusChatPrompt,
+  isTerminalFocused,
+} from "../utils/focusTargets";
 
 export function useKeyboardShortcuts() {
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
@@ -113,6 +118,26 @@ export function useKeyboardShortcuts() {
         return;
       }
 
+      // Cmd/Ctrl+0: focus-toggle between terminal and chat prompt.
+      // Unlike Cmd+` this NEVER changes panel visibility — it only moves
+      // focus. If the panel is hidden, we reveal it first so the user can
+      // actually see the terminal we're putting focus into.
+      if (e.key === "0" && !e.shiftKey) {
+        e.preventDefault();
+        if (isTerminalFocused()) {
+          focusChatPrompt();
+        } else {
+          const store = useAppStore.getState();
+          if (!store.terminalPanelVisible) {
+            store.toggleTerminalPanel();
+            requestAnimationFrame(() => focusActiveTerminal());
+          } else {
+            focusActiveTerminal();
+          }
+        }
+        return;
+      }
+
       switch (e.key) {
         case "b":
           e.preventDefault();
@@ -131,9 +156,25 @@ export function useKeyboardShortcuts() {
           toggleRightSidebar();
           break;
         case "`":
+          // Cmd+` — toggle terminal panel AND move focus to whichever
+          // surface just became active: terminal when showing, chat when
+          // hiding. The shells keep running while hidden (the panel is
+          // CSS-hidden, not unmounted).
           e.preventDefault();
           toggleTerminalPanel();
+          requestAnimationFrame(() => {
+            const visible = useAppStore.getState().terminalPanelVisible;
+            if (visible) focusActiveTerminal();
+            else focusChatPrompt();
+          });
           break;
+        // NOTE: Terminal-scoped hotkeys (Cmd+T for new tab, Cmd+Shift+[/]
+        // for prev/next tab) are intentionally NOT bound here. They are
+        // intercepted inside xterm via attachCustomKeyEventHandler in
+        // TerminalPanel.tsx so they only fire when the terminal has focus
+        // and xterm can suppress forwarding the key to the PTY. Cmd+` and
+        // Cmd+0 are bound both here (for focus arriving from the chat side)
+        // and in the xterm handler (so they don't send bytes to the PTY).
         case ",":
           e.preventDefault();
           {

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "./useAppStore";
+import type { TerminalTab } from "../types/terminal";
+
+const WS_A = "workspace-a";
+const WS_B = "workspace-b";
+
+function makeTab(id: number, workspaceId: string): TerminalTab {
+  return {
+    id,
+    workspace_id: workspaceId,
+    title: `Terminal ${id}`,
+    is_script_output: false,
+    sort_order: id,
+    created_at: "",
+  };
+}
+
+describe("terminal slice: activeTerminalTabId is workspace-scoped", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      terminalTabs: {},
+      activeTerminalTabId: {},
+    });
+  });
+
+  it("setActiveTerminalTab writes under the given workspace key", () => {
+    useAppStore.getState().setActiveTerminalTab(WS_A, 42);
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(42);
+  });
+
+  it("does not pollute sibling workspaces", () => {
+    useAppStore.getState().setActiveTerminalTab(WS_A, 42);
+    useAppStore.getState().setActiveTerminalTab(WS_B, 7);
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(42);
+    expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBe(7);
+  });
+
+  it("setActiveTerminalTab(null) clears the active tab for that workspace", () => {
+    useAppStore.getState().setActiveTerminalTab(WS_A, 42);
+    useAppStore.getState().setActiveTerminalTab(WS_A, null);
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBeNull();
+  });
+});
+
+describe("terminal slice: addTerminalTab", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      terminalTabs: {},
+      activeTerminalTabId: {},
+      terminalPanelVisible: false,
+    });
+  });
+
+  it("appends the tab and sets it active for that workspace", () => {
+    const tab = makeTab(10, WS_A);
+    useAppStore.getState().addTerminalTab(WS_A, tab);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([tab]);
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(10);
+  });
+
+  it("adding to workspace A does not change workspace B's active tab", () => {
+    useAppStore.getState().addTerminalTab(WS_A, makeTab(1, WS_A));
+    useAppStore.getState().setActiveTerminalTab(WS_B, 99);
+
+    useAppStore.getState().addTerminalTab(WS_A, makeTab(2, WS_A));
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(2);
+    expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBe(99);
+  });
+
+  it("auto-shows the terminal panel", () => {
+    useAppStore.getState().addTerminalTab(WS_A, makeTab(1, WS_A));
+    expect(useAppStore.getState().terminalPanelVisible).toBe(true);
+  });
+});
+
+describe("terminal slice: removeTerminalTab", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      terminalTabs: {},
+      activeTerminalTabId: {},
+    });
+  });
+
+  it("removes the tab from its workspace", () => {
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 1);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    const remaining = useAppStore.getState().terminalTabs[WS_A];
+    expect(remaining.map((t) => t.id)).toEqual([2]);
+  });
+
+  it("when removing the active tab, falls back to the first remaining tab in that workspace", () => {
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 1);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(2);
+  });
+
+  it("when removing the active tab and none remain, sets the workspace's active to null", () => {
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 1);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBeNull();
+  });
+
+  it("removing a non-active tab does not change the active id", () => {
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 2);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(2);
+  });
+
+  it("does not touch another workspace's active tab", () => {
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 1);
+    useAppStore.getState().setActiveTerminalTab(WS_B, 99);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBe(99);
+  });
+});
+
+describe("workspace removal cascades to terminal state", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      repositories: [],
+      workspaces: [],
+      terminalTabs: {},
+      activeTerminalTabId: {},
+      unreadCompletions: new Set<string>(),
+      selectedWorkspaceId: null,
+    });
+  });
+
+  it("removeWorkspace drops terminalTabs and activeTerminalTabId entries", () => {
+    useAppStore.setState({
+      workspaces: [
+        {
+          id: WS_A,
+          repository_id: "repo-1",
+          name: "ws-a",
+          branch: "main",
+          worktree_path: "/tmp/a",
+          status: "Active",
+          created_at: "",
+          agent_status: "Idle",
+          remote_connection_id: null,
+        } as never,
+      ],
+      terminalTabs: { [WS_A]: [makeTab(1, WS_A)] },
+      activeTerminalTabId: { [WS_A]: 1 },
+    });
+
+    useAppStore.getState().removeWorkspace(WS_A);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toBeUndefined();
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBeUndefined();
+  });
+
+  it("removeRepository cascades through its workspaces' terminal state", () => {
+    useAppStore.setState({
+      repositories: [
+        { id: "repo-1", name: "r", root_path: "/r" } as never,
+      ],
+      workspaces: [
+        {
+          id: WS_A,
+          repository_id: "repo-1",
+          name: "a",
+          branch: "main",
+          worktree_path: "/tmp/a",
+          status: "Active",
+          created_at: "",
+          agent_status: "Idle",
+          remote_connection_id: null,
+        } as never,
+        {
+          id: WS_B,
+          repository_id: "repo-1",
+          name: "b",
+          branch: "main",
+          worktree_path: "/tmp/b",
+          status: "Active",
+          created_at: "",
+          agent_status: "Idle",
+          remote_connection_id: null,
+        } as never,
+      ],
+      terminalTabs: {
+        [WS_A]: [makeTab(1, WS_A)],
+        [WS_B]: [makeTab(2, WS_B)],
+      },
+      activeTerminalTabId: { [WS_A]: 1, [WS_B]: 2 },
+    });
+
+    useAppStore.getState().removeRepository("repo-1");
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toBeUndefined();
+    expect(useAppStore.getState().terminalTabs[WS_B]).toBeUndefined();
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBeUndefined();
+    expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBeUndefined();
+  });
+});

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -139,12 +139,13 @@ describe("workspace removal cascades to terminal state", () => {
       workspaces: [],
       terminalTabs: {},
       activeTerminalTabId: {},
+      workspaceTerminalCommands: {},
       unreadCompletions: new Set<string>(),
       selectedWorkspaceId: null,
     });
   });
 
-  it("removeWorkspace drops terminalTabs and activeTerminalTabId entries", () => {
+  it("removeWorkspace drops terminalTabs, activeTerminalTabId, and workspaceTerminalCommands", () => {
     useAppStore.setState({
       workspaces: [
         {
@@ -161,12 +162,16 @@ describe("workspace removal cascades to terminal state", () => {
       ],
       terminalTabs: { [WS_A]: [makeTab(1, WS_A)] },
       activeTerminalTabId: { [WS_A]: 1 },
+      workspaceTerminalCommands: {
+        [WS_A]: { command: "cargo test", isRunning: true, exitCode: null },
+      },
     });
 
     useAppStore.getState().removeWorkspace(WS_A);
 
     expect(useAppStore.getState().terminalTabs[WS_A]).toBeUndefined();
     expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBeUndefined();
+    expect(useAppStore.getState().workspaceTerminalCommands[WS_A]).toBeUndefined();
   });
 
   it("removeRepository cascades through its workspaces' terminal state", () => {
@@ -203,6 +208,10 @@ describe("workspace removal cascades to terminal state", () => {
         [WS_B]: [makeTab(2, WS_B)],
       },
       activeTerminalTabId: { [WS_A]: 1, [WS_B]: 2 },
+      workspaceTerminalCommands: {
+        [WS_A]: { command: null, isRunning: false, exitCode: null },
+        [WS_B]: { command: null, isRunning: false, exitCode: null },
+      },
     });
 
     useAppStore.getState().removeRepository("repo-1");
@@ -211,5 +220,75 @@ describe("workspace removal cascades to terminal state", () => {
     expect(useAppStore.getState().terminalTabs[WS_B]).toBeUndefined();
     expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBeUndefined();
     expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBeUndefined();
+    expect(useAppStore.getState().workspaceTerminalCommands[WS_A]).toBeUndefined();
+    expect(useAppStore.getState().workspaceTerminalCommands[WS_B]).toBeUndefined();
+  });
+
+  it("removeRepository deselects a workspace that belonged to the removed repo", () => {
+    useAppStore.setState({
+      repositories: [
+        { id: "repo-1", name: "r", root_path: "/r" } as never,
+      ],
+      workspaces: [
+        {
+          id: WS_A,
+          repository_id: "repo-1",
+          name: "a",
+          branch: "main",
+          worktree_path: "/tmp/a",
+          status: "Active",
+          created_at: "",
+          agent_status: "Idle",
+          remote_connection_id: null,
+        } as never,
+      ],
+      selectedWorkspaceId: WS_A,
+      unreadCompletions: new Set([WS_A]),
+    });
+
+    useAppStore.getState().removeRepository("repo-1");
+
+    expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
+    // unreadCompletions entry for the removed workspace should also go.
+    expect(useAppStore.getState().unreadCompletions.has(WS_A)).toBe(false);
+  });
+
+  it("removeRepository preserves selectedWorkspaceId when it belongs to another repo", () => {
+    useAppStore.setState({
+      repositories: [
+        { id: "repo-1", name: "r1", root_path: "/r1" } as never,
+        { id: "repo-2", name: "r2", root_path: "/r2" } as never,
+      ],
+      workspaces: [
+        {
+          id: WS_A,
+          repository_id: "repo-1",
+          name: "a",
+          branch: "main",
+          worktree_path: "/tmp/a",
+          status: "Active",
+          created_at: "",
+          agent_status: "Idle",
+          remote_connection_id: null,
+        } as never,
+        {
+          id: WS_B,
+          repository_id: "repo-2",
+          name: "b",
+          branch: "main",
+          worktree_path: "/tmp/b",
+          status: "Active",
+          created_at: "",
+          agent_status: "Idle",
+          remote_connection_id: null,
+        } as never,
+      ],
+      selectedWorkspaceId: WS_B,
+    });
+
+    useAppStore.getState().removeRepository("repo-1");
+
+    // repo-2's workspace is still selected — removing repo-1 shouldn't affect it.
+    expect(useAppStore.getState().selectedWorkspaceId).toBe(WS_B);
   });
 });

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -194,13 +194,15 @@ interface AppState {
 
   // -- Terminal --
   terminalTabs: Record<string, TerminalTab[]>;
-  activeTerminalTabId: number | null;
+  // Active tab id is workspace-scoped: switching workspaces preserves each
+  // workspace's last-active tab independently.
+  activeTerminalTabId: Record<string, number | null>;
   terminalPanelVisible: boolean;
   workspaceTerminalCommands: Record<string, WorkspaceCommandState>;
   setTerminalTabs: (wsId: string, tabs: TerminalTab[]) => void;
   addTerminalTab: (wsId: string, tab: TerminalTab) => void;
   removeTerminalTab: (wsId: string, tabId: number) => void;
-  setActiveTerminalTab: (id: number | null) => void;
+  setActiveTerminalTab: (wsId: string, id: number | null) => void;
   toggleTerminalPanel: () => void;
   setWorkspaceTerminalCommand: (
     wsId: string,
@@ -331,10 +333,23 @@ export const useAppStore = create<AppState>((set) => ({
       ),
     })),
   removeRepository: (id) =>
-    set((s) => ({
-      repositories: s.repositories.filter((r) => r.id !== id),
-      workspaces: s.workspaces.filter((w) => w.repository_id !== id),
-    })),
+    set((s) => {
+      const removedWsIds = s.workspaces
+        .filter((w) => w.repository_id === id)
+        .map((w) => w.id);
+      const newTerminalTabs = { ...s.terminalTabs };
+      const newActiveTerminalTabId = { ...s.activeTerminalTabId };
+      for (const wsId of removedWsIds) {
+        delete newTerminalTabs[wsId];
+        delete newActiveTerminalTabId[wsId];
+      }
+      return {
+        repositories: s.repositories.filter((r) => r.id !== id),
+        workspaces: s.workspaces.filter((w) => w.repository_id !== id),
+        terminalTabs: newTerminalTabs,
+        activeTerminalTabId: newActiveTerminalTabId,
+      };
+    }),
 
   // -- Workspaces --
   workspaces: [],
@@ -351,11 +366,20 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => {
       const newUnreadCompletions = new Set(s.unreadCompletions);
       newUnreadCompletions.delete(id);
+      // Drop terminal state for the removed workspace. The cleanup effect in
+      // TerminalPanel watches `terminalTabs` and tears down xterm instances
+      // and PTYs whose tab ids no longer exist in any workspace.
+      const newTerminalTabs = { ...s.terminalTabs };
+      delete newTerminalTabs[id];
+      const newActiveTerminalTabId = { ...s.activeTerminalTabId };
+      delete newActiveTerminalTabId[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
           s.selectedWorkspaceId === id ? null : s.selectedWorkspaceId,
         unreadCompletions: newUnreadCompletions,
+        terminalTabs: newTerminalTabs,
+        activeTerminalTabId: newActiveTerminalTabId,
       };
     }),
   selectWorkspace: (id) =>
@@ -742,7 +766,7 @@ export const useAppStore = create<AppState>((set) => ({
 
   // -- Terminal --
   terminalTabs: {},
-  activeTerminalTabId: null,
+  activeTerminalTabId: {},
   terminalPanelVisible: false,
   workspaceTerminalCommands: {},
   setTerminalTabs: (wsId, tabs) =>
@@ -755,21 +779,24 @@ export const useAppStore = create<AppState>((set) => ({
         ...s.terminalTabs,
         [wsId]: [...(s.terminalTabs[wsId] || []), tab],
       },
-      activeTerminalTabId: tab.id,
+      activeTerminalTabId: { ...s.activeTerminalTabId, [wsId]: tab.id },
       terminalPanelVisible: true,
     })),
   removeTerminalTab: (wsId, tabId) =>
     set((s) => {
       const tabs = (s.terminalTabs[wsId] || []).filter((t) => t.id !== tabId);
+      const wasActive = s.activeTerminalTabId[wsId] === tabId;
       return {
         terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
-        activeTerminalTabId:
-          s.activeTerminalTabId === tabId
-            ? (tabs[0]?.id ?? null)
-            : s.activeTerminalTabId,
+        activeTerminalTabId: wasActive
+          ? { ...s.activeTerminalTabId, [wsId]: tabs[0]?.id ?? null }
+          : s.activeTerminalTabId,
       };
     }),
-  setActiveTerminalTab: (id) => set({ activeTerminalTabId: id }),
+  setActiveTerminalTab: (wsId, id) =>
+    set((s) => ({
+      activeTerminalTabId: { ...s.activeTerminalTabId, [wsId]: id },
+    })),
   toggleTerminalPanel: () =>
     set((s) => ({ terminalPanelVisible: !s.terminalPanelVisible })),
   setWorkspaceTerminalCommand: (wsId, state) =>

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -337,17 +337,30 @@ export const useAppStore = create<AppState>((set) => ({
       const removedWsIds = s.workspaces
         .filter((w) => w.repository_id === id)
         .map((w) => w.id);
+      const removedWsIdSet = new Set(removedWsIds);
       const newTerminalTabs = { ...s.terminalTabs };
       const newActiveTerminalTabId = { ...s.activeTerminalTabId };
+      const newWorkspaceTerminalCommands = { ...s.workspaceTerminalCommands };
+      const newUnreadCompletions = new Set(s.unreadCompletions);
       for (const wsId of removedWsIds) {
         delete newTerminalTabs[wsId];
         delete newActiveTerminalTabId[wsId];
+        delete newWorkspaceTerminalCommands[wsId];
+        newUnreadCompletions.delete(wsId);
       }
       return {
         repositories: s.repositories.filter((r) => r.id !== id),
         workspaces: s.workspaces.filter((w) => w.repository_id !== id),
+        // If the selected workspace belonged to the removed repo, deselect
+        // it so the rest of the app doesn't point at a vanished id.
+        selectedWorkspaceId:
+          s.selectedWorkspaceId && removedWsIdSet.has(s.selectedWorkspaceId)
+            ? null
+            : s.selectedWorkspaceId,
         terminalTabs: newTerminalTabs,
         activeTerminalTabId: newActiveTerminalTabId,
+        workspaceTerminalCommands: newWorkspaceTerminalCommands,
+        unreadCompletions: newUnreadCompletions,
       };
     }),
 
@@ -366,13 +379,16 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => {
       const newUnreadCompletions = new Set(s.unreadCompletions);
       newUnreadCompletions.delete(id);
-      // Drop terminal state for the removed workspace. The cleanup effect in
-      // TerminalPanel watches `terminalTabs` and tears down xterm instances
-      // and PTYs whose tab ids no longer exist in any workspace.
+      // Drop all per-workspace terminal state for the removed workspace.
+      // The cleanup effect in TerminalPanel watches `terminalTabs` and tears
+      // down xterm instances and PTYs whose tab ids no longer exist in any
+      // workspace; the other maps are value-keyed by workspace id.
       const newTerminalTabs = { ...s.terminalTabs };
       delete newTerminalTabs[id];
       const newActiveTerminalTabId = { ...s.activeTerminalTabId };
       delete newActiveTerminalTabId[id];
+      const newWorkspaceTerminalCommands = { ...s.workspaceTerminalCommands };
+      delete newWorkspaceTerminalCommands[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -380,6 +396,7 @@ export const useAppStore = create<AppState>((set) => ({
         unreadCompletions: newUnreadCompletions,
         terminalTabs: newTerminalTabs,
         activeTerminalTabId: newActiveTerminalTabId,
+        workspaceTerminalCommands: newWorkspaceTerminalCommands,
       };
     }),
   selectWorkspace: (id) =>

--- a/src/ui/src/utils/focusTargets.test.ts
+++ b/src/ui/src/utils/focusTargets.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  focusChatPrompt,
+  focusActiveTerminal,
+  isTerminalFocused,
+} from "./focusTargets";
+
+/**
+ * vitest runs in the Node environment (no `document`), so we hand-roll a
+ * minimal Document shim with just the surface `focusTargets` touches. This
+ * keeps the helpers testable without pulling in jsdom as a dependency.
+ */
+
+type FakeElement = {
+  focus: () => void;
+  offsetParent?: unknown;
+  closest?: (sel: string) => FakeElement | null;
+};
+
+function makeDoc(options: {
+  chat?: FakeElement | null;
+  helpers?: FakeElement[];
+  activeElement?: FakeElement | null;
+}): Document {
+  const { chat = null, helpers = [], activeElement = null } = options;
+  return {
+    querySelector: ((sel: string) => {
+      if (sel === "textarea[data-chat-input]") return chat;
+      if (sel === ".xterm-helper-textarea") return helpers[0] ?? null;
+      return null;
+    }) as Document["querySelector"],
+    querySelectorAll: ((sel: string) => {
+      if (sel === ".xterm-helper-textarea") {
+        return helpers as unknown as NodeListOf<Element>;
+      }
+      return [] as unknown as NodeListOf<Element>;
+    }) as Document["querySelectorAll"],
+    activeElement: activeElement as Element | null,
+  } as unknown as Document;
+}
+
+describe("focusChatPrompt", () => {
+  it("focuses the chat textarea and returns true when present", () => {
+    const focus = vi.fn();
+    const doc = makeDoc({ chat: { focus } });
+    expect(focusChatPrompt(doc)).toBe(true);
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it("returns false when no chat textarea is in the DOM", () => {
+    const doc = makeDoc({ chat: null });
+    expect(focusChatPrompt(doc)).toBe(false);
+  });
+});
+
+describe("focusActiveTerminal", () => {
+  it("prefers the first helper whose offsetParent is non-null (visible tab)", () => {
+    const hidden = { focus: vi.fn(), offsetParent: null };
+    const visible = { focus: vi.fn(), offsetParent: {} };
+    const doc = makeDoc({ helpers: [hidden, visible] });
+
+    expect(focusActiveTerminal(doc)).toBe(true);
+    expect(visible.focus).toHaveBeenCalledOnce();
+    expect(hidden.focus).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the first helper when none report layout (jsdom/node)", () => {
+    const a = { focus: vi.fn(), offsetParent: null };
+    const b = { focus: vi.fn(), offsetParent: null };
+    const doc = makeDoc({ helpers: [a, b] });
+
+    expect(focusActiveTerminal(doc)).toBe(true);
+    expect(a.focus).toHaveBeenCalledOnce();
+    expect(b.focus).not.toHaveBeenCalled();
+  });
+
+  it("returns false when no terminals exist", () => {
+    const doc = makeDoc({ helpers: [] });
+    expect(focusActiveTerminal(doc)).toBe(false);
+  });
+});
+
+describe("isTerminalFocused", () => {
+  it("returns true when activeElement is inside an .xterm ancestor", () => {
+    const xtermWrapper = { focus: vi.fn() };
+    const active: FakeElement = {
+      focus: vi.fn(),
+      closest: (sel) => (sel === ".xterm" ? xtermWrapper : null),
+    };
+    const doc = makeDoc({ activeElement: active });
+    expect(isTerminalFocused(doc)).toBe(true);
+  });
+
+  it("returns false when activeElement is outside any xterm", () => {
+    const active: FakeElement = {
+      focus: vi.fn(),
+      closest: () => null,
+    };
+    const doc = makeDoc({ activeElement: active });
+    expect(isTerminalFocused(doc)).toBe(false);
+  });
+
+  it("returns false when activeElement is null", () => {
+    const doc = makeDoc({ activeElement: null });
+    expect(isTerminalFocused(doc)).toBe(false);
+  });
+});

--- a/src/ui/src/utils/focusTargets.ts
+++ b/src/ui/src/utils/focusTargets.ts
@@ -1,0 +1,59 @@
+/**
+ * Focus helpers for the Cmd+` / Cmd+0 chat↔terminal focus toggle.
+ *
+ * These are DOM-level lookups rather than React refs because the global
+ * keyboard-shortcut handler in `useKeyboardShortcuts.ts` runs outside the
+ * component tree, and the xterm helper textarea is owned by xterm.js, not
+ * React. Keeping the lookups centralized here means the selectors appear
+ * exactly once and can be unit-tested in isolation.
+ */
+
+const CHAT_INPUT_SELECTOR = "textarea[data-chat-input]";
+/** xterm.js renders a hidden textarea that receives keyboard input. */
+const XTERM_HELPER_SELECTOR = ".xterm-helper-textarea";
+/** The container class xterm wraps every Terminal instance in. */
+const XTERM_CONTAINER_SELECTOR = ".xterm";
+
+/**
+ * Focus the chat prompt textarea if it's in the DOM.
+ * Returns whether focus was actually placed — callers use this to decide
+ * whether to fall back to another target.
+ */
+export function focusChatPrompt(doc: Document = document): boolean {
+  const el = doc.querySelector<HTMLTextAreaElement>(CHAT_INPUT_SELECTOR);
+  if (!el) return false;
+  el.focus();
+  return true;
+}
+
+/**
+ * Focus the xterm helper textarea of the currently visible terminal tab.
+ * Inactive tab containers have `display: none`, so their textareas have a
+ * null `offsetParent` — this picks the first one that isn't hidden.
+ */
+export function focusActiveTerminal(doc: Document = document): boolean {
+  const helpers = doc.querySelectorAll<HTMLTextAreaElement>(XTERM_HELPER_SELECTOR);
+  for (const el of Array.from(helpers)) {
+    if ((el as HTMLElement).offsetParent !== null) {
+      el.focus();
+      return true;
+    }
+  }
+  // Fallback: first helper in the DOM (jsdom doesn't compute layout, so
+  // offsetParent is always null there — this keeps the helpers testable).
+  if (helpers.length > 0) {
+    helpers[0].focus();
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True when focus currently lives inside an xterm terminal instance.
+ * Used by Cmd+0 to decide which direction to toggle.
+ */
+export function isTerminalFocused(doc: Document = document): boolean {
+  const active = doc.activeElement;
+  if (!active) return false;
+  return !!(active as HTMLElement).closest?.(XTERM_CONTAINER_SELECTOR);
+}


### PR DESCRIPTION
Closes #210.

## Summary

- **Lifecycle persistence.** \`<TerminalPanel>\` is now always mounted when a workspace is selected and toggled via CSS. The old behavior unmounted the whole component on every panel collapse, which disposed xterm instances and killed PTY children. Shells now survive panel collapse, workspace switching, and tab hiding.
- **Terminal-scoped keybindings.** Intercepted inside xterm via \`attachCustomKeyEventHandler\` so they only fire when the terminal has focus and xterm can suppress forwarding the key to the PTY. Uses \`stopImmediatePropagation\` so \`Cmd+Shift+[/]\` inside the terminal cycles tabs instead of cycling workspaces.
- **Workspace-scoped state.** \`activeTerminalTabId\` is now \`Record<string, number | null>\` keyed by workspace id. \`removeWorkspace\` / \`removeRepository\` drop the removed workspaces' terminal state; the existing cleanup effect then tears down their xterm instances and closes their PTYs.
- **Spawn-failure UX.** Inline error banner inside the failing tab with a Retry button, instead of a silent blank tab.
- **Focus shortcuts.**
  - \`Cmd+\\\`\` — toggle terminal panel AND move focus (chat when hiding, terminal when showing).
  - \`Cmd+0\` — focus-toggle between terminal and chat, panel visibility untouched (reveals terminal if hidden so there's something to focus).

## Keybinding reference (terminal-focused)

| Shortcut | Action | Platform |
|---|---|---|
| \`Cmd+Shift+[\` / \`Cmd+Shift+]\` | Prev / next tab | Mac |
| \`Ctrl+Shift+[\` / \`Ctrl+Shift+]\` | Prev / next tab | Linux/Windows |
| \`Cmd+T\` | New tab | Mac |
| \`Ctrl+Shift+T\` | New tab | Linux/Windows |
| \`Cmd+\\\`\` / \`Ctrl+\\\`\` | Toggle panel + follow focus | All |
| \`Cmd+0\` / \`Ctrl+0\` | Focus-toggle (no layout change) | All |

Bare \`Ctrl+T\` is intentionally **not** hijacked — readline uses it for \`transpose-chars\`.

## What's NOT in this PR

- **Close-confirmation when a shell is running a command.** The issue mentions it but it requires a synchronous OSC 133 running-state query that the backend doesn't expose yet, plus modal UX decisions that would balloon scope. Deferred to a follow-up issue. Existing OSC 133 event stream is unchanged.
- **Remote-workspace terminals.** Pre-existing behavior (they call into the DB-backed tab APIs); covered by the separate remote-terminal TDD. This PR does not regress it — the workspace-load effect is now gated on \`terminalPanelVisible\`, so remote workspaces don't hit the failing path until the user explicitly opens the terminal.

## Tests

- **Frontend (vitest, 172 total across 12 files, 41 new in this PR).**
  - \`useAppStore.terminal.test.ts\` — workspace-scoped \`activeTerminalTabId\`, add/remove tab semantics, null-fallback, \`removeWorkspace\` / \`removeRepository\` cascade.
  - \`terminalShortcuts.test.ts\` — cycle wrap-around, modifier-platform detection, guard against intercepting bare \`Ctrl+T\` and \`Cmd+Shift+T\`, coverage for \`Cmd+\\\`\` / \`Cmd+0\`.
  - \`focusTargets.test.ts\` — DOM lookup helpers for chat prompt, active terminal, and terminal-focus detection.
- **Backend (Rust, 2 new in \`pty.rs\`, unix-only).**
  - Smoke test on the \`portable_pty\` spawn → read → kill path used by \`spawn_pty\` / \`close_pty\`. Guards against future regressions in the PTY bring-up code.

## Verified

- \`cargo fmt --all --check\` ✅
- \`RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets\` ✅
- \`cargo test --all-features\` ✅ (348 passing in claudette + 6 in claudette-tauri including new PTY tests)
- \`bunx tsc --noEmit\` ✅
- \`bun run test\` ✅ (172 tests / 12 files)
- \`bun run build\` ✅
- Codex peer review run; two regressions it caught have been fixed in the follow-up commit \`eb4ddc9\` (hidden-panel auto-reopen and bare Ctrl+T hijack).

## Test plan

- [ ] Open a terminal, run \`vim\` (or any TUI). Press \`Cmd+\\\`\` to collapse the panel and again to restore it. vim is still running, scroll buffer intact.
- [ ] Switch to a different workspace (which has its own terminal), then switch back. Both terminals' shells are still alive and cursor position is preserved.
- [ ] In workspace A, make tab #2 active. Switch to workspace B, switch back — A's active tab is still #2.
- [ ] Delete a workspace (via the sidebar menu). Its PTY children terminate (confirm with \`ps\` outside the app) and no orphan \`.xterm\` DOM containers remain.
- [ ] Focus the terminal. Press \`Cmd+Shift+]\` — cycles terminal tabs, NOT workspaces. Click the chat and press \`Cmd+Shift+]\` — cycles workspaces as before.
- [ ] Focus the terminal. Press \`Cmd+T\` — new tab opens, letter \`t\` does NOT appear in the shell.
- [ ] Focus the terminal. Press \`Ctrl+T\` (Linux) — \`transpose-chars\` runs in readline as expected. Press \`Ctrl+Shift+T\` — new tab opens.
- [ ] Focus the terminal. Press \`Cmd+0\` — focus jumps to chat prompt, terminal stays visible. Press again — focus returns to terminal.
- [ ] Collapse the terminal panel. Select a new workspace that has no saved terminal tabs. Verify the panel does NOT reopen on its own (this is the Codex-caught regression).
- [ ] Temporarily break PTY spawn (e.g., workspace cwd that no longer exists) — the tab shows the error banner with a Retry button; clicking Retry spawns cleanly once the path is fixed.