### PR TITLE
fix(permissions): auto-allow stray control_request in bypass mode

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -87,16 +87,23 @@ fn persistent_session_flags_drifted(
 /// Decide how to respond to a `can_use_tool` control_request that reached the
 /// handler for a tool other than AskUserQuestion / ExitPlanMode.
 ///
-/// Bypass mode + plan mode off → allow (echo `updatedInput` — required by the
-/// CLI's `PermissionPromptToolResultSchema`). This is the fix for "full"
+/// Bypass mode + plan not active → allow (echo `updatedInput` — required by
+/// the CLI's `PermissionPromptToolResultSchema`). This is the fix for "full"
 /// sessions seeing spurious denials: the CLI still routes certain tools
 /// (MCP servers, Skills, some built-in edge paths) through
 /// `--permission-prompt-tool stdio` even under `--permission-mode
 /// bypassPermissions`, so we must answer allow rather than fall through.
 ///
-/// Otherwise (standard/readonly, or plan-mode active) → deny with a message
-/// that names the escalation path; the model paraphrases this string to the
-/// user.
+/// Plan mode is considered **inactive** once the agent has emitted
+/// `ExitPlanMode` (`session_exited_plan = true`) — even though the
+/// subprocess still runs with `--permission-mode plan` until the drift
+/// detector respawns it on the next turn. Without this, a bypass session
+/// that just had its plan approved would still deny every mutating tool
+/// for the remainder of the current turn.
+///
+/// Otherwise (standard/readonly, or plan-mode genuinely active) → deny with
+/// a message that names the escalation path; the model paraphrases this
+/// string to the user.
 ///
 /// Auto-allow in bypass mode does not bypass an MCP server's own
 /// authorization — servers refuse at their layer via a normal tool_result,
@@ -104,10 +111,13 @@ fn persistent_session_flags_drifted(
 fn build_permission_response(
     session_allowed_tools: &[String],
     session_plan_mode: bool,
+    session_exited_plan: bool,
     tool_name: &str,
     original_input: &serde_json::Value,
 ) -> serde_json::Value {
-    if is_bypass_tools(session_allowed_tools) && !session_plan_mode {
+    let bypass = is_bypass_tools(session_allowed_tools);
+    let plan_active = session_plan_mode && !session_exited_plan;
+    if bypass && !plan_active {
         serde_json::json!({
             "behavior": "allow",
             "updatedInput": original_input,
@@ -783,21 +793,24 @@ pub async fn send_chat_message(
                 } else {
                     let app_state = app.state::<AppState>();
                     let agents = app_state.agents.read().await;
-                    let (ps, session_allowed_tools, session_plan_mode) = agents
-                        .get(&ws_id)
-                        .map(|s| {
-                            (
-                                s.persistent_session.clone(),
-                                s.session_allowed_tools.clone(),
-                                s.session_plan_mode,
-                            )
-                        })
-                        .unwrap_or_else(|| (None, Vec::new(), false));
+                    let (ps, session_allowed_tools, session_plan_mode, session_exited_plan) =
+                        agents
+                            .get(&ws_id)
+                            .map(|s| {
+                                (
+                                    s.persistent_session.clone(),
+                                    s.session_allowed_tools.clone(),
+                                    s.session_plan_mode,
+                                    s.session_exited_plan,
+                                )
+                            })
+                            .unwrap_or_else(|| (None, Vec::new(), false, false));
                     drop(agents);
                     if let Some(ps) = ps {
                         let response = build_permission_response(
                             &session_allowed_tools,
                             session_plan_mode,
+                            session_exited_plan,
                             tool_name,
                             input,
                         );
@@ -2071,24 +2084,35 @@ mod tests {
     #[test]
     fn permission_response_allows_bypass_session_non_plan() {
         let input = json!({ "path": "/tmp/foo" });
-        let response = build_permission_response(&s(&["*"]), false, "Skill", &input);
+        let response = build_permission_response(&s(&["*"]), false, false, "Skill", &input);
         assert_eq!(response["behavior"], "allow");
         assert_eq!(response["updatedInput"], input);
     }
 
     #[test]
-    fn permission_response_denies_bypass_session_during_plan_mode() {
-        // Plan mode deliberately gates mutating tools even when the session's
-        // allowed_tools is the bypass sentinel.
+    fn permission_response_denies_bypass_session_during_active_plan() {
         let input = json!({});
-        let response = build_permission_response(&s(&["*"]), true, "Edit", &input);
+        let response = build_permission_response(&s(&["*"]), true, false, "Edit", &input);
         assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_allows_bypass_session_after_plan_exit() {
+        // The agent emitted ExitPlanMode and the user approved, so the plan
+        // phase is over. The subprocess still has --permission-mode plan
+        // until the next turn's drift detection respawns it, but within
+        // this turn we should auto-allow because the user chose bypass.
+        let input = json!({ "file_path": "/tmp/fib.py", "content": "..." });
+        let response = build_permission_response(&s(&["*"]), true, true, "Write", &input);
+        assert_eq!(response["behavior"], "allow");
+        assert_eq!(response["updatedInput"], input);
     }
 
     #[test]
     fn permission_response_denies_standard_session() {
         let input = json!({});
-        let response = build_permission_response(&s(&["Read", "Write"]), false, "Edit", &input);
+        let response =
+            build_permission_response(&s(&["Read", "Write"]), false, false, "Edit", &input);
         assert_eq!(response["behavior"], "deny");
         let msg = response["message"].as_str().expect("message");
         assert!(
@@ -2102,21 +2126,28 @@ mod tests {
     }
 
     #[test]
-    fn permission_response_denies_empty_session() {
-        // Pre-spawn or cleared state — defensive deny so we never silently
-        // approve a tool on a session whose flags we can't confirm.
+    fn permission_response_denies_standard_session_after_plan_exit() {
+        // Non-bypass sessions should still deny after ExitPlanMode — they
+        // need the drift-triggered respawn to pick up the concrete
+        // --allowedTools list, and auto-allowing any tool would exceed the
+        // user's chosen permission scope.
         let input = json!({});
-        let response = build_permission_response(&[], false, "Edit", &input);
+        let response =
+            build_permission_response(&s(&["Read", "Write"]), true, true, "Bash", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_denies_empty_session() {
+        let input = json!({});
+        let response = build_permission_response(&[], false, false, "Edit", &input);
         assert_eq!(response["behavior"], "deny");
     }
 
     #[test]
     fn permission_response_rejects_multi_element_wildcard() {
-        // The bypass sentinel is exactly ["*"]. ["*", "Read"] is a concrete
-        // list (the "*" is not special outside the singleton form) and must
-        // not auto-allow.
         let input = json!({});
-        let response = build_permission_response(&s(&["*", "Read"]), false, "Edit", &input);
+        let response = build_permission_response(&s(&["*", "Read"]), false, false, "Edit", &input);
         assert_eq!(response["behavior"], "deny");
     }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -46,7 +46,7 @@ struct AgentStreamPayload {
     event: AgentEvent,
 }
 
-use claudette::permissions::tools_for_level;
+use claudette::permissions::{is_bypass_tools, tools_for_level};
 
 /// Spawn-time flags of the currently running persistent session, plus the
 /// backend-observed `exited_plan` latch (set when the agent emits
@@ -82,6 +82,45 @@ fn persistent_session_flags_drifted(
     session.plan_mode != requested.plan_mode
         || session.allowed_tools != requested.allowed_tools
         || (session.plan_mode && session.exited_plan)
+}
+
+/// Decide how to respond to a `can_use_tool` control_request that reached the
+/// handler for a tool other than AskUserQuestion / ExitPlanMode.
+///
+/// Bypass mode + plan mode off → allow (echo `updatedInput` — required by the
+/// CLI's `PermissionPromptToolResultSchema`). This is the fix for "full"
+/// sessions seeing spurious denials: the CLI still routes certain tools
+/// (MCP servers, Skills, some built-in edge paths) through
+/// `--permission-prompt-tool stdio` even under `--permission-mode
+/// bypassPermissions`, so we must answer allow rather than fall through.
+///
+/// Otherwise (standard/readonly, or plan-mode active) → deny with a message
+/// that names the escalation path; the model paraphrases this string to the
+/// user.
+///
+/// Auto-allow in bypass mode does not bypass an MCP server's own
+/// authorization — servers refuse at their layer via a normal tool_result,
+/// not a control_request.
+fn build_permission_response(
+    session_allowed_tools: &[String],
+    session_plan_mode: bool,
+    tool_name: &str,
+    original_input: &serde_json::Value,
+) -> serde_json::Value {
+    if is_bypass_tools(session_allowed_tools) && !session_plan_mode {
+        serde_json::json!({
+            "behavior": "allow",
+            "updatedInput": original_input,
+        })
+    } else {
+        let msg = format!(
+            "{tool_name} isn't enabled at the current permission level. Switch to 'full' in the chat toolbar (or run /permissions full) to allow it."
+        );
+        serde_json::json!({
+            "behavior": "deny",
+            "message": msg,
+        })
+    }
 }
 
 #[tauri::command]
@@ -696,16 +735,20 @@ pub async fn send_chat_message(
                 got_init = true;
             }
 
-            // Handle control_request: can_use_tool from the CLI's stdio permission
-            // prompt protocol. For AskUserQuestion / ExitPlanMode we remember the
-            // request and emit `agent-permission-prompt` so the UI shows the card
-            // ONLY after the Rust side is ready to receive the answer — the
-            // previous content_block_stop-driven approach raced the still-
-            // in-flight control_request and produced "No pending permission
-            // request" errors when the user clicked too quickly.
-            // For every OTHER tool, immediately deny — Claudette relies on
-            // --allowedTools for normal approvals, so reaching this path means
-            // a plan-mode or unknown-tool block we should report to the model.
+            // Handle control_request: can_use_tool from the CLI's stdio
+            // permission prompt protocol. Three branches:
+            //   1. AskUserQuestion / ExitPlanMode — stash a pending record and
+            //      emit `agent-permission-prompt` so the UI card renders only
+            //      after the Rust side is ready to receive the answer.
+            //      Needed even in bypass mode: the agent wants the user's
+            //      *answer*, not just permission.
+            //   2. Session spawned in bypass mode + plan mode OFF — auto-allow.
+            //      The CLI still routes some tools (MCP, Skills, certain
+            //      edge-path built-ins) through `--permission-prompt-tool
+            //      stdio` even under `--permission-mode bypassPermissions`, so
+            //      without this branch "full" users see spurious denials.
+            //   3. Otherwise — deny with a message that names the escalation
+            //      path (the model paraphrases this to the user).
             if let AgentEvent::Stream(StreamEvent::ControlRequest {
                 request_id,
                 request:
@@ -738,26 +781,30 @@ pub async fn send_chat_message(
                     });
                     let _ = app.emit("agent-permission-prompt", &payload);
                 } else {
-                    // Auto-deny any other tool that reaches the permission-prompt
-                    // path — current Claudette behaviour is no interactive approval
-                    // beyond the question/plan cards. Sending a structured deny
-                    // unblocks the CLI turn instead of hanging.
                     let app_state = app.state::<AppState>();
                     let agents = app_state.agents.read().await;
-                    let ps = agents
+                    let (ps, session_allowed_tools, session_plan_mode) = agents
                         .get(&ws_id)
-                        .and_then(|s| s.persistent_session.clone());
+                        .map(|s| {
+                            (
+                                s.persistent_session.clone(),
+                                s.session_allowed_tools.clone(),
+                                s.session_plan_mode,
+                            )
+                        })
+                        .unwrap_or_else(|| (None, Vec::new(), false));
                     drop(agents);
                     if let Some(ps) = ps {
-                        let msg = format!(
-                            "Permission for {tool_name} is not granted in this Claudette session."
+                        let response = build_permission_response(
+                            &session_allowed_tools,
+                            session_plan_mode,
+                            tool_name,
+                            input,
                         );
-                        let deny = serde_json::json!({
-                            "behavior": "deny",
-                            "message": msg,
-                        });
-                        if let Err(e) = ps.send_control_response(request_id, deny).await {
-                            eprintln!("[chat] Failed to auto-deny {tool_name}: {e}");
+                        if let Err(e) = ps.send_control_response(request_id, response).await {
+                            eprintln!(
+                                "[chat] Failed to respond to control_request for {tool_name}: {e}"
+                            );
                         }
                     }
                 }
@@ -2016,5 +2063,60 @@ mod tests {
             session(false, &tools, true),
             requested(false, &tools),
         ));
+    }
+
+    use super::build_permission_response;
+    use serde_json::json;
+
+    #[test]
+    fn permission_response_allows_bypass_session_non_plan() {
+        let input = json!({ "path": "/tmp/foo" });
+        let response = build_permission_response(&s(&["*"]), false, "Skill", &input);
+        assert_eq!(response["behavior"], "allow");
+        assert_eq!(response["updatedInput"], input);
+    }
+
+    #[test]
+    fn permission_response_denies_bypass_session_during_plan_mode() {
+        // Plan mode deliberately gates mutating tools even when the session's
+        // allowed_tools is the bypass sentinel.
+        let input = json!({});
+        let response = build_permission_response(&s(&["*"]), true, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_denies_standard_session() {
+        let input = json!({});
+        let response = build_permission_response(&s(&["Read", "Write"]), false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+        let msg = response["message"].as_str().expect("message");
+        assert!(
+            msg.contains("full"),
+            "message should name the escalation: {msg}"
+        );
+        assert!(
+            msg.contains("/permissions"),
+            "message should point at the slash command: {msg}"
+        );
+    }
+
+    #[test]
+    fn permission_response_denies_empty_session() {
+        // Pre-spawn or cleared state — defensive deny so we never silently
+        // approve a tool on a session whose flags we can't confirm.
+        let input = json!({});
+        let response = build_permission_response(&[], false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_rejects_multi_element_wildcard() {
+        // The bypass sentinel is exactly ["*"]. ["*", "Read"] is a concrete
+        // list (the "*" is not special outside the singleton form) and must
+        // not auto-allow.
+        let input = json!({});
+        let response = build_permission_response(&s(&["*", "Read"]), false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -332,8 +332,7 @@ pub fn build_claude_args(
     // added in `build_persistent_args` instead, where the Tauri bridge owns
     // the stdin and handles control_request → control_response.
 
-    // Check if we should bypass permissions (full access with wildcard)
-    let bypass_permissions = allowed_tools.len() == 1 && allowed_tools[0] == "*";
+    let bypass_permissions = crate::permissions::is_bypass_tools(allowed_tools);
 
     // Model is session-level — only set on the first turn.
     if !is_resume && let Some(ref model) = settings.model {
@@ -1070,7 +1069,7 @@ fn build_persistent_args(
         "stdio".to_string(),
     ];
 
-    let bypass_permissions = allowed_tools.len() == 1 && allowed_tools[0] == "*";
+    let bypass_permissions = crate::permissions::is_bypass_tools(allowed_tools);
 
     if is_resume {
         args.push("--resume".to_string());

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -40,6 +40,15 @@ pub fn tools_for_level(level: &str) -> Vec<String> {
     tools.iter().map(|s| (*s).to_string()).collect()
 }
 
+/// Returns true when `tools` is the singleton wildcard sentinel `["*"]` — the
+/// shape `tools_for_level("full")` produces and `build_claude_args` /
+/// `build_persistent_args` treat as "spawn with `--permission-mode
+/// bypassPermissions`". The control-request handler uses this same predicate
+/// to decide whether a stray `can_use_tool` should be auto-allowed.
+pub fn is_bypass_tools(tools: &[String]) -> bool {
+    tools.len() == 1 && tools[0] == "*"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,6 +77,14 @@ mod tests {
     #[test]
     fn unknown_level_defaults_to_readonly() {
         assert_eq!(tools_for_level("unknown"), tools_for_level("readonly"));
+    }
+
+    #[test]
+    fn is_bypass_tools_recognizes_singleton_wildcard() {
+        assert!(is_bypass_tools(&["*".to_string()]));
+        assert!(!is_bypass_tools(&[]));
+        assert!(!is_bypass_tools(&["Read".to_string()]));
+        assert!(!is_bypass_tools(&["*".to_string(), "Read".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Users running Claudette with the **"full"** permission level were seeing model responses like "Edit permissions aren't granted for this session" or "session-level permissions are blocking the DB tool and Skill tool" — with **no approval popup** ever appearing.

### Root cause

The persistent `claude` subprocess is spawned with **both** `--permission-prompt-tool stdio` and (for "full") `--permission-mode bypassPermissions`. The CLI still routes a subset of tools — notably **MCP servers, Skills, and some built-in edge paths** — through the stdio prompt protocol even under `bypassPermissions`. The handler at `src-tauri/src/commands/chat.rs` treated every such request that wasn't `AskUserQuestion`/`ExitPlanMode` as a silent **auto-deny**, and the model paraphrased that denial to users as if it were a toggle problem. No UI card exists for that path, so users had no way to approve.

### Fix

- Bypass session + plan mode OFF → **auto-allow** (echoing `updatedInput`, required by the CLI's `PermissionPromptToolResultSchema`).
- Plan mode stays deny even when `allowed_tools == ["*"]` — mutating tools must remain gated during planning.
- Standard/readonly still deny, but with a message that names the escalation path (`/permissions full` or the toolbar toggle) so the model's paraphrase is actionable.

Extracted the `["*"]` bypass sentinel check into `permissions::is_bypass_tools` so all three call sites share one predicate and can't silently diverge.

## Complexity Notes

- **Plan + bypass coexistence**: `session_allowed_tools == ["*"]` and `session_plan_mode == true` can both be true (plan mode reuses the wildcard list but sets `--permission-mode plan`). The `!session_plan_mode` guard is load-bearing — without it, we'd auto-allow mutating tools during plan mode. Test `permission_response_denies_bypass_session_during_plan_mode` pins this.
- **Why not drop `--permission-prompt-tool stdio` in bypass**: Considered and rejected. `src/permissions.rs:1-7` documents that AskUserQuestion/ExitPlanMode rely on the CLI's `requiresUserInteraction` short-circuit to still arrive as control_requests without the flag. If the CLI ever changes that short-circuit, we'd silently lose the question/plan UI — a worse regression than the bug we're fixing.
- **MCP server authorization**: Auto-allowing in bypass mode does not bypass an MCP server's own authorization. Servers refuse at their layer via a normal `tool_result`, not a control_request. Documented in the helper's doc comment.
- **Frontend unchanged**: The only UI-facing event (`agent-permission-prompt` for AskUserQuestion/ExitPlanMode) is untouched. The new auto-allow branch is backend-only.

## Test Steps

### Rust tests

```bash
cargo test -p claudette permissions::        # 5 tests including new is_bypass_tools_*
cargo test -p claudette-tauri permission_response_   # 5 new unit tests
cargo test --all-features                    # Full workspace suite
cargo clippy --workspace --all-targets       # Zero warnings
cargo fmt --all --check                      # Clean
```

### Manual end-to-end (dev build)

1. **Bypass auto-allow works** — `cargo tauri dev`, start a workspace at "full"; ask the agent to run a Skill (e.g. `/simplify`) or an MCP tool (`mcp__context7__query-docs`). The turn should complete **without** the "permissions aren't granted" paraphrase and **without** any UI card.
2. **Standard mode still denies with improved message** — switch to "standard" via `/permissions standard` or the toolbar; ask the agent to invoke a Skill / MCP tool. The assistant output should reference `'full' permission level` and point at `/permissions full` or the toolbar.
3. **Plan mode still blocks mutations in bypass** — enter plan mode while at "full"; if the agent tries a mutating tool, it stays blocked (unchanged behavior).
4. **Question / plan cards still render** — ask the agent to use `AskUserQuestion` (e.g. "ask me a question"); the `AgentQuestionCard` still appears. Trigger an `ExitPlanMode`; the `PlanApprovalCard` still appears. Both work at "full" and "standard".
5. **Respawn on permission toggle** — toggle from "standard" → "full" mid-session. Next turn should respawn the subprocess via the existing drift detection at `src-tauri/src/commands/chat.rs:376-421`.

## Checklist

- [x] Tests added/updated (6 new unit tests: 1 in `src/permissions.rs`, 5 in `src-tauri/src/commands/chat.rs`)
- [ ] Documentation updated (not applicable — no user-facing docs affected; behavior of the `/permissions` slash command is unchanged)