### PR TITLE
feat(scm): auto-archive notifications and per-repo settings

### DIFF
--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -525,8 +525,10 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
         loop {
             let app_state = handle.state::<AppState>();
 
-            // All DB reads for this poll cycle in one block
-            let (workspace_ids, archive_on_merge) = {
+            // All DB reads for this poll cycle in one block.
+            // Collect workspace IDs with their repo IDs so we can resolve
+            // per-repo archive_on_merge overrides after polling.
+            let (workspace_ids, global_archive, per_repo_archive) = {
                 let db = match Database::open(&app_state.db_path) {
                     Ok(db) => db,
                     Err(_) => {
@@ -534,47 +536,69 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
                         continue;
                     }
                 };
-                let ids: Vec<String> = db
+                let active: Vec<(String, String)> = db
                     .list_workspaces()
                     .unwrap_or_default()
                     .into_iter()
                     .filter(|ws| ws.status == claudette::model::WorkspaceStatus::Active)
-                    .map(|ws| ws.id)
+                    .map(|ws| (ws.id, ws.repository_id))
                     .collect();
-                let merge_setting = db
+                let global = db
                     .get_app_setting("archive_on_merge")
                     .ok()
                     .flatten()
                     .as_deref()
                     == Some("true");
-                (ids, merge_setting)
+                let repo_ids: std::collections::HashSet<&str> =
+                    active.iter().map(|(_, rid)| rid.as_str()).collect();
+                let per_repo: std::collections::HashMap<String, bool> = repo_ids
+                    .into_iter()
+                    .filter_map(|rid| {
+                        let key = format!("repo:{rid}:archive_on_merge");
+                        let val = db.get_app_setting(&key).ok().flatten()?;
+                        if val.is_empty() {
+                            return None;
+                        }
+                        Some((rid.to_string(), val == "true"))
+                    })
+                    .collect();
+                (active, global, per_repo)
             };
 
             // Poll all workspaces concurrently. The semaphore inside
             // poll_workspace_scm limits actual CLI invocations to 4 at a time.
-            let results: Vec<(String, Option<ScmDetail>)> = stream::iter(workspace_ids)
-                .map(|ws_id| {
+            let results: Vec<((String, String), Option<ScmDetail>)> = stream::iter(workspace_ids)
+                .map(|(ws_id, repo_id)| {
                     let state = &*app_state;
                     async move {
                         let detail = poll_workspace_scm(state, &ws_id).await;
-                        (ws_id, detail)
+                        ((ws_id, repo_id), detail)
                     }
                 })
                 .buffer_unordered(8)
                 .collect()
                 .await;
 
-            for (ws_id, detail) in results {
+            for ((ws_id, repo_id), detail) in results {
                 if let Some(detail) = detail {
                     let _ = handle.emit("scm-data-updated", &detail);
 
-                    if archive_on_merge
+                    let should_archive = per_repo_archive
+                        .get(&repo_id)
+                        .copied()
+                        .unwrap_or(global_archive);
+
+                    if should_archive
                         && detail.pull_request.as_ref().is_some_and(|pr| {
                             pr.state == claudette::scm_provider::scm::PrState::Merged
                         })
                     {
                         eprintln!("[scm] PR merged for workspace {} — auto-archiving", ws_id);
-                        auto_archive_workspace(&handle, &app_state, &ws_id).await;
+                        let pr_info = detail
+                            .pull_request
+                            .as_ref()
+                            .map(|pr| (pr.number, pr.title.clone()));
+                        auto_archive_workspace(&handle, &app_state, &ws_id, pr_info).await;
                     }
                 }
             }
@@ -593,9 +617,10 @@ async fn auto_archive_workspace(
     handle: &tauri::AppHandle,
     app_state: &AppState,
     workspace_id: &str,
+    pr_info: Option<(u64, String)>,
 ) {
     // All DB work in a block (Database is not Send — must not hold across .await)
-    let archive_info: Option<(String, String, Option<String>, Option<String>)> = {
+    let archive_info: Option<(String, String, Option<String>, Option<String>, String)> = {
         let db = match Database::open(&app_state.db_path) {
             Ok(db) => db,
             Err(e) => {
@@ -618,6 +643,12 @@ async fn auto_archive_workspace(
             .flatten()
             .map(|r| r.path);
 
+        let sound = db
+            .get_app_setting("notification_sound")
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| "Default".to_string());
+
         // Update DB status
         let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
         let _ = db.update_workspace_status(
@@ -631,10 +662,11 @@ async fn auto_archive_workspace(
             ws.name.clone(),
             ws.worktree_path.clone(),
             repo_path,
+            sound,
         ))
     };
 
-    let Some((ws_id, ws_name, wt_path, repo_path)) = archive_info else {
+    let Some((ws_id, ws_name, wt_path, repo_path, sound)) = archive_info else {
         return;
     };
 
@@ -655,11 +687,22 @@ async fn auto_archive_workspace(
 
     // Rebuild tray and notify frontend
     crate::tray::rebuild_tray(handle);
+
+    let pr_number = pr_info.as_ref().map(|(n, _)| *n);
+    let body = match &pr_info {
+        Some((num, _)) => {
+            format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR #{num} merged")
+        }
+        None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
+    };
+    crate::tray::send_notification(handle, "", "Claudette", &body, &sound);
+
     let _ = handle.emit(
         "workspace-auto-archived",
         serde_json::json!({
             "workspace_id": ws_id,
             "workspace_name": ws_name,
+            "pr_number": pr_number,
         }),
     );
     eprintln!("[scm] Auto-archived workspace '{ws_name}' ({ws_id})");

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -594,11 +594,8 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
                         })
                     {
                         eprintln!("[scm] PR merged for workspace {} — auto-archiving", ws_id);
-                        let pr_info = detail
-                            .pull_request
-                            .as_ref()
-                            .map(|pr| (pr.number, pr.title.clone()));
-                        auto_archive_workspace(&handle, &app_state, &ws_id, pr_info).await;
+                        let pr_number = detail.pull_request.as_ref().map(|pr| pr.number);
+                        auto_archive_workspace(&handle, &app_state, &ws_id, pr_number).await;
                     }
                 }
             }
@@ -617,7 +614,7 @@ async fn auto_archive_workspace(
     handle: &tauri::AppHandle,
     app_state: &AppState,
     workspace_id: &str,
-    pr_info: Option<(u64, String)>,
+    pr_number: Option<u64>,
 ) {
     // All DB work in a block (Database is not Send — must not hold across .await)
     let archive_info: Option<(String, String, Option<String>, Option<String>, String)> = {
@@ -643,10 +640,18 @@ async fn auto_archive_workspace(
             .flatten()
             .map(|r| r.path);
 
+        // Match the legacy fallback chain from notify_attention in tray.rs:
+        // notification_sound → audio_notifications=false → "Default"
         let sound = db
             .get_app_setting("notification_sound")
             .ok()
             .flatten()
+            .or_else(
+                || match db.get_app_setting("audio_notifications").ok().flatten() {
+                    Some(v) if v == "false" => Some("None".to_string()),
+                    _ => None,
+                },
+            )
             .unwrap_or_else(|| "Default".to_string());
 
         // Update DB status
@@ -688,22 +693,21 @@ async fn auto_archive_workspace(
     // Rebuild tray and notify frontend
     crate::tray::rebuild_tray(handle);
 
-    let pr_number = pr_info.as_ref().map(|(n, _)| *n);
-    let body = match &pr_info {
-        Some((num, _)) => {
+    let body = match pr_number {
+        Some(num) => {
             format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR #{num} merged")
         }
         None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
     };
     crate::tray::send_notification(handle, "", "Claudette", &body, &sound);
 
-    let _ = handle.emit(
-        "workspace-auto-archived",
-        serde_json::json!({
-            "workspace_id": ws_id,
-            "workspace_name": ws_name,
-            "pr_number": pr_number,
-        }),
-    );
+    let mut payload = serde_json::json!({
+        "workspace_id": ws_id,
+        "workspace_name": ws_name,
+    });
+    if let Some(num) = pr_number {
+        payload["pr_number"] = serde_json::json!(num);
+    }
+    let _ = handle.emit("workspace-auto-archived", payload);
     eprintln!("[scm] Auto-archived workspace '{ws_name}' ({ws_id})");
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -543,7 +543,13 @@ fn build_tray_menu_with_db(app: &AppHandle, db: &Database) -> Result<Menu<tauri:
     Menu::with_items(app, &item_refs).map_err(|e| e.to_string())
 }
 
-fn send_notification(app: &AppHandle, workspace_id: &str, title: &str, body: &str, sound: &str) {
+pub(crate) fn send_notification(
+    app: &AppHandle,
+    workspace_id: &str,
+    title: &str,
+    body: &str,
+    sound: &str,
+) {
     // On macOS, use mac-notification-sys directly so we can block for the
     // click response. When the user clicks the notification, show the window
     // and navigate to the session — even if the window was hidden (close-to-tray).

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -582,7 +582,9 @@ pub(crate) fn send_notification(
                 )
             {
                 show_and_focus(&app_clone);
-                let _ = app_clone.emit("tray-select-workspace", ws_id);
+                if !ws_id.is_empty() {
+                    let _ = app_clone.emit("tray-select-workspace", ws_id);
+                }
             }
         });
     }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -206,14 +206,17 @@ function App() {
     });
 
     // Listen for workspace auto-archived events (e.g. PR merged with archive_on_merge).
-    const unlistenAutoArchived = listen<{ workspace_id: string; workspace_name: string }>("workspace-auto-archived", (event) => {
-      const { workspace_id } = event.payload;
+    const unlistenAutoArchived = listen<{ workspace_id: string; workspace_name: string; pr_number?: number }>("workspace-auto-archived", (event) => {
+      const { workspace_id, workspace_name, pr_number } = event.payload;
       const store = useAppStore.getState();
       store.updateWorkspace(workspace_id, { status: "Archived" as const });
-      // If the archived workspace was selected, deselect it
       if (store.selectedWorkspaceId === workspace_id) {
         store.selectWorkspace(null);
       }
+      const msg = pr_number
+        ? `Workspace \u201c${workspace_name}\u201d archived \u2014 PR #${pr_number} merged`
+        : `Workspace \u201c${workspace_name}\u201d archived \u2014 PR merged`;
+      store.addToast(msg);
     });
 
     return () => {

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -213,7 +213,7 @@ function App() {
       if (store.selectedWorkspaceId === workspace_id) {
         store.selectWorkspace(null);
       }
-      const msg = pr_number
+      const msg = pr_number != null
         ? `Workspace \u201c${workspace_name}\u201d archived \u2014 PR #${pr_number} merged`
         : `Workspace \u201c${workspace_name}\u201d archived \u2014 PR merged`;
       store.addToast(msg);

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -11,6 +11,7 @@ import { Dashboard } from "./Dashboard";
 import { ModalRouter } from "../modals/ModalRouter";
 import { SettingsPage } from "../settings/SettingsPage";
 import { ResizeHandle } from "./ResizeHandle";
+import { ToastContainer } from "./Toast";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useBranchRefresh } from "../../hooks/useBranchRefresh";
 import { useAutoUpdater } from "../../hooks/useAutoUpdater";
@@ -165,6 +166,7 @@ export function AppLayout() {
       <ModalRouter />
       {fuzzyFinderOpen && <FuzzyFinder />}
       {commandPaletteOpen && <CommandPalette />}
+      <ToastContainer />
     </div>
   );
 }

--- a/src/ui/src/components/layout/Toast.module.css
+++ b/src/ui/src/components/layout/Toast.module.css
@@ -1,0 +1,57 @@
+.container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--selected-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  font-size: 12px;
+  color: var(--text-primary);
+  pointer-events: auto;
+  animation: toastIn 0.2s ease;
+  max-width: 360px;
+}
+
+.message {
+  flex: 1;
+  min-width: 0;
+}
+
+.dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.dismiss:hover {
+  color: var(--text-primary);
+}
+
+@keyframes toastIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/ui/src/components/layout/Toast.tsx
+++ b/src/ui/src/components/layout/Toast.tsx
@@ -1,0 +1,26 @@
+import { useAppStore } from "../../stores/useAppStore";
+import styles from "./Toast.module.css";
+
+export function ToastContainer() {
+  const toasts = useAppStore((s) => s.toasts);
+  const removeToast = useAppStore((s) => s.removeToast);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className={styles.container}>
+      {toasts.map((t) => (
+        <div key={t.id} className={styles.toast}>
+          <span className={styles.message}>{t.message}</span>
+          <button
+            className={styles.dismiss}
+            onClick={() => removeToast(t.id)}
+            aria-label="Dismiss"
+          >
+            &times;
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/src/components/layout/Toast.tsx
+++ b/src/ui/src/components/layout/Toast.tsx
@@ -8,7 +8,7 @@ export function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} role="status" aria-live="polite" aria-atomic="false">
       {toasts.map((t) => (
         <div key={t.id} className={styles.toast}>
           <span className={styles.message}>{t.message}</span>

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
-import { updateRepositorySettings, getRepoConfig } from "../../../services/tauri";
+import { updateRepositorySettings, getRepoConfig, getAppSetting, setAppSetting } from "../../../services/tauri";
 import {
   loadRepositoryMcps,
   detectMcpServers,
@@ -45,6 +45,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const [error, setError] = useState<string | null>(null);
   const [repoConfig, setRepoConfig] = useState<RepoConfigInfo | null>(null);
   const [mcpServers, setMcpServers] = useState<SavedMcpServer[]>([]);
+  const [archiveOnMerge, setArchiveOnMerge] = useState<"inherit" | "true" | "false">("inherit");
   const iconPopoverRef = useRef<HTMLDivElement>(null);
 
   // Reset local state only when switching to a different repo
@@ -64,6 +65,16 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
     getRepoConfig(repoId)
       .then(setRepoConfig)
       .catch(() => setRepoConfig(null));
+  }, [repoId]);
+
+  useEffect(() => {
+    getAppSetting(`repo:${repoId}:archive_on_merge`)
+      .then((val) => {
+        if (val === "true") setArchiveOnMerge("true");
+        else if (val === "false") setArchiveOnMerge("false");
+        else setArchiveOnMerge("inherit");
+      })
+      .catch(() => setArchiveOnMerge("inherit"));
   }, [repoId]);
 
   const refreshMcpServers = useCallback(() => {
@@ -501,6 +512,41 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
               Refresh status
             </button>
           )}
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Archive on merge</div>
+          <div className={styles.settingDescription}>
+            Automatically archive workspaces when their PR is merged. Overrides
+            the global setting for this repository.
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <select
+            className={styles.select}
+            value={archiveOnMerge}
+            onChange={async (e) => {
+              const val = e.target.value as "inherit" | "true" | "false";
+              const prev = archiveOnMerge;
+              setArchiveOnMerge(val);
+              try {
+                setError(null);
+                await setAppSetting(
+                  `repo:${repoId}:archive_on_merge`,
+                  val === "inherit" ? "" : val,
+                );
+              } catch (err) {
+                setArchiveOnMerge(prev);
+                setError(String(err));
+              }
+            }}
+          >
+            <option value="inherit">Use global default</option>
+            <option value="true">Enabled</option>
+            <option value="false">Disabled</option>
+          </select>
         </div>
       </div>
 

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -57,6 +57,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
       setCustomInstructions(repo.custom_instructions ?? "");
       setBranchRenamePreferences(repo.branch_rename_preferences ?? "");
       setAutoRunSetup(repo.setup_script_auto_run ?? false);
+      setArchiveOnMerge("inherit");
       setError(null);
     }
   }, [repoId]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -175,6 +175,11 @@ interface AppState {
   markWorkspaceAsUnread: (wsId: string) => void;
   clearUnreadCompletion: (wsId: string) => void;
 
+  // -- Toasts --
+  toasts: { id: string; message: string }[];
+  addToast: (message: string) => void;
+  removeToast: (id: string) => void;
+
   // -- Permissions --
   permissionLevel: Record<string, PermissionLevel>;
   setPermissionLevel: (wsId: string, level: PermissionLevel) => void;
@@ -784,6 +789,18 @@ export const useAppStore = create<AppState>((set) => ({
       newSet.delete(wsId);
       return { unreadCompletions: newSet };
     }),
+
+  // -- Toasts --
+  toasts: [],
+  addToast: (message) => {
+    const id = crypto.randomUUID();
+    set((s) => ({ toasts: [...s.toasts, { id, message }] }));
+    setTimeout(() => {
+      set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+    }, 5000);
+  },
+  removeToast: (id) =>
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
 
   // -- Permissions --
   permissionLevel: {},

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -381,6 +381,8 @@ interface AppState {
   setSlashCommands: (wsId: string, cmds: SlashCommand[]) => void;
 }
 
+const toastTimers = new Map<string, number>();
+
 export const useAppStore = create<AppState>((set) => ({
   // -- Repositories --
   repositories: [],
@@ -795,12 +797,20 @@ export const useAppStore = create<AppState>((set) => ({
   addToast: (message) => {
     const id = crypto.randomUUID();
     set((s) => ({ toasts: [...s.toasts, { id, message }] }));
-    setTimeout(() => {
+    const handle = window.setTimeout(() => {
+      toastTimers.delete(id);
       set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
     }, 5000);
+    toastTimers.set(id, handle);
   },
-  removeToast: (id) =>
-    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+  removeToast: (id) => {
+    const handle = toastTimers.get(id);
+    if (handle != null) {
+      window.clearTimeout(handle);
+      toastTimers.delete(id);
+    }
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+  },
 
   // -- Permissions --
   permissionLevel: {},


### PR DESCRIPTION
## Summary

Completes the auto-archive-on-merge feature (#293). The core backend logic (polling, merge detection, workspace archival) and the global setting toggle already existed — this PR fills in the missing pieces:

- **Native system notification** when a workspace is auto-archived (e.g., "Workspace 'foo' archived — PR #123 merged"), using the existing `send_notification` infrastructure (macOS: `mac-notification-sys` with click-to-focus; Linux: `tauri-plugin-notification`)
- **In-app toast notification** so users actively working in the app also get visual feedback (auto-dismisses after 5 seconds)
- **Per-repository setting override** — each repo can be set to Enabled / Disabled / Use global default via a new select in repo settings. Uses the existing `repo:{id}:key` pattern in the `app_settings` table
- **PR number in notification text** — the `workspace-auto-archived` event payload now includes `pr_number` for richer notification messages

```mermaid
flowchart TD
    A[SCM Polling Loop - 30s] --> B{PR merged?}
    B -->|No| A
    B -->|Yes| C{Should archive?}
    C -->|Check per-repo setting| D{Per-repo override exists?}
    D -->|Yes| E[Use per-repo value]
    D -->|No| F[Use global setting]
    E --> G{Enabled?}
    F --> G
    G -->|No| A
    G -->|Yes| H[auto_archive_workspace]
    H --> I[Remove worktree + stop agent]
    I --> J[Send native notification]
    I --> K[Emit workspace-auto-archived event]
    K --> L[Frontend: update store + show toast]
```

## Complexity Notes

- `send_notification` was changed from `fn` to `pub(crate) fn` in `tray.rs` to allow `commands/scm.rs` to call it. On macOS, this function blocks a background thread waiting for click response — passing `""` as `workspace_id` means clicking the notification focuses the app without navigating to a (now-archived) workspace.
- The per-repo setting resolution happens in the polling loop's sync DB block. A `HashMap<String, bool>` collects only repos with explicit overrides; missing entries fall through to the global default via `unwrap_or(global_archive)`.

## Test Steps

1. **Global setting**: Settings → General → enable "Archive on merge". Create a workspace with a PR, merge the PR externally. Within 30 seconds, verify:
   - The workspace moves to the "Archived" filter in the sidebar
   - A native OS notification appears with the workspace name and PR number
   - An in-app toast appears (bottom-right) and auto-dismisses after 5 seconds
2. **Per-repo override**: Settings → [Repository] → set "Archive on merge" to "Disabled". Merge a PR for a workspace in that repo. Verify the workspace is **not** archived. Change it to "Enabled" and repeat — verify it **is** archived.
3. **Toast dismiss**: Click the × button on a toast — verify it disappears immediately.
4. **No PR workspace**: Verify workspaces without associated PRs are unaffected by the setting.

## Checklist

- [x] Tests pass (453 Rust, 486 frontend)
- [x] `cargo clippy` clean, `cargo fmt` clean, `tsc --noEmit` clean
- [ ] Manual testing of notification flow
- [ ] Documentation updated (if applicable) — no docs changes needed; feature is self-documenting via UI labels