### PR TITLE
fix(chat): force session teardown after ExitPlanMode

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -48,27 +48,40 @@ struct AgentStreamPayload {
 
 use claudette::permissions::tools_for_level;
 
+/// Spawn-time flags of the currently running persistent session, plus the
+/// backend-observed `exited_plan` latch (set when the agent emits
+/// `ExitPlanMode` during this session).
+struct SessionFlags<'a> {
+    plan_mode: bool,
+    allowed_tools: &'a [String],
+    exited_plan: bool,
+}
+
+/// Flags the next turn is asking for. Compared against [`SessionFlags`] to
+/// decide whether the process must be torn down and respawned.
+struct RequestedFlags<'a> {
+    plan_mode: bool,
+    allowed_tools: &'a [String],
+}
+
 /// Detect whether the persistent session's spawn-time flags have drifted
 /// from what the current turn is asking for. Both `--permission-mode` and
 /// `--allowedTools` are only applied when the `claude` process starts, so
 /// a drift means the running process cannot serve this turn correctly and
 /// must be torn down.
 ///
-/// `session_exited_plan` is a backend-observed signal that the agent called
+/// `exited_plan` is a backend-observed signal that the agent called
 /// `ExitPlanMode` during the current session. When set alongside
-/// `session_plan_mode`, the plan phase is over regardless of whether the
-/// frontend remembered to send `plan_mode=false` — force a teardown so the
-/// CLI respawns without `--permission-mode plan`.
+/// `plan_mode`, the plan phase is over regardless of whether the frontend
+/// remembered to send `plan_mode=false` — force a teardown so the CLI
+/// respawns without `--permission-mode plan`.
 fn persistent_session_flags_drifted(
-    session_plan_mode: bool,
-    session_allowed_tools: &[String],
-    session_exited_plan: bool,
-    requested_plan_mode: bool,
-    requested_allowed_tools: &[String],
+    session: SessionFlags<'_>,
+    requested: RequestedFlags<'_>,
 ) -> bool {
-    session_plan_mode != requested_plan_mode
-        || session_allowed_tools != requested_allowed_tools
-        || (session_plan_mode && session_exited_plan)
+    session.plan_mode != requested.plan_mode
+        || session.allowed_tools != requested.allowed_tools
+        || (session.plan_mode && session.exited_plan)
 }
 
 #[tauri::command]
@@ -358,11 +371,15 @@ pub async fn send_chat_message(
     // tool is silently auto-denied.
     if session.persistent_session.is_some()
         && persistent_session_flags_drifted(
-            session.session_plan_mode,
-            &session.session_allowed_tools,
-            session.session_exited_plan,
-            agent_settings.plan_mode,
-            &allowed_tools,
+            SessionFlags {
+                plan_mode: session.session_plan_mode,
+                allowed_tools: &session.session_allowed_tools,
+                exited_plan: session.session_exited_plan,
+            },
+            RequestedFlags {
+                plan_mode: agent_settings.plan_mode,
+                allowed_tools: &allowed_tools,
+            },
         )
     {
         eprintln!(
@@ -382,7 +399,10 @@ pub async fn send_chat_message(
         // without this clear, a failed respawn + next turn would SIGKILL a
         // potentially recycled PID via the stale-process teardown branch.
         session.active_pid = None;
-        // Reset the ExitPlanMode observation — the next session starts fresh.
+        // The spawn-completion sites below also clear this alongside
+        // `session_plan_mode`; resetting here too documents that drift-driven
+        // teardown ends the plan observation at the teardown point, not the
+        // respawn point.
         session.session_exited_plan = false;
         if stale_pid.is_some() || to_deny_drift.is_some() {
             drop(agents);
@@ -495,6 +515,11 @@ pub async fn send_chat_message(
                 session.session_id = final_sid;
                 session.session_plan_mode = agent_settings.plan_mode;
                 session.session_allowed_tools = allowed_tools.clone();
+                // Fresh process — any prior ExitPlanMode observation belongs
+                // to the dead session. Keep this in lockstep with the
+                // spawn-time flags above so the latch can't leak across
+                // respawns (including paths that skip the drift branch).
+                session.session_exited_plan = false;
                 handle
             }
         }
@@ -559,6 +584,8 @@ pub async fn send_chat_message(
         session.session_id = final_sid.clone();
         session.session_plan_mode = agent_settings.plan_mode;
         session.session_allowed_tools = allowed_tools.clone();
+        // See the sibling reset above — fresh process, fresh latch.
+        session.session_exited_plan = false;
         let _ = db.save_agent_session(&workspace_id, &final_sid, session.turn_count);
         handle
     };
@@ -1720,17 +1747,37 @@ fn now_iso() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::persistent_session_flags_drifted;
+    use super::{RequestedFlags, SessionFlags, persistent_session_flags_drifted};
 
     fn s(values: &[&str]) -> Vec<String> {
         values.iter().map(|v| (*v).to_string()).collect()
+    }
+
+    fn session<'a>(
+        plan_mode: bool,
+        allowed_tools: &'a [String],
+        exited_plan: bool,
+    ) -> SessionFlags<'a> {
+        SessionFlags {
+            plan_mode,
+            allowed_tools,
+            exited_plan,
+        }
+    }
+
+    fn requested<'a>(plan_mode: bool, allowed_tools: &'a [String]) -> RequestedFlags<'a> {
+        RequestedFlags {
+            plan_mode,
+            allowed_tools,
+        }
     }
 
     #[test]
     fn no_drift_when_plan_mode_and_tools_match() {
         let tools = s(&["Read", "Write"]);
         assert!(!persistent_session_flags_drifted(
-            false, &tools, false, false, &tools,
+            session(false, &tools, false),
+            requested(false, &tools),
         ));
     }
 
@@ -1739,7 +1786,8 @@ mod tests {
         // Session was spawned with --permission-mode plan; next turn is not.
         let tools = s(&["Read", "Write"]);
         assert!(persistent_session_flags_drifted(
-            true, &tools, false, false, &tools,
+            session(true, &tools, false),
+            requested(false, &tools),
         ));
     }
 
@@ -1747,7 +1795,8 @@ mod tests {
     fn drift_when_plan_mode_flips_on() {
         let tools = s(&["Read"]);
         assert!(persistent_session_flags_drifted(
-            false, &tools, false, true, &tools,
+            session(false, &tools, false),
+            requested(true, &tools),
         ));
     }
 
@@ -1756,7 +1805,8 @@ mod tests {
         let before = s(&["Read", "Glob"]);
         let after = s(&["Read", "Write", "Edit"]);
         assert!(persistent_session_flags_drifted(
-            false, &before, false, false, &after,
+            session(false, &before, false),
+            requested(false, &after),
         ));
     }
 
@@ -1765,12 +1815,11 @@ mod tests {
         // Strict equality: a different order counts as drift. Callers build
         // the list deterministically from the permission level, so any
         // observed diff signals a real configuration change.
+        let before = s(&["Read", "Write"]);
+        let after = s(&["Write", "Read"]);
         assert!(persistent_session_flags_drifted(
-            false,
-            &s(&["Read", "Write"]),
-            false,
-            false,
-            &s(&["Write", "Read"]),
+            session(false, &before, false),
+            requested(false, &after),
         ));
     }
 
@@ -1780,7 +1829,8 @@ mod tests {
         // the same bypass-permissions session should not trigger a respawn.
         let full = s(&["*"]);
         assert!(!persistent_session_flags_drifted(
-            false, &full, false, false, &full,
+            session(false, &full, false),
+            requested(false, &full),
         ));
     }
 
@@ -1792,7 +1842,8 @@ mod tests {
         let standard = s(&["Read", "Write", "Edit"]);
         let full = s(&["*"]);
         assert!(persistent_session_flags_drifted(
-            false, &standard, false, false, &full,
+            session(false, &standard, false),
+            requested(false, &full),
         ));
     }
 
@@ -1804,7 +1855,8 @@ mod tests {
         let full = s(&["*"]);
         let readonly = s(&["Read", "Glob", "Grep"]);
         assert!(persistent_session_flags_drifted(
-            false, &full, false, false, &readonly,
+            session(false, &full, false),
+            requested(false, &readonly),
         ));
     }
 
@@ -1816,10 +1868,8 @@ mod tests {
         // no longer auto-denies mutating tools.
         let tools = s(&["Read", "Write"]);
         assert!(persistent_session_flags_drifted(
-            true, // session was spawned with plan mode
-            &tools, true, // ExitPlanMode was observed
-            true, // buggy client still says plan_mode=true
-            &tools,
+            session(true, &tools, true),
+            requested(true, &tools),
         ));
     }
 
@@ -1829,7 +1879,8 @@ mod tests {
         // the exited-plan flag is irrelevant and should not trigger drift.
         let tools = s(&["Read"]);
         assert!(!persistent_session_flags_drifted(
-            false, &tools, true, false, &tools,
+            session(false, &tools, true),
+            requested(false, &tools),
         ));
     }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -53,13 +53,22 @@ use claudette::permissions::tools_for_level;
 /// `--allowedTools` are only applied when the `claude` process starts, so
 /// a drift means the running process cannot serve this turn correctly and
 /// must be torn down.
+///
+/// `session_exited_plan` is a backend-observed signal that the agent called
+/// `ExitPlanMode` during the current session. When set alongside
+/// `session_plan_mode`, the plan phase is over regardless of whether the
+/// frontend remembered to send `plan_mode=false` — force a teardown so the
+/// CLI respawns without `--permission-mode plan`.
 fn persistent_session_flags_drifted(
     session_plan_mode: bool,
     session_allowed_tools: &[String],
+    session_exited_plan: bool,
     requested_plan_mode: bool,
     requested_allowed_tools: &[String],
 ) -> bool {
-    session_plan_mode != requested_plan_mode || session_allowed_tools != requested_allowed_tools
+    session_plan_mode != requested_plan_mode
+        || session_allowed_tools != requested_allowed_tools
+        || (session_plan_mode && session_exited_plan)
 }
 
 #[tauri::command]
@@ -242,6 +251,7 @@ pub async fn send_chat_message(
                 session_plan_mode: false,
                 session_allowed_tools: Vec::new(),
                 pending_permissions: std::collections::HashMap::new(),
+                session_exited_plan: false,
             };
         }
 
@@ -257,6 +267,7 @@ pub async fn send_chat_message(
             session_plan_mode: false,
             session_allowed_tools: Vec::new(),
             pending_permissions: std::collections::HashMap::new(),
+            session_exited_plan: false,
         }
     });
 
@@ -349,15 +360,17 @@ pub async fn send_chat_message(
         && persistent_session_flags_drifted(
             session.session_plan_mode,
             &session.session_allowed_tools,
+            session.session_exited_plan,
             agent_settings.plan_mode,
             &allowed_tools,
         )
     {
         eprintln!(
-            "[chat] session flags drifted (plan_mode {} -> {}, allowed_tools changed: {}) — tearing down persistent session for {workspace_id}",
+            "[chat] session flags drifted (plan_mode {} -> {}, allowed_tools changed: {}, exited_plan: {}) — tearing down persistent session for {workspace_id}",
             session.session_plan_mode,
             agent_settings.plan_mode,
             session.session_allowed_tools != allowed_tools,
+            session.session_exited_plan,
         );
         // Resolve any pending permission requests against the doomed process
         // before we kill it, so the next turn doesn't carry stale tool_use_ids.
@@ -369,6 +382,8 @@ pub async fn send_chat_message(
         // without this clear, a failed respawn + next turn would SIGKILL a
         // potentially recycled PID via the stale-process teardown branch.
         session.active_pid = None;
+        // Reset the ExitPlanMode observation — the next session starts fresh.
+        session.session_exited_plan = false;
         if stale_pid.is_some() || to_deny_drift.is_some() {
             drop(agents);
             if let Some((ref ps, drained)) = to_deny_drift {
@@ -714,12 +729,19 @@ pub async fn send_chat_message(
                 } else {
                     crate::state::AttentionKind::Plan
                 };
+                let is_exit_plan = name == "ExitPlanMode";
                 let app_state = app.state::<AppState>();
                 let mut agents = app_state.agents.write().await;
                 let already_notified = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
                 if let Some(session) = agents.get_mut(&ws_id) {
                     session.needs_attention = true;
                     session.attention_kind = Some(kind);
+                    // Observed ExitPlanMode — the plan phase is ending. Mark
+                    // so the next turn forces a subprocess teardown even if
+                    // the frontend fails to flip `plan_mode=false`.
+                    if is_exit_plan {
+                        session.session_exited_plan = true;
+                    }
                 }
                 drop(agents);
                 // Only send notification once per attention cycle — skip if
@@ -1709,7 +1731,7 @@ mod tests {
     fn no_drift_when_plan_mode_and_tools_match() {
         let tools = s(&["Read", "Write"]);
         assert!(!persistent_session_flags_drifted(
-            false, &tools, false, &tools,
+            false, &tools, false, false, &tools,
         ));
     }
 
@@ -1718,7 +1740,7 @@ mod tests {
         // Session was spawned with --permission-mode plan; next turn is not.
         let tools = s(&["Read", "Write"]);
         assert!(persistent_session_flags_drifted(
-            true, &tools, false, &tools,
+            true, &tools, false, false, &tools,
         ));
     }
 
@@ -1726,7 +1748,7 @@ mod tests {
     fn drift_when_plan_mode_flips_on() {
         let tools = s(&["Read"]);
         assert!(persistent_session_flags_drifted(
-            false, &tools, true, &tools,
+            false, &tools, false, true, &tools,
         ));
     }
 
@@ -1735,7 +1757,7 @@ mod tests {
         let before = s(&["Read", "Glob"]);
         let after = s(&["Read", "Write", "Edit"]);
         assert!(persistent_session_flags_drifted(
-            false, &before, false, &after,
+            false, &before, false, false, &after,
         ));
     }
 
@@ -1748,6 +1770,7 @@ mod tests {
             false,
             &s(&["Read", "Write"]),
             false,
+            false,
             &s(&["Write", "Read"]),
         ));
     }
@@ -1758,7 +1781,7 @@ mod tests {
         // the same bypass-permissions session should not trigger a respawn.
         let full = s(&["*"]);
         assert!(!persistent_session_flags_drifted(
-            false, &full, false, &full,
+            false, &full, false, false, &full,
         ));
     }
 
@@ -1770,7 +1793,7 @@ mod tests {
         let standard = s(&["Read", "Write", "Edit"]);
         let full = s(&["*"]);
         assert!(persistent_session_flags_drifted(
-            false, &standard, false, &full,
+            false, &standard, false, false, &full,
         ));
     }
 
@@ -1782,7 +1805,32 @@ mod tests {
         let full = s(&["*"]);
         let readonly = s(&["Read", "Glob", "Grep"]);
         assert!(persistent_session_flags_drifted(
-            false, &full, false, &readonly,
+            false, &full, false, false, &readonly,
+        ));
+    }
+
+    #[test]
+    fn drift_when_session_exited_plan_even_if_request_still_says_plan() {
+        // Safety net: agent emitted ExitPlanMode so the plan phase is over.
+        // Even if the frontend forgets to flip plan_mode=false on the next
+        // turn (known bug class), the backend must still respawn so the CLI
+        // no longer auto-denies mutating tools.
+        let tools = s(&["Read", "Write"]);
+        assert!(persistent_session_flags_drifted(
+            true, // session was spawned with plan mode
+            &tools, true, // ExitPlanMode was observed
+            true, // buggy client still says plan_mode=true
+            &tools,
+        ));
+    }
+
+    #[test]
+    fn no_drift_when_exited_plan_but_session_never_had_plan() {
+        // Nonsense state defensively handled: if session_plan_mode is false
+        // the exited-plan flag is irrelevant and should not trigger drift.
+        let tools = s(&["Read"]);
+        assert!(!persistent_session_flags_drifted(
+            false, &tools, true, false, &tools,
         ));
     }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -729,7 +729,6 @@ pub async fn send_chat_message(
                 } else {
                     crate::state::AttentionKind::Plan
                 };
-                let is_exit_plan = name == "ExitPlanMode";
                 let app_state = app.state::<AppState>();
                 let mut agents = app_state.agents.write().await;
                 let already_notified = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
@@ -739,7 +738,7 @@ pub async fn send_chat_message(
                     // Observed ExitPlanMode — the plan phase is ending. Mark
                     // so the next turn forces a subprocess teardown even if
                     // the frontend fails to flip `plan_mode=false`.
-                    if is_exit_plan {
+                    if name == "ExitPlanMode" {
                         session.session_exited_plan = true;
                     }
                 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -72,6 +72,11 @@ pub struct AgentSessionState {
     /// Outstanding `can_use_tool` control requests awaiting a `control_response`,
     /// keyed by tool_use_id. See [`PendingPermission`].
     pub pending_permissions: HashMap<String, PendingPermission>,
+    /// Set when the agent emits `ExitPlanMode` during the current persistent
+    /// session. The plan phase is over even if the frontend fails to flip
+    /// `plan_mode=false` on the next turn, so we force a teardown regardless
+    /// of the requested flag. Reset after teardown.
+    pub session_exited_plan: bool,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -635,6 +635,7 @@ mod tests {
             session_plan_mode: false,
             session_allowed_tools: Vec::new(),
             pending_permissions: HashMap::new(),
+            session_exited_plan: false,
         }
     }
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -222,6 +222,7 @@ export function ChatPanel() {
     (s) => (selectedWorkspaceId ? s.planApprovals[selectedWorkspaceId] ?? null : null)
   );
   const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
+  const setPlanMode = useAppStore((s) => s.setPlanMode);
   const queuedMessage = useAppStore(
     (s) => (selectedWorkspaceId ? s.queuedMessages[selectedWorkspaceId] ?? null : null)
   );
@@ -910,6 +911,12 @@ export function ChatPanel() {
                     try {
                       await submitPlanApproval(wsId, toolUseId, approved, reason);
                       clearPlanApproval(wsId);
+                      // User action is authoritative for ending the plan
+                      // phase — flip planMode off so the next turn triggers
+                      // drift detection (backend `session_exited_plan` covers
+                      // this already, but clearing the UI state keeps the
+                      // toolbar chip in sync).
+                      setPlanMode(wsId, false);
                     } catch (e) {
                       console.error("Failed to submit plan approval:", e);
                       setError(String(e));

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -66,9 +66,13 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
       const effectiveThinking = thinking === "true" || (!thinking && defThinking === "true");
       setFastMode(workspaceId, effectiveFast);
       setThinkingEnabled(workspaceId, effectiveThinking);
-      // Plan mode is not persisted per-workspace (in-memory only);
-      // always apply the global default on load.
-      setPlanMode(workspaceId, defPlan === "true");
+      // Plan mode is not persisted per-workspace (in-memory only). Apply the
+      // global default only when the store has no runtime value yet — a
+      // remount mid-flow (e.g. workspace swap-and-return, remote reconnect)
+      // must not clobber an agent-driven clear of planMode.
+      if (useAppStore.getState().planMode[workspaceId] === undefined) {
+        setPlanMode(workspaceId, defPlan === "true");
+      }
       // Normalize effort against the loaded model to prevent stale values.
       const effectiveEffort = effort ?? defEffort;
       if (effectiveEffort) {

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -6,6 +6,7 @@ import { ModelSelector, MODELS } from "./ModelSelector";
 import { EffortSelector, EFFORT_LEVELS } from "./EffortSelector";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "./modelCapabilities";
 import { applySelectedModel } from "./applySelectedModel";
+import { applyPlanModeMountDefault } from "./applyPlanModeMountDefault";
 import styles from "./ChatToolbar.module.css";
 
 interface ChatToolbarProps {
@@ -66,13 +67,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
       const effectiveThinking = thinking === "true" || (!thinking && defThinking === "true");
       setFastMode(workspaceId, effectiveFast);
       setThinkingEnabled(workspaceId, effectiveThinking);
-      // Plan mode is not persisted per-workspace (in-memory only). Apply the
-      // global default only when the store has no runtime value yet — a
-      // remount mid-flow (e.g. workspace swap-and-return, remote reconnect)
-      // must not clobber an agent-driven clear of planMode.
-      if (useAppStore.getState().planMode[workspaceId] === undefined) {
-        setPlanMode(workspaceId, defPlan === "true");
-      }
+      applyPlanModeMountDefault(workspaceId, defPlan === "true");
       // Normalize effort against the loaded model to prevent stale values.
       const effectiveEffort = effort ?? defEffort;
       if (effectiveEffort) {
@@ -91,7 +86,7 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
     }
     load();
     return () => { cancelled = true; };
-  }, [workspaceId, setSelectedModel, setFastMode, setThinkingEnabled, setPlanMode, setEffortLevel, setShowThinkingBlocks, setChromeEnabled]);
+  }, [workspaceId, setSelectedModel, setFastMode, setThinkingEnabled, setEffortLevel, setShowThinkingBlocks, setChromeEnabled]);
 
   const handleModelSelect = useCallback(
     async (model: string) => {

--- a/src/ui/src/components/chat/applyPlanModeMountDefault.ts
+++ b/src/ui/src/components/chat/applyPlanModeMountDefault.ts
@@ -1,0 +1,16 @@
+import { useAppStore } from "../../stores/useAppStore";
+
+/**
+ * Apply the global `default_plan_mode` to a workspace only if the store has no
+ * runtime value for that workspace yet. A remount mid-flow (workspace swap,
+ * remote reconnect, HMR) must not clobber an agent-driven clear of plan mode.
+ */
+export function applyPlanModeMountDefault(
+  workspaceId: string,
+  defaultValue: boolean,
+): void {
+  const store = useAppStore.getState();
+  if (store.planMode[workspaceId] === undefined) {
+    store.setPlanMode(workspaceId, defaultValue);
+  }
+}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -182,6 +182,7 @@ export function useAgentStream() {
                     if (inner.content_block.name === "EnterPlanMode") {
                       setPlanMode(wsId, true);
                     } else if (inner.content_block.name === "ExitPlanMode") {
+                      debugChat("plan-mode", "ExitPlanMode → setPlanMode(false)", { wsId, origin: "content_block_start" });
                       setPlanMode(wsId, false);
                     }
                   }
@@ -354,6 +355,11 @@ export function useAgentStream() {
           }
         }
       } else if (toolName === "ExitPlanMode") {
+        // Mirror the content_block_start clear at the control_request boundary
+        // in case that event arrived without the tool `name` populated.
+        // Idempotent — setting to the same value is a no-op.
+        debugChat("plan-mode", "ExitPlanMode → setPlanMode(false)", { wsId, origin: "agent-permission-prompt" });
+        setPlanMode(wsId, false);
         let allowedPrompts: Array<{ tool: string; prompt: string }> = [];
         if (input && typeof input === "object" && "allowedPrompts" in input) {
           const ap = (input as { allowedPrompts?: unknown }).allowedPrompts;
@@ -393,7 +399,7 @@ export function useAgentStream() {
       active = false;
       unlisten.then((fn) => fn());
     };
-  }, [setAgentQuestion, setPlanApproval]);
+  }, [setAgentQuestion, setPlanApproval, setPlanMode]);
 
   // Listen for checkpoint-created events from the backend.
   const addCheckpoint = useAppStore((s) => s.addCheckpoint);

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -276,6 +276,38 @@ describe("agentQuestion lifecycle (per-workspace)", () => {
   });
 });
 
+describe("planMode mount-default gate", () => {
+  // ChatToolbar applies a persisted default only when the runtime value is
+  // undefined; otherwise it preserves the agent-driven clear. This codifies
+  // the contract a remount (workspace swap, remote reconnect, HMR) must obey.
+  beforeEach(() => {
+    useAppStore.setState({ planMode: {} });
+  });
+
+  function applyMountDefault(wsId: string, defaultPlan: boolean) {
+    if (useAppStore.getState().planMode[wsId] === undefined) {
+      useAppStore.getState().setPlanMode(wsId, defaultPlan);
+    }
+  }
+
+  it("applies default when store has no runtime value", () => {
+    applyMountDefault(WS_ID, true);
+    expect(useAppStore.getState().planMode[WS_ID]).toBe(true);
+  });
+
+  it("preserves existing false runtime value on remount", () => {
+    useAppStore.getState().setPlanMode(WS_ID, false);
+    applyMountDefault(WS_ID, true);
+    expect(useAppStore.getState().planMode[WS_ID]).toBe(false);
+  });
+
+  it("preserves existing true runtime value on remount", () => {
+    useAppStore.getState().setPlanMode(WS_ID, true);
+    applyMountDefault(WS_ID, false);
+    expect(useAppStore.getState().planMode[WS_ID]).toBe(true);
+  });
+});
+
 describe("finalizeTurn afterMessageIndex", () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "./useAppStore";
 import type { AgentQuestion } from "./useAppStore";
 import type { ConversationCheckpoint } from "../types/checkpoint";
+import { applyPlanModeMountDefault } from "../components/chat/applyPlanModeMountDefault";
 
 const WS_ID = "test-workspace";
 
@@ -276,34 +277,29 @@ describe("agentQuestion lifecycle (per-workspace)", () => {
   });
 });
 
-describe("planMode mount-default gate", () => {
-  // ChatToolbar applies a persisted default only when the runtime value is
-  // undefined; otherwise it preserves the agent-driven clear. This codifies
-  // the contract a remount (workspace swap, remote reconnect, HMR) must obey.
+describe("applyPlanModeMountDefault", () => {
+  // ChatToolbar delegates its mount-time "apply global default" step to this
+  // helper. The contract: only touch the store if the runtime value is
+  // undefined; a remount (workspace swap, remote reconnect, HMR) must not
+  // clobber an agent-driven clear of planMode.
   beforeEach(() => {
     useAppStore.setState({ planMode: {} });
   });
 
-  function applyMountDefault(wsId: string, defaultPlan: boolean) {
-    if (useAppStore.getState().planMode[wsId] === undefined) {
-      useAppStore.getState().setPlanMode(wsId, defaultPlan);
-    }
-  }
-
   it("applies default when store has no runtime value", () => {
-    applyMountDefault(WS_ID, true);
+    applyPlanModeMountDefault(WS_ID, true);
     expect(useAppStore.getState().planMode[WS_ID]).toBe(true);
   });
 
   it("preserves existing false runtime value on remount", () => {
     useAppStore.getState().setPlanMode(WS_ID, false);
-    applyMountDefault(WS_ID, true);
+    applyPlanModeMountDefault(WS_ID, true);
     expect(useAppStore.getState().planMode[WS_ID]).toBe(false);
   });
 
   it("preserves existing true runtime value on remount", () => {
     useAppStore.getState().setPlanMode(WS_ID, true);
-    applyMountDefault(WS_ID, false);
+    applyPlanModeMountDefault(WS_ID, false);
     expect(useAppStore.getState().planMode[WS_ID]).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where, after the agent called `ExitPlanMode` and the user approved the plan, subsequent write tool calls were still auto-denied because the `claude` subprocess was still running with `--permission-mode plan`. The Plan chip also stayed highlighted in the toolbar.

### Root causes

PR #264 added drift detection: if `plan_mode` differs between the existing persistent session and the next turn's request, the subprocess is torn down and respawned. That depends on the frontend's Zustand `planMode[wsId]` being `false` by the next turn. Two things broke that guarantee:

1. **`ChatToolbar.tsx`** unconditionally re-applied `default_plan_mode` on every mount — a remount mid-flow (workspace swap, remote reconnect, HMR) silently clobbered the agent-driven clear.
2. **`useAgentStream.ts`** detected `ExitPlanMode` from `content_block_start`'s `name` field, but the wire format does not always populate `name` there.

### Fix (defense in depth)

- **`PlanApprovalCard`** — on successful `submitPlanApproval`, the callback clears `planApproval` and calls `setPlanMode(wsId, false)`. The user's accept/deny click is the authoritative signal for clearing plan mode; the backend `session_exited_plan` latch (below) handles the process-teardown half, while this keeps the UI chip in sync.
- **`ChatToolbar`** — only applies `default_plan_mode` when `planMode[wsId]` is `undefined` (first mount for the workspace). Later remounts preserve runtime state. Covered by three new store tests.
- **`useAgentStream`** — mirrors the `setPlanMode(false)` detection at the new `agent-permission-prompt` event boundary (post-rebase on PR #271), so the clear still fires even if `content_block_start` arrives without the tool `name` populated. Includes `debugChat` logs tagging `origin: "content_block_start" | "agent-permission-prompt"`.
- **Backend safety net** — new `AgentSessionState.session_exited_plan: bool`, latched in the event-handling block when `ContentBlockStart { ToolUse { name: "ExitPlanMode", .. } }` is observed. The drift check (`persistent_session_flags_drifted`) forces teardown whenever `session_plan_mode && session_exited_plan`, even if the frontend still requests `plan_mode=true`. Flag reset after teardown. Ensures a drifted frontend cannot keep the subprocess trapped in plan mode.

```mermaid
flowchart TD
    A[Agent emits ExitPlanMode] -->|content_block_start| B[useAgentStream: setPlanMode false]
    A -->|event handler| C[Backend: session_exited_plan = true]
    A -->|agent-permission-prompt| B
    D[User approves/denies plan] -->|PlanApprovalCard| E[submitPlanApproval + setPlanMode false]
    E --> F[Next user turn]
    B --> F
    F -->|request plan_mode=false| G{Drift check}
    C -->|even if request still plan_mode=true| G
    G -->|drifted| H[Teardown + respawn without --permission-mode plan]
    G -->|match| I[Reuse session]
```

## Complexity Notes

- Post-rebase on PR #271 (`fix(chat): round-trip AskUserQuestion / ExitPlanMode via control_response`), `submitPlanApproval` is a control_response to the CLI's pending `can_use_tool` request — not a new user turn. That means `setPlanMode(wsId, false)` in `onRespond` doesn't influence the immediate CLI continuation; it influences the NEXT user turn, which is when the backend drift check runs. The `session_exited_plan` latch closes the window if that next turn still carries `plan_mode=true`.
- `session_exited_plan` is a one-way latch until teardown. The drift test suite covers all six `persistent_session_flags_drifted` combinations plus two new safety-net cases. Reset lives inside the drift branch right after `active_pid = None`, grouped with other teardown bookkeeping.
- `useAgentStream` now sets `planMode=false` from three sites (`content_block_start`, `agent-permission-prompt`, and `PlanApprovalCard.onRespond`). Redundant by design — setting to the same value is a no-op.
- Frontend rendering tests are absent (the codebase has no React Testing Library); the gate contract is covered by pure-logic tests in `useAppStore.test.ts` that mirror the exact conditional.

## Test Steps

1. **Approve path (primary repro)**:
   - `cargo tauri dev`
   - Open a workspace, toggle the **Plan** chip on.
   - Send a prompt that drives the agent to a plan (e.g., *"Plan adding a log line to the main init"*).
   - When the plan card appears, click **Approve**.
   - ✅ Plan chip deactivates immediately.
   - ✅ Agent's next turn can write — no permission-denied errors.
   - ✅ Backend log contains `[chat] session flags drifted (plan_mode true -> false, …) — tearing down persistent session`.

2. **Deny path**:
   - Repeat, click **Deny** instead. Submit a revision.
   - ✅ Next turn succeeds without plan-mode restrictions.

3. **Workspace swap during plan**:
   - Enter plan mode, start a prompt. While streaming, switch to another workspace and back.
   - ✅ Plan chip state matches the workspace's runtime state, not `default_plan_mode`.

4. **Backend safety net (drifted-frontend simulation)**:
   - In `/claudette-debug` eval, force `planMode[wsId]=true` after approval. Send a new turn.
   - ✅ Subprocess still respawns (safety net triggers via `session_exited_plan`).

5. **Unit tests**:
   - `cargo test --all-features -p claudette-tauri chat::tests::` — 10/10 pass, including two new safety-net tests.
   - `cd src/ui && bun run test` — 476/476 pass, including three new mount-default gate tests.

## Checklist
- [x] Tests added/updated (Rust: drift + safety-net tests in `chat.rs`; TS: mount-default gate tests in `useAppStore.test.ts`)
- [ ] Documentation updated (N/A — no user-facing surface change)