### PR TITLE
fix(mcp): defer MCP config restart to next turn boundary

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -223,6 +223,7 @@ pub async fn send_chat_message(
                 needs_attention: false,
                 attention_kind: None,
                 persistent_session: None,
+                mcp_config_dirty: false,
             };
         }
 
@@ -234,6 +235,7 @@ pub async fn send_chat_message(
             needs_attention: false,
             attention_kind: None,
             persistent_session: None,
+            mcp_config_dirty: false,
         }
     });
 
@@ -250,6 +252,22 @@ pub async fn send_chat_message(
         agents = state.agents.write().await;
         let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
         session.active_pid = None;
+    }
+    let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
+
+    // MCP config changed while a previous turn was in flight — tear down the
+    // persistent session so the next spawn picks up updated --mcp-config.
+    // The session is idle between turns so a graceful SIGTERM is sufficient.
+    if session.mcp_config_dirty {
+        eprintln!("[chat] MCP config dirty — tearing down persistent session for {workspace_id}");
+        let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
+        session.persistent_session = None;
+        session.mcp_config_dirty = false;
+        if let Some(pid) = stale_pid {
+            drop(agents);
+            let _ = agent::stop_agent_graceful(pid).await;
+            agents = state.agents.write().await;
+        }
     }
     let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
 

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -254,7 +254,8 @@ pub async fn set_mcp_server_enabled(
     // Mark affected sessions as dirty so the next turn tears down the
     // persistent session and starts a fresh one with updated MCP config.
     // This avoids killing an agent mid-turn — the current turn completes
-    // normally and the config change takes effect on the next send_message.
+    // normally and the config change takes effect on the next
+    // `send_chat_message` command.
     let workspaces = db.list_workspaces().unwrap_or_default();
     let repo_workspace_ids: Vec<String> = workspaces
         .iter()

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -251,10 +251,10 @@ pub async fn set_mcp_server_enabled(
         .set_server_enabled(&repo_id, &server_name, enabled)
         .await;
 
-    // Invalidate persistent sessions for all workspaces in this repo so the
-    // next turn starts a fresh process with the updated MCP config.
-    // Collect PIDs under the lock, then drop it before awaiting stop_agent
-    // to avoid blocking other workspace commands during process shutdown.
+    // Mark affected sessions as dirty so the next turn tears down the
+    // persistent session and starts a fresh one with updated MCP config.
+    // This avoids killing an agent mid-turn — the current turn completes
+    // normally and the config change takes effect on the next send_message.
     let workspaces = db.list_workspaces().unwrap_or_default();
     let repo_workspace_ids: Vec<String> = workspaces
         .iter()
@@ -262,22 +262,13 @@ pub async fn set_mcp_server_enabled(
         .map(|w| w.id.clone())
         .collect();
 
-    let pids_to_stop = {
+    {
         let mut agents = state.agents.write().await;
-        let mut pids = Vec::new();
         for ws_id in &repo_workspace_ids {
             if let Some(session) = agents.get_mut(ws_id) {
-                if let Some(pid) = session.active_pid.take() {
-                    pids.push(pid);
-                }
-                session.persistent_session = None;
+                session.mcp_config_dirty = true;
             }
         }
-        pids
-    };
-
-    for pid in pids_to_stop {
-        let _ = claudette::agent::stop_agent(pid).await;
     }
 
     Ok(())

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -40,7 +40,7 @@ pub struct AgentSessionState {
     /// spawning new processes.
     pub persistent_session: Option<Arc<PersistentSession>>,
     /// Set when MCP server config changes while a turn is in flight.
-    /// The next call to `send_message` tears down the persistent session
+    /// The next call to `send_chat_message` tears down the persistent session
     /// and starts a fresh one with updated `--mcp-config`, then clears
     /// the flag. This avoids killing an agent mid-turn.
     pub mcp_config_dirty: bool,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -39,6 +39,11 @@ pub struct AgentSessionState {
     /// When present, subsequent turns write to this process's stdin instead of
     /// spawning new processes.
     pub persistent_session: Option<Arc<PersistentSession>>,
+    /// Set when MCP server config changes while a turn is in flight.
+    /// The next call to `send_message` tears down the persistent session
+    /// and starts a fresh one with updated `--mcp-config`, then clears
+    /// the flag. This avoids killing an agent mid-turn.
+    pub mcp_config_dirty: bool,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -615,6 +615,7 @@ mod tests {
                 None
             },
             persistent_session: None,
+            mcp_config_dirty: false,
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2438,4 +2438,39 @@ mod tests {
         let args = build_persistent_args("sess-1", false, &[], Some("   "), &settings);
         assert!(!args.iter().any(|a| a == "--append-system-prompt"));
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_stop_agent_graceful_stops_process_before_escalation() {
+        // Spawn a process that traps SIGTERM and exits cleanly.
+        let mut child = tokio::process::Command::new("sh")
+            .args(["-c", "trap 'exit 0' TERM; sleep 5"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("failed to spawn test child");
+
+        let pid = child.id().expect("child pid should be available");
+
+        let result = stop_agent_graceful(pid).await;
+        assert!(
+            result.is_ok(),
+            "expected graceful stop to succeed: {result:?}"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), child.wait())
+            .await
+            .expect("child did not exit in time")
+            .expect("failed to reap child");
+
+        // kill -0 should fail for a dead process.
+        let probe = tokio::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output()
+            .await;
+        assert!(
+            probe.is_ok_and(|o| !o.status.success()),
+            "process {pid} should no longer exist after graceful stop"
+        );
+    }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -685,6 +685,35 @@ pub async fn stop_agent(pid: u32) -> Result<(), String> {
     }
 }
 
+/// Gracefully stop an agent process (SIGTERM → wait → SIGKILL).
+///
+/// Sends SIGTERM first and allows up to 500 ms for the process to exit.
+/// Falls back to SIGKILL if the deadline expires. Suitable for tearing
+/// down idle persistent sessions at turn boundaries where we don't need
+/// an instant kill.
+pub async fn stop_agent_graceful(pid: u32) -> Result<(), String> {
+    // Send SIGTERM for graceful shutdown.
+    let _ = tokio::process::Command::new("kill")
+        .args(["-15", &pid.to_string()])
+        .output()
+        .await;
+
+    // Poll for up to 500 ms.
+    for _ in 0..10 {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let probe = tokio::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output()
+            .await;
+        if probe.is_ok_and(|o| !o.status.success()) {
+            return Ok(());
+        }
+    }
+
+    // Escalate to SIGKILL.
+    stop_agent(pid).await
+}
+
 // ---------------------------------------------------------------------------
 // Persistent session — long-lived process for multi-turn MCP retention
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Toggling an MCP server on/off while an agent turn is running no longer kills the process with SIGKILL
- Instead, sets an `mcp_config_dirty` flag on `AgentSessionState` that defers the restart to the next turn boundary
- `send_chat_message` checks the flag, gracefully tears down the stale persistent session (SIGTERM + 500ms grace period), and spawns a fresh one with updated `--mcp-config`
- Adds `stop_agent_graceful` as an async SIGTERM-first alternative to the existing `stop_agent` (SIGKILL)

## Test plan

- [x] `cargo test --all-features` — 357 tests pass
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] `bunx tsc --noEmit` — no type errors
- [ ] Manual: start an agent turn, toggle an MCP server mid-turn, verify the turn completes normally
- [ ] Manual: send a follow-up message after toggling — verify the persistent session restarts with updated MCP config
- [ ] Manual: verify toggling MCP servers with no running agent still works immediately on next turn

Closes #231