### PR TITLE
feat(metrics): token usage analytics on dashboard

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -460,6 +460,8 @@ impl Database {
                 "ALTER TABLE deleted_workspace_summaries ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0;
                  ALTER TABLE deleted_workspace_summaries ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0;
 
+                 CREATE INDEX idx_chat_messages_created ON chat_messages(created_at);
+
                  PRAGMA user_version = 24;",
             )?;
         }
@@ -937,22 +939,26 @@ impl Database {
             |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
         )?;
 
-        // Message aggregates by role + cost + date range.
-        let (msgs_user, msgs_assistant, msgs_system, total_cost_usd, first_msg, last_msg): (
-            i64,
-            i64,
-            i64,
-            f64,
-            Option<String>,
-            Option<String>,
-        ) = tx.query_row(
+        // Message aggregates by role + cost + date range + tokens.
+        let (
+            msgs_user,
+            msgs_assistant,
+            msgs_system,
+            total_cost_usd,
+            first_msg,
+            last_msg,
+            total_input_tokens,
+            total_output_tokens,
+        ): (i64, i64, i64, f64, Option<String>, Option<String>, i64, i64) = tx.query_row(
             "SELECT
                 SUM(CASE WHEN role = 'user' THEN 1 ELSE 0 END),
                 SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END),
                 SUM(CASE WHEN role = 'system' THEN 1 ELSE 0 END),
                 COALESCE(SUM(cost_usd), 0),
                 MIN(created_at),
-                MAX(created_at)
+                MAX(created_at),
+                COALESCE(SUM(COALESCE(input_tokens, 0)), 0),
+                COALESCE(SUM(COALESCE(output_tokens, 0)), 0)
              FROM chat_messages WHERE workspace_id = ?1",
             params![workspace_id],
             |r| {
@@ -963,6 +969,8 @@ impl Database {
                     r.get(3)?,
                     r.get(4)?,
                     r.get(5)?,
+                    r.get(6)?,
+                    r.get(7)?,
                 ))
             },
         )?;
@@ -972,15 +980,6 @@ impl Database {
             "SELECT COALESCE(SUM(use_count), 0) FROM slash_command_usage WHERE workspace_id = ?1",
             params![workspace_id],
             |r| r.get(0),
-        )?;
-
-        // Token aggregates.
-        let (total_input_tokens, total_output_tokens): (i64, i64) = tx.query_row(
-            "SELECT COALESCE(SUM(COALESCE(input_tokens, 0)), 0),
-                    COALESCE(SUM(COALESCE(output_tokens, 0)), 0)
-             FROM chat_messages WHERE workspace_id = ?1",
-            params![workspace_id],
-            |r| Ok((r.get(0)?, r.get(1)?)),
         )?;
 
         let id = uuid::Uuid::new_v4().to_string();

--- a/src/db.rs
+++ b/src/db.rs
@@ -455,6 +455,15 @@ impl Database {
             )?;
         }
 
+        if version < 24 {
+            self.conn.execute_batch(
+                "ALTER TABLE deleted_workspace_summaries ADD COLUMN total_input_tokens INTEGER NOT NULL DEFAULT 0;
+                 ALTER TABLE deleted_workspace_summaries ADD COLUMN total_output_tokens INTEGER NOT NULL DEFAULT 0;
+
+                 PRAGMA user_version = 24;",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -965,6 +974,15 @@ impl Database {
             |r| r.get(0),
         )?;
 
+        // Token aggregates.
+        let (total_input_tokens, total_output_tokens): (i64, i64) = tx.query_row(
+            "SELECT COALESCE(SUM(COALESCE(input_tokens, 0)), 0),
+                    COALESCE(SUM(COALESCE(output_tokens, 0)), 0)
+             FROM chat_messages WHERE workspace_id = ?1",
+            params![workspace_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )?;
+
         let id = uuid::Uuid::new_v4().to_string();
         tx.execute(
             "INSERT INTO deleted_workspace_summaries (
@@ -972,13 +990,15 @@ impl Database {
                 sessions_started, sessions_completed, total_turns, total_session_duration_ms,
                 commits_made, total_additions, total_deletions, total_files_changed,
                 messages_user, messages_assistant, messages_system, total_cost_usd,
-                first_message_at, last_message_at, slash_commands_used
+                first_message_at, last_message_at, slash_commands_used,
+                total_input_tokens, total_output_tokens
              ) VALUES (
                 ?1, ?2, ?3, ?4, ?5,
                 ?6, ?7, ?8, ?9,
                 ?10, ?11, ?12, ?13,
                 ?14, ?15, ?16, ?17,
-                ?18, ?19, ?20
+                ?18, ?19, ?20,
+                ?21, ?22
              )",
             params![
                 id,
@@ -1001,6 +1021,8 @@ impl Database {
                 first_msg,
                 last_msg,
                 slash_commands_used,
+                total_input_tokens,
+                total_output_tokens,
             ],
         )?;
         Ok(())
@@ -3484,12 +3506,7 @@ mod tests {
         db.insert_agent_commits_batch("w1", "r1", Some("s1"), &[commit])
             .unwrap();
 
-        for (id, role) in [
-            ("m1", "user"),
-            ("m2", "assistant"),
-            ("m3", "user"),
-            ("m4", "system"),
-        ] {
+        for (id, role) in [("m1", "user"), ("m3", "user"), ("m4", "system")] {
             db.conn
                 .execute(
                     "INSERT INTO chat_messages (id, workspace_id, role, content, cost_usd)
@@ -3498,6 +3515,13 @@ mod tests {
                 )
                 .unwrap();
         }
+        db.conn
+            .execute(
+                "INSERT INTO chat_messages (id, workspace_id, role, content, cost_usd, input_tokens, output_tokens)
+                 VALUES ('m2', 'w1', 'assistant', 'x', 0.01, 12000, 3000)",
+                [],
+            )
+            .unwrap();
         db.conn
             .execute(
                 "INSERT INTO slash_command_usage (workspace_id, command_name, use_count)
@@ -3568,6 +3592,18 @@ mod tests {
         assert_eq!(msgs_a, 1);
         assert_eq!(msgs_s, 1);
         assert_eq!(slash_used, 7);
+
+        let (total_in, total_out): (i64, i64) = db
+            .conn
+            .query_row(
+                "SELECT total_input_tokens, total_output_tokens
+                 FROM deleted_workspace_summaries WHERE workspace_id = 'w1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(total_in, 12000);
+        assert_eq!(total_out, 3000);
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -159,8 +159,48 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
         )?
         .unwrap_or(0.0) as f32;
 
+    let (live_input_30d, live_output_30d): (u64, u64) = conn.query_row(
+        "SELECT COALESCE(SUM(COALESCE(input_tokens, 0)), 0),
+                COALESCE(SUM(COALESCE(output_tokens, 0)), 0)
+         FROM chat_messages
+         WHERE created_at >= date('now','-29 days')",
+        [],
+        |row| Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64)),
+    )?;
+    let (deleted_input_30d, deleted_output_30d): (u64, u64) = conn.query_row(
+        "SELECT COALESCE(SUM(total_input_tokens), 0),
+                COALESCE(SUM(total_output_tokens), 0)
+         FROM deleted_workspace_summaries
+         WHERE last_message_at IS NOT NULL
+           AND last_message_at >= date('now','-29 days')",
+        [],
+        |row| Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64)),
+    )?;
+    let total_input_tokens_30d = live_input_30d + deleted_input_30d;
+    let total_output_tokens_30d = live_output_30d + deleted_output_30d;
+
+    let (cache_reads_30d, cache_denom_30d): (u64, u64) = conn.query_row(
+        "SELECT COALESCE(SUM(COALESCE(cache_read_tokens, 0)), 0),
+                COALESCE(SUM(
+                    COALESCE(input_tokens, 0)
+                    + COALESCE(cache_creation_tokens, 0)
+                    + COALESCE(cache_read_tokens, 0)
+                ), 0)
+         FROM chat_messages
+         WHERE role = 'assistant'
+           AND created_at >= date('now','-29 days')",
+        [],
+        |row| Ok((row.get::<_, i64>(0)? as u64, row.get::<_, i64>(1)? as u64)),
+    )?;
+    let cache_hit_rate_30d = if cache_denom_30d > 0 {
+        cache_reads_30d as f32 / cache_denom_30d as f32
+    } else {
+        0.0
+    };
+
     let commits_daily_14d = daily_counts_14d(conn)?;
     let cost_daily_30d = daily_cost_30d(conn)?;
+    let tokens_daily_30d = daily_tokens_30d(conn)?;
 
     Ok(DashboardMetrics {
         active_sessions,
@@ -172,6 +212,10 @@ fn dashboard_metrics_with(conn: &Connection) -> Result<DashboardMetrics, rusqlit
         success_rate_30d,
         commits_daily_14d,
         cost_daily_30d,
+        total_input_tokens_30d,
+        total_output_tokens_30d,
+        cache_hit_rate_30d,
+        tokens_daily_30d,
     })
 }
 
@@ -201,6 +245,22 @@ fn daily_cost_30d(conn: &Connection) -> Result<Vec<f64>, rusqlite::Error> {
         })?
         .collect::<Result<_, _>>()?;
     fill_last_n_days(conn, 30, |d| costs.get(d).copied().unwrap_or(0.0))
+}
+
+fn daily_tokens_30d(conn: &Connection) -> Result<Vec<u64>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT date(created_at) AS d,
+                COALESCE(SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)), 0)
+         FROM chat_messages
+         WHERE created_at >= date('now','-29 days')
+         GROUP BY d",
+    )?;
+    let tokens: HashMap<String, u64> = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+        })?
+        .collect::<Result<_, _>>()?;
+    fill_last_n_days(conn, 30, |d| tokens.get(d).copied().unwrap_or(0))
 }
 
 fn fill_last_n_days<T, F>(conn: &Connection, n: i64, mut f: F) -> Result<Vec<T>, rusqlite::Error>
@@ -307,8 +367,6 @@ fn analytics_metrics_with(conn: &Connection) -> Result<AnalyticsMetrics, rusqlit
 }
 
 fn repo_leaderboard(conn: &Connection) -> Result<Vec<RepoLeaderRow>, rusqlite::Error> {
-    // Merge live sessions + commits + chat cost with frozen deleted-workspace summaries,
-    // then re-aggregate per repository.
     let sql = "
         WITH repo_ids AS (
             SELECT DISTINCT repository_id FROM agent_sessions
@@ -322,26 +380,38 @@ fn repo_leaderboard(conn: &Connection) -> Result<Vec<RepoLeaderRow>, rusqlite::E
                 (SELECT COUNT(*) FROM agent_commits  c WHERE c.repository_id = r.repository_id) AS commits,
                 (SELECT COALESCE(SUM(m.cost_usd),0) FROM chat_messages m
                  JOIN workspaces w ON w.id = m.workspace_id
-                 WHERE w.repository_id = r.repository_id) AS total_cost_usd
+                 WHERE w.repository_id = r.repository_id) AS total_cost_usd,
+                (SELECT COALESCE(SUM(COALESCE(m.input_tokens, 0)), 0) FROM chat_messages m
+                 JOIN workspaces w ON w.id = m.workspace_id
+                 WHERE w.repository_id = r.repository_id) AS total_input_tokens,
+                (SELECT COALESCE(SUM(COALESCE(m.output_tokens, 0)), 0) FROM chat_messages m
+                 JOIN workspaces w ON w.id = m.workspace_id
+                 WHERE w.repository_id = r.repository_id) AS total_output_tokens
             FROM repo_ids r
         ),
         deleted AS (
             SELECT repository_id,
                 COALESCE(SUM(sessions_started), 0) AS sessions,
                 COALESCE(SUM(commits_made),    0) AS commits,
-                COALESCE(SUM(total_cost_usd),  0) AS total_cost_usd
+                COALESCE(SUM(total_cost_usd),  0) AS total_cost_usd,
+                COALESCE(SUM(total_input_tokens),  0) AS total_input_tokens,
+                COALESCE(SUM(total_output_tokens), 0) AS total_output_tokens
             FROM deleted_workspace_summaries
             GROUP BY repository_id
         ),
         merged AS (
-            SELECT repository_id, sessions, commits, total_cost_usd FROM live
+            SELECT repository_id, sessions, commits, total_cost_usd,
+                   total_input_tokens, total_output_tokens FROM live
             UNION ALL
-            SELECT repository_id, sessions, commits, total_cost_usd FROM deleted
+            SELECT repository_id, sessions, commits, total_cost_usd,
+                   total_input_tokens, total_output_tokens FROM deleted
         )
         SELECT repository_id,
                CAST(COALESCE(SUM(sessions), 0) AS INTEGER) AS sessions,
                CAST(COALESCE(SUM(commits),  0) AS INTEGER) AS commits,
-               COALESCE(SUM(total_cost_usd), 0) AS total_cost_usd
+               COALESCE(SUM(total_cost_usd), 0) AS total_cost_usd,
+               CAST(COALESCE(SUM(total_input_tokens),  0) AS INTEGER) AS total_input_tokens,
+               CAST(COALESCE(SUM(total_output_tokens), 0) AS INTEGER) AS total_output_tokens
         FROM merged
         GROUP BY repository_id
         ORDER BY sessions DESC, commits DESC, total_cost_usd DESC
@@ -354,6 +424,8 @@ fn repo_leaderboard(conn: &Connection) -> Result<Vec<RepoLeaderRow>, rusqlite::E
             sessions: row.get::<_, i64>(1)? as u32,
             commits: row.get::<_, i64>(2)? as u32,
             total_cost_usd: row.get(3)?,
+            total_input_tokens: row.get::<_, i64>(4)? as u64,
+            total_output_tokens: row.get::<_, i64>(5)? as u64,
         })
     })?
     .collect()
@@ -500,6 +572,11 @@ mod tests {
         assert!(m.commits_daily_14d.iter().all(|&n| n == 0));
         assert_eq!(m.cost_daily_30d.len(), 30);
         assert!(m.cost_daily_30d.iter().all(|&n| n == 0.0));
+        assert_eq!(m.total_input_tokens_30d, 0);
+        assert_eq!(m.total_output_tokens_30d, 0);
+        assert_eq!(m.cache_hit_rate_30d, 0.0);
+        assert_eq!(m.tokens_daily_30d.len(), 30);
+        assert!(m.tokens_daily_30d.iter().all(|&n| n == 0));
     }
 
     #[test]
@@ -630,18 +707,18 @@ mod tests {
         );
         exec(
             &conn,
-            "INSERT INTO chat_messages (id, workspace_id, role, content, cost_usd)
-             VALUES ('m1', 'wsA', 'assistant', 'hi', 2.0)",
+            "INSERT INTO chat_messages (id, workspace_id, role, content, cost_usd, input_tokens, output_tokens)
+             VALUES ('m1', 'wsA', 'assistant', 'hi', 2.0, 5000, 1000)",
         );
         exec(
             &conn,
-            "INSERT INTO deleted_workspace_summaries (id, workspace_id, workspace_name, repository_id, workspace_created_at, sessions_started, commits_made, total_cost_usd)
-             VALUES ('d1', 'wsGone', 'gone', 'repoA', datetime('now'), 3, 2, 4.0)",
+            "INSERT INTO deleted_workspace_summaries (id, workspace_id, workspace_name, repository_id, workspace_created_at, sessions_started, commits_made, total_cost_usd, total_input_tokens, total_output_tokens)
+             VALUES ('d1', 'wsGone', 'gone', 'repoA', datetime('now'), 3, 2, 4.0, 20000, 4000)",
         );
         exec(
             &conn,
-            "INSERT INTO deleted_workspace_summaries (id, workspace_id, workspace_name, repository_id, workspace_created_at, sessions_started, commits_made, total_cost_usd)
-             VALUES ('d2', 'wsOld', 'old', 'repoB', datetime('now'), 1, 0, 0.5)",
+            "INSERT INTO deleted_workspace_summaries (id, workspace_id, workspace_name, repository_id, workspace_created_at, sessions_started, commits_made, total_cost_usd, total_input_tokens, total_output_tokens)
+             VALUES ('d2', 'wsOld', 'old', 'repoB', datetime('now'), 1, 0, 0.5, 3000, 500)",
         );
 
         let a = analytics_metrics(&path).unwrap();
@@ -653,6 +730,8 @@ mod tests {
         assert_eq!(a_row.sessions, 5);
         assert_eq!(a_row.commits, 3);
         assert!((a_row.total_cost_usd - 6.0).abs() < 1e-6);
+        assert_eq!(a_row.total_input_tokens, 25000);
+        assert_eq!(a_row.total_output_tokens, 5000);
 
         let b_row = a
             .repo_leaderboard
@@ -662,6 +741,8 @@ mod tests {
         assert_eq!(b_row.sessions, 1);
         assert_eq!(b_row.commits, 0);
         assert!((b_row.total_cost_usd - 0.5).abs() < 1e-6);
+        assert_eq!(b_row.total_input_tokens, 3000);
+        assert_eq!(b_row.total_output_tokens, 500);
     }
 
     #[test]
@@ -760,5 +841,77 @@ mod tests {
         assert_eq!(a.recent_sessions_24h[0].workspace_id, "w");
         assert!(a.recent_sessions_24h[0].completed_ok);
         assert!(!a.recent_sessions_24h[1].completed_ok);
+    }
+
+    #[test]
+    fn dashboard_tokens_merges_live_and_deleted() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        insert_workspace(&conn, "ws1", "r");
+        exec(
+            &conn,
+            "INSERT INTO chat_messages (id, workspace_id, role, content, input_tokens, output_tokens)
+             VALUES ('m1', 'ws1', 'assistant', 'hi', 10000, 2000),
+                    ('m2', 'ws1', 'assistant', 'bye', 8000, 1500)",
+        );
+        exec(
+            &conn,
+            "INSERT INTO deleted_workspace_summaries (id, workspace_id, workspace_name, repository_id, workspace_created_at, total_input_tokens, total_output_tokens, last_message_at)
+             VALUES ('d1', 'wsDel', 'dead', 'r', datetime('now','-10 days'), 50000, 7000, datetime('now','-5 days'))",
+        );
+        let m = dashboard_metrics(&path).unwrap();
+        assert_eq!(m.total_input_tokens_30d, 68000);
+        assert_eq!(m.total_output_tokens_30d, 10500);
+    }
+
+    #[test]
+    fn dashboard_cache_hit_rate_computes_correctly() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        insert_workspace(&conn, "ws1", "r");
+        exec(
+            &conn,
+            "INSERT INTO chat_messages (id, workspace_id, role, content, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+             VALUES ('m1', 'ws1', 'assistant', 'hi', 1000, 500, 9000, 0)",
+        );
+        let m = dashboard_metrics(&path).unwrap();
+        // cache_reads=9000, denom=1000+0+9000=10000, rate=0.9
+        assert!((m.cache_hit_rate_30d - 0.9).abs() < 1e-5);
+    }
+
+    #[test]
+    fn dashboard_cache_hit_rate_excludes_system_messages() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        insert_workspace(&conn, "ws1", "r");
+        exec(
+            &conn,
+            "INSERT INTO chat_messages (id, workspace_id, role, content, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens)
+             VALUES ('m1', 'ws1', 'assistant', 'hi', 2000, 500, 8000, 0),
+                    ('m2', 'ws1', 'system', 'COMPACTION:auto:200000:80000:5000', NULL, NULL, 80000, NULL)",
+        );
+        let m = dashboard_metrics(&path).unwrap();
+        // Only the assistant message counts: cache_reads=8000, denom=2000+0+8000=10000
+        assert!((m.cache_hit_rate_30d - 0.8).abs() < 1e-5);
+    }
+
+    #[test]
+    fn dashboard_tokens_daily_30d_has_30_entries() {
+        let (_dir, path) = setup_db();
+        let conn = Connection::open(&path).unwrap();
+        insert_repo(&conn, "r");
+        insert_workspace(&conn, "ws1", "r");
+        exec(
+            &conn,
+            "INSERT INTO chat_messages (id, workspace_id, role, content, input_tokens, output_tokens)
+             VALUES ('m1', 'ws1', 'assistant', 'hi', 5000, 1000)",
+        );
+        let m = dashboard_metrics(&path).unwrap();
+        assert_eq!(m.tokens_daily_30d.len(), 30);
+        assert_eq!(*m.tokens_daily_30d.last().unwrap(), 6000);
+        assert_eq!(m.tokens_daily_30d[..29].iter().sum::<u64>(), 0);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -374,20 +374,24 @@ fn repo_leaderboard(conn: &Connection) -> Result<Vec<RepoLeaderRow>, rusqlite::E
             UNION SELECT DISTINCT repository_id FROM deleted_workspace_summaries
             UNION SELECT DISTINCT w.repository_id FROM chat_messages m JOIN workspaces w ON w.id = m.workspace_id
         ),
+        chat_agg AS (
+            SELECT w.repository_id,
+                   COALESCE(SUM(m.cost_usd), 0) AS total_cost_usd,
+                   COALESCE(SUM(COALESCE(m.input_tokens, 0)), 0) AS total_input_tokens,
+                   COALESCE(SUM(COALESCE(m.output_tokens, 0)), 0) AS total_output_tokens
+            FROM chat_messages m
+            JOIN workspaces w ON w.id = m.workspace_id
+            GROUP BY w.repository_id
+        ),
         live AS (
             SELECT r.repository_id,
                 (SELECT COUNT(*) FROM agent_sessions s WHERE s.repository_id = r.repository_id) AS sessions,
                 (SELECT COUNT(*) FROM agent_commits  c WHERE c.repository_id = r.repository_id) AS commits,
-                (SELECT COALESCE(SUM(m.cost_usd),0) FROM chat_messages m
-                 JOIN workspaces w ON w.id = m.workspace_id
-                 WHERE w.repository_id = r.repository_id) AS total_cost_usd,
-                (SELECT COALESCE(SUM(COALESCE(m.input_tokens, 0)), 0) FROM chat_messages m
-                 JOIN workspaces w ON w.id = m.workspace_id
-                 WHERE w.repository_id = r.repository_id) AS total_input_tokens,
-                (SELECT COALESCE(SUM(COALESCE(m.output_tokens, 0)), 0) FROM chat_messages m
-                 JOIN workspaces w ON w.id = m.workspace_id
-                 WHERE w.repository_id = r.repository_id) AS total_output_tokens
+                COALESCE(ca.total_cost_usd, 0) AS total_cost_usd,
+                COALESCE(ca.total_input_tokens, 0) AS total_input_tokens,
+                COALESCE(ca.total_output_tokens, 0) AS total_output_tokens
             FROM repo_ids r
+            LEFT JOIN chat_agg ca ON ca.repository_id = r.repository_id
         ),
         deleted AS (
             SELECT repository_id,

--- a/src/model/metrics.rs
+++ b/src/model/metrics.rs
@@ -57,6 +57,8 @@ pub struct DeletedWorkspaceSummary {
     pub first_message_at: Option<String>,
     pub last_message_at: Option<String>,
     pub slash_commands_used: i64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
 }
 
 /// Aggregated metrics for the top-of-dashboard `StatsStrip`.
@@ -72,6 +74,10 @@ pub struct DashboardMetrics {
     pub success_rate_30d: f32,
     pub commits_daily_14d: Vec<u32>,
     pub cost_daily_30d: Vec<f64>,
+    pub total_input_tokens_30d: u64,
+    pub total_output_tokens_30d: u64,
+    pub cache_hit_rate_30d: f32,
+    pub tokens_daily_30d: Vec<u64>,
 }
 
 /// Per-workspace metrics shown in the workspace-card `MicroStats` chip.
@@ -92,6 +98,8 @@ pub struct RepoLeaderRow {
     pub sessions: u32,
     pub commits: u32,
     pub total_cost_usd: f64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
 }
 
 /// One cell in the 13-week session heatmap.

--- a/src/ui/src/components/metrics/metrics.module.css
+++ b/src/ui/src/components/metrics/metrics.module.css
@@ -2,7 +2,7 @@
 
 .statsStrip {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 12px;
   padding: 12px 20px;
   border-bottom: 1px solid var(--divider);
@@ -123,6 +123,12 @@
   .statsStrip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  .hideNarrow {
+    display: none;
+  }
+  .leaderRow {
+    grid-template-columns: 1fr auto;
+  }
 }
 
 .panel {
@@ -146,6 +152,7 @@
 
 .panelFull {
   grid-column: 1 / -1;
+  min-height: auto;
 }
 
 /* Empty / placeholder variants ------------------------------------------- */
@@ -349,7 +356,7 @@
 }
 
 .leaderRow {
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: 1fr auto auto auto auto;
 }
 
 .slashRow {

--- a/src/ui/src/components/metrics/widgets/AnalyticsSection.tsx
+++ b/src/ui/src/components/metrics/widgets/AnalyticsSection.tsx
@@ -5,7 +5,6 @@ import { RepoLeaderboard } from "./RepoLeaderboard";
 import { SessionHeatmap } from "./SessionHeatmap";
 import { TurnHistogram } from "./TurnHistogram";
 import { SlashCommandTop } from "./SlashCommandTop";
-import { SessionTimeline } from "./SessionTimeline";
 
 export function AnalyticsSection() {
   const [open, setOpen] = useState(true);
@@ -22,15 +21,12 @@ export function AnalyticsSection() {
         <span className={styles.analyticsTitle}>Analytics</span>
       </button>
       {open ? (
-        <>
-          <div className={styles.analyticsGrid}>
-            <RepoLeaderboard />
-            <SessionHeatmap />
-            <TurnHistogram />
-            <SlashCommandTop />
-          </div>
-          <SessionTimeline />
-        </>
+        <div className={styles.analyticsGrid}>
+          <RepoLeaderboard />
+          <SessionHeatmap />
+          <TurnHistogram />
+          <SlashCommandTop />
+        </div>
       ) : null}
     </div>
   );

--- a/src/ui/src/components/metrics/widgets/RepoLeaderboard.tsx
+++ b/src/ui/src/components/metrics/widgets/RepoLeaderboard.tsx
@@ -1,6 +1,7 @@
 import styles from "../metrics.module.css";
 import { useAppStore } from "../../../stores/useAppStore";
 import { RepoIcon } from "../../shared/RepoIcon";
+import { formatTokens } from "../../chat/formatTokens";
 
 function formatUsd(n: number): string {
   if (n >= 1000) return `$${(n / 1000).toFixed(1)}k`;
@@ -31,9 +32,12 @@ export function RepoLeaderboard() {
                   ) : null}
                   {name}
                 </span>
-                <span className={styles.rowMuted}>{row.sessions}s</span>
-                <span className={styles.rowMuted}>{row.commits}c</span>
-                <span className={styles.rowValue}>
+                <span className={`${styles.rowMuted} ${styles.hideNarrow}`} title="sessions">{row.sessions}s</span>
+                <span className={`${styles.rowMuted} ${styles.hideNarrow}`} title="commits">{row.commits}c</span>
+                <span className={`${styles.rowMuted} ${styles.hideNarrow}`} title="tokens (in + out)">
+                  {formatTokens(row.totalInputTokens + row.totalOutputTokens)}t
+                </span>
+                <span className={styles.rowValue} title="cost">
                   {formatUsd(row.totalCostUsd)}
                 </span>
               </div>

--- a/src/ui/src/components/metrics/widgets/StatsStrip.tsx
+++ b/src/ui/src/components/metrics/widgets/StatsStrip.tsx
@@ -4,6 +4,7 @@ import { CommitsSparkline } from "./CommitsSparkline";
 import { ChurnBar } from "./ChurnBar";
 import { SuccessRing } from "./SuccessRing";
 import { CostCard } from "./CostCard";
+import { TokenUsageTile } from "./TokenUsageTile";
 
 export function StatsStrip() {
   return (
@@ -13,6 +14,7 @@ export function StatsStrip() {
       <ChurnBar />
       <SuccessRing />
       <CostCard />
+      <TokenUsageTile />
     </div>
   );
 }

--- a/src/ui/src/components/metrics/widgets/TokenUsageTile.tsx
+++ b/src/ui/src/components/metrics/widgets/TokenUsageTile.tsx
@@ -1,0 +1,27 @@
+import styles from "../metrics.module.css";
+import { useAppStore } from "../../../stores/useAppStore";
+import { Sparkline } from "../primitives/Sparkline";
+import { formatTokens } from "../../chat/formatTokens";
+
+export function TokenUsageTile() {
+  const metrics = useAppStore((s) => s.dashboardMetrics);
+  const input = metrics?.totalInputTokens30d ?? 0;
+  const output = metrics?.totalOutputTokens30d ?? 0;
+  const total = input + output;
+  const cacheRate = metrics?.cacheHitRate30d ?? 0;
+  const series = metrics?.tokensDaily30d ?? [];
+
+  return (
+    <div className={styles.tile}>
+      <span className={styles.tileLabel}>Tokens · 30d</span>
+      <div className={styles.tileValue}>{formatTokens(total)}</div>
+      <span className={styles.tileSub}>
+        {formatTokens(input)} in · {formatTokens(output)} out
+        {total > 0 ? ` · ${Math.round(cacheRate * 100)}% cached` : null}
+      </span>
+      <div style={{ marginTop: 4 }}>
+        <Sparkline values={series} title="daily tokens (30d)" />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/types/metrics.ts
+++ b/src/ui/src/types/metrics.ts
@@ -10,6 +10,12 @@ export interface DashboardMetrics {
   commitsDaily14d: number[];
   /** 30 entries, oldest first. */
   costDaily30d: number[];
+  totalInputTokens30d: number;
+  totalOutputTokens30d: number;
+  /** Cache hit rate [0, 1] over 30 days (live data only). */
+  cacheHitRate30d: number;
+  /** 30 entries, oldest first. Input + output tokens per day. */
+  tokensDaily30d: number[];
 }
 
 export interface WorkspaceMetrics {
@@ -24,6 +30,8 @@ export interface RepoLeaderRow {
   sessions: number;
   commits: number;
   totalCostUsd: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
 }
 
 export interface HeatmapCell {


### PR DESCRIPTION
## Summary

- **New TokenUsageTile** in StatsStrip showing 30-day total tokens, input/output split, cache hit rate, and daily sparkline
- **RepoLeaderboard** enriched with per-repo token totals; responsive layout hides secondary stats (sessions, commits, tokens) at narrow widths
- **DB migration v23** adds `total_input_tokens` / `total_output_tokens` to `deleted_workspace_summaries` so token totals survive workspace deletion
- **Removed** the redundant Sessions · Last 24h timeline (the heatmap already covers temporal session patterns)
- Backend SQL aggregation for token totals (live + deleted), cache hit rate (excludes compaction sentinels), daily token sparkline, and per-repo token breakdown in the leaderboard CTE

## Test plan

- [x] `cargo test --all-features` — 500 tests pass (4 new token-specific tests)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cd src/ui && bunx tsc --noEmit` — clean
- [x] `cd src/ui && bun run test` — 579 tests pass
- [ ] `cargo tauri dev` — verify dashboard renders TokenUsageTile with sparkline, leaderboard shows token column, responsive layout hides stats at narrow width
- [ ] Verify empty DB shows zeros / "no data yet" gracefully