### PR TITLE
fix(ui): use shadow token for Toast to satisfy design-system check

### DIFF
--- a/src/ui/src/components/layout/Toast.module.css
+++ b/src/ui/src/components/layout/Toast.module.css
@@ -17,7 +17,7 @@
   background: var(--selected-bg);
   border: 1px solid var(--divider);
   border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   font-size: 12px;
   color: var(--text-primary);
   pointer-events: auto;


### PR DESCRIPTION
## Summary
- `main` CI (run 24697454659) is red on the `Frontend` job: `bun run lint:css` rejects a hardcoded `rgba(0, 0, 0, 0.15)` literal in `Toast.module.css`, which was introduced in #297.
- Replace the literal with `var(--shadow-md)` — an existing per-theme token in `styles/theme.css` — so the toast drop shadow tracks the active theme instead of being hardcoded.

## Test plan
- [x] `bun run lint:css` passes locally
- [x] `bunx tsc --noEmit` passes
- [x] `bun run build` succeeds
- [x] `bun run test` — 553 tests pass