### PR TITLE
fix(chat): keep thinking block visible through typewriter drain

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -225,6 +225,7 @@ export function ChatPanel() {
     (s) => (selectedWorkspaceId ? s.agentQuestions[selectedWorkspaceId] ?? null : null)
   );
   const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
+  const finishTypewriterDrainTop = useAppStore((s) => s.finishTypewriterDrain);
   const pendingPlan = useAppStore(
     (s) => (selectedWorkspaceId ? s.planApprovals[selectedWorkspaceId] ?? null : null)
   );
@@ -723,10 +724,14 @@ export function ChatPanel() {
     }
 
     // Clear any pending agent question or plan approval — the user is sending
-    // a new message (answer from a card or manual override).
+    // a new message (answer from a card or manual override). Also release any
+    // stuck typewriter drain from the previous turn so the completed message
+    // doesn't stay hidden behind pendingTypewriter across turns (the
+    // drain-complete effect cannot fire while isStreaming flips back to true).
     if (selectedWorkspaceId) {
       clearAgentQuestion(selectedWorkspaceId);
       clearPlanApproval(selectedWorkspaceId);
+      finishTypewriterDrainTop(selectedWorkspaceId);
     }
 
     setError(null);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1039,7 +1039,7 @@ const StreamingMessage = memo(function StreamingMessage({
   const isStreaming = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.agent_status === "Running"
   );
-  const clearPendingTypewriter = useAppStore((s) => s.clearPendingTypewriter);
+  const finishTypewriterDrain = useAppStore((s) => s.finishTypewriterDrain);
   const { handleContentChanged } = useContext(ScrollContext);
 
   const fullText = streaming || pendingText;
@@ -1050,12 +1050,14 @@ const StreamingMessage = memo(function StreamingMessage({
   }, [displayed, handleContentChanged]);
 
   // Drain complete + we're in pending-typewriter phase → release the hidden
-  // completed message so it takes over visually without a jump.
+  // completed message so it takes over visually without a jump. Also clears
+  // streamingThinking in the same store update so StreamingThinkingBlock
+  // unmounts atomically with the completed message unhiding.
   useEffect(() => {
     if (!showCaret && !streaming && pendingText) {
-      clearPendingTypewriter(workspaceId);
+      finishTypewriterDrain(workspaceId);
     }
-  }, [showCaret, streaming, pendingText, workspaceId, clearPendingTypewriter]);
+  }, [showCaret, streaming, pendingText, workspaceId, finishTypewriterDrain]);
 
   if (!displayed) return null;
 

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -269,8 +269,11 @@ export function useAgentStream() {
                 cache_read_tokens: null,
                 cache_creation_tokens: null,
               });
-              // Clear thinking only after attaching it to a text message.
-              clearStreamingThinking(wsId);
+              // streamingThinking is NOT cleared here — StreamingThinkingBlock
+              // needs to keep rendering through the typewriter drain so the
+              // block doesn't vanish between streamingContent clearing and the
+              // completed message unhiding. It's cleared atomically with
+              // pendingTypewriter at drain-complete via finishTypewriterDrain.
             }
             setStreamingContent(wsId, "");
             break;

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -99,6 +99,41 @@ describe("streamingThinking (per-workspace)", () => {
   });
 });
 
+describe("finishTypewriterDrain (per-workspace)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ pendingTypewriter: {}, streamingThinking: {} });
+  });
+
+  it("clears pendingTypewriter and streamingThinking in one update", () => {
+    useAppStore.getState().setPendingTypewriter(WS_ID, "msg-1", "hello world");
+    useAppStore.getState().appendStreamingThinking(WS_ID, "hm...");
+    useAppStore.getState().finishTypewriterDrain(WS_ID);
+    expect(useAppStore.getState().pendingTypewriter[WS_ID]).toBeNull();
+    expect(useAppStore.getState().streamingThinking[WS_ID]).toBe("");
+  });
+
+  it("is isolated per workspace — other workspaces are unaffected", () => {
+    useAppStore.getState().setPendingTypewriter("ws-a", "msg-a", "alpha");
+    useAppStore.getState().appendStreamingThinking("ws-a", "think-a");
+    useAppStore.getState().setPendingTypewriter("ws-b", "msg-b", "beta");
+    useAppStore.getState().appendStreamingThinking("ws-b", "think-b");
+    useAppStore.getState().finishTypewriterDrain("ws-a");
+    expect(useAppStore.getState().pendingTypewriter["ws-a"]).toBeNull();
+    expect(useAppStore.getState().streamingThinking["ws-a"]).toBe("");
+    expect(useAppStore.getState().pendingTypewriter["ws-b"]).toEqual({
+      messageId: "msg-b",
+      text: "beta",
+    });
+    expect(useAppStore.getState().streamingThinking["ws-b"]).toBe("think-b");
+  });
+
+  it("is a no-op when called with no prior state", () => {
+    useAppStore.getState().finishTypewriterDrain(WS_ID);
+    expect(useAppStore.getState().pendingTypewriter[WS_ID]).toBeNull();
+    expect(useAppStore.getState().streamingThinking[WS_ID]).toBe("");
+  });
+});
+
 describe("plugin settings routing", () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -161,7 +161,6 @@ interface AppState {
   setStreamingContent: (wsId: string, content: string) => void;
   appendStreamingContent: (wsId: string, text: string) => void;
   setPendingTypewriter: (wsId: string, messageId: string, text: string) => void;
-  clearPendingTypewriter: (wsId: string) => void;
   /** Atomic drain-end handoff: clears both `pendingTypewriter` and
    *  `streamingThinking` in a single store update so the streaming thinking
    *  block and the draining assistant text hand off to the completed message
@@ -603,10 +602,6 @@ export const useAppStore = create<AppState>((set) => ({
         ...s.pendingTypewriter,
         [wsId]: { messageId, text },
       },
-    })),
-  clearPendingTypewriter: (wsId) =>
-    set((s) => ({
-      pendingTypewriter: { ...s.pendingTypewriter, [wsId]: null },
     })),
   finishTypewriterDrain: (wsId) =>
     set((s) => ({

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -162,6 +162,11 @@ interface AppState {
   appendStreamingContent: (wsId: string, text: string) => void;
   setPendingTypewriter: (wsId: string, messageId: string, text: string) => void;
   clearPendingTypewriter: (wsId: string) => void;
+  /** Atomic drain-end handoff: clears both `pendingTypewriter` and
+   *  `streamingThinking` in a single store update so the streaming thinking
+   *  block and the draining assistant text hand off to the completed message
+   *  in the same render, without a gap or a 1-frame duplicate. */
+  finishTypewriterDrain: (wsId: string) => void;
   appendStreamingThinking: (wsId: string, text: string) => void;
   clearStreamingThinking: (wsId: string) => void;
   setShowThinkingBlocks: (wsId: string, show: boolean) => void;
@@ -602,6 +607,11 @@ export const useAppStore = create<AppState>((set) => ({
   clearPendingTypewriter: (wsId) =>
     set((s) => ({
       pendingTypewriter: { ...s.pendingTypewriter, [wsId]: null },
+    })),
+  finishTypewriterDrain: (wsId) =>
+    set((s) => ({
+      pendingTypewriter: { ...s.pendingTypewriter, [wsId]: null },
+      streamingThinking: { ...s.streamingThinking, [wsId]: "" },
     })),
   appendStreamingThinking: (wsId, text) =>
     set((s) => ({


### PR DESCRIPTION
## Summary

Thinking blocks flashed and disappeared mid-turn during streaming. The root cause was a gap in the streaming-to-completed-message handoff:

- In `useAgentStream.ts`, the assistant event cleared `streamingThinking[wsId]` immediately, unmounting `StreamingThinkingBlock`.
- Meanwhile `MessagesWithTurns` (`ChatPanel.tsx:1547`) kept the completed assistant message (including its `msg.thinking` block) hidden behind `pendingTypewriter.messageId` for the duration of the typewriter drain.
- During that window — tens to thousands of milliseconds at the 60 chars/sec base rate — nothing rendered a thinking block. It reappeared only when `StreamingMessage`'s drain-complete effect unhid the message.

This bug actually predates #296 (thinking typewriter); it was introduced by #291 (assistant typewriter + `pendingTypewriter` hide-during-drain). #296 made it noticeable because it drew attention to thinking blocks.

### Fix

- Defer the `streamingThinking` clear to drain completion instead of firing it on the assistant event.
- New `finishTypewriterDrain(wsId)` store action clears both `pendingTypewriter[wsId]` and `streamingThinking[wsId]` in a single `set()` call. One Zustand notification → one subscriber re-render pass, so `StreamingThinkingBlock` unmounts in the same render the completed message unhides. No gap, no duplicate.

Scope is intentionally minimal (21 additions, 6 deletions across 3 files); `ThinkingBlock.tsx` and `useTypewriter.ts` are unchanged.

```mermaid
sequenceDiagram
  participant Stream as useAgentStream
  participant Store as useAppStore
  participant SThink as StreamingThinkingBlock
  participant SMsg as StreamingMessage
  participant MWT as MessagesWithTurns

  Stream->>Store: appendStreamingThinking (deltas)
  SThink-->>SThink: renders while streamingThinking non-empty
  Stream->>Store: appendStreamingContent (deltas)
  SMsg-->>SMsg: renders typewriter
  Stream->>Store: setPendingTypewriter + addChatMessage
  Note over Stream,Store: streamingThinking NOT cleared here (was the bug)
  Stream->>Store: setStreamingContent("")
  SMsg->>SMsg: drains pendingTypewriter.text
  SMsg->>Store: finishTypewriterDrain (atomic)
  Note over Store,MWT: pendingTypewriter + streamingThinking cleared in one set()
  SThink--xSThink: unmounts
  MWT-->>MWT: completed message with msg.thinking renders
```

## Complexity Notes

- The atomic `set()` call in `finishTypewriterDrain` is load-bearing. `StreamingThinkingBlock` and `MessagesWithTurns` subscribe through independent selectors; two sequential updates could produce a 1-frame render where both render thinking simultaneously. Keep the clears bundled if this action is refactored later.
- `addChatMessage` at `useAgentStream.ts:266` captures `streamingThinking[wsId]` into `msg.thinking` BEFORE the (now delayed) clear, so `msg.thinking` persistence is unaffected.
- `clearStreamingThinking` calls at `useAgentStream.ts:165` (new turn) and in the ProcessExited abort path are unchanged — only the assistant-event path was deferred.

## Test Steps

1. `cd src/ui && bun install && bun run test` — all existing tests pass (550/550).
2. `cd src/ui && bun run build` (or run `tsc --noEmit`) — type-check is clean.
3. `cargo tauri dev` and in the UI:
   1. Enable thinking blocks for a workspace.
   2. Send a prompt that triggers extended thinking (e.g., "think carefully about X before responding").
   3. **Verify**: the "Thinking…" header appears as soon as thinking starts streaming and stays visible continuously while the assistant text drains via the typewriter. It should NOT flash and disappear.
   4. Expand the thinking block mid-stream — the typewriter reveal runs on new chars; existing chars snap in.
   5. After the turn completes, collapse and re-expand the thinking block to confirm it is still interactive.
   6. Send a follow-up prompt — subsequent turns' thinking blocks should also render without flashing.
4. Optional store inspection via `/claudette-debug`:
   - `/claudette-debug state streamingThinking` — stays non-empty through drain, clears when `pendingTypewriter` clears.
   - `/claudette-debug state pendingTypewriter` — clears at the same render as `streamingThinking`.

## Checklist

- [ ] Tests added/updated — no new tests added; the bug is in component-coordination and reproducing it requires mounting `ChatPanel` with a mocked Zustand store (high setup cost, low ongoing value per CLAUDE.md norms). Existing `useTypewriter.test.ts` covers the unchanged hook.
- [ ] Documentation updated (if applicable) — N/A.