### PR TITLE
fix(chat): keep WorkspaceActions dropdown enabled during agent runs

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -596,7 +596,6 @@ export function ChatPanel() {
         <div className={styles.headerRight}>
           <WorkspaceActions
             worktreePath={ws.worktree_path}
-            disabled={isRunning}
           />
           <HeaderMenu
             label="Permissions"


### PR DESCRIPTION
## Summary
- Remove `disabled={isRunning}` from the `WorkspaceActions` dropdown in `ChatPanel.tsx`
- The Actions dropdown contains navigational items (open in Finder, VS Code, terminal, etc.) that don't mutate agent state, so they should remain usable during runs

Closes #219

## Test plan
- [ ] Start an agent run and verify the Actions dropdown is clickable
- [ ] Confirm navigational actions (Open in Finder, Open in VS Code, etc.) work during a run
- [ ] Verify the Permissions dropdown still correctly disables during runs