### PR TITLE
feat(chat): honor 200k context window for non-[1m] model variants

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -48,6 +48,7 @@ pub async fn handle_request(
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let chrome_enabled = params.get("chrome_enabled").and_then(|v| v.as_bool());
+            let disable_1m_context = params.get("disable_1m_context").and_then(|v| v.as_bool());
             let mentioned_files: Option<Vec<String>> = params
                 .get("mentioned_files")
                 .and_then(|v| serde_json::from_value(v.clone()).ok());
@@ -63,6 +64,7 @@ pub async fn handle_request(
                 plan_mode,
                 effort,
                 chrome_enabled,
+                disable_1m_context,
                 mentioned_files,
             )
             .await
@@ -320,6 +322,7 @@ async fn handle_send_chat_message(
     plan_mode: Option<bool>,
     effort: Option<String>,
     chrome_enabled: Option<bool>,
+    disable_1m_context: Option<bool>,
     mentioned_files: Option<Vec<String>>,
 ) -> Result<serde_json::Value, String> {
     let db = open_db(state)?;
@@ -403,7 +406,7 @@ async fn handle_send_chat_message(
         effort,
         chrome_enabled: chrome_enabled.unwrap_or(false),
         mcp_config,
-        disable_1m_context: false,
+        disable_1m_context: disable_1m_context.unwrap_or(false),
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -403,6 +403,7 @@ async fn handle_send_chat_message(
         effort,
         chrome_enabled: chrome_enabled.unwrap_or(false),
         mcp_config,
+        disable_1m_context: false,
     };
 
     // Expand @-file mentions into inline file content for the agent prompt.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -445,11 +445,13 @@ pub async fn send_chat_message(
         )
     {
         eprintln!(
-            "[chat] session flags drifted (plan_mode {} -> {}, allowed_tools changed: {}, exited_plan: {}) — tearing down persistent session for {workspace_id}",
+            "[chat] session flags drifted (plan_mode {} -> {}, allowed_tools changed: {}, exited_plan: {}, disable_1m_context {} -> {}) — tearing down persistent session for {workspace_id}",
             session.session_plan_mode,
             agent_settings.plan_mode,
             session.session_allowed_tools != allowed_tools,
             session.session_exited_plan,
+            session.session_disable_1m_context,
+            agent_settings.disable_1m_context,
         );
         // Resolve any pending permission requests against the doomed process
         // before we kill it, so the next turn doesn't carry stale tool_use_ids.
@@ -2167,6 +2169,58 @@ mod tests {
         assert!(!persistent_session_flags_drifted(
             session(false, &tools, true),
             requested(false, &tools),
+        ));
+    }
+
+    #[test]
+    fn drift_when_disable_1m_context_flips() {
+        // Switching between a 200k model SKU (disable_1m_context=true) and a
+        // 1M SKU (false) must respawn: CLAUDE_CODE_DISABLE_1M_CONTEXT is baked
+        // into the subprocess env at spawn and cannot be changed per-turn.
+        let tools = s(&["Read", "Write"]);
+        assert!(persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                exited_plan: false,
+                disable_1m_context: false,
+            },
+            RequestedFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                disable_1m_context: true,
+            },
+        ));
+        assert!(persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                exited_plan: false,
+                disable_1m_context: true,
+            },
+            RequestedFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                disable_1m_context: false,
+            },
+        ));
+    }
+
+    #[test]
+    fn no_drift_when_disable_1m_context_matches() {
+        let tools = s(&["Read"]);
+        assert!(!persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                exited_plan: false,
+                disable_1m_context: true,
+            },
+            RequestedFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                disable_1m_context: true,
+            },
         ));
     }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -55,6 +55,7 @@ struct SessionFlags<'a> {
     plan_mode: bool,
     allowed_tools: &'a [String],
     exited_plan: bool,
+    disable_1m_context: bool,
 }
 
 /// Flags the next turn is asking for. Compared against [`SessionFlags`] to
@@ -62,6 +63,7 @@ struct SessionFlags<'a> {
 struct RequestedFlags<'a> {
     plan_mode: bool,
     allowed_tools: &'a [String],
+    disable_1m_context: bool,
 }
 
 /// Detect whether the persistent session's spawn-time flags have drifted
@@ -81,6 +83,7 @@ fn persistent_session_flags_drifted(
 ) -> bool {
     session.plan_mode != requested.plan_mode
         || session.allowed_tools != requested.allowed_tools
+        || session.disable_1m_context != requested.disable_1m_context
         || (session.plan_mode && session.exited_plan)
 }
 
@@ -157,6 +160,7 @@ pub async fn send_chat_message(
     plan_mode: Option<bool>,
     effort: Option<String>,
     chrome_enabled: Option<bool>,
+    disable_1m_context: Option<bool>,
     attachments: Option<Vec<AttachmentInput>>,
     app: AppHandle,
     state: State<'_, AppState>,
@@ -316,6 +320,7 @@ pub async fn send_chat_message(
                 mcp_config_dirty: false,
                 session_plan_mode: false,
                 session_allowed_tools: Vec::new(),
+                session_disable_1m_context: false,
                 pending_permissions: std::collections::HashMap::new(),
                 session_exited_plan: false,
             };
@@ -332,6 +337,7 @@ pub async fn send_chat_message(
             mcp_config_dirty: false,
             session_plan_mode: false,
             session_allowed_tools: Vec::new(),
+            session_disable_1m_context: false,
             pending_permissions: std::collections::HashMap::new(),
             session_exited_plan: false,
         }
@@ -412,6 +418,7 @@ pub async fn send_chat_message(
         effort,
         chrome_enabled: chrome_enabled.unwrap_or(false),
         mcp_config,
+        disable_1m_context: disable_1m_context.unwrap_or(false),
     };
 
     // `--permission-mode` and `--allowedTools` are baked into the persistent
@@ -428,10 +435,12 @@ pub async fn send_chat_message(
                 plan_mode: session.session_plan_mode,
                 allowed_tools: &session.session_allowed_tools,
                 exited_plan: session.session_exited_plan,
+                disable_1m_context: session.session_disable_1m_context,
             },
             RequestedFlags {
                 plan_mode: agent_settings.plan_mode,
                 allowed_tools: &allowed_tools,
+                disable_1m_context: agent_settings.disable_1m_context,
             },
         )
     {
@@ -568,6 +577,7 @@ pub async fn send_chat_message(
                 session.session_id = final_sid;
                 session.session_plan_mode = agent_settings.plan_mode;
                 session.session_allowed_tools = allowed_tools.clone();
+                session.session_disable_1m_context = agent_settings.disable_1m_context;
                 // Fresh process — any prior ExitPlanMode observation belongs
                 // to the dead session. Keep this in lockstep with the
                 // spawn-time flags above so the latch can't leak across
@@ -637,6 +647,7 @@ pub async fn send_chat_message(
         session.session_id = final_sid.clone();
         session.session_plan_mode = agent_settings.plan_mode;
         session.session_allowed_tools = allowed_tools.clone();
+        session.session_disable_1m_context = agent_settings.disable_1m_context;
         // See the sibling reset above — fresh process, fresh latch.
         session.session_exited_plan = false;
         let _ = db.save_agent_session(&workspace_id, &final_sid, session.turn_count);
@@ -2035,6 +2046,7 @@ mod tests {
             plan_mode,
             allowed_tools,
             exited_plan,
+            disable_1m_context: false,
         }
     }
 
@@ -2042,6 +2054,7 @@ mod tests {
         RequestedFlags {
             plan_mode,
             allowed_tools,
+            disable_1m_context: false,
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -69,6 +69,11 @@ pub struct AgentSessionState {
     /// A mismatch on the next turn (e.g. permission level changed, or plan
     /// approval elevates access) forces a teardown + respawn.
     pub session_allowed_tools: Vec<String>,
+    /// `CLAUDE_CODE_DISABLE_1M_CONTEXT` value baked into the current
+    /// `persistent_session` at spawn. A mismatch on the next turn (user
+    /// switched from 200k to 1M model variant, or vice versa) forces a
+    /// teardown + respawn so the env var matches the new selection.
+    pub session_disable_1m_context: bool,
     /// Outstanding `can_use_tool` control requests awaiting a `control_response`,
     /// keyed by tool_use_id. See [`PendingPermission`].
     pub pending_permissions: HashMap<String, PendingPermission>,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -676,6 +676,7 @@ mod tests {
             mcp_config_dirty: false,
             session_plan_mode: false,
             session_allowed_tools: Vec::new(),
+            session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
             session_exited_plan: false,
         }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -339,6 +339,11 @@ pub struct AgentSettings {
     /// turn since each `claude` process is independent and doesn't inherit
     /// MCP connections from previous turns.
     pub mcp_config: Option<String>,
+    /// When true, set `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` on the spawned CLI
+    /// process so the Max-plan auto-upgrade to 1M is suppressed and the
+    /// selected model runs at its 200k window. Derived frontend-side from
+    /// the model registry's `contextWindowTokens`.
+    pub disable_1m_context: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -717,6 +722,10 @@ pub async fn run_turn(
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
+    if settings.disable_1m_context {
+        cmd.env("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1");
+    }
+
     if let Some(env) = ws_env {
         env.apply(&mut cmd);
     }
@@ -904,6 +913,10 @@ impl PersistentSession {
         }
         cmd.env_remove("CLAUDECODE");
         cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+        if settings.disable_1m_context {
+            cmd.env("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1");
+        }
 
         if let Some(env) = ws_env {
             env.apply(&mut cmd);
@@ -2595,6 +2608,7 @@ mod tests {
             effort: Some("high".to_string()),
             chrome_enabled: true,
             mcp_config: Some(r#"{"mcpServers":{}}"#.to_string()),
+            disable_1m_context: false,
         };
         let args = build_persistent_args(
             "sess-1",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -722,6 +722,7 @@ pub async fn run_turn(
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
+    cmd.env_remove("CLAUDE_CODE_DISABLE_1M_CONTEXT");
     if settings.disable_1m_context {
         cmd.env("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1");
     }
@@ -914,6 +915,7 @@ impl PersistentSession {
         cmd.env_remove("CLAUDECODE");
         cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
 
+        cmd.env_remove("CLAUDE_CODE_DISABLE_1M_CONTEXT");
         if settings.disable_1m_context {
             cmd.env("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1");
         }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -29,6 +29,7 @@ import {
   forkWorkspaceAtCheckpoint,
 } from "../../services/tauri";
 import { applySelectedModel } from "./applySelectedModel";
+import { MODELS } from "./modelRegistry";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { findLatestPlanFilePath } from "./planFilePath";
 import type { PermissionLevel } from "../../stores/useAppStore";
@@ -81,6 +82,12 @@ import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../../utils/spinnerFrames";
 import { formatTokens } from "./formatTokens";
 
 /** Format a duration in seconds as "15s" or "2m 34s". */
+function shouldDisable1mContext(modelId: string | null): boolean {
+  if (!modelId) return false;
+  const entry = MODELS.find((m) => m.id === modelId);
+  return entry ? entry.contextWindowTokens < 1_000_000 : false;
+}
+
 function formatElapsedSeconds(secs: number): string {
   if (secs < 60) return `${secs}s`;
   const m = Math.floor(secs / 60);
@@ -787,17 +794,20 @@ export function ChatPanel() {
       if (ws?.remote_connection_id) {
         // Route to remote server via WebSocket.
         const state = useAppStore.getState();
+        const selectedModel = state.selectedModel[selectedWorkspaceId] || null;
+        const disable1mContext = shouldDisable1mContext(selectedModel);
         await sendRemoteCommand(ws.remote_connection_id, "send_chat_message", {
           workspace_id: selectedWorkspaceId,
           content: trimmed,
           mentioned_files: mentionedFilesArray,
           permission_level: permissionLevel,
-          model: state.selectedModel[selectedWorkspaceId] || null,
+          model: selectedModel,
           fast_mode: state.fastMode[selectedWorkspaceId] || false,
           thinking_enabled: state.thinkingEnabled[selectedWorkspaceId] || false,
           plan_mode: state.planMode[selectedWorkspaceId] || false,
           effort: state.effortLevel[selectedWorkspaceId] || null,
           chrome_enabled: state.chromeEnabled[selectedWorkspaceId] || false,
+          disable_1m_context: disable1mContext,
         });
       } else {
         const state = useAppStore.getState();
@@ -807,6 +817,7 @@ export function ChatPanel() {
         const planMode = state.planMode[selectedWorkspaceId] || false;
         const effort = state.effortLevel[selectedWorkspaceId] || undefined;
         const chromeEnabled = state.chromeEnabled[selectedWorkspaceId] || false;
+        const disable1mContext = shouldDisable1mContext(model ?? null);
         await sendChatMessage(
           selectedWorkspaceId,
           trimmed,
@@ -818,6 +829,7 @@ export function ChatPanel() {
           planMode || undefined,
           effort,
           chromeEnabled || undefined,
+          disable1mContext || undefined,
           attachments,
           optimisticMsgId,
         );

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -81,13 +81,13 @@ import caretStyles from "./caret.module.css";
 import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../../utils/spinnerFrames";
 import { formatTokens } from "./formatTokens";
 
-/** Format a duration in seconds as "15s" or "2m 34s". */
 function shouldDisable1mContext(modelId: string | null): boolean {
   if (!modelId) return false;
   const entry = MODELS.find((m) => m.id === modelId);
   return entry ? entry.contextWindowTokens < 1_000_000 : false;
 }
 
+/** Format a duration in seconds as "15s" or "2m 34s". */
 function formatElapsedSeconds(secs: number): string {
   if (secs < 60) return `${secs}s`;
   const m = Math.floor(secs / 60);

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -407,6 +407,7 @@ export function sendChatMessage(
   planMode?: boolean,
   effort?: string,
   chromeEnabled?: boolean,
+  disable1mContext?: boolean,
   attachments?: AttachmentInput[],
   messageId?: string,
 ): Promise<void> {
@@ -422,6 +423,7 @@ export function sendChatMessage(
     planMode: planMode ?? null,
     effort: effort ?? null,
     chromeEnabled: chromeEnabled ?? null,
+    disable1mContext: disable1mContext ?? null,
     attachments: attachments ?? null,
   });
 }


### PR DESCRIPTION
## Summary
- The Claude CLI auto-upgrades Opus to a 1M context window on Max/Team/Enterprise plans, even when `--model claude-opus-4-7` is passed. The ContextMeter's 200k registry entry was therefore inaccurate — on a Max plan, a session sat at 223k/200k with no compaction because the CLI was silently running at 1M.
- Thread `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` to the spawned `claude` subprocess when the selected model's registry entry has `contextWindowTokens < 1_000_000`. The frontend derives the flag from `MODELS` (single source of truth) and passes it through the `send_chat_message` Tauri command → `AgentSettings` → both `run_turn` and `PersistentSession::start`.
- Added `disable_1m_context` to `SessionFlags` / `RequestedFlags` so drift detection tears down and respawns the persistent session when a user switches between 200k and 1M variants mid-session — same mechanism that already handles `plan_mode` / `allowedTools` drift.

## Test plan
- [x] `cargo clippy --workspace --all-targets` — clean (one pre-existing unrelated warning)
- [x] `cargo test -p claudette --lib` — 496 pass
- [x] `cargo test -p claudette-tauri` — 114 pass (one pre-existing flaky `usage::tests::stale_cache_triggers_refetch_but_falls_back` that passes in isolation)
- [x] `bunx tsc --noEmit` in `src/ui` — clean
- [x] `bun run test` in `src/ui` — 579 pass
- [ ] Manual: pick "Opus 4.7" (200k) and push past ~160k → auto-compaction fires (verified on branch via raw CLI stream logs showing `compact_boundary` with `trigger:"auto"`, `pre_tokens:167814`, `post_tokens:13420`)
- [ ] Manual: pick "Opus 4.7 1M" → env var stays unset, 1M window preserved
- [ ] Manual: switch from 200k → 1M mid-session → persistent session is torn down and respawned cleanly (observable via new pid and session_id after the next turn)