### PR TITLE
fix(ui): right-align MCP badge and populate it before workspace selection

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -240,14 +240,14 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* MCP server health indicator next to repo name */
+/* MCP server health indicator — pushed to end of repo header row */
 .mcpIndicator {
   display: inline-flex;
   align-items: center;
   gap: 3px;
   font-size: 10px;
   color: var(--text-dim);
-  margin-left: 4px;
+  order: 1;
   font-variant-numeric: tabular-nums;
 }
 

--- a/src/ui/src/hooks/useMcpStatus.ts
+++ b/src/ui/src/hooks/useMcpStatus.ts
@@ -8,15 +8,15 @@ import { ensureAndValidateMcps } from "../services/mcp";
  * Listen for "mcp-status-changed" events from the Rust MCP supervisor
  * and update the Zustand store with the latest per-repository status.
  *
- * Also triggers MCP detection + validation when the active workspace changes.
+ * Triggers MCP detection + validation for every known repository once per
+ * session so the sidebar indicators populate without waiting for a workspace
+ * to be selected.
  */
 export function useMcpStatus() {
   const setMcpStatus = useAppStore((s) => s.setMcpStatus);
   const clearMcpStatus = useAppStore((s) => s.clearMcpStatus);
-  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
-  const workspaces = useAppStore((s) => s.workspaces);
   const repositories = useAppStore((s) => s.repositories);
-  const lastRepoId = useRef<string | null>(null);
+  const validated = useRef<Set<string>>(new Set());
 
   // Listen for supervisor status events.
   useEffect(() => {
@@ -41,24 +41,17 @@ export function useMcpStatus() {
     };
   }, [clearMcpStatus]);
 
-  // When the selected workspace changes, ensure MCPs are detected + validated.
+  // Validate MCPs for every repository once per session. Runs on initial load
+  // and whenever a new repo is added. The AttachMenu re-detects on open for
+  // fresh state, so we don't need to re-validate on workspace switches.
   useEffect(() => {
-    if (!selectedWorkspaceId) return;
-    const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
-    if (!ws) return;
-    const repoId = ws.repository_id;
-
-    // Skip if we already validated this repo during this session.
-    // This avoids re-running detection on every workspace switch within the
-    // same repo. The AttachMenu always re-detects on open for fresh state.
-    if (lastRepoId.current === repoId) return;
-    lastRepoId.current = repoId;
-
-    // Check repo exists.
-    if (!repositories.some((r) => r.id === repoId)) return;
-
-    ensureAndValidateMcps(repoId)
-      .then((snapshot) => setMcpStatus(repoId, snapshot))
-      .catch(() => {});
-  }, [selectedWorkspaceId, workspaces, repositories, setMcpStatus]);
+    for (const repo of repositories) {
+      if (!repo.path_valid) continue;
+      if (validated.current.has(repo.id)) continue;
+      validated.current.add(repo.id);
+      ensureAndValidateMcps(repo.id)
+        .then((snapshot) => setMcpStatus(repo.id, snapshot))
+        .catch(() => {});
+    }
+  }, [repositories, setMcpStatus]);
 }


### PR DESCRIPTION
## Summary

Two small fixes to the sidebar MCP status indicator (the `[dot] connected/total` badge next to each repo name):

- **Right-align the badge.** The `.repoHeader` flex row contains the MCP badge *before* the `+` / settings icon buttons. Those buttons have `opacity: 0` until hover, but still occupy flex space, so the badge landed mid-right instead of at the edge. Added `order: 1` to `.mcpIndicator` so it renders after all siblings regardless of hover state, and removed the stray `margin-left: 4px` so the uniform `gap: 6px` handles spacing. DOM order in `Sidebar.tsx` is unchanged — `order` only affects visual layout.
- **Populate the badge without waiting for a workspace selection.** `useMcpStatus` previously only called `ensureAndValidateMcps` for the repo tied to the *selected* workspace. The hook now iterates every known repository on load (skipping `path_valid: false` repos), deduped via a `Set<string>` ref so it's once-per-session. New repos added mid-session also get validated. Supervisor status events still flow through the existing `mcp-status-changed` listener, so badges populate progressively as each repo's MCPs connect.

## Test plan

- [ ] `cd src/ui && bunx tsc --noEmit` passes (verified locally).
- [ ] `cargo tauri dev`: open the app with no workspace selected — MCP badges should appear on repos with configured MCPs within a second or two of startup.
- [ ] Badges sit flush against the right edge of each repo row, including when hovering to reveal the `+` / settings buttons.
- [ ] Switching between workspaces within the same repo does not re-trigger validation (once-per-session dedupe).
- [ ] Adding a new repo mid-session triggers validation for that repo only.
- [ ] Repos with `path_valid: false` are skipped (no failed-detection spam).