### PR TITLE
feat(chat): native slash command framework with aliases and kinds

### DIFF
--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -4,6 +4,19 @@ use std::path::Path;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Kind of native slash command. Only set for entries produced by the native
+/// registry; file-based commands (user/project/plugin) leave this as `None`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeKind {
+    /// Mutates local UI state without contacting the agent.
+    LocalAction,
+    /// Opens a settings route/panel.
+    SettingsRoute,
+    /// Expands into seeded prompt text that then flows through the agent pipeline.
+    PromptExpansion,
+}
+
 /// A discovered slash command or skill.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct SlashCommand {
@@ -11,6 +24,75 @@ pub struct SlashCommand {
     pub description: String,
     /// Where the command was found: "builtin", "user", "project", or "plugin".
     pub source: String,
+    /// Alternative names that resolve to this same canonical command.
+    /// Always empty for file-based entries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+    /// Short hint describing the expected argument shape, e.g. `[add|remove] <source>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argument_hint: Option<String>,
+    /// Native command kind. `None` for file-based commands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<NativeKind>,
+}
+
+impl SlashCommand {
+    fn file_based(name: String, description: String, source: &str) -> Self {
+        SlashCommand {
+            name,
+            description,
+            source: source.to_string(),
+            aliases: Vec::new(),
+            argument_hint: None,
+            kind: None,
+        }
+    }
+}
+
+/// Build the registry of native slash commands.
+///
+/// Each entry is fully described here (canonical name, aliases, argument hint, kind).
+/// The matching frontend `NATIVE_HANDLERS` table binds handler functions to these
+/// canonical names.
+pub fn native_command_registry(plugin_management_enabled: bool) -> Vec<SlashCommand> {
+    let mut commands = Vec::new();
+    if plugin_management_enabled {
+        commands.push(SlashCommand {
+            name: "plugin".to_string(),
+            description: "Browse and manage plugins in settings".to_string(),
+            source: "builtin".to_string(),
+            aliases: vec!["plugins".to_string()],
+            argument_hint: Some(
+                "[install|enable|disable|uninstall|update|manage|browse|marketplace …]".to_string(),
+            ),
+            kind: Some(NativeKind::SettingsRoute),
+        });
+        commands.push(SlashCommand {
+            name: "marketplace".to_string(),
+            description: "Manage plugin marketplaces in settings".to_string(),
+            source: "builtin".to_string(),
+            aliases: Vec::new(),
+            argument_hint: Some("[add|remove|update] <source>".to_string()),
+            kind: Some(NativeKind::SettingsRoute),
+        });
+    }
+    commands
+}
+
+/// Resolve an input token (command name without the leading `/`) against the native registry,
+/// matching canonical names and aliases case-insensitively.
+pub fn resolve_native<'a>(token: &str, natives: &'a [SlashCommand]) -> Option<&'a SlashCommand> {
+    let needle = token.trim().to_ascii_lowercase();
+    if needle.is_empty() {
+        return None;
+    }
+    natives.iter().find(|cmd| {
+        cmd.name.to_ascii_lowercase() == needle
+            || cmd
+                .aliases
+                .iter()
+                .any(|alias| alias.to_ascii_lowercase() == needle)
+    })
 }
 
 /// Discover all available slash commands by scanning known Claude Code directories.
@@ -43,8 +125,8 @@ pub fn discover_slash_commands(
         collect_commands_from_dir(&project.join(".claude/commands"), "project", &mut commands);
     }
 
-    // Built-in app commands must always win.
-    collect_builtin_commands(&mut commands, plugin_management_enabled);
+    // Native app commands must always win.
+    collect_native_commands(&mut commands, plugin_management_enabled);
 
     // Sort by name for consistent ordering.
     commands.sort_by(|a, b| a.name.cmp(&b.name));
@@ -70,18 +152,10 @@ struct PluginCommandSpec {
     explicit_description: Option<String>,
 }
 
-fn collect_builtin_commands(commands: &mut Vec<SlashCommand>, plugin_management_enabled: bool) {
-    if !plugin_management_enabled {
-        return;
+fn collect_native_commands(commands: &mut Vec<SlashCommand>, plugin_management_enabled: bool) {
+    for native in native_command_registry(plugin_management_enabled) {
+        upsert_command(commands, native);
     }
-    upsert_command(
-        commands,
-        SlashCommand {
-            name: "plugin".to_string(),
-            description: "Browse and manage plugins in settings".to_string(),
-            source: "builtin".to_string(),
-        },
-    );
 }
 
 /// Scan a directory of `*.md` command files.
@@ -116,11 +190,7 @@ fn collect_skills_from_dir(dir: &Path, source: &str, commands: &mut Vec<SlashCom
                 let description = parse_description(&contents);
                 upsert_command(
                     commands,
-                    SlashCommand {
-                        name,
-                        description,
-                        source: source.to_string(),
-                    },
+                    SlashCommand::file_based(name, description, source),
                 );
             }
         }
@@ -296,11 +366,7 @@ fn collect_plugin_command_path(
                 .unwrap_or_else(|| plugin_skill_name(plugin_name, base_dir, path));
             upsert_command(
                 commands,
-                SlashCommand {
-                    name,
-                    description,
-                    source: "plugin".to_string(),
-                },
+                SlashCommand::file_based(name, description, "plugin"),
             );
         }
         return;
@@ -373,11 +439,7 @@ fn parse_command_file(path: &Path, source: &str) -> Option<SlashCommand> {
     let name = path.file_stem()?.to_string_lossy().into_owned();
     let contents = std::fs::read_to_string(path).ok()?;
     let description = parse_description(&contents);
-    Some(SlashCommand {
-        name,
-        description,
-        source: source.to_string(),
-    })
+    Some(SlashCommand::file_based(name, description, source))
 }
 
 /// Extract a description from file contents.
@@ -521,19 +583,15 @@ mod tests {
 
     #[test]
     fn test_upsert_replaces_by_name() {
-        let mut commands = vec![SlashCommand {
-            name: "commit".into(),
-            description: "Plugin commit".into(),
-            source: "plugin".into(),
-        }];
+        let mut commands = vec![SlashCommand::file_based(
+            "commit".into(),
+            "Plugin commit".into(),
+            "plugin",
+        )];
 
         upsert_command(
             &mut commands,
-            SlashCommand {
-                name: "commit".into(),
-                description: "User commit".into(),
-                source: "user".into(),
-            },
+            SlashCommand::file_based("commit".into(), "User commit".into(), "user"),
         );
 
         assert_eq!(commands.len(), 1);
@@ -542,19 +600,65 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_builtin_commands_injects_plugin() {
+    fn test_collect_native_commands_injects_plugin_and_marketplace() {
         let mut commands = Vec::new();
-        collect_builtin_commands(&mut commands, true);
-        assert_eq!(commands.len(), 1);
-        assert_eq!(commands[0].name, "plugin");
-        assert_eq!(commands[0].source, "builtin");
+        collect_native_commands(&mut commands, true);
+        let names: Vec<_> = commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"plugin"));
+        assert!(names.contains(&"marketplace"));
+        let plugin = commands.iter().find(|c| c.name == "plugin").unwrap();
+        assert_eq!(plugin.source, "builtin");
+        assert_eq!(plugin.aliases, vec!["plugins".to_string()]);
+        assert_eq!(plugin.kind, Some(NativeKind::SettingsRoute));
+        assert!(plugin.argument_hint.is_some());
     }
 
     #[test]
-    fn test_collect_builtin_commands_skips_plugin_when_disabled() {
+    fn test_collect_native_commands_skips_when_disabled() {
         let mut commands = Vec::new();
-        collect_builtin_commands(&mut commands, false);
+        collect_native_commands(&mut commands, false);
         assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_native_matches_canonical_and_alias_case_insensitive() {
+        let natives = native_command_registry(true);
+        assert_eq!(resolve_native("plugin", &natives).unwrap().name, "plugin");
+        assert_eq!(resolve_native("Plugin", &natives).unwrap().name, "plugin");
+        assert_eq!(resolve_native("PLUGINS", &natives).unwrap().name, "plugin");
+        assert_eq!(
+            resolve_native("marketplace", &natives).unwrap().name,
+            "marketplace"
+        );
+        assert!(resolve_native("unknown", &natives).is_none());
+        assert!(resolve_native("", &natives).is_none());
+    }
+
+    #[test]
+    fn test_native_command_registry_canonicals_are_unique() {
+        let natives = native_command_registry(true);
+        let mut names: Vec<_> = natives.iter().map(|c| c.name.clone()).collect();
+        names.sort();
+        let before = names.len();
+        names.dedup();
+        assert_eq!(before, names.len());
+    }
+
+    #[test]
+    fn test_native_kind_serializes_snake_case() {
+        let json = serde_json::to_string(&NativeKind::SettingsRoute).unwrap();
+        assert_eq!(json, "\"settings_route\"");
+        let round: NativeKind = serde_json::from_str("\"prompt_expansion\"").unwrap();
+        assert_eq!(round, NativeKind::PromptExpansion);
+    }
+
+    #[test]
+    fn test_slash_command_serialization_skips_empty_native_fields_for_file_based() {
+        let cmd = SlashCommand::file_based("commit".into(), "do it".into(), "user");
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(!json.contains("aliases"));
+        assert!(!json.contains("argument_hint"));
+        assert!(!json.contains("kind"));
     }
 
     #[test]
@@ -607,21 +711,9 @@ mod tests {
     #[test]
     fn test_sort_commands_by_usage() {
         let mut commands = vec![
-            SlashCommand {
-                name: "alpha".into(),
-                description: "".into(),
-                source: "user".into(),
-            },
-            SlashCommand {
-                name: "beta".into(),
-                description: "".into(),
-                source: "user".into(),
-            },
-            SlashCommand {
-                name: "gamma".into(),
-                description: "".into(),
-                source: "user".into(),
-            },
+            SlashCommand::file_based("alpha".into(), "".into(), "user"),
+            SlashCommand::file_based("beta".into(), "".into(), "user"),
+            SlashCommand::file_based("gamma".into(), "".into(), "user"),
         ];
 
         let mut usage = HashMap::new();
@@ -638,16 +730,8 @@ mod tests {
     #[test]
     fn test_sort_commands_by_usage_alphabetical_tiebreaker() {
         let mut commands = vec![
-            SlashCommand {
-                name: "zebra".into(),
-                description: "".into(),
-                source: "user".into(),
-            },
-            SlashCommand {
-                name: "apple".into(),
-                description: "".into(),
-                source: "user".into(),
-            },
+            SlashCommand::file_based("zebra".into(), "".into(), "user"),
+            SlashCommand::file_based("apple".into(), "".into(), "user"),
         ];
 
         let usage = HashMap::new(); // no usage

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -153,7 +153,20 @@ struct PluginCommandSpec {
 }
 
 fn collect_native_commands(commands: &mut Vec<SlashCommand>, plugin_management_enabled: bool) {
-    for native in native_command_registry(plugin_management_enabled) {
+    let natives = native_command_registry(plugin_management_enabled);
+    // Drop any file-based command whose name collides with a native's canonical
+    // name or alias. The native registry owns these slots; otherwise the alias
+    // would resolve to the native handler while the file-based entry still
+    // rendered in the picker, creating an unreachable duplicate.
+    if !natives.is_empty() {
+        let reserved: std::collections::HashSet<String> = natives
+            .iter()
+            .flat_map(|cmd| std::iter::once(&cmd.name).chain(cmd.aliases.iter()))
+            .map(|name| name.to_ascii_lowercase())
+            .collect();
+        commands.retain(|cmd| !reserved.contains(&cmd.name.to_ascii_lowercase()));
+    }
+    for native in natives {
         upsert_command(commands, native);
     }
 }
@@ -618,6 +631,46 @@ mod tests {
         let mut commands = Vec::new();
         collect_native_commands(&mut commands, false);
         assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn test_collect_native_commands_drops_file_based_alias_collisions() {
+        // Simulate the state of `commands` after file-based discovery has run:
+        // three file-based entries, one of which shadows a native alias ("plugins")
+        // and one that shadows a native canonical name ("plugin"). Both should be
+        // removed so the native registry owns those slots exclusively.
+        let mut commands = vec![
+            SlashCommand::file_based("plugin".into(), "User plugin override".into(), "user"),
+            SlashCommand::file_based("plugins".into(), "Project plugins cmd".into(), "project"),
+            SlashCommand::file_based("commit".into(), "Commit changes".into(), "user"),
+        ];
+        collect_native_commands(&mut commands, true);
+
+        // "commit" stays, file-based "plugin"/"plugins" are replaced by the
+        // native entries, and no duplicate rows remain.
+        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"commit"));
+        assert!(names.contains(&"plugin"));
+        assert!(names.contains(&"marketplace"));
+        // No file-based row survives under a reserved name.
+        assert!(
+            !commands
+                .iter()
+                .any(|c| c.source != "builtin" && (c.name == "plugin" || c.name == "plugins"))
+        );
+        let plugin = commands.iter().find(|c| c.name == "plugin").unwrap();
+        assert_eq!(plugin.source, "builtin");
+    }
+
+    #[test]
+    fn test_collect_native_commands_case_insensitive_collision() {
+        let mut commands = vec![SlashCommand::file_based(
+            "PLUGINS".into(),
+            "Uppercase override".into(),
+            "user",
+        )];
+        collect_native_commands(&mut commands, true);
+        assert!(commands.iter().all(|c| c.name != "PLUGINS"));
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -40,7 +40,11 @@ import { HeaderMenu } from "./HeaderMenu";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { AttachMenu } from "./AttachMenu";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
-import { isPluginSlashCommandInput, parsePluginSlashCommand } from "./pluginSlashCommand";
+import {
+  isNativeCanonicalName,
+  parseSlashInput,
+  resolveNativeHandler,
+} from "./nativeSlashCommands";
 import { checkpointHasFileChanges, clearAllHasFileChanges, buildRollbackMap } from "../../utils/checkpointUtils";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { PanelToggles } from "../shared/PanelToggles";
@@ -422,7 +426,7 @@ export function ChatPanel() {
     mentionedFiles?: Set<string>,
     attachments?: AttachmentInput[],
   ) => {
-    const trimmed = content.trim();
+    let trimmed = content.trim();
     if ((!trimmed && !attachments?.length) || !selectedWorkspaceId) return;
 
     // Convert mentioned files set to array for the backend.
@@ -430,21 +434,33 @@ export function ChatPanel() {
       ? [...mentionedFiles]
       : undefined;
 
-    const pluginSlash = parsePluginSlashCommand(
-      trimmed,
-      repo?.remote_connection_id ? null : repo?.id ?? null,
-      pluginManagementEnabled,
-    );
-    if (pluginSlash) {
-      openPluginSettings(pluginSlash.intent);
-      if (selectedWorkspaceId) {
-        recordSlashCommandUsage(selectedWorkspaceId, pluginSlash.usageCommandName)
-          .catch((nextError) => console.error("Failed to record slash command usage:", nextError));
+    // Native slash command dispatch. Runs before the agent send path so that
+    // local_action/settings_route commands never leak to the CLI and
+    // prompt_expansion commands can rewrite the prompt before it is sent.
+    const parsedSlash = parseSlashInput(trimmed);
+    if (parsedSlash) {
+      const nativeHandler = resolveNativeHandler(parsedSlash.token);
+      if (nativeHandler) {
+        const result = nativeHandler.execute(
+          {
+            repoId: repo?.remote_connection_id ? null : repo?.id ?? null,
+            pluginManagementEnabled,
+            openPluginSettings,
+          },
+          parsedSlash.args,
+        );
+        if (result.kind !== "skipped") {
+          recordSlashCommandUsage(selectedWorkspaceId, result.canonicalName)
+            .catch((nextError) => console.error("Failed to record slash command usage:", nextError));
+        }
+        if (result.kind === "handled") return;
+        if (result.kind === "expand") {
+          // Rewrite the outgoing content to the expanded prompt and fall through
+          // to the normal agent send path (queue, optimistic message, stream).
+          trimmed = result.prompt.trim();
+          if (!trimmed) return;
+        }
       }
-      return;
-    }
-    if (!pluginManagementEnabled && isPluginSlashCommandInput(trimmed)) {
-      return;
     }
 
     // If the agent is running, queue the message instead of interrupting.
@@ -1744,7 +1760,10 @@ function ChatInputArea({
         if (cmd) {
           onSend("/" + cmd.name);
           setChatInput("");
-          if (cmd.name !== "plugin") {
+          // Native commands record their canonical name from inside the
+          // handleSend dispatcher; record here only for file-based commands
+          // that go straight to the agent.
+          if (!isNativeCanonicalName(cmd.name)) {
             recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
               .then(refreshSlashCommands)
               .catch((e) => console.error("Failed to record slash command usage:", e));
@@ -1819,7 +1838,7 @@ function ChatInputArea({
           onSelect={(cmd) => {
             onSend("/" + cmd.name);
             setChatInput("");
-            if (cmd.name !== "plugin") {
+            if (!isNativeCanonicalName(cmd.name)) {
               recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
                 .then(refreshSlashCommands)
                 .catch((e) => console.error("Failed to record slash command usage:", e));

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -41,7 +41,7 @@ import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { AttachMenu } from "./AttachMenu";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
 import {
-  isNativeCanonicalName,
+  describeSlashQuery,
   parseSlashInput,
   resolveNativeHandler,
 } from "./nativeSlashCommands";
@@ -1395,17 +1395,22 @@ function ChatInputArea({
     };
   }, [projectPath, selectedWorkspaceId]);
 
-  const slashQuery = chatInput.startsWith("/") ? chatInput.slice(1) : null;
+  // Filter by the command-name token (text before the first whitespace) so the
+  // picker stays open while the user types arguments. This keeps the argument
+  // hint visible for native commands like `/plugin install …`.
+  const slashQuery = describeSlashQuery(chatInput);
+  const slashQueryToken = slashQuery?.token ?? null;
+  const slashHasArgs = slashQuery?.hasArgs ?? false;
   const slashResults = useMemo(
-    () => (slashQuery === null ? [] : filterSlashCommands(slashCommands, slashQuery)),
-    [slashCommands, slashQuery],
+    () => (slashQueryToken === null ? [] : filterSlashCommands(slashCommands, slashQueryToken)),
+    [slashCommands, slashQueryToken],
   );
-  const showSlashPicker = slashQuery !== null && slashResults.length > 0 && !slashPickerDismissed;
+  const showSlashPicker = slashQueryToken !== null && slashResults.length > 0 && !slashPickerDismissed;
 
   useEffect(() => {
     setSlashPickerIndex(0);
     setSlashPickerDismissed(false);
-  }, [slashQuery]);
+  }, [slashQueryToken]);
 
   // --- File mention picker ---
 
@@ -1758,12 +1763,15 @@ function ChatInputArea({
         e.preventDefault();
         const cmd = slashResults[slashPickerIndex];
         if (cmd) {
-          onSend("/" + cmd.name);
+          // If the user has already typed arguments after the command name,
+          // keep what they typed; otherwise substitute the canonical name.
+          const send = slashHasArgs ? chatInput : "/" + cmd.name;
+          onSend(send);
           setChatInput("");
           // Native commands record their canonical name from inside the
           // handleSend dispatcher; record here only for file-based commands
           // that go straight to the agent.
-          if (!isNativeCanonicalName(cmd.name)) {
+          if (!cmd.kind) {
             recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
               .then(refreshSlashCommands)
               .catch((e) => console.error("Failed to record slash command usage:", e));
@@ -1836,9 +1844,10 @@ function ChatInputArea({
           commands={slashResults}
           selectedIndex={slashPickerIndex}
           onSelect={(cmd) => {
-            onSend("/" + cmd.name);
+            const send = slashHasArgs ? chatInput : "/" + cmd.name;
+            onSend(send);
             setChatInput("");
-            if (!isNativeCanonicalName(cmd.name)) {
+            if (!cmd.kind) {
               recordSlashCommandUsage(selectedWorkspaceId, cmd.name)
                 .then(refreshSlashCommands)
                 .catch((e) => console.error("Failed to record slash command usage:", e));

--- a/src/ui/src/components/chat/SlashCommandPicker.module.css
+++ b/src/ui/src/components/chat/SlashCommandPicker.module.css
@@ -57,3 +57,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.commandArgHint {
+  color: var(--text-muted, var(--text-dim));
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  margin-left: 8px;
+  white-space: nowrap;
+  opacity: 0.7;
+}

--- a/src/ui/src/components/chat/SlashCommandPicker.test.ts
+++ b/src/ui/src/components/chat/SlashCommandPicker.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import type { SlashCommand } from "../../services/tauri";
+import { filterSlashCommands } from "./SlashCommandPicker";
+
+function cmd(partial: Partial<SlashCommand> & { name: string }): SlashCommand {
+  return {
+    description: partial.description ?? "",
+    source: partial.source ?? "builtin",
+    aliases: partial.aliases,
+    argument_hint: partial.argument_hint,
+    kind: partial.kind,
+    ...partial,
+  };
+}
+
+describe("filterSlashCommands", () => {
+  const commands: SlashCommand[] = [
+    cmd({ name: "plugin", aliases: ["plugins"], kind: "settings_route" }),
+    cmd({ name: "marketplace", kind: "settings_route" }),
+    cmd({ name: "commit", source: "user" }),
+    cmd({ name: "deploy", source: "project" }),
+    cmd({ name: "cmux-browser", source: "plugin" }),
+  ];
+
+  it("matches by substring on the canonical name", () => {
+    expect(filterSlashCommands(commands, "plug").map((c) => c.name)).toEqual([
+      "plugin",
+    ]);
+  });
+
+  it("matches by alias so /plugins surfaces the plugin card", () => {
+    expect(filterSlashCommands(commands, "plugins").map((c) => c.name)).toEqual([
+      "plugin",
+    ]);
+  });
+
+  it("returns every command for an empty query", () => {
+    expect(filterSlashCommands(commands, "").length).toBe(commands.length);
+  });
+
+  it("returns nothing for an unrelated token", () => {
+    expect(filterSlashCommands(commands, "xyzzy")).toEqual([]);
+  });
+
+  it("is case-insensitive on aliases", () => {
+    expect(
+      filterSlashCommands(commands, "PLUGINS").map((c) => c.name),
+    ).toEqual(["plugin"]);
+  });
+
+  it("tolerates commands without the optional aliases field", () => {
+    const legacy: SlashCommand[] = [
+      { name: "legacy", description: "", source: "user" },
+    ];
+    expect(filterSlashCommands(legacy, "leg").map((c) => c.name)).toEqual([
+      "legacy",
+    ]);
+  });
+});

--- a/src/ui/src/components/chat/SlashCommandPicker.tsx
+++ b/src/ui/src/components/chat/SlashCommandPicker.tsx
@@ -29,6 +29,9 @@ export function SlashCommandPicker({
         >
           <span className={styles.commandSlash}>/</span>
           <span className={styles.commandName}>{cmd.name}</span>
+          {cmd.argument_hint ? (
+            <span className={styles.commandArgHint}>{cmd.argument_hint}</span>
+          ) : null}
           <span className={styles.commandDesc}>{cmd.description}</span>
         </div>
       ))}
@@ -38,5 +41,9 @@ export function SlashCommandPicker({
 
 export function filterSlashCommands(commands: SlashCommand[], query: string): SlashCommand[] {
   const q = query.toLowerCase();
-  return commands.filter((cmd) => cmd.name.toLowerCase().includes(q));
+  return commands.filter((cmd) => {
+    if (cmd.name.toLowerCase().includes(q)) return true;
+    const aliases = cmd.aliases ?? [];
+    return aliases.some((alias) => alias.toLowerCase().includes(q));
+  });
 }

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PluginSettingsIntent } from "../../types/plugins";
+import {
+  NATIVE_HANDLERS,
+  isNativeCanonicalName,
+  parseSlashInput,
+  resolveNativeHandler,
+  type NativeCommandContext,
+  type NativeCommandResult,
+  type NativeHandler,
+} from "./nativeSlashCommands";
+
+function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandContext {
+  return {
+    repoId: "repo-1",
+    pluginManagementEnabled: true,
+    openPluginSettings: vi.fn<(intent: Partial<PluginSettingsIntent>) => void>(),
+    ...overrides,
+  };
+}
+
+describe("parseSlashInput", () => {
+  it("returns null for non-slash input", () => {
+    expect(parseSlashInput("hello")).toBeNull();
+    expect(parseSlashInput("")).toBeNull();
+  });
+
+  it("parses a bare token with no args", () => {
+    expect(parseSlashInput("/plugin")).toEqual({ token: "plugin", args: "" });
+  });
+
+  it("splits token from the remaining args", () => {
+    expect(parseSlashInput("/plugin install demo --scope user")).toEqual({
+      token: "plugin",
+      args: "install demo --scope user",
+    });
+  });
+
+  it("preserves whitespace and quoted content in args", () => {
+    expect(parseSlashInput('/foo "one two" three')).toEqual({
+      token: "foo",
+      args: '"one two" three',
+    });
+  });
+
+  it("ignores leading whitespace before the slash", () => {
+    expect(parseSlashInput("   /plugin install demo")).toEqual({
+      token: "plugin",
+      args: "install demo",
+    });
+  });
+});
+
+describe("resolveNativeHandler", () => {
+  it("matches canonical names", () => {
+    expect(resolveNativeHandler("plugin")?.name).toBe("plugin");
+    expect(resolveNativeHandler("marketplace")?.name).toBe("marketplace");
+  });
+
+  it("matches aliases", () => {
+    expect(resolveNativeHandler("plugins")?.name).toBe("plugin");
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveNativeHandler("PLUGIN")?.name).toBe("plugin");
+    expect(resolveNativeHandler("Plugins")?.name).toBe("plugin");
+    expect(resolveNativeHandler("MarketPlace")?.name).toBe("marketplace");
+  });
+
+  it("returns null for unknown tokens", () => {
+    expect(resolveNativeHandler("totally-unknown")).toBeNull();
+    expect(resolveNativeHandler("")).toBeNull();
+  });
+});
+
+describe("plugin native handler", () => {
+  it("routes /plugin to the plugin settings intent with canonical 'plugin'", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("plugin")!;
+    const result = handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "plugin" });
+    expect(ctx.openPluginSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ tab: "available", action: null }),
+    );
+  });
+
+  it("routes alias /plugins through the plugin handler", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("plugins")!;
+    expect(handler.name).toBe("plugin");
+    const result = handler.execute(ctx, "manage");
+    expect(result).toEqual({ kind: "handled", canonicalName: "plugin" });
+    expect(ctx.openPluginSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ tab: "installed" }),
+    );
+  });
+
+  it("parses /plugin install <target> --scope project", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("plugin")!;
+    handler.execute(ctx, "install demo@market --scope project");
+    expect(ctx.openPluginSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "install",
+        source: "demo@market",
+        scope: "project",
+        tab: "available",
+      }),
+    );
+  });
+
+  it("routes /marketplace add to canonical 'marketplace'", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("marketplace")!;
+    const result = handler.execute(ctx, "add github:owner/repo --scope local");
+    expect(result).toEqual({ kind: "handled", canonicalName: "marketplace" });
+    expect(ctx.openPluginSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "marketplace-add",
+        source: "github:owner/repo",
+        scope: "local",
+        tab: "marketplaces",
+      }),
+    );
+  });
+
+  it("swallows /plugin when plugin management is disabled without opening settings", () => {
+    const ctx = makeCtx({ pluginManagementEnabled: false });
+    const handler = resolveNativeHandler("plugin")!;
+    const result = handler.execute(ctx, "install demo");
+    expect(result).toEqual({ kind: "handled", canonicalName: "plugin" });
+    expect(ctx.openPluginSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatcher across native kinds", () => {
+  it("handles local_action results without producing a prompt", () => {
+    const localAction: NativeHandler = {
+      name: "clear-draft",
+      aliases: [],
+      kind: "local_action",
+      execute: () => ({ kind: "handled", canonicalName: "clear-draft" }),
+    };
+    const resolved = resolveNativeHandler("clear-draft", [localAction]);
+    expect(resolved).toBe(localAction);
+    const result = resolved!.execute(makeCtx(), "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "clear-draft" });
+  });
+
+  it("handles prompt_expansion results by returning seeded prompt text", () => {
+    const expander: NativeHandler = {
+      name: "ask-clearly",
+      aliases: ["ac"],
+      kind: "prompt_expansion",
+      execute: (_ctx, args): NativeCommandResult => ({
+        kind: "expand",
+        canonicalName: "ask-clearly",
+        prompt: `Please answer clearly: ${args}`,
+      }),
+    };
+    const resolved = resolveNativeHandler("ac", [expander]);
+    expect(resolved).toBe(expander);
+    const result = resolved!.execute(makeCtx(), "what is 2+2");
+    expect(result).toEqual({
+      kind: "expand",
+      canonicalName: "ask-clearly",
+      prompt: "Please answer clearly: what is 2+2",
+    });
+  });
+});
+
+describe("isNativeCanonicalName", () => {
+  it("identifies canonical names from the built-in table", () => {
+    expect(isNativeCanonicalName("plugin")).toBe(true);
+    expect(isNativeCanonicalName("marketplace")).toBe(true);
+    expect(isNativeCanonicalName("Plugin")).toBe(true);
+  });
+
+  it("does not match aliases or unrelated names", () => {
+    expect(isNativeCanonicalName("plugins")).toBe(false);
+    expect(isNativeCanonicalName("commit")).toBe(false);
+  });
+});
+
+describe("native handler table", () => {
+  it("exposes plugin and marketplace canonical entries", () => {
+    const names = NATIVE_HANDLERS.map((h) => h.name);
+    expect(names).toContain("plugin");
+    expect(names).toContain("marketplace");
+  });
+});

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PluginSettingsIntent } from "../../types/plugins";
 import {
   NATIVE_HANDLERS,
-  isNativeCanonicalName,
+  describeSlashQuery,
   parseSlashInput,
   resolveNativeHandler,
   type NativeCommandContext,
@@ -170,16 +170,35 @@ describe("dispatcher across native kinds", () => {
   });
 });
 
-describe("isNativeCanonicalName", () => {
-  it("identifies canonical names from the built-in table", () => {
-    expect(isNativeCanonicalName("plugin")).toBe(true);
-    expect(isNativeCanonicalName("marketplace")).toBe(true);
-    expect(isNativeCanonicalName("Plugin")).toBe(true);
+describe("describeSlashQuery", () => {
+  it("returns null for non-slash input", () => {
+    expect(describeSlashQuery("hello")).toBeNull();
+    expect(describeSlashQuery("")).toBeNull();
   });
 
-  it("does not match aliases or unrelated names", () => {
-    expect(isNativeCanonicalName("plugins")).toBe(false);
-    expect(isNativeCanonicalName("commit")).toBe(false);
+  it("returns an empty token for a bare slash so the picker shows every command", () => {
+    expect(describeSlashQuery("/")).toEqual({ token: "", hasArgs: false });
+  });
+
+  it("returns just the token when no whitespace follows", () => {
+    expect(describeSlashQuery("/plug")).toEqual({ token: "plug", hasArgs: false });
+    expect(describeSlashQuery("/plugin")).toEqual({ token: "plugin", hasArgs: false });
+  });
+
+  it("flags hasArgs once whitespace appears so the picker can preserve typed args", () => {
+    expect(describeSlashQuery("/plugin ")).toEqual({
+      token: "plugin",
+      hasArgs: true,
+    });
+    expect(describeSlashQuery("/plugin install demo")).toEqual({
+      token: "plugin",
+      hasArgs: true,
+    });
+  });
+
+  it("does not consume a leading slash inside a longer prefix", () => {
+    expect(describeSlashQuery("  /plugin")).toBeNull();
+    expect(describeSlashQuery("not/a/command")).toBeNull();
   });
 });
 

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -1,0 +1,92 @@
+import type { PluginSettingsIntent } from "../../types/plugins";
+import type { NativeSlashKind } from "../../services/tauri";
+import { parsePluginSlashCommand } from "./pluginSlashCommand";
+
+export type { NativeSlashKind };
+
+export interface NativeCommandContext {
+  repoId: string | null;
+  pluginManagementEnabled: boolean;
+  openPluginSettings: (intent: Partial<PluginSettingsIntent>) => void;
+}
+
+export type NativeCommandResult =
+  | { kind: "handled"; canonicalName: string }
+  | { kind: "expand"; canonicalName: string; prompt: string }
+  | { kind: "skipped" };
+
+export interface NativeHandler {
+  name: string;
+  aliases: string[];
+  kind: NativeSlashKind;
+  execute: (ctx: NativeCommandContext, args: string) => NativeCommandResult;
+}
+
+/** Split `/token rest of args` into its token and the argument tail. */
+export function parseSlashInput(
+  input: string,
+): { token: string; args: string } | null {
+  const trimmed = input.trimStart();
+  if (!trimmed.startsWith("/")) return null;
+  const body = trimmed.slice(1);
+  const match = body.match(/^(\S+)(\s+([\s\S]*))?$/);
+  if (!match) return null;
+  const token = match[1];
+  const args = match[3] ?? "";
+  return { token, args };
+}
+
+function pluginHandler(root: "plugin" | "marketplace"): NativeHandler {
+  return {
+    name: root,
+    aliases: root === "plugin" ? ["plugins"] : [],
+    kind: "settings_route",
+    execute: (ctx, args) => {
+      if (!ctx.pluginManagementEnabled) {
+        // Plugin management disabled — swallow the command so it never reaches
+        // the agent, but do not mutate settings.
+        return { kind: "handled", canonicalName: root };
+      }
+      const reconstructed = args.length > 0 ? `/${root} ${args}` : `/${root}`;
+      const parsed = parsePluginSlashCommand(
+        reconstructed,
+        ctx.repoId,
+        ctx.pluginManagementEnabled,
+      );
+      if (!parsed) {
+        return { kind: "handled", canonicalName: root };
+      }
+      ctx.openPluginSettings(parsed.intent);
+      return { kind: "handled", canonicalName: parsed.usageCommandName };
+    },
+  };
+}
+
+export const NATIVE_HANDLERS: NativeHandler[] = [
+  pluginHandler("plugin"),
+  pluginHandler("marketplace"),
+];
+
+/** Resolve a slash command token (no leading `/`) against the native handler table. */
+export function resolveNativeHandler(
+  token: string,
+  handlers: NativeHandler[] = NATIVE_HANDLERS,
+): NativeHandler | null {
+  const needle = token.trim().toLowerCase();
+  if (!needle) return null;
+  return (
+    handlers.find(
+      (h) =>
+        h.name.toLowerCase() === needle
+        || h.aliases.some((a) => a.toLowerCase() === needle),
+    ) ?? null
+  );
+}
+
+/** Returns true if `name` is the canonical name of a native handler. */
+export function isNativeCanonicalName(
+  name: string,
+  handlers: NativeHandler[] = NATIVE_HANDLERS,
+): boolean {
+  return handlers.some((h) => h.name.toLowerCase() === name.toLowerCase());
+}

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -36,6 +36,27 @@ export function parseSlashInput(
   return { token, args };
 }
 
+/**
+ * Describe the slash picker query derived from the current chat input.
+ *
+ * - `token` is the text between the leading `/` and the first whitespace.
+ *   Use it for picker filtering so the picker stays open while the user
+ *   types arguments after the command name.
+ * - `hasArgs` is true if any whitespace follows the token — used by the
+ *   picker to decide whether Enter should replace the input with the
+ *   canonical name or preserve the user's typed arguments.
+ * - Returns `null` if the input is not a slash command.
+ */
+export function describeSlashQuery(
+  input: string,
+): { token: string; hasArgs: boolean } | null {
+  if (!input.startsWith("/")) return null;
+  const rest = input.slice(1);
+  const match = rest.match(/^(\S*)(\s([\s\S]*))?$/);
+  if (!match) return null;
+  return { token: match[1] ?? "", hasArgs: match[2] !== undefined };
+}
+
 function pluginHandler(root: "plugin" | "marketplace"): NativeHandler {
   return {
     name: root,
@@ -83,10 +104,3 @@ export function resolveNativeHandler(
   );
 }
 
-/** Returns true if `name` is the canonical name of a native handler. */
-export function isNativeCanonicalName(
-  name: string,
-  handlers: NativeHandler[] = NATIVE_HANDLERS,
-): boolean {
-  return handlers.some((h) => h.name.toLowerCase() === name.toLowerCase());
-}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -141,10 +141,18 @@ export function openWorkspaceInTerminal(worktreePath: string): Promise<void> {
 
 // -- Slash Commands --
 
+export type NativeSlashKind = "local_action" | "settings_route" | "prompt_expansion";
+
 export interface SlashCommand {
   name: string;
   description: string;
   source: string;
+  /** Alternative names for this canonical command. Empty for file-based entries. */
+  aliases?: string[];
+  /** Short hint describing expected argument shape, e.g. "[add|remove] <source>". */
+  argument_hint?: string | null;
+  /** Native command kind. Absent for file-based commands. */
+  kind?: NativeSlashKind | null;
 }
 
 export function listSlashCommands(


### PR DESCRIPTION
## Summary

Generalizes the existing plugin-only slash command special case into a first-class native slash command registry. Closes #241.

- Rust `slash_commands::SlashCommand` now carries `aliases`, `argument_hint`, and a `NativeKind` (`local_action` / `settings_route` / `prompt_expansion`). New `native_command_registry` is the single source of truth for built-in entries, and `resolve_native` resolves a token against canonical names + aliases case-insensitively.
- New frontend module `src/ui/src/components/chat/nativeSlashCommands.ts` ships `parseSlashInput`, `resolveNativeHandler`, `isNativeCanonicalName`, and a `NATIVE_HANDLERS` table that registers `plugin` (alias `plugins`) and `marketplace` as `settings_route` commands. Handlers reuse `parsePluginSlashCommand` so intent parsing is unchanged.
- `ChatPanel.handleSend` now dispatches through the framework before the agent send path: native `handled` results short-circuit, `expand` results rewrite the outgoing prompt and fall through to `sendChatMessage`, and everything else passes through unchanged to the agent.
- Usage tracking always records the **canonical** name — if the user types `/plugins`, the DB row is `plugin`.
- Slash picker filters by alias as well as name and renders the `argument_hint` in a dim mono column.

## Scope note

Per the issue's "out of scope" list, no new public commands are added in this PR beyond the existing `/plugin`, `/plugins`, `/marketplace`. Follow-up issues can register `/clear`, `/plan`, `/model`, etc. against the new framework. The `local_action` and `prompt_expansion` code paths are covered by the dispatcher + unit tests in this PR; they will get real registered commands in follow-ups.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --all-features` — 376 passed (5 new native-registry tests)
- [x] `bun run test` — 303 passed (24 new `nativeSlashCommands` tests)
- [x] `bunx tsc --noEmit`
- [x] Live UAT against `cargo tauri dev` with a fresh UAT workspace under latentforge — see below

## UAT notes

Live UAT driven through the `/claudette-debug` TCP eval server against `cargo tauri dev`. A scratch workspace (`uat-slash-framework-*`) was created under the latentforge repo and removed when done.

Matrix exercised:

- **Registry shape from backend**: `list_slash_commands` returns `plugin` (aliases `["plugins"]`, kind `settings_route`, argument hint) and `marketplace` (kind `settings_route`, argument hint). Other sources (`user`, `project`, `plugin`, `builtin`) coexist.
- **Picker filter**: typing `p` surfaces plugin + marketplace among user/project commands; typing `plugins` (alias) still surfaces the plugin card; typing `market` surfaces marketplace; typing `xyzzy` returns none.
- **Canonical + alias + case resolution**: `resolveNativeHandler("plugin")`, `"plugins"`, and `"PLUGIN"` all resolve to canonical `plugin`; `"marketplace"` resolves to itself; unknown tokens return `null`.
- **Argument parsing**: `/plugin` (no args), `/plugin install demo@market --scope project`, `/marketplace add github:owner/repo --scope local`, quoted and whitespace-padded variants all parse.
- **settings_route dispatch**: `/plugin`, `/plugins`, `/plugin install demo@market --scope project`, `/plugin manage`, `/PLUGIN update demo`, and `/marketplace add …`/`/marketplace remove …` each open settings to `plugins` with the expected `pluginSettingsTab` (`available`, `installed`, or `marketplaces`) and correct intent (`action`, `source`, `target`, `scope`).
- **Plugin management disabled**: `/plugin install demo` with `pluginManagementEnabled=false` returns `handled` without calling `openPluginSettings` and leaves `settingsOpen=false`.
- **local_action kind**: synthetic handler registered at eval time resolves by alias and returns `{ kind: "handled", canonicalName }`.
- **prompt_expansion kind**: synthetic handler returns `{ kind: "expand", canonicalName, prompt }` — dispatcher rewrites `trimmed` and falls through to `sendChatMessage` (covered by unit tests; verified dispatcher shape here).
- **Unknown slash passthrough**: `/commit with message` → `parseSlashInput` returns `{ token: "commit", args: "with message" }`, `resolveNativeHandler` returns `null`, so `handleSend` falls through to the agent unchanged.
- **Usage tracking records canonical**: typing `/plugins` (alias) records `plugin` in the DB. After several alias + canonical writes, the top of the usage-sorted list is `["plugin", "marketplace", ...]` and no `plugins` row exists.

No UI screenshots captured — capture/window-activation was not used during this UAT; store state and `list_slash_commands` responses were inspected directly through the debug server.