### PR TITLE
feat(chat): redesign composer with pill toolbar and segmented context meter

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -864,45 +864,65 @@
   color: var(--text-primary);
 }
 
-/* Input area */
+/* Input area — Composer wrapper */
 .inputArea {
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 6px 14px;
-  border-top: 1px solid var(--divider);
-  background: transparent;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  margin: 0 6px;
+  outline: none;
+}
+
+.inputArea:focus-within {
+  border-color: rgba(var(--accent-primary-rgb), 0.5);
 }
 
 .inputControls {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 8px;
-  padding-top: 6px;
+  padding: 8px 10px;
+}
+
+.inputControlsLeft {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.inputControlsRight {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  position: relative;
 }
 
 .input {
   flex: 1;
-  background: var(--chat-input-bg);
-  border: 1px solid var(--divider);
-  border-radius: 10px;
-  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  padding: 14px 18px 8px;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: var(--fs-md);
   font-family: inherit;
-  line-height: 1.5;
+  line-height: var(--lh-body);
   outline: none;
   resize: none;
-  min-height: 44px;
+  min-height: 52px;
   max-height: 160px;
-  transition: border-color var(--transition-normal), box-shadow var(--transition-normal),
-              background var(--transition-normal);
 }
 
-.input:focus {
-  border-color: rgba(var(--accent-primary-rgb), 0.4);
-  box-shadow: 0 0 0 3px rgba(var(--accent-primary-rgb), 0.08);
+.input:focus-visible {
+  box-shadow: none;
 }
 
 .input::placeholder {
@@ -910,13 +930,12 @@
 }
 
 .inputPlanMode {
-  border: 2px dashed rgba(var(--accent-primary-rgb), 0.5);
+  border-bottom: 2px dashed rgba(var(--accent-primary-rgb), 0.5);
   background: rgba(var(--accent-primary-rgb), 0.04);
 }
 
 .inputPlanMode:focus {
-  border-color: rgba(var(--accent-primary-rgb), 0.6);
-  box-shadow: 0 0 0 3px rgba(var(--accent-primary-rgb), 0.12);
+  border-bottom-color: rgba(var(--accent-primary-rgb), 0.6);
 }
 
 .sendBtn {
@@ -924,22 +943,21 @@
   align-items: center;
   justify-content: center;
   background: var(--accent-primary);
-  border: 1px solid var(--accent-primary);
+  border: none;
   color: var(--app-bg);
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   padding: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  margin-left: auto;
   flex-shrink: 0;
-  transition: background var(--transition-fast), border-color var(--transition-fast),
-              color var(--transition-fast), opacity var(--transition-fast);
+  transition: background var(--transition-fast);
+  box-shadow: 0 2px 8px rgba(var(--accent-primary-rgb), 0.35),
+              inset 0 1px 0 rgba(255, 255, 255, 0.15);
 }
 
 .sendBtn:hover:not(:disabled) {
   background: var(--accent-dim);
-  border-color: var(--accent-dim);
 }
 
 .sendBtn:active:not(:disabled) {
@@ -949,12 +967,14 @@
 .sendBtn:disabled {
   opacity: 0.35;
   cursor: not-allowed;
+  filter: saturate(0.5);
 }
 
 .sendBtnStop {
   background: var(--hover-bg-subtle);
-  border-color: var(--divider);
+  border: 1px solid var(--divider);
   color: var(--text-muted);
+  box-shadow: none;
 }
 
 .sendBtnStop:hover:not(:disabled) {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -952,8 +952,7 @@
   cursor: pointer;
   flex-shrink: 0;
   transition: background var(--transition-fast);
-  box-shadow: 0 2px 8px rgba(var(--accent-primary-rgb), 0.35),
-              inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  box-shadow: 0 2px 8px rgba(var(--accent-primary-rgb), 0.35);
 }
 
 .sendBtn:hover:not(:disabled) {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -24,6 +24,7 @@ import {
   setAppSetting,
   listWorkspaceFiles,
   clearConversation,
+  resetAgentSession,
   readPlanFile,
   loadDiffFiles,
   forkWorkspaceAtCheckpoint,
@@ -50,7 +51,9 @@ import { useTypewriter } from "../../hooks/useTypewriter";
 import { extractToolSummary } from "../../hooks/toolSummary";
 import { AgentQuestionCard } from "./AgentQuestionCard";
 import { PlanApprovalCard } from "./PlanApprovalCard";
-import { ChatToolbar } from "./ChatToolbar";
+import { ComposerToolbar } from "./composer/ComposerToolbar";
+import { SegmentedMeter } from "./composer/SegmentedMeter";
+import { ContextPopover } from "./composer/ContextPopover";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { AttachMenu } from "./AttachMenu";
@@ -1857,6 +1860,7 @@ function ChatInputArea({
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [dragActive, setDragActive] = useState(false);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false);
+  const [contextPopoverOpen, setContextPopoverOpen] = useState(false);
   const pluginRefreshToken = useAppStore((s) => s.pluginRefreshToken);
 
   // Per-workspace draft storage: save input when switching away,
@@ -2423,39 +2427,55 @@ function ChatInputArea({
         placeholder={isRunning ? "Type to queue a message..." : "Send a message..."}
       />
       <div className={styles.inputControls}>
-        <div className={styles.attachBtnWrap}>
+        <div className={styles.inputControlsLeft}>
+          <div className={styles.attachBtnWrap}>
+            <button
+              className={`${styles.attachBtn} ${attachMenuOpen ? styles.attachBtnActive : ""}`}
+              onClick={() => setAttachMenuOpen((v) => !v)}
+              title="Add files or connectors"
+            >
+              <Plus size={16} />
+            </button>
+            {attachMenuOpen && (
+              <AttachMenu
+                repoId={repoId}
+                onAttachFiles={() => {
+                  setAttachMenuOpen(false);
+                  handleAttachClick();
+                }}
+                onClose={() => setAttachMenuOpen(false)}
+                isRemote={isRemote}
+              />
+            )}
+          </div>
+          <ComposerToolbar
+            workspaceId={selectedWorkspaceId}
+            disabled={isRunning}
+          />
+        </div>
+        <div className={styles.inputControlsRight}>
+          <SegmentedMeter
+            workspaceId={selectedWorkspaceId}
+            onClick={() => setContextPopoverOpen((v) => !v)}
+          />
           <button
-            className={`${styles.attachBtn} ${attachMenuOpen ? styles.attachBtnActive : ""}`}
-            onClick={() => setAttachMenuOpen((v) => !v)}
-            title="Add files or connectors"
+            className={`${styles.sendBtn} ${isRunning ? styles.sendBtnStop : ""}`}
+            onClick={isRunning ? onStop : handleSend}
+            disabled={!isRunning && !chatInput.trim() && pendingAttachments.length === 0}
+            title={isRunning ? "Stop agent" : "Send message"}
+            aria-label={isRunning ? "Stop agent" : "Send message"}
           >
-            <Plus size={16} />
+            {isRunning ? <Square size={16} /> : <Send size={16} />}
           </button>
-          {attachMenuOpen && (
-            <AttachMenu
-              repoId={repoId}
-              onAttachFiles={() => {
-                setAttachMenuOpen(false);
-                handleAttachClick();
-              }}
-              onClose={() => setAttachMenuOpen(false)}
-              isRemote={isRemote}
+          {contextPopoverOpen && (
+            <ContextPopover
+              workspaceId={selectedWorkspaceId}
+              onClose={() => setContextPopoverOpen(false)}
+              onCompact={() => resetAgentSession(selectedWorkspaceId)}
+              onClear={() => clearConversation(selectedWorkspaceId, false)}
             />
           )}
         </div>
-        <ChatToolbar
-          workspaceId={selectedWorkspaceId}
-          disabled={isRunning}
-        />
-        <button
-          className={`${styles.sendBtn} ${isRunning ? styles.sendBtnStop : ""}`}
-          onClick={isRunning ? onStop : handleSend}
-          disabled={!isRunning && !chatInput.trim() && pendingAttachments.length === 0}
-          title={isRunning ? "Stop agent" : "Send message"}
-          aria-label={isRunning ? "Stop agent" : "Send message"}
-        >
-          {isRunning ? <Square size={16} /> : <Send size={16} />}
-        </button>
       </div>
     </div>
   );

--- a/src/ui/src/components/chat/composer/ComposerToolbar.module.css
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.module.css
@@ -1,0 +1,19 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  position: relative;
+  min-width: 0;
+}
+
+.modelPillWrap {
+  position: relative;
+}
+
+.accentIcon {
+  color: var(--accent-primary);
+}
+
+.extraUsage {
+  color: var(--text-dim);
+}

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useState } from "react";
+import { BadgeDollarSign, Sparkles, BookOpen } from "lucide-react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { getAppSetting, setAppSetting } from "../../../services/tauri";
+import { ModelSelector, MODELS } from "../ModelSelector";
+import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "../modelCapabilities";
+import { applySelectedModel } from "../applySelectedModel";
+import { applyPlanModeMountDefault } from "../applyPlanModeMountDefault";
+import { ToolbarPill } from "./ToolbarPill";
+import { ReasoningPill } from "./ReasoningPill";
+import { OverflowMenu } from "./OverflowMenu";
+import styles from "./ComposerToolbar.module.css";
+
+interface ComposerToolbarProps {
+  workspaceId: string;
+  disabled: boolean;
+}
+
+export function ComposerToolbar({ workspaceId, disabled }: ComposerToolbarProps) {
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId] ?? "opus");
+  const thinkingEnabled = useAppStore((s) => s.thinkingEnabled[workspaceId] ?? false);
+  const planMode = useAppStore((s) => s.planMode[workspaceId] ?? false);
+  const modelSelectorOpen = useAppStore((s) => s.modelSelectorOpen);
+  const setSelectedModel = useAppStore((s) => s.setSelectedModel);
+  const setFastMode = useAppStore((s) => s.setFastMode);
+  const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
+  const setPlanMode = useAppStore((s) => s.setPlanMode);
+  const setEffortLevel = useAppStore((s) => s.setEffortLevel);
+  const setChromeEnabled = useAppStore((s) => s.setChromeEnabled);
+  const setShowThinkingBlocks = useAppStore((s) => s.setShowThinkingBlocks);
+  const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
+  const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
+
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const [model, fast, thinking, effort, showThinking, chrome, defModel, defFast, defThinking, defPlan, defEffort, defShowThinking, defChrome] = await Promise.all([
+        getAppSetting(`model:${workspaceId}`),
+        getAppSetting(`fast_mode:${workspaceId}`),
+        getAppSetting(`thinking_enabled:${workspaceId}`),
+        getAppSetting(`effort_level:${workspaceId}`),
+        getAppSetting(`show_thinking:${workspaceId}`),
+        getAppSetting(`chrome_enabled:${workspaceId}`),
+        getAppSetting("default_model"),
+        getAppSetting("default_fast_mode"),
+        getAppSetting("default_thinking"),
+        getAppSetting("default_plan_mode"),
+        getAppSetting("default_effort"),
+        getAppSetting("default_show_thinking"),
+        getAppSetting("default_chrome"),
+      ]);
+      if (cancelled) return;
+      const loadedModel = model ?? defModel ?? "opus";
+      setSelectedModel(workspaceId, loadedModel);
+      const effectiveFast = isFastSupported(loadedModel) && (fast === "true" || (!fast && defFast === "true"));
+      const effectiveThinking = thinking === "true" || (!thinking && defThinking === "true");
+      setFastMode(workspaceId, effectiveFast);
+      setThinkingEnabled(workspaceId, effectiveThinking);
+      applyPlanModeMountDefault(workspaceId, defPlan === "true");
+      const effectiveEffort = effort ?? defEffort;
+      if (effectiveEffort) {
+        const normalized = !isEffortSupported(loadedModel)
+          ? "auto"
+          : effectiveEffort === "xhigh" && !isXhighEffortAllowed(loadedModel)
+            ? "high"
+            : effectiveEffort === "max" && !isMaxEffortAllowed(loadedModel)
+              ? "high"
+              : effectiveEffort;
+        setEffortLevel(workspaceId, normalized);
+      }
+      setShowThinkingBlocks(workspaceId, showThinking === "true" || (!showThinking && defShowThinking === "true"));
+      setChromeEnabled(workspaceId, chrome === "true" || (!chrome && defChrome === "true"));
+      setLoaded(true);
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [workspaceId, setSelectedModel, setFastMode, setThinkingEnabled, setEffortLevel, setShowThinkingBlocks, setChromeEnabled]);
+
+  const handleModelSelect = useCallback(
+    async (model: string) => {
+      if (model !== selectedModel) {
+        await applySelectedModel(workspaceId, model);
+      }
+      setModelSelectorOpen(false);
+    },
+    [workspaceId, selectedModel, setModelSelectorOpen],
+  );
+
+  const toggleThinking = useCallback(async () => {
+    const next = !thinkingEnabled;
+    setThinkingEnabled(workspaceId, next);
+    await setAppSetting(`thinking_enabled:${workspaceId}`, String(next));
+  }, [workspaceId, thinkingEnabled, setThinkingEnabled]);
+
+  const togglePlan = useCallback(() => {
+    setPlanMode(workspaceId, !planMode);
+  }, [workspaceId, planMode, setPlanMode]);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.metaKey && e.key === "t") {
+        e.preventDefault();
+        if (!disabled) toggleThinking();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [disabled, toggleThinking]);
+
+  const currentModel = MODELS.find((m) => m.id === selectedModel);
+  const modelLabel = currentModel?.label ?? selectedModel;
+  const isExtraUsage = currentModel?.extraUsage ?? false;
+
+  if (!loaded) return null;
+
+  return (
+    <div className={styles.toolbar}>
+      <div className={styles.modelPillWrap}>
+        <ToolbarPill
+          icon={<Sparkles size={14} className={styles.accentIcon} />}
+          label={modelLabel}
+          chevron
+          onClick={() => setModelSelectorOpen(!modelSelectorOpen)}
+          disabled={disabled}
+          title={isExtraUsage ? "Change model (extra usage: 1M context billed at API rates)" : "Change model"}
+        >
+          {isExtraUsage && <BadgeDollarSign size={14} className={styles.extraUsage} />}
+        </ToolbarPill>
+        {modelSelectorOpen && (
+          <ModelSelector
+            selected={selectedModel}
+            onSelect={handleModelSelect}
+            onClose={() => setModelSelectorOpen(false)}
+          />
+        )}
+      </div>
+
+      <ToolbarPill
+        icon={<BookOpen size={14} />}
+        label="Plan"
+        active={planMode}
+        onClick={togglePlan}
+        disabled={disabled}
+        title={`${planMode ? "Disable" : "Enable"} plan mode`}
+        ariaPressed={planMode}
+      />
+
+      <ReasoningPill workspaceId={workspaceId} disabled={disabled} />
+
+      <OverflowMenu workspaceId={workspaceId} disabled={disabled} />
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -29,7 +29,6 @@ export function ComposerToolbar({ workspaceId, disabled }: ComposerToolbarProps)
   const setChromeEnabled = useAppStore((s) => s.setChromeEnabled);
   const setShowThinkingBlocks = useAppStore((s) => s.setShowThinkingBlocks);
   const setModelSelectorOpen = useAppStore((s) => s.setModelSelectorOpen);
-  const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
 
   const [loaded, setLoaded] = useState(false);
 

--- a/src/ui/src/components/chat/composer/ContextPopover.module.css
+++ b/src/ui/src/components/chat/composer/ContextPopover.module.css
@@ -1,0 +1,162 @@
+.popover {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  right: 0;
+  width: 320px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-xl);
+  padding: 16px;
+  box-shadow: var(--shadow-lg);
+  z-index: 50;
+  animation: fadeUp 160ms var(--ease-out-quick);
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 2px;
+}
+
+.caption {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.stateLabel {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+}
+
+.bigReadout {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.bigNumber {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.bigDenom {
+  font-family: var(--font-mono);
+  font-size: var(--fs-base);
+  color: var(--text-dim);
+}
+
+.bar {
+  display: flex;
+  height: 6px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--divider);
+  margin-bottom: 10px;
+}
+
+.barSegment {
+  transition: width 400ms;
+}
+
+.segmentList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.segmentRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: var(--fs-sm);
+}
+
+.segmentLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.segmentDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.segmentValue {
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-top: 1px solid var(--divider);
+  border-bottom: 1px solid var(--divider);
+  margin-bottom: 12px;
+  font-size: var(--fs-sm);
+}
+
+.footerCol {
+  display: flex;
+  flex-direction: column;
+}
+
+.footerColRight {
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+}
+
+.footerCaption {
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footerValue {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  margin-top: 2px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.actionBtn {
+  flex: 1;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--sidebar-border);
+  color: var(--text-primary);
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  font-size: var(--fs-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.actionBtn:hover {
+  background: var(--hover-bg);
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/ui/src/components/chat/composer/ContextPopover.tsx
+++ b/src/ui/src/components/chat/composer/ContextPopover.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from "react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { MODELS } from "../modelRegistry";
+import { computeMeterState } from "../contextMeterLogic";
+import { formatTokens } from "../formatTokens";
+import { segmentedBand, segmentedColor, stateLabel } from "./segmentedMeterLogic";
+import { estimateCost, formatCost } from "./formatCost";
+import styles from "./ContextPopover.module.css";
+
+interface ContextPopoverProps {
+  workspaceId: string;
+  onClose: () => void;
+  onCompact: () => void;
+  onClear: () => void;
+}
+
+const SEGMENTS = [
+  { label: "System + tools", shareKey: "system" as const },
+  { label: "Conversation", shareKey: "conversation" as const },
+  { label: "Latest files", shareKey: "files" as const },
+];
+
+const SEGMENT_COLORS = [
+  "var(--text-dim)",
+  "var(--accent-primary)",
+  "var(--accent-dim)",
+];
+
+export function ContextPopover({ workspaceId, onClose, onCompact, onClear }: ContextPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const usage = useAppStore((s) => s.latestTurnUsage[workspaceId]);
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId]);
+
+  const model = MODELS.find((m) => m.id === selectedModel);
+  const state = computeMeterState(usage, model?.contextWindowTokens);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
+
+  if (!state) return null;
+
+  const ratio = state.totalTokens / state.capacity;
+  const band = segmentedBand(ratio);
+  const color = segmentedColor(band);
+  const remaining = state.capacity - state.totalTokens;
+  const cost = estimateCost(state.totalTokens);
+
+  const systemShare = 0.08;
+  const filesShare = 0.07;
+  const convShare = Math.max(0, ratio - systemShare - filesShare);
+  const shares = [systemShare, convShare, filesShare];
+
+  return (
+    <div ref={popoverRef} className={styles.popover}>
+      <div className={styles.header}>
+        <span className={styles.caption}>Context</span>
+        <span className={styles.stateLabel} style={{ color }}>{stateLabel(ratio)}</span>
+      </div>
+
+      <div className={styles.bigReadout}>
+        <span className={styles.bigNumber}>{formatTokens(state.totalTokens)}</span>
+        <span className={styles.bigDenom}>/ {formatTokens(state.capacity)} tokens</span>
+      </div>
+
+      <div className={styles.bar}>
+        {shares.map((share, i) => (
+          <div
+            key={i}
+            className={styles.barSegment}
+            style={{
+              width: `${share * 100}%`,
+              background: SEGMENT_COLORS[i],
+            }}
+          />
+        ))}
+      </div>
+
+      <div className={styles.segmentList}>
+        {SEGMENTS.map((seg, i) => (
+          <div key={i} className={styles.segmentRow}>
+            <div className={styles.segmentLabel}>
+              <span
+                className={styles.segmentDot}
+                style={{ background: SEGMENT_COLORS[i] }}
+              />
+              <span>{seg.label}</span>
+            </div>
+            <span className={styles.segmentValue}>
+              {formatTokens(shares[i] * state.capacity)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.footer}>
+        <div className={styles.footerCol}>
+          <span className={styles.footerCaption}>Remaining</span>
+          <span className={styles.footerValue}>
+            {formatTokens(Math.max(0, remaining))}
+          </span>
+        </div>
+        <div className={styles.footerColRight}>
+          <span className={styles.footerCaption}>This session</span>
+          <span className={styles.footerValue}>{formatCost(cost)}</span>
+        </div>
+      </div>
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.actionBtn}
+          onClick={() => { onCompact(); onClose(); }}
+        >
+          Compact
+        </button>
+        <button
+          type="button"
+          className={styles.actionBtn}
+          onClick={() => { onClear(); onClose(); }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/composer/ContextPopover.tsx
+++ b/src/ui/src/components/chat/composer/ContextPopover.tsx
@@ -63,8 +63,12 @@ export function ContextPopover({ workspaceId, onClose, onCompact, onClear }: Con
   const remaining = state.capacity - state.totalTokens;
   const cost = estimateCost(state.totalTokens);
 
-  const systemShare = 0.08;
-  const filesShare = 0.07;
+  const baseSystemShare = 0.08;
+  const baseFilesShare = 0.07;
+  const fixedTotal = baseSystemShare + baseFilesShare;
+  const scale = fixedTotal > 0 ? Math.min(1, ratio / fixedTotal) : 0;
+  const systemShare = baseSystemShare * scale;
+  const filesShare = baseFilesShare * scale;
   const convShare = Math.max(0, ratio - systemShare - filesShare);
   const shares = [systemShare, convShare, filesShare];
 
@@ -104,7 +108,7 @@ export function ContextPopover({ workspaceId, onClose, onCompact, onClear }: Con
               <span>{seg.label}</span>
             </div>
             <span className={styles.segmentValue}>
-              {formatTokens(shares[i] * state.capacity)}
+              {formatTokens(Math.trunc(shares[i] * state.capacity))}
             </span>
           </div>
         ))}

--- a/src/ui/src/components/chat/composer/OverflowMenu.module.css
+++ b/src/ui/src/components/chat/composer/OverflowMenu.module.css
@@ -1,0 +1,114 @@
+.wrap {
+  position: relative;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-width: 32px;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  position: relative;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.trigger:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--hover-bg);
+}
+
+.trigger:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 2px;
+  background: currentColor;
+}
+
+.badge {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 5px;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--accent-primary);
+  box-shadow: 0 0 0 1.5px var(--sidebar-bg);
+}
+
+.dropdown {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  width: 220px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-lg);
+  padding: 6px;
+  box-shadow: var(--shadow-lg);
+  z-index: 40;
+  animation: fadeUp 160ms var(--ease-out-quick);
+}
+
+.item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  border-radius: var(--radius-md);
+  text-align: left;
+  cursor: pointer;
+  font-size: var(--fs-base);
+  font-family: inherit;
+  transition: background var(--transition-fast);
+}
+
+.item:hover {
+  background: var(--hover-bg);
+}
+
+.itemActive {
+  background: var(--selected-bg);
+  color: var(--accent-primary);
+}
+
+.itemActive:hover {
+  background: var(--selected-bg);
+}
+
+.itemIcon {
+  display: flex;
+  width: 16px;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.itemLabel {
+  flex: 1;
+}
+
+.itemMeta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Zap, Globe } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
@@ -110,7 +111,7 @@ function MenuItem({
   meta,
   onClick,
 }: {
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   active: boolean;
   meta: string;

--- a/src/ui/src/components/chat/composer/OverflowMenu.tsx
+++ b/src/ui/src/components/chat/composer/OverflowMenu.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Zap, Globe } from "lucide-react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { resetAgentSession, setAppSetting } from "../../../services/tauri";
+import { isFastSupported } from "../modelCapabilities";
+import styles from "./OverflowMenu.module.css";
+
+interface OverflowMenuProps {
+  workspaceId: string;
+  disabled: boolean;
+}
+
+export function OverflowMenu({ workspaceId, disabled }: OverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId] ?? "opus");
+  const fastMode = useAppStore((s) => s.fastMode[workspaceId] ?? false);
+  const chromeEnabled = useAppStore((s) => s.chromeEnabled[workspaceId] ?? false);
+  const setFastMode = useAppStore((s) => s.setFastMode);
+  const setChromeEnabled = useAppStore((s) => s.setChromeEnabled);
+  const clearAgentQuestion = useAppStore((s) => s.clearAgentQuestion);
+  const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
+
+  const showFast = isFastSupported(selectedModel);
+  const anyActive = fastMode || chromeEnabled;
+
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const toggleFast = useCallback(async () => {
+    const next = !fastMode;
+    setFastMode(workspaceId, next);
+    await setAppSetting(`fast_mode:${workspaceId}`, String(next));
+  }, [workspaceId, fastMode, setFastMode]);
+
+  const toggleChrome = useCallback(async () => {
+    const next = !chromeEnabled;
+    setChromeEnabled(workspaceId, next);
+    await setAppSetting(`chrome_enabled:${workspaceId}`, String(next));
+    await resetAgentSession(workspaceId);
+    clearAgentQuestion(workspaceId);
+    clearPlanApproval(workspaceId);
+  }, [workspaceId, chromeEnabled, setChromeEnabled, clearAgentQuestion, clearPlanApproval]);
+
+  return (
+    <div ref={containerRef} className={styles.wrap}>
+      <button
+        type="button"
+        className={styles.trigger}
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+        aria-label="More options"
+        aria-expanded={open}
+      >
+        <span className={styles.dot} />
+        <span className={styles.dot} />
+        <span className={styles.dot} />
+        {anyActive && <span className={styles.badge} />}
+      </button>
+
+      {open && (
+        <div className={styles.dropdown}>
+          {showFast && (
+            <MenuItem
+              icon={<Zap size={14} />}
+              label="Fast mode"
+              active={fastMode}
+              meta={fastMode ? "on" : "off"}
+              onClick={toggleFast}
+            />
+          )}
+          <MenuItem
+            icon={<Globe size={14} />}
+            label="Claude in Chrome"
+            active={chromeEnabled}
+            meta={chromeEnabled ? "on" : "off"}
+            onClick={toggleChrome}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItem({
+  icon,
+  label,
+  active,
+  meta,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  meta: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`${styles.item} ${active ? styles.itemActive : ""}`}
+      onClick={onClick}
+    >
+      <span className={styles.itemIcon}>{icon}</span>
+      <span className={styles.itemLabel}>{label}</span>
+      <span className={styles.itemMeta}>{meta}</span>
+    </button>
+  );
+}

--- a/src/ui/src/components/chat/composer/ReasoningPill.module.css
+++ b/src/ui/src/components/chat/composer/ReasoningPill.module.css
@@ -1,0 +1,193 @@
+.wrap {
+  position: relative;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.pillActive {
+  background: var(--toolbar-active);
+  border-color: rgba(var(--accent-primary-rgb), 0.28);
+}
+
+.segment {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--fs-base);
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  position: relative;
+}
+
+.pillActive .segment {
+  color: var(--toolbar-active-text);
+}
+
+.segment:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.pillActive .segment:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+
+.segment:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.segment:first-child {
+  border-radius: var(--radius-pill) 0 0 var(--radius-pill);
+}
+
+.segment:last-child {
+  border-radius: 0 var(--radius-pill) var(--radius-pill) 0;
+}
+
+.segmentLabel {
+  line-height: 1;
+}
+
+.effortLabel {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1;
+}
+
+.chevron {
+  display: flex;
+  align-items: center;
+  opacity: 0.6;
+}
+
+.divider {
+  width: 1px;
+  height: 12px;
+  background: rgba(var(--accent-primary-rgb), 0.3);
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.shortcutBadge {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border: 1px solid var(--sidebar-border);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-xs);
+  background: var(--sidebar-bg);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+}
+
+/* ── Dropdown ── */
+
+.dropdown {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  width: 260px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-lg);
+  padding: 6px;
+  box-shadow: var(--shadow-lg);
+  z-index: 40;
+  animation: fadeUp 160ms var(--ease-out-quick);
+}
+
+.sectionLabel {
+  padding: 8px 10px 4px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  user-select: none;
+}
+
+.sectionDivider {
+  height: 1px;
+  background: var(--sidebar-border);
+  margin: 6px 0;
+}
+
+.menuItem {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  border-radius: var(--radius-md);
+  text-align: left;
+  cursor: pointer;
+  font-size: var(--fs-base);
+  font-family: inherit;
+  transition: background var(--transition-fast);
+}
+
+.menuItem:hover {
+  background: var(--hover-bg);
+}
+
+.menuItemActive {
+  background: var(--selected-bg);
+  color: var(--accent-primary);
+}
+
+.menuItemActive:hover {
+  background: var(--selected-bg);
+}
+
+.menuIcon {
+  display: flex;
+  width: 16px;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.menuLabel {
+  flex: 1;
+}
+
+.menuMeta {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+}
+
+.effortDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/ui/src/components/chat/composer/ReasoningPill.tsx
+++ b/src/ui/src/components/chat/composer/ReasoningPill.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Brain, Eye, EyeOff, ChevronDown } from "lucide-react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { setAppSetting } from "../../../services/tauri";
+import { isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "../modelCapabilities";
+import { EFFORT_LEVELS } from "../EffortSelector";
+import styles from "./ReasoningPill.module.css";
+
+interface ReasoningPillProps {
+  workspaceId: string;
+  disabled: boolean;
+}
+
+function getAvailableLevels(model: string) {
+  if (isXhighEffortAllowed(model)) return EFFORT_LEVELS;
+  if (isMaxEffortAllowed(model)) return EFFORT_LEVELS.filter((l) => l.id !== "xhigh");
+  return EFFORT_LEVELS.filter((l) => l.id !== "xhigh" && l.id !== "max");
+}
+
+export function ReasoningPill({ workspaceId, disabled }: ReasoningPillProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId] ?? "opus");
+  const thinkingEnabled = useAppStore((s) => s.thinkingEnabled[workspaceId] ?? false);
+  const showThinkingBlocks = useAppStore((s) => s.showThinkingBlocks[workspaceId] === true);
+  const effortLevel = useAppStore((s) => s.effortLevel[workspaceId] ?? "auto");
+  const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
+  const setShowThinkingBlocks = useAppStore((s) => s.setShowThinkingBlocks);
+  const setEffortLevel = useAppStore((s) => s.setEffortLevel);
+  const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
+
+  const isMac = typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
+  const mod = isMac ? "⌘" : "Ctrl+";
+
+  const showEffort = isEffortSupported(selectedModel);
+  const effortLabel = EFFORT_LEVELS.find((l) => l.id === effortLevel)?.label ?? effortLevel;
+  const isActive = thinkingEnabled;
+
+  const openDropdown = useCallback(() => {
+    if (!disabled) setDropdownOpen(true);
+  }, [disabled]);
+
+  const toggleThinking = useCallback(async () => {
+    const next = !thinkingEnabled;
+    setThinkingEnabled(workspaceId, next);
+    await setAppSetting(`thinking_enabled:${workspaceId}`, String(next));
+  }, [workspaceId, thinkingEnabled, setThinkingEnabled]);
+
+  const toggleShowThinking = useCallback(async () => {
+    const next = !showThinkingBlocks;
+    setShowThinkingBlocks(workspaceId, next);
+    await setAppSetting(`show_thinking:${workspaceId}`, String(next));
+  }, [workspaceId, showThinkingBlocks, setShowThinkingBlocks]);
+
+  const handleEffortSelect = useCallback(
+    async (level: string) => {
+      setEffortLevel(workspaceId, level);
+      await setAppSetting(`effort_level:${workspaceId}`, level);
+      setDropdownOpen(false);
+    },
+    [workspaceId, setEffortLevel],
+  );
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setDropdownOpen(false);
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [dropdownOpen]);
+
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [dropdownOpen]);
+
+  const levels = getAvailableLevels(selectedModel);
+
+  return (
+    <div ref={containerRef} className={styles.wrap}>
+      <div className={`${styles.pill} ${isActive ? styles.pillActive : ""}`}>
+        <button
+          type="button"
+          className={styles.segment}
+          onClick={openDropdown}
+          disabled={disabled}
+          title={`${thinkingEnabled ? "Disable" : "Enable"} extended thinking`}
+          aria-expanded={dropdownOpen}
+        >
+          <Brain size={14} />
+          <span className={styles.segmentLabel}>Thinking</span>
+          {metaKeyHeld && (
+            <kbd className={styles.shortcutBadge} aria-hidden="true">{mod}T</kbd>
+          )}
+        </button>
+
+        <span className={styles.divider} />
+
+        <button
+          type="button"
+          className={styles.segment}
+          onClick={openDropdown}
+          disabled={disabled}
+          title={`${showThinkingBlocks ? "Hide" : "Show"} thinking traces`}
+          aria-expanded={dropdownOpen}
+        >
+          {showThinkingBlocks ? <Eye size={13} /> : <EyeOff size={13} />}
+        </button>
+
+        {showEffort && (
+          <>
+            <span className={styles.divider} />
+            <button
+              type="button"
+              className={styles.segment}
+              onClick={openDropdown}
+              disabled={disabled}
+              title="Set effort level"
+              aria-expanded={dropdownOpen}
+            >
+              <span className={styles.effortLabel}>{effortLabel.toLowerCase()}</span>
+              <span className={styles.chevron}>
+                <ChevronDown size={12} />
+              </span>
+            </button>
+          </>
+        )}
+      </div>
+
+      {dropdownOpen && (
+        <div className={styles.dropdown}>
+          <div className={styles.sectionLabel}>Reasoning</div>
+          <button
+            type="button"
+            className={`${styles.menuItem} ${thinkingEnabled ? styles.menuItemActive : ""}`}
+            onClick={toggleThinking}
+          >
+            <span className={styles.menuIcon}><Brain size={14} /></span>
+            <span className={styles.menuLabel}>Thinking</span>
+            <span className={styles.menuMeta}>{thinkingEnabled ? "on" : "off"}</span>
+          </button>
+          <button
+            type="button"
+            className={`${styles.menuItem} ${showThinkingBlocks ? styles.menuItemActive : ""}`}
+            onClick={toggleShowThinking}
+          >
+            <span className={styles.menuIcon}>
+              {showThinkingBlocks ? <Eye size={14} /> : <EyeOff size={14} />}
+            </span>
+            <span className={styles.menuLabel}>Show thinking</span>
+            <span className={styles.menuMeta}>{showThinkingBlocks ? "on" : "off"}</span>
+          </button>
+
+          {showEffort && (
+            <>
+              <div className={styles.sectionDivider} />
+              <div className={styles.sectionLabel}>Effort</div>
+              {levels.map((level) => (
+                <button
+                  key={level.id}
+                  type="button"
+                  className={`${styles.menuItem} ${level.id === effortLevel ? styles.menuItemActive : ""}`}
+                  onClick={() => handleEffortSelect(level.id)}
+                >
+                  <span
+                    className={styles.effortDot}
+                    style={{
+                      background: level.id === effortLevel
+                        ? "var(--accent-primary)"
+                        : "var(--text-dim)",
+                    }}
+                  />
+                  <span className={styles.menuLabel}>{level.label}</span>
+                  {level.id === effortLevel && (
+                    <span className={styles.menuMeta}>&#x2713;</span>
+                  )}
+                </button>
+              ))}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/composer/ReasoningPill.tsx
+++ b/src/ui/src/components/chat/composer/ReasoningPill.tsx
@@ -95,8 +95,9 @@ export function ReasoningPill({ workspaceId, disabled }: ReasoningPillProps) {
           className={styles.segment}
           onClick={openDropdown}
           disabled={disabled}
-          title={`${thinkingEnabled ? "Disable" : "Enable"} extended thinking`}
+          title="Reasoning settings"
           aria-expanded={dropdownOpen}
+          aria-label="Reasoning settings"
         >
           <Brain size={14} />
           <span className={styles.segmentLabel}>Thinking</span>
@@ -112,7 +113,7 @@ export function ReasoningPill({ workspaceId, disabled }: ReasoningPillProps) {
           className={styles.segment}
           onClick={openDropdown}
           disabled={disabled}
-          title={`${showThinkingBlocks ? "Hide" : "Show"} thinking traces`}
+          title="Reasoning settings"
           aria-expanded={dropdownOpen}
         >
           {showThinkingBlocks ? <Eye size={13} /> : <EyeOff size={13} />}

--- a/src/ui/src/components/chat/composer/SegmentedMeter.module.css
+++ b/src/ui/src/components/chat/composer/SegmentedMeter.module.css
@@ -1,0 +1,119 @@
+.meter {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+  font-family: inherit;
+}
+
+.meter:hover {
+  background: var(--hover-bg);
+}
+
+.cells {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cell {
+  position: relative;
+  width: 3px;
+  height: 14px;
+  border-radius: 1.5px;
+  background: var(--divider);
+  overflow: visible;
+  transition: background 240ms ease-out;
+  transition-delay: calc(var(--cell-index, 0) * 20ms);
+  transform-origin: center;
+}
+
+.cellFilled {
+  background: var(--cell-color);
+}
+
+.cellPartial {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 1.5px;
+  transition: height 500ms var(--ease-out-quick);
+}
+
+.readout {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.edgePulse {
+  position: absolute;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+/* ── Animations (respect prefers-reduced-motion) ── */
+
+@media (prefers-reduced-motion: no-preference) {
+  .cellBreathing {
+    animation: ctx-breath var(--breath-duration, 1.8s) ease-in-out infinite;
+  }
+
+  .cellPartial {
+    animation: ctx-lead-pulse var(--lead-duration, 2.2s) ease-in-out infinite;
+  }
+
+  .cellEmpty::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--hover-bg);
+    border-radius: 1.5px;
+    opacity: 0;
+    animation: ctx-shimmer 4s ease-in-out infinite;
+    animation-delay: calc(var(--cell-index, 0) * 120ms);
+  }
+
+  .meterUrgent .cellFilled {
+    box-shadow: 0 0 6px var(--cell-color);
+  }
+
+  .edgePulse {
+    background: radial-gradient(circle, color-mix(in srgb, var(--cell-color) 40%, transparent) 0%, transparent 60%);
+    animation: ctx-edge-pulse 1.2s ease-in-out infinite;
+  }
+}
+
+@keyframes ctx-breath {
+  0%, 100% { transform: scaleY(1); filter: brightness(1); }
+  50% { transform: scaleY(1.15); filter: brightness(1.35); }
+}
+
+@keyframes ctx-lead-pulse {
+  0%, 100% { opacity: 0.55; transform: scaleY(0.9); }
+  50% { opacity: 1; transform: scaleY(1); }
+}
+
+@keyframes ctx-shimmer {
+  0%, 85%, 100% { opacity: 0; }
+  90% { opacity: 0.35; }
+}
+
+@keyframes ctx-edge-pulse {
+  0%, 100% { opacity: 0.35; transform: translate(-50%, -50%) scale(0.9); }
+  50% { opacity: 0.9; transform: translate(-50%, -50%) scale(1.25); }
+}

--- a/src/ui/src/components/chat/composer/SegmentedMeter.tsx
+++ b/src/ui/src/components/chat/composer/SegmentedMeter.tsx
@@ -1,0 +1,87 @@
+import { useAppStore } from "../../../stores/useAppStore";
+import { MODELS } from "../modelRegistry";
+import { computeMeterState } from "../contextMeterLogic";
+import { formatTokens } from "../formatTokens";
+import { segmentedBand, segmentedColor } from "./segmentedMeterLogic";
+import styles from "./SegmentedMeter.module.css";
+
+const CELL_COUNT = 10;
+
+interface SegmentedMeterProps {
+  workspaceId: string;
+  onClick: () => void;
+}
+
+export function SegmentedMeter({ workspaceId, onClick }: SegmentedMeterProps) {
+  const usage = useAppStore((s) => s.latestTurnUsage[workspaceId]);
+  const selectedModel = useAppStore((s) => s.selectedModel[workspaceId]);
+
+  const model = MODELS.find((m) => m.id === selectedModel);
+  const state = computeMeterState(usage, model?.contextWindowTokens);
+  if (!state) return null;
+
+  const ratio = state.totalTokens / state.capacity;
+  const band = segmentedBand(ratio);
+  const color = segmentedColor(band);
+  const urgent = ratio >= 0.85;
+
+  const filledFloat = (state.fillPercent / 100) * CELL_COUNT;
+  const filled = Math.floor(filledFloat);
+  const partial = filledFloat - filled;
+
+  return (
+    <button
+      type="button"
+      className={`${styles.meter} ${urgent ? styles.meterUrgent : ""}`}
+      onClick={onClick}
+      aria-label={`Context ${state.percentRounded}% used`}
+    >
+      <div className={styles.cells}>
+        {Array.from({ length: CELL_COUNT }, (_, i) => {
+          const isFilled = i < filled;
+          const isLeading = i === filled && partial > 0.02;
+          const isEmpty = !isFilled && !isLeading;
+          const isBreathing = isFilled && i === filled - 1;
+
+          return (
+            <span
+              key={i}
+              className={`${styles.cell} ${isFilled ? styles.cellFilled : ""} ${isBreathing ? styles.cellBreathing : ""} ${isEmpty ? styles.cellEmpty : ""}`}
+              style={{
+                "--cell-index": i,
+                "--cell-color": color,
+                "--breath-duration": urgent ? "0.9s" : "1.8s",
+                "--lead-duration": urgent ? "1.2s" : "2.2s",
+              } as React.CSSProperties}
+            >
+              {isLeading && (
+                <span
+                  className={styles.cellPartial}
+                  style={{
+                    height: `${partial * 100}%`,
+                    background: color,
+                  }}
+                />
+              )}
+            </span>
+          );
+        })}
+
+        {urgent && (
+          <span
+            className={styles.edgePulse}
+            aria-hidden
+            style={{
+              left: `calc(${filled * 7}px)`,
+              "--cell-color": color,
+            } as React.CSSProperties}
+          />
+        )}
+      </div>
+
+      <span className={styles.readout}>
+        {formatTokens(state.totalTokens)} / {formatTokens(state.capacity)}
+      </span>
+    </button>
+  );
+}

--- a/src/ui/src/components/chat/composer/SegmentedMeter.tsx
+++ b/src/ui/src/components/chat/composer/SegmentedMeter.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { MODELS } from "../modelRegistry";
 import { computeMeterState } from "../contextMeterLogic";
@@ -52,7 +53,7 @@ export function SegmentedMeter({ workspaceId, onClick }: SegmentedMeterProps) {
                 "--cell-color": color,
                 "--breath-duration": urgent ? "0.9s" : "1.8s",
                 "--lead-duration": urgent ? "1.2s" : "2.2s",
-              } as React.CSSProperties}
+              } as CSSProperties}
             >
               {isLeading && (
                 <span
@@ -72,9 +73,9 @@ export function SegmentedMeter({ workspaceId, onClick }: SegmentedMeterProps) {
             className={styles.edgePulse}
             aria-hidden
             style={{
-              left: `calc(${filled * 7}px)`,
+              left: `calc(${Math.min(filled, CELL_COUNT - 1) * 7}px)`,
               "--cell-color": color,
-            } as React.CSSProperties}
+            } as CSSProperties}
           />
         )}
       </div>

--- a/src/ui/src/components/chat/composer/ToolbarPill.module.css
+++ b/src/ui/src/components/chat/composer/ToolbarPill.module.css
@@ -1,0 +1,53 @@
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--fs-base);
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--transition-fast),
+              color var(--transition-fast),
+              border-color var(--transition-fast);
+}
+
+.pill:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.pill:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.pillActive {
+  background: var(--toolbar-active);
+  color: var(--toolbar-active-text);
+  border-color: rgba(var(--accent-primary-rgb), 0.28);
+}
+
+.pillActive:hover:not(:disabled) {
+  color: var(--toolbar-active-text);
+  filter: brightness(1.15);
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+}
+
+.label {
+  line-height: 1;
+}
+
+.chevron {
+  display: flex;
+  align-items: center;
+  opacity: 0.5;
+}

--- a/src/ui/src/components/chat/composer/ToolbarPill.tsx
+++ b/src/ui/src/components/chat/composer/ToolbarPill.tsx
@@ -1,8 +1,9 @@
+import type { ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
 import styles from "./ToolbarPill.module.css";
 
 interface ToolbarPillProps {
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   label?: string;
   active?: boolean;
   disabled?: boolean;
@@ -13,7 +14,7 @@ interface ToolbarPillProps {
   ariaExpanded?: boolean;
   ariaLabel?: string;
   className?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function ToolbarPill({

--- a/src/ui/src/components/chat/composer/ToolbarPill.tsx
+++ b/src/ui/src/components/chat/composer/ToolbarPill.tsx
@@ -1,0 +1,54 @@
+import { ChevronDown } from "lucide-react";
+import styles from "./ToolbarPill.module.css";
+
+interface ToolbarPillProps {
+  icon?: React.ReactNode;
+  label?: string;
+  active?: boolean;
+  disabled?: boolean;
+  title?: string;
+  chevron?: boolean;
+  onClick?: () => void;
+  ariaPressed?: boolean;
+  ariaExpanded?: boolean;
+  ariaLabel?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function ToolbarPill({
+  icon,
+  label,
+  active,
+  disabled,
+  title,
+  chevron,
+  onClick,
+  ariaPressed,
+  ariaExpanded,
+  ariaLabel,
+  className,
+  children,
+}: ToolbarPillProps) {
+  return (
+    <button
+      type="button"
+      className={`${styles.pill} ${active ? styles.pillActive : ""} ${className ?? ""}`}
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-pressed={ariaPressed}
+      aria-expanded={ariaExpanded}
+      aria-label={ariaLabel}
+    >
+      {icon && <span className={styles.icon}>{icon}</span>}
+      {label && <span className={styles.label}>{label}</span>}
+      {children}
+      {chevron && (
+        <span className={styles.chevron}>
+          <ChevronDown size={12} />
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/ui/src/components/chat/composer/formatCost.test.ts
+++ b/src/ui/src/components/chat/composer/formatCost.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { estimateCost, formatCost } from "./formatCost";
+
+describe("estimateCost", () => {
+  it("returns 0 for 0 tokens", () => {
+    expect(estimateCost(0)).toBe(0);
+  });
+
+  it("computes cost at $15/M tokens", () => {
+    expect(estimateCost(1_000_000)).toBe(15);
+    expect(estimateCost(100_000)).toBeCloseTo(1.5);
+    expect(estimateCost(200_000)).toBeCloseTo(3.0);
+  });
+});
+
+describe("formatCost", () => {
+  it("shows <$0.01 for very small amounts", () => {
+    expect(formatCost(0)).toBe("<$0.01");
+    expect(formatCost(0.005)).toBe("<$0.01");
+    expect(formatCost(0.009)).toBe("<$0.01");
+  });
+
+  it("formats normal amounts with 2 decimal places", () => {
+    expect(formatCost(0.01)).toBe("$0.01");
+    expect(formatCost(1.50)).toBe("$1.50");
+    expect(formatCost(15.00)).toBe("$15.00");
+    expect(formatCost(99.99)).toBe("$99.99");
+  });
+
+  it("drops decimals for amounts >= $100", () => {
+    expect(formatCost(100)).toBe("$100");
+    expect(formatCost(150.75)).toBe("$151");
+    expect(formatCost(1000)).toBe("$1000");
+  });
+});

--- a/src/ui/src/components/chat/composer/formatCost.ts
+++ b/src/ui/src/components/chat/composer/formatCost.ts
@@ -1,0 +1,9 @@
+export function estimateCost(totalTokens: number): number {
+  return (totalTokens / 1_000_000) * 15;
+}
+
+export function formatCost(usd: number): string {
+  if (usd < 0.01) return "<$0.01";
+  if (usd >= 100) return `$${usd.toFixed(0)}`;
+  return `$${usd.toFixed(2)}`;
+}

--- a/src/ui/src/components/chat/composer/segmentedMeterLogic.test.ts
+++ b/src/ui/src/components/chat/composer/segmentedMeterLogic.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { segmentedBand, stateLabel, segmentedColor } from "./segmentedMeterLogic";
+
+describe("segmentedBand", () => {
+  it("returns normal below 60%", () => {
+    expect(segmentedBand(0)).toBe("normal");
+    expect(segmentedBand(0.1)).toBe("normal");
+    expect(segmentedBand(0.42)).toBe("normal");
+    expect(segmentedBand(0.599)).toBe("normal");
+  });
+
+  it("returns warn at 60% through 84%", () => {
+    expect(segmentedBand(0.60)).toBe("warn");
+    expect(segmentedBand(0.70)).toBe("warn");
+    expect(segmentedBand(0.849)).toBe("warn");
+  });
+
+  it("returns critical at 85% and above", () => {
+    expect(segmentedBand(0.85)).toBe("critical");
+    expect(segmentedBand(0.88)).toBe("critical");
+    expect(segmentedBand(0.96)).toBe("critical");
+    expect(segmentedBand(1.0)).toBe("critical");
+    expect(segmentedBand(1.5)).toBe("critical");
+  });
+});
+
+describe("stateLabel", () => {
+  it("returns healthy below 60%", () => {
+    expect(stateLabel(0)).toBe("healthy");
+    expect(stateLabel(0.42)).toBe("healthy");
+    expect(stateLabel(0.599)).toBe("healthy");
+  });
+
+  it("returns filling up from 60% to 84%", () => {
+    expect(stateLabel(0.60)).toBe("filling up");
+    expect(stateLabel(0.70)).toBe("filling up");
+    expect(stateLabel(0.849)).toBe("filling up");
+  });
+
+  it("returns nearing limit at 85% and above", () => {
+    expect(stateLabel(0.85)).toBe("nearing limit");
+    expect(stateLabel(0.96)).toBe("nearing limit");
+    expect(stateLabel(1.0)).toBe("nearing limit");
+  });
+});
+
+describe("segmentedColor", () => {
+  it("maps bands to the correct CSS variables", () => {
+    expect(segmentedColor("normal")).toBe("var(--accent-primary)");
+    expect(segmentedColor("warn")).toBe("var(--badge-ask)");
+    expect(segmentedColor("critical")).toBe("var(--status-stopped)");
+  });
+});

--- a/src/ui/src/components/chat/composer/segmentedMeterLogic.ts
+++ b/src/ui/src/components/chat/composer/segmentedMeterLogic.ts
@@ -1,0 +1,24 @@
+export type SegmentedBand = "normal" | "warn" | "critical";
+
+export function segmentedBand(ratio: number): SegmentedBand {
+  if (ratio >= 0.85) return "critical";
+  if (ratio >= 0.60) return "warn";
+  return "normal";
+}
+
+export function stateLabel(ratio: number): string {
+  if (ratio < 0.6) return "healthy";
+  if (ratio < 0.85) return "filling up";
+  return "nearing limit";
+}
+
+export function segmentedColor(band: SegmentedBand): string {
+  switch (band) {
+    case "normal":
+      return "var(--accent-primary)";
+    case "warn":
+      return "var(--badge-ask)";
+    case "critical":
+      return "var(--status-stopped)";
+  }
+}


### PR DESCRIPTION
## Summary

- **New composer toolbar** — replaces flat-chip `ChatToolbar` with pill-shaped controls: model selector, plan toggle, grouped reasoning pill, and overflow menu. Extracted into a `composer/` subdirectory with 8 new component files.
- **Grouped reasoning pill** — compound `[Brain "Thinking" | Eye | effort ▾]` pill that opens a unified dropdown with REASONING toggles (Thinking, Show thinking) and EFFORT level selection (Auto/Low/Medium/High/Max). Show Thinking removed from overflow menu since it now lives here.
- **Segmented context meter** — 10-cell animated meter with breath/pulse/shimmer/edge-pulse CSS animations (all gated by `prefers-reduced-motion`). Clicking opens a context popover showing token breakdown, stacked bar, remaining capacity, and session cost estimate.
- **Composer input restyling** — rounded container with `border-radius`, shadow, and focus-within accent border instead of rectangular focus ring. Textarea focus ring suppressed to preserve rounded aesthetic.

```mermaid
graph LR
  ChatPanel --> ComposerToolbar
  ChatPanel --> SegmentedMeter
  ChatPanel --> ContextPopover
  ComposerToolbar --> ToolbarPill
  ComposerToolbar --> ReasoningPill
  ComposerToolbar --> OverflowMenu
  ComposerToolbar --> ModelSelector["ModelSelector (existing)"]
  ReasoningPill --> EffortSelector["EffortSelector (existing)"]
  SegmentedMeter --> contextMeterLogic["contextMeterLogic (existing)"]
  ContextPopover --> contextMeterLogic
```

## Complexity Notes

- The segmented meter uses CSS custom properties per-cell (`--cell-index`, `--cell-color`) to drive staggered animations entirely in CSS — no JS timers. Four keyframe animations (`ctx-breath`, `ctx-lead-pulse`, `ctx-shimmer`, `ctx-edge-pulse`) are all gated behind `@media (prefers-reduced-motion: no-preference)`.
- `segmentedMeterLogic.ts` introduces a 3-band threshold system (60%/85%) that differs from the existing 4-band system in `contextMeterLogic.ts` — both are kept separate intentionally.
- The `$15/M` token cost estimate in `formatCost.ts` is a rough approximation; actual costs vary by model.

## Test Steps

1. `cd src/ui && bun run test` — verify all 591 tests pass (includes new `formatCost.test.ts` and `segmentedMeterLogic.test.ts`)
2. `cd src/ui && bunx tsc --noEmit` — verify zero type errors
3. `cargo tauri dev` — open a workspace and verify:
   - Pill-shaped toolbar renders: `[Model ▾] [Plan] [Thinking | Eye | auto ▾] [...]`
   - Clicking any reasoning pill segment opens unified dropdown with REASONING + EFFORT sections
   - Overflow menu shows only Fast mode and Chrome (not Show thinking)
   - Segmented meter animates with context usage, click opens popover
   - Popover shows token breakdown, cost, Compact/Clear actions
   - Clicking into textarea shows no rectangular focus outline
   - Input container border highlights with accent color on focus
   - Plan mode shows dashed bottom border on textarea
4. Test with `prefers-reduced-motion: reduce` — all meter animations should be disabled
5. Verify dark and light themes render correctly

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)