### PR TITLE
fix(scm): use enriched PATH so plugins find gh/glab in release builds

### DIFF
--- a/src/scm_provider/host_api.rs
+++ b/src/scm_provider/host_api.rs
@@ -156,6 +156,11 @@ async fn host_exec(
     let mut command = Command::new(cmd);
     command.args(&args);
     command.current_dir(&ctx.workspace_info.worktree_path);
+    // macOS GUI apps inherit a minimal launchd PATH, so binaries like
+    // `gh`/`glab` (typically in /opt/homebrew/bin) wouldn't be found.
+    // Pass the enriched PATH so the child — and anything it shells out
+    // to (git, credential helpers, editors) — can resolve them.
+    command.env("PATH", crate::env::enriched_path());
     command.kill_on_drop(true);
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());

--- a/src/scm_provider/mod.rs
+++ b/src/scm_provider/mod.rs
@@ -236,8 +236,12 @@ impl PluginRegistry {
 }
 
 /// Check if all required CLI tools are available on PATH.
+///
+/// Uses the enriched PATH (login-shell probed) so Homebrew-installed CLIs
+/// like `gh`/`glab` resolve correctly when the app is launched from Finder.
 fn check_clis_available(clis: &[String]) -> bool {
-    clis.iter().all(|cli| which::which(cli).is_ok())
+    clis.iter()
+        .all(|cli| crate::env::which_in_enriched_path(cli).is_ok())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

SCM provider plugins (GitHub via `gh`, GitLab via `glab`) detect correctly in `cargo tauri dev` but show **"No SCM provider detected"** in the released `.app` even when the CLIs are installed.

**Root cause** is the classic macOS GUI-app PATH problem: apps launched from Finder/Dock/Spotlight inherit launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), which excludes `/opt/homebrew/bin` and `/usr/local/bin` where Homebrew installs `gh`/`glab`. Dev mode works because the binary inherits the terminal's full shell PATH.

This PR brings the SCM provider code in line with the rest of the codebase — `agent.rs`, `mcp_supervisor.rs`, `plugin.rs`, `commands/workspace.rs`, and `usage.rs` already use `crate::env::enriched_path()` / `which_in_enriched_path` (see `src/env.rs`). The SCM plugin code just missed adopting the helper.

**Two surgical changes**, both required:

1. `src/scm_provider/mod.rs:240` — `check_clis_available` now uses `which_in_enriched_path` instead of plain `which::which`. This fixes plugin filtering at discovery time so `cli_available = true` in release builds.
2. `src/scm_provider/host_api.rs:156` — `host.exec` subprocesses now get `PATH = enriched_path()`. Without this, detection would say "gh available" but every Lua-driven `host.exec("gh", …)` call would still ENOENT in release. Setting PATH on the immediate child also covers anything `gh` shells out to (git, credential helpers, editors).

```mermaid
flowchart LR
    A[App startup] --> B[PluginRegistry::discover]
    B --> C[check_clis_available]
    C -->|before| D[which::which raw PATH<br/>❌ misses Homebrew]
    C -->|after| E[which_in_enriched_path<br/>✅ login-shell PATH]
    E --> F[plugin.cli_available = true]
    F --> G[detect_provider returns plugin]
    G --> H[host.exec gh ...]
    H -->|before| I[Command::new gh<br/>❌ ENOENT]
    H -->|after| J[Command + env PATH<br/>✅ resolves]
```

## Complexity Notes

- **Cache-at-startup**: `cli_available` is computed once during `PluginRegistry::discover()` at app startup. If a user installs `gh` after launch, they'll need to restart Claudette. This matches existing behavior for any GUI app discovering tools via PATH (Homebrew, asdf, mise, Nix profiles all have the same restart requirement) and isn't worth the complexity of re-discovery.
- **Login-shell probe failure**: If `$SHELL` is unset or the probe times out (5s), `enriched_path()` falls back to the process PATH. Behavior degrades to today's broken state — no regression, just no improvement in that pathological case.
- **No regression test added**: The only way to truly catch a revert to plain `which::which` would be to mutate `PATH` in a test, which is unsafe under Cargo's parallel test execution. The other 5 callsites of `enriched_path` in this codebase don't carry per-callsite tests either; they rely on the helper's own tests in `src/env.rs:241-256`. Inline doc comments at both fix sites explain the why for future readers.

## Test Steps

1. **Unit + integration tests**:
   ```bash
   cargo test --all-features --workspace      # 555 tests, all green
   cargo clippy --workspace --all-targets     # zero warnings (CI sets -Dwarnings)
   cargo fmt --all --check                    # passes
   ```
2. **Manual dev-mode regression check** (confirm no breakage):
   ```bash
   cargo tauri dev
   ```
   Open a workspace cloned from a GitHub repo. Confirm the right-sidebar SCM panel still shows the GitHub provider and that `host.exec`-driven operations (e.g. listing PRs) still work.
3. **Manual release-mode verification** (the actual bug):
   ```bash
   cargo tauri build
   open target/release/bundle/macos/Claudette.app
   ```
   **Important**: open from Finder/Dock/Spotlight, NOT from the terminal — that's the bug condition.
   - Open a GitHub workspace → SCM panel should show GitHub provider (was broken before).
   - Open a GitLab workspace → SCM panel should show GitLab provider (was broken before).
   - Trigger an SCM operation (e.g. list PRs) to confirm `host.exec` works end-to-end, not just detection.
4. **Stderr log check** (optional): the existing log line `[plugin] Discovered N plugin(s): github, gitlab` from `src-tauri/src/main.rs:90-99` should still appear at startup. The `cli_available` flag isn't logged but UI behavior confirms it.

## Checklist

- [x] Tests added/updated — relied on existing `which_in_enriched_path` tests in `src/env.rs`; new test would require unsafe `PATH` mutation (see Complexity Notes).
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs changed.