### PR TITLE
fix(chat): open links in system browser instead of navigating webview

### DIFF
--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -187,6 +187,16 @@ pub async fn open_in_editor(path: String) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+pub async fn open_url(url: String) -> Result<(), String> {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = opener::open(&url) {
+            eprintln!("Failed to open URL in system browser: {e}");
+        }
+    });
+    Ok(())
+}
+
 mod opener {
     use std::process::Command;
 

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -187,8 +187,16 @@ pub async fn open_in_editor(path: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Returns true if the URL uses a scheme safe for opening in the system browser.
+fn is_safe_url_scheme(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://") || url.starts_with("mailto:")
+}
+
 #[tauri::command]
 pub async fn open_url(url: String) -> Result<(), String> {
+    if !is_safe_url_scheme(&url) {
+        return Err(format!("Blocked URL with unsupported scheme: {url}"));
+    }
     tauri::async_runtime::spawn(async move {
         if let Err(e) = opener::open(&url) {
             eprintln!("Failed to open URL in system browser: {e}");
@@ -217,5 +225,55 @@ mod opener {
         ));
 
         cmd.map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_safe_url_scheme_allows_http() {
+        assert!(is_safe_url_scheme("http://example.com"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_allows_https() {
+        assert!(is_safe_url_scheme("https://github.com/utensils/claudette"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_allows_mailto() {
+        assert!(is_safe_url_scheme("mailto:user@example.com"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_blocks_file() {
+        assert!(!is_safe_url_scheme("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_blocks_javascript() {
+        assert!(!is_safe_url_scheme("javascript:alert(1)"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_blocks_data() {
+        assert!(!is_safe_url_scheme("data:text/html,<h1>hi</h1>"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_blocks_empty() {
+        assert!(!is_safe_url_scheme(""));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_blocks_relative_path() {
+        assert!(!is_safe_url_scheme("/some/path"));
+    }
+
+    #[test]
+    fn is_safe_url_scheme_blocks_fragment() {
+        assert!(!is_safe_url_scheme("#section"));
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -360,6 +360,7 @@ fn main() {
             commands::shell::setup_shell_integration,
             commands::shell::apply_shell_integration,
             commands::shell::open_in_editor,
+            commands::shell::open_url,
             // MCP
             commands::mcp::detect_mcp_servers,
             commands::mcp::save_repository_mcps,

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
-import { preprocessContent, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
+import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
 import { FileText, GitBranch, LayoutDashboard, Plus, RotateCcw, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
@@ -815,6 +815,7 @@ const StreamingMessage = memo(function StreamingMessage({
         <Markdown
           remarkPlugins={REMARK_PLUGINS}
           rehypePlugins={REHYPE_PLUGINS}
+          components={MARKDOWN_COMPONENTS}
         >
           {preprocessContent(displayed)}
         </Markdown>
@@ -1093,6 +1094,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                 <Markdown
                   remarkPlugins={REMARK_PLUGINS}
                   rehypePlugins={REHYPE_PLUGINS}
+                  components={MARKDOWN_COMPONENTS}
                 >
                   {preprocessContent(msg.content)}
                 </Markdown>

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Markdown from "react-markdown";
-import { preprocessContent, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
+import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
 import type { PlanApproval } from "../../stores/useAppStore";
 import { readPlanFile, sendRemoteCommand } from "../../services/tauri";
 import styles from "./PlanApprovalCard.module.css";
@@ -70,7 +70,7 @@ export function PlanApprovalCard({
 
       {expanded && planContent && (
         <div className={styles.planContent}>
-          <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS}>
+          <Markdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} components={MARKDOWN_COMPONENTS}>
             {preprocessContent(planContent)}
           </Markdown>
         </div>

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -372,6 +372,10 @@ export function listUserThemes(): Promise<ThemeDefinition[]> {
   return invoke("list_user_themes");
 }
 
+export function openUrl(url: string): Promise<void> {
+  return invoke("open_url", { url });
+}
+
 export function getGitUsername(): Promise<string | null> {
   return invoke("get_git_username");
 }

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { EXTERNAL_SCHEMES } from "./markdown";
+
+describe("EXTERNAL_SCHEMES", () => {
+  it("matches http URLs", () => {
+    expect(EXTERNAL_SCHEMES.test("http://example.com")).toBe(true);
+  });
+
+  it("matches https URLs", () => {
+    expect(EXTERNAL_SCHEMES.test("https://github.com/utensils/claudette")).toBe(true);
+  });
+
+  it("matches mailto URLs", () => {
+    expect(EXTERNAL_SCHEMES.test("mailto:user@example.com")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(EXTERNAL_SCHEMES.test("HTTPS://EXAMPLE.COM")).toBe(true);
+    expect(EXTERNAL_SCHEMES.test("HTTP://EXAMPLE.COM")).toBe(true);
+    expect(EXTERNAL_SCHEMES.test("Mailto:user@example.com")).toBe(true);
+  });
+
+  it("rejects file:// URLs", () => {
+    expect(EXTERNAL_SCHEMES.test("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(EXTERNAL_SCHEMES.test("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects data: URLs", () => {
+    expect(EXTERNAL_SCHEMES.test("data:text/html,<h1>hi</h1>")).toBe(false);
+  });
+
+  it("rejects fragment links", () => {
+    expect(EXTERNAL_SCHEMES.test("#section")).toBe(false);
+  });
+
+  it("rejects relative paths", () => {
+    expect(EXTERNAL_SCHEMES.test("/some/path")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(EXTERNAL_SCHEMES.test("")).toBe(false);
+  });
+});

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -1,9 +1,12 @@
+import { createElement } from "react";
 import type { PluggableList } from "unified";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeHighlight from "rehype-highlight";
 import { AnsiUp } from "ansi_up";
+import { openUrl } from "../services/tauri";
 
 // Shared AnsiUp instance for converting ANSI escape sequences to HTML.
 const ansiUp = new AnsiUp();
@@ -99,3 +102,22 @@ export const REHYPE_PLUGINS: PluggableList = [
   rehypeHighlight,
 ];
 export const REMARK_PLUGINS: PluggableList = [remarkGfm];
+
+// Override <a> to open links in the system browser instead of navigating the webview.
+export const MARKDOWN_COMPONENTS: Components = {
+  a: ({ href, children, ...props }) =>
+    createElement(
+      "a",
+      {
+        ...props,
+        href,
+        onClick: (e: MouseEvent) => {
+          if (href) {
+            e.preventDefault();
+            openUrl(href);
+          }
+        },
+      },
+      children,
+    ),
+};

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import React, { createElement } from "react";
 import type { PluggableList } from "unified";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -103,18 +103,24 @@ export const REHYPE_PLUGINS: PluggableList = [
 ];
 export const REMARK_PLUGINS: PluggableList = [remarkGfm];
 
-// Override <a> to open links in the system browser instead of navigating the webview.
+// Schemes that should open in the system browser rather than navigate the webview.
+export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
+
+// Override <a> to open external links in the system browser instead of navigating the webview.
 export const MARKDOWN_COMPONENTS: Components = {
-  a: ({ href, children, ...props }) =>
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  a: ({ node, href, children, ...props }) =>
     createElement(
       "a",
       {
         ...props,
         href,
-        onClick: (e: MouseEvent) => {
-          if (href) {
+        onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+          if (href && EXTERNAL_SCHEMES.test(href)) {
             e.preventDefault();
-            openUrl(href);
+            void openUrl(href).catch((err) =>
+              console.error("Failed to open URL:", href, err),
+            );
           }
         },
       },


### PR DESCRIPTION
## Summary

- Clicking links in the chat panel navigated the Tauri webview to the URL, which failed due to CSP `default-src 'self'` restrictions and left the app on a white screen
- Added a `MARKDOWN_COMPONENTS` override in `utils/markdown.ts` that intercepts `<a>` clicks with `preventDefault()` and routes them through a new `open_url` Tauri command
- The `open_url` command reuses the existing `opener` module (`open` on macOS, `xdg-open` on Linux) to open URLs in the system default browser
- Applied the override to all three `<Markdown>` render sites: streaming messages, completed messages (ChatPanel), and plan content (PlanApprovalCard)

Closes #216

## Test plan

- [x] Click a URL in an assistant chat message — should open in system browser
- [x] Click a URL in a streaming message — should open in system browser
- [ ] Click a link in a plan approval card — should open in system browser
- [x] Verify the webview does not navigate away from the app in any case
- [x] Verify `cargo clippy`, `cargo fmt --check`, `bunx tsc --noEmit`, and `cargo test` all pass