### PR TITLE
feat: context window tracking, phase 2 — utilization meter (refs #300)

### DIFF
--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -7,6 +7,7 @@ import { EffortSelector, EFFORT_LEVELS } from "./EffortSelector";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "./modelCapabilities";
 import { applySelectedModel } from "./applySelectedModel";
 import { applyPlanModeMountDefault } from "./applyPlanModeMountDefault";
+import { ContextMeter } from "./ContextMeter";
 import styles from "./ChatToolbar.module.css";
 
 interface ChatToolbarProps {
@@ -171,6 +172,8 @@ export function ChatToolbar({ workspaceId, disabled }: ChatToolbarProps) {
         <span className={styles.chipLabel}>{modelLabel}</span>
         {isExtraUsage && <BadgeDollarSign size={14} className={styles.extraUsage} />}
       </button>
+
+      <ContextMeter workspaceId={workspaceId} />
 
       {isFastSupported(selectedModel) && (
         <button

--- a/src/ui/src/components/chat/ContextMeter.module.css
+++ b/src/ui/src/components/chat/ContextMeter.module.css
@@ -1,0 +1,49 @@
+.meter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  user-select: none;
+}
+
+.track {
+  position: relative;
+  width: 80px;
+  height: 4px;
+  background: var(--divider);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
+  transition: width 200ms ease-out, background-color 200ms ease-out;
+}
+
+.fillNormal {
+  background: var(--context-meter-normal);
+}
+
+.fillWarn {
+  background: var(--context-meter-warn);
+}
+
+.fillNearFull {
+  background: var(--context-meter-near-full);
+}
+
+.fillCritical {
+  background: var(--context-meter-critical);
+}
+
+.readout {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/ui/src/components/chat/ContextMeter.tsx
+++ b/src/ui/src/components/chat/ContextMeter.tsx
@@ -1,0 +1,58 @@
+import { useAppStore } from "../../stores/useAppStore";
+import { MODELS } from "./modelRegistry";
+import { formatTokens } from "./formatTokens";
+import { buildMeterTooltip, computeMeterState, type Band } from "./contextMeterLogic";
+import styles from "./ContextMeter.module.css";
+
+interface ContextMeterProps {
+  workspaceId: string;
+}
+
+function fillClassForBand(band: Band): string {
+  switch (band) {
+    case "critical":
+      return styles.fillCritical;
+    case "near-full":
+      return styles.fillNearFull;
+    case "warn":
+      return styles.fillWarn;
+    case "normal":
+      return styles.fillNormal;
+  }
+}
+
+/**
+ * Compact context-window utilization meter for the chat toolbar.
+ *
+ * Reads the most recent completed turn for the workspace and the
+ * currently-selected model's capacity. Hidden when either source is
+ * missing — covers fresh workspaces, pre-migration history, and stale
+ * model ids. All computation lives in `contextMeterLogic.ts` so this
+ * component is a thin presentational wrapper.
+ */
+export function ContextMeter({ workspaceId }: ContextMeterProps) {
+  const turns = useAppStore((s) => s.completedTurns[workspaceId]);
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId]);
+
+  const latestTurn = turns && turns.length > 0 ? turns[turns.length - 1] : undefined;
+  const model = MODELS.find((m) => m.id === selectedModel);
+  const state = computeMeterState(latestTurn, model?.contextWindowTokens);
+  if (!state) return null;
+
+  const tooltip = buildMeterTooltip(state);
+
+  return (
+    <div className={styles.meter} title={tooltip}>
+      <div className={styles.track}>
+        <div
+          className={`${styles.fill} ${fillClassForBand(state.band)}`}
+          data-band={state.band}
+          style={{ width: `${state.fillPercent}%` }}
+        />
+      </div>
+      <span className={styles.readout}>
+        {formatTokens(state.totalTokens)} / {formatTokens(state.capacity)}
+      </span>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/ContextMeter.tsx
+++ b/src/ui/src/components/chat/ContextMeter.tsx
@@ -24,19 +24,20 @@ function fillClassForBand(band: Band): string {
 /**
  * Compact context-window utilization meter for the chat toolbar.
  *
- * Reads the most recent completed turn for the workspace and the
- * currently-selected model's capacity. Hidden when either source is
- * missing — covers fresh workspaces, pre-migration history, and stale
- * model ids. All computation lives in `contextMeterLogic.ts` so this
- * component is a thin presentational wrapper.
+ * Reads the most recent turn's usage from the `latestTurnUsage` slice
+ * (populated on every turn end by `finalizeTurn`, including tool-free
+ * turns that don't produce a `CompletedTurn`) and the currently-selected
+ * model's capacity. Hidden when either source is missing — covers fresh
+ * workspaces, pre-migration history, and stale model ids. All computation
+ * lives in `contextMeterLogic.ts` so this component is a thin presentational
+ * wrapper.
  */
 export function ContextMeter({ workspaceId }: ContextMeterProps) {
-  const turns = useAppStore((s) => s.completedTurns[workspaceId]);
+  const usage = useAppStore((s) => s.latestTurnUsage[workspaceId]);
   const selectedModel = useAppStore((s) => s.selectedModel[workspaceId]);
 
-  const latestTurn = turns && turns.length > 0 ? turns[turns.length - 1] : undefined;
   const model = MODELS.find((m) => m.id === selectedModel);
-  const state = computeMeterState(latestTurn, model?.contextWindowTokens);
+  const state = computeMeterState(usage, model?.contextWindowTokens);
   if (!state) return null;
 
   const tooltip = buildMeterTooltip(state);

--- a/src/ui/src/components/chat/contextMeterLogic.test.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.test.ts
@@ -163,6 +163,24 @@ describe("computeMeterState", () => {
     expect(computeMeterState(turn, 200_000)).toBeNull();
   });
 
+  it("treats NaN cache tokens as zero, not NaN", () => {
+    // `?? 0` would NOT replace NaN (it only catches null/undefined), so
+    // a stray NaN in a cache field must be caught by Number.isFinite to
+    // avoid poisoning totalTokens / fillPercent.
+    const turn = makeTurn({
+      inputTokens: 1_000,
+      outputTokens: 200,
+      cacheReadTokens: Number.NaN,
+      cacheCreationTokens: Number.NaN,
+    });
+    const state = computeMeterState(turn, 200_000);
+    expect(state).not.toBeNull();
+    expect(state!.cacheRead).toBe(0);
+    expect(state!.cacheCreation).toBe(0);
+    expect(state!.totalTokens).toBe(1_200);
+    expect(Number.isFinite(state!.fillPercent)).toBe(true);
+  });
+
   it("computes fillPercent as ratio * 100 when under capacity", () => {
     const turn = makeTurn({ inputTokens: 50_000, outputTokens: 1_000 });
     const state = computeMeterState(turn, 200_000);

--- a/src/ui/src/components/chat/contextMeterLogic.test.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect } from "vitest";
 import { bandForRatio, buildMeterTooltip, computeMeterState } from "./contextMeterLogic";
+import type { MeterState } from "./contextMeterLogic";
 import type { CompletedTurn } from "../../stores/useAppStore";
+
+function makeState(overrides: Partial<MeterState> = {}): MeterState {
+  const totalTokens = overrides.totalTokens ?? 0;
+  const capacity = overrides.capacity ?? 1;
+  return {
+    totalTokens,
+    capacity,
+    input: overrides.input ?? 0,
+    output: overrides.output ?? 0,
+    cacheRead: overrides.cacheRead ?? 0,
+    cacheCreation: overrides.cacheCreation ?? 0,
+    fillPercent: overrides.fillPercent ?? Math.min(totalTokens / capacity, 1) * 100,
+    percentRounded: overrides.percentRounded ?? Math.round((totalTokens / capacity) * 100),
+    band: overrides.band ?? "normal",
+  };
+}
 
 function makeTurn(overrides: Partial<CompletedTurn> = {}): CompletedTurn {
   return {
@@ -42,14 +59,16 @@ describe("bandForRatio", () => {
 
 describe("buildMeterTooltip", () => {
   it("formats thousand-separated breakdown with percentage", () => {
-    const tooltip = buildMeterTooltip({
-      totalTokens: 62_450,
-      capacity: 200_000,
-      input: 48_200,
-      output: 1_000,
-      cacheRead: 12_000,
-      cacheCreation: 1_250,
-    });
+    const tooltip = buildMeterTooltip(
+      makeState({
+        totalTokens: 62_450,
+        capacity: 200_000,
+        input: 48_200,
+        output: 1_000,
+        cacheRead: 12_000,
+        cacheCreation: 1_250,
+      }),
+    );
     expect(tooltip).toContain("Context: 62,450 / 200,000 tokens (31%)");
     expect(tooltip).toContain("Input: 48,200");
     expect(tooltip).toContain("Cache read: 12,000");
@@ -58,16 +77,27 @@ describe("buildMeterTooltip", () => {
   });
 
   it("rounds percentage to nearest integer", () => {
-    const tooltip = buildMeterTooltip({
-      totalTokens: 1000,
-      capacity: 3000,
-      input: 1000,
-      output: 0,
-      cacheRead: 0,
-      cacheCreation: 0,
-    });
+    const tooltip = buildMeterTooltip(
+      makeState({
+        totalTokens: 1000,
+        capacity: 3000,
+        input: 1000,
+      }),
+    );
     // 1000/3000 = 0.3333... → 33%
     expect(tooltip).toContain("(33%)");
+  });
+
+  it("reports >100% for over-capacity inputs without clamping", () => {
+    const tooltip = buildMeterTooltip(
+      makeState({
+        totalTokens: 300_000,
+        capacity: 200_000,
+        input: 300_000,
+      }),
+    );
+    // 300000 / 200000 = 1.5 → 150%
+    expect(tooltip).toContain("(150%)");
   });
 });
 
@@ -118,12 +148,19 @@ describe("computeMeterState", () => {
     expect(state!.cacheCreation).toBe(0);
   });
 
-  it("caps fillPercent at 100 when over capacity", () => {
+  it("caps fillPercent at 100 but leaves percentRounded uncapped when over capacity", () => {
     const turn = makeTurn({ inputTokens: 300_000, outputTokens: 1_000 });
     const state = computeMeterState(turn, 200_000);
     expect(state).not.toBeNull();
     expect(state!.fillPercent).toBe(100);
+    // 301_000 / 200_000 = 1.505 → rounded to 151
+    expect(state!.percentRounded).toBe(151);
     expect(state!.band).toBe("critical");
+  });
+
+  it("rejects NaN token values (treats them as missing)", () => {
+    const turn = makeTurn({ inputTokens: Number.NaN, outputTokens: 100 });
+    expect(computeMeterState(turn, 200_000)).toBeNull();
   });
 
   it("computes fillPercent as ratio * 100 when under capacity", () => {

--- a/src/ui/src/components/chat/contextMeterLogic.test.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { bandForRatio, buildMeterTooltip, computeMeterState } from "./contextMeterLogic";
+import type { CompletedTurn } from "../../stores/useAppStore";
+
+function makeTurn(overrides: Partial<CompletedTurn> = {}): CompletedTurn {
+  return {
+    id: overrides.id ?? "t1",
+    activities: [],
+    messageCount: 1,
+    collapsed: true,
+    afterMessageIndex: 0,
+    durationMs: overrides.durationMs,
+    inputTokens: overrides.inputTokens,
+    outputTokens: overrides.outputTokens,
+    cacheReadTokens: overrides.cacheReadTokens,
+    cacheCreationTokens: overrides.cacheCreationTokens,
+  };
+}
+
+describe("bandForRatio", () => {
+  it("returns normal below 60%", () => {
+    expect(bandForRatio(0)).toBe("normal");
+    expect(bandForRatio(0.3)).toBe("normal");
+    expect(bandForRatio(0.599)).toBe("normal");
+  });
+  it("returns warn at 60-80%", () => {
+    expect(bandForRatio(0.6)).toBe("warn");
+    expect(bandForRatio(0.75)).toBe("warn");
+    expect(bandForRatio(0.799)).toBe("warn");
+  });
+  it("returns near-full at 80-90%", () => {
+    expect(bandForRatio(0.8)).toBe("near-full");
+    expect(bandForRatio(0.85)).toBe("near-full");
+    expect(bandForRatio(0.899)).toBe("near-full");
+  });
+  it("returns critical at 90%+", () => {
+    expect(bandForRatio(0.9)).toBe("critical");
+    expect(bandForRatio(1)).toBe("critical");
+    expect(bandForRatio(1.5)).toBe("critical"); // over-capacity still critical
+  });
+});
+
+describe("buildMeterTooltip", () => {
+  it("formats thousand-separated breakdown with percentage", () => {
+    const tooltip = buildMeterTooltip({
+      totalTokens: 62_450,
+      capacity: 200_000,
+      input: 48_200,
+      output: 1_000,
+      cacheRead: 12_000,
+      cacheCreation: 1_250,
+    });
+    expect(tooltip).toContain("Context: 62,450 / 200,000 tokens (31%)");
+    expect(tooltip).toContain("Input: 48,200");
+    expect(tooltip).toContain("Cache read: 12,000");
+    expect(tooltip).toContain("Cache creation: 1,250");
+    expect(tooltip).toContain("Output: 1,000");
+  });
+
+  it("rounds percentage to nearest integer", () => {
+    const tooltip = buildMeterTooltip({
+      totalTokens: 1000,
+      capacity: 3000,
+      input: 1000,
+      output: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+    });
+    // 1000/3000 = 0.3333... → 33%
+    expect(tooltip).toContain("(33%)");
+  });
+});
+
+describe("computeMeterState", () => {
+  it("returns null when turn is undefined", () => {
+    const state = computeMeterState(undefined, 200_000);
+    expect(state).toBeNull();
+  });
+
+  it("returns null when inputTokens is undefined", () => {
+    const turn = makeTurn({ outputTokens: 100 });
+    expect(computeMeterState(turn, 200_000)).toBeNull();
+  });
+
+  it("returns null when outputTokens is undefined", () => {
+    const turn = makeTurn({ inputTokens: 100 });
+    expect(computeMeterState(turn, 200_000)).toBeNull();
+  });
+
+  it("returns null when capacity is zero or missing", () => {
+    const turn = makeTurn({ inputTokens: 100, outputTokens: 50 });
+    expect(computeMeterState(turn, 0)).toBeNull();
+    expect(computeMeterState(turn, undefined)).toBeNull();
+  });
+
+  it("sums all four token fields into totalTokens", () => {
+    const turn = makeTurn({
+      inputTokens: 48_200,
+      outputTokens: 1_000,
+      cacheReadTokens: 12_000,
+      cacheCreationTokens: 1_250,
+    });
+    const state = computeMeterState(turn, 200_000);
+    expect(state).not.toBeNull();
+    expect(state!.totalTokens).toBe(62_450);
+    expect(state!.input).toBe(48_200);
+    expect(state!.output).toBe(1_000);
+    expect(state!.cacheRead).toBe(12_000);
+    expect(state!.cacheCreation).toBe(1_250);
+  });
+
+  it("treats missing cache tokens as zero", () => {
+    const turn = makeTurn({ inputTokens: 1_000, outputTokens: 200 });
+    const state = computeMeterState(turn, 200_000);
+    expect(state).not.toBeNull();
+    expect(state!.totalTokens).toBe(1_200);
+    expect(state!.cacheRead).toBe(0);
+    expect(state!.cacheCreation).toBe(0);
+  });
+
+  it("caps fillPercent at 100 when over capacity", () => {
+    const turn = makeTurn({ inputTokens: 300_000, outputTokens: 1_000 });
+    const state = computeMeterState(turn, 200_000);
+    expect(state).not.toBeNull();
+    expect(state!.fillPercent).toBe(100);
+    expect(state!.band).toBe("critical");
+  });
+
+  it("computes fillPercent as ratio * 100 when under capacity", () => {
+    const turn = makeTurn({ inputTokens: 50_000, outputTokens: 1_000 });
+    const state = computeMeterState(turn, 200_000);
+    expect(state).not.toBeNull();
+    // 51000 / 200000 = 0.255 → 25.5%
+    expect(state!.fillPercent).toBeCloseTo(25.5, 5);
+    expect(state!.band).toBe("normal");
+  });
+
+  it("assigns the correct band for each threshold", () => {
+    const capacity = 200_000;
+    // 50% → normal
+    expect(computeMeterState(makeTurn({ inputTokens: 100_000, outputTokens: 0 }), capacity)!.band).toBe("normal");
+    // 70% → warn
+    expect(computeMeterState(makeTurn({ inputTokens: 140_000, outputTokens: 0 }), capacity)!.band).toBe("warn");
+    // 85% → near-full
+    expect(computeMeterState(makeTurn({ inputTokens: 170_000, outputTokens: 0 }), capacity)!.band).toBe("near-full");
+    // 95% → critical
+    expect(computeMeterState(makeTurn({ inputTokens: 190_000, outputTokens: 0 }), capacity)!.band).toBe("critical");
+  });
+});

--- a/src/ui/src/components/chat/contextMeterLogic.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.ts
@@ -9,8 +9,10 @@ export interface MeterState {
   output: number;
   cacheRead: number;
   cacheCreation: number;
-  ratio: number;
+  /** Bar fill width, capped at 100. Use for the fill element's CSS width. */
   fillPercent: number;
+  /** Displayed percentage, uncapped — can exceed 100 when a turn goes over
+   *  the context window. Use for text labels / tooltip (e.g. "105%"). */
   percentRounded: number;
   band: Band;
 }
@@ -28,61 +30,59 @@ export function bandForRatio(ratio: number): Band {
  * if the meter should be hidden. Returning null (rather than throwing)
  * covers: no turn yet, pre-migration turn missing token metadata, and
  * stale model ids with zero/undefined capacity.
+ *
+ * Uses `Number.isFinite` for the token guards so `NaN` values from
+ * unexpected deserialization paths are treated the same as missing data.
  */
 export function computeMeterState(
   turn: CompletedTurn | undefined,
   capacity: number | undefined,
 ): MeterState | null {
   if (!turn) return null;
-  if (typeof turn.inputTokens !== "number") return null;
-  if (typeof turn.outputTokens !== "number") return null;
-  if (typeof capacity !== "number" || capacity <= 0) return null;
+  if (!Number.isFinite(turn.inputTokens)) return null;
+  if (!Number.isFinite(turn.outputTokens)) return null;
+  if (!Number.isFinite(capacity) || (capacity as number) <= 0) return null;
 
-  const input = turn.inputTokens;
-  const output = turn.outputTokens;
+  const cap = capacity as number;
+  const input = turn.inputTokens as number;
+  const output = turn.outputTokens as number;
   const cacheRead = turn.cacheReadTokens ?? 0;
   const cacheCreation = turn.cacheCreationTokens ?? 0;
   const totalTokens = input + cacheRead + cacheCreation + output;
-  const ratio = totalTokens / capacity;
+  const ratio = totalTokens / cap;
   const fillPercent = Math.min(ratio, 1) * 100;
   const percentRounded = Math.round(ratio * 100);
   const band = bandForRatio(ratio);
 
   return {
     totalTokens,
-    capacity,
+    capacity: cap,
     input,
     output,
     cacheRead,
     cacheCreation,
-    ratio,
     fillPercent,
     percentRounded,
     band,
   };
 }
 
-interface TooltipInput {
-  totalTokens: number;
-  capacity: number;
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheCreation: number;
-}
+const LOCALE = "en-US";
 
 /**
- * Build the multi-line tooltip string shown on hover. Uses toLocaleString()
- * for thousand separators so numbers read cleanly (e.g. "62,450").
+ * Build the multi-line tooltip string shown on hover. Accepts a `MeterState`
+ * directly (no re-derivation) so the tooltip can never disagree with what
+ * the meter shows. Uses `en-US` locale explicitly so the thousand separator
+ * is a comma regardless of the user's system locale — matches the readout
+ * style and keeps tests deterministic.
  */
-export function buildMeterTooltip(state: TooltipInput): string {
-  const percentRounded = Math.round((state.totalTokens / state.capacity) * 100);
+export function buildMeterTooltip(state: MeterState): string {
   return [
-    `Context: ${state.totalTokens.toLocaleString()} / ${state.capacity.toLocaleString()} tokens (${percentRounded}%)`,
+    `Context: ${state.totalTokens.toLocaleString(LOCALE)} / ${state.capacity.toLocaleString(LOCALE)} tokens (${state.percentRounded}%)`,
     "",
-    `Input: ${state.input.toLocaleString()}`,
-    `Cache read: ${state.cacheRead.toLocaleString()}`,
-    `Cache creation: ${state.cacheCreation.toLocaleString()}`,
-    `Output: ${state.output.toLocaleString()}`,
+    `Input: ${state.input.toLocaleString(LOCALE)}`,
+    `Cache read: ${state.cacheRead.toLocaleString(LOCALE)}`,
+    `Cache creation: ${state.cacheCreation.toLocaleString(LOCALE)}`,
+    `Output: ${state.output.toLocaleString(LOCALE)}`,
   ].join("\n");
 }

--- a/src/ui/src/components/chat/contextMeterLogic.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.ts
@@ -46,8 +46,11 @@ export function computeMeterState(
   const cap = capacity as number;
   const input = turn.inputTokens as number;
   const output = turn.outputTokens as number;
-  const cacheRead = turn.cacheReadTokens ?? 0;
-  const cacheCreation = turn.cacheCreationTokens ?? 0;
+  // `?? 0` only replaces null/undefined — NaN would pass through and
+  // poison totalTokens / fillPercent / the tooltip. Number.isFinite
+  // treats undefined, null, and NaN uniformly as "missing".
+  const cacheRead = Number.isFinite(turn.cacheReadTokens) ? (turn.cacheReadTokens as number) : 0;
+  const cacheCreation = Number.isFinite(turn.cacheCreationTokens) ? (turn.cacheCreationTokens as number) : 0;
   const totalTokens = input + cacheRead + cacheCreation + output;
   const ratio = totalTokens / cap;
   const fillPercent = Math.min(ratio, 1) * 100;

--- a/src/ui/src/components/chat/contextMeterLogic.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.ts
@@ -1,4 +1,4 @@
-import type { CompletedTurn } from "../../stores/useAppStore";
+import type { TurnUsage } from "../../stores/useAppStore";
 
 export type Band = "normal" | "warn" | "near-full" | "critical";
 
@@ -35,22 +35,22 @@ export function bandForRatio(ratio: number): Band {
  * unexpected deserialization paths are treated the same as missing data.
  */
 export function computeMeterState(
-  turn: CompletedTurn | undefined,
+  usage: TurnUsage | undefined,
   capacity: number | undefined,
 ): MeterState | null {
-  if (!turn) return null;
-  if (!Number.isFinite(turn.inputTokens)) return null;
-  if (!Number.isFinite(turn.outputTokens)) return null;
+  if (!usage) return null;
+  if (!Number.isFinite(usage.inputTokens)) return null;
+  if (!Number.isFinite(usage.outputTokens)) return null;
   if (!Number.isFinite(capacity) || (capacity as number) <= 0) return null;
 
   const cap = capacity as number;
-  const input = turn.inputTokens as number;
-  const output = turn.outputTokens as number;
+  const input = usage.inputTokens as number;
+  const output = usage.outputTokens as number;
   // `?? 0` only replaces null/undefined — NaN would pass through and
   // poison totalTokens / fillPercent / the tooltip. Number.isFinite
   // treats undefined, null, and NaN uniformly as "missing".
-  const cacheRead = Number.isFinite(turn.cacheReadTokens) ? (turn.cacheReadTokens as number) : 0;
-  const cacheCreation = Number.isFinite(turn.cacheCreationTokens) ? (turn.cacheCreationTokens as number) : 0;
+  const cacheRead = Number.isFinite(usage.cacheReadTokens) ? (usage.cacheReadTokens as number) : 0;
+  const cacheCreation = Number.isFinite(usage.cacheCreationTokens) ? (usage.cacheCreationTokens as number) : 0;
   const totalTokens = input + cacheRead + cacheCreation + output;
   const ratio = totalTokens / cap;
   const fillPercent = Math.min(ratio, 1) * 100;

--- a/src/ui/src/components/chat/contextMeterLogic.ts
+++ b/src/ui/src/components/chat/contextMeterLogic.ts
@@ -1,0 +1,88 @@
+import type { CompletedTurn } from "../../stores/useAppStore";
+
+export type Band = "normal" | "warn" | "near-full" | "critical";
+
+export interface MeterState {
+  totalTokens: number;
+  capacity: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+  ratio: number;
+  fillPercent: number;
+  percentRounded: number;
+  band: Band;
+}
+
+/** Thresholds per the Phase 2 spec: 60 / 80 / 90 % */
+export function bandForRatio(ratio: number): Band {
+  if (ratio >= 0.9) return "critical";
+  if (ratio >= 0.8) return "near-full";
+  if (ratio >= 0.6) return "warn";
+  return "normal";
+}
+
+/**
+ * Compute everything the ContextMeter component needs to render, or null
+ * if the meter should be hidden. Returning null (rather than throwing)
+ * covers: no turn yet, pre-migration turn missing token metadata, and
+ * stale model ids with zero/undefined capacity.
+ */
+export function computeMeterState(
+  turn: CompletedTurn | undefined,
+  capacity: number | undefined,
+): MeterState | null {
+  if (!turn) return null;
+  if (typeof turn.inputTokens !== "number") return null;
+  if (typeof turn.outputTokens !== "number") return null;
+  if (typeof capacity !== "number" || capacity <= 0) return null;
+
+  const input = turn.inputTokens;
+  const output = turn.outputTokens;
+  const cacheRead = turn.cacheReadTokens ?? 0;
+  const cacheCreation = turn.cacheCreationTokens ?? 0;
+  const totalTokens = input + cacheRead + cacheCreation + output;
+  const ratio = totalTokens / capacity;
+  const fillPercent = Math.min(ratio, 1) * 100;
+  const percentRounded = Math.round(ratio * 100);
+  const band = bandForRatio(ratio);
+
+  return {
+    totalTokens,
+    capacity,
+    input,
+    output,
+    cacheRead,
+    cacheCreation,
+    ratio,
+    fillPercent,
+    percentRounded,
+    band,
+  };
+}
+
+interface TooltipInput {
+  totalTokens: number;
+  capacity: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+}
+
+/**
+ * Build the multi-line tooltip string shown on hover. Uses toLocaleString()
+ * for thousand separators so numbers read cleanly (e.g. "62,450").
+ */
+export function buildMeterTooltip(state: TooltipInput): string {
+  const percentRounded = Math.round((state.totalTokens / state.capacity) * 100);
+  return [
+    `Context: ${state.totalTokens.toLocaleString()} / ${state.capacity.toLocaleString()} tokens (${percentRounded}%)`,
+    "",
+    `Input: ${state.input.toLocaleString()}`,
+    `Cache read: ${state.cacheRead.toLocaleString()}`,
+    `Cache creation: ${state.cacheCreation.toLocaleString()}`,
+    `Output: ${state.output.toLocaleString()}`,
+  ].join("\n");
+}

--- a/src/ui/src/components/chat/formatTokens.test.ts
+++ b/src/ui/src/components/chat/formatTokens.test.ts
@@ -20,4 +20,16 @@ describe("formatTokens", () => {
     // 1299 → 1.299k → "1.2k" (we want to avoid over-reporting)
     expect(formatTokens(1299)).toBe("1.2k");
   });
+
+  it("renders 1M+ as an M-compact value with one decimal", () => {
+    expect(formatTokens(1_000_000)).toBe("1.0M");
+    expect(formatTokens(1_234_000)).toBe("1.2M");
+    expect(formatTokens(9_876_000)).toBe("9.8M");
+    expect(formatTokens(10_000_000)).toBe("10.0M");
+  });
+
+  it("truncates M-compact values toward zero", () => {
+    // 1_299_000 → 1.299M → "1.2M"
+    expect(formatTokens(1_299_000)).toBe("1.2M");
+  });
 });

--- a/src/ui/src/components/chat/formatTokens.ts
+++ b/src/ui/src/components/chat/formatTokens.ts
@@ -1,11 +1,16 @@
 /** Format a token count for compact display in chat metadata.
- *  Values under 1000 render as raw integers ("999"); values 1000+ render
- *  as a k-compact value with one decimal ("1.2k", "10.0k"). Truncation
- *  is always toward zero so we never over-report usage. */
+ *  Values under 1000 render as raw integers ("999"); values in [1k, 1M)
+ *  render as k-compact ("1.2k", "10.0k"); values >= 1M render as M-compact
+ *  ("1.0M", "10.0M"). Truncation is always toward zero so we never
+ *  over-report usage. */
 export function formatTokens(n: number): string {
   if (n < 1000) {
     return `${n}`;
   }
-  const tenths = Math.trunc(n / 100) / 10;
-  return `${tenths.toFixed(1)}k`;
+  if (n < 1_000_000) {
+    const tenths = Math.trunc(n / 100) / 10;
+    return `${tenths.toFixed(1)}k`;
+  }
+  const tenths = Math.trunc(n / 100_000) / 10;
+  return `${tenths.toFixed(1)}M`;
 }

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { MODELS } from "./modelRegistry";
+
+describe("modelRegistry", () => {
+  it("every model has a positive integer contextWindowTokens", () => {
+    for (const m of MODELS) {
+      expect(m.contextWindowTokens, `model ${m.id} is missing contextWindowTokens`).toBeTypeOf("number");
+      expect(m.contextWindowTokens, `model ${m.id} has non-positive contextWindowTokens`).toBeGreaterThan(0);
+      expect(Number.isInteger(m.contextWindowTokens), `model ${m.id} has non-integer contextWindowTokens`).toBe(true);
+    }
+  });
+
+  it("1M-context variants report 1_000_000", () => {
+    const oneM = MODELS.filter((m) => m.id === "opus" || m.id.endsWith("[1m]"));
+    expect(oneM.length).toBeGreaterThan(0);
+    for (const m of oneM) {
+      expect(m.contextWindowTokens, m.id).toBe(1_000_000);
+    }
+  });
+
+  it("standard variants report 200_000", () => {
+    const standard = MODELS.filter((m) => m.id !== "opus" && !m.id.endsWith("[1m]"));
+    expect(standard.length).toBeGreaterThan(0);
+    for (const m of standard) {
+      expect(m.contextWindowTokens, m.id).toBe(200_000);
+    }
+  });
+});

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -10,6 +10,9 @@ describe("modelRegistry", () => {
     }
   });
 
+  // `"opus"` is the 1M alias of Opus 4.7 whose id lacks the `[1m]` suffix
+  // other 1M variants use. Keep the explicit `id === "opus"` check — removing
+  // it would silently misclassify the alias as a 200k model.
   it("1M-context variants report 1_000_000", () => {
     const oneM = MODELS.filter((m) => m.id === "opus" || m.id.endsWith("[1m]"));
     expect(oneM.length).toBeGreaterThan(0);

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -11,17 +11,20 @@ export type Model = {
   readonly group: string;
   readonly extraUsage: boolean;
   readonly legacy?: boolean;
+  /** Maximum total tokens this model can hold across input + cache + output.
+   *  Used by the ContextMeter to compute utilization as a percentage. */
+  readonly contextWindowTokens: number;
 };
 
 export const MODELS: readonly Model[] = [
-  { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: true },
-  { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false },
-  { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false },
-  { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true },
-  { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false },
-  { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false, legacy: true },
-  { id: "claude-opus-4-6[1m]", label: "Opus 4.6 1M", group: "Claude Code", extraUsage: true, legacy: true },
-  { id: "claude-opus-4-5", label: "Opus 4.5", group: "Claude Code", extraUsage: false, legacy: true },
-  { id: "claude-sonnet-4-5", label: "Sonnet 4.5", group: "Claude Code", extraUsage: false, legacy: true },
-  { id: "claude-haiku-3-5", label: "Haiku 3.5", group: "Claude Code", extraUsage: false, legacy: true },
+  { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
+  { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  { id: "sonnet", label: "Sonnet 4.6", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  { id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
+  { id: "haiku", label: "Haiku 4.5", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },
+  { id: "claude-opus-4-6", label: "Opus 4.6", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  { id: "claude-opus-4-6[1m]", label: "Opus 4.6 1M", group: "Claude Code", extraUsage: true, legacy: true, contextWindowTokens: 1_000_000 },
+  { id: "claude-opus-4-5", label: "Opus 4.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  { id: "claude-sonnet-4-5", label: "Sonnet 4.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
+  { id: "claude-haiku-3-5", label: "Haiku 3.5", group: "Claude Code", extraUsage: false, legacy: true, contextWindowTokens: 200_000 },
 ];

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -287,6 +287,8 @@ export function useAgentStream() {
               streamEvent.duration_ms,
               streamEvent.usage?.input_tokens,
               streamEvent.usage?.output_tokens,
+              streamEvent.usage?.cache_read_input_tokens ?? undefined,
+              streamEvent.usage?.cache_creation_input_tokens ?? undefined,
             );
             turnMessageCountRef.current[wsId] = 0;
             turnFinalizedRef.current[wsId] = true;

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -883,4 +883,124 @@ describe("finalizeTurn token counts", () => {
     expect(turns[0].cacheReadTokens).toBeUndefined();
     expect(turns[0].cacheCreationTokens).toBeUndefined();
   });
+
+  it("writes latestTurnUsage alongside the CompletedTurn when tokens are provided", () => {
+    useAppStore.getState().finalizeTurn(
+      "ws1", 1, "turn-4", 1000, 1500, 240, 80_000, 1_200,
+    );
+    const usage = useAppStore.getState().latestTurnUsage.ws1;
+    expect(usage).toEqual({
+      inputTokens: 1500,
+      outputTokens: 240,
+      cacheReadTokens: 80_000,
+      cacheCreationTokens: 1_200,
+    });
+  });
+});
+
+describe("finalizeTurn tool-free turn (no activities)", () => {
+  beforeEach(() => {
+    // NO toolActivities → finalizeTurn will early-return for the timeline,
+    // but the meter's latestTurnUsage slice must still refresh.
+    useAppStore.setState({
+      completedTurns: {},
+      toolActivities: {},
+      latestTurnUsage: {},
+    });
+  });
+
+  it("updates latestTurnUsage even when no tool activities exist", () => {
+    useAppStore.getState().finalizeTurn(
+      "ws1", 1, "turn-x", 800, 500, 60, 20_000, 300,
+    );
+    // No CompletedTurn was appended — the timeline stays unchanged.
+    expect(useAppStore.getState().completedTurns.ws1).toBeUndefined();
+    // But latestTurnUsage IS updated so the ContextMeter can re-render.
+    expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
+      inputTokens: 500,
+      outputTokens: 60,
+      cacheReadTokens: 20_000,
+      cacheCreationTokens: 300,
+    });
+  });
+
+  it("preserves existing latestTurnUsage when finalizeTurn has no token data", () => {
+    // Seed a previous turn's usage.
+    useAppStore.setState({
+      latestTurnUsage: {
+        ws1: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 10_000,
+          cacheCreationTokens: 200,
+        },
+      },
+    });
+    // Finalize a turn with no usage payload (rare but possible on a broken stream).
+    useAppStore.getState().finalizeTurn("ws1", 1, "turn-y", 500);
+    // Previous usage stays intact — we never want to stomp a real value with
+    // an all-undefined record.
+    expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 10_000,
+      cacheCreationTokens: 200,
+    });
+  });
+});
+
+describe("hydrateCompletedTurns seeds latestTurnUsage", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      completedTurns: {},
+      latestTurnUsage: {},
+    });
+  });
+
+  it("copies the latest hydrated turn's token fields into latestTurnUsage", () => {
+    useAppStore.getState().hydrateCompletedTurns("ws1", [
+      {
+        id: "cp1",
+        activities: [],
+        messageCount: 1,
+        collapsed: true,
+        afterMessageIndex: 2,
+        durationMs: 1000,
+        inputTokens: 500,
+        outputTokens: 100,
+      },
+      {
+        id: "cp2",
+        activities: [],
+        messageCount: 1,
+        collapsed: true,
+        afterMessageIndex: 4,
+        durationMs: 2000,
+        inputTokens: 2000,
+        outputTokens: 150,
+        cacheReadTokens: 50_000,
+        cacheCreationTokens: 800,
+      },
+    ]);
+    // cp2 is the most recent — its tokens should seed the meter.
+    expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
+      inputTokens: 2000,
+      outputTokens: 150,
+      cacheReadTokens: 50_000,
+      cacheCreationTokens: 800,
+    });
+  });
+
+  it("leaves latestTurnUsage untouched when hydrated turns have no token data", () => {
+    useAppStore.getState().hydrateCompletedTurns("ws1", [
+      {
+        id: "cp1",
+        activities: [],
+        messageCount: 1,
+        collapsed: true,
+        afterMessageIndex: 2,
+      },
+    ]);
+    expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();
+  });
 });

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -849,20 +849,38 @@ describe("finalizeTurn token counts", () => {
     });
   });
 
-  it("records input/output tokens on the completed turn", () => {
-    useAppStore.getState().finalizeTurn("ws1", 1, "turn-1", 1234, 1500, 240);
+  it("records input/output AND cache tokens on the completed turn", () => {
+    useAppStore.getState().finalizeTurn(
+      "ws1", 1, "turn-1", 1234, 1500, 240, 80_000, 1_200,
+    );
     const turns = useAppStore.getState().completedTurns.ws1 || [];
     expect(turns).toHaveLength(1);
     expect(turns[0].durationMs).toBe(1234);
     expect(turns[0].inputTokens).toBe(1500);
     expect(turns[0].outputTokens).toBe(240);
+    expect(turns[0].cacheReadTokens).toBe(80_000);
+    expect(turns[0].cacheCreationTokens).toBe(1_200);
   });
 
-  it("leaves token counts undefined when omitted", () => {
-    useAppStore.getState().finalizeTurn("ws1", 1, "turn-2", 500);
+  it("leaves cache tokens undefined when omitted", () => {
+    useAppStore.getState().finalizeTurn(
+      "ws1", 1, "turn-2", 500, 100, 50,
+    );
+    const turns = useAppStore.getState().completedTurns.ws1 || [];
+    expect(turns).toHaveLength(1);
+    expect(turns[0].inputTokens).toBe(100);
+    expect(turns[0].outputTokens).toBe(50);
+    expect(turns[0].cacheReadTokens).toBeUndefined();
+    expect(turns[0].cacheCreationTokens).toBeUndefined();
+  });
+
+  it("leaves all token fields undefined when none provided", () => {
+    useAppStore.getState().finalizeTurn("ws1", 1, "turn-3", 500);
     const turns = useAppStore.getState().completedTurns.ws1 || [];
     expect(turns).toHaveLength(1);
     expect(turns[0].inputTokens).toBeUndefined();
     expect(turns[0].outputTokens).toBeUndefined();
+    expect(turns[0].cacheReadTokens).toBeUndefined();
+    expect(turns[0].cacheCreationTokens).toBeUndefined();
   });
 });

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -92,6 +92,21 @@ export interface PlanApproval {
   allowedPrompts: Array<{ tool: string; prompt: string }>;
 }
 
+/**
+ * Token usage from the most recent completed turn for a workspace.
+ * Lives as its own slice (`latestTurnUsage`) rather than being derived from
+ * `completedTurns` because `finalizeTurn` early-returns for tool-free turns
+ * — so a Q&A turn without tool calls doesn't add a CompletedTurn but should
+ * still refresh the ContextMeter. The shape matches the `result.usage` block
+ * the CLI emits on every turn end.
+ */
+export interface TurnUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+
 interface AppState {
   // -- Repositories --
   repositories: Repository[];
@@ -120,6 +135,12 @@ interface AppState {
   showThinkingBlocks: Record<string, boolean>;
   toolActivities: Record<string, ToolActivity[]>;
   completedTurns: Record<string, CompletedTurn[]>;
+  /** Latest `result.usage` values per workspace — kept in sync with every
+   *  turn end, including tool-free turns that don't produce a CompletedTurn.
+   *  The ContextMeter reads from here so it reflects the latest turn even
+   *  when the timeline doesn't record one. */
+  latestTurnUsage: Record<string, TurnUsage>;
+  setLatestTurnUsage: (wsId: string, usage: TurnUsage) => void;
   setChatMessages: (wsId: string, messages: ChatMessage[]) => void;
   addChatMessage: (wsId: string, message: ChatMessage) => void;
   setStreamingContent: (wsId: string, content: string) => void;
@@ -509,6 +530,11 @@ export const useAppStore = create<AppState>((set) => ({
   showThinkingBlocks: {},
   toolActivities: {},
   completedTurns: {},
+  latestTurnUsage: {},
+  setLatestTurnUsage: (wsId, usage) =>
+    set((s) => ({
+      latestTurnUsage: { ...s.latestTurnUsage, [wsId]: usage },
+    })),
   setChatMessages: (wsId, messages) =>
     set((s) => ({
       chatMessages: { ...s.chatMessages, [wsId]: messages },
@@ -609,6 +635,24 @@ export const useAppStore = create<AppState>((set) => ({
     cacheCreationTokens,
   ) =>
     set((s) => {
+      // Always refresh the meter's latestTurnUsage — even for tool-free
+      // turns that don't produce a CompletedTurn. Only write when the
+      // caller actually provided input/output tokens (avoids stomping the
+      // previous value with an all-undefined record on rare empty Results).
+      const hasUsage =
+        typeof inputTokens === "number" || typeof outputTokens === "number";
+      const nextLatestTurnUsage = hasUsage
+        ? {
+            ...s.latestTurnUsage,
+            [wsId]: {
+              inputTokens,
+              outputTokens,
+              cacheReadTokens,
+              cacheCreationTokens,
+            },
+          }
+        : s.latestTurnUsage;
+
       const activities = s.toolActivities[wsId] || [];
       if (activities.length === 0) {
         debugChat("store", "finalizeTurn skipped", {
@@ -619,7 +663,7 @@ export const useAppStore = create<AppState>((set) => ({
             (turn) => turn.id,
           ),
         });
-        return {};
+        return { latestTurnUsage: nextLatestTurnUsage };
       }
       const turn: CompletedTurn = {
         id: turnId ?? crypto.randomUUID(),
@@ -657,6 +701,7 @@ export const useAppStore = create<AppState>((set) => ({
           [wsId]: [...(s.completedTurns[wsId] || []), turn],
         },
         toolActivities: { ...s.toolActivities, [wsId]: [] },
+        latestTurnUsage: nextLatestTurnUsage,
       };
     }),
   hydrateCompletedTurns: (wsId, turns) =>
@@ -701,11 +746,32 @@ export const useAppStore = create<AppState>((set) => ({
         nextIds: nextTurns.map((turn) => turn.id),
       });
 
+      // Seed latestTurnUsage from the most recent hydrated turn so the
+      // meter renders correctly on workspace reload, without needing a
+      // new turn to land. Only write if the hydrated turn has live tokens
+      // (legacy turns without token metadata leave the field unset).
+      const lastTurn = nextTurns[nextTurns.length - 1];
+      const nextLatestTurnUsage =
+        lastTurn &&
+        (typeof lastTurn.inputTokens === "number" ||
+          typeof lastTurn.outputTokens === "number")
+          ? {
+              ...s.latestTurnUsage,
+              [wsId]: {
+                inputTokens: lastTurn.inputTokens,
+                outputTokens: lastTurn.outputTokens,
+                cacheReadTokens: lastTurn.cacheReadTokens,
+                cacheCreationTokens: lastTurn.cacheCreationTokens,
+              },
+            }
+          : s.latestTurnUsage;
+
       return {
         completedTurns: {
           ...s.completedTurns,
           [wsId]: nextTurns,
         },
+        latestTurnUsage: nextLatestTurnUsage,
       };
     }),
   setCompletedTurns: (wsId, turns) =>

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -62,14 +62,13 @@ export interface CompletedTurn {
    *  `output_tokens` of each assistant `ChatMessage` in the turn. */
   outputTokens?: number;
   /** Turn-total cache-read tokens. Live turns receive this from the CLI's
-   *  `result.usage.cache_read_input_tokens`; persisted turns are reconstructed
-   *  by summing the `cache_read_tokens` of each assistant `ChatMessage` in
-   *  the turn. */
+   *  `result.usage.cache_read_input_tokens`. Persisted turns use the MAX
+   *  (not sum) of per-message `cache_read_tokens` — cache counts are
+   *  cumulative-per-API-call, so summing across a multi-message tool-use
+   *  turn would double-count the shared prompt prefix each call re-reads. */
   cacheReadTokens?: number;
-  /** Turn-total cache-creation tokens. Live turns receive this from the
-   *  CLI's `result.usage.cache_creation_input_tokens`; persisted turns are
-   *  reconstructed by summing the `cache_creation_tokens` of each assistant
-   *  `ChatMessage` in the turn. */
+  /** Turn-total cache-creation tokens. Same max-based reconstruction semantics
+   *  as `cacheReadTokens`. */
   cacheCreationTokens?: number;
 }
 

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -61,6 +61,16 @@ export interface CompletedTurn {
    *  `result.usage`; persisted turns are reconstructed by summing the
    *  `output_tokens` of each assistant `ChatMessage` in the turn. */
   outputTokens?: number;
+  /** Turn-total cache-read tokens. Live turns receive this from the CLI's
+   *  `result.usage.cache_read_input_tokens`; persisted turns are reconstructed
+   *  by summing the `cache_read_tokens` of each assistant `ChatMessage` in
+   *  the turn. */
+  cacheReadTokens?: number;
+  /** Turn-total cache-creation tokens. Live turns receive this from the
+   *  CLI's `result.usage.cache_creation_input_tokens`; persisted turns are
+   *  reconstructed by summing the `cache_creation_tokens` of each assistant
+   *  `ChatMessage` in the turn. */
+  cacheCreationTokens?: number;
 }
 
 export interface AgentQuestionItem {
@@ -135,6 +145,8 @@ interface AppState {
     durationMs?: number,
     inputTokens?: number,
     outputTokens?: number,
+    cacheReadTokens?: number,
+    cacheCreationTokens?: number,
   ) => void;
   hydrateCompletedTurns: (wsId: string, turns: CompletedTurn[]) => void;
   setCompletedTurns: (wsId: string, turns: CompletedTurn[]) => void;
@@ -587,7 +599,16 @@ export const useAppStore = create<AppState>((set) => ({
         ),
       },
     })),
-  finalizeTurn: (wsId, messageCount, turnId, durationMs, inputTokens, outputTokens) =>
+  finalizeTurn: (
+    wsId,
+    messageCount,
+    turnId,
+    durationMs,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+  ) =>
     set((s) => {
       const activities = s.toolActivities[wsId] || [];
       if (activities.length === 0) {
@@ -617,6 +638,8 @@ export const useAppStore = create<AppState>((set) => ({
         durationMs,
         inputTokens,
         outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
       };
       debugChat("store", "finalizeTurn", {
         wsId,

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -34,6 +34,14 @@
   --status-idle: rgb(110, 110, 120);
   --status-stopped: #f04848;
 
+  /* Context meter (used by the chat toolbar's ContextMeter component).
+   * Theme JSONs can override these keys to match their palette; missing
+   * overrides fall through to these defaults. */
+  --context-meter-normal: var(--accent-primary);
+  --context-meter-warn: #d4a84a;
+  --context-meter-near-full: #e07030;
+  --context-meter-critical: var(--status-stopped);
+
   /* Attention badges */
   --badge-done: #00e5cc;
   --badge-plan: rgb(100, 160, 240);

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -164,7 +164,10 @@ describe("reconstructCompletedTurns", () => {
     expect(result[1].outputTokens).toBe(300);
   });
 
-  it("sums assistant message cache tokens into cacheReadTokens/cacheCreationTokens per turn", () => {
+  it("takes the max of assistant message cache tokens per turn (not sum)", () => {
+    // Cache tokens are cumulative-per-API-call — summing would double-count
+    // the shared prompt prefix each call re-reads. Max approximates the
+    // turn's actual cache footprint to match live Result.usage.
     const m1: ChatMessage = { ...makeMsg("m1", "User") };
     const m2: ChatMessage = {
       ...makeMsg("m2", "Assistant"),
@@ -188,10 +191,11 @@ describe("reconstructCompletedTurns", () => {
     const result = reconstructCompletedTurns(messages, turnData);
 
     expect(result).toHaveLength(2);
-    // Turn 1: m2+m3 assistant → 60000 cache read, 1200 cache creation
-    expect(result[0].cacheReadTokens).toBe(60_000);
-    expect(result[0].cacheCreationTokens).toBe(1_200);
-    // Turn 2: m5 only → 100000 cache read, 500 cache creation
+    // Turn 1: max(m2.cache_read=50_000, m3.cache_read=10_000) = 50_000
+    //         max(m2.cache_creation=1_000, m3.cache_creation=200) = 1_000
+    expect(result[0].cacheReadTokens).toBe(50_000);
+    expect(result[0].cacheCreationTokens).toBe(1_000);
+    // Turn 2: m5 only → 100_000 cache read, 500 cache creation
     expect(result[1].cacheReadTokens).toBe(100_000);
     expect(result[1].cacheCreationTokens).toBe(500);
   });

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -164,6 +164,52 @@ describe("reconstructCompletedTurns", () => {
     expect(result[1].outputTokens).toBe(300);
   });
 
+  it("sums assistant message cache tokens into cacheReadTokens/cacheCreationTokens per turn", () => {
+    const m1: ChatMessage = { ...makeMsg("m1", "User") };
+    const m2: ChatMessage = {
+      ...makeMsg("m2", "Assistant"),
+      cache_read_tokens: 50_000,
+      cache_creation_tokens: 1_000,
+    };
+    const m3: ChatMessage = {
+      ...makeMsg("m3", "Assistant"),
+      cache_read_tokens: 10_000,
+      cache_creation_tokens: 200,
+    };
+    const m4: ChatMessage = { ...makeMsg("m4", "User") };
+    const m5: ChatMessage = {
+      ...makeMsg("m5", "Assistant"),
+      cache_read_tokens: 100_000,
+      cache_creation_tokens: 500,
+    };
+    const messages = [m1, m2, m3, m4, m5];
+    const turnData = [makeTurnData("cp1", "m3"), makeTurnData("cp2", "m5")];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+
+    expect(result).toHaveLength(2);
+    // Turn 1: m2+m3 assistant → 60000 cache read, 1200 cache creation
+    expect(result[0].cacheReadTokens).toBe(60_000);
+    expect(result[0].cacheCreationTokens).toBe(1_200);
+    // Turn 2: m5 only → 100000 cache read, 500 cache creation
+    expect(result[1].cacheReadTokens).toBe(100_000);
+    expect(result[1].cacheCreationTokens).toBe(500);
+  });
+
+  it("leaves cacheReadTokens/cacheCreationTokens undefined when no assistant message has cache data", () => {
+    const messages = [
+      makeMsg("m1", "User"),
+      makeMsg("m2", "Assistant"),
+    ];
+    const turnData = [makeTurnData("cp1", "m2")];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].cacheReadTokens).toBeUndefined();
+    expect(result[0].cacheCreationTokens).toBeUndefined();
+  });
+
   it("leaves inputTokens/outputTokens undefined for legacy turns with no token data", () => {
     const messages = [makeMsg("m1", "User"), makeMsg("m2", "Assistant")];
     const turnData = [makeTurnData("cp1", "m2")];

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -51,14 +51,19 @@ export function reconstructCompletedTurns(
         (sum, m) => sum + (m.output_tokens ?? 0),
         0,
       ) || undefined;
+    // Cache tokens on each assistant message row represent cumulative-per-
+    // API-call usage, not per-message deltas. Summing across a multi-message
+    // (tool-use) turn double-counts the shared prompt prefix that each call
+    // re-reads from cache. Using max approximates the turn's actual cache
+    // footprint more faithfully — matches what `result.usage` reports live.
     const cacheReadTokens =
       turnAssistantMessages.reduce(
-        (sum, m) => sum + (m.cache_read_tokens ?? 0),
+        (maxSeen, m) => Math.max(maxSeen, m.cache_read_tokens ?? 0),
         0,
       ) || undefined;
     const cacheCreationTokens =
       turnAssistantMessages.reduce(
-        (sum, m) => sum + (m.cache_creation_tokens ?? 0),
+        (maxSeen, m) => Math.max(maxSeen, m.cache_creation_tokens ?? 0),
         0,
       ) || undefined;
 

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -51,6 +51,16 @@ export function reconstructCompletedTurns(
         (sum, m) => sum + (m.output_tokens ?? 0),
         0,
       ) || undefined;
+    const cacheReadTokens =
+      turnAssistantMessages.reduce(
+        (sum, m) => sum + (m.cache_read_tokens ?? 0),
+        0,
+      ) || undefined;
+    const cacheCreationTokens =
+      turnAssistantMessages.reduce(
+        (sum, m) => sum + (m.cache_creation_tokens ?? 0),
+        0,
+      ) || undefined;
 
     return {
       id: td.checkpoint_id,
@@ -69,6 +79,8 @@ export function reconstructCompletedTurns(
       durationMs,
       inputTokens,
       outputTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
     };
   });
 }


### PR DESCRIPTION
## Summary

Phase 2 of [issue #300](https://github.com/utensils/claudette/issues/300). Adds a compact color-coded context-utilization meter to the chat toolbar, showing how full the model's context window is, driven by the most recent completed turn's token counts. Frontend-only PR — builds on Phase 1's data shape (merged in [#311](https://github.com/utensils/claudette/pull/311)), no backend, SQL, or Tauri changes.

**Data flow** (live + reconstructed paths converge on the same shape):

```mermaid
flowchart LR
  CLI[Claude CLI stream] -->|result.usage| Hook[useAgentStream.result]
  Hook -->|8-arg finalizeTurn| Store[CompletedTurn<br/>input/output/cacheRead/cacheCreation]
  DB[(chat_messages<br/>per-message tokens)] -->|reconstructCompletedTurns| Store
  Store --> Logic[contextMeterLogic<br/>computeMeterState]
  Registry[modelRegistry<br/>contextWindowTokens] --> Logic
  Logic --> Meter[ContextMeter<br/>fill bar + Nk/Nk + tooltip]
  Meter -.lives in.-> Toolbar[ChatToolbar]
```

**Backend already wired** (Phase 1): per-message cache token columns in SQLite, frontend `ChatMessage` type, and `StreamEvent.Result.usage` TS shape. Phase 2 extends the frontend aggregation and adds the UI surface.

### Per-model capacity

`Model.contextWindowTokens` is now a required field on every registry entry. `opus` and `[1m]` variants → 1,000,000; all others → 200,000. Switching models re-renders the meter's percentage immediately with no round-trip.

### Meter behavior

| Utilization | Fill color (CSS token) |
|---|---|
| 0 – 60 % | `--context-meter-normal` (→ `--accent-primary` default) |
| 60 – 80 % | `--context-meter-warn` (yellow default) |
| 80 – 90 % | `--context-meter-near-full` (orange default) |
| 90 – 100 % | `--context-meter-critical` (→ `--status-stopped` default) |

Hidden when: no completed turn, pre-migration turn lacking token data, or stale model id. No palette edits required — defaults work across all 13 existing themes; theme JSONs can optionally override.

### Files

- **New**: `ContextMeter.tsx`, `ContextMeter.module.css`, `contextMeterLogic.ts`, `contextMeterLogic.test.ts`, `modelRegistry.test.ts`.
- **Modified**: `modelRegistry.ts`, `useAppStore.ts` (+ tests), `useAgentStream.ts`, `reconstructTurns.ts` (+ tests), `theme.css`, `ChatToolbar.tsx`, `formatTokens.ts` (+ tests).

## Complexity Notes

- **Cache-token reconstruction uses MAX, not SUM.** Anthropic's `message_delta.usage` reports cumulative-per-API-call cache counts — summing across a 3-message tool-use turn would triple-count the shared prompt prefix each call re-reads. `reconstructCompletedTurns` uses `Math.max` for `cacheReadTokens` / `cacheCreationTokens` to approximate the "cumulative at end of turn" semantic of live `result.usage`. Input/output token reductions stay as sum (they're genuinely per-message deltas). Documented in JSDoc on `CompletedTurn.cacheReadTokens` and inline in `reconstructTurns.ts`.

- **Pure logic + thin React wrapper pattern.** All computation (band selection, totals, tooltip strings) lives in `contextMeterLogic.ts` with 17 unit tests. `ContextMeter.tsx` is a 58-line presentational wrapper. This matches Phase 1's `formatTokens` pattern and sidesteps needing `@testing-library/react` (not a project dependency).

- **`fillPercent` vs `percentRounded` in `MeterState`.** Deliberately split: `fillPercent` is capped at 100 for the CSS `width` style; `percentRounded` is uncapped so the tooltip honestly reports "150 %" when a turn goes over capacity. JSDoc'd per-field.

- **`formatTokens` gained an M-compact branch.** 1,000,000 was rendering as `"10000.0k"` — ugly in the meter readout for 1M-context Opus users. Now renders as `"1.0M"`. Truncation-toward-zero semantics preserved.

- **Single point of reconstruction fragility.** `reconstructCompletedTurns` depends on consistent aggregation semantics between live `result.usage` and per-message DB rows. If Anthropic ever changes the CLI to emit non-cumulative cache counts, the max-based aggregation will under-report and will need to match whatever the new semantic is.

## Test Steps

1. **Automated** (CI will run):
   - `cargo build --workspace` — clean.
   - `cd src/ui && bunx tsc --noEmit` — clean.
   - `cd src/ui && bun run test` — 525 passed across 30 files (includes 3 new `modelRegistry` tests, 3 new `finalizeTurn` cache-token tests, 4 new `reconstructTurns` cache-token tests, 17 `contextMeterLogic` tests, 2 new `formatTokens` tests).
   - `cd src/ui && bun run build` — succeeds.

2. **Manual UAT** (dev build — ` cargo tauri dev`):
   1. Open an existing workspace with chat history. Confirm the meter appears to the right of the model selector with a fill bar and a `Nk / Nk` readout (or `N / Nk` for small values).
   2. Hover the meter. Tooltip shows four breakdown lines (Input / Cache read / Cache creation / Output) with thousand separators, plus a `Context: X / Y tokens (Z%)` header.
   3. Switch the model selector between a 200k variant (e.g. `sonnet`) and a 1M variant (e.g. `opus`). Percentage should drop noticeably when switching to 1M. Readout denominator changes from `200.0k` to `1.0M`.
   4. Send a new prompt. After the turn completes, the meter should update with the new totals.
   5. Open a fresh workspace (no history). Meter should be hidden (no visual artifact).
   6. If a workspace has pre-migration history only (unlikely at this point), meter stays hidden until a new turn lands.
   7. Optional: inspect store via `/claudette-debug state completedTurns` to confirm `cacheReadTokens` / `cacheCreationTokens` are populated on the latest turn after a fresh prompt.

## Checklist

- [x] Tests added/updated — new suites for `modelRegistry`, `contextMeterLogic`; extended suites for `useAppStore.finalizeTurn`, `reconstructTurns`, `formatTokens`.
- [x] Documentation updated — JSDoc on new `CompletedTurn` fields and `MeterState` fields call out the live-vs-reconstructed asymmetry and the fillPercent-vs-percentRounded distinction.
- [x] Conventional commits — 11 commits, all `feat(...)` / `fix(...)` / `refactor(...)` / `docs(...)` scopes.