### PR TITLE
fix(chat): tone down completed progress bar brightness

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -717,7 +717,7 @@
 }
 
 .taskProgressDone {
-  background: var(--diff-added-text);
+  background: var(--badge-done);
 }
 
 .taskProgressLabel {


### PR DESCRIPTION
## Summary

- Use `--badge-done` (muted teal) instead of `--diff-added-text` (bright green) for the completed task progress bar
- The bright green was reported as visually distracting (#183)
- `--badge-done` is already used for sidebar completion badges, so this brings visual consistency

This is the remaining half of #183 — tool call auto-collapse was already fixed in PR #205.

Closes #183

## Test plan

- [x] Verified `taskProgressDone` CSS rule resolves to `var(--badge-done)` via debug eval
- [x] Injected before/after visual comparison in running app — muted teal vs bright green
- [x] TypeScript type check passes (`bunx tsc --noEmit`)