### PR TITLE
docs(claudette-debug): forbid launching installed app from skill

### DIFF
--- a/.claude/skills/claudette-debug/SKILL.md
+++ b/.claude/skills/claudette-debug/SKILL.md
@@ -30,6 +30,8 @@ Execute JavaScript inside the running Claudette Tauri webview via a TCP debug se
 - Port 19432 available on localhost
 - `python3` in PATH (used by eval helper)
 
+**Do NOT launch the installed app.** Never run `osascript -e 'tell application "Claudette" to activate'`, `open -a Claudette`, or double-click `/Applications/Claudette.app`. The debug TCP server on port 19432 only exists in dev builds (gated by `#[cfg(debug_assertions)]`); the installed release build has no debug server and eval calls against it will fail or silently target the wrong process. If the dev build is not already running, ask the user to start `cargo tauri dev` — do not start it yourself and do not fall back to the installed app.
+
 ## Scripts
 
 All scripts live in `${CLAUDE_SKILL_DIR}/scripts/`:

--- a/.claude/skills/claudette-debug/scripts/debug-eval.sh
+++ b/.claude/skills/claudette-debug/scripts/debug-eval.sh
@@ -27,7 +27,9 @@ try:
     s.connect(('${HOST}', ${PORT}))
 except ConnectionRefusedError:
     print('ERROR: Cannot connect to debug server on ${HOST}:${PORT}', file=sys.stderr)
-    print('Is the app running via cargo tauri dev?', file=sys.stderr)
+    print('The dev build must be running via \`cargo tauri dev\`.', file=sys.stderr)
+    print('Do NOT launch the installed /Applications/Claudette.app — it has no debug server.', file=sys.stderr)
+    print('Ask the user to start \`cargo tauri dev\` if it is not already running.', file=sys.stderr)
     sys.exit(1)
 s.sendall(sys.stdin.buffer.read())
 s.shutdown(socket.SHUT_WR)


### PR DESCRIPTION
## Summary

Agents using `/claudette-debug` have been improvising `osascript -e 'tell application \"Claudette\" to activate'` when they couldn't find the dev build running. That launches `/Applications/Claudette.app` — a release build — which has no debug TCP server (gated behind `#[cfg(debug_assertions)]`), so subsequent eval calls either time out, fail with `ConnectionRefused`, or worst-case attach to the wrong Claudette process.

The skill itself never instructed this behavior; it was pure agent improvisation. This PR closes the loophole by making the prohibition explicit in two places:

- **`SKILL.md` Prerequisites** — new paragraph stating: do NOT run `osascript activate`, `open -a Claudette`, or double-click the installed app; the release build has no debug server; if `cargo tauri dev` isn't running, ask the user rather than falling back.
- **`debug-eval.sh` error path** — on `ConnectionRefusedError`, the message now tells the agent explicitly not to launch `/Applications/Claudette.app` and to ask the user to start `cargo tauri dev`.

## Test plan

- [ ] Read updated `SKILL.md` prerequisites and confirm the prohibition is clear
- [ ] Kill any running dev build and run `.claude/skills/claudette-debug/scripts/debug-eval.sh 'return 1+1'` — verify the updated error message appears
- [ ] Confirm running `cargo tauri dev` and re-running the same command still works normally