### PR TITLE
docs(site): add SCM providers feature page and git-status groups

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig({
           items: [
             { slug: 'features/parallel-agents' },
             { slug: 'features/git-worktrees' },
+            { slug: 'features/scm-providers' },
             { slug: 'features/diff-viewer' },
             { slug: 'features/integrated-terminal' },
             { slug: 'features/remote-workspaces' },

--- a/site/src/components/FeatureCards.astro
+++ b/site/src/components/FeatureCards.astro
@@ -2,6 +2,7 @@
 const features = [
   { icon: 'bot', title: 'Parallel Agents', desc: 'Run multiple Claude Code agents simultaneously, each in its own isolated workspace.' },
   { icon: 'git-branch', title: 'Git Worktrees', desc: 'Native git worktree integration for branch-based parallel development without conflicts.' },
+  { icon: 'git-pull-request', title: 'PR & CI Status', desc: 'See pull request state and CI checks right in your sidebar. Extensible via Lua plugins — GitHub and GitLab built in.' },
   { icon: 'globe', title: 'Remote Workspaces', desc: 'Connect to remote machines via encrypted WebSocket with automatic mDNS discovery.' },
   { icon: 'terminal', title: 'Integrated Terminal', desc: 'Multi-tab terminal with xterm.js, right alongside your agents and code diffs.' },
   { icon: 'file-diff', title: 'Diff Viewer', desc: 'Real-time git diff tracking with unified view and syntax highlighting.' },
@@ -13,6 +14,7 @@ const features = [
 const icons: Record<string, string> = {
   'bot': '<path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>',
   'git-branch': '<line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>',
+  'git-pull-request': '<circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><line x1="6" x2="6" y1="9" y2="21"/>',
   'globe': '<circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/>',
   'terminal': '<polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/>',
   'file-diff': '<path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M9 15h6"/><path d="M12 18v-6"/>',

--- a/site/src/content/docs/features/diff-viewer.mdx
+++ b/site/src/content/docs/features/diff-viewer.mdx
@@ -22,6 +22,17 @@ A screenshot showing the diff viewer with code changes will be added here.
 
 The **right sidebar** (`⌘/Ctrl + D` to toggle) displays a list of all files that have been changed in the current workspace. Click any file to jump to its diff.
 
+## Change Groups
+
+The changed files list organizes files into collapsible sections that mirror `git status`:
+
+- **Committed** — files changed on this branch compared to the base branch
+- **Staged** — files added to the git index (`git add`)
+- **Unstaged** — tracked files with working tree modifications
+- **Untracked** — new files not yet tracked by git
+
+Each section has a colored left border for quick visual scanning. A file can appear in more than one group — for example, a file with both staged and unstaged changes shows up in both sections. Clicking a file opens the diff for that specific layer, not the combined diff.
+
 ## How It Works
 
 Claudette runs `git diff` against the workspace's worktree to detect changes. The diff updates automatically as the agent writes code, so you can watch changes appear in real time during streaming.

--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -1,0 +1,57 @@
+---
+title: SCM Providers
+description: Pull request status, CI checks, and extensible plugin support for GitHub, GitLab, and more.
+---
+
+Claudette shows pull request state and CI check results for every workspace, right in the sidebar. No sign-in required — it wraps the CLI tools you already have authenticated (`gh`, `glab`).
+
+## What You See
+
+**Sidebar badges** — each workspace displays a git icon indicating its PR state:
+
+- **Open** — arrow icon, colored by CI status (green = passing, yellow = running, red = failing)
+- **Draft** — dashed circle icon
+- **Merged** — merge icon in purple
+- **Closed** — closed-PR icon, muted
+- **No PR** — dashed circle icon, muted
+
+**PR status banner** — a color-coded banner appears above the right sidebar tabs showing the PR number (clickable), a status icon, and a human-readable label like "Ready to merge" or "CI failed."
+
+**SCM tab** — the right sidebar includes a dedicated SCM tab with:
+
+- PR title, author, base branch, and a link to open in your browser
+- A list of CI checks with individual pass/fail/pending status
+- **Create PR** and **Merge PR** buttons for common actions without leaving the app
+
+## How It Works
+
+Claudette auto-detects your SCM provider by matching `git remote get-url origin` against known hostname patterns (e.g., `github.com`, `gitlab.com`). A background polling loop fetches PR and CI data every 30 seconds across all active workspaces — no manual refresh needed.
+
+All data is cached in memory, keyed by repository and branch. Concurrent CLI calls are capped at 4 to avoid overwhelming your machine.
+
+## Requirements
+
+| Provider | CLI tool | Auth |
+|----------|----------|------|
+| GitHub | [`gh`](https://cli.github.com/) | `gh auth login` |
+| GitLab | [`glab`](https://gitlab.com/gitlab-org/cli) | `glab auth login` |
+
+If the CLI isn't installed or authenticated, the SCM tab shows a helpful status message instead of failing silently.
+
+## Auto-Archive on Merge
+
+Enable **Settings > General > Archive on merge** to automatically archive a workspace when its PR is detected as merged. The sidebar cleans itself up without manual intervention.
+
+## Custom Plugins
+
+SCM providers are **Lua plugins** that live in `~/.claudette/plugins/<name>/`. Each plugin has a `plugin.json` manifest declaring which CLI it wraps, which hostnames it handles, and which operations it supports.
+
+GitHub and GitLab ship as bundled plugins — they're seeded to disk on first launch and kept up to date automatically. If you've customized a bundled plugin, your changes are preserved.
+
+The plugin sandbox enforces strict security:
+
+- **CLI allowlist** — plugins can only invoke the executables declared in their manifest
+- **30-second timeout** — per CLI invocation
+- **No filesystem or network access** — all I/O goes through the host API
+
+To write your own plugin for another provider (Gitea, Forgejo, Bitbucket, etc.), see the [SCM Provider Plugins TDD](https://github.com/utensils/Claudette/blob/main/docs/scm-provider-plugins-tdd.md) for the full plugin authoring guide.


### PR DESCRIPTION
## Summary

Adds documentation for two features that shipped recently but weren't reflected on the marketing site:

- **New feature page**: `features/scm-providers.mdx` — covers the PR/CI status sidebar, the SCM tab, auto-archive on merge, and the Lua plugin sandbox model (GitHub + GitLab built in).
- **Homepage feature card**: adds a "PR & CI Status" entry to `FeatureCards.astro` with a new `git-pull-request` icon.
- **Diff viewer page**: documents the new "Change Groups" section of the changed-files list (Committed / Staged / Unstaged / Untracked) that mirrors `git status`.
- **Sidebar nav**: registers `features/scm-providers` in `astro.config.mjs` so the new page appears in the Starlight sidebar.

No code or schema changes — pure `site/` content.

## Test Steps

1. Check out the branch and run the docs site locally:
   ```bash
   cd site
   bun install --frozen-lockfile
   bun run dev
   ```
2. Visit `http://localhost:4321/` and confirm the **PR & CI Status** card appears on the homepage feature grid with the pull-request icon.
3. Navigate to **Features → SCM Providers** in the sidebar and verify:
   - The page renders without errors
   - The Requirements table shows GitHub (`gh`) and GitLab (`glab`) rows
   - The link to the SCM Provider Plugins TDD resolves
4. Navigate to **Features → Diff Viewer** and confirm the new **Change Groups** section lists the four git-status categories.
5. Run `bun run build` and confirm the site builds cleanly.

## Checklist

- [x] Tests added/updated — N/A (docs-only change)
- [x] Documentation updated — this PR *is* the documentation update