### PR TITLE
feat(sidebar): sort workspaces by SCM status in repo-grouped view

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, BadgeCheck, Ba
 import { RepoIcon } from "../shared/RepoIcon";
 import { UpdateBanner } from "../layout/UpdateBanner";
 import { useSpinnerFrame } from "../../hooks/useSpinnerFrame";
+import { getScmSortPriority } from "../../utils/scmSortPriority";
 import styles from "./Sidebar.module.css";
 
 type StatusBucketKey = "in-progress" | "in-review" | "draft" | "merged" | "closed" | "archived";
@@ -560,9 +561,9 @@ export const Sidebar = memo(function Sidebar() {
           .filter((r) => sidebarRepoFilter === "all" || r.id === sidebarRepoFilter)
           .map((repo, repoIdx) => {
           const collapsed = repoCollapsed[repo.id];
-          const repoWorkspaces = filteredWorkspaces.filter(
-            (ws) => ws.repository_id === repo.id
-          );
+          const repoWorkspaces = filteredWorkspaces
+            .filter((ws) => ws.repository_id === repo.id)
+            .sort((a, b) => getScmSortPriority(scmSummary[a.id]) - getScmSortPriority(scmSummary[b.id]));
           const runningCount = repoWorkspaces.filter(
             (ws) => ws.agent_status === "Running"
           ).length;

--- a/src/ui/src/utils/scmSortPriority.test.ts
+++ b/src/ui/src/utils/scmSortPriority.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { getScmSortPriority } from "./scmSortPriority";
+import type { ScmSummary } from "../types/plugin";
+
+function makeSummary(
+  prState: ScmSummary["prState"],
+  ciState: ScmSummary["ciState"],
+  hasPr = true,
+): ScmSummary {
+  return { hasPr, prState, ciState, lastUpdated: Date.now() };
+}
+
+describe("getScmSortPriority", () => {
+  it("returns 0 for open PR with CI passing", () => {
+    expect(getScmSortPriority(makeSummary("open", "success"))).toBe(0);
+  });
+
+  it("returns 1 for open PR with CI pending", () => {
+    expect(getScmSortPriority(makeSummary("open", "pending"))).toBe(1);
+  });
+
+  it("returns 2 for open PR with CI failing", () => {
+    expect(getScmSortPriority(makeSummary("open", "failure"))).toBe(2);
+  });
+
+  it("returns 3 for open PR with no CI data", () => {
+    expect(getScmSortPriority(makeSummary("open", null))).toBe(3);
+  });
+
+  it("returns 4 for draft PR", () => {
+    expect(getScmSortPriority(makeSummary("draft", null))).toBe(4);
+  });
+
+  it("returns 5 for no PR (hasPr false)", () => {
+    expect(getScmSortPriority(makeSummary(null, null, false))).toBe(5);
+  });
+
+  it("returns 5 for undefined summary", () => {
+    expect(getScmSortPriority(undefined)).toBe(5);
+  });
+
+  it("returns 5 for null prState with hasPr true", () => {
+    expect(getScmSortPriority(makeSummary(null, null, true))).toBe(5);
+  });
+
+  it("returns 6 for merged PR", () => {
+    expect(getScmSortPriority(makeSummary("merged", null))).toBe(6);
+  });
+
+  it("returns 7 for closed PR", () => {
+    expect(getScmSortPriority(makeSummary("closed", null))).toBe(7);
+  });
+
+  it("sorts workspaces in correct priority order", () => {
+    const summaries: ScmSummary[] = [
+      makeSummary(null, null, false),
+      makeSummary("closed", null),
+      makeSummary("open", "success"),
+      makeSummary("draft", null),
+      makeSummary("open", "failure"),
+      makeSummary("merged", null),
+      makeSummary("open", "pending"),
+      makeSummary("open", null),
+    ];
+
+    const sorted = [...summaries].sort(
+      (a, b) => getScmSortPriority(a) - getScmSortPriority(b),
+    );
+
+    expect(sorted.map(getScmSortPriority)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+});

--- a/src/ui/src/utils/scmSortPriority.ts
+++ b/src/ui/src/utils/scmSortPriority.ts
@@ -1,0 +1,27 @@
+import type { ScmSummary } from "../types/plugin";
+
+export function getScmSortPriority(summary: ScmSummary | undefined): number {
+  if (!summary || !summary.hasPr) return 5;
+
+  switch (summary.prState) {
+    case "open":
+      switch (summary.ciState) {
+        case "success":
+          return 0;
+        case "pending":
+          return 1;
+        case "failure":
+          return 2;
+        default:
+          return 3;
+      }
+    case "draft":
+      return 4;
+    case "merged":
+      return 6;
+    case "closed":
+      return 7;
+    default:
+      return 5;
+  }
+}


### PR DESCRIPTION
## Summary

When the sidebar is grouped by repo, workspaces within each repository group are now sorted by their SCM lifecycle priority — most actionable workspaces appear first.

**Sort order (highest priority first):**

| Priority | State |
|----------|-------|
| 0 | PR with CI passing |
| 1 | PR with CI pending |
| 2 | PR with CI failing |
| 3 | PR with no CI data |
| 4 | Draft PR |
| 5 | No PR |
| 6 | Merged PR |
| 7 | Closed PR |

The sort is reactive — when background SCM polling updates CI status, workspaces automatically reorder.

## Complexity Notes

JavaScript's `Array.prototype.sort` moves literal `undefined` elements to the end regardless of the comparator (per the ES spec). This doesn't affect production code (the sort comparator calls `getScmSortPriority(scmSummary[ws.id])` where a missing key yields `undefined` as a function argument, not as an array element), but was a gotcha in the unit test.

## Test Steps

1. `cd src/ui && bun run test` — all 608 tests pass including 11 new ones for `getScmSortPriority`
2. `cargo tauri dev` — open the app
3. Switch sidebar to "Group by repo" mode
4. Verify workspaces within a repo group are sorted by PR/CI status (CI passing first, no PR near the bottom)
5. Verify the "Group by status" view is unchanged
6. Verify workspace order updates when CI status changes (wait for a poll cycle or trigger a refresh)

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)