### PR TITLE
feat(chat): add /review, /security-review, /pr-comments native slash commands

### DIFF
--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -76,6 +76,30 @@ pub fn native_command_registry(plugin_management_enabled: bool) -> Vec<SlashComm
             kind: Some(NativeKind::SettingsRoute),
         });
     }
+    commands.push(SlashCommand {
+        name: "review".to_string(),
+        description: "Seed a code review of the current branch against its base".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: Some("[extra focus areas]".to_string()),
+        kind: Some(NativeKind::PromptExpansion),
+    });
+    commands.push(SlashCommand {
+        name: "security-review".to_string(),
+        description: "Seed a security-focused review of the current branch".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: Some("[extra focus areas]".to_string()),
+        kind: Some(NativeKind::PromptExpansion),
+    });
+    commands.push(SlashCommand {
+        name: "pr-comments".to_string(),
+        description: "Summarize PR comments for the current branch".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: Some("[PR number or extra guidance]".to_string()),
+        kind: Some(NativeKind::PromptExpansion),
+    });
     commands
 }
 
@@ -627,10 +651,39 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_native_commands_skips_when_disabled() {
+    fn test_collect_native_commands_skips_plugin_entries_when_disabled() {
         let mut commands = Vec::new();
         collect_native_commands(&mut commands, false);
-        assert!(commands.is_empty());
+        let names: Vec<_> = commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(!names.contains(&"plugin"));
+        assert!(!names.contains(&"marketplace"));
+        // Review workflow entries are always present regardless of the plugin flag.
+        assert!(names.contains(&"review"));
+        assert!(names.contains(&"security-review"));
+        assert!(names.contains(&"pr-comments"));
+    }
+
+    #[test]
+    fn test_native_command_registry_includes_review_workflow_entries() {
+        for enabled in [true, false] {
+            let natives = native_command_registry(enabled);
+            for name in ["review", "security-review", "pr-comments"] {
+                let entry = natives
+                    .iter()
+                    .find(|c| c.name == name)
+                    .unwrap_or_else(|| panic!("missing native entry `{name}` (enabled={enabled})"));
+                assert_eq!(entry.source, "builtin");
+                assert_eq!(entry.kind, Some(NativeKind::PromptExpansion));
+                assert!(
+                    entry.argument_hint.is_some(),
+                    "argument hint missing for `{name}`"
+                );
+                assert!(
+                    entry.aliases.is_empty(),
+                    "review commands expose no aliases"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -445,6 +445,11 @@ export function ChatPanel() {
             repoId: repo?.remote_connection_id ? null : repo?.id ?? null,
             pluginManagementEnabled,
             openPluginSettings,
+            repository: repo ? { name: repo.name, path: repo.path } : null,
+            workspace: ws
+              ? { branch: ws.branch_name, worktreePath: ws.worktree_path }
+              : null,
+            defaultBranch: defaultBranch ?? null,
           },
           parsedSlash.args,
         );

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -449,7 +449,7 @@ export function ChatPanel() {
             workspace: ws
               ? { branch: ws.branch_name, worktreePath: ws.worktree_path }
               : null,
-            defaultBranch: defaultBranch ?? null,
+            repoDefaultBranch: defaultBranch ?? null,
           },
           parsedSlash.args,
         );

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -18,7 +18,7 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     openPluginSettings: vi.fn<(intent: Partial<PluginSettingsIntent>) => void>(),
     repository: { name: "claudette", path: "/tmp/repos/claudette" },
     workspace: { branch: "feat/review-cmds", worktreePath: "/tmp/wt/review-cmds" },
-    defaultBranch: "origin/main",
+    repoDefaultBranch: "origin/main",
     ...overrides,
   };
 }
@@ -244,6 +244,9 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).toContain("/tmp/wt/review-cmds");
         expect(result.prompt).toContain("feat/review-cmds");
         expect(result.prompt).toContain("origin/main");
+        // Must label the repo default as a hint, not as the guaranteed review base.
+        expect(result.prompt).toContain("Repo default branch");
+        expect(result.prompt).toContain("hint only");
         expect(result.prompt).not.toContain("Additional guidance from user");
         expect(result.prompt).not.toContain("undefined");
         expect(result.prompt).not.toContain("null");
@@ -266,11 +269,11 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).toContain(`Additional guidance from user: ${args}`);
       });
 
-      it("omits missing workspace/repo/defaultBranch fields without leaking placeholders", () => {
+      it("omits missing workspace/repo/repoDefaultBranch fields without leaking placeholders", () => {
         const ctx = makeCtx({
           repository: null,
           workspace: null,
-          defaultBranch: null,
+          repoDefaultBranch: null,
         });
         const handler = resolveNativeHandler(name)!;
         const result = handler.execute(ctx, "");
@@ -278,7 +281,7 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).not.toContain("undefined");
         expect(result.prompt).not.toContain("null");
         expect(result.prompt).not.toMatch(/Repository:\s*$/m);
-        expect(result.prompt).not.toMatch(/Base branch:\s*$/m);
+        expect(result.prompt).not.toMatch(/Repo default branch[^:]*:\s*$/m);
         expect(result.prompt).not.toMatch(/Current branch:\s*$/m);
         expect(result.prompt).not.toMatch(/Worktree:\s*$/m);
       });
@@ -287,7 +290,7 @@ describe("review workflow native handlers", () => {
         const ctx = makeCtx({
           repository: { name: "claudette", path: "/tmp/repos/claudette" },
           workspace: { branch: "feat/x", worktreePath: null },
-          defaultBranch: null,
+          repoDefaultBranch: null,
         });
         const handler = resolveNativeHandler(name)!;
         const result = handler.execute(ctx, "");
@@ -295,7 +298,7 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).toContain("claudette");
         expect(result.prompt).toContain("feat/x");
         expect(result.prompt).not.toContain("Worktree:");
-        expect(result.prompt).not.toContain("Base branch:");
+        expect(result.prompt).not.toContain("Repo default branch");
       });
 
       it("returns an expand result (not handled) so ChatPanel forwards the prompt to sendChatMessage", () => {
@@ -323,6 +326,45 @@ describe("review workflow native handlers", () => {
       });
     });
   }
+
+  describe("review base resolution (P1/P2 fixes)", () => {
+    it("/review instructs the agent to resolve the review base via gh/git, not to trust the repo default as the base", () => {
+      const handler = resolveNativeHandler("review")!;
+      const result = handler.execute(makeCtx(), "");
+      if (result.kind !== "expand") throw new Error("expected expand");
+      expect(result.prompt).toMatch(/Resolve the review base ref/);
+      expect(result.prompt).toContain("gh pr view");
+      expect(result.prompt).toContain("@{upstream}");
+      // The repo default is surfaced only as a labeled hint/fallback.
+      expect(result.prompt).toMatch(/hint only.*not guaranteed to be this branch's review base/);
+    });
+
+    it("/security-review uses the same resolve-base guidance", () => {
+      const handler = resolveNativeHandler("security-review")!;
+      const result = handler.execute(makeCtx(), "");
+      if (result.kind !== "expand") throw new Error("expected expand");
+      expect(result.prompt).toMatch(/Resolve the review base ref/);
+      expect(result.prompt).toContain("gh pr view");
+    });
+
+    it("prompt still instructs base-resolution when repoDefaultBranch is missing (remote-workspace case)", () => {
+      // On paired remote workspaces today, defaultBranch may not be in the
+      // store. The prompt must still tell the agent to determine a base ref
+      // itself rather than diffing against an unnamed / empty ref.
+      const ctx = makeCtx({ repoDefaultBranch: null });
+      for (const name of ["review", "security-review"] as const) {
+        const result = resolveNativeHandler(name)!.execute(ctx, "");
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.prompt).toMatch(/Resolve the review base ref/);
+        expect(result.prompt).toContain("gh pr view");
+        expect(result.prompt).toContain("@{upstream}");
+        // And must include an explicit instruction to ask the user if no base
+        // can be resolved, so the agent never runs `git diff ...HEAD` with an
+        // empty base.
+        expect(result.prompt).toMatch(/stop and ask the user/);
+      }
+    });
+  });
 
   it("each command produces a distinct seeded prompt", () => {
     const ctx = makeCtx();

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -16,6 +16,9 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     repoId: "repo-1",
     pluginManagementEnabled: true,
     openPluginSettings: vi.fn<(intent: Partial<PluginSettingsIntent>) => void>(),
+    repository: { name: "claudette", path: "/tmp/repos/claudette" },
+    workspace: { branch: "feat/review-cmds", worktreePath: "/tmp/wt/review-cmds" },
+    defaultBranch: "origin/main",
     ...overrides,
   };
 }
@@ -207,5 +210,128 @@ describe("native handler table", () => {
     const names = NATIVE_HANDLERS.map((h) => h.name);
     expect(names).toContain("plugin");
     expect(names).toContain("marketplace");
+  });
+
+  it("exposes review, security-review, and pr-comments as prompt_expansion handlers", () => {
+    for (const name of ["review", "security-review", "pr-comments"] as const) {
+      const handler = NATIVE_HANDLERS.find((h) => h.name === name);
+      expect(handler, `missing NATIVE_HANDLERS entry for ${name}`).toBeDefined();
+      expect(handler!.kind).toBe("prompt_expansion");
+      expect(handler!.aliases).toEqual([]);
+    }
+  });
+});
+
+describe("review workflow native handlers", () => {
+  const REVIEW_NAMES = ["review", "security-review", "pr-comments"] as const;
+
+  for (const name of REVIEW_NAMES) {
+    describe(`/${name}`, () => {
+      it("resolves by canonical name (case-insensitive)", () => {
+        expect(resolveNativeHandler(name)?.name).toBe(name);
+        expect(resolveNativeHandler(name.toUpperCase())?.name).toBe(name);
+      });
+
+      it("expands with empty args into a seeded prompt grounded in workspace context", () => {
+        const ctx = makeCtx();
+        const handler = resolveNativeHandler(name)!;
+        const result = handler.execute(ctx, "");
+        expect(result.kind).toBe("expand");
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.canonicalName).toBe(name);
+        expect(result.prompt).toContain("claudette");
+        expect(result.prompt).toContain("/tmp/repos/claudette");
+        expect(result.prompt).toContain("/tmp/wt/review-cmds");
+        expect(result.prompt).toContain("feat/review-cmds");
+        expect(result.prompt).toContain("origin/main");
+        expect(result.prompt).not.toContain("Additional guidance from user");
+        expect(result.prompt).not.toContain("undefined");
+        expect(result.prompt).not.toContain("null");
+      });
+
+      it("expands with whitespace-only args the same as empty args", () => {
+        const ctx = makeCtx();
+        const handler = resolveNativeHandler(name)!;
+        const result = handler.execute(ctx, "   \t\n  ");
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.prompt).not.toContain("Additional guidance from user");
+      });
+
+      it("preserves user-supplied arguments verbatim in a guidance line", () => {
+        const ctx = makeCtx();
+        const handler = resolveNativeHandler(name)!;
+        const args = 'focus on "diff.rs" and the PTY bridge';
+        const result = handler.execute(ctx, args);
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.prompt).toContain(`Additional guidance from user: ${args}`);
+      });
+
+      it("omits missing workspace/repo/defaultBranch fields without leaking placeholders", () => {
+        const ctx = makeCtx({
+          repository: null,
+          workspace: null,
+          defaultBranch: null,
+        });
+        const handler = resolveNativeHandler(name)!;
+        const result = handler.execute(ctx, "");
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.prompt).not.toContain("undefined");
+        expect(result.prompt).not.toContain("null");
+        expect(result.prompt).not.toMatch(/Repository:\s*$/m);
+        expect(result.prompt).not.toMatch(/Base branch:\s*$/m);
+        expect(result.prompt).not.toMatch(/Current branch:\s*$/m);
+        expect(result.prompt).not.toMatch(/Worktree:\s*$/m);
+      });
+
+      it("omits individual missing fields but keeps populated ones", () => {
+        const ctx = makeCtx({
+          repository: { name: "claudette", path: "/tmp/repos/claudette" },
+          workspace: { branch: "feat/x", worktreePath: null },
+          defaultBranch: null,
+        });
+        const handler = resolveNativeHandler(name)!;
+        const result = handler.execute(ctx, "");
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.prompt).toContain("claudette");
+        expect(result.prompt).toContain("feat/x");
+        expect(result.prompt).not.toContain("Worktree:");
+        expect(result.prompt).not.toContain("Base branch:");
+      });
+
+      it("returns an expand result (not handled) so ChatPanel forwards the prompt to sendChatMessage", () => {
+        // The ChatPanel send path only falls through to sendChatMessage when
+        // the native dispatcher returns `kind: "expand"`. A "handled" result
+        // would short-circuit and swallow the command. These handlers must
+        // therefore always return "expand" — they seed the prompt and let the
+        // normal agent pipeline run it.
+        const ctx = makeCtx();
+        const handler = resolveNativeHandler(name)!;
+        const empty = handler.execute(ctx, "");
+        const withArgs = handler.execute(ctx, "hello");
+        expect(empty.kind).toBe("expand");
+        expect(withArgs.kind).toBe("expand");
+      });
+
+      it("does not pass the raw slash input through verbatim — the expansion differs from `/<name> …`", () => {
+        const ctx = makeCtx();
+        const handler = resolveNativeHandler(name)!;
+        const rawInput = `/${name} focus on perf`;
+        const result = handler.execute(ctx, "focus on perf");
+        if (result.kind !== "expand") throw new Error("expected expand");
+        expect(result.prompt).not.toBe(rawInput);
+        expect(result.prompt.length).toBeGreaterThan(rawInput.length);
+      });
+    });
+  }
+
+  it("each command produces a distinct seeded prompt", () => {
+    const ctx = makeCtx();
+    const prompts = REVIEW_NAMES.map((n) => {
+      const r = resolveNativeHandler(n)!.execute(ctx, "");
+      if (r.kind !== "expand") throw new Error("expected expand");
+      return r.prompt;
+    });
+    const unique = new Set(prompts);
+    expect(unique.size).toBe(REVIEW_NAMES.length);
   });
 });

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -347,6 +347,25 @@ describe("review workflow native handlers", () => {
       expect(result.prompt).toContain("gh pr view");
     });
 
+    it("does not hardcode the `origin/` remote prefix in the base-resolution block", () => {
+      // Non-`origin` remotes (e.g. `upstream` in fork workflows) exist — the
+      // Rust backend already handles this in `src/git.rs`. The prompt must not
+      // instruct the agent to assume `origin/`.
+      const prompt = resolveNativeHandler("review")!.execute(makeCtx(), "");
+      if (prompt.kind !== "expand") throw new Error("expected expand");
+      expect(prompt.prompt).toMatch(/git remote/);
+      expect(prompt.prompt).not.toMatch(/prefixed with ['"`]origin\//);
+    });
+
+    it("warns against treating `@{upstream}` as the review base when it just names the branch's own tracking ref", () => {
+      // The most common case of `@{upstream}` is the feature branch's remote
+      // copy — diffing HEAD against that yields an empty diff. The prompt
+      // must spell this out rather than treating upstream as authoritative.
+      const prompt = resolveNativeHandler("review")!.execute(makeCtx(), "");
+      if (prompt.kind !== "expand") throw new Error("expected expand");
+      expect(prompt.prompt).toMatch(/only use this when the upstream clearly names the review target/i);
+    });
+
     it("prompt still instructs base-resolution when repoDefaultBranch is missing (remote-workspace case)", () => {
       // On paired remote workspaces today, defaultBranch may not be in the
       // store. The prompt must still tell the agent to determine a base ref

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -8,6 +8,12 @@ export interface NativeCommandContext {
   repoId: string | null;
   pluginManagementEnabled: boolean;
   openPluginSettings: (intent: Partial<PluginSettingsIntent>) => void;
+  /** Repository metadata for the current workspace — used by review-workflow handlers. */
+  repository: { name: string; path: string } | null;
+  /** Workspace branch + worktree path for the current workspace. */
+  workspace: { branch: string; worktreePath: string | null } | null;
+  /** Base branch (e.g. `origin/main`) for the current repo, when known. */
+  defaultBranch: string | null;
 }
 
 export type NativeCommandResult =
@@ -83,9 +89,122 @@ function pluginHandler(root: "plugin" | "marketplace"): NativeHandler {
   };
 }
 
+/**
+ * Build a workspace-grounded context block for review-style prompt expansions.
+ *
+ * Emits only the lines for fields that are populated, so missing metadata does
+ * not leak `undefined` / `null` into the outgoing prompt.
+ */
+export function buildReviewContextBlock(ctx: NativeCommandContext): string {
+  const lines: string[] = [];
+  if (ctx.repository?.name) lines.push(`- Repository: ${ctx.repository.name}`);
+  if (ctx.repository?.path) lines.push(`- Repository path: ${ctx.repository.path}`);
+  if (ctx.workspace?.worktreePath) lines.push(`- Worktree: ${ctx.workspace.worktreePath}`);
+  if (ctx.workspace?.branch) lines.push(`- Current branch: ${ctx.workspace.branch}`);
+  if (ctx.defaultBranch) lines.push(`- Base branch: ${ctx.defaultBranch}`);
+  return lines.join("\n");
+}
+
+function buildUserGuidanceBlock(args: string): string {
+  const trimmed = args.trim();
+  return trimmed ? `\n\nAdditional guidance from user: ${trimmed}` : "";
+}
+
+/**
+ * Prompt for `/review` — general code review over the current branch's diff
+ * vs. the base branch. Emphasizes correctness, regressions, risk, and tests.
+ */
+const REVIEW_PROMPT = [
+  "Perform a focused code review of the current branch against the base branch.",
+  "",
+  "Review scope:",
+  "- Inspect the diff between the base branch and HEAD in the worktree above.",
+  "- Use `git diff <base>...HEAD` (three dots) to see only this branch's changes.",
+  "",
+  "What to look for, in priority order:",
+  "1. Correctness bugs and regressions in behavior.",
+  "2. Risk: concurrency, error handling, migrations, security-adjacent changes.",
+  "3. Test coverage for the changed behavior — are the interesting cases exercised?",
+  "4. Clarity issues that could bite a future reader (hidden invariants, surprising control flow).",
+  "",
+  "Output format:",
+  "- Group findings by file.",
+  "- For each finding give: file:line, severity (high/medium/low), the issue, and a concrete suggestion.",
+  "- End with a short overall summary and a ship / don't-ship recommendation.",
+  "- Skip style nits and generic praise.",
+].join("\n");
+
+/**
+ * Prompt for `/security-review` — security-focused review over the same diff.
+ * Concrete high-signal findings only.
+ */
+const SECURITY_REVIEW_PROMPT = [
+  "Perform a security-focused review of the current branch against the base branch.",
+  "",
+  "Review scope:",
+  "- Inspect the diff between the base branch and HEAD in the worktree above.",
+  "- Use `git diff <base>...HEAD` (three dots) to see only this branch's changes.",
+  "",
+  "Focus areas (only report concrete, high-signal findings — no generic checklist output):",
+  "- Authentication and authorization changes; privilege boundaries.",
+  "- Untrusted input handling: injection (SQL, shell, path), deserialization, SSRF, XSS.",
+  "- Secrets, credentials, tokens — leakage via logs, errors, responses, or commits.",
+  "- Cryptography misuse (weak algorithms, hard-coded keys, bad randomness).",
+  "- Unsafe dependencies, vulnerable patterns, or removed safety checks.",
+  "- Logic flaws that change the security posture (rate limiting, CSRF, same-origin, etc.).",
+  "",
+  "Output format:",
+  "- For each finding: file:line, severity (critical/high/medium/low), exploit scenario, fix.",
+  "- If no security-relevant changes exist, say so plainly rather than padding.",
+].join("\n");
+
+/**
+ * Prompt for `/pr-comments` — fetch and summarize PR comments for the current branch.
+ * Users may pass an explicit PR number as the argument.
+ */
+const PR_COMMENTS_PROMPT = [
+  "Fetch and summarize pull request comments for the current branch.",
+  "",
+  "Workflow:",
+  "- If the user supplied a PR number in the additional guidance, use that PR directly.",
+  "- Otherwise, resolve the PR for the current branch with `gh pr view --json number,url,title`.",
+  "- Pull review comments with `gh pr view <number> --comments` and, when useful,",
+  "  `gh api repos/{owner}/{repo}/pulls/{number}/comments` for inline review threads.",
+  "",
+  "Summary output:",
+  "- Group by thread / reviewer.",
+  "- For each comment: author, file:line (when inline), the ask, and whether it looks addressed on HEAD.",
+  "- End with a short actionable punch list of unresolved items the user should respond to.",
+  "- Skip bot noise and resolved threads unless they still contain open asks.",
+].join("\n");
+
+function reviewHandler(
+  name: "review" | "security-review" | "pr-comments",
+  template: string,
+): NativeHandler {
+  return {
+    name,
+    aliases: [],
+    kind: "prompt_expansion",
+    execute: (ctx, args) => {
+      const header = [
+        "You are reviewing work inside a Claudette workspace. Ground your review in this context:",
+        buildReviewContextBlock(ctx),
+      ]
+        .filter((section) => section.length > 0)
+        .join("\n");
+      const prompt = `${header}\n\n${template}${buildUserGuidanceBlock(args)}`;
+      return { kind: "expand", canonicalName: name, prompt };
+    },
+  };
+}
+
 export const NATIVE_HANDLERS: NativeHandler[] = [
   pluginHandler("plugin"),
   pluginHandler("marketplace"),
+  reviewHandler("review", REVIEW_PROMPT),
+  reviewHandler("security-review", SECURITY_REVIEW_PROMPT),
+  reviewHandler("pr-comments", PR_COMMENTS_PROMPT),
 ];
 
 /** Resolve a slash command token (no leading `/`) against the native handler table. */

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -12,8 +12,14 @@ export interface NativeCommandContext {
   repository: { name: string; path: string } | null;
   /** Workspace branch + worktree path for the current workspace. */
   workspace: { branch: string; worktreePath: string | null } | null;
-  /** Base branch (e.g. `origin/main`) for the current repo, when known. */
-  defaultBranch: string | null;
+  /**
+   * Repo-level default branch (e.g. `origin/main`) when known. This is the
+   * repository's default branch, NOT a guaranteed review base — a branch may
+   * target a release/hotfix branch or be stacked on another feature branch.
+   * Review-workflow prompts treat it as a hint and ask the agent to resolve
+   * the real review base via git/gh.
+   */
+  repoDefaultBranch: string | null;
 }
 
 export type NativeCommandResult =
@@ -101,7 +107,11 @@ export function buildReviewContextBlock(ctx: NativeCommandContext): string {
   if (ctx.repository?.path) lines.push(`- Repository path: ${ctx.repository.path}`);
   if (ctx.workspace?.worktreePath) lines.push(`- Worktree: ${ctx.workspace.worktreePath}`);
   if (ctx.workspace?.branch) lines.push(`- Current branch: ${ctx.workspace.branch}`);
-  if (ctx.defaultBranch) lines.push(`- Base branch: ${ctx.defaultBranch}`);
+  if (ctx.repoDefaultBranch) {
+    lines.push(
+      `- Repo default branch (hint only — not guaranteed to be this branch's review base): ${ctx.repoDefaultBranch}`,
+    );
+  }
   return lines.join("\n");
 }
 
@@ -111,15 +121,31 @@ function buildUserGuidanceBlock(args: string): string {
 }
 
 /**
+ * Shared instruction block telling the agent how to resolve the actual review
+ * base for the current branch. Repo default branch is only a fallback hint —
+ * a branch may target a release/hotfix branch, or be stacked on another
+ * feature branch, so the agent must check the upstream and PR metadata first.
+ */
+const RESOLVE_REVIEW_BASE_BLOCK = [
+  "Resolve the review base ref before diffing. Prefer in this order:",
+  "1. `gh pr view --json baseRefName -q .baseRefName` — use it (prefixed with `origin/`) if a PR exists.",
+  "2. `git rev-parse --abbrev-ref @{upstream}` — use it if the branch tracks an explicit upstream.",
+  "3. Otherwise, fall back to the repo default branch listed in the context above.",
+  "4. If none of those yield a ref, stop and ask the user which branch to review against.",
+  "Call the resolved ref `<base>` in the rest of this task.",
+].join("\n");
+
+/**
  * Prompt for `/review` — general code review over the current branch's diff
  * vs. the base branch. Emphasizes correctness, regressions, risk, and tests.
  */
 const REVIEW_PROMPT = [
-  "Perform a focused code review of the current branch against the base branch.",
+  "Perform a focused code review of the current branch against its review base.",
+  "",
+  RESOLVE_REVIEW_BASE_BLOCK,
   "",
   "Review scope:",
-  "- Inspect the diff between the base branch and HEAD in the worktree above.",
-  "- Use `git diff <base>...HEAD` (three dots) to see only this branch's changes.",
+  "- Run `git diff <base>...HEAD` (three dots) in the worktree above to see only this branch's changes.",
   "",
   "What to look for, in priority order:",
   "1. Correctness bugs and regressions in behavior.",
@@ -139,11 +165,12 @@ const REVIEW_PROMPT = [
  * Concrete high-signal findings only.
  */
 const SECURITY_REVIEW_PROMPT = [
-  "Perform a security-focused review of the current branch against the base branch.",
+  "Perform a security-focused review of the current branch against its review base.",
+  "",
+  RESOLVE_REVIEW_BASE_BLOCK,
   "",
   "Review scope:",
-  "- Inspect the diff between the base branch and HEAD in the worktree above.",
-  "- Use `git diff <base>...HEAD` (three dots) to see only this branch's changes.",
+  "- Run `git diff <base>...HEAD` (three dots) in the worktree above to see only this branch's changes.",
   "",
   "Focus areas (only report concrete, high-signal findings — no generic checklist output):",
   "- Authentication and authorization changes; privilege boundaries.",

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -128,10 +128,10 @@ function buildUserGuidanceBlock(args: string): string {
  */
 const RESOLVE_REVIEW_BASE_BLOCK = [
   "Resolve the review base ref before diffing. Prefer in this order:",
-  "1. `gh pr view --json baseRefName -q .baseRefName` — use it (prefixed with `origin/`) if a PR exists.",
-  "2. `git rev-parse --abbrev-ref @{upstream}` — use it if the branch tracks an explicit upstream.",
-  "3. Otherwise, fall back to the repo default branch listed in the context above.",
-  "4. If none of those yield a ref, stop and ask the user which branch to review against.",
+  "1. `gh pr view --json baseRefName -q .baseRefName` — if a PR exists, take that branch name and resolve it against the primary remote. Do NOT hardcode `origin/`; use `git remote` to find the actual remote name (may be `upstream` in fork workflows), then build `<remote>/<baseRefName>`.",
+  "2. `git rev-parse --abbrev-ref @{upstream}` — only use this when the upstream clearly names the review target branch (for example, the branch's PR base). Do NOT use it when `@{upstream}` is just this branch's own remote-tracking ref (e.g. `origin/feat/x` while you are on `feat/x`) — that yields an empty diff.",
+  "3. Otherwise, use the repo default branch listed in the context above as a fallback hint.",
+  "4. If none of those yield a confident base ref, stop and ask the user which branch to review against.",
   "Call the resolved ref `<base>` in the rest of this task.",
 ].join("\n");
 

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -655,3 +655,77 @@ describe("rollbackConversation", () => {
     expect(useAppStore.getState().checkpoints[OTHER_WS]).toHaveLength(1);
   });
 });
+
+describe("mergeRemoteData / clearRemoteData default branches", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      repositories: [],
+      workspaces: [],
+      defaultBranches: {},
+    });
+  });
+
+  function makeRemotePayload(overrides: Partial<{
+    repoId: string;
+    defaultBranches: Record<string, string>;
+  }> = {}) {
+    const repoId = overrides.repoId ?? "remote-repo-1";
+    return {
+      repositories: [
+        {
+          id: repoId,
+          path: "/srv/claudette",
+          name: "claudette-server",
+          path_slug: "claudette",
+          icon: null,
+          created_at: "",
+          setup_script: null,
+          custom_instructions: null,
+          sort_order: 0,
+          branch_rename_preferences: null,
+          setup_script_auto_run: false,
+          path_valid: true,
+          remote_connection_id: null,
+        },
+      ],
+      workspaces: [],
+      worktree_base_dir: "/srv/wt",
+      default_branches: overrides.defaultBranches ?? { [repoId]: "origin/main" },
+      last_messages: [],
+    };
+  }
+
+  it("merges remote default_branches into defaultBranches so review commands can use them", () => {
+    useAppStore.getState().mergeRemoteData("conn-1", makeRemotePayload());
+    expect(useAppStore.getState().defaultBranches["remote-repo-1"]).toBe("origin/main");
+  });
+
+  it("preserves local repo defaultBranches when remote data merges", () => {
+    useAppStore.setState({ defaultBranches: { "local-repo": "origin/main" } });
+    useAppStore.getState().mergeRemoteData("conn-1", makeRemotePayload());
+    const defaults = useAppStore.getState().defaultBranches;
+    expect(defaults["local-repo"]).toBe("origin/main");
+    expect(defaults["remote-repo-1"]).toBe("origin/main");
+  });
+
+  it("overwrites stale defaultBranches for the same repo id on re-merge", () => {
+    useAppStore.getState().mergeRemoteData(
+      "conn-1",
+      makeRemotePayload({ defaultBranches: { "remote-repo-1": "origin/old" } }),
+    );
+    useAppStore.getState().mergeRemoteData(
+      "conn-1",
+      makeRemotePayload({ defaultBranches: { "remote-repo-1": "origin/new" } }),
+    );
+    expect(useAppStore.getState().defaultBranches["remote-repo-1"]).toBe("origin/new");
+  });
+
+  it("clearRemoteData drops defaultBranches for the disconnected connection's repos", () => {
+    useAppStore.getState().mergeRemoteData("conn-1", makeRemotePayload());
+    useAppStore.setState((s) => ({ defaultBranches: { ...s.defaultBranches, "local-repo": "origin/main" } }));
+    useAppStore.getState().clearRemoteData("conn-1");
+    const defaults = useAppStore.getState().defaultBranches;
+    expect(defaults["remote-repo-1"]).toBeUndefined();
+    expect(defaults["local-repo"]).toBe("origin/main");
+  });
+});

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -720,6 +720,60 @@ describe("mergeRemoteData / clearRemoteData default branches", () => {
     expect(useAppStore.getState().defaultBranches["remote-repo-1"]).toBe("origin/new");
   });
 
+  it("prunes defaultBranches for repos removed from a new remote payload (prev-repo-id based pruning)", () => {
+    // Seed connection with two remote repos.
+    useAppStore.getState().mergeRemoteData("conn-1", {
+      repositories: [
+        {
+          id: "remote-repo-1",
+          path: "/srv/a",
+          name: "a",
+          path_slug: "a",
+          icon: null,
+          created_at: "",
+          setup_script: null,
+          custom_instructions: null,
+          sort_order: 0,
+          branch_rename_preferences: null,
+          setup_script_auto_run: false,
+          path_valid: true,
+          remote_connection_id: null,
+        },
+        {
+          id: "remote-repo-2",
+          path: "/srv/b",
+          name: "b",
+          path_slug: "b",
+          icon: null,
+          created_at: "",
+          setup_script: null,
+          custom_instructions: null,
+          sort_order: 0,
+          branch_rename_preferences: null,
+          setup_script_auto_run: false,
+          path_valid: true,
+          remote_connection_id: null,
+        },
+      ],
+      workspaces: [],
+      worktree_base_dir: "/srv",
+      default_branches: {
+        "remote-repo-1": "origin/main",
+        "remote-repo-2": "origin/main",
+      },
+      last_messages: [],
+    });
+    expect(useAppStore.getState().defaultBranches["remote-repo-2"]).toBe("origin/main");
+
+    // Re-merge with only remote-repo-1. remote-repo-2 must disappear from both
+    // repositories and defaultBranches — otherwise stale defaults linger.
+    useAppStore.getState().mergeRemoteData("conn-1", makeRemotePayload({ repoId: "remote-repo-1" }));
+    const state = useAppStore.getState();
+    expect(state.repositories.find((r) => r.id === "remote-repo-2")).toBeUndefined();
+    expect(state.defaultBranches["remote-repo-2"]).toBeUndefined();
+    expect(state.defaultBranches["remote-repo-1"]).toBe("origin/main");
+  });
+
   it("clearRemoteData drops defaultBranches for the disconnected connection's repos", () => {
     useAppStore.getState().mergeRemoteData("conn-1", makeRemotePayload());
     useAppStore.setState((s) => ({ defaultBranches: { ...s.defaultBranches, "local-repo": "origin/main" } }));

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -1024,6 +1024,12 @@ export const useAppStore = create<AppState>((set) => ({
         ...w,
         remote_connection_id: connectionId,
       }));
+      // Merge remote repo default branches so review-workflow prompts and any
+      // other UI keyed off `defaultBranches[repo.id]` work for paired servers.
+      const remoteRepoIds = new Set(taggedRepos.map((r) => r.id));
+      const prunedDefaults = Object.fromEntries(
+        Object.entries(s.defaultBranches).filter(([id]) => !remoteRepoIds.has(id)),
+      );
       return {
         repositories: [
           ...s.repositories.filter(
@@ -1037,17 +1043,29 @@ export const useAppStore = create<AppState>((set) => ({
           ),
           ...taggedWorkspaces,
         ],
+        defaultBranches: { ...prunedDefaults, ...data.default_branches },
       };
     }),
   clearRemoteData: (connectionId) =>
-    set((s) => ({
-      repositories: s.repositories.filter(
-        (r) => r.remote_connection_id !== connectionId,
-      ),
-      workspaces: s.workspaces.filter(
-        (w) => w.remote_connection_id !== connectionId,
-      ),
-    })),
+    set((s) => {
+      const clearedRepoIds = new Set(
+        s.repositories
+          .filter((r) => r.remote_connection_id === connectionId)
+          .map((r) => r.id),
+      );
+      const prunedDefaults = Object.fromEntries(
+        Object.entries(s.defaultBranches).filter(([id]) => !clearedRepoIds.has(id)),
+      );
+      return {
+        repositories: s.repositories.filter(
+          (r) => r.remote_connection_id !== connectionId,
+        ),
+        workspaces: s.workspaces.filter(
+          (w) => w.remote_connection_id !== connectionId,
+        ),
+        defaultBranches: prunedDefaults,
+      };
+    }),
 
   // -- Local Server --
   localServerRunning: false,

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -1026,9 +1026,17 @@ export const useAppStore = create<AppState>((set) => ({
       }));
       // Merge remote repo default branches so review-workflow prompts and any
       // other UI keyed off `defaultBranches[repo.id]` work for paired servers.
-      const remoteRepoIds = new Set(taggedRepos.map((r) => r.id));
+      // Prune using the repos *previously* stored for this connection so
+      // entries for repos removed from the latest payload don't linger.
+      const previousRemoteRepoIds = new Set(
+        s.repositories
+          .filter((r) => r.remote_connection_id === connectionId)
+          .map((r) => r.id),
+      );
       const prunedDefaults = Object.fromEntries(
-        Object.entries(s.defaultBranches).filter(([id]) => !remoteRepoIds.has(id)),
+        Object.entries(s.defaultBranches).filter(
+          ([id]) => !previousRemoteRepoIds.has(id),
+        ),
       );
       return {
         repositories: [


### PR DESCRIPTION
## Summary

Closes #244. Implements the review workflow command group on top of the native slash command framework (#248).

- Adds three `prompt_expansion` native handlers — `/review`, `/security-review`, `/pr-comments` — that seed a workspace-grounded prompt and continue through the existing `sendChatMessage` pipeline. Raw `/review …` text is never sent to the agent verbatim.
- Prompts include repo name/path, worktree path, current branch, and a labeled repo-default-branch hint. User-supplied arguments are preserved as an `Additional guidance from user:` line.
- `/review` and `/security-review` instruct the agent to resolve the review base dynamically (`gh pr view --json baseRefName` → `git rev-parse --abbrev-ref @{upstream}` → repo default → stop-and-ask) so stacked PRs and branches targeting release/hotfix refs aren't diffed against the wrong base.
- `mergeRemoteData()` now plumbs `default_branches` into the Zustand store and `clearRemoteData()` prunes them on disconnect, so paired-server workspaces also get the hint in context.
- Native registry updated in `src/slash_commands.rs` so the picker exposes all three entries with argument hints and `PromptExpansion` kind.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo test --all-features` — 379 passed
- [x] `bun run test` (vitest) — 361 passed across 24 files (23 new tests)
- [x] `bunx tsc --noEmit` — zero errors
- [x] Manual UAT: open a Claudette workspace, run `/review`, `/security-review`, `/pr-comments` — verify each expands to a seeded prompt grounded in the current branch/repo and that the agent runs the normal chat pipeline (no raw `/…` leaking to the CLI).
- [ ] Manual UAT on a paired remote workspace: confirm the repo default branch is now available to the review prompts (P2 fix).