### PR TITLE
feat(chat): support drag-and-drop and attachment of any file type

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -235,12 +235,20 @@ pub async fn send_chat_message(
                 return Err("Invalid PDF: missing %PDF- header".to_string());
             }
             let text_content = if input.media_type == "text/plain" {
+                let check_len = data.len().min(8192);
+                if data[..check_len].contains(&0) {
+                    return Err(
+                        "Invalid text/plain attachment: binary content detected".to_string()
+                    );
+                }
+                let decoded = std::str::from_utf8(&data).map_err(|_| {
+                    "Invalid text/plain attachment: payload is not valid UTF-8".to_string()
+                })?;
                 Some(
                     input
                         .text_content
                         .clone()
-                        .or_else(|| String::from_utf8(data.clone()).ok())
-                        .unwrap_or_default(),
+                        .unwrap_or_else(|| decoded.to_owned()),
                 )
             } else {
                 None
@@ -1908,7 +1916,7 @@ pub async fn load_attachments_for_workspace(
                 String::new()
             };
             let text_content = if is_text {
-                String::from_utf8(a.data.clone()).ok()
+                std::str::from_utf8(&a.data).ok().map(str::to_owned)
             } else {
                 None
             };
@@ -1979,35 +1987,39 @@ pub async fn read_file_as_base64(path: String) -> Result<AttachmentResponse, Str
         _ => None,
     };
 
+    // Check file size via metadata before reading to avoid loading huge
+    // files into memory only to reject them.
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .map_err(|e| format!("Failed to read file: {e}"))?;
+    let file_len = metadata.len() as usize;
+    if file_len == 0 {
+        return Err("File is empty".to_string());
+    }
+    let max_for_read = if known_media_type == Some("application/pdf") {
+        MAX_PDF_SIZE
+    } else if known_media_type.is_some() {
+        MAX_IMAGE_SIZE
+    } else {
+        MAX_TEXT_SIZE
+    };
+    if file_len > max_for_read {
+        return Err(format!(
+            "File too large: {} (max {})",
+            humanize_size(file_len),
+            humanize_size(max_for_read)
+        ));
+    }
+
     let data = tokio::fs::read(&path)
         .await
         .map_err(|e| format!("Failed to read file: {e}"))?;
 
-    if data.is_empty() {
-        return Err("File is empty".to_string());
-    }
-
     let size_bytes = data.len() as i64;
 
     if let Some(media_type) = known_media_type {
-        // Known binary type — enforce per-type size limits.
-        if media_type == "application/pdf" {
-            if data.len() > MAX_PDF_SIZE {
-                return Err(format!(
-                    "PDF too large: {:.1} MB (max {} MB)",
-                    data.len() as f64 / 1_048_576.0,
-                    MAX_PDF_SIZE / 1_048_576
-                ));
-            }
-            if !data.starts_with(b"%PDF-") {
-                return Err("Invalid PDF file: missing %PDF- header".to_string());
-            }
-        } else if data.len() > MAX_IMAGE_SIZE {
-            return Err(format!(
-                "Image too large: {:.1} MB (max {:.1} MB)",
-                data.len() as f64 / 1_048_576.0,
-                MAX_IMAGE_SIZE as f64 / 1_048_576.0
-            ));
+        if media_type == "application/pdf" && !data.starts_with(b"%PDF-") {
+            return Err("Invalid PDF file: missing %PDF- header".to_string());
         }
 
         let data_base64 = base64_encode(&data);
@@ -2024,13 +2036,6 @@ pub async fn read_file_as_base64(path: String) -> Result<AttachmentResponse, Str
         })
     } else {
         // Unknown extension — attempt to read as text.
-        if data.len() > MAX_TEXT_SIZE {
-            return Err(format!(
-                "Text file too large: {} KB (max {} KB)",
-                data.len() / 1024,
-                MAX_TEXT_SIZE / 1024
-            ));
-        }
         let check_len = data.len().min(8192);
         if data[..check_len].contains(&0) {
             return Err(format!("Unsupported binary file type: .{ext}"));
@@ -2052,6 +2057,14 @@ pub async fn read_file_as_base64(path: String) -> Result<AttachmentResponse, Str
             }
             Err(_) => Err(format!("Unsupported binary file type: .{ext}")),
         }
+    }
+}
+
+fn humanize_size(bytes: usize) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else {
+        format!("{} KB", bytes / 1024)
     }
 }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::{
-    self, AgentEvent, AgentSettings, ControlRequestInner, ImageAttachment, InnerStreamEvent,
+    self, AgentEvent, AgentSettings, ControlRequestInner, FileAttachment, InnerStreamEvent,
     PersistentSession, StartContentBlock, StreamEvent,
 };
 use claudette::db::Database;
@@ -19,12 +19,13 @@ use claudette::{base64_decode, base64_encode};
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
 
-/// Frontend-facing input for an image attachment (base64-encoded).
+/// Frontend-facing input for a file attachment (base64-encoded).
 #[derive(Clone, Deserialize)]
 pub struct AttachmentInput {
     pub filename: String,
     pub media_type: String,
     pub data_base64: String,
+    pub text_content: Option<String>,
 }
 
 /// Frontend-facing response for a stored attachment (base64-encoded data).
@@ -35,6 +36,7 @@ pub struct AttachmentResponse {
     pub filename: String,
     pub media_type: String,
     pub data_base64: String,
+    pub text_content: Option<String>,
     pub width: Option<i32>,
     pub height: Option<i32>,
     pub size_bytes: i64,
@@ -200,12 +202,14 @@ pub async fn send_chat_message(
         "image/gif",
         "image/webp",
         "application/pdf",
+        "text/plain",
     ];
     const MAX_IMAGE_BYTES: usize = 3_932_160; // 3.75 MB
     const MAX_PDF_BYTES: usize = 20_971_520; // 20 MB
+    const MAX_TEXT_BYTES: usize = 512_000; // 500 KB
 
     let mut att_models: Vec<Attachment> = Vec::new();
-    let mut cli_atts: Vec<ImageAttachment> = Vec::new();
+    let mut cli_atts: Vec<FileAttachment> = Vec::new();
 
     if let Some(ref inputs) = attachments {
         for input in inputs {
@@ -215,6 +219,8 @@ pub async fn send_chat_message(
             let data = base64_decode(&input.data_base64).map_err(|e| format!("Bad base64: {e}"))?;
             let max = if input.media_type == "application/pdf" {
                 MAX_PDF_BYTES
+            } else if input.media_type == "text/plain" {
+                MAX_TEXT_BYTES
             } else {
                 MAX_IMAGE_BYTES
             };
@@ -228,6 +234,17 @@ pub async fn send_chat_message(
             if input.media_type == "application/pdf" && !data.starts_with(b"%PDF-") {
                 return Err("Invalid PDF: missing %PDF- header".to_string());
             }
+            let text_content = if input.media_type == "text/plain" {
+                Some(
+                    input
+                        .text_content
+                        .clone()
+                        .or_else(|| String::from_utf8(data.clone()).ok())
+                        .unwrap_or_default(),
+                )
+            } else {
+                None
+            };
             let size_bytes = data.len() as i64;
             att_models.push(Attachment {
                 id: uuid::Uuid::new_v4().to_string(),
@@ -240,9 +257,11 @@ pub async fn send_chat_message(
                 data,
                 created_at: now_iso(),
             });
-            cli_atts.push(ImageAttachment {
+            cli_atts.push(FileAttachment {
                 media_type: input.media_type.clone(),
                 data_base64: input.data_base64.clone(),
+                text_content,
+                filename: Some(input.filename.clone()),
             });
         }
     }
@@ -1880,12 +1899,18 @@ pub async fn load_attachments_for_workspace(
     let mut result = Vec::new();
     for (_, atts) in att_map {
         for a in atts {
-            // Only inline base64 data for images — PDFs are too large to
-            // push through IPC eagerly and would stall the renderer.
-            let data_base64 = if a.media_type.starts_with("image/") {
+            // Inline base64 data for images and text files — PDFs are too
+            // large to push through IPC eagerly and would stall the renderer.
+            let is_text = a.media_type == "text/plain";
+            let data_base64 = if a.media_type.starts_with("image/") || is_text {
                 base64_encode(&a.data)
             } else {
                 String::new()
+            };
+            let text_content = if is_text {
+                String::from_utf8(a.data.clone()).ok()
+            } else {
+                None
             };
             result.push(AttachmentResponse {
                 id: a.id,
@@ -1893,6 +1918,7 @@ pub async fn load_attachments_for_workspace(
                 filename: a.filename,
                 media_type: a.media_type,
                 data_base64,
+                text_content,
                 width: a.width,
                 height: a.height,
                 size_bytes: a.size_bytes,
@@ -1920,15 +1946,16 @@ pub async fn load_attachment_data(
 /// Read a file from disk and return it as base64 with metadata.
 /// Used by the frontend file picker — avoids needing the `plugin-fs` dependency.
 ///
-/// Supported types: PNG, JPEG, GIF, WebP (images), PDF (documents).
-/// Images are capped at ~3.75 MB (encodes to ~5 MB base64).
-/// PDFs are capped at 20 MB (the Anthropic API raw-PDF limit).
+/// Known types (images, PDFs) use their specific MIME types and size limits.
+/// Unknown extensions are tested for UTF-8 validity — valid text files are
+/// returned as `text/plain` with the content in `text_content`.
 #[tauri::command]
 pub async fn read_file_as_base64(path: String) -> Result<AttachmentResponse, String> {
     use std::path::Path;
 
     const MAX_IMAGE_SIZE: usize = 3_932_160; // 3.75 MB
     const MAX_PDF_SIZE: usize = 20_971_520; // 20 MB
+    const MAX_TEXT_SIZE: usize = 512_000; // 500 KB
 
     let file_path = Path::new(&path);
     let filename = file_path
@@ -1943,55 +1970,89 @@ pub async fn read_file_as_base64(path: String) -> Result<AttachmentResponse, Str
         .unwrap_or("")
         .to_lowercase();
 
-    let media_type = match ext.as_str() {
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "pdf" => "application/pdf",
-        other => return Err(format!("Unsupported file type: .{other}")),
-    }
-    .to_string();
+    let known_media_type = match ext.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "pdf" => Some("application/pdf"),
+        _ => None,
+    };
 
     let data = tokio::fs::read(&path)
         .await
         .map_err(|e| format!("Failed to read file: {e}"))?;
 
-    let size_bytes = data.len() as i64;
-
-    // Enforce size limits per content type.
-    if media_type == "application/pdf" {
-        if data.len() > MAX_PDF_SIZE {
-            return Err(format!(
-                "PDF too large: {:.1} MB (max {} MB)",
-                data.len() as f64 / 1_048_576.0,
-                MAX_PDF_SIZE / 1_048_576
-            ));
-        }
-        // Validate PDF magic bytes (%PDF-) to prevent session poisoning.
-        if !data.starts_with(b"%PDF-") {
-            return Err("Invalid PDF file: missing %PDF- header".to_string());
-        }
-    } else if data.len() > MAX_IMAGE_SIZE {
-        return Err(format!(
-            "Image too large: {:.1} MB (max {:.1} MB)",
-            data.len() as f64 / 1_048_576.0,
-            MAX_IMAGE_SIZE as f64 / 1_048_576.0
-        ));
+    if data.is_empty() {
+        return Err("File is empty".to_string());
     }
 
-    let data_base64 = base64_encode(&data);
+    let size_bytes = data.len() as i64;
 
-    Ok(AttachmentResponse {
-        id: String::new(),
-        message_id: String::new(),
-        filename,
-        media_type,
-        data_base64,
-        width: None,
-        height: None,
-        size_bytes,
-    })
+    if let Some(media_type) = known_media_type {
+        // Known binary type — enforce per-type size limits.
+        if media_type == "application/pdf" {
+            if data.len() > MAX_PDF_SIZE {
+                return Err(format!(
+                    "PDF too large: {:.1} MB (max {} MB)",
+                    data.len() as f64 / 1_048_576.0,
+                    MAX_PDF_SIZE / 1_048_576
+                ));
+            }
+            if !data.starts_with(b"%PDF-") {
+                return Err("Invalid PDF file: missing %PDF- header".to_string());
+            }
+        } else if data.len() > MAX_IMAGE_SIZE {
+            return Err(format!(
+                "Image too large: {:.1} MB (max {:.1} MB)",
+                data.len() as f64 / 1_048_576.0,
+                MAX_IMAGE_SIZE as f64 / 1_048_576.0
+            ));
+        }
+
+        let data_base64 = base64_encode(&data);
+        Ok(AttachmentResponse {
+            id: String::new(),
+            message_id: String::new(),
+            filename,
+            media_type: media_type.to_string(),
+            data_base64,
+            text_content: None,
+            width: None,
+            height: None,
+            size_bytes,
+        })
+    } else {
+        // Unknown extension — attempt to read as text.
+        if data.len() > MAX_TEXT_SIZE {
+            return Err(format!(
+                "Text file too large: {} KB (max {} KB)",
+                data.len() / 1024,
+                MAX_TEXT_SIZE / 1024
+            ));
+        }
+        let check_len = data.len().min(8192);
+        if data[..check_len].contains(&0) {
+            return Err(format!("Unsupported binary file type: .{ext}"));
+        }
+        match String::from_utf8(data.clone()) {
+            Ok(text) => {
+                let data_base64 = base64_encode(&data);
+                Ok(AttachmentResponse {
+                    id: String::new(),
+                    message_id: String::new(),
+                    filename,
+                    media_type: "text/plain".to_string(),
+                    data_base64,
+                    text_content: Some(text),
+                    width: None,
+                    height: None,
+                    size_bytes,
+                })
+            }
+            Err(_) => Err(format!("Unsupported binary file type: .{ext}")),
+        }
+    }
 }
 
 fn now_iso() -> String {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -306,14 +306,17 @@ pub enum AgentEvent {
 // Per-turn agent settings
 // ---------------------------------------------------------------------------
 
-/// An attachment (image or document) to send alongside the prompt via stream-json stdin.
+/// An attachment to send alongside the prompt via stream-json stdin.
 ///
-/// Images use `"type": "image"` content blocks; PDFs use `"type": "document"`.
-/// The block type is determined by [`media_type`] in [`build_stdin_message`].
+/// Images use `"type": "image"` content blocks; PDFs use `"type": "document"`;
+/// text files (when [`text_content`] is `Some`) use `"type": "text"`.
+/// The block type is determined in [`build_stdin_message`].
 #[derive(Debug, Clone)]
-pub struct ImageAttachment {
+pub struct FileAttachment {
     pub media_type: String,
     pub data_base64: String,
+    pub text_content: Option<String>,
+    pub filename: Option<String>,
 }
 
 /// Per-turn settings that control CLI flags for the agent subprocess.
@@ -476,9 +479,9 @@ pub fn build_claude_args(
 /// Build a single-line JSON payload for stdin when using `--input-format stream-json`.
 ///
 /// Produces an `SDKUserMessage` with content blocks: one text block for the
-/// prompt, then one `image` or `document` block per attachment (PDFs use the
-/// `document` block type; all other supported formats use `image`).
-pub fn build_stdin_message(prompt: &str, attachments: &[ImageAttachment]) -> String {
+/// prompt, then one block per attachment — text files become `"text"` blocks,
+/// PDFs become `"document"` blocks, and images become `"image"` blocks.
+pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> String {
     let mut content_blocks = Vec::new();
 
     // Only add a text block if the prompt is non-empty — the API rejects
@@ -488,19 +491,29 @@ pub fn build_stdin_message(prompt: &str, attachments: &[ImageAttachment]) -> Str
     }
 
     for att in attachments {
-        let block_type = if att.media_type == "application/pdf" {
-            "document"
+        if let Some(ref text) = att.text_content {
+            let label = att.filename.as_deref().unwrap_or("file");
+            let block_text = format!("Content of `{label}`:\n```\n{text}\n```");
+            content_blocks.push(serde_json::json!({"type": "text", "text": block_text}));
+        } else if att.media_type == "application/pdf" {
+            content_blocks.push(serde_json::json!({
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": att.media_type,
+                    "data": att.data_base64,
+                }
+            }));
         } else {
-            "image"
-        };
-        content_blocks.push(serde_json::json!({
-            "type": block_type,
-            "source": {
-                "type": "base64",
-                "media_type": att.media_type,
-                "data": att.data_base64,
-            }
-        }));
+            content_blocks.push(serde_json::json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": att.media_type,
+                    "data": att.data_base64,
+                }
+            }));
+        }
     }
 
     serde_json::json!({
@@ -677,7 +690,7 @@ pub async fn run_turn(
     allowed_tools: &[String],
     custom_instructions: Option<&str>,
     settings: &AgentSettings,
-    attachments: &[ImageAttachment],
+    attachments: &[FileAttachment],
     ws_env: Option<&WorkspaceEnv>,
 ) -> Result<TurnHandle, String> {
     let has_attachments = !attachments.is_empty();
@@ -998,7 +1011,7 @@ impl PersistentSession {
     pub async fn send_turn(
         &self,
         prompt: &str,
-        attachments: &[ImageAttachment],
+        attachments: &[FileAttachment],
     ) -> Result<TurnHandle, String> {
         use tokio::io::AsyncWriteExt;
 
@@ -2356,9 +2369,11 @@ mod tests {
 
     #[test]
     fn test_build_stdin_message_empty_prompt_omits_text_block() {
-        let attachments = vec![ImageAttachment {
+        let attachments = vec![FileAttachment {
             media_type: "image/png".into(),
             data_base64: "data".into(),
+            text_content: None,
+            filename: None,
         }];
         let msg = build_stdin_message("", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -2370,9 +2385,11 @@ mod tests {
 
     #[test]
     fn test_build_stdin_message_whitespace_prompt_omits_text_block() {
-        let attachments = vec![ImageAttachment {
+        let attachments = vec![FileAttachment {
             media_type: "image/png".into(),
             data_base64: "data".into(),
+            text_content: None,
+            filename: None,
         }];
         let msg = build_stdin_message("   ", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -2383,9 +2400,11 @@ mod tests {
 
     #[test]
     fn test_build_stdin_message_with_image() {
-        let attachments = vec![ImageAttachment {
+        let attachments = vec![FileAttachment {
             media_type: "image/png".into(),
             data_base64: "iVBORw0KGgo=".into(),
+            text_content: None,
+            filename: None,
         }];
         let msg = build_stdin_message("describe this", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -2402,17 +2421,23 @@ mod tests {
     #[test]
     fn test_build_stdin_message_multiple_images() {
         let attachments = vec![
-            ImageAttachment {
+            FileAttachment {
                 media_type: "image/png".into(),
                 data_base64: "png_data".into(),
+                text_content: None,
+                filename: None,
             },
-            ImageAttachment {
+            FileAttachment {
                 media_type: "image/jpeg".into(),
                 data_base64: "jpg_data".into(),
+                text_content: None,
+                filename: None,
             },
-            ImageAttachment {
+            FileAttachment {
                 media_type: "image/webp".into(),
                 data_base64: "webp_data".into(),
+                text_content: None,
+                filename: None,
             },
         ];
         let msg = build_stdin_message("compare these", &attachments);
@@ -2426,9 +2451,11 @@ mod tests {
 
     #[test]
     fn test_build_stdin_message_pdf_uses_document_block() {
-        let attachments = vec![ImageAttachment {
+        let attachments = vec![FileAttachment {
             media_type: "application/pdf".into(),
             data_base64: "JVBERi0xLjQ=".into(),
+            text_content: None,
+            filename: None,
         }];
         let msg = build_stdin_message("review this doc", &attachments);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
@@ -2445,13 +2472,17 @@ mod tests {
     #[test]
     fn test_build_stdin_message_mixed_images_and_pdf() {
         let attachments = vec![
-            ImageAttachment {
+            FileAttachment {
                 media_type: "image/png".into(),
                 data_base64: "png_data".into(),
+                text_content: None,
+                filename: None,
             },
-            ImageAttachment {
+            FileAttachment {
                 media_type: "application/pdf".into(),
                 data_base64: "pdf_data".into(),
+                text_content: None,
+                filename: None,
             },
         ];
         let msg = build_stdin_message("here are files", &attachments);
@@ -2460,6 +2491,76 @@ mod tests {
         assert_eq!(content.len(), 3); // 1 text + 1 image + 1 document
         assert_eq!(content[1]["type"], "image");
         assert_eq!(content[2]["type"], "document");
+    }
+
+    #[test]
+    fn test_build_stdin_message_text_file() {
+        let attachments = vec![FileAttachment {
+            media_type: "text/plain".into(),
+            data_base64: String::new(),
+            text_content: Some("fn main() {}".into()),
+            filename: Some("main.rs".into()),
+        }];
+        let msg = build_stdin_message("review this", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "review this");
+        assert_eq!(content[1]["type"], "text");
+        let text = content[1]["text"].as_str().unwrap();
+        assert!(text.contains("main.rs"));
+        assert!(text.contains("fn main() {}"));
+    }
+
+    #[test]
+    fn test_build_stdin_message_mixed_all_types() {
+        let attachments = vec![
+            FileAttachment {
+                media_type: "text/plain".into(),
+                data_base64: String::new(),
+                text_content: Some("hello world".into()),
+                filename: Some("readme.txt".into()),
+            },
+            FileAttachment {
+                media_type: "image/png".into(),
+                data_base64: "png_data".into(),
+                text_content: None,
+                filename: None,
+            },
+            FileAttachment {
+                media_type: "application/pdf".into(),
+                data_base64: "pdf_data".into(),
+                text_content: None,
+                filename: None,
+            },
+        ];
+        let msg = build_stdin_message("check these", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 4); // 1 prompt + 1 text file + 1 image + 1 document
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "check these");
+        assert_eq!(content[1]["type"], "text");
+        assert!(content[1]["text"].as_str().unwrap().contains("readme.txt"));
+        assert_eq!(content[2]["type"], "image");
+        assert_eq!(content[3]["type"], "document");
+    }
+
+    #[test]
+    fn test_build_stdin_message_text_file_no_filename_uses_default() {
+        let attachments = vec![FileAttachment {
+            media_type: "text/plain".into(),
+            data_base64: String::new(),
+            text_content: Some("data".into()),
+            filename: None,
+        }];
+        let msg = build_stdin_message("", &attachments);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        let text = content[0]["text"].as_str().unwrap();
+        assert!(text.contains("`file`"));
     }
 
     // -- Persistent session args --

--- a/src/ui/src/components/chat/AttachMenu.tsx
+++ b/src/ui/src/components/chat/AttachMenu.tsx
@@ -135,7 +135,7 @@ export function AttachMenu({
           <span className={styles.menuIcon}>
             <Paperclip size={14} />
           </span>
-          Add files or images
+          Add files
         </button>
 
         {/* Connectors — servers grouped by source with toggle switches */}

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -1087,3 +1087,31 @@
   color: var(--text-muted);
   font-size: 13px;
 }
+
+.textFileBadge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  gap: 2px;
+  background: var(--hover-bg-subtle);
+  color: var(--text-muted);
+  padding: 4px;
+  text-align: center;
+  overflow: hidden;
+}
+
+.textFileName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  font-size: 9px;
+}
+
+.textFileSize {
+  font-size: 9px;
+  color: var(--text-faint);
+}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -39,10 +39,12 @@ import type { SlashCommand, FileEntry } from "../../services/tauri";
 import type { ChatMessage, ChatAttachment, AttachmentInput, PendingAttachment } from "../../types/chat";
 import { base64ToBytes } from "../../utils/base64";
 import {
+  SUPPORTED_IMAGE_TYPES,
   SUPPORTED_DOCUMENT_TYPES,
   SUPPORTED_ATTACHMENT_TYPES,
   MAX_ATTACHMENTS,
   maxSizeFor,
+  isTextFile,
 } from "../../utils/attachmentValidation";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { useTypewriter } from "../../hooks/useTypewriter";
@@ -1614,6 +1616,16 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                         filename={att.filename}
                         className={styles.messageImage}
                       />
+                    ) : att.media_type === "text/plain" ? (
+                      <div key={att.id} className={styles.messagePdf}>
+                        <FileText size={14} />
+                        <span>{att.filename}</span>
+                        <span className={styles.textFileSize}>
+                          {att.size_bytes < 1024
+                            ? `${att.size_bytes} B`
+                            : `${(att.size_bytes / 1024).toFixed(0)} KB`}
+                        </span>
+                      </div>
                     ) : (
                       <img
                         key={att.id}
@@ -2010,13 +2022,15 @@ function ChatInputArea({
 
   // -- Attachment helpers --
 
-  const addAttachment = useCallback(async (file: Blob, filename: string) => {
+  const addAttachment = useCallback(async (file: Blob, filename: string, textContent?: string) => {
     if (isRemote) return; // Attachments not supported over remote transport
     if (!SUPPORTED_ATTACHMENT_TYPES.has(file.type)) {
       console.warn(`Unsupported file type: ${file.type}`);
       return;
     }
     const isPdf = SUPPORTED_DOCUMENT_TYPES.has(file.type);
+    const isImage = SUPPORTED_IMAGE_TYPES.has(file.type);
+    const isText = isTextFile(file.type);
     const sizeLimit = maxSizeFor(file.type);
     if (file.size > sizeLimit) {
       console.warn(
@@ -2025,15 +2039,16 @@ function ChatInputArea({
       return;
     }
     const data_base64 = await fileToBase64(file);
-    // PDFs get a rendered first-page thumbnail; images use a blob URL.
     let preview_url: string;
     if (isPdf) {
       const { generatePdfThumbnail } = await import("../../utils/pdfThumbnail");
       preview_url = await generatePdfThumbnail(await file.arrayBuffer()).catch(() => "");
-    } else {
+      if (!preview_url) return;
+    } else if (isImage) {
       preview_url = URL.createObjectURL(file);
+    } else {
+      preview_url = "";
     }
-    if (!preview_url) return; // PDF thumbnail generation failed
     const att: PendingAttachment = {
       id: crypto.randomUUID(),
       filename,
@@ -2041,6 +2056,7 @@ function ChatInputArea({
       data_base64,
       preview_url,
       size_bytes: file.size,
+      text_content: isText ? (textContent ?? null) : null,
     };
     setPendingAttachments((prev) => {
       if (prev.length >= MAX_ATTACHMENTS) {
@@ -2083,7 +2099,7 @@ function ChatInputArea({
       for (const a of attachmentsPrefill) {
         const bytes = base64ToBytes(a.data_base64);
         const blob = new Blob([bytes], { type: a.media_type });
-        await addAttachment(blob, a.filename);
+        await addAttachment(blob, a.filename, a.text_content ?? undefined);
       }
     })().catch((e) => console.error("Failed to restore attachment prefill:", e));
   }, [attachmentsPrefill, setAttachmentsPrefill, addAttachment]);
@@ -2094,6 +2110,9 @@ function ChatInputArea({
       if (!items) return;
 
       for (const item of items) {
+        // Skip text/plain — pasting text should insert into the textarea,
+        // not create a file attachment.
+        if (item.type === "text/plain") continue;
         if (SUPPORTED_ATTACHMENT_TYPES.has(item.type)) {
           e.preventDefault();
           const file = item.getAsFile();
@@ -2144,7 +2163,7 @@ function ChatInputArea({
                   if (cancelled) return;
                   const bytes = base64ToBytes(result.data_base64);
                   const blob = new Blob([bytes], { type: result.media_type });
-                  addAttachmentRef.current(blob, result.filename);
+                  addAttachmentRef.current(blob, result.filename, result.text_content ?? undefined);
                 })
                 .catch((err) =>
                   console.warn("Skipped dropped file:", err),
@@ -2171,15 +2190,7 @@ function ChatInputArea({
   }, [isRemote]); // Stable dep — no re-registration on callback changes
 
   const handleAttachClick = useCallback(async () => {
-    const selected = await open({
-      multiple: true,
-      filters: [
-        {
-          name: "Images & Documents",
-          extensions: ["png", "jpg", "jpeg", "gif", "webp", "pdf"],
-        },
-      ],
-    });
+    const selected = await open({ multiple: true });
     if (!selected) return;
     const paths = Array.isArray(selected) ? selected : [selected];
     for (const filePath of paths) {
@@ -2187,7 +2198,7 @@ function ChatInputArea({
         const result = await readFileAsBase64(filePath);
         const bytes = base64ToBytes(result.data_base64);
         const blob = new Blob([bytes], { type: result.media_type });
-        await addAttachment(blob, result.filename);
+        await addAttachment(blob, result.filename, result.text_content ?? undefined);
       } catch (err) {
         console.error("Failed to read file:", err);
       }
@@ -2210,6 +2221,7 @@ function ChatInputArea({
             filename: a.filename,
             media_type: a.media_type,
             data_base64: a.data_base64,
+            text_content: a.text_content ?? undefined,
           }))
         : undefined;
     onSend(chatInput, files, attachmentPayload);
@@ -2379,7 +2391,19 @@ function ChatInputArea({
         <div className={styles.attachmentStrip}>
           {pendingAttachments.map((att) => (
             <div key={att.id} className={styles.attachmentThumb} title={att.filename}>
-              <img src={att.preview_url} alt={att.filename} />
+              {att.text_content != null ? (
+                <div className={styles.textFileBadge}>
+                  <FileText size={16} />
+                  <span className={styles.textFileName}>{att.filename}</span>
+                  <span className={styles.textFileSize}>
+                    {att.size_bytes < 1024
+                      ? `${att.size_bytes} B`
+                      : `${(att.size_bytes / 1024).toFixed(0)} KB`}
+                  </span>
+                </div>
+              ) : (
+                <img src={att.preview_url} alt={att.filename} />
+              )}
               <button
                 className={styles.attachmentRemove}
                 onClick={() => removeAttachment(att.id)}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -2057,7 +2057,7 @@ function ChatInputArea({
       data_base64,
       preview_url,
       size_bytes: file.size,
-      text_content: isText ? (textContent ?? null) : null,
+      text_content: isText ? (textContent ?? await file.text()) : null,
     };
     setPendingAttachments((prev) => {
       if (prev.length >= MAX_ATTACHMENTS) {
@@ -2392,7 +2392,7 @@ function ChatInputArea({
         <div className={styles.attachmentStrip}>
           {pendingAttachments.map((att) => (
             <div key={att.id} className={styles.attachmentThumb} title={att.filename}>
-              {att.text_content != null ? (
+              {isTextFile(att.media_type) ? (
                 <div className={styles.textFileBadge}>
                   <FileText size={16} />
                   <span className={styles.textFileName}>{att.filename}</span>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -776,6 +776,7 @@ export function ChatPanel() {
         filename: a.filename,
         media_type: a.media_type,
         data_base64: a.data_base64,
+        text_content: a.text_content ?? null,
         width: null,
         height: null,
         size_bytes: Math.ceil(a.data_base64.length * 0.75),

--- a/src/ui/src/components/chat/attachments.test.ts
+++ b/src/ui/src/components/chat/attachments.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
   SUPPORTED_IMAGE_TYPES,
   SUPPORTED_DOCUMENT_TYPES,
+  SUPPORTED_TEXT_TYPES,
   SUPPORTED_ATTACHMENT_TYPES,
   MAX_IMAGE_SIZE,
   MAX_PDF_SIZE,
+  MAX_TEXT_SIZE,
   MAX_ATTACHMENTS,
   maxSizeFor,
+  isTextFile,
 } from "../../utils/attachmentValidation";
 
 function isSupported(mimeType: string): boolean {
@@ -26,7 +29,8 @@ function validateSize(mimeType: string, sizeBytes: number): boolean {
 }
 
 /** Mirrors the content block type selection in build_stdin_message. */
-function contentBlockType(mimeType: string): "image" | "document" {
+function contentBlockType(mimeType: string): "image" | "document" | "text" {
+  if (isTextFile(mimeType)) return "text";
   return mimeType === "application/pdf" ? "document" : "image";
 }
 
@@ -42,20 +46,28 @@ describe("attachment type validation", () => {
     expect(isSupported("application/pdf")).toBe(true);
   });
 
+  it("accepts text/plain files", () => {
+    expect(isSupported("text/plain")).toBe(true);
+  });
+
   it("rejects unsupported file types", () => {
     expect(isSupported("image/svg+xml")).toBe(false);
-    expect(isSupported("text/plain")).toBe(false);
     expect(isSupported("image/bmp")).toBe(false);
     expect(isSupported("video/mp4")).toBe(false);
     expect(isSupported("application/json")).toBe(false);
     expect(isSupported("application/zip")).toBe(false);
   });
 
-  it("classifies images vs documents", () => {
+  it("classifies images vs documents vs text", () => {
     expect(isImage("image/png")).toBe(true);
     expect(isDocument("image/png")).toBe(false);
+    expect(isTextFile("image/png")).toBe(false);
     expect(isImage("application/pdf")).toBe(false);
     expect(isDocument("application/pdf")).toBe(true);
+    expect(isTextFile("application/pdf")).toBe(false);
+    expect(isImage("text/plain")).toBe(false);
+    expect(isDocument("text/plain")).toBe(false);
+    expect(isTextFile("text/plain")).toBe(true);
   });
 });
 
@@ -75,10 +87,17 @@ describe("attachment size validation", () => {
     expect(validateSize("application/pdf", MAX_PDF_SIZE + 1)).toBe(false);
   });
 
+  it("enforces text file size limit at 500 KB", () => {
+    expect(validateSize("text/plain", 100 * 1024)).toBe(true);
+    expect(validateSize("text/plain", MAX_TEXT_SIZE)).toBe(true);
+    expect(validateSize("text/plain", MAX_TEXT_SIZE + 1)).toBe(false);
+  });
+
   it("applies correct limit per type", () => {
     const size = 10 * 1024 * 1024; // 10 MB — valid for PDF, invalid for image
     expect(validateSize("application/pdf", size)).toBe(true);
     expect(validateSize("image/png", size)).toBe(false);
+    expect(validateSize("text/plain", size)).toBe(false);
   });
 });
 
@@ -100,6 +119,28 @@ describe("content block type mapping", () => {
 
   it("uses document blocks for PDFs", () => {
     expect(contentBlockType("application/pdf")).toBe("document");
+  });
+
+  it("uses text blocks for text files", () => {
+    expect(contentBlockType("text/plain")).toBe("text");
+  });
+});
+
+describe("text file helpers", () => {
+  it("isTextFile identifies text MIME types", () => {
+    expect(isTextFile("text/plain")).toBe(true);
+    expect(isTextFile("image/png")).toBe(false);
+    expect(isTextFile("application/pdf")).toBe(false);
+    expect(isTextFile("application/json")).toBe(false);
+  });
+
+  it("maxSizeFor returns 500 KB for text files", () => {
+    expect(maxSizeFor("text/plain")).toBe(500 * 1024);
+  });
+
+  it("SUPPORTED_TEXT_TYPES contains text/plain", () => {
+    expect(SUPPORTED_TEXT_TYPES.has("text/plain")).toBe(true);
+    expect(SUPPORTED_TEXT_TYPES.size).toBe(1);
   });
 });
 

--- a/src/ui/src/types/chat.ts
+++ b/src/ui/src/types/chat.ts
@@ -15,13 +15,14 @@ export interface ChatMessage {
   cache_creation_tokens: number | null;
 }
 
-/** A persisted image attachment returned from the backend (base64-encoded). */
+/** A persisted attachment returned from the backend (base64-encoded). */
 export interface ChatAttachment {
   id: string;
   message_id: string;
   filename: string;
   media_type: string;
   data_base64: string;
+  text_content: string | null;
   width: number | null;
   height: number | null;
   size_bytes: number;
@@ -32,6 +33,7 @@ export interface AttachmentInput {
   filename: string;
   media_type: string;
   data_base64: string;
+  text_content?: string;
 }
 
 /** A staged attachment in the frontend before the message is sent. */
@@ -42,4 +44,5 @@ export interface PendingAttachment {
   data_base64: string;
   preview_url: string; // blob: URL for thumbnail display
   size_bytes: number;
+  text_content: string | null;
 }

--- a/src/ui/src/utils/attachmentValidation.ts
+++ b/src/ui/src/utils/attachmentValidation.ts
@@ -9,10 +9,14 @@ export const SUPPORTED_IMAGE_TYPES = new Set([
 /** Supported document MIME types. */
 export const SUPPORTED_DOCUMENT_TYPES = new Set(["application/pdf"]);
 
-/** All supported attachment MIME types (images + documents). */
+/** Supported text file MIME types. */
+export const SUPPORTED_TEXT_TYPES = new Set(["text/plain"]);
+
+/** All supported attachment MIME types (images + documents + text). */
 export const SUPPORTED_ATTACHMENT_TYPES = new Set([
   ...SUPPORTED_IMAGE_TYPES,
   ...SUPPORTED_DOCUMENT_TYPES,
+  ...SUPPORTED_TEXT_TYPES,
 ]);
 
 /** Max raw file size for an image attachment (3.75 MB -> ~5 MB base64). */
@@ -21,10 +25,20 @@ export const MAX_IMAGE_SIZE = 3.75 * 1024 * 1024;
 /** Max raw file size for a PDF attachment (20 MB — Anthropic API limit). */
 export const MAX_PDF_SIZE = 20 * 1024 * 1024;
 
+/** Max raw file size for a text file attachment (500 KB). */
+export const MAX_TEXT_SIZE = 500 * 1024;
+
 /** Max number of attachments per message. */
 export const MAX_ATTACHMENTS = 5;
 
 /** Get the size limit for a given MIME type. */
 export function maxSizeFor(mimeType: string): number {
-  return SUPPORTED_DOCUMENT_TYPES.has(mimeType) ? MAX_PDF_SIZE : MAX_IMAGE_SIZE;
+  if (SUPPORTED_DOCUMENT_TYPES.has(mimeType)) return MAX_PDF_SIZE;
+  if (SUPPORTED_TEXT_TYPES.has(mimeType)) return MAX_TEXT_SIZE;
+  return MAX_IMAGE_SIZE;
+}
+
+/** Whether a MIME type represents a text file attachment. */
+export function isTextFile(mimeType: string): boolean {
+  return SUPPORTED_TEXT_TYPES.has(mimeType);
 }


### PR DESCRIPTION
## Summary

Extends the chat attachment system to accept **any text-based file type** (source code, JSON, YAML, Markdown, logs, CSV, config files, etc.) alongside the existing image and PDF support. Unknown file extensions are auto-detected as text via UTF-8 validation with null-byte binary detection — no extension allowlist needed.

**Key changes across the stack:**
- **Rust agent layer**: Renamed `ImageAttachment` → `FileAttachment` with `text_content`/`filename` fields. `build_stdin_message` now emits `type: "text"` content blocks for text files (formatted with filename labels in code fences).
- **Rust command layer**: `read_file_as_base64` auto-detects text files for unknown extensions (500 KB limit, binary rejected). `send_chat_message` validates `text/plain` alongside images and PDFs.
- **Frontend**: File picker accepts all files (backend validates). Drag-and-drop works for any file. Paste handler explicitly skips `text/plain` to preserve normal text paste. Text files render as filename badges (with icon + size) in both the pending attachment strip and message history.

```mermaid
flowchart LR
    A[User drops/picks file] --> B{Known type?}
    B -- Image --> C[Image content block]
    B -- PDF --> D[Document content block]
    B -- Unknown ext --> E{UTF-8 valid?}
    E -- Yes --> F[Text content block]
    E -- No/Binary --> G[Reject with error]
```

## Complexity Notes

- **Binary detection heuristic**: Uses the same null-byte-in-first-8KB check as the existing `file_expand.rs` for @-file mentions. This is fast and reliable for real-world files but could theoretically misclassify a binary file that happens to have no nulls in its first 8 KB. The 500 KB size cap limits the blast radius.
- **Paste handler exclusion**: `text/plain` is now in `SUPPORTED_ATTACHMENT_TYPES` but explicitly skipped in the paste handler to avoid intercepting normal text paste. This is intentional — text files can only be attached via drag-and-drop or the file picker, where we have actual file paths.

## Test Steps

1. **Text file drag-and-drop**: Drag a `.rs`, `.json`, `.py`, or `.yaml` file into the chat input → should show a filename badge (icon + name + size) in the attachment strip
2. **Image drag-and-drop**: Drag a `.png` file → should show image thumbnail (existing behavior preserved)
3. **PDF drag-and-drop**: Drag a `.pdf` file → should show PDF thumbnail (existing behavior preserved)
4. **Binary file rejection**: Drag a `.zip` or `.exe` file → should be silently rejected (check console for warning)
5. **File picker**: Click the attach button → file picker should show all files (no filter) → select a text file → filename badge appears
6. **Paste text**: Copy text and paste into the textarea → should insert as text, NOT create attachment
7. **Paste image**: Copy an image and paste → should create image attachment (existing behavior)
8. **Send with text attachment**: Attach a text file and send a message → verify the agent receives the file content
9. **Message history**: Reload the workspace → text file attachments should appear as filename badges in the message history
10. **Size limit**: Try attaching a text file > 500 KB → should be rejected with an error

## Checklist

- [x] Tests added/updated (3 new Rust tests for `build_stdin_message` with text files; frontend tests updated for `text/plain` support, `isTextFile`, `maxSizeFor`, content block type mapping)
- [x] No documentation changes needed (no new public API)

Closes #337