### PR TITLE
feat(metrics): show total tokens on workspace cards with hover tooltips

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -353,6 +353,30 @@ fn workspace_metrics_batch_with(
         }
     }
 
+    let token_sql = format!(
+        "SELECT workspace_id,
+                COALESCE(SUM(COALESCE(input_tokens, 0)), 0),
+                COALESCE(SUM(COALESCE(output_tokens, 0)), 0)
+         FROM chat_messages
+         WHERE workspace_id IN ({placeholders})
+         GROUP BY workspace_id"
+    );
+    let mut token_stmt = conn.prepare(&token_sql)?;
+    let token_rows = token_stmt.query_map(id_params.as_slice(), |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)? as u64,
+            row.get::<_, i64>(2)? as u64,
+        ))
+    })?;
+    for row in token_rows {
+        let (id, input_tokens, output_tokens) = row?;
+        if let Some(slot) = result.get_mut(&id) {
+            slot.total_input_tokens = input_tokens;
+            slot.total_output_tokens = output_tokens;
+        }
+    }
+
     Ok(result)
 }
 
@@ -673,6 +697,14 @@ mod tests {
                     ('s_new', 'ws1', 'r', datetime('now'),           datetime('now'),           7)",
         );
 
+        exec(
+            &conn,
+            "INSERT INTO chat_messages (id, workspace_id, role, content, input_tokens, output_tokens)
+             VALUES ('m1', 'ws1', 'assistant', 'hi', 5000, 1000),
+                    ('m2', 'ws1', 'assistant', 'ok', 3000, 500),
+                    ('m3', 'ws2', 'assistant', 'yo', 2000, NULL)",
+        );
+
         let ids = vec!["ws1".to_string(), "ws2".to_string(), "missing".to_string()];
         let m = workspace_metrics_batch(&path, &ids).unwrap();
 
@@ -681,14 +713,20 @@ mod tests {
         assert_eq!(ws1.additions, 15);
         assert_eq!(ws1.deletions, 3);
         assert_eq!(ws1.latest_session_turns, 7);
+        assert_eq!(ws1.total_input_tokens, 8000);
+        assert_eq!(ws1.total_output_tokens, 1500);
 
         let ws2 = m.get("ws2").unwrap();
         assert_eq!(ws2.commits_count, 1);
         assert_eq!(ws2.latest_session_turns, 0);
+        assert_eq!(ws2.total_input_tokens, 2000);
+        assert_eq!(ws2.total_output_tokens, 0);
 
         let missing = m.get("missing").unwrap();
         assert_eq!(missing.commits_count, 0);
         assert_eq!(missing.latest_session_turns, 0);
+        assert_eq!(missing.total_input_tokens, 0);
+        assert_eq!(missing.total_output_tokens, 0);
     }
 
     #[test]

--- a/src/model/metrics.rs
+++ b/src/model/metrics.rs
@@ -88,6 +88,8 @@ pub struct WorkspaceMetrics {
     pub additions: u64,
     pub deletions: u64,
     pub latest_session_turns: u32,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
 }
 
 /// One row in the repo leaderboard widget.

--- a/src/ui/src/components/metrics/widgets/MicroStats.tsx
+++ b/src/ui/src/components/metrics/widgets/MicroStats.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import styles from "../metrics.module.css";
 import { useAppStore } from "../../../stores/useAppStore";
+import { formatTokens } from "../../chat/formatTokens";
 
 interface MicroStatsProps {
   workspaceId: string;
@@ -15,19 +16,20 @@ function formatShort(n: number): string {
 export function MicroStats({ workspaceId }: MicroStatsProps) {
   const stats = useAppStore((s) => s.workspaceMetrics[workspaceId]);
   if (!stats) return null;
-  const { commitsCount, additions, deletions, latestSessionTurns } = stats;
+  const { commitsCount, additions, deletions, totalInputTokens, totalOutputTokens } = stats;
+  const totalTokens = totalInputTokens + totalOutputTokens;
   if (
     commitsCount === 0 &&
     additions === 0 &&
     deletions === 0 &&
-    latestSessionTurns === 0
+    totalTokens === 0
   ) {
     return null;
   }
   const parts: ReactNode[] = [];
   if (additions > 0 || deletions > 0) {
     parts.push(
-      <span key="churn">
+      <span key="churn" title="lines added / removed">
         <span className={styles.microAdd}>+{formatShort(additions)}</span>
         <span className={styles.microSep}>/</span>
         <span className={styles.microDel}>-{formatShort(deletions)}</span>
@@ -35,10 +37,10 @@ export function MicroStats({ workspaceId }: MicroStatsProps) {
     );
   }
   if (commitsCount > 0) {
-    parts.push(<span key="commits">{commitsCount}c</span>);
+    parts.push(<span key="commits" title="commits">{commitsCount}c</span>);
   }
-  if (latestSessionTurns > 0) {
-    parts.push(<span key="turns">{latestSessionTurns}t</span>);
+  if (totalTokens > 0) {
+    parts.push(<span key="tokens" title="tokens (in + out)">{formatTokens(totalTokens)}t</span>);
   }
   return (
     <div className={styles.microChip}>

--- a/src/ui/src/types/metrics.ts
+++ b/src/ui/src/types/metrics.ts
@@ -23,6 +23,8 @@ export interface WorkspaceMetrics {
   additions: number;
   deletions: number;
   latestSessionTurns: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
 }
 
 export interface RepoLeaderRow {


### PR DESCRIPTION
## Summary

- **Workspace card stats now show total tokens (in + out)** instead of latest session turn count — the previous "4t" was confusing because "t" reads as "tokens" but was actually "turns," showing misleadingly low numbers
- **Added native hover tooltips** to all MicroStats spans (`lines added / removed`, `commits`, `tokens (in + out)`) matching the existing pattern in the repo leaderboard
- Added `total_input_tokens` / `total_output_tokens` fields to `WorkspaceMetrics` on both the Rust model and TypeScript type, queried from `chat_messages`

## Test Steps

1. Run `cargo tauri dev` and open the dashboard
2. Hover over each stat in a workspace card — tooltips should appear for the line diff (`lines added / removed`), commits (`commits`), and tokens (`tokens (in + out)`)
3. Verify the token number shown is realistic (thousands/millions, not single digits) — it should match the sum of input + output tokens from all chat messages in that workspace
4. Compare formatting with the repo leaderboard row — both should use the same `Xt` format (e.g., `1.2kt`, `10.0kt`)

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)