### PR TITLE
chore(nix): fix devshell + package build for mlua/Luau on macOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1775236976,
-        "narHash": "sha256-gCgX+AXN7K1gAIEqcLcZHxmC+QoZcwn9m6Z9r2Az+N8=",
+        "lastModified": 1776396856,
+        "narHash": "sha256-aRJpIJUlZLaf06ekPvqjuU46zvO9K90IxJGpbqodkPs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6c23998526351a53ce734f0ac84940da988ccef1",
+        "rev": "28462d6d55c33206ffa5a56c7907ca3125ed788f",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1775547409,
-        "narHash": "sha256-dNIhLmwrR7N78amgliAJvFx58RjrhDWorV9B9Kiayeo=",
+        "lastModified": 1776413252,
+        "narHash": "sha256-ZQhyB2vnFsE1KcWJlWle1UujEDVjTJVL3oMIHUvnzuo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "a260dea172f86c7afa65cec0c6e6a9dd91530017",
+        "rev": "a318c3c6120e91375eea1d7c57a0cd101a81b14a",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775579569,
-        "narHash": "sha256-/m3yyS/EnXqoPGBJYVy4jTOsirdgsEZ3JdN2gGkBr14=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfd9566f82a6e1d55c30f861879186440614696e",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1775499626,
-        "narHash": "sha256-6PyDFl9fJu12xfdjgEiQKEVjX6/cdkN1DeKRLKwUz44=",
+        "lastModified": 1776343166,
+        "narHash": "sha256-ZiHQPWwuUZk44epAZRbyFz23Kd4CYaq8WlBgAmCqAzQ=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "129f6167ab924c42fb16d4e3d1b31b6e725c7523",
+        "rev": "b8458013c217be4fccefc4e4f194026fa04ab4ca",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775125835,
-        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -125,14 +125,17 @@
           # Used by buildDepsOnly so UI/asset changes don't rebuild deps.
           cargoSrc = craneLib.cleanCargoSource ./.;
 
-          # Full source: Cargo files + src-tauri config + assets (logo for tauri-codegen).
+          # Full source: Cargo files + src-tauri config + assets (logo for
+          # tauri-codegen) + plugins (seeded into the binary via include_str!
+          # from src/scm_provider/seed.rs).
           src = lib.cleanSourceWith {
             src = ./.;
             filter =
               path: type:
               (craneLib.filterCargoSources path type)
               || (builtins.match ".*src-tauri/.*" path != null)
-              || (builtins.match ".*assets/.*" path != null);
+              || (builtins.match ".*assets/.*" path != null)
+              || (builtins.match ".*plugins/.*" path != null);
           };
 
           # Platform-specific build dependencies
@@ -226,6 +229,13 @@
                 mkdir -p src/ui/dist
                 cp -r ${frontend}/* src/ui/dist/
               '';
+
+              # claudette-tauri's pty/usage tests spawn real shells and hit
+              # the network — neither works in the Nix sandbox. CI (GitHub
+              # Actions) runs `cargo test -p claudette -p claudette-server`
+              # against a regular Linux runner to cover the logic under
+              # test; skip tests here to keep `nix build` reproducible.
+              doCheck = false;
 
               meta = commonMeta // {
                 description = "Cross-platform desktop orchestrator for parallel Claude Code agents";
@@ -399,6 +409,33 @@
                 # mismatches (e.g. -mmacosx-version-min=26.4) that break aws-lc-sys
                 name = "CC";
                 value = "/usr/bin/cc";
+              }
+              {
+                # Pin the C++ compiler to Apple's clang++ too. Without this
+                # override, `cc-rs` (used by mlua-sys to build Luau and by
+                # libsqlite3-sys/objc2 for their C++ shims) resolves `c++`
+                # from PATH. On a nix-darwin system that's typically a
+                # /run/current-system/sw/bin/c++ symlink into the GCC
+                # wrapper, which compiles against libstdc++ (producing
+                # `std::__cxx11::...` and `std::__glibcxx_assert_fail`
+                # references). The final link uses Apple clang which pulls
+                # in libc++ (`std::__1::...`), so the libstdc++ symbols go
+                # undefined. Forcing CXX to Apple's clang++ keeps the
+                # whole toolchain on libc++.
+                name = "CXX";
+                value = "/usr/bin/c++";
+              }
+              {
+                # `cc-rs` reads the HOST_ variants for build-script-side
+                # compilation. Set them too so build scripts (e.g. tauri
+                # codegen, proc macros that shell out) don't fall back to
+                # the nix-darwin GCC wrapper either.
+                name = "HOST_CC";
+                value = "/usr/bin/cc";
+              }
+              {
+                name = "HOST_CXX";
+                value = "/usr/bin/c++";
               }
               {
                 name = "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER";


### PR DESCRIPTION
## Summary

PR #238 added `mlua` with the `luau` feature, which compiles Luau's C++ sources via `cc-rs`. That surfaced three Nix-side regressions that weren't caught by CI (which only runs `cargo test` for the library crates on Ubuntu):

- **Darwin devshell link failure.** `cc-rs` resolves `c++` from `PATH`, and on nix-darwin that points at the GCC wrapper (libstdc++). The final link uses Apple clang (libc++), so Luau's objects referenced `std::__cxx11::…` / `std::__glibcxx_assert_fail` that the linker couldn't find. Fix: pin `CXX`/`HOST_CXX` to `/usr/bin/c++` on Darwin so the whole toolchain stays on libc++.
- **`nix build .#claudette` missing `plugins/`.** `src/scm_provider/seed.rs` uses `include_str!("../../plugins/github/plugin.json")` (and three more). The crane source filter didn't include `plugins/`. Added it.
- **`nix build .#claudette` failing in sandbox on pty/usage tests.** `claudette-tauri`'s pty/usage tests spawn real shells and hit the network — neither works inside the Nix sandbox. Set `doCheck = false` on the claudette binary; CI's `cargo test -p claudette -p claudette-server` still covers the library logic.

Also refreshed `flake.lock` (nixpkgs → 2026-04-15, fenix → 2026-04-17, crane → 2026-04-17, treefmt-nix → 2026-04-08).

## Test plan

- [x] `nix develop` enters the shell with `CXX=/usr/bin/c++`, `HOST_CXX=/usr/bin/c++`.
- [x] `cargo build -p claudette-tauri` succeeds inside the devshell on aarch64-darwin.
- [x] `nix build .#claudette` succeeds on aarch64-darwin.
- [x] `nix build .#claudette-server` and `nix build .#frontend` succeed.
- [x] `nix build .#checks.aarch64-darwin.clippy` passes.
- [x] `nix flake check --no-build` evaluates cleanly.
- [ ] Linux build (x86_64-linux / aarch64-linux) verified — evaluation succeeds; would be good to exercise on a Linux host.