### PR TITLE
fix(ui): apply default plan mode regardless of thinking/fast defaults

### DIFF
--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -66,9 +66,9 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
       const effectiveThinking = thinking === "true" || (!thinking && defThinking === "true");
       setFastMode(workspaceId, effectiveFast);
       setThinkingEnabled(workspaceId, effectiveThinking);
-      // Plan mode is not persisted per-workspace (in-memory only); apply global
-      // default only when fast/thinking aren't already enabled.
-      setPlanMode(workspaceId, !effectiveFast && !effectiveThinking && defPlan === "true");
+      // Plan mode is not persisted per-workspace (in-memory only);
+      // always apply the global default on load.
+      setPlanMode(workspaceId, defPlan === "true");
       // Normalize effort against the loaded model to prevent stale values.
       const effectiveEffort = effort ?? defEffort;
       if (effectiveEffort) {


### PR DESCRIPTION
## Summary

The ChatToolbar load effect at `src/ui/src/components/chat/ChatToolbar.tsx:71` gated plan-mode activation on `!effectiveFast && !effectiveThinking`, so the `default_plan_mode` user setting was silently dropped whenever either **Default thinking** or **Default fast mode** was on.

Plan mode is `--permission-mode plan` in the Claude CLI (`src/agent.rs:279-281`). Thinking (extended reasoning) and fast mode (output speed) are orthogonal to permission mode — there is no technical reason for mutual exclusion. This change removes the gate so `default_plan_mode` alone determines whether plan mode activates on workspace load.

```
default_plan_mode=true in SQLite
   └─► ModelSettings.tsx writes it (OK)
       └─► ChatToolbar.tsx reads it on mount (OK)
           └─► BEFORE: !fast && !thinking && defPlan === "true"  ← silently dropped
           └─► AFTER:  defPlan === "true"                         ← applied
               └─► ChatPanel forwards plan_mode to Rust
                   └─► agent.rs emits --permission-mode plan
```

## Complexity Notes

- Plan mode intentionally remains **in-memory only** per-workspace (no `plan_mode:{workspaceId}` DB key). The toolbar's `togglePlan` at lines 129-131 does not call `setAppSetting`, so a per-workspace toggle resets on workspace reload and re-applies the default. This matches the pre-existing comment on lines 69-70 and is out of scope for this PR.

## Test Steps

1. Checkout this branch and `cargo tauri dev`.
2. **Settings → Models**: enable **Default thinking on** _and_ **Default to plan mode**.
3. Create a new workspace.
4. Confirm the **Plan** chip in the chat toolbar is active (blue/highlighted) on entry — before this fix it would be inactive.
5. Optional store check via `/claudette-debug state planMode` → `{ [wsId]: true }`.
6. Send any prompt and verify the agent enters plan mode (produces an `ExitPlanMode` response rather than editing files), confirming the flag reaches `--permission-mode plan`.
7. Regression: disable thinking, enable **Default fast mode** + **Default plan mode** → both chips active on a fresh workspace.

## Checklist

- [x] Tests added/updated — existing 469 vitest cases still pass; no new test added (the toolbar's default-application logic is not currently covered, and this is a pure behavior change. A follow-up vitest case mocking `getAppSetting` could harden it.)
- [ ] Documentation updated (if applicable) — N/A