### PR TITLE
fix(site): use lowercase /claudette/ base path for internal URLs

### DIFF
--- a/site/src/components/CTASection.astro
+++ b/site/src/components/CTASection.astro
@@ -2,7 +2,7 @@
 ---
 
 <section class="cta-section">
-  <img src="/Claudette/mascot.png" alt="Claudette mascot" class="cta-mascot" />
+  <img src="/claudette/mascot.png" alt="Claudette mascot" class="cta-mascot" />
   <h2>Ready to meet your better half?</h2>
   <p>Claudette is free and open source. Download it, try it out, and join the community.</p>
   <div class="cta-buttons">

--- a/site/src/content/docs/features/git-worktrees.mdx
+++ b/site/src/content/docs/features/git-worktrees.mdx
@@ -23,7 +23,7 @@ When you archive a workspace, the worktree and its directory are cleaned up auto
 
 New workspace branches are given a random name initially. After your first prompt, the agent automatically renames the branch to something descriptive based on the work being done.
 
-You can configure branch naming behavior in [Settings > Git](/Claudette/features/settings/):
+You can configure branch naming behavior in [Settings > Git](/claudette/features/settings/):
 
 - **Username prefix**: branches are prefixed with your git username (e.g., `sean/add-health-check`)
 - **Custom prefix**: use your own prefix (e.g., `feature/`, `fix/`)

--- a/site/src/content/docs/features/integrated-terminal.mdx
+++ b/site/src/content/docs/features/integrated-terminal.mdx
@@ -24,8 +24,8 @@ Adjust the terminal font size in `Settings > Appearance > Terminal font size` (r
 
 ## Environment Variables
 
-Every terminal session has [workspace environment variables](/Claudette/features/settings/#environment-variables) set automatically — `$CLAUDETTE_WORKSPACE_NAME`, `$CLAUDETTE_WORKSPACE_PATH`, `$CLAUDETTE_ROOT_PATH`, and others. These are useful for scripts and tools that need to know which workspace they're running in.
+Every terminal session has [workspace environment variables](/claudette/features/settings/#environment-variables) set automatically — `$CLAUDETTE_WORKSPACE_NAME`, `$CLAUDETTE_WORKSPACE_PATH`, `$CLAUDETTE_ROOT_PATH`, and others. These are useful for scripts and tools that need to know which workspace they're running in.
 
 ## Shell Integration
 
-For enhanced terminal tracking — including command status indicators in the sidebar — see the [Shell Integration](/Claudette/features/shell-integration/) guide.
+For enhanced terminal tracking — including command status indicators in the sidebar — see the [Shell Integration](/claudette/features/shell-integration/) guide.

--- a/site/src/content/docs/features/per-repo-settings.mdx
+++ b/site/src/content/docs/features/per-repo-settings.mdx
@@ -26,7 +26,7 @@ python -m venv .venv && source .venv/bin/activate && pip install -r requirements
 mix deps.get && mix ecto.setup
 ```
 
-The script runs in the workspace's worktree directory using your default shell. [Workspace environment variables](/Claudette/features/settings/#environment-variables) like `$CLAUDETTE_WORKSPACE_NAME` and `$CLAUDETTE_ROOT_PATH` are available in setup scripts.
+The script runs in the workspace's worktree directory using your default shell. [Workspace environment variables](/claudette/features/settings/#environment-variables) like `$CLAUDETTE_WORKSPACE_NAME` and `$CLAUDETTE_ROOT_PATH` are available in setup scripts.
 
 ## Custom Instructions
 

--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -40,7 +40,7 @@ If the CLI isn't installed or authenticated, the SCM tab shows a helpful status 
 
 ## Auto-Archive on Merge
 
-Enable [**Settings > General > Archive on merge**](/Claudette/features/settings/#general) to automatically archive a workspace when its PR is detected as merged. The sidebar cleans itself up without manual intervention.
+Enable [**Settings > General > Archive on merge**](/claudette/features/settings/#general) to automatically archive a workspace when its PR is detected as merged. The sidebar cleans itself up without manual intervention.
 
 ## Custom Plugins
 

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -11,7 +11,7 @@ Open settings with `⌘/Ctrl + ,` or from the sidebar. Settings are organized in
 |---------|-------------|---------|
 | Worktree base directory | Directory where new workspaces are created | `~/.claudette/workspaces` |
 | System tray | Enable/disable system tray integration | Enabled |
-| Archive on merge | Automatically archive a workspace when its pull request is merged. See [SCM Providers](/Claudette/features/scm-providers/). | Off |
+| Archive on merge | Automatically archive a workspace when its pull request is merged. See [SCM Providers](/claudette/features/scm-providers/). | Off |
 
 ## Models
 
@@ -26,7 +26,7 @@ Default values applied to all new agent sessions. Per-workspace overrides are av
 | Default plan mode | Start new sessions in plan mode | Off |
 | Default fast mode | Start new sessions in fast mode | Off |
 
-See [Agent Configuration](/Claudette/features/agent-configuration/) for detailed descriptions of each option.
+See [Agent Configuration](/claudette/features/agent-configuration/) for detailed descriptions of each option.
 
 ## Appearance
 
@@ -35,7 +35,7 @@ See [Agent Configuration](/Claudette/features/agent-configuration/) for detailed
 | Theme | Color theme (12 built-in + custom) | Default Dark |
 | Terminal font size | Font size for terminal tabs (8–24px) | 11px |
 
-See [Theming](/Claudette/features/theming/) for details on built-in themes and creating custom themes.
+See [Theming](/claudette/features/theming/) for details on built-in themes and creating custom themes.
 
 ## Notifications
 
@@ -84,7 +84,7 @@ When enabled, archiving a workspace deletes the local branch — but only if the
 
 ## Repository
 
-Per-repository settings are documented in [Per-Repo Settings](/Claudette/features/per-repo-settings/).
+Per-repository settings are documented in [Per-Repo Settings](/claudette/features/per-repo-settings/).
 
 ## Environment Variables
 
@@ -99,4 +99,4 @@ Claudette sets the following `CLAUDETTE_*` environment variables in every subpro
 | `CLAUDETTE_DEFAULT_BRANCH` | Default branch name | `main` |
 | `CLAUDETTE_BRANCH_NAME` | Workspace branch name | `sean/fix-auth-bug` |
 
-These are useful in [setup scripts](/Claudette/features/per-repo-settings/#setup-script), [notification commands](#notification-command), and any tools you run in the [integrated terminal](/Claudette/features/integrated-terminal/).
+These are useful in [setup scripts](/claudette/features/per-repo-settings/#setup-script), [notification commands](#notification-command), and any tools you run in the [integrated terminal](/claudette/features/integrated-terminal/).

--- a/site/src/content/docs/getting-started/first-workspace.mdx
+++ b/site/src/content/docs/getting-started/first-workspace.mdx
@@ -60,6 +60,6 @@ From here you can:
 
 ## Next Steps
 
-- Learn about the [full workflow](/Claudette/getting-started/workflow/) for using Claudette day-to-day
-- Set up [per-repo settings](/Claudette/features/per-repo-settings/) like custom instructions and setup scripts
-- Explore [parallel agents](/Claudette/features/parallel-agents/) to work on multiple tasks at once
+- Learn about the [full workflow](/claudette/getting-started/workflow/) for using Claudette day-to-day
+- Set up [per-repo settings](/claudette/features/per-repo-settings/) like custom instructions and setup scripts
+- Explore [parallel agents](/claudette/features/parallel-agents/) to work on multiple tasks at once

--- a/site/src/content/docs/getting-started/workflow.mdx
+++ b/site/src/content/docs/getting-started/workflow.mdx
@@ -37,5 +37,5 @@ The integrated terminal (`⌘/Ctrl + `` ` ``) runs inside each workspace's workt
 
 - **Be specific** in your prompts — the more context you give, the better the output
 - **Use plan mode** (`Shift + Tab`) for complex tasks — the agent will outline its approach before writing code
-- **Set up a setup script** in [repo settings](/Claudette/features/per-repo-settings/) so each new workspace starts with dependencies installed
+- **Set up a setup script** in [repo settings](/claudette/features/per-repo-settings/) so each new workspace starts with dependencies installed
 - **Use @-mentions** to reference specific files in your prompt (type `@` and start typing a filename)

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
       variant: minimal
       icon: github
     - text: Read the Docs
-      link: /Claudette/getting-started/installation/
+      link: /claudette/getting-started/installation/
       variant: secondary
 ---
 

--- a/site/src/content/docs/privacy.mdx
+++ b/site/src/content/docs/privacy.mdx
@@ -42,7 +42,7 @@ This database contains workspace names, chat messages, and settings — all stor
 
 ## Remote Workspaces
 
-The optional [remote workspaces](/Claudette/features/remote-workspaces/) feature connects to servers **you** set up and control. Claudette never routes traffic through our infrastructure. The connection is:
+The optional [remote workspaces](/claudette/features/remote-workspaces/) feature connects to servers **you** set up and control. Claudette never routes traffic through our infrastructure. The connection is:
 
 - **End-to-end encrypted** with TLS
 - **Authenticated** with trust-on-first-use certificate pinning

--- a/site/src/content/docs/quickstart/index.mdx
+++ b/site/src/content/docs/quickstart/index.mdx
@@ -11,12 +11,12 @@ These guides show how to configure Claudette for popular frameworks. Each guide 
 
 | Framework | Package Manager | Guide |
 |-----------|----------------|-------|
-| Django | pip | [Django & pip](/Claudette/quickstart/django/) |
-| Next.js | npm | [Next.js & npm](/Claudette/quickstart/nextjs/) |
-| Phoenix | mix | [Phoenix & mix](/Claudette/quickstart/phoenix/) |
-| Rails | bundler | [Rails & bundler](/Claudette/quickstart/rails/) |
-| Hono | bun | [Hono & bun](/Claudette/quickstart/hono/) |
-| FastAPI | uv | [FastAPI & uv](/Claudette/quickstart/fastapi/) |
+| Django | pip | [Django & pip](/claudette/quickstart/django/) |
+| Next.js | npm | [Next.js & npm](/claudette/quickstart/nextjs/) |
+| Phoenix | mix | [Phoenix & mix](/claudette/quickstart/phoenix/) |
+| Rails | bundler | [Rails & bundler](/claudette/quickstart/rails/) |
+| Hono | bun | [Hono & bun](/claudette/quickstart/hono/) |
+| FastAPI | uv | [FastAPI & uv](/claudette/quickstart/fastapi/) |
 
 ## The Pattern
 
@@ -27,4 +27,4 @@ Every quickstart follows the same pattern:
 3. Create a workspace — the setup script runs automatically
 4. Start prompting the agent
 
-The `.claudette.json` file tells Claudette how to bootstrap each workspace. See [Per-Repo Settings](/Claudette/features/per-repo-settings/) for the full schema.
+The `.claudette.json` file tells Claudette how to bootstrap each workspace. See [Per-Repo Settings](/claudette/features/per-repo-settings/) for the full schema.


### PR DESCRIPTION
## Summary

The Astro `base` config is `/claudette` (lowercase), but several absolute paths in `site/` were hardcoded as `/Claudette/`. Local dev tolerated the mismatch (case-insensitive macOS filesystem + forgiving local server) but GitHub Pages serves from a case-sensitive Linux filesystem and returned 404s. The most visible symptom was the mascot image failing to load in `CTASection` near the bottom of the homepage.

This PR lowercases every internal `/Claudette/` → `/claudette/`. External `github.com/utensils/Claudette/` repo URLs are untouched (the repo name itself is unchanged on those links, even though the repo now canonically redirects to lowercase).

**Affected paths:**
- `site/src/components/CTASection.astro` — the mascot `<img src>`
- 10 MDX docs files with broken internal links (settings, scm-providers, quickstart, etc.)

## Complexity Notes

- Used surgical patterns (`](/Claudette/` for markdown links, `src="/Claudette/` for attributes, `link: /Claudette/` for YAML frontmatter) rather than a blind find/replace, because `github.com/utensils/Claudette/` contains `/Claudette/` as a substring and must not be rewritten.
- A follow-up worth considering: drop hardcoded absolute paths entirely. Components can use `` `${import.meta.env.BASE_URL}mascot.png` `` and MDX can use relative slugs (`[Settings](../settings/)`) so the `base` is applied automatically. That would make this class of bug impossible to reintroduce.

## Test Steps

1. `cd site && bun install && bun run build` — should complete with 26 pages built, no errors.
2. `cd site && bun run preview` and visit `http://localhost:4321/claudette/` — scroll to the CTA section at the bottom; mascot image should render.
3. Click through a few internal links (e.g., the "Read the Docs" hero CTA on the homepage, the "Per-Repo Settings" link from the Quickstart index) — all should resolve without 404.
4. After merge, confirm `https://utensils.github.io/claudette/` homepage shows the mascot in the CTA section, and navigate a few doc-to-doc links.

## Checklist

- [x] Tests added/updated — N/A (docs-site content fix; `bun run build` is the CI validation and passes)
- [x] Documentation updated — this change _is_ the documentation fix