### PR TITLE
fix(git): fetch remote before worktree creation and add setup script auto-run

### DIFF
--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -47,6 +47,7 @@ pub async fn add_repository(
         custom_instructions: None,
         sort_order: 0,
         branch_rename_preferences: None,
+        setup_script_auto_run: false,
         path_valid: true,
     };
 
@@ -67,6 +68,7 @@ pub async fn update_repository_settings(
     setup_script: Option<String>,
     custom_instructions: Option<String>,
     branch_rename_preferences: Option<String>,
+    setup_script_auto_run: bool,
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -81,9 +83,23 @@ pub async fn update_repository_settings(
         .map_err(|e| e.to_string())?;
     db.update_repository_branch_rename_preferences(&id, branch_rename_preferences.as_deref())
         .map_err(|e| e.to_string())?;
+    db.update_repository_setup_script_auto_run(&id, setup_script_auto_run)
+        .map_err(|e| e.to_string())?;
 
     crate::tray::rebuild_tray(&app);
 
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn set_setup_script_auto_run(
+    repo_id: String,
+    enabled: bool,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.update_repository_setup_script_auto_run(&repo_id, enabled)
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -302,6 +302,7 @@ fn main() {
             commands::repository::get_repo_config,
             commands::repository::get_default_branch,
             commands::repository::reorder_repositories,
+            commands::repository::set_setup_script_auto_run,
             // Workspace
             commands::workspace::create_workspace,
             commands::workspace::run_workspace_setup,

--- a/src/db.rs
+++ b/src/db.rs
@@ -340,6 +340,14 @@ impl Database {
             )?;
         }
 
+        if version < 19 {
+            self.conn.execute_batch(
+                "ALTER TABLE repositories ADD COLUMN setup_script_auto_run INTEGER NOT NULL DEFAULT 0;
+
+                PRAGMA user_version = 19;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -375,13 +383,14 @@ impl Database {
             custom_instructions: row.get(7)?,
             sort_order: row.get(8)?,
             branch_rename_preferences: row.get(9)?,
+            setup_script_auto_run: row.get::<_, i32>(10).unwrap_or(0) != 0,
             path_valid: true, // validated after load
         })
     }
 
     pub fn list_repositories(&self) -> Result<Vec<Repository>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences
+            "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences, setup_script_auto_run
              FROM repositories ORDER BY sort_order, name",
         )?;
         let rows = stmt.query_map([], Self::parse_repo_row)?;
@@ -391,7 +400,7 @@ impl Database {
     pub fn get_repository(&self, id: &str) -> Result<Option<Repository>, rusqlite::Error> {
         self.conn
             .query_row(
-                "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences
+                "SELECT id, path, name, icon, path_slug, created_at, setup_script, custom_instructions, sort_order, branch_rename_preferences, setup_script_auto_run
                  FROM repositories WHERE id = ?1",
                 params![id],
                 Self::parse_repo_row,
@@ -456,6 +465,18 @@ impl Database {
         self.conn.execute(
             "UPDATE repositories SET setup_script = ?1 WHERE id = ?2",
             params![script, id],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_repository_setup_script_auto_run(
+        &self,
+        id: &str,
+        enabled: bool,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE repositories SET setup_script_auto_run = ?1 WHERE id = ?2",
+            params![enabled as i32, id],
         )?;
         Ok(())
     }
@@ -1439,6 +1460,7 @@ mod tests {
             custom_instructions: None,
             sort_order: 0,
             branch_rename_preferences: None,
+            setup_script_auto_run: false,
             path_valid: true,
         }
     }
@@ -1916,6 +1938,7 @@ mod tests {
             custom_instructions: None,
             sort_order: 0,
             branch_rename_preferences: None,
+            setup_script_auto_run: false,
             path_valid: true,
         };
         db.insert_repository(&repo).unwrap();

--- a/src/git.rs
+++ b/src/git.rs
@@ -149,13 +149,19 @@ pub async fn fetch_remote(repo_path: &str) -> Result<(), GitError> {
         .unwrap_or_else(|| "origin".to_string());
 
     // Spawn with kill_on_drop so the child is terminated if the timeout fires.
-    let mut child = Command::new("git")
+    let mut child = match Command::new("git")
         .args(["-C", repo_path, "fetch", &remote])
         .kill_on_drop(true)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
         .spawn()
-        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[git] failed to spawn fetch {remote}: {e}");
+            return Ok(());
+        }
+    };
 
     match tokio::time::timeout(std::time::Duration::from_secs(15), child.wait()).await {
         Ok(Ok(status)) if status.success() => Ok(()),

--- a/src/git.rs
+++ b/src/git.rs
@@ -136,11 +136,51 @@ pub async fn default_branch(repo_path: &str) -> Result<String, GitError> {
     ))
 }
 
+/// Fetch from the primary remote (best-effort).
+///
+/// Resolves the first configured remote and runs `git fetch` with a 15-second
+/// timeout. Failures are logged but never propagated — callers can proceed with
+/// potentially stale refs when the network is unavailable.
+pub async fn fetch_remote(repo_path: &str) -> Result<(), GitError> {
+    let remote = run_git(repo_path, &["remote"])
+        .await
+        .ok()
+        .and_then(|out| out.lines().next().map(|l| l.to_string()))
+        .unwrap_or_else(|| "origin".to_string());
+
+    // Spawn with kill_on_drop so the child is terminated if the timeout fires.
+    let mut child = Command::new("git")
+        .args(["-C", repo_path, "fetch", &remote])
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
+
+    match tokio::time::timeout(std::time::Duration::from_secs(15), child.wait()).await {
+        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(Ok(status)) => {
+            eprintln!("[git] fetch {remote} exited with {status} (continuing with local refs)");
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            eprintln!("[git] fetch {remote} failed (continuing with local refs): {e}");
+            Ok(())
+        }
+        Err(_) => {
+            eprintln!("[git] fetch {remote} timed out after 15s (continuing with local refs)");
+            Ok(())
+        }
+    }
+}
+
 pub async fn create_worktree(
     repo_path: &str,
     branch_name: &str,
     worktree_path: &str,
 ) -> Result<String, GitError> {
+    // Fetch latest remote state before branching (best-effort).
+    let _ = fetch_remote(repo_path).await;
     let base = default_branch(repo_path).await?;
     run_git(
         repo_path,
@@ -466,5 +506,95 @@ mod tests {
         // Renaming branch-a to branch-b should fail (already exists).
         let result = rename_branch(path, "branch-a", "branch-b").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_remote_no_remote() {
+        // fetch_remote should succeed (best-effort) even with no remote.
+        let dir = setup_temp_repo().await;
+        let path = dir.path().to_str().unwrap();
+        fetch_remote(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_worktree_with_remote() {
+        // Set up a bare "remote" and a clone that tracks it.
+        let remote_dir = tempfile::tempdir().unwrap();
+        let remote_path = remote_dir.path().to_str().unwrap();
+        run_git(remote_path, &["init", "--bare", "-b", "main"])
+            .await
+            .unwrap();
+
+        // Clone from bare remote.
+        let clone_dir = tempfile::tempdir().unwrap();
+        let clone_path = clone_dir.path().to_str().unwrap();
+        let output = tokio::process::Command::new("git")
+            .args(["clone", remote_path, clone_path])
+            .output()
+            .await
+            .unwrap();
+        assert!(output.status.success(), "clone failed");
+
+        // Configure user for clone.
+        run_git(clone_path, &["config", "user.email", "test@test.com"])
+            .await
+            .unwrap();
+        run_git(clone_path, &["config", "user.name", "Test"])
+            .await
+            .unwrap();
+
+        // Push an initial commit.
+        let file = clone_dir.path().join("a.txt");
+        std::fs::write(&file, "v1").unwrap();
+        run_git(clone_path, &["add", "-A"]).await.unwrap();
+        run_git(clone_path, &["commit", "-m", "v1"]).await.unwrap();
+        run_git(clone_path, &["push", "origin", "main"])
+            .await
+            .unwrap();
+
+        // Record the clone's current HEAD.
+        let clone_head = run_git(clone_path, &["rev-parse", "origin/main"])
+            .await
+            .unwrap();
+
+        // Push a new commit directly to the bare remote via a temp worktree.
+        let pusher = tempfile::tempdir().unwrap();
+        let pusher_path = pusher.path().to_str().unwrap();
+        let out = tokio::process::Command::new("git")
+            .args(["clone", remote_path, pusher_path])
+            .output()
+            .await
+            .unwrap();
+        assert!(out.status.success());
+        run_git(pusher_path, &["config", "user.email", "test@test.com"])
+            .await
+            .unwrap();
+        run_git(pusher_path, &["config", "user.name", "Test"])
+            .await
+            .unwrap();
+        std::fs::write(pusher.path().join("b.txt"), "v2").unwrap();
+        run_git(pusher_path, &["add", "-A"]).await.unwrap();
+        run_git(pusher_path, &["commit", "-m", "v2"]).await.unwrap();
+        run_git(pusher_path, &["push", "origin", "main"])
+            .await
+            .unwrap();
+
+        // At this point the clone's origin/main is stale (v1), remote has v2.
+        // create_worktree should fetch and branch from the latest commit.
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().to_str().unwrap();
+        create_worktree(clone_path, "test/fresh-branch", wt_path)
+            .await
+            .unwrap();
+
+        // The worktree's HEAD should be the new v2 commit, not the stale v1.
+        let wt_head = run_git(wt_path, &["rev-parse", "HEAD"]).await.unwrap();
+        assert_ne!(
+            wt_head, clone_head,
+            "worktree should be based on the latest remote commit, not the stale one"
+        );
+
+        // Clean up.
+        remove_worktree(clone_path, wt_path, true).await.unwrap();
     }
 }

--- a/src/model/repository.rs
+++ b/src/model/repository.rs
@@ -20,6 +20,8 @@ pub struct Repository {
     pub sort_order: i32,
     /// Custom instructions for how branch names should be generated during auto-rename.
     pub branch_rename_preferences: Option<String>,
+    /// When true, setup scripts run automatically without a confirmation modal.
+    pub setup_script_auto_run: bool,
     /// Runtime-only: whether the repo path still exists on disk. Not persisted.
     pub path_valid: bool,
 }

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -146,7 +146,17 @@ export function CommandPalette() {
                   thinking: null,
                 });
               }
-            }).catch(() => {});
+            }).catch((err) => {
+              addChatMessage(wsId, {
+                id: crypto.randomUUID(),
+                workspace_id: wsId,
+                role: "System",
+                content: `Setup script failed: ${err}`,
+                cost_usd: null, duration_ms: null,
+                created_at: new Date().toISOString(),
+                thinking: null,
+              });
+            });
           } else {
             openModal("confirmSetupScript", {
               workspaceId: result.workspace.id,

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -10,6 +10,7 @@ import {
   generateWorkspaceName,
   createWorkspace as createWorkspaceService,
   getRepoConfig,
+  runWorkspaceSetup,
 } from "../../services/tauri";
 import type { ThemeDefinition } from "../../types/theme";
 import { scoreCommand } from "./searchScore";
@@ -129,11 +130,31 @@ export function CommandPalette() {
         const script = config.setup_script ?? repo?.setup_script;
         const source = config.setup_script ? "repo" : "settings";
         if (script) {
-          openModal("confirmSetupScript", {
-            workspaceId: result.workspace.id,
-            script,
-            source,
-          });
+          if (repo?.setup_script_auto_run) {
+            const wsId = result.workspace.id;
+            runWorkspaceSetup(wsId).then((sr) => {
+              if (sr) {
+                const lbl = sr.source === "repo" ? ".claudette.json" : "settings";
+                const status = sr.success ? "completed" : sr.timed_out ? "timed out" : "failed";
+                addChatMessage(wsId, {
+                  id: crypto.randomUUID(),
+                  workspace_id: wsId,
+                  role: "System",
+                  content: `Setup script (${lbl}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
+                  cost_usd: null, duration_ms: null,
+                  created_at: new Date().toISOString(),
+                  thinking: null,
+                });
+              }
+            }).catch(() => {});
+          } else {
+            openModal("confirmSetupScript", {
+              workspaceId: result.workspace.id,
+              repoId,
+              script,
+              source,
+            });
+          }
         }
       } catch {
         // No config — no setup script to run.

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
-import { runWorkspaceSetup } from "../../services/tauri";
+import { runWorkspaceSetup, setSetupScriptAutoRun } from "../../services/tauri";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
@@ -8,15 +8,22 @@ export function ConfirmSetupScriptModal() {
   const closeModal = useAppStore((s) => s.closeModal);
   const modalData = useAppStore((s) => s.modalData);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
+  const updateRepository = useAppStore((s) => s.updateRepository);
   const [loading, setLoading] = useState(false);
+  const [alwaysRun, setAlwaysRun] = useState(false);
 
   const workspaceId = modalData.workspaceId as string;
   const script = modalData.script as string;
   const source = modalData.source as string;
+  const repoId = modalData.repoId as string;
 
   const handleRun = async () => {
     setLoading(true);
     try {
+      if (alwaysRun && repoId) {
+        await setSetupScriptAutoRun(repoId, true);
+        updateRepository(repoId, { setup_script_auto_run: true });
+      }
       const sr = await runWorkspaceSetup(workspaceId);
       if (sr) {
         const label = sr.source === "repo" ? ".claudette.json" : "settings";
@@ -79,6 +86,25 @@ export function ConfirmSetupScriptModal() {
         >
           {script}
         </pre>
+      </div>
+      <div className={shared.field}>
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            fontSize: 12,
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={alwaysRun}
+            onChange={(e) => setAlwaysRun(e.target.checked)}
+          />
+          Always run setup scripts for this repo
+        </label>
       </div>
       <div className={shared.actions}>
         <button className={shared.btn} onClick={closeModal}>

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -40,6 +40,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const [branchRenamePreferences, setBranchRenamePreferences] = useState(
     repo?.branch_rename_preferences ?? ""
   );
+  const [autoRunSetup, setAutoRunSetup] = useState(repo?.setup_script_auto_run ?? false);
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [repoConfig, setRepoConfig] = useState<RepoConfigInfo | null>(null);
@@ -54,6 +55,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
       setSetupScript(repo.setup_script ?? "");
       setCustomInstructions(repo.custom_instructions ?? "");
       setBranchRenamePreferences(repo.branch_rename_preferences ?? "");
+      setAutoRunSetup(repo.setup_script_auto_run ?? false);
       setError(null);
     }
   }, [repoId]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -123,11 +125,13 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const setupScriptRef = useRef(setupScript);
   const customInstructionsRef = useRef(customInstructions);
   const branchRenamePreferencesRef = useRef(branchRenamePreferences);
+  const autoRunSetupRef = useRef(autoRunSetup);
   nameRef.current = name;
   iconRef.current = icon;
   setupScriptRef.current = setupScript;
   customInstructionsRef.current = customInstructions;
   branchRenamePreferencesRef.current = branchRenamePreferences;
+  autoRunSetupRef.current = autoRunSetup;
 
   const save = useCallback(
     async (updates: {
@@ -136,6 +140,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
       setup_script?: string | null;
       custom_instructions?: string | null;
       branch_rename_preferences?: string | null;
+      setup_script_auto_run?: boolean;
     }) => {
       const finalName = (updates.name ?? nameRef.current).trim();
       if (!finalName) return;
@@ -155,6 +160,10 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         updates.branch_rename_preferences !== undefined
           ? updates.branch_rename_preferences
           : branchRenamePreferencesRef.current.trim() || null;
+      const finalAutoRun =
+        updates.setup_script_auto_run !== undefined
+          ? updates.setup_script_auto_run
+          : autoRunSetupRef.current;
 
       try {
         setError(null);
@@ -164,7 +173,8 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           finalIcon,
           finalScript,
           finalInstructions,
-          finalBranchPrefs
+          finalBranchPrefs,
+          finalAutoRun
         );
         updateRepo(repoId, {
           name: finalName,
@@ -172,6 +182,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           setup_script: finalScript,
           custom_instructions: finalInstructions,
           branch_rename_preferences: finalBranchPrefs,
+          setup_script_auto_run: finalAutoRun,
         });
       } catch (e) {
         setError(String(e));
@@ -266,6 +277,27 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         <div className={styles.fieldHint}>
           Runs automatically when a new workspace is created.
         </div>
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginTop: 8,
+            fontSize: 12,
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={autoRunSetup}
+            onChange={(e) => {
+              setAutoRunSetup(e.target.checked);
+              save({ setup_script_auto_run: e.target.checked });
+            }}
+          />
+          Skip confirmation when running setup scripts
+        </label>
       </div>
 
       <div className={styles.fieldGroup}>

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -134,7 +134,17 @@ export const Sidebar = memo(function Sidebar() {
                   thinking: null,
                 });
               }
-            }).catch(() => {});
+            }).catch((err) => {
+              addChatMessage(wsId, {
+                id: crypto.randomUUID(),
+                workspace_id: wsId,
+                role: "System",
+                content: `Setup script failed: ${err}`,
+                cost_usd: null, duration_ms: null,
+                created_at: new Date().toISOString(),
+                thinking: null,
+              });
+            });
           } else {
             openModal("confirmSetupScript", {
               workspaceId: result.workspace.id,

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   generateWorkspaceName,
   createWorkspace,
   getRepoConfig,
+  runWorkspaceSetup,
   connectRemote,
   disconnectRemote,
   removeRemoteConnection,
@@ -117,11 +118,31 @@ export const Sidebar = memo(function Sidebar() {
         const script = config.setup_script ?? repo?.setup_script;
         const source = config.setup_script ? "repo" : "settings";
         if (script) {
-          openModal("confirmSetupScript", {
-            workspaceId: result.workspace.id,
-            script,
-            source,
-          });
+          if (repo?.setup_script_auto_run) {
+            const wsId = result.workspace.id;
+            runWorkspaceSetup(wsId).then((sr) => {
+              if (sr) {
+                const lbl = sr.source === "repo" ? ".claudette.json" : "settings";
+                const status = sr.success ? "completed" : sr.timed_out ? "timed out" : "failed";
+                addChatMessage(wsId, {
+                  id: crypto.randomUUID(),
+                  workspace_id: wsId,
+                  role: "System",
+                  content: `Setup script (${lbl}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
+                  cost_usd: null, duration_ms: null,
+                  created_at: new Date().toISOString(),
+                  thinking: null,
+                });
+              }
+            }).catch(() => {});
+          } else {
+            openModal("confirmSetupScript", {
+              workspaceId: result.workspace.id,
+              repoId,
+              script,
+              source,
+            });
+          }
         }
       } catch {
         // No config or error reading it — no setup script to run.

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -47,7 +47,8 @@ export function updateRepositorySettings(
   icon: string | null,
   setupScript: string | null,
   customInstructions: string | null,
-  branchRenamePreferences: string | null
+  branchRenamePreferences: string | null,
+  setupScriptAutoRun: boolean
 ): Promise<void> {
   return invoke("update_repository_settings", {
     id,
@@ -56,6 +57,7 @@ export function updateRepositorySettings(
     setupScript,
     customInstructions,
     branchRenamePreferences,
+    setupScriptAutoRun,
   });
 }
 
@@ -77,6 +79,10 @@ export function getDefaultBranch(repoId: string): Promise<string | null> {
 
 export function reorderRepositories(ids: string[]): Promise<void> {
   return invoke("reorder_repositories", { ids });
+}
+
+export function setSetupScriptAutoRun(repoId: string, enabled: boolean): Promise<void> {
+  return invoke("set_setup_script_auto_run", { repoId, enabled });
 }
 
 // -- Workspace --

--- a/src/ui/src/types/repository.ts
+++ b/src/ui/src/types/repository.ts
@@ -9,6 +9,7 @@ export interface Repository {
   custom_instructions: string | null;
   sort_order: number;
   branch_rename_preferences: string | null;
+  setup_script_auto_run: boolean;
   path_valid: boolean;
   /** Non-null when this repo belongs to a remote connection. */
   remote_connection_id: string | null;


### PR DESCRIPTION
## Summary

Fixes two issues reported in #217:

1. **Stale worktree refs** — New worktrees were branched from local remote-tracking refs that were never fetched, so they started from the clone-time commit instead of the latest remote state. Added `fetch_remote()` to `git.rs` that runs a best-effort `git fetch` with a 15-second timeout before every `create_worktree()` call. Uses `kill_on_drop(true)` to ensure the git process is terminated on timeout rather than orphaned.

2. **Setup script confirmation fatigue** — Users who rely on setup scripts (including those who added `git pull` as a workaround for issue 1) were prompted to approve on every workspace creation with no "trust" option. Added a per-repo `setup_script_auto_run` setting (DB migration 19) that skips the confirmation modal. Togglable from:
   - A checkbox in the setup script confirmation modal ("Always run setup scripts for this repo")
   - A checkbox in repo settings ("Skip confirmation when running setup scripts")

```mermaid
flowchart TD
    A[Create Workspace] --> B[fetch_remote — 15s timeout, best-effort]
    B --> C[create_worktree from latest ref]
    C --> D{Setup script exists?}
    D -->|No| E[Done]
    D -->|Yes| F{auto_run enabled?}
    F -->|Yes| G[Run script, report result to chat]
    F -->|No| H[Show confirmation modal]
    H -->|Run + checkbox| I[Run script + persist auto_run]
    H -->|Run| J[Run script]
    H -->|Skip| E
```

## Complexity Notes

- `fetch_remote()` spawns the git process with `kill_on_drop(true)` and pipes stderr to null — this ensures clean timeout behavior but means fetch errors are only logged to Rust stderr, not surfaced to users. This is intentional: fetch failures are expected (offline, firewalls) and silently falling back to stale refs matches the pre-existing behavior.

## Test Steps

1. **Verify fetch before worktree**:
   - Add a repo to Claudette, wait for new commits on the remote
   - Create a new workspace — it should be based on the latest remote commit
   - `cargo test test_create_worktree_with_remote` verifies this end-to-end

2. **Verify auto-run toggle**:
   - Create a workspace for a repo with a setup script configured
   - Modal should appear with "Always run setup scripts for this repo" checkbox
   - Check the box and click "Run Script"
   - Create another workspace — setup script should run automatically without the modal
   - Verify a System message appears in chat with the script result

3. **Verify settings revocation**:
   - Open repo settings → Setup script section
   - Uncheck "Skip confirmation when running setup scripts"
   - Create another workspace — confirmation modal should appear again

4. **Verify offline resilience**:
   - Disconnect from network
   - Create a workspace — should succeed with stale refs after 15s timeout (or immediately if no remote configured)

## Checklist

- [x] Tests added/updated (`test_fetch_remote_no_remote`, `test_create_worktree_with_remote`)
- [x] DB migration added (version 19)
- [x] Clippy clean, tsc clean, 350/350 tests pass

Closes #217