### PR TITLE
fix(diff): don't overflow individual diff lines

### DIFF
--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -121,6 +121,11 @@
   padding-left: 4px;
 }
 
+.sbsCell .lineContent {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
 /* ---- Side-by-Side Mode ---- */
 
 .sideBySide {

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -61,6 +61,7 @@
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
+  min-width: max-content;
 }
 
 .hunkHeader {
@@ -117,7 +118,6 @@
 .lineContent {
   flex: 1;
   white-space: pre;
-  overflow-x: auto;
   padding-left: 4px;
 }
 


### PR DESCRIPTION
Fixes horizontal scrolling behavior in the diff viewer so long lines expand the diff as a whole (single shared horizontal scroll) rather than creating per-line scrollbars.

**Changes:**
- Added `min-width: max-content` to `.diffTable` so the unified diff container expands to fit long lines rather than clamping them.
- Removed `overflow-x: auto` from `.lineContent` to avoid independent per-line horizontal scrollbars in unified mode.
- Added `.sbsCell .lineContent { overflow-x: auto; overflow-y: hidden; }` to restore horizontal scrolling specifically for side-by-side cells, which need it because `.sbsCell` clips overflow.