### PR TITLE
feat(chat): /init and /help native slash commands

### DIFF
--- a/docs/slash-commands-245-246-tdd.md
+++ b/docs/slash-commands-245-246-tdd.md
@@ -2,7 +2,7 @@
 
 **Scope:** Implementation plan for GitHub issues [#245](https://github.com/utensils/claudette/issues/245) and [#246](https://github.com/utensils/claudette/issues/246) on top of the native slash command framework that landed in PR #248 (issue #241).
 
-**Status:** planning — not yet implemented.
+**Status:** partially implemented — #245 (`/help`, `/init`) shipped in this branch; #246 (`/compact`, `/context`, `/files`, `/cost`) remains planned.
 
 **Related:** #247 (tracker). #241-#244 merged. This doc finishes the slash command parity cluster.
 
@@ -22,7 +22,7 @@ Each handler returns `NativeCommandResult` (`{ kind: "handled" | "expand" | "ski
 
 ### What's currently registered
 
-`/plugin`, `/marketplace`, `/review`, `/security-review`, `/pr-comments`, `/config`, `/usage`, `/extra-usage`, `/release-notes`, `/version`, `/clear`, `/plan`, `/model`, `/permissions`, `/status` — all from `nativeSlashCommands.ts:557-573` and `slash_commands.rs:57-186`.
+`/plugin`, `/marketplace`, `/review`, `/security-review`, `/pr-comments`, `/config`, `/usage`, `/extra-usage`, `/release-notes`, `/version`, `/clear`, `/plan`, `/model`, `/permissions`, `/status`, `/help`, `/init` — all from `nativeSlashCommands.ts` `NATIVE_HANDLERS` array and `slash_commands.rs` `native_command_registry`. The last two (`/help`, `/init`) ship in this branch.
 
 ### Frontend dependencies that need **no new infrastructure**
 
@@ -78,7 +78,7 @@ Each handler returns `NativeCommandResult` (`{ kind: "handled" | "expand" | "ski
 
 **Arguments:** none. Optional future: `/help <name>` to deep-dive a single command. Out of scope for first pass.
 
-**No Rust changes** — pure UI command. Registry entry goes in both `nativeSlashCommands.ts` (handler) and `slash_commands.rs` (registry entry, so the picker lists it).
+**No new backend handlers/Tauri commands** — behavior is UI-driven, but a registry entry is still added in `slash_commands.rs` so `list_slash_commands` and the picker include it alongside the UI-side handler in `nativeSlashCommands.ts`.
 
 ### 2.2 `/init`
 
@@ -99,7 +99,7 @@ Each handler returns `NativeCommandResult` (`{ kind: "handled" | "expand" | "ski
 
 **`CLAUDE.md` vs `.claudette.json`:** Claudette currently reads custom instructions from `.claudette.json` (`src/config.rs:28-41`, `src-tauri/src/commands/chat.rs:204-213`). `CLAUDE.md` is the Claude Code convention. The seeded prompt targets `CLAUDE.md` (matches CLI parity + existing repo pattern — the Claudette repo itself has one), and notes `.claudette.json` as the place the app actually reads at runtime.
 
-**No Rust changes** — prompt-expansion only.
+**No new backend handlers/Tauri commands** — the prompt flows through the existing `sendChatMessage` pipeline. A registry entry is still added in `slash_commands.rs` so the picker lists `/init`.
 
 ### 2.3 Registry entries (`src/slash_commands.rs:57-186`)
 

--- a/docs/slash-commands-245-246-tdd.md
+++ b/docs/slash-commands-245-246-tdd.md
@@ -1,0 +1,448 @@
+# TDD: Native slash commands `/init`, `/help`, `/compact`, `/context`, `/files`, `/cost`
+
+**Scope:** Implementation plan for GitHub issues [#245](https://github.com/utensils/claudette/issues/245) and [#246](https://github.com/utensils/claudette/issues/246) on top of the native slash command framework that landed in PR #248 (issue #241).
+
+**Status:** planning — not yet implemented.
+
+**Related:** #247 (tracker). #241-#244 merged. This doc finishes the slash command parity cluster.
+
+---
+
+## 1. Context
+
+PR #248 introduced a UI-side registry (`NATIVE_HANDLERS`) and Rust-side registry (`native_command_registry`) with three command kinds:
+
+| Kind | Behavior | Example |
+|---|---|---|
+| `LocalAction` | UI-only state mutation, renders a local message via `ctx.addLocalMessage(...)` | `/status`, `/clear`, `/version` |
+| `SettingsRoute` | Calls `ctx.openSettings(section)` to open the existing settings surface | `/config`, `/usage` |
+| `PromptExpansion` | Rewrites the chat input into a seeded prompt, then flows through `sendChatMessage` | `/review`, `/security-review`, `/pr-comments` |
+
+Each handler returns `NativeCommandResult` (`{ kind: "handled" | "expand" | "skipped", ... }`). `ChatPanel.handleSend` intercepts slash input at `src/ui/src/components/chat/ChatPanel.tsx:437-657`, resolves via `resolveNativeHandler`, and dispatches. Usage is recorded under the canonical name via `recordSlashCommandUsage` (`ChatPanel.tsx:646-649`).
+
+### What's currently registered
+
+`/plugin`, `/marketplace`, `/review`, `/security-review`, `/pr-comments`, `/config`, `/usage`, `/extra-usage`, `/release-notes`, `/version`, `/clear`, `/plan`, `/model`, `/permissions`, `/status` — all from `nativeSlashCommands.ts:557-573` and `slash_commands.rs:57-186`.
+
+### Frontend dependencies that need **no new infrastructure**
+
+- Per-message `cost_usd` and `duration_ms` already exist in `chat_messages` (`src/db.rs:106-120`), populated from the CLI `result` event's `total_cost_usd` (`src/agent.rs:35-44`, capture at `src-tauri/src/commands/chat.rs:779-791`).
+- `list_workspace_files` already enumerates worktree files via `git ls-files --cached --others --exclude-standard` (`src-tauri/src/commands/files.rs:32-93`, capped at 10,000).
+- `load_attachments_for_workspace` enumerates stored image/PDF attachments (`src-tauri/src/commands/chat.rs:1198`).
+- `load_chat_history` returns full message history (`src-tauri/src/commands/chat.rs:52-59`, ordered by `created_at, rowid`).
+- Checkpoints + file snapshots already support rollback (`src/db.rs:214-226`, `src-tauri/src/commands/chat.rs:956-985`).
+- `get_claude_code_usage` returns **org-level** 5-hour / 7-day rolling windows from claude.ai (`src-tauri/src/usage.rs:77-83`).
+
+### Gaps that need new code
+
+- No session-level cost aggregation (must sum per-message `cost_usd`).
+- No existing compaction/summarization logic anywhere (`grep`: zero hits for "compact", "summariz*").
+- No `AsyncBackendAction` kind in the framework yet (needed for `/compact`).
+- No CLAUDE.md handling (Claudette today reads custom instructions only from `.claudette.json`, `src/config.rs:28-41`).
+
+---
+
+## 2. Issue #245 — `/init` and `/help`
+
+### 2.1 `/help`
+
+**Kind:** `LocalAction` (pure UI, reads the registry, renders a multi-line message).
+
+**Rationale:** The slash picker at `SlashCommandPicker.tsx:11-40` already surfaces `name`, `description`, `argument_hint`, and `aliases` from the same `SlashCommand[]` list. `/help` must consume the same list so the two surfaces cannot drift — which is exactly the acceptance criterion in the issue.
+
+**Data source:** `listSlashCommands()` from `services/tauri.ts` (already called elsewhere), or the in-memory list that the picker is currently bound to. Do NOT enumerate `NATIVE_HANDLERS` directly — that would miss file-based commands (project, user, plugin) and defeat the point.
+
+**Output format (chat-rendered as markdown via `ctx.addLocalMessage`):**
+
+```
+**Native slash commands**
+
+/clear — Clear the current workspace conversation
+/model [id] — Show or change the workspace model
+/permissions [mode]  (alias: /allowed-tools) — Show or change permission mode
+/status — Show a summary of the current workspace
+... (grouped by kind in this order: LocalAction, SettingsRoute, PromptExpansion)
+
+**File-based commands**
+
+/<name> — <description>  (project)
+/<name> — <description>  (user)
+/<name> — <description>  (plugin: <plugin-name>)
+```
+
+**Grouping:** Use `SlashCommand.kind` for native; `SlashCommand.source` for file-based (`project`, `user`, `plugin`). Skip `builtin` in the second section since those are already in the first.
+
+**Aliases:** render inline as `(alias: /x, /y)` when `aliases.length > 0`.
+
+**Argument hint:** append `[hint]` after the command name when present (matches picker formatting).
+
+**Arguments:** none. Optional future: `/help <name>` to deep-dive a single command. Out of scope for first pass.
+
+**No Rust changes** — pure UI command. Registry entry goes in both `nativeSlashCommands.ts` (handler) and `slash_commands.rs` (registry entry, so the picker lists it).
+
+### 2.2 `/init`
+
+**Kind:** `PromptExpansion`.
+
+**Rationale:** The issue explicitly says prefer "a prompt-driven implementation through the normal agent pipeline rather than a bespoke Tauri wizard." Expansion kind seeds a prompt, then `handleSend` replaces `trimmed` with the expanded text and falls through to `sendChatMessage` — same path `/review` already uses (`ChatPanel.tsx:651-656`).
+
+**Context available to the handler:** `NativeCommandContext` already exposes `repository: { name, path }`, `workspace: { branch, worktreePath }`, `repoDefaultBranch`. No new plumbing needed (`nativeSlashCommands.ts:24-67`).
+
+**Seeded prompt template (single-line in code, shown formatted here):**
+
+> Bootstrap project guidance for this repository. Inspect the codebase layout, primary languages and frameworks, build/test commands, and key architectural patterns. Then produce or update a repo-level `CLAUDE.md` at the repo root with: project summary, build and test commands (as copy-paste shell snippets), code style / linting / formatting conventions the repo uses, commit conventions, architecture overview (crates/modules and what they do), project structure tree, guidelines for new code, and a "debugging" section if the repo has non-trivial debug tooling. If a `CLAUDE.md` already exists, merge new findings rather than overwriting — preserve existing guidance. If the repo uses `.claudette.json` for instructions, cross-reference the two and keep them consistent. Make the file useful for a future agent who has never seen this codebase. Do not commit or push — only write the file.
+>
+> Current repo: `{repository.name}` at `{repository.path}`
+> Current branch: `{workspace.branch}` (default: `{repoDefaultBranch}`)
+
+**Arguments:** `/init` accepts optional free-form args that get appended to the seeded prompt as `Additional guidance: {args}`. Lets the user request emphasis (e.g. `/init focus on the Tauri command surface`) without re-typing the whole prompt.
+
+**`CLAUDE.md` vs `.claudette.json`:** Claudette currently reads custom instructions from `.claudette.json` (`src/config.rs:28-41`, `src-tauri/src/commands/chat.rs:204-213`). `CLAUDE.md` is the Claude Code convention. The seeded prompt targets `CLAUDE.md` (matches CLI parity + existing repo pattern — the Claudette repo itself has one), and notes `.claudette.json` as the place the app actually reads at runtime.
+
+**No Rust changes** — prompt-expansion only.
+
+### 2.3 Registry entries (`src/slash_commands.rs:57-186`)
+
+```rust
+SlashCommand {
+    name: "help",
+    description: "List available slash commands",
+    source: "builtin",
+    aliases: vec![],
+    argument_hint: None,
+    kind: Some(NativeKind::LocalAction),
+},
+SlashCommand {
+    name: "init",
+    description: "Bootstrap repo guidance (CLAUDE.md) via the agent",
+    source: "builtin",
+    aliases: vec![],
+    argument_hint: Some("[extra guidance]".into()),
+    kind: Some(NativeKind::PromptExpansion),
+},
+```
+
+### 2.4 Test coverage for #245
+
+In `nativeSlashCommands.test.ts`:
+
+- `/help` renders all registered native commands grouped by kind, in the stated order.
+- `/help` includes aliases formatted as `(alias: /x)` when present.
+- `/help` includes argument hints when present.
+- `/help` includes file-based commands grouped by source (project/user/plugin) with the plugin name.
+- `/help` excludes `builtin` from the file-based section.
+- `/help` surface uses the SAME data source as the picker (mock `listSlashCommands`, assert it's called — no duplicated registry list).
+- `/help` resolves by canonical name only (no aliases defined).
+- `/init` with no args produces a prompt containing repo name, path, branch, and the CLAUDE.md-producing directive.
+- `/init` with args appends them under "Additional guidance: ...".
+- `/init` returns `{ kind: "expand" }` so `handleSend` rewrites trimmed and falls through to `sendChatMessage`.
+- `/init` does NOT add a local message (it's expansion, not local).
+
+In `SlashCommandPicker.test.ts`:
+
+- `/help` and `/init` appear in the picker when typing `/` with matching prefix.
+
+Rust side (`src/slash_commands.rs` test module):
+
+- `native_command_registry` includes `help` with `kind = LocalAction`.
+- `native_command_registry` includes `init` with `kind = PromptExpansion` and `argument_hint = Some(...)`.
+
+---
+
+## 3. Issue #246 — `/compact`, `/context`, `/files`, `/cost`
+
+This is the "product work, not just wiring" group. Each command below first **defines Claudette-specific semantics** (the issue's explicit acceptance criterion), then describes the implementation.
+
+### 3.1 `/compact` — conversation summarization
+
+#### Product definition
+
+> Compaction replaces the current workspace's message history with an agent-authored summary that preserves enough continuity for the session to keep working productively, while reducing future turn input size. Before the mutation, Claudette creates a reversible checkpoint so the user can undo via the existing rollback path.
+
+Explicit non-behaviors:
+
+- **Not `/clear`.** `/clear` deletes; `/compact` preserves a summary.
+- **Not silent.** Compaction emits a visible system message in chat with the summary and a "view full history" affordance (existing rollback flow).
+- **Always rollbackable.** Rollback uses the existing checkpoint mechanism (`src-tauri/src/commands/chat.rs:956-985`), which already supports file + message state restore.
+
+#### Semantics (first-pass)
+
+1. **User types** `/compact` (optional free-form arg: custom summarization instructions).
+2. **Handler calls new Tauri command** `compact_conversation(workspace_id, extra_instructions)`.
+3. **Rust side:**
+   - Load full history (`db.list_chat_messages(workspace_id)`).
+   - Create a checkpoint anchored to the LAST existing message, with `has_file_state: false` (compaction is message-only; file state not relevant). This is the undo point.
+   - Run a one-shot agent turn with a summarization prompt + full history as the user turn. Capture the summary text.
+   - Transactionally: delete all existing messages, insert a single system message with the summary + `cost_usd` from the summarization turn + a marker (e.g. `content` prefixed with `"[compact summary]\n"` or new `role` variant — see open question).
+   - Return `{ summary_message_id, checkpoint_id, messages_replaced: N }`.
+4. **Frontend**:
+   - Reloads chat history (already happens via event).
+   - Renders the system message as normal (the marker lets the UI optionally style it differently — **out of scope for first pass**, plain system message is fine).
+   - Shows a local confirmation: `"Compacted N messages into a summary. Use the checkpoint menu to restore."`
+
+#### Open question — how to run the summarization turn
+
+Two options:
+
+- **(A)** Kick off a full `send_chat_message`-style turn with a `compact` flag, but suppress normal user-message insertion. Pros: reuses agent plumbing. Cons: invasive to `send_chat_message`.
+- **(B)** New standalone path `run_oneshot_prompt(workspace_id, prompt)` that spawns the agent, collects streamed output, returns result. Pros: clean separation. Cons: parallel code.
+
+**Recommendation:** (B) — keeping compaction out of `send_chat_message` avoids regressions in the normal path, and a oneshot helper is likely useful for other future commands (`/security-review` background runs, etc.).
+
+#### Test coverage
+
+- Compacting with history > 1 creates a checkpoint and replaces messages with a single summary message.
+- Compaction failure (agent error) leaves history untouched — no partial state.
+- Compacting an empty conversation returns a no-op result (`messages_replaced: 0`).
+- Rollback of the post-compact checkpoint restores the pre-compact message count.
+- `/compact extra text` passes `extra text` to the summarization prompt as additional instructions.
+- Summary message's `cost_usd` is populated from the oneshot turn.
+
+### 3.2 `/context` — current context report
+
+#### Product definition
+
+> `/context` reports what Claudette considers the active workspace's current conversational context: a scoped set of state Claudette can report authoritatively from its own DB and filesystem, without pretending to mirror the underlying agent's token window.
+
+Scope (explicitly NOT the agent's view):
+
+| Field | Source | Notes |
+|---|---|---|
+| Workspace name | `ws.display_name` | From `workspaces` table |
+| Branch | `ws.branch_name` | |
+| Worktree path | `ws.worktree_path` | |
+| Repository | `repo.name`, `repo.path` | |
+| Messages in history | `COUNT(*) FROM chat_messages WHERE workspace_id = ?` | New query; alternatively client-side count from `load_chat_history()` |
+| Attachments | `load_attachments_for_workspace(workspace_id).len()` | |
+| Checkpoints | `COUNT(*) FROM checkpoints WHERE workspace_id = ?` | New query or client-side |
+| Active plan file | Check `{worktree_path}/.claude/plans/*.md` exists | Filesystem check; plan state is file-based (`src-tauri/src/commands/plan.rs`) |
+| Session cost (sum) | `SUM(cost_usd) FROM chat_messages WHERE workspace_id = ?` | See `/cost` |
+| Plan mode | `ctx.planMode` | UI state |
+| Permission mode | `ctx.permissionLevel` | UI state |
+| Model | `ctx.selectedModel` | UI state |
+
+Explicitly NOT included in first pass: per-message token counts, agent-side context window utilization, "files the agent has read this session" — Claudette can't observe those reliably.
+
+#### Kind
+
+`LocalAction`. Handler calls a new Tauri command `get_session_context(workspace_id)` that returns the DB/FS-derived fields, combines with UI state from `ctx`, and renders via `addLocalMessage`.
+
+#### Output (multi-line, markdown-rendered)
+
+```
+**Workspace context**
+
+Repo:        claudette (/Users/.../Claudette)
+Branch:      main (default: main)
+Worktree:    /Users/.../Claudette
+Messages:    47
+Attachments: 3
+Checkpoints: 12
+Plan file:   .claude/plans/refactor.md
+Session cost: $0.84
+
+Model:       claude-opus-4-7
+Permissions: default
+Plan mode:   off
+```
+
+Field omitted if unavailable (e.g. no plan file → skip that line).
+
+#### Test coverage
+
+- `get_session_context` returns correct counts against a seeded in-memory DB.
+- Absent plan file → field omitted in render.
+- Zero messages → "Messages: 0", no cost line (or "Session cost: $0.00").
+- Renders via `addLocalMessage` not `sendChatMessage`.
+
+### 3.3 `/files` — files in context
+
+#### Product definition
+
+> `/files` reports two categories of files Claudette can enumerate authoritatively: **attachments** stored in the DB, and **@-mentions** extracted from the persisted message history by regex. This is explicitly narrower than "everything the agent has read" — Claudette doesn't track agent-side file reads.
+
+The issue explicitly allows this scope: "A reasonable first pass may be limited to the files Claudette already tracks directly, such as mentioned files and attachments, rather than claiming to expose the full underlying agent context."
+
+#### Data sources
+
+- **Attachments:** `load_attachments_for_workspace(workspace_id)` returns `Vec<Attachment>` with `filename`, `media_type`, `size_bytes`, `created_at` (`src/model/attachment.rs`).
+- **@-mentions:** extract from `chat_messages.content` via regex. `send_chat_message` expands mentions inline into content (`src-tauri/src/commands/chat.rs:292-297`), so post-expansion the `@path` text remains in the stored content. Regex `@([\w.\-/]+)` over user-role messages; dedupe preserving first-occurrence order.
+
+#### Kind
+
+`LocalAction`. Handler calls new Tauri command `get_session_files(workspace_id)` that returns `{ attachments: Vec<AttachmentSummary>, mentioned: Vec<String> }`.
+
+#### Output
+
+```
+**Files in this conversation**
+
+Attachments (3):
+  screenshot.png  (image/png, 124 KB)
+  debug.log       (text/plain, 8 KB)
+  design.pdf      (application/pdf, 2.1 MB)
+
+Mentioned (5):
+  src/ui/src/components/chat/ChatPanel.tsx
+  src/slash_commands.rs
+  docs/mcp-detection-tdd.md
+  CLAUDE.md
+  .claudette.json
+```
+
+Empty categories omitted.
+
+#### Arguments (future, out of first-pass scope)
+
+- `/files workspace` — list worktree files from `list_workspace_files()`. Out of scope for first pass because the acceptance criterion explicitly warns against claiming agent-context coverage.
+
+#### Test coverage
+
+- `get_session_files` returns attachment summaries with media type and byte size.
+- `get_session_files` extracts unique `@paths` from user-role messages in order.
+- Non-user messages (assistant, system) are not scanned for mentions.
+- Regex correctly extracts nested paths (`@src/ui/x.tsx`), stops at whitespace/punctuation.
+- Empty workspace → `/files` renders `"No attachments or mentioned files in this conversation."`.
+
+### 3.4 `/cost` — session cost
+
+#### Product definition
+
+> `/cost` reports two independent facts Claudette can answer reliably: **session cost** (sum of `cost_usd` across stored assistant messages in the active workspace) and **org-level rolling usage** (from the existing `get_claude_code_usage` claude.ai API, not per-session).
+
+Explicit honesty: these are different scopes. Session cost comes from CLI `total_cost_usd` attached per turn. Org usage is a separate rolling window shared across all Claude Code sessions and subscriptions.
+
+#### Kind
+
+`LocalAction`. Handler calls new Tauri command `get_session_cost(workspace_id)` returning `{ total_usd, turn_count, messages_with_cost }`. Separately calls existing `get_claude_code_usage()` for org numbers.
+
+#### Output
+
+```
+**This workspace**
+
+Session cost:  $0.84
+Turns:         12
+Messages with cost: 12 of 24
+
+**Org usage (claude.ai)**
+
+5-hour window:  42% utilized (resets in 2h 14m)
+7-day window:   18% utilized (resets in 4d 8h)
+  Sonnet:       14%
+  Opus:         21%
+```
+
+If `get_claude_code_usage` fails (unauthenticated, offline, etc.), the org section becomes `"Org usage unavailable: <reason>"`. The session section always works (it's a local SQL query).
+
+#### Test coverage
+
+- `get_session_cost` sums `cost_usd` across assistant messages, ignores nulls.
+- `get_session_cost` reports `messages_with_cost` as the count of non-null `cost_usd` rows.
+- Empty workspace → `total_usd: 0`, `turn_count: 0`.
+- Handler falls back gracefully when `get_claude_code_usage` errors (renders session data, error line for org).
+- Handler does not render zero-value org fields when API returns partial data.
+
+### 3.5 Framework changes needed
+
+Add `NativeKind::AsyncBackendAction` variant in `src/slash_commands.rs:7-18` so `/compact`, `/context`, `/files`, `/cost` can be distinguished in the picker from pure UI `LocalAction` commands. Frontend-side `NativeCommandResult` already supports async (`Promise<NativeCommandResult>` return type, `nativeSlashCommands.ts:69-82`), so no TS framework change — only the registry tagging.
+
+Alternative: keep them as `LocalAction` since the UI handler *is* local (it just calls a Tauri command). This is simpler and matches how `/status` works (it's LocalAction but reads UI state that came from the backend). **Recommendation:** stick with `LocalAction`. No framework change needed.
+
+### 3.6 New Tauri commands (signatures)
+
+```rust
+// src-tauri/src/commands/chat.rs or new compact.rs
+#[tauri::command]
+async fn compact_conversation(
+    workspace_id: String,
+    extra_instructions: Option<String>,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<CompactResult, String>;
+
+#[tauri::command]
+async fn get_session_context(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<SessionContext, String>;
+
+#[tauri::command]
+async fn get_session_files(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<SessionFiles, String>;
+
+#[tauri::command]
+async fn get_session_cost(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<SessionCost, String>;
+```
+
+Types live in `src/model/session.rs` (new file) — `Serialize`-derived structs with fields from the tables above.
+
+### 3.7 New DB methods
+
+- `Database::count_chat_messages(workspace_id) -> Result<i64>`
+- `Database::count_checkpoints(workspace_id) -> Result<i64>`
+- `Database::sum_session_cost(workspace_id) -> Result<(f64, i64, i64)>` — returns `(total_usd, turns_with_cost, total_turns)`
+- `Database::list_user_message_contents(workspace_id) -> Result<Vec<String>>` — for `/files` @-mention extraction
+
+All use the existing `Database::open(&state.db_path)` pattern per Tauri command.
+
+---
+
+## 4. Sequencing
+
+Recommended order within #246:
+
+1. **Framework: confirm no changes needed** — validate that `LocalAction` is enough for async backend calls by looking at `/status` handler (it already awaits `ctx` state). Expected: confirmed, no framework change.
+2. **`/cost`** — smallest; pure read, reuses `get_claude_code_usage`, only new work is `sum_session_cost` DB method.
+3. **`/files`** — pure read, attachment listing exists, regex extraction is small.
+4. **`/context`** — pure read, aggregates everything from #2-3 plus counts.
+5. **`/compact`** — the large one; requires the oneshot-prompt helper plus checkpoint-before-mutation. Should land in its own PR.
+
+#245 (`/help`, `/init`) is independent of #246 and can land in parallel. Do it first if the goal is to maximize visible parity quickly — `/help` is trivial and makes the rest of the command surface discoverable.
+
+---
+
+## 5. Acceptance criteria (summary, checked against issue text)
+
+### #245
+
+- [x] `/init` resolves locally — `PromptExpansion` handler, no raw slash sent to agent.
+- [x] `/init` uses current workspace context automatically — `NativeCommandContext` provides repo + branch + worktree.
+- [x] `/init` goes through the normal agent pipeline — `expand` result falls through to `sendChatMessage`.
+- [x] `/help` generated from the same registry that powers the picker — consumes `listSlashCommands()`, not a hand-maintained list.
+- [x] `/help` includes aliases and argument hints — formatted inline per-entry.
+- [x] Both discoverable in slash picker — via registry entries in `slash_commands.rs`.
+
+### #246
+
+- [x] Claudette-specific semantics documented for each command — §3.1-3.4.
+- [x] Native registry entries — one each in `nativeSlashCommands.ts` and `slash_commands.rs`.
+- [x] `/compact` is not a renamed `/clear` — creates checkpoint, produces summary, preserves continuity (§3.1).
+- [x] `/context` and `/files` report data Claudette can justify — §3.2 and §3.3 explicitly scope to DB + FS facts.
+- [x] `/cost` only reports reliable data — session sum from DB, org from existing API, handles API failure.
+
+---
+
+## 6. Open questions
+
+1. **Compaction summary message role.** Store the summary as `role = 'system'` (existing variant) or introduce a new role/marker? Recommendation: use existing `system` role with a content prefix marker (`[compact summary]`) so the UI can optionally style it without a schema change.
+2. **Compaction cost attribution.** The oneshot summarization turn itself costs tokens. Store its `cost_usd` on the summary message so `/cost` and `/context` naturally include it — not separately accounted.
+3. **`/help` surface form.** Chat message (local) vs. modal. First pass: chat message, consistent with `/status`. If the list gets unwieldy with many file-based plugin commands, revisit.
+4. **`/init` and existing CLAUDE.md.** Seeded prompt should instruct the agent to merge, not overwrite. Left to the agent's judgment; acceptable given the prompt-driven approach.
+5. **Attachment size formatting.** `format_size(size_bytes)` helper — pull in existing one if any, otherwise trivial KB/MB formatter.
+
+---
+
+## 7. Not in scope
+
+- Agent-side context window tracking (Claudette can't observe this).
+- Multi-workspace cost aggregation (`/cost all` or similar).
+- `/compact` with selective message retention (keep last N turns verbatim + summarize rest).
+- Full command-detail surface (`/help /compact` deep-dive).
+- `/files workspace` expansion to full worktree tree.
+- UI for compaction-summary styling distinct from normal system messages.

--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -182,6 +182,22 @@ pub fn native_command_registry(plugin_management_enabled: bool) -> Vec<SlashComm
         argument_hint: None,
         kind: Some(NativeKind::LocalAction),
     });
+    commands.push(SlashCommand {
+        name: "help".to_string(),
+        description: "List available slash commands".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: None,
+        kind: Some(NativeKind::LocalAction),
+    });
+    commands.push(SlashCommand {
+        name: "init".to_string(),
+        description: "Bootstrap repo guidance (CLAUDE.md) via the agent".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: Some("[extra guidance]".to_string()),
+        kind: Some(NativeKind::PromptExpansion),
+    });
     commands
 }
 
@@ -771,6 +787,9 @@ mod tests {
         assert!(names.contains(&"model"));
         assert!(names.contains(&"permissions"));
         assert!(names.contains(&"status"));
+        // Repo-bootstrap commands are also unconditional.
+        assert!(names.contains(&"help"));
+        assert!(names.contains(&"init"));
     }
 
     #[test]
@@ -905,6 +924,51 @@ mod tests {
             assert_eq!(version.kind, Some(NativeKind::LocalAction));
             assert_eq!(version.aliases, vec!["about".to_string()]);
         }
+    }
+
+    #[test]
+    fn test_native_command_registry_includes_help_and_init() {
+        for enabled in [true, false] {
+            let natives = native_command_registry(enabled);
+            let by_name: HashMap<&str, &SlashCommand> =
+                natives.iter().map(|c| (c.name.as_str(), c)).collect();
+
+            let help = by_name
+                .get("help")
+                .unwrap_or_else(|| panic!("help missing (enabled={enabled})"));
+            assert_eq!(help.source, "builtin");
+            assert_eq!(help.kind, Some(NativeKind::LocalAction));
+            assert!(help.aliases.is_empty(), "/help exposes no aliases");
+            assert!(help.argument_hint.is_none(), "/help takes no arguments");
+            assert_eq!(help.description, "List available slash commands");
+
+            let init = by_name
+                .get("init")
+                .unwrap_or_else(|| panic!("init missing (enabled={enabled})"));
+            assert_eq!(init.source, "builtin");
+            assert_eq!(init.kind, Some(NativeKind::PromptExpansion));
+            assert!(init.aliases.is_empty(), "/init exposes no aliases");
+            assert_eq!(init.argument_hint.as_deref(), Some("[extra guidance]"));
+        }
+    }
+
+    #[test]
+    fn test_collect_native_commands_yields_help_and_init_to_user_markdown() {
+        // /help and /init are non-reserved natives, so a user-defined
+        // commands/help.md or commands/init.md should win — matches the
+        // precedence rule for /config, /review, etc.
+        let mut commands = vec![
+            SlashCommand::file_based("help".into(), "User custom help".into(), "user"),
+            SlashCommand::file_based("init".into(), "Project custom init".into(), "project"),
+        ];
+        collect_native_commands(&mut commands, false);
+
+        let help = commands.iter().find(|c| c.name == "help").unwrap();
+        assert_eq!(help.source, "user");
+        assert_eq!(help.description, "User custom help");
+
+        let init = commands.iter().find(|c| c.name == "init").unwrap();
+        assert_eq!(init.source, "project");
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -640,6 +640,7 @@ export function ChatPanel() {
             setPlanMode: setPlanModeBound,
             clearConversation: clearConversationBound,
             readPlanFile: readPlanFileBound,
+            slashCommands: cmds,
           },
           parsedSlash.args,
         );

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { PluginSettingsIntent } from "../../types/plugins";
+import type { SlashCommand } from "../../services/tauri";
 import {
   CONFIG_SECTIONS,
   NATIVE_HANDLERS,
   describeSlashQuery,
+  formatHelpMessage,
   formatVersionMessage,
   parseSlashInput,
   resolveNativeHandler,
@@ -42,6 +44,7 @@ function makeCtx(overrides: Partial<NativeCommandContext> = {}): NativeCommandCo
     setPlanMode: vi.fn(),
     clearConversation: vi.fn(async () => {}),
     readPlanFile: vi.fn(async () => "plan content"),
+    slashCommands: [],
     ...overrides,
   };
 }
@@ -949,5 +952,302 @@ describe("workspace-control picker filtering", () => {
   it("resolves /allowed-tools as an alias to /permissions", () => {
     expect(resolveNativeHandler("allowed-tools")?.name).toBe("permissions");
     expect(resolveNativeHandler("Allowed-Tools")?.name).toBe("permissions");
+  });
+});
+
+// Shared fixture for /help rendering tests — mirrors the shape of what the
+// Rust side would return for a typical workspace.
+const helpFixture: SlashCommand[] = [
+  {
+    name: "clear",
+    description: "Clear the current workspace conversation",
+    source: "builtin",
+    aliases: [],
+    kind: "local_action",
+  },
+  {
+    name: "config",
+    description: "Open Claudette settings",
+    source: "builtin",
+    aliases: ["configure"],
+    argument_hint: "[general|models|usage]",
+    kind: "settings_route",
+  },
+  {
+    name: "help",
+    description: "List available slash commands",
+    source: "builtin",
+    aliases: [],
+    kind: "local_action",
+  },
+  {
+    name: "init",
+    description: "Bootstrap repo guidance (CLAUDE.md) via the agent",
+    source: "builtin",
+    aliases: [],
+    argument_hint: "[extra guidance]",
+    kind: "prompt_expansion",
+  },
+  {
+    name: "review",
+    description: "Seed a code review of the current branch against its base",
+    source: "builtin",
+    aliases: [],
+    argument_hint: "[extra focus areas]",
+    kind: "prompt_expansion",
+  },
+  {
+    name: "my-project-cmd",
+    description: "A project command",
+    source: "project",
+    aliases: [],
+  },
+  {
+    name: "my-user-cmd",
+    description: "A user command",
+    source: "user",
+    aliases: [],
+  },
+  {
+    name: "plugin-ns:deploy",
+    description: "Deploy via plugin",
+    source: "plugin",
+    aliases: [],
+  },
+];
+
+describe("formatHelpMessage", () => {
+  it("groups native commands by kind with the specified heading order", () => {
+    const out = formatHelpMessage(helpFixture);
+    const actionsIdx = out.indexOf("_Actions (stay local");
+    const settingsIdx = out.indexOf("_Settings shortcuts_");
+    const promptIdx = out.indexOf("_Prompt expansions");
+    expect(actionsIdx).toBeGreaterThan(-1);
+    expect(settingsIdx).toBeGreaterThan(actionsIdx);
+    expect(promptIdx).toBeGreaterThan(settingsIdx);
+  });
+
+  it("alphabetizes entries within each group", () => {
+    const out = formatHelpMessage(helpFixture);
+    // /clear, /help come before /status alphabetically — confirm clear precedes help.
+    expect(out.indexOf("- /clear ")).toBeLessThan(out.indexOf("- /help "));
+    // Within prompt_expansion, /init precedes /review.
+    expect(out.indexOf("- /init ")).toBeLessThan(out.indexOf("- /review "));
+  });
+
+  it("renders argument hints and descriptions inline", () => {
+    const out = formatHelpMessage(helpFixture);
+    expect(out).toContain("- /config [general|models|usage]  (alias: /configure) — Open Claudette settings");
+    expect(out).toContain("- /init [extra guidance] — Bootstrap repo guidance (CLAUDE.md) via the agent");
+  });
+
+  it("renders aliases as '(alias: /x, /y)'", () => {
+    const withMulti: SlashCommand[] = [
+      {
+        name: "permissions",
+        description: "Show or change the workspace permission mode",
+        source: "builtin",
+        aliases: ["allowed-tools", "perm"],
+        argument_hint: "[readonly|standard|full]",
+        kind: "local_action",
+      },
+    ];
+    const out = formatHelpMessage(withMulti);
+    expect(out).toContain("(alias: /allowed-tools, /perm)");
+  });
+
+  it("groups file-based commands by source under dedicated headings", () => {
+    const out = formatHelpMessage(helpFixture);
+    expect(out).toContain("**Project commands**");
+    expect(out).toContain("- /my-project-cmd — A project command");
+    expect(out).toContain("**User commands**");
+    expect(out).toContain("- /my-user-cmd — A user command");
+    expect(out).toContain("**Plugin commands**");
+    expect(out).toContain("- /plugin-ns:deploy — Deploy via plugin");
+  });
+
+  it("omits an entire group heading when the group is empty", () => {
+    const onlyNative: SlashCommand[] = [
+      {
+        name: "version",
+        description: "Show the current Claudette version",
+        source: "builtin",
+        aliases: ["about"],
+        kind: "local_action",
+      },
+    ];
+    const out = formatHelpMessage(onlyNative);
+    expect(out).not.toContain("**Project commands**");
+    expect(out).not.toContain("**User commands**");
+    expect(out).not.toContain("**Plugin commands**");
+    expect(out).not.toContain("_Settings shortcuts_");
+    expect(out).not.toContain("_Prompt expansions");
+    expect(out).toContain("_Actions (stay local");
+  });
+
+  it("excludes builtin commands that are missing a kind", () => {
+    // Defensive: a builtin without `kind` would have no handler, so it must not
+    // appear in /help output either.
+    const malformed: SlashCommand[] = [
+      { name: "broken", description: "no kind set", source: "builtin", aliases: [] },
+    ];
+    expect(formatHelpMessage(malformed)).toBe("No slash commands are registered.");
+  });
+
+  it("returns a graceful message when no commands are registered", () => {
+    expect(formatHelpMessage([])).toBe("No slash commands are registered.");
+  });
+
+  it("does not include builtin entries in the file-based sections", () => {
+    // Prevent regressions where `/config` could be double-listed under User
+    // commands if the source filter were mis-spelled.
+    const out = formatHelpMessage(helpFixture);
+    // Everything after the first file-based heading should NOT contain /config.
+    const firstFileHeading = out.indexOf("**Project commands**");
+    if (firstFileHeading !== -1) {
+      const tail = out.slice(firstFileHeading);
+      expect(tail).not.toContain("/config");
+      expect(tail).not.toContain("/review");
+    }
+  });
+});
+
+describe("help native handler", () => {
+  it("routes /help to addLocalMessage using the context's slashCommands", async () => {
+    const ctx = makeCtx({ slashCommands: helpFixture });
+    const handler = resolveNativeHandler("help")!;
+    expect(handler.name).toBe("help");
+    expect(handler.kind).toBe("local_action");
+    const result = await handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "help" });
+    expect(ctx.addLocalMessage).toHaveBeenCalledOnce();
+    const rendered = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(rendered).toBe(formatHelpMessage(helpFixture));
+  });
+
+  it("does not send anything to the agent", async () => {
+    // The handler is local_action and must return "handled" so handleSend never
+    // falls through to sendChatMessage. Any accidental kind=expand would cause
+    // the agent to be invoked.
+    const ctx = makeCtx({ slashCommands: helpFixture });
+    const result = await resolveNativeHandler("help")!.execute(ctx, "");
+    expect(result.kind).toBe("handled");
+  });
+
+  it("renders a graceful placeholder when the registry is empty", async () => {
+    const ctx = makeCtx({ slashCommands: [] });
+    await resolveNativeHandler("help")!.execute(ctx, "");
+    const rendered = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(rendered).toBe("No slash commands are registered.");
+  });
+
+  it("consumes ctx.slashCommands rather than NATIVE_HANDLERS directly", async () => {
+    // If the handler accidentally used NATIVE_HANDLERS, file-based user/project
+    // commands would be invisible in /help. Pass a list containing only a
+    // user command and assert it IS rendered.
+    const onlyUser: SlashCommand[] = [
+      {
+        name: "deploy",
+        description: "User-authored deploy command",
+        source: "user",
+        aliases: [],
+      },
+    ];
+    const ctx = makeCtx({ slashCommands: onlyUser });
+    await resolveNativeHandler("help")!.execute(ctx, "");
+    const rendered = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(rendered).toContain("**User commands**");
+    expect(rendered).toContain("- /deploy — User-authored deploy command");
+  });
+});
+
+describe("init native handler", () => {
+  it("is registered as prompt_expansion with no aliases", () => {
+    const handler = resolveNativeHandler("init")!;
+    expect(handler.name).toBe("init");
+    expect(handler.kind).toBe("prompt_expansion");
+    expect(handler.aliases).toEqual([]);
+  });
+
+  it("expands with repo, branch, worktree, and default-branch context", async () => {
+    const ctx = makeCtx({
+      repository: { name: "claudette", path: "/Users/me/Projects/claudette" },
+      workspace: { branch: "feat/init-help", worktreePath: "/Users/me/wt/init-help" },
+      repoDefaultBranch: "origin/main",
+    });
+    const handler = resolveNativeHandler("init")!;
+    const result = await handler.execute(ctx, "");
+    expect(result.kind).toBe("expand");
+    if (result.kind !== "expand") return;
+    expect(result.canonicalName).toBe("init");
+    expect(result.prompt).toContain("CLAUDE.md");
+    expect(result.prompt).toContain("Workspace context:");
+    expect(result.prompt).toContain("- Repository: claudette");
+    expect(result.prompt).toContain("- Repository path: /Users/me/Projects/claudette");
+    expect(result.prompt).toContain("- Worktree: /Users/me/wt/init-help");
+    expect(result.prompt).toContain("- Current branch: feat/init-help");
+    expect(result.prompt).toContain("- Repo default branch (hint): origin/main");
+  });
+
+  it("instructs the agent to merge, not overwrite, existing CLAUDE.md", async () => {
+    const ctx = makeCtx();
+    const result = await resolveNativeHandler("init")!.execute(ctx, "");
+    if (result.kind !== "expand") throw new Error("expected expand");
+    expect(result.prompt.toLowerCase()).toContain("merge");
+    expect(result.prompt).toContain("preserve existing guidance");
+  });
+
+  it("instructs the agent not to commit or push", async () => {
+    const ctx = makeCtx();
+    const result = await resolveNativeHandler("init")!.execute(ctx, "");
+    if (result.kind !== "expand") throw new Error("expected expand");
+    expect(result.prompt).toContain("Do not commit or push");
+  });
+
+  it("omits missing context fields without leaking undefined/null", async () => {
+    const ctx = makeCtx({
+      repository: null,
+      workspace: null,
+      repoDefaultBranch: null,
+    });
+    const result = await resolveNativeHandler("init")!.execute(ctx, "");
+    if (result.kind !== "expand") throw new Error("expected expand");
+    expect(result.prompt).not.toContain("null");
+    expect(result.prompt).not.toContain("undefined");
+    expect(result.prompt).not.toContain("Workspace context:");
+  });
+
+  it("appends user arguments under 'Additional guidance from user:'", async () => {
+    const ctx = makeCtx();
+    const result = await resolveNativeHandler("init")!.execute(
+      ctx,
+      "focus on the Tauri command surface",
+    );
+    if (result.kind !== "expand") throw new Error("expected expand");
+    expect(result.prompt).toContain(
+      "Additional guidance from user: focus on the Tauri command surface",
+    );
+  });
+
+  it("does not add a local message (expansion only)", async () => {
+    const ctx = makeCtx();
+    await resolveNativeHandler("init")!.execute(ctx, "");
+    expect(ctx.addLocalMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("repo-bootstrap picker filtering", () => {
+  it("exposes /help and /init as canonical NATIVE_HANDLERS entries", () => {
+    const names = NATIVE_HANDLERS.map((h) => h.name);
+    expect(names).toContain("help");
+    expect(names).toContain("init");
+  });
+
+  it("/help and /init expose no aliases", () => {
+    expect(NATIVE_HANDLERS.find((h) => h.name === "help")!.aliases).toEqual([]);
+    expect(NATIVE_HANDLERS.find((h) => h.name === "init")!.aliases).toEqual([]);
   });
 });

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -1030,18 +1030,50 @@ describe("formatHelpMessage", () => {
   it("alphabetizes entries within each group", () => {
     const out = formatHelpMessage(helpFixture);
     // /clear, /help come before /status alphabetically — confirm clear precedes help.
-    expect(out.indexOf("- /clear ")).toBeLessThan(out.indexOf("- /help "));
+    expect(out.indexOf("`/clear`")).toBeLessThan(out.indexOf("`/help`"));
     // Within prompt_expansion, /init precedes /review.
-    expect(out.indexOf("- /init ")).toBeLessThan(out.indexOf("- /review "));
+    expect(out.indexOf("`/init ")).toBeLessThan(out.indexOf("`/review "));
   });
 
-  it("renders argument hints and descriptions inline", () => {
+  it("renders the command invocation as inline code and appends description", () => {
     const out = formatHelpMessage(helpFixture);
-    expect(out).toContain("- /config [general|models|usage]  (alias: /configure) — Open Claudette settings");
-    expect(out).toContain("- /init [extra guidance] — Bootstrap repo guidance (CLAUDE.md) via the agent");
+    expect(out).toContain(
+      "- `/config [general|models|usage]`  (alias: /configure) — Open Claudette settings",
+    );
+    expect(out).toContain(
+      "- `/init [extra guidance]` — Bootstrap repo guidance (CLAUDE.md) via the agent",
+    );
+    expect(out).toContain("- `/help` — List available slash commands");
   });
 
-  it("renders aliases as '(alias: /x, /y)'", () => {
+  it("wraps angle-bracket placeholders so the markdown pipeline renders them literally", () => {
+    // Regression: without inline code, `<source>` / `<model>` are parsed by
+    // rehype-raw as HTML tags, get dropped by rehype-sanitize, and the hint
+    // disappears from the rendered /help output.
+    const withAngles: SlashCommand[] = [
+      {
+        name: "marketplace",
+        description: "Manage plugin marketplaces in settings",
+        source: "builtin",
+        aliases: [],
+        argument_hint: "[add|remove|update] <source>",
+        kind: "settings_route",
+      },
+      {
+        name: "model",
+        description: "Show or change the workspace model",
+        source: "builtin",
+        aliases: [],
+        argument_hint: "[<model>]",
+        kind: "local_action",
+      },
+    ];
+    const out = formatHelpMessage(withAngles);
+    expect(out).toContain("`/marketplace [add|remove|update] <source>`");
+    expect(out).toContain("`/model [<model>]`");
+  });
+
+  it("renders aliases as '(alias: /x, /y)' when not shadowed", () => {
     const withMulti: SlashCommand[] = [
       {
         name: "permissions",
@@ -1056,14 +1088,85 @@ describe("formatHelpMessage", () => {
     expect(out).toContain("(alias: /allowed-tools, /perm)");
   });
 
+  it("omits aliases shadowed by a user/project command of the same name", () => {
+    // Regression: the ChatPanel dispatcher routes typed native aliases to a
+    // file-based command when a user/project markdown with that name exists.
+    // /help must not continue advertising the alias as routing to the native.
+    const withShadow: SlashCommand[] = [
+      {
+        name: "permissions",
+        description: "Show or change the workspace permission mode",
+        source: "builtin",
+        aliases: ["allowed-tools", "perm"],
+        argument_hint: "[readonly|standard|full]",
+        kind: "local_action",
+      },
+      // User has .claude/commands/allowed-tools.md — shadows the native alias.
+      {
+        name: "allowed-tools",
+        description: "User override",
+        source: "user",
+        aliases: [],
+      },
+    ];
+    const out = formatHelpMessage(withShadow);
+    // Only the non-shadowed alias survives on the native's line.
+    expect(out).toContain("`/permissions [readonly|standard|full]`  (alias: /perm) —");
+    expect(out).not.toContain("/allowed-tools)");
+    // The file-based command still shows up under **User commands**.
+    expect(out).toContain("- `/allowed-tools` — User override");
+  });
+
+  it("drops the whole alias block when every alias is shadowed", () => {
+    const allShadowed: SlashCommand[] = [
+      {
+        name: "config",
+        description: "Open Claudette settings",
+        source: "builtin",
+        aliases: ["configure"],
+        argument_hint: "[general|models]",
+        kind: "settings_route",
+      },
+      {
+        name: "configure",
+        description: "User-defined configure",
+        source: "project",
+        aliases: [],
+      },
+    ];
+    const out = formatHelpMessage(allShadowed);
+    expect(out).toContain("- `/config [general|models]` — Open Claudette settings");
+    expect(out).not.toContain("(alias:");
+  });
+
+  it("alias shadow check is case-insensitive", () => {
+    const mixedCase: SlashCommand[] = [
+      {
+        name: "config",
+        description: "Open Claudette settings",
+        source: "builtin",
+        aliases: ["Configure"],
+        kind: "settings_route",
+      },
+      {
+        name: "CONFIGURE",
+        description: "User override",
+        source: "user",
+        aliases: [],
+      },
+    ];
+    const out = formatHelpMessage(mixedCase);
+    expect(out).not.toContain("(alias: /Configure)");
+  });
+
   it("groups file-based commands by source under dedicated headings", () => {
     const out = formatHelpMessage(helpFixture);
     expect(out).toContain("**Project commands**");
-    expect(out).toContain("- /my-project-cmd — A project command");
+    expect(out).toContain("- `/my-project-cmd` — A project command");
     expect(out).toContain("**User commands**");
-    expect(out).toContain("- /my-user-cmd — A user command");
+    expect(out).toContain("- `/my-user-cmd` — A user command");
     expect(out).toContain("**Plugin commands**");
-    expect(out).toContain("- /plugin-ns:deploy — Deploy via plugin");
+    expect(out).toContain("- `/plugin-ns:deploy` — Deploy via plugin");
   });
 
   it("omits an entire group heading when the group is empty", () => {
@@ -1160,7 +1263,7 @@ describe("help native handler", () => {
     const rendered = (ctx.addLocalMessage as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
     expect(rendered).toContain("**User commands**");
-    expect(rendered).toContain("- /deploy — User-authored deploy command");
+    expect(rendered).toContain("- `/deploy` — User-authored deploy command");
   });
 });
 

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -1,5 +1,5 @@
 import type { PluginSettingsIntent } from "../../types/plugins";
-import type { NativeSlashKind } from "../../services/tauri";
+import type { NativeSlashKind, SlashCommand } from "../../services/tauri";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import { parsePluginSlashCommand } from "./pluginSlashCommand";
 import { MODELS } from "./modelRegistry";
@@ -64,6 +64,13 @@ export interface NativeCommandContext {
   setPlanMode: (enabled: boolean) => void;
   clearConversation: (restoreFiles: boolean) => Promise<void>;
   readPlanFile: (path: string) => Promise<string>;
+
+  /**
+   * Full slash command registry as exposed to the picker. Read by `/help`
+   * so the help surface and the picker can never drift. Pass the same list
+   * `list_slash_commands` returned for this workspace — do not reconstruct.
+   */
+  slashCommands: SlashCommand[];
 }
 
 export type NativeCommandResult =
@@ -524,6 +531,170 @@ const permissionsHandler: NativeHandler = {
   },
 };
 
+/**
+ * Seed prompt for `/init` — repo-bootstrap workflow. The seeded text is sent
+ * through the normal agent pipeline so the agent can inspect the codebase and
+ * write or update `CLAUDE.md` via the standard tool flow. Existing `CLAUDE.md`
+ * content must be merged, not overwritten, so mature repos don't lose guidance.
+ */
+const INIT_PROMPT = [
+  "Bootstrap project guidance for this repository.",
+  "",
+  "Goal: produce or update a repo-level `CLAUDE.md` at the repo root that is useful to a future agent (or engineer) who has never seen this codebase. If `CLAUDE.md` already exists, MERGE new findings into it — preserve existing guidance, only add or refine.",
+  "",
+  "Inspection pass (do this first):",
+  "- Identify the project type, primary languages, and frameworks.",
+  "- Find the build, test, lint, and format commands (look at package.json, Cargo.toml, Makefile, flake.nix, pyproject.toml, etc.).",
+  "- Map the top-level directory structure and what each area is for.",
+  "- Note the commit convention (scan `git log --oneline -20`).",
+  "- Note any code-style config (rustfmt, prettier, ruff, .editorconfig) and the stance it encodes.",
+  "- Detect any existing `.claudette.json` or similar instruction files — cross-reference so CLAUDE.md doesn't contradict them.",
+  "",
+  "CLAUDE.md should include, in this order:",
+  "1. One-paragraph project summary.",
+  "2. Build & test commands as copy-paste shell snippets.",
+  "3. Code style conventions the repo actually uses.",
+  "4. Commit conventions (e.g. Conventional Commits, PR title rules).",
+  "5. Architecture overview: crates/modules/packages and their responsibilities.",
+  "6. Project structure tree (pruned — skip node_modules, target, dist, etc.).",
+  "7. Guidelines for new code (where data types live, where commands live, state conventions).",
+  "8. Debugging / dev loop notes if the repo has non-trivial dev tooling.",
+  "",
+  "Rules:",
+  "- Write the file via the normal file-write tool flow.",
+  "- Do not commit or push.",
+  "- If a `CLAUDE.md` already exists, read it first and preserve sections the user has clearly authored (custom conventions, team rules). Only update sections that are stale or missing.",
+  "- Keep the file concise and high-signal; this is agent instruction material, not marketing copy.",
+].join("\n");
+
+const initHandler: NativeHandler = {
+  name: "init",
+  aliases: [],
+  kind: "prompt_expansion",
+  execute: (ctx, args) => {
+    const lines: string[] = [];
+    if (ctx.repository?.name) lines.push(`- Repository: ${ctx.repository.name}`);
+    if (ctx.repository?.path) lines.push(`- Repository path: ${ctx.repository.path}`);
+    if (ctx.workspace?.worktreePath) lines.push(`- Worktree: ${ctx.workspace.worktreePath}`);
+    if (ctx.workspace?.branch) lines.push(`- Current branch: ${ctx.workspace.branch}`);
+    if (ctx.repoDefaultBranch)
+      lines.push(`- Repo default branch (hint): ${ctx.repoDefaultBranch}`);
+    const contextBlock = lines.length > 0 ? `\n\nWorkspace context:\n${lines.join("\n")}` : "";
+    const prompt = `${INIT_PROMPT}${contextBlock}${buildUserGuidanceBlock(args)}`;
+    return { kind: "expand", canonicalName: "init", prompt };
+  },
+};
+
+function formatCommandLine(cmd: SlashCommand): string {
+  const head = cmd.argument_hint ? `/${cmd.name} ${cmd.argument_hint}` : `/${cmd.name}`;
+  const aliasPart =
+    cmd.aliases && cmd.aliases.length > 0
+      ? `  (alias: ${cmd.aliases.map((a) => `/${a}`).join(", ")})`
+      : "";
+  const desc = cmd.description.trim().length > 0 ? ` — ${cmd.description}` : "";
+  return `- ${head}${aliasPart}${desc}`;
+}
+
+/**
+ * Build the multi-line `/help` output. Pure function so tests can pin exact
+ * formatting without spinning up a context.
+ *
+ * Layout:
+ *   **Native commands**
+ *   _Actions (stay local, do not contact the agent)_
+ *     - /clear — ...
+ *   _Settings shortcuts_
+ *     - /config [...] — ...
+ *   _Prompt expansions (seed a prompt, then send to the agent)_
+ *     - /review [...] — ...
+ *   **Project commands** / **User commands** / **Plugin commands**
+ *
+ * Native entries are grouped by `kind`. File-based entries are grouped by
+ * `source`. Each group is alphabetized. Empty groups are omitted entirely so
+ * the output stays tight when plugin/project commands don't apply.
+ */
+export function formatHelpMessage(commands: SlashCommand[]): string {
+  const sorted = [...commands].sort((a, b) => a.name.localeCompare(b.name));
+
+  const byKind = new Map<NativeSlashKind, SlashCommand[]>();
+  const bySource: Record<"project" | "user" | "plugin", SlashCommand[]> = {
+    project: [],
+    user: [],
+    plugin: [],
+  };
+
+  for (const cmd of sorted) {
+    if (cmd.source === "builtin") {
+      const kind = cmd.kind ?? null;
+      if (!kind) continue;
+      if (!byKind.has(kind)) byKind.set(kind, []);
+      byKind.get(kind)!.push(cmd);
+    } else if (cmd.source === "project" || cmd.source === "user" || cmd.source === "plugin") {
+      bySource[cmd.source].push(cmd);
+    }
+  }
+
+  const sections: string[] = [];
+  const nativeLines: string[] = [];
+
+  const kindOrder: Array<{ kind: NativeSlashKind; heading: string }> = [
+    {
+      kind: "local_action",
+      heading: "_Actions (stay local, do not contact the agent)_",
+    },
+    { kind: "settings_route", heading: "_Settings shortcuts_" },
+    {
+      kind: "prompt_expansion",
+      heading: "_Prompt expansions (seed a prompt, then send to the agent)_",
+    },
+  ];
+
+  for (const { kind, heading } of kindOrder) {
+    const entries = byKind.get(kind);
+    if (!entries || entries.length === 0) continue;
+    nativeLines.push(heading);
+    entries.forEach((cmd) => nativeLines.push(formatCommandLine(cmd)));
+    nativeLines.push("");
+  }
+
+  if (nativeLines.length > 0) {
+    // Drop trailing blank line from the native block before emitting.
+    while (nativeLines.length > 0 && nativeLines[nativeLines.length - 1] === "") {
+      nativeLines.pop();
+    }
+    sections.push(["**Native commands**", "", ...nativeLines].join("\n"));
+  }
+
+  const sourceOrder: Array<{ key: "project" | "user" | "plugin"; heading: string }> = [
+    { key: "project", heading: "**Project commands**" },
+    { key: "user", heading: "**User commands**" },
+    { key: "plugin", heading: "**Plugin commands**" },
+  ];
+
+  for (const { key, heading } of sourceOrder) {
+    const entries = bySource[key];
+    if (entries.length === 0) continue;
+    const block = [heading, "", ...entries.map(formatCommandLine)];
+    sections.push(block.join("\n"));
+  }
+
+  if (sections.length === 0) {
+    return "No slash commands are registered.";
+  }
+
+  return sections.join("\n\n");
+}
+
+const helpHandler: NativeHandler = {
+  name: "help",
+  aliases: [],
+  kind: "local_action",
+  execute: (ctx) => {
+    ctx.addLocalMessage(formatHelpMessage(ctx.slashCommands));
+    return { kind: "handled", canonicalName: "help" };
+  },
+};
+
 const statusHandler: NativeHandler = {
   name: "status",
   aliases: [],
@@ -570,6 +741,8 @@ export const NATIVE_HANDLERS: NativeHandler[] = [
   modelHandler,
   permissionsHandler,
   statusHandler,
+  helpHandler,
+  initHandler,
 ];
 
 /** Resolve a slash command token (no leading `/`) against the native handler table. */

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -585,11 +585,30 @@ const initHandler: NativeHandler = {
   },
 };
 
-function formatCommandLine(cmd: SlashCommand): string {
-  const head = cmd.argument_hint ? `/${cmd.name} ${cmd.argument_hint}` : `/${cmd.name}`;
+function formatCommandLine(
+  cmd: SlashCommand,
+  shadowedAliases: ReadonlySet<string>,
+): string {
+  // Wrap the command invocation in inline code so angle-bracket placeholders
+  // like `<source>` and `<model>` survive the markdown pipeline intact —
+  // rehype-raw otherwise parses them as HTML tags and either drops them via
+  // rehype-sanitize or renders them as self-closing tags. Inline code also
+  // gives /help a consistent visual anchor in the chat transcript.
+  const head = cmd.argument_hint
+    ? `\`/${cmd.name} ${cmd.argument_hint}\``
+    : `\`/${cmd.name}\``;
+
+  // Drop aliases that a file-based user/project command has shadowed. The
+  // dispatcher in ChatPanel.handleSend treats typing such an alias as a
+  // file-based invocation, so /help advertising it as "(alias: …)" for the
+  // native would be misleading. Aliases owned by the native (no file-based
+  // collision) render normally.
+  const visibleAliases = (cmd.aliases ?? []).filter(
+    (alias) => !shadowedAliases.has(alias.toLowerCase()),
+  );
   const aliasPart =
-    cmd.aliases && cmd.aliases.length > 0
-      ? `  (alias: ${cmd.aliases.map((a) => `/${a}`).join(", ")})`
+    visibleAliases.length > 0
+      ? `  (alias: ${visibleAliases.map((a) => `/${a}`).join(", ")})`
       : "";
   const desc = cmd.description.trim().length > 0 ? ` — ${cmd.description}` : "";
   return `- ${head}${aliasPart}${desc}`;
@@ -615,6 +634,15 @@ function formatCommandLine(cmd: SlashCommand): string {
  */
 export function formatHelpMessage(commands: SlashCommand[]): string {
   const sorted = [...commands].sort((a, b) => a.name.localeCompare(b.name));
+
+  // Names claimed by a user/project markdown command shadow any colliding
+  // native alias in ChatPanel's dispatcher, so /help must suppress those
+  // alias lines to stay consistent with actual routing behavior.
+  const shadowedAliases: ReadonlySet<string> = new Set(
+    sorted
+      .filter((c) => c.source === "user" || c.source === "project")
+      .map((c) => c.name.toLowerCase()),
+  );
 
   const byKind = new Map<NativeSlashKind, SlashCommand[]>();
   const bySource: Record<"project" | "user" | "plugin", SlashCommand[]> = {
@@ -653,7 +681,7 @@ export function formatHelpMessage(commands: SlashCommand[]): string {
     const entries = byKind.get(kind);
     if (!entries || entries.length === 0) continue;
     nativeLines.push(heading);
-    entries.forEach((cmd) => nativeLines.push(formatCommandLine(cmd)));
+    entries.forEach((cmd) => nativeLines.push(formatCommandLine(cmd, shadowedAliases)));
     nativeLines.push("");
   }
 
@@ -674,7 +702,7 @@ export function formatHelpMessage(commands: SlashCommand[]): string {
   for (const { key, heading } of sourceOrder) {
     const entries = bySource[key];
     if (entries.length === 0) continue;
-    const block = [heading, "", ...entries.map(formatCommandLine)];
+    const block = [heading, "", ...entries.map((cmd) => formatCommandLine(cmd, shadowedAliases))];
     sections.push(block.join("\n"));
   }
 


### PR DESCRIPTION
## Summary

Closes #245.

Adds the final two repo-bootstrap commands on top of the native slash command framework from #241/#248:

- **`/init`** — `prompt_expansion` handler that seeds a CLAUDE.md-producing prompt grounded in the active workspace (repo, path, branch, default branch). Instructs the agent to merge rather than overwrite existing `CLAUDE.md` and forbids commit/push so the user stays in control of the diff. Optional free-form arguments land under `Additional guidance from user:`.
- **`/help`** — `local_action` handler that renders the live slash command registry grouped by kind (actions / settings / prompt expansions) with a separate section per file-based source (project / user / plugin). Consumes the same `SlashCommand[]` list the picker reads, so the two surfaces cannot drift. Handles empty-registry and kindless-builtin cases gracefully.

A `slashCommands: SlashCommand[]` field was added to `NativeCommandContext` so handlers can read the live picker registry without a second IPC hop — wired from the already-cached list in `ChatPanel.handleSend`.

## Peer-review fixes already applied

The first cut of `/help` had two correctness bugs caught by a Codex review before PR open:

1. Argument hints containing `<...>` (e.g. `<source>`, `<model>`) were parsed as HTML by rehype-raw/rehype-sanitize and vanished from the rendered output. Fixed by wrapping `/name <hint>` in inline code.
2. `/help` kept advertising native aliases (e.g. `(alias: /allowed-tools)`) even when a user/project markdown shadowed them in `ChatPanel.handleSend`. Fixed by filtering each native's aliases against the discovered file-based names (case-insensitive) before rendering.

Both paths have regression tests.

## Design doc

`docs/slash-commands-245-246-tdd.md` covers this cluster plus the follow-up #246 (`/compact`, `/context`, `/files`, `/cost`). The #245 sections reflect what shipped; the #246 sections stand as an implementation plan for the next branch.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --all-features` — 390 passed (+2 new: `test_native_command_registry_includes_help_and_init`, `test_collect_native_commands_yields_help_and_init_to_user_markdown`)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 464 passed (+14 new covering formatHelpMessage grouping, alphabetization, alias rendering, angle-bracket escaping, shadowed-alias filtering, case-insensitive shadow detection, all-aliases-shadowed case, helpHandler dispatch, initHandler expansion shape / merge / no-commit / missing-context / user args)
- [ ] Manual UAT in a dev build: type `/help` with and without project/user markdown commands, type `/init` in a repo with and without an existing CLAUDE.md, verify picker lists both entries