### PR TITLE
feat(terminal): hide terminal pane when last terminal is closed

### DIFF
--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -130,6 +130,43 @@ describe("terminal slice: removeTerminalTab", () => {
 
     expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBe(99);
   });
+
+  it("auto-hides the pane when the selected workspace's last tab is closed", () => {
+    useAppStore.setState({
+      selectedWorkspaceId: WS_A,
+      terminalPanelVisible: true,
+    });
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 1);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().terminalPanelVisible).toBe(false);
+  });
+
+  it("does not hide the pane when tabs remain in the selected workspace", () => {
+    useAppStore.setState({
+      selectedWorkspaceId: WS_A,
+      terminalPanelVisible: true,
+    });
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A)]);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().terminalPanelVisible).toBe(true);
+  });
+
+  it("does not hide the pane when the affected workspace is not selected", () => {
+    useAppStore.setState({
+      selectedWorkspaceId: WS_B,
+      terminalPanelVisible: true,
+    });
+    useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A)]);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().terminalPanelVisible).toBe(true);
+  });
 });
 
 describe("workspace removal cascades to terminal state", () => {

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -81,6 +81,8 @@ describe("terminal slice: removeTerminalTab", () => {
     useAppStore.setState({
       terminalTabs: {},
       activeTerminalTabId: {},
+      selectedWorkspaceId: null,
+      terminalPanelVisible: false,
     });
   });
 

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -1075,11 +1075,14 @@ export const useAppStore = create<AppState>((set) => ({
     set((s) => {
       const tabs = (s.terminalTabs[wsId] || []).filter((t) => t.id !== tabId);
       const wasActive = s.activeTerminalTabId[wsId] === tabId;
+      const hidePane =
+        tabs.length === 0 && wsId === s.selectedWorkspaceId && s.terminalPanelVisible;
       return {
         terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
         activeTerminalTabId: wasActive
           ? { ...s.activeTerminalTabId, [wsId]: tabs[0]?.id ?? null }
           : s.activeTerminalTabId,
+        ...(hidePane ? { terminalPanelVisible: false } : {}),
       };
     }),
   setActiveTerminalTab: (wsId, id) =>


### PR DESCRIPTION
## Summary

Automatically hides the terminal panel when the last terminal tab in the currently selected workspace is closed. Previously, closing all terminals would leave an empty, unusable terminal pane visible. Now the pane collapses itself, keeping the layout clean without requiring a manual toggle.

The logic lives entirely in `removeTerminalTab` in the Zustand store — the pane is only hidden when all three conditions are true: no tabs remain, the affected workspace is the currently selected one, and the pane is currently visible.

## Test Steps

1. Open a workspace and launch a terminal tab (`+` button in the terminal panel).
2. Close the terminal tab (× button or `exit` in the shell).
3. **Expected**: the terminal panel automatically collapses.
4. Open two terminal tabs, close one.
5. **Expected**: the terminal panel stays visible.
6. With multiple workspaces open, close the last tab in a *non-selected* workspace.
7. **Expected**: the terminal panel for the currently selected workspace is unaffected.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)
