### PR TITLE
fix(ui): make chat toolbar chips respect UI font size

### DIFF
--- a/src/ui/src/components/chat/ChatToolbar.module.css
+++ b/src/ui/src/components/chat/ChatToolbar.module.css
@@ -15,7 +15,6 @@
   border-radius: 6px;
   background: transparent;
   color: var(--text-dim);
-  font-size: 12px;
   cursor: pointer;
   white-space: nowrap;
   position: relative;
@@ -54,7 +53,6 @@
 }
 
 .chipLabel {
-  font-size: 12px;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary

The chat composer's bottom toolbar (model picker, Thinking, eye toggle, Auto, Plan, Chrome) had `font-size: 12px` hardcoded on `.chip` and `.chipLabel`. The app's UI font size setting scales the whole UI via CSS `zoom` on `:root` (`theme.ts:95`) from a 13px baseline (`theme.css:122`), so the toolbar labels *did* scale, but always rendered ~8% below the user's configured size — visibly smaller than adjacent chat UI (Send button at 13px, input at 14px).

Dropping both `font-size: 12px` overrides lets the chips inherit the 13px baseline. The existing `button { font-size: inherit }` rule in `theme.css:105-111` carries that inheritance into the `<button>` elements, and the `zoom` mechanism scales them proportionally with every other UI element.

The `.chipLabel` rule still keeps `line-height: 1` — that's load-bearing to stop the label's default line box from stretching the chip taller than its 14px icon.

## Complexity Notes

None. Two-line CSS deletion, no logic change. Worth knowing: the fix implicitly depends on `button, input, select, textarea { font-size: inherit }` in `theme.css` — if that rule is ever removed, the chips would silently regress to the UA default (~13.333px in WebKit).

## Test Steps

1. Run `cargo tauri dev` and open any workspace.
2. In the chat composer, confirm the toolbar labels ("Opus 4.7", "Thinking", "Auto", "Plan", "Chrome") appear at the same size as the "Send" button to their right.
3. Open Settings → Appearance. Change **UI font size** to `16`. Confirm the toolbar labels scale up in lockstep with the rest of the UI.
4. Change the UI font size to `10` (min). Confirm the toolbar labels shrink uniformly with the rest of the UI.
5. Hold `⌘` (macOS) / `Ctrl` (Linux). The `⌘T` shortcut badge on the Thinking chip and the `⇧Tab` badge on the Plan chip should still render centered over chip content.

## Checklist

- [ ] Tests added/updated (N/A — CSS-only; existing vitest suite passes unchanged)
- [ ] Documentation updated (N/A)