### PR TITLE
feat(chat): add /config, /usage, /extra-usage, /release-notes, /version commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tags
 
 # Claude Code
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Superpowers brainstorm
 .superpowers/

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -10,8 +10,15 @@ pub async fn get_claude_code_usage(state: State<'_, AppState>) -> Result<ClaudeC
 
 #[tauri::command]
 pub async fn open_usage_settings() -> Result<(), String> {
-    let url = "https://claude.ai/settings/usage";
+    open_external_url("https://claude.ai/settings/usage").await
+}
 
+#[tauri::command]
+pub async fn open_release_notes() -> Result<(), String> {
+    open_external_url("https://github.com/utensils/Claudette/releases").await
+}
+
+async fn open_external_url(url: &str) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         tokio::process::Command::new("open")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -402,6 +402,7 @@ fn main() {
             // Usage
             commands::usage::get_claude_code_usage,
             commands::usage::open_usage_settings,
+            commands::usage::open_release_notes,
             // Local server
             commands::remote::start_local_server,
             commands::remote::stop_local_server,

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -238,12 +238,15 @@ fn collect_native_commands(commands: &mut Vec<SlashCommand>, plugin_management_e
     for native in natives {
         let lowered = native.name.to_ascii_lowercase();
         if !is_reserved_native_name(&lowered)
-            && commands
-                .iter()
-                .any(|existing| existing.name.eq_ignore_ascii_case(&native.name))
+            && commands.iter().any(|existing| {
+                existing.name.eq_ignore_ascii_case(&native.name)
+                    && matches!(existing.source.as_str(), "user" | "project")
+            })
         {
-            // A user/project/plugin file-based command already owns this slot;
-            // the native is non-reserved, so let the custom command win.
+            // A user/project markdown command already owns this slot; the
+            // native is non-reserved, so let the custom command win. Plugin
+            // commands do NOT get this precedence — only humans editing
+            // `.claude/commands/*.md` should be able to override built-ins.
             continue;
         }
         upsert_command(commands, native);
@@ -822,6 +825,25 @@ mod tests {
         assert!(names.contains(&"version"));
         assert!(names.contains(&"security-review"));
         assert!(names.contains(&"pr-comments"));
+    }
+
+    #[test]
+    fn test_collect_native_commands_ignores_plugin_source_shadows() {
+        // Plugin-provided commands must NOT override non-reserved natives:
+        // the user/project markdown precedence applies to humans editing
+        // `.claude/commands/*.md`, not to anything a plugin drops in.
+        let mut commands = vec![
+            SlashCommand::file_based("config".into(), "Plugin hostile config".into(), "plugin"),
+            SlashCommand::file_based("usage".into(), "Plugin hostile usage".into(), "plugin"),
+        ];
+        collect_native_commands(&mut commands, true);
+
+        // The natives own these slots: both the builtin entry wins via upsert,
+        // and the plugin entries get replaced in place.
+        let config = commands.iter().find(|c| c.name == "config").unwrap();
+        assert_eq!(config.source, "builtin");
+        let usage = commands.iter().find(|c| c.name == "usage").unwrap();
+        assert_eq!(usage.source, "builtin");
     }
 
     #[test]

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -100,6 +100,48 @@ pub fn native_command_registry(plugin_management_enabled: bool) -> Vec<SlashComm
         argument_hint: Some("[PR number or extra guidance]".to_string()),
         kind: Some(NativeKind::PromptExpansion),
     });
+    commands.push(SlashCommand {
+        name: "config".to_string(),
+        description: "Open Claudette settings".to_string(),
+        source: "builtin".to_string(),
+        aliases: vec!["configure".to_string()],
+        argument_hint: Some(
+            "[general|models|usage|appearance|notifications|git|plugins|experimental]".to_string(),
+        ),
+        kind: Some(NativeKind::SettingsRoute),
+    });
+    commands.push(SlashCommand {
+        name: "usage".to_string(),
+        description: "Open the Claude Code usage panel".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: None,
+        kind: Some(NativeKind::SettingsRoute),
+    });
+    commands.push(SlashCommand {
+        name: "extra-usage".to_string(),
+        description: "Manage extra usage on claude.ai".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: None,
+        kind: Some(NativeKind::SettingsRoute),
+    });
+    commands.push(SlashCommand {
+        name: "release-notes".to_string(),
+        description: "Open Claudette release notes".to_string(),
+        source: "builtin".to_string(),
+        aliases: vec!["changelog".to_string()],
+        argument_hint: None,
+        kind: Some(NativeKind::LocalAction),
+    });
+    commands.push(SlashCommand {
+        name: "version".to_string(),
+        description: "Show the current Claudette version".to_string(),
+        source: "builtin".to_string(),
+        aliases: vec!["about".to_string()],
+        argument_hint: None,
+        kind: Some(NativeKind::LocalAction),
+    });
     commands
 }
 
@@ -176,21 +218,34 @@ struct PluginCommandSpec {
     explicit_description: Option<String>,
 }
 
+/// Native command names that always win against file-based commands.
+///
+/// `plugin`/`marketplace` control plugin management and cannot be shadowed —
+/// their aliases are also reserved so the picker never exposes an unreachable
+/// duplicate. Other native commands (`config`, `usage`, `version`, `review`, …)
+/// use plausible names that users may already have defined as local markdown
+/// commands, so they yield to file-based entries when a collision exists.
+fn is_reserved_native_name(name: &str) -> bool {
+    matches!(name, "plugin" | "plugins" | "marketplace")
+}
+
 fn collect_native_commands(commands: &mut Vec<SlashCommand>, plugin_management_enabled: bool) {
     let natives = native_command_registry(plugin_management_enabled);
-    // Drop any file-based command whose name collides with a native's canonical
-    // name or alias. The native registry owns these slots; otherwise the alias
-    // would resolve to the native handler while the file-based entry still
-    // rendered in the picker, creating an unreachable duplicate.
-    if !natives.is_empty() {
-        let reserved: std::collections::HashSet<String> = natives
-            .iter()
-            .flat_map(|cmd| std::iter::once(&cmd.name).chain(cmd.aliases.iter()))
-            .map(|name| name.to_ascii_lowercase())
-            .collect();
-        commands.retain(|cmd| !reserved.contains(&cmd.name.to_ascii_lowercase()));
-    }
+    // For reserved natives (plugin/marketplace), drop any file-based command
+    // whose name collides with the native canonical name or alias: the native
+    // registry owns those slots outright.
+    commands.retain(|cmd| !is_reserved_native_name(&cmd.name.to_ascii_lowercase()));
     for native in natives {
+        let lowered = native.name.to_ascii_lowercase();
+        if !is_reserved_native_name(&lowered)
+            && commands
+                .iter()
+                .any(|existing| existing.name.eq_ignore_ascii_case(&native.name))
+        {
+            // A user/project/plugin file-based command already owns this slot;
+            // the native is non-reserved, so let the custom command win.
+            continue;
+        }
         upsert_command(commands, native);
     }
 }
@@ -654,13 +709,19 @@ mod tests {
     fn test_collect_native_commands_skips_plugin_entries_when_disabled() {
         let mut commands = Vec::new();
         collect_native_commands(&mut commands, false);
-        let names: Vec<_> = commands.iter().map(|c| c.name.as_str()).collect();
+        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
         assert!(!names.contains(&"plugin"));
         assert!(!names.contains(&"marketplace"));
         // Review workflow entries are always present regardless of the plugin flag.
         assert!(names.contains(&"review"));
         assert!(names.contains(&"security-review"));
         assert!(names.contains(&"pr-comments"));
+        // Non-plugin native settings/version commands are still registered.
+        assert!(names.contains(&"config"));
+        assert!(names.contains(&"usage"));
+        assert!(names.contains(&"extra-usage"));
+        assert!(names.contains(&"release-notes"));
+        assert!(names.contains(&"version"));
     }
 
     #[test]
@@ -684,6 +745,83 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_native_command_registry_includes_settings_and_version_commands() {
+        for enabled in [true, false] {
+            let natives = native_command_registry(enabled);
+            let by_name: HashMap<&str, &SlashCommand> =
+                natives.iter().map(|c| (c.name.as_str(), c)).collect();
+
+            let config = by_name.get("config").expect("config registered");
+            assert_eq!(config.kind, Some(NativeKind::SettingsRoute));
+            assert_eq!(config.aliases, vec!["configure".to_string()]);
+            assert!(config.argument_hint.is_some());
+
+            let usage = by_name.get("usage").expect("usage registered");
+            assert_eq!(usage.kind, Some(NativeKind::SettingsRoute));
+            assert!(usage.aliases.is_empty());
+
+            let extra = by_name.get("extra-usage").expect("extra-usage registered");
+            assert_eq!(extra.kind, Some(NativeKind::SettingsRoute));
+
+            let release = by_name
+                .get("release-notes")
+                .expect("release-notes registered");
+            assert_eq!(release.kind, Some(NativeKind::LocalAction));
+            assert_eq!(release.aliases, vec!["changelog".to_string()]);
+
+            let version = by_name.get("version").expect("version registered");
+            assert_eq!(version.kind, Some(NativeKind::LocalAction));
+            assert_eq!(version.aliases, vec!["about".to_string()]);
+        }
+    }
+
+    #[test]
+    fn test_resolve_native_resolves_new_command_aliases() {
+        let natives = native_command_registry(false);
+        assert_eq!(
+            resolve_native("configure", &natives).unwrap().name,
+            "config"
+        );
+        assert_eq!(
+            resolve_native("CONFIGURE", &natives).unwrap().name,
+            "config"
+        );
+        assert_eq!(
+            resolve_native("changelog", &natives).unwrap().name,
+            "release-notes"
+        );
+        assert_eq!(resolve_native("about", &natives).unwrap().name, "version");
+    }
+
+    #[test]
+    fn test_collect_native_commands_yields_to_user_commands_for_non_reserved_slots() {
+        // A user-defined `config`/`review` command should take priority over the
+        // built-in natives — unlike plugin/marketplace, generic names like
+        // `config`/`usage`/`version`/`review` must not silently displace
+        // pre-existing custom workflows.
+        let mut commands = vec![
+            SlashCommand::file_based("config".into(), "User custom config".into(), "user"),
+            SlashCommand::file_based("review".into(), "Project custom review".into(), "project"),
+        ];
+        collect_native_commands(&mut commands, true);
+
+        let config = commands.iter().find(|c| c.name == "config").unwrap();
+        assert_eq!(config.source, "user");
+        assert_eq!(config.description, "User custom config");
+
+        let review = commands.iter().find(|c| c.name == "review").unwrap();
+        assert_eq!(review.source, "project");
+
+        // Other natives still register when no collision exists.
+        let names: Vec<&str> = commands.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"usage"));
+        assert!(names.contains(&"extra-usage"));
+        assert!(names.contains(&"version"));
+        assert!(names.contains(&"security-review"));
+        assert!(names.contains(&"pr-comments"));
     }
 
     #[test]

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "./stores/useAppStore";
 import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, clearAttention, detectInstalledApps, listSystemFonts } from "./services/tauri";
 import { applyTheme, applyUserFonts, loadAllThemes, findTheme } from "./utils/theme";
@@ -28,6 +29,7 @@ function App() {
   const setDetectedApps = useAppStore((s) => s.setDetectedApps);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
   const setPluginManagementEnabled = useAppStore((s) => s.setPluginManagementEnabled);
+  const setAppVersion = useAppStore((s) => s.setAppVersion);
 
   // Listen for MCP supervisor status events from the Rust backend.
   useMcpStatus();
@@ -79,6 +81,9 @@ function App() {
         applyUserFonts(sans, mono, size >= 10 && size <= 20 ? size : 13);
       })
       .catch((err) => console.error("Failed to load theme:", err));
+    getVersion()
+      .then((v) => setAppVersion(v))
+      .catch((err) => console.error("Failed to load app version:", err));
     listRemoteConnections()
       .then(setRemoteConnections)
       .catch((err) => console.error("Failed to load remote connections:", err));
@@ -196,7 +201,7 @@ function App() {
       unlistenZoomOut.then((fn) => fn());
       unlistenResetZoom.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setPluginManagementEnabled]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setPluginManagementEnabled, setAppVersion]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -149,6 +149,7 @@ export function ChatPanel() {
   const openSettings = useAppStore((s) => s.openSettings);
   const appVersion = useAppStore((s) => s.appVersion);
   const slashCommandsByWorkspace = useAppStore((s) => s.slashCommandsByWorkspace);
+  const setSlashCommandsCache = useAppStore((s) => s.setSlashCommands);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
@@ -444,18 +445,47 @@ export function ChatPanel() {
     // prompt_expansion commands can rewrite the prompt before it is sent.
     const parsedSlash = parseSlashInput(trimmed);
     if (parsedSlash) {
-      // A user- or project-defined file-based command with the same name takes
+      // A user- or project-defined markdown command with the same name takes
       // priority over non-reserved natives (plugin/marketplace remain reserved
-      // upstream in the backend registry). Skip native dispatch entirely when a
-      // file-based shadow exists so the custom markdown prompt reaches Claude.
-      const cmds = slashCommandsByWorkspace[selectedWorkspaceId] ?? [];
+      // upstream in the backend registry). Plugin-source commands do NOT get
+      // this precedence — only humans editing `.claude/commands/*.md` can
+      // override built-ins. Skip native dispatch when such a shadow exists so
+      // the custom markdown prompt reaches Claude.
+      //
+      // The slash-command cache is populated async by ChatInputArea on mount
+      // and on workspace change. If a user sends a slash command before that
+      // first fetch lands (rare but possible on fast startup), fall back to a
+      // synchronous fetch here so shadowing decisions are always made against
+      // a fresh list. The Rust side already returns a 5-minute cached result.
+      let cmds = slashCommandsByWorkspace[selectedWorkspaceId];
+      if (!cmds) {
+        try {
+          cmds = await listSlashCommands(repo?.path, selectedWorkspaceId);
+          setSlashCommandsCache(selectedWorkspaceId, cmds);
+        } catch (err) {
+          console.error("Failed to load slash commands before native dispatch:", err);
+          cmds = [];
+        }
+      }
       const tokenLower = parsedSlash.token.toLowerCase();
+      const candidateHandler = resolveNativeHandler(parsedSlash.token);
+      // Also guard against a user-defined command shadowing the native's
+      // canonical name or any of its aliases — e.g. `config.md` should
+      // disable `/configure` just as it disables `/config`, so the picker and
+      // the dispatcher stay consistent.
+      const shadowNames = new Set<string>([tokenLower]);
+      if (candidateHandler) {
+        shadowNames.add(candidateHandler.name.toLowerCase());
+        for (const alias of candidateHandler.aliases) {
+          shadowNames.add(alias.toLowerCase());
+        }
+      }
       const shadowed = cmds.some(
-        (c) => c.source !== "builtin" && c.name.toLowerCase() === tokenLower,
+        (c) =>
+          (c.source === "user" || c.source === "project") &&
+          shadowNames.has(c.name.toLowerCase()),
       );
-      const nativeHandler = shadowed
-        ? null
-        : resolveNativeHandler(parsedSlash.token);
+      const nativeHandler = shadowed ? null : candidateHandler;
       if (nativeHandler) {
         const workspaceId = selectedWorkspaceId;
         const result = nativeHandler.execute(

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -469,15 +469,21 @@ export function ChatPanel() {
       }
       const tokenLower = parsedSlash.token.toLowerCase();
       const candidateHandler = resolveNativeHandler(parsedSlash.token);
-      // Also guard against a user-defined command shadowing the native's
-      // canonical name or any of its aliases — e.g. `config.md` should
-      // disable `/configure` just as it disables `/config`, so the picker and
-      // the dispatcher stay consistent.
+      // Only same-name collisions shadow native dispatch. If the typed token
+      // is a native alias, also honor a file-based command for the canonical
+      // name — the user has replaced the whole native, so the alias should
+      // route through the replacement too. If the typed token is the
+      // canonical name, do NOT expand to aliases: a user `configure.md`
+      // should not hijack `/config` when the canonical slot is still the
+      // built-in.
       const shadowNames = new Set<string>([tokenLower]);
       if (candidateHandler) {
-        shadowNames.add(candidateHandler.name.toLowerCase());
-        for (const alias of candidateHandler.aliases) {
-          shadowNames.add(alias.toLowerCase());
+        const canonicalLower = candidateHandler.name.toLowerCase();
+        const typedIsAlias = candidateHandler.aliases.some(
+          (alias) => alias.toLowerCase() === tokenLower,
+        );
+        if (typedIsAlias) {
+          shadowNames.add(canonicalLower);
         }
       }
       const shadowed = cmds.some(

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -11,6 +11,8 @@ import {
   listCheckpoints,
   loadCompletedTurns,
   listSlashCommands,
+  openReleaseNotes,
+  openUsageSettings,
   recordSlashCommandUsage,
   sendChatMessage,
   sendRemoteCommand,
@@ -143,6 +145,8 @@ export function ChatPanel() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const openPluginSettings = useAppStore((s) => s.openPluginSettings);
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
+  const openSettings = useAppStore((s) => s.openSettings);
+  const appVersion = useAppStore((s) => s.appVersion);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
@@ -440,6 +444,7 @@ export function ChatPanel() {
     if (parsedSlash) {
       const nativeHandler = resolveNativeHandler(parsedSlash.token);
       if (nativeHandler) {
+        const workspaceId = selectedWorkspaceId;
         const result = nativeHandler.execute(
           {
             repoId: repo?.remote_connection_id ? null : repo?.id ?? null,
@@ -450,6 +455,30 @@ export function ChatPanel() {
               ? { branch: ws.branch_name, worktreePath: ws.worktree_path }
               : null,
             repoDefaultBranch: defaultBranch ?? null,
+            openSettings,
+            appVersion,
+            addLocalMessage: (text: string) => {
+              addChatMessage(workspaceId, {
+                id: crypto.randomUUID(),
+                workspace_id: workspaceId,
+                role: "System",
+                content: text,
+                cost_usd: null,
+                duration_ms: null,
+                created_at: new Date().toISOString(),
+                thinking: null,
+              });
+            },
+            openUsageSettingsExternal: () => {
+              void openUsageSettings().catch((err) =>
+                console.error("Failed to open usage settings:", err),
+              );
+            },
+            openReleaseNotes: () => {
+              void openReleaseNotes().catch((err) =>
+                console.error("Failed to open release notes:", err),
+              );
+            },
           },
           parsedSlash.args,
         );

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -145,8 +145,10 @@ export function ChatPanel() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const openPluginSettings = useAppStore((s) => s.openPluginSettings);
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
+  const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
   const openSettings = useAppStore((s) => s.openSettings);
   const appVersion = useAppStore((s) => s.appVersion);
+  const slashCommandsByWorkspace = useAppStore((s) => s.slashCommandsByWorkspace);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
@@ -442,13 +444,25 @@ export function ChatPanel() {
     // prompt_expansion commands can rewrite the prompt before it is sent.
     const parsedSlash = parseSlashInput(trimmed);
     if (parsedSlash) {
-      const nativeHandler = resolveNativeHandler(parsedSlash.token);
+      // A user- or project-defined file-based command with the same name takes
+      // priority over non-reserved natives (plugin/marketplace remain reserved
+      // upstream in the backend registry). Skip native dispatch entirely when a
+      // file-based shadow exists so the custom markdown prompt reaches Claude.
+      const cmds = slashCommandsByWorkspace[selectedWorkspaceId] ?? [];
+      const tokenLower = parsedSlash.token.toLowerCase();
+      const shadowed = cmds.some(
+        (c) => c.source !== "builtin" && c.name.toLowerCase() === tokenLower,
+      );
+      const nativeHandler = shadowed
+        ? null
+        : resolveNativeHandler(parsedSlash.token);
       if (nativeHandler) {
         const workspaceId = selectedWorkspaceId;
         const result = nativeHandler.execute(
           {
             repoId: repo?.remote_connection_id ? null : repo?.id ?? null,
             pluginManagementEnabled,
+            usageInsightsEnabled,
             openPluginSettings,
             repository: repo ? { name: repo.name, path: repo.path } : null,
             workspace: ws
@@ -1338,7 +1352,15 @@ function ChatInputArea({
   const [cursorPos, setCursorPos] = useState(0);
   const [slashPickerIndex, setSlashPickerIndex] = useState(0);
   const [slashPickerDismissed, setSlashPickerDismissed] = useState(false);
-  const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
+  const [slashCommands, setSlashCommandsLocal] = useState<SlashCommand[]>([]);
+  const setSlashCommandsStore = useAppStore((s) => s.setSlashCommands);
+  const setSlashCommands = useCallback(
+    (cmds: SlashCommand[]) => {
+      setSlashCommandsLocal(cmds);
+      setSlashCommandsStore(selectedWorkspaceId, cmds);
+    },
+    [selectedWorkspaceId, setSlashCommandsStore],
+  );
   const [filePickerIndex, setFilePickerIndex] = useState(0);
   const [filePickerDismissed, setFilePickerDismissed] = useState(false);
   const [workspaceFiles, setWorkspaceFiles] = useState<FileEntry[]>([]);

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -17,6 +17,7 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
   return {
     repoId: "repo-1",
     pluginManagementEnabled: true,
+    usageInsightsEnabled: true,
     openPluginSettings: vi.fn<(intent: Partial<PluginSettingsIntent>) => void>(),
     repository: { name: "claudette", path: "/tmp/repos/claudette" },
     workspace: { branch: "feat/review-cmds", worktreePath: "/tmp/wt/review-cmds" },
@@ -448,6 +449,13 @@ describe("config native handler", () => {
     }
   });
 
+  it("redirects /config usage to experimental when Usage Insights is disabled", () => {
+    const ctx = makeCtx({ usageInsightsEnabled: false });
+    const handler = resolveNativeHandler("config")!;
+    handler.execute(ctx, "usage");
+    expect(ctx.openSettings).toHaveBeenCalledWith("experimental");
+  });
+
   it("is case-insensitive for section names", () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("config")!;
@@ -472,7 +480,7 @@ describe("config native handler", () => {
 });
 
 describe("usage native handler", () => {
-  it("resolves /usage and opens the usage settings section", () => {
+  it("resolves /usage and opens the usage settings section when the gate is on", () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("usage")!;
     const result = handler.execute(ctx, "");
@@ -480,16 +488,31 @@ describe("usage native handler", () => {
     expect(ctx.openSettings).toHaveBeenCalledWith("usage");
     expect(ctx.openUsageSettingsExternal).not.toHaveBeenCalled();
   });
+
+  it("routes /usage to Experimental when Usage Insights is disabled", () => {
+    const ctx = makeCtx({ usageInsightsEnabled: false });
+    const handler = resolveNativeHandler("usage")!;
+    handler.execute(ctx, "");
+    expect(ctx.openSettings).toHaveBeenCalledWith("experimental");
+  });
 });
 
 describe("extra-usage native handler", () => {
-  it("resolves /extra-usage and reuses both the in-app and external usage paths", () => {
+  it("reuses both the in-app and external usage paths when the gate is on", () => {
     const ctx = makeCtx();
     const handler = resolveNativeHandler("extra-usage")!;
     const result = handler.execute(ctx, "");
     expect(result).toEqual({ kind: "handled", canonicalName: "extra-usage" });
     expect(ctx.openSettings).toHaveBeenCalledWith("usage");
     expect(ctx.openUsageSettingsExternal).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes /extra-usage to Experimental and does NOT launch claude.ai when gated off", () => {
+    const ctx = makeCtx({ usageInsightsEnabled: false });
+    const handler = resolveNativeHandler("extra-usage")!;
+    handler.execute(ctx, "");
+    expect(ctx.openSettings).toHaveBeenCalledWith("experimental");
+    expect(ctx.openUsageSettingsExternal).not.toHaveBeenCalled();
   });
 });
 

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { PluginSettingsIntent } from "../../types/plugins";
 import {
+  CONFIG_SECTIONS,
   NATIVE_HANDLERS,
   describeSlashQuery,
+  formatVersionMessage,
   parseSlashInput,
   resolveNativeHandler,
   type NativeCommandContext,
@@ -19,6 +21,11 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     repository: { name: "claudette", path: "/tmp/repos/claudette" },
     workspace: { branch: "feat/review-cmds", worktreePath: "/tmp/wt/review-cmds" },
     repoDefaultBranch: "origin/main",
+    openSettings: vi.fn<(section?: string) => void>(),
+    appVersion: "1.2.3",
+    addLocalMessage: vi.fn<(text: string) => void>(),
+    openUsageSettingsExternal: vi.fn<() => void>(),
+    openReleaseNotes: vi.fn<() => void>(),
     ...overrides,
   };
 }
@@ -220,6 +227,24 @@ describe("native handler table", () => {
       expect(handler!.aliases).toEqual([]);
     }
   });
+
+  it("exposes config, usage, extra-usage, release-notes, and version entries", () => {
+    const names = NATIVE_HANDLERS.map((h) => h.name);
+    expect(names).toContain("config");
+    expect(names).toContain("usage");
+    expect(names).toContain("extra-usage");
+    expect(names).toContain("release-notes");
+    expect(names).toContain("version");
+  });
+
+  it("declares the expected kinds for the settings/version handlers", () => {
+    const byName = new Map(NATIVE_HANDLERS.map((h) => [h.name, h]));
+    expect(byName.get("config")?.kind).toBe("settings_route");
+    expect(byName.get("usage")?.kind).toBe("settings_route");
+    expect(byName.get("extra-usage")?.kind).toBe("settings_route");
+    expect(byName.get("release-notes")?.kind).toBe("local_action");
+    expect(byName.get("version")?.kind).toBe("local_action");
+  });
 });
 
 describe("review workflow native handlers", () => {
@@ -394,5 +419,123 @@ describe("review workflow native handlers", () => {
     });
     const unique = new Set(prompts);
     expect(unique.size).toBe(REVIEW_NAMES.length);
+  });
+});
+
+describe("config native handler", () => {
+  it("opens settings with the default general section when no args given", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("config")!;
+    const result = handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "config" });
+    expect(ctx.openSettings).toHaveBeenCalledTimes(1);
+    expect(ctx.openSettings).toHaveBeenCalledWith("general");
+  });
+
+  it("resolves the /configure alias to the config handler", () => {
+    expect(resolveNativeHandler("configure")?.name).toBe("config");
+    expect(resolveNativeHandler("CONFIGURE")?.name).toBe("config");
+  });
+
+  it("routes each valid section to openSettings with that section", () => {
+    const handler = resolveNativeHandler("config")!;
+    for (const section of CONFIG_SECTIONS) {
+      const ctx = makeCtx();
+      const result = handler.execute(ctx, section);
+      expect(result).toEqual({ kind: "handled", canonicalName: "config" });
+      expect(ctx.openSettings).toHaveBeenCalledTimes(1);
+      expect(ctx.openSettings).toHaveBeenCalledWith(section);
+    }
+  });
+
+  it("is case-insensitive for section names", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("config")!;
+    handler.execute(ctx, "APPEARANCE");
+    expect(ctx.openSettings).toHaveBeenCalledWith("appearance");
+  });
+
+  it("ignores extra arguments after the section token", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("config")!;
+    handler.execute(ctx, "models foo bar");
+    expect(ctx.openSettings).toHaveBeenCalledWith("models");
+  });
+
+  it("falls back to general for an unknown section", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("config")!;
+    const result = handler.execute(ctx, "bogus-section");
+    expect(result).toEqual({ kind: "handled", canonicalName: "config" });
+    expect(ctx.openSettings).toHaveBeenCalledWith("general");
+  });
+});
+
+describe("usage native handler", () => {
+  it("resolves /usage and opens the usage settings section", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("usage")!;
+    const result = handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "usage" });
+    expect(ctx.openSettings).toHaveBeenCalledWith("usage");
+    expect(ctx.openUsageSettingsExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("extra-usage native handler", () => {
+  it("resolves /extra-usage and reuses both the in-app and external usage paths", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("extra-usage")!;
+    const result = handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "extra-usage" });
+    expect(ctx.openSettings).toHaveBeenCalledWith("usage");
+    expect(ctx.openUsageSettingsExternal).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("release-notes native handler", () => {
+  it("resolves /release-notes and routes through openReleaseNotes", () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("release-notes")!;
+    const result = handler.execute(ctx, "");
+    expect(result).toEqual({
+      kind: "handled",
+      canonicalName: "release-notes",
+    });
+    expect(ctx.openReleaseNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves the /changelog alias to the release-notes handler", () => {
+    expect(resolveNativeHandler("changelog")?.name).toBe("release-notes");
+  });
+});
+
+describe("version native handler", () => {
+  it("formats the version string with a v-prefix", () => {
+    expect(formatVersionMessage("1.2.3")).toBe("Claudette v1.2.3");
+  });
+
+  it("falls back to 'unknown' when no version is available", () => {
+    expect(formatVersionMessage(null)).toBe("Claudette vunknown");
+  });
+
+  it("posts a local message containing the provided app version", () => {
+    const ctx = makeCtx({ appVersion: "9.9.9" });
+    const handler = resolveNativeHandler("version")!;
+    const result = handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "version" });
+    expect(ctx.addLocalMessage).toHaveBeenCalledTimes(1);
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Claudette v9.9.9");
+  });
+
+  it("posts a local 'unknown' fallback when appVersion is null", () => {
+    const ctx = makeCtx({ appVersion: null });
+    const handler = resolveNativeHandler("version")!;
+    handler.execute(ctx, "");
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith("Claudette vunknown");
+  });
+
+  it("resolves the /about alias to the version handler", () => {
+    expect(resolveNativeHandler("about")?.name).toBe("version");
   });
 });

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -22,6 +22,7 @@ export type ConfigSection = (typeof CONFIG_SECTIONS)[number];
 export interface NativeCommandContext {
   repoId: string | null;
   pluginManagementEnabled: boolean;
+  usageInsightsEnabled: boolean;
   openPluginSettings: (intent: Partial<PluginSettingsIntent>) => void;
   /** Repository metadata for the current workspace — used by review-workflow handlers. */
   repository: { name: string; path: string } | null;
@@ -253,9 +254,17 @@ const configHandler: NativeHandler = {
   execute: (ctx, args) => {
     const first = args.trim().split(/\s+/, 1)[0] ?? "";
     const lowered = first.toLowerCase();
-    const section = (CONFIG_SECTIONS as readonly string[]).includes(lowered)
+    const validSection = (CONFIG_SECTIONS as readonly string[]).includes(lowered)
       ? (lowered as ConfigSection)
       : "general";
+    // Respect the Usage Insights experimental gate: when the user hasn't
+    // opted in, the settings sidebar hides the Usage row, so `/config usage`
+    // should land on Experimental where the toggle lives instead of silently
+    // opening the hidden page.
+    const section =
+      validSection === "usage" && !ctx.usageInsightsEnabled
+        ? "experimental"
+        : validSection;
     ctx.openSettings(section);
     return { kind: "handled", canonicalName: "config" };
   },
@@ -266,7 +275,8 @@ const usageHandler: NativeHandler = {
   aliases: [],
   kind: "settings_route",
   execute: (ctx) => {
-    ctx.openSettings("usage");
+    // Mirror `/config usage` — route to Experimental when the gate is off.
+    ctx.openSettings(ctx.usageInsightsEnabled ? "usage" : "experimental");
     return { kind: "handled", canonicalName: "usage" };
   },
 };
@@ -276,9 +286,15 @@ const extraUsageHandler: NativeHandler = {
   aliases: [],
   kind: "settings_route",
   execute: (ctx) => {
-    // Reuse the existing in-app usage panel (which shows extra-usage status
-    // and a Manage/Enable link) and also deep-link to claude.ai settings so
-    // the user can toggle extra usage immediately in either state.
+    if (!ctx.usageInsightsEnabled) {
+      // Gate off: do not surface the hidden panel and do not launch claude.ai.
+      // Send the user to Experimental where they can opt in first.
+      ctx.openSettings("experimental");
+      return { kind: "handled", canonicalName: "extra-usage" };
+    }
+    // Reuse the in-app usage panel (which shows extra-usage status and a
+    // Manage/Enable link) and deep-link to claude.ai settings so the user can
+    // toggle extra usage immediately in either state.
     ctx.openSettings("usage");
     ctx.openUsageSettingsExternal();
     return { kind: "handled", canonicalName: "extra-usage" };

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -4,6 +4,21 @@ import { parsePluginSlashCommand } from "./pluginSlashCommand";
 
 export type { NativeSlashKind };
 
+/** Valid section ids accepted by `/config <section>`. Mirrors the sections
+ *  handled by `SettingsPage.tsx`. Unknown/empty sections fall back to `general`. */
+export const CONFIG_SECTIONS = [
+  "general",
+  "models",
+  "usage",
+  "appearance",
+  "notifications",
+  "git",
+  "plugins",
+  "experimental",
+] as const;
+
+export type ConfigSection = (typeof CONFIG_SECTIONS)[number];
+
 export interface NativeCommandContext {
   repoId: string | null;
   pluginManagementEnabled: boolean;
@@ -20,6 +35,11 @@ export interface NativeCommandContext {
    * the real review base via git/gh.
    */
   repoDefaultBranch: string | null;
+  openSettings: (section?: string) => void;
+  appVersion: string | null;
+  addLocalMessage: (text: string) => void;
+  openUsageSettingsExternal: () => void;
+  openReleaseNotes: () => void;
 }
 
 export type NativeCommandResult =
@@ -226,12 +246,81 @@ function reviewHandler(
   };
 }
 
+const configHandler: NativeHandler = {
+  name: "config",
+  aliases: ["configure"],
+  kind: "settings_route",
+  execute: (ctx, args) => {
+    const first = args.trim().split(/\s+/, 1)[0] ?? "";
+    const lowered = first.toLowerCase();
+    const section = (CONFIG_SECTIONS as readonly string[]).includes(lowered)
+      ? (lowered as ConfigSection)
+      : "general";
+    ctx.openSettings(section);
+    return { kind: "handled", canonicalName: "config" };
+  },
+};
+
+const usageHandler: NativeHandler = {
+  name: "usage",
+  aliases: [],
+  kind: "settings_route",
+  execute: (ctx) => {
+    ctx.openSettings("usage");
+    return { kind: "handled", canonicalName: "usage" };
+  },
+};
+
+const extraUsageHandler: NativeHandler = {
+  name: "extra-usage",
+  aliases: [],
+  kind: "settings_route",
+  execute: (ctx) => {
+    // Reuse the existing in-app usage panel (which shows extra-usage status
+    // and a Manage/Enable link) and also deep-link to claude.ai settings so
+    // the user can toggle extra usage immediately in either state.
+    ctx.openSettings("usage");
+    ctx.openUsageSettingsExternal();
+    return { kind: "handled", canonicalName: "extra-usage" };
+  },
+};
+
+const releaseNotesHandler: NativeHandler = {
+  name: "release-notes",
+  aliases: ["changelog"],
+  kind: "local_action",
+  execute: (ctx) => {
+    ctx.openReleaseNotes();
+    return { kind: "handled", canonicalName: "release-notes" };
+  },
+};
+
+/** Format the text shown by `/version`. Exported for testing. */
+export function formatVersionMessage(version: string | null): string {
+  return `Claudette v${version ?? "unknown"}`;
+}
+
+const versionHandler: NativeHandler = {
+  name: "version",
+  aliases: ["about"],
+  kind: "local_action",
+  execute: (ctx) => {
+    ctx.addLocalMessage(formatVersionMessage(ctx.appVersion));
+    return { kind: "handled", canonicalName: "version" };
+  },
+};
+
 export const NATIVE_HANDLERS: NativeHandler[] = [
   pluginHandler("plugin"),
   pluginHandler("marketplace"),
   reviewHandler("review", REVIEW_PROMPT),
   reviewHandler("security-review", SECURITY_REVIEW_PROMPT),
   reviewHandler("pr-comments", PR_COMMENTS_PROMPT),
+  configHandler,
+  usageHandler,
+  extraUsageHandler,
+  releaseNotesHandler,
+  versionHandler,
 ];
 
 /** Resolve a slash command token (no leading `/`) against the native handler table. */
@@ -249,4 +338,3 @@ export function resolveNativeHandler(
     ) ?? null
   );
 }
-

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -689,6 +689,10 @@ export function openUsageSettings(): Promise<void> {
   return invoke("open_usage_settings");
 }
 
+export function openReleaseNotes(): Promise<void> {
+  return invoke("open_release_notes");
+}
+
 // -- Debug (dev builds only) --
 
 export function debugEvalJs(js: string): Promise<string> {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -20,6 +20,7 @@ import type { McpStatusSnapshot } from "../types/mcp";
 import type { RemoteInitialData } from "../types/remote";
 import type { DetectedApp } from "../types/apps";
 import type { ClaudeCodeUsage } from "../types/usage";
+import type { SlashCommand } from "../services/tauri";
 import type {
   PluginSettingsIntent,
   PluginSettingsTab,
@@ -345,6 +346,10 @@ interface AppState {
   // -- App info --
   appVersion: string | null;
   setAppVersion: (version: string | null) => void;
+
+  // -- Slash commands (shared so native dispatch can honor file-based shadows) --
+  slashCommandsByWorkspace: Record<string, SlashCommand[]>;
+  setSlashCommands: (wsId: string, cmds: SlashCommand[]) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -1152,6 +1157,13 @@ export const useAppStore = create<AppState>((set) => ({
   // -- App info --
   appVersion: null,
   setAppVersion: (version) => set({ appVersion: version }),
+
+  // -- Slash commands --
+  slashCommandsByWorkspace: {},
+  setSlashCommands: (wsId, cmds) =>
+    set((s) => ({
+      slashCommandsByWorkspace: { ...s.slashCommandsByWorkspace, [wsId]: cmds },
+    })),
 }));
 
 // Expose store on window in dev builds for debug_eval_js access.

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -341,6 +341,10 @@ interface AppState {
   setUpdateInstallWhenIdle: (enabled: boolean) => void;
   setUpdateDownloading: (downloading: boolean) => void;
   setUpdateProgress: (progress: number) => void;
+
+  // -- App info --
+  appVersion: string | null;
+  setAppVersion: (version: string | null) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -1144,6 +1148,10 @@ export const useAppStore = create<AppState>((set) => ({
   setUpdateDownloading: (downloading) =>
     set({ updateDownloading: downloading }),
   setUpdateProgress: (progress) => set({ updateProgress: progress }),
+
+  // -- App info --
+  appVersion: null,
+  setAppVersion: (version) => set({ appVersion: version }),
 }));
 
 // Expose store on window in dev builds for debug_eval_js access.


### PR DESCRIPTION
## Summary

- Adds five native slash commands on top of the framework from #248, routing into existing settings and version surfaces rather than duplicating them:
  - `/config [section]` (alias `/configure`) — opens settings; sections: `general`, `models`, `usage`, `appearance`, `notifications`, `git`, `plugins`, `experimental`; unknown → `general`.
  - `/usage` — opens the in-app usage panel.
  - `/extra-usage` — opens the in-app usage panel and deep-links to `claude.ai/settings/usage`.
  - `/release-notes` (alias `/changelog`) — opens the GitHub releases page via a new `open_release_notes` Tauri command sharing an `open_external_url` helper with `open_usage_settings`.
  - `/version` (alias `/about`) — posts a local System message with the app version from the same `getVersion()` source used in `GeneralSettings` (loaded once at app init into the Zustand store).
- Non-`plugin`/`marketplace` natives yield to file-based user/project markdown commands with the same name. The Rust picker skips the native when a file-based entry already owns the slot; the frontend dispatcher honors the same rule by consulting a shared slash-command cache.
- `/usage`, `/extra-usage`, and `/config usage` respect the existing `usageInsightsEnabled` experimental gate — when disabled they redirect to the Experimental settings section (mirroring the `pluginManagementEnabled` pattern), and `/extra-usage` does not launch `claude.ai` until the user opts in.

Closes #243

## Test plan

- [x] `cargo fmt --all --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets`
- [x] `cargo test --all-features --workspace` (476 tests)
- [x] `bun run test` in `src/ui` (348 tests)
- [x] `bunx tsc --noEmit` clean
- [ ] Manual UAT: `/config appearance`, `/usage`, `/extra-usage` with Usage Insights both on and off, `/release-notes`, `/version`, and user-defined `.claude/commands/config.md` overriding `/config`