### PR TITLE
feat(chat): add native /clear, /plan, /model, /permissions, /status

### DIFF
--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -142,6 +142,46 @@ pub fn native_command_registry(plugin_management_enabled: bool) -> Vec<SlashComm
         argument_hint: None,
         kind: Some(NativeKind::LocalAction),
     });
+    commands.push(SlashCommand {
+        name: "clear".to_string(),
+        description: "Clear the current workspace conversation".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: None,
+        kind: Some(NativeKind::LocalAction),
+    });
+    commands.push(SlashCommand {
+        name: "plan".to_string(),
+        description: "Show, toggle, or open the current plan".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: Some("[on|off|toggle|open]".to_string()),
+        kind: Some(NativeKind::LocalAction),
+    });
+    commands.push(SlashCommand {
+        name: "model".to_string(),
+        description: "Show or change the workspace model".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: Some("[<model>]".to_string()),
+        kind: Some(NativeKind::LocalAction),
+    });
+    commands.push(SlashCommand {
+        name: "permissions".to_string(),
+        description: "Show or change the workspace permission mode".to_string(),
+        source: "builtin".to_string(),
+        aliases: vec!["allowed-tools".to_string()],
+        argument_hint: Some("[readonly|standard|full]".to_string()),
+        kind: Some(NativeKind::LocalAction),
+    });
+    commands.push(SlashCommand {
+        name: "status".to_string(),
+        description: "Show a summary of the current workspace".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: None,
+        kind: Some(NativeKind::LocalAction),
+    });
     commands
 }
 
@@ -725,6 +765,92 @@ mod tests {
         assert!(names.contains(&"extra-usage"));
         assert!(names.contains(&"release-notes"));
         assert!(names.contains(&"version"));
+        // Workspace-control commands are unconditional too.
+        assert!(names.contains(&"clear"));
+        assert!(names.contains(&"plan"));
+        assert!(names.contains(&"model"));
+        assert!(names.contains(&"permissions"));
+        assert!(names.contains(&"status"));
+    }
+
+    #[test]
+    fn test_native_command_registry_includes_workspace_control_commands() {
+        let natives = native_command_registry(false);
+        for name in ["clear", "plan", "model", "permissions", "status"] {
+            let cmd = natives
+                .iter()
+                .find(|c| c.name == name)
+                .unwrap_or_else(|| panic!("missing native command {name}"));
+            assert_eq!(cmd.source, "builtin");
+            assert_eq!(cmd.kind, Some(NativeKind::LocalAction));
+        }
+    }
+
+    #[test]
+    fn test_permissions_exposes_allowed_tools_alias() {
+        let natives = native_command_registry(false);
+        let permissions = natives
+            .iter()
+            .find(|c| c.name == "permissions")
+            .expect("missing permissions command");
+        assert_eq!(permissions.aliases, vec!["allowed-tools".to_string()]);
+        assert_eq!(
+            resolve_native("allowed-tools", &natives).map(|c| c.name.as_str()),
+            Some("permissions")
+        );
+        assert_eq!(
+            resolve_native("Allowed-Tools", &natives).map(|c| c.name.as_str()),
+            Some("permissions")
+        );
+    }
+
+    #[test]
+    fn test_workspace_control_commands_have_argument_hints() {
+        let natives = native_command_registry(false);
+        // Commands that accept arguments advertise an argument hint.
+        for name in ["plan", "model", "permissions"] {
+            let cmd = natives.iter().find(|c| c.name == name).unwrap();
+            assert!(
+                cmd.argument_hint.is_some(),
+                "{name} should have an argument hint"
+            );
+        }
+        // /clear and /status take no arguments.
+        for name in ["clear", "status"] {
+            let cmd = natives.iter().find(|c| c.name == name).unwrap();
+            assert!(
+                cmd.argument_hint.is_none(),
+                "{name} should not expose an argument hint"
+            );
+        }
+    }
+
+    #[test]
+    fn test_collect_native_commands_yields_workspace_control_slots_to_user_markdown() {
+        // Workspace-control natives (clear/plan/model/permissions/status) are
+        // NOT on the reserved list — they share `is_reserved_native_name`'s
+        // rules with config/usage/review: if a human has a `.claude/commands/
+        // clear.md`, their version wins so Claudette does not silently displace
+        // a custom workflow the user already relied on.
+        let mut commands = vec![
+            SlashCommand::file_based("clear".into(), "User custom clear".into(), "user"),
+            SlashCommand::file_based("status".into(), "Project custom status".into(), "project"),
+            SlashCommand::file_based("keep-me".into(), "Unrelated".into(), "user"),
+        ];
+        collect_native_commands(&mut commands, false);
+
+        let clear = commands.iter().find(|c| c.name == "clear").unwrap();
+        assert_eq!(clear.source, "user");
+        assert_eq!(clear.description, "User custom clear");
+        let status = commands.iter().find(|c| c.name == "status").unwrap();
+        assert_eq!(status.source, "project");
+
+        // Non-colliding workspace-control natives still register from the registry.
+        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"plan"));
+        assert!(names.contains(&"model"));
+        assert!(names.contains(&"permissions"));
+        assert!(names.contains(&"keep-me"));
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -233,6 +233,27 @@
   margin: 12px 0;
 }
 
+/*
+ * Multi-line system messages (e.g. /plan open dumping a plan file) need a
+ * card treatment instead of the single-line pill — lists, headings, and
+ * code fences don't read centered.
+ */
+.role_System_block {
+  background: var(--chat-system-bg);
+  text-align: left;
+  font-size: 13px;
+  color: var(--text-primary);
+  border-radius: 10px;
+  padding: 12px 16px;
+  align-self: stretch;
+  max-width: 100%;
+  margin: 12px 0;
+}
+
+.role_System_block .content {
+  text-align: left;
+}
+
 /* Role labels */
 .roleLabel {
   font-size: 10px;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -549,6 +549,17 @@ export function ChatPanel() {
           useAppStore.getState().setPlanMode(workspaceId, enabled);
         };
 
+        // Route plan-file reads through the remote server for remote
+        // workspaces, matching the PlanApprovalCard's "View plan" dispatch.
+        // Falls through to the local Tauri command for local workspaces.
+        const remoteConnectionId = ws.remote_connection_id;
+        const readPlanFileBound = remoteConnectionId
+          ? async (path: string) =>
+              (await sendRemoteCommand(remoteConnectionId, "read_plan_file", {
+                path,
+              })) as string
+          : readPlanFile;
+
         const clearConversationBound = async (restoreFiles: boolean) => {
           // The /clear pipeline (clearConversation + follow-up reloads) runs
           // via local Tauri invokes only — RollbackModal has the same
@@ -628,7 +639,7 @@ export function ChatPanel() {
             setPermissionLevel: setPermissionLevelBound,
             setPlanMode: setPlanModeBound,
             clearConversation: clearConversationBound,
-            readPlanFile,
+            readPlanFile: readPlanFileBound,
           },
           parsedSlash.args,
         );

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -20,7 +20,12 @@ import {
   getAppSetting,
   setAppSetting,
   listWorkspaceFiles,
+  clearConversation,
+  readPlanFile,
+  loadDiffFiles,
 } from "../../services/tauri";
+import { applySelectedModel } from "./applySelectedModel";
+import type { PermissionLevel } from "../../stores/useAppStore";
 import { open } from "@tauri-apps/plugin-dialog";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
 import type { SlashCommand, FileEntry } from "../../services/tauri";
@@ -494,7 +499,97 @@ export function ChatPanel() {
       const nativeHandler = shadowed ? null : candidateHandler;
       if (nativeHandler) {
         const workspaceId = selectedWorkspaceId;
-        const result = nativeHandler.execute(
+        const state = useAppStore.getState();
+        const currentModel = state.selectedModel[workspaceId] ?? "opus";
+        const currentPermission: PermissionLevel =
+          state.permissionLevel[workspaceId] ?? "full";
+        const currentPlanMode = state.planMode[workspaceId] ?? false;
+        const currentFastMode = state.fastMode[workspaceId] ?? false;
+        const currentThinking = state.thinkingEnabled[workspaceId] ?? false;
+        const currentChrome = state.chromeEnabled[workspaceId] ?? false;
+        const currentEffort = state.effortLevel[workspaceId] ?? "auto";
+        const pendingPlanFilePath =
+          state.planApprovals[workspaceId]?.planFilePath ?? null;
+        const agentStatusLabel =
+          typeof ws.agent_status === "string"
+            ? ws.agent_status
+            : `Error: ${ws.agent_status.Error}`;
+        const isRemoteWorkspace = !!ws.remote_connection_id;
+
+        const addLocalMessage = (text: string) => {
+          addChatMessage(workspaceId, {
+            id: crypto.randomUUID(),
+            workspace_id: workspaceId,
+            role: "System",
+            content: text,
+            cost_usd: null,
+            duration_ms: null,
+            created_at: new Date().toISOString(),
+            thinking: null,
+          });
+        };
+
+        const setSelectedModelBound = (nextModel: string) =>
+          applySelectedModel(workspaceId, nextModel);
+
+        const setPermissionLevelBound = async (level: PermissionLevel) => {
+          const previous =
+            useAppStore.getState().permissionLevel[workspaceId] ?? "full";
+          useAppStore.getState().setPermissionLevel(workspaceId, level);
+          try {
+            await setAppSetting(`permission_level:${workspaceId}`, level);
+          } catch (err) {
+            useAppStore.getState().setPermissionLevel(workspaceId, previous);
+            throw err;
+          }
+        };
+
+        const setPlanModeBound = (enabled: boolean) => {
+          useAppStore.getState().setPlanMode(workspaceId, enabled);
+        };
+
+        const clearConversationBound = async (restoreFiles: boolean) => {
+          // The /clear pipeline (clearConversation + follow-up reloads) runs
+          // via local Tauri invokes only — RollbackModal has the same
+          // boundary. Surface a clear local message on remote workspaces
+          // rather than partially executing and leaving the UI in a
+          // half-reset state.
+          if (isRemoteWorkspace) {
+            throw new Error(
+              "/clear is not yet supported for remote workspaces",
+            );
+          }
+          const store = useAppStore.getState();
+          const messages = await clearConversation(workspaceId, restoreFiles);
+          store.rollbackConversation(workspaceId, "__clear__", messages);
+          loadCompletedTurns(workspaceId)
+            .then((turnData) => {
+              const turns = reconstructCompletedTurns(messages, turnData);
+              useAppStore.getState().setCompletedTurns(workspaceId, turns);
+            })
+            .catch((err) =>
+              console.error("Failed to reload turns after /clear:", err),
+            );
+          loadAttachmentsForWorkspace(workspaceId)
+            .then((atts) =>
+              useAppStore.getState().setChatAttachments(workspaceId, atts),
+            )
+            .catch((err) =>
+              console.error("Failed to reload attachments after /clear:", err),
+            );
+          useAppStore.getState().clearDiff();
+          loadDiffFiles(workspaceId)
+            .then((result) =>
+              useAppStore
+                .getState()
+                .setDiffFiles(result.files, result.merge_base),
+            )
+            .catch((err) =>
+              console.error("Failed to refresh diff after /clear:", err),
+            );
+        };
+
+        const result = await nativeHandler.execute(
           {
             repoId: repo?.remote_connection_id ? null : repo?.id ?? null,
             pluginManagementEnabled,
@@ -507,18 +602,7 @@ export function ChatPanel() {
             repoDefaultBranch: defaultBranch ?? null,
             openSettings,
             appVersion,
-            addLocalMessage: (text: string) => {
-              addChatMessage(workspaceId, {
-                id: crypto.randomUUID(),
-                workspace_id: workspaceId,
-                role: "System",
-                content: text,
-                cost_usd: null,
-                duration_ms: null,
-                created_at: new Date().toISOString(),
-                thinking: null,
-              });
-            },
+            addLocalMessage,
             openUsageSettingsExternal: () => {
               void openUsageSettings().catch((err) =>
                 console.error("Failed to open usage settings:", err),
@@ -529,6 +613,21 @@ export function ChatPanel() {
                 console.error("Failed to open release notes:", err),
               );
             },
+            workspaceId,
+            agentStatus: agentStatusLabel,
+            selectedModel: currentModel,
+            permissionLevel: currentPermission,
+            planMode: currentPlanMode,
+            fastMode: currentFastMode,
+            thinkingEnabled: currentThinking,
+            chromeEnabled: currentChrome,
+            effortLevel: currentEffort,
+            pendingPlanFilePath,
+            setSelectedModel: setSelectedModelBound,
+            setPermissionLevel: setPermissionLevelBound,
+            setPlanMode: setPlanModeBound,
+            clearConversation: clearConversationBound,
+            readPlanFile,
           },
           parsedSlash.args,
         );

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -25,6 +25,7 @@ import {
   loadDiffFiles,
 } from "../../services/tauri";
 import { applySelectedModel } from "./applySelectedModel";
+import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { findLatestPlanFilePath } from "./planFilePath";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -1243,7 +1244,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
       {messages.map((msg, idx) => (
         <React.Fragment key={msg.id}>
           {renderTurns(idx)}
-          <div className={`${styles.message} ${styles[`role_${msg.role}`]}`}>
+          <div className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}`}>
             {msg.role === "User" && (
               <div className={styles.roleLabel}>You</div>
             )}
@@ -1297,7 +1298,11 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                   )}
                 </div>
               )}
-              {msg.role === "Assistant" ? (
+              {shouldRenderAsMarkdown(msg.role) ? (
+                // Assistant + System: run through Markdown so plan-mode dumps,
+                // setup-script output, and other multi-line system notes
+                // preserve headings, lists, and code blocks instead of
+                // collapsing newlines into a single paragraph.
                 <Markdown
                   remarkPlugins={REMARK_PLUGINS}
                   rehypePlugins={REHYPE_PLUGINS}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -25,6 +25,7 @@ import {
   loadDiffFiles,
 } from "../../services/tauri";
 import { applySelectedModel } from "./applySelectedModel";
+import { findLatestPlanFilePath } from "./planFilePath";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import { open } from "@tauri-apps/plugin-dialog";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
@@ -508,8 +509,7 @@ export function ChatPanel() {
         const currentThinking = state.thinkingEnabled[workspaceId] ?? false;
         const currentChrome = state.chromeEnabled[workspaceId] ?? false;
         const currentEffort = state.effortLevel[workspaceId] ?? "auto";
-        const pendingPlanFilePath =
-          state.planApprovals[workspaceId]?.planFilePath ?? null;
+        const planFilePath = findLatestPlanFilePath(workspaceId);
         const agentStatusLabel =
           typeof ws.agent_status === "string"
             ? ws.agent_status
@@ -622,7 +622,7 @@ export function ChatPanel() {
             thinkingEnabled: currentThinking,
             chromeEnabled: currentChrome,
             effortLevel: currentEffort,
-            pendingPlanFilePath,
+            planFilePath,
             setSelectedModel: setSelectedModelBound,
             setPermissionLevel: setPermissionLevelBound,
             setPlanMode: setPlanModeBound,

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -5,6 +5,7 @@ import { resetAgentSession, setAppSetting, getAppSetting } from "../../services/
 import { ModelSelector, MODELS } from "./ModelSelector";
 import { EffortSelector, EFFORT_LEVELS } from "./EffortSelector";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "./modelCapabilities";
+import { applySelectedModel } from "./applySelectedModel";
 import styles from "./ChatToolbar.module.css";
 
 interface ChatToolbarProps {
@@ -92,35 +93,11 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
   const handleModelSelect = useCallback(
     async (model: string) => {
       if (model !== selectedModel) {
-        setSelectedModel(workspaceId, model);
-        await setAppSetting(`model:${workspaceId}`, model);
-        // Model is session-level — reset session so next turn uses the new model.
-        await resetAgentSession(workspaceId);
-        clearAgentQuestion(workspaceId);
-        clearPlanApproval(workspaceId);
-        // Turn off fast mode if the new model doesn't support it.
-        if (fastMode && !isFastSupported(model)) {
-          setFastMode(workspaceId, false);
-          await setAppSetting(`fast_mode:${workspaceId}`, "false");
-        }
-        // Reset effort when switching to a model with different support.
-        if (!isEffortSupported(model)) {
-          // Model doesn't support effort at all — clear to auto (won't be sent).
-          setEffortLevel(workspaceId, "auto");
-          await setAppSetting(`effort_level:${workspaceId}`, "auto");
-        } else if (effortLevel === "xhigh" && !isXhighEffortAllowed(model)) {
-          // Model supports effort but not "xhigh" — fall back to high.
-          setEffortLevel(workspaceId, "high");
-          await setAppSetting(`effort_level:${workspaceId}`, "high");
-        } else if (effortLevel === "max" && !isMaxEffortAllowed(model)) {
-          // Model supports effort but not "max" — fall back to high.
-          setEffortLevel(workspaceId, "high");
-          await setAppSetting(`effort_level:${workspaceId}`, "high");
-        }
+        await applySelectedModel(workspaceId, model);
       }
       setModelSelectorOpen(false);
     },
-    [workspaceId, selectedModel, fastMode, effortLevel, setSelectedModel, setFastMode, setEffortLevel, setModelSelectorOpen, clearAgentQuestion, clearPlanApproval]
+    [workspaceId, selectedModel, setModelSelectorOpen],
   );
 
   const handleEffortSelect = useCallback(

--- a/src/ui/src/components/chat/ModelSelector.tsx
+++ b/src/ui/src/components/chat/ModelSelector.tsx
@@ -1,15 +1,9 @@
 import { useEffect, useRef, type RefObject } from "react";
 import { BadgeDollarSign } from "lucide-react";
 import styles from "./ModelSelector.module.css";
+import { MODELS } from "./modelRegistry";
 
-export const MODELS = [
-  { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: true },
-  { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false },
-  { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false },
-  { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false },
-  { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true },
-  { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false },
-] as const;
+export { MODELS } from "./modelRegistry";
 
 interface ModelSelectorProps {
   anchorRef: RefObject<HTMLButtonElement | null>;

--- a/src/ui/src/components/chat/SlashCommandPicker.test.ts
+++ b/src/ui/src/components/chat/SlashCommandPicker.test.ts
@@ -18,6 +18,15 @@ describe("filterSlashCommands", () => {
   const commands: SlashCommand[] = [
     cmd({ name: "plugin", aliases: ["plugins"], kind: "settings_route" }),
     cmd({ name: "marketplace", kind: "settings_route" }),
+    cmd({ name: "clear", kind: "local_action" }),
+    cmd({ name: "plan", kind: "local_action" }),
+    cmd({ name: "model", kind: "local_action" }),
+    cmd({
+      name: "permissions",
+      aliases: ["allowed-tools"],
+      kind: "local_action",
+    }),
+    cmd({ name: "status", kind: "local_action" }),
     cmd({ name: "commit", source: "user" }),
     cmd({ name: "deploy", source: "project" }),
     cmd({ name: "cmux-browser", source: "plugin" }),
@@ -56,5 +65,32 @@ describe("filterSlashCommands", () => {
     expect(filterSlashCommands(legacy, "leg").map((c) => c.name)).toEqual([
       "legacy",
     ]);
+  });
+
+  it("surfaces /clear, /plan, /model, /status from their prefixes", () => {
+    expect(filterSlashCommands(commands, "clear").map((c) => c.name)).toEqual([
+      "clear",
+    ]);
+    expect(filterSlashCommands(commands, "plan").map((c) => c.name)).toEqual([
+      "plan",
+    ]);
+    expect(filterSlashCommands(commands, "mod").map((c) => c.name)).toEqual([
+      "model",
+    ]);
+    expect(filterSlashCommands(commands, "status").map((c) => c.name)).toEqual([
+      "status",
+    ]);
+  });
+
+  it("surfaces /permissions by canonical name or via its allowed-tools alias", () => {
+    expect(
+      filterSlashCommands(commands, "permissions").map((c) => c.name),
+    ).toEqual(["permissions"]);
+    expect(
+      filterSlashCommands(commands, "allowed-tools").map((c) => c.name),
+    ).toEqual(["permissions"]);
+    expect(
+      filterSlashCommands(commands, "Allowed-Tools").map((c) => c.name),
+    ).toEqual(["permissions"]);
   });
 });

--- a/src/ui/src/components/chat/applySelectedModel.ts
+++ b/src/ui/src/components/chat/applySelectedModel.ts
@@ -1,0 +1,50 @@
+import { resetAgentSession, setAppSetting } from "../../services/tauri";
+import { useAppStore } from "../../stores/useAppStore";
+import {
+  isEffortSupported,
+  isFastSupported,
+  isMaxEffortAllowed,
+  isXhighEffortAllowed,
+} from "./modelCapabilities";
+
+/**
+ * Apply a model change for a workspace.
+ *
+ * Owns the full switch protocol so the toolbar and the `/model` slash command
+ * stay in lockstep: persist the new model, reset the agent session (model is
+ * session-level), clear any pending agent question/plan approval, and drop
+ * any per-workspace flags the new model doesn't support (fast mode, effort
+ * tiers like xhigh/max).
+ *
+ * Safe to call even when the model is unchanged; callers should short-circuit
+ * earlier if they want the no-op to skip the session reset.
+ */
+export async function applySelectedModel(
+  workspaceId: string,
+  nextModel: string,
+): Promise<void> {
+  const store = useAppStore.getState();
+  store.setSelectedModel(workspaceId, nextModel);
+  await setAppSetting(`model:${workspaceId}`, nextModel);
+  await resetAgentSession(workspaceId);
+  store.clearAgentQuestion(workspaceId);
+  store.clearPlanApproval(workspaceId);
+
+  const prevFastMode = store.fastMode[workspaceId] ?? false;
+  if (prevFastMode && !isFastSupported(nextModel)) {
+    store.setFastMode(workspaceId, false);
+    await setAppSetting(`fast_mode:${workspaceId}`, "false");
+  }
+
+  const prevEffort = store.effortLevel[workspaceId] ?? "auto";
+  if (!isEffortSupported(nextModel)) {
+    store.setEffortLevel(workspaceId, "auto");
+    await setAppSetting(`effort_level:${workspaceId}`, "auto");
+  } else if (prevEffort === "xhigh" && !isXhighEffortAllowed(nextModel)) {
+    store.setEffortLevel(workspaceId, "high");
+    await setAppSetting(`effort_level:${workspaceId}`, "high");
+  } else if (prevEffort === "max" && !isMaxEffortAllowed(nextModel)) {
+    store.setEffortLevel(workspaceId, "high");
+    await setAppSetting(`effort_level:${workspaceId}`, "high");
+  }
+}

--- a/src/ui/src/components/chat/messageRendering.test.ts
+++ b/src/ui/src/components/chat/messageRendering.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
+
+describe("shouldRenderAsMarkdown", () => {
+  it("routes assistant output through the markdown renderer", () => {
+    // Agent output is agent-authored markdown (headings, tables, code blocks).
+    expect(shouldRenderAsMarkdown("Assistant")).toBe(true);
+  });
+
+  it("routes system output through the markdown renderer", () => {
+    // System messages emitted by /plan open, /status, setup-script output
+    // etc. may contain multi-line markdown that must render as distinct blocks.
+    expect(shouldRenderAsMarkdown("System")).toBe(true);
+  });
+
+  it("leaves user-authored messages as plain text", () => {
+    // Users type literal characters — leading `#`, `*`, backticks — that
+    // should NOT be interpreted as markdown syntax in their own prompt.
+    expect(shouldRenderAsMarkdown("User")).toBe(false);
+  });
+});
+
+describe("roleClassKey", () => {
+  it("uses the compact pill style for single-line system notifications", () => {
+    // One-liners like "Conversation cleared." keep the centered pill look.
+    expect(roleClassKey("System", "Conversation cleared.")).toBe("role_System");
+    expect(roleClassKey("System", "Model set to sonnet.")).toBe("role_System");
+    expect(roleClassKey("System", "")).toBe("role_System");
+  });
+
+  it("promotes multi-line system messages to the left-aligned block card", () => {
+    // Plan dumps from /plan open, /status multi-line summaries, and
+    // setup-script output land on the block variant so markdown headings,
+    // lists, and code fences render correctly.
+    const planDump = [
+      "_Plan file — `/tmp/.claude/plans/x.md`_",
+      "",
+      "# Plan: do the thing",
+      "",
+      "- step one",
+      "- step two",
+    ].join("\n");
+    expect(roleClassKey("System", planDump)).toBe("role_System_block");
+  });
+
+  it("promotes even a two-line status summary to the block card", () => {
+    const status = "Repo: demo\nBranch: main";
+    expect(roleClassKey("System", status)).toBe("role_System_block");
+  });
+
+  it("keeps assistant and user roles on their canonical class regardless of content shape", () => {
+    // Block layout is a System-only concern — Assistant bubbles already have
+    // their own layout, and User messages never render markdown anyway.
+    expect(roleClassKey("Assistant", "single line")).toBe("role_Assistant");
+    expect(roleClassKey("Assistant", "line one\nline two")).toBe(
+      "role_Assistant",
+    );
+    expect(roleClassKey("User", "hello")).toBe("role_User");
+    expect(roleClassKey("User", "line one\nline two")).toBe("role_User");
+  });
+
+  it("detects any newline character — \\r\\n input would still be promoted", () => {
+    // Guard against line-ending differences from pasted content. `includes`
+    // on `\n` catches both unix and windows line endings since `\r\n`
+    // contains `\n`.
+    expect(roleClassKey("System", "header\r\n\r\nbody")).toBe(
+      "role_System_block",
+    );
+  });
+});

--- a/src/ui/src/components/chat/messageRendering.ts
+++ b/src/ui/src/components/chat/messageRendering.ts
@@ -1,0 +1,40 @@
+import type { ChatRole } from "../../types/chat";
+
+/**
+ * Returns true if a chat message with the given role should be rendered
+ * through the Markdown pipeline in the chat transcript.
+ *
+ * Assistant output is agent-generated markdown (tables, code fences, etc).
+ * System messages are emitted by local action handlers (e.g. `/plan open`,
+ * `/status`, setup-script output) and often contain multi-line plan text or
+ * fenced code that must render the same way — otherwise newlines collapse
+ * into one paragraph block.
+ *
+ * User-authored messages are rendered as plain text so that typed-by-the-
+ * human characters (`*`, backticks, leading `#`, etc.) stay literal and do
+ * not turn the user's own prompt into unintended markdown.
+ */
+export function shouldRenderAsMarkdown(role: ChatRole): boolean {
+  return role !== "User";
+}
+
+/**
+ * Pick the CSS modifier key for a chat message based on its role and content.
+ *
+ * System messages default to a compact centered pill (`role_System`) because
+ * most local notifications are one-liners ("Conversation cleared.",
+ * "Model set to sonnet.", setup-script status). When the message has line
+ * breaks — the plan dumps from `/plan open`, longer status summaries, or
+ * multi-section setup-script output — the pill's centered layout collapses
+ * markdown structure. Those messages use `role_System_block` instead, which
+ * is a left-aligned card.
+ *
+ * Returns the key used to look up the CSS module class (e.g.
+ * `styles.role_User`, `styles.role_System_block`).
+ */
+export function roleClassKey(role: ChatRole, content: string): string {
+  if (role === "System" && content.includes("\n")) {
+    return "role_System_block";
+  }
+  return `role_${role}`;
+}

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -1,0 +1,17 @@
+/**
+ * Model registry — the canonical list of models the UI exposes.
+ *
+ * Lives in a non-React module so logic that only needs the metadata
+ * (slash command validation, toolbar state normalization) can import it
+ * without dragging in component CSS or React deps.
+ */
+export const MODELS = [
+  { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: true },
+  { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false },
+  { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false },
+  { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false },
+  { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true },
+  { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false },
+] as const;
+
+export type Model = (typeof MODELS)[number];

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -685,9 +685,49 @@ describe("/plan handler", () => {
     expect(ctx.readPlanFile).toHaveBeenCalledWith(
       "/tmp/.claude/plans/draft.md",
     );
-    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
-      expect.stringContaining("# Draft plan"),
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    // Path header is markdown-formatted (italic + inline code) so the
+    // System-message renderer treats it as metadata above the body.
+    expect(msg).toContain("_Plan file — `/tmp/.claude/plans/draft.md`_");
+    // A blank line separates the header from the plan body so the
+    // markdown renderer sees them as distinct blocks.
+    expect(msg).toContain(
+      "_Plan file — `/tmp/.claude/plans/draft.md`_\n\n# Draft plan",
     );
+    // The plan body itself is passed through verbatim so the renderer can
+    // handle its internal headings, lists, and code blocks.
+    expect(msg).toContain("# Draft plan");
+  });
+
+  it("preserves plan-body newlines so the markdown renderer sees distinct blocks", async () => {
+    const planBody = [
+      "# Plan: make it work",
+      "",
+      "## Context",
+      "- one",
+      "- two",
+      "",
+      "```bash",
+      "cargo test",
+      "```",
+    ].join("\n");
+    const ctx = makeCtx({
+      planFilePath: "/tmp/.claude/plans/multi-block.md",
+      readPlanFile: vi.fn(async () => planBody),
+    });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "open");
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    // All the original newlines survive — nothing is collapsed to one paragraph.
+    expect(msg.split("\n").length).toBeGreaterThanOrEqual(
+      planBody.split("\n").length,
+    );
+    // Each markdown block the renderer relies on is still intact.
+    expect(msg).toContain("## Context");
+    expect(msg).toContain("- one\n- two");
+    expect(msg).toContain("```bash\ncargo test\n```");
   });
 
   it("reports when /plan open has no plan file to open", async () => {

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -27,35 +27,50 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     addLocalMessage: vi.fn<(text: string) => void>(),
     openUsageSettingsExternal: vi.fn<() => void>(),
     openReleaseNotes: vi.fn<() => void>(),
+    workspaceId: "ws-1",
+    agentStatus: "Idle",
+    selectedModel: "opus",
+    permissionLevel: "full",
+    planMode: false,
+    fastMode: false,
+    thinkingEnabled: false,
+    chromeEnabled: false,
+    effortLevel: "auto",
+    pendingPlanFilePath: null,
+    setSelectedModel: vi.fn(async () => {}),
+    setPermissionLevel: vi.fn(async () => {}),
+    setPlanMode: vi.fn(),
+    clearConversation: vi.fn(async () => {}),
+    readPlanFile: vi.fn(async () => "plan content"),
     ...overrides,
   };
 }
 
 describe("parseSlashInput", () => {
-  it("returns null for non-slash input", () => {
+  it("returns null for non-slash input", async () => {
     expect(parseSlashInput("hello")).toBeNull();
     expect(parseSlashInput("")).toBeNull();
   });
 
-  it("parses a bare token with no args", () => {
+  it("parses a bare token with no args", async () => {
     expect(parseSlashInput("/plugin")).toEqual({ token: "plugin", args: "" });
   });
 
-  it("splits token from the remaining args", () => {
+  it("splits token from the remaining args", async () => {
     expect(parseSlashInput("/plugin install demo --scope user")).toEqual({
       token: "plugin",
       args: "install demo --scope user",
     });
   });
 
-  it("preserves whitespace and quoted content in args", () => {
+  it("preserves whitespace and quoted content in args", async () => {
     expect(parseSlashInput('/foo "one two" three')).toEqual({
       token: "foo",
       args: '"one two" three',
     });
   });
 
-  it("ignores leading whitespace before the slash", () => {
+  it("ignores leading whitespace before the slash", async () => {
     expect(parseSlashInput("   /plugin install demo")).toEqual({
       token: "plugin",
       args: "install demo",
@@ -64,53 +79,53 @@ describe("parseSlashInput", () => {
 });
 
 describe("resolveNativeHandler", () => {
-  it("matches canonical names", () => {
+  it("matches canonical names", async () => {
     expect(resolveNativeHandler("plugin")?.name).toBe("plugin");
     expect(resolveNativeHandler("marketplace")?.name).toBe("marketplace");
   });
 
-  it("matches aliases", () => {
+  it("matches aliases", async () => {
     expect(resolveNativeHandler("plugins")?.name).toBe("plugin");
   });
 
-  it("is case-insensitive", () => {
+  it("is case-insensitive", async () => {
     expect(resolveNativeHandler("PLUGIN")?.name).toBe("plugin");
     expect(resolveNativeHandler("Plugins")?.name).toBe("plugin");
     expect(resolveNativeHandler("MarketPlace")?.name).toBe("marketplace");
   });
 
-  it("returns null for unknown tokens", () => {
+  it("returns null for unknown tokens", async () => {
     expect(resolveNativeHandler("totally-unknown")).toBeNull();
     expect(resolveNativeHandler("")).toBeNull();
   });
 });
 
 describe("plugin native handler", () => {
-  it("routes /plugin to the plugin settings intent with canonical 'plugin'", () => {
+  it("routes /plugin to the plugin settings intent with canonical 'plugin'", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("plugin")!;
-    const result = handler.execute(ctx, "");
+    const result = await handler.execute(ctx, "");
     expect(result).toEqual({ kind: "handled", canonicalName: "plugin" });
     expect(ctx.openPluginSettings).toHaveBeenCalledWith(
       expect.objectContaining({ tab: "available", action: null }),
     );
   });
 
-  it("routes alias /plugins through the plugin handler", () => {
+  it("routes alias /plugins through the plugin handler", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("plugins")!;
     expect(handler.name).toBe("plugin");
-    const result = handler.execute(ctx, "manage");
+    const result = await handler.execute(ctx, "manage");
     expect(result).toEqual({ kind: "handled", canonicalName: "plugin" });
     expect(ctx.openPluginSettings).toHaveBeenCalledWith(
       expect.objectContaining({ tab: "installed" }),
     );
   });
 
-  it("parses /plugin install <target> --scope project", () => {
+  it("parses /plugin install <target> --scope project", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("plugin")!;
-    handler.execute(ctx, "install demo@market --scope project");
+    await handler.execute(ctx, "install demo@market --scope project");
     expect(ctx.openPluginSettings).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "install",
@@ -121,10 +136,10 @@ describe("plugin native handler", () => {
     );
   });
 
-  it("routes /marketplace add to canonical 'marketplace'", () => {
+  it("routes /marketplace add to canonical 'marketplace'", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("marketplace")!;
-    const result = handler.execute(ctx, "add github:owner/repo --scope local");
+    const result = await handler.execute(ctx, "add github:owner/repo --scope local");
     expect(result).toEqual({ kind: "handled", canonicalName: "marketplace" });
     expect(ctx.openPluginSettings).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -136,17 +151,17 @@ describe("plugin native handler", () => {
     );
   });
 
-  it("swallows /plugin when plugin management is disabled without opening settings", () => {
+  it("swallows /plugin when plugin management is disabled without opening settings", async () => {
     const ctx = makeCtx({ pluginManagementEnabled: false });
     const handler = resolveNativeHandler("plugin")!;
-    const result = handler.execute(ctx, "install demo");
+    const result = await handler.execute(ctx, "install demo");
     expect(result).toEqual({ kind: "handled", canonicalName: "plugin" });
     expect(ctx.openPluginSettings).not.toHaveBeenCalled();
   });
 });
 
 describe("dispatcher across native kinds", () => {
-  it("handles local_action results without producing a prompt", () => {
+  it("handles local_action results without producing a prompt", async () => {
     const localAction: NativeHandler = {
       name: "clear-draft",
       aliases: [],
@@ -155,11 +170,11 @@ describe("dispatcher across native kinds", () => {
     };
     const resolved = resolveNativeHandler("clear-draft", [localAction]);
     expect(resolved).toBe(localAction);
-    const result = resolved!.execute(makeCtx(), "");
+    const result = await resolved!.execute(makeCtx(), "");
     expect(result).toEqual({ kind: "handled", canonicalName: "clear-draft" });
   });
 
-  it("handles prompt_expansion results by returning seeded prompt text", () => {
+  it("handles prompt_expansion results by returning seeded prompt text", async () => {
     const expander: NativeHandler = {
       name: "ask-clearly",
       aliases: ["ac"],
@@ -172,7 +187,7 @@ describe("dispatcher across native kinds", () => {
     };
     const resolved = resolveNativeHandler("ac", [expander]);
     expect(resolved).toBe(expander);
-    const result = resolved!.execute(makeCtx(), "what is 2+2");
+    const result = await resolved!.execute(makeCtx(), "what is 2+2");
     expect(result).toEqual({
       kind: "expand",
       canonicalName: "ask-clearly",
@@ -182,21 +197,21 @@ describe("dispatcher across native kinds", () => {
 });
 
 describe("describeSlashQuery", () => {
-  it("returns null for non-slash input", () => {
+  it("returns null for non-slash input", async () => {
     expect(describeSlashQuery("hello")).toBeNull();
     expect(describeSlashQuery("")).toBeNull();
   });
 
-  it("returns an empty token for a bare slash so the picker shows every command", () => {
+  it("returns an empty token for a bare slash so the picker shows every command", async () => {
     expect(describeSlashQuery("/")).toEqual({ token: "", hasArgs: false });
   });
 
-  it("returns just the token when no whitespace follows", () => {
+  it("returns just the token when no whitespace follows", async () => {
     expect(describeSlashQuery("/plug")).toEqual({ token: "plug", hasArgs: false });
     expect(describeSlashQuery("/plugin")).toEqual({ token: "plugin", hasArgs: false });
   });
 
-  it("flags hasArgs once whitespace appears so the picker can preserve typed args", () => {
+  it("flags hasArgs once whitespace appears so the picker can preserve typed args", async () => {
     expect(describeSlashQuery("/plugin ")).toEqual({
       token: "plugin",
       hasArgs: true,
@@ -207,20 +222,20 @@ describe("describeSlashQuery", () => {
     });
   });
 
-  it("does not consume a leading slash inside a longer prefix", () => {
+  it("does not consume a leading slash inside a longer prefix", async () => {
     expect(describeSlashQuery("  /plugin")).toBeNull();
     expect(describeSlashQuery("not/a/command")).toBeNull();
   });
 });
 
 describe("native handler table", () => {
-  it("exposes plugin and marketplace canonical entries", () => {
+  it("exposes plugin and marketplace canonical entries", async () => {
     const names = NATIVE_HANDLERS.map((h) => h.name);
     expect(names).toContain("plugin");
     expect(names).toContain("marketplace");
   });
 
-  it("exposes review, security-review, and pr-comments as prompt_expansion handlers", () => {
+  it("exposes review, security-review, and pr-comments as prompt_expansion handlers", async () => {
     for (const name of ["review", "security-review", "pr-comments"] as const) {
       const handler = NATIVE_HANDLERS.find((h) => h.name === name);
       expect(handler, `missing NATIVE_HANDLERS entry for ${name}`).toBeDefined();
@@ -229,7 +244,7 @@ describe("native handler table", () => {
     }
   });
 
-  it("exposes config, usage, extra-usage, release-notes, and version entries", () => {
+  it("exposes config, usage, extra-usage, release-notes, and version entries", async () => {
     const names = NATIVE_HANDLERS.map((h) => h.name);
     expect(names).toContain("config");
     expect(names).toContain("usage");
@@ -238,7 +253,7 @@ describe("native handler table", () => {
     expect(names).toContain("version");
   });
 
-  it("declares the expected kinds for the settings/version handlers", () => {
+  it("declares the expected kinds for the settings/version handlers", async () => {
     const byName = new Map(NATIVE_HANDLERS.map((h) => [h.name, h]));
     expect(byName.get("config")?.kind).toBe("settings_route");
     expect(byName.get("usage")?.kind).toBe("settings_route");
@@ -253,15 +268,15 @@ describe("review workflow native handlers", () => {
 
   for (const name of REVIEW_NAMES) {
     describe(`/${name}`, () => {
-      it("resolves by canonical name (case-insensitive)", () => {
+      it("resolves by canonical name (case-insensitive)", async () => {
         expect(resolveNativeHandler(name)?.name).toBe(name);
         expect(resolveNativeHandler(name.toUpperCase())?.name).toBe(name);
       });
 
-      it("expands with empty args into a seeded prompt grounded in workspace context", () => {
+      it("expands with empty args into a seeded prompt grounded in workspace context", async () => {
         const ctx = makeCtx();
         const handler = resolveNativeHandler(name)!;
-        const result = handler.execute(ctx, "");
+        const result = await handler.execute(ctx, "");
         expect(result.kind).toBe("expand");
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.canonicalName).toBe(name);
@@ -278,31 +293,31 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).not.toContain("null");
       });
 
-      it("expands with whitespace-only args the same as empty args", () => {
+      it("expands with whitespace-only args the same as empty args", async () => {
         const ctx = makeCtx();
         const handler = resolveNativeHandler(name)!;
-        const result = handler.execute(ctx, "   \t\n  ");
+        const result = await handler.execute(ctx, "   \t\n  ");
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.prompt).not.toContain("Additional guidance from user");
       });
 
-      it("preserves user-supplied arguments verbatim in a guidance line", () => {
+      it("preserves user-supplied arguments verbatim in a guidance line", async () => {
         const ctx = makeCtx();
         const handler = resolveNativeHandler(name)!;
         const args = 'focus on "diff.rs" and the PTY bridge';
-        const result = handler.execute(ctx, args);
+        const result = await handler.execute(ctx, args);
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.prompt).toContain(`Additional guidance from user: ${args}`);
       });
 
-      it("omits missing workspace/repo/repoDefaultBranch fields without leaking placeholders", () => {
+      it("omits missing workspace/repo/repoDefaultBranch fields without leaking placeholders", async () => {
         const ctx = makeCtx({
           repository: null,
           workspace: null,
           repoDefaultBranch: null,
         });
         const handler = resolveNativeHandler(name)!;
-        const result = handler.execute(ctx, "");
+        const result = await handler.execute(ctx, "");
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.prompt).not.toContain("undefined");
         expect(result.prompt).not.toContain("null");
@@ -312,14 +327,14 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).not.toMatch(/Worktree:\s*$/m);
       });
 
-      it("omits individual missing fields but keeps populated ones", () => {
+      it("omits individual missing fields but keeps populated ones", async () => {
         const ctx = makeCtx({
           repository: { name: "claudette", path: "/tmp/repos/claudette" },
           workspace: { branch: "feat/x", worktreePath: null },
           repoDefaultBranch: null,
         });
         const handler = resolveNativeHandler(name)!;
-        const result = handler.execute(ctx, "");
+        const result = await handler.execute(ctx, "");
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.prompt).toContain("claudette");
         expect(result.prompt).toContain("feat/x");
@@ -327,7 +342,7 @@ describe("review workflow native handlers", () => {
         expect(result.prompt).not.toContain("Repo default branch");
       });
 
-      it("returns an expand result (not handled) so ChatPanel forwards the prompt to sendChatMessage", () => {
+      it("returns an expand result (not handled) so ChatPanel forwards the prompt to sendChatMessage", async () => {
         // The ChatPanel send path only falls through to sendChatMessage when
         // the native dispatcher returns `kind: "expand"`. A "handled" result
         // would short-circuit and swallow the command. These handlers must
@@ -335,17 +350,17 @@ describe("review workflow native handlers", () => {
         // normal agent pipeline run it.
         const ctx = makeCtx();
         const handler = resolveNativeHandler(name)!;
-        const empty = handler.execute(ctx, "");
-        const withArgs = handler.execute(ctx, "hello");
+        const empty = await handler.execute(ctx, "");
+        const withArgs = await handler.execute(ctx, "hello");
         expect(empty.kind).toBe("expand");
         expect(withArgs.kind).toBe("expand");
       });
 
-      it("does not pass the raw slash input through verbatim — the expansion differs from `/<name> …`", () => {
+      it("does not pass the raw slash input through verbatim — the expansion differs from `/<name> …`", async () => {
         const ctx = makeCtx();
         const handler = resolveNativeHandler(name)!;
         const rawInput = `/${name} focus on perf`;
-        const result = handler.execute(ctx, "focus on perf");
+        const result = await handler.execute(ctx, "focus on perf");
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.prompt).not.toBe(rawInput);
         expect(result.prompt.length).toBeGreaterThan(rawInput.length);
@@ -354,9 +369,9 @@ describe("review workflow native handlers", () => {
   }
 
   describe("review base resolution (P1/P2 fixes)", () => {
-    it("/review instructs the agent to resolve the review base via gh/git, not to trust the repo default as the base", () => {
+    it("/review instructs the agent to resolve the review base via gh/git, not to trust the repo default as the base", async () => {
       const handler = resolveNativeHandler("review")!;
-      const result = handler.execute(makeCtx(), "");
+      const result = await handler.execute(makeCtx(), "");
       if (result.kind !== "expand") throw new Error("expected expand");
       expect(result.prompt).toMatch(/Resolve the review base ref/);
       expect(result.prompt).toContain("gh pr view");
@@ -365,40 +380,40 @@ describe("review workflow native handlers", () => {
       expect(result.prompt).toMatch(/hint only.*not guaranteed to be this branch's review base/);
     });
 
-    it("/security-review uses the same resolve-base guidance", () => {
+    it("/security-review uses the same resolve-base guidance", async () => {
       const handler = resolveNativeHandler("security-review")!;
-      const result = handler.execute(makeCtx(), "");
+      const result = await handler.execute(makeCtx(), "");
       if (result.kind !== "expand") throw new Error("expected expand");
       expect(result.prompt).toMatch(/Resolve the review base ref/);
       expect(result.prompt).toContain("gh pr view");
     });
 
-    it("does not hardcode the `origin/` remote prefix in the base-resolution block", () => {
+    it("does not hardcode the `origin/` remote prefix in the base-resolution block", async () => {
       // Non-`origin` remotes (e.g. `upstream` in fork workflows) exist — the
       // Rust backend already handles this in `src/git.rs`. The prompt must not
       // instruct the agent to assume `origin/`.
-      const prompt = resolveNativeHandler("review")!.execute(makeCtx(), "");
+      const prompt = await resolveNativeHandler("review")!.execute(makeCtx(), "");
       if (prompt.kind !== "expand") throw new Error("expected expand");
       expect(prompt.prompt).toMatch(/git remote/);
       expect(prompt.prompt).not.toMatch(/prefixed with ['"`]origin\//);
     });
 
-    it("warns against treating `@{upstream}` as the review base when it just names the branch's own tracking ref", () => {
+    it("warns against treating `@{upstream}` as the review base when it just names the branch's own tracking ref", async () => {
       // The most common case of `@{upstream}` is the feature branch's remote
       // copy — diffing HEAD against that yields an empty diff. The prompt
       // must spell this out rather than treating upstream as authoritative.
-      const prompt = resolveNativeHandler("review")!.execute(makeCtx(), "");
+      const prompt = await resolveNativeHandler("review")!.execute(makeCtx(), "");
       if (prompt.kind !== "expand") throw new Error("expected expand");
       expect(prompt.prompt).toMatch(/only use this when the upstream clearly names the review target/i);
     });
 
-    it("prompt still instructs base-resolution when repoDefaultBranch is missing (remote-workspace case)", () => {
+    it("prompt still instructs base-resolution when repoDefaultBranch is missing (remote-workspace case)", async () => {
       // On paired remote workspaces today, defaultBranch may not be in the
       // store. The prompt must still tell the agent to determine a base ref
       // itself rather than diffing against an unnamed / empty ref.
       const ctx = makeCtx({ repoDefaultBranch: null });
       for (const name of ["review", "security-review"] as const) {
-        const result = resolveNativeHandler(name)!.execute(ctx, "");
+        const result = await resolveNativeHandler(name)!.execute(ctx, "");
         if (result.kind !== "expand") throw new Error("expected expand");
         expect(result.prompt).toMatch(/Resolve the review base ref/);
         expect(result.prompt).toContain("gh pr view");
@@ -411,116 +426,118 @@ describe("review workflow native handlers", () => {
     });
   });
 
-  it("each command produces a distinct seeded prompt", () => {
+  it("each command produces a distinct seeded prompt", async () => {
     const ctx = makeCtx();
-    const prompts = REVIEW_NAMES.map((n) => {
-      const r = resolveNativeHandler(n)!.execute(ctx, "");
-      if (r.kind !== "expand") throw new Error("expected expand");
-      return r.prompt;
-    });
+    const prompts = await Promise.all(
+      REVIEW_NAMES.map(async (n) => {
+        const r = await resolveNativeHandler(n)!.execute(ctx, "");
+        if (r.kind !== "expand") throw new Error("expected expand");
+        return r.prompt;
+      }),
+    );
     const unique = new Set(prompts);
     expect(unique.size).toBe(REVIEW_NAMES.length);
   });
 });
 
 describe("config native handler", () => {
-  it("opens settings with the default general section when no args given", () => {
+  it("opens settings with the default general section when no args given", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("config")!;
-    const result = handler.execute(ctx, "");
+    const result = await handler.execute(ctx, "");
     expect(result).toEqual({ kind: "handled", canonicalName: "config" });
     expect(ctx.openSettings).toHaveBeenCalledTimes(1);
     expect(ctx.openSettings).toHaveBeenCalledWith("general");
   });
 
-  it("resolves the /configure alias to the config handler", () => {
+  it("resolves the /configure alias to the config handler", async () => {
     expect(resolveNativeHandler("configure")?.name).toBe("config");
     expect(resolveNativeHandler("CONFIGURE")?.name).toBe("config");
   });
 
-  it("routes each valid section to openSettings with that section", () => {
+  it("routes each valid section to openSettings with that section", async () => {
     const handler = resolveNativeHandler("config")!;
     for (const section of CONFIG_SECTIONS) {
       const ctx = makeCtx();
-      const result = handler.execute(ctx, section);
+      const result = await handler.execute(ctx, section);
       expect(result).toEqual({ kind: "handled", canonicalName: "config" });
       expect(ctx.openSettings).toHaveBeenCalledTimes(1);
       expect(ctx.openSettings).toHaveBeenCalledWith(section);
     }
   });
 
-  it("redirects /config usage to experimental when Usage Insights is disabled", () => {
+  it("redirects /config usage to experimental when Usage Insights is disabled", async () => {
     const ctx = makeCtx({ usageInsightsEnabled: false });
     const handler = resolveNativeHandler("config")!;
-    handler.execute(ctx, "usage");
+    await handler.execute(ctx, "usage");
     expect(ctx.openSettings).toHaveBeenCalledWith("experimental");
   });
 
-  it("is case-insensitive for section names", () => {
+  it("is case-insensitive for section names", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("config")!;
-    handler.execute(ctx, "APPEARANCE");
+    await handler.execute(ctx, "APPEARANCE");
     expect(ctx.openSettings).toHaveBeenCalledWith("appearance");
   });
 
-  it("ignores extra arguments after the section token", () => {
+  it("ignores extra arguments after the section token", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("config")!;
-    handler.execute(ctx, "models foo bar");
+    await handler.execute(ctx, "models foo bar");
     expect(ctx.openSettings).toHaveBeenCalledWith("models");
   });
 
-  it("falls back to general for an unknown section", () => {
+  it("falls back to general for an unknown section", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("config")!;
-    const result = handler.execute(ctx, "bogus-section");
+    const result = await handler.execute(ctx, "bogus-section");
     expect(result).toEqual({ kind: "handled", canonicalName: "config" });
     expect(ctx.openSettings).toHaveBeenCalledWith("general");
   });
 });
 
 describe("usage native handler", () => {
-  it("resolves /usage and opens the usage settings section when the gate is on", () => {
+  it("resolves /usage and opens the usage settings section when the gate is on", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("usage")!;
-    const result = handler.execute(ctx, "");
+    const result = await handler.execute(ctx, "");
     expect(result).toEqual({ kind: "handled", canonicalName: "usage" });
     expect(ctx.openSettings).toHaveBeenCalledWith("usage");
     expect(ctx.openUsageSettingsExternal).not.toHaveBeenCalled();
   });
 
-  it("routes /usage to Experimental when Usage Insights is disabled", () => {
+  it("routes /usage to Experimental when Usage Insights is disabled", async () => {
     const ctx = makeCtx({ usageInsightsEnabled: false });
     const handler = resolveNativeHandler("usage")!;
-    handler.execute(ctx, "");
+    await handler.execute(ctx, "");
     expect(ctx.openSettings).toHaveBeenCalledWith("experimental");
   });
 });
 
 describe("extra-usage native handler", () => {
-  it("reuses both the in-app and external usage paths when the gate is on", () => {
+  it("reuses both the in-app and external usage paths when the gate is on", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("extra-usage")!;
-    const result = handler.execute(ctx, "");
+    const result = await handler.execute(ctx, "");
     expect(result).toEqual({ kind: "handled", canonicalName: "extra-usage" });
     expect(ctx.openSettings).toHaveBeenCalledWith("usage");
     expect(ctx.openUsageSettingsExternal).toHaveBeenCalledTimes(1);
   });
 
-  it("routes /extra-usage to Experimental and does NOT launch claude.ai when gated off", () => {
+  it("routes /extra-usage to Experimental and does NOT launch claude.ai when gated off", async () => {
     const ctx = makeCtx({ usageInsightsEnabled: false });
     const handler = resolveNativeHandler("extra-usage")!;
-    handler.execute(ctx, "");
+    await handler.execute(ctx, "");
     expect(ctx.openSettings).toHaveBeenCalledWith("experimental");
     expect(ctx.openUsageSettingsExternal).not.toHaveBeenCalled();
   });
 });
 
 describe("release-notes native handler", () => {
-  it("resolves /release-notes and routes through openReleaseNotes", () => {
+  it("resolves /release-notes and routes through openReleaseNotes", async () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("release-notes")!;
-    const result = handler.execute(ctx, "");
+    const result = await handler.execute(ctx, "");
     expect(result).toEqual({
       kind: "handled",
       canonicalName: "release-notes",
@@ -528,37 +545,364 @@ describe("release-notes native handler", () => {
     expect(ctx.openReleaseNotes).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves the /changelog alias to the release-notes handler", () => {
+  it("resolves the /changelog alias to the release-notes handler", async () => {
     expect(resolveNativeHandler("changelog")?.name).toBe("release-notes");
   });
 });
 
 describe("version native handler", () => {
-  it("formats the version string with a v-prefix", () => {
+  it("formats the version string with a v-prefix", async () => {
     expect(formatVersionMessage("1.2.3")).toBe("Claudette v1.2.3");
   });
 
-  it("falls back to 'unknown' when no version is available", () => {
+  it("falls back to 'unknown' when no version is available", async () => {
     expect(formatVersionMessage(null)).toBe("Claudette vunknown");
   });
 
-  it("posts a local message containing the provided app version", () => {
+  it("posts a local message containing the provided app version", async () => {
     const ctx = makeCtx({ appVersion: "9.9.9" });
     const handler = resolveNativeHandler("version")!;
-    const result = handler.execute(ctx, "");
+    const result = await handler.execute(ctx, "");
     expect(result).toEqual({ kind: "handled", canonicalName: "version" });
     expect(ctx.addLocalMessage).toHaveBeenCalledTimes(1);
     expect(ctx.addLocalMessage).toHaveBeenCalledWith("Claudette v9.9.9");
   });
 
-  it("posts a local 'unknown' fallback when appVersion is null", () => {
+  it("posts a local 'unknown' fallback when appVersion is null", async () => {
     const ctx = makeCtx({ appVersion: null });
     const handler = resolveNativeHandler("version")!;
-    handler.execute(ctx, "");
+    await handler.execute(ctx, "");
     expect(ctx.addLocalMessage).toHaveBeenCalledWith("Claudette vunknown");
   });
 
-  it("resolves the /about alias to the version handler", () => {
+  it("resolves the /about alias to the version handler", async () => {
     expect(resolveNativeHandler("about")?.name).toBe("version");
+  });
+});
+
+describe("/clear handler", () => {
+  it("clears conversation when called with no args", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("clear")!;
+    const result = await handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "clear" });
+    expect(ctx.clearConversation).toHaveBeenCalledWith(false);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Conversation cleared.");
+  });
+
+  it("never passes restoreFiles=true — file restore belongs to the rollback modal, not to /clear", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("clear")!;
+    await handler.execute(ctx, "");
+    expect(ctx.clearConversation).toHaveBeenCalledWith(false);
+  });
+
+  it("rejects any argument without calling clearConversation", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("clear")!;
+    await handler.execute(ctx, "files");
+    expect(ctx.clearConversation).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("does not accept arguments"),
+    );
+  });
+
+  it("surfaces errors from the clearConversation call as a local message", async () => {
+    const ctx = makeCtx({
+      clearConversation: vi.fn(async () => {
+        throw new Error("agent running");
+      }),
+    });
+    const handler = resolveNativeHandler("clear")!;
+    await handler.execute(ctx, "");
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("agent running"),
+    );
+  });
+
+  it("bails out gracefully if no workspace is selected", async () => {
+    const ctx = makeCtx({ workspaceId: null });
+    const handler = resolveNativeHandler("clear")!;
+    await handler.execute(ctx, "");
+    expect(ctx.clearConversation).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("no active workspace"),
+    );
+  });
+});
+
+describe("/plan handler", () => {
+  it("toggles plan mode off when invoked with no args and plan mode is currently on", async () => {
+    const ctx = makeCtx({ planMode: true });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "");
+    expect(ctx.setPlanMode).toHaveBeenCalledWith(false);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Plan mode off.");
+  });
+
+  it("toggles plan mode on when invoked with no args and plan mode is currently off", async () => {
+    const ctx = makeCtx({ planMode: false });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "");
+    expect(ctx.setPlanMode).toHaveBeenCalledWith(true);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Plan mode on.");
+  });
+
+  it("enables plan mode via /plan on", async () => {
+    const ctx = makeCtx({ planMode: false });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "on");
+    expect(ctx.setPlanMode).toHaveBeenCalledWith(true);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Plan mode enabled.");
+  });
+
+  it("disables plan mode via /plan off", async () => {
+    const ctx = makeCtx({ planMode: true });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "off");
+    expect(ctx.setPlanMode).toHaveBeenCalledWith(false);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Plan mode disabled.");
+  });
+
+  it("toggles plan mode via /plan toggle", async () => {
+    const ctx = makeCtx({ planMode: false });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "toggle");
+    expect(ctx.setPlanMode).toHaveBeenCalledWith(true);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Plan mode on.");
+  });
+
+  it("opens the pending plan file when one exists", async () => {
+    const ctx = makeCtx({
+      pendingPlanFilePath: "/tmp/.claude/plans/draft.md",
+      readPlanFile: vi.fn(async () => "# Draft plan"),
+    });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "open");
+    expect(ctx.readPlanFile).toHaveBeenCalledWith("/tmp/.claude/plans/draft.md");
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("# Draft plan"),
+    );
+  });
+
+  it("reports when /plan open has no active plan file", async () => {
+    const ctx = makeCtx({ pendingPlanFilePath: null });
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "open");
+    expect(ctx.readPlanFile).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("no active plan file"),
+    );
+  });
+
+  it("rejects unknown arguments without mutating plan mode", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("plan")!;
+    await handler.execute(ctx, "soon");
+    expect(ctx.setPlanMode).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("unknown argument"),
+    );
+  });
+});
+
+describe("/model handler", () => {
+  it("prints the current model and available options with no args", async () => {
+    const ctx = makeCtx({ selectedModel: "sonnet" });
+    const handler = resolveNativeHandler("model")!;
+    await handler.execute(ctx, "");
+    expect(ctx.setSelectedModel).not.toHaveBeenCalled();
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Current model: sonnet");
+    expect(msg).toContain("opus");
+    expect(msg).toContain("haiku");
+  });
+
+  it("updates the model when a valid id is supplied", async () => {
+    const ctx = makeCtx({ selectedModel: "opus" });
+    const handler = resolveNativeHandler("model")!;
+    await handler.execute(ctx, "sonnet");
+    expect(ctx.setSelectedModel).toHaveBeenCalledWith("sonnet");
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Model set to sonnet.");
+  });
+
+  it("resolves model ids case-insensitively to their canonical form", async () => {
+    const ctx = makeCtx({ selectedModel: "opus" });
+    const handler = resolveNativeHandler("model")!;
+    await handler.execute(ctx, "SONNET");
+    expect(ctx.setSelectedModel).toHaveBeenCalledWith("sonnet");
+  });
+
+  it("no-ops when the requested model equals the current one", async () => {
+    const ctx = makeCtx({ selectedModel: "opus" });
+    const handler = resolveNativeHandler("model")!;
+    await handler.execute(ctx, "opus");
+    expect(ctx.setSelectedModel).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Model is already opus.");
+  });
+
+  it("rejects unknown model ids with a list of valid options", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("model")!;
+    await handler.execute(ctx, "gpt-5");
+    expect(ctx.setSelectedModel).not.toHaveBeenCalled();
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("unknown model");
+    expect(msg).toContain("opus");
+    expect(msg).toContain("sonnet");
+    expect(msg).toContain("haiku");
+  });
+
+  it("surfaces errors from setSelectedModel", async () => {
+    const ctx = makeCtx({
+      selectedModel: "opus",
+      setSelectedModel: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const handler = resolveNativeHandler("model")!;
+    await handler.execute(ctx, "sonnet");
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("boom"),
+    );
+  });
+});
+
+describe("/permissions handler", () => {
+  it("reports current level when invoked with no args", async () => {
+    const ctx = makeCtx({ permissionLevel: "standard" });
+    const handler = resolveNativeHandler("permissions")!;
+    await handler.execute(ctx, "");
+    expect(ctx.setPermissionLevel).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("Permission mode: standard"),
+    );
+  });
+
+  it("updates level when given a valid mode", async () => {
+    const ctx = makeCtx({ permissionLevel: "full" });
+    const handler = resolveNativeHandler("permissions")!;
+    await handler.execute(ctx, "readonly");
+    expect(ctx.setPermissionLevel).toHaveBeenCalledWith("readonly");
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      "Permission mode set to readonly.",
+    );
+  });
+
+  it("accepts the /allowed-tools alias and updates the same state", async () => {
+    const ctx = makeCtx({ permissionLevel: "full" });
+    const handler = resolveNativeHandler("allowed-tools")!;
+    expect(handler.name).toBe("permissions");
+    const result = await handler.execute(ctx, "standard");
+    expect(result).toEqual({
+      kind: "handled",
+      canonicalName: "permissions",
+    });
+    expect(ctx.setPermissionLevel).toHaveBeenCalledWith("standard");
+  });
+
+  it("is case-insensitive on the mode argument", async () => {
+    const ctx = makeCtx({ permissionLevel: "full" });
+    const handler = resolveNativeHandler("permissions")!;
+    await handler.execute(ctx, "READONLY");
+    expect(ctx.setPermissionLevel).toHaveBeenCalledWith("readonly");
+  });
+
+  it("no-ops when the requested mode matches the current one", async () => {
+    const ctx = makeCtx({ permissionLevel: "full" });
+    const handler = resolveNativeHandler("permissions")!;
+    await handler.execute(ctx, "full");
+    expect(ctx.setPermissionLevel).not.toHaveBeenCalled();
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      "Permission mode is already full.",
+    );
+  });
+
+  it("rejects unknown modes with a list of valid options", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("permissions")!;
+    await handler.execute(ctx, "god");
+    expect(ctx.setPermissionLevel).not.toHaveBeenCalled();
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain('unknown mode "god"');
+    expect(msg).toContain("readonly");
+    expect(msg).toContain("standard");
+    expect(msg).toContain("full");
+  });
+});
+
+describe("/status handler", () => {
+  it("emits a single local message reporting the current workspace state", async () => {
+    const ctx = makeCtx({
+      repository: { name: "acme", path: "/tmp/repos/acme" },
+      workspace: { branch: "feat/slashes", worktreePath: "/tmp/wt/slashes" },
+      agentStatus: "Running",
+      selectedModel: "sonnet",
+      permissionLevel: "standard",
+      planMode: true,
+      fastMode: false,
+      thinkingEnabled: true,
+      chromeEnabled: false,
+      effortLevel: "high",
+    });
+    const handler = resolveNativeHandler("status")!;
+    const result = await handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "status" });
+    expect(ctx.addLocalMessage).toHaveBeenCalledTimes(1);
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("Repo: acme");
+    expect(msg).toContain("Branch: feat/slashes");
+    expect(msg).toContain("Agent: Running");
+    expect(msg).toContain("Model: sonnet");
+    expect(msg).toContain("Permission: standard");
+    expect(msg).toContain("Plan mode: on");
+    expect(msg).toContain("Fast: off");
+    expect(msg).toContain("Thinking: on");
+    expect(msg).toContain("Chrome: off");
+    expect(msg).toContain("Effort: high");
+  });
+
+  it("does not mutate any workspace state", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("status")!;
+    await handler.execute(ctx, "");
+    expect(ctx.setSelectedModel).not.toHaveBeenCalled();
+    expect(ctx.setPermissionLevel).not.toHaveBeenCalled();
+    expect(ctx.setPlanMode).not.toHaveBeenCalled();
+    expect(ctx.clearConversation).not.toHaveBeenCalled();
+  });
+
+  it("falls back gracefully when workspace metadata is missing", async () => {
+    const ctx = makeCtx({
+      repository: null,
+      workspace: null,
+      agentStatus: null,
+    });
+    const handler = resolveNativeHandler("status")!;
+    await handler.execute(ctx, "");
+    const msg = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(msg).toContain("unknown repo");
+    expect(msg).toContain("no branch");
+  });
+});
+
+describe("workspace-control picker filtering", () => {
+  it("exposes every workspace-control canonical entry from NATIVE_HANDLERS", () => {
+    const names = NATIVE_HANDLERS.map((h) => h.name);
+    expect(names).toContain("clear");
+    expect(names).toContain("plan");
+    expect(names).toContain("model");
+    expect(names).toContain("permissions");
+    expect(names).toContain("status");
+  });
+
+  it("resolves /allowed-tools as an alias to /permissions", () => {
+    expect(resolveNativeHandler("allowed-tools")?.name).toBe("permissions");
+    expect(resolveNativeHandler("Allowed-Tools")?.name).toBe("permissions");
   });
 });

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -36,7 +36,7 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     thinkingEnabled: false,
     chromeEnabled: false,
     effortLevel: "auto",
-    pendingPlanFilePath: null,
+    planFilePath: null,
     setSelectedModel: vi.fn(async () => {}),
     setPermissionLevel: vi.fn(async () => {}),
     setPlanMode: vi.fn(),
@@ -672,26 +672,31 @@ describe("/plan handler", () => {
     expect(ctx.addLocalMessage).toHaveBeenCalledWith("Plan mode on.");
   });
 
-  it("opens the pending plan file when one exists", async () => {
+  it("opens the plan file resolved by ChatPanel regardless of pending-approval state", async () => {
+    // The handler treats planFilePath as opaque — it reads whatever ChatPanel
+    // resolved via findLatestPlanFilePath, which also scans chat history after
+    // the approval card has been dismissed.
     const ctx = makeCtx({
-      pendingPlanFilePath: "/tmp/.claude/plans/draft.md",
+      planFilePath: "/tmp/.claude/plans/draft.md",
       readPlanFile: vi.fn(async () => "# Draft plan"),
     });
     const handler = resolveNativeHandler("plan")!;
     await handler.execute(ctx, "open");
-    expect(ctx.readPlanFile).toHaveBeenCalledWith("/tmp/.claude/plans/draft.md");
+    expect(ctx.readPlanFile).toHaveBeenCalledWith(
+      "/tmp/.claude/plans/draft.md",
+    );
     expect(ctx.addLocalMessage).toHaveBeenCalledWith(
       expect.stringContaining("# Draft plan"),
     );
   });
 
-  it("reports when /plan open has no active plan file", async () => {
-    const ctx = makeCtx({ pendingPlanFilePath: null });
+  it("reports when /plan open has no plan file to open", async () => {
+    const ctx = makeCtx({ planFilePath: null });
     const handler = resolveNativeHandler("plan")!;
     await handler.execute(ctx, "open");
     expect(ctx.readPlanFile).not.toHaveBeenCalled();
     expect(ctx.addLocalMessage).toHaveBeenCalledWith(
-      expect.stringContaining("no active plan file"),
+      expect.stringContaining("no plan file found"),
     );
   });
 

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -1,6 +1,8 @@
 import type { PluginSettingsIntent } from "../../types/plugins";
 import type { NativeSlashKind } from "../../services/tauri";
+import type { PermissionLevel } from "../../stores/useAppStore";
 import { parsePluginSlashCommand } from "./pluginSlashCommand";
+import { MODELS } from "./modelRegistry";
 
 export type { NativeSlashKind };
 
@@ -41,6 +43,27 @@ export interface NativeCommandContext {
   addLocalMessage: (text: string) => void;
   openUsageSettingsExternal: () => void;
   openReleaseNotes: () => void;
+
+  // -- Per-workspace state read by workspace-control commands
+  // (/clear, /plan, /model, /permissions, /status). --
+  workspaceId: string | null;
+  agentStatus: string | null;
+  selectedModel: string;
+  permissionLevel: PermissionLevel;
+  planMode: boolean;
+  fastMode: boolean;
+  thinkingEnabled: boolean;
+  chromeEnabled: boolean;
+  effortLevel: string;
+  pendingPlanFilePath: string | null;
+
+  // -- Pre-bound per-workspace write callbacks. Callers wire these to the
+  // same store setters / backend commands the toolbar and shortcuts use. --
+  setSelectedModel: (model: string) => Promise<void>;
+  setPermissionLevel: (level: PermissionLevel) => Promise<void>;
+  setPlanMode: (enabled: boolean) => void;
+  clearConversation: (restoreFiles: boolean) => Promise<void>;
+  readPlanFile: (path: string) => Promise<string>;
 }
 
 export type NativeCommandResult =
@@ -52,7 +75,10 @@ export interface NativeHandler {
   name: string;
   aliases: string[];
   kind: NativeSlashKind;
-  execute: (ctx: NativeCommandContext, args: string) => NativeCommandResult;
+  execute: (
+    ctx: NativeCommandContext,
+    args: string,
+  ) => NativeCommandResult | Promise<NativeCommandResult>;
 }
 
 /** Split `/token rest of args` into its token and the argument tail. */
@@ -326,6 +352,205 @@ const versionHandler: NativeHandler = {
   },
 };
 
+const PERMISSION_MODES: PermissionLevel[] = ["readonly", "standard", "full"];
+
+function isPermissionLevel(value: string): value is PermissionLevel {
+  return (PERMISSION_MODES as string[]).includes(value);
+}
+
+function formatOnOff(enabled: boolean): string {
+  return enabled ? "on" : "off";
+}
+
+const clearHandler: NativeHandler = {
+  name: "clear",
+  aliases: [],
+  kind: "local_action",
+  execute: async (ctx, args) => {
+    const handled = { kind: "handled" as const, canonicalName: "clear" };
+    if (!ctx.workspaceId) {
+      ctx.addLocalMessage("/clear: no active workspace");
+      return handled;
+    }
+    if (args.trim() !== "") {
+      ctx.addLocalMessage("/clear: does not accept arguments. Usage: /clear");
+      return handled;
+    }
+    try {
+      // Chat history only — file restore is available from the rollback modal
+      // when the user explicitly wants it.
+      await ctx.clearConversation(false);
+      ctx.addLocalMessage("Conversation cleared.");
+    } catch (error) {
+      ctx.addLocalMessage(`/clear failed: ${String(error)}`);
+    }
+    return handled;
+  },
+};
+
+const planHandler: NativeHandler = {
+  name: "plan",
+  aliases: [],
+  kind: "local_action",
+  execute: async (ctx, args) => {
+    const handled = { kind: "handled" as const, canonicalName: "plan" };
+    if (!ctx.workspaceId) {
+      ctx.addLocalMessage("/plan: no active workspace");
+      return handled;
+    }
+    const arg = args.trim().toLowerCase();
+    if (arg === "" || arg === "toggle") {
+      const next = !ctx.planMode;
+      ctx.setPlanMode(next);
+      ctx.addLocalMessage(`Plan mode ${formatOnOff(next)}.`);
+      return handled;
+    }
+    if (arg === "on") {
+      ctx.setPlanMode(true);
+      ctx.addLocalMessage("Plan mode enabled.");
+      return handled;
+    }
+    if (arg === "off") {
+      ctx.setPlanMode(false);
+      ctx.addLocalMessage("Plan mode disabled.");
+      return handled;
+    }
+    if (arg === "open") {
+      if (!ctx.pendingPlanFilePath) {
+        ctx.addLocalMessage(
+          "/plan open: no active plan file. Enable plan mode and run a turn to produce one.",
+        );
+        return handled;
+      }
+      try {
+        const content = await ctx.readPlanFile(ctx.pendingPlanFilePath);
+        ctx.addLocalMessage(
+          `Plan file — ${ctx.pendingPlanFilePath}\n\n${content}`,
+        );
+      } catch (error) {
+        ctx.addLocalMessage(`/plan open failed: ${String(error)}`);
+      }
+      return handled;
+    }
+    ctx.addLocalMessage(
+      "/plan: unknown argument. Usage: /plan [on|off|toggle|open]",
+    );
+    return handled;
+  },
+};
+
+const modelHandler: NativeHandler = {
+  name: "model",
+  aliases: [],
+  kind: "local_action",
+  execute: async (ctx, args) => {
+    const handled = { kind: "handled" as const, canonicalName: "model" };
+    if (!ctx.workspaceId) {
+      ctx.addLocalMessage("/model: no active workspace");
+      return handled;
+    }
+    const arg = args.trim();
+    const modelIds = MODELS.map((m) => m.id);
+    if (arg === "") {
+      const lines = MODELS.map((m) => {
+        const marker = m.id === ctx.selectedModel ? "•" : " ";
+        return ` ${marker} ${m.id} — ${m.label}`;
+      }).join("\n");
+      ctx.addLocalMessage(`Current model: ${ctx.selectedModel}\n${lines}`);
+      return handled;
+    }
+    const normalized = arg.toLowerCase();
+    const match = MODELS.find((m) => m.id.toLowerCase() === normalized);
+    if (!match) {
+      ctx.addLocalMessage(
+        `/model: unknown model "${arg}". Valid options: ${modelIds.join(", ")}`,
+      );
+      return handled;
+    }
+    if (match.id === ctx.selectedModel) {
+      ctx.addLocalMessage(`Model is already ${match.id}.`);
+      return handled;
+    }
+    try {
+      await ctx.setSelectedModel(match.id);
+      ctx.addLocalMessage(`Model set to ${match.id}.`);
+    } catch (error) {
+      ctx.addLocalMessage(`/model failed: ${String(error)}`);
+    }
+    return handled;
+  },
+};
+
+const permissionsHandler: NativeHandler = {
+  name: "permissions",
+  aliases: ["allowed-tools"],
+  kind: "local_action",
+  execute: async (ctx, args) => {
+    const handled = {
+      kind: "handled" as const,
+      canonicalName: "permissions",
+    };
+    if (!ctx.workspaceId) {
+      ctx.addLocalMessage("/permissions: no active workspace");
+      return handled;
+    }
+    const arg = args.trim().toLowerCase();
+    if (arg === "") {
+      ctx.addLocalMessage(
+        `Permission mode: ${ctx.permissionLevel}. Options: ${PERMISSION_MODES.join(", ")}`,
+      );
+      return handled;
+    }
+    if (!isPermissionLevel(arg)) {
+      ctx.addLocalMessage(
+        `/permissions: unknown mode "${args.trim()}". Valid options: ${PERMISSION_MODES.join(", ")}`,
+      );
+      return handled;
+    }
+    if (arg === ctx.permissionLevel) {
+      ctx.addLocalMessage(`Permission mode is already ${arg}.`);
+      return handled;
+    }
+    try {
+      await ctx.setPermissionLevel(arg);
+      ctx.addLocalMessage(`Permission mode set to ${arg}.`);
+    } catch (error) {
+      ctx.addLocalMessage(`/permissions failed: ${String(error)}`);
+    }
+    return handled;
+  },
+};
+
+const statusHandler: NativeHandler = {
+  name: "status",
+  aliases: [],
+  kind: "local_action",
+  execute: (ctx) => {
+    const handled = { kind: "handled" as const, canonicalName: "status" };
+    if (!ctx.workspaceId) {
+      ctx.addLocalMessage("/status: no active workspace");
+      return handled;
+    }
+    const repo = ctx.repository?.name ?? "(unknown repo)";
+    const branch = ctx.workspace?.branch ?? "(no branch)";
+    const agent = ctx.agentStatus ?? "(unknown)";
+    const lines = [
+      `Repo: ${repo}`,
+      `Branch: ${branch}`,
+      `Agent: ${agent}`,
+      `Model: ${ctx.selectedModel}`,
+      `Permission: ${ctx.permissionLevel}`,
+      `Plan mode: ${formatOnOff(ctx.planMode)}`,
+      `Fast: ${formatOnOff(ctx.fastMode)}`,
+      `Thinking: ${formatOnOff(ctx.thinkingEnabled)}`,
+      `Chrome: ${formatOnOff(ctx.chromeEnabled)}`,
+      `Effort: ${ctx.effortLevel}`,
+    ];
+    ctx.addLocalMessage(lines.join("\n"));
+    return handled;
+  },
+};
+
 export const NATIVE_HANDLERS: NativeHandler[] = [
   pluginHandler("plugin"),
   pluginHandler("marketplace"),
@@ -337,6 +562,11 @@ export const NATIVE_HANDLERS: NativeHandler[] = [
   extraUsageHandler,
   releaseNotesHandler,
   versionHandler,
+  clearHandler,
+  planHandler,
+  modelHandler,
+  permissionsHandler,
+  statusHandler,
 ];
 
 /** Resolve a slash command token (no leading `/`) against the native handler table. */

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -424,7 +424,12 @@ const planHandler: NativeHandler = {
       }
       try {
         const content = await ctx.readPlanFile(ctx.planFilePath);
-        ctx.addLocalMessage(`Plan file — ${ctx.planFilePath}\n\n${content}`);
+        // Emit as markdown so the renderer surfaces headings, lists, and code
+        // fences inside the plan instead of collapsing it into one paragraph.
+        // The path line is rendered as italic muted metadata above the body.
+        ctx.addLocalMessage(
+          `_Plan file — \`${ctx.planFilePath}\`_\n\n${content}`,
+        );
       } catch (error) {
         ctx.addLocalMessage(`/plan open failed: ${String(error)}`);
       }

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -55,7 +55,7 @@ export interface NativeCommandContext {
   thinkingEnabled: boolean;
   chromeEnabled: boolean;
   effortLevel: string;
-  pendingPlanFilePath: string | null;
+  planFilePath: string | null;
 
   // -- Pre-bound per-workspace write callbacks. Callers wire these to the
   // same store setters / backend commands the toolbar and shortcuts use. --
@@ -416,17 +416,15 @@ const planHandler: NativeHandler = {
       return handled;
     }
     if (arg === "open") {
-      if (!ctx.pendingPlanFilePath) {
+      if (!ctx.planFilePath) {
         ctx.addLocalMessage(
-          "/plan open: no active plan file. Enable plan mode and run a turn to produce one.",
+          "/plan open: no plan file found for this workspace. Enable plan mode and run a turn to produce one.",
         );
         return handled;
       }
       try {
-        const content = await ctx.readPlanFile(ctx.pendingPlanFilePath);
-        ctx.addLocalMessage(
-          `Plan file — ${ctx.pendingPlanFilePath}\n\n${content}`,
-        );
+        const content = await ctx.readPlanFile(ctx.planFilePath);
+        ctx.addLocalMessage(`Plan file — ${ctx.planFilePath}\n\n${content}`);
       } catch (error) {
         ctx.addLocalMessage(`/plan open failed: ${String(error)}`);
       }

--- a/src/ui/src/components/chat/planFilePath.test.ts
+++ b/src/ui/src/components/chat/planFilePath.test.ts
@@ -174,6 +174,85 @@ describe("findLatestPlanFilePath", () => {
     expect(findLatestPlanFilePath(WS)).toBeNull();
   });
 
+  it("extracts a plan path that contains whitespace (macOS home dirs with spaces)", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "Plan written to /Users/Ada Lovelace/.claude/plans/compiler notes.md.",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/Users/Ada Lovelace/.claude/plans/compiler notes.md",
+    );
+  });
+
+  it("stops the match at trailing punctuation rather than swallowing following prose", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "See /Users/alice/.claude/plans/final.md, then come back.",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/Users/alice/.claude/plans/final.md",
+    );
+  });
+
+  it("returns the NEWEST tool activity when several activities mention different plans", () => {
+    // addToolActivity appends to the end of the array — scan must iterate
+    // newest-first so the most recent plan wins when a workspace has produced
+    // plans across multiple turns within the same session window.
+    useAppStore.setState({
+      toolActivities: {
+        [WS]: [
+          activity({
+            toolUseId: "tu-old",
+            toolName: "EnterPlanMode",
+            resultText: "/repo/.claude/plans/oldest.md",
+          }),
+          activity({
+            toolUseId: "tu-mid",
+            toolName: "EnterPlanMode",
+            resultText: "/repo/.claude/plans/middle.md",
+          }),
+          activity({
+            toolUseId: "tu-new",
+            toolName: "EnterPlanMode",
+            resultText: "/repo/.claude/plans/newest.md",
+          }),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe("/repo/.claude/plans/newest.md");
+  });
+
+  it("ignores paths that do not point under `.claude/plans/` with a .md suffix", () => {
+    // Guard the whitespace-allowing regex against overreach: it must still
+    // only match the specific plan-file shape.
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "see /Users/alice/.claude/plans/draft.txt or /other/file.md",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBeNull();
+  });
+
   it("scopes results by workspace id — one workspace's plan does not leak to another", () => {
     useAppStore.setState({
       chatMessages: {

--- a/src/ui/src/components/chat/planFilePath.test.ts
+++ b/src/ui/src/components/chat/planFilePath.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAppStore } from "../../stores/useAppStore";
+import type { ChatMessage } from "../../types/chat";
+import type { ToolActivity } from "../../stores/useAppStore";
+import { findLatestPlanFilePath } from "./planFilePath";
+
+const WS = "ws-plan";
+
+function msg(
+  id: string,
+  role: ChatMessage["role"],
+  content: string,
+): ChatMessage {
+  return {
+    id,
+    workspace_id: WS,
+    role,
+    content,
+    cost_usd: null,
+    duration_ms: null,
+    created_at: new Date().toISOString(),
+    thinking: null,
+  };
+}
+
+function activity(overrides: Partial<ToolActivity> = {}): ToolActivity {
+  return {
+    toolUseId: "tu-1",
+    toolName: "ExitPlanMode",
+    inputJson: "",
+    resultText: "",
+    collapsed: true,
+    summary: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Reset the scan inputs this helper reads from. Other slices can stay
+  // untouched since findLatestPlanFilePath only looks at these maps.
+  useAppStore.setState({
+    chatMessages: {},
+    streamingContent: {},
+    toolActivities: {},
+    planApprovals: {},
+  });
+});
+
+describe("findLatestPlanFilePath", () => {
+  it("returns null when the workspace has never surfaced a plan path", () => {
+    expect(findLatestPlanFilePath(WS)).toBeNull();
+  });
+
+  it("extracts the plan path from a recent chat message", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg("m1", "User", "please plan this"),
+          msg(
+            "m2",
+            "Assistant",
+            "Plan written to /Users/alice/.claude/plans/refactor-login.md.",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/Users/alice/.claude/plans/refactor-login.md",
+    );
+  });
+
+  it("prefers the newest message when multiple messages mention plan paths", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "old plan at /home/dev/.claude/plans/old-plan.md",
+          ),
+          msg("m2", "User", "approved"),
+          msg(
+            "m3",
+            "Assistant",
+            "Plan written to /home/dev/.claude/plans/new-plan.md.",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/home/dev/.claude/plans/new-plan.md",
+    );
+  });
+
+  it("keeps returning the plan path even after the pending approval is cleared", () => {
+    // Simulates the "user approved the plan" state the reporter hit: the
+    // PlanApprovalCard clears planApprovals[wsId], but the chat history
+    // still carries the plan path, so /plan open must still resolve it.
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "Plan written to /Users/alice/.claude/plans/readme-refresh.md.",
+          ),
+          msg("m2", "User", "Plan approved. Proceed with implementation."),
+        ],
+      },
+      planApprovals: {}, // cleared after approval
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/Users/alice/.claude/plans/readme-refresh.md",
+    );
+  });
+
+  it("falls back to the active streaming buffer when no message has landed yet", () => {
+    useAppStore.setState({
+      streamingContent: {
+        [WS]: "Writing Plan written to /tmp/.claude/plans/streaming.md now.",
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe("/tmp/.claude/plans/streaming.md");
+  });
+
+  it("falls back to tool activity input/result text", () => {
+    useAppStore.setState({
+      toolActivities: {
+        [WS]: [
+          activity({
+            toolName: "EnterPlanMode",
+            inputJson: JSON.stringify({
+              planPath: "/var/work/.claude/plans/enter-plan.md",
+            }),
+            resultText: "",
+          }),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/var/work/.claude/plans/enter-plan.md",
+    );
+  });
+
+  it("falls back to the pending plan approval's planFilePath as a last resort", () => {
+    useAppStore.setState({
+      planApprovals: {
+        [WS]: {
+          workspaceId: WS,
+          toolUseId: "tu-approval",
+          planFilePath: "/repo/.claude/plans/approval-fallback.md",
+          allowedPrompts: [],
+        },
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe(
+      "/repo/.claude/plans/approval-fallback.md",
+    );
+  });
+
+  it("only looks at paths under `.claude/plans/` with a .md extension", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "see /Users/alice/.claude/notes/random.md and /tmp/other.md",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBeNull();
+  });
+
+  it("scopes results by workspace id — one workspace's plan does not leak to another", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS]: [
+          msg(
+            "m1",
+            "Assistant",
+            "Plan written to /repo/.claude/plans/a.md.",
+          ),
+        ],
+        "other-ws": [
+          msg(
+            "m2",
+            "Assistant",
+            "Plan written to /repo/.claude/plans/b.md.",
+          ),
+        ],
+      },
+    });
+    expect(findLatestPlanFilePath(WS)).toBe("/repo/.claude/plans/a.md");
+    expect(findLatestPlanFilePath("other-ws")).toBe(
+      "/repo/.claude/plans/b.md",
+    );
+    expect(findLatestPlanFilePath("no-ws")).toBeNull();
+  });
+});

--- a/src/ui/src/components/chat/planFilePath.ts
+++ b/src/ui/src/components/chat/planFilePath.ts
@@ -1,6 +1,14 @@
 import { useAppStore } from "../../stores/useAppStore";
 
-const PLAN_PATH_RE = /(\/[^\s)"`]+\/\.claude\/plans\/[^\s)"`]+\.md)/;
+// Match POSIX absolute paths pointing at `.claude/plans/*.md`. Allows spaces
+// in directory segments (macOS home directories with spaces are legitimate)
+// but keeps the filename portion on a single path segment — otherwise a
+// stretch of prose like "see /a/.claude/plans/x.txt or /b/y.md" would match
+// across the intermediate directory boundary. Windows-style drive paths are
+// intentionally not matched — Claudette only targets macOS and Linux (see
+// CLAUDE.md).
+const PLAN_PATH_RE =
+  /(\/[^\r\n)"`]*?\/\.claude\/plans\/[^\r\n/)"`]+?\.md)(?=$|[\s)"'`.,:;!?])/;
 
 /**
  * Locate the most recent plan file path for the given workspace by scanning
@@ -27,8 +35,12 @@ export function findLatestPlanFilePath(workspaceId: string): string | null {
   const streamingMatch = streaming.match(PLAN_PATH_RE);
   if (streamingMatch) return streamingMatch[1];
 
+  // Tool activities are appended in insertion order, so iterate newest-first
+  // to match the "most recent" contract when a workspace has produced plans
+  // across multiple turns within the current session window.
   const activities = state.toolActivities[workspaceId] ?? [];
-  for (const activity of activities) {
+  for (let i = activities.length - 1; i >= 0; i--) {
+    const activity = activities[i];
     const match = (activity.inputJson + activity.resultText).match(
       PLAN_PATH_RE,
     );

--- a/src/ui/src/components/chat/planFilePath.ts
+++ b/src/ui/src/components/chat/planFilePath.ts
@@ -1,0 +1,39 @@
+import { useAppStore } from "../../stores/useAppStore";
+
+const PLAN_PATH_RE = /(\/[^\s)"`]+\/\.claude\/plans\/[^\s)"`]+\.md)/;
+
+/**
+ * Locate the most recent plan file path for the given workspace by scanning
+ * the current in-memory state — chat messages first (newest-first), then the
+ * active streaming buffer, then tool-activity input/result text, then the
+ * pending plan approval's `planFilePath`.
+ *
+ * Returns `null` if no `.claude/plans/*.md` path has been emitted yet.
+ *
+ * Used by `/plan open` so that the command keeps working after the user has
+ * already approved or denied the plan approval card (which clears the
+ * pending approval but leaves the plan file itself on disk).
+ */
+export function findLatestPlanFilePath(workspaceId: string): string | null {
+  const state = useAppStore.getState();
+
+  const messages = state.chatMessages[workspaceId] ?? [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const match = messages[i].content.match(PLAN_PATH_RE);
+    if (match) return match[1];
+  }
+
+  const streaming = state.streamingContent[workspaceId] ?? "";
+  const streamingMatch = streaming.match(PLAN_PATH_RE);
+  if (streamingMatch) return streamingMatch[1];
+
+  const activities = state.toolActivities[workspaceId] ?? [];
+  for (const activity of activities) {
+    const match = (activity.inputJson + activity.resultText).match(
+      PLAN_PATH_RE,
+    );
+    if (match) return match[1];
+  }
+
+  return state.planApprovals[workspaceId]?.planFilePath ?? null;
+}


### PR DESCRIPTION
## Summary

Implements the workspace-control slash commands from #242 on top of the native slash command framework.

Each command reflects and mutates the **same** per-workspace store state the chat toolbar and keyboard shortcut already own — no parallel state machine:

- **`/clear`** — reuses the existing `clear_conversation` tauri command to clear chat history. Takes **no arguments**; file restore is reachable only through the rollback modal where it requires explicit confirmation. Mirrors the RollbackModal post-clear cleanup (rollback store, reload completed turns + attachments, refresh diff). Gated on remote workspaces with a clear local message — the whole `/clear` pipeline is local-Tauri-only today, matching RollbackModal's boundary.
- **`/plan [on|off|toggle|open]`** — bare `/plan` (and `/plan toggle`) **toggles** plan mode; `/plan on`/`off` set explicitly; `/plan open` reads the pending plan file. All paths drive the same `planMode` flag Shift+Tab and the toolbar toggle.
- **`/model [<id>]`** — no-arg lists models with current highlighted; `<id>` validates against the `MODELS` table case-insensitively, then runs the same persist + session-reset + fast-mode/effort-normalization path `ChatToolbar.handleModelSelect` uses. Both call sites share the new `applySelectedModel` helper so they cannot drift.
- **`/permissions [readonly|standard|full]`** (alias `/allowed-tools`) — reads and persists the same HeaderMenu permission level. `/allowed-tools` is a real alias wired through both the picker filter and the handler dispatcher.
- **`/status`** — emits a single local `System` chat message summarizing repo, branch, agent status, model, permission, plan, fast/thinking/chrome, and effort.

All commands are registered in `native_command_registry` with `kind=LocalAction` and appropriate argument hints. Workspace-control natives yield to user/project markdown commands of the same name, matching main's collision policy for non-reserved natives.

## Framework extension

Minimal additions to the native-slash framework:

- `NativeCommandContext` gains per-workspace read state (`selectedModel`, `permissionLevel`, `planMode`, `fastMode`, `thinkingEnabled`, `chromeEnabled`, `effortLevel`, `pendingPlanFilePath`, `agentStatus`, `workspaceId`) and write callbacks (`setSelectedModel`, `setPermissionLevel`, `setPlanMode`, `clearConversation`, `readPlanFile`). Callbacks are pre-bound to the active workspace.
- `NativeHandler.execute` now returns `NativeCommandResult | Promise<NativeCommandResult>` so `/clear`, `/model`, and `/permissions` can run async backend work. `ChatPanel.handleSend` awaits the result.
- Local output is rendered via ephemeral local `System` messages through `ctx.addLocalMessage` — same pattern `CommandPalette` and `ConfirmSetupScriptModal` already use.

Supporting refactors:

- **`modelRegistry.ts`** — extracted `MODELS` metadata to a non-React module so slash-command logic (and its tests) does not transitively import `ModelSelector.tsx`'s React + CSS deps. `ModelSelector` re-exports for existing consumers.
- **`applySelectedModel.ts`** — shared helper owning the full model-switch protocol (persist, reset agent session, clear pending question/plan approval, drop fast/xhigh/max flags for models that don't support them). `ChatToolbar.handleModelSelect` and the `/model` slash command both call into it.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets` — 0 warnings
- [x] `cargo test --all-features` — 388 passed
- [x] `bun run test` (vitest) — 416 passed, including new unit tests across the 5 handlers (canonical + alias resolution, no-arg behavior, arg parsing, state-mutation invocations, unknown-arg paths, async error surfacing) and picker-filter coverage for the new canonicals + alias
- [x] `bunx tsc --noEmit` clean
- [x] `bun run build` succeeds

## Post-merge manual UAT

- [ ] `/clear` with agent idle clears chat; with agent running surfaces backend error as local message; any argument is rejected
- [ ] `/plan` with no args toggles the toolbar Plan chip in the same render (shared state); `/plan open` echoes the current plan when a PlanApprovalCard is visible
- [ ] `/model sonnet` updates the toolbar chip and resets the session so the next send uses the new model
- [ ] `/permissions readonly` updates the HeaderMenu label and persists across workspace switches
- [ ] `/allowed-tools standard` works identically to `/permissions standard`
- [ ] `/status` emits a single readable summary

Closes #242