### PR TITLE
fix(env): enrich PATH for subprocesses launched from Finder

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -206,6 +206,7 @@ async fn resolve_and_run_setup(
         .arg("-c")
         .arg(&script)
         .current_dir(worktree_path)
+        .env("PATH", claudette::env::enriched_path())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .process_group(0)

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -135,6 +135,7 @@ static USER_AGENT_CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new(
 pub fn warm_user_agent_cache_sync() {
     let output = std::process::Command::new("claude")
         .arg("--version")
+        .env("PATH", claudette::env::enriched_path())
         .output();
     let ua = match output {
         Ok(o) if o.status.success() => {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -527,81 +527,10 @@ fn search_path_dirs(path: &std::ffi::OsStr, exists: &impl Fn(&Path) -> bool) -> 
 
 /// Get the PATH as seen by the user's login shell.
 ///
-/// Runs `$SHELL -l -c 'printf "%s\n" "$PATH"'` to pick up profile/rc files
-/// that desktop-launched apps don't source. For fish shells, uses
-/// `string join :` to convert fish's space-separated list to colon-separated.
-///
-/// If the shell prints startup output (motd, banner, etc.), only the last
-/// non-empty line is used as the PATH value.
-///
-/// A 5-second timeout kills the subprocess if the shell init hangs (nvm,
-/// pyenv, etc.), preventing leaked processes.
-///
-/// Returns `None` if `$SHELL` is unset or not an absolute path.
+/// Delegates to the shared `crate::env::shell_path()` which probes the
+/// login shell once and caches the result for the process lifetime.
 fn login_shell_path() -> Option<OsString> {
-    let shell = std::env::var("SHELL").ok()?;
-
-    // Validate: must be an absolute path.
-    if !shell.starts_with('/') {
-        return None;
-    }
-
-    // Fish treats $PATH as a list and prints space-separated entries.
-    // Convert to colon-separated so std::env::split_paths works correctly.
-    let is_fish = shell.ends_with("/fish");
-    let cmd_arg = if is_fish {
-        r#"printf '%s\n' (string join : $PATH)"#
-    } else {
-        r#"printf '%s\n' "$PATH""#
-    };
-
-    let mut child = std::process::Command::new(&shell)
-        .args(["-l", "-c", cmd_arg])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok()?;
-
-    // Wait up to 5 seconds. If the shell init hangs (nvm, pyenv, etc.),
-    // kill the subprocess to avoid leaking a stuck process.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break Some(status),
-            Ok(None) => {
-                if std::time::Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    break None;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
-            Err(_) => break None,
-        }
-    };
-
-    let status = status?;
-    if !status.success() {
-        return None;
-    }
-
-    let mut stdout = String::new();
-    if let Some(mut out) = child.stdout.take() {
-        use std::io::Read;
-        let _ = out.read_to_string(&mut stdout);
-    }
-    // Take the last non-empty line to skip any startup banner output.
-    let path = stdout
-        .lines()
-        .rev()
-        .find(|line| !line.trim().is_empty())
-        .map(|line| line.trim().to_string())?;
-    if path.is_empty() {
-        None
-    } else {
-        Some(OsString::from(path))
-    }
+    crate::env::shell_path().cloned()
 }
 
 /// Run a single agent turn by spawning `claude -p` with the given prompt.
@@ -638,7 +567,8 @@ pub async fn run_turn(
     cmd.args(&args)
         .current_dir(working_dir)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
+        .stderr(std::process::Stdio::piped())
+        .env("PATH", crate::env::enriched_path());
 
     if has_attachments {
         cmd.stdin(std::process::Stdio::piped());
@@ -800,7 +730,8 @@ impl PersistentSession {
             .current_dir(working_dir)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
+            .stderr(std::process::Stdio::piped())
+            .env("PATH", crate::env::enriched_path());
 
         // Strip OAuth tokens (same as run_turn).
         if let Ok(key) = std::env::var("ANTHROPIC_API_KEY")
@@ -1109,7 +1040,8 @@ pub async fn generate_branch_name(
 
     let claude_path = resolve_claude_path().await;
     let mut cmd = Command::new(&claude_path);
-    cmd.stdin(std::process::Stdio::null());
+    cmd.stdin(std::process::Stdio::null())
+        .env("PATH", crate::env::enriched_path());
     // Run in the user's worktree so the CLI loads *their* project context.
     cmd.current_dir(worktree_path);
     let user_message = format!(

--- a/src/env.rs
+++ b/src/env.rs
@@ -157,10 +157,7 @@ mod tests {
     #[test]
     fn enriched_path_is_nonempty() {
         let enriched = enriched_path();
-        assert!(
-            !enriched.is_empty(),
-            "enriched PATH must never be empty"
-        );
+        assert!(!enriched.is_empty(), "enriched PATH must never be empty");
     }
 
     #[test]
@@ -190,10 +187,7 @@ mod tests {
     #[test]
     fn which_in_enriched_path_rejects_missing_command() {
         let result = which_in_enriched_path("nonexistent_binary_xyz_12345");
-        assert!(
-            result.is_err(),
-            "should not find a nonexistent command"
-        );
+        assert!(result.is_err(), "should not find a nonexistent command");
     }
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,213 @@
+//! Enriched environment for child processes.
+//!
+//! macOS apps launched from Finder inherit a minimal PATH
+//! (`/usr/bin:/bin:/usr/sbin:/sbin`). Tools like `npx`, `node`, `python`,
+//! and `claude` typically live in directories added by the user's shell
+//! profile (`.zshrc`, `.bashrc`, etc.).
+//!
+//! This module probes the user's login shell once, caches the result, and
+//! exposes it for subprocess spawning and PATH-based command lookup.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::sync::OnceLock;
+
+/// Cached login-shell PATH, resolved once per process lifetime.
+static SHELL_PATH: OnceLock<Option<OsString>> = OnceLock::new();
+
+/// Get the user's full PATH as seen by their login shell.
+///
+/// On first call, spawns `$SHELL -l -c 'printf "%s\n" "$PATH"'` (with a
+/// 5-second timeout) and caches the result. Subsequent calls return the
+/// cached value instantly.
+///
+/// Returns `None` if `$SHELL` is unset, the probe times out, or the shell
+/// exits with non-zero status.
+pub fn shell_path() -> Option<&'static OsString> {
+    SHELL_PATH.get_or_init(login_shell_path_probe).as_ref()
+}
+
+/// Build a PATH string that merges the login-shell PATH with the process PATH.
+///
+/// If the login shell probe succeeded, its PATH is used as the base with any
+/// additional process-PATH entries appended (deduped). If it failed, the
+/// process PATH is returned unchanged.
+///
+/// This ensures that both user-installed tools (from shell profile) and any
+/// extra entries set by the launching context (e.g. Tauri dev server) are
+/// available.
+pub fn enriched_path() -> OsString {
+    let process_path = std::env::var_os("PATH").unwrap_or_default();
+    let Some(shell) = shell_path() else {
+        return process_path;
+    };
+
+    // Start with shell PATH entries, then append any process-PATH entries
+    // that aren't already present.
+    let shell_dirs: Vec<std::path::PathBuf> = std::env::split_paths(shell).collect();
+    let mut merged = shell.clone();
+
+    for dir in std::env::split_paths(&process_path) {
+        if !shell_dirs.contains(&dir) {
+            merged.push(":");
+            merged.push(dir);
+        }
+    }
+
+    merged
+}
+
+/// Probe the login shell for its PATH.
+///
+/// Runs `$SHELL -l -c 'printf "%s\n" "$PATH"'` with a 5-second timeout.
+/// For fish shells, uses `string join :` to convert the space-separated list.
+///
+/// If the shell prints startup output (motd, banner, etc.), only the last
+/// non-empty line is used as the PATH value.
+fn login_shell_path_probe() -> Option<OsString> {
+    let shell = std::env::var("SHELL").ok()?;
+
+    // Validate: must be an absolute path.
+    if !shell.starts_with('/') {
+        return None;
+    }
+
+    // Fish treats $PATH as a list and prints space-separated entries.
+    let is_fish = shell.ends_with("/fish");
+    let cmd_arg = if is_fish {
+        r#"printf '%s\n' (string join : $PATH)"#
+    } else {
+        r#"printf '%s\n' "$PATH""#
+    };
+
+    let mut child = std::process::Command::new(&shell)
+        .args(["-l", "-c", cmd_arg])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Wait up to 5 seconds. If the shell init hangs (nvm, pyenv, etc.),
+    // kill the subprocess to avoid leaking a stuck process.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(_) => break None,
+        }
+    };
+
+    let status = status?;
+    if !status.success() {
+        return None;
+    }
+
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        use std::io::Read;
+        let _ = out.read_to_string(&mut stdout);
+    }
+    // Take the last non-empty line to skip any startup banner output.
+    let path = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.trim().to_string())?;
+    if path.is_empty() {
+        None
+    } else {
+        Some(OsString::from(path))
+    }
+}
+
+/// Search for a command binary in the enriched PATH.
+///
+/// Uses `which::which_in` with the enriched PATH so that commands installed
+/// in the user's shell profile are found even when the app is launched from
+/// Finder.
+pub fn which_in_enriched_path(command: &str) -> Result<std::path::PathBuf, which::Error> {
+    let path = enriched_path();
+    which::which_in(command, Some(path), Path::new("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enriched_path_includes_process_path() {
+        let enriched = enriched_path();
+        let enriched_str = enriched.to_string_lossy();
+        // /usr/bin should always be present (from process or shell PATH).
+        assert!(
+            enriched_str.contains("/usr/bin"),
+            "enriched PATH should contain /usr/bin"
+        );
+    }
+
+    #[test]
+    fn enriched_path_is_nonempty() {
+        let enriched = enriched_path();
+        assert!(
+            !enriched.is_empty(),
+            "enriched PATH must never be empty"
+        );
+    }
+
+    #[test]
+    fn enriched_path_contains_no_empty_entries() {
+        // Empty entries (::) can cause cwd-relative resolution — ensure
+        // the merge logic doesn't produce them.
+        let enriched = enriched_path();
+        let enriched_str = enriched.to_string_lossy();
+        assert!(
+            !enriched_str.contains("::"),
+            "enriched PATH must not contain empty entries (::)"
+        );
+    }
+
+    #[test]
+    fn which_in_enriched_path_finds_echo() {
+        let result = which_in_enriched_path("echo");
+        assert!(result.is_ok(), "should find `echo` in enriched PATH");
+    }
+
+    #[test]
+    fn which_in_enriched_path_finds_sh() {
+        let result = which_in_enriched_path("sh");
+        assert!(result.is_ok(), "should find `sh` in enriched PATH");
+    }
+
+    #[test]
+    fn which_in_enriched_path_rejects_missing_command() {
+        let result = which_in_enriched_path("nonexistent_binary_xyz_12345");
+        assert!(
+            result.is_err(),
+            "should not find a nonexistent command"
+        );
+    }
+
+    #[test]
+    fn shell_path_returns_consistent_value() {
+        // Calling shell_path twice must return the same cached reference.
+        let first = shell_path();
+        let second = shell_path();
+        match (first, second) {
+            (Some(a), Some(b)) => assert!(
+                std::ptr::eq(a, b),
+                "shell_path must return a cached reference"
+            ),
+            (None, None) => {} // Both None is fine (e.g. CI with no $SHELL)
+            _ => panic!("shell_path returned inconsistent results"),
+        }
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,7 +3,7 @@
 //! macOS apps launched from Finder inherit a minimal PATH
 //! (`/usr/bin:/bin:/usr/sbin:/sbin`). Tools like `npx`, `node`, `python`,
 //! and `claude` typically live in directories added by the user's shell
-//! profile (`.zshrc`, `.bashrc`, etc.).
+//! login profile (`.zprofile`, `.bash_profile`, `.profile`, etc.).
 //!
 //! This module probes the user's login shell once, caches the result, and
 //! exposes it for subprocess spawning and PATH-based command lookup.
@@ -42,19 +42,19 @@ pub fn enriched_path() -> OsString {
         return process_path;
     };
 
-    // Start with shell PATH entries, then append any process-PATH entries
-    // that aren't already present.
-    let shell_dirs: Vec<std::path::PathBuf> = std::env::split_paths(shell).collect();
-    let mut merged = shell.clone();
+    // Start with shell PATH entries, then append any non-empty process-PATH
+    // entries that aren't already present.
+    let mut merged_dirs: Vec<std::path::PathBuf> = std::env::split_paths(shell)
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .collect();
 
     for dir in std::env::split_paths(&process_path) {
-        if !shell_dirs.contains(&dir) {
-            merged.push(":");
-            merged.push(dir);
+        if !dir.as_os_str().is_empty() && !merged_dirs.contains(&dir) {
+            merged_dirs.push(dir);
         }
     }
 
-    merged
+    std::env::join_paths(&merged_dirs).unwrap_or(process_path)
 }
 
 /// Probe the login shell for its PATH.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod config;
 pub mod db;
 pub mod diff;
+pub mod env;
 pub mod file_expand;
 pub mod git;
 pub mod mcp;

--- a/src/mcp_supervisor.rs
+++ b/src/mcp_supervisor.rs
@@ -182,7 +182,7 @@ pub async fn validate_stdio_server(config: &serde_json::Value) -> Result<(), Str
         .and_then(|v| v.as_str())
         .ok_or("stdio server config missing 'command' field")?;
 
-    which::which(command)
+    crate::env::which_in_enriched_path(command)
         .map(|_| ())
         .map_err(|_| format!("command not found in PATH: {command}"))
 }


### PR DESCRIPTION
## Summary

- macOS apps launched from Finder/Spotlight inherit a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), which causes MCP servers and Claude CLI subprocesses to fail because user-installed tools (`npx`, `node`, `claude`, etc.) are not found
- Added `src/env.rs` — a shared login-shell PATH probe with `OnceLock` caching that runs `$SHELL -l -c 'printf "%s\n" "$PATH"'` once per process lifetime, then merges the result with the process PATH
- All subprocess spawn sites now explicitly set `PATH` via `env::enriched_path()`: Claude CLI (`run_turn`, `PersistentSession::start`, `generate_branch_name`), MCP validation, `claude --version` user-agent probe, and workspace setup script runner
- Replaced the duplicate `login_shell_path()` in `agent.rs` (65 lines) with a 3-line delegate to the shared `env::shell_path()`

## Test plan

- [x] `cargo test --all-features` — 357 tests pass (5 new in `env::tests`)
- [x] `cargo clippy --workspace --all-targets` with `-Dwarnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bunx tsc --noEmit` — clean
- [x] Verified MCP servers connect successfully in release build launched from Finder
- [x] Verify MCP servers still work in dev mode (`cargo tauri dev`)
- [ ] Verify on a non-Nix macOS system (standard Homebrew/npm PATH)