### PR TITLE
feat(updater): add stable/nightly update channel toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "url",
  "urlencoding",
  "uuid",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ urlencoding = "2"
 parking_lot = "0.12"
 chrono = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+url = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,5 +15,6 @@ pub mod settings;
 pub mod shell;
 pub mod slash_commands;
 pub mod terminal;
+pub mod updater;
 pub mod usage;
 pub mod workspace;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -5,9 +5,9 @@ use tauri_plugin_updater::UpdaterExt;
 use crate::state::AppState;
 
 const STABLE_URL: &str =
-    "https://github.com/utensils/Claudette/releases/latest/download/latest.json";
+    "https://github.com/utensils/claudette/releases/latest/download/latest.json";
 const NIGHTLY_URL: &str =
-    "https://github.com/utensils/Claudette/releases/download/nightly/latest.json";
+    "https://github.com/utensils/claudette/releases/download/nightly/latest.json";
 
 /// Subset of [`tauri_plugin_updater::Update`] that we expose across the IPC boundary.
 #[derive(Serialize)]
@@ -20,8 +20,12 @@ pub struct UpdateInfo {
 
 fn endpoint_for(channel: &str) -> &'static str {
     match channel {
+        "stable" => STABLE_URL,
         "nightly" => NIGHTLY_URL,
-        _ => STABLE_URL,
+        other => {
+            eprintln!("[updater] Unknown channel {other:?}, falling back to stable");
+            STABLE_URL
+        }
     }
 }
 
@@ -109,5 +113,7 @@ pub async fn install_pending_update(
         .await
         .map_err(|e| e.to_string())?;
 
+    // `AppHandle::restart` returns `!` (it ends the process), so it satisfies
+    // the `Result<(), String>` signature without an explicit `Ok(())`.
     app.restart();
 }

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,113 @@
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+use tauri_plugin_updater::UpdaterExt;
+
+use crate::state::AppState;
+
+const STABLE_URL: &str =
+    "https://github.com/utensils/Claudette/releases/latest/download/latest.json";
+const NIGHTLY_URL: &str =
+    "https://github.com/utensils/Claudette/releases/download/nightly/latest.json";
+
+/// Subset of [`tauri_plugin_updater::Update`] that we expose across the IPC boundary.
+#[derive(Serialize)]
+pub struct UpdateInfo {
+    pub version: String,
+    pub current_version: String,
+    pub body: Option<String>,
+    pub date: Option<String>,
+}
+
+fn endpoint_for(channel: &str) -> &'static str {
+    match channel {
+        "nightly" => NIGHTLY_URL,
+        _ => STABLE_URL,
+    }
+}
+
+/// Check the configured channel's release feed for an update.
+///
+/// On success, the resulting [`tauri_plugin_updater::Update`] is stashed in
+/// [`AppState::pending_update`] so that [`install_pending_update`] can hand it
+/// off to the platform installer. The serializable [`UpdateInfo`] is returned
+/// to JS so the UI can render the version banner.
+#[tauri::command]
+pub async fn check_for_updates_with_channel(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    channel: String,
+) -> Result<Option<UpdateInfo>, String> {
+    let endpoint = endpoint_for(&channel)
+        .parse()
+        .map_err(|e: url::ParseError| e.to_string())?;
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?
+        .check()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut slot = state.pending_update.lock().await;
+    match update {
+        Some(u) => {
+            let info = UpdateInfo {
+                version: u.version.clone(),
+                current_version: u.current_version.clone(),
+                body: u.body.clone(),
+                date: u.date.map(|d| d.to_string()),
+            };
+            *slot = Some(u);
+            Ok(Some(info))
+        }
+        None => {
+            *slot = None;
+            Ok(None)
+        }
+    }
+}
+
+/// Download and install the pending update, then restart the app.
+///
+/// Emits `updater://progress` (u32, 0–100) as bytes arrive so the UI can drive
+/// its progress bar. Returns an error if no update is pending.
+#[tauri::command]
+pub async fn install_pending_update(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let update = state
+        .pending_update
+        .lock()
+        .await
+        .take()
+        .ok_or_else(|| "No pending update".to_string())?;
+
+    let app_for_cb = app.clone();
+    let mut total: u64 = 0;
+    let mut downloaded: u64 = 0;
+
+    update
+        .download_and_install(
+            move |chunk_len, content_len| {
+                if let Some(c) = content_len {
+                    total = c;
+                }
+                downloaded += chunk_len as u64;
+                let pct = if total > 0 {
+                    ((downloaded * 100) / total).min(100) as u32
+                } else {
+                    0
+                };
+                let _ = app_for_cb.emit("updater://progress", pct);
+            },
+            || {},
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    app.restart();
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -387,6 +387,9 @@ fn main() {
             commands::settings::play_notification_sound,
             commands::settings::run_notification_command,
             commands::settings::get_git_username,
+            // Updater
+            commands::updater::check_for_updates_with_channel,
+            commands::updater::install_pending_update,
             // Plugins
             commands::plugin::list_plugins,
             commands::plugin::list_plugin_catalog,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -269,6 +269,10 @@ pub struct AppState {
     pub scm_cache: ScmCache,
     /// Limits concurrent SCM CLI invocations.
     pub scm_semaphore: Arc<Semaphore>,
+    /// Pending updater handle from the most recent `check_for_updates_with_channel`
+    /// call. The Update struct holds the downloaded payload + signature context
+    /// and is not Serialize, so it lives here instead of crossing the IPC boundary.
+    pub pending_update: tokio::sync::Mutex<Option<tauri_plugin_updater::Update>>,
 }
 
 impl AppState {
@@ -288,6 +292,7 @@ impl AppState {
             plugins: RwLock::new(plugins),
             scm_cache: ScmCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
+            pending_update: tokio::sync::Mutex::new(None),
         }
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,7 +63,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI1NkQwQUJEQ0REREVDOUIKUldTYjdOM052UXB0SmZMdFNVRnhXQmJMTitTaGtUZjdjcWNQWmFsR0JJUmxVYTV6STVxN0F3TVUK",
       "endpoints": [
-        "https://github.com/utensils/Claudette/releases/latest/download/latest.json"
+        "https://github.com/utensils/claudette/releases/latest/download/latest.json"
       ]
     }
   }

--- a/src/ui/src/components/layout/UpdateBanner.tsx
+++ b/src/ui/src/components/layout/UpdateBanner.tsx
@@ -9,8 +9,12 @@ export function UpdateBanner() {
   const updateInstallWhenIdle = useAppStore((s) => s.updateInstallWhenIdle);
   const updateDownloading = useAppStore((s) => s.updateDownloading);
   const updateProgress = useAppStore((s) => s.updateProgress);
+  const updateChannel = useAppStore((s) => s.updateChannel);
 
   if (!updateAvailable || updateDismissed) return null;
+
+  const productLabel =
+    updateChannel === "nightly" ? "Claudette Nightly" : "Claudette";
 
   return (
     <div className={styles.banner}>
@@ -44,8 +48,9 @@ export function UpdateBanner() {
       ) : (
         <>
           <span className={styles.message}>
-            Claudette <span className={styles.version}>v{updateVersion}</span>{" "}
-            is available
+            {productLabel}{" "}
+            <span className={styles.version}>v{updateVersion}</span> is
+            available
           </span>
           <div className={styles.actions}>
             <button className={styles.btnPrimary} onClick={installNow}>

--- a/src/ui/src/components/modals/ConfirmNightlyChannelModal.tsx
+++ b/src/ui/src/components/modals/ConfirmNightlyChannelModal.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { useAppStore } from "../../stores/useAppStore";
+import { applyUpdateChannel } from "../../hooks/useAutoUpdater";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+
+export function ConfirmNightlyChannelModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await applyUpdateChannel("nightly");
+      closeModal();
+    } catch (e) {
+      setError(String(e));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal title="Switch to Nightly Channel?" onClose={closeModal}>
+      <div className={shared.warning}>
+        Nightly builds are untested pre-releases built from the latest{" "}
+        <strong>main</strong> branch. They may contain bugs or break features.
+        You can switch back to Stable at any time.
+      </div>
+      {error && <div className={shared.error}>{error}</div>}
+      <div className={shared.actions}>
+        <button className={shared.btn} onClick={closeModal} disabled={loading}>
+          Cancel
+        </button>
+        <button
+          className={shared.btnPrimary}
+          onClick={handleConfirm}
+          disabled={loading}
+        >
+          {loading ? "Switching..." : "Switch to Nightly"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/ConfirmNightlyChannelModal.tsx
+++ b/src/ui/src/components/modals/ConfirmNightlyChannelModal.tsx
@@ -20,8 +20,16 @@ export function ConfirmNightlyChannelModal() {
     }
   };
 
+  // Block backdrop dismiss while the channel switch is in flight — matches
+  // the disabled Cancel button below, and avoids the catch handler trying to
+  // setError on an unmounted component if the request later fails.
+  const handleClose = () => {
+    if (loading) return;
+    closeModal();
+  };
+
   return (
-    <Modal title="Switch to Nightly Channel?" onClose={closeModal}>
+    <Modal title="Switch to Nightly Channel?" onClose={handleClose}>
       <div className={shared.warning}>
         Nightly builds are untested pre-releases built from the latest{" "}
         <strong>main</strong> branch. They may contain bugs or break features.

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -9,6 +9,7 @@ import { ShareModal } from "./ShareModal";
 import { ConfirmSetupScriptModal } from "./ConfirmSetupScriptModal";
 import { McpSelectionModal } from "./McpSelectionModal";
 import { ImportWorktreesModal } from "./ImportWorktreesModal";
+import { ConfirmNightlyChannelModal } from "./ConfirmNightlyChannelModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -34,6 +35,8 @@ export function ModalRouter() {
       return <McpSelectionModal />;
     case "importWorktrees":
       return <ImportWorktreesModal />;
+    case "confirmNightlyChannel":
+      return <ConfirmNightlyChannelModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -12,7 +12,15 @@ export function GeneralSettings() {
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
   const updateAvailable = useAppStore((s) => s.updateAvailable);
   const updateChannel = useAppStore((s) => s.updateChannel);
+  const updateDownloading = useAppStore((s) => s.updateDownloading);
+  const updateInstallWhenIdle = useAppStore((s) => s.updateInstallWhenIdle);
   const openModal = useAppStore((s) => s.openModal);
+
+  // While an install is in flight (downloading, or queued to install when
+  // agents go idle), changing the channel would silently swap the endpoint
+  // for an update that's already on its way. Lock the dropdown until that
+  // resolves (the app restarts after install, so this is short-lived).
+  const channelLocked = updateDownloading || updateInstallWhenIdle;
 
   const [path, setPath] = useState(worktreeBaseDir);
   const [trayEnabled, setTrayEnabled] = useState(true);
@@ -173,8 +181,9 @@ export function GeneralSettings() {
         <div className={styles.settingInfo}>
           <div className={styles.settingLabel}>Update channel</div>
           <div className={styles.settingDescription}>
-            Nightly builds include the latest features and fixes but may be
-            unstable.
+            {channelLocked
+              ? "Locked while an update is installing. Available again after restart."
+              : "Nightly builds include the latest features and fixes but may be unstable."}
           </div>
         </div>
         <div className={styles.settingControl}>
@@ -182,6 +191,7 @@ export function GeneralSettings() {
             className={styles.select}
             value={updateChannel}
             aria-label="Update channel"
+            disabled={channelLocked}
             onChange={(e) => {
               const value = e.target.value;
               if (value === "stable" || value === "nightly") {

--- a/src/ui/src/components/settings/sections/GeneralSettings.tsx
+++ b/src/ui/src/components/settings/sections/GeneralSettings.tsx
@@ -4,13 +4,15 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "../../../stores/useAppStore";
 import { getAppSetting, setAppSetting } from "../../../services/tauri";
-import { checkForUpdate } from "../../../hooks/useAutoUpdater";
+import { applyUpdateChannel, checkForUpdate } from "../../../hooks/useAutoUpdater";
 import styles from "../Settings.module.css";
 
 export function GeneralSettings() {
   const worktreeBaseDir = useAppStore((s) => s.worktreeBaseDir);
   const setWorktreeBaseDir = useAppStore((s) => s.setWorktreeBaseDir);
   const updateAvailable = useAppStore((s) => s.updateAvailable);
+  const updateChannel = useAppStore((s) => s.updateChannel);
+  const openModal = useAppStore((s) => s.openModal);
 
   const [path, setPath] = useState(worktreeBaseDir);
   const [trayEnabled, setTrayEnabled] = useState(true);
@@ -123,6 +125,22 @@ export function GeneralSettings() {
     }
   };
 
+  const handleUpdateChannelChange = async (next: "stable" | "nightly") => {
+    if (next === updateChannel) return;
+    if (next === "nightly") {
+      // Nightly opt-in is gated behind a confirmation modal; the modal owns
+      // the persist + store update on confirm.
+      openModal("confirmNightlyChannel");
+      return;
+    }
+    try {
+      setError(null);
+      await applyUpdateChannel(next);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
   return (
     <div>
       <h2 className={styles.sectionTitle}>General</h2>
@@ -148,6 +166,32 @@ export function GeneralSettings() {
                 ? "Up to date"
                 : "Check for Updates"}
           </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Update channel</div>
+          <div className={styles.settingDescription}>
+            Nightly builds include the latest features and fixes but may be
+            unstable.
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <select
+            className={styles.select}
+            value={updateChannel}
+            aria-label="Update channel"
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === "stable" || value === "nightly") {
+                handleUpdateChannelChange(value);
+              }
+            }}
+          >
+            <option value="stable">Stable (recommended)</option>
+            <option value="nightly">Nightly (latest main)</option>
+          </select>
         </div>
       </div>
 

--- a/src/ui/src/hooks/useAutoUpdater.test.ts
+++ b/src/ui/src/hooks/useAutoUpdater.test.ts
@@ -1,26 +1,38 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mocks (vi.hoisted runs before vi.mock factories) ────────────────
-const { mockCheck, mockSetUpdateAvailable } = vi.hoisted(() => ({
-  mockCheck: vi.fn(),
+const {
+  mockCheckForUpdatesWithChannel,
+  mockSetUpdateAvailable,
+  storeState,
+} = vi.hoisted(() => ({
+  mockCheckForUpdatesWithChannel: vi.fn(),
   mockSetUpdateAvailable: vi.fn(),
+  storeState: {
+    setUpdateAvailable: vi.fn(),
+    updateDownloading: false,
+    workspaces: [] as { agent_status: string }[],
+    updateChannel: "stable" as "stable" | "nightly",
+  },
 }));
 
-vi.mock("@tauri-apps/plugin-updater", () => ({
-  check: mockCheck,
+// Wire the hoisted helpers into the store mock.
+storeState.setUpdateAvailable = mockSetUpdateAvailable;
+
+vi.mock("../services/tauri", () => ({
+  checkForUpdatesWithChannel: mockCheckForUpdatesWithChannel,
+  installPendingUpdate: vi.fn(),
+  getAppSetting: vi.fn().mockResolvedValue(null),
+  setAppSetting: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@tauri-apps/plugin-process", () => ({
-  relaunch: vi.fn(),
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
 vi.mock("../stores/useAppStore", () => ({
   useAppStore: Object.assign(() => null, {
-    getState: () => ({
-      setUpdateAvailable: mockSetUpdateAvailable,
-      updateDownloading: false,
-      workspaces: [],
-    }),
+    getState: () => storeState,
   }),
 }));
 
@@ -30,19 +42,21 @@ import { checkForUpdate } from "./useAutoUpdater";
 describe("checkForUpdate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    storeState.updateChannel = "stable";
   });
 
   it('returns "available" and sets store when an update exists', async () => {
-    mockCheck.mockResolvedValue({ version: "2.0.0" });
+    mockCheckForUpdatesWithChannel.mockResolvedValue({ version: "2.0.0" });
 
     const result = await checkForUpdate();
 
     expect(result).toBe("available");
+    expect(mockCheckForUpdatesWithChannel).toHaveBeenCalledWith("stable");
     expect(mockSetUpdateAvailable).toHaveBeenCalledWith(true, "2.0.0");
   });
 
   it('returns "up-to-date" and clears store when no update exists', async () => {
-    mockCheck.mockResolvedValue(null);
+    mockCheckForUpdatesWithChannel.mockResolvedValue(null);
 
     const result = await checkForUpdate();
 
@@ -51,11 +65,20 @@ describe("checkForUpdate", () => {
   });
 
   it('returns "error" and does not touch store when check throws', async () => {
-    mockCheck.mockRejectedValue(new Error("network failure"));
+    mockCheckForUpdatesWithChannel.mockRejectedValue(new Error("network failure"));
 
     const result = await checkForUpdate();
 
     expect(result).toBe("error");
     expect(mockSetUpdateAvailable).not.toHaveBeenCalled();
+  });
+
+  it("passes the active channel through to the Rust command", async () => {
+    storeState.updateChannel = "nightly";
+    mockCheckForUpdatesWithChannel.mockResolvedValue(null);
+
+    await checkForUpdate();
+
+    expect(mockCheckForUpdatesWithChannel).toHaveBeenCalledWith("nightly");
   });
 });

--- a/src/ui/src/hooks/useAutoUpdater.test.ts
+++ b/src/ui/src/hooks/useAutoUpdater.test.ts
@@ -3,13 +3,22 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks (vi.hoisted runs before vi.mock factories) ────────────────
 const {
   mockCheckForUpdatesWithChannel,
+  mockInstallPendingUpdate,
+  mockGetAppSetting,
+  mockSetAppSetting,
   mockSetUpdateAvailable,
+  mockSetUpdateChannel,
   storeState,
 } = vi.hoisted(() => ({
   mockCheckForUpdatesWithChannel: vi.fn(),
+  mockInstallPendingUpdate: vi.fn(),
+  mockGetAppSetting: vi.fn(),
+  mockSetAppSetting: vi.fn(),
   mockSetUpdateAvailable: vi.fn(),
+  mockSetUpdateChannel: vi.fn(),
   storeState: {
     setUpdateAvailable: vi.fn(),
+    setUpdateChannel: vi.fn(),
     updateDownloading: false,
     workspaces: [] as { agent_status: string }[],
     updateChannel: "stable" as "stable" | "nightly",
@@ -18,12 +27,13 @@ const {
 
 // Wire the hoisted helpers into the store mock.
 storeState.setUpdateAvailable = mockSetUpdateAvailable;
+storeState.setUpdateChannel = mockSetUpdateChannel;
 
 vi.mock("../services/tauri", () => ({
   checkForUpdatesWithChannel: mockCheckForUpdatesWithChannel,
-  installPendingUpdate: vi.fn(),
-  getAppSetting: vi.fn().mockResolvedValue(null),
-  setAppSetting: vi.fn().mockResolvedValue(undefined),
+  installPendingUpdate: mockInstallPendingUpdate,
+  getAppSetting: mockGetAppSetting,
+  setAppSetting: mockSetAppSetting,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -37,7 +47,11 @@ vi.mock("../stores/useAppStore", () => ({
 }));
 
 // ── Import under test (after mocks) ─────────────────────────────────
-import { checkForUpdate } from "./useAutoUpdater";
+import {
+  checkForUpdate,
+  applyUpdateChannel,
+  loadUpdateChannel,
+} from "./useAutoUpdater";
 
 describe("checkForUpdate", () => {
   beforeEach(() => {
@@ -80,5 +94,89 @@ describe("checkForUpdate", () => {
     await checkForUpdate();
 
     expect(mockCheckForUpdatesWithChannel).toHaveBeenCalledWith("nightly");
+  });
+});
+
+describe("applyUpdateChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState.updateChannel = "stable";
+    mockSetAppSetting.mockResolvedValue(undefined);
+    mockCheckForUpdatesWithChannel.mockResolvedValue(null);
+  });
+
+  it("persists the channel before updating the store and triggering a check", async () => {
+    // Track call order across the three side effects so a refactor that
+    // accidentally swaps them surfaces here.
+    const calls: string[] = [];
+    mockSetAppSetting.mockImplementation(async () => {
+      calls.push("setAppSetting");
+    });
+    mockSetUpdateChannel.mockImplementation(() => {
+      calls.push("setUpdateChannel");
+    });
+    mockCheckForUpdatesWithChannel.mockImplementation(async () => {
+      calls.push("check");
+      return null;
+    });
+
+    await applyUpdateChannel("nightly");
+
+    expect(mockSetAppSetting).toHaveBeenCalledWith("update_channel", "nightly");
+    expect(mockSetUpdateChannel).toHaveBeenCalledWith("nightly");
+    // applyUpdateChannel doesn't await the check, so let the microtask queue
+    // drain before asserting on it.
+    await Promise.resolve();
+    expect(calls).toEqual(["setAppSetting", "setUpdateChannel", "check"]);
+  });
+
+  it("propagates errors from setAppSetting without touching the store", async () => {
+    mockSetAppSetting.mockRejectedValue(new Error("disk full"));
+
+    await expect(applyUpdateChannel("nightly")).rejects.toThrow("disk full");
+    expect(mockSetUpdateChannel).not.toHaveBeenCalled();
+    expect(mockCheckForUpdatesWithChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadUpdateChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults to stable when no value is persisted", async () => {
+    mockGetAppSetting.mockResolvedValue(null);
+
+    const channel = await loadUpdateChannel();
+
+    expect(channel).toBe("stable");
+    expect(mockSetUpdateChannel).toHaveBeenCalledWith("stable");
+  });
+
+  it("resolves to nightly when persisted as nightly", async () => {
+    mockGetAppSetting.mockResolvedValue("nightly");
+
+    const channel = await loadUpdateChannel();
+
+    expect(channel).toBe("nightly");
+    expect(mockSetUpdateChannel).toHaveBeenCalledWith("nightly");
+  });
+
+  it("falls back to stable when getAppSetting throws", async () => {
+    mockGetAppSetting.mockRejectedValue(new Error("db locked"));
+
+    const channel = await loadUpdateChannel();
+
+    expect(channel).toBe("stable");
+    expect(mockSetUpdateChannel).toHaveBeenCalledWith("stable");
+  });
+
+  it("treats unknown persisted values as stable", async () => {
+    mockGetAppSetting.mockResolvedValue("beta");
+
+    const channel = await loadUpdateChannel();
+
+    expect(channel).toBe("stable");
+    expect(mockSetUpdateChannel).toHaveBeenCalledWith("stable");
   });
 });

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -1,26 +1,27 @@
 import { useEffect } from "react";
-import { check, type Update } from "@tauri-apps/plugin-updater";
-import { relaunch } from "@tauri-apps/plugin-process";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useAppStore } from "../stores/useAppStore";
+import {
+  checkForUpdatesWithChannel,
+  installPendingUpdate,
+  getAppSetting,
+  setAppSetting,
+  type UpdateChannel,
+} from "../services/tauri";
 
 const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
-// Module-level storage so both the hook and external callers (e.g. Settings)
-// share the same Update handle.
-let pendingUpdate: Update | null = null;
-
 export type UpdateCheckResult = "available" | "up-to-date" | "error";
 
-/** Check the updater endpoint and update Zustand state. */
+/** Check the updater endpoint for the active channel and update Zustand state. */
 export async function checkForUpdate(): Promise<UpdateCheckResult> {
+  const channel = useAppStore.getState().updateChannel;
   try {
-    const update = await check();
+    const update = await checkForUpdatesWithChannel(channel);
     if (update) {
-      pendingUpdate = update;
       useAppStore.getState().setUpdateAvailable(true, update.version);
       return "available";
     } else {
-      pendingUpdate = null;
       useAppStore.getState().setUpdateAvailable(false, null);
       return "up-to-date";
     }
@@ -31,32 +32,18 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
 }
 
 export async function installNow(): Promise<void> {
-  const update = pendingUpdate;
-  if (!update) return;
-  if (useAppStore.getState().updateDownloading) return;
+  const store = useAppStore.getState();
+  if (store.updateDownloading) return;
+  if (!store.updateAvailable) return;
 
-  useAppStore.getState().setUpdateDownloading(true);
-  useAppStore.getState().setUpdateProgress(0);
-
-  let totalBytes = 0;
-  let downloadedBytes = 0;
+  store.setUpdateDownloading(true);
+  store.setUpdateProgress(0);
 
   try {
-    await update.downloadAndInstall((event) => {
-      if (event.event === "Started" && event.data.contentLength) {
-        totalBytes = event.data.contentLength;
-      } else if (event.event === "Progress") {
-        downloadedBytes += event.data.chunkLength;
-        if (totalBytes > 0) {
-          useAppStore.getState().setUpdateProgress(
-            Math.round((downloadedBytes / totalBytes) * 100)
-          );
-        }
-      } else if (event.event === "Finished") {
-        useAppStore.getState().setUpdateProgress(100);
-      }
-    });
-    await relaunch();
+    await installPendingUpdate();
+    // The Rust side calls app.restart() after install completes, so this
+    // line typically isn't reached. If it is (e.g. install failed silently),
+    // fall through to the catch on the next tick.
   } catch (e) {
     console.error("[updater] Install failed:", e);
     useAppStore.getState().setUpdateDownloading(false);
@@ -81,24 +68,74 @@ export function dismiss(): void {
   useAppStore.getState().setUpdateDismissed(true);
 }
 
+/**
+ * Apply a channel change: persist it, update store state, and trigger a fresh
+ * check against the new endpoint. Used by the Settings UI and the
+ * Nightly-confirmation modal.
+ */
+export async function applyUpdateChannel(channel: UpdateChannel): Promise<void> {
+  await setAppSetting("update_channel", channel);
+  useAppStore.getState().setUpdateChannel(channel);
+  // Don't await — the banner state will update when the check returns.
+  checkForUpdate();
+}
+
+/** Read the persisted channel into the store. Returns the resolved channel. */
+async function loadUpdateChannel(): Promise<UpdateChannel> {
+  let channel: UpdateChannel = "stable";
+  try {
+    const stored = await getAppSetting("update_channel");
+    if (stored === "nightly") channel = "nightly";
+  } catch (e) {
+    console.error("[updater] Failed to load update_channel setting:", e);
+  }
+  // Set even when channel matches the default — this resets cached state and
+  // ensures the store reflects the persisted value before the first check.
+  useAppStore.getState().setUpdateChannel(channel);
+  return channel;
+}
+
 export function useAutoUpdater() {
-  useEffect(() => {
-    if (import.meta.env.DEV) return;
-
-    checkForUpdate();
-    const intervalId = window.setInterval(checkForUpdate, CHECK_INTERVAL_MS);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
   const updateInstallWhenIdle = useAppStore((s) => s.updateInstallWhenIdle);
   const updateAvailable = useAppStore((s) => s.updateAvailable);
   const hasRunningAgents = useAppStore(
     (s) => s.workspaces.some((ws) => ws.agent_status === "Running")
   );
 
+  // Subscribe to the Rust-side download progress event.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    listen<number>("updater://progress", (event) => {
+      useAppStore.getState().setUpdateProgress(event.payload);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  // Load persisted channel, then start the check loop. Loading first avoids a
+  // wasted check against the default ("stable") before the persisted ("nightly")
+  // arrives.
+  useEffect(() => {
+    if (import.meta.env.DEV) return;
+    let intervalId: number | undefined;
+    let cancelled = false;
+    loadUpdateChannel().then(() => {
+      if (cancelled) return;
+      checkForUpdate();
+      intervalId = window.setInterval(checkForUpdate, CHECK_INTERVAL_MS);
+    });
+    return () => {
+      cancelled = true;
+      if (intervalId !== undefined) window.clearInterval(intervalId);
+    };
+  }, []);
+
   useEffect(() => {
     if (updateInstallWhenIdle && updateAvailable && !hasRunningAgents) {
       installNow();
     }
-  }, [updateInstallWhenIdle, updateAvailable, hasRunningAgents, installNow]);
+  }, [updateInstallWhenIdle, updateAvailable, hasRunningAgents]);
 }

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -81,7 +81,7 @@ export async function applyUpdateChannel(channel: UpdateChannel): Promise<void> 
 }
 
 /** Read the persisted channel into the store. Returns the resolved channel. */
-async function loadUpdateChannel(): Promise<UpdateChannel> {
+export async function loadUpdateChannel(): Promise<UpdateChannel> {
   let channel: UpdateChannel = "stable";
   try {
     const stored = await getAppSetting("update_channel");

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -108,10 +108,14 @@ export function useAutoUpdater() {
     let unlisten: UnlistenFn | undefined;
     listen<number>("updater://progress", (event) => {
       useAppStore.getState().setUpdateProgress(event.payload);
-    }).then((fn) => {
-      if (cancelled) fn();
-      else unlisten = fn;
-    });
+    })
+      .then((fn) => {
+        if (cancelled) fn();
+        else unlisten = fn;
+      })
+      .catch((e) => {
+        console.error("[updater] Failed to subscribe to progress events:", e);
+      });
     return () => {
       cancelled = true;
       unlisten?.();

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -104,13 +104,16 @@ export function useAutoUpdater() {
 
   // Subscribe to the Rust-side download progress event.
   useEffect(() => {
+    let cancelled = false;
     let unlisten: UnlistenFn | undefined;
     listen<number>("updater://progress", (event) => {
       useAppStore.getState().setUpdateProgress(event.payload);
     }).then((fn) => {
-      unlisten = fn;
+      if (cancelled) fn();
+      else unlisten = fn;
     });
     return () => {
+      cancelled = true;
       unlisten?.();
     };
   }, []);

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -644,6 +644,27 @@ export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
 
+// -- Updater --
+
+export type UpdateChannel = "stable" | "nightly";
+
+export interface UpdateInfo {
+  version: string;
+  current_version: string;
+  body: string | null;
+  date: string | null;
+}
+
+export function checkForUpdatesWithChannel(
+  channel: UpdateChannel,
+): Promise<UpdateInfo | null> {
+  return invoke("check_for_updates_with_channel", { channel });
+}
+
+export function installPendingUpdate(): Promise<void> {
+  return invoke("install_pending_update");
+}
+
 import type { ThemeDefinition } from "../types/theme";
 
 export function listUserThemes(): Promise<ThemeDefinition[]> {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -367,11 +367,13 @@ interface AppState {
   updateInstallWhenIdle: boolean;
   updateDownloading: boolean;
   updateProgress: number;
+  updateChannel: "stable" | "nightly";
   setUpdateAvailable: (available: boolean, version: string | null) => void;
   setUpdateDismissed: (dismissed: boolean) => void;
   setUpdateInstallWhenIdle: (enabled: boolean) => void;
   setUpdateDownloading: (downloading: boolean) => void;
   setUpdateProgress: (progress: number) => void;
+  setUpdateChannel: (channel: "stable" | "nightly") => void;
 
   // -- App info --
   appVersion: string | null;
@@ -1210,6 +1212,7 @@ export const useAppStore = create<AppState>((set) => ({
   updateInstallWhenIdle: false,
   updateDownloading: false,
   updateProgress: 0,
+  updateChannel: "stable",
   setUpdateAvailable: (available, version) =>
     set((state) => ({
       updateAvailable: available,
@@ -1223,6 +1226,14 @@ export const useAppStore = create<AppState>((set) => ({
   setUpdateDownloading: (downloading) =>
     set({ updateDownloading: downloading }),
   setUpdateProgress: (progress) => set({ updateProgress: progress }),
+  setUpdateChannel: (channel) =>
+    set({
+      updateChannel: channel,
+      updateAvailable: false,
+      updateVersion: null,
+      updateDismissed: false,
+      updateInstallWhenIdle: false,
+    }),
 
   // -- App info --
   appVersion: null,


### PR DESCRIPTION
## Summary

Adds an in-app setting that lets users opt into a **nightly** update channel, the app-side companion to the nightly release workflow.

The Tauri JS plugin's `check()` has no endpoint-override option, so channel switching is implemented via two new Rust commands that build a fresh `UpdaterBuilder` per call. The resulting `Update` handle (which holds the downloaded payload + signature context and isn't `Serialize`) is stored in `AppState` so it doesn't have to cross the IPC boundary.

```mermaid
sequenceDiagram
    participant UI as Settings UI
    participant Store as Zustand
    participant TS as useAutoUpdater.ts
    participant Rust as updater.rs
    participant State as AppState
    participant GH as GitHub

    UI->>Store: setUpdateChannel('nightly')
    UI->>TS: applyUpdateChannel('nightly')
    TS->>Rust: check_for_updates_with_channel('nightly')
    Rust->>GH: GET nightly/latest.json
    GH-->>Rust: Update manifest
    Rust->>State: pending_update = Some(update)
    Rust-->>TS: UpdateInfo { version, ... }
    TS->>Store: setUpdateAvailable(true, version)
    UI->>TS: installNow()
    TS->>Rust: install_pending_update()
    Rust->>State: take pending_update
    Rust->>Rust: download_and_install(progress_cb)
    Rust-->>TS: emit('updater://progress', pct)
    Rust->>Rust: app.restart()
```

Channel persistence reuses the existing `app_settings` key/value table — no DB migration required.

Closes #282.

## Complexity Notes

- **Race condition guard in `useAutoUpdater.ts`**: the first update check is gated on `loadUpdateChannel()` resolving so we don't fire a stale check against the default `stable` endpoint before the persisted `nightly` value arrives. The mount-time effect uses a `cancelled` flag to handle unmount during the async load.
- **`Update` lives in Rust state**: `tauri_plugin_updater::Update` isn't `Serialize`able. Storing it in `AppState.pending_update: Mutex<Option<Update>>` mirrors the previous JS module-level `pendingUpdate` pattern. `install_pending_update` `take()`s the slot, so a fresh `check` is required if install fails before completion.
- **Stale `tauri.conf.json` endpoint**: the static stable endpoint stays in `tauri.conf.json` as a fallback for any code path that still uses the JS plugin directly. The new commands take precedence in our app's flow.
- **Nightly opt-in modal**: switching *to* nightly goes through `ConfirmNightlyChannelModal`, which owns the persist + store update. Switching back to stable persists immediately (no confirmation — opt-out is harmless).

## Test Steps

1. **Build & lint** (already passing locally):
   - \`cargo clippy --workspace --all-targets\` — zero warnings
   - \`cargo fmt --all --check\`
   - \`cd src/ui && bun x tsc --noEmit\`
2. **Unit tests**:
   - \`cargo test --all-features\` — 557/557 passing
   - \`cd src/ui && bun run test\` — all suites passing, including new channel-pass-through case in \`useAutoUpdater.test.ts\`
3. **Manual UAT** (\`cargo tauri dev\`):
   - Open Settings → General → \"Update channel\"; confirm dropdown renders with **Stable (recommended)** selected.
   - Switch to **Nightly** → confirmation modal appears. Cancel → no change. Confirm → channel persists, UpdateBanner copy switches to \"Claudette Nightly\".
   - In a dev console: \`window.__CLAUDETTE_INVOKE__('get_app_setting', { key: 'update_channel' })\` returns \`\"nightly\"\`.
   - Restart the app and confirm the channel persists across restarts.
   - Switch back to **Stable** — cached update state resets and a fresh check fires immediately.
   - Click **Check for Updates** with each channel and confirm the request URL changes (Network tab / proxy).

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a — UI-discoverable, no public API change)