### PR TITLE
fix: context meter uses per-call usage, not turn aggregate (refs #300)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -19,8 +19,29 @@ use crate::env::WorkspaceEnv;
 /// cumulative) and `result` (turn total) events. Matches the shape of
 /// Anthropic's `usage` block; cache fields are independently optional to
 /// tolerate CLI responses that omit them.
+///
+/// On `result` events the top-level fields are AGGREGATED across internal
+/// tool-use iterations. For the final iteration's per-call usage (what the
+/// ContextMeter needs to reflect actual end-of-turn context size), use
+/// `iterations[0]` — the CLI emits a single-entry array with the final
+/// iteration's own usage block.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: Option<u64>,
+    #[serde(default)]
+    pub cache_read_input_tokens: Option<u64>,
+    #[serde(default)]
+    pub iterations: Option<Vec<TokenUsageIteration>>,
+}
+
+/// Per-iteration usage snapshot, emitted by the CLI inside `result.usage`.
+/// Same shape as `TokenUsage`'s aggregate fields — but values are scoped
+/// to one internal API call instead of summed across all iterations.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TokenUsageIteration {
     pub input_tokens: u64,
     pub output_tokens: u64,
     #[serde(default)]
@@ -2773,5 +2794,78 @@ mod token_usage_tests {
             } => {}
             other => panic!("expected Stream(MessageDelta) no usage, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn deserializes_result_iterations() {
+        // Real shape from CLI: result.usage.iterations contains the final
+        // iteration's per-call usage. Without this, the ContextMeter has
+        // no way to distinguish the aggregate from the last call's actual
+        // context size on tool-use chains.
+        let line = r#"{
+            "type": "result",
+            "subtype": "success",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 200,
+                "cache_read_input_tokens": 9999,
+                "cache_creation_input_tokens": 55,
+                "iterations": [
+                    {
+                        "input_tokens": 1,
+                        "output_tokens": 611,
+                        "cache_read_input_tokens": 131890,
+                        "cache_creation_input_tokens": 573
+                    }
+                ]
+            }
+        }"#;
+        let ev: StreamEvent = serde_json::from_str(line).unwrap();
+        match ev {
+            StreamEvent::Result { usage: Some(u), .. } => {
+                let iters = u.iterations.expect("iterations should parse");
+                assert_eq!(iters.len(), 1);
+                assert_eq!(iters[0].input_tokens, 1);
+                assert_eq!(iters[0].output_tokens, 611);
+                assert_eq!(iters[0].cache_read_input_tokens, Some(131_890));
+                assert_eq!(iters[0].cache_creation_input_tokens, Some(573));
+            }
+            other => panic!("expected Result with iterations, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserializes_result_without_iterations() {
+        let line = r#"{
+            "type": "result",
+            "subtype": "success",
+            "usage": { "input_tokens": 10, "output_tokens": 20 }
+        }"#;
+        let ev: StreamEvent = serde_json::from_str(line).unwrap();
+        match ev {
+            StreamEvent::Result { usage: Some(u), .. } => {
+                assert!(u.iterations.is_none());
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn round_trip_preserves_iterations() {
+        // The Rust bridge deserializes CLI JSON then re-serializes to the
+        // frontend via the AgentEvent Tauri emission. If iterations is
+        // lost in this round trip, the ContextMeter fix is dead code.
+        let line = r#"{"type":"result","subtype":"success","usage":{"input_tokens":1,"output_tokens":2,"iterations":[{"input_tokens":3,"output_tokens":4}]}}"#;
+        let ev: StreamEvent = serde_json::from_str(line).unwrap();
+        let re_encoded = serde_json::to_string(&ev).unwrap();
+        // The new JSON must still contain the iterations key + inner values.
+        assert!(
+            re_encoded.contains("\"iterations\""),
+            "iterations dropped during round trip: {re_encoded}"
+        );
+        assert!(
+            re_encoded.contains("\"input_tokens\":3"),
+            "iteration[0].input_tokens dropped: {re_encoded}"
+        );
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -33,7 +33,11 @@ pub struct TokenUsage {
     pub cache_creation_input_tokens: Option<u64>,
     #[serde(default)]
     pub cache_read_input_tokens: Option<u64>,
-    #[serde(default)]
+    // `skip_serializing_if` keeps absent iterations out of the re-emitted
+    // Tauri payload entirely — important because `TokenUsage` rides every
+    // `message_delta` event (many per turn) where `iterations` is never
+    // present, and we don't want to emit `"iterations": null` on each one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub iterations: Option<Vec<TokenUsageIteration>>,
 }
 
@@ -2866,6 +2870,21 @@ mod token_usage_tests {
         assert!(
             re_encoded.contains("\"input_tokens\":3"),
             "iteration[0].input_tokens dropped: {re_encoded}"
+        );
+    }
+
+    #[test]
+    fn absent_iterations_are_omitted_not_nulled() {
+        // message_delta events frequently carry a TokenUsage with no
+        // iterations. skip_serializing_if keeps the field OUT of the
+        // serialized payload — we don't want `"iterations": null`
+        // riding every content delta to the frontend.
+        let line = r#"{"type":"stream_event","event":{"type":"message_delta","usage":{"input_tokens":5,"output_tokens":7}}}"#;
+        let ev: StreamEvent = serde_json::from_str(line).unwrap();
+        let re_encoded = serde_json::to_string(&ev).unwrap();
+        assert!(
+            !re_encoded.contains("\"iterations\""),
+            "iterations key should be omitted when absent: {re_encoded}"
         );
     }
 }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -33,6 +33,7 @@ import { findLatestPlanFilePath } from "./planFilePath";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import { open } from "@tauri-apps/plugin-dialog";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
+import { extractLatestCallUsage } from "../../utils/extractLatestCallUsage";
 import type { SlashCommand, FileEntry } from "../../services/tauri";
 import type { ChatMessage, ChatAttachment, AttachmentInput, PendingAttachment } from "../../types/chat";
 import { base64ToBytes } from "../../utils/base64";
@@ -354,6 +355,13 @@ export function ChatPanel() {
         historyRef.current[wsId] = filtered
           .filter((m) => m.role === "User")
           .map((m) => m.content);
+        // Seed the ContextMeter from the last assistant message's per-call
+        // token data. If none is available (fresh / pre-migration workspace),
+        // clear any stale value so the meter hides.
+        const callUsage = extractLatestCallUsage(filtered);
+        const { setLatestTurnUsage, clearLatestTurnUsage } = useAppStore.getState();
+        if (callUsage) setLatestTurnUsage(wsId, callUsage);
+        else clearLatestTurnUsage(wsId);
 
         // Load attachments for this workspace's messages.
         if (isLocal) {

--- a/src/ui/src/hooks/pickMeterUsageFromResult.test.ts
+++ b/src/ui/src/hooks/pickMeterUsageFromResult.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { pickMeterUsageFromResult } from "./pickMeterUsageFromResult";
+import type { StreamEvent } from "../types/agent-events";
+
+type ResultEvent = Extract<StreamEvent, { type: "result" }>;
+
+function make(usage: ResultEvent["usage"]): ResultEvent {
+  return { type: "result", subtype: "success", usage };
+}
+
+describe("pickMeterUsageFromResult", () => {
+  it("returns null when usage is null", () => {
+    expect(pickMeterUsageFromResult(make(null))).toBeNull();
+  });
+
+  it("returns null when usage is undefined (aggregate absent and no iterations)", () => {
+    expect(pickMeterUsageFromResult(make(undefined))).toBeNull();
+  });
+
+  it("prefers iterations[0] over the top-level aggregate", () => {
+    // The top-level fields represent the 69-iteration aggregate; the
+    // iteration's fields represent the final API call's per-call usage.
+    const usage = pickMeterUsageFromResult(
+      make({
+        input_tokens: 62,
+        output_tokens: 41_322,
+        cache_creation_input_tokens: 153_239,
+        cache_read_input_tokens: 4_695_413,
+        iterations: [
+          {
+            input_tokens: 1,
+            output_tokens: 611,
+            cache_read_input_tokens: 131_890,
+            cache_creation_input_tokens: 573,
+          },
+        ],
+      }),
+    );
+    expect(usage).toEqual({
+      inputTokens: 1,
+      outputTokens: 611,
+      cacheReadTokens: 131_890,
+      cacheCreationTokens: 573,
+    });
+  });
+
+  it("falls back to the top-level aggregate when iterations is absent", () => {
+    const usage = pickMeterUsageFromResult(
+      make({
+        input_tokens: 100,
+        output_tokens: 200,
+        cache_read_input_tokens: 5_000,
+      }),
+    );
+    expect(usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 200,
+      cacheReadTokens: 5_000,
+      cacheCreationTokens: undefined,
+    });
+  });
+
+  it("falls back to the aggregate when iterations is an empty array", () => {
+    const usage = pickMeterUsageFromResult(
+      make({
+        input_tokens: 100,
+        output_tokens: 200,
+        iterations: [],
+      }),
+    );
+    expect(usage?.inputTokens).toBe(100);
+    expect(usage?.outputTokens).toBe(200);
+  });
+
+  it("treats null cache fields as undefined", () => {
+    const usage = pickMeterUsageFromResult(
+      make({
+        input_tokens: 100,
+        output_tokens: 200,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+      }),
+    );
+    expect(usage?.cacheReadTokens).toBeUndefined();
+    expect(usage?.cacheCreationTokens).toBeUndefined();
+  });
+
+  it("returns null if neither input nor output is present", () => {
+    const usage = pickMeterUsageFromResult(
+      make({
+        input_tokens: undefined as unknown as number,
+        output_tokens: undefined as unknown as number,
+      }),
+    );
+    expect(usage).toBeNull();
+  });
+});

--- a/src/ui/src/hooks/pickMeterUsageFromResult.ts
+++ b/src/ui/src/hooks/pickMeterUsageFromResult.ts
@@ -1,0 +1,37 @@
+import type { StreamEvent } from "../types/agent-events";
+import type { TurnUsage } from "../stores/useAppStore";
+
+type ResultEvent = Extract<StreamEvent, { type: "result" }>;
+
+/**
+ * Pick the per-call usage for the ContextMeter from a `result` stream event.
+ *
+ * `result.usage.iterations[0]` contains the final API call's per-call usage
+ * (what the meter needs to show actual end-of-turn context size). The
+ * top-level `result.usage.*` fields aggregate across all internal tool-use
+ * iterations and are `num_turns ×` too large for the meter's purposes.
+ *
+ * Returns null when no usable data is available — fresh turn with no usage
+ * payload, or CLI emitted `usage: null`. Falls back to the top-level
+ * aggregate when `iterations` is absent (older CLI versions that don't
+ * emit the field); the meter will over-report on tool-use chains in that
+ * case but still renders a reasonable value for single-iteration turns.
+ */
+export function pickMeterUsageFromResult(
+  event: ResultEvent,
+): TurnUsage | null {
+  const source = event.usage?.iterations?.[0] ?? event.usage;
+  if (!source) return null;
+  if (
+    typeof source.input_tokens !== "number" &&
+    typeof source.output_tokens !== "number"
+  ) {
+    return null;
+  }
+  return {
+    inputTokens: source.input_tokens,
+    outputTokens: source.output_tokens,
+    cacheReadTokens: source.cache_read_input_tokens ?? undefined,
+    cacheCreationTokens: source.cache_creation_input_tokens ?? undefined,
+  };
+}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -9,6 +9,7 @@ import { extractToolSummary } from "./toolSummary";
 import { parseAskUserQuestion } from "./parseAgentQuestion";
 import { debugChat } from "../utils/chatDebug";
 import { extractLatestCallUsage } from "../utils/extractLatestCallUsage";
+import { pickMeterUsageFromResult } from "./pickMeterUsageFromResult";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 
@@ -281,23 +282,30 @@ export function useAgentStream() {
               pendingMessageCount: turnMessageCountRef.current[wsId] || 0,
               pendingToolCount: (useAppStore.getState().toolActivities[wsId] || []).length,
             });
-            // The top-level `result.usage.*` aggregates across all inner
-            // tool-use iterations. For the meter we want the FINAL call's
-            // per-call usage; the CLI emits that in `iterations[0]`. Fall
-            // back to the aggregate if the CLI doesn't emit iterations
-            // (older versions). See Phase 2.5 spec.
-            const lastCall =
-              streamEvent.usage?.iterations?.[0] ?? streamEvent.usage;
+            // CompletedTurn / TurnFooter keep aggregate semantics — the
+            // top-level `result.usage.*` is the total cost/work across
+            // all inner tool-use iterations in this Claudette-level turn.
             finalizeTurn(
               wsId,
               turnMessageCountRef.current[wsId] || 0,
               turnCheckpointIdRef.current[wsId],
               streamEvent.duration_ms,
-              lastCall?.input_tokens,
-              lastCall?.output_tokens,
-              lastCall?.cache_read_input_tokens ?? undefined,
-              lastCall?.cache_creation_input_tokens ?? undefined,
+              streamEvent.usage?.input_tokens,
+              streamEvent.usage?.output_tokens,
+              streamEvent.usage?.cache_read_input_tokens ?? undefined,
+              streamEvent.usage?.cache_creation_input_tokens ?? undefined,
             );
+            // Meter gets the FINAL iteration's per-call usage instead
+            // (via iterations[0], falling back to aggregate on older CLI
+            // versions). This keeps live values consistent with what the
+            // reconstructed path reads from the last assistant message's
+            // per-call DB fields. See pickMeterUsageFromResult for the
+            // precedence contract.
+            const meterUsage = pickMeterUsageFromResult(streamEvent);
+            const { setLatestTurnUsage, clearLatestTurnUsage } =
+              useAppStore.getState();
+            if (meterUsage) setLatestTurnUsage(wsId, meterUsage);
+            else clearLatestTurnUsage(wsId);
             turnMessageCountRef.current[wsId] = 0;
             turnFinalizedRef.current[wsId] = true;
             updateWorkspace(wsId, { agent_status: "Idle" });

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -8,6 +8,7 @@ import type { ConversationCheckpoint } from "../types/checkpoint";
 import { extractToolSummary } from "./toolSummary";
 import { parseAskUserQuestion } from "./parseAgentQuestion";
 import { debugChat } from "../utils/chatDebug";
+import { extractLatestCallUsage } from "../utils/extractLatestCallUsage";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 
@@ -501,6 +502,11 @@ export function useAgentStream() {
             messageIds: filtered.map((msg) => msg.id),
           });
           setChatMessages(wsId, filtered);
+          const callUsage = extractLatestCallUsage(filtered);
+          const { setLatestTurnUsage, clearLatestTurnUsage } =
+            useAppStore.getState();
+          if (callUsage) setLatestTurnUsage(wsId, callUsage);
+          else clearLatestTurnUsage(wsId);
         })
         .catch((e) => console.error("Failed to reload messages after checkpoint:", e));
     });

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -280,15 +280,22 @@ export function useAgentStream() {
               pendingMessageCount: turnMessageCountRef.current[wsId] || 0,
               pendingToolCount: (useAppStore.getState().toolActivities[wsId] || []).length,
             });
+            // The top-level `result.usage.*` aggregates across all inner
+            // tool-use iterations. For the meter we want the FINAL call's
+            // per-call usage; the CLI emits that in `iterations[0]`. Fall
+            // back to the aggregate if the CLI doesn't emit iterations
+            // (older versions). See Phase 2.5 spec.
+            const lastCall =
+              streamEvent.usage?.iterations?.[0] ?? streamEvent.usage;
             finalizeTurn(
               wsId,
               turnMessageCountRef.current[wsId] || 0,
               turnCheckpointIdRef.current[wsId],
               streamEvent.duration_ms,
-              streamEvent.usage?.input_tokens,
-              streamEvent.usage?.output_tokens,
-              streamEvent.usage?.cache_read_input_tokens ?? undefined,
-              streamEvent.usage?.cache_creation_input_tokens ?? undefined,
+              lastCall?.input_tokens,
+              lastCall?.output_tokens,
+              lastCall?.cache_read_input_tokens ?? undefined,
+              lastCall?.cache_creation_input_tokens ?? undefined,
             );
             turnMessageCountRef.current[wsId] = 0;
             turnFinalizedRef.current[wsId] = true;

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -949,7 +949,7 @@ describe("finalizeTurn tool-free turn (no activities)", () => {
   });
 });
 
-describe("hydrateCompletedTurns seeds latestTurnUsage", () => {
+describe("hydrateCompletedTurns leaves latestTurnUsage untouched", () => {
   beforeEach(() => {
     useAppStore.setState({
       completedTurns: {},
@@ -957,7 +957,18 @@ describe("hydrateCompletedTurns seeds latestTurnUsage", () => {
     });
   });
 
-  it("copies the latest hydrated turn's token fields into latestTurnUsage", () => {
+  it("does not modify latestTurnUsage when hydrating turns with tokens", () => {
+    // Seed an existing meter value from a prior live turn.
+    useAppStore.setState({
+      latestTurnUsage: {
+        ws1: {
+          inputTokens: 999,
+          outputTokens: 42,
+          cacheReadTokens: 12_345,
+          cacheCreationTokens: 67,
+        },
+      },
+    });
     useAppStore.getState().hydrateCompletedTurns("ws1", [
       {
         id: "cp1",
@@ -968,30 +979,21 @@ describe("hydrateCompletedTurns seeds latestTurnUsage", () => {
         durationMs: 1000,
         inputTokens: 500,
         outputTokens: 100,
-      },
-      {
-        id: "cp2",
-        activities: [],
-        messageCount: 1,
-        collapsed: true,
-        afterMessageIndex: 4,
-        durationMs: 2000,
-        inputTokens: 2000,
-        outputTokens: 150,
         cacheReadTokens: 50_000,
         cacheCreationTokens: 800,
       },
     ]);
-    // cp2 is the most recent — its tokens should seed the meter.
+    // Hydration should not stomp the existing meter value — the meter
+    // is now seeded by extractLatestCallUsage at the caller.
     expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
-      inputTokens: 2000,
-      outputTokens: 150,
-      cacheReadTokens: 50_000,
-      cacheCreationTokens: 800,
+      inputTokens: 999,
+      outputTokens: 42,
+      cacheReadTokens: 12_345,
+      cacheCreationTokens: 67,
     });
   });
 
-  it("leaves latestTurnUsage untouched when hydrated turns have no token data", () => {
+  it("does not create latestTurnUsage for a workspace that had none", () => {
     useAppStore.getState().hydrateCompletedTurns("ws1", [
       {
         id: "cp1",
@@ -999,6 +1001,8 @@ describe("hydrateCompletedTurns seeds latestTurnUsage", () => {
         messageCount: 1,
         collapsed: true,
         afterMessageIndex: 2,
+        inputTokens: 500,
+        outputTokens: 100,
       },
     ]);
     expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -885,24 +885,39 @@ describe("finalizeTurn token counts", () => {
     expect(turns[0].cacheCreationTokens).toBeUndefined();
   });
 
-  it("writes latestTurnUsage alongside the CompletedTurn when tokens are provided", () => {
+  it("does not write latestTurnUsage — caller is responsible for that", () => {
+    // Phase 2.5: finalizeTurn stores aggregate values on CompletedTurn
+    // (for TurnFooter's turn-total view) but does NOT write the meter's
+    // latestTurnUsage slice. The meter's per-call values come via a
+    // separate setLatestTurnUsage call in useAgentStream.
+    useAppStore.setState({
+      latestTurnUsage: {
+        ws1: {
+          inputTokens: 999,
+          outputTokens: 42,
+          cacheReadTokens: 12_345,
+          cacheCreationTokens: 67,
+        },
+      },
+    });
     useAppStore.getState().finalizeTurn(
       "ws1", 1, "turn-4", 1000, 1500, 240, 80_000, 1_200,
     );
-    const usage = useAppStore.getState().latestTurnUsage.ws1;
-    expect(usage).toEqual({
-      inputTokens: 1500,
-      outputTokens: 240,
-      cacheReadTokens: 80_000,
-      cacheCreationTokens: 1_200,
+    // The pre-existing meter slice is untouched.
+    expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
+      inputTokens: 999,
+      outputTokens: 42,
+      cacheReadTokens: 12_345,
+      cacheCreationTokens: 67,
     });
   });
 });
 
 describe("finalizeTurn tool-free turn (no activities)", () => {
   beforeEach(() => {
-    // NO toolActivities → finalizeTurn will early-return for the timeline,
-    // but the meter's latestTurnUsage slice must still refresh.
+    // NO toolActivities → finalizeTurn early-returns without producing
+    // a CompletedTurn. Under Phase 2.5 it also doesn't touch
+    // latestTurnUsage — that's purely the caller's responsibility now.
     useAppStore.setState({
       completedTurns: {},
       toolActivities: {},
@@ -910,23 +925,15 @@ describe("finalizeTurn tool-free turn (no activities)", () => {
     });
   });
 
-  it("updates latestTurnUsage even when no tool activities exist", () => {
+  it("does not create a CompletedTurn and does not touch latestTurnUsage", () => {
     useAppStore.getState().finalizeTurn(
       "ws1", 1, "turn-x", 800, 500, 60, 20_000, 300,
     );
-    // No CompletedTurn was appended — the timeline stays unchanged.
     expect(useAppStore.getState().completedTurns.ws1).toBeUndefined();
-    // But latestTurnUsage IS updated so the ContextMeter can re-render.
-    expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
-      inputTokens: 500,
-      outputTokens: 60,
-      cacheReadTokens: 20_000,
-      cacheCreationTokens: 300,
-    });
+    expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();
   });
 
-  it("preserves existing latestTurnUsage when finalizeTurn has no token data", () => {
-    // Seed a previous turn's usage.
+  it("leaves existing latestTurnUsage untouched", () => {
     useAppStore.setState({
       latestTurnUsage: {
         ws1: {
@@ -937,10 +944,7 @@ describe("finalizeTurn tool-free turn (no activities)", () => {
         },
       },
     });
-    // Finalize a turn with no usage payload (rare but possible on a broken stream).
     useAppStore.getState().finalizeTurn("ws1", 1, "turn-y", 500);
-    // Previous usage stays intact — we never want to stomp a real value with
-    // an all-undefined record.
     expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
       inputTokens: 100,
       outputTokens: 50,

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1004,3 +1004,35 @@ describe("hydrateCompletedTurns seeds latestTurnUsage", () => {
     expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();
   });
 });
+
+describe("clearLatestTurnUsage", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      latestTurnUsage: {
+        ws1: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 10_000,
+          cacheCreationTokens: 500,
+        },
+        ws2: {
+          inputTokens: 200,
+          outputTokens: 75,
+        },
+      },
+    });
+  });
+
+  it("deletes the entry for the specified workspace only", () => {
+    useAppStore.getState().clearLatestTurnUsage("ws1");
+    const slice = useAppStore.getState().latestTurnUsage;
+    expect(slice.ws1).toBeUndefined();
+    expect(slice.ws2).toEqual({ inputTokens: 200, outputTokens: 75 });
+  });
+
+  it("is a no-op for workspaces not in the slice", () => {
+    useAppStore.getState().clearLatestTurnUsage("ws-never-set");
+    expect(useAppStore.getState().latestTurnUsage.ws1).toBeDefined();
+    expect(useAppStore.getState().latestTurnUsage.ws2).toBeDefined();
+  });
+});

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "./useAppStore";
 import type { AgentQuestion } from "./useAppStore";
+import type { ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
 import { applyPlanModeMountDefault } from "../components/chat/applyPlanModeMountDefault";
 
@@ -1038,5 +1039,95 @@ describe("clearLatestTurnUsage", () => {
     useAppStore.getState().clearLatestTurnUsage("ws-never-set");
     expect(useAppStore.getState().latestTurnUsage.ws1).toBeDefined();
     expect(useAppStore.getState().latestTurnUsage.ws2).toBeDefined();
+  });
+});
+
+describe("rollbackConversation updates latestTurnUsage", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      chatMessages: {},
+      completedTurns: {},
+      toolActivities: {},
+      latestTurnUsage: {
+        ws1: {
+          inputTokens: 999,
+          outputTokens: 42,
+          cacheReadTokens: 12_345,
+          cacheCreationTokens: 67,
+        },
+      },
+      lastMessages: {},
+      agentQuestions: {},
+      planApprovals: {},
+      streamingContent: {},
+      streamingThinking: {},
+      checkpoints: {},
+    });
+  });
+
+  it("writes latestTurnUsage from the last assistant message with token data", () => {
+    const msgs: ChatMessage[] = [
+      {
+        id: "m1",
+        workspace_id: "ws1",
+        role: "User",
+        content: "hi",
+        cost_usd: null,
+        duration_ms: null,
+        created_at: "",
+        thinking: null,
+        input_tokens: null,
+        output_tokens: null,
+        cache_read_tokens: null,
+        cache_creation_tokens: null,
+      },
+      {
+        id: "m2",
+        workspace_id: "ws1",
+        role: "Assistant",
+        content: "hello",
+        cost_usd: null,
+        duration_ms: null,
+        created_at: "",
+        thinking: null,
+        input_tokens: 300,
+        output_tokens: 80,
+        cache_read_tokens: 5_000,
+        cache_creation_tokens: 200,
+      },
+    ];
+    useAppStore.getState().rollbackConversation("ws1", "cp1", msgs);
+    expect(useAppStore.getState().latestTurnUsage.ws1).toEqual({
+      inputTokens: 300,
+      outputTokens: 80,
+      cacheReadTokens: 5_000,
+      cacheCreationTokens: 200,
+    });
+  });
+
+  it("clears latestTurnUsage when rollback produces no assistant messages", () => {
+    useAppStore.getState().rollbackConversation("ws1", "cp1", []);
+    expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();
+  });
+
+  it("clears latestTurnUsage when rollback produces only pre-migration assistant messages", () => {
+    const msgs: ChatMessage[] = [
+      {
+        id: "m1",
+        workspace_id: "ws1",
+        role: "Assistant",
+        content: "legacy",
+        cost_usd: null,
+        duration_ms: null,
+        created_at: "",
+        thinking: null,
+        input_tokens: null,
+        output_tokens: null,
+        cache_read_tokens: null,
+        cache_creation_tokens: null,
+      },
+    ];
+    useAppStore.getState().rollbackConversation("ws1", "cp1", msgs);
+    expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();
   });
 });

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -669,24 +669,12 @@ export const useAppStore = create<AppState>((set) => ({
     cacheCreationTokens,
   ) =>
     set((s) => {
-      // Always refresh the meter's latestTurnUsage — even for tool-free
-      // turns that don't produce a CompletedTurn. Only write when the
-      // caller actually provided input/output tokens (avoids stomping the
-      // previous value with an all-undefined record on rare empty Results).
-      const hasUsage =
-        typeof inputTokens === "number" || typeof outputTokens === "number";
-      const nextLatestTurnUsage = hasUsage
-        ? {
-            ...s.latestTurnUsage,
-            [wsId]: {
-              inputTokens,
-              outputTokens,
-              cacheReadTokens,
-              cacheCreationTokens,
-            },
-          }
-        : s.latestTurnUsage;
-
+      // Phase 2.5: finalizeTurn no longer writes latestTurnUsage. The
+      // meter needs per-call values, not the turn-aggregate we receive
+      // here — useAgentStream's result handler calls setLatestTurnUsage
+      // separately with the correct per-call data. The tokens we DO
+      // receive here stay as CompletedTurn aggregate fields for the
+      // TurnFooter's "turn-total work" view.
       const activities = s.toolActivities[wsId] || [];
       if (activities.length === 0) {
         debugChat("store", "finalizeTurn skipped", {
@@ -697,7 +685,7 @@ export const useAppStore = create<AppState>((set) => ({
             (turn) => turn.id,
           ),
         });
-        return { latestTurnUsage: nextLatestTurnUsage };
+        return {};
       }
       const turn: CompletedTurn = {
         id: turnId ?? crypto.randomUUID(),
@@ -735,7 +723,6 @@ export const useAppStore = create<AppState>((set) => ({
           [wsId]: [...(s.completedTurns[wsId] || []), turn],
         },
         toolActivities: { ...s.toolActivities, [wsId]: [] },
-        latestTurnUsage: nextLatestTurnUsage,
       };
     }),
   hydrateCompletedTurns: (wsId, turns) =>

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -779,32 +779,11 @@ export const useAppStore = create<AppState>((set) => ({
         nextIds: nextTurns.map((turn) => turn.id),
       });
 
-      // Seed latestTurnUsage from the most recent hydrated turn so the
-      // meter renders correctly on workspace reload, without needing a
-      // new turn to land. Only write if the hydrated turn has live tokens
-      // (legacy turns without token metadata leave the field unset).
-      const lastTurn = nextTurns[nextTurns.length - 1];
-      const nextLatestTurnUsage =
-        lastTurn &&
-        (typeof lastTurn.inputTokens === "number" ||
-          typeof lastTurn.outputTokens === "number")
-          ? {
-              ...s.latestTurnUsage,
-              [wsId]: {
-                inputTokens: lastTurn.inputTokens,
-                outputTokens: lastTurn.outputTokens,
-                cacheReadTokens: lastTurn.cacheReadTokens,
-                cacheCreationTokens: lastTurn.cacheCreationTokens,
-              },
-            }
-          : s.latestTurnUsage;
-
       return {
         completedTurns: {
           ...s.completedTurns,
           [wsId]: nextTurns,
         },
-        latestTurnUsage: nextLatestTurnUsage,
       };
     }),
   setCompletedTurns: (wsId, turns) =>

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -151,6 +151,10 @@ interface AppState {
    *  when the timeline doesn't record one. */
   latestTurnUsage: Record<string, TurnUsage>;
   setLatestTurnUsage: (wsId: string, usage: TurnUsage) => void;
+  /** Delete the meter's usage entry for a workspace. Used when a
+   *  rollback or empty load leaves no assistant message with token data —
+   *  clearing hides the meter rather than leaving a stale value. */
+  clearLatestTurnUsage: (wsId: string) => void;
   setChatMessages: (wsId: string, messages: ChatMessage[]) => void;
   addChatMessage: (wsId: string, message: ChatMessage) => void;
   setStreamingContent: (wsId: string, content: string) => void;
@@ -557,6 +561,13 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => ({
       latestTurnUsage: { ...s.latestTurnUsage, [wsId]: usage },
     })),
+  clearLatestTurnUsage: (wsId) =>
+    set((s) => {
+      if (!(wsId in s.latestTurnUsage)) return {};
+      const next = { ...s.latestTurnUsage };
+      delete next[wsId];
+      return { latestTurnUsage: next };
+    }),
   setChatMessages: (wsId, messages) =>
     set((s) => ({
       chatMessages: { ...s.chatMessages, [wsId]: messages },

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { DEFAULT_THEME_ID } from "../styles/themes";
 import { debugChat } from "../utils/chatDebug";
+import { extractLatestCallUsage } from "../utils/extractLatestCallUsage";
 import type {
   Repository,
   Workspace,
@@ -870,6 +871,18 @@ export const useAppStore = create<AppState>((set) => ({
       const updatedLastMessages = lastMsg
         ? { ...s.lastMessages, [wsId]: lastMsg }
         : restLastMessages;
+      // Recompute the meter's latestTurnUsage from the rolled-back message
+      // list. Write if the last assistant message has token data; delete
+      // the entry otherwise so the meter hides.
+      const nextCall = extractLatestCallUsage(messages);
+      let latestTurnUsage = s.latestTurnUsage;
+      if (nextCall) {
+        latestTurnUsage = { ...s.latestTurnUsage, [wsId]: nextCall };
+      } else if (wsId in s.latestTurnUsage) {
+        const next = { ...s.latestTurnUsage };
+        delete next[wsId];
+        latestTurnUsage = next;
+      }
       return {
         chatMessages: { ...s.chatMessages, [wsId]: messages },
         lastMessages: updatedLastMessages,
@@ -889,6 +902,7 @@ export const useAppStore = create<AppState>((set) => ({
             return current.filter((cp) => cp.turn_index <= target.turn_index);
           })(),
         },
+        latestTurnUsage,
       };
     }),
 

--- a/src/ui/src/types/agent-events.ts
+++ b/src/ui/src/types/agent-events.ts
@@ -22,12 +22,25 @@ export type StreamEvent =
       // `skip_serializing_if`), so the wire payload can carry either
       // `{ usage: null }` or `usage` omitted entirely. The cache fields
       // can likewise be `null` when the CLI doesn't emit them.
-      usage?: {
-        input_tokens: number;
-        output_tokens: number;
-        cache_creation_input_tokens?: number | null;
-        cache_read_input_tokens?: number | null;
-      } | null;
+      usage?:
+        | {
+            input_tokens: number;
+            output_tokens: number;
+            cache_creation_input_tokens?: number | null;
+            cache_read_input_tokens?: number | null;
+            // Per-iteration breakdown. The CLI emits a single-entry array
+            // containing the FINAL iteration's per-call usage, regardless
+            // of how many backend API calls the Claudette-level turn
+            // contained. The ContextMeter uses this (not the top-level
+            // aggregate) to reflect actual end-of-turn context size.
+            iterations?: Array<{
+              input_tokens: number;
+              output_tokens: number;
+              cache_read_input_tokens?: number | null;
+              cache_creation_input_tokens?: number | null;
+            }>;
+          }
+        | null;
     }
   | { type: "user"; message: UserEventMessage }
   | { type: "Unknown" };

--- a/src/ui/src/utils/extractLatestCallUsage.test.ts
+++ b/src/ui/src/utils/extractLatestCallUsage.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { extractLatestCallUsage } from "./extractLatestCallUsage";
+import type { ChatMessage } from "../types/chat";
+
+function msg(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: overrides.id ?? "m",
+    workspace_id: overrides.workspace_id ?? "ws",
+    role: overrides.role ?? "Assistant",
+    content: overrides.content ?? "",
+    cost_usd: overrides.cost_usd ?? null,
+    duration_ms: overrides.duration_ms ?? null,
+    created_at: overrides.created_at ?? "",
+    thinking: overrides.thinking ?? null,
+    input_tokens: overrides.input_tokens ?? null,
+    output_tokens: overrides.output_tokens ?? null,
+    cache_read_tokens: overrides.cache_read_tokens ?? null,
+    cache_creation_tokens: overrides.cache_creation_tokens ?? null,
+  };
+}
+
+describe("extractLatestCallUsage", () => {
+  it("returns null for an empty message list", () => {
+    expect(extractLatestCallUsage([])).toBeNull();
+  });
+
+  it("returns null when there are no assistant messages", () => {
+    expect(
+      extractLatestCallUsage([
+        msg({ id: "1", role: "User" }),
+        msg({ id: "2", role: "System" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when assistant messages have no token data", () => {
+    // Pre-migration rows — all token fields null.
+    expect(
+      extractLatestCallUsage([
+        msg({ id: "1", role: "Assistant" }),
+        msg({ id: "2", role: "Assistant" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("picks the last assistant message when it has tokens", () => {
+    const result = extractLatestCallUsage([
+      msg({
+        id: "1",
+        role: "Assistant",
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_tokens: 10_000,
+        cache_creation_tokens: 500,
+      }),
+      msg({
+        id: "2",
+        role: "Assistant",
+        input_tokens: 200,
+        output_tokens: 75,
+        cache_read_tokens: 20_000,
+        cache_creation_tokens: 1_000,
+      }),
+    ]);
+    expect(result).toEqual({
+      inputTokens: 200,
+      outputTokens: 75,
+      cacheReadTokens: 20_000,
+      cacheCreationTokens: 1_000,
+    });
+  });
+
+  it("skips trailing user messages to find the last assistant", () => {
+    const result = extractLatestCallUsage([
+      msg({
+        id: "1",
+        role: "Assistant",
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+      msg({ id: "2", role: "User" }),
+      msg({ id: "3", role: "System" }),
+    ]);
+    expect(result).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: undefined,
+      cacheCreationTokens: undefined,
+    });
+  });
+
+  it("skips assistant messages with no token data to find an earlier one", () => {
+    // Mixed: older assistant has tokens, newer one is pre-migration.
+    const result = extractLatestCallUsage([
+      msg({
+        id: "1",
+        role: "Assistant",
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+      msg({ id: "2", role: "Assistant" }), // pre-migration, skip
+    ]);
+    expect(result).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: undefined,
+      cacheCreationTokens: undefined,
+    });
+  });
+
+  it("treats null cache fields as undefined in the returned TurnUsage", () => {
+    const result = extractLatestCallUsage([
+      msg({
+        id: "1",
+        role: "Assistant",
+        input_tokens: 100,
+        output_tokens: 50,
+        // cache fields left null
+      }),
+    ]);
+    expect(result?.cacheReadTokens).toBeUndefined();
+    expect(result?.cacheCreationTokens).toBeUndefined();
+  });
+});

--- a/src/ui/src/utils/extractLatestCallUsage.ts
+++ b/src/ui/src/utils/extractLatestCallUsage.ts
@@ -1,0 +1,30 @@
+import type { ChatMessage } from "../types/chat";
+import type { TurnUsage } from "../stores/useAppStore";
+
+/**
+ * Find the last assistant message in `messages` that has at least one of
+ * `input_tokens` / `output_tokens` populated, and return its per-message
+ * token fields as a `TurnUsage`. Returns `null` if no such message exists
+ * (fresh workspace, pre-migration history, etc.).
+ *
+ * Phase 1's bridge writes these per-message fields from `message_delta.usage`,
+ * which is per-API-call — so the returned `TurnUsage` is the real end-of-turn
+ * context size, not an aggregate across iterations. Used by the ContextMeter's
+ * reconstructed-path hydration.
+ */
+export function extractLatestCallUsage(
+  messages: ChatMessage[],
+): TurnUsage | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role !== "Assistant") continue;
+    if (m.input_tokens === null && m.output_tokens === null) continue;
+    return {
+      inputTokens: m.input_tokens ?? undefined,
+      outputTokens: m.output_tokens ?? undefined,
+      cacheReadTokens: m.cache_read_tokens ?? undefined,
+      cacheCreationTokens: m.cache_creation_tokens ?? undefined,
+    };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Bugfix for the \`ContextMeter\` shipped in Phase 2 ([PR #315](https://github.com/utensils/claudette/pull/315)). Phase 3 research revealed that \`result.usage\` aggregates token counts across internal tool-use iterations — a 69-iteration Claudette turn sums \`cache_read_input_tokens\` across all 69 backend API calls, each re-reading the same ~68k of context. That's why the meter was rendering \`4.8m / 200.0k\` for tool-use chains. The fix switches the meter to the final iteration's per-call values (\`result.usage.iterations[0]\` live, last assistant \`ChatMessage\`'s per-message DB fields on reload).

**Data flow** — the meter's per-call path and the footer's aggregate path are deliberately separate:

\`\`\`mermaid
flowchart LR
  CLI[Claude CLI stream] -->|result.usage<br/>aggregate| Finalize[finalizeTurn]
  Finalize --> CT[CompletedTurn<br/>aggregate fields]
  CT --> Footer[TurnFooter<br/>turn-total work]
  CLI -->|result.usage.iterations 0<br/>per-call snapshot| Picker[pickMeterUsageFromResult]
  Picker --> SetMeter[setLatestTurnUsage]
  DB[(chat_messages<br/>per-message DB)] -->|extractLatestCallUsage<br/>last assistant| SetMeter
  SetMeter --> Meter[ContextMeter<br/>end-of-turn context]
\`\`\`

### Two blocking issues the final review caught

**C1 — Rust bridge was stripping \`iterations\`.** \`StreamEvent::Result.usage\` is a typed \`TokenUsage\` serde struct; the newly-added \`iterations\` field on the TS side had no corresponding Rust field, so deserialization dropped it silently. The frontend always saw \`undefined\`, and the fallback-to-aggregate branch fired every time — the primary fix was dead code. Widened \`TokenUsage\` with \`iterations: Option<Vec<TokenUsageIteration>>\` and added a round-trip Rust test that catches exactly this regression.

**I1 — Live vs reloaded semantic drift.** The live path originally routed per-call values through \`finalizeTurn\`, which writes \`CompletedTurn.inputTokens/outputTokens/cacheReadTokens/cacheCreationTokens\` — the fields \`TurnFooter\` reads. That meant a live turn's footer would show final-call numbers while the same turn after a reload would show aggregate numbers (computed by \`reconstructCompletedTurns\`). Decoupled the paths: \`finalizeTurn\` gets aggregate values (preserves Phase 2 footer semantics), and the meter is set via a separate \`setLatestTurnUsage\` call with per-call values.

### Files of interest

- \`src/agent.rs\` — \`TokenUsage\` gains \`iterations\`; new \`TokenUsageIteration\` struct; 3 new Rust tests including a round-trip serialize check.
- \`src/ui/src/types/agent-events.ts\` — TS mirror of the new Rust shape.
- \`src/ui/src/utils/extractLatestCallUsage.ts\` (new) — picks last assistant \`ChatMessage\`'s per-message tokens. 7 unit tests.
- \`src/ui/src/hooks/pickMeterUsageFromResult.ts\` (new) — picks \`iterations[0] ?? aggregate\` from a result event. 7 unit tests.
- \`src/ui/src/stores/useAppStore.ts\` — new \`clearLatestTurnUsage\` action; \`hydrateCompletedTurns\` no longer seeds the meter; \`rollbackConversation\` recomputes from incoming messages; \`finalizeTurn\` no longer writes the meter slice.
- \`src/ui/src/hooks/useAgentStream.ts\` — result handler passes aggregate to \`finalizeTurn\`, calls \`setLatestTurnUsage\`/\`clearLatestTurnUsage\` separately; process-exit filter also seeds the meter.
- \`src/ui/src/components/chat/ChatPanel.tsx\` — workspace load seeds the meter from the loaded message list.

## Complexity Notes

- **\`TurnUsage\` is deliberately different from \`CompletedTurn.{input,output,cacheRead,cacheCreation}Tokens\`.** Both are populated by the bridge, but via different pipelines with different semantics (per-call vs turn-aggregate). If a future change needs to display the same number in both places, think carefully about which one is correct for that UI — they can and do legitimately differ for multi-iteration turns.

- **\`iterations\` is undocumented in the CLI's public surface.** Observed in stream-json captures of both 2-iteration and 69-iteration turns; always a single-entry array containing the final iteration. The \`?? streamEvent.usage\` fallback keeps the meter functional if the CLI ever drops or renames the field — worst case degrades to the previous (inflated) behavior, no crashes.

- **Phase 2 tests asserting \`finalizeTurn\` writes \`latestTurnUsage\` flipped meaning.** This PR updated them to assert the caller-driven contract. The removed expectations (\"finalizeTurn updates the meter on tool-free turns\") are now tested at the caller — \`useAgentStream\`'s result handler — via the \`pickMeterUsageFromResult\` helper's unit tests.

- **Rollback previously left the meter stale.** Not strictly a Phase 2.5 regression — it was a latent Phase 2 bug that surfaced once the meter was decoupled from hydration. Fixed as part of this PR since the helper and \`clearLatestTurnUsage\` make the correct behavior one line.

## Test Steps

1. **Automated** (CI will run):
   - \`cargo test --all-features\` — includes 3 new \`token_usage_tests\` exercising \`iterations\` parse + round-trip.
   - \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
   - \`cargo fmt --all --check\` — clean.
   - \`cd src/ui && bunx tsc --noEmit\` — clean.
   - \`cd src/ui && bun run test\` — 550 passed (32 files; +19 new tests over Phase 2 baseline).
   - \`cd src/ui && bun run build\` — succeeds.

2. **Manual UAT** (dev build — \`cargo tauri dev\`):
   1. Open a workspace that previously showed an over-capacity meter reading (e.g. \`4.8m / 200.0k\` after a 69-iteration turn). Confirm the meter now renders a sensible value under capacity.
   2. Send a short prompt with no tool use. Confirm meter updates to a small percentage — single-iteration turns have \`iterations[0]\` = aggregate, so this value should match the pre-fix value for the same input.
   3. Send a prompt that triggers tool use (multiple inner iterations). Confirm the meter lands at the final-call value (not a multiple of capacity), while the \`TurnFooter\` still shows the aggregate \"Nk in · N out\" as before.
   4. Restart the app. Confirm the meter renders from the last assistant message's per-message DB fields — same value as showed live.
   5. Rollback to an earlier checkpoint. Confirm the meter updates to the historical call's context.
   6. Clear the conversation (rollback to empty). Confirm the meter disappears.
   7. Create a fresh workspace. Confirm meter is hidden until the first turn completes.

## Checklist

- [x] Tests added/updated — 7 \`extractLatestCallUsage\` + 7 \`pickMeterUsageFromResult\` + 2 \`clearLatestTurnUsage\` + 2 hydrate-non-seeding + 3 rollback-meter + 3 Rust \`iterations\` parse/round-trip.
- [x] Documentation — JSDoc on \`TokenUsage\` (Rust) and \`TurnUsage\` (TS) explains aggregate vs per-call semantics; \`CompletedTurn.*Tokens\` docs still accurate since Phase 2 aggregate semantics are preserved.
- [x] Conventional commits — 8 commits, all \`feat(...)\` / \`fix(...)\` / \`refactor(...)\` scopes.