### PR TITLE
fix(chat): round-trip AskUserQuestion / ExitPlanMode via control_response

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1379,33 +1379,36 @@ pub async fn submit_agent_answer(
     annotations: Option<serde_json::Value>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    // Validate everything BEFORE removing the pending entry: if the session
+    // has been torn down or the entry maps to the wrong tool, the entry must
+    // stay so the user (or the correct submit_* command) can still see it.
     let (pending, ps) = {
         let mut agents = state.agents.write().await;
         let session = agents.get_mut(&workspace_id).ok_or("Session not found")?;
-        let pending = session
-            .pending_permissions
-            .remove(&tool_use_id)
-            .ok_or("No pending permission request for that tool_use_id")?;
+        // 1. Persistent session must be alive — otherwise nobody is reading
+        //    stdin and the response would be discarded.
         let ps = session
             .persistent_session
             .clone()
             .ok_or("Agent session is not active")?;
+        // 2. Tool kind must match — peek by reference.
+        match session.pending_permissions.get(&tool_use_id) {
+            None => return Err("No pending permission request for that tool_use_id".to_string()),
+            Some(p) if p.tool_name != "AskUserQuestion" => {
+                return Err(format!(
+                    "Pending tool is {}, not AskUserQuestion",
+                    p.tool_name
+                ));
+            }
+            _ => {}
+        }
+        // 3. All checks passed — now it is safe to remove.
+        let pending = session
+            .pending_permissions
+            .remove(&tool_use_id)
+            .expect("checked above");
         (pending, ps)
     };
-
-    if pending.tool_name != "AskUserQuestion" {
-        // Re-insert so the correct command can resolve it.
-        let mut agents = state.agents.write().await;
-        if let Some(session) = agents.get_mut(&workspace_id) {
-            session
-                .pending_permissions
-                .insert(tool_use_id, pending.clone());
-        }
-        return Err(format!(
-            "Pending tool is {}, not AskUserQuestion",
-            pending.tool_name
-        ));
-    }
 
     // Layer answers (and annotations, if any) onto the original input.
     let mut updated_input = pending.original_input.clone();
@@ -1441,32 +1444,28 @@ pub async fn submit_plan_approval(
     reason: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    // Same validate-before-remove pattern as submit_agent_answer — see that
+    // function for the rationale.
     let (pending, ps) = {
         let mut agents = state.agents.write().await;
         let session = agents.get_mut(&workspace_id).ok_or("Session not found")?;
-        let pending = session
-            .pending_permissions
-            .remove(&tool_use_id)
-            .ok_or("No pending permission request for that tool_use_id")?;
         let ps = session
             .persistent_session
             .clone()
             .ok_or("Agent session is not active")?;
+        match session.pending_permissions.get(&tool_use_id) {
+            None => return Err("No pending permission request for that tool_use_id".to_string()),
+            Some(p) if p.tool_name != "ExitPlanMode" => {
+                return Err(format!("Pending tool is {}, not ExitPlanMode", p.tool_name));
+            }
+            _ => {}
+        }
+        let pending = session
+            .pending_permissions
+            .remove(&tool_use_id)
+            .expect("checked above");
         (pending, ps)
     };
-
-    if pending.tool_name != "ExitPlanMode" {
-        let mut agents = state.agents.write().await;
-        if let Some(session) = agents.get_mut(&workspace_id) {
-            session
-                .pending_permissions
-                .insert(tool_use_id, pending.clone());
-        }
-        return Err(format!(
-            "Pending tool is {}, not ExitPlanMode",
-            pending.tool_name
-        ));
-    }
 
     let response = if approved {
         serde_json::json!({

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -263,8 +263,9 @@ pub async fn send_chat_message(
     // Clear any unresolved permission requests so the CLI doesn't hang when
     // we send the next turn. This replaces the old behaviour where the
     // AgentQuestionCard dismissed on a new user message — the CLI is actually
-    // blocked mid-turn and needs an explicit control_response.
-    cancel_pending_permissions(session, "User sent a new message instead of answering.").await;
+    // blocked mid-turn and needs an explicit control_response. The drain is
+    // synchronous (under the lock); the deny sends happen after we drop it.
+    let to_deny_new_turn = drain_pending_permissions(session);
 
     // If a previous turn is still running and there's no persistent session,
     // stop the stale process. With a persistent session, the process is shared
@@ -274,11 +275,22 @@ pub async fn send_chat_message(
     {
         eprintln!("[chat] Stopping stale process {old_pid} before new turn");
         drop(agents); // release lock while waiting
+        if let Some((ref ps, drained)) = to_deny_new_turn {
+            deny_drained_permissions(drained, ps, "User sent a new message instead of answering.")
+                .await;
+        }
         let _ = agent::stop_agent(old_pid).await;
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         agents = state.agents.write().await;
         let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
         session.active_pid = None;
+    } else if let Some((ref ps, drained)) = to_deny_new_turn {
+        // No stale-pid teardown — release the lock just for the deny sends,
+        // then re-acquire so the rest of this function can mutate the session.
+        drop(agents);
+        deny_drained_permissions(drained, ps, "User sent a new message instead of answering.")
+            .await;
+        agents = state.agents.write().await;
     }
     let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
 
@@ -287,7 +299,7 @@ pub async fn send_chat_message(
     // The session is idle between turns so a graceful SIGTERM is sufficient.
     if session.mcp_config_dirty {
         eprintln!("[chat] MCP config dirty — tearing down persistent session for {workspace_id}");
-        cancel_pending_permissions(session, "Session restarted with new MCP config.").await;
+        let to_deny_mcp = drain_pending_permissions(session);
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;
         // Clear active_pid alongside persistent_session so a failed respawn
@@ -295,9 +307,15 @@ pub async fn send_chat_message(
         // have recycled (would get SIGKILLed by the stale-process branch).
         session.active_pid = None;
         session.mcp_config_dirty = false;
-        if let Some(pid) = stale_pid {
+        if stale_pid.is_some() || to_deny_mcp.is_some() {
             drop(agents);
-            let _ = agent::stop_agent_graceful(pid).await;
+            if let Some((ref ps, drained)) = to_deny_mcp {
+                deny_drained_permissions(drained, ps, "Session restarted with new MCP config.")
+                    .await;
+            }
+            if let Some(pid) = stale_pid {
+                let _ = agent::stop_agent_graceful(pid).await;
+            }
             agents = state.agents.write().await;
         }
     }
@@ -343,7 +361,7 @@ pub async fn send_chat_message(
         );
         // Resolve any pending permission requests against the doomed process
         // before we kill it, so the next turn doesn't carry stale tool_use_ids.
-        cancel_pending_permissions(session, "Session restarted with new flags.").await;
+        let to_deny_drift = drain_pending_permissions(session);
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;
         // Clear active_pid alongside persistent_session. A concurrent turn
@@ -351,9 +369,14 @@ pub async fn send_chat_message(
         // without this clear, a failed respawn + next turn would SIGKILL a
         // potentially recycled PID via the stale-process teardown branch.
         session.active_pid = None;
-        if let Some(pid) = stale_pid {
+        if stale_pid.is_some() || to_deny_drift.is_some() {
             drop(agents);
-            let _ = agent::stop_agent_graceful(pid).await;
+            if let Some((ref ps, drained)) = to_deny_drift {
+                deny_drained_permissions(drained, ps, "Session restarted with new flags.").await;
+            }
+            if let Some(pid) = stale_pid {
+                let _ = agent::stop_agent_graceful(pid).await;
+            }
             agents = state.agents.write().await;
         }
     }
@@ -993,21 +1016,30 @@ pub async fn stop_agent(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let mut agents = state.agents.write().await;
-    if let Some(session) = agents.get_mut(&workspace_id) {
-        // Unblock the CLI on any pending can_use_tool requests before we kill
-        // the process so the deny is recorded in the transcript cleanly.
-        cancel_pending_permissions(session, "Session stopped by user.").await;
-        // Clear persistent session and reset session state so the next
-        // turn starts completely fresh (not --resume with a stale ID).
-        session.persistent_session = None;
-        session.turn_count = 0;
-        session.session_id = String::new();
-        if let Some(pid) = session.active_pid.take() {
-            agent::stop_agent(pid).await?;
+    // Drain pending permissions and snapshot the cleanup state synchronously
+    // under the lock; deny sends + the kill happen after we release it.
+    let (to_deny_stop, pid_to_kill) = {
+        let mut agents = state.agents.write().await;
+        match agents.get_mut(&workspace_id) {
+            Some(session) => {
+                let drained = drain_pending_permissions(session);
+                // Clear persistent session and reset session state so the next
+                // turn starts completely fresh (not --resume with a stale ID).
+                session.persistent_session = None;
+                session.turn_count = 0;
+                session.session_id = String::new();
+                (drained, session.active_pid.take())
+            }
+            None => (None, None),
         }
+    };
+
+    if let Some((ref ps, drained)) = to_deny_stop {
+        deny_drained_permissions(drained, ps, "Session stopped by user.").await;
     }
-    drop(agents);
+    if let Some(pid) = pid_to_kill {
+        agent::stop_agent(pid).await?;
+    }
 
     // Clear persisted session from DB too.
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
@@ -1037,12 +1069,19 @@ pub async fn reset_agent_session(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let mut agents = state.agents.write().await;
-    if let Some(session) = agents.get_mut(&workspace_id) {
-        cancel_pending_permissions(session, "Session reset.").await;
+    // Drain pending permissions under the lock; deny sends happen after release.
+    let to_deny_reset = {
+        let mut agents = state.agents.write().await;
+        let drained = agents
+            .get_mut(&workspace_id)
+            .and_then(drain_pending_permissions);
+        agents.remove(&workspace_id);
+        drained
+    };
+
+    if let Some((ref ps, drained)) = to_deny_reset {
+        deny_drained_permissions(drained, ps, "Session reset.").await;
     }
-    agents.remove(&workspace_id);
-    drop(agents);
 
     // Clear persisted session so the next turn starts fresh.
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
@@ -1444,22 +1483,40 @@ pub async fn submit_plan_approval(
         .await
 }
 
-/// Cancel any pending permission requests for a workspace by sending a deny
-/// `control_response` for each. Called when the session is being torn down
-/// (stop_agent / reset_agent_session / stale-process cleanup) to prevent the
-/// CLI from hanging waiting for a response that will never come.
-async fn cancel_pending_permissions(session: &mut AgentSessionState, reason: &str) {
+/// Synchronously drain any pending permission requests from `session` and
+/// snapshot the [`PersistentSession`] needed to deny them. Designed to be
+/// called while holding the agents write lock — does no async work itself.
+///
+/// Returns `None` when there is nothing to do (no pending entries) or when
+/// there is no live `PersistentSession` to receive the denies (entries are
+/// dropped in that case, since nobody could read the response anyway).
+fn drain_pending_permissions(
+    session: &mut AgentSessionState,
+) -> Option<(Arc<PersistentSession>, Vec<PendingPermission>)> {
     if session.pending_permissions.is_empty() {
-        return;
+        return None;
     }
     let Some(ps) = session.persistent_session.clone() else {
-        // Without an active process nothing will read the response, so just drop
-        // the pending entries.
         session.pending_permissions.clear();
-        return;
+        return None;
     };
-    let drained: Vec<(String, PendingPermission)> = session.pending_permissions.drain().collect();
-    for (_tool_use_id, pending) in drained {
+    let drained: Vec<PendingPermission> = session
+        .pending_permissions
+        .drain()
+        .map(|(_, p)| p)
+        .collect();
+    Some((ps, drained))
+}
+
+/// Send a deny `control_response` for each drained permission. Caller must
+/// have already released the agents lock — this performs async I/O against
+/// the CLI's stdin and would otherwise serialize all other agent-state ops.
+async fn deny_drained_permissions(
+    drained: Vec<PendingPermission>,
+    ps: &PersistentSession,
+    reason: &str,
+) {
+    for pending in drained {
         let deny = serde_json::json!({
             "behavior": "deny",
             "message": reason,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -631,9 +631,11 @@ pub async fn send_chat_message(
 
             // Handle control_request: can_use_tool from the CLI's stdio permission
             // prompt protocol. For AskUserQuestion / ExitPlanMode we remember the
-            // request and surface it to the UI (the existing content_block_start
-            // handler populated the AgentQuestion / PlanApproval card); the UI
-            // then calls submit_agent_answer / submit_plan_approval to resolve.
+            // request and emit `agent-permission-prompt` so the UI shows the card
+            // ONLY after the Rust side is ready to receive the answer — the
+            // previous content_block_stop-driven approach raced the still-
+            // in-flight control_request and produced "No pending permission
+            // request" errors when the user clicked too quickly.
             // For every OTHER tool, immediately deny — Claudette relies on
             // --allowedTools for normal approvals, so reaching this path means
             // a plan-mode or unknown-tool block we should report to the model.
@@ -660,6 +662,14 @@ pub async fn send_chat_message(
                             },
                         );
                     }
+                    drop(agents);
+                    let payload = serde_json::json!({
+                        "workspace_id": &ws_id,
+                        "tool_use_id": tool_use_id,
+                        "tool_name": tool_name,
+                        "input": input,
+                    });
+                    let _ = app.emit("agent-permission-prompt", &payload);
                 } else {
                     // Auto-deny any other tool that reaches the permission-prompt
                     // path — current Claudette behaviour is no interactive approval
@@ -1393,10 +1403,16 @@ pub async fn submit_agent_answer(
             .ok_or("Agent session is not active")?;
         // 2. Tool kind must match — peek by reference.
         match session.pending_permissions.get(&tool_use_id) {
-            None => return Err("No pending permission request for that tool_use_id".to_string()),
+            None => {
+                let pending_ids: Vec<String> =
+                    session.pending_permissions.keys().cloned().collect();
+                return Err(format!(
+                    "No pending permission request for tool_use_id {tool_use_id} (pending: {pending_ids:?})"
+                ));
+            }
             Some(p) if p.tool_name != "AskUserQuestion" => {
                 return Err(format!(
-                    "Pending tool is {}, not AskUserQuestion",
+                    "Pending tool for {tool_use_id} is {}, not AskUserQuestion",
                     p.tool_name
                 ));
             }
@@ -1454,9 +1470,18 @@ pub async fn submit_plan_approval(
             .clone()
             .ok_or("Agent session is not active")?;
         match session.pending_permissions.get(&tool_use_id) {
-            None => return Err("No pending permission request for that tool_use_id".to_string()),
+            None => {
+                let pending_ids: Vec<String> =
+                    session.pending_permissions.keys().cloned().collect();
+                return Err(format!(
+                    "No pending permission request for tool_use_id {tool_use_id} (pending: {pending_ids:?})"
+                ));
+            }
             Some(p) if p.tool_name != "ExitPlanMode" => {
-                return Err(format!("Pending tool is {}, not ExitPlanMode", p.tool_name));
+                return Err(format!(
+                    "Pending tool for {tool_use_id} is {}, not ExitPlanMode",
+                    p.tool_name
+                ));
             }
             _ => {}
         }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::{
-    self, AgentEvent, AgentSettings, ImageAttachment, InnerStreamEvent, PersistentSession,
-    StartContentBlock, StreamEvent,
+    self, AgentEvent, AgentSettings, ControlRequestInner, ImageAttachment, InnerStreamEvent,
+    PersistentSession, StartContentBlock, StreamEvent,
 };
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
@@ -17,7 +17,7 @@ use claudette::model::{
 use claudette::snapshot;
 use claudette::{base64_decode, base64_encode};
 
-use crate::state::{AgentSessionState, AppState};
+use crate::state::{AgentSessionState, AppState, PendingPermission};
 
 /// Frontend-facing input for an image attachment (base64-encoded).
 #[derive(Clone, Deserialize)]
@@ -241,6 +241,7 @@ pub async fn send_chat_message(
                 mcp_config_dirty: false,
                 session_plan_mode: false,
                 session_allowed_tools: Vec::new(),
+                pending_permissions: std::collections::HashMap::new(),
             };
         }
 
@@ -255,8 +256,15 @@ pub async fn send_chat_message(
             mcp_config_dirty: false,
             session_plan_mode: false,
             session_allowed_tools: Vec::new(),
+            pending_permissions: std::collections::HashMap::new(),
         }
     });
+
+    // Clear any unresolved permission requests so the CLI doesn't hang when
+    // we send the next turn. This replaces the old behaviour where the
+    // AgentQuestionCard dismissed on a new user message — the CLI is actually
+    // blocked mid-turn and needs an explicit control_response.
+    cancel_pending_permissions(session, "User sent a new message instead of answering.").await;
 
     // If a previous turn is still running and there's no persistent session,
     // stop the stale process. With a persistent session, the process is shared
@@ -279,6 +287,7 @@ pub async fn send_chat_message(
     // The session is idle between turns so a graceful SIGTERM is sufficient.
     if session.mcp_config_dirty {
         eprintln!("[chat] MCP config dirty — tearing down persistent session for {workspace_id}");
+        cancel_pending_permissions(session, "Session restarted with new MCP config.").await;
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;
         // Clear active_pid alongside persistent_session so a failed respawn
@@ -332,6 +341,9 @@ pub async fn send_chat_message(
             agent_settings.plan_mode,
             session.session_allowed_tools != allowed_tools,
         );
+        // Resolve any pending permission requests against the doomed process
+        // before we kill it, so the next turn doesn't carry stale tool_use_ids.
+        cancel_pending_permissions(session, "Session restarted with new flags.").await;
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
         session.persistent_session = None;
         // Clear active_pid alongside persistent_session. A concurrent turn
@@ -592,6 +604,63 @@ pub async fn send_chat_message(
                 && subtype == "init"
             {
                 got_init = true;
+            }
+
+            // Handle control_request: can_use_tool from the CLI's stdio permission
+            // prompt protocol. For AskUserQuestion / ExitPlanMode we remember the
+            // request and surface it to the UI (the existing content_block_start
+            // handler populated the AgentQuestion / PlanApproval card); the UI
+            // then calls submit_agent_answer / submit_plan_approval to resolve.
+            // For every OTHER tool, immediately deny — Claudette relies on
+            // --allowedTools for normal approvals, so reaching this path means
+            // a plan-mode or unknown-tool block we should report to the model.
+            if let AgentEvent::Stream(StreamEvent::ControlRequest {
+                request_id,
+                request:
+                    ControlRequestInner::CanUseTool {
+                        tool_name,
+                        tool_use_id,
+                        input,
+                    },
+            }) = &event
+            {
+                if matches!(tool_name.as_str(), "AskUserQuestion" | "ExitPlanMode") {
+                    let app_state = app.state::<AppState>();
+                    let mut agents = app_state.agents.write().await;
+                    if let Some(session) = agents.get_mut(&ws_id) {
+                        session.pending_permissions.insert(
+                            tool_use_id.clone(),
+                            PendingPermission {
+                                request_id: request_id.clone(),
+                                tool_name: tool_name.clone(),
+                                original_input: input.clone(),
+                            },
+                        );
+                    }
+                } else {
+                    // Auto-deny any other tool that reaches the permission-prompt
+                    // path — current Claudette behaviour is no interactive approval
+                    // beyond the question/plan cards. Sending a structured deny
+                    // unblocks the CLI turn instead of hanging.
+                    let app_state = app.state::<AppState>();
+                    let agents = app_state.agents.read().await;
+                    let ps = agents
+                        .get(&ws_id)
+                        .and_then(|s| s.persistent_session.clone());
+                    drop(agents);
+                    if let Some(ps) = ps {
+                        let msg = format!(
+                            "Permission for {tool_name} is not granted in this Claudette session."
+                        );
+                        let deny = serde_json::json!({
+                            "behavior": "deny",
+                            "message": msg,
+                        });
+                        if let Err(e) = ps.send_control_response(request_id, deny).await {
+                            eprintln!("[chat] Failed to auto-deny {tool_name}: {e}");
+                        }
+                    }
+                }
             }
 
             // Detect tool calls that require user input (question, plan approval).
@@ -926,6 +995,9 @@ pub async fn stop_agent(
 ) -> Result<(), String> {
     let mut agents = state.agents.write().await;
     if let Some(session) = agents.get_mut(&workspace_id) {
+        // Unblock the CLI on any pending can_use_tool requests before we kill
+        // the process so the deny is recorded in the transcript cleanly.
+        cancel_pending_permissions(session, "Session stopped by user.").await;
         // Clear persistent session and reset session state so the next
         // turn starts completely fresh (not --resume with a stale ID).
         session.persistent_session = None;
@@ -966,6 +1038,9 @@ pub async fn reset_agent_session(
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let mut agents = state.agents.write().await;
+    if let Some(session) = agents.get_mut(&workspace_id) {
+        cancel_pending_permissions(session, "Session reset.").await;
+    }
     agents.remove(&workspace_id);
     drop(agents);
 
@@ -1250,6 +1325,152 @@ pub async fn clear_attention(
         crate::tray::rebuild_tray(&app);
     }
     Ok(())
+}
+
+/// Resolve a pending AskUserQuestion `can_use_tool` request with the user's
+/// answers. `answers` is keyed by question text (matching the CLI's
+/// `mapToolResultToToolResultBlockParam` expectation) and layered onto the
+/// original tool input as `updatedInput`. The CLI then runs the tool's
+/// `call(updatedInput)` which produces the real tool_result.
+#[tauri::command]
+pub async fn submit_agent_answer(
+    workspace_id: String,
+    tool_use_id: String,
+    answers: std::collections::HashMap<String, String>,
+    annotations: Option<serde_json::Value>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let (pending, ps) = {
+        let mut agents = state.agents.write().await;
+        let session = agents.get_mut(&workspace_id).ok_or("Session not found")?;
+        let pending = session
+            .pending_permissions
+            .remove(&tool_use_id)
+            .ok_or("No pending permission request for that tool_use_id")?;
+        let ps = session
+            .persistent_session
+            .clone()
+            .ok_or("Agent session is not active")?;
+        (pending, ps)
+    };
+
+    if pending.tool_name != "AskUserQuestion" {
+        // Re-insert so the correct command can resolve it.
+        let mut agents = state.agents.write().await;
+        if let Some(session) = agents.get_mut(&workspace_id) {
+            session
+                .pending_permissions
+                .insert(tool_use_id, pending.clone());
+        }
+        return Err(format!(
+            "Pending tool is {}, not AskUserQuestion",
+            pending.tool_name
+        ));
+    }
+
+    // Layer answers (and annotations, if any) onto the original input.
+    let mut updated_input = pending.original_input.clone();
+    if !updated_input.is_object() {
+        updated_input = serde_json::Value::Object(serde_json::Map::new());
+    }
+    if let Some(obj) = updated_input.as_object_mut() {
+        let answers_value =
+            serde_json::to_value(&answers).map_err(|e| format!("Failed to encode answers: {e}"))?;
+        obj.insert("answers".to_string(), answers_value);
+        if let Some(ann) = annotations {
+            obj.insert("annotations".to_string(), ann);
+        }
+    }
+
+    let response = serde_json::json!({
+        "behavior": "allow",
+        "updatedInput": updated_input,
+    });
+    ps.send_control_response(&pending.request_id, response)
+        .await
+}
+
+/// Resolve a pending ExitPlanMode `can_use_tool` request.
+/// `approved=true` → allow with the model's original input (the CLI's
+/// `call()` will save the plan and emit the real tool_result).
+/// `approved=false` → deny with the given reason (or a sensible default).
+#[tauri::command]
+pub async fn submit_plan_approval(
+    workspace_id: String,
+    tool_use_id: String,
+    approved: bool,
+    reason: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let (pending, ps) = {
+        let mut agents = state.agents.write().await;
+        let session = agents.get_mut(&workspace_id).ok_or("Session not found")?;
+        let pending = session
+            .pending_permissions
+            .remove(&tool_use_id)
+            .ok_or("No pending permission request for that tool_use_id")?;
+        let ps = session
+            .persistent_session
+            .clone()
+            .ok_or("Agent session is not active")?;
+        (pending, ps)
+    };
+
+    if pending.tool_name != "ExitPlanMode" {
+        let mut agents = state.agents.write().await;
+        if let Some(session) = agents.get_mut(&workspace_id) {
+            session
+                .pending_permissions
+                .insert(tool_use_id, pending.clone());
+        }
+        return Err(format!(
+            "Pending tool is {}, not ExitPlanMode",
+            pending.tool_name
+        ));
+    }
+
+    let response = if approved {
+        serde_json::json!({
+            "behavior": "allow",
+            "updatedInput": pending.original_input,
+        })
+    } else {
+        serde_json::json!({
+            "behavior": "deny",
+            "message": reason.unwrap_or_else(|| "Plan denied. Please revise the approach.".into()),
+        })
+    };
+    ps.send_control_response(&pending.request_id, response)
+        .await
+}
+
+/// Cancel any pending permission requests for a workspace by sending a deny
+/// `control_response` for each. Called when the session is being torn down
+/// (stop_agent / reset_agent_session / stale-process cleanup) to prevent the
+/// CLI from hanging waiting for a response that will never come.
+async fn cancel_pending_permissions(session: &mut AgentSessionState, reason: &str) {
+    if session.pending_permissions.is_empty() {
+        return;
+    }
+    let Some(ps) = session.persistent_session.clone() else {
+        // Without an active process nothing will read the response, so just drop
+        // the pending entries.
+        session.pending_permissions.clear();
+        return;
+    };
+    let drained: Vec<(String, PendingPermission)> = session.pending_permissions.drain().collect();
+    for (_tool_use_id, pending) in drained {
+        let deny = serde_json::json!({
+            "behavior": "deny",
+            "message": reason,
+        });
+        if let Err(e) = ps.send_control_response(&pending.request_id, deny).await {
+            eprintln!(
+                "[chat] Failed to deny pending {} on cleanup: {e}",
+                pending.tool_name
+            );
+        }
+    }
 }
 
 /// Load attachment metadata for a workspace's chat history.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -355,6 +355,8 @@ fn main() {
             commands::chat::stop_agent,
             commands::chat::reset_agent_session,
             commands::chat::clear_attention,
+            commands::chat::submit_agent_answer,
+            commands::chat::submit_plan_approval,
             commands::chat::list_checkpoints,
             commands::chat::rollback_to_checkpoint,
             commands::chat::clear_conversation,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -27,6 +27,19 @@ pub enum AttentionKind {
     Plan,
 }
 
+/// A `control_request: can_use_tool` the CLI is waiting on the host to
+/// resolve via `control_response`. Keyed in `AgentSessionState::pending_permissions`
+/// by tool_use_id so UI callbacks (AgentQuestionCard, PlanApprovalCard) can
+/// resolve them using the tool_use_id they already track.
+#[derive(Debug, Clone)]
+pub struct PendingPermission {
+    pub request_id: String,
+    pub tool_name: String,
+    /// Original tool input sent by the model — used verbatim as the base for
+    /// `updatedInput` when approving (we layer user-collected answers on top).
+    pub original_input: serde_json::Value,
+}
+
 /// Per-workspace agent session state managed on the Rust side.
 pub struct AgentSessionState {
     pub session_id: String,
@@ -56,6 +69,9 @@ pub struct AgentSessionState {
     /// A mismatch on the next turn (e.g. permission level changed, or plan
     /// approval elevates access) forces a teardown + respawn.
     pub session_allowed_tools: Vec<String>,
+    /// Outstanding `can_use_tool` control requests awaiting a `control_response`,
+    /// keyed by tool_use_id. See [`PendingPermission`].
+    pub pending_permissions: HashMap<String, PendingPermission>,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -634,6 +634,7 @@ mod tests {
             mcp_config_dirty: false,
             session_plan_mode: false,
             session_allowed_tools: Vec::new(),
+            pending_permissions: HashMap::new(),
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -279,14 +279,14 @@ pub fn build_claude_args(
         "stream-json".to_string(),
         "--verbose".to_string(),
         "--include-partial-messages".to_string(),
-        // Route permission "ask" decisions through the stream-json control
-        // protocol so the host (Claudette) can collect user answers and return
-        // them via `control_response`. Required for AskUserQuestion /
-        // ExitPlanMode round-trip — their `checkPermissions` short-circuits to
-        // `ask` regardless of --allowedTools or --permission-mode.
-        "--permission-prompt-tool".to_string(),
-        "stdio".to_string(),
     ];
+    // NOTE: `--permission-prompt-tool stdio` is intentionally NOT added here.
+    // `run_turn` runs with stdin closed (or only used for image upload), so
+    // there's nobody to answer a `can_use_tool` control_request — advertising
+    // the protocol would let the CLI hang waiting for AskUserQuestion /
+    // ExitPlanMode approval that no consumer is listening for. The flag is
+    // added in `build_persistent_args` instead, where the Tauri bridge owns
+    // the stdin and handles control_request → control_response.
 
     // Check if we should bypass permissions (full access with wildcard)
     let bypass_permissions = allowed_tools.len() == 1 && allowed_tools[0] == "*";
@@ -2579,7 +2579,11 @@ mod tests {
     // --- control_request parsing + stdio permission prompt flag ---
 
     #[test]
-    fn build_claude_args_includes_stdio_permission_prompt() {
+    fn build_claude_args_omits_stdio_permission_prompt() {
+        // run_turn doesn't keep stdin open for control_response, so the flag
+        // must NOT appear here — otherwise the CLI would block on
+        // AskUserQuestion / ExitPlanMode forever in non-persistent flows
+        // (used by the WebSocket server in src-server/src/handler.rs).
         let args = build_claude_args(
             "sid",
             "hi",
@@ -2589,12 +2593,10 @@ mod tests {
             &AgentSettings::default(),
             false,
         );
-        // Must appear as a pair so the CLI interprets it correctly.
-        let idx = args
-            .iter()
-            .position(|a| a == "--permission-prompt-tool")
-            .expect("--permission-prompt-tool missing");
-        assert_eq!(args.get(idx + 1).map(String::as_str), Some("stdio"));
+        assert!(
+            !args.iter().any(|a| a == "--permission-prompt-tool"),
+            "build_claude_args must not enable the stdio permission prompt"
+        );
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -46,6 +46,34 @@ pub enum StreamEvent {
     #[serde(rename = "user")]
     User { message: UserEventMessage },
 
+    /// A permission-prompt control request sent by the CLI when
+    /// `--permission-prompt-tool stdio` is active. Each `can_use_tool` request
+    /// must be answered with a `control_response` keyed by `request_id` —
+    /// see [`PersistentSession::send_control_response`].
+    #[serde(rename = "control_request")]
+    ControlRequest {
+        request_id: String,
+        request: ControlRequestInner,
+    },
+
+    #[serde(other)]
+    Unknown,
+}
+
+/// Inner payload of a `control_request`. We only care about `can_use_tool` for
+/// permission-prompt routing; other subtypes are captured as [`ControlRequestInner::Unknown`]
+/// and forwarded to the frontend for observability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "subtype")]
+pub enum ControlRequestInner {
+    #[serde(rename = "can_use_tool")]
+    CanUseTool {
+        tool_name: String,
+        tool_use_id: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+
     #[serde(other)]
     Unknown,
 }
@@ -251,6 +279,13 @@ pub fn build_claude_args(
         "stream-json".to_string(),
         "--verbose".to_string(),
         "--include-partial-messages".to_string(),
+        // Route permission "ask" decisions through the stream-json control
+        // protocol so the host (Claudette) can collect user answers and return
+        // them via `control_response`. Required for AskUserQuestion /
+        // ExitPlanMode round-trip — their `checkPermissions` short-circuits to
+        // `ask` regardless of --allowedTools or --permission-mode.
+        "--permission-prompt-tool".to_string(),
+        "stdio".to_string(),
     ];
 
     // Check if we should bypass permissions (full access with wildcard)
@@ -925,6 +960,42 @@ impl PersistentSession {
         })
     }
 
+    /// Write a `control_response` line to the CLI's stdin, answering a
+    /// prior `control_request: can_use_tool`. The inner `response` value is
+    /// either a permission-allow (`{ behavior: "allow", updatedInput }`) or
+    /// a permission-deny (`{ behavior: "deny", message }`); see
+    /// `PermissionPromptToolResultSchema` in the upstream CLI.
+    pub async fn send_control_response(
+        &self,
+        request_id: &str,
+        response: serde_json::Value,
+    ) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt;
+        let message = serde_json::json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": request_id,
+                "response": response,
+            },
+        })
+        .to_string();
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(message.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write control_response: {e}"))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("Failed to write control_response newline: {e}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| format!("Failed to flush control_response: {e}"))?;
+        Ok(())
+    }
+
     /// Get the process ID.
     pub fn pid(&self) -> u32 {
         self.pid
@@ -950,6 +1021,9 @@ fn build_persistent_args(
         "stream-json".to_string(),
         "--verbose".to_string(),
         "--include-partial-messages".to_string(),
+        // See build_claude_args for rationale.
+        "--permission-prompt-tool".to_string(),
+        "stdio".to_string(),
     ];
 
     let bypass_permissions = allowed_tools.len() == 1 && allowed_tools[0] == "*";
@@ -2500,5 +2574,82 @@ mod tests {
             probe.is_ok_and(|o| !o.status.success()),
             "process {pid} should no longer exist after graceful stop"
         );
+    }
+
+    // --- control_request parsing + stdio permission prompt flag ---
+
+    #[test]
+    fn build_claude_args_includes_stdio_permission_prompt() {
+        let args = build_claude_args(
+            "sid",
+            "hi",
+            false,
+            &["Read".to_string()],
+            None,
+            &AgentSettings::default(),
+            false,
+        );
+        // Must appear as a pair so the CLI interprets it correctly.
+        let idx = args
+            .iter()
+            .position(|a| a == "--permission-prompt-tool")
+            .expect("--permission-prompt-tool missing");
+        assert_eq!(args.get(idx + 1).map(String::as_str), Some("stdio"));
+    }
+
+    #[test]
+    fn build_persistent_args_includes_stdio_permission_prompt() {
+        let args = build_persistent_args(
+            "sid",
+            false,
+            &["Read".to_string()],
+            None,
+            &AgentSettings::default(),
+        );
+        let idx = args
+            .iter()
+            .position(|a| a == "--permission-prompt-tool")
+            .expect("--permission-prompt-tool missing in persistent args");
+        assert_eq!(args.get(idx + 1).map(String::as_str), Some("stdio"));
+    }
+
+    #[test]
+    fn parse_control_request_can_use_tool() {
+        let line = r#"{"type":"control_request","request_id":"req-1","request":{"subtype":"can_use_tool","tool_name":"AskUserQuestion","tool_use_id":"toolu_xyz","input":{"questions":[{"question":"Go?","options":[{"label":"yes"},{"label":"no"}]}]}}}"#;
+        let ev = parse_stream_line(line).expect("parse");
+        match ev {
+            StreamEvent::ControlRequest {
+                request_id,
+                request,
+            } => {
+                assert_eq!(request_id, "req-1");
+                match request {
+                    ControlRequestInner::CanUseTool {
+                        tool_name,
+                        tool_use_id,
+                        input,
+                    } => {
+                        assert_eq!(tool_name, "AskUserQuestion");
+                        assert_eq!(tool_use_id, "toolu_xyz");
+                        assert!(input.is_object());
+                    }
+                    _ => panic!("expected CanUseTool"),
+                }
+            }
+            other => panic!("expected ControlRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_control_request_unknown_subtype_is_nonfatal() {
+        let line =
+            r#"{"type":"control_request","request_id":"req-2","request":{"subtype":"mcp_status"}}"#;
+        let ev = parse_stream_line(line).expect("parse");
+        match ev {
+            StreamEvent::ControlRequest { request, .. } => {
+                assert!(matches!(request, ControlRequestInner::Unknown));
+            }
+            other => panic!("expected ControlRequest, got {other:?}"),
+        }
     }
 }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -71,7 +71,9 @@ mod tests {
     }
 
     #[test]
-    fn ask_user_question_is_allowed_at_every_level() {
+    fn ask_user_question_is_allowed_at_readonly_and_standard_levels() {
+        // `full` returns the wildcard sentinel `["*"]`, so the explicit
+        // names only need to be present at the more restricted levels.
         for level in ["readonly", "standard"] {
             let tools = tools_for_level(level);
             assert!(

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,3 +1,10 @@
+// AskUserQuestion and ExitPlanMode are the mechanism the agent uses to talk
+// to the user — they are always legitimate regardless of permission level.
+// They are ALSO gated by the CLI's own `requiresUserInteraction` step (which
+// runs before --allowedTools), so their round-trip is driven through the
+// `--permission-prompt-tool stdio` control-request protocol. Listing them
+// here is a correctness policy statement and a guard against future CLI
+// changes that might drop the requiresUserInteraction short-circuit.
 const TOOLS_STANDARD: &[&str] = &[
     "Read",
     "Write",
@@ -6,9 +13,19 @@ const TOOLS_STANDARD: &[&str] = &[
     "Grep",
     "WebSearch",
     "WebFetch",
+    "AskUserQuestion",
+    "ExitPlanMode",
 ];
 
-const TOOLS_READONLY: &[&str] = &["Read", "Glob", "Grep", "WebSearch", "WebFetch"];
+const TOOLS_READONLY: &[&str] = &[
+    "Read",
+    "Glob",
+    "Grep",
+    "WebSearch",
+    "WebFetch",
+    "AskUserQuestion",
+    "ExitPlanMode",
+];
 
 /// Map a permission level name to the tools to pre-approve.
 /// "full" returns the wildcard sentinel `["*"]`, which `build_claude_args`
@@ -51,5 +68,20 @@ mod tests {
     #[test]
     fn unknown_level_defaults_to_readonly() {
         assert_eq!(tools_for_level("unknown"), tools_for_level("readonly"));
+    }
+
+    #[test]
+    fn ask_user_question_is_allowed_at_every_level() {
+        for level in ["readonly", "standard"] {
+            let tools = tools_for_level(level);
+            assert!(
+                tools.contains(&"AskUserQuestion".to_string()),
+                "AskUserQuestion missing at level {level}"
+            );
+            assert!(
+                tools.contains(&"ExitPlanMode".to_string()),
+                "ExitPlanMode missing at level {level}"
+            );
+        }
     }
 }

--- a/src/ui/src/components/chat/AgentQuestionCard.tsx
+++ b/src/ui/src/components/chat/AgentQuestionCard.tsx
@@ -4,7 +4,12 @@ import styles from "./AgentQuestionCard.module.css";
 
 interface AgentQuestionCardProps {
   question: AgentQuestion;
-  onRespond: (response: string) => void;
+  /**
+   * Called with answers keyed by question text — matches the CLI's
+   * `mapToolResultToToolResultBlockParam` input shape. Multi-select answers
+   * are comma-separated into a single string per question.
+   */
+  onRespond: (answers: Record<string, string>) => void;
 }
 
 export function AgentQuestionCard({
@@ -31,10 +36,14 @@ export function AgentQuestionCard({
     const isMulti = q.multiSelect ?? false;
     const currentSelections = selections[0] ?? new Set<number>();
 
+    const respondSingle = (answer: string) => {
+      onRespond({ [q.question]: answer });
+    };
+
     const toggleSingle = (optIdx: number) => {
       if (!isMulti) {
         const opt = q.options[optIdx];
-        if (opt) onRespond(opt.label);
+        if (opt) respondSingle(opt.label);
         return;
       }
       setSelections((prev) => {
@@ -83,7 +92,7 @@ export function AgentQuestionCard({
               const chosen = [...currentSelections]
                 .map((idx) => q.options[idx]?.label)
                 .filter(Boolean);
-              if (chosen.length > 0) onRespond(chosen.join(", "));
+              if (chosen.length > 0) respondSingle(chosen.join(", "));
             }}
           >
             Submit answer
@@ -99,7 +108,7 @@ export function AgentQuestionCard({
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 const text = freeform.trim();
-                if (text) onRespond(text);
+                if (text) respondSingle(text);
               }
             }}
             placeholder="Type a response..."
@@ -109,7 +118,7 @@ export function AgentQuestionCard({
             className={styles.submitBtn}
             onClick={() => {
               const text = freeform.trim();
-              if (text) onRespond(text);
+              if (text) respondSingle(text);
             }}
             disabled={!freeform.trim()}
           >
@@ -141,16 +150,16 @@ export function AgentQuestionCard({
   };
 
   const submitAll = (finalAnswers: Record<number, string>) => {
-    const parts: string[] = [];
+    const payload: Record<string, string> = {};
     for (let i = 0; i < total; i++) {
       const qItem = question.questions[i];
       const answer = finalAnswers[i];
       if (answer) {
-        parts.push(`${qItem.question}: ${answer}`);
+        payload[qItem.question] = answer;
       }
     }
-    if (parts.length > 0) {
-      onRespond(parts.join("\n"));
+    if (Object.keys(payload).length > 0) {
+      onRespond(payload);
     }
   };
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -880,15 +880,21 @@ export function ChatPanel() {
               {pendingQuestion && (
                 <AgentQuestionCard
                   question={pendingQuestion}
-                  onRespond={(answers) => {
+                  onRespond={async (answers) => {
                     if (!selectedWorkspaceId) return;
                     const wsId = selectedWorkspaceId;
                     const toolUseId = pendingQuestion.toolUseId;
-                    clearAgentQuestion(wsId);
-                    submitAgentAnswer(wsId, toolUseId, answers).catch((e) => {
+                    // Send first; only clear the card on success. If the
+                    // invoke fails (IPC error, session reset, …) the card
+                    // stays visible so the user can retry instead of leaving
+                    // the CLI blocked on an unanswerable can_use_tool.
+                    try {
+                      await submitAgentAnswer(wsId, toolUseId, answers);
+                      clearAgentQuestion(wsId);
+                    } catch (e) {
                       console.error("Failed to submit agent answer:", e);
                       setError(String(e));
-                    });
+                    }
                   }}
                 />
               )}
@@ -897,15 +903,17 @@ export function ChatPanel() {
                 <PlanApprovalCard
                   approval={pendingPlan}
                   remoteConnectionId={ws?.remote_connection_id ?? undefined}
-                  onRespond={(approved, reason) => {
+                  onRespond={async (approved, reason) => {
                     if (!selectedWorkspaceId) return;
                     const wsId = selectedWorkspaceId;
                     const toolUseId = pendingPlan.toolUseId;
-                    clearPlanApproval(wsId);
-                    submitPlanApproval(wsId, toolUseId, approved, reason).catch((e) => {
+                    try {
+                      await submitPlanApproval(wsId, toolUseId, approved, reason);
+                      clearPlanApproval(wsId);
+                    } catch (e) {
                       console.error("Failed to submit plan approval:", e);
                       setError(String(e));
-                    });
+                    }
                   }}
                 />
               )}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -17,6 +17,8 @@ import {
   sendChatMessage,
   sendRemoteCommand,
   stopAgent,
+  submitAgentAnswer,
+  submitPlanApproval,
   getAppSetting,
   setAppSetting,
   listWorkspaceFiles,
@@ -878,9 +880,15 @@ export function ChatPanel() {
               {pendingQuestion && (
                 <AgentQuestionCard
                   question={pendingQuestion}
-                  onRespond={(response) => {
-                    if (selectedWorkspaceId) clearAgentQuestion(selectedWorkspaceId);
-                    handleSend(response);
+                  onRespond={(answers) => {
+                    if (!selectedWorkspaceId) return;
+                    const wsId = selectedWorkspaceId;
+                    const toolUseId = pendingQuestion.toolUseId;
+                    clearAgentQuestion(wsId);
+                    submitAgentAnswer(wsId, toolUseId, answers).catch((e) => {
+                      console.error("Failed to submit agent answer:", e);
+                      setError(String(e));
+                    });
                   }}
                 />
               )}
@@ -889,9 +897,15 @@ export function ChatPanel() {
                 <PlanApprovalCard
                   approval={pendingPlan}
                   remoteConnectionId={ws?.remote_connection_id ?? undefined}
-                  onRespond={(response) => {
-                    if (selectedWorkspaceId) clearPlanApproval(selectedWorkspaceId);
-                    handleSend(response);
+                  onRespond={(approved, reason) => {
+                    if (!selectedWorkspaceId) return;
+                    const wsId = selectedWorkspaceId;
+                    const toolUseId = pendingPlan.toolUseId;
+                    clearPlanApproval(wsId);
+                    submitPlanApproval(wsId, toolUseId, approved, reason).catch((e) => {
+                      console.error("Failed to submit plan approval:", e);
+                      setError(String(e));
+                    });
                   }}
                 />
               )}

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -7,7 +7,12 @@ import styles from "./PlanApprovalCard.module.css";
 
 interface PlanApprovalCardProps {
   approval: PlanApproval;
-  onRespond: (response: string) => void;
+  /**
+   * Called with the user's decision. `approved=true` lets the CLI run the
+   * ExitPlanMode tool's `call()` (which writes the plan file and emits the
+   * real tool_result). `approved=false` sends a deny with the given reason.
+   */
+  onRespond: (approved: boolean, reason?: string) => void;
   remoteConnectionId?: string;
 }
 
@@ -93,13 +98,13 @@ export function PlanApprovalCard({
       <div className={styles.actions}>
         <button
           className={styles.approveBtn}
-          onClick={() => onRespond("Plan approved. Proceed with implementation.")}
+          onClick={() => onRespond(true)}
         >
           Approve plan
         </button>
         <button
           className={styles.denyBtn}
-          onClick={() => onRespond("Plan denied. Please revise the approach.")}
+          onClick={() => onRespond(false, "Plan denied. Please revise the approach.")}
         >
           Deny
         </button>

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -213,75 +213,13 @@ export function useAgentStream() {
                     }
                   }
 
-                  // Handle AskUserQuestion specifically.
-                  if (
-                    entry.toolName === ASK_USER_QUESTION_TOOL &&
-                    activity?.inputJson
-                  ) {
-                    try {
-                      const parsed = JSON.parse(activity.inputJson);
-                      const questions = parseAskUserQuestion(parsed);
-                      if (questions.length > 0) {
-                        setAgentQuestion({
-                          workspaceId: wsId,
-                          toolUseId: entry.toolUseId,
-                          questions,
-                        });
-                      }
-                    } catch {
-                      // Malformed JSON — ignore, question won't show
-                    }
-                  }
-
-                  // Handle ExitPlanMode — show approval card.
-                  if (entry.toolName === "ExitPlanMode") {
-                    let allowedPrompts: Array<{ tool: string; prompt: string }> = [];
-                    if (activity?.inputJson) {
-                      try {
-                        const parsed = JSON.parse(activity.inputJson);
-                        if (Array.isArray(parsed.allowedPrompts)) {
-                          allowedPrompts = parsed.allowedPrompts;
-                        }
-                      } catch { /* ignore */ }
-                    }
-
-                    // Extract absolute plan file path from ALL messages (the
-                    // path is typically mentioned when entering plan mode,
-                    // which may be many messages back). Search newest-first.
-                    const planPathRe = /(\/[^\s)"`]+\/\.claude\/plans\/[^\s)"`]+\.md)/;
-                    const messages = useAppStore.getState().chatMessages[wsId] || [];
-                    let planFilePath: string | null = null;
-                    for (let i = messages.length - 1; i >= 0; i--) {
-                      const m = messages[i].content.match(planPathRe);
-                      if (m) { planFilePath = m[1]; break; }
-                    }
-
-                    // Also check current streaming content and tool activity
-                    // input (the plan path may appear in tool results).
-                    if (!planFilePath) {
-                      const streaming = useAppStore.getState().streamingContent[wsId] || "";
-                      const m = streaming.match(planPathRe);
-                      if (m) planFilePath = m[1];
-                    }
-                    if (!planFilePath) {
-                      const allActivities = useAppStore.getState().toolActivities[wsId] || [];
-                      for (const act of allActivities) {
-                        const m = (act.inputJson + act.resultText).match(planPathRe);
-                        if (m) { planFilePath = m[1]; break; }
-                      }
-                    }
-                    // Fall back to cached path from EnterPlanMode tool result.
-                    if (!planFilePath && planFilePathRef.current[wsId]) {
-                      planFilePath = planFilePathRef.current[wsId];
-                    }
-
-                    setPlanApproval({
-                      workspaceId: wsId,
-                      toolUseId: entry.toolUseId,
-                      planFilePath,
-                      allowedPrompts,
-                    });
-                  }
+                  // NOTE: AskUserQuestion / ExitPlanMode card-showing is no
+                  // longer driven by content_block_stop. The Rust bridge emits
+                  // an `agent-permission-prompt` event the moment the CLI's
+                  // `control_request` is captured (and pending_permissions is
+                  // populated). The listener below handles those tools — that
+                  // way the card cannot be clicked before the Rust side is
+                  // ready to receive the answer.
                   break;
                 }
               }
@@ -384,6 +322,74 @@ export function useAgentStream() {
     finalizeTurn,
     setPlanMode,
   ]);
+
+  // Listen for `agent-permission-prompt` — emitted by the Rust bridge the
+  // moment a CLI `control_request: can_use_tool` is captured for
+  // AskUserQuestion / ExitPlanMode and the corresponding pending_permissions
+  // entry exists. Driving the card from this event (instead of the much
+  // earlier `content_block_stop`) eliminates the race where the user could
+  // click before the Rust side was ready to receive the answer.
+  useEffect(() => {
+    let active = true;
+    const unlisten = listen<{
+      workspace_id: string;
+      tool_use_id: string;
+      tool_name: string;
+      input: unknown;
+    }>("agent-permission-prompt", (event) => {
+      if (!active) return;
+      const { workspace_id: wsId, tool_use_id: toolUseId, tool_name: toolName, input } = event.payload;
+      if (toolName === ASK_USER_QUESTION_TOOL) {
+        try {
+          const questions = parseAskUserQuestion(input);
+          if (questions.length > 0) {
+            setAgentQuestion({ workspaceId: wsId, toolUseId, questions });
+          }
+        } catch {
+          // Malformed input — ignore (CLI will eventually time out and we
+          // auto-deny on session cleanup).
+        }
+      } else if (toolName === "ExitPlanMode") {
+        let allowedPrompts: Array<{ tool: string; prompt: string }> = [];
+        if (input && typeof input === "object" && "allowedPrompts" in input) {
+          const ap = (input as { allowedPrompts?: unknown }).allowedPrompts;
+          if (Array.isArray(ap)) {
+            allowedPrompts = ap as Array<{ tool: string; prompt: string }>;
+          }
+        }
+        // Reuse the same plan-file-path discovery the old content_block_stop
+        // path used: assistant text, then streaming text, then tool inputs/
+        // results, then the cached EnterPlanMode result path.
+        const planPathRe = /(\/[^\s)"`]+\/\.claude\/plans\/[^\s)"`]+\.md)/;
+        const messages = useAppStore.getState().chatMessages[wsId] || [];
+        let planFilePath: string | null = null;
+        for (let i = messages.length - 1; i >= 0; i--) {
+          const m = messages[i].content.match(planPathRe);
+          if (m) { planFilePath = m[1]; break; }
+        }
+        if (!planFilePath) {
+          const streaming = useAppStore.getState().streamingContent[wsId] || "";
+          const m = streaming.match(planPathRe);
+          if (m) planFilePath = m[1];
+        }
+        if (!planFilePath) {
+          const allActivities = useAppStore.getState().toolActivities[wsId] || [];
+          for (const act of allActivities) {
+            const m = (act.inputJson + act.resultText).match(planPathRe);
+            if (m) { planFilePath = m[1]; break; }
+          }
+        }
+        if (!planFilePath && planFilePathRef.current[wsId]) {
+          planFilePath = planFilePathRef.current[wsId];
+        }
+        setPlanApproval({ workspaceId: wsId, toolUseId, planFilePath, allowedPrompts });
+      }
+    });
+    return () => {
+      active = false;
+      unlisten.then((fn) => fn());
+    };
+  }, [setAgentQuestion, setPlanApproval]);
 
   // Listen for checkpoint-created events from the backend.
   const addCheckpoint = useAppStore((s) => s.addCheckpoint);

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -340,14 +340,18 @@ export function useAgentStream() {
       if (!active) return;
       const { workspace_id: wsId, tool_use_id: toolUseId, tool_name: toolName, input } = event.payload;
       if (toolName === ASK_USER_QUESTION_TOOL) {
-        try {
-          const questions = parseAskUserQuestion(input);
-          if (questions.length > 0) {
-            setAgentQuestion({ workspaceId: wsId, toolUseId, questions });
+        // The CLI guarantees `input` is the validated tool-input object —
+        // narrow before handing it to the parser.
+        if (input && typeof input === "object") {
+          try {
+            const questions = parseAskUserQuestion(input as Record<string, unknown>);
+            if (questions.length > 0) {
+              setAgentQuestion({ workspaceId: wsId, toolUseId, questions });
+            }
+          } catch {
+            // Malformed input — ignore (CLI will eventually time out and we
+            // auto-deny on session cleanup).
           }
-        } catch {
-          // Malformed input — ignore (CLI will eventually time out and we
-          // auto-deny on session cleanup).
         }
       } else if (toolName === "ExitPlanMode") {
         let allowedPrompts: Array<{ tool: string; prompt: string }> = [];

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -449,9 +449,11 @@ export function clearAttention(workspaceId: string): Promise<void> {
   return invoke("clear_attention", { workspaceId });
 }
 
-/// Send the user's answers for a pending AskUserQuestion tool_use, keyed by
-/// question text. The Rust side layers them onto the tool's original input as
-/// `updatedInput.answers` and writes a `control_response` to the CLI.
+/**
+ * Send the user's answers for a pending AskUserQuestion tool_use, keyed by
+ * question text. The Rust side layers them onto the tool's original input as
+ * `updatedInput.answers` and writes a `control_response` to the CLI.
+ */
 export function submitAgentAnswer(
   workspaceId: string,
   toolUseId: string,
@@ -465,8 +467,10 @@ export function submitAgentAnswer(
   });
 }
 
-/// Approve or reject a pending ExitPlanMode tool_use. On approve the CLI
-/// runs the tool's `call()` and emits the normal "Plan approved" tool_result.
+/**
+ * Approve or reject a pending ExitPlanMode tool_use. On approve the CLI
+ * runs the tool's `call()` and emits the normal "Plan approved" tool_result.
+ */
 export function submitPlanApproval(
   workspaceId: string,
   toolUseId: string,

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -449,6 +449,38 @@ export function clearAttention(workspaceId: string): Promise<void> {
   return invoke("clear_attention", { workspaceId });
 }
 
+/// Send the user's answers for a pending AskUserQuestion tool_use, keyed by
+/// question text. The Rust side layers them onto the tool's original input as
+/// `updatedInput.answers` and writes a `control_response` to the CLI.
+export function submitAgentAnswer(
+  workspaceId: string,
+  toolUseId: string,
+  answers: Record<string, string>,
+): Promise<void> {
+  return invoke("submit_agent_answer", {
+    workspaceId,
+    toolUseId,
+    answers,
+    annotations: null,
+  });
+}
+
+/// Approve or reject a pending ExitPlanMode tool_use. On approve the CLI
+/// runs the tool's `call()` and emits the normal "Plan approved" tool_result.
+export function submitPlanApproval(
+  workspaceId: string,
+  toolUseId: string,
+  approved: boolean,
+  reason?: string,
+): Promise<void> {
+  return invoke("submit_plan_approval", {
+    workspaceId,
+    toolUseId,
+    approved,
+    reason: reason ?? null,
+  });
+}
+
 // -- Checkpoints --
 
 import type { ConversationCheckpoint } from "../types/checkpoint";


### PR DESCRIPTION
Fixes #268.

## Summary

The `AskUserQuestion` / `ExitPlanMode` cards were rendered but the user's selection was never delivered back to the CLI as a structured `tool_result` keyed to the original `tool_use_id`. Under any "ask"-bearing permission decision the CLI auto-rejected the tool ("User declined to answer questions") and the answer landed as a fresh free-text user turn.

The fix routes these tools through the CLI's stream-json **control protocol**, captures the request on the Rust side, surfaces the card from the bridge (no race), and resolves it with a structured `control_response` once the user clicks.

### Root cause
`AskUserQuestion.checkPermissions` always returns `{ behavior: 'ask' }` and `requiresUserInteraction()` is true. In the upstream `hasPermissionsToUseTool`, step 1e (`permissions.ts:1230`) short-circuits **before** `--allowedTools` (step 2b) or `bypassPermissions` (step 2a) — so neither plan-mode, `--allowedTools`, nor `bypassPermissions` changes the outcome. Without `--permission-prompt-tool`, the CLI has no way to resolve the ask in `--print` mode, so `toolExecution.ts` writes an error `tool_result` (`"Answer questions?"`, `is_error: true`) and the tool's `call()` never runs.

### Fix
1. **`--permission-prompt-tool stdio`** in `build_persistent_args` only — the persistent Tauri session keeps stdin open and owns a control-request handler. The non-persistent `run_turn` (used by `src-server`) intentionally does **not** advertise the protocol because it has no responder; doing so would let the CLI hang forever.
2. **New `StreamEvent::ControlRequest` + `ControlRequestInner::CanUseTool`** in `src/agent.rs` to parse the inbound `control_request` line, plus `PersistentSession::send_control_response` to write the `control_response` back to stdin.
3. **`PendingPermission` map** on `AgentSessionState` (keyed by `tool_use_id`) populated by the bridge when a `can_use_tool` request arrives. Other tools that reach this path are auto-denied with a clear message — preserves prior behaviour.
4. **`agent-permission-prompt` Tauri event** emitted from the bridge **at the same moment `pending_permissions` is populated**. The frontend's `useAgentStream` listens for that event and only then renders `AgentQuestionCard` / `PlanApprovalCard`. Driving the card from the *control_request* (rather than the much earlier `content_block_stop`) eliminates the race that produced "No pending permission request for that tool_use_id" when users clicked too quickly.
5. **Two new Tauri commands**:
   - `submit_agent_answer(workspaceId, toolUseId, answers)` — layers answers (keyed by question text, matching `mapToolResultToToolResultBlockParam`) onto the original input as `updatedInput.answers`, then sends `{ behavior: "allow", updatedInput }`. The CLI's `call(updatedInput)` produces the canonical tool_result.
   - `submit_plan_approval(workspaceId, toolUseId, approved, reason?)` — approve: allow with original input (the CLI saves the plan and emits the real approval tool_result). Deny: `{ behavior: "deny", message: reason }`.
   - Both validate (live persistent_session, matching tool kind) **before** removing the pending entry, so a transient failure leaves the user able to retry.
6. **In-flight cleanup**: pending requests are explicitly denied on session stop, reset, new-user-turn, MCP-config drift, and persistent-session flag drift, so the CLI never hangs on a stale ask. Drain happens synchronously under the agents lock; the deny `control_response` writes happen after the lock is released, so other workspaces are not serialised behind the CLI stdin.
7. **`AskUserQuestion` + `ExitPlanMode`** added to `TOOLS_STANDARD` / `TOOLS_READONLY` — policy guard against future CLI changes (step 1e still drives the round-trip today).
8. **Better error message**: includes the tool_use_id and the list of currently-pending IDs so future reports are self-diagnosing.

### Files

| Area | File | What changed |
|---|---|---|
| Rust lib | `src/permissions.rs` | `AskUserQuestion` + `ExitPlanMode` in `TOOLS_STANDARD` / `TOOLS_READONLY`; new test |
| Rust lib | `src/agent.rs` | `--permission-prompt-tool stdio` on persistent path only; `StreamEvent::ControlRequest`; `ControlRequestInner::CanUseTool`; `PersistentSession::send_control_response`; tests |
| Tauri | `src-tauri/src/state.rs` | `PendingPermission` type + `pending_permissions: HashMap<tool_use_id, PendingPermission>` on `AgentSessionState` |
| Tauri | `src-tauri/src/commands/chat.rs` | Bridge captures `can_use_tool`, emits `agent-permission-prompt`; auto-denies non-question tools; `submit_agent_answer`, `submit_plan_approval` (validate-before-remove); `drain_pending_permissions` + `deny_drained_permissions` lock-safe cleanup on stop/reset/new-turn/drift |
| Tauri | `src-tauri/src/main.rs` | Register the two new commands |
| Tauri | `src-tauri/src/tray.rs` | Test fixture updated for new session state field |
| UI | `src/ui/src/services/tauri.ts` | `submitAgentAnswer`, `submitPlanApproval` invoke wrappers (JSDoc) |
| UI | `src/ui/src/components/chat/AgentQuestionCard.tsx` | `onRespond` emits `Record<questionText, answer>` for single / multi / freeform / wizard paths |
| UI | `src/ui/src/components/chat/PlanApprovalCard.tsx` | `onRespond(approved, reason?)` |
| UI | `src/ui/src/components/chat/ChatPanel.tsx` | Cards wired to the new commands; await before clearing the card so failures stay retry-able |
| UI | `src/ui/src/hooks/useAgentStream.ts` | Listen for `agent-permission-prompt` and call `setAgentQuestion` / `setPlanApproval` from there (removed the `content_block_stop` path for these tools) |

### Test plan

Automated (passing on this branch):
- [x] `cargo test --all-features --workspace`
- [x] `cargo clippy --workspace --all-targets` — zero warnings
- [x] `cargo fmt --all --check`
- [x] `cd src/ui && bunx tsc --noEmit`
- [x] `cd src/ui && bun run test` — 473/473

Manual UAT (verified on a live dev build):
- [x] AskUserQuestion round-trip across multiple back-to-back turns — agent's reply reflects the actual answer (no "dismissed").
- [x] Multi-question wizard — answers map populated per question.
- [x] Multi-select — comma-separated answer string lands correctly.
- [x] Freeform textarea — free text becomes the answer.
- [x] Plan mode ON × permission level ∈ {readonly, standard, full} — same outcome.
- [x] Cancel paths (stop/reset, new user turn, plan exit + flag drift) — CLI unblocks via `control_response: deny` instead of hanging.
- [x] `ExitPlanMode` approve / deny — round-trips cleanly.