### PR TITLE
chore: ignore /docs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ tags
 
 # Superpowers brainstorm
 .superpowers/
+
+# Documentation
+/docs


### PR DESCRIPTION
### Summary
Adds `/docs` to `.gitignore` (anchored to the repo root) so locally- or AI-generated documentation doesn't accidentally get tracked. Slotted under a new `# Documentation` section, matching the file's existing ecosystem-grouped style.

### Test Steps
1. Check out this branch.
2. `mkdir -p docs && echo hi > docs/test.md`
3. `git status` — `docs/` should not appear.
4. `mkdir -p src/ui/docs && echo hi > src/ui/docs/test.md`
5. `git status` — nested `docs/` at `src/ui/docs/` **should** appear as untracked (leading `/` anchors the ignore to the root).
6. Clean up: `rm -rf docs src/ui/docs`.

### Checklist
- [ ] Tests added/updated — N/A (gitignore-only)
- [ ] Documentation updated — N/A