### PR TITLE
feat(sidebar): strengthen repo→workspace hierarchy with indent guide

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -176,10 +176,10 @@
 .repoName {
   flex: 1;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
   display: flex;
   align-items: center;
   gap: 6px;

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -118,7 +118,9 @@
 }
 
 .repoGroup {
-  margin-bottom: 4px;
+  /* Generous rhythm between groups — white space is the cheapest separator
+     and makes the sidebar scan as "paragraphs" of related workspaces. */
+  margin-bottom: 14px;
   touch-action: none;
   transition: opacity 0.15s ease;
 }
@@ -168,10 +170,16 @@
   transition: transform var(--transition-fast);
 }
 
+/* Repo names read as section-header labels, not primary destinations — the
+   workspaces under them are the interactive targets. Smaller, uppercase, and
+   tracked letter-spacing matches the existing WORKSPACES title treatment. */
 .repoName {
   flex: 1;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -280,11 +288,26 @@
   background: var(--hover-bg);
 }
 
+/* Indent guide — a thin hairline running through the workspace stack,
+   visually binding children to their parent repo. Rendered via ::before so
+   it stacks with the ::after selection accent without either overriding
+   the other on selected rows. Top/bottom at 0 so stacked items form a
+   continuous line. */
+.wsItem::before {
+  content: "";
+  position: absolute;
+  left: 16px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--divider);
+}
+
 .wsSelected {
   background: var(--selected-bg);
 }
 
-.wsSelected::before {
+.wsSelected::after {
   content: "";
   position: absolute;
   left: 12px;


### PR DESCRIPTION
## Summary

Tightens the visual hierarchy in the sidebar so workspaces read as the primary interactive targets and their parent repos read as section-header labels.

- **Repo names** demoted to section-header styling: 11px, uppercase, 0.06em letter-spacing, `--text-muted` — matches the existing `WORKSPACES` title treatment for consistency.
- **Indent guide**: a 1px hairline (`--divider`) down the left edge of the workspace stack, visually binding children to their parent repo. Rendered via `::before` on `.wsItem` with `top:0; bottom:0` so stacked rows form a continuous line.
- **Group rhythm**: `.repoGroup` bottom margin bumped from 4px → 14px so the sidebar scans as paragraphs of related workspaces.
- **Selection accent relocated**: moved from `::before` to `::after` on `.wsSelected`, so the indent guide and the selection bar coexist on a selected row without one overriding the other.

## Complexity Notes

The `::before` / `::after` split on `.wsItem` / `.wsSelected` is the subtle part: both pseudo-elements are absolutely positioned on the same row, and the selection accent had to move off `::before` to make room for the new indent guide. A comment in the CSS flags this so a future editor doesn't re-collide them.

## Test Steps

1. `cargo tauri dev` and open the app.
2. Confirm repo names render small, uppercase, muted — matching the `WORKSPACES` title above them.
3. Confirm a thin vertical hairline runs down the left side of each workspace stack.
4. Click through workspaces — the accent bar on the selected row should still render (now as `::after`) without breaking the indent guide.
5. Hover rows to confirm `--hover-bg` still applies cleanly.
6. Verify spacing between repo groups feels like visual paragraphs rather than a dense list.

## Checklist

- [ ] Tests added/updated — N/A (CSS-only presentational change)
- [ ] Documentation updated — N/A