### PR TITLE
fix(chat): shrink send/attach buttons and restyle stop indicator

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -947,44 +947,17 @@
   cursor: not-allowed;
 }
 
-/* Stop state — drop button chrome and show only a small red square. */
-.sendBtnStop,
+/* Stop state — match the neutral .attachBtn chrome to the left so the two
+   buttons visually pair, with a red icon to signal the stop affordance. */
+.sendBtnStop {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--divider);
+  color: var(--status-stopped);
+}
+
 .sendBtnStop:hover:not(:disabled) {
-  background: transparent;
-  border-color: transparent;
-}
-
-/* Override the inherited .sendBtn:active brightness so it doesn't compose
-   with the child .stopSquare filter and dim the square more than intended. */
-.sendBtnStop:active:not(:disabled) {
-  filter: none;
-}
-
-.sendBtnStop:hover:not(:disabled) .stopSquare {
-  filter: brightness(1.1);
-}
-
-.sendBtnStop:active:not(:disabled) .stopSquare {
-  filter: brightness(0.9);
-}
-
-.stopSquare {
-  display: block;
-  width: 10px;
-  height: 10px;
-  background: var(--status-stopped);
-  animation: stopPulse 1.2s ease-in-out infinite;
-}
-
-@keyframes stopPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.45; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .stopSquare {
-    animation: none;
-  }
+  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--text-dim);
 }
 
 /* -- Attachment UI -- */

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -922,10 +922,10 @@
   background: var(--accent-primary);
   border: 1px solid var(--accent-primary);
   color: var(--app-bg);
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   padding: 0;
-  border-radius: 8px;
+  border-radius: 6px;
   cursor: pointer;
   margin-left: auto;
   flex-shrink: 0;
@@ -947,20 +947,32 @@
   cursor: not-allowed;
 }
 
-.sendBtnStop {
-  background: var(--status-stopped);
-  border-color: var(--status-stopped);
-  color: var(--app-bg);
+/* Stop state — drop button chrome and show only a small red square. */
+.sendBtnStop,
+.sendBtnStop:hover:not(:disabled) {
+  background: transparent;
+  border-color: transparent;
 }
 
-.sendBtnStop:hover:not(:disabled) {
-  background: var(--status-stopped);
-  border-color: var(--status-stopped);
+.sendBtnStop:hover:not(:disabled) .stopSquare {
   filter: brightness(1.1);
 }
 
-.sendBtnStop:active:not(:disabled) {
-  filter: brightness(0.95);
+.sendBtnStop:active:not(:disabled) .stopSquare {
+  filter: brightness(0.9);
+}
+
+.stopSquare {
+  display: block;
+  width: 10px;
+  height: 10px;
+  background: var(--status-stopped);
+  animation: stopPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes stopPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
 }
 
 /* -- Attachment UI -- */
@@ -1021,14 +1033,14 @@
   border: 1px solid var(--divider);
   color: var(--text-muted);
   cursor: pointer;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   margin-right: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: 6px;
   flex-shrink: 0;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -954,6 +954,12 @@
   border-color: transparent;
 }
 
+/* Override the inherited .sendBtn:active brightness so it doesn't compose
+   with the child .stopSquare filter and dim the square more than intended. */
+.sendBtnStop:active:not(:disabled) {
+  filter: none;
+}
+
 .sendBtnStop:hover:not(:disabled) .stopSquare {
   filter: brightness(1.1);
 }
@@ -973,6 +979,12 @@
 @keyframes stopPulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.45; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stopSquare {
+    animation: none;
+  }
 }
 
 /* -- Attachment UI -- */

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
-import { FileText, GitBranch, Plus, RotateCcw, Send, X } from "lucide-react";
+import { FileText, GitBranch, Plus, RotateCcw, Send, Square, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
@@ -2072,7 +2072,7 @@ function ChatInputArea({
           title={isRunning ? "Stop agent" : "Send message"}
           aria-label={isRunning ? "Stop agent" : "Send message"}
         >
-          {isRunning ? <span className={styles.stopSquare} /> : <Send size={14} />}
+          {isRunning ? <Square size={14} fill="currentColor" /> : <Send size={14} />}
         </button>
       </div>
     </div>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
-import { FileText, GitBranch, Octagon, Plus, RotateCcw, Send, X } from "lucide-react";
+import { FileText, GitBranch, Plus, RotateCcw, Send, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
@@ -2047,7 +2047,7 @@ function ChatInputArea({
             onClick={() => setAttachMenuOpen((v) => !v)}
             title="Add files or connectors"
           >
-            <Plus size={16} />
+            <Plus size={14} />
           </button>
           {attachMenuOpen && (
             <AttachMenu
@@ -2072,7 +2072,7 @@ function ChatInputArea({
           title={isRunning ? "Stop agent" : "Send message"}
           aria-label={isRunning ? "Stop agent" : "Send message"}
         >
-          {isRunning ? <Octagon size={16} /> : <Send size={16} />}
+          {isRunning ? <span className={styles.stopSquare} /> : <Send size={14} />}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The chat input's send/attach buttons and running-state stop indicator visually dominated the surrounding UI — 16px icons inside 28x28 filled buttons, while the rest of the app uses 12-14px icons (14px is the dominant size, 32 occurrences across `src/ui/src/components/`). The "stop" state rendered as a red rounded rectangle that read as a blob.

- **Shrink the buttons**: `.sendBtn` and `.attachBtn` from 28x28 to 24x24, `border-radius` 8 -> 6.
- **Match icon sizes**: `Plus`, `Send` from 16 -> 14, in line with the app's dominant 14px size.
- **Restyle the stop state**: drop the button chrome (transparent background and border) and render a borderless 10x10 solid red square (`.stopSquare`) inside. The 24x24 click target is preserved.
- **Pulse the stop indicator**: a gentle 1.2s `ease-in-out` opacity pulse (1 -> 0.45 -> 1) — same vocabulary as the existing `pulse-badge` keyframe in `Sidebar.module.css`.
- **Drop the now-unused `Octagon` import** from `lucide-react`.

## Test plan

- [x] `bunx tsc --noEmit` passes.
- [ ] `cargo tauri dev`: send and attach buttons sit comfortably with the rest of the input row, no longer dominating the toolbar.
- [ ] While an agent is running, the stop indicator shows as a small pulsing red square (no button background or border). Clicking anywhere in the 24x24 area still stops the agent.
- [ ] Hover over the stop square: it brightens slightly while continuing to pulse.
- [ ] Send button still goes accent-colored when input is non-empty, and 35%-opacity disabled when empty.