### PR TITLE
feat(settings): add configurable data directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 0.8.2",
  "url",
  "uuid",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 which = "7"
 dirs = "6"
+toml = "0.8"
 open = "5"
 rand = "0.8"
 

--- a/src-server/src/lib.rs
+++ b/src-server/src/lib.rs
@@ -46,10 +46,7 @@ pub fn default_config_path() -> PathBuf {
 }
 
 pub fn db_path() -> PathBuf {
-    dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("claudette")
-        .join("claudette.db")
+    claudette::app_config::resolve_db_path()
 }
 
 /// Run the claudette-server with the given options. Blocks indefinitely,
@@ -89,9 +86,9 @@ pub async fn run(options: ServerOptions) -> Result<(), Box<dyn std::error::Error
     let _ = claudette::db::Database::open(&db_path);
 
     let worktree_base_dir = {
-        let default = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".claudette")
+        let default = db_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
             .join("workspaces");
         if let Ok(db) = claudette::db::Database::open(&db_path) {
             db.get_app_setting("worktree_base_dir")

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -32,6 +32,10 @@ struct Cli {
     #[arg(long)]
     config: Option<PathBuf>,
 
+    /// Override the data directory (where claudette.db is stored).
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -47,6 +51,13 @@ enum Commands {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+
+    // If --data-dir is provided, set the env var so the shared resolver picks it up.
+    // SAFETY: called before any threads are spawned (single-threaded main at this point).
+    if let Some(ref dir) = cli.data_dir {
+        unsafe { std::env::set_var("CLAUDETTE_DATA_DIR", dir) };
+    }
+
     let config_path = cli.config.clone().unwrap_or_else(default_config_path);
 
     match &cli.command {

--- a/src-server/src/main.rs
+++ b/src-server/src/main.rs
@@ -48,16 +48,24 @@ enum Commands {
     ShowConnectionString,
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     // If --data-dir is provided, set the env var so the shared resolver picks it up.
-    // SAFETY: called before any threads are spawned (single-threaded main at this point).
+    // SAFETY: called before the Tokio runtime is constructed, so no worker
+    // threads have been spawned yet.
     if let Some(ref dir) = cli.data_dir {
         unsafe { std::env::set_var("CLAUDETTE_DATA_DIR", dir) };
     }
 
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    runtime.block_on(async_main(cli))
+}
+
+async fn async_main(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = cli.config.clone().unwrap_or_else(default_config_path);
 
     match &cli.command {

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -52,8 +52,10 @@ pub struct DetectedApp {
 // ---------------------------------------------------------------------------
 
 /// Resolve the path to the user's apps.json config file.
+///
+/// Lives inside the data directory alongside the database, themes, etc.
 fn apps_config_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claudette").join("apps.json"))
+    Some(claudette::app_config::resolve_data_dir().join("apps.json"))
 }
 
 /// Load and parse apps.json from the given path.
@@ -84,7 +86,7 @@ fn load_apps_config_from(path: &Path) -> AppsConfig {
     serde_json::from_str(DEFAULT_APPS_JSON).expect("embedded default-apps.json must be valid")
 }
 
-/// Public entry point — resolves ~/.claudette/apps.json and loads it.
+/// Public entry point — resolves apps.json from the data directory and loads it.
 fn load_apps_config() -> AppsConfig {
     match apps_config_path() {
         Some(path) => load_apps_config_from(&path),

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -280,8 +280,11 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
         let server_bin = std::env::current_exe()
             .map_err(|e| format!("Failed to locate current executable: {e}"))?;
 
+        let data_dir = state.db_path.parent().unwrap_or(std::path::Path::new("."));
+
         let mut child = tokio::process::Command::new(&server_bin)
             .arg("--server")
+            .env("CLAUDETTE_DATA_DIR", data_dir)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -74,6 +74,48 @@ pub async fn set_app_setting(
     Ok(())
 }
 
+/// Information about the current data directory configuration.
+#[derive(Serialize)]
+pub struct DataDirInfo {
+    /// The currently active data directory path.
+    pub current: String,
+    /// The configured override (from config.toml), if any.
+    pub configured: Option<String>,
+    /// Whether the CLAUDETTE_DATA_DIR env var is set.
+    pub env_override: bool,
+    /// The config file path, for display in the UI.
+    pub config_path: Option<String>,
+}
+
+#[tauri::command]
+pub async fn get_data_dir_info(state: State<'_, AppState>) -> Result<DataDirInfo, String> {
+    let current = state
+        .db_path
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .to_string_lossy()
+        .to_string();
+
+    let config = claudette::app_config::load_app_config();
+    let env_override = std::env::var("CLAUDETTE_DATA_DIR")
+        .ok()
+        .is_some_and(|v| !v.trim().is_empty());
+    let config_path =
+        claudette::app_config::app_config_path().map(|p| p.to_string_lossy().to_string());
+
+    Ok(DataDirInfo {
+        current,
+        configured: config.data_dir,
+        env_override,
+        config_path,
+    })
+}
+
+#[tauri::command]
+pub async fn set_data_dir(data_dir: Option<String>) -> Result<(), String> {
+    claudette::app_config::save_data_dir_config(data_dir.as_deref())
+}
+
 /// Read the global `git config user.name` and return it as a branch-safe slug.
 #[tauri::command]
 pub async fn get_git_username() -> Result<Option<String>, String> {
@@ -280,12 +322,15 @@ pub fn run_notification_command(
 }
 
 #[tauri::command]
-pub async fn list_user_themes() -> Result<Vec<ThemeDefinition>, String> {
-    tauri::async_runtime::spawn_blocking(|| {
-        let themes_dir = dirs::home_dir()
-            .ok_or("Could not determine home directory")?
-            .join(".claudette")
-            .join("themes");
+pub async fn list_user_themes(state: State<'_, AppState>) -> Result<Vec<ThemeDefinition>, String> {
+    let data_dir = state
+        .db_path
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .to_path_buf();
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let themes_dir = data_dir.join("themes");
 
         if !themes_dir.exists() {
             return Ok(Vec::new());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,19 +42,16 @@ fn main() {
     }
 
     // Determine database and worktree paths.
-    let data_dir = dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("claudette");
-    let db_path = data_dir.join("claudette.db");
+    let db_path = claudette::app_config::resolve_db_path();
 
     // Ensure DB exists and migrations are applied.
     let _ = Database::open(&db_path);
 
-    // Load worktree base dir from settings, or use default.
+    // Load worktree base dir from settings, or use default (inside data dir).
     let worktree_base_dir = {
-        let default = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".claudette")
+        let default = db_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
             .join("workspaces");
         if let Ok(db) = Database::open(&db_path) {
             db.get_app_setting("worktree_base_dir")
@@ -350,6 +347,8 @@ fn main() {
             // Settings
             commands::settings::get_app_setting,
             commands::settings::set_app_setting,
+            commands::settings::get_data_dir_info,
+            commands::settings::set_data_dir,
             commands::settings::list_user_themes,
             commands::settings::list_notification_sounds,
             commands::settings::list_system_fonts,

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -1,0 +1,223 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// App-level configuration stored outside the database.
+///
+/// This lives at a fixed platform path (`dirs::config_dir()/claudette/config.toml`)
+/// and is read before the database is opened — solving the chicken-and-egg problem
+/// of storing the data directory override in the database it configures.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct AppConfig {
+    /// Override the default data directory (where `claudette.db` is stored).
+    pub data_dir: Option<String>,
+}
+
+/// Fixed path where the app-level config file lives.
+pub fn app_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("claudette").join("config.toml"))
+}
+
+/// Read and parse the app config file. Returns `Default` on any error.
+pub fn load_app_config() -> AppConfig {
+    let Some(config_path) = app_config_path() else {
+        return AppConfig::default();
+    };
+    let Ok(contents) = std::fs::read_to_string(&config_path) else {
+        return AppConfig::default();
+    };
+    toml::from_str(&contents).unwrap_or_default()
+}
+
+/// Expand a leading `~` to the user's home directory.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    } else if path == "~"
+        && let Some(home) = dirs::home_dir()
+    {
+        return home;
+    }
+    PathBuf::from(path)
+}
+
+/// Resolve the data directory using: env var > config file > platform default.
+pub fn resolve_data_dir() -> PathBuf {
+    // 1. Environment variable (highest priority).
+    if let Ok(val) = std::env::var("CLAUDETTE_DATA_DIR") {
+        let val = val.trim();
+        if !val.is_empty() {
+            return expand_tilde(val);
+        }
+    }
+
+    // 2. Config file.
+    let config = load_app_config();
+    if let Some(ref dir) = config.data_dir {
+        let dir = dir.trim();
+        if !dir.is_empty() {
+            return expand_tilde(dir);
+        }
+    }
+
+    // 3. Platform default.
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("claudette")
+}
+
+/// Resolve the full database path: `<data_dir>/claudette.db`.
+pub fn resolve_db_path() -> PathBuf {
+    resolve_data_dir().join("claudette.db")
+}
+
+/// Save a data directory override to the config file.
+///
+/// Pass `None` to clear the override and revert to the platform default.
+pub fn save_data_dir_config(data_dir: Option<&str>) -> Result<(), String> {
+    let config_path = app_config_path().ok_or("Could not determine config directory")?;
+
+    let config = AppConfig {
+        data_dir: data_dir.map(|s| s.to_string()),
+    };
+
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config directory: {e}"))?;
+    }
+
+    let content =
+        toml::to_string_pretty(&config).map_err(|e| format!("Failed to serialize config: {e}"))?;
+    std::fs::write(&config_path, content)
+        .map_err(|e| format!("Failed to write config file: {e}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_tilde_with_subpath() {
+        let result = expand_tilde("~/foo/bar");
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(result, home.join("foo/bar"));
+        }
+    }
+
+    #[test]
+    fn test_expand_tilde_bare() {
+        let result = expand_tilde("~");
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(result, home);
+        }
+    }
+
+    #[test]
+    fn test_expand_tilde_absolute_passthrough() {
+        let result = expand_tilde("/tmp/claudette");
+        assert_eq!(result, PathBuf::from("/tmp/claudette"));
+    }
+
+    #[test]
+    fn test_resolve_data_dir_env_override() {
+        // Temporarily set the env var and verify it takes priority.
+        let key = "CLAUDETTE_DATA_DIR";
+        let prev = std::env::var(key).ok();
+        // SAFETY: test runs serially; no other thread reads this env var concurrently.
+        unsafe { std::env::set_var(key, "/tmp/claudette-test-env") };
+
+        let result = resolve_data_dir();
+        assert_eq!(result, PathBuf::from("/tmp/claudette-test-env"));
+
+        // Restore previous value.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
+    fn test_resolve_data_dir_default_has_claudette_suffix() {
+        let key = "CLAUDETTE_DATA_DIR";
+        let prev = std::env::var(key).ok();
+        // SAFETY: test runs serially; no other thread reads this env var concurrently.
+        unsafe { std::env::remove_var(key) };
+
+        let result = resolve_data_dir();
+        // The default should end with "claudette" (the directory name).
+        assert!(
+            result
+                .file_name()
+                .is_some_and(|n| n.to_string_lossy() == "claudette"),
+            "Expected default data dir to end with 'claudette', got: {result:?}"
+        );
+
+        if let Some(v) = prev {
+            // SAFETY: restoring previous env state.
+            unsafe { std::env::set_var(key, v) };
+        }
+    }
+
+    #[test]
+    fn test_resolve_db_path_ends_with_db_file() {
+        let key = "CLAUDETTE_DATA_DIR";
+        let prev = std::env::var(key).ok();
+        // SAFETY: test runs serially; no other thread reads this env var concurrently.
+        unsafe { std::env::set_var(key, "/tmp/claudette-test-db") };
+
+        let result = resolve_db_path();
+        assert_eq!(result, PathBuf::from("/tmp/claudette-test-db/claudette.db"));
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    #[test]
+    fn test_save_and_load_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+
+        let config = AppConfig {
+            data_dir: Some("/custom/path".to_string()),
+        };
+
+        let content = toml::to_string_pretty(&config).unwrap();
+        std::fs::write(&config_path, &content).unwrap();
+
+        let loaded: AppConfig =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(loaded.data_dir.as_deref(), Some("/custom/path"));
+    }
+
+    #[test]
+    fn test_load_config_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        let loaded: AppConfig =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert!(loaded.data_dir.is_none());
+    }
+
+    #[test]
+    fn test_load_config_no_data_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "# just a comment\n").unwrap();
+
+        let loaded: AppConfig =
+            toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert!(loaded.data_dir.is_none());
+    }
+}

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -100,6 +100,12 @@ pub fn save_data_dir_config(data_dir: Option<&str>) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    /// Guard for tests that mutate the `CLAUDETTE_DATA_DIR` env var.
+    /// `std::env::set_var` is unsafe because it can race with concurrent
+    /// readers. This mutex serializes all env-var-mutating tests so the
+    /// `unsafe` blocks are sound.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_expand_tilde_with_subpath() {
         let result = expand_tilde("~/foo/bar");
@@ -124,16 +130,15 @@ mod tests {
 
     #[test]
     fn test_resolve_data_dir_env_override() {
-        // Temporarily set the env var and verify it takes priority.
+        let _guard = ENV_MUTEX.lock().unwrap();
         let key = "CLAUDETTE_DATA_DIR";
         let prev = std::env::var(key).ok();
-        // SAFETY: test runs serially; no other thread reads this env var concurrently.
+        // SAFETY: ENV_MUTEX serializes all env-var-mutating tests.
         unsafe { std::env::set_var(key, "/tmp/claudette-test-env") };
 
         let result = resolve_data_dir();
         assert_eq!(result, PathBuf::from("/tmp/claudette-test-env"));
 
-        // Restore previous value.
         unsafe {
             match prev {
                 Some(v) => std::env::set_var(key, v),
@@ -144,13 +149,13 @@ mod tests {
 
     #[test]
     fn test_resolve_data_dir_default_has_claudette_suffix() {
+        let _guard = ENV_MUTEX.lock().unwrap();
         let key = "CLAUDETTE_DATA_DIR";
         let prev = std::env::var(key).ok();
-        // SAFETY: test runs serially; no other thread reads this env var concurrently.
+        // SAFETY: ENV_MUTEX serializes all env-var-mutating tests.
         unsafe { std::env::remove_var(key) };
 
         let result = resolve_data_dir();
-        // The default should end with "claudette" (the directory name).
         assert!(
             result
                 .file_name()
@@ -158,17 +163,20 @@ mod tests {
             "Expected default data dir to end with 'claudette', got: {result:?}"
         );
 
-        if let Some(v) = prev {
-            // SAFETY: restoring previous env state.
-            unsafe { std::env::set_var(key, v) };
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
         }
     }
 
     #[test]
     fn test_resolve_db_path_ends_with_db_file() {
+        let _guard = ENV_MUTEX.lock().unwrap();
         let key = "CLAUDETTE_DATA_DIR";
         let prev = std::env::var(key).ok();
-        // SAFETY: test runs serially; no other thread reads this env var concurrently.
+        // SAFETY: ENV_MUTEX serializes all env-var-mutating tests.
         unsafe { std::env::set_var(key, "/tmp/claudette-test-db") };
 
         let result = resolve_db_path();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod app_config;
 pub mod config;
 pub mod db;
 pub mod diff;

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useState } from "react";
-import { FolderOpen } from "lucide-react";
+import { FolderOpen, RotateCcw } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { getVersion } from "@tauri-apps/api/app";
+import { relaunch } from "@tauri-apps/plugin-process";
 import { useAppStore } from "../../../stores/useAppStore";
-import { getAppSetting, setAppSetting } from "../../../services/tauri";
+import {
+  getAppSetting,
+  setAppSetting,
+  getDataDirInfo,
+  setDataDir,
+} from "../../../services/tauri";
+import type { DataDirInfo } from "../../../services/tauri";
 import { checkForUpdate } from "../../../hooks/useAutoUpdater";
 import styles from "../Settings.module.css";
 
@@ -20,6 +27,11 @@ export function GeneralSettings() {
   const [error, setError] = useState<string | null>(null);
   const [appVersion, setAppVersion] = useState("");
   const [checkState, setCheckState] = useState<"idle" | "checking" | "up-to-date">("idle");
+
+  // Data directory state
+  const [dataDirInfo, setDataDirInfo] = useState<DataDirInfo | null>(null);
+  const [dataDirInput, setDataDirInput] = useState("");
+  const [dataDirChanged, setDataDirChanged] = useState(false);
 
   useEffect(() => {
     setPath(worktreeBaseDir);
@@ -56,6 +68,16 @@ export function GeneralSettings() {
     if (updateAvailable) setCheckState("idle");
   }, [updateAvailable]);
 
+  // Load data directory info on mount.
+  useEffect(() => {
+    getDataDirInfo()
+      .then((info) => {
+        setDataDirInfo(info);
+        setDataDirInput(info.configured ?? info.current);
+      })
+      .catch(() => {});
+  }, []);
+
   const handleCheckForUpdates = async () => {
     setError(null);
     setCheckState("checking");
@@ -89,6 +111,35 @@ export function GeneralSettings() {
       await setAppSetting("tray_enabled", next ? "true" : "false");
     } catch (e) {
       setTrayEnabled(!next);
+      setError(String(e));
+    }
+  };
+
+  const handleDataDirBlur = async () => {
+    const trimmed = dataDirInput.trim();
+    if (!dataDirInfo || !trimmed) return;
+    // If the input matches the current active dir and there's no existing
+    // override, nothing to do.
+    if (trimmed === dataDirInfo.current && !dataDirInfo.configured) return;
+    try {
+      setError(null);
+      await setDataDir(trimmed);
+      setDataDirInfo((prev) => prev ? { ...prev, configured: trimmed } : prev);
+      setDataDirChanged(trimmed !== dataDirInfo.current);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handleDataDirReset = async () => {
+    if (!dataDirInfo) return;
+    try {
+      setError(null);
+      await setDataDir(null);
+      setDataDirInput(dataDirInfo.current);
+      setDataDirInfo((prev) => prev ? { ...prev, configured: null } : prev);
+      setDataDirChanged(false);
+    } catch (e) {
       setError(String(e));
     }
   };
@@ -171,6 +222,97 @@ export function GeneralSettings() {
               <FolderOpen size={14} />
             </button>
           </div>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Data directory</div>
+          <div className={styles.settingDescription}>
+            Where Claudette stores its data (database, themes, apps config).
+            Existing data is not moved automatically.
+            {dataDirInfo?.env_override && (
+              <>
+                <br />
+                <span style={{ color: "var(--text-tertiary)" }}>
+                  Overridden by CLAUDETTE_DATA_DIR environment variable
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          {dataDirInfo?.env_override ? (
+            <span className={styles.input} style={{ opacity: 0.6 }}>
+              {dataDirInfo.current}
+            </span>
+          ) : (
+            <div className={styles.inlineControl}>
+              <input
+                className={styles.input}
+                value={dataDirInput}
+                onChange={(e) => setDataDirInput(e.target.value)}
+                onBlur={handleDataDirBlur}
+                placeholder={dataDirInfo?.current ?? ""}
+              />
+              <button
+                className={styles.iconBtn}
+                onClick={async () => {
+                  try {
+                    const selected = await open({
+                      directory: true,
+                      multiple: false,
+                    });
+                    if (selected && dataDirInfo) {
+                      setDataDirInput(selected);
+                      setError(null);
+                      await setDataDir(selected);
+                      setDataDirInfo((prev) =>
+                        prev ? { ...prev, configured: selected } : prev,
+                      );
+                      setDataDirChanged(selected !== dataDirInfo.current);
+                    }
+                  } catch (e) {
+                    setError(String(e));
+                  }
+                }}
+                title="Browse"
+              >
+                <FolderOpen size={14} />
+              </button>
+              {dataDirInfo?.configured && (
+                <button
+                  className={styles.iconBtn}
+                  onClick={handleDataDirReset}
+                  title="Reset to default"
+                >
+                  <RotateCcw size={14} />
+                </button>
+              )}
+            </div>
+          )}
+          {dataDirChanged && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginTop: 6,
+              }}
+            >
+              <span
+                style={{
+                  fontSize: "0.8em",
+                  color: "var(--text-warning, var(--text-tertiary))",
+                }}
+              >
+                Restart required
+              </span>
+              <button className={styles.iconBtn} onClick={() => relaunch()}>
+                Restart now
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -118,9 +118,10 @@ export function GeneralSettings() {
   const handleDataDirBlur = async () => {
     const trimmed = dataDirInput.trim();
     if (!dataDirInfo || !trimmed) return;
-    // If the input matches the current active dir and there's no existing
-    // override, nothing to do.
+    // Skip if unchanged: matches current with no override, or matches the
+    // existing configured value. Avoids unnecessary disk I/O on every blur.
     if (trimmed === dataDirInfo.current && !dataDirInfo.configured) return;
+    if (trimmed === dataDirInfo.configured) return;
     try {
       setError(null);
       await setDataDir(trimmed);

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -366,6 +366,21 @@ export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
 
+export interface DataDirInfo {
+  current: string;
+  configured: string | null;
+  env_override: boolean;
+  config_path: string | null;
+}
+
+export function getDataDirInfo(): Promise<DataDirInfo> {
+  return invoke("get_data_dir_info");
+}
+
+export function setDataDir(dataDir: string | null): Promise<void> {
+  return invoke("set_data_dir", { dataDir });
+}
+
 import type { ThemeDefinition } from "../types/theme";
 
 export function listUserThemes(): Promise<ThemeDefinition[]> {


### PR DESCRIPTION
## Summary

- Adds a **Data directory** setting in General settings that lets users configure where Claudette stores its files (database, themes, apps config, default workspaces)
- Resolves data directory with 3-tier priority: `CLAUDETTE_DATA_DIR` env var > `config.toml` > platform default
- Config file (`config.toml`) lives at a fixed platform path outside the database, solving the chicken-and-egg bootstrapping problem
- Unifies all app data under one configurable root — themes, apps.json, and default worktree base dir now live alongside the database instead of hardcoded to `~/.claudette/`

```mermaid
flowchart LR
    A[CLAUDETTE_DATA_DIR env var] -->|highest priority| D[Resolved data dir]
    B[config.toml data_dir] -->|medium priority| D
    C[Platform default] -->|fallback| D
    D --> E[claudette.db]
    D --> F[themes/]
    D --> G[apps.json]
    D --> H[workspaces/]
```

### Files changed

| Area | Files | What |
|------|-------|------|
| Core | `src/app_config.rs` (new), `src/lib.rs`, `Cargo.toml` | Config resolution module with TOML parsing, tilde expansion, 9 unit tests |
| Tauri app | `src-tauri/src/main.rs` | Use `resolve_db_path()`, derive default worktree base from data dir |
| Tauri commands | `src-tauri/src/commands/settings.rs` | `get_data_dir_info` + `set_data_dir` commands; themes now read from data dir |
| Tauri commands | `src-tauri/src/commands/apps.rs` | Apps config now lives in data dir |
| Tauri commands | `src-tauri/src/commands/remote.rs` | Propagate `CLAUDETTE_DATA_DIR` to embedded server subprocess |
| Server | `src-server/src/lib.rs`, `src-server/src/main.rs` | Use shared resolver; add `--data-dir` CLI flag |
| Frontend | `GeneralSettings.tsx`, `tauri.ts` | Data directory setting row with folder picker, restart flow, env var detection |

## Complexity Notes

- **Chicken-and-egg problem**: Settings live in SQLite, but the data directory determines where SQLite is stored. The override is stored in a TOML config file at a fixed platform path (`dirs::config_dir()/claudette/config.toml`), read before the DB is opened.
- **`set_var` is unsafe in edition 2024**: The server CLI and tests wrap `std::env::set_var` in `unsafe` blocks with safety comments — this is required because Rust 2024 marks env var mutation as unsafe due to thread-safety concerns.
- **Shell integration scripts are intentionally NOT moved**: They live at `~/.config/claudette/` and are sourced from shell RC files with hardcoded paths — moving them would break existing setups.

## Test Steps

1. `cargo test --all-features` — 357 tests pass including 9 new `app_config` tests
2. `cargo clippy --workspace --all-targets` with `RUSTFLAGS="-Dwarnings"` — zero warnings
3. `bunx tsc --noEmit` — clean TypeScript compilation
4. Launch app, open Settings > General, verify "Data directory" row appears showing current path
5. Change path via folder picker, verify "Restart required" indicator and "Restart now" button appear
6. Click reset button, verify path reverts to current value and restart indicator disappears
7. Set `CLAUDETTE_DATA_DIR=/tmp/claudette-test` env var, launch app, verify field shows override path as read-only with env var message
8. Verify `claudette-server --data-dir /tmp/test` accepts the flag (via `--help`)

## Checklist
- [x] Tests added/updated (9 new unit tests for config resolution, tilde expansion, serialization)
- [ ] Documentation updated (if applicable)