### PR TITLE
fix(debug): correct agent status reporting in debug skill

### DIFF
--- a/.claude/skills/claudette-debug/SKILL.md
+++ b/.claude/skills/claudette-debug/SKILL.md
@@ -149,9 +149,11 @@ const turns = s.completedTurns[wsId] || [];
 const last = acts[acts.length - 1];
 const c = document.querySelector('[class*="messages_"]');
 const gap = c ? Math.round(c.scrollHeight - c.scrollTop - c.clientHeight) : -1;
+const storeStatus = ws?.agent_status;
+const isActive = storeStatus === 'Running' || stream.length > 0 || acts.length > 0 || (s.streamingThinking[wsId] || '').length > 0;
 return {
   workspace: ws?.name,
-  agentStatus: ws?.agent_status,
+  agentStatus: isActive ? 'Running' : storeStatus,
   messageCount: msgs.length,
   lastMessageRole: msgs[msgs.length - 1]?.role,
   streaming: stream.length > 0,
@@ -177,6 +179,11 @@ JS
 
 Substitute `MESSAGE_TEXT_HERE` with the actual message. Escape backticks with `\``.
 
+**Important**: This sets `agent_status` to `"Running"` in the store before invoking the
+Tauri command. The normal UI path (ChatPanel) does this in React; since we bypass that
+component, we must replicate it here so that `wait`, `monitor`, and `status` see the
+correct state.
+
 ```bash
 ${CLAUDE_SKILL_DIR}/scripts/debug-eval.sh <<'JS'
 const s = window.__CLAUDETTE_STORE__.getState();
@@ -184,6 +191,8 @@ const wsId = s.selectedWorkspaceId;
 if (!wsId) return 'ERROR: no workspace selected';
 const ws = s.workspaces.find(w => w.id === wsId);
 if (ws?.agent_status === 'Running') return 'ERROR: agent already running';
+s.updateWorkspace(wsId, { agent_status: 'Running' });
+s.clearUnreadCompletion(wsId);
 await window.__CLAUDETTE_INVOKE__('send_chat_message', {
   workspaceId: wsId,
   content: `MESSAGE_TEXT_HERE`,
@@ -235,8 +244,11 @@ if (wsId) {
   const stream = s.streamingContent[wsId] || '';
   const acts = s.toolActivities[wsId] || [];
   const turns = s.completedTurns[wsId] || [];
+  const storeStatus = ws?.agent_status;
+  const isActive = storeStatus === 'Running' || stream.length > 0 || acts.length > 0 || (s.streamingThinking[wsId] || '').length > 0;
+  const effectiveStatus = isActive ? 'Running' : storeStatus;
   lines.push('=== Active: ' + ws?.name + ' (' + wsId.substring(0, 8) + ') ===');
-  lines.push('  agentStatus: ' + ws?.agent_status);
+  lines.push('  agentStatus: ' + effectiveStatus);
   lines.push('  messages: ' + msgs.length + (msgs.length > 0 ? ' (last: ' + msgs[msgs.length-1].role + ')' : ''));
   lines.push('  streaming: ' + (stream.length > 0 ? stream.length + ' chars' : 'false'));
   lines.push('  activeTools: ' + acts.length + (acts.length > 0 ? ' (last: ' + acts[acts.length-1].toolName + ')' : ''));

--- a/.claude/skills/claudette-debug/scripts/debug-monitor.sh
+++ b/.claude/skills/claudette-debug/scripts/debug-monitor.sh
@@ -14,8 +14,12 @@ INTERVAL=1
 MAX_ITER=3600  # 1 hour at 1s interval
 LOGFILE="/tmp/claudette-debug/monitor.log"
 
-# Default JS expression: comprehensive session state
-JS_EXPR='const s=window.__CLAUDETTE_STORE__.getState();const w=s.selectedWorkspaceId;const acts=s.toolActivities[w]||[];const completedTurns=(s.completedTurns[w]||[]).length;const agentStatus=s.workspaces.find(x=>x.id===w)?.agent_status||"unknown";const c=document.querySelector("[class*=messages_]");const scrollGap=c?Math.round(c.scrollHeight-c.scrollTop-c.clientHeight):-1;const messageCount=(s.chatMessages[w]||[]).length;const last=acts[acts.length-1];const inputJsonValid=last?.inputJson?((()=>{try{JSON.parse(last.inputJson);return true}catch{return false}})()):null;const streaming=(s.streamingContent[w]||"").length>0;const thinking=(s.streamingThinking[w]||"").length;const thinkingEnabled=s.thinkingEnabled[w]||false;const showThinking=s.showThinkingBlocks[w]===true;return JSON.stringify({toolCount:acts.length,completedTurns,agentStatus,scrollGap,messageCount,lastToolSummary:last?.summary?.substring(0,60)||"",inputJsonValid,streaming,thinking,thinkingEnabled,showThinking})'
+# Default JS expression: comprehensive session state.
+# NOTE: agentStatus reads the store's workspace.agent_status field.
+# effectiveStatus derives the real status from streaming/tool signals — the store
+# value can lag when messages are sent via the debug eval API (bypasses the
+# ChatPanel React handler that sets agent_status to "Running").
+JS_EXPR='const s=window.__CLAUDETTE_STORE__.getState();const w=s.selectedWorkspaceId;const acts=s.toolActivities[w]||[];const completedTurns=(s.completedTurns[w]||[]).length;const storeStatus=s.workspaces.find(x=>x.id===w)?.agent_status||"unknown";const c=document.querySelector("[class*=messages_]");const scrollGap=c?Math.round(c.scrollHeight-c.scrollTop-c.clientHeight):-1;const messageCount=(s.chatMessages[w]||[]).length;const last=acts[acts.length-1];const inputJsonValid=last?.inputJson?((()=>{try{JSON.parse(last.inputJson);return true}catch{return false}})()):null;const streaming=(s.streamingContent[w]||"").length>0;const thinking=(s.streamingThinking[w]||"").length;const thinkingEnabled=s.thinkingEnabled[w]||false;const showThinking=s.showThinkingBlocks[w]===true;const effectiveStatus=(storeStatus==="Running"||streaming||acts.length>0||thinking>0)?"Running":storeStatus;return JSON.stringify({toolCount:acts.length,completedTurns,agentStatus:effectiveStatus,scrollGap,messageCount,lastToolSummary:last?.summary?.substring(0,60)||"",inputJsonValid,streaming,thinking,thinkingEnabled,showThinking})'
 
 # Parse args
 while [[ $# -gt 0 ]]; do

--- a/.claude/skills/claudette-debug/scripts/debug-wait.sh
+++ b/.claude/skills/claudette-debug/scripts/debug-wait.sh
@@ -32,7 +32,18 @@ else
   WS_SELECTOR="const wsId = s.selectedWorkspaceId; if (!wsId) return JSON.stringify({error:'no workspace selected'});"
 fi
 
-JS_CHECK="const s=window.__CLAUDETTE_STORE__.getState();${WS_SELECTOR}const ws=s.workspaces.find(x=>x.id===wsId);const acts=s.toolActivities[wsId]||[];const stream=(s.streamingContent[wsId]||'');const msgs=(s.chatMessages[wsId]||[]);const turns=(s.completedTurns[wsId]||[]);const last=acts[acts.length-1];const running=ws?.agent_status==='Running'||stream.length>0||acts.length>0;if(running){return JSON.stringify({running:true,agentStatus:ws?.agent_status,messageCount:msgs.length,toolCount:acts.length,streamingLength:stream.length,lastTool:last?.toolName,lastToolSummary:last?.summary?.substring(0,60)})}const elapsed=Math.round((Date.now()/1000)-${start_ts});const lastTurn=turns[turns.length-1];return JSON.stringify({running:false,agentStatus:ws?.agent_status,messageCount:msgs.length,completedTurns:turns.length,lastTurnTools:lastTurn?lastTurn.activities.length:0,lastToolSummary:lastTurn?.activities[lastTurn.activities.length-1]?.summary?.substring(0,80),durationSeconds:elapsed})"
+# The running check uses multiple signals because agent_status in the store may
+# not reflect "Running" when the message was sent via the debug eval API (which
+# bypasses the ChatPanel React handler).  We treat the agent as running when ANY
+# of these are true: store says "Running", streaming content is accumulating,
+# tool activities exist, or thinking content is present.
+JS_CHECK="const s=window.__CLAUDETTE_STORE__.getState();${WS_SELECTOR}const ws=s.workspaces.find(x=>x.id===wsId);const acts=s.toolActivities[wsId]||[];const stream=(s.streamingContent[wsId]||'');const thinking=(s.streamingThinking[wsId]||'');const msgs=(s.chatMessages[wsId]||[]);const turns=(s.completedTurns[wsId]||[]);const last=acts[acts.length-1];const running=ws?.agent_status==='Running'||stream.length>0||acts.length>0||thinking.length>0;if(running){return JSON.stringify({running:true,agentStatus:ws?.agent_status,messageCount:msgs.length,toolCount:acts.length,streamingLength:stream.length,lastTool:last?.toolName,lastToolSummary:last?.summary?.substring(0,60)})}const elapsed=Math.round((Date.now()/1000)-${start_ts});const lastTurn=turns[turns.length-1];return JSON.stringify({running:false,agentStatus:ws?.agent_status,messageCount:msgs.length,completedTurns:turns.length,lastTurnTools:lastTurn?lastTurn.activities.length:0,lastToolSummary:lastTurn?.activities[lastTurn.activities.length-1]?.summary?.substring(0,80),durationSeconds:elapsed})"
+
+# Track whether we've ever seen the agent in a running state.  If not, we give
+# a grace period (up to GRACE_POLLS) for the agent process to start and begin
+# streaming before concluding it is idle.
+GRACE_POLLS=$(( 5 > (TIMEOUT / INTERVAL) ? (TIMEOUT / INTERVAL) : 5 ))
+seen_running=false
 
 for i in $(seq 1 "$iterations"); do
   result=$("$EVAL_SCRIPT" "$JS_CHECK" 2>/dev/null) || true
@@ -42,10 +53,17 @@ for i in $(seq 1 "$iterations"); do
       echo "$result"
       exit 1
     fi
-    # Check if no longer running
+    # Check if running
+    if echo "$result" | grep -q '"running":true'; then
+      seen_running=true
+    fi
+    # Only report idle if we've seen it running at least once, OR we've
+    # exhausted the grace period (agent never started).
     if echo "$result" | grep -q '"running":false'; then
-      echo "$result"
-      exit 0
+      if $seen_running || [[ $i -gt $GRACE_POLLS ]]; then
+        echo "$result"
+        exit 0
+      fi
     fi
   fi
   sleep "$INTERVAL"


### PR DESCRIPTION
## Summary

- The debug skill's `send` recipe bypassed the `ChatPanel` React handler that sets `agent_status` to `"Running"`, so `monitor`, `wait`, and `status` always reported `"Idle"` during active agent work
- The `send` recipe now sets `agent_status: "Running"` in the Zustand store before invoking the Tauri command, mirroring what `ChatPanel.tsx:482` does
- `monitor` and `status` recipes now derive an effective status from streaming content, tool activity, and thinking signals instead of trusting the raw store value
- `wait` script adds a grace period (5 polls) so it doesn't exit prematurely before the agent process starts streaming

## Test plan

- [x] Send a message via the debug `send` recipe and verify `agentStatus` shows `"Running"` in the monitor log during active work
- [x] Verify the monitor captures a clean `Running` → `Idle` transition when the agent completes
- [x] Verify the `wait` script correctly waits for the full agent turn (33s observed) instead of exiting immediately (0s before fix)
- [x] Verify the `status` recipe reports `"Running"` when streaming/tools are active