### PR TITLE
fix(ui): remove MCP status indicator from sidebar

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -240,24 +240,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* MCP server health indicator next to repo name */
-.mcpIndicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  font-size: 10px;
-  color: var(--text-dim);
-  margin-left: 4px;
-  font-variant-numeric: tabular-nums;
-}
-
-.mcpDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
 /* Keyboard shortcut badge shown on Cmd/Ctrl hold — absolutely positioned
    so it doesn't reflow the header when it appears/disappears. */
 .shortcutBadge {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -18,44 +18,12 @@ import {
 import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog, Filter, Check, LayoutDashboard } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { useSpinnerFrame } from "../../hooks/useSpinnerFrame";
-import type { McpStatusSnapshot } from "../../types/mcp";
 import styles from "./Sidebar.module.css";
-
-/** Compact MCP status badge for the repo row: [dot] connected/enabled */
-function McpStatusBadge({ status }: { status: McpStatusSnapshot | undefined }) {
-  if (!status || status.servers.length === 0) return null;
-  const enabled = status.servers.filter((s) => s.enabled);
-  if (enabled.length === 0) return null;
-  const connected = enabled.filter((s) => s.state === "connected").length;
-  const total = enabled.length;
-  const hasFailed = enabled.some((s) => s.state === "failed");
-  const allConnected = connected === total;
-  return (
-    <span
-      className={styles.mcpIndicator}
-      title={`MCP: ${connected}/${total} connected`}
-    >
-      <span
-        className={styles.mcpDot}
-        style={{
-          background: allConnected
-            ? "var(--status-running)"
-            : hasFailed
-              ? "var(--status-stopped)"
-              : "var(--status-idle)",
-        }}
-      />
-      {connected}/{total}
-    </span>
-  );
-}
-
 
 export const Sidebar = memo(function Sidebar() {
   const repositories = useAppStore((s) => s.repositories);
   const workspaces = useAppStore((s) => s.workspaces);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
-  const mcpStatus = useAppStore((s) => s.mcpStatus);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
   const sidebarFilter = useAppStore((s) => s.sidebarFilter);
   const setSidebarFilter = useAppStore((s) => s.setSidebarFilter);
@@ -416,7 +384,6 @@ export const Sidebar = memo(function Sidebar() {
                     <span className={styles.runningBadge}>{runningCount}</span>
                   )}
                 </span>
-                <McpStatusBadge status={mcpStatus[repo.id]} />
                 {!repo.path_valid && (
                   <span className={styles.invalidBadge}>!</span>
                 )}


### PR DESCRIPTION
## Summary

Removes the `[dot] connected/total` MCP badge that appeared next to each repository name in the sidebar.

- Deletes the local `McpStatusBadge` component and its JSX usage in `Sidebar.tsx`.
- Drops the `mcpStatus` Zustand subscription (now unused in this component) and the `McpStatusSnapshot` import.
- Removes the `.mcpIndicator` and `.mcpDot` rules from `Sidebar.module.css`.

The underlying MCP status system is **not** touched: the `mcpStatus` store slice, `useMcpStatus` hook, supervisor events, and service commands all remain. `RepoSettings` still renders per-server status dots and `AttachMenu` still reads live state from `mcpStatus` when picking MCP tools.

Net change: **-51 lines across 2 files.**

## Test plan

- [x] `bunx tsc --noEmit` passes (no stale references to `McpStatusBadge`, `McpStatusSnapshot`, `mcpIndicator`, or `mcpDot`).
- [x] `bun run test` — 464/464 vitest tests pass.
- [ ] `cargo tauri dev`: sidebar rows no longer show a connected/total badge; other row affordances (chevron, running-count badge, `!` invalid indicator, `+` / settings buttons, ⌘-hold shortcut badge) still render correctly.
- [ ] Open Repo Settings for a repo with MCPs — per-server status dots still appear.
- [ ] Open the AttachMenu in a workspace — MCP server states still render correctly there.