### PR TITLE
feat(chat): typewriter-style streaming reveal for assistant messages

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -553,19 +553,24 @@
   margin: 12px 0;
 }
 
-.cursor {
+.caret {
   display: inline-block;
-  width: 2px;
+  width: 1px;
   height: 1em;
-  background: var(--accent-primary);
-  margin-left: 2px;
-  vertical-align: text-bottom;
-  animation: blink 1s step-end infinite;
+  vertical-align: -0.15em;
+  margin-left: 1px;
+  background: currentColor;
+  animation: claudette-caret-blink 0.9s steps(2, end) infinite;
 }
 
-@keyframes blink {
-  0%, 100% { opacity: 1; }
+@keyframes claudette-caret-blink {
   50% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caret {
+    animation: none;
+  }
 }
 
 /* Processing indicator */

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -43,6 +43,7 @@ import {
   maxSizeFor,
 } from "../../utils/attachmentValidation";
 import { useAgentStream } from "../../hooks/useAgentStream";
+import { useTypewriter } from "../../hooks/useTypewriter";
 import { extractToolSummary } from "../../hooks/toolSummary";
 import { AgentQuestionCard } from "./AgentQuestionCard";
 import { PlanApprovalCard } from "./PlanApprovalCard";
@@ -195,6 +196,9 @@ export function ChatPanel() {
   // Subscribe only to boolean — avoids re-render on every streaming character
   const hasStreaming = useAppStore(
     (s) => !!(selectedWorkspaceId && s.streamingContent[selectedWorkspaceId])
+  );
+  const hasPendingTypewriter = useAppStore(
+    (s) => !!(selectedWorkspaceId && s.pendingTypewriter[selectedWorkspaceId])
   );
   const hasThinking = useAppStore(
     (s) => !!(selectedWorkspaceId && s.streamingThinking[selectedWorkspaceId])
@@ -863,7 +867,7 @@ export function ChatPanel() {
                 <StreamingThinkingBlock workspaceId={selectedWorkspaceId} isStreaming={isRunning ?? false} />
               )}
 
-              {selectedWorkspaceId && hasStreaming && (
+              {selectedWorkspaceId && (hasStreaming || hasPendingTypewriter) && (
                 <StreamingMessage workspaceId={selectedWorkspaceId} />
               )}
 
@@ -997,9 +1001,11 @@ const StreamingThinkingBlock = memo(function StreamingThinkingBlock({
 });
 
 /**
- * Isolated streaming message component — subscribes to streaming text directly
- * and throttles Markdown re-parsing to ~16fps via requestAnimationFrame.
- * This prevents the entire ChatPanel from re-rendering on every character delta.
+ * Isolated streaming message component — runs the typewriter reveal at a steady
+ * rate while the agent streams, and keeps draining the latched text after
+ * streamingContent clears so the transition to the completed message is smooth
+ * (the just-added chat message is hidden behind pendingTypewriter until drain
+ * completes).
  */
 const StreamingMessage = memo(function StreamingMessage({
   workspaceId,
@@ -1009,39 +1015,38 @@ const StreamingMessage = memo(function StreamingMessage({
   const streaming = useAppStore(
     (s) => s.streamingContent[workspaceId] || ""
   );
+  const pendingText = useAppStore(
+    (s) => s.pendingTypewriter[workspaceId]?.text ?? ""
+  );
+  const isStreaming = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.agent_status === "Running"
+  );
+  const clearPendingTypewriter = useAppStore((s) => s.clearPendingTypewriter);
   const { handleContentChanged } = useContext(ScrollContext);
 
-  // Throttle Markdown rendering: store latest text in ref, update at ~16fps
-  const latestRef = useRef(streaming);
-  latestRef.current = streaming;
-  const [displayed, setDisplayed] = useState(streaming);
-  const rafRef = useRef<number | null>(null);
+  const fullText = streaming || pendingText;
+  const { displayed, showCaret } = useTypewriter(fullText, isStreaming);
 
-  useEffect(() => {
-    let lastTime = 0;
-    const THROTTLE_MS = 60; // ~16fps
-    const tick = (time: number) => {
-      if (time - lastTime >= THROTTLE_MS) {
-        lastTime = time;
-        setDisplayed(latestRef.current);
-      }
-      rafRef.current = requestAnimationFrame(tick);
-    };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => {
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-    };
-  }, []);
-
-  // Auto-scroll when streaming content grows — respects user scroll intent.
   useEffect(() => {
     handleContentChanged();
   }, [displayed, handleContentChanged]);
 
+  // Drain complete + we're in pending-typewriter phase → release the hidden
+  // completed message so it takes over visually without a jump.
+  useEffect(() => {
+    if (!showCaret && !streaming && pendingText) {
+      clearPendingTypewriter(workspaceId);
+    }
+  }, [showCaret, streaming, pendingText, workspaceId, clearPendingTypewriter]);
+
   if (!displayed) return null;
 
   return (
-    <div className={`${styles.message} ${styles.role_Assistant}`}>
+    <div
+      className={`${styles.message} ${styles.role_Assistant}`}
+      aria-live="polite"
+      aria-busy={isStreaming}
+    >
       <div className={styles.content}>
         <Markdown
           remarkPlugins={REMARK_PLUGINS}
@@ -1050,7 +1055,7 @@ const StreamingMessage = memo(function StreamingMessage({
         >
           {preprocessContent(displayed)}
         </Markdown>
-        <span className={styles.cursor} />
+        {showCaret && <span className={styles.caret} aria-hidden="true" />}
       </div>
     </div>
   );
@@ -1331,6 +1336,12 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   const showThinkingBlocks = useAppStore(
     (s) => s.showThinkingBlocks[workspaceId] === true
   );
+  // While the typewriter is finishing the drain after streamingContent cleared,
+  // hide the just-added completed assistant message — StreamingMessage renders
+  // it in-place, so showing both would duplicate the text.
+  const pendingMessageId = useAppStore(
+    (s) => s.pendingTypewriter[workspaceId]?.messageId ?? null
+  );
   const chatAttachments = useAppStore(
     (s) => s.chatAttachments[workspaceId] ?? EMPTY_ATTACHMENTS
   );
@@ -1494,6 +1505,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
       {messages.map((msg, idx) => (
         <React.Fragment key={msg.id}>
           {renderTurns(idx)}
+          {msg.id === pendingMessageId ? null : (
           <div className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}`}>
             {msg.role === "User" && (
               <div className={styles.roleLabel}>You</div>
@@ -1541,6 +1553,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
               )}
             </div>
           </div>
+          )}
         </React.Fragment>
       ))}
       {/* Turns that finalized after or at the last message index */}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -14,6 +14,7 @@ const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 export function useAgentStream() {
   const appendStreamingContent = useAppStore((s) => s.appendStreamingContent);
   const setStreamingContent = useAppStore((s) => s.setStreamingContent);
+  const setPendingTypewriter = useAppStore((s) => s.setPendingTypewriter);
   const appendStreamingThinking = useAppStore((s) => s.appendStreamingThinking);
   const clearStreamingThinking = useAppStore((s) => s.clearStreamingThinking);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
@@ -246,8 +247,14 @@ export function useAgentStream() {
                 textLength: text.length,
                 turnMessageCount: turnMessageCountRef.current[wsId],
               });
+              const messageId = crypto.randomUUID();
+              // Latch the final text for the typewriter so StreamingMessage
+              // can keep draining after streamingContent clears. The matching
+              // messageId tells MessagesWithTurns to hide the just-added
+              // completed message until drain finishes.
+              setPendingTypewriter(wsId, messageId, text);
               addChatMessage(wsId, {
-                id: crypto.randomUUID(),
+                id: messageId,
                 workspace_id: wsId,
                 role: "Assistant",
                 content: text,

--- a/src/ui/src/hooks/useTypewriter.test.ts
+++ b/src/ui/src/hooks/useTypewriter.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+  TYPEWRITER_BASE_RATE,
+  TYPEWRITER_MAX_LAG_MS,
+  computeNextState,
+  type TypewriterState,
+} from "./useTypewriter";
+
+function fresh(target = ""): TypewriterState {
+  return { revealed: 0, target };
+}
+
+describe("computeNextState", () => {
+  it("reveals at base rate when lag fits within the allowed buffer", () => {
+    // Target is short enough (5 chars) that lag < allowedBuffer (12 chars) —
+    // acceleration should NOT kick in, so we advance at exactly baseRate.
+    // 50ms at 60 chars/sec = 3 chars.
+    const next = computeNextState({
+      state: fresh(),
+      fullText: "short",
+      deltaMs: 50,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(next.revealed).toBeCloseTo(3, 5);
+    expect(next.target).toBe("short");
+  });
+
+  it("accumulates across ticks without losing fractions", () => {
+    // Two ticks of 8ms each = 16ms total @ 60cps = 0.96 chars
+    let s = fresh("Hello world");
+    const params = {
+      fullText: "Hello world",
+      deltaMs: 8,
+      baseRate: 60,
+      maxLagMs: 200,
+    };
+    s = computeNextState({ state: s, ...params });
+    s = computeNextState({ state: s, ...params });
+    expect(s.revealed).toBeCloseTo(16 * 60 / 1000, 5);
+    // Floor is still 0 — fractions preserved, not rounded prematurely.
+    expect(Math.floor(s.revealed)).toBe(0);
+  });
+
+  it("accelerates when lag exceeds maxLagMs budget", () => {
+    // 600-char target, one 200ms tick. Base rate alone would yield 12 chars.
+    // Acceleration should drain the whole 600 chars in 200ms.
+    const next = computeNextState({
+      state: fresh(),
+      fullText: "x".repeat(600),
+      deltaMs: 200,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(next.revealed).toBe(600);
+  });
+
+  it("keeps lag-in-time bounded to maxLagMs at every tick (steady-state invariant)", () => {
+    // The spec's promise is "never lag more than ~200ms behind the true text":
+    // interpreted as "remaining buffer / current rate ≤ maxLagMs" at every
+    // instant. Simulate many small ticks on a fast-growing target and check
+    // the invariant holds after each tick.
+    let s = fresh();
+    const baseRate = 60;
+    const maxLagMs = 200;
+    for (let i = 0; i < 30; i++) {
+      s = computeNextState({
+        state: s,
+        fullText: "x".repeat(600),
+        deltaMs: 10,
+        baseRate,
+        maxLagMs,
+      });
+      const lag = Math.max(0, s.target.length - s.revealed);
+      const rate = Math.max(baseRate, lag / (maxLagMs / 1000));
+      const lagSeconds = lag === 0 ? 0 : lag / rate;
+      expect(lagSeconds).toBeLessThanOrEqual(maxLagMs / 1000 + 1e-9);
+    }
+  });
+
+  it("latches target when fullText empties — continues revealing", () => {
+    let s = fresh();
+    // Phase 1: streaming "done" for 30ms (~1.8 chars revealed @ 60cps)
+    s = computeNextState({
+      state: s,
+      fullText: "done",
+      deltaMs: 30,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(s.target).toBe("done");
+    expect(s.revealed).toBeGreaterThan(0);
+    expect(s.revealed).toBeLessThan(4);
+
+    // Phase 2: source cleared. Target should latch; reveal keeps climbing.
+    const prev = s.revealed;
+    s = computeNextState({
+      state: s,
+      fullText: "",
+      deltaMs: 30,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(s.target).toBe("done");
+    expect(s.revealed).toBeGreaterThan(prev);
+  });
+
+  it("clamps revealed at target.length — never overshoots", () => {
+    const s = computeNextState({
+      state: { revealed: 3.9, target: "done" },
+      fullText: "done",
+      deltaMs: 1000,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(s.revealed).toBe(4);
+  });
+
+  it("rewinds revealed when a new target doesn't extend the previous one", () => {
+    // Mid-drain on turn A: revealed=3 of "Hello world".
+    const midA: TypewriterState = { revealed: 3, target: "Hello world" };
+    // Turn B starts before A's drain finished — brand-new text arrives.
+    const next = computeNextState({
+      state: midA,
+      fullText: "Goodbye",
+      deltaMs: 16,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(next.target).toBe("Goodbye");
+    // revealed was reset to 0, then advanced by 16ms of accelerated drain.
+    // Lag = 7, rate = max(60, 7/0.2) = 60 (since 35 > 60 is false → 60 > 35).
+    // Actually lag=7 > allowedBuffer(12)? No, 7 < 12, so rate = 60.
+    // 16/1000 * 60 = 0.96 chars.
+    expect(next.revealed).toBeGreaterThanOrEqual(0);
+    expect(next.revealed).toBeLessThan(1.5);
+  });
+
+  it("keeps revealed when new fullText merely extends the latched target", () => {
+    // Mid-reveal of "Hello" with 3 chars shown so far.
+    const mid: TypewriterState = { revealed: 3, target: "Hello" };
+    // A text delta extends it to "Hello world".
+    const next = computeNextState({
+      state: mid,
+      fullText: "Hello world",
+      deltaMs: 16,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(next.target).toBe("Hello world");
+    // No rewind — revealed should grow from 3, not restart at 0.
+    expect(next.revealed).toBeGreaterThan(3);
+  });
+
+  it("idles at zero cost when already drained and target is stable", () => {
+    const drained: TypewriterState = { revealed: 5, target: "hello" };
+    const s = computeNextState({
+      state: drained,
+      fullText: "hello",
+      deltaMs: 16,
+      baseRate: 60,
+      maxLagMs: 200,
+    });
+    expect(s.revealed).toBe(5);
+    expect(s.target).toBe("hello");
+  });
+});
+
+describe("exported constants", () => {
+  it("exposes default base rate and max lag", () => {
+    expect(TYPEWRITER_BASE_RATE).toBe(60);
+    expect(TYPEWRITER_MAX_LAG_MS).toBe(200);
+  });
+});

--- a/src/ui/src/hooks/useTypewriter.ts
+++ b/src/ui/src/hooks/useTypewriter.ts
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from "react";
+
+export const TYPEWRITER_BASE_RATE = 60;
+export const TYPEWRITER_MAX_LAG_MS = 200;
+
+export interface UseTypewriterOptions {
+  /** Base reveal rate in chars/sec. Default 60. */
+  baseRate?: number;
+  /** Max lag in ms before we accelerate. Default 200. */
+  maxLagMs?: number;
+}
+
+export interface UseTypewriterResult {
+  /** The substring to render right now. */
+  displayed: string;
+  /** Whether to show the blinking caret. */
+  showCaret: boolean;
+}
+
+export interface TypewriterState {
+  /** Float accumulator — sub-character fractions are preserved across frames. */
+  revealed: number;
+  /** Latched target text; sticks at the last non-empty fullText seen. */
+  target: string;
+}
+
+export interface TickParams {
+  state: TypewriterState;
+  fullText: string;
+  deltaMs: number;
+  baseRate: number;
+  maxLagMs: number;
+}
+
+// Target latches at the highest-seen non-empty fullText so the hook can keep
+// draining after the source string clears (e.g. when streamingContent resets
+// but the just-added completed message is still hidden behind pendingTypewriter).
+export function computeNextState(params: TickParams): TypewriterState {
+  const { state, fullText, deltaMs, baseRate, maxLagMs } = params;
+  const target = fullText.length > 0 ? fullText : state.target;
+  // A new target that doesn't extend the previous one means the source
+  // restarted (e.g. next turn began before the prior drain finished) — rewind
+  // the reveal counter so we don't skip past the new text.
+  const revealed = target.startsWith(state.target) ? state.revealed : 0;
+  const lag = Math.max(0, target.length - revealed);
+  // Base rate covers small lag; larger lag drains within maxLagMs regardless.
+  const rate = Math.max(baseRate, lag / (maxLagMs / 1000));
+  const nextRevealed = Math.min(
+    target.length,
+    revealed + (deltaMs / 1000) * rate,
+  );
+  return { revealed: nextRevealed, target };
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * Reveal `fullText` one character at a time at a steady rate, with gentle
+ * acceleration when the source races ahead. Respects `prefers-reduced-motion`
+ * (returns the full text directly, no caret).
+ */
+export function useTypewriter(
+  fullText: string,
+  isStreaming: boolean,
+  opts?: UseTypewriterOptions,
+): UseTypewriterResult {
+  const baseRate = opts?.baseRate ?? TYPEWRITER_BASE_RATE;
+  const maxLagMs = opts?.maxLagMs ?? TYPEWRITER_MAX_LAG_MS;
+
+  const [reducedMotion, setReducedMotion] = useState<boolean>(
+    prefersReducedMotion,
+  );
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const listener = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener?.("change", listener);
+    return () => mq.removeEventListener?.("change", listener);
+  }, []);
+
+  const [displayedState, setDisplayed] = useState<string>("");
+  const [showCaretState, setShowCaret] = useState<boolean>(false);
+
+  const stateRef = useRef<TypewriterState>({ revealed: 0, target: "" });
+  const fullTextRef = useRef(fullText);
+  const isStreamingRef = useRef(isStreaming);
+  const rafRef = useRef<number | null>(null);
+  const lastTimeRef = useRef<number | null>(null);
+  const frameCountRef = useRef(0);
+
+  // Keep refs in sync with the latest props so the RAF loop (which reads refs,
+  // not captured values) always sees the current fullText/isStreaming.
+  useEffect(() => {
+    fullTextRef.current = fullText;
+    isStreamingRef.current = isStreaming;
+  });
+
+  useEffect(() => {
+    if (reducedMotion) return;
+    const tick = (now: number) => {
+      const last = lastTimeRef.current;
+      const deltaMs = last === null ? 0 : now - last;
+      lastTimeRef.current = now;
+
+      stateRef.current = computeNextState({
+        state: stateRef.current,
+        fullText: fullTextRef.current,
+        deltaMs,
+        baseRate,
+        maxLagMs,
+      });
+
+      // Advance math every frame; commit React state every other frame to keep
+      // markdown re-parse cost down.
+      frameCountRef.current += 1;
+      const floor = Math.floor(stateRef.current.revealed);
+      if (frameCountRef.current % 2 === 0) {
+        setDisplayed(stateRef.current.target.slice(0, floor));
+      }
+
+      const drained = floor >= stateRef.current.target.length;
+      setShowCaret(isStreamingRef.current || !drained);
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      lastTimeRef.current = null;
+    };
+  }, [reducedMotion, baseRate, maxLagMs]);
+
+  if (reducedMotion) {
+    return { displayed: fullText, showCaret: false };
+  }
+  return { displayed: displayedState, showCaret: showCaretState };
+}

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -97,6 +97,7 @@ interface AppState {
   addChatAttachments: (wsId: string, attachments: ChatAttachment[]) => void;
   streamingContent: Record<string, string>;
   streamingThinking: Record<string, string>;
+  pendingTypewriter: Record<string, { messageId: string; text: string } | null>;
   showThinkingBlocks: Record<string, boolean>;
   toolActivities: Record<string, ToolActivity[]>;
   completedTurns: Record<string, CompletedTurn[]>;
@@ -104,6 +105,8 @@ interface AppState {
   addChatMessage: (wsId: string, message: ChatMessage) => void;
   setStreamingContent: (wsId: string, content: string) => void;
   appendStreamingContent: (wsId: string, text: string) => void;
+  setPendingTypewriter: (wsId: string, messageId: string, text: string) => void;
+  clearPendingTypewriter: (wsId: string) => void;
   appendStreamingThinking: (wsId: string, text: string) => void;
   clearStreamingThinking: (wsId: string) => void;
   setShowThinkingBlocks: (wsId: string, show: boolean) => void;
@@ -471,6 +474,7 @@ export const useAppStore = create<AppState>((set) => ({
     })),
   streamingContent: {},
   streamingThinking: {},
+  pendingTypewriter: {},
   showThinkingBlocks: {},
   toolActivities: {},
   completedTurns: {},
@@ -496,6 +500,17 @@ export const useAppStore = create<AppState>((set) => ({
         ...s.streamingContent,
         [wsId]: (s.streamingContent[wsId] || "") + text,
       },
+    })),
+  setPendingTypewriter: (wsId, messageId, text) =>
+    set((s) => ({
+      pendingTypewriter: {
+        ...s.pendingTypewriter,
+        [wsId]: { messageId, text },
+      },
+    })),
+  clearPendingTypewriter: (wsId) =>
+    set((s) => ({
+      pendingTypewriter: { ...s.pendingTypewriter, [wsId]: null },
     })),
   appendStreamingThinking: (wsId, text) =>
     set((s) => ({


### PR DESCRIPTION
## Summary

Assistant responses now feel like they're being typed: a steady ~60 chars/sec reveal with a blinking caret, decoupled from the bursty `agent-stream` delta cadence. When the model runs ahead, reveal gently accelerates so lag stays within a 200 ms budget; when the stream ends with buffered text unread, the caret keeps draining instead of snapping to the full message. Respects `prefers-reduced-motion` (returns full text instantly, no caret).

- New `useTypewriter(fullText, isStreaming)` hook with a pure `computeNextState` for unit testing.
- `StreamingMessage` consumes the hook; caret + `aria-live="polite" aria-busy` wrapper added.
- Store gains a small `pendingTypewriter` slice so the just-added completed message stays hidden until the drain finishes (latch-and-hide).

```mermaid
flowchart LR
  A[agent-stream delta] --> B[streamingContent wsId]
  B --> C[useTypewriter fullText]
  C --> D[displayed prefix + caret]
  E[assistant event finalizes] -->|setPendingTypewriter before addChatMessage| F[pendingTypewriter wsId]
  F -.hides.-> G[just-added message]
  C -->|drain complete| H[clearPendingTypewriter]
  H --> G
```

## Complexity Notes

- **Latch-and-hide handoff.** `useAgentStream` sets `pendingTypewriter[wsId] = { messageId, text }` *before* calling `addChatMessage` + `setStreamingContent("")`. `MessagesWithTurns` filters out the message with that id while the drain runs; `StreamingMessage` clears the flag via effect when `!showCaret && !streaming`. Mis-ordering these would cause a duplicate render or a dropped tail.
- **Target latching inside the hook.** `computeNextState` keeps the last non-empty `fullText` as its target, so it can keep revealing after `streamingContent` clears. The reset guard `target.startsWith(state.target) ? state.revealed : 0` rewinds if a brand-new turn starts before the prior drain finishes — without it the next turn teleports past its first N characters.
- **Rate invariant.** `rate = max(baseRate, lag / (maxLagMs/1000))` guarantees "remaining buffer / current rate ≤ maxLagMs" at every tick, not "full drain within maxLagMs real time." Test `keeps lag-in-time bounded to maxLagMs at every tick` encodes exactly that.
- **Render cost lever.** Math advances every RAF (60 fps), but `setDisplayed` commits every other frame (~30 fps) to keep react-markdown re-parses cheap. Caret state is committed every frame since it doesn't trigger markdown work.

## Test Steps

1. `cd src/ui && bun install --frozen-lockfile && bun run test` — confirms the 10 new `computeNextState` tests pass (rate, acceleration, lag invariant, target latching, reset guard, clamp, idle).
2. `cd src/ui && bunx tsc --noEmit` — clean.
3. `cargo clippy --workspace --all-targets` — clean (no Rust changes).
4. `cargo tauri dev` → open a workspace → send a prompt to Claude and verify:
   - Text reveals at a steady pace with a blinking caret next to the last character.
   - If the model bursts (e.g. a long paragraph arrives in one delta), the reveal accelerates briefly but doesn't snap.
   - After the stream ends, the caret keeps typing the remainder, then disappears — message stays where it was, no flicker/jump when the "completed" message takes over.
   - Hit stop-generation mid-stream → drain finishes the already-received text, caret disappears, no leaked caret/duplicate bubble.
5. System Settings → Accessibility → Display → Reduce motion → back to Claudette → send a prompt → full text appears immediately, no caret.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a — user-facing behavior; no new APIs)