### PR TITLE
fix(ci): use cargo test on PRs, llvm-cov on main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,23 +35,21 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ github.event_name == 'push' && 45 || 20 }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: llvm-tools-preview
+          components: ${{ github.event_name == 'push' && 'llvm-tools-preview' || '' }}
       - uses: taiki-e/install-action@cargo-llvm-cov
+        if: github.event_name == 'push'
       - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        if: github.event_name != 'push'
+        run: cargo test -p claudette -p claudette-server --all-features
       - name: Run tests with coverage
-        # Use cargo llvm-cov on main (warm cache), plain cargo test on PRs
-        # to avoid 45+ min LLVM instrumented rebuild on cache miss.
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            cargo llvm-cov -p claudette -p claudette-server --all-features --lcov --output-path lcov.info
-          else
-            cargo test -p claudette -p claudette-server --all-features
-          fi
+        if: github.event_name == 'push'
+        run: cargo llvm-cov -p claudette -p claudette-server --all-features --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         if: github.event_name == 'push'
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -43,8 +44,16 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
       - name: Run tests with coverage
-        run: cargo llvm-cov -p claudette -p claudette-server --all-features --lcov --output-path lcov.info
+        # Use cargo llvm-cov on main (warm cache), plain cargo test on PRs
+        # to avoid 45+ min LLVM instrumented rebuild on cache miss.
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            cargo llvm-cov -p claudette -p claudette-server --all-features --lcov --output-path lcov.info
+          else
+            cargo test -p claudette -p claudette-server --all-features
+          fi
       - name: Upload coverage to Codecov
+        if: github.event_name == 'push'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- PR test jobs use `cargo test` (no LLVM instrumentation) — compiles in minutes
- Push-to-main uses `cargo llvm-cov` (warm cache) — coverage uploaded to Codecov
- Adds `timeout-minutes: 20` to the Test job as a safety net

## Why

`cargo llvm-cov` with a partial Rust cache miss takes 45+ minutes on CI runners due to LLVM instrumented recompilation of the entire dependency tree. This blocks every PR that touches `Cargo.toml` or adds test files.

## Test plan

- [ ] This PR's own CI should pass (it's a push event, so it uses `cargo llvm-cov` with warm cache)
- [ ] After merge, PR #213 CI should use `cargo test` and complete in minutes