### PR TITLE
feat(notifications): custom sound packs with random selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "mdns-sd",
  "parking_lot",
  "portable-pty",
+ "rand 0.8.5",
  "reqwest",
  "rustls",
  "rustls-pemfile",

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -53,6 +53,7 @@ export default defineConfig({
             { slug: 'features/remote-workspaces' },
             { slug: 'features/agent-configuration' },
             { slug: 'features/theming' },
+            { slug: 'features/sound-packs' },
             { slug: 'features/shell-integration' },
             { slug: 'features/keyboard-shortcuts' },
             { slug: 'features/per-repo-settings' },

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -39,19 +39,22 @@ See [Theming](/claudette/features/theming/) for details on built-in themes and c
 
 ## Notifications
 
+Each notification event has its own sound setting:
+
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Notification sound | Sound played when an agent needs input or finishes | Default |
+| Agent question | Sound when an agent needs your input | Default |
+| Plan ready | Sound when an agent has a plan for review | Default |
+| Work complete | Sound when an agent finishes its task | Default |
 | Notification command | Custom shell command to run on notification | — |
 
-### Notification Sound
+### Notification Sounds
 
-Choose from built-in sounds or your system's sound library:
+Each event can use a system sound or a [sound pack](/claudette/features/sound-packs/):
 
-- **macOS**: System sounds from `/System/Library/Sounds/`
-- **Linux**: XDG sound theme sounds
-
-Select **None** to disable notification sounds.
+- **System sounds** — choose from your platform's sound library (macOS: `/System/Library/Sounds/`, Linux: XDG sound theme)
+- **Sound packs** — install custom sound bundles with random selection per event
+- **None** — disable sound for that event
 
 ### Notification Command
 

--- a/site/src/content/docs/features/sound-packs.mdx
+++ b/site/src/content/docs/features/sound-packs.mdx
@@ -1,0 +1,136 @@
+---
+title: Sound Packs
+description: Install custom notification sound packs with random selection.
+---
+
+Sound packs let you bundle multiple sounds per notification event. When a pack is selected, Claudette randomly picks one sound each time — adding variety and personality to notifications.
+
+## How It Works
+
+Each notification event — **Agent question**, **Plan ready**, and **Work complete** — can be assigned a sound pack instead of a single system sound. When a notification fires, Claudette picks a random sound from that event's array in the pack.
+
+If an event has no sounds defined in the pack, the notification is silent for that event.
+
+## Installing Sound Packs
+
+Place sound pack directories in:
+
+```
+~/.claudette/sound-packs/
+```
+
+Each pack is a directory containing a `pack.json` manifest and audio files:
+
+```
+~/.claudette/sound-packs/my-pack/
+  pack.json
+  ask/
+    curious-chirp.wav
+    hey-listen.wav
+    gentle-ding.wav
+  plan/
+    tada.wav
+    ready-set.wav
+  finished/
+    victory-fanfare.wav
+    job-done.wav
+    applause.wav
+```
+
+Claudette detects installed packs on the next visit to `Settings > Notifications` — no restart required.
+
+## Manifest Format
+
+The `pack.json` manifest maps event names to arrays of relative audio file paths:
+
+```json
+{
+  "name": "My Fun Pack",
+  "version": "1.0.0",
+  "author": "someone",
+  "description": "A playful set of notification sounds",
+  "events": {
+    "ask": ["ask/curious-chirp.wav", "ask/hey-listen.wav", "ask/gentle-ding.wav"],
+    "plan": ["plan/tada.wav", "plan/ready-set.wav"],
+    "finished": ["finished/victory-fanfare.wav", "finished/job-done.wav", "finished/applause.wav"]
+  }
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name shown in the sound picker |
+| `events` | object | Map of event names to arrays of audio file paths |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Pack version |
+| `author` | string | Pack author name |
+| `description` | string | Brief description |
+
+### Event Names
+
+| Event | Triggers when |
+|-------|--------------|
+| `ask` | An agent needs your input (AskUserQuestion) |
+| `plan` | An agent has a plan for review (ExitPlanMode) |
+| `finished` | An agent finishes its task |
+
+A pack does not need to define sounds for every event. Only events with valid audio files appear as options in the settings.
+
+### Supported Audio Formats
+
+- **macOS**: `.aiff`, `.wav`, `.mp3`, `.m4a`, `.aac`, `.caf` (via `afplay`)
+- **Linux**: `.wav`, `.ogg`, `.flac` (via `paplay`)
+
+### File Limits
+
+- Maximum manifest size: **1 MB**
+- Audio file paths in the manifest are relative to the pack directory
+- Files referenced in the manifest but missing on disk are silently skipped
+
+## Selecting a Sound Pack
+
+Open `Settings > Notifications`. Each event dropdown shows two groups:
+
+- **System Sounds** — individual system sounds (Default, None, Glass, etc.)
+- **Sound Packs** — installed packs that have sounds for that event, labeled with "(random)"
+
+Select a pack to use random selection for that event. You can mix and match — for example, use a sound pack for "Agent question" and a system sound for "Work complete".
+
+The preview button plays a random sound from the selected pack so you can hear what it sounds like.
+
+## Example: Creating a Pack
+
+1. Create the directory structure:
+
+```bash
+mkdir -p ~/.claudette/sound-packs/office-sounds/{ask,plan,finished}
+```
+
+2. Add audio files to each event folder.
+
+3. Create `~/.claudette/sound-packs/office-sounds/pack.json`:
+
+```json
+{
+  "name": "Office Sounds",
+  "version": "1.0.0",
+  "author": "Your Name",
+  "description": "Familiar office notification sounds",
+  "events": {
+    "ask": ["ask/knock.wav", "ask/doorbell.wav"],
+    "finished": ["finished/applause.wav", "finished/cha-ching.wav"]
+  }
+}
+```
+
+4. Open `Settings > Notifications` and select "Office Sounds (random)" from any event dropdown.
+
+:::note
+This pack defines sounds for `ask` and `finished` but not `plan`. It will only appear in the dropdown for events it covers.
+:::

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ async-trait = "0.1"
 gethostname = "1"
 urlencoding = "2"
 parking_lot = "0.12"
+rand = "0.8"
 chrono = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 url = "2"

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1102,17 +1102,7 @@ pub async fn send_chat_message(
                         &db,
                         crate::tray::NotificationEvent::Finished,
                     );
-                    if let Some(dir_name) = sound.strip_prefix("pack:") {
-                        if let Some(path) =
-                            crate::commands::settings::resolve_random_pack_sound_path(
-                                dir_name, "finished",
-                            )
-                        {
-                            crate::commands::settings::play_sound_file(&path);
-                        }
-                    } else if sound != "None" {
-                        crate::commands::settings::play_notification_sound(sound);
-                    }
+                    crate::commands::settings::play_resolved_notification_sound(&sound, "finished");
                     // Run notification command if configured — uses the same
                     // tested helper as the settings test button and tray path.
                     // Rebuild WorkspaceEnv from the DB so it reflects any

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1102,7 +1102,15 @@ pub async fn send_chat_message(
                         &db,
                         crate::tray::NotificationEvent::Finished,
                     );
-                    if sound != "None" {
+                    if let Some(dir_name) = sound.strip_prefix("pack:") {
+                        if let Some(path) =
+                            crate::commands::settings::resolve_random_pack_sound_path(
+                                dir_name, "finished",
+                            )
+                        {
+                            crate::commands::settings::play_sound_file(&path);
+                        }
+                    } else if sound != "None" {
                         crate::commands::settings::play_notification_sound(sound);
                     }
                     // Run notification command if configured — uses the same

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -688,16 +688,9 @@ async fn auto_archive_workspace(
         }
         None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
     };
-    if let Some(dir_name) = sound.strip_prefix("pack:") {
-        if let Some(path) =
-            crate::commands::settings::resolve_random_pack_sound_path(dir_name, "finished")
-        {
-            crate::commands::settings::play_sound_file(&path);
-        }
-        crate::tray::send_notification(handle, "", "Claudette", &body, "None");
-    } else {
-        crate::tray::send_notification(handle, "", "Claudette", &body, &sound);
-    }
+    let notification_sound =
+        crate::commands::settings::play_resolved_notification_sound(&sound, "finished");
+    crate::tray::send_notification(handle, "", "Claudette", &body, &notification_sound);
 
     let mut payload = serde_json::json!({
         "workspace_id": ws_id,

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -688,7 +688,16 @@ async fn auto_archive_workspace(
         }
         None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
     };
-    crate::tray::send_notification(handle, "", "Claudette", &body, &sound);
+    if let Some(dir_name) = sound.strip_prefix("pack:") {
+        if let Some(path) =
+            crate::commands::settings::resolve_random_pack_sound_path(dir_name, "finished")
+        {
+            crate::commands::settings::play_sound_file(&path);
+        }
+        crate::tray::send_notification(handle, "", "Claudette", &body, "None");
+    } else {
+        crate::tray::send_notification(handle, "", "Claudette", &body, &sound);
+    }
 
     let mut payload = serde_json::json!({
         "workspace_id": ws_id,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -361,6 +361,48 @@ fn sound_packs_dir() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".claudette").join("sound-packs"))
 }
 
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+fn load_sound_pack_manifest(pack_dir: &std::path::Path) -> Option<SoundPackManifest> {
+    let manifest_path = pack_dir.join("pack.json");
+    let meta = std::fs::metadata(&manifest_path).ok()?;
+    if meta.len() > MAX_MANIFEST_BYTES {
+        eprintln!(
+            "[sound-packs] Skipping {}: manifest too large ({} bytes)",
+            pack_dir.display(),
+            meta.len()
+        );
+        return None;
+    }
+    let content = std::fs::read_to_string(&manifest_path).ok()?;
+    match serde_json::from_str(&content) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            eprintln!("[sound-packs] Skipping {}: {e}", pack_dir.display());
+            None
+        }
+    }
+}
+
+fn is_safe_pack_path(pack_dir: &std::path::Path, relative: &str) -> Option<std::path::PathBuf> {
+    let rel = std::path::Path::new(relative);
+    if rel.is_absolute()
+        || rel
+            .components()
+            .any(|c| c == std::path::Component::ParentDir)
+    {
+        return None;
+    }
+    let candidate = pack_dir.join(rel);
+    let canonical = candidate.canonicalize().ok()?;
+    let canonical_base = pack_dir.canonicalize().ok()?;
+    if canonical.starts_with(&canonical_base) {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
 #[tauri::command]
 pub async fn list_sound_packs() -> Result<Vec<SoundPackInfo>, String> {
     tauri::async_runtime::spawn_blocking(|| {
@@ -372,45 +414,14 @@ pub async fn list_sound_packs() -> Result<Vec<SoundPackInfo>, String> {
 
         let mut packs = Vec::new();
         let entries = std::fs::read_dir(&packs_dir).map_err(|e| e.to_string())?;
-        const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_dir() {
                 continue;
             }
-            let manifest_path = path.join("pack.json");
-            if !manifest_path.exists() {
+            let Some(manifest) = load_sound_pack_manifest(&path) else {
                 continue;
-            }
-            match std::fs::metadata(&manifest_path) {
-                Ok(meta) if meta.len() > MAX_MANIFEST_BYTES => {
-                    eprintln!(
-                        "[sound-packs] Skipping {}: manifest too large ({} bytes)",
-                        path.display(),
-                        meta.len()
-                    );
-                    continue;
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    eprintln!("[sound-packs] Skipping {}: {e}", path.display());
-                    continue;
-                }
-            }
-            let content = match std::fs::read_to_string(&manifest_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    eprintln!("[sound-packs] Skipping {}: {e}", path.display());
-                    continue;
-                }
-            };
-            let manifest: SoundPackManifest = match serde_json::from_str(&content) {
-                Ok(m) => m,
-                Err(e) => {
-                    eprintln!("[sound-packs] Skipping {}: {e}", path.display());
-                    continue;
-                }
             };
             let dir_name = path
                 .file_name()
@@ -421,7 +432,10 @@ pub async fn list_sound_packs() -> Result<Vec<SoundPackInfo>, String> {
                 .events
                 .iter()
                 .map(|(event, files)| {
-                    let valid = files.iter().filter(|f| path.join(f).exists()).count();
+                    let valid = files
+                        .iter()
+                        .filter(|f| is_safe_pack_path(&path, f).is_some_and(|p| p.exists()))
+                        .count();
                     (event.clone(), valid)
                 })
                 .filter(|(_, count)| *count > 0)
@@ -464,16 +478,13 @@ pub(crate) fn play_sound_file(path: &str) {
     }
 }
 
-/// Resolve a random audio file path from a sound pack for a given event.
 pub(crate) fn resolve_random_pack_sound_path(dir_name: &str, event: &str) -> Option<String> {
     let pack_dir = sound_packs_dir()?.join(dir_name);
-    let manifest_path = pack_dir.join("pack.json");
-    let content = std::fs::read_to_string(&manifest_path).ok()?;
-    let manifest: SoundPackManifest = serde_json::from_str(&content).ok()?;
+    let manifest = load_sound_pack_manifest(&pack_dir)?;
     let files = manifest.events.get(event)?;
     let valid_files: Vec<_> = files
         .iter()
-        .map(|f| pack_dir.join(f))
+        .filter_map(|f| is_safe_pack_path(&pack_dir, f))
         .filter(|p| p.exists())
         .collect();
     if valid_files.is_empty() {
@@ -484,9 +495,14 @@ pub(crate) fn resolve_random_pack_sound_path(dir_name: &str, event: &str) -> Opt
 }
 
 #[tauri::command]
-pub fn preview_pack_sound(dir_name: String, event: String) -> Result<(), String> {
-    let path = resolve_random_pack_sound_path(&dir_name, &event)
-        .ok_or_else(|| format!("No sounds found for event '{event}' in pack '{dir_name}'"))?;
+pub async fn preview_pack_sound(dir_name: String, event: String) -> Result<(), String> {
+    let dir = dir_name.clone();
+    let evt = event.clone();
+    let path =
+        tauri::async_runtime::spawn_blocking(move || resolve_random_pack_sound_path(&dir, &evt))
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("No sounds found for event '{event}' in pack '{dir_name}'"))?;
     play_sound_file(&path);
     Ok(())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
 
 use claudette::db::Database;
+use claudette::model::SoundPackManifest;
 
 use crate::state::AppState;
 
@@ -346,6 +348,149 @@ pub async fn list_user_themes() -> Result<Vec<ThemeDefinition>, String> {
     .map_err(|e| e.to_string())?
 }
 
+#[derive(Serialize)]
+pub struct SoundPackInfo {
+    pub dir_name: String,
+    pub name: String,
+    pub author: Option<String>,
+    pub description: Option<String>,
+    pub event_counts: HashMap<String, usize>,
+}
+
+fn sound_packs_dir() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claudette").join("sound-packs"))
+}
+
+#[tauri::command]
+pub async fn list_sound_packs() -> Result<Vec<SoundPackInfo>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let packs_dir = sound_packs_dir().ok_or("Could not determine home directory")?;
+
+        if !packs_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut packs = Vec::new();
+        let entries = std::fs::read_dir(&packs_dir).map_err(|e| e.to_string())?;
+        const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let manifest_path = path.join("pack.json");
+            if !manifest_path.exists() {
+                continue;
+            }
+            match std::fs::metadata(&manifest_path) {
+                Ok(meta) if meta.len() > MAX_MANIFEST_BYTES => {
+                    eprintln!(
+                        "[sound-packs] Skipping {}: manifest too large ({} bytes)",
+                        path.display(),
+                        meta.len()
+                    );
+                    continue;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("[sound-packs] Skipping {}: {e}", path.display());
+                    continue;
+                }
+            }
+            let content = match std::fs::read_to_string(&manifest_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("[sound-packs] Skipping {}: {e}", path.display());
+                    continue;
+                }
+            };
+            let manifest: SoundPackManifest = match serde_json::from_str(&content) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!("[sound-packs] Skipping {}: {e}", path.display());
+                    continue;
+                }
+            };
+            let dir_name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let event_counts = manifest
+                .events
+                .iter()
+                .map(|(event, files)| {
+                    let valid = files.iter().filter(|f| path.join(f).exists()).count();
+                    (event.clone(), valid)
+                })
+                .filter(|(_, count)| *count > 0)
+                .collect();
+            packs.push(SoundPackInfo {
+                dir_name,
+                name: manifest.name,
+                author: manifest.author,
+                description: manifest.description,
+                event_counts,
+            });
+        }
+        Ok(packs)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Play an arbitrary audio file by absolute path.
+pub(crate) fn play_sound_file(path: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(child) = std::process::Command::new("afplay").arg(path).spawn() {
+            spawn_and_reap(child);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(child) = std::process::Command::new("paplay")
+            .arg(path)
+            .spawn()
+            .or_else(|_| std::process::Command::new("aplay").arg(path).spawn())
+        {
+            spawn_and_reap(child);
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = path;
+    }
+}
+
+/// Resolve a random audio file path from a sound pack for a given event.
+pub(crate) fn resolve_random_pack_sound_path(dir_name: &str, event: &str) -> Option<String> {
+    let pack_dir = sound_packs_dir()?.join(dir_name);
+    let manifest_path = pack_dir.join("pack.json");
+    let content = std::fs::read_to_string(&manifest_path).ok()?;
+    let manifest: SoundPackManifest = serde_json::from_str(&content).ok()?;
+    let files = manifest.events.get(event)?;
+    let valid_files: Vec<_> = files
+        .iter()
+        .map(|f| pack_dir.join(f))
+        .filter(|p| p.exists())
+        .collect();
+    if valid_files.is_empty() {
+        return None;
+    }
+    let idx = rand::thread_rng().gen_range(0..valid_files.len());
+    Some(valid_files[idx].to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub fn preview_pack_sound(dir_name: String, event: String) -> Result<(), String> {
+    let path = resolve_random_pack_sound_path(&dir_name, &event)
+        .ok_or_else(|| format!("No sounds found for event '{event}' in pack '{dir_name}'"))?;
+    play_sound_file(&path);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -454,5 +599,161 @@ mod tests {
         let output = std::fs::read_to_string(&tmp).expect("Failed to read output file");
         std::fs::remove_file(&tmp).ok();
         assert_eq!(output.trim(), "my-workspace,/home/user/repo");
+    }
+
+    // --- Sound pack tests ---
+
+    fn create_test_pack(dir: &std::path::Path, name: &str, events: &[(&str, &[&str])]) {
+        let pack_dir = dir.join(name);
+        std::fs::create_dir_all(&pack_dir).unwrap();
+        let mut events_map = HashMap::new();
+        for (event, files) in events {
+            let event_dir = pack_dir.join(event);
+            std::fs::create_dir_all(&event_dir).unwrap();
+            let mut paths = Vec::new();
+            for file in *files {
+                let rel = format!("{event}/{file}");
+                std::fs::write(pack_dir.join(&rel), b"fake audio").unwrap();
+                paths.push(rel);
+            }
+            events_map.insert(
+                event.to_string(),
+                paths
+                    .iter()
+                    .map(|p| serde_json::Value::String(p.clone()))
+                    .collect::<Vec<_>>(),
+            );
+        }
+        let manifest = serde_json::json!({
+            "name": format!("Test Pack {name}"),
+            "version": "1.0.0",
+            "author": "tester",
+            "description": "A test sound pack",
+            "events": events_map,
+        });
+        std::fs::write(
+            pack_dir.join("pack.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_resolve_random_pack_sound_nonexistent_dir() {
+        assert!(resolve_random_pack_sound_path("nonexistent-pack-xyz", "ask").is_none());
+    }
+
+    #[test]
+    fn test_resolve_random_pack_sound_missing_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Temporarily override the packs dir by creating a pack in a known location.
+        // Since resolve_random_pack_sound_path uses sound_packs_dir() which resolves
+        // to ~/.claudette/sound-packs, we test the internal logic via a direct manifest
+        // parse instead.
+        let pack_dir = tmp.path().join("test-pack");
+        std::fs::create_dir_all(&pack_dir).unwrap();
+        let manifest = serde_json::json!({
+            "name": "Test",
+            "events": {
+                "ask": ["ask/sound.wav"]
+            }
+        });
+        std::fs::write(
+            pack_dir.join("pack.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let content = std::fs::read_to_string(pack_dir.join("pack.json")).unwrap();
+        let parsed: SoundPackManifest = serde_json::from_str(&content).unwrap();
+        assert!(parsed.events.get("plan").is_none());
+        assert!(parsed.events.get("ask").is_some());
+    }
+
+    #[test]
+    fn test_sound_pack_manifest_deserializes() {
+        let json = r#"{
+            "name": "Fun Pack",
+            "version": "1.0.0",
+            "author": "someone",
+            "description": "A playful set",
+            "events": {
+                "ask": ["ask/chirp.wav", "ask/ding.wav"],
+                "plan": ["plan/tada.wav"],
+                "finished": ["finished/fanfare.wav"]
+            }
+        }"#;
+        let manifest: SoundPackManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.name, "Fun Pack");
+        assert_eq!(manifest.author.as_deref(), Some("someone"));
+        assert_eq!(manifest.events.len(), 3);
+        assert_eq!(manifest.events["ask"].len(), 2);
+    }
+
+    #[test]
+    fn test_sound_pack_manifest_optional_fields() {
+        let json = r#"{"name": "Minimal", "events": {}}"#;
+        let manifest: SoundPackManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.name, "Minimal");
+        assert!(manifest.version.is_none());
+        assert!(manifest.author.is_none());
+        assert!(manifest.description.is_none());
+        assert!(manifest.events.is_empty());
+    }
+
+    #[test]
+    fn test_sound_pack_info_event_counts_only_valid_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        create_test_pack(
+            tmp.path(),
+            "my-pack",
+            &[("ask", &["sound1.wav", "sound2.wav"])],
+        );
+
+        let pack_dir = tmp.path().join("my-pack");
+        let content = std::fs::read_to_string(pack_dir.join("pack.json")).unwrap();
+        let manifest: SoundPackManifest = serde_json::from_str(&content).unwrap();
+
+        let event_counts: HashMap<String, usize> = manifest
+            .events
+            .iter()
+            .map(|(event, files)| {
+                let valid = files.iter().filter(|f| pack_dir.join(f).exists()).count();
+                (event.clone(), valid)
+            })
+            .filter(|(_, count)| *count > 0)
+            .collect();
+
+        assert_eq!(event_counts["ask"], 2);
+        assert!(!event_counts.contains_key("plan"));
+    }
+
+    #[test]
+    fn test_sound_pack_info_skips_missing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pack_dir = tmp.path().join("broken-pack");
+        std::fs::create_dir_all(&pack_dir).unwrap();
+        let manifest = serde_json::json!({
+            "name": "Broken",
+            "events": {
+                "ask": ["ask/exists.wav", "ask/missing.wav"]
+            }
+        });
+        std::fs::write(
+            pack_dir.join("pack.json"),
+            serde_json::to_string(&manifest).unwrap(),
+        )
+        .unwrap();
+        let ask_dir = pack_dir.join("ask");
+        std::fs::create_dir_all(&ask_dir).unwrap();
+        std::fs::write(ask_dir.join("exists.wav"), b"fake").unwrap();
+
+        let content = std::fs::read_to_string(pack_dir.join("pack.json")).unwrap();
+        let parsed: SoundPackManifest = serde_json::from_str(&content).unwrap();
+        let valid: Vec<_> = parsed.events["ask"]
+            .iter()
+            .filter(|f| pack_dir.join(f).exists())
+            .collect();
+        assert_eq!(valid.len(), 1);
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -358,6 +358,10 @@ pub struct SoundPackInfo {
 }
 
 fn sound_packs_dir() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Ok(override_dir) = std::env::var("CLAUDETTE_SOUND_PACKS_DIR") {
+        return Some(std::path::PathBuf::from(override_dir));
+    }
     dirs::home_dir().map(|h| h.join(".claudette").join("sound-packs"))
 }
 
@@ -492,6 +496,27 @@ pub(crate) fn resolve_random_pack_sound_path(dir_name: &str, event: &str) -> Opt
     }
     let idx = rand::thread_rng().gen_range(0..valid_files.len());
     Some(valid_files[idx].to_string_lossy().to_string())
+}
+
+/// Play the appropriate sound for a notification setting value.
+///
+/// Handles `pack:<dir>` values by resolving a random sound from the pack,
+/// and falls back to `play_notification_sound` for system/named sounds.
+/// Returns the sound value to pass to `send_notification` — `"None"` if a
+/// pack sound was played (so the notification itself stays silent), or the
+/// original value for system sounds.
+pub(crate) fn play_resolved_notification_sound(sound_setting: &str, event_name: &str) -> String {
+    if let Some(dir_name) = sound_setting.strip_prefix("pack:") {
+        if let Some(path) = resolve_random_pack_sound_path(dir_name, event_name) {
+            play_sound_file(&path);
+        }
+        "None".to_string()
+    } else {
+        if sound_setting != "None" {
+            play_notification_sound(sound_setting.to_string());
+        }
+        sound_setting.to_string()
+    }
 }
 
 #[tauri::command]
@@ -656,7 +681,16 @@ mod tests {
 
     #[test]
     fn test_resolve_random_pack_sound_nonexistent_dir() {
-        assert!(resolve_random_pack_sound_path("nonexistent-pack-xyz", "ask").is_none());
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: test-only, single-threaded access to this env var.
+        unsafe {
+            std::env::set_var("CLAUDETTE_SOUND_PACKS_DIR", tmp.path());
+        }
+        let result = resolve_random_pack_sound_path("nonexistent-pack", "ask");
+        unsafe {
+            std::env::remove_var("CLAUDETTE_SOUND_PACKS_DIR");
+        }
+        assert!(result.is_none());
     }
 
     #[test]
@@ -682,8 +716,8 @@ mod tests {
 
         let content = std::fs::read_to_string(pack_dir.join("pack.json")).unwrap();
         let parsed: SoundPackManifest = serde_json::from_str(&content).unwrap();
-        assert!(parsed.events.get("plan").is_none());
-        assert!(parsed.events.get("ask").is_some());
+        assert!(!parsed.events.contains_key("plan"));
+        assert!(parsed.events.contains_key("ask"));
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -394,8 +394,10 @@ fn main() {
             commands::settings::set_app_setting,
             commands::settings::list_user_themes,
             commands::settings::list_notification_sounds,
+            commands::settings::list_sound_packs,
             commands::settings::list_system_fonts,
             commands::settings::play_notification_sound,
+            commands::settings::preview_pack_sound,
             commands::settings::run_notification_command,
             commands::settings::get_git_username,
             // Updater

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -390,16 +390,9 @@ pub fn notify_attention(app: &AppHandle, workspace_id: &str, kind: AttentionKind
     let title = "Claudette — Input Required";
     let body = format!("{ws_name} is waiting for your response");
 
-    if let Some(dir_name) = sound.strip_prefix("pack:") {
-        if let Some(path) =
-            crate::commands::settings::resolve_random_pack_sound_path(dir_name, event.event_name())
-        {
-            crate::commands::settings::play_sound_file(&path);
-        }
-        send_notification(app, workspace_id, title, &body, "None");
-    } else {
-        send_notification(app, workspace_id, title, &body, &sound);
-    }
+    let notification_sound =
+        crate::commands::settings::play_resolved_notification_sound(&sound, event.event_name());
+    send_notification(app, workspace_id, title, &body, &notification_sound);
 
     // Run user-configured notification command (if set).
     // Build a best-effort WorkspaceEnv even when the workspace lookup fails

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -9,6 +9,7 @@ use claudette::model::WorkspaceStatus;
 use crate::state::{AppState, AttentionKind};
 
 /// Notification event types for per-event sound selection.
+#[derive(Clone, Copy)]
 pub enum NotificationEvent {
     Ask,
     Plan,
@@ -21,6 +22,14 @@ impl NotificationEvent {
             Self::Ask => "notification_sound_ask",
             Self::Plan => "notification_sound_plan",
             Self::Finished => "notification_sound_finished",
+        }
+    }
+
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::Ask => "ask",
+            Self::Plan => "plan",
+            Self::Finished => "finished",
         }
     }
 }
@@ -375,12 +384,22 @@ pub fn notify_attention(app: &AppHandle, workspace_id: &str, kind: AttentionKind
         .map(|w| w.name.clone())
         .unwrap_or_else(|| "An agent".to_string());
 
-    let sound = resolve_notification_sound(&db, NotificationEvent::from(kind));
+    let event = NotificationEvent::from(kind);
+    let sound = resolve_notification_sound(&db, event);
 
     let title = "Claudette — Input Required";
     let body = format!("{ws_name} is waiting for your response");
 
-    send_notification(app, workspace_id, title, &body, &sound);
+    if let Some(dir_name) = sound.strip_prefix("pack:") {
+        if let Some(path) =
+            crate::commands::settings::resolve_random_pack_sound_path(dir_name, event.event_name())
+        {
+            crate::commands::settings::play_sound_file(&path);
+        }
+        send_notification(app, workspace_id, title, &body, "None");
+    } else {
+        send_notification(app, workspace_id, title, &body, &sound);
+    }
 
     // Run user-configured notification command (if set).
     // Build a best-effort WorkspaceEnv even when the workspace lookup fails
@@ -1093,5 +1112,25 @@ mod tests {
             NotificationEvent::Finished,
         );
         assert_eq!(resolved, "Default");
+    }
+
+    #[test]
+    fn resolve_sound_returns_pack_prefix_unchanged() {
+        let settings = HashMap::from([(
+            "notification_sound_ask".to_string(),
+            "pack:my-fun-pack".to_string(),
+        )]);
+        let resolved = resolve_notification_sound_with(
+            |key| settings.get(key).cloned(),
+            NotificationEvent::Ask,
+        );
+        assert_eq!(resolved, "pack:my-fun-pack");
+    }
+
+    #[test]
+    fn event_name_maps_correctly() {
+        assert_eq!(NotificationEvent::Ask.event_name(), "ask");
+        assert_eq!(NotificationEvent::Plan.event_name(), "plan");
+        assert_eq!(NotificationEvent::Finished.event_name(), "finished");
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,6 +5,7 @@ pub mod diff;
 mod metrics;
 mod remote_connection;
 mod repository;
+mod sound_pack;
 mod terminal_tab;
 mod workspace;
 
@@ -17,5 +18,6 @@ pub use metrics::{
 };
 pub use remote_connection::RemoteConnection;
 pub use repository::Repository;
+pub use sound_pack::SoundPackManifest;
 pub use terminal_tab::TerminalTab;
 pub use workspace::{AgentStatus, Workspace, WorkspaceStatus};

--- a/src/model/sound_pack.rs
+++ b/src/model/sound_pack.rs
@@ -1,0 +1,12 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SoundPackManifest {
+    pub name: String,
+    pub version: Option<String>,
+    pub author: Option<String>,
+    pub description: Option<String>,
+    pub events: HashMap<String, Vec<String>>,
+}

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -3,13 +3,17 @@ import {
   getAppSetting,
   setAppSetting,
   listNotificationSounds,
+  listSoundPacks,
   playNotificationSound,
+  previewPackSound,
   runNotificationCommand,
 } from "../../../services/tauri";
+import type { SoundPackInfo } from "../../../services/tauri";
 import styles from "../Settings.module.css";
 
 interface SoundEvent {
   key: string;
+  eventName: string;
   label: string;
   description: string;
 }
@@ -17,16 +21,19 @@ interface SoundEvent {
 const SOUND_EVENTS: SoundEvent[] = [
   {
     key: "notification_sound_ask",
+    eventName: "ask",
     label: "Agent question",
     description: "Sound when an agent needs your input",
   },
   {
     key: "notification_sound_plan",
+    eventName: "plan",
     label: "Plan ready",
     description: "Sound when an agent has a plan for review",
   },
   {
     key: "notification_sound_finished",
+    eventName: "finished",
     label: "Work complete",
     description: "Sound when an agent finishes its task",
   },
@@ -52,11 +59,13 @@ export function NotificationsSettings() {
     "Default",
     "None",
   ]);
+  const [soundPacks, setSoundPacks] = useState<SoundPackInfo[]>([]);
   const [notificationCommand, setNotificationCommand] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     listNotificationSounds().then(setAvailableSounds).catch(() => {});
+    listSoundPacks().then(setSoundPacks).catch(() => {});
     for (const event of SOUND_EVENTS) {
       resolveSound(event.key)
         .then((val) =>
@@ -80,6 +89,14 @@ export function NotificationsSettings() {
     } catch (e) {
       setSounds((s) => ({ ...s, [key]: prev }));
       setError(String(e));
+    }
+  };
+
+  const handlePreview = (eventName: string, sound: string) => {
+    if (sound.startsWith("pack:")) {
+      previewPackSound(sound.slice(5), eventName);
+    } else {
+      playNotificationSound(sound);
     }
   };
 
@@ -109,45 +126,70 @@ export function NotificationsSettings() {
     }
   };
 
+  const packsForEvent = (eventName: string) =>
+    soundPacks.filter(
+      (p) => (p.event_counts[eventName] ?? 0) > 0,
+    );
+
   return (
     <div>
       <h2 className={styles.sectionTitle}>Notifications</h2>
 
-      {SOUND_EVENTS.map((event) => (
-        <div key={event.key} className={styles.settingRow}>
-          <div className={styles.settingInfo}>
-            <div className={styles.settingLabel}>{event.label}</div>
-            <div className={styles.settingDescription}>
-              {event.description}
+      {SOUND_EVENTS.map((event) => {
+        const packs = packsForEvent(event.eventName);
+        return (
+          <div key={event.key} className={styles.settingRow}>
+            <div className={styles.settingInfo}>
+              <div className={styles.settingLabel}>{event.label}</div>
+              <div className={styles.settingDescription}>
+                {event.description}
+              </div>
+            </div>
+            <div className={styles.settingControl}>
+              <div className={styles.inlineControl}>
+                <select
+                  className={styles.select}
+                  value={sounds[event.key]}
+                  onChange={(e) =>
+                    handleSoundChange(event.key, e.target.value)
+                  }
+                >
+                  <optgroup label="System Sounds">
+                    {availableSounds.map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </optgroup>
+                  {packs.length > 0 && (
+                    <optgroup label="Sound Packs">
+                      {packs.map((pack) => (
+                        <option
+                          key={`pack:${pack.dir_name}`}
+                          value={`pack:${pack.dir_name}`}
+                        >
+                          {pack.name} (random)
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                </select>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() =>
+                    handlePreview(event.eventName, sounds[event.key])
+                  }
+                  disabled={sounds[event.key] === "None"}
+                  title="Preview sound"
+                  aria-label={`Preview ${event.label} sound`}
+                >
+                  &#9654;
+                </button>
+              </div>
             </div>
           </div>
-          <div className={styles.settingControl}>
-            <div className={styles.inlineControl}>
-              <select
-                className={styles.select}
-                value={sounds[event.key]}
-                onChange={(e) =>
-                  handleSoundChange(event.key, e.target.value)
-                }
-              >
-                {availableSounds.map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-              <button
-                className={styles.iconBtn}
-                onClick={() => playNotificationSound(sounds[event.key])}
-                title="Preview sound"
-                aria-label={`Preview ${event.label} sound`}
-              >
-                &#9654;
-              </button>
-            </div>
-          </div>
-        </div>
-      ))}
+        );
+      })}
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -92,11 +92,16 @@ export function NotificationsSettings() {
     }
   };
 
-  const handlePreview = (eventName: string, sound: string) => {
-    if (sound.startsWith("pack:")) {
-      previewPackSound(sound.slice(5), eventName);
-    } else {
-      playNotificationSound(sound);
+  const handlePreview = async (eventName: string, sound: string) => {
+    try {
+      setError(null);
+      if (sound.startsWith("pack:")) {
+        await previewPackSound(sound.slice(5), eventName);
+      } else {
+        playNotificationSound(sound);
+      }
+    } catch (e) {
+      setError(String(e));
     }
   };
 

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -688,12 +688,31 @@ export function listNotificationSounds(): Promise<string[]> {
   return invoke("list_notification_sounds");
 }
 
+export interface SoundPackInfo {
+  dir_name: string;
+  name: string;
+  author: string | null;
+  description: string | null;
+  event_counts: Record<string, number>;
+}
+
+export function listSoundPacks(): Promise<SoundPackInfo[]> {
+  return invoke("list_sound_packs");
+}
+
 export function listSystemFonts(): Promise<string[]> {
   return invoke("list_system_fonts");
 }
 
 export function playNotificationSound(sound: string): Promise<void> {
   return invoke("play_notification_sound", { sound });
+}
+
+export function previewPackSound(
+  dirName: string,
+  event: string,
+): Promise<void> {
+  return invoke("preview_pack_sound", { dirName, event });
 }
 
 export function runNotificationCommand(


### PR DESCRIPTION
## Summary

- Adds installable sound packs at `~/.claudette/sound-packs/` with `pack.json` manifests mapping notification events to arrays of audio files
- When a pack is selected for an event, Claudette randomly picks one sound each time it fires
- Settings value uses `pack:<dir_name>` prefix to distinguish from system sound names
- All three notification paths (tray attention, agent finished, SCM auto-archive) handle pack sounds correctly
- Frontend dropdowns use `<optgroup>` to separate system sounds from installed packs

## Test plan

- [ ] Create `~/.claudette/sound-packs/test-pack/` with `pack.json` and audio files for ask/plan/finished events
- [ ] Open Settings → Notifications — verify pack appears in dropdown optgroups for events with sounds
- [ ] Select a pack for an event, click preview — verify a random sound plays
- [ ] Trigger agent question notification — verify random pack sound plays
- [ ] Trigger agent finished notification — verify random pack sound plays
- [ ] Verify system sounds still work when selected (no regression)
- [ ] Verify "None" still silences notifications
- [ ] Delete the test pack directory, reopen settings — verify graceful handling (no crash)

Closes #329