### PR TITLE
chore(release-please): keep breaking changes as minor bumps pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "release-type": "rust",
+  "bump-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Adds `"bump-minor-pre-major": true` to `release-please-config.json` so that breaking-change footers in commits bump the **minor** version while the project is in the 0.x phase, instead of jumping straight to 1.0.0.

## Why

PR #227 (`feat: add CLAUDETTE_* environment variables to all subprocesses`) was merged with a legitimate breaking-change footer documenting the removal of two notification env vars. release-please correctly interpreted that footer per the Conventional Commits spec and opened release PR #201 (`chore(main): release 1.0.0`) — bumping us from 0.10.0 straight to 1.0.0.

This was unexpected. The 1.0 milestone should mark an intentional API-stability commitment, not a side effect of one removed env var. Per the [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md), the `bump-minor-pre-major` option ensures breaking changes only bump the semver minor when the current version is below 1.0.0 — i.e. the standard SemVer 0.x convention.

## What happens after this lands

Once merged to `main`, release-please re-runs automatically (via `.github/workflows/release-please.yml`) and **updates PR #201 in place**:
- Title: `chore(main): release 1.0.0` → `chore(main): release 0.11.0`
- Cargo.toml / `.release-please-manifest.json` diffs: `0.10.0 → 0.11.0` instead of `0.10.0 → 1.0.0`
- The breaking-changes callout in the changelog is preserved — readers still get the warning, we just don't burn the 1.0 number on it.

This option becomes a no-op once we hit 1.0.0 intentionally, so it's safe to leave in permanently.

## Test plan

- [ ] After merge, confirm a new release-please workflow run completes successfully
- [ ] Confirm PR #201 is updated to `chore(main): release 0.11.0`
- [ ] Confirm `gh pr diff 201` shows version bumps to `0.11.0` (not `1.0.0`) across `Cargo.toml`, `src-tauri/Cargo.toml`, `src-server/Cargo.toml`, `.release-please-manifest.json`
- [ ] Confirm the breaking-changes callout is still present in PR #201's body
- [ ] Confirm no `v1.0.0` tag or release exists