### PR TITLE
docs(site): update SCM provider site pages

### DIFF
--- a/site/src/content/docs/features/diff-viewer.mdx
+++ b/site/src/content/docs/features/diff-viewer.mdx
@@ -24,7 +24,7 @@ The **right sidebar** (`⌘/Ctrl + D` to toggle) displays a list of all files th
 
 ## Change Groups
 
-The changed files list organizes files into collapsible sections that mirror `git status`:
+The changed files list organizes files into collapsible sections, one per git layer:
 
 - **Committed** — files changed on this branch compared to the base branch
 - **Staged** — files added to the git index (`git add`)
@@ -35,4 +35,13 @@ Each section has a colored left border for quick visual scanning. A file can app
 
 ## How It Works
 
-Claudette runs `git diff` against the workspace's worktree to detect changes. The diff updates automatically as the agent writes code, so you can watch changes appear in real time during streaming.
+Claudette runs a different git command per layer to build the changed-files list and the per-file diff:
+
+| Layer | Command |
+|-------|---------|
+| Committed | `git diff <merge-base>..HEAD` |
+| Staged | `git diff --cached` |
+| Unstaged | `git diff` |
+| Untracked | `git ls-files --others --exclude-standard` (diffed against `/dev/null`) |
+
+The list updates automatically as the agent writes code, so you can watch changes appear in real time during streaming.

--- a/site/src/content/docs/features/diff-viewer.mdx
+++ b/site/src/content/docs/features/diff-viewer.mdx
@@ -35,13 +35,13 @@ Each section has a colored left border for quick visual scanning. A file can app
 
 ## How It Works
 
-Claudette runs a different git command per layer to build the changed-files list and the per-file diff:
+Claudette uses separate git operations per layer to build the changed-files list and to render the diff for a selected file. In some cases these are the same base command with different flags, and for untracked files the list and diff steps are different commands entirely:
 
-| Layer | Command |
-|-------|---------|
-| Committed | `git diff <merge-base>..HEAD` |
-| Staged | `git diff --cached` |
-| Unstaged | `git diff` |
-| Untracked | `git ls-files --others --exclude-standard` (diffed against `/dev/null`) |
+| Layer | Changed-files list | Per-file diff |
+|-------|--------------------|---------------|
+| Committed | `git diff <merge-base>..HEAD --name-status` / `--numstat` | `git diff <merge-base>..HEAD -- <path>` |
+| Staged | `git diff --cached --name-status` / `--numstat` | `git diff --cached -- <path>` |
+| Unstaged | `git diff --name-status` / `--numstat` | `git diff -- <path>` |
+| Untracked | `git ls-files --others --exclude-standard` | `git diff --no-index -- /dev/null <path>` |
 
 The list updates automatically as the agent writes code, so you can watch changes appear in real time during streaming.

--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -3,7 +3,7 @@ title: SCM Providers
 description: Pull request status, CI checks, and extensible plugin support for GitHub, GitLab, and more.
 ---
 
-Claudette shows pull request state and CI check results for every workspace, right in the sidebar. No sign-in required — it wraps the CLI tools you already have authenticated (`gh`, `glab`).
+Claudette shows pull request state and CI check results for every workspace, right in the sidebar. No in-app sign-in required — it wraps the CLI tools you already have authenticated (`gh`, `glab`).
 
 ## What You See
 
@@ -40,7 +40,7 @@ If the CLI isn't installed or authenticated, the SCM tab shows a helpful status 
 
 ## Auto-Archive on Merge
 
-Enable **Settings > General > Archive on merge** to automatically archive a workspace when its PR is detected as merged. The sidebar cleans itself up without manual intervention.
+Enable [**Settings > General > Archive on merge**](/Claudette/features/settings/#general) to automatically archive a workspace when its PR is detected as merged. The sidebar cleans itself up without manual intervention.
 
 ## Custom Plugins
 

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -11,6 +11,7 @@ Open settings with `⌘/Ctrl + ,` or from the sidebar. Settings are organized in
 |---------|-------------|---------|
 | Worktree base directory | Directory where new workspaces are created | `~/.claudette/workspaces` |
 | System tray | Enable/disable system tray integration | Enabled |
+| Archive on merge | Automatically archive a workspace when its pull request is merged. See [SCM Providers](/Claudette/features/scm-providers/). | Off |
 
 ## Models
 


### PR DESCRIPTION
Follow-up to #278. The Copilot review arrived ~13 seconds after that PR was merged, so this PR incorporates the feedback separately.

## Summary

- **Diff viewer — "How It Works" accuracy** ([comment](https://github.com/utensils/claudette/pull/278#discussion_r3104224474)): The previous single-line description said Claudette "runs git diff against the worktree," which is incomplete now that the UI surfaces four git layers (committed, staged, unstaged, untracked) that each need a different command. Replaced with a per-layer command table. Also removed the inaccurate "mirror git status" phrasing since `git status` has no "Committed" group.
- **SCM providers — contradictory wording** ([comment](https://github.com/utensils/claudette/pull/278#discussion_r3104224480)): "No sign-in required" contradicted the Requirements section which calls out `gh auth login` / `glab auth login`. Changed to "No in-app sign-in required."
- **SCM providers — missing settings docs** ([comment](https://github.com/utensils/claudette/pull/278#discussion_r3104224496)): The "Archive on merge" toggle wasn't documented on the Settings reference page. Added a row under **General** and linked to it from the SCM providers page.

Docs-only change — only `site/**` touched.

## Test Steps

1. `cd site && bun install --frozen-lockfile && bun run dev`
2. Visit **Features → Diff Viewer** and confirm the "How It Works" section renders a 4-row table of per-layer git commands.
3. Visit **Features → SCM Providers**:
   - Opening paragraph now reads "No in-app sign-in required…"
   - "Auto-Archive on Merge" section links to `/Claudette/features/settings/#general`.
4. Visit **Features → Settings → General** and confirm the new **Archive on merge** row appears with a cross-link back to SCM Providers.
5. Run `bun run build` and confirm it succeeds.

## Checklist

- [x] Tests added/updated — N/A (docs-only change)
- [x] Documentation updated — this PR *is* the documentation update