### PR TITLE
feat(ci): add nightly build workflow for continuous pre-release artifacts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   compute-version:
     name: Compute Version
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,213 @@
+name: Nightly Build
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "site/**"
+      - "docs/**"
+      - "**/*.md"
+      - ".github/workflows/deploy-site.yml"
+      - ".github/workflows/conventional-commits.yml"
+      - ".github/workflows/update-frontend-hash.yml"
+      - ".github/workflows/release-please.yml"
+      - ".release-please-manifest.json"
+      - "CHANGELOG.md"
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  compute-version:
+    name: Compute Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      short_sha: ${{ steps.v.outputs.short_sha }}
+      last_tag: ${{ steps.v.outputs.last_tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: v
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          IFS='.' read -r MAJ MIN _ <<< "$CURRENT"
+          NEXT_MINOR="${MAJ}.$((MIN + 1)).0"
+
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMITS=$(git rev-list --count "${LAST_TAG}..HEAD")
+          else
+            COMMITS=$(git rev-list --count HEAD)
+          fi
+
+          SHORT=$(git rev-parse --short=7 HEAD)
+          VERSION="${NEXT_MINOR}-dev.${COMMITS}.${SHORT}"
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT}" >> "$GITHUB_OUTPUT"
+          echo "last_tag=${LAST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Computed nightly version: ${VERSION}"
+
+  prepare-release:
+    name: Prepare Release
+    needs: compute-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Reset nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          LAST_TAG: ${{ needs.compute-version.outputs.last_tag }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+          NOTES="Automated nightly build of \`${GITHUB_SHA}\`.
+
+          **Version:** \`${VERSION}\`
+          **Built:** $(date -u +%FT%TZ)"
+
+          if [ -n "$LAST_TAG" ]; then
+            DIFF_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${LAST_TAG}...${GITHUB_SHA}"
+            NOTES="${NOTES}
+          [Changes since ${LAST_TAG}](${DIFF_URL})"
+          fi
+
+          NOTES="${NOTES}
+
+          > **These builds are unstable pre-releases.** See [nightly-builds.md](https://github.com/${GITHUB_REPOSITORY}/blob/main/docs/nightly-builds.md)."
+
+          gh release create nightly \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly ${VERSION}" \
+            --notes "$NOTES" \
+            --prerelease \
+            --draft
+
+  build:
+    needs: [compute-version, prepare-release]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            rust-target: aarch64-apple-darwin
+            bundles: app,dmg
+            label: macos-aarch64
+          - platform: macos-15-intel
+            rust-target: x86_64-apple-darwin
+            bundles: app,dmg
+            label: macos-x86_64
+          - platform: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-gnu
+            bundles: appimage,deb
+            label: linux-x86_64
+
+    name: Build (${{ matrix.label }})
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Stamp nightly version
+        shell: bash
+        env:
+          NIGHTLY_VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' Cargo.toml
+          perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' src-tauri/Cargo.toml
+          perl -i -pe 's/^version\s*=\s*"[^"]+"/version = "$ENV{NIGHTLY_VERSION}"/' src-server/Cargo.toml
+          grep '^version' Cargo.toml src-tauri/Cargo.toml src-server/Cargo.toml
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+          targets: ${{ matrix.rust-target }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: nightly-${{ matrix.label }}
+
+      - name: Install Linux system dependencies
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "latest"
+
+      - name: Install frontend dependencies
+        run: cd src/ui && bun install --frozen-lockfile
+
+      - name: Generate icons
+        run: npx @tauri-apps/cli icon assets/logo.png
+
+      - name: Build and upload desktop app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ runner.os == 'macOS' && secrets.APPLE_SIGNING_IDENTITY || '' }}
+          APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
+          APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
+        with:
+          tagName: nightly
+          releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
+          releaseDraft: true
+          prerelease: true
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      - name: Build headless server
+        run: cargo build --release -p claudette-server --target ${{ matrix.rust-target }}
+
+      - name: Upload headless server binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BIN="target/${{ matrix.rust-target }}/release/claudette-server"
+          ASSET="claudette-server-${{ matrix.label }}"
+          cp "$BIN" "$ASSET"
+          gh release upload nightly "$ASSET" --clobber
+
+  # Nightly builds are not announced to Discord — too noisy. Stable releases only.
+  publish:
+    name: Publish Nightly
+    needs: build
+    if: always() && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Un-draft the nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit nightly --draft=false --prerelease --repo "$GITHUB_REPOSITORY"

--- a/docs/nightly-builds.md
+++ b/docs/nightly-builds.md
@@ -66,6 +66,6 @@ If a build fails mid-way, the previous nightly release is already deleted. Users
 
 **"Old nightly download link returns 404"** — Expected. The rolling tag was updated by a newer build. Use the `nightly` tag URL above to always get the latest.
 
-**"App won't auto-update from nightly to stable"** — The Tauri updater only offers upgrades within the configured channel. To switch back to stable, download and install the stable release manually.
+**"App won't auto-update from nightly to stable"** — Stable and nightly use different updater manifests, and a nightly build may also compare higher than the current stable release (for example, `0.14.0-dev.*` is higher than any `0.13.*` stable). In that case, the stable feed will not appear as an upgrade. To switch back to stable, download and install the stable release manually.
 
 **"Version looks wrong / shows old version"** — The version is computed from the `Cargo.toml` version on `main` at build time. If release-please hasn't merged a version bump yet, the "next minor" component may look stale. The commit SHA in the version string is always accurate.

--- a/docs/nightly-builds.md
+++ b/docs/nightly-builds.md
@@ -1,0 +1,71 @@
+# Nightly Builds
+
+Nightly builds are pre-release artifacts automatically built from every push to `main`. They are fully signed and notarized — identical pipeline to stable releases, just more frequent and less tested.
+
+## Version scheme
+
+Nightly versions follow the pattern:
+
+```
+<next-minor>-dev.<commits-since-last-release>.<short-sha>
+```
+
+For example, if `Cargo.toml` on `main` reads `0.12.0` and there have been 42 commits since the last release tag:
+
+```
+0.13.0-dev.42.a1b2c3d
+```
+
+This is valid SemVer with pre-release identifiers. It sorts **higher** than `0.12.0` and **lower** than `0.13.0`, which is the correct behavior for the Tauri updater.
+
+> **Note:** Immediately after a release-please version bump (e.g., `0.12.0` → `0.13.0`), the nightly version jumps to `0.14.0-dev.N.SHA`. This is expected — the "next minor" is always one above whatever version is in `Cargo.toml` at build time.
+
+## Download
+
+Nightly artifacts are published to a single rolling GitHub Release:
+
+**<https://github.com/utensils/Claudette/releases/tag/nightly>**
+
+Available artifacts per platform:
+
+| Platform | Artifacts |
+|---|---|
+| macOS (Apple Silicon) | `.dmg`, `.app.tar.gz` |
+| macOS (Intel) | `.dmg`, `.app.tar.gz` |
+| Linux (x86_64) | `.AppImage`, `.deb` |
+
+The `claudette-server` headless binary is also available for each platform.
+
+## Updater channel
+
+The default in-app updater checks the **stable** channel (`releases/latest/download/latest.json`). Nightly builds produce their own updater manifest at:
+
+```
+https://github.com/utensils/Claudette/releases/download/nightly/latest.json
+```
+
+A future update (see [#282](https://github.com/utensils/Claudette/issues/282)) will add an in-app toggle to switch between stable and nightly update channels.
+
+## When they run
+
+- **Automatically** on every push to `main` that changes code (docs-only and site-only changes are skipped).
+- **Manually** via `workflow_dispatch` from the GitHub Actions UI.
+- Rapid consecutive pushes are coalesced — only the most recent push builds.
+
+## Rolling tag semantics
+
+The `nightly` tag and release are **deleted and recreated** on every successful build. This means:
+
+- The `nightly` tag always points to the most recent successful build.
+- Old nightly download URLs will 404 after the next build replaces them.
+- To reference a specific nightly build, record the **commit SHA** from the release body — not the tag.
+
+If a build fails mid-way, the previous nightly release is already deleted. Users will see no nightly available until the next successful build. This is expected behavior for a pre-release channel.
+
+## Troubleshooting
+
+**"Old nightly download link returns 404"** — Expected. The rolling tag was updated by a newer build. Use the `nightly` tag URL above to always get the latest.
+
+**"App won't auto-update from nightly to stable"** — The Tauri updater only offers upgrades within the configured channel. To switch back to stable, download and install the stable release manually.
+
+**"Version looks wrong / shows old version"** — The version is computed from the `Cargo.toml` version on `main` at build time. If release-please hasn't merged a version bump yet, the "next minor" component may look stale. The commit SHA in the version string is always accurate.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds, signs, notarizes, and publishes Claudette on every push to `main`, producing pre-release artifacts at a rolling `nightly` GitHub Release tag. This gives early adopters and contributors access to the latest builds without building from source.

```mermaid
graph LR
    A[Push to main] --> B[compute-version]
    B --> C[prepare-release]
    C --> D1[Build macOS aarch64]
    C --> D2[Build macOS x86_64]
    C --> D3[Build Linux x86_64]
    D1 --> E[publish]
    D2 --> E
    D3 --> E
    E --> F["nightly release<br/>(pre-release, public)"]
```

**Key design decisions:**
- **Version scheme**: `<next-minor>-dev.<commits>.<sha>` (e.g., `0.13.0-dev.9.55a8ec2`) — valid SemVer pre-release that Cargo accepts and Tauri's updater compares correctly
- **Rolling tag**: the `nightly` release is deleted and recreated each run (draft → build → un-draft)
- **Build matrix**: mirrors `release-please.yml` exactly — same runners, Rust 1.94, signing secrets, Apple notarization
- **Version stamping**: all 3 workspace `Cargo.toml` files patched at runtime via `perl -i -pe` with `$ENV{}` (cross-platform safe, never committed)
- **Concurrency**: `cancel-in-progress: true` coalesces rapid pushes
- **Path filtering**: skips docs-only and site-only changes
- **No Discord**: nightly notifications would be too noisy

Companion issue #282 will add the app-side update channel toggle.

## Complexity Notes

- The `prepare-release` job deletes the previous nightly before builds start. If a run is cancelled mid-build, users see no nightly until the next successful run — acceptable for a pre-release channel.
- After a release-please version bump (e.g., `0.12.0` → `0.13.0`), the nightly version jumps to `0.14.0-dev.N.SHA`. This is expected and documented.

## Test Steps

1. **YAML validation**: Verify the workflow YAML parses correctly (no syntax errors in the Actions tab after merge)
2. **Manual trigger**: After merge, run `workflow_dispatch` from the GitHub Actions UI on `main`
3. **Version check**: Confirm the computed version in the "Compute Version" job logs matches the `<next-minor>-dev.<N>.<sha>` pattern
4. **Version stamp**: Confirm the "Stamp nightly version" step logs show all 3 `Cargo.toml` files updated
5. **Release artifacts**: After all builds complete, verify:
   - A `nightly` release exists at https://github.com/utensils/Claudette/releases/tag/nightly
   - It is marked as pre-release
   - DMG (×2), AppImage, deb, and `claudette-server` binaries (×3) are attached
   - `latest.json` updater manifest is attached with entries for all platforms
6. **Re-trigger**: Push another commit or re-run `workflow_dispatch` and confirm the rolling tag updates cleanly

## Checklist

- [ ] Tests added/updated — N/A (CI-only changes, no application code modified)
- [x] Documentation updated — `docs/nightly-builds.md` added

Closes #281