### PR TITLE
fix(sidebar): show empty state when status grouping renders nothing

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -494,6 +494,45 @@
   white-space: nowrap;
 }
 
+.emptyState {
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.emptyStateMessage {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.emptyStateActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+}
+
+.emptyStateAction {
+  background: var(--hover-bg);
+  border: 1px solid var(--divider);
+  color: var(--text-primary);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.emptyStateAction:hover {
+  color: var(--accent-primary);
+  background: var(--accent-bg);
+  border-color: rgba(var(--accent-primary-rgb), 0.25);
+}
+
 .footer {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -491,24 +491,22 @@ export const Sidebar = memo(function Sidebar() {
                 (sidebarRepoFilter === "all" || ws.repository_id === sidebarRepoFilter)
             );
           const repoFilterActive = sidebarRepoFilter !== "all";
-          const hasNoWorkspaces =
-            workspaces.filter((ws) => !ws.remote_connection_id).length === 0;
-          const targetRepo =
-            (repoFilterActive
-              ? localRepos.find((r) => r.id === sidebarRepoFilter && r.path_valid)
-              : undefined) ?? localRepos.find((r) => r.path_valid);
+          const hasNoWorkspaces = !workspaces.some((ws) => !ws.remote_connection_id);
+          const targetRepo = repoFilterActive
+            ? localRepos.find((r) => r.id === sidebarRepoFilter && r.path_valid)
+            : localRepos.find((r) => r.path_valid);
 
           let message: string;
           if (hasHiddenArchived && repoFilterActive) {
             message = "No matching workspaces — all workspaces for this repo are archived.";
           } else if (hasHiddenArchived) {
             message = "All workspaces are archived.";
-          } else if (repoFilterActive) {
-            message = "No workspaces match this repo filter.";
           } else if (hasNoWorkspaces && localRepos.length === 0) {
             message = "No repositories yet — add one from the toolbar below.";
           } else if (hasNoWorkspaces) {
             message = "No workspaces yet.";
+          } else if (repoFilterActive) {
+            message = "No workspaces match this repo filter.";
           } else {
             message = "Nothing to show.";
           }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -502,7 +502,7 @@ export const Sidebar = memo(function Sidebar() {
           } else if (hasHiddenArchived) {
             message = "All workspaces are archived.";
           } else if (hasNoWorkspaces && localRepos.length === 0) {
-            message = "No repositories yet — add one from the toolbar below.";
+            message = "No local repositories yet — add one from the toolbar below.";
           } else if (hasNoWorkspaces) {
             message = "No workspaces yet.";
           } else if (repoFilterActive) {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -480,6 +480,72 @@ export const Sidebar = memo(function Sidebar() {
           );
         })}
 
+        {sidebarGroupBy === "status" && filteredWorkspaces.length === 0 && (() => {
+          const localRepos = repositories.filter((r) => !r.remote_connection_id);
+          const hasHiddenArchived =
+            !sidebarShowArchived &&
+            workspaces.some(
+              (ws) =>
+                !ws.remote_connection_id &&
+                ws.status === "Archived" &&
+                (sidebarRepoFilter === "all" || ws.repository_id === sidebarRepoFilter)
+            );
+          const repoFilterActive = sidebarRepoFilter !== "all";
+          const hasNoWorkspaces =
+            workspaces.filter((ws) => !ws.remote_connection_id).length === 0;
+          const targetRepo =
+            (repoFilterActive
+              ? localRepos.find((r) => r.id === sidebarRepoFilter && r.path_valid)
+              : undefined) ?? localRepos.find((r) => r.path_valid);
+
+          let message: string;
+          if (hasHiddenArchived && repoFilterActive) {
+            message = "No matching workspaces — all workspaces for this repo are archived.";
+          } else if (hasHiddenArchived) {
+            message = "All workspaces are archived.";
+          } else if (repoFilterActive) {
+            message = "No workspaces match this repo filter.";
+          } else if (hasNoWorkspaces && localRepos.length === 0) {
+            message = "No repositories yet — add one from the toolbar below.";
+          } else if (hasNoWorkspaces) {
+            message = "No workspaces yet.";
+          } else {
+            message = "Nothing to show.";
+          }
+
+          return (
+            <div className={styles.emptyState}>
+              <div className={styles.emptyStateMessage}>{message}</div>
+              <div className={styles.emptyStateActions}>
+                {hasHiddenArchived && (
+                  <button
+                    className={styles.emptyStateAction}
+                    onClick={() => setSidebarShowArchived(true)}
+                  >
+                    Show archived
+                  </button>
+                )}
+                {repoFilterActive && (
+                  <button
+                    className={styles.emptyStateAction}
+                    onClick={() => setSidebarRepoFilter("all")}
+                  >
+                    Clear repo filter
+                  </button>
+                )}
+                {hasNoWorkspaces && targetRepo && (
+                  <button
+                    className={styles.emptyStateAction}
+                    onClick={() => handleCreateWorkspace(targetRepo.id)}
+                  >
+                    New workspace
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })()}
+
         {sidebarGroupBy === "repo" && repositories
           .filter((r) => !r.remote_connection_id)
           .filter((r) => sidebarRepoFilter === "all" || r.id === sidebarRepoFilter)

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -933,7 +933,7 @@ export const useAppStore = create<AppState>((set) => ({
   rightSidebarWidth: 250,
   terminalHeight: 300,
   rightSidebarTab: "changes",
-  sidebarGroupBy: "status",
+  sidebarGroupBy: "repo",
   sidebarRepoFilter: "all",
   sidebarShowArchived: false,
   repoCollapsed: {},


### PR DESCRIPTION
## Summary

Closes #308.

When the sidebar's **Group by** is set to **Status** and every status bucket ends up empty after filtering (e.g., all workspaces archived with *Show archived* off, or a repo filter that excludes everything), the sidebar body rendered as a complete blank — no headers, no hints, no way to recover from the UI.

Root cause (`src/ui/src/components/sidebar/Sidebar.tsx:457-481`): the status branch iterates `STATUS_BUCKET_ORDER.map(...)` and returns `null` for any empty bucket. When every bucket is empty, every iteration returns `null`, so nothing renders. The repo-grouping branch already self-recovers because it iterates over `repositories` and always renders a header per repo.

This change adds an inline empty-state immediately after the status `.map(...)`, gated on `sidebarGroupBy === "status" && filteredWorkspaces.length === 0`. The message and actions are derived from the *cause* of emptiness so they're directly useful:

- Hidden archived workspaces → **Show archived** button (calls `setSidebarShowArchived(true)`)
- Active repo filter → **Clear repo filter** button (calls `setSidebarRepoFilter("all")`)
- No workspaces yet (but repos exist) → **New workspace** button (reuses the same `handleCreateWorkspace` handler as the per-repo `+` button)
- No repositories at all → short hint pointing to the footer's "Add repository" `+` button

Multiple actions can appear together when multiple causes apply (e.g., archived hidden *and* repo filter set).

Scope intentionally limited to the status branch. The repo branch already self-recovers and the issue's bonus repo-filter empty-state is left for a follow-up.

### Additional change: default `Group by` is now `Repo`

This PR also flips the default value of `sidebarGroupBy` from `"status"` to `"repo"` in the Zustand store initializer. Repo grouping is the more discoverable default — every repo header is always visible (with its `+ new workspace` button), so a fresh install with no workspaces still shows something actionable rather than a blank list under status buckets. The empty-state added in the first commit remains the safety net for users who switch to Status grouping. The store has no `persist` middleware, so this affects every fresh app start (no migration needed); existing in-session selections are not preserved across restarts.

## Test plan

- [x] `cd src/ui && bunx tsc --noEmit` — passes
- [x] `cd src/ui && bun run test` — all 486 tests pass
- [x] `cd src/ui && bun run lint` — no new issues introduced in `Sidebar.tsx` / `Sidebar.module.css`
- [ ] Manual repro in `cargo tauri dev`: set Group by = Status, archive all workspaces, Show archived = off → empty state with "Show archived" appears; clicking it restores the list. **Not yet verified in a running dev build** — the Claudette dev build on this machine is serving a different workspace, so HMR couldn't pick up these changes.
- [ ] Manual: set Group by = Status + Repo filter to a repo with no workspaces → "Clear repo filter" appears and works.
- [ ] Manual: fresh repo with no workspaces, Group by = Status → "New workspace" appears and creates a workspace.
- [ ] Manual regression: with at least one non-archived workspace visible, confirm empty state does NOT render and existing status group headers behave as before.
- [ ] Manual: confirm fresh app start defaults to **Group by: Repo**.