### PR TITLE
fix(chat): gate first-turn auto-rename on persistent workspace flag

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -677,6 +677,27 @@ pub async fn send_chat_message(
         .and_then(|r| r.branch_rename_preferences.clone());
     let rename_ws_env = ws_env.clone();
 
+    // Atomically claim the one-shot auto-rename slot here — on the calling
+    // task's existing DB handle — so the spawned bridge doesn't need to
+    // reopen the database just to flip a flag, and so any SQLite error
+    // surfaces as a visible log rather than silently skipping the rename.
+    // The flag is a persistent per-workspace marker; a session that restarts
+    // for any reason (app reopen, stop_agent, spawn failure, `!got_init`
+    // early exit) can't re-trigger a rename on a later prompt because the
+    // claim has already been taken. The flag tracks the claim, not the
+    // outcome: a Haiku/git failure below intentionally does not release it.
+    let claimed_rename = if has_repo {
+        match db.claim_branch_auto_rename(&workspace_id) {
+            Ok(claimed) => claimed,
+            Err(e) => {
+                eprintln!("[chat] claim_branch_auto_rename failed for {workspace_id}: {e}");
+                false
+            }
+        }
+    } else {
+        false
+    };
+
     crate::tray::rebuild_tray(&app);
 
     // Bridge: read from mpsc receiver, emit Tauri events.
@@ -687,18 +708,6 @@ pub async fn send_chat_message(
     let repo_id_for_mcp = ws.repository_id.clone();
     drop(ws_env); // consumed by rename_ws_env; notification path rebuilds from DB
     tokio::spawn(async move {
-        // Auto-rename the branch via Haiku exactly once per workspace — on
-        // the first prompt. The gate is a persistent per-workspace flag
-        // (`workspaces.branch_auto_renamed`) claimed via a conditional
-        // UPDATE, so a session that restarts for any reason (app reopen,
-        // stop_agent, spawn failure, !got_init early exit) can't re-trigger
-        // a rename based on a later prompt. `claim_branch_auto_rename`
-        // returns true only for the caller that flips 0→1.
-        let claimed_rename = has_repo
-            && Database::open(&db_path)
-                .ok()
-                .and_then(|db| db.claim_branch_auto_rename(&ws_id).ok())
-                .unwrap_or(false);
         if claimed_rename {
             let ws_id2 = ws_id.clone();
             let wt_path2 = wt_path.clone();

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -687,11 +687,19 @@ pub async fn send_chat_message(
     let repo_id_for_mcp = ws.repository_id.clone();
     drop(ws_env); // consumed by rename_ws_env; notification path rebuilds from DB
     tokio::spawn(async move {
-        // On the first turn, spawn a background task to auto-rename the branch
-        // using Haiku. Gate on turn count (not persistent_session) because
-        // persistent_session is in-memory only and is None after app restart
-        // even for resumed sessions.
-        if saved_turn_count <= 1 && has_repo {
+        // Auto-rename the branch via Haiku exactly once per workspace — on
+        // the first prompt. The gate is a persistent per-workspace flag
+        // (`workspaces.branch_auto_renamed`) claimed via a conditional
+        // UPDATE, so a session that restarts for any reason (app reopen,
+        // stop_agent, spawn failure, !got_init early exit) can't re-trigger
+        // a rename based on a later prompt. `claim_branch_auto_rename`
+        // returns true only for the caller that flips 0→1.
+        let claimed_rename = has_repo
+            && Database::open(&db_path)
+                .ok()
+                .and_then(|db| db.claim_branch_auto_rename(&ws_id).ok())
+                .unwrap_or(false);
+        if claimed_rename {
             let ws_id2 = ws_id.clone();
             let wt_path2 = wt_path.clone();
             let old_branch2 = rename_old_branch.clone();

--- a/src/db.rs
+++ b/src/db.rs
@@ -439,12 +439,16 @@ impl Database {
             // spuriously whenever the in-memory session was wiped — on
             // `stop_agent`, spawn failure, or `!got_init` CLI exits — letting
             // a later prompt rename a workspace that had already had its
-            // first-prompt rename. Backfill existing workspaces with prior
-            // chat history so an upgrade doesn't rename them on the next turn.
+            // first-prompt rename. The flag tracks the one-shot *claim*, not
+            // the rename outcome: it's set on the prompt that reserves the
+            // slot, so a Haiku/git failure leaves the workspace with its
+            // original name but doesn't retry on later prompts. Backfill
+            // existing workspaces with prior chat history so an upgrade
+            // doesn't rename them on the next turn.
             self.conn.execute_batch(
-                "ALTER TABLE workspaces ADD COLUMN branch_auto_renamed INTEGER NOT NULL DEFAULT 0;
+                "ALTER TABLE workspaces ADD COLUMN branch_auto_rename_claimed INTEGER NOT NULL DEFAULT 0;
 
-                 UPDATE workspaces SET branch_auto_renamed = 1
+                 UPDATE workspaces SET branch_auto_rename_claimed = 1
                    WHERE id IN (SELECT DISTINCT workspace_id FROM chat_messages);
 
                  PRAGMA user_version = 23;",
@@ -1054,22 +1058,24 @@ impl Database {
     /// caller should proceed with the rename); `false` if the flag was already
     /// set or the workspace doesn't exist. The conditional UPDATE is the
     /// race-safe primitive that prevents two concurrent turns from both firing
-    /// a Haiku rename on the same workspace.
+    /// a Haiku rename on the same workspace. The flag tracks the claim, not
+    /// the outcome — a later rename failure intentionally does not "release"
+    /// it, matching the product rule that rename is a first-prompt-only event.
     pub fn claim_branch_auto_rename(&self, id: &str) -> Result<bool, rusqlite::Error> {
         let rows = self.conn.execute(
-            "UPDATE workspaces SET branch_auto_renamed = 1
-             WHERE id = ?1 AND branch_auto_renamed = 0",
+            "UPDATE workspaces SET branch_auto_rename_claimed = 1
+             WHERE id = ?1 AND branch_auto_rename_claimed = 0",
             params![id],
         )?;
         Ok(rows == 1)
     }
 
-    /// Peek at whether the first-turn auto-rename has already been claimed
-    /// for this workspace. Returns `false` for nonexistent workspaces so
-    /// callers can treat missing rows as "nothing to do".
-    pub fn is_branch_auto_renamed(&self, id: &str) -> Result<bool, rusqlite::Error> {
+    /// Peek at whether the first-turn auto-rename slot has already been
+    /// claimed for this workspace. Returns `false` for nonexistent workspaces
+    /// so callers can treat missing rows as "nothing to do".
+    pub fn is_branch_auto_rename_claimed(&self, id: &str) -> Result<bool, rusqlite::Error> {
         match self.conn.query_row(
-            "SELECT branch_auto_renamed FROM workspaces WHERE id = ?1",
+            "SELECT branch_auto_rename_claimed FROM workspaces WHERE id = ?1",
             params![id],
             |row| {
                 let v: i64 = row.get(0)?;
@@ -2121,21 +2127,21 @@ mod tests {
     }
 
     #[test]
-    fn test_is_branch_auto_renamed_defaults_false() {
+    fn test_is_branch_auto_rename_claimed_defaults_false() {
         let db = Database::open_in_memory().unwrap();
         db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
             .unwrap();
         db.insert_workspace(&make_workspace("w1", "r1", "fresh"))
             .unwrap();
-        assert!(!db.is_branch_auto_renamed("w1").unwrap());
+        assert!(!db.is_branch_auto_rename_claimed("w1").unwrap());
     }
 
     #[test]
-    fn test_is_branch_auto_renamed_missing_returns_false() {
-        // Nonexistent workspaces should read as "not renamed" rather than
+    fn test_is_branch_auto_rename_claimed_missing_returns_false() {
+        // Nonexistent workspaces should read as "not claimed" rather than
         // erroring so callers can treat the missing row as a no-op.
         let db = Database::open_in_memory().unwrap();
-        assert!(!db.is_branch_auto_renamed("no-such-id").unwrap());
+        assert!(!db.is_branch_auto_rename_claimed("no-such-id").unwrap());
     }
 
     #[test]
@@ -2147,7 +2153,7 @@ mod tests {
             .unwrap();
         // First claim wins, flag flips to 1.
         assert!(db.claim_branch_auto_rename("w1").unwrap());
-        assert!(db.is_branch_auto_renamed("w1").unwrap());
+        assert!(db.is_branch_auto_rename_claimed("w1").unwrap());
         // Second claim is rejected — this is the property that prevents a
         // session restart from re-triggering rename.
         assert!(!db.claim_branch_auto_rename("w1").unwrap());
@@ -2163,13 +2169,13 @@ mod tests {
     #[test]
     fn test_migration_23_backfill_sql_marks_workspaces_with_chat_history() {
         // Verifies the backfill UPDATE the migration runs: workspaces that
-        // already have chat messages at upgrade time get `branch_auto_renamed
-        // = 1` so a later turn won't rename them, while chatless workspaces
-        // stay at 0 so their first-prompt rename still fires. We exercise the
-        // exact UPDATE statement embedded in the version-23 migration against
-        // a seeded DB — `open_in_memory` runs migrations on an empty schema,
-        // so the only way to observe the backfill path is to re-run its
-        // statement after seeding.
+        // already have chat messages at upgrade time get
+        // `branch_auto_rename_claimed = 1` so a later turn won't rename them,
+        // while chatless workspaces stay at 0 so their first-prompt rename
+        // still fires. We exercise the exact UPDATE statement embedded in the
+        // version-23 migration against a seeded DB — `open_in_memory` runs
+        // migrations on an empty schema, so the only way to observe the
+        // backfill path is to re-run its statement after seeding.
         let db = Database::open_in_memory().unwrap();
         db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
             .unwrap();
@@ -2181,12 +2187,12 @@ mod tests {
             .unwrap();
         db.conn
             .execute_batch(
-                "UPDATE workspaces SET branch_auto_renamed = 1
+                "UPDATE workspaces SET branch_auto_rename_claimed = 1
                    WHERE id IN (SELECT DISTINCT workspace_id FROM chat_messages);",
             )
             .unwrap();
-        assert!(db.is_branch_auto_renamed("w1").unwrap());
-        assert!(!db.is_branch_auto_renamed("w2").unwrap());
+        assert!(db.is_branch_auto_rename_claimed("w1").unwrap());
+        assert!(!db.is_branch_auto_rename_claimed("w2").unwrap());
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -433,6 +433,24 @@ impl Database {
             )?;
         }
 
+        if version < 23 {
+            // Gate the first-turn auto-rename on a persistent per-workspace
+            // flag. The previous gate (`session.turn_count <= 1`) tripped
+            // spuriously whenever the in-memory session was wiped — on
+            // `stop_agent`, spawn failure, or `!got_init` CLI exits — letting
+            // a later prompt rename a workspace that had already had its
+            // first-prompt rename. Backfill existing workspaces with prior
+            // chat history so an upgrade doesn't rename them on the next turn.
+            self.conn.execute_batch(
+                "ALTER TABLE workspaces ADD COLUMN branch_auto_renamed INTEGER NOT NULL DEFAULT 0;
+
+                 UPDATE workspaces SET branch_auto_renamed = 1
+                   WHERE id IN (SELECT DISTINCT workspace_id FROM chat_messages);
+
+                 PRAGMA user_version = 23;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -1029,6 +1047,39 @@ impl Database {
             return Err(rusqlite::Error::StatementChangedRows(rows_affected));
         }
         Ok(())
+    }
+
+    /// Atomically claim the one-shot branch auto-rename for this workspace.
+    /// Returns `true` iff this call set the flag from `0` to `1` (i.e. the
+    /// caller should proceed with the rename); `false` if the flag was already
+    /// set or the workspace doesn't exist. The conditional UPDATE is the
+    /// race-safe primitive that prevents two concurrent turns from both firing
+    /// a Haiku rename on the same workspace.
+    pub fn claim_branch_auto_rename(&self, id: &str) -> Result<bool, rusqlite::Error> {
+        let rows = self.conn.execute(
+            "UPDATE workspaces SET branch_auto_renamed = 1
+             WHERE id = ?1 AND branch_auto_renamed = 0",
+            params![id],
+        )?;
+        Ok(rows == 1)
+    }
+
+    /// Peek at whether the first-turn auto-rename has already been claimed
+    /// for this workspace. Returns `false` for nonexistent workspaces so
+    /// callers can treat missing rows as "nothing to do".
+    pub fn is_branch_auto_renamed(&self, id: &str) -> Result<bool, rusqlite::Error> {
+        match self.conn.query_row(
+            "SELECT branch_auto_renamed FROM workspaces WHERE id = ?1",
+            params![id],
+            |row| {
+                let v: i64 = row.get(0)?;
+                Ok(v != 0)
+            },
+        ) {
+            Ok(v) => Ok(v),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 
     /// Reconcile the stored branch name with the worktree's actual branch.
@@ -2067,6 +2118,75 @@ mod tests {
         // Renaming a workspace that doesn't exist should fail.
         let result = db.rename_workspace("no-such-id", "new-name", "claudette/new-name");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_branch_auto_renamed_defaults_false() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fresh"))
+            .unwrap();
+        assert!(!db.is_branch_auto_renamed("w1").unwrap());
+    }
+
+    #[test]
+    fn test_is_branch_auto_renamed_missing_returns_false() {
+        // Nonexistent workspaces should read as "not renamed" rather than
+        // erroring so callers can treat the missing row as a no-op.
+        let db = Database::open_in_memory().unwrap();
+        assert!(!db.is_branch_auto_renamed("no-such-id").unwrap());
+    }
+
+    #[test]
+    fn test_claim_branch_auto_rename_is_one_shot() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fresh"))
+            .unwrap();
+        // First claim wins, flag flips to 1.
+        assert!(db.claim_branch_auto_rename("w1").unwrap());
+        assert!(db.is_branch_auto_renamed("w1").unwrap());
+        // Second claim is rejected — this is the property that prevents a
+        // session restart from re-triggering rename.
+        assert!(!db.claim_branch_auto_rename("w1").unwrap());
+    }
+
+    #[test]
+    fn test_claim_branch_auto_rename_nonexistent_workspace() {
+        let db = Database::open_in_memory().unwrap();
+        // No row to update, so nothing is claimed. Must not error.
+        assert!(!db.claim_branch_auto_rename("no-such-id").unwrap());
+    }
+
+    #[test]
+    fn test_migration_23_backfill_sql_marks_workspaces_with_chat_history() {
+        // Verifies the backfill UPDATE the migration runs: workspaces that
+        // already have chat messages at upgrade time get `branch_auto_renamed
+        // = 1` so a later turn won't rename them, while chatless workspaces
+        // stay at 0 so their first-prompt rename still fires. We exercise the
+        // exact UPDATE statement embedded in the version-23 migration against
+        // a seeded DB — `open_in_memory` runs migrations on an empty schema,
+        // so the only way to observe the backfill path is to re-run its
+        // statement after seeding.
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "talked"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "never-talked"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg("m1", "w1", ChatRole::User, "hi"))
+            .unwrap();
+        db.conn
+            .execute_batch(
+                "UPDATE workspaces SET branch_auto_renamed = 1
+                   WHERE id IN (SELECT DISTINCT workspace_id FROM chat_messages);",
+            )
+            .unwrap();
+        assert!(db.is_branch_auto_renamed("w1").unwrap());
+        assert!(!db.is_branch_auto_renamed("w2").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace the session-scoped `saved_turn_count <= 1` gate in `try_auto_rename` with a persistent per-workspace flag (`workspaces.branch_auto_renamed`) claimed via an atomic conditional UPDATE, so session resets — `stop_agent`, spawn failures, `!got_init` CLI exits, app restarts — can no longer re-trigger a rename against a later prompt.
- Migration 23 adds the column and backfills workspaces that already have chat history, so upgrading users don't see a spurious rename on their next turn.
- Add DB tests for the claim primitive, the read helper, and the migration's backfill SQL.

## Test plan
- [x] `cargo test --all-features` — 501 passed
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo check -p claudette-tauri --all-targets`
- [ ] Manual: fresh workspace, send first prompt → branch renames. Stop the agent, send another prompt → name stays.
- [ ] Manual: upgrade existing install → workspaces with prior chat history don't rename on next turn.