### PR TITLE
refactor(db): replace user_version with timestamp-keyed schema_migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,15 @@ src-server/             — Standalone + embeddable remote server
 ### Database conventions
 
 - `rusqlite::Connection` is not `Send` — open a fresh connection in each Tauri command via `Database::open(&state.db_path)`
-- Schema migrations use `PRAGMA user_version` — bump the version when adding new migrations
 - UI-only state (collapsed sections, panel widths, selection) is NOT persisted — keep in Zustand
+
+### Schema migrations
+
+- Migrations live as `.sql` files under `src/migrations/` and are registered in `src/migrations/mod.rs` as `Migration` entries in the `MIGRATIONS` const slice.
+- **Adding a migration:** create `src/migrations/YYYYMMDDHHMMSS_snake_case_description.sql` using the current UTC timestamp, then append a matching `Migration { id, sql: include_str!(...), legacy_version: None }` entry to `MIGRATIONS`. Migration IDs must be unique — a test enforces this.
+- **Never edit the SQL of a released migration.** The `id` is the tracked identity; rewriting or renaming applied migrations will desync databases in the field. Fix forward with a new migration.
+- **Merging branches:** each new migration is a distinct `.sql` file and a distinct `MIGRATIONS` entry, so parallel-branch migrations no longer collide on an integer version — both apply when merged. If two branches happen to choose the same timestamp (e.g. from `date -u +%Y%m%d%H%M%S` run at the same second), git will surface the clash as a merge conflict in `mod.rs`; bump one timestamp by a second and rename its file to resolve.
+- `PRAGMA user_version` is retained only to seed `schema_migrations` once on pre-redesign databases during the first run of the new runner. Do not read or write it in new code.
 
 ## Project context
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -120,13 +120,14 @@ impl Database {
     /// `schema_migrations`. Each migration's SQL and its tracking-row insert
     /// run inside a single transaction, so a failure leaves no partial state.
     fn run_migrations(conn: &Connection, migrations: &[Migration]) -> Result<(), rusqlite::Error> {
-        debug_assert!(
-            {
-                let mut seen = HashSet::new();
-                migrations.iter().all(|m| seen.insert(m.id))
-            },
-            "duplicate migration id in MIGRATIONS",
-        );
+        let mut seen: HashSet<&str> = HashSet::with_capacity(migrations.len());
+        for m in migrations {
+            assert!(
+                seen.insert(m.id),
+                "duplicate migration id in MIGRATIONS: {}",
+                m.id,
+            );
+        }
 
         let applied: HashSet<String> = conn
             .prepare("SELECT id FROM schema_migrations")?

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension, params};
 
 use serde::{Deserialize, Serialize};
 
+use crate::migrations::{MIGRATIONS, Migration};
 use crate::model::{
     Attachment, ChatMessage, CheckpointFile, CompletedTurnData, ConversationCheckpoint,
     RemoteConnection, Repository, TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
@@ -72,403 +74,98 @@ impl Database {
     }
 
     fn migrate(&self) -> Result<(), rusqlite::Error> {
-        let version: i32 = self
+        self.bootstrap_and_backfill(MIGRATIONS)?;
+        Self::run_migrations(&self.conn, MIGRATIONS)
+    }
+
+    /// Ensure `schema_migrations` exists; seed it from `PRAGMA user_version`
+    /// on pre-redesign databases. Idempotent: subsequent calls are no-ops.
+    fn bootstrap_and_backfill(&self, migrations: &[Migration]) -> Result<(), rusqlite::Error> {
+        let table_exists: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                           WHERE type='table' AND name='schema_migrations')",
+            [],
+            |r| r.get(0),
+        )?;
+        if table_exists {
+            return Ok(());
+        }
+
+        let legacy_version: i32 = self
             .conn
-            .query_row("PRAGMA user_version", [], |row| row.get(0))?;
+            .query_row("PRAGMA user_version", [], |r| r.get(0))?;
 
-        if version < 1 {
-            self.conn.execute_batch(
-                "CREATE TABLE repositories (
-                    id          TEXT PRIMARY KEY,
-                    path        TEXT NOT NULL UNIQUE,
-                    name        TEXT NOT NULL,
-                    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                CREATE TABLE workspaces (
-                    id              TEXT PRIMARY KEY,
-                    repository_id   TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-                    name            TEXT NOT NULL,
-                    branch_name     TEXT NOT NULL,
-                    worktree_path   TEXT,
-                    status          TEXT NOT NULL DEFAULT 'active',
-                    status_line     TEXT NOT NULL DEFAULT '',
-                    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-                    UNIQUE(repository_id, name)
-                );
-
-                PRAGMA user_version = 1;",
-            )?;
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute_batch(
+            "CREATE TABLE schema_migrations (
+                 id         TEXT PRIMARY KEY,
+                 applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+             );",
+        )?;
+        for m in migrations {
+            if let Some(v) = m.legacy_version
+                && v <= legacy_version
+            {
+                tx.execute(
+                    "INSERT INTO schema_migrations (id) VALUES (?1)",
+                    params![m.id],
+                )?;
+            }
         }
-
-        if version < 2 {
-            self.conn.execute_batch(
-                "CREATE TABLE chat_messages (
-                    id            TEXT PRIMARY KEY,
-                    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-                    role          TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system')),
-                    content       TEXT NOT NULL,
-                    cost_usd      REAL,
-                    duration_ms   INTEGER,
-                    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                CREATE INDEX idx_chat_messages_workspace
-                    ON chat_messages(workspace_id, created_at);
-
-                PRAGMA user_version = 2;",
-            )?;
-        }
-
-        if version < 3 {
-            self.conn.execute_batch(
-                "ALTER TABLE repositories ADD COLUMN icon TEXT;
-                 ALTER TABLE repositories ADD COLUMN path_slug TEXT;
-                 UPDATE repositories SET path_slug = name WHERE path_slug IS NULL;
-
-                 CREATE TABLE app_settings (
-                     key   TEXT PRIMARY KEY,
-                     value TEXT NOT NULL
-                 );
-
-                 PRAGMA user_version = 3;",
-            )?;
-        }
-
-        if version < 4 {
-            self.conn.execute_batch(
-                "CREATE TABLE terminal_tabs (
-                    id               INTEGER PRIMARY KEY,
-                    workspace_id     TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-                    title            TEXT NOT NULL DEFAULT 'Terminal',
-                    is_script_output INTEGER NOT NULL DEFAULT 0,
-                    sort_order       INTEGER NOT NULL DEFAULT 0,
-                    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                CREATE INDEX idx_terminal_tabs_workspace
-                    ON terminal_tabs(workspace_id, sort_order);
-
-                PRAGMA user_version = 4;",
-            )?;
-        }
-
-        if version < 5 {
-            self.conn.execute_batch(
-                "ALTER TABLE repositories ADD COLUMN setup_script TEXT;
-
-                 PRAGMA user_version = 5;",
-            )?;
-        }
-
-        if version < 6 {
-            self.conn.execute_batch(
-                "ALTER TABLE repositories ADD COLUMN custom_instructions TEXT;
-
-                 PRAGMA user_version = 6;",
-            )?;
-        }
-
-        if version < 7 {
-            self.conn.execute_batch(
-                "CREATE TABLE remote_connections (
-                    id                  TEXT PRIMARY KEY,
-                    name                TEXT NOT NULL,
-                    host                TEXT NOT NULL,
-                    port                INTEGER DEFAULT 7683,
-                    session_token       TEXT,
-                    cert_fingerprint    TEXT,
-                    auto_connect        INTEGER DEFAULT 0,
-                    created_at          TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                PRAGMA user_version = 7;",
-            )?;
-        }
-
-        if version < 8 {
-            self.conn.execute_batch(
-                "CREATE TABLE slash_command_usage (
-                    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-                    command_name  TEXT NOT NULL,
-                    use_count     INTEGER NOT NULL DEFAULT 1,
-                    last_used_at  TEXT NOT NULL DEFAULT (datetime('now')),
-                    PRIMARY KEY (workspace_id, command_name)
-                );
-
-                PRAGMA user_version = 8;",
-            )?;
-        }
-
-        if version < 9 {
-            self.conn.execute_batch(
-                "ALTER TABLE workspaces ADD COLUMN session_id TEXT;
-                 ALTER TABLE workspaces ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0;
-
-                 PRAGMA user_version = 9;",
-            )?;
-        }
-
-        if version < 10 {
-            self.conn.execute_batch(
-                "CREATE TABLE conversation_checkpoints (
-                    id            TEXT PRIMARY KEY,
-                    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-                    message_id    TEXT NOT NULL,
-                    commit_hash   TEXT,
-                    turn_index    INTEGER NOT NULL,
-                    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                CREATE INDEX idx_checkpoints_workspace
-                    ON conversation_checkpoints(workspace_id, turn_index);
-
-                PRAGMA user_version = 10;",
-            )?;
-        }
-
-        if version < 11 {
-            self.conn.execute_batch(
-                "CREATE TABLE turn_tool_activities (
-                    id              TEXT PRIMARY KEY,
-                    checkpoint_id   TEXT NOT NULL REFERENCES conversation_checkpoints(id) ON DELETE CASCADE,
-                    tool_use_id     TEXT NOT NULL,
-                    tool_name       TEXT NOT NULL,
-                    input_json      TEXT NOT NULL DEFAULT '',
-                    result_text     TEXT NOT NULL DEFAULT '',
-                    summary         TEXT NOT NULL DEFAULT '',
-                    sort_order      INTEGER NOT NULL DEFAULT 0
-                );
-
-                CREATE INDEX idx_turn_tool_activities_checkpoint
-                    ON turn_tool_activities(checkpoint_id, sort_order);
-
-                ALTER TABLE conversation_checkpoints ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0;
-
-                PRAGMA user_version = 11;",
-            )?;
-        }
-
-        if version < 12 {
-            // Single batch so the column add, backfill, and version bump are
-            // atomic — a partial apply won't leave user_version stale.
-            self.conn.execute_batch(
-                "ALTER TABLE repositories ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
-
-                UPDATE repositories SET sort_order = (
-                    SELECT COUNT(*) FROM repositories r2 WHERE r2.name < repositories.name
-                );
-
-                PRAGMA user_version = 12;",
-            )?;
-        }
-
-        if version < 13 {
-            self.conn.execute_batch(
-                "ALTER TABLE chat_messages ADD COLUMN thinking TEXT;
-                 PRAGMA user_version = 13;",
-            )?;
-        }
-
-        if version < 14 {
-            self.conn.execute_batch(
-                "ALTER TABLE repositories ADD COLUMN branch_rename_preferences TEXT;
-                 PRAGMA user_version = 14;",
-            )?;
-        }
-
-        if version < 15 {
-            self.conn.execute_batch(
-                "CREATE TABLE checkpoint_files (
-                    id              TEXT PRIMARY KEY,
-                    checkpoint_id   TEXT NOT NULL REFERENCES conversation_checkpoints(id) ON DELETE CASCADE,
-                    file_path       TEXT NOT NULL,
-                    content         BLOB,
-                    file_mode       INTEGER NOT NULL DEFAULT 33188,
-                    UNIQUE(checkpoint_id, file_path)
-                );
-
-                CREATE INDEX idx_checkpoint_files_checkpoint
-                    ON checkpoint_files(checkpoint_id);
-
-                PRAGMA user_version = 15;",
-            )?;
-        }
-
-        if version < 16 {
-            self.conn.execute_batch(
-                "CREATE TABLE attachments (
-                    id           TEXT PRIMARY KEY,
-                    message_id   TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
-                    filename     TEXT NOT NULL,
-                    media_type   TEXT NOT NULL,
-                    data         BLOB NOT NULL,
-                    width        INTEGER,
-                    height       INTEGER,
-                    size_bytes   INTEGER NOT NULL,
-                    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                CREATE INDEX idx_attachments_message
-                    ON attachments(message_id);
-
-                PRAGMA user_version = 16;",
-            )?;
-        }
-
-        if version < 17 {
-            self.conn.execute_batch(
-                "CREATE TABLE IF NOT EXISTS repository_mcp_servers (
-                    id              TEXT PRIMARY KEY,
-                    repository_id   TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-                    name            TEXT NOT NULL,
-                    config_json     TEXT NOT NULL,
-                    source          TEXT NOT NULL,
-                    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
-                    UNIQUE(repository_id, name)
-                );
-
-                PRAGMA user_version = 17;",
-            )?;
-        }
-
-        if version < 18 {
-            self.conn.execute_batch(
-                "ALTER TABLE repository_mcp_servers ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;
-
-                PRAGMA user_version = 18;",
-            )?;
-        }
-
-        if version < 19 {
-            self.conn.execute_batch(
-                "ALTER TABLE repositories ADD COLUMN setup_script_auto_run INTEGER NOT NULL DEFAULT 0;
-
-                PRAGMA user_version = 19;",
-            )?;
-        }
-
-        if version < 20 {
-            self.conn.execute_batch(
-                "ALTER TABLE chat_messages ADD COLUMN input_tokens INTEGER;
-                 ALTER TABLE chat_messages ADD COLUMN output_tokens INTEGER;
-                 ALTER TABLE chat_messages ADD COLUMN cache_read_tokens INTEGER;
-                 ALTER TABLE chat_messages ADD COLUMN cache_creation_tokens INTEGER;
-
-                 PRAGMA user_version = 20;",
-            )?;
-        }
-
-        if version < 21 {
-            // Metrics capture foundation: per-session lifecycle rows, per-commit
-            // rows, and a frozen-aggregates table for workspaces that get
-            // hard-deleted (so lifetime dashboard stats survive `delete_workspace`).
-            self.conn.execute_batch(
-                "CREATE TABLE agent_sessions (
-                    id              TEXT PRIMARY KEY,
-                    workspace_id    TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
-                    repository_id   TEXT NOT NULL,
-                    started_at      TEXT NOT NULL DEFAULT (datetime('now')),
-                    last_message_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    ended_at        TEXT,
-                    turn_count      INTEGER NOT NULL DEFAULT 0,
-                    completed_ok    INTEGER NOT NULL DEFAULT 0
-                );
-                CREATE INDEX idx_agent_sessions_workspace ON agent_sessions(workspace_id);
-                CREATE INDEX idx_agent_sessions_started   ON agent_sessions(started_at);
-
-                CREATE TABLE agent_commits (
-                    commit_hash     TEXT NOT NULL,
-                    workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
-                    repository_id   TEXT NOT NULL,
-                    session_id      TEXT,
-                    additions       INTEGER NOT NULL DEFAULT 0,
-                    deletions       INTEGER NOT NULL DEFAULT 0,
-                    files_changed   INTEGER NOT NULL DEFAULT 0,
-                    committed_at    TEXT NOT NULL,
-                    PRIMARY KEY (workspace_id, commit_hash)
-                );
-                CREATE INDEX idx_agent_commits_workspace ON agent_commits(workspace_id);
-                CREATE INDEX idx_agent_commits_committed ON agent_commits(committed_at);
-
-                CREATE TABLE deleted_workspace_summaries (
-                    id                        TEXT PRIMARY KEY,
-                    workspace_id              TEXT NOT NULL,
-                    workspace_name            TEXT NOT NULL,
-                    repository_id             TEXT NOT NULL,
-                    workspace_created_at      TEXT NOT NULL,
-                    deleted_at                TEXT NOT NULL DEFAULT (datetime('now')),
-                    sessions_started          INTEGER NOT NULL DEFAULT 0,
-                    sessions_completed        INTEGER NOT NULL DEFAULT 0,
-                    total_turns               INTEGER NOT NULL DEFAULT 0,
-                    total_session_duration_ms INTEGER NOT NULL DEFAULT 0,
-                    commits_made              INTEGER NOT NULL DEFAULT 0,
-                    total_additions           INTEGER NOT NULL DEFAULT 0,
-                    total_deletions           INTEGER NOT NULL DEFAULT 0,
-                    total_files_changed       INTEGER NOT NULL DEFAULT 0,
-                    messages_user             INTEGER NOT NULL DEFAULT 0,
-                    messages_assistant        INTEGER NOT NULL DEFAULT 0,
-                    messages_system           INTEGER NOT NULL DEFAULT 0,
-                    total_cost_usd            REAL NOT NULL DEFAULT 0,
-                    first_message_at          TEXT,
-                    last_message_at           TEXT,
-                    slash_commands_used       INTEGER NOT NULL DEFAULT 0
-                );
-                CREATE INDEX idx_deleted_ws_summaries_repo ON deleted_workspace_summaries(repository_id);
-
-                PRAGMA user_version = 21;",
-            )?;
-        }
-
-        if version < 22 {
-            // Leaderboard and per-repo aggregations do correlated subquery
-            // lookups like `WHERE s.repository_id = r.repository_id` and
-            // `GROUP BY repository_id`. Without these indexes those scans are
-            // full-table, which the 30s dashboard poll amplifies.
-            self.conn.execute_batch(
-                "CREATE INDEX idx_agent_sessions_repo ON agent_sessions(repository_id);
-                 CREATE INDEX idx_agent_commits_repo  ON agent_commits(repository_id);
-
-                 PRAGMA user_version = 22;",
-            )?;
-        }
-
-        if version < 23 {
-            // Gate the first-turn auto-rename on a persistent per-workspace
-            // flag. The previous gate (`session.turn_count <= 1`) tripped
-            // spuriously whenever the in-memory session was wiped — on
-            // `stop_agent`, spawn failure, or `!got_init` CLI exits — letting
-            // a later prompt rename a workspace that had already had its
-            // first-prompt rename. The flag tracks the one-shot *claim*, not
-            // the rename outcome: it's set on the prompt that reserves the
-            // slot, so a Haiku/git failure leaves the workspace with its
-            // original name but doesn't retry on later prompts. Backfill
-            // existing workspaces with prior chat history so an upgrade
-            // doesn't rename them on the next turn.
-            self.conn.execute_batch(
-                "ALTER TABLE workspaces ADD COLUMN branch_auto_rename_claimed INTEGER NOT NULL DEFAULT 0;
-
-                 UPDATE workspaces SET branch_auto_rename_claimed = 1
-                   WHERE id IN (SELECT DISTINCT workspace_id FROM chat_messages);
-
-                 PRAGMA user_version = 23;",
-            )?;
-        }
-
-        if version < 24 {
-            self.conn.execute_batch(
-                "ALTER TABLE deleted_workspace_summaries ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0;
-                 ALTER TABLE deleted_workspace_summaries ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0;
-
-                 CREATE INDEX idx_chat_messages_created ON chat_messages(created_at);
-
-                 PRAGMA user_version = 24;",
-            )?;
-        }
-
+        tx.commit()?;
         Ok(())
     }
 
+    /// Apply every migration in `migrations` that is not already recorded in
+    /// `schema_migrations`. Each migration's SQL and its tracking-row insert
+    /// run inside a single transaction, so a failure leaves no partial state.
+    fn run_migrations(conn: &Connection, migrations: &[Migration]) -> Result<(), rusqlite::Error> {
+        debug_assert!(
+            {
+                let mut seen = HashSet::new();
+                migrations.iter().all(|m| seen.insert(m.id))
+            },
+            "duplicate migration id in MIGRATIONS",
+        );
+
+        let applied: HashSet<String> = conn
+            .prepare("SELECT id FROM schema_migrations")?
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<Result<_, _>>()?;
+
+        for m in migrations {
+            if applied.contains(m.id) {
+                continue;
+            }
+            let tx = conn.unchecked_transaction()?;
+            tx.execute_batch(m.sql)?;
+            tx.execute(
+                "INSERT INTO schema_migrations (id) VALUES (?1)",
+                params![m.id],
+            )?;
+            tx.commit()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+impl Database {
+    /// Test-only accessor: expose the underlying connection for setup needs
+    /// that don't fit `execute_batch` (e.g. parameterized queries).
+    pub fn conn(&self) -> &Connection {
+        &self.conn
+    }
+
+    /// Test-only: run the migration runner against a caller-supplied slice.
+    /// Used to inject synthetic migrations for error-path and ordering tests.
+    pub fn migrate_with(&self, migrations: &[Migration]) -> Result<(), rusqlite::Error> {
+        self.bootstrap_and_backfill(migrations)?;
+        Self::run_migrations(&self.conn, migrations)
+    }
+}
+
+impl Database {
     // --- Repositories ---
 
     pub fn insert_repository(&self, repo: &Repository) -> Result<(), rusqlite::Error> {
@@ -3754,5 +3451,183 @@ mod tests {
             .unwrap();
         assert_eq!((turns_w1, adds_w1), (4, 12));
         assert_eq!((turns_w2, adds_w2), (9, 30));
+    }
+
+    // --- Migration runner tests ---
+
+    fn count_applied(db: &Database) -> i64 {
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn applied_ids(db: &Database) -> Vec<String> {
+        let mut stmt = db
+            .conn()
+            .prepare("SELECT id FROM schema_migrations ORDER BY id")
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    /// Apply the SQL bodies of the first N pre-redesign migrations directly,
+    /// then set `PRAGMA user_version = N`, producing a DB that looks exactly
+    /// like one from before the redesign at that version.
+    fn build_legacy_db_at_version(n: i32) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        for m in MIGRATIONS.iter().take(n as usize) {
+            conn.execute_batch(m.sql).unwrap();
+        }
+        conn.execute_batch(&format!("PRAGMA user_version = {n};"))
+            .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_migrations_unique_ids() {
+        let mut seen = HashSet::new();
+        for m in MIGRATIONS {
+            assert!(
+                seen.insert(m.id),
+                "duplicate migration id in MIGRATIONS: {}",
+                m.id,
+            );
+        }
+    }
+
+    #[test]
+    fn test_migrations_timestamp_prefix_format() {
+        for m in MIGRATIONS {
+            let prefix: String = m.id.chars().take(14).collect();
+            assert_eq!(
+                prefix.len(),
+                14,
+                "migration id too short, expected 14-digit timestamp prefix: {}",
+                m.id,
+            );
+            assert!(
+                prefix.chars().all(|c| c.is_ascii_digit()),
+                "migration id must start with 14 ASCII digits: {}",
+                m.id,
+            );
+            assert_eq!(
+                m.id.chars().nth(14),
+                Some('_'),
+                "migration id must have underscore after timestamp: {}",
+                m.id,
+            );
+        }
+    }
+
+    #[test]
+    fn test_fresh_db_applies_all_migrations() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(count_applied(&db) as usize, MIGRATIONS.len());
+    }
+
+    #[test]
+    fn test_migrate_is_idempotent() {
+        let db = Database::open_in_memory().unwrap();
+        let before = count_applied(&db);
+        // Re-invoke — same MIGRATIONS slice, already-applied rows must be skipped.
+        db.migrate_with(MIGRATIONS).unwrap();
+        assert_eq!(before, count_applied(&db));
+    }
+
+    #[test]
+    fn test_backfill_from_user_version_19() {
+        let conn = build_legacy_db_at_version(19);
+        let db = Database { conn };
+        db.migrate().unwrap();
+
+        let ids = applied_ids(&db);
+        assert_eq!(ids.len(), MIGRATIONS.len());
+        for m in MIGRATIONS {
+            assert!(
+                ids.contains(&m.id.to_string()),
+                "missing backfilled id: {}",
+                m.id,
+            );
+        }
+    }
+
+    #[test]
+    fn test_backfill_from_user_version_0() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        let db = Database { conn };
+        db.migrate().unwrap();
+        assert_eq!(count_applied(&db) as usize, MIGRATIONS.len());
+    }
+
+    #[test]
+    fn test_partial_backfill_from_mid_version() {
+        let conn = build_legacy_db_at_version(10);
+        let db = Database { conn };
+        db.migrate().unwrap();
+
+        // All 19 legacy + none extra: migrations 1-10 got backfilled rows,
+        // 11-19 ran for real as fresh migrations. Either way the final row
+        // count is MIGRATIONS.len() and all IDs are present.
+        assert_eq!(count_applied(&db) as usize, MIGRATIONS.len());
+        for m in MIGRATIONS {
+            let present: bool = db
+                .conn()
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE id = ?1)",
+                    params![m.id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert!(present, "id not present after partial backfill: {}", m.id);
+        }
+    }
+
+    #[test]
+    fn test_skips_already_applied_migration() {
+        // Synthetic migration: inject an id into schema_migrations and point
+        // its SQL at something that would fail if re-run. The runner must
+        // skip it because the id is already present.
+        let db = Database::open_in_memory().unwrap();
+        let synthetic = [Migration {
+            id: "29991231235959_synthetic_broken_sql",
+            sql: "this is not valid sql and would fail if executed",
+            legacy_version: None,
+        }];
+        db.conn()
+            .execute(
+                "INSERT INTO schema_migrations (id) VALUES (?1)",
+                params![synthetic[0].id],
+            )
+            .unwrap();
+        db.migrate_with(&synthetic).unwrap();
+    }
+
+    #[test]
+    fn test_migration_failure_is_atomic() {
+        let db = Database::open_in_memory().unwrap();
+        let bad = [Migration {
+            id: "29991231235959_synthetic_bad",
+            sql: "ALTER TABLE does_not_exist ADD COLUMN x INTEGER;",
+            legacy_version: None,
+        }];
+        let err = db.migrate_with(&bad);
+        assert!(err.is_err(), "expected migration failure to bubble up");
+
+        let present: bool = db
+            .conn()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE id = ?1)",
+                params![bad[0].id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            !present,
+            "failed migration must not leave tracking row in schema_migrations",
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod git;
 pub mod mcp;
 pub mod mcp_supervisor;
 pub mod metrics;
+pub mod migrations;
 pub mod model;
 pub mod names;
 pub mod permissions;

--- a/src/migrations/20250101000001_initial_repos_and_workspaces.sql
+++ b/src/migrations/20250101000001_initial_repos_and_workspaces.sql
@@ -1,0 +1,18 @@
+CREATE TABLE repositories (
+    id          TEXT PRIMARY KEY,
+    path        TEXT NOT NULL UNIQUE,
+    name        TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE workspaces (
+    id              TEXT PRIMARY KEY,
+    repository_id   TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    name            TEXT NOT NULL,
+    branch_name     TEXT NOT NULL,
+    worktree_path   TEXT,
+    status          TEXT NOT NULL DEFAULT 'active',
+    status_line     TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(repository_id, name)
+);

--- a/src/migrations/20250101000002_chat_messages.sql
+++ b/src/migrations/20250101000002_chat_messages.sql
@@ -1,0 +1,12 @@
+CREATE TABLE chat_messages (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    role          TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'system')),
+    content       TEXT NOT NULL,
+    cost_usd      REAL,
+    duration_ms   INTEGER,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_chat_messages_workspace
+    ON chat_messages(workspace_id, created_at);

--- a/src/migrations/20250101000003_repository_icon_and_app_settings.sql
+++ b/src/migrations/20250101000003_repository_icon_and_app_settings.sql
@@ -1,0 +1,8 @@
+ALTER TABLE repositories ADD COLUMN icon TEXT;
+ALTER TABLE repositories ADD COLUMN path_slug TEXT;
+UPDATE repositories SET path_slug = name WHERE path_slug IS NULL;
+
+CREATE TABLE app_settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/src/migrations/20250101000004_terminal_tabs.sql
+++ b/src/migrations/20250101000004_terminal_tabs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE terminal_tabs (
+    id               INTEGER PRIMARY KEY,
+    workspace_id     TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    title            TEXT NOT NULL DEFAULT 'Terminal',
+    is_script_output INTEGER NOT NULL DEFAULT 0,
+    sort_order       INTEGER NOT NULL DEFAULT 0,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_terminal_tabs_workspace
+    ON terminal_tabs(workspace_id, sort_order);

--- a/src/migrations/20250101000005_setup_script_column.sql
+++ b/src/migrations/20250101000005_setup_script_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories ADD COLUMN setup_script TEXT;

--- a/src/migrations/20250101000006_custom_instructions_column.sql
+++ b/src/migrations/20250101000006_custom_instructions_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories ADD COLUMN custom_instructions TEXT;

--- a/src/migrations/20250101000007_remote_connections.sql
+++ b/src/migrations/20250101000007_remote_connections.sql
@@ -1,0 +1,10 @@
+CREATE TABLE remote_connections (
+    id                  TEXT PRIMARY KEY,
+    name                TEXT NOT NULL,
+    host                TEXT NOT NULL,
+    port                INTEGER DEFAULT 7683,
+    session_token       TEXT,
+    cert_fingerprint    TEXT,
+    auto_connect        INTEGER DEFAULT 0,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/src/migrations/20250101000008_slash_command_usage.sql
+++ b/src/migrations/20250101000008_slash_command_usage.sql
@@ -1,0 +1,7 @@
+CREATE TABLE slash_command_usage (
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    command_name  TEXT NOT NULL,
+    use_count     INTEGER NOT NULL DEFAULT 1,
+    last_used_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (workspace_id, command_name)
+);

--- a/src/migrations/20250101000009_workspace_session_and_turn_count.sql
+++ b/src/migrations/20250101000009_workspace_session_and_turn_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspaces ADD COLUMN session_id TEXT;
+ALTER TABLE workspaces ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0;

--- a/src/migrations/20250101000010_conversation_checkpoints.sql
+++ b/src/migrations/20250101000010_conversation_checkpoints.sql
@@ -1,0 +1,11 @@
+CREATE TABLE conversation_checkpoints (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    message_id    TEXT NOT NULL,
+    commit_hash   TEXT,
+    turn_index    INTEGER NOT NULL,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_checkpoints_workspace
+    ON conversation_checkpoints(workspace_id, turn_index);

--- a/src/migrations/20250101000011_turn_tool_activities_and_message_count.sql
+++ b/src/migrations/20250101000011_turn_tool_activities_and_message_count.sql
@@ -1,0 +1,15 @@
+CREATE TABLE turn_tool_activities (
+    id              TEXT PRIMARY KEY,
+    checkpoint_id   TEXT NOT NULL REFERENCES conversation_checkpoints(id) ON DELETE CASCADE,
+    tool_use_id     TEXT NOT NULL,
+    tool_name       TEXT NOT NULL,
+    input_json      TEXT NOT NULL DEFAULT '',
+    result_text     TEXT NOT NULL DEFAULT '',
+    summary         TEXT NOT NULL DEFAULT '',
+    sort_order      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_turn_tool_activities_checkpoint
+    ON turn_tool_activities(checkpoint_id, sort_order);
+
+ALTER TABLE conversation_checkpoints ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0;

--- a/src/migrations/20250101000012_repository_sort_order.sql
+++ b/src/migrations/20250101000012_repository_sort_order.sql
@@ -1,0 +1,5 @@
+ALTER TABLE repositories ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+
+UPDATE repositories SET sort_order = (
+    SELECT COUNT(*) FROM repositories r2 WHERE r2.name < repositories.name
+);

--- a/src/migrations/20250101000013_chat_message_thinking.sql
+++ b/src/migrations/20250101000013_chat_message_thinking.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chat_messages ADD COLUMN thinking TEXT;

--- a/src/migrations/20250101000014_branch_rename_preferences.sql
+++ b/src/migrations/20250101000014_branch_rename_preferences.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories ADD COLUMN branch_rename_preferences TEXT;

--- a/src/migrations/20250101000015_checkpoint_files.sql
+++ b/src/migrations/20250101000015_checkpoint_files.sql
@@ -1,0 +1,11 @@
+CREATE TABLE checkpoint_files (
+    id              TEXT PRIMARY KEY,
+    checkpoint_id   TEXT NOT NULL REFERENCES conversation_checkpoints(id) ON DELETE CASCADE,
+    file_path       TEXT NOT NULL,
+    content         BLOB,
+    file_mode       INTEGER NOT NULL DEFAULT 33188,
+    UNIQUE(checkpoint_id, file_path)
+);
+
+CREATE INDEX idx_checkpoint_files_checkpoint
+    ON checkpoint_files(checkpoint_id);

--- a/src/migrations/20250101000016_attachments.sql
+++ b/src/migrations/20250101000016_attachments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE attachments (
+    id           TEXT PRIMARY KEY,
+    message_id   TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+    filename     TEXT NOT NULL,
+    media_type   TEXT NOT NULL,
+    data         BLOB NOT NULL,
+    width        INTEGER,
+    height       INTEGER,
+    size_bytes   INTEGER NOT NULL,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_attachments_message
+    ON attachments(message_id);

--- a/src/migrations/20250101000017_repository_mcp_servers.sql
+++ b/src/migrations/20250101000017_repository_mcp_servers.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS repository_mcp_servers (
+    id              TEXT PRIMARY KEY,
+    repository_id   TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    name            TEXT NOT NULL,
+    config_json     TEXT NOT NULL,
+    source          TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(repository_id, name)
+);

--- a/src/migrations/20250101000018_repository_mcp_servers_enabled.sql
+++ b/src/migrations/20250101000018_repository_mcp_servers_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repository_mcp_servers ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1;

--- a/src/migrations/20250101000019_setup_script_auto_run.sql
+++ b/src/migrations/20250101000019_setup_script_auto_run.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories ADD COLUMN setup_script_auto_run INTEGER NOT NULL DEFAULT 0;

--- a/src/migrations/20260420001941_chat_message_token_tracking.sql
+++ b/src/migrations/20260420001941_chat_message_token_tracking.sql
@@ -1,0 +1,4 @@
+ALTER TABLE chat_messages ADD COLUMN input_tokens INTEGER;
+ALTER TABLE chat_messages ADD COLUMN output_tokens INTEGER;
+ALTER TABLE chat_messages ADD COLUMN cache_read_tokens INTEGER;
+ALTER TABLE chat_messages ADD COLUMN cache_creation_tokens INTEGER;

--- a/src/migrations/20260420185200_agent_metrics.sql
+++ b/src/migrations/20260420185200_agent_metrics.sql
@@ -1,0 +1,51 @@
+CREATE TABLE agent_sessions (
+    id              TEXT PRIMARY KEY,
+    workspace_id    TEXT REFERENCES workspaces(id) ON DELETE CASCADE,
+    repository_id   TEXT NOT NULL,
+    started_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    last_message_at TEXT NOT NULL DEFAULT (datetime('now')),
+    ended_at        TEXT,
+    turn_count      INTEGER NOT NULL DEFAULT 0,
+    completed_ok    INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_agent_sessions_workspace ON agent_sessions(workspace_id);
+CREATE INDEX idx_agent_sessions_started   ON agent_sessions(started_at);
+
+CREATE TABLE agent_commits (
+    commit_hash     TEXT NOT NULL,
+    workspace_id    TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    repository_id   TEXT NOT NULL,
+    session_id      TEXT,
+    additions       INTEGER NOT NULL DEFAULT 0,
+    deletions       INTEGER NOT NULL DEFAULT 0,
+    files_changed   INTEGER NOT NULL DEFAULT 0,
+    committed_at    TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, commit_hash)
+);
+CREATE INDEX idx_agent_commits_workspace ON agent_commits(workspace_id);
+CREATE INDEX idx_agent_commits_committed ON agent_commits(committed_at);
+
+CREATE TABLE deleted_workspace_summaries (
+    id                        TEXT PRIMARY KEY,
+    workspace_id              TEXT NOT NULL,
+    workspace_name            TEXT NOT NULL,
+    repository_id             TEXT NOT NULL,
+    workspace_created_at      TEXT NOT NULL,
+    deleted_at                TEXT NOT NULL DEFAULT (datetime('now')),
+    sessions_started          INTEGER NOT NULL DEFAULT 0,
+    sessions_completed        INTEGER NOT NULL DEFAULT 0,
+    total_turns               INTEGER NOT NULL DEFAULT 0,
+    total_session_duration_ms INTEGER NOT NULL DEFAULT 0,
+    commits_made              INTEGER NOT NULL DEFAULT 0,
+    total_additions           INTEGER NOT NULL DEFAULT 0,
+    total_deletions           INTEGER NOT NULL DEFAULT 0,
+    total_files_changed       INTEGER NOT NULL DEFAULT 0,
+    messages_user             INTEGER NOT NULL DEFAULT 0,
+    messages_assistant        INTEGER NOT NULL DEFAULT 0,
+    messages_system           INTEGER NOT NULL DEFAULT 0,
+    total_cost_usd            REAL NOT NULL DEFAULT 0,
+    first_message_at          TEXT,
+    last_message_at           TEXT,
+    slash_commands_used       INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_deleted_ws_summaries_repo ON deleted_workspace_summaries(repository_id);

--- a/src/migrations/20260420185201_agent_metrics_repo_indexes.sql
+++ b/src/migrations/20260420185201_agent_metrics_repo_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_agent_sessions_repo ON agent_sessions(repository_id);
+CREATE INDEX idx_agent_commits_repo  ON agent_commits(repository_id);

--- a/src/migrations/20260421192849_workspace_branch_auto_rename_claimed.sql
+++ b/src/migrations/20260421192849_workspace_branch_auto_rename_claimed.sql
@@ -1,0 +1,4 @@
+ALTER TABLE workspaces ADD COLUMN branch_auto_rename_claimed INTEGER NOT NULL DEFAULT 0;
+
+UPDATE workspaces SET branch_auto_rename_claimed = 1
+  WHERE id IN (SELECT DISTINCT workspace_id FROM chat_messages);

--- a/src/migrations/20260421202734_deleted_workspace_summaries_tokens_and_chat_index.sql
+++ b/src/migrations/20260421202734_deleted_workspace_summaries_tokens_and_chat_index.sql
@@ -1,0 +1,4 @@
+ALTER TABLE deleted_workspace_summaries ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE deleted_workspace_summaries ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_chat_messages_created ON chat_messages(created_at);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -1,0 +1,137 @@
+/// A single schema migration.
+///
+/// Identity is the string `id` (typically `YYYYMMDDHHMMSS_snake_case`). Two
+/// migrations authored on separate branches append entries to [`MIGRATIONS`]
+/// with distinct IDs, so both run regardless of merge order.
+pub struct Migration {
+    pub id: &'static str,
+    pub sql: &'static str,
+    /// For migrations that existed before the `schema_migrations` redesign,
+    /// the `PRAGMA user_version` this migration corresponds to. Used only
+    /// during one-time backfill on pre-redesign databases. `None` for any
+    /// migration added after the redesign.
+    pub legacy_version: Option<i32>,
+}
+
+pub const MIGRATIONS: &[Migration] = &[
+    Migration {
+        id: "20250101000001_initial_repos_and_workspaces",
+        sql: include_str!("20250101000001_initial_repos_and_workspaces.sql"),
+        legacy_version: Some(1),
+    },
+    Migration {
+        id: "20250101000002_chat_messages",
+        sql: include_str!("20250101000002_chat_messages.sql"),
+        legacy_version: Some(2),
+    },
+    Migration {
+        id: "20250101000003_repository_icon_and_app_settings",
+        sql: include_str!("20250101000003_repository_icon_and_app_settings.sql"),
+        legacy_version: Some(3),
+    },
+    Migration {
+        id: "20250101000004_terminal_tabs",
+        sql: include_str!("20250101000004_terminal_tabs.sql"),
+        legacy_version: Some(4),
+    },
+    Migration {
+        id: "20250101000005_setup_script_column",
+        sql: include_str!("20250101000005_setup_script_column.sql"),
+        legacy_version: Some(5),
+    },
+    Migration {
+        id: "20250101000006_custom_instructions_column",
+        sql: include_str!("20250101000006_custom_instructions_column.sql"),
+        legacy_version: Some(6),
+    },
+    Migration {
+        id: "20250101000007_remote_connections",
+        sql: include_str!("20250101000007_remote_connections.sql"),
+        legacy_version: Some(7),
+    },
+    Migration {
+        id: "20250101000008_slash_command_usage",
+        sql: include_str!("20250101000008_slash_command_usage.sql"),
+        legacy_version: Some(8),
+    },
+    Migration {
+        id: "20250101000009_workspace_session_and_turn_count",
+        sql: include_str!("20250101000009_workspace_session_and_turn_count.sql"),
+        legacy_version: Some(9),
+    },
+    Migration {
+        id: "20250101000010_conversation_checkpoints",
+        sql: include_str!("20250101000010_conversation_checkpoints.sql"),
+        legacy_version: Some(10),
+    },
+    Migration {
+        id: "20250101000011_turn_tool_activities_and_message_count",
+        sql: include_str!("20250101000011_turn_tool_activities_and_message_count.sql"),
+        legacy_version: Some(11),
+    },
+    Migration {
+        id: "20250101000012_repository_sort_order",
+        sql: include_str!("20250101000012_repository_sort_order.sql"),
+        legacy_version: Some(12),
+    },
+    Migration {
+        id: "20250101000013_chat_message_thinking",
+        sql: include_str!("20250101000013_chat_message_thinking.sql"),
+        legacy_version: Some(13),
+    },
+    Migration {
+        id: "20250101000014_branch_rename_preferences",
+        sql: include_str!("20250101000014_branch_rename_preferences.sql"),
+        legacy_version: Some(14),
+    },
+    Migration {
+        id: "20250101000015_checkpoint_files",
+        sql: include_str!("20250101000015_checkpoint_files.sql"),
+        legacy_version: Some(15),
+    },
+    Migration {
+        id: "20250101000016_attachments",
+        sql: include_str!("20250101000016_attachments.sql"),
+        legacy_version: Some(16),
+    },
+    Migration {
+        id: "20250101000017_repository_mcp_servers",
+        sql: include_str!("20250101000017_repository_mcp_servers.sql"),
+        legacy_version: Some(17),
+    },
+    Migration {
+        id: "20250101000018_repository_mcp_servers_enabled",
+        sql: include_str!("20250101000018_repository_mcp_servers_enabled.sql"),
+        legacy_version: Some(18),
+    },
+    Migration {
+        id: "20250101000019_setup_script_auto_run",
+        sql: include_str!("20250101000019_setup_script_auto_run.sql"),
+        legacy_version: Some(19),
+    },
+    Migration {
+        id: "20260420001941_chat_message_token_tracking",
+        sql: include_str!("20260420001941_chat_message_token_tracking.sql"),
+        legacy_version: Some(20),
+    },
+    Migration {
+        id: "20260420185200_agent_metrics",
+        sql: include_str!("20260420185200_agent_metrics.sql"),
+        legacy_version: Some(21),
+    },
+    Migration {
+        id: "20260420185201_agent_metrics_repo_indexes",
+        sql: include_str!("20260420185201_agent_metrics_repo_indexes.sql"),
+        legacy_version: Some(22),
+    },
+    Migration {
+        id: "20260421192849_workspace_branch_auto_rename_claimed",
+        sql: include_str!("20260421192849_workspace_branch_auto_rename_claimed.sql"),
+        legacy_version: Some(23),
+    },
+    Migration {
+        id: "20260421202734_deleted_workspace_summaries_tokens_and_chat_index",
+        sql: include_str!("20260421202734_deleted_workspace_summaries_tokens_and_chat_index.sql"),
+        legacy_version: Some(24),
+    },
+];


### PR DESCRIPTION
## Summary

Migrations are now identified by stable timestamped string IDs (`YYYYMMDDHHMMSS_snake_case`) tracked in a `schema_migrations` table, instead of an integer `PRAGMA user_version`. Parallel branches can each append a new `.sql` file + `MIGRATIONS` entry and both run on merge, in any order — eliminating the silent-skip bug where two branches both author "migration N" and the second-to-merge never applies on DBs already at `user_version = N`.

Implementation mirrors the approved plan:
- 19 legacy inline SQL blocks extracted to `src/migrations/*.sql` and embedded via `include_str!`.
- One-time bootstrap reads `PRAGMA user_version`, creates `schema_migrations`, and backfills legacy IDs whose `legacy_version ≤ user_version`. After that, the pragma is never read or written again.
- Runner iterates `MIGRATIONS`, skipping any ID already in `schema_migrations`; each migration's SQL + tracking-row insert run in one `unchecked_transaction()` so failures leave no partial state.
- Migrations landed on `main` while this PR was open (`chat_messages` token columns as v20, agent-metrics v21/v22, `branch_auto_rename_claimed` v23, deleted-workspace token totals + chat-messages index v24) are carried as timestamp-keyed entries with `legacy_version: Some(N)` so existing installs get the ID backfilled (no re-run) and installs at `≤ N-1` get it as a fresh migration.

```mermaid
flowchart TD
    A[Start migrate] --> B{schema_migrations<br/>table exists?}
    B -- no --> C[Read PRAGMA user_version]
    C --> D[CREATE TABLE schema_migrations]
    D --> E[Insert IDs where<br/>legacy_version ≤ user_version]
    E --> F[run_migrations]
    B -- yes --> F
    F --> G[SELECT id FROM schema_migrations]
    G --> H{For each m in MIGRATIONS:<br/>applied?}
    H -- yes --> H
    H -- no --> I[BEGIN; execute_batch m.sql;<br/>INSERT id; COMMIT]
    I --> H
```

## Complexity Notes

- **Backfill is idempotent but one-shot in spirit.** It only runs when `schema_migrations` does not exist. Any future code that tries to re-read `PRAGMA user_version` will read the old, frozen value — which is deliberate (forensic history) but worth being aware of.
- **`legacy_version` is a transitional field.** Every new migration after this PR ships should use `legacy_version: None`. The field exists solely so existing DBs can be seeded from their old pragma value. The existing entries with `Some(N)` cover dev/released installs of migrations that landed on `main` before this refactor.
- **Timestamp collision = merge conflict.** Two branches picking the same timestamp both append to the bottom of `MIGRATIONS`, so git surfaces it in `mod.rs`. A runtime `assert!` and a unit test catch duplicate IDs if one slips past the conflict.
- **`PRAGMA user_version` is now legacy.** Do not read or write it in new code.

## Dev-only rollout note

Developers who installed a dev build of a feature branch (e.g. `bakedbean/context-tracking-phase-1`) before it merged will have `user_version` matching that branch's integer and the corresponding columns already present. The matching `legacy_version: Some(N)` entry seeds the ID during backfill so the runner skips it — no "duplicate column" error. Released users and fresh installs are unaffected.

## Test Steps

1. **Fresh install** — delete local DB (`~/Library/Application Support/com.claudette.Claudette/claudette.sqlite` on macOS), launch `cargo tauri dev`, and verify startup succeeds and `schema_migrations` contains 24 rows matching `MIGRATIONS`.
2. **Pre-redesign upgrade** — from a build with `user_version = 19`, launch this build, confirm startup succeeds, and spot-check that `schema_migrations` is populated with all 19 legacy IDs plus the post-19 IDs (token-tracking, metrics, branch-rename-claimed, deleted-summary tokens).
3. **Existing dev-branch upgrade** — from a build at `user_version ∈ {20..24}` (installed from merged main), launch this build, confirm startup succeeds, no "duplicate column" error, and all 24 IDs are present in `schema_migrations`.
4. **Automated checks** — run:
   - `cargo test --lib -p claudette` (the 9 new tests in `db.rs::tests` exercise fresh DB, idempotency, backfill at versions 0/10/19, skip-applied, and atomic-failure rollback).
   - `cargo clippy --workspace --all-targets` (zero warnings).
   - `cargo fmt --all --check`.

## Checklist

- [x] Tests added/updated (9 new tests in `src/db.rs`)
- [x] Documentation updated (`CLAUDE.md` migration workflow section rewritten)