### PR TITLE
feat(chat): per-turn footer with elapsed, copy, fork, and rollback

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -125,7 +125,7 @@ pub async fn create_workspace(
         id: uuid::Uuid::new_v4().to_string(),
         repository_id: repo_id,
         name,
-        branch_name,
+        branch_name: branch_name.clone(),
         worktree_path: Some(actual_path.clone()),
         status: WorkspaceStatus::Active,
         agent_status: AgentStatus::Idle,
@@ -133,7 +133,13 @@ pub async fn create_workspace(
         created_at: now_iso(),
     };
 
-    db.insert_workspace(&ws).map_err(|e| e.to_string())?;
+    // If the DB insert fails, roll back the worktree + branch we just created
+    // so we don't leave orphan git state pointing to nothing.
+    if let Err(e) = db.insert_workspace(&ws) {
+        let _ = git::remove_worktree(&repo_path, &actual_path, true).await;
+        let _ = git::branch_delete(&repo_path, &branch_name).await;
+        return Err(e.to_string());
+    }
 
     // Resolve and execute setup script (unless caller requested skip).
     let setup_result = if skip_setup.unwrap_or(false) {

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -10,6 +10,7 @@ use claudette::agent;
 use claudette::config;
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
+use claudette::fork::{self, ForkInputs};
 use claudette::git;
 use claudette::mcp_supervisor::McpSupervisor;
 use claudette::model::{AgentStatus, Workspace, WorkspaceStatus};
@@ -152,6 +153,50 @@ pub async fn create_workspace(
     Ok(CreateWorkspaceResult {
         workspace: ws,
         setup_result,
+    })
+}
+
+#[derive(Serialize)]
+pub struct ForkWorkspaceResult {
+    pub workspace: Workspace,
+    /// Whether the Claude session JSONL was copied so the fork can `--resume`
+    /// its conversation history. When `false`, the fork starts a fresh session.
+    pub session_resumed: bool,
+}
+
+#[tauri::command]
+pub async fn fork_workspace_at_checkpoint(
+    workspace_id: String,
+    checkpoint_id: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ForkWorkspaceResult, String> {
+    let mut db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    let (prefix_mode, prefix_custom) = read_branch_prefix_settings(&db);
+    let prefix = resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
+
+    let worktree_base = state.worktree_base_dir.read().await.clone();
+
+    let outcome = fork::fork_workspace_at_checkpoint(
+        &mut db,
+        ForkInputs {
+            source_workspace_id: &workspace_id,
+            checkpoint_id: &checkpoint_id,
+            worktree_base: worktree_base.as_path(),
+            branch_prefix: &prefix,
+            db_path: state.db_path.as_path(),
+            now_iso,
+        },
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    crate::tray::rebuild_tray(&app);
+
+    Ok(ForkWorkspaceResult {
+        workspace: outcome.workspace,
+        session_resumed: outcome.session_resumed,
     })
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -330,6 +330,7 @@ fn main() {
             commands::repository::set_setup_script_auto_run,
             // Workspace
             commands::workspace::create_workspace,
+            commands::workspace::fork_workspace_at_checkpoint,
             commands::workspace::run_workspace_setup,
             commands::workspace::archive_workspace,
             commands::workspace::restore_workspace,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1001,6 +1001,73 @@ impl Database {
         Ok(deleted)
     }
 
+    /// Return checkpoints for `workspace_id` whose `turn_index` is at most
+    /// `max_turn_index`, ordered by `turn_index`. Used by the fork
+    /// orchestrator to copy only checkpoints up to (and including) the fork
+    /// point.
+    pub fn list_checkpoints_up_to(
+        &self,
+        workspace_id: &str,
+        max_turn_index: i32,
+    ) -> Result<Vec<ConversationCheckpoint>, rusqlite::Error> {
+        let sql = format!(
+            "SELECT {} FROM conversation_checkpoints \
+             WHERE workspace_id = ?1 AND turn_index <= ?2 ORDER BY turn_index",
+            Self::CHECKPOINT_COLS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            params![workspace_id, max_turn_index],
+            Self::parse_checkpoint_row,
+        )?;
+        rows.collect()
+    }
+
+    /// Return chat messages for `workspace_id` up to and including the row
+    /// identified by `last_message_id`, ordered by (created_at, rowid). If
+    /// `last_message_id` is not found, returns an empty vec. Used by the fork
+    /// orchestrator to copy conversation history up to the fork point.
+    pub fn list_messages_up_to(
+        &self,
+        workspace_id: &str,
+        last_message_id: &str,
+    ) -> Result<Vec<ChatMessage>, rusqlite::Error> {
+        let boundary: Option<(String, i64)> = self
+            .conn
+            .query_row(
+                "SELECT created_at, rowid FROM chat_messages \
+                 WHERE id = ?1 AND workspace_id = ?2",
+                params![last_message_id, workspace_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((created_at, rowid)) = boundary else {
+            return Ok(Vec::new());
+        };
+
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, role, content, cost_usd, duration_ms, created_at, thinking
+             FROM chat_messages
+             WHERE workspace_id = ?1
+               AND (created_at < ?2 OR (created_at = ?2 AND rowid <= ?3))
+             ORDER BY created_at, rowid",
+        )?;
+        let rows = stmt.query_map(params![workspace_id, created_at, rowid], |row| {
+            let role_str: String = row.get(2)?;
+            Ok(ChatMessage {
+                id: row.get(0)?,
+                workspace_id: row.get(1)?,
+                role: role_str.parse().unwrap(),
+                content: row.get(3)?,
+                cost_usd: row.get(4)?,
+                duration_ms: row.get(5)?,
+                created_at: row.get(6)?,
+                thinking: row.get(7)?,
+            })
+        })?;
+        rows.collect()
+    }
+
     // --- Checkpoint Files ---
 
     pub fn insert_checkpoint_files(&self, files: &[CheckpointFile]) -> Result<(), rusqlite::Error> {
@@ -1184,6 +1251,7 @@ impl Database {
                     message_id: cp.message_id,
                     turn_index: cp.turn_index,
                     message_count: cp.message_count,
+                    commit_hash: cp.commit_hash,
                     activities: acts,
                 })
             })
@@ -2516,6 +2584,54 @@ mod tests {
         assert_eq!(turns[0].activities.len(), 2);
         assert_eq!(turns[1].activities.len(), 1);
         assert_eq!(turns[1].activities[0].tool_name, "Bash");
+    }
+
+    #[test]
+    fn test_list_messages_up_to_includes_boundary() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "a"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "b"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m3", "w1", ChatRole::User, "c"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m4", "w1", ChatRole::Assistant, "d"))
+            .unwrap();
+
+        let msgs = db.list_messages_up_to("w1", "m2").unwrap();
+        let ids: Vec<_> = msgs.iter().map(|m| m.id.clone()).collect();
+        assert_eq!(ids, vec!["m1".to_string(), "m2".to_string()]);
+    }
+
+    #[test]
+    fn test_list_messages_up_to_missing_returns_empty() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "a"))
+            .unwrap();
+        let msgs = db.list_messages_up_to("w1", "nonexistent").unwrap();
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn test_list_checkpoints_up_to() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "b"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m3", "w1", ChatRole::Assistant, "c"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint("cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint("cp2", "w1", "m2", 1))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint("cp3", "w1", "m3", 2))
+            .unwrap();
+
+        let up_to_1 = db.list_checkpoints_up_to("w1", 1).unwrap();
+        assert_eq!(up_to_1.len(), 2);
+        assert_eq!(up_to_1[0].id, "cp1");
+        assert_eq!(up_to_1[1].id, "cp2");
     }
 
     #[test]

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -18,7 +18,8 @@ use std::path::{Path, PathBuf};
 use crate::db::Database;
 use crate::git;
 use crate::model::{
-    AgentStatus, ChatMessage, ConversationCheckpoint, TurnToolActivity, Workspace, WorkspaceStatus,
+    AgentStatus, ChatMessage, CheckpointFile, ConversationCheckpoint, TurnToolActivity, Workspace,
+    WorkspaceStatus,
 };
 use crate::snapshot;
 
@@ -158,6 +159,38 @@ pub async fn fork_workspace_at_checkpoint(
         git::create_worktree_from_ref(&repo.path, &new_branch_name, &worktree_path_str, &base_ref)
             .await?;
 
+    // From here on we own a worktree + branch on disk. If any subsequent step
+    // fails, roll them back best-effort so we don't leave orphan state.
+    let outcome = fork_after_worktree(
+        db,
+        &inputs,
+        &source_ws,
+        &checkpoint,
+        new_name,
+        new_branch_name.clone(),
+        actual_path.clone(),
+    )
+    .await;
+
+    if outcome.is_err() {
+        let _ = git::remove_worktree(&repo.path, &actual_path, true).await;
+        let _ = git::branch_delete(&repo.path, &new_branch_name).await;
+    }
+
+    outcome
+}
+
+/// Steps that run after a successful `create_worktree_from_ref`. Split out so
+/// the caller can funnel all failures through a single cleanup path.
+async fn fork_after_worktree(
+    db: &mut Database,
+    inputs: &ForkInputs<'_>,
+    source_ws: &Workspace,
+    checkpoint: &ConversationCheckpoint,
+    new_name: String,
+    new_branch_name: String,
+    actual_path: String,
+) -> Result<ForkOutcome, ForkError> {
     // Restore the checkpoint's file snapshot (if present) onto the new
     // worktree so its files match the selected turn, not the base commit.
     if checkpoint.has_file_state {
@@ -179,7 +212,7 @@ pub async fn fork_workspace_at_checkpoint(
     };
     db.insert_workspace(&new_ws)?;
 
-    copy_history(db, &source_ws.id, &new_ws.id, &checkpoint)?;
+    copy_history(db, &source_ws.id, &new_ws.id, checkpoint)?;
 
     let session_resumed = if let Some(src_wt) = source_ws.worktree_path.as_deref() {
         copy_claude_session(db, &source_ws.id, &new_ws.id, src_wt, &actual_path)?
@@ -280,14 +313,36 @@ fn copy_history(
             workspace_id: new_ws_id.to_string(),
             message_id: new_msg_id.clone(),
             commit_hash: cp.commit_hash.clone(),
-            // The fork's worktree is already at the checkpoint commit — we
-            // don't also need file-level snapshots in checkpoint_files.
-            has_file_state: false,
+            // `has_file_state` is derived by the DB from the presence of
+            // `checkpoint_files` rows, so this field is informational on
+            // insert; the real source of truth is the rows we copy below.
+            has_file_state: cp.has_file_state,
             turn_index: cp.turn_index,
             message_count: cp.message_count,
             created_at: String::new(),
         };
         db.insert_checkpoint(&new_cp)?;
+
+        // Copy snapshot files so rollback in the fork can restore to this
+        // checkpoint. Without this, snapshot-only checkpoints (the norm
+        // since Claudette migrated away from git-commit checkpoints) would
+        // have neither a commit nor file data to restore from in the fork.
+        if cp.has_file_state {
+            let files = db.get_checkpoint_files(&cp.id)?;
+            let remapped_files: Vec<CheckpointFile> = files
+                .into_iter()
+                .map(|f| CheckpointFile {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    checkpoint_id: new_cp_id.clone(),
+                    file_path: f.file_path,
+                    content: f.content,
+                    file_mode: f.file_mode,
+                })
+                .collect();
+            if !remapped_files.is_empty() {
+                db.insert_checkpoint_files(&remapped_files)?;
+            }
+        }
 
         if let Some(acts) = activities_by_cp.get(&cp.id) {
             let remapped: Vec<TurnToolActivity> = acts
@@ -352,9 +407,10 @@ fn copy_claude_session(
 /// Convert an absolute filesystem path to Claude CLI's project slug
 /// convention (used as the directory name under `~/.claude/projects/`).
 ///
-/// Claude CLI replaces path separators with `-` to form the slug.
+/// Claude CLI replaces path separators with `-` to form the slug. Handle
+/// both `/` and `\` so Windows paths produce the correct slug.
 fn claude_project_slug(path: &str) -> String {
-    path.replace('/', "-")
+    path.replace(['/', '\\'], "-")
 }
 
 #[cfg(test)]

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -1,0 +1,553 @@
+//! Workspace forking: clone a workspace at a specific conversation
+//! checkpoint so the user can continue the conversation from that point
+//! without disturbing the original.
+//!
+//! A fork creates a new workspace whose:
+//!   - git worktree is branched from the checkpoint's commit (file state
+//!     matches the chosen turn),
+//!   - chat messages and conversation checkpoints are copied from the
+//!     source workspace up to and including the chosen turn,
+//!   - Claude CLI session (JSONL transcript) is copied when present so the
+//!     next turn can `--resume` without losing conversational context.
+//!
+//! The heavy lifting lives here (rather than in `src-tauri`) so the logic
+//! is testable without a Tauri runtime.
+
+use std::path::{Path, PathBuf};
+
+use crate::db::Database;
+use crate::git;
+use crate::model::{
+    AgentStatus, ChatMessage, ConversationCheckpoint, TurnToolActivity, Workspace, WorkspaceStatus,
+};
+use crate::snapshot;
+
+#[derive(Debug)]
+pub enum ForkError {
+    SourceWorkspaceMissing,
+    SourceRepoMissing,
+    CheckpointMissing,
+    /// The source workspace has no worktree on disk, so we cannot resolve a
+    /// base ref to branch the fork from.
+    SourceWorktreeMissing,
+    /// A checkpoint/message mapping was missing during the copy.
+    InconsistentHistory(String),
+    Db(rusqlite::Error),
+    Git(git::GitError),
+    Snapshot(String),
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for ForkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SourceWorkspaceMissing => write!(f, "Source workspace not found"),
+            Self::SourceRepoMissing => write!(f, "Source workspace's repository not found"),
+            Self::CheckpointMissing => write!(f, "Checkpoint not found"),
+            Self::SourceWorktreeMissing => write!(
+                f,
+                "Source workspace has no worktree on disk; cannot determine base ref for fork"
+            ),
+            Self::InconsistentHistory(msg) => write!(f, "Inconsistent history: {msg}"),
+            Self::Db(e) => write!(f, "Database error: {e}"),
+            Self::Git(e) => write!(f, "Git error: {e:?}"),
+            Self::Snapshot(msg) => write!(f, "Snapshot error: {msg}"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ForkError {}
+
+impl From<rusqlite::Error> for ForkError {
+    fn from(e: rusqlite::Error) -> Self {
+        Self::Db(e)
+    }
+}
+
+impl From<git::GitError> for ForkError {
+    fn from(e: git::GitError) -> Self {
+        Self::Git(e)
+    }
+}
+
+impl From<std::io::Error> for ForkError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Inputs to [`fork_workspace_at_checkpoint`], grouped for clarity since the
+/// list is long and several fields are orthogonal.
+pub struct ForkInputs<'a> {
+    pub source_workspace_id: &'a str,
+    pub checkpoint_id: &'a str,
+    /// e.g. `.../worktrees/{repo_slug}/{name}` — caller joins base dir.
+    pub worktree_base: &'a Path,
+    /// e.g. `"seancallan/"` or `""` — caller resolves prefix from settings.
+    pub branch_prefix: &'a str,
+    /// Path to the SQLite database. Needed because
+    /// [`snapshot::restore_snapshot`] opens its own connection to avoid the
+    /// `rusqlite::Connection: !Send` problem across await points.
+    pub db_path: &'a Path,
+    /// Function that produces the current timestamp string used for
+    /// `Workspace::created_at`. Injected for deterministic tests.
+    pub now_iso: fn() -> String,
+}
+
+pub struct ForkOutcome {
+    pub workspace: Workspace,
+    /// Whether a Claude session JSONL transcript was successfully copied,
+    /// allowing the new workspace to `--resume` on its next turn.
+    pub session_resumed: bool,
+}
+
+/// Takes `&mut Database` so the returned future is `Send` — `Database` wraps
+/// a `rusqlite::Connection` (holds a `RefCell`), making `&Database: !Send`.
+/// Exclusive access lets us keep the reference across the single `await`.
+pub async fn fork_workspace_at_checkpoint(
+    db: &mut Database,
+    inputs: ForkInputs<'_>,
+) -> Result<ForkOutcome, ForkError> {
+    let source_ws = db
+        .list_workspaces()?
+        .into_iter()
+        .find(|w| w.id == inputs.source_workspace_id)
+        .ok_or(ForkError::SourceWorkspaceMissing)?;
+    let repo = db
+        .list_repositories()?
+        .into_iter()
+        .find(|r| r.id == source_ws.repository_id)
+        .ok_or(ForkError::SourceRepoMissing)?;
+    let checkpoint = db
+        .get_checkpoint(inputs.checkpoint_id)?
+        .ok_or(ForkError::CheckpointMissing)?;
+
+    if checkpoint.workspace_id != source_ws.id {
+        return Err(ForkError::InconsistentHistory(format!(
+            "checkpoint {} does not belong to workspace {}",
+            checkpoint.id, source_ws.id
+        )));
+    }
+
+    // Resolve the base commit to branch from. Prefer the checkpoint's
+    // recorded commit_hash (legacy path); otherwise fall back to the source
+    // worktree's current HEAD — the fork still gets a stable ancestry point,
+    // and the snapshot restore below will overwrite files to match the
+    // chosen turn.
+    let base_ref = if let Some(hash) = checkpoint.commit_hash.clone() {
+        hash
+    } else {
+        let src_wt = source_ws
+            .worktree_path
+            .as_deref()
+            .ok_or(ForkError::SourceWorktreeMissing)?;
+        git::head_commit(src_wt).await?
+    };
+
+    let (new_name, new_branch_name) = allocate_name_and_branch(
+        db,
+        &source_ws.repository_id,
+        &source_ws.name,
+        inputs.branch_prefix,
+    )?;
+    let worktree_path: PathBuf = inputs.worktree_base.join(&repo.path_slug).join(&new_name);
+    let worktree_path_str = worktree_path.to_string_lossy().to_string();
+
+    let actual_path =
+        git::create_worktree_from_ref(&repo.path, &new_branch_name, &worktree_path_str, &base_ref)
+            .await?;
+
+    // Restore the checkpoint's file snapshot (if present) onto the new
+    // worktree so its files match the selected turn, not the base commit.
+    if checkpoint.has_file_state {
+        snapshot::restore_snapshot(inputs.db_path, &checkpoint.id, &actual_path)
+            .await
+            .map_err(|e| ForkError::Snapshot(e.to_string()))?;
+    }
+
+    let new_ws = Workspace {
+        id: uuid::Uuid::new_v4().to_string(),
+        repository_id: source_ws.repository_id.clone(),
+        name: new_name,
+        branch_name: new_branch_name,
+        worktree_path: Some(actual_path.clone()),
+        status: WorkspaceStatus::Active,
+        agent_status: AgentStatus::Idle,
+        status_line: String::new(),
+        created_at: (inputs.now_iso)(),
+    };
+    db.insert_workspace(&new_ws)?;
+
+    copy_history(db, &source_ws.id, &new_ws.id, &checkpoint)?;
+
+    let session_resumed = if let Some(src_wt) = source_ws.worktree_path.as_deref() {
+        copy_claude_session(db, &source_ws.id, &new_ws.id, src_wt, &actual_path)?
+    } else {
+        false
+    };
+
+    Ok(ForkOutcome {
+        workspace: new_ws,
+        session_resumed,
+    })
+}
+
+/// Allocate a workspace name + branch name that do not collide with existing
+/// workspaces in the same repository. Appends `-fork`, then `-fork-2`, etc.
+fn allocate_name_and_branch(
+    db: &Database,
+    repo_id: &str,
+    source_name: &str,
+    branch_prefix: &str,
+) -> Result<(String, String), ForkError> {
+    let existing_names: std::collections::HashSet<String> = db
+        .list_workspaces()?
+        .into_iter()
+        .filter(|w| w.repository_id == repo_id)
+        .map(|w| w.name)
+        .collect();
+
+    let base = format!("{source_name}-fork");
+    let name = if !existing_names.contains(&base) {
+        base
+    } else {
+        let mut n = 2;
+        loop {
+            let candidate = format!("{source_name}-fork-{n}");
+            if !existing_names.contains(&candidate) {
+                break candidate;
+            }
+            n += 1;
+        }
+    };
+    let branch = format!("{branch_prefix}{name}");
+    Ok((name, branch))
+}
+
+/// Copy chat messages, checkpoints and tool activities from the source
+/// workspace up to and including the checkpoint.
+///
+/// Messages and checkpoints get fresh UUIDs in the fork; we map old→new
+/// message IDs so each copied checkpoint's `message_id` anchors to the new
+/// message it corresponds to.
+fn copy_history(
+    db: &Database,
+    source_ws_id: &str,
+    new_ws_id: &str,
+    checkpoint: &ConversationCheckpoint,
+) -> Result<(), ForkError> {
+    let source_messages = db.list_messages_up_to(source_ws_id, &checkpoint.message_id)?;
+
+    let mut msg_id_map: std::collections::HashMap<String, String> =
+        std::collections::HashMap::with_capacity(source_messages.len());
+
+    for msg in &source_messages {
+        let new_id = uuid::Uuid::new_v4().to_string();
+        msg_id_map.insert(msg.id.clone(), new_id.clone());
+        let copied = ChatMessage {
+            id: new_id,
+            workspace_id: new_ws_id.to_string(),
+            role: msg.role.clone(),
+            content: msg.content.clone(),
+            cost_usd: msg.cost_usd,
+            duration_ms: msg.duration_ms,
+            // created_at is set by the DB default on insert.
+            created_at: String::new(),
+            thinking: msg.thinking.clone(),
+        };
+        db.insert_chat_message(&copied)?;
+    }
+
+    let source_checkpoints = db.list_checkpoints_up_to(source_ws_id, checkpoint.turn_index)?;
+    let source_turn_data = db.list_completed_turns(source_ws_id)?;
+    let activities_by_cp: std::collections::HashMap<String, Vec<TurnToolActivity>> =
+        source_turn_data
+            .into_iter()
+            .map(|td| (td.checkpoint_id, td.activities))
+            .collect();
+
+    for cp in source_checkpoints {
+        let new_cp_id = uuid::Uuid::new_v4().to_string();
+        let new_msg_id = msg_id_map.get(&cp.message_id).ok_or_else(|| {
+            ForkError::InconsistentHistory(format!(
+                "checkpoint {} anchors to message {} which was not copied",
+                cp.id, cp.message_id
+            ))
+        })?;
+        let new_cp = ConversationCheckpoint {
+            id: new_cp_id.clone(),
+            workspace_id: new_ws_id.to_string(),
+            message_id: new_msg_id.clone(),
+            commit_hash: cp.commit_hash.clone(),
+            // The fork's worktree is already at the checkpoint commit — we
+            // don't also need file-level snapshots in checkpoint_files.
+            has_file_state: false,
+            turn_index: cp.turn_index,
+            message_count: cp.message_count,
+            created_at: String::new(),
+        };
+        db.insert_checkpoint(&new_cp)?;
+
+        if let Some(acts) = activities_by_cp.get(&cp.id) {
+            let remapped: Vec<TurnToolActivity> = acts
+                .iter()
+                .map(|a| TurnToolActivity {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    checkpoint_id: new_cp_id.clone(),
+                    tool_use_id: a.tool_use_id.clone(),
+                    tool_name: a.tool_name.clone(),
+                    input_json: a.input_json.clone(),
+                    result_text: a.result_text.clone(),
+                    summary: a.summary.clone(),
+                    sort_order: a.sort_order,
+                })
+                .collect();
+            db.insert_turn_tool_activities(&remapped)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Copy Claude CLI's JSONL session transcript from the source workspace's
+/// project directory to the new workspace's project directory, so the
+/// forked workspace can `--resume` from the same session history.
+///
+/// Returns `true` if the transcript was found and copied (session id is
+/// persisted for the new workspace). Returns `false` if there was no
+/// session to resume — in that case the new workspace simply starts a
+/// fresh Claude session on its first turn, which is the intended graceful
+/// degradation rather than an error.
+fn copy_claude_session(
+    db: &Database,
+    source_ws_id: &str,
+    new_ws_id: &str,
+    source_worktree: &str,
+    new_worktree: &str,
+) -> Result<bool, ForkError> {
+    let Some((session_id, turn_count)) = db.get_agent_session(source_ws_id)? else {
+        return Ok(false);
+    };
+
+    let Some(home) = dirs::home_dir() else {
+        return Ok(false);
+    };
+    let projects_dir = home.join(".claude").join("projects");
+    let src_file = projects_dir
+        .join(claude_project_slug(source_worktree))
+        .join(format!("{session_id}.jsonl"));
+    if !src_file.exists() {
+        return Ok(false);
+    }
+    let dest_dir = projects_dir.join(claude_project_slug(new_worktree));
+    std::fs::create_dir_all(&dest_dir)?;
+    let dest_file = dest_dir.join(format!("{session_id}.jsonl"));
+    std::fs::copy(&src_file, &dest_file)?;
+
+    db.save_agent_session(new_ws_id, &session_id, turn_count)?;
+    Ok(true)
+}
+
+/// Convert an absolute filesystem path to Claude CLI's project slug
+/// convention (used as the directory name under `~/.claude/projects/`).
+///
+/// Claude CLI replaces path separators with `-` to form the slug.
+fn claude_project_slug(path: &str) -> String {
+    path.replace('/', "-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ChatRole, Repository};
+
+    fn make_repo(id: &str) -> Repository {
+        Repository {
+            id: id.into(),
+            name: "repo1".into(),
+            path: "/tmp/repo1".into(),
+            path_slug: "repo1".into(),
+            icon: None,
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            path_valid: true,
+            created_at: String::new(),
+        }
+    }
+
+    fn make_workspace(id: &str, repo: &str, name: &str) -> Workspace {
+        Workspace {
+            id: id.into(),
+            repository_id: repo.into(),
+            name: name.into(),
+            branch_name: format!("u/{name}"),
+            worktree_path: Some(format!("/tmp/wt/{name}")),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+        }
+    }
+
+    fn make_chat_msg(id: &str, ws: &str, role: ChatRole, content: &str) -> ChatMessage {
+        ChatMessage {
+            id: id.into(),
+            workspace_id: ws.into(),
+            role,
+            content: content.into(),
+            cost_usd: None,
+            duration_ms: None,
+            created_at: String::new(),
+            thinking: None,
+        }
+    }
+
+    fn make_checkpoint(
+        id: &str,
+        ws: &str,
+        msg: &str,
+        turn: i32,
+        commit: Option<&str>,
+    ) -> ConversationCheckpoint {
+        ConversationCheckpoint {
+            id: id.into(),
+            workspace_id: ws.into(),
+            message_id: msg.into(),
+            commit_hash: commit.map(String::from),
+            has_file_state: false,
+            turn_index: turn,
+            message_count: 0,
+            created_at: String::new(),
+        }
+    }
+
+    fn setup_db_with_history() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "source"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "hi"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m2", "w1", ChatRole::Assistant, "hello"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m3", "w1", ChatRole::User, "more"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m4", "w1", ChatRole::Assistant, "ok"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint("cp1", "w1", "m2", 0, Some("abc")))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint("cp2", "w1", "m4", 1, Some("def")))
+            .unwrap();
+        db.insert_turn_tool_activities(&[TurnToolActivity {
+            id: "a1".into(),
+            checkpoint_id: "cp1".into(),
+            tool_use_id: "tu1".into(),
+            tool_name: "Read".into(),
+            input_json: "{}".into(),
+            result_text: "ok".into(),
+            summary: "read file".into(),
+            sort_order: 0,
+        }])
+        .unwrap();
+        db.insert_turn_tool_activities(&[TurnToolActivity {
+            id: "a2".into(),
+            checkpoint_id: "cp2".into(),
+            tool_use_id: "tu2".into(),
+            tool_name: "Edit".into(),
+            input_json: "{}".into(),
+            result_text: "ok".into(),
+            summary: "edit file".into(),
+            sort_order: 0,
+        }])
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn copy_history_copies_up_to_checkpoint_and_remaps_ids() {
+        let db = setup_db_with_history();
+        db.insert_workspace(&make_workspace("w-fork", "r1", "source-fork"))
+            .unwrap();
+
+        let cp1 = db.get_checkpoint("cp1").unwrap().unwrap();
+        copy_history(&db, "w1", "w-fork", &cp1).unwrap();
+
+        let forked_msgs = db.list_chat_messages("w-fork").unwrap();
+        assert_eq!(forked_msgs.len(), 2);
+        // New IDs, but same content.
+        assert_ne!(forked_msgs[0].id, "m1");
+        assert_ne!(forked_msgs[1].id, "m2");
+        assert_eq!(forked_msgs[0].content, "hi");
+        assert_eq!(forked_msgs[1].content, "hello");
+
+        let forked_cps = db.list_checkpoints("w-fork").unwrap();
+        assert_eq!(forked_cps.len(), 1);
+        assert_ne!(forked_cps[0].id, "cp1");
+        assert_eq!(forked_cps[0].turn_index, 0);
+        // message_id should be remapped to the new assistant message id.
+        assert_eq!(forked_cps[0].message_id, forked_msgs[1].id);
+        // Commit hash carries over so the fork stays anchored.
+        assert_eq!(forked_cps[0].commit_hash.as_deref(), Some("abc"));
+
+        let forked_turns = db.list_completed_turns("w-fork").unwrap();
+        assert_eq!(forked_turns.len(), 1);
+        assert_eq!(forked_turns[0].activities.len(), 1);
+        assert_eq!(forked_turns[0].activities[0].tool_name, "Read");
+    }
+
+    #[test]
+    fn copy_history_with_second_checkpoint_includes_both() {
+        let db = setup_db_with_history();
+        db.insert_workspace(&make_workspace("w-fork", "r1", "source-fork"))
+            .unwrap();
+
+        let cp2 = db.get_checkpoint("cp2").unwrap().unwrap();
+        copy_history(&db, "w1", "w-fork", &cp2).unwrap();
+
+        let forked_msgs = db.list_chat_messages("w-fork").unwrap();
+        assert_eq!(forked_msgs.len(), 4);
+
+        let forked_cps = db.list_checkpoints("w-fork").unwrap();
+        assert_eq!(forked_cps.len(), 2);
+        assert_eq!(forked_cps[0].turn_index, 0);
+        assert_eq!(forked_cps[1].turn_index, 1);
+    }
+
+    #[test]
+    fn allocate_name_suffixes_on_collision() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "source"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "source-fork"))
+            .unwrap();
+
+        let (name, branch) = allocate_name_and_branch(&db, "r1", "source", "pfx/").unwrap();
+        assert_eq!(name, "source-fork-2");
+        assert_eq!(branch, "pfx/source-fork-2");
+    }
+
+    #[test]
+    fn allocate_name_no_collision() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "source"))
+            .unwrap();
+
+        let (name, branch) = allocate_name_and_branch(&db, "r1", "source", "").unwrap();
+        assert_eq!(name, "source-fork");
+        assert_eq!(branch, "source-fork");
+    }
+
+    #[test]
+    fn claude_project_slug_replaces_separators() {
+        assert_eq!(
+            claude_project_slug("/Users/alice/projects/foo"),
+            "-Users-alice-projects-foo"
+        );
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -202,6 +202,36 @@ pub async fn create_worktree(
     Ok(abs_path.to_string_lossy().to_string())
 }
 
+/// Create a worktree + new branch rooted at an explicit git ref (commit hash,
+/// tag, or branch name). Unlike [`create_worktree`], this does NOT fetch or
+/// resolve the default branch — the caller supplies the exact base ref.
+///
+/// Used by workspace forking to anchor a new worktree to a checkpoint's commit.
+pub async fn create_worktree_from_ref(
+    repo_path: &str,
+    branch_name: &str,
+    worktree_path: &str,
+    base_ref: &str,
+) -> Result<String, GitError> {
+    run_git(
+        repo_path,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            worktree_path,
+            base_ref,
+        ],
+    )
+    .await?;
+
+    let abs_path = std::path::Path::new(worktree_path)
+        .canonicalize()
+        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
+    Ok(abs_path.to_string_lossy().to_string())
+}
+
 /// Restore a worktree for an existing branch (no -b flag).
 pub async fn restore_worktree(
     repo_path: &str,
@@ -292,6 +322,13 @@ pub async fn get_remote_url(repo_path: &str) -> Result<String, GitError> {
         .unwrap_or_else(|| "origin".to_string());
 
     run_git(repo_path, &["remote", "get-url", &remote]).await
+}
+
+/// Resolve HEAD to a commit hash for a worktree or repository. Works even in
+/// detached HEAD state — unlike [`current_branch`] which only returns branch
+/// names.
+pub async fn head_commit(repo_path: &str) -> Result<String, GitError> {
+    run_git(repo_path, &["rev-parse", "HEAD"]).await
 }
 
 /// Get the current branch name for a worktree or repository.
@@ -719,6 +756,40 @@ mod tests {
         remove_worktree(repo_path, wt2.path().to_str().unwrap(), true)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_worktree_from_ref_anchors_to_commit() {
+        let dir = setup_temp_repo().await;
+        let repo_path = dir.path().to_str().unwrap();
+        let file = dir.path().join("data.txt");
+
+        // Commit v1 and capture hash.
+        std::fs::write(&file, "v1").unwrap();
+        run_git(repo_path, &["add", "-A"]).await.unwrap();
+        run_git(repo_path, &["commit", "-m", "v1"]).await.unwrap();
+        let hash1 = run_git(repo_path, &["rev-parse", "HEAD"]).await.unwrap();
+
+        // Commit v2 on main.
+        std::fs::write(&file, "v2").unwrap();
+        run_git(repo_path, &["add", "-A"]).await.unwrap();
+        run_git(repo_path, &["commit", "-m", "v2"]).await.unwrap();
+
+        // Fork from the v1 commit — worktree should see "v1" not "v2".
+        let fork_dir = tempfile::tempdir().unwrap();
+        let fork_path = fork_dir.path().to_str().unwrap();
+        let out = create_worktree_from_ref(repo_path, "forked", fork_path, &hash1)
+            .await
+            .unwrap();
+        assert!(!out.is_empty());
+
+        let forked_file = fork_dir.path().join("data.txt");
+        assert_eq!(std::fs::read_to_string(&forked_file).unwrap(), "v1");
+
+        let forked_head = run_git(fork_path, &["rev-parse", "HEAD"]).await.unwrap();
+        assert_eq!(forked_head, hash1);
+
+        remove_worktree(repo_path, fork_path, true).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod diff;
 pub mod env;
 pub mod file_expand;
+pub mod fork;
 pub mod git;
 pub mod mcp;
 pub mod mcp_supervisor;

--- a/src/model/checkpoint.rs
+++ b/src/model/checkpoint.rs
@@ -43,5 +43,6 @@ pub struct CompletedTurnData {
     pub message_id: String,
     pub turn_index: i32,
     pub message_count: i32,
+    pub commit_hash: Option<String>,
     pub activities: Vec<TurnToolActivity>,
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -171,29 +171,6 @@
   color: var(--text-muted);
 }
 
-/* Rollback button — always visible on eligible user messages */
-.rollbackBtn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: none;
-  border: none;
-  color: var(--text-faint);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  opacity: 0.4;
-  transition: opacity var(--transition-fast), color var(--transition-fast),
-    background var(--transition-fast);
-  line-height: 1;
-}
-
-.rollbackBtn:hover {
-  opacity: 1;
-  color: var(--accent-primary);
-  background: var(--accent-bg);
-}
-
 /* Assistant messages — clean prose, no chrome */
 .role_Assistant {
   background: transparent;
@@ -689,6 +666,52 @@
 
 .turnSummaryWrapper > .turnSummary {
   margin: 0;
+}
+
+/* Footer below a completed turn: elapsed time + copy + fork actions. */
+.turnFooter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 2px;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.turnFooterElapsed {
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+}
+
+.turnFooterDot {
+  color: var(--text-faint);
+  user-select: none;
+}
+
+.turnFooterButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.turnFooterButton:hover {
+  color: var(--text);
+  background: var(--hover-bg-subtle);
+}
+
+.turnFooterButton:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .taskProgressBar {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1047,7 +1047,7 @@ function TurnSummary({
    *  When empty, the copy button is not rendered. */
   assistantText: string;
   /** Called when the user clicks fork. When undefined the fork button is not
-   *  rendered (e.g. remote workspaces or missing commit hash). */
+   *  rendered (e.g. remote workspaces, where the fork command cannot run). */
   onFork?: () => void;
   /** Called when the user clicks rollback. Undefined hides the button
    *  (e.g. turn is running, or no checkpoint exists for this turn). */

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import Markdown from "react-markdown";
 import { preprocessContent, MARKDOWN_COMPONENTS, REHYPE_PLUGINS, REMARK_PLUGINS } from "../../utils/markdown";
-import { FileText, GitBranch, Plus, RotateCcw, Send, Square, X } from "lucide-react";
+import { FileText, GitBranch, Plus, RotateCcw, Send, Split, Square, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
@@ -23,6 +23,7 @@ import {
   clearConversation,
   readPlanFile,
   loadDiffFiles,
+  forkWorkspaceAtCheckpoint,
 } from "../../services/tauri";
 import { applySelectedModel } from "./applySelectedModel";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
@@ -64,6 +65,20 @@ import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 
 import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../../utils/spinnerFrames";
+
+/** Format a duration in seconds as "15s" or "2m 34s". */
+function formatElapsedSeconds(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}m ${s}s`;
+}
+
+/** Format a duration in milliseconds as "15s" or "2m 34s". Sub-second turns
+ *  round up to "1s" so the footer always shows something meaningful. */
+function formatDurationMs(ms: number): string {
+  return formatElapsedSeconds(Math.max(1, Math.floor(ms / 1000)));
+}
 
 /**
  * Lazily renders a PDF first-page thumbnail.
@@ -210,7 +225,28 @@ export function ChatPanel() {
   );
   const setQueuedMessage = useAppStore((s) => s.setQueuedMessage);
   const clearQueuedMessage = useAppStore((s) => s.clearQueuedMessage);
+  const addWorkspace = useAppStore((s) => s.addWorkspace);
+  const selectWorkspace = useAppStore((s) => s.selectWorkspace);
   const isRunning = ws?.agent_status === "Running";
+
+  const isRemote = !!ws?.remote_connection_id;
+
+  const handleFork = useCallback(
+    async (checkpointId: string) => {
+      if (!selectedWorkspaceId || isRemote) return;
+      try {
+        const result = await forkWorkspaceAtCheckpoint(
+          selectedWorkspaceId,
+          checkpointId,
+        );
+        addWorkspace(result.workspace);
+        selectWorkspace(result.workspace.id);
+      } catch (err) {
+        setError(`Failed to fork workspace: ${err}`);
+      }
+    },
+    [selectedWorkspaceId, isRemote, addWorkspace, selectWorkspace],
+  );
 
   // Sticky scroll: auto-follow when at bottom, stop when user scrolls up.
   const { isAtBottom, scrollToBottom, handleContentChanged } =
@@ -246,12 +282,7 @@ export function ChatPanel() {
     return () => clearInterval(interval);
   }, [isRunning]);
 
-  const formatElapsed = useCallback((secs: number) => {
-    if (secs < 60) return `${secs}s`;
-    const m = Math.floor(secs / 60);
-    const s = secs % 60;
-    return `${m}m ${s}s`;
-  }, []);
+  const formatElapsed = formatElapsedSeconds;
 
   // Load persisted permission level when workspace changes.
   useEffect(() => {
@@ -821,6 +852,7 @@ export function ChatPanel() {
                   messages={messages}
                   workspaceId={selectedWorkspaceId}
                   isRunning={isRunning}
+                  onForkTurn={isRemote ? undefined : handleFork}
                 />
               )}
 
@@ -1003,12 +1035,30 @@ function TurnSummary({
   collapsed,
   onToggle,
   taskProgress,
+  assistantText,
+  onFork,
+  onRollback,
 }: {
   turn: CompletedTurn;
   collapsed: boolean;
   onToggle: () => void;
   taskProgress?: TaskTrackerResult;
+  /** Joined text from assistant messages in this turn, used by copy action.
+   *  When empty, the copy button is not rendered. */
+  assistantText: string;
+  /** Called when the user clicks fork. When undefined the fork button is not
+   *  rendered (e.g. remote workspaces or missing commit hash). */
+  onFork?: () => void;
+  /** Called when the user clicks rollback. Undefined hides the button
+   *  (e.g. turn is running, or no checkpoint exists for this turn). */
+  onRollback?: () => void;
 }) {
+  const hasElapsed = typeof turn.durationMs === "number" && turn.durationMs > 0;
+  const hasCopy = assistantText.length > 0;
+  const hasFork = !!onFork;
+  const hasRollback = !!onRollback;
+  const showFooter = hasElapsed || hasCopy || hasFork || hasRollback;
+
   return (
     <div className={styles.turnSummaryWrapper}>
       <div
@@ -1059,6 +1109,138 @@ function TurnSummary({
           totalCount={taskProgress.totalCount}
         />
       )}
+      {showFooter && (
+        <TurnFooter
+          durationMs={turn.durationMs}
+          assistantText={hasCopy ? assistantText : undefined}
+          onFork={onFork}
+          onRollback={onRollback}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Bottom-of-turn action row: elapsed time, copy output, fork, rollback.
+ *  Rendered below the turn summary for every completed turn. */
+function TurnFooter({
+  durationMs,
+  assistantText,
+  onFork,
+  onRollback,
+}: {
+  durationMs?: number;
+  assistantText?: string;
+  onFork?: () => void;
+  onRollback?: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!assistantText) return;
+    navigator.clipboard
+      .writeText(assistantText)
+      .then(() => {
+        setCopied(true);
+        if (copyTimeoutRef.current !== null) {
+          window.clearTimeout(copyTimeoutRef.current);
+        }
+        copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
+      })
+      .catch((err) => {
+        console.error("Copy to clipboard failed:", err);
+      });
+  };
+
+  const handleFork = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onFork?.();
+  };
+
+  const handleRollback = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRollback?.();
+  };
+
+  const elapsedNode =
+    typeof durationMs === "number" && durationMs > 0 ? (
+      <span key="elapsed" className={styles.turnFooterElapsed}>
+        {formatDurationMs(durationMs)}
+      </span>
+    ) : null;
+
+  const actionButtons: React.ReactNode[] = [];
+  if (assistantText) {
+    actionButtons.push(
+      <button
+        key="copy"
+        type="button"
+        className={styles.turnFooterButton}
+        onClick={handleCopy}
+        title={copied ? "Copied" : "Copy output"}
+        aria-label="Copy agent output"
+      >
+        {copied ? (
+          // Checkmark feedback for ~1.2s after successful copy.
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+          </svg>
+        )}
+      </button>,
+    );
+  }
+  if (onFork) {
+    actionButtons.push(
+      <button
+        key="fork"
+        type="button"
+        className={styles.turnFooterButton}
+        onClick={handleFork}
+        title="Fork workspace at this turn"
+        aria-label="Fork workspace at this turn"
+      >
+        <Split size={14} />
+      </button>,
+    );
+  }
+  if (onRollback) {
+    actionButtons.push(
+      <button
+        key="rollback"
+        type="button"
+        className={styles.turnFooterButton}
+        onClick={handleRollback}
+        title="Roll back to before this turn"
+        aria-label="Roll back to before this turn"
+      >
+        <RotateCcw size={14} />
+      </button>,
+    );
+  }
+
+  if (!elapsedNode && actionButtons.length === 0) return null;
+
+  return (
+    <div className={styles.turnFooter} onClick={(e) => e.stopPropagation()}>
+      {elapsedNode}
+      {elapsedNode && actionButtons.length > 0 && (
+        <span className={styles.turnFooterDot} aria-hidden="true">·</span>
+      )}
+      {actionButtons}
     </div>
   );
 }
@@ -1100,10 +1282,14 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   messages,
   workspaceId,
   isRunning,
+  onForkTurn,
 }: {
   messages: ChatMessage[];
   workspaceId: string;
   isRunning: boolean;
+  /** Handler invoked when the user forks a turn. Undefined disables the fork
+   *  button (e.g. for remote workspaces where the command cannot run). */
+  onForkTurn?: (checkpointId: string) => void;
 }) {
   const completedTurns = useAppStore(
     (s) => s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS
@@ -1142,6 +1328,24 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
     return map;
   }, [completedTurns]);
 
+  // Joined assistant text per turn, used by the "Copy output" action in the
+  // turn footer. A turn's slice is [prevTurn.afterMessageIndex, afterMessageIndex).
+  const assistantTextByTurnId = useMemo(() => {
+    const map = new Map<string, string>();
+    let prevBoundary = 0;
+    for (const turn of completedTurns) {
+      const text = messages
+        .slice(prevBoundary, turn.afterMessageIndex)
+        .filter((m) => m.role === "Assistant")
+        .map((m) => m.content)
+        .join("\n\n")
+        .trim();
+      map.set(turn.id, text);
+      prevBoundary = turn.afterMessageIndex;
+    }
+    return map;
+  }, [completedTurns, messages]);
+
   // Map user message index → checkpoint for the preceding turn.
   // Checks the message immediately before this user message (assistant or
   // user for tool-only turns) for a matching checkpoint. Index 0 always
@@ -1150,6 +1354,58 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
     () => buildRollbackMap(messages, checkpoints),
     [messages, checkpoints],
   );
+
+  // Per-turn rollback data, keyed by turn.id. A turn's rollback target is
+  // the checkpoint captured just before the triggering user message ran.
+  // A turn's triggering user message is the first User message in its range
+  // [prevBoundary, afterMessageIndex) — the checkpoint itself is anchored to
+  // the last assistant message of the turn, so we can't use cp.message_id.
+  const rollbackByTurnId = useMemo(() => {
+    const result = new Map<
+      string,
+      {
+        workspaceId: string;
+        checkpointId: string | null;
+        messageId: string;
+        messagePreview: string;
+        messageContent: string;
+        hasFileChanges: boolean;
+      }
+    >();
+    let prevBoundary = 0;
+    for (const turn of completedTurns) {
+      let userIdx = -1;
+      for (let i = prevBoundary; i < turn.afterMessageIndex && i < messages.length; i++) {
+        if (messages[i].role === "User") {
+          userIdx = i;
+          break;
+        }
+      }
+      prevBoundary = turn.afterMessageIndex;
+      if (userIdx === -1) continue;
+      if (!rollbackCheckpointByIdx.has(userIdx)) continue;
+      const target = rollbackCheckpointByIdx.get(userIdx) ?? null;
+      const userMsg = messages[userIdx];
+      result.set(turn.id, {
+        workspaceId,
+        checkpointId: target ? target.id : null,
+        messageId: userMsg.id,
+        messagePreview: userMsg.content.slice(0, 100),
+        messageContent: userMsg.content,
+        hasFileChanges: target
+          ? checkpointHasFileChanges(target, checkpoints)
+          : clearAllHasFileChanges(checkpoints),
+      });
+    }
+    return result;
+  }, [completedTurns, checkpoints, messages, workspaceId, rollbackCheckpointByIdx]);
+
+  const buildOnRollback = (turnId: string) => {
+    if (isRunning) return undefined;
+    const data = rollbackByTurnId.get(turnId);
+    if (!data) return undefined;
+    return () => openModal("rollback", data);
+  };
 
   // Compute cumulative task progress at each turn index in a single O(n) pass.
   // Carries taskMap/todoMap forward across iterations instead of re-slicing.
@@ -1197,6 +1453,9 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
         collapsed={turn.collapsed}
         onToggle={() => toggleCompletedTurn(workspaceId, globalIdx)}
         taskProgress={taskProgressByTurn.get(globalIdx)}
+        assistantText={assistantTextByTurnId.get(turn.id) ?? ""}
+        onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
+        onRollback={buildOnRollback(turn.id)}
       />
     ));
   };
@@ -1210,30 +1469,6 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
             {msg.role === "User" && (
               <div className={styles.roleLabel}>You</div>
             )}
-            {msg.role === "User" &&
-              !isRunning &&
-              rollbackCheckpointByIdx.has(idx) && (
-                <button
-                  className={styles.rollbackBtn}
-                  title="Roll back to before this message"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    const cp = rollbackCheckpointByIdx.get(idx);
-                    openModal("rollback", {
-                      workspaceId,
-                      checkpointId: cp ? cp.id : null,
-                      messageId: msg.id,
-                      messagePreview: msg.content.slice(0, 100),
-                      messageContent: msg.content,
-                      hasFileChanges: cp
-                        ? checkpointHasFileChanges(cp, checkpoints)
-                        : clearAllHasFileChanges(checkpoints),
-                    });
-                  }}
-                >
-                  <RotateCcw size={14} />
-                </button>
-              )}
             {msg.role === "Assistant" && msg.thinking && showThinkingBlocks && (
               <ThinkingBlock content={msg.thinking} isStreaming={false} />
             )}
@@ -1290,6 +1525,9 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
             collapsed={turn.collapsed}
             onToggle={() => toggleCompletedTurn(workspaceId, globalIdx)}
             taskProgress={taskProgressByTurn.get(globalIdx)}
+            assistantText={assistantTextByTurnId.get(turn.id) ?? ""}
+            onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
+            onRollback={buildOnRollback(turn.id)}
           />
         ))}
     </>

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -333,7 +333,8 @@ export function useAgentStream() {
             finalizeTurn(
               wsId,
               turnMessageCountRef.current[wsId] || 0,
-              turnCheckpointIdRef.current[wsId]
+              turnCheckpointIdRef.current[wsId],
+              streamEvent.duration_ms,
             );
             turnMessageCountRef.current[wsId] = 0;
             turnFinalizedRef.current[wsId] = true;

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -103,6 +103,18 @@ export function createWorkspace(
   return invoke("create_workspace", { repoId, name, skipSetup: skipSetup ?? false });
 }
 
+export interface ForkWorkspaceResult {
+  workspace: Workspace;
+  session_resumed: boolean;
+}
+
+export function forkWorkspaceAtCheckpoint(
+  workspaceId: string,
+  checkpointId: string
+): Promise<ForkWorkspaceResult> {
+  return invoke("fork_workspace_at_checkpoint", { workspaceId, checkpointId });
+}
+
 export function runWorkspaceSetup(
   workspaceId: string
 ): Promise<import("../types/repository").SetupResult | null> {

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -331,6 +331,23 @@ describe("finalizeTurn afterMessageIndex", () => {
     expect(turns[0].afterMessageIndex).toBe(0);
   });
 
+  it("stores durationMs when provided", () => {
+    addToolActivities();
+    useAppStore.getState().finalizeTurn(WS_ID, 1, undefined, 12_345);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns).toHaveLength(1);
+    expect(turns[0].durationMs).toBe(12_345);
+  });
+
+  it("leaves durationMs undefined when not provided", () => {
+    addToolActivities();
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns[0].durationMs).toBeUndefined();
+  });
+
   it("successive turns get increasing afterMessageIndex", () => {
     useAppStore.setState({
       chatMessages: { [WS_ID]: [{ id: "m1", workspace_id: WS_ID, role: "Assistant", content: "a", cost_usd: null, duration_ms: null, created_at: "", thinking: null }] },

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -45,6 +45,12 @@ export interface CompletedTurn {
   /** Index into chatMessages at the time of finalization — used to render
    *  the turn summary at the correct chronological position. */
   afterMessageIndex: number;
+  /** Commit hash from the corresponding conversation checkpoint, if any.
+   *  Used to gate the "fork workspace at this turn" action. */
+  commitHash?: string | null;
+  /** Total time this turn took, in milliseconds. Summed from the
+   *  duration_ms of assistant messages produced during the turn. */
+  durationMs?: number;
 }
 
 export interface AgentQuestionItem {
@@ -109,7 +115,12 @@ interface AppState {
     updates: Partial<ToolActivity>,
   ) => void;
   toggleToolActivityCollapsed: (wsId: string, index: number) => void;
-  finalizeTurn: (wsId: string, messageCount: number, turnId?: string) => void;
+  finalizeTurn: (
+    wsId: string,
+    messageCount: number,
+    turnId?: string,
+    durationMs?: number,
+  ) => void;
   hydrateCompletedTurns: (wsId: string, turns: CompletedTurn[]) => void;
   setCompletedTurns: (wsId: string, turns: CompletedTurn[]) => void;
   toggleCompletedTurn: (wsId: string, turnIndex: number) => void;
@@ -541,7 +552,7 @@ export const useAppStore = create<AppState>((set) => ({
         ),
       },
     })),
-  finalizeTurn: (wsId, messageCount, turnId) =>
+  finalizeTurn: (wsId, messageCount, turnId, durationMs) =>
     set((s) => {
       const activities = s.toolActivities[wsId] || [];
       if (activities.length === 0) {
@@ -568,6 +579,7 @@ export const useAppStore = create<AppState>((set) => ({
         messageCount,
         collapsed: true,
         afterMessageIndex: (s.chatMessages[wsId] || []).length,
+        durationMs,
       };
       debugChat("store", "finalizeTurn", {
         wsId,

--- a/src/ui/src/types/checkpoint.ts
+++ b/src/ui/src/types/checkpoint.ts
@@ -25,5 +25,6 @@ export interface CompletedTurnData {
   message_id: string;
   turn_index: number;
   message_count: number;
+  commit_hash: string | null;
   activities: TurnToolActivityData[];
 }

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -29,6 +29,7 @@ function makeTurnData(
     message_id: messageId,
     turn_index: 0,
     message_count: 1,
+    commit_hash: null,
     activities: Array.from({ length: toolCount }, (_, i) => ({
       id: `act-${checkpointId}-${i}`,
       checkpoint_id: checkpointId,
@@ -109,6 +110,41 @@ describe("reconstructCompletedTurns", () => {
     expect(result[0].afterMessageIndex).toBe(1); // index 0 + 1
   });
 
+  it("sums assistant message duration_ms into durationMs per turn", () => {
+    const m1: ChatMessage = { ...makeMsg("m1", "User"), duration_ms: 99_999 };
+    const m2: ChatMessage = { ...makeMsg("m2", "Assistant"), duration_ms: 1_200 };
+    const m3: ChatMessage = { ...makeMsg("m3", "Assistant"), duration_ms: 800 };
+    const m4: ChatMessage = { ...makeMsg("m4", "User"), duration_ms: 99_999 };
+    const m5: ChatMessage = { ...makeMsg("m5", "Assistant"), duration_ms: 3_000 };
+    const messages = [m1, m2, m3, m4, m5];
+    const turnData = [makeTurnData("cp1", "m3"), makeTurnData("cp2", "m5")];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+
+    expect(result).toHaveLength(2);
+    // Turn 1: spans m1..m3 — only m2+m3 are assistant → 2000ms
+    expect(result[0].durationMs).toBe(2_000);
+    // Turn 2: spans m4..m5 — only m5 is assistant → 3000ms
+    expect(result[1].durationMs).toBe(3_000);
+  });
+
+  it("passes commit_hash through as commitHash", () => {
+    const messages = [makeMsg("m1")];
+    const turnData: CompletedTurnData[] = [
+      {
+        checkpoint_id: "cp1",
+        message_id: "m1",
+        turn_index: 0,
+        message_count: 1,
+        commit_hash: "abc123",
+        activities: [],
+      },
+    ];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+    expect(result[0].commitHash).toBe("abc123");
+  });
+
   it("maps activity fields correctly", () => {
     const messages = [makeMsg("m1")];
     const turnData: CompletedTurnData[] = [
@@ -117,6 +153,7 @@ describe("reconstructCompletedTurns", () => {
         message_id: "m1",
         turn_index: 0,
         message_count: 5,
+        commit_hash: null,
         activities: [
           {
             id: "act-1",

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -27,24 +27,33 @@ export function reconstructCompletedTurns(
     });
   }
 
-  return turnData
-    .filter((td) => msgIdToIndex.has(td.message_id))
-    .map((td) => {
-      const afterMessageIndex = msgIdToIndex.get(td.message_id)! + 1;
+  const valid = turnData.filter((td) => msgIdToIndex.has(td.message_id));
 
-      return {
-        id: td.checkpoint_id,
-        activities: td.activities.map((a) => ({
-          toolUseId: a.tool_use_id,
-          toolName: a.tool_name,
-          inputJson: a.input_json,
-          resultText: a.result_text,
-          collapsed: true,
-          summary: a.summary,
-        })),
-        messageCount: td.message_count,
+  return valid.map((td, i) => {
+    const afterMessageIndex = msgIdToIndex.get(td.message_id)! + 1;
+    const priorBoundary =
+      i > 0 ? msgIdToIndex.get(valid[i - 1].message_id)! + 1 : 0;
+    const durationMs =
+      messages
+        .slice(priorBoundary, afterMessageIndex)
+        .filter((m) => m.role === "Assistant")
+        .reduce((sum, m) => sum + (m.duration_ms ?? 0), 0) || undefined;
+
+    return {
+      id: td.checkpoint_id,
+      activities: td.activities.map((a) => ({
+        toolUseId: a.tool_use_id,
+        toolName: a.tool_name,
+        inputJson: a.input_json,
+        resultText: a.result_text,
         collapsed: true,
-        afterMessageIndex,
-      };
-    });
+        summary: a.summary,
+      })),
+      messageCount: td.message_count,
+      collapsed: true,
+      afterMessageIndex,
+      commitHash: td.commit_hash,
+      durationMs,
+    };
+  });
 }


### PR DESCRIPTION
## Summary

Adds a persistent action row beneath every completed turn in the chat — elapsed time, copy assistant output, fork workspace at this turn, and rollback to before this turn. The rollback control moves from the user-message block into the new footer so all turn-scoped actions live in one place.

- **Elapsed time** — derived from the per-message `duration_ms` already persisted by the Claude CLI; no schema migration.
- **Copy output** — writes the concatenated assistant text of that turn to the clipboard with brief "copied" feedback.
- **Fork workspace** — new backend feature. Creates a worktree branched from the turn's checkpoint (SQLite snapshot if present, otherwise source worktree `HEAD`), copies messages + checkpoints + tool activities up to that turn, and copies the Claude session JSONL so the fork can `--resume` cleanly.
- **Rollback** — unchanged semantics, relocated to the footer. The new turn→rollback mapping finds the *triggering* user message (first User role in the turn's range) rather than the checkpoint's anchor message (last assistant), since checkpoints are anchored to turn-end.

```mermaid
flowchart LR
  Turn[Completed turn] --> Footer[TurnFooter]
  Footer --> E[Elapsed]
  Footer --> C[Copy]
  Footer --> F[Fork]
  Footer --> R[Rollback]
  F -.creates.-> NewWS[New workspace<br/>branched from checkpoint]
  R -.opens.-> Modal[Rollback modal]
```

## Complexity Notes

- **Fork orchestrator** (`src/fork.rs`): resolves the base ref by preferring `checkpoint.commit_hash` then falling back to `git::head_commit(source_worktree)` — because Claudette migrated to SQLite snapshots, `commit_hash` is mostly null. After creating the worktree, it restores the checkpoint's snapshot to the new path if `has_file_state`. Session copy is best-effort: if the source JSONL doesn't exist (first turn or cleared), the fork skips session-resume and leaves `session_id` unset.
- **Tauri async + `!Sync` SQLite**: `Database` wraps `RefCell<Connection>`, which is `!Sync`. The fork command takes `&mut Database` (not `&Database`) so the future stays `Send` across await points.
- **Turn → user message resolution** (`ChatPanel.tsx`): a turn's checkpoint is anchored to the *last assistant* message, so the rollback lookup can't use `cp.message_id` directly. The new `rollbackByTurnId` scans `messages[prevBoundary..afterMessageIndex)` for the first User role and then looks up the rollback target through `buildRollbackMap` — preserving the "first user = clear-all" rule in a single place.
- **Two TurnSummary render sites**: `MessagesWithTurns` renders turns inline via `renderTurns()` AND in a trailing filter for turns after the last message. Both callsites need the same prop wiring.

## Test Steps

1. Launch `cargo tauri dev` and open a local workspace. Send a prompt and let the agent respond.
2. After the turn finalizes, verify the footer below the turn summary shows `<duration>s · <copy> <fork> <rollback>` with a single `·` between elapsed time and the icons (no dots between icons).
3. **Copy** — click the clipboard icon, paste into a scratch editor, confirm it matches only that turn's assistant text (not earlier turns).
4. **Fork** — click the split icon. Expect a new workspace to appear in the sidebar, auto-selected. Run `git -C <new worktree path> rev-parse HEAD` and confirm it matches the turn's checkpoint commit (or source HEAD if snapshot-only). Send a follow-up message — it should resume the Claude session seamlessly.
5. **Rollback** — click the rotate-ccw icon. Confirm the modal opens with the triggering user message's preview/content. Complete the rollback and confirm conversation reverts. For the first turn in a chat, the modal should say "Clear all".
6. **Regression** — send multiple turns, then rollback the middle one. Confirm subsequent turns are removed and the input prefills with the rolled-back prompt.
7. Run `cargo test --all-features`, `cargo clippy --workspace --all-targets`, `cd src/ui && ./node_modules/.bin/tsc --noEmit`, and `cd src/ui && bun run test` — all should pass.

## Checklist

- [x] Tests added/updated (reconstructTurns, useAppStore, fork orchestrator, git::create_worktree_from_ref, git::head_commit)
- [ ] Documentation updated (if applicable)