### PR TITLE
fix(agent): respawn persistent session when plan_mode or allowedTools drift

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -281,6 +281,10 @@ pub async fn send_chat_message(
         eprintln!("[chat] MCP config dirty — tearing down persistent session for {workspace_id}");
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;
+        // Clear active_pid alongside persistent_session so a failed respawn
+        // can't leave the next turn with a stale PID that the kernel may
+        // have recycled (would get SIGKILLed by the stale-process branch).
+        session.active_pid = None;
         session.mcp_config_dirty = false;
         if let Some(pid) = stale_pid {
             drop(agents);
@@ -330,6 +334,11 @@ pub async fn send_chat_message(
         );
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;
+        // Clear active_pid alongside persistent_session. A concurrent turn
+        // streaming this process at drift time would leave active_pid set;
+        // without this clear, a failed respawn + next turn would SIGKILL a
+        // potentially recycled PID via the stale-process teardown branch.
+        session.active_pid = None;
         if let Some(pid) = stale_pid {
             drop(agents);
             let _ = agent::stop_agent_graceful(pid).await;

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1440,4 +1440,38 @@ mod tests {
             &s(&["Write", "Read"]),
         ));
     }
+
+    #[test]
+    fn no_drift_when_wildcard_unchanged() {
+        // Permission level "full" resolves to the wildcard sentinel; reusing
+        // the same bypass-permissions session should not trigger a respawn.
+        let full = s(&["*"]);
+        assert!(!persistent_session_flags_drifted(
+            false, &full, false, &full,
+        ));
+    }
+
+    #[test]
+    fn drift_when_escalating_to_wildcard() {
+        // Switching from a concrete list ("standard"/"readonly") up to "full"
+        // needs a respawn so `build_claude_args` can apply
+        // `--permission-mode bypassPermissions`.
+        let standard = s(&["Read", "Write", "Edit"]);
+        let full = s(&["*"]);
+        assert!(persistent_session_flags_drifted(
+            false, &standard, false, &full,
+        ));
+    }
+
+    #[test]
+    fn drift_when_demoting_from_wildcard() {
+        // Dropping from "full" back to a concrete list needs a respawn so
+        // the bypass-permissions mode is cleared and `--allowedTools` is
+        // constrained.
+        let full = s(&["*"]);
+        let readonly = s(&["Read", "Glob", "Grep"]);
+        assert!(persistent_session_flags_drifted(
+            false, &full, false, &readonly,
+        ));
+    }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -48,6 +48,20 @@ struct AgentStreamPayload {
 
 use claudette::permissions::tools_for_level;
 
+/// Detect whether the persistent session's spawn-time flags have drifted
+/// from what the current turn is asking for. Both `--permission-mode` and
+/// `--allowedTools` are only applied when the `claude` process starts, so
+/// a drift means the running process cannot serve this turn correctly and
+/// must be torn down.
+fn persistent_session_flags_drifted(
+    session_plan_mode: bool,
+    session_allowed_tools: &[String],
+    requested_plan_mode: bool,
+    requested_allowed_tools: &[String],
+) -> bool {
+    session_plan_mode != requested_plan_mode || session_allowed_tools != requested_allowed_tools
+}
+
 #[tauri::command]
 pub async fn load_chat_history(
     workspace_id: String,
@@ -225,6 +239,8 @@ pub async fn send_chat_message(
                 attention_kind: None,
                 persistent_session: None,
                 mcp_config_dirty: false,
+                session_plan_mode: false,
+                session_allowed_tools: Vec::new(),
             };
         }
 
@@ -237,6 +253,8 @@ pub async fn send_chat_message(
             attention_kind: None,
             persistent_session: None,
             mcp_config_dirty: false,
+            session_plan_mode: false,
+            session_allowed_tools: Vec::new(),
         }
     });
 
@@ -287,6 +305,35 @@ pub async fn send_chat_message(
         chrome_enabled: chrome_enabled.unwrap_or(false),
         mcp_config,
     };
+
+    // `--permission-mode` and `--allowedTools` are baked into the persistent
+    // `claude` process at spawn — subsequent stdin turns cannot change them.
+    // If the caller's requested values no longer match what the current
+    // process was spawned with, tear it down so the next spawn can apply the
+    // new flags. The common case this fixes: user finishes plan mode, clicks
+    // "Approve plan", and the next turn arrives with `plan_mode=false`.
+    // Without a teardown the process stays in plan mode and every mutating
+    // tool is silently auto-denied.
+    if session.persistent_session.is_some()
+        && persistent_session_flags_drifted(
+            session.session_plan_mode,
+            &session.session_allowed_tools,
+            agent_settings.plan_mode,
+            &allowed_tools,
+        )
+    {
+        eprintln!(
+            "[chat] session flags drifted (plan_mode or allowed_tools) — tearing down persistent session for {workspace_id}"
+        );
+        let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
+        session.persistent_session = None;
+        if let Some(pid) = stale_pid {
+            drop(agents);
+            let _ = agent::stop_agent_graceful(pid).await;
+            agents = state.agents.write().await;
+        }
+    }
+    let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
 
     // Expand @-file mentions into inline file content for the agent prompt.
     let prompt = claudette::file_expand::expand_file_mentions(
@@ -384,6 +431,8 @@ pub async fn send_chat_message(
                 let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
                 session.persistent_session = Some(ps);
                 session.session_id = final_sid;
+                session.session_plan_mode = agent_settings.plan_mode;
+                session.session_allowed_tools = allowed_tools.clone();
                 handle
             }
         }
@@ -446,6 +495,8 @@ pub async fn send_chat_message(
         let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
         session.persistent_session = Some(ps);
         session.session_id = final_sid.clone();
+        session.session_plan_mode = agent_settings.plan_mode;
+        session.session_allowed_tools = allowed_tools.clone();
         let _ = db.save_agent_session(&workspace_id, &final_sid, session.turn_count);
         handle
     };
@@ -1330,4 +1381,60 @@ fn now_iso() -> String {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     format!("{}", dur.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::persistent_session_flags_drifted;
+
+    fn s(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| (*v).to_string()).collect()
+    }
+
+    #[test]
+    fn no_drift_when_plan_mode_and_tools_match() {
+        let tools = s(&["Read", "Write"]);
+        assert!(!persistent_session_flags_drifted(
+            false, &tools, false, &tools,
+        ));
+    }
+
+    #[test]
+    fn drift_when_plan_mode_flips_off_after_approval() {
+        // Session was spawned with --permission-mode plan; next turn is not.
+        let tools = s(&["Read", "Write"]);
+        assert!(persistent_session_flags_drifted(
+            true, &tools, false, &tools,
+        ));
+    }
+
+    #[test]
+    fn drift_when_plan_mode_flips_on() {
+        let tools = s(&["Read"]);
+        assert!(persistent_session_flags_drifted(
+            false, &tools, true, &tools,
+        ));
+    }
+
+    #[test]
+    fn drift_when_permission_level_changes() {
+        let before = s(&["Read", "Glob"]);
+        let after = s(&["Read", "Write", "Edit"]);
+        assert!(persistent_session_flags_drifted(
+            false, &before, false, &after,
+        ));
+    }
+
+    #[test]
+    fn drift_when_allowed_tools_reordered() {
+        // Strict equality: a different order counts as drift. Callers build
+        // the list deterministically from the permission level, so any
+        // observed diff signals a real configuration change.
+        assert!(persistent_session_flags_drifted(
+            false,
+            &s(&["Read", "Write"]),
+            false,
+            &s(&["Write", "Read"]),
+        ));
+    }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -323,7 +323,10 @@ pub async fn send_chat_message(
         )
     {
         eprintln!(
-            "[chat] session flags drifted (plan_mode or allowed_tools) — tearing down persistent session for {workspace_id}"
+            "[chat] session flags drifted (plan_mode {} -> {}, allowed_tools changed: {}) — tearing down persistent session for {workspace_id}",
+            session.session_plan_mode,
+            agent_settings.plan_mode,
+            session.session_allowed_tools != allowed_tools,
         );
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -44,6 +44,14 @@ pub struct AgentSessionState {
     /// and starts a fresh one with updated `--mcp-config`, then clears
     /// the flag. This avoids killing an agent mid-turn.
     pub mcp_config_dirty: bool,
+    /// `--permission-mode plan` flag baked into the current `persistent_session`.
+    /// Checked each turn against the requested `plan_mode`; a mismatch forces
+    /// a teardown + respawn so the CLI actually exits plan mode after approval.
+    pub session_plan_mode: bool,
+    /// `--allowedTools` list the current `persistent_session` was spawned with.
+    /// A mismatch on the next turn (e.g. permission level changed, or plan
+    /// approval elevates access) forces a teardown + respawn.
+    pub session_allowed_tools: Vec<String>,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -632,6 +632,8 @@ mod tests {
             },
             persistent_session: None,
             mcp_config_dirty: false,
+            session_plan_mode: false,
+            session_allowed_tools: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Claudette uses a long-lived `claude` subprocess per workspace (`PersistentSession`) to keep MCP servers alive across turns. Turns are sent via stdin; a new process is **not** spawned per turn. The `--permission-mode` and `--allowedTools` flags are baked into the process at spawn in `build_persistent_args` and cannot be changed after the fact.

As a result, after a user approved a plan:

1. The persistent session was still running with `--permission-mode plan`.
2. Any mutating tool call on the next turn was silently auto-denied (per `docs/permission-handling-design.md`: *"In `--print` mode, tools that need approval are auto-denied"*).
3. The agent, with no visibility into the denial's cause, hallucinated a *"please approve the permission prompt"* narrative, leaving the user unable to unblock the work.

This change tracks the `plan_mode` and `allowed_tools` values the persistent session was spawned with on `AgentSessionState`. Before reusing the session each turn, we compare the tracked values against the request. On mismatch, we tear down the subprocess (reusing the existing `mcp_config_dirty` teardown path) and respawn with the correct flags on the next iteration.

A follow-on safety fix clears `active_pid` alongside `persistent_session` in both teardown branches so a failed respawn can't leave a stale PID that the next turn's SIGKILL path would act on.

```mermaid
sequenceDiagram
  participant U as User
  participant UI as Claudette UI
  participant CMD as send_chat_message
  participant S as AgentSessionState
  participant P as claude subprocess
  U->>UI: Plan mode on, ask for change
  UI->>CMD: turn (plan_mode=true)
  CMD->>P: spawn with --permission-mode plan
  CMD->>S: stash session_plan_mode=true
  P-->>UI: ExitPlanMode
  U->>UI: Approve plan
  UI->>CMD: turn (plan_mode=false)
  CMD->>S: drift detected (true != false)
  CMD->>P: graceful stop
  CMD->>S: clear persistent_session + active_pid
  CMD->>P: respawn without plan flag
  CMD->>S: stash session_plan_mode=false
  P-->>UI: tool calls succeed
```

## Complexity Notes

- The teardown reuses the same pattern as `mcp_config_dirty` (see `chat.rs` flow near the MCP branch) — dropping the `agents` write lock around `stop_agent_graceful` to avoid deadlock, then re-acquiring. The `session.get_mut` after reacquire is necessary because the `HashMap` reference is invalidated across the await point.
- The drift check is guarded by `session.persistent_session.is_some()`, which short-circuits on the first turn *and* on the first turn after an app restart (restored sessions also load `persistent_session: None`). So there is no extra respawn cost on startup — the fresh spawn simply stashes the correct flags.
- **Test coverage**: 8 unit tests in `commands::chat::tests` cover the `persistent_session_flags_drifted` comparator: no drift, plan_mode drift both directions, permission-level change, reorder sensitivity, and three wildcard-sentinel transitions (`["*"]` staying, escalating to, and demoting from `["*"]`). The teardown glue itself (drop-lock → `stop_agent_graceful` → re-stash on respawn) is not covered by a unit test because process spawning is heavy for a logic test — this matches the existing `chat.rs` test pattern per `CLAUDE.md`. Manual repro below.
- **Out of scope**: if the workspace `permission_level` is `readonly`, `Write`/`Edit` are still silently denied even after this fix, because they're not in `--allowedTools`. That's an adjacent UX gap (plan approval should arguably elevate permissions for the implementation turn, or we should surface a clearer denial message). Tracked for a follow-up.

## Test Steps

1. `cd src-tauri && cargo test --all-features` — runs the 8 comparator unit tests in `commands::chat::tests`.
2. `cargo tauri dev` for a manual repro:
   - Set permission level to `standard` (Write allowed).
   - Toggle plan mode on.
   - Ask the agent to create or edit a small file.
   - Approve the plan.
   - **Before fix**: agent reports *"permission prompts appear to be blocked"* / *"write permissions aren't granted yet"*.
   - **After fix**: agent writes the file. Look for `[chat] session flags drifted (plan_mode true -> false, allowed_tools changed: false)` in the backend log confirming the teardown.
3. Regression checks:
   - `cargo clippy --workspace --all-targets` — zero warnings.
   - `cargo fmt --all --check`.
   - `cd src/ui && bun run tsc --noEmit && bun run test`.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)