### PR TITLE
fix(ui): remove stale macOS left padding from diff viewer header

### DIFF
--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -9,13 +9,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--sidebar-border);
+  padding: 10px 20px;
   background: var(--chat-header-bg);
-}
-
-[data-platform="mac"] .header {
-  padding-left: 78px;
+  border-bottom: 1px solid var(--divider);
+  box-shadow: var(--shadow-sm);
 }
 
 .headerLeft {


### PR DESCRIPTION
### Summary

The DiffViewer detail header (`← Back` + filename) still had the legacy macOS-only `padding-left: 78px` rule that was removed from `ChatPanel.module.css` in b1e6833. With Tauri's overlay titlebar, the `data-tauri-drag-region` already absorbs the traffic-light area, so the extra left padding just pushed content visually out of alignment with the chat header it swaps in for.

This PR:

1. Deletes the stale `[data-platform="mac"] .header { padding-left: 78px; }` block from `DiffViewer.module.css`.
2. Aligns the rest of the `.header` styling (`padding`, `border-bottom`, `box-shadow`) with `ChatPanel.module.css` so the two headers swap in place without visual drift when the user clicks Back.

Audited every other header in `src/ui/src/components/`:

| Component | File | Status |
|---|---|---|
| ChatPanel header | `chat/ChatPanel.module.css` | Already fixed in b1e6833 |
| Dashboard toolbar | `layout/Dashboard.module.css` | Already correct |
| **DiffViewer header** | `diff/DiffViewer.module.css` | **Fixed in this PR** |
| Sidebar / Settings | `sidebar/Sidebar.module.css`, `settings/Settings.module.css` | Use `padding-top: 38px` (correct) |
| RightSidebar tab bar | `right-sidebar/RightSidebar.module.css` | Already correct |

### Complexity Notes

None — pure CSS change, no logic touched. The Dashboard toolbar still lacks `box-shadow: var(--shadow-sm)` while ChatPanel and now DiffViewer have it. That's a pre-existing inconsistency I intentionally did not touch in this PR; flagging for awareness.

### Test Steps

1. Pull this branch and run `cargo tauri dev` on macOS.
2. Select a workspace that has uncommitted diff content.
3. Click into any file in the diff list — the `← Back` button should sit flush at the same left edge that the chat header repo/branch info sits at (no ~78px gap from the traffic lights).
4. Click `← Back` and confirm the chat header appears in the exact same horizontal position with no visual shift in border color, shadow, or padding.
5. Compare the two headers side-by-side in DevTools — both should report `padding: 10px 20px`, `border-bottom-color: var(--divider)`, `box-shadow: var(--shadow-sm)`.
6. Quick regression sweep on Linux (no `data-platform="mac"` selector applies anyway, so behavior should be unchanged) and on Dashboard / Sidebar / Settings (untouched).

### Checklist

- [ ] Tests added/updated — n/a, CSS-only change with no testable behavior in vitest
- [ ] Documentation updated — n/a