### PR TITLE
refactor(ui): tone down stop button and swap icon to Square

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -948,15 +948,16 @@
 }
 
 .sendBtnStop {
-  background: var(--status-stopped);
-  border-color: var(--status-stopped);
-  color: var(--app-bg);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--divider);
+  color: var(--text-muted);
 }
 
 .sendBtnStop:hover:not(:disabled) {
-  background: var(--status-stopped);
-  border-color: var(--status-stopped);
-  filter: brightness(1.1);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--text-dim);
+  color: var(--text-primary);
+  filter: none;
 }
 
 .sendBtnStop:active:not(:disabled) {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
-import { FileText, GitBranch, Octagon, Plus, RotateCcw, Send, X } from "lucide-react";
+import { FileText, GitBranch, Plus, RotateCcw, Send, Square, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
@@ -2072,7 +2072,7 @@ function ChatInputArea({
           title={isRunning ? "Stop agent" : "Send message"}
           aria-label={isRunning ? "Stop agent" : "Send message"}
         >
-          {isRunning ? <Octagon size={16} /> : <Send size={16} />}
+          {isRunning ? <Square size={16} /> : <Send size={16} />}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Follow-up to #266 (which unified send/stop into one button). The stop state was styled with a saturated red fill (`--status-stopped`) and an `Octagon` icon, which read as attention-grabbing for an action users rarely invoke. This change softens the stop state to match the visual weight of the `+` attach button on the opposite side of the composer and swaps the icon to a cleaner `Square`.

- `.sendBtnStop` in `ChatPanel.module.css` now mirrors `.attachBtn`: `rgba(255,255,255,0.06)` bg, `--divider` border, `--text-muted` text. Hover brightens to `rgba(255,255,255,0.1)` with `--text-primary` text.
- `Octagon` → `Square` in `ChatPanel.tsx`. Size (28×28) and border-radius (8px) unchanged — left/right buttons remain dimensionally identical.

## Complexity Notes

- The `--status-stopped` token is intentionally **not** changed. It's a semantic color likely used elsewhere (status badges, workspace list indicators) where red urgency is still appropriate. The override is scoped to `.sendBtnStop` only.
- `filter: none` on `.sendBtnStop:hover` is defensive — cancels any future `filter` the base `.sendBtn:hover` might pick up that would otherwise leak through to the ghost variant.

## Test Steps

1. `cd src/ui && bun run test` — 469 tests should still pass.
2. `cargo tauri dev` to launch the app.
3. Open a workspace and send a message so the agent is running.
4. Confirm the right-side stop button:
   - Has the same subtle ghost background as the `+` button on the left.
   - Displays a `Square` icon (not `Octagon`), not red-filled.
   - Both buttons measure 28×28 — inspect in DevTools or via `/claudette-debug`:
     ```
     /claudette-debug eval 'const a=document.querySelector("[title=\"Add files or connectors\"]"); const s=document.querySelector("[aria-label=\"Stop agent\"]"); return {attach:a?.getBoundingClientRect(), stop:s?.getBoundingClientRect()};'
     ```
5. Hover both buttons — both brighten to the same elevated ghost state.
6. Click stop — agent stops correctly (no behavioral change).
7. After agent finishes, the button reverts to the teal send state.

## Checklist

- [ ] Tests added/updated _(not applicable — pure visual restyle)_
- [ ] Documentation updated (if applicable) _(no user-facing docs reference the button styling)_