### PR TITLE
feat: discover and import existing git worktrees when adding repos

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -94,12 +94,7 @@ pub async fn create_workspace(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CreateWorkspaceResult, String> {
-    // Validate workspace name: must be ASCII alphanumeric + hyphens only (branch-safe).
-    if name.is_empty()
-        || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
-        || name.starts_with('-')
-        || name.ends_with('-')
-    {
+    if !is_valid_workspace_name(&name) {
         return Err(format!("Invalid workspace name: '{name}'"));
     }
 
@@ -652,6 +647,10 @@ pub struct WorktreeImport {
 }
 
 /// Import existing git worktrees as Claudette workspaces.
+///
+/// Re-validates each import against `git worktree list` to ensure the paths
+/// are genuine linked worktrees. All inserts are atomic — either all succeed
+/// or none are committed.
 #[tauri::command]
 pub async fn import_worktrees(
     repo_id: String,
@@ -661,31 +660,48 @@ pub async fn import_worktrees(
 ) -> Result<Vec<Workspace>, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let repos = db.list_repositories().map_err(|e| e.to_string())?;
-    let _repo = repos
+    let repo = repos
         .iter()
         .find(|r| r.id == repo_id)
         .ok_or("Repository not found")?;
 
+    // Re-validate imports against the actual git worktree list.
+    let worktrees = git::list_worktrees(&repo.path)
+        .await
+        .map_err(|e| e.to_string())?;
+    let valid_worktree_paths: std::collections::HashSet<String> = worktrees
+        .iter()
+        .filter(|wt| wt.branch.is_some() && !wt.is_bare)
+        .filter_map(|wt| {
+            std::fs::canonicalize(&wt.path)
+                .map(|p| p.to_string_lossy().to_string())
+                .ok()
+        })
+        .collect();
+
     let mut created = Vec::new();
 
-    for imp in imports {
+    for imp in &imports {
         if !is_valid_workspace_name(&imp.name) {
             return Err(format!("Invalid workspace name: '{}'", imp.name));
-        }
-
-        if !Path::new(&imp.path).is_dir() {
-            return Err(format!("Worktree path does not exist: '{}'", imp.path));
         }
 
         let canon = std::fs::canonicalize(&imp.path)
             .map_err(|e| format!("Invalid path '{}': {e}", imp.path))?;
         let canon_str = canon.to_string_lossy().to_string();
 
+        if !valid_worktree_paths.contains(&canon_str) {
+            return Err(format!(
+                "'{}' is not a linked worktree of this repository",
+                imp.path
+            ));
+        }
+
         let ws = Workspace {
             id: uuid::Uuid::new_v4().to_string(),
             repository_id: repo_id.clone(),
-            name: imp.name,
-            branch_name: imp.branch_name,
+            name: imp.name.clone(),
+            branch_name: imp.branch_name.clone(),
             worktree_path: Some(canon_str),
             status: WorkspaceStatus::Active,
             agent_status: AgentStatus::Idle,
@@ -693,9 +709,12 @@ pub async fn import_worktrees(
             created_at: now_iso(),
         };
 
-        db.insert_workspace(&ws).map_err(|e| e.to_string())?;
         created.push(ws);
     }
+
+    // Atomic batch insert — all or nothing.
+    db.insert_workspaces_batch(&created)
+        .map_err(|e| e.to_string())?;
 
     crate::tray::rebuild_tray(&app);
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 use tokio::process::Command as TokioCommand;
 
@@ -540,6 +540,166 @@ pub async fn refresh_branches(state: State<'_, AppState>) -> Result<Vec<(String,
     }
 
     Ok(updates)
+}
+
+#[derive(Serialize)]
+pub struct DiscoveredWorktree {
+    pub path: String,
+    pub branch_name: String,
+    pub head_sha: String,
+    pub suggested_name: String,
+    pub name_valid: bool,
+}
+
+/// Validate a workspace name: ASCII alphanumeric + hyphens, no leading/trailing hyphens.
+fn is_valid_workspace_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        && !name.starts_with('-')
+        && !name.ends_with('-')
+}
+
+/// Discover existing git worktrees for a repository that are not yet tracked in Claudette.
+#[tauri::command]
+pub async fn discover_worktrees(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<DiscoveredWorktree>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let repo = repos
+        .iter()
+        .find(|r| r.id == repo_id)
+        .ok_or("Repository not found")?;
+
+    let worktrees = git::list_worktrees(&repo.path)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Build sets of already-tracked paths and branches for filtering.
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let tracked_paths: std::collections::HashSet<String> = workspaces
+        .iter()
+        .filter(|w| w.repository_id == repo_id)
+        .filter_map(|w| w.worktree_path.clone())
+        .collect();
+    let tracked_branches: std::collections::HashSet<&str> = workspaces
+        .iter()
+        .filter(|w| w.repository_id == repo_id)
+        .map(|w| w.branch_name.as_str())
+        .collect();
+
+    let repo_canon = std::fs::canonicalize(&repo.path)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| repo.path.clone());
+
+    let mut discovered = Vec::new();
+
+    for wt in worktrees {
+        // Skip the main repo entry.
+        let wt_canon = std::fs::canonicalize(&wt.path)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| wt.path.clone());
+        if wt_canon == repo_canon || wt.is_bare {
+            continue;
+        }
+
+        // Skip detached HEAD worktrees.
+        let branch = match &wt.branch {
+            Some(b) => b.clone(),
+            None => continue,
+        };
+
+        // Skip worktrees that don't exist on disk.
+        if !Path::new(&wt.path).is_dir() {
+            continue;
+        }
+
+        // Skip already-tracked worktrees.
+        if tracked_paths.contains(&wt_canon) || tracked_branches.contains(branch.as_str()) {
+            continue;
+        }
+
+        let suggested_name = Path::new(&wt.path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+
+        let name_valid = is_valid_workspace_name(&suggested_name);
+
+        discovered.push(DiscoveredWorktree {
+            path: wt_path_display(&wt.path),
+            branch_name: branch,
+            head_sha: wt.head,
+            suggested_name,
+            name_valid,
+        });
+    }
+
+    Ok(discovered)
+}
+
+/// Return a display-friendly path (use the raw path, not canonicalized).
+fn wt_path_display(path: &str) -> String {
+    path.to_string()
+}
+
+#[derive(Deserialize)]
+pub struct WorktreeImport {
+    pub path: String,
+    pub branch_name: String,
+    pub name: String,
+}
+
+/// Import existing git worktrees as Claudette workspaces.
+#[tauri::command]
+pub async fn import_worktrees(
+    repo_id: String,
+    imports: Vec<WorktreeImport>,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Vec<Workspace>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let _repo = repos
+        .iter()
+        .find(|r| r.id == repo_id)
+        .ok_or("Repository not found")?;
+
+    let mut created = Vec::new();
+
+    for imp in imports {
+        if !is_valid_workspace_name(&imp.name) {
+            return Err(format!("Invalid workspace name: '{}'", imp.name));
+        }
+
+        if !Path::new(&imp.path).is_dir() {
+            return Err(format!("Worktree path does not exist: '{}'", imp.path));
+        }
+
+        let canon = std::fs::canonicalize(&imp.path)
+            .map_err(|e| format!("Invalid path '{}': {e}", imp.path))?;
+        let canon_str = canon.to_string_lossy().to_string();
+
+        let ws = Workspace {
+            id: uuid::Uuid::new_v4().to_string(),
+            repository_id: repo_id.clone(),
+            name: imp.name,
+            branch_name: imp.branch_name,
+            worktree_path: Some(canon_str),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: now_iso(),
+        };
+
+        db.insert_workspace(&ws).map_err(|e| e.to_string())?;
+        created.push(ws);
+    }
+
+    crate::tray::rebuild_tray(&app);
+
+    Ok(created)
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -311,6 +311,8 @@ fn main() {
             commands::workspace::delete_workspace,
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
+            commands::workspace::discover_worktrees,
+            commands::workspace::import_worktrees,
             commands::workspace::open_workspace_in_terminal,
             // Slash commands
             commands::slash_commands::list_slash_commands,

--- a/src/db.rs
+++ b/src/db.rs
@@ -547,6 +547,30 @@ impl Database {
         Ok(())
     }
 
+    /// Insert multiple workspaces atomically. All succeed or none are committed.
+    pub fn insert_workspaces_batch(&self, workspaces: &[Workspace]) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO workspaces (id, repository_id, name, branch_name, worktree_path, status, status_line)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            )?;
+            for ws in workspaces {
+                stmt.execute(params![
+                    ws.id,
+                    ws.repository_id,
+                    ws.name,
+                    ws.branch_name,
+                    ws.worktree_path,
+                    ws.status.as_str(),
+                    ws.status_line,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     pub fn list_workspaces(&self) -> Result<Vec<Workspace>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repository_id, name, branch_name, worktree_path, status, status_line, created_at

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::path::Path;
 
+use serde::Serialize;
 use tokio::process::Command;
 
 #[derive(Debug, Clone)]
@@ -292,6 +293,66 @@ pub async fn current_branch(repo_path: &str) -> Result<String, GitError> {
         ));
     }
     Ok(branch)
+}
+
+/// Information about a single git worktree, parsed from `git worktree list --porcelain`.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeInfo {
+    pub path: String,
+    pub head: String,
+    pub branch: Option<String>,
+    pub is_bare: bool,
+}
+
+/// List all worktrees for a repository.
+///
+/// The first entry is always the main worktree (the repository itself or, for
+/// bare repos, the bare directory). Callers that only want linked worktrees
+/// should skip entries whose path matches the repository path.
+pub async fn list_worktrees(repo_path: &str) -> Result<Vec<WorktreeInfo>, GitError> {
+    let output = run_git(repo_path, &["worktree", "list", "--porcelain"]).await?;
+
+    let mut worktrees = Vec::new();
+    let mut path = None;
+    let mut head = None;
+    let mut branch = None;
+    let mut is_bare = false;
+
+    for line in output.lines() {
+        if line.is_empty() {
+            if let (Some(p), Some(h)) = (path.take(), head.take()) {
+                worktrees.push(WorktreeInfo {
+                    path: p,
+                    head: h,
+                    branch: branch.take(),
+                    is_bare,
+                });
+            }
+            is_bare = false;
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            path = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("HEAD ") {
+            head = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch refs/heads/") {
+            branch = Some(rest.to_string());
+        } else if line == "bare" {
+            is_bare = true;
+        }
+    }
+
+    // Flush the last entry (porcelain output may not end with a blank line).
+    if let (Some(p), Some(h)) = (path, head) {
+        worktrees.push(WorktreeInfo {
+            path: p,
+            head: h,
+            branch,
+            is_bare,
+        });
+    }
+
+    Ok(worktrees)
 }
 
 #[cfg(test)]
@@ -602,5 +663,64 @@ mod tests {
 
         // Clean up.
         remove_worktree(clone_path, wt_path, true).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_worktrees() {
+        let dir = setup_temp_repo().await;
+        let repo_path = dir.path().to_str().unwrap();
+
+        // Initially just the main worktree.
+        let wts = list_worktrees(repo_path).await.unwrap();
+        assert_eq!(wts.len(), 1);
+        assert_eq!(wts[0].branch.as_deref(), Some("main"));
+        assert!(!wts[0].is_bare);
+
+        // Add two linked worktrees.
+        let wt1 = tempfile::tempdir().unwrap();
+        let wt2 = tempfile::tempdir().unwrap();
+        create_worktree(repo_path, "feature-a", wt1.path().to_str().unwrap())
+            .await
+            .unwrap();
+        create_worktree(repo_path, "feature-b", wt2.path().to_str().unwrap())
+            .await
+            .unwrap();
+
+        let wts = list_worktrees(repo_path).await.unwrap();
+        assert_eq!(wts.len(), 3);
+
+        let branches: Vec<_> = wts.iter().filter_map(|w| w.branch.as_deref()).collect();
+        assert!(branches.contains(&"main"));
+        assert!(branches.contains(&"feature-a"));
+        assert!(branches.contains(&"feature-b"));
+
+        // All should have non-empty head SHAs and paths.
+        for wt in &wts {
+            assert!(!wt.head.is_empty());
+            assert!(!wt.path.is_empty());
+        }
+
+        // Clean up.
+        remove_worktree(repo_path, wt1.path().to_str().unwrap(), true)
+            .await
+            .unwrap();
+        remove_worktree(repo_path, wt2.path().to_str().unwrap(), true)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_list_worktrees_bare_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let bare_path = dir.path().to_str().unwrap();
+        run_git(bare_path, &["init", "--bare", "-b", "main"])
+            .await
+            .unwrap();
+
+        // Bare repos should return at least the main entry with is_bare=true.
+        // Note: bare repos with no commits may have limited output, but should
+        // not error.
+        let result = list_worktrees(bare_path).await;
+        assert!(result.is_ok());
     }
 }

--- a/src/ui/src/components/modals/AddRepoModal.tsx
+++ b/src/ui/src/components/modals/AddRepoModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../stores/useAppStore";
-import { addRepository, getDefaultBranch } from "../../services/tauri";
+import { addRepository, getDefaultBranch, discoverWorktrees } from "../../services/tauri";
 import { detectMcpServers } from "../../services/mcp";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
@@ -41,16 +41,30 @@ export function AddRepoModal() {
           setDefaultBranches({ ...defaultBranches, [repo.id]: branch });
         }
       });
-      // Detect non-portable MCP servers. If found, open selection modal;
-      // otherwise just close.
+      // Detect existing worktrees and MCP servers (both best-effort).
+      let mcps: Awaited<ReturnType<typeof detectMcpServers>> = [];
       try {
-        const mcps = await detectMcpServers(repo.id);
-        if (mcps.length > 0) {
-          openModal("mcpSelection", { repoId: repo.id });
+        mcps = await detectMcpServers(repo.id);
+      } catch {
+        // MCP detection is best-effort.
+      }
+
+      try {
+        const worktrees = await discoverWorktrees(repo.id);
+        if (worktrees.length > 0) {
+          openModal("importWorktrees", {
+            repoId: repo.id,
+            pendingMcps: mcps.length > 0 ? mcps : undefined,
+          });
           return;
         }
       } catch {
-        // MCP detection is best-effort — don't block repo addition.
+        // Worktree discovery is best-effort.
+      }
+
+      if (mcps.length > 0) {
+        openModal("mcpSelection", { repoId: repo.id });
+        return;
       }
       closeModal();
     } catch (e) {

--- a/src/ui/src/components/modals/AddRepoModal.tsx
+++ b/src/ui/src/components/modals/AddRepoModal.tsx
@@ -63,7 +63,7 @@ export function AddRepoModal() {
       }
 
       if (mcps.length > 0) {
-        openModal("mcpSelection", { repoId: repo.id });
+        openModal("mcpSelection", { repoId: repo.id, detectedMcps: mcps });
         return;
       }
       closeModal();

--- a/src/ui/src/components/modals/ImportWorktreesModal.module.css
+++ b/src/ui/src/components/modals/ImportWorktreesModal.module.css
@@ -1,0 +1,92 @@
+.loading {
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 16px 0;
+  text-align: center;
+}
+
+.description {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.worktreeList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.worktreeRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.worktreeRow:hover {
+  background: var(--hover-bg);
+}
+
+.worktreeRow input[type="checkbox"] {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.worktreeInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.worktreeHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.nameInput {
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  padding: 2px 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  width: 160px;
+  outline: none;
+}
+
+.nameInput:focus {
+  border-color: var(--text-dim);
+}
+
+.nameInputInvalid {
+  composes: nameInput;
+  border-color: var(--status-stopped);
+}
+
+.badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--selected-bg);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.worktreePath {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/ui/src/components/modals/ImportWorktreesModal.tsx
+++ b/src/ui/src/components/modals/ImportWorktreesModal.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from "react";
+import { useAppStore } from "../../stores/useAppStore";
+import {
+  discoverWorktrees,
+  importWorktrees,
+} from "../../services/tauri";
+import type { DiscoveredWorktree, WorktreeImport } from "../../services/tauri";
+import type { McpServer } from "../../types/mcp";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+import styles from "./ImportWorktreesModal.module.css";
+
+const NAME_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+
+interface WorktreeRow extends DiscoveredWorktree {
+  editedName: string;
+}
+
+export function ImportWorktreesModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const openModal = useAppStore((s) => s.openModal);
+  const addWorkspace = useAppStore((s) => s.addWorkspace);
+  const modalData = useAppStore((s) => s.modalData);
+  const repoId = modalData.repoId as string;
+  const pendingMcps = modalData.pendingMcps as McpServer[] | undefined;
+
+  const [rows, setRows] = useState<WorktreeRow[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!repoId) return;
+    setLoading(true);
+
+    discoverWorktrees(repoId)
+      .then((discovered) => {
+        if (discovered.length === 0) {
+          chainOrClose();
+          return;
+        }
+        const mapped = discovered.map((wt) => ({
+          ...wt,
+          editedName: wt.suggested_name,
+        }));
+        setRows(mapped);
+        setSelected(new Set(discovered.map((wt) => wt.path)));
+      })
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repoId]);
+
+  const chainOrClose = () => {
+    if (pendingMcps && pendingMcps.length > 0) {
+      openModal("mcpSelection", { repoId });
+    } else {
+      closeModal();
+    }
+  };
+
+  const toggleRow = (path: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const updateName = (path: string, name: string) => {
+    setRows((prev) =>
+      prev.map((r) => (r.path === path ? { ...r, editedName: name } : r))
+    );
+  };
+
+  const selectedRows = rows.filter((r) => selected.has(r.path));
+  const allNamesValid = selectedRows.every((r) => NAME_RE.test(r.editedName));
+
+  const handleImport = async () => {
+    setImporting(true);
+    setError(null);
+    try {
+      const imports: WorktreeImport[] = selectedRows.map((r) => ({
+        path: r.path,
+        branch_name: r.branch_name,
+        name: r.editedName,
+      }));
+      const created = await importWorktrees(repoId, imports);
+      for (const ws of created) {
+        addWorkspace(ws);
+      }
+      chainOrClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Modal title="Import Worktrees" onClose={chainOrClose}>
+        <div className={styles.loading}>Scanning for existing worktrees...</div>
+      </Modal>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Modal title="Import Worktrees" onClose={chainOrClose}>
+        <p className={styles.description}>
+          No existing worktrees found for this repository.
+        </p>
+        <div className={shared.actions}>
+          <button className={shared.btn} onClick={chainOrClose}>
+            Close
+          </button>
+        </div>
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal title="Existing Worktrees Found" onClose={chainOrClose}>
+      <p className={styles.description}>
+        These git worktrees already exist for this repository.
+        Select which ones to import as workspaces:
+      </p>
+
+      <div className={styles.worktreeList}>
+        {rows.map((row) => {
+          const isSelected = selected.has(row.path);
+          const nameValid = NAME_RE.test(row.editedName);
+          return (
+            <label key={row.path} className={styles.worktreeRow}>
+              <input
+                type="checkbox"
+                checked={isSelected}
+                onChange={() => toggleRow(row.path)}
+              />
+              <div className={styles.worktreeInfo}>
+                <div className={styles.worktreeHeader}>
+                  <input
+                    type="text"
+                    className={
+                      isSelected && !nameValid
+                        ? styles.nameInputInvalid
+                        : styles.nameInput
+                    }
+                    value={row.editedName}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      updateName(row.path, e.target.value);
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                  <span className={styles.badge}>{row.branch_name}</span>
+                </div>
+                <div className={styles.worktreePath}>{row.path}</div>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+
+      {error && <div className={shared.error}>{error}</div>}
+
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={chainOrClose}>
+          Skip
+        </button>
+        <button
+          className={shared.btnPrimary}
+          onClick={handleImport}
+          disabled={importing || selected.size === 0 || !allNamesValid}
+        >
+          {importing
+            ? "Importing..."
+            : `Import ${selected.size} Workspace${selected.size !== 1 ? "s" : ""}`}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/ImportWorktreesModal.tsx
+++ b/src/ui/src/components/modals/ImportWorktreesModal.tsx
@@ -54,7 +54,7 @@ export function ImportWorktreesModal() {
 
   const chainOrClose = () => {
     if (pendingMcps && pendingMcps.length > 0) {
-      openModal("mcpSelection", { repoId });
+      openModal("mcpSelection", { repoId, detectedMcps: pendingMcps });
     } else {
       closeModal();
     }

--- a/src/ui/src/components/modals/McpSelectionModal.tsx
+++ b/src/ui/src/components/modals/McpSelectionModal.tsx
@@ -48,6 +48,9 @@ export function McpSelectionModal() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Accept pre-fetched detected servers via modalData to avoid redundant detection.
+  const prefetchedMcps = modalData.detectedMcps as McpServer[] | undefined;
+
   useEffect(() => {
     if (!repoId) return;
     setLoading(true);
@@ -55,7 +58,10 @@ export function McpSelectionModal() {
     // Load both detected and already-saved servers, then merge.
     // Already-saved servers stay selected; newly detected ones are also
     // pre-selected (opt-out default).
-    Promise.all([detectMcpServers(repoId), loadRepositoryMcps(repoId)])
+    const detectPromise = prefetchedMcps
+      ? Promise.resolve(prefetchedMcps)
+      : detectMcpServers(repoId);
+    Promise.all([detectPromise, loadRepositoryMcps(repoId)])
       .then(([detected, saved]) => {
         const savedNames = new Set(saved.map((s) => s.name));
 

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -8,6 +8,7 @@ import { RollbackModal } from "./RollbackModal";
 import { ShareModal } from "./ShareModal";
 import { ConfirmSetupScriptModal } from "./ConfirmSetupScriptModal";
 import { McpSelectionModal } from "./McpSelectionModal";
+import { ImportWorktreesModal } from "./ImportWorktreesModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -31,6 +32,8 @@ export function ModalRouter() {
       return <ConfirmSetupScriptModal />;
     case "mcpSelection":
       return <McpSelectionModal />;
+    case "importWorktrees":
+      return <ImportWorktreesModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -504,6 +504,20 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         </div>
       </div>
 
+      <div className={styles.fieldGroup}>
+        <div className={styles.fieldLabel}>Worktree discovery</div>
+        <div className={styles.fieldHint} style={{ marginBottom: 8 }}>
+          Scan for existing git worktrees (e.g. from Conductor) and import them
+          as workspaces.
+        </div>
+        <button
+          className={styles.iconBtn}
+          onClick={() => openModal("importWorktrees", { repoId })}
+        >
+          Discover worktrees
+        </button>
+      </div>
+
       <div className={styles.dangerZone}>
         <div className={styles.dangerLabel}>Danger Zone</div>
         <button

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -139,6 +139,33 @@ export function openWorkspaceInTerminal(worktreePath: string): Promise<void> {
   return invoke("open_workspace_in_terminal", { worktreePath });
 }
 
+// -- Worktree Discovery --
+
+export interface DiscoveredWorktree {
+  path: string;
+  branch_name: string;
+  head_sha: string;
+  suggested_name: string;
+  name_valid: boolean;
+}
+
+export function discoverWorktrees(repoId: string): Promise<DiscoveredWorktree[]> {
+  return invoke("discover_worktrees", { repoId });
+}
+
+export interface WorktreeImport {
+  path: string;
+  branch_name: string;
+  name: string;
+}
+
+export function importWorktrees(
+  repoId: string,
+  imports: WorktreeImport[]
+): Promise<Workspace[]> {
+  return invoke("import_worktrees", { repoId, imports });
+}
+
 // -- Slash Commands --
 
 export type NativeSlashKind = "local_action" | "settings_route" | "prompt_expansion";


### PR DESCRIPTION
## Summary

When adding a repository that already has linked git worktrees (e.g. from Conductor or manual `git worktree add`), Claudette now detects them and offers to import them as workspaces. This is the key missing piece for migrating from other worktree-based tools — users no longer need to recreate each workspace manually.

- **Backend**: New `list_worktrees()` in `git.rs` parses `git worktree list --porcelain` to discover worktrees. Two new Tauri commands — `discover_worktrees` (filters out main repo, detached HEADs, already-tracked) and `import_worktrees` (creates workspace DB records pointing at external paths).
- **Frontend**: `ImportWorktreesModal` with checkbox list, editable names, branch badges, and path display. Chains into the add-repo flow between repo creation and MCP detection.
- **Repo settings**: "Discover worktrees" button for on-demand discovery after initial add.

```mermaid
flowchart LR
    A[Add Repository] --> B{Existing worktrees?}
    B -->|Yes| C[Import Worktrees Modal]
    B -->|No| D{MCP servers?}
    C --> D
    D -->|Yes| E[MCP Selection Modal]
    D -->|No| F[Done]
    E --> F
```

Imported workspaces keep their worktree directory in-place (not moved to `~/.claudette/workspaces/`). Once imported, Claudette manages the workspace lifecycle normally.

## Complexity Notes

- **External worktree paths**: The `worktree_path` field already supports arbitrary absolute paths, so no schema changes were needed. Archive/delete operations will remove the worktree directory even if it lives outside `~/.claudette/workspaces/` — this is consistent behavior (once imported, Claudette owns it).
- **Filtering logic**: `discover_worktrees` canonicalizes paths for comparison and filters by both `worktree_path` and `branch_name` to avoid duplicating already-tracked workspaces.

## Test Steps

1. Add a repository that has existing git worktrees (e.g. from Conductor)
2. Verify the "Existing Worktrees Found" modal appears with the correct worktrees listed
3. Verify each row shows: editable name, branch badge, file path
4. Edit a name to something invalid (e.g. add underscores) — Import button should disable
5. Select/deselect worktrees, click "Import Selected"
6. Verify imported workspaces appear in the sidebar and function normally
7. Go to Settings > [repo] and click "Discover worktrees" — should show the same modal (with already-imported ones filtered out)
8. Add a repo with no extra worktrees — modal should not appear

## Checklist

- [x] Tests added/updated (`test_list_worktrees`, `test_list_worktrees_bare_repo`)
- [ ] Documentation updated (if applicable)