### PR TITLE
feat(notifications): per-event notification sound selection

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -735,9 +735,9 @@ pub async fn send_chat_message(
         // to None after each persistence so per-message counts stay distinct
         // across multi-message turns.
         let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
-        let mut pending_attention_notify: bool;
+        let mut pending_attention_kind: Option<crate::state::AttentionKind>;
         while let Some(event) = rx.recv().await {
-            pending_attention_notify = false;
+            pending_attention_kind = None;
             // Track whether the CLI initialized successfully.
             if let AgentEvent::Stream(StreamEvent::System { subtype, .. }) = &event
                 && subtype == "init"
@@ -893,7 +893,7 @@ pub async fn send_chat_message(
                 // Only send notification once per attention cycle — skip if
                 // we already notified the user about this workspace.
                 if !already_notified {
-                    pending_attention_notify = true;
+                    pending_attention_kind = Some(kind);
                 }
             }
 
@@ -1098,19 +1098,10 @@ pub async fn send_chat_message(
                     && !needs_attention_now
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    let sound = db
-                        .get_app_setting("notification_sound")
-                        .ok()
-                        .flatten()
-                        .or_else(|| {
-                            // Honour legacy setting for users who disabled
-                            // audio before the new notification_sound key existed.
-                            match db.get_app_setting("audio_notifications").ok().flatten() {
-                                Some(v) if v == "false" => Some("None".to_string()),
-                                _ => None,
-                            }
-                        })
-                        .unwrap_or_else(|| "Default".to_string());
+                    let sound = crate::tray::resolve_notification_sound(
+                        &db,
+                        crate::tray::NotificationEvent::Finished,
+                    );
                     if sound != "None" {
                         crate::commands::settings::play_notification_sound(sound);
                     }
@@ -1298,8 +1289,8 @@ pub async fn send_chat_message(
             // frontend — this gives the UI time to update before the system
             // notification / sound fires, so the badge is already visible
             // when the user sees the notification.
-            if pending_attention_notify {
-                crate::tray::notify_attention(&app, &ws_id);
+            if let Some(kind) = pending_attention_kind {
+                crate::tray::notify_attention(&app, &ws_id, kind);
             }
         }
     });

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -640,19 +640,8 @@ async fn auto_archive_workspace(
             .flatten()
             .map(|r| r.path);
 
-        // Match the legacy fallback chain from notify_attention in tray.rs:
-        // notification_sound → audio_notifications=false → "Default"
-        let sound = db
-            .get_app_setting("notification_sound")
-            .ok()
-            .flatten()
-            .or_else(
-                || match db.get_app_setting("audio_notifications").ok().flatten() {
-                    Some(v) if v == "false" => Some("None".to_string()),
-                    _ => None,
-                },
-            )
-            .unwrap_or_else(|| "Default".to_string());
+        let sound =
+            crate::tray::resolve_notification_sound(&db, crate::tray::NotificationEvent::Finished);
 
         // Update DB status
         let _ = db.delete_terminal_tabs_for_workspace(workspace_id);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -34,21 +34,24 @@ impl From<AttentionKind> for NotificationEvent {
     }
 }
 
+fn resolve_notification_sound_with<F>(mut get_setting: F, event: NotificationEvent) -> String
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    get_setting(event.setting_key())
+        .or_else(|| get_setting("notification_sound"))
+        .or_else(|| match get_setting("audio_notifications") {
+            Some(v) if v == "false" => Some("None".to_string()),
+            _ => None,
+        })
+        .unwrap_or_else(|| "Default".to_string())
+}
+
 /// Resolve the notification sound for a given event.
 ///
 /// Fallback: per-event key -> global `notification_sound` -> legacy `audio_notifications` -> "Default"
 pub fn resolve_notification_sound(db: &Database, event: NotificationEvent) -> String {
-    db.get_app_setting(event.setting_key())
-        .ok()
-        .flatten()
-        .or_else(|| db.get_app_setting("notification_sound").ok().flatten())
-        .or_else(
-            || match db.get_app_setting("audio_notifications").ok().flatten() {
-                Some(v) if v == "false" => Some("None".to_string()),
-                _ => None,
-            },
-        )
-        .unwrap_or_else(|| "Default".to_string())
+    resolve_notification_sound_with(|key| db.get_app_setting(key).ok().flatten(), event)
 }
 
 // Baseline tray icons (the ones shipped for the Auto style).
@@ -1046,5 +1049,49 @@ mod tests {
             color_bytes.as_ptr(),
             "light and color idle icons must be distinct PNGs"
         );
+    }
+
+    #[test]
+    fn resolve_sound_uses_per_event_override() {
+        let settings = HashMap::from([
+            ("notification_sound_ask".to_string(), "Bell".to_string()),
+            ("notification_sound".to_string(), "Chime".to_string()),
+            ("audio_notifications".to_string(), "false".to_string()),
+        ]);
+        let resolved = resolve_notification_sound_with(
+            |key| settings.get(key).cloned(),
+            NotificationEvent::Ask,
+        );
+        assert_eq!(resolved, "Bell");
+    }
+
+    #[test]
+    fn resolve_sound_falls_back_to_global() {
+        let settings = HashMap::from([("notification_sound".to_string(), "Chime".to_string())]);
+        let resolved = resolve_notification_sound_with(
+            |key| settings.get(key).cloned(),
+            NotificationEvent::Plan,
+        );
+        assert_eq!(resolved, "Chime");
+    }
+
+    #[test]
+    fn resolve_sound_legacy_audio_false_means_none() {
+        let settings = HashMap::from([("audio_notifications".to_string(), "false".to_string())]);
+        let resolved = resolve_notification_sound_with(
+            |key| settings.get(key).cloned(),
+            NotificationEvent::Finished,
+        );
+        assert_eq!(resolved, "None");
+    }
+
+    #[test]
+    fn resolve_sound_defaults_when_no_settings() {
+        let settings = HashMap::<String, String>::new();
+        let resolved = resolve_notification_sound_with(
+            |key| settings.get(key).cloned(),
+            NotificationEvent::Finished,
+        );
+        assert_eq!(resolved, "Default");
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -6,7 +6,50 @@ use tauri::{AppHandle, Emitter, Manager};
 use claudette::db::Database;
 use claudette::model::WorkspaceStatus;
 
-use crate::state::AppState;
+use crate::state::{AppState, AttentionKind};
+
+/// Notification event types for per-event sound selection.
+pub enum NotificationEvent {
+    Ask,
+    Plan,
+    Finished,
+}
+
+impl NotificationEvent {
+    fn setting_key(&self) -> &'static str {
+        match self {
+            Self::Ask => "notification_sound_ask",
+            Self::Plan => "notification_sound_plan",
+            Self::Finished => "notification_sound_finished",
+        }
+    }
+}
+
+impl From<AttentionKind> for NotificationEvent {
+    fn from(kind: AttentionKind) -> Self {
+        match kind {
+            AttentionKind::Ask => Self::Ask,
+            AttentionKind::Plan => Self::Plan,
+        }
+    }
+}
+
+/// Resolve the notification sound for a given event.
+///
+/// Fallback: per-event key -> global `notification_sound` -> legacy `audio_notifications` -> "Default"
+pub fn resolve_notification_sound(db: &Database, event: NotificationEvent) -> String {
+    db.get_app_setting(event.setting_key())
+        .ok()
+        .flatten()
+        .or_else(|| db.get_app_setting("notification_sound").ok().flatten())
+        .or_else(
+            || match db.get_app_setting("audio_notifications").ok().flatten() {
+                Some(v) if v == "false" => Some("None".to_string()),
+                _ => None,
+            },
+        )
+        .unwrap_or_else(|| "Default".to_string())
+}
 
 // Baseline tray icons (the ones shipped for the Auto style).
 //
@@ -310,7 +353,7 @@ pub fn rebuild_tray(app: &AppHandle) {
 
 /// Called when an agent starts waiting for user input.
 /// Updates the tray icon and sends a native notification.
-pub fn notify_attention(app: &AppHandle, workspace_id: &str) {
+pub fn notify_attention(app: &AppHandle, workspace_id: &str, kind: AttentionKind) {
     rebuild_tray(app);
 
     let state = app.state::<AppState>();
@@ -329,19 +372,7 @@ pub fn notify_attention(app: &AppHandle, workspace_id: &str) {
         .map(|w| w.name.clone())
         .unwrap_or_else(|| "An agent".to_string());
 
-    // Read notification sound preference (default: "Default").
-    // Honour legacy audio_notifications=false for users who haven't opened settings yet.
-    let sound = db
-        .get_app_setting("notification_sound")
-        .ok()
-        .flatten()
-        .or_else(
-            || match db.get_app_setting("audio_notifications").ok().flatten() {
-                Some(v) if v == "false" => Some("None".to_string()),
-                _ => None,
-            },
-        )
-        .unwrap_or_else(|| "Default".to_string());
+    let sound = resolve_notification_sound(&db, NotificationEvent::from(kind));
 
     let title = "Claudette — Input Required";
     let body = format!("{ws_name} is waiting for your response");

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -8,8 +8,46 @@ import {
 } from "../../../services/tauri";
 import styles from "../Settings.module.css";
 
+interface SoundEvent {
+  key: string;
+  label: string;
+  description: string;
+}
+
+const SOUND_EVENTS: SoundEvent[] = [
+  {
+    key: "notification_sound_ask",
+    label: "Agent question",
+    description: "Sound when an agent needs your input",
+  },
+  {
+    key: "notification_sound_plan",
+    label: "Plan ready",
+    description: "Sound when an agent has a plan for review",
+  },
+  {
+    key: "notification_sound_finished",
+    label: "Work complete",
+    description: "Sound when an agent finishes its task",
+  },
+];
+
+async function resolveSound(eventKey: string): Promise<string> {
+  const perEvent = await getAppSetting(eventKey);
+  if (perEvent) return perEvent;
+  const global = await getAppSetting("notification_sound");
+  if (global) return global;
+  const legacy = await getAppSetting("audio_notifications");
+  if (legacy === "false") return "None";
+  return "Default";
+}
+
 export function NotificationsSettings() {
-  const [notificationSound, setNotificationSound] = useState("Default");
+  const [sounds, setSounds] = useState<Record<string, string>>({
+    notification_sound_ask: "Default",
+    notification_sound_plan: "Default",
+    notification_sound_finished: "Default",
+  });
   const [availableSounds, setAvailableSounds] = useState<string[]>([
     "Default",
     "None",
@@ -19,17 +57,13 @@ export function NotificationsSettings() {
 
   useEffect(() => {
     listNotificationSounds().then(setAvailableSounds).catch(() => {});
-    getAppSetting("notification_sound")
-      .then(async (val) => {
-        if (val) {
-          setNotificationSound(val);
-        } else {
-          const legacy = await getAppSetting("audio_notifications");
-          if (legacy === "false") setNotificationSound("None");
-          else setNotificationSound("Default");
-        }
-      })
-      .catch(() => {});
+    for (const event of SOUND_EVENTS) {
+      resolveSound(event.key)
+        .then((val) =>
+          setSounds((prev) => ({ ...prev, [event.key]: val })),
+        )
+        .catch(() => {});
+    }
     getAppSetting("notification_command")
       .then((val) => {
         if (val) setNotificationCommand(val);
@@ -37,14 +71,14 @@ export function NotificationsSettings() {
       .catch(() => {});
   }, []);
 
-  const handleSoundChange = async (sound: string) => {
-    const prev = notificationSound;
-    setNotificationSound(sound);
+  const handleSoundChange = async (key: string, sound: string) => {
+    const prev = sounds[key];
+    setSounds((s) => ({ ...s, [key]: sound }));
     try {
       setError(null);
-      await setAppSetting("notification_sound", sound);
+      await setAppSetting(key, sound);
     } catch (e) {
-      setNotificationSound(prev);
+      setSounds((s) => ({ ...s, [key]: prev }));
       setError(String(e));
     }
   };
@@ -68,7 +102,7 @@ export function NotificationsSettings() {
         "",
         "",
         "main",
-        "claudette/test-workspace"
+        "claudette/test-workspace",
       );
     } catch (e) {
       setError(e instanceof Error ? e.message : "Command failed");
@@ -79,37 +113,41 @@ export function NotificationsSettings() {
     <div>
       <h2 className={styles.sectionTitle}>Notifications</h2>
 
-      <div className={styles.settingRow}>
-        <div className={styles.settingInfo}>
-          <div className={styles.settingLabel}>Notification sound</div>
-          <div className={styles.settingDescription}>
-            Sound played when an agent needs input or finishes in the background
+      {SOUND_EVENTS.map((event) => (
+        <div key={event.key} className={styles.settingRow}>
+          <div className={styles.settingInfo}>
+            <div className={styles.settingLabel}>{event.label}</div>
+            <div className={styles.settingDescription}>
+              {event.description}
+            </div>
+          </div>
+          <div className={styles.settingControl}>
+            <div className={styles.inlineControl}>
+              <select
+                className={styles.select}
+                value={sounds[event.key]}
+                onChange={(e) =>
+                  handleSoundChange(event.key, e.target.value)
+                }
+              >
+                {availableSounds.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <button
+                className={styles.iconBtn}
+                onClick={() => playNotificationSound(sounds[event.key])}
+                title="Preview sound"
+                aria-label={`Preview ${event.label} sound`}
+              >
+                &#9654;
+              </button>
+            </div>
           </div>
         </div>
-        <div className={styles.settingControl}>
-          <div className={styles.inlineControl}>
-            <select
-              className={styles.select}
-              value={notificationSound}
-              onChange={(e) => handleSoundChange(e.target.value)}
-            >
-              {availableSounds.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
-            <button
-              className={styles.iconBtn}
-              onClick={() => playNotificationSound(notificationSound)}
-              title="Preview sound"
-              aria-label="Preview sound"
-            >
-              &#9654;
-            </button>
-          </div>
-        </div>
-      </div>
+      ))}
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>


### PR DESCRIPTION
## Summary

Replace the single `notification_sound` setting with three per-event sound pickers so users can assign distinct sounds to each notification type:

| Event | Setting key | UI label |
|---|---|---|
| AskUserQuestion | `notification_sound_ask` | Agent question |
| ExitPlanMode | `notification_sound_plan` | Plan ready |
| Agent finished | `notification_sound_finished` | Work complete |

**Backend:** Adds a shared `resolve_notification_sound` helper in `tray.rs` with a 3-tier fallback chain (`per-event key` → `notification_sound` → legacy `audio_notifications` → `"Default"`), replacing the duplicated fallback logic in `tray.rs`, `chat.rs`, and `scm.rs`. Threads `AttentionKind` through `notify_attention` so the tray path reads the correct per-event key.

**Frontend:** Replaces the single sound dropdown in `NotificationsSettings.tsx` with three data-driven per-event dropdowns, each with its own preview button.

**Backward compatibility:** No DB migration needed. Existing users see their current `notification_sound` value for all events via the fallback chain. Per-event overrides only take effect once a user explicitly changes a specific event's sound.

Closes #328

## Complexity Notes

- The `AttentionKind` is now passed as a parameter to `notify_attention` (via `pending_attention_kind: Option<AttentionKind>` replacing the old `pending_attention_notify: bool`) rather than reading it from session state, because `notify_attention` is synchronous and cannot await the async `RwLock` on the agents map.

## Test Steps

1. Open Settings → Notifications
2. Verify three sound dropdowns appear: "Agent question", "Plan ready", "Work complete"
3. Each should default to the current global sound (or "Default" for fresh installs)
4. Change each to a different sound and click the preview ▶ button — confirm the correct sound plays
5. Trigger each event type and verify the correct sound plays:
   - Send a message that triggers AskUserQuestion → should play the "Agent question" sound
   - Send a message that triggers ExitPlanMode → should play the "Plan ready" sound
   - Let an agent finish its task → should play the "Work complete" sound
6. Restart the app and verify the per-event selections persist
7. For a fresh user (no settings), confirm all three default to "Default"

## Checklist

- [x] Tests pass (488 Rust, 553 frontend)
- [x] Clippy clean, `cargo fmt` clean, `tsc --noEmit` clean
- [ ] Documentation updated (if applicable)