### PR TITLE
feat(sidebar): group by SCM status and filter by repo

### DIFF
--- a/.claude/skills/claudette-debug/reference/store-actions.md
+++ b/.claude/skills/claudette-debug/reference/store-actions.md
@@ -104,8 +104,11 @@ All actions are on `window.__CLAUDETTE_STORE__.getState()`.
 - `setSidebarWidth(w)` -- set left sidebar width
 - `setRightSidebarWidth(w)` -- set right sidebar width
 - `setTerminalHeight(h)` -- set terminal panel height
-- `setSidebarFilter(f)` -- "all", "active", or "archived"
+- `setSidebarGroupBy(g)` -- "status" or "repo"
+- `setSidebarRepoFilter(id)` -- repo ID or "all"
+- `setSidebarShowArchived(show)` -- bool
 - `toggleRepoCollapsed(id)` -- toggle repository collapse
+- `toggleStatusGroupCollapsed(key)` -- toggle status-bucket collapse
 - `toggleFuzzyFinder()` -- show/hide fuzzy finder
 - `toggleCommandPalette()` -- show/hide command palette
 - `setMetaKeyHeld(held)` -- track meta key state

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -152,6 +152,25 @@
   transition: opacity 0.15s ease;
 }
 
+.statusGroup {
+  margin-bottom: 4px;
+}
+
+.statusGroupHeader {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 5px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  gap: 6px;
+  transition: background var(--transition-fast);
+}
+
+.statusGroupHeader:hover {
+  background: var(--hover-bg);
+}
+
 .repoGroup.dragging {
   opacity: 0.35;
   cursor: grabbing;

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -76,39 +76,68 @@
   margin-top: 4px;
   background: var(--chat-input-bg);
   border: 1px solid var(--divider);
-  border-radius: 6px;
+  border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  min-width: 120px;
+  min-width: 240px;
   z-index: 100;
-  overflow: hidden;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.filterMenuItem {
-  width: 100%;
-  background: none;
-  border: none;
-  color: var(--text-primary);
-  font-size: 13px;
-  padding: 8px 12px;
+.filterRow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  transition: background var(--transition-fast);
-  text-align: left;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--text-primary);
 }
 
-.filterMenuItem:hover {
-  background: var(--hover-bg);
-}
-
-.filterMenuItem span {
-  flex: 1;
-}
-
-.filterMenuItem svg {
-  color: var(--accent-primary);
+.filterLabel {
+  color: var(--text-muted);
   flex-shrink: 0;
+  min-width: 70px;
+}
+
+.filterSelect {
+  flex: 1;
+  background: var(--input-bg, var(--hover-bg));
+  color: var(--text-primary);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  cursor: pointer;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.filterSelect:hover,
+.filterSelect:focus {
+  border-color: var(--accent-primary);
+}
+
+.filterCheckboxRow {
+  gap: 8px;
+  cursor: pointer;
+}
+
+.filterCheckboxRow input[type="checkbox"] {
+  cursor: pointer;
+  accent-color: var(--accent-primary);
+  margin: 0;
+}
+
+.filterCheckboxRow .filterLabel {
+  min-width: 0;
+}
+
+.statusGroupCount {
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-weight: 500;
 }
 
 .list {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -182,6 +182,7 @@ export const Sidebar = memo(function Sidebar() {
 
   const filteredWorkspaces = useMemo(
     () => workspaces.filter((ws) => {
+      if (ws.remote_connection_id) return false;
       if (!sidebarShowArchived && ws.status === "Archived") return false;
       if (sidebarRepoFilter !== "all" && ws.repository_id !== sidebarRepoFilter) return false;
       return true;
@@ -401,14 +402,14 @@ export const Sidebar = memo(function Sidebar() {
               onClick={() => setFilterMenuOpen((open) => !open)}
               title="Filter workspaces"
               aria-label="Filter workspaces"
-              aria-haspopup="menu"
+              aria-haspopup="dialog"
               aria-expanded={filterMenuOpen}
               aria-controls="workspace-filter-menu"
             >
               <Filter size={12} />
             </button>
           {filterMenuOpen && (
-            <div className={styles.filterMenu} id="workspace-filter-menu" role="group" aria-label="Workspace filters">
+            <div className={styles.filterMenu} id="workspace-filter-menu" role="dialog" aria-label="Workspace filters">
               <label className={styles.filterRow}>
                 <span className={styles.filterLabel}>Group by</span>
                 <select
@@ -459,9 +460,9 @@ export const Sidebar = memo(function Sidebar() {
           const collapsed = statusGroupCollapsed[groupKey];
           const runningCount = bucketWorkspaces.filter((ws) => ws.agent_status === "Running").length;
           return (
-            <div key={groupKey} className={styles.repoGroup}>
+            <div key={groupKey} className={styles.statusGroup}>
               <div
-                className={styles.repoHeader}
+                className={styles.statusGroupHeader}
                 onClick={() => toggleStatusGroupCollapsed(groupKey)}
               >
                 <span className={styles.chevron}>{collapsed ? "›" : "⌄"}</span>

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -23,10 +23,10 @@ import styles from "./Sidebar.module.css";
 
 type StatusBucketKey = "in-progress" | "in-review" | "draft" | "merged" | "closed" | "archived";
 const STATUS_BUCKET_ORDER: { key: StatusBucketKey; label: string }[] = [
-  { key: "in-progress", label: "In progress" },
+  { key: "merged", label: "Merged" },
   { key: "in-review", label: "In review" },
   { key: "draft", label: "Draft" },
-  { key: "merged", label: "Merged" },
+  { key: "in-progress", label: "In progress" },
   { key: "closed", label: "Closed" },
   { key: "archived", label: "Archived" },
 ];

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -15,21 +15,37 @@ import {
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog, Filter, Check, LayoutDashboard, CircleDashed, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, BadgeInfo, BadgeQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { UpdateBanner } from "../layout/UpdateBanner";
 import { useSpinnerFrame } from "../../hooks/useSpinnerFrame";
 import styles from "./Sidebar.module.css";
+
+type StatusBucketKey = "in-progress" | "in-review" | "draft" | "merged" | "closed" | "archived";
+const STATUS_BUCKET_ORDER: { key: StatusBucketKey; label: string }[] = [
+  { key: "in-progress", label: "In progress" },
+  { key: "in-review", label: "In review" },
+  { key: "draft", label: "Draft" },
+  { key: "merged", label: "Merged" },
+  { key: "closed", label: "Closed" },
+  { key: "archived", label: "Archived" },
+];
 
 export const Sidebar = memo(function Sidebar() {
   const repositories = useAppStore((s) => s.repositories);
   const workspaces = useAppStore((s) => s.workspaces);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
-  const sidebarFilter = useAppStore((s) => s.sidebarFilter);
-  const setSidebarFilter = useAppStore((s) => s.setSidebarFilter);
+  const sidebarGroupBy = useAppStore((s) => s.sidebarGroupBy);
+  const setSidebarGroupBy = useAppStore((s) => s.setSidebarGroupBy);
+  const sidebarRepoFilter = useAppStore((s) => s.sidebarRepoFilter);
+  const setSidebarRepoFilter = useAppStore((s) => s.setSidebarRepoFilter);
+  const sidebarShowArchived = useAppStore((s) => s.sidebarShowArchived);
+  const setSidebarShowArchived = useAppStore((s) => s.setSidebarShowArchived);
   const repoCollapsed = useAppStore((s) => s.repoCollapsed);
   const toggleRepoCollapsed = useAppStore((s) => s.toggleRepoCollapsed);
+  const statusGroupCollapsed = useAppStore((s) => s.statusGroupCollapsed);
+  const toggleStatusGroupCollapsed = useAppStore((s) => s.toggleStatusGroupCollapsed);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
   const openModal = useAppStore((s) => s.openModal);
@@ -41,8 +57,6 @@ export const Sidebar = memo(function Sidebar() {
   const scmSummary = useAppStore((s) => s.scmSummary);
   const setRepositories = useAppStore((s) => s.setRepositories);
   const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
-  const remoteConnections = useAppStore((s) => s.remoteConnections);
-  const discoveredServers = useAppStore((s) => s.discoveredServers);
   const isMac = navigator.platform.startsWith("Mac");
 
   // Filter dropdown state
@@ -168,12 +182,38 @@ export const Sidebar = memo(function Sidebar() {
 
   const filteredWorkspaces = useMemo(
     () => workspaces.filter((ws) => {
-      if (sidebarFilter === "active") return ws.status === "Active";
-      if (sidebarFilter === "archived") return ws.status === "Archived";
+      if (!sidebarShowArchived && ws.status === "Archived") return false;
+      if (sidebarRepoFilter !== "all" && ws.repository_id !== sidebarRepoFilter) return false;
       return true;
     }),
-    [workspaces, sidebarFilter]
+    [workspaces, sidebarShowArchived, sidebarRepoFilter]
   );
+
+  const statusBuckets = useMemo(() => {
+    const buckets = new Map<StatusBucketKey, typeof workspaces>();
+    for (const { key } of STATUS_BUCKET_ORDER) buckets.set(key, []);
+    for (const ws of filteredWorkspaces) {
+      let key: StatusBucketKey;
+      if (ws.status === "Archived") {
+        key = "archived";
+      } else {
+        const summary = scmSummary[ws.id];
+        if (!summary?.hasPr) {
+          key = "in-progress";
+        } else if (summary.prState === "merged") {
+          key = "merged";
+        } else if (summary.prState === "closed") {
+          key = "closed";
+        } else if (summary.prState === "draft") {
+          key = "draft";
+        } else {
+          key = "in-review";
+        }
+      }
+      buckets.get(key)!.push(ws);
+    }
+    return buckets;
+  }, [filteredWorkspaces, scmSummary]);
 
   const handleArchive = useCallback(async (wsId: string) => {
     if (archivingRef.current.has(wsId)) return;
@@ -206,6 +246,142 @@ export const Sidebar = memo(function Sidebar() {
     }
   }, [updateWorkspace]);
 
+  const renderWorkspace = (ws: typeof workspaces[number]) => {
+    const badge: "ask" | "plan" | "done" | null =
+      agentQuestions[ws.id] ? "ask" :
+      planApprovals[ws.id] ? "plan" :
+      unreadCompletions.has(ws.id) && ws.agent_status !== "Running" ? "done" :
+      null;
+    return (
+      <div
+        key={ws.id}
+        className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""} ${badge ? styles.wsUnread : ""}`}
+        onClick={() => {
+          selectWorkspace(ws.id);
+        }}
+      >
+        {badge === "done" ? (
+          <span className={styles.badgeDone} title="Completed" aria-label="Completed" role="img">
+            <BadgeCheck size={14} />
+          </span>
+        ) : badge === "plan" ? (
+          <span className={styles.badgePlan} title="Plan approval needed" aria-label="Plan approval needed" role="img">
+            <BadgeInfo size={14} />
+          </span>
+        ) : badge === "ask" ? (
+          <span className={styles.badgeAsk} title="Question requires attention" aria-label="Question requires attention" role="img">
+            <BadgeQuestionMark size={14} />
+          </span>
+        ) : ws.agent_status === "Running" ? (
+          <span className={styles.statusSpinner} aria-hidden="true">
+            {spinnerChar}
+          </span>
+        ) : (() => {
+          const summary = scmSummary[ws.id];
+          if (summary?.hasPr) {
+            const prState = summary.prState;
+            const ciState = summary.ciState;
+            const Icon = prState === "merged" ? GitMerge
+              : prState === "closed" ? GitPullRequestClosed
+              : prState === "draft" ? GitPullRequestDraft
+              : GitPullRequestArrow;
+            const color = prState === "merged" ? "var(--purple, #a855f7)"
+              : prState === "closed" ? "var(--red, #ef4444)"
+              : prState === "draft" ? "var(--text-dim)"
+              : ciState === "failure" ? "var(--red, #ef4444)"
+              : ciState === "pending" ? "var(--yellow, #eab308)"
+              : "var(--green, #22c55e)";
+            const titleText = `PR: ${prState}${ciState ? `, CI: ${ciState}` : ""}`;
+            return (
+              <span className={styles.statusIcon} title={titleText}>
+                <Icon size={14} style={{ color }} />
+              </span>
+            );
+          }
+          return (
+            <span className={styles.statusIcon} title={ws.agent_status === "Stopped" ? "Stopped" : "Idle"}>
+              <CircleDashed size={14} style={{ color: ws.agent_status === "Stopped" ? "var(--status-stopped)" : "var(--text-dim)" }} />
+            </span>
+          );
+        })()}
+        <div className={styles.wsInfo}>
+          <span className={styles.wsName}>
+            {ws.name}
+          </span>
+          <span className={styles.wsBranch}>{ws.branch_name}</span>
+          {(() => {
+            const commandState = workspaceTerminalCommands[ws.id];
+            if (!commandState?.command) return null;
+
+            const truncateCommand = (cmd: string, maxLen: number) => {
+              if (cmd.length <= maxLen) return cmd;
+              return cmd.slice(0, maxLen - 3) + "...";
+            };
+
+            return (
+              <div className={styles.terminalCommand}>
+                {commandState.isRunning ? (
+                  <span title="Running" aria-label="Running">
+                    <Cog size={12} className={styles.runningIcon} />
+                  </span>
+                ) : commandState.exitCode === 0 ? (
+                  <span className={styles.successIcon} title="Exited successfully">✓</span>
+                ) : commandState.exitCode !== null ? (
+                  <span className={styles.errorIcon} title={`Exit code: ${commandState.exitCode}`}>✗</span>
+                ) : (
+                  <span className={styles.commandIcon}>▸</span>
+                )}
+                <span className={styles.commandText} title={commandState.command}>
+                  {truncateCommand(commandState.command, 40)}
+                </span>
+              </div>
+            );
+          })()}
+        </div>
+        <div className={styles.wsActions}>
+          {ws.status === "Active" ? (
+            <button
+              className={styles.iconBtn}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleArchive(ws.id);
+              }}
+              title="Archive"
+            >
+              <Archive size={12} />
+            </button>
+          ) : (
+            <>
+              <button
+                className={styles.iconBtn}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRestore(ws.id);
+                }}
+                title="Restore"
+              >
+                ↺
+              </button>
+              <button
+                className={`${styles.iconBtn} ${styles.iconBtnDanger}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  openModal("deleteWorkspace", {
+                    wsId: ws.id,
+                    wsName: ws.name,
+                  });
+                }}
+                title="Delete"
+              >
+                <Trash2 size={12} />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className={styles.sidebar}>
       <div className={styles.header} data-tauri-drag-region>
@@ -232,53 +408,43 @@ export const Sidebar = memo(function Sidebar() {
               <Filter size={12} />
             </button>
           {filterMenuOpen && (
-            <div className={styles.filterMenu} id="workspace-filter-menu" role="menu">
-              <button
-                className={styles.filterMenuItem}
-                onClick={() => {
-                  setSidebarFilter("all");
-                  setFilterMenuOpen(false);
-                }}
-                role="menuitem"
-              >
-                <span>All</span>
-                {sidebarFilter === "all" && <Check size={14} />}
-              </button>
-              <button
-                className={styles.filterMenuItem}
-                onClick={() => {
-                  setSidebarFilter("active");
-                  setFilterMenuOpen(false);
-                }}
-                role="menuitem"
-              >
-                <span>Active</span>
-                {sidebarFilter === "active" && <Check size={14} />}
-              </button>
-              <button
-                className={styles.filterMenuItem}
-                onClick={() => {
-                  setSidebarFilter("archived");
-                  setFilterMenuOpen(false);
-                }}
-                role="menuitem"
-              >
-                <span>Archived</span>
-                {sidebarFilter === "archived" && <Check size={14} />}
-              </button>
-              {(remoteConnections.length > 0 || discoveredServers.length > 0) && (
-                <button
-                  className={styles.filterMenuItem}
-                  onClick={() => {
-                    setSidebarFilter("remote");
-                    setFilterMenuOpen(false);
-                  }}
-                  role="menuitem"
+            <div className={styles.filterMenu} id="workspace-filter-menu" role="group" aria-label="Workspace filters">
+              <label className={styles.filterRow}>
+                <span className={styles.filterLabel}>Group by</span>
+                <select
+                  className={styles.filterSelect}
+                  value={sidebarGroupBy}
+                  onChange={(e) => setSidebarGroupBy(e.target.value as "status" | "repo")}
                 >
-                  <span>Remote</span>
-                  {sidebarFilter === "remote" && <Check size={14} />}
-                </button>
-              )}
+                  <option value="status">Status</option>
+                  <option value="repo">Repo</option>
+                </select>
+              </label>
+              <label className={styles.filterRow}>
+                <span className={styles.filterLabel}>Repo</span>
+                <select
+                  className={styles.filterSelect}
+                  value={sidebarRepoFilter}
+                  onChange={(e) => setSidebarRepoFilter(e.target.value)}
+                >
+                  <option value="all">All repos</option>
+                  {repositories
+                    .filter((r) => !r.remote_connection_id)
+                    .map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {r.name}
+                      </option>
+                    ))}
+                </select>
+              </label>
+              <label className={`${styles.filterRow} ${styles.filterCheckboxRow}`}>
+                <input
+                  type="checkbox"
+                  checked={sidebarShowArchived}
+                  onChange={(e) => setSidebarShowArchived(e.target.checked)}
+                />
+                <span className={styles.filterLabel}>Show archived</span>
+              </label>
             </div>
           )}
           </div>
@@ -286,7 +452,36 @@ export const Sidebar = memo(function Sidebar() {
       </div>
 
       <div className={styles.list}>
-        {sidebarFilter !== "remote" && repositories.filter((r) => !r.remote_connection_id).map((repo, repoIdx) => {
+        {sidebarGroupBy === "status" && STATUS_BUCKET_ORDER.map(({ key, label }) => {
+          const bucketWorkspaces = statusBuckets.get(key) ?? [];
+          if (bucketWorkspaces.length === 0) return null;
+          const groupKey = `status:${key}`;
+          const collapsed = statusGroupCollapsed[groupKey];
+          const runningCount = bucketWorkspaces.filter((ws) => ws.agent_status === "Running").length;
+          return (
+            <div key={groupKey} className={styles.repoGroup}>
+              <div
+                className={styles.repoHeader}
+                onClick={() => toggleStatusGroupCollapsed(groupKey)}
+              >
+                <span className={styles.chevron}>{collapsed ? "›" : "⌄"}</span>
+                <span className={styles.repoName}>
+                  {label}
+                  {runningCount > 0 && (
+                    <span className={styles.runningBadge}>{runningCount}</span>
+                  )}
+                  <span className={styles.statusGroupCount}>{bucketWorkspaces.length}</span>
+                </span>
+              </div>
+              {!collapsed && bucketWorkspaces.map(renderWorkspace)}
+            </div>
+          );
+        })}
+
+        {sidebarGroupBy === "repo" && repositories
+          .filter((r) => !r.remote_connection_id)
+          .filter((r) => sidebarRepoFilter === "all" || r.id === sidebarRepoFilter)
+          .map((repo, repoIdx) => {
           const collapsed = repoCollapsed[repo.id];
           const repoWorkspaces = filteredWorkspaces.filter(
             (ws) => ws.repository_id === repo.id
@@ -469,142 +664,7 @@ export const Sidebar = memo(function Sidebar() {
                 )}
               </div>
 
-              {!collapsed &&
-                repoWorkspaces.map((ws) => {
-                  const badge: "ask" | "plan" | "done" | null =
-                    agentQuestions[ws.id] ? "ask" :
-                    planApprovals[ws.id] ? "plan" :
-                    unreadCompletions.has(ws.id) && ws.agent_status !== "Running" ? "done" :
-                    null;
-                  return (
-                  <div
-                    key={ws.id}
-                    className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""} ${badge ? styles.wsUnread : ""}`}
-                    onClick={() => {
-                      selectWorkspace(ws.id);
-                    }}
-                  >
-                    {badge === "done" ? (
-                      <span className={styles.badgeDone} title="Completed" aria-label="Completed" role="img">
-                        <BadgeCheck size={14} />
-                      </span>
-                    ) : badge === "plan" ? (
-                      <span className={styles.badgePlan} title="Plan approval needed" aria-label="Plan approval needed" role="img">
-                        <BadgeInfo size={14} />
-                      </span>
-                    ) : badge === "ask" ? (
-                      <span className={styles.badgeAsk} title="Question requires attention" aria-label="Question requires attention" role="img">
-                        <BadgeQuestionMark size={14} />
-                      </span>
-                    ) : ws.agent_status === "Running" ? (
-                      <span className={styles.statusSpinner} aria-hidden="true">
-                        {spinnerChar}
-                      </span>
-                    ) : (() => {
-                      const summary = scmSummary[ws.id];
-                      if (summary?.hasPr) {
-                        const prState = summary.prState;
-                        const ciState = summary.ciState;
-                        const Icon = prState === "merged" ? GitMerge
-                          : prState === "closed" ? GitPullRequestClosed
-                          : prState === "draft" ? GitPullRequestDraft
-                          : GitPullRequestArrow;
-                        const color = prState === "merged" ? "var(--purple, #a855f7)"
-                          : prState === "closed" ? "var(--red, #ef4444)"
-                          : prState === "draft" ? "var(--text-dim)"
-                          : ciState === "failure" ? "var(--red, #ef4444)"
-                          : ciState === "pending" ? "var(--yellow, #eab308)"
-                          : "var(--green, #22c55e)";
-                        const titleText = `PR: ${prState}${ciState ? `, CI: ${ciState}` : ""}`;
-                        return (
-                          <span className={styles.statusIcon} title={titleText}>
-                            <Icon size={14} style={{ color }} />
-                          </span>
-                        );
-                      }
-                      return (
-                        <span className={styles.statusIcon} title={ws.agent_status === "Stopped" ? "Stopped" : "Idle"}>
-                          <CircleDashed size={14} style={{ color: ws.agent_status === "Stopped" ? "var(--status-stopped)" : "var(--text-dim)" }} />
-                        </span>
-                      );
-                    })()}
-                    <div className={styles.wsInfo}>
-                      <span className={styles.wsName}>
-                        {ws.name}
-                      </span>
-                      <span className={styles.wsBranch}>{ws.branch_name}</span>
-                      {(() => {
-                        const commandState = workspaceTerminalCommands[ws.id];
-                        if (!commandState?.command) return null;
-
-                        const truncateCommand = (cmd: string, maxLen: number) => {
-                          if (cmd.length <= maxLen) return cmd;
-                          return cmd.slice(0, maxLen - 3) + "...";
-                        };
-
-                        return (
-                          <div className={styles.terminalCommand}>
-                            {commandState.isRunning ? (
-                              <span title="Running" aria-label="Running">
-                                <Cog size={12} className={styles.runningIcon} />
-                              </span>
-                            ) : commandState.exitCode === 0 ? (
-                              <span className={styles.successIcon} title="Exited successfully">✓</span>
-                            ) : commandState.exitCode !== null ? (
-                              <span className={styles.errorIcon} title={`Exit code: ${commandState.exitCode}`}>✗</span>
-                            ) : (
-                              <span className={styles.commandIcon}>▸</span>
-                            )}
-                            <span className={styles.commandText} title={commandState.command}>
-                              {truncateCommand(commandState.command, 40)}
-                            </span>
-                          </div>
-                        );
-                      })()}
-                    </div>
-                    <div className={styles.wsActions}>
-                      {ws.status === "Active" ? (
-                        <button
-                          className={styles.iconBtn}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleArchive(ws.id);
-                          }}
-                          title="Archive"
-                        >
-                          <Archive size={12} />
-                        </button>
-                      ) : (
-                        <>
-                          <button
-                            className={styles.iconBtn}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleRestore(ws.id);
-                            }}
-                            title="Restore"
-                          >
-                            ↺
-                          </button>
-                          <button
-                            className={`${styles.iconBtn} ${styles.iconBtnDanger}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              openModal("deleteWorkspace", {
-                                wsId: ws.id,
-                                wsName: ws.name,
-                              });
-                            }}
-                            title="Delete"
-                          >
-                            <Trash2 size={12} />
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  );
-                })}
+              {!collapsed && repoWorkspaces.map(renderWorkspace)}
               {/* Show loading workspace while creating */}
               {!collapsed && creatingWorkspace && creatingWorkspace.repoId === repo.id && (
                 <div className={`${styles.wsItem} ${styles.wsItemLoading}`}>
@@ -621,11 +681,11 @@ export const Sidebar = memo(function Sidebar() {
             </div>
           );
         })}
-        {sidebarFilter !== "remote" && draggedRepoId && dropTargetIdx === repositories.filter((r) => !r.remote_connection_id).length && (
+        {sidebarGroupBy === "repo" && draggedRepoId && dropTargetIdx === repositories.filter((r) => !r.remote_connection_id).length && (
           <div className={styles.dropIndicator} />
         )}
 
-        {sidebarFilter === "all" || sidebarFilter === "remote" ? <RemoteSections /> : null}
+        <RemoteSections />
       </div>
 
       <UpdateBanner />

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -248,8 +248,11 @@ interface AppState {
   rightSidebarWidth: number;
   terminalHeight: number;
   rightSidebarTab: "changes" | "tasks" | "scm";
-  sidebarFilter: "all" | "active" | "archived" | "remote";
+  sidebarGroupBy: "status" | "repo";
+  sidebarRepoFilter: string; // repo ID or "all"
+  sidebarShowArchived: boolean;
   repoCollapsed: Record<string, boolean>;
+  statusGroupCollapsed: Record<string, boolean>;
   fuzzyFinderOpen: boolean;
   commandPaletteOpen: boolean;
   toggleSidebar: () => void;
@@ -258,8 +261,11 @@ interface AppState {
   setSidebarWidth: (w: number) => void;
   setRightSidebarWidth: (w: number) => void;
   setTerminalHeight: (h: number) => void;
-  setSidebarFilter: (f: "all" | "active" | "archived" | "remote") => void;
+  setSidebarGroupBy: (g: "status" | "repo") => void;
+  setSidebarRepoFilter: (id: string) => void;
+  setSidebarShowArchived: (show: boolean) => void;
   toggleRepoCollapsed: (id: string) => void;
+  toggleStatusGroupCollapsed: (id: string) => void;
   toggleFuzzyFinder: () => void;
   toggleCommandPalette: () => void;
 
@@ -927,8 +933,11 @@ export const useAppStore = create<AppState>((set) => ({
   rightSidebarWidth: 250,
   terminalHeight: 300,
   rightSidebarTab: "changes",
-  sidebarFilter: "all",
+  sidebarGroupBy: "status",
+  sidebarRepoFilter: "all",
+  sidebarShowArchived: false,
   repoCollapsed: {},
+  statusGroupCollapsed: {},
   fuzzyFinderOpen: false,
   toggleSidebar: () => set((s) => ({ sidebarVisible: !s.sidebarVisible })),
   toggleRightSidebar: () =>
@@ -937,12 +946,21 @@ export const useAppStore = create<AppState>((set) => ({
   setSidebarWidth: (w) => set({ sidebarWidth: w }),
   setRightSidebarWidth: (w) => set({ rightSidebarWidth: w }),
   setTerminalHeight: (h) => set({ terminalHeight: h }),
-  setSidebarFilter: (f) => set({ sidebarFilter: f }),
+  setSidebarGroupBy: (g) => set({ sidebarGroupBy: g }),
+  setSidebarRepoFilter: (id) => set({ sidebarRepoFilter: id }),
+  setSidebarShowArchived: (show) => set({ sidebarShowArchived: show }),
   toggleRepoCollapsed: (id) =>
     set((s) => ({
       repoCollapsed: {
         ...s.repoCollapsed,
         [id]: !s.repoCollapsed[id],
+      },
+    })),
+  toggleStatusGroupCollapsed: (id) =>
+    set((s) => ({
+      statusGroupCollapsed: {
+        ...s.statusGroupCollapsed,
+        [id]: !s.statusGroupCollapsed[id],
       },
     })),
   toggleFuzzyFinder: () =>


### PR DESCRIPTION
## Summary

Replaces the single **All / Active / Archived / Remote** workspace filter with a three-control popover that lets users triage across many repos:

- **Group by** — `Status` (default) or `Repo`
- **Repo** — `All repos` or one specific repo
- **Show archived** — checkbox; archived workspaces are hidden by default

In **Group by Status** mode, workspaces are bucketed by SCM state (derived from the existing ` scmSummary` store):

```
In progress → In review → Draft → Merged → Closed → [Archived]
```

Empty buckets render nothing. In **Group by Repo** mode, behavior matches today's per-repo sections (including drag-to-reorder), narrowed by the Repo select.

`RemoteSections` now renders unconditionally — it already self-hides when there are no remote connections — so the old "Remote" filter value is no longer needed.

```mermaid
flowchart LR
  WS[workspaces] --> FR[filter by repo + archived]
  FR --> G{sidebarGroupBy}
  G -->|status| B[bucket by SCM status] --> S[Status groups]
  G -->|repo| R[bucket by repo_id] --> P[Repo groups + drag-reorder]
  S --> L[sidebar list]
  P --> L
  L --> RS[RemoteSections always rendered below]
```

## Complexity Notes

- **Store migration**: `sidebarFilter` is removed and replaced with `sidebarGroupBy`, `sidebarRepoFilter`, and `sidebarShowArchived`. There are no back-compat shims — existing callers (only `Sidebar.tsx`) were updated in this PR. Runtime state is non-persisted (Zustand only), so no SQLite migration is needed.
- The 130-line workspace-row JSX was extracted into a `renderWorkspace(ws)` helper reused by both grouping modes. It captures closures (handlers, store values) directly, so behavior should be identical; worth a targeted eye from a reviewer familiar with the row.
- `STATUS_BUCKET_ORDER` is hoisted to module scope to keep the `useMemo` dep list stable.
- Bucket collapse state lives in a new `statusGroupCollapsed` store slice, separate from `repoCollapsed`. Collapsed state per mode is independent — acceptable behavior per plan.

## Test Steps

1. `cd src/ui && bunx tsc --noEmit` → clean.
2. `cd src/ui && bun run test` → 486 tests pass.
3. `cargo tauri dev`, then in the sidebar:
   1. Default view: **Group by Status** is selected; buckets appear top-to-bottom as documented; archived workspaces are hidden.
   2. Toggle **Show archived** → Archived bucket appears (status mode) / archived workspaces appear inside repo groups (repo mode).
   3. Switch **Group by** to **Repo** → today's per-repo sections return; drag-reorder still works.
   4. Set **Repo** to a specific repo → only that repo's workspaces appear in either grouping mode.
   5. Confirm selection highlight, agent-status spinner, PR/CI icons, badges (ask/plan/done), and the "Creating workspace..." placeholder all still render correctly.
   6. If remote connections exist, confirm `RemoteSections` renders below the main list regardless of filter settings.

## Checklist

- [x] TypeScript typecheck passes
- [x] Vitest suite passes (486/486)
- [x] ESLint clean on changed files (`Sidebar.tsx`, `useAppStore.ts`)
- [x] Updated `claudette-debug` store-actions reference
- [ ] Visual verification in `cargo tauri dev` (blocked by local `mlua-sys` build cache — unrelated to this change)