### PR TITLE
fix(ui): match dropdown height to text input height

### DIFF
--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -147,7 +147,7 @@
 /* ── Controls ── */
 
 .input {
-  background: rgba(0, 0, 0, 0.25);
+  background-color: rgba(0, 0, 0, 0.25);
   border: 1px solid var(--divider);
   border-radius: 6px;
   padding: 6px 12px;

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -164,6 +164,7 @@
 .select {
   composes: input;
   cursor: pointer;
+  padding-right: 26px;
 }
 
 /* ── Font picker (custom dropdown with font previews) ── */

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -102,15 +102,18 @@
 
 .filterSelect {
   flex: 1;
-  background: var(--input-bg, var(--hover-bg));
+  background-color: var(--input-bg, var(--hover-bg));
   color: var(--text-primary);
   border: 1px solid var(--divider);
   border-radius: 4px;
-  padding: 4px 8px;
+  padding: 4px 22px 4px 8px;
   font-size: 13px;
   cursor: pointer;
   outline: none;
   transition: border-color var(--transition-fast);
+  background-position:
+    calc(100% - 10px) 50%,
+    calc(100% - 6px) 50%;
 }
 
 .filterSelect:hover,

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -110,6 +110,32 @@ textarea {
   font-size: inherit;
 }
 
+/* WebKit ignores padding/height on native <select>, so dropdowns render
+   shorter than inputs despite identical CSS. appearance:none hands the box
+   model back to CSS; chevron is a pair of linear-gradients so it tracks
+   theme colors without an SVG asset. */
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 14px) 50%,
+    calc(100% - 9px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 26px;
+}
+
+select:disabled {
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-faint) 50%),
+    linear-gradient(135deg, var(--text-faint) 50%, transparent 50%);
+  cursor: not-allowed;
+}
+
 html,
 body,
 #root {

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -113,7 +113,10 @@ textarea {
 /* WebKit ignores padding/height on native <select>, so dropdowns render
    shorter than inputs despite identical CSS. appearance:none hands the box
    model back to CSS; chevron is a pair of linear-gradients so it tracks
-   theme colors without an SVG asset. */
+   theme colors without an SVG asset. Component-level rules that style a
+   <select> must use `background-color:` (not the `background:` shorthand,
+   which resets background-image and wipes the chevron) and reserve
+   >= 26px of right padding so option text doesn't overlap the chevron. */
 select {
   appearance: none;
   -webkit-appearance: none;


### PR DESCRIPTION
## Summary

Native `<select>` dropdowns have been rendering ~9px shorter than sibling `<input>` elements on macOS, despite `.select` composing `.input` in `Settings.module.css` (identical `padding: 6px 12px`, border, and font-size).

Root cause: WebKit ignores CSS padding on native selects and renders them at the system-imposed height (~21px at 13px font). Measured in the running dev build: input height 30px, select height 21px, select computed `padding: 0px` with `appearance: auto` — the browser discards the CSS box model for native selects.

Fix: one global rule in `theme.css` that switches every `<select>` to `appearance: none` and paints a pure-CSS chevron using two `linear-gradient`s keyed to `var(--text-muted)` (Bootstrap's technique — no SVG asset, tracks theme colors automatically). A `:disabled` variant dims the chevron to `var(--text-faint)` and sets `cursor: not-allowed`.

Two companion edits change `background:` → `background-color:` on `.input` (Settings) and `.filterSelect` (Sidebar), so the shorthand reset doesn't wipe the inherited `background-image` from the global rule. The sidebar filter also gets `padding-right: 22px` and a tighter `background-position` to keep its compact sizing while accommodating the new chevron.

## Complexity Notes

- **Cascade interaction**: CSS shorthand `background:` resets `background-image`, so the global `select` rule's chevron only survives if class-level rules use `background-color:` instead. This is why the Settings and Sidebar files both needed an edit beyond the global rule — easy to miss when adding a new select class in the future.
- **Visible chrome change**: replacing `appearance: auto` removes the native macOS chevron (double triangle). The replacement is a single chevron drawn with two 45°/135° gradients. Expected, but worth a visual check.
- **Not verified in the live app**: the dev server was running from a parallel Conductor workspace, so I could not HMR the change into the webview during development. CSS was validated via `bun run build` (clean), `bunx tsc --noEmit` (clean), and `bun run test` (486/486).

## Test Steps

1. Pull the branch and run `cargo tauri dev`.
2. Open **Settings → Models**: the Default Model, Thinking, and Default Effort dropdowns should all render at the same height as the worktree base dir input under **General** (30px in the current theme).
3. Switch through **General / Appearance / Notifications / Plugins** and verify every `<select>` matches the text input height.
4. Pick a model without effort support (e.g., Haiku) so the Effort dropdown becomes disabled — confirm the chevron dims to `var(--text-faint)`, cursor is `not-allowed`, and inline `opacity: 0.5` still applies.
5. In the **Sidebar**, open the filter row and confirm Status/Repo dropdowns still render compact (4px vertical padding) but now have the matching chevron.
6. Tab into a Settings select — focus ring still teal; border still transitions to `--text-dim` on focus.
7. Click a select — native option popup still appears in dark mode (verifies `color-scheme: dark` is intact).

## Checklist

- [ ] Tests added/updated _(n/a — pure visual CSS change, no behavior to assert)_
- [ ] Documentation updated _(n/a)_