### PR TITLE
fix(ui): remove visible gap between left sidebar and main panel

### DIFF
--- a/src/ui/src/components/layout/ResizeHandle.module.css
+++ b/src/ui/src/components/layout/ResizeHandle.module.css
@@ -5,8 +5,13 @@
   transition: background var(--transition-fast);
 }
 
+/* Negative margins collapse the handle's layout width to 0 while keeping a
+   4px-wide mouse-capture zone that overlaps the adjacent panels. Without this
+   the handle would leave a visible gap between panels (equal to its width)
+   because its background is transparent and the app background shows through. */
 .horizontal {
   width: 4px;
+  margin: 0 -2px;
   cursor: col-resize;
   flex-shrink: 0;
 }
@@ -18,6 +23,7 @@
 
 .vertical {
   height: 4px;
+  margin: -2px 0;
   cursor: row-resize;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

The left sidebar and main chat panel had a visible 1–2 px gap between them. Root cause: `ResizeHandle` sat as a 4 px-wide flex sibling with `background: transparent`, so the app background showed through as a stripe between the sidebar's `border-right` and the chat panel's content.

Standard fix for this pattern (used by VS Code, iTerm, most IDEs): collapse the handle's **layout contribution** to 0 via symmetric negative margins while keeping its 4 px-wide **mouse-capture zone** for good drag ergonomics. The handle overlaps 2 px into each neighbouring panel, and `z-index: 10` (already present) keeps it clickable on top. The sidebar's `border-right` now sits directly against the chat panel as the visible divider.

Applied symmetrically to the vertical (terminal) handle so the 1 px `border-top` on `.terminal` isn't visually separated from the content above.

## Test plan

- [x] `bunx tsc --noEmit` passes (no TS change, CSS-only fix).
- [ ] `cargo tauri dev`: no visible gap between the left sidebar and the chat/diff panel; sidebar's right border is flush against the main panel.
- [ ] Hover over the sidebar/panel boundary: cursor still changes to `col-resize` within ~2 px of the divider on each side.
- [ ] Drag to resize: behaviour unchanged; `--sidebar-w` updates correctly, no jumpy first-click.
- [ ] Same check for the right sidebar divider.
- [ ] Same check for the terminal panel's top divider (vertical handle).