### PR TITLE
feat(sidebar): replace workspace filter buttons with compact dropdown menu

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -6,6 +6,9 @@
 
 .header {
   padding: 14px 16px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 [data-platform="mac"] .header {
@@ -20,31 +23,68 @@
   letter-spacing: 0.08em;
 }
 
-.filters {
-  display: flex;
-  gap: 2px;
-  padding: 0 12px 8px;
+.filterDropdown {
+  position: relative;
 }
 
-.filterBtn {
+.filterToggle {
   background: none;
   border: none;
   color: var(--text-dim);
-  font-size: 12px;
-  padding: 3px 8px;
-  border-radius: 4px;
   cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
   transition: color var(--transition-fast), background var(--transition-fast);
 }
 
-.filterBtn:hover {
+.filterToggle:hover {
   background: var(--hover-bg);
   color: var(--text-muted);
 }
 
-.filterActive {
+.filterMenu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 120px;
+  z-index: 100;
+  overflow: hidden;
+}
+
+.filterMenuItem {
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  text-align: left;
+}
+
+.filterMenuItem:hover {
+  background: var(--hover-bg);
+}
+
+.filterMenuItem span {
+  flex: 1;
+}
+
+.filterMenuItem svg {
   color: var(--accent-primary);
-  background: var(--accent-bg);
+  flex-shrink: 0;
 }
 
 .list {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState, useMemo, useCallback } from "react";
+import { memo, useRef, useState, useMemo, useCallback, useEffect } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   archiveWorkspace,
@@ -14,7 +14,7 @@ import {
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog, Filter, Check } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { useSpinnerFrame } from "../../hooks/useSpinnerFrame";
 import type { McpStatusSnapshot } from "../../types/mcp";
@@ -70,8 +70,25 @@ export const Sidebar = memo(function Sidebar() {
   const planApprovals = useAppStore((s) => s.planApprovals);
   const setRepositories = useAppStore((s) => s.setRepositories);
   const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
-  const remoteConnections = useAppStore((s) => s.remoteConnections);
   const isMac = navigator.platform.startsWith("Mac");
+
+  // Filter dropdown state
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const filterDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close filter menu when clicking outside
+  useEffect(() => {
+    if (!filterMenuOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (filterDropdownRef.current && !filterDropdownRef.current.contains(e.target as Node)) {
+        setFilterMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [filterMenuOpen]);
 
   // Pointer-based reorder state (HTML5 drag-and-drop doesn't work in WKWebView)
   const [draggedRepoId, setDraggedRepoId] = useState<string | null>(null);
@@ -170,18 +187,59 @@ export const Sidebar = memo(function Sidebar() {
     <div className={styles.sidebar}>
       <div className={styles.header} data-tauri-drag-region>
         <span className={styles.title}>Workspaces</span>
-      </div>
-
-      <div className={styles.filters}>
-        {(["all", "active", "archived", ...(remoteConnections.length > 0 ? ["remote" as const] : [])] as const).map((f) => (
+        <div className={styles.filterDropdown} ref={filterDropdownRef}>
           <button
-            key={f}
-            className={`${styles.filterBtn} ${sidebarFilter === f ? styles.filterActive : ""}`}
-            onClick={() => setSidebarFilter(f)}
+            className={styles.filterToggle}
+            onClick={() => setFilterMenuOpen(!filterMenuOpen)}
+            title="Filter workspaces"
           >
-            {f.charAt(0).toUpperCase() + f.slice(1)}
+            <Filter size={12} />
           </button>
-        ))}
+          {filterMenuOpen && (
+            <div className={styles.filterMenu}>
+              <button
+                className={styles.filterMenuItem}
+                onClick={() => {
+                  setSidebarFilter("all");
+                  setFilterMenuOpen(false);
+                }}
+              >
+                <span>All</span>
+                {sidebarFilter === "all" && <Check size={14} />}
+              </button>
+              <button
+                className={styles.filterMenuItem}
+                onClick={() => {
+                  setSidebarFilter("active");
+                  setFilterMenuOpen(false);
+                }}
+              >
+                <span>Active</span>
+                {sidebarFilter === "active" && <Check size={14} />}
+              </button>
+              <button
+                className={styles.filterMenuItem}
+                onClick={() => {
+                  setSidebarFilter("archived");
+                  setFilterMenuOpen(false);
+                }}
+              >
+                <span>Archived</span>
+                {sidebarFilter === "archived" && <Check size={14} />}
+              </button>
+              <button
+                className={styles.filterMenuItem}
+                onClick={() => {
+                  setSidebarFilter("remote");
+                  setFilterMenuOpen(false);
+                }}
+              >
+                <span>Remote</span>
+                {sidebarFilter === "remote" && <Check size={14} />}
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       <div className={styles.list}>

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -70,6 +70,8 @@ export const Sidebar = memo(function Sidebar() {
   const planApprovals = useAppStore((s) => s.planApprovals);
   const setRepositories = useAppStore((s) => s.setRepositories);
   const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
+  const remoteConnections = useAppStore((s) => s.remoteConnections);
+  const discoveredServers = useAppStore((s) => s.discoveredServers);
   const isMac = navigator.platform.startsWith("Mac");
 
   // Filter dropdown state
@@ -190,19 +192,24 @@ export const Sidebar = memo(function Sidebar() {
         <div className={styles.filterDropdown} ref={filterDropdownRef}>
           <button
             className={styles.filterToggle}
-            onClick={() => setFilterMenuOpen(!filterMenuOpen)}
+            onClick={() => setFilterMenuOpen((open) => !open)}
             title="Filter workspaces"
+            aria-label="Filter workspaces"
+            aria-haspopup="menu"
+            aria-expanded={filterMenuOpen}
+            aria-controls="workspace-filter-menu"
           >
             <Filter size={12} />
           </button>
           {filterMenuOpen && (
-            <div className={styles.filterMenu}>
+            <div className={styles.filterMenu} id="workspace-filter-menu" role="menu">
               <button
                 className={styles.filterMenuItem}
                 onClick={() => {
                   setSidebarFilter("all");
                   setFilterMenuOpen(false);
                 }}
+                role="menuitem"
               >
                 <span>All</span>
                 {sidebarFilter === "all" && <Check size={14} />}
@@ -213,6 +220,7 @@ export const Sidebar = memo(function Sidebar() {
                   setSidebarFilter("active");
                   setFilterMenuOpen(false);
                 }}
+                role="menuitem"
               >
                 <span>Active</span>
                 {sidebarFilter === "active" && <Check size={14} />}
@@ -223,20 +231,24 @@ export const Sidebar = memo(function Sidebar() {
                   setSidebarFilter("archived");
                   setFilterMenuOpen(false);
                 }}
+                role="menuitem"
               >
                 <span>Archived</span>
                 {sidebarFilter === "archived" && <Check size={14} />}
               </button>
-              <button
-                className={styles.filterMenuItem}
-                onClick={() => {
-                  setSidebarFilter("remote");
-                  setFilterMenuOpen(false);
-                }}
-              >
-                <span>Remote</span>
-                {sidebarFilter === "remote" && <Check size={14} />}
-              </button>
+              {(remoteConnections.length > 0 || discoveredServers.length > 0) && (
+                <button
+                  className={styles.filterMenuItem}
+                  onClick={() => {
+                    setSidebarFilter("remote");
+                    setFilterMenuOpen(false);
+                  }}
+                  role="menuitem"
+                >
+                  <span>Remote</span>
+                  {sidebarFilter === "remote" && <Check size={14} />}
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Replaces the horizontal row of filter buttons (All, Active, Archived, Remote) with a compact dropdown menu triggered by a filter icon in the sidebar header.

## Changes

- **Filter icon in header**: Added a small filter icon (right-aligned) next to the "Workspaces" title
- **Dropdown menu**: Clicking the icon opens a menu with all filter options
- **Active state indicator**: The currently selected filter shows a checkmark (✓)
- **Auto-close behavior**: Menu closes automatically when selecting an option or clicking outside
- **Consistent styling**: Uses existing theme variables (`--chat-input-bg`, `--divider`, etc.)

## Benefits

- **Vertical space savings**: Removed entire filter button row, reclaiming ~40px of vertical space
- **Cleaner UI**: Sidebar header is now just "Workspaces" with a subtle filter icon
- **Familiar pattern**: Standard dropdown menu that users understand intuitively
- **Maintains functionality**: All four filters (All, Active, Archived, Remote) remain accessible
- **Better scalability**: Easy to add more filter options in the future without consuming more space

## Testing

- ✅ All filter options functional (All, Active, Archived, Remote)
- ✅ Checkmark correctly indicates active filter
- ✅ Click outside closes the dropdown
- ✅ TypeScript type check passes
- ✅ Frontend build successful

## Risk Assessment

**Low risk** - UI-only change with no backend impact:
- No changes to filter logic or state management
- Only modifies presentation layer (TSX/CSS)
- Maintains all existing functionality