### PR TITLE
feat(ui): simplify chat header and unify send/stop button

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -959,6 +959,10 @@
   filter: brightness(1.1);
 }
 
+.sendBtnStop:active:not(:disabled) {
+  filter: brightness(0.95);
+}
+
 /* -- Attachment UI -- */
 
 .inputDragActive {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -95,26 +95,6 @@
 }
 
 
-.statusBadge {
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.stopBtn {
-  background: none;
-  border: 1px solid var(--status-stopped);
-  color: var(--status-stopped);
-  padding: 2px 10px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 11px;
-  transition: background var(--transition-fast);
-}
-
-.stopBtn:hover {
-  background: var(--error-hover);
-}
-
 /* Messages area */
 .messages {
   flex: 1;
@@ -936,32 +916,47 @@
 }
 
 .sendBtn {
-  background: transparent;
-  border: 1px solid rgba(var(--accent-primary-rgb), 0.2);
-  color: var(--accent-dim);
-  padding: 7px 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-primary);
+  color: var(--app-bg);
+  width: 28px;
+  height: 28px;
+  padding: 0;
   border-radius: 8px;
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
   margin-left: auto;
-  transition: background var(--transition-fast), color var(--transition-fast),
-              border-color var(--transition-fast);
+  flex-shrink: 0;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+              color var(--transition-fast), opacity var(--transition-fast);
 }
 
 .sendBtn:hover:not(:disabled) {
-  background: rgba(var(--accent-primary-rgb), 0.08);
-  color: var(--accent-primary);
-  border-color: rgba(var(--accent-primary-rgb), 0.3);
+  background: var(--accent-dim);
+  border-color: var(--accent-dim);
 }
 
 .sendBtn:active:not(:disabled) {
-  background: rgba(var(--accent-primary-rgb), 0.12);
+  filter: brightness(0.95);
 }
 
 .sendBtn:disabled {
-  opacity: 0.25;
+  opacity: 0.35;
   cursor: not-allowed;
+}
+
+.sendBtnStop {
+  background: var(--status-stopped);
+  border-color: var(--status-stopped);
+  color: var(--app-bg);
+}
+
+.sendBtnStop:hover:not(:disabled) {
+  background: var(--status-stopped);
+  border-color: var(--status-stopped);
+  filter: brightness(1.1);
 }
 
 /* -- Attachment UI -- */

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -866,7 +866,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 12px 28px 16px;
+  padding: 6px 14px;
   border-top: 1px solid var(--divider);
   background: transparent;
 }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
-import { FileText, GitBranch, Plus, RotateCcw, X } from "lucide-react";
+import { FileText, GitBranch, Octagon, Plus, RotateCcw, Send, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
@@ -779,19 +779,6 @@ export function ChatPanel() {
     }
   };
 
-  const agentStatusLabel =
-    typeof ws.agent_status === "string"
-      ? ws.agent_status
-      : `Error: ${ws.agent_status.Error}`;
-
-  const agentStatusColor =
-    ws.agent_status === "Running"
-      ? "var(--status-running)"
-      : ws.agent_status === "Stopped" ||
-          typeof ws.agent_status !== "string"
-        ? "var(--status-stopped)"
-        : "var(--status-idle)";
-
   return (
     <div className={styles.panel}>
       <div className={styles.header} data-tauri-drag-region>
@@ -817,17 +804,6 @@ export function ChatPanel() {
           <WorkspaceActions
             worktreePath={ws.worktree_path}
           />
-          <span
-            className={styles.statusBadge}
-            style={{ color: agentStatusColor }}
-          >
-            {agentStatusLabel}
-          </span>
-          {isRunning ? (
-            <button className={styles.stopBtn} onClick={handleStop}>
-              Stop
-            </button>
-          ) : null}
           <PanelToggles />
         </div>
       </div>
@@ -927,6 +903,7 @@ export function ChatPanel() {
 
       <ChatInputArea
         onSend={handleSend}
+        onStop={handleStop}
         isRunning={isRunning}
         isRemote={!!ws?.remote_connection_id}
         selectedWorkspaceId={selectedWorkspaceId!}
@@ -1450,6 +1427,7 @@ function fileToBase64(file: Blob): Promise<string> {
 
 function ChatInputArea({
   onSend,
+  onStop,
   isRunning,
   isRemote,
   selectedWorkspaceId,
@@ -1464,6 +1442,7 @@ function ChatInputArea({
     mentionedFiles?: Set<string>,
     attachments?: AttachmentInput[],
   ) => Promise<void>;
+  onStop: () => void | Promise<void>;
   isRunning: boolean;
   isRemote: boolean;
   selectedWorkspaceId: string;
@@ -2087,11 +2066,13 @@ function ChatInputArea({
           disabled={isRunning}
         />
         <button
-          className={styles.sendBtn}
-          onClick={handleSend}
-          disabled={!chatInput.trim() && pendingAttachments.length === 0}
+          className={`${styles.sendBtn} ${isRunning ? styles.sendBtnStop : ""}`}
+          onClick={isRunning ? onStop : handleSend}
+          disabled={!isRunning && !chatInput.trim() && pendingAttachments.length === 0}
+          title={isRunning ? "Stop agent" : "Send message"}
+          aria-label={isRunning ? "Stop agent" : "Send message"}
         >
-          Send
+          {isRunning ? <Octagon size={16} /> : <Send size={16} />}
         </button>
       </div>
     </div>

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -437,8 +437,7 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  padding: 8px 12px;
-  border-top: 1px solid var(--sidebar-border);
+  padding: 6px 12px;
 }
 
 .footerBtn {


### PR DESCRIPTION
## Summary

Simplifies the chat panel chrome by consolidating send/stop into a single icon-button affordance and aligns the sidebar footer with the chat input controls so they share a horizontal baseline.

- **Header:** Removes the `Idle/Running/Stopped` status badge and the text `Stop` button from the chat header. Agent state is already communicated by the streaming UI and by the icon on the send button itself, so the header surface was redundant.
- **Send button:** Replaces the text `Send` button with a filled icon button (Lucide `Send`, 28×28 to match the attach `+` button). When the agent is running, the icon swaps to `Octagon` and the click handler calls `handleStop` — one affordance, two states.
- **Bottom-strip alignment:** Tightens padding on both `.inputArea` (chat input) and the sidebar `.footer` so the button centers in both rows line up within ~1px of each other. Drops the now-unneeded top border on the sidebar footer at the tighter spacing.

## Complexity Notes

- Queue-while-running still works via the **Enter** key — `handleKeyDown` still calls `handleSend`, which routes to queue when `isRunning`. The button click only performs stop during runs, so users who want to queue mid-run must use keyboard input. Worth confirming this is the intended UX during review.
- `ChatInputArea` gains a new `onStop: () => void | Promise<void>` prop threaded from `ChatPanel`. This is the only new coupling between the two.
- Dimensions are deliberately matched against `.attachBtn` (28×28 + 8px radius) so the `+` and send/stop buttons mirror each other at the edges of the input controls row.

## Test Steps

1. Run `cd src/ui && bun run test` — 469 vitest tests should pass.
2. Run `cd src/ui && bunx tsc --noEmit` — no TypeScript errors.
3. Run `cargo tauri dev` and verify in the UI:
   1. Chat panel header shows repo/branch info and panel toggles only — no "Idle/Running/Stopped" badge, no text Stop button.
   2. With an empty input, the Send icon button is visibly disabled (dimmed) on the right side of the input controls row.
   3. Type text → button becomes fully opaque (filled teal).
   4. Click Send → message sends; while agent runs, icon swaps to a red stop octagon.
   5. Click the octagon → agent stops; icon reverts to Send.
   6. While agent is running, type a message and press **Enter** → message queues (a "Queued" bubble appears above the input). Button stays as the octagon.
   7. Hover tooltips read `Send message` / `Stop agent`.
   8. Look at the bottom of the window: the sidebar footer row (`+`, globe, share, gear) and the chat input controls row (`+`, model picker, thinking, etc., send/stop) sit on the same horizontal baseline.
   9. Sidebar footer has no top border separator above it.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)