### PR TITLE
feat(diff): syntax highlighting in diff view

### DIFF
--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -14,6 +14,7 @@
         "@xterm/xterm": "^6.0.0",
         "ansi_up": "^6.0.6",
         "hast-util-to-html": "^9.0.5",
+        "highlight.js": "^11.11.1",
         "lucide-react": "^1.7.0",
         "mermaid": "^11.14.0",
         "pdfjs-dist": "^5.6.205",
@@ -610,6 +611,8 @@
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,6 +24,7 @@
     "@xterm/xterm": "^6.0.0",
     "ansi_up": "^6.0.6",
     "hast-util-to-html": "^9.0.5",
+    "highlight.js": "^11.11.1",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.14.0",
     "pdfjs-dist": "^5.6.205",

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -280,11 +280,15 @@
 /* highlight.js themes set .hljs { background, padding } which would
    override our per-row diff backgrounds (added/removed/empty) and break
    the flex layout. Keep the text colors, drop everything else. */
-.lineContent:global(.hljs),
+.lineContent:global(.hljs) {
+  background: transparent !important;
+  padding: 0 0 0 4px;
+}
+
 .lineContent :global(.hljs-addition),
 .lineContent :global(.hljs-deletion) {
   background: transparent !important;
-  padding: 0 0 0 4px;
+  padding: 0;
 }
 
 .sbsCell .lineContent {

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -217,7 +217,8 @@
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
-  min-width: max-content;
+  width: max-content;
+  min-width: 100%;
 }
 
 .hunkHeader {
@@ -302,6 +303,7 @@
   font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.5;
+  min-width: 100%;
 }
 
 .sbsRow {

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -277,6 +277,16 @@
   padding-left: 4px;
 }
 
+/* highlight.js themes set .hljs { background, padding } which would
+   override our per-row diff backgrounds (added/removed/empty) and break
+   the flex layout. Keep the text colors, drop everything else. */
+.lineContent:global(.hljs),
+.lineContent :global(.hljs-addition),
+.lineContent :global(.hljs-deletion) {
+  background: transparent !important;
+  padding: 0 0 0 4px;
+}
+
 .sbsCell .lineContent {
   overflow-x: auto;
   overflow-y: hidden;

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -278,14 +278,9 @@
   padding-left: 4px;
 }
 
-/* highlight.js themes set .hljs { background, padding } which would
-   override our per-row diff backgrounds (added/removed/empty) and break
-   the flex layout. Keep the text colors, drop everything else. */
-.lineContent:global(.hljs) {
-  background: transparent !important;
-  padding: 0 0 0 4px;
-}
-
+/* When the diff language is active, highlight.js emits .hljs-addition /
+   .hljs-deletion spans with their own backgrounds. Neutralize them so
+   our per-row diff colours (lineAdded / lineRemoved) show through. */
 .lineContent :global(.hljs-addition),
 .lineContent :global(.hljs-deletion) {
   background: transparent !important;

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -4,6 +4,7 @@ import { loadFileDiff, readWorkspaceFile } from "../../services/tauri";
 import { PanelToggles } from "../shared/PanelToggles";
 import { SessionTabs } from "../chat/SessionTabs";
 import { MessageMarkdown } from "../chat/MessageMarkdown";
+import { highlightLine, languageForFile } from "../../utils/syntaxHighlight";
 import type { DiffLine } from "../../types/diff";
 import styles from "./DiffViewer.module.css";
 
@@ -18,6 +19,25 @@ function formatBytes(bytes: number): string {
 interface SideBySideRow {
   left: DiffLine | null;
   right: DiffLine | null;
+}
+
+function LineContent({
+  content,
+  language,
+}: {
+  content: string;
+  language: string | null;
+}) {
+  const html = highlightLine(content, language);
+  if (html !== null) {
+    return (
+      <span
+        className={`${styles.lineContent} hljs`}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+  return <span className={styles.lineContent}>{content}</span>;
 }
 
 /** Pair unified diff lines into side-by-side rows.
@@ -154,6 +174,11 @@ export function DiffViewer() {
     }));
   }, [diffContent]);
 
+  const language = useMemo(
+    () => languageForFile(diffSelectedFile),
+    [diffSelectedFile],
+  );
+
   return (
     <div className={styles.viewer}>
       <div className={styles.header} data-tauri-drag-region>
@@ -250,9 +275,7 @@ export function DiffViewer() {
                           ? "-"
                           : " "}
                     </span>
-                    <span className={styles.lineContent}>
-                      {line.content}
-                    </span>
+                    <LineContent content={line.content} language={language} />
                   </div>
                 ))}
               </div>
@@ -280,9 +303,10 @@ export function DiffViewer() {
                       <span className={styles.linePrefix}>
                         {row.left?.line_type === "Removed" ? "-" : row.left ? " " : ""}
                       </span>
-                      <span className={styles.lineContent}>
-                        {row.left?.content ?? ""}
-                      </span>
+                      <LineContent
+                        content={row.left?.content ?? ""}
+                        language={language}
+                      />
                     </div>
                     <div
                       className={`${styles.sbsCell} ${
@@ -299,9 +323,10 @@ export function DiffViewer() {
                       <span className={styles.linePrefix}>
                         {row.right?.line_type === "Added" ? "+" : row.right ? " " : ""}
                       </span>
-                      <span className={styles.lineContent}>
-                        {row.right?.content ?? ""}
-                      </span>
+                      <LineContent
+                        content={row.right?.content ?? ""}
+                        language={language}
+                      />
                     </div>
                   </div>
                 ))}

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { loadFileDiff, readWorkspaceFile } from "../../services/tauri";
 import { PanelToggles } from "../shared/PanelToggles";
@@ -21,14 +21,14 @@ interface SideBySideRow {
   right: DiffLine | null;
 }
 
-function LineContent({
+const LineContent = memo(function LineContent({
   content,
   language,
 }: {
   content: string;
   language: string | null;
 }) {
-  const html = highlightLine(content, language);
+  const html = useMemo(() => highlightLine(content, language), [content, language]);
   if (html !== null) {
     return (
       <span
@@ -38,7 +38,7 @@ function LineContent({
     );
   }
   return <span className={styles.lineContent}>{content}</span>;
-}
+});
 
 /** Pair unified diff lines into side-by-side rows.
  *  Consecutive Removed lines are buffered and paired 1:1 with subsequent Added lines.

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -32,7 +32,7 @@ const LineContent = memo(function LineContent({
   if (html !== null) {
     return (
       <span
-        className={`${styles.lineContent} hljs`}
+        className={styles.lineContent}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     );

--- a/src/ui/src/utils/syntaxHighlight.test.ts
+++ b/src/ui/src/utils/syntaxHighlight.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { highlightLine, languageForFile } from "./syntaxHighlight";
+
+describe("languageForFile", () => {
+  it("returns null for null/undefined/empty", () => {
+    expect(languageForFile(null)).toBeNull();
+    expect(languageForFile(undefined)).toBeNull();
+    expect(languageForFile("")).toBeNull();
+  });
+
+  it("detects by full filename (case-insensitive)", () => {
+    expect(languageForFile("Dockerfile")).toBe("dockerfile");
+    expect(languageForFile("dockerfile")).toBe("dockerfile");
+    expect(languageForFile("Makefile")).toBe("makefile");
+    expect(languageForFile("CMakeLists.txt")).toBe("cmake");
+    expect(languageForFile("cmakelists.txt")).toBe("cmake");
+  });
+
+  it("detects by extension", () => {
+    expect(languageForFile("foo.rs")).toBe("rust");
+    expect(languageForFile("foo.ts")).toBe("typescript");
+    expect(languageForFile("foo.tsx")).toBe("typescript");
+    expect(languageForFile("foo.py")).toBe("python");
+    expect(languageForFile("foo.go")).toBe("go");
+    expect(languageForFile("foo.js")).toBe("javascript");
+    expect(languageForFile("foo.json")).toBe("json");
+    expect(languageForFile("foo.toml")).toBe("ini");
+    expect(languageForFile("foo.yaml")).toBe("yaml");
+    expect(languageForFile("foo.yml")).toBe("yaml");
+    expect(languageForFile("foo.sh")).toBe("bash");
+    expect(languageForFile("foo.css")).toBe("css");
+    expect(languageForFile("foo.html")).toBe("xml");
+  });
+
+  it("uses the basename from a full path", () => {
+    expect(languageForFile("src/lib/main.rs")).toBe("rust");
+    expect(languageForFile("/home/user/project/Dockerfile")).toBe("dockerfile");
+  });
+
+  it("returns null for unknown extensions", () => {
+    expect(languageForFile("foo.unknown")).toBeNull();
+    expect(languageForFile("foo.xyz123")).toBeNull();
+    expect(languageForFile("noextension")).toBeNull();
+  });
+});
+
+describe("highlightLine", () => {
+  it("returns null when language is null", () => {
+    expect(highlightLine("const x = 1;", null)).toBeNull();
+  });
+
+  it("returns null for empty content", () => {
+    expect(highlightLine("", "typescript")).toBeNull();
+  });
+
+  it("returns null for an unknown language", () => {
+    expect(highlightLine("hello", "notareallanguage")).toBeNull();
+  });
+
+  it("returns highlighted HTML for a known language", () => {
+    const result = highlightLine("const x = 1;", "typescript");
+    expect(result).not.toBeNull();
+    expect(result).toContain("hljs");
+  });
+});

--- a/src/ui/src/utils/syntaxHighlight.ts
+++ b/src/ui/src/utils/syntaxHighlight.ts
@@ -66,7 +66,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
 const FILENAME_TO_LANGUAGE: Record<string, string> = {
   dockerfile: "dockerfile",
   makefile: "makefile",
-  cmakelists: "cmake",
+  "cmakelists.txt": "cmake",
 };
 
 export function languageForFile(path: string | null | undefined): string | null {

--- a/src/ui/src/utils/syntaxHighlight.ts
+++ b/src/ui/src/utils/syntaxHighlight.ts
@@ -1,0 +1,101 @@
+import hljs from "highlight.js/lib/common";
+
+// Extension → highlight.js language name. Only languages bundled in
+// highlight.js/lib/common are usable here; unknown extensions fall back to
+// plain text rendering.
+const EXT_TO_LANGUAGE: Record<string, string> = {
+  bash: "bash",
+  sh: "bash",
+  zsh: "bash",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cxx: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  hxx: "cpp",
+  cs: "csharp",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  diff: "diff",
+  patch: "diff",
+  go: "go",
+  graphql: "graphql",
+  gql: "graphql",
+  html: "xml",
+  htm: "xml",
+  xml: "xml",
+  svg: "xml",
+  java: "java",
+  js: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  jsx: "javascript",
+  json: "json",
+  jsonc: "json",
+  kt: "kotlin",
+  kts: "kotlin",
+  lua: "lua",
+  md: "markdown",
+  markdown: "markdown",
+  mdx: "markdown",
+  makefile: "makefile",
+  mk: "makefile",
+  pl: "perl",
+  pm: "perl",
+  php: "php",
+  py: "python",
+  pyi: "python",
+  r: "r",
+  rb: "ruby",
+  rs: "rust",
+  scala: "scala",
+  sql: "sql",
+  swift: "swift",
+  toml: "ini",
+  ts: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  tsx: "typescript",
+  vue: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+};
+
+const FILENAME_TO_LANGUAGE: Record<string, string> = {
+  dockerfile: "dockerfile",
+  makefile: "makefile",
+  cmakelists: "cmake",
+};
+
+export function languageForFile(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const base = path.split("/").pop() ?? path;
+  const lower = base.toLowerCase();
+
+  const filenameMatch = FILENAME_TO_LANGUAGE[lower];
+  if (filenameMatch) return filenameMatch;
+
+  const dot = lower.lastIndexOf(".");
+  if (dot < 0) return null;
+  const ext = lower.slice(dot + 1);
+  return EXT_TO_LANGUAGE[ext] ?? null;
+}
+
+/** Highlight a single line of source. Returns HTML with hljs-* class spans,
+ *  or null if the language is unknown. The caller should render null as plain
+ *  text. Multi-line constructs (block comments, template literals) may be
+ *  mis-tokenized because each line is highlighted in isolation. */
+export function highlightLine(
+  content: string,
+  language: string | null,
+): string | null {
+  if (!language || !content) return null;
+  if (!hljs.getLanguage(language)) return null;
+  try {
+    return hljs.highlight(content, { language, ignoreIllegals: true }).value;
+  } catch {
+    return null;
+  }
+}

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -25,6 +25,16 @@ function applyHljsTheme(isLight: boolean): void {
   link.href = isLight ? hljsLightUrl : hljsDarkUrl;
 }
 
+// Fire once at module load — before async settings load and the first React
+// render — so the diff viewer doesn't paint hljs-* tokens against a missing
+// stylesheet. The pre-hydration script in index.html already set data-theme
+// synchronously, which means computed `color-scheme` is correct here.
+if (typeof window !== "undefined" && typeof getComputedStyle === "function") {
+  applyHljsTheme(
+    getComputedStyle(document.documentElement).colorScheme === "light",
+  );
+}
+
 // localStorage key used by index.html's pre-hydration script to set
 // data-theme before React mounts. Keep in sync with that script.
 const THEME_CACHE_KEY = "claudette.theme";

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -1,4 +1,6 @@
 import type { ITheme } from "@xterm/xterm";
+import hljsDarkUrl from "highlight.js/styles/github-dark.min.css?url";
+import hljsLightUrl from "highlight.js/styles/github.min.css?url";
 import type { ThemeDefinition } from "../types/theme";
 import {
   BUILTIN_THEME_IDS,
@@ -7,6 +9,21 @@ import {
   DEFAULT_LIGHT_THEME_ID,
 } from "../styles/themes";
 import { listUserThemes } from "../services/tauri";
+
+// highlight.js renders tokens as <span class="hljs-keyword"> etc. The class
+// names have no built-in colors — a theme stylesheet provides them. We swap
+// the active stylesheet on light/dark transitions instead of loading both,
+// so unused tokens never paint.
+function applyHljsTheme(isLight: boolean): void {
+  let link = document.getElementById("hljs-theme") as HTMLLinkElement | null;
+  if (!link) {
+    link = document.createElement("link");
+    link.id = "hljs-theme";
+    link.rel = "stylesheet";
+    document.head.appendChild(link);
+  }
+  link.href = isLight ? hljsLightUrl : hljsDarkUrl;
+}
 
 // localStorage key used by index.html's pre-hydration script to set
 // data-theme before React mounts. Keep in sync with that script.
@@ -169,10 +186,14 @@ export function applyTheme(theme: ThemeDefinition): void {
   const isBuiltin = BUILTIN_THEME_IDS.has(theme.id);
 
   let dataThemeAttr: string;
+  let isLight: boolean;
   if (isBuiltin) {
     clearThemeableInlineVars();
     dataThemeAttr = theme.id;
     root.setAttribute("data-theme", dataThemeAttr);
+    isLight =
+      BUILTIN_THEME_META.find((m) => m.id === theme.id)?.colorScheme ===
+      "light";
   } else {
     // User-provided JSON theme. Pick the baseline matching the theme's
     // declared color-scheme so a light user theme starts from light defaults
@@ -189,8 +210,10 @@ export function applyTheme(theme: ThemeDefinition): void {
     }
     const scheme = theme.colors["color-scheme"] ?? "dark";
     root.style.setProperty("color-scheme", scheme);
+    isLight = scheme === "light";
   }
 
+  applyHljsTheme(isLight);
   cacheDataTheme(dataThemeAttr);
 }
 


### PR DESCRIPTION
## Summary

Adds syntax highlighting to the diff viewer using [highlight.js](https://highlightjs.org/). Both unified and side-by-side modes now colorize code in 40+ languages, detected automatically from the file's extension or filename (e.g. `Dockerfile`, `Makefile`).

- New `src/ui/src/utils/syntaxHighlight.ts` module handles language detection (`languageForFile`) and per-line highlighting (`highlightLine`), using only the `highlight.js/lib/common` bundle to keep the binary lean.
- A `LineContent` component in `DiffViewer.tsx` replaces the plain `<span>` used for line text, rendering highlighted HTML via `dangerouslySetInnerHTML` when a language is detected, with a plain-text fallback otherwise.
- CSS overrides strip the `background` and `padding` that highlight.js injects on `.hljs` nodes, preserving the existing per-row added/removed/context background colors.

## Complexity Notes

- **Per-line highlighting**: Each line is highlighted in isolation (no stateful tokenizer). This means multi-line constructs — block comments, template literals, heredocs — may be partially mis-tokenized near their boundaries. This is an accepted trade-off for simplicity; adding stateful multi-line support would require significant complexity.
- **`dangerouslySetInnerHTML`**: The HTML inserted comes entirely from highlight.js, which operates on already-parsed diff content (never raw user network input), so XSS risk is low. Still worth a reviewer eyeball.
- **CSS specificity battle**: The `.lineContent.hljs` override uses `!important` to beat the highlight.js stylesheet. This is intentional and documented in the CSS comment.

## Test Steps

1. Open Claudette in a workspace with a git diff containing TypeScript, Rust, or Python files.
2. Open the **Diff Viewer** panel and select a changed file — confirm syntax-colored tokens appear in the diff lines.
3. Toggle between **Unified** and **Side-by-Side** modes and verify highlighting appears in both.
4. Select a file with no recognized extension (e.g. a dotfile) — confirm it falls back to plain text with no errors.
5. Verify that added (green) and removed (red) row backgrounds are still visible and are not overridden by highlight.js styles.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
