### PR TITLE
fix: persist diff selection and chat drafts across workspace switches

### DIFF
--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -93,9 +93,9 @@ export function ChatInputArea({
   sessionId: string;
   repoId: string | undefined;
   projectPath: string | undefined;
-  historyRef: React.MutableRefObject<Record<string, string[]>>;
-  historyIndexRef: React.MutableRefObject<number>;
-  draftRef: React.MutableRefObject<string>;
+  historyRef: React.RefObject<Record<string, string[]>>;
+  historyIndexRef: React.RefObject<number>;
+  draftRef: React.RefObject<string>;
   onAttachmentContextMenu?: (
     e: React.MouseEvent,
     attachment: DownloadableAttachment,

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -105,7 +105,14 @@ export function ChatInputArea({
     attachment: DownloadableAttachment,
   ) => void;
 }) {
-  const [chatInput, setChatInput] = useState("");
+  const chatInput = useAppStore(
+    (s) => s.chatDrafts[selectedWorkspaceId] ?? "",
+  );
+  const setChatDraftInStore = useAppStore((s) => s.setChatDraft);
+  const setChatInput = useCallback(
+    (value: string) => setChatDraftInStore(selectedWorkspaceId, value),
+    [selectedWorkspaceId, setChatDraftInStore],
+  );
   const [cursorPos, setCursorPos] = useState(0);
   const [inputScrollTop, setInputScrollTop] = useState(0);
   const [slashPickerIndex, setSlashPickerIndex] = useState(0);
@@ -168,16 +175,6 @@ export function ChatInputArea({
     voice.activeProvider,
   );
 
-  // Esc cancels an active recording regardless of where focus is. The
-  // textarea's onKeyDown also handles Esc when it has focus; clicking
-  // the mic moves focus to the button, where Esc would otherwise just
-  // defocus it instead of stopping the recording.
-  //
-  // While recording, Esc is treated as exclusively "cancel recording" —
-  // we capture it ahead of bubbling handlers and stop propagation so
-  // it doesn't also close an unrelated popover/modal that happens to
-  // be open. Without this, the same keypress could cancel recording
-  // *and* dismiss the surrounding UI, which feels jumpy.
   useEffect(() => {
     if (voice.state !== "recording") return;
     const onKey = (e: KeyboardEvent) => {
@@ -195,23 +192,17 @@ export function ChatInputArea({
     textareaRef.current?.focus();
   }, []);
 
-  // Per-session draft storage: save input when switching away,
-  // restore when switching back.
   const draftsRef = useRef<Record<string, string>>({});
   const prevSessionRef = useRef(sessionId);
   useEffect(() => {
     const prev = prevSessionRef.current;
     if (prev !== sessionId) {
-      // Save draft for the session we're leaving.
       draftsRef.current[prev] = chatInput;
-      // Restore draft for the session we're entering.
       setChatInput(draftsRef.current[sessionId] ?? "");
       prevSessionRef.current = sessionId;
-      // Reset file picker and attachment state for new session.
       setFilesLoaded(false);
       setWorkspaceFiles([]);
       mentionedFilesRef.current = new Set();
-      // Clear staged attachments so they don't leak across sessions.
       setPendingAttachments((prev) => {
         for (const a of prev) {
           if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
@@ -243,13 +234,13 @@ export function ChatInputArea({
         }
       });
     }
-  }, [chatInputPrefill, setChatInputPrefill]);
+  }, [setChatInput, chatInputPrefill, setChatInputPrefill]);
 
   const refreshSlashCommands = useCallback(() => {
     listSlashCommands(projectPath, selectedWorkspaceId)
       .then(setSlashCommands)
       .catch((e) => console.error("Failed to load slash commands:", e));
-  }, [pluginRefreshToken, projectPath, selectedWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [projectPath, selectedWorkspaceId, setSlashCommands]);
 
   useEffect(() => {
     let cancelled = false;
@@ -261,7 +252,7 @@ export function ChatInputArea({
     return () => {
       cancelled = true;
     };
-  }, [projectPath, selectedWorkspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [projectPath, selectedWorkspaceId, setSlashCommands]);
 
   // Filter by the command-name token (text before the first whitespace) so the
   // picker stays open while the user types arguments. This keeps the argument

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -145,23 +145,16 @@ export function ChatInputArea({
     const ta = textareaRef.current;
     const start = ta?.selectionStart ?? cursorPos;
     const end = ta?.selectionEnd ?? cursorPos;
-    setChatInput((currentInput) => {
-      const next = insertTranscriptAtSelection(
-        currentInput,
-        transcript,
-        start,
-        end,
-      );
-      setCursorPos(next.cursor);
-      requestAnimationFrame(() => {
-        const current = textareaRef.current;
-        if (!current) return;
-        current.focus();
-        current.selectionStart = current.selectionEnd = next.cursor;
-      });
-      return next.text;
+    const next = insertTranscriptAtSelection(chatInput, transcript, start, end);
+    setCursorPos(next.cursor);
+    requestAnimationFrame(() => {
+      const current = textareaRef.current;
+      if (!current) return;
+      current.focus();
+      current.selectionStart = current.selectionEnd = next.cursor;
     });
-  }, [cursorPos]);
+    setChatInput(next.text);
+  }, [cursorPos, chatInput, setChatInput]);
 
   const focusVoiceProvider = useAppStore((s) => s.focusVoiceProvider);
   const voice = useVoiceInput(
@@ -188,9 +181,9 @@ export function ChatInputArea({
   }, [voice.state, voice.cancel]);
 
   const handleInsertPinnedCommand = useCallback((commandText: string) => {
-    setChatInput((prev) => commandText + (prev ? " " + prev : ""));
+    setChatInput(commandText + (chatInput ? " " + chatInput : ""));
     textareaRef.current?.focus();
-  }, []);
+  }, [chatInput, setChatInput]);
 
   const draftsRef = useRef<Record<string, string>>({});
   const prevSessionRef = useRef(sessionId);

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -252,7 +252,7 @@ export function ChatInputArea({
     return () => {
       cancelled = true;
     };
-  }, [projectPath, selectedWorkspaceId, setSlashCommands]);
+  }, [projectPath, selectedWorkspaceId, setSlashCommands, pluginRefreshToken]);
 
   // Filter by the command-name token (text before the first whitespace) so the
   // picker stays open while the user types arguments. This keeps the argument

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity } from "../../stores/useAppStore";
 import { relativizePath } from "../../hooks/toolSummary";
@@ -26,15 +26,17 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
   const [collapsed, setCollapsed] = useState(true);
+  const [prevActivitiesLength, setPrevActivitiesLength] = useState(0);
 
-  // Auto-collapse when a new turn starts (activities goes from 0 to non-zero)
-  const prevLengthRef = useRef(0);
-  useEffect(() => {
-    if (isRunning && activities.length > 0 && prevLengthRef.current === 0) {
+  // Auto-collapse when a new turn starts (activities goes from 0 to non-zero).
+  // Done during render (not in an effect) so React re-renders immediately without
+  // committing the intermediate state, avoiding cascading renders.
+  if (prevActivitiesLength !== activities.length) {
+    setPrevActivitiesLength(activities.length);
+    if (isRunning && activities.length > 0 && prevActivitiesLength === 0) {
       setCollapsed(true);
     }
-    prevLengthRef.current = activities.length;
-  }, [isRunning, activities.length]);
+  }
 
   if (activities.length === 0) return null;
 

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -140,6 +140,12 @@ export interface ChatSlice {
   ) => void;
   lastMessages: Record<string, ChatMessage>;
   setLastMessages: (msgs: Record<string, ChatMessage>) => void;
+  // Per-workspace unsent-message drafts. Lives in the store (not local
+  // component state) so drafts survive ChatPanel unmounting — e.g., when
+  // the user switches to the diff view (AppLayout swaps ChatPanel for
+  // DiffViewer) or switches workspaces entirely.
+  chatDrafts: Record<string, string>;
+  setChatDraft: (wsId: string, draft: string) => void;
 }
 
 export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
@@ -428,4 +434,9 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
     })),
   lastMessages: {},
   setLastMessages: (msgs) => set({ lastMessages: msgs }),
+  chatDrafts: {},
+  setChatDraft: (wsId, draft) =>
+    set((s) => ({
+      chatDrafts: { ...s.chatDrafts, [wsId]: draft },
+    })),
 });

--- a/src/ui/src/stores/slices/diffSlice.ts
+++ b/src/ui/src/stores/slices/diffSlice.ts
@@ -14,6 +14,14 @@ export interface DiffSlice {
   diffMergeBase: string | null;
   diffSelectedFile: string | null;
   diffSelectedLayer: DiffLayer | null;
+  // Per-workspace persisted diff selection. Switching workspaces saves the
+  // current (file, layer) here and restores the destination workspace's last
+  // selection on entry, so the diff view remembers what the user was looking
+  // at in each workspace across switches.
+  diffSelectionByWorkspace: Record<
+    string,
+    { path: string | null; layer: DiffLayer | null }
+  >;
   diffStagedFiles: StagedDiffFiles | null;
   diffContent: FileDiff | null;
   diffViewMode: DiffViewMode;
@@ -74,6 +82,7 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
   diffMergeBase: null,
   diffSelectedFile: null,
   diffSelectedLayer: null,
+  diffSelectionByWorkspace: {},
   diffStagedFiles: null,
   diffContent: null,
   diffViewMode: "Unified",
@@ -91,7 +100,17 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
       diffStagedFiles: stagedFiles ?? null,
     }),
   setDiffSelectedFile: (path, layer) =>
-    set({ diffSelectedFile: path, diffSelectedLayer: layer ?? null }),
+    set((s) => {
+      const ws = s.selectedWorkspaceId;
+      const next = { path, layer: layer ?? null };
+      return {
+        diffSelectedFile: path,
+        diffSelectedLayer: layer ?? null,
+        diffSelectionByWorkspace: ws
+          ? { ...s.diffSelectionByWorkspace, [ws]: next }
+          : s.diffSelectionByWorkspace,
+      };
+    }),
   setDiffContent: (content) => set({ diffContent: content }),
   setDiffViewMode: (mode) => set({ diffViewMode: mode }),
   setDiffLoading: (loading) => set({ diffLoading: loading }),
@@ -101,19 +120,25 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
   setDiffPreviewLoading: (loading) => set({ diffPreviewLoading: loading }),
   setDiffPreviewError: (error) => set({ diffPreviewError: error }),
   clearDiff: () =>
-    set({
-      diffFiles: [],
-      diffMergeBase: null,
-      diffSelectedFile: null,
-      diffSelectedLayer: null,
-      diffStagedFiles: null,
-      diffContent: null,
-      diffError: null,
-      diffPreviewMode: "diff",
-      diffPreviewContent: null,
-      diffPreviewLoading: false,
-      diffPreviewError: null,
-      diffTabsByWorkspace: {},
+    set((s) => {
+      const ws = s.selectedWorkspaceId;
+      const selectionMap = { ...s.diffSelectionByWorkspace };
+      if (ws) delete selectionMap[ws];
+      return {
+        diffFiles: [],
+        diffMergeBase: null,
+        diffSelectedFile: null,
+        diffSelectedLayer: null,
+        diffStagedFiles: null,
+        diffContent: null,
+        diffError: null,
+        diffPreviewMode: "diff",
+        diffPreviewContent: null,
+        diffPreviewLoading: false,
+        diffPreviewError: null,
+        diffTabsByWorkspace: {},
+        diffSelectionByWorkspace: selectionMap,
+      };
     }),
   openDiffTab: (workspaceId, path, layer) =>
     set((s) => {

--- a/src/ui/src/stores/slices/repositoriesSlice.ts
+++ b/src/ui/src/stores/slices/repositoriesSlice.ts
@@ -39,12 +39,16 @@ export const createRepositoriesSlice: StateCreator<
       // Collect all tab ids we're about to orphan, then drop their pane
       // trees and active-pane entries alongside the workspace-keyed maps.
       const orphanedTabIds = new Set<number>();
+      const newDiffSelectionByWorkspace = { ...s.diffSelectionByWorkspace };
+      const newChatDrafts = { ...s.chatDrafts };
       for (const wsId of removedWsIds) {
         for (const tab of s.terminalTabs[wsId] ?? []) orphanedTabIds.add(tab.id);
         delete newTerminalTabs[wsId];
         delete newActiveTerminalTabId[wsId];
         delete newWorkspaceTerminalCommands[wsId];
         newUnreadCompletions.delete(wsId);
+        delete newDiffSelectionByWorkspace[wsId];
+        delete newChatDrafts[wsId];
       }
       const newPaneTrees = { ...s.terminalPaneTrees };
       const newActivePane = { ...s.activeTerminalPaneId };
@@ -72,6 +76,8 @@ export const createRepositoriesSlice: StateCreator<
         terminalPaneTrees: newPaneTrees,
         activeTerminalPaneId: newActivePane,
         diffTabsByWorkspace: newDiffTabs,
+        diffSelectionByWorkspace: newDiffSelectionByWorkspace,
+        chatDrafts: newChatDrafts,
       };
     }),
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -72,6 +72,7 @@ export const createWorkspacesSlice: StateCreator<
     }),
   selectWorkspace: (id) =>
     set((s) => {
+      if (id === s.selectedWorkspaceId) return s;
       // Save the outgoing workspace's diff selection before switching, then
       // restore the incoming workspace's last selection (if any). Per-workspace
       // diff *tabs* live in diffTabsByWorkspace and are preserved.

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -51,6 +51,10 @@ export const createWorkspacesSlice: StateCreator<
       }
       const newDiffTabs = { ...s.diffTabsByWorkspace };
       delete newDiffTabs[id];
+      const newDiffSelectionByWorkspace = { ...s.diffSelectionByWorkspace };
+      delete newDiffSelectionByWorkspace[id];
+      const newChatDrafts = { ...s.chatDrafts };
+      delete newChatDrafts[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -62,19 +66,32 @@ export const createWorkspacesSlice: StateCreator<
         terminalPaneTrees: newPaneTrees,
         activeTerminalPaneId: newActivePane,
         diffTabsByWorkspace: newDiffTabs,
+        diffSelectionByWorkspace: newDiffSelectionByWorkspace,
+        chatDrafts: newChatDrafts,
       };
     }),
   selectWorkspace: (id) =>
     set((s) => {
+      // Save the outgoing workspace's diff selection before switching, then
+      // restore the incoming workspace's last selection (if any). Per-workspace
+      // diff *tabs* live in diffTabsByWorkspace and are preserved.
+      const prev = s.selectedWorkspaceId;
+      const selectionMap = prev
+        ? {
+            ...s.diffSelectionByWorkspace,
+            [prev]: {
+              path: s.diffSelectedFile,
+              layer: s.diffSelectedLayer,
+            },
+          }
+        : s.diffSelectionByWorkspace;
+      const restored = id ? selectionMap[id] : undefined;
       const updates: Partial<AppState> = {
         selectedWorkspaceId: id,
         rightSidebarTab: "changes",
-        // diffSelectedFile/Layer are workspace-global pointers; switching
-        // workspaces must drop them so the new workspace's tab strip and
-        // content render cleanly. Per-workspace diff *tabs* live in
-        // diffTabsByWorkspace and are preserved.
-        diffSelectedFile: null,
-        diffSelectedLayer: null,
+        diffSelectionByWorkspace: selectionMap,
+        diffSelectedFile: restored?.path ?? null,
+        diffSelectedLayer: restored?.layer ?? null,
         diffContent: null,
         diffError: null,
         diffPreviewMode: "diff",

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1700,7 +1700,7 @@ describe("selectWorkspace diff selection persistence", () => {
       diffContent: null,
       diffError: null,
       diffSelectionByWorkspace: {},
-      rightSidebarTab: "chat",
+      rightSidebarTab: "changes",
     });
   });
 
@@ -1709,15 +1709,13 @@ describe("selectWorkspace diff selection persistence", () => {
       selectedWorkspaceId: "ws-a",
       diffSelectedFile: "src/main.rs",
       diffSelectedLayer: "staged",
-      diffContent: "some content",
     });
     const before = useAppStore.getState();
     useAppStore.getState().selectWorkspace("ws-a");
     const after = useAppStore.getState();
-    expect(after.diffContent).toBe("some content");
     expect(after.diffSelectedFile).toBe("src/main.rs");
     expect(after.selectedWorkspaceId).toBe("ws-a");
-    expect(after.diffContent).toBe(before.diffContent);
+    expect(after.diffSelectedFile).toBe(before.diffSelectedFile);
   });
 
   it("saves outgoing workspace diff selection and restores the incoming one", () => {
@@ -1773,7 +1771,7 @@ describe("clearDiff per-workspace cleanup", () => {
       diffFiles: [],
       diffMergeBase: null,
       diffStagedFiles: null,
-      diffContent: "content",
+      diffContent: null,
       diffError: null,
     });
   });

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -4,6 +4,7 @@ import type { AgentQuestion } from "./useAppStore";
 import type { ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
 import type { Workspace } from "../types/workspace";
+import type { Repository } from "../types/repository";
 import { applyPlanModeMountDefault } from "../components/chat/applyPlanModeMountDefault";
 
 const WS_ID = "test-workspace";
@@ -1573,7 +1574,6 @@ describe("removeWorkspace", () => {
     expect(s.terminalTabs["ws-a"]).toBeUndefined();
     expect(s.activeTerminalTabId["ws-a"]).toBeUndefined();
     expect(s.workspaceTerminalCommands["ws-a"]).toBeUndefined();
-    // Other workspace's state is untouched.
     expect(s.terminalTabs["ws-b"]).toBeDefined();
   });
 
@@ -1626,11 +1626,7 @@ describe("addChatAttachments accepts agent-origin rows", () => {
     expect(list[1].origin).toBe("agent");
   });
 
-  it("keeps origin field intact through addChatAttachments — needed for the assistant-message re-route in ChatPanel", () => {
-    // ChatPanel routes `origin: 'agent'` rows to the next assistant message
-    // chronologically (instead of the FK anchor user message). The store
-    // must not strip or default-shift this field, otherwise the visual
-    // anchoring breaks.
+  it("keeps origin field intact through addChatAttachments", () => {
     const wsId = "ws-route";
     useAppStore.getState().addChatAttachments(wsId, [
       {
@@ -1653,8 +1649,6 @@ describe("addChatAttachments accepts agent-origin rows", () => {
   });
 
   it("preserves field-by-field round trip for SVG agent attachments", () => {
-    // SVG is allowed by policy; rendering uses data:image/svg+xml URL — make
-    // sure the type flows through unchanged.
     const wsId = "ws-2";
     useAppStore.getState().addChatAttachments(wsId, [
       {
@@ -1674,5 +1668,194 @@ describe("addChatAttachments accepts agent-origin rows", () => {
     const att = useAppStore.getState().chatAttachments[wsId][0];
     expect(att.media_type).toBe("image/svg+xml");
     expect(att.data_base64).toBe("PHN2Zy8+");
+  });
+});
+
+function makeRepository(id: string): Repository {
+  return {
+    id,
+    path: `/repos/${id}`,
+    name: id,
+    path_slug: id,
+    icon: null,
+    created_at: "",
+    setup_script: null,
+    custom_instructions: null,
+    sort_order: 0,
+    branch_rename_preferences: null,
+    setup_script_auto_run: false,
+    base_branch: null,
+    default_remote: null,
+    path_valid: true,
+    remote_connection_id: null,
+  };
+}
+
+describe("selectWorkspace diff selection persistence", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      selectedWorkspaceId: null,
+      diffSelectedFile: null,
+      diffSelectedLayer: null,
+      diffContent: null,
+      diffError: null,
+      diffSelectionByWorkspace: {},
+      rightSidebarTab: "chat",
+    });
+  });
+
+  it("no-op when called with the already-selected workspace id", () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-a",
+      diffSelectedFile: "src/main.rs",
+      diffSelectedLayer: "staged",
+      diffContent: "some content",
+    });
+    const before = useAppStore.getState();
+    useAppStore.getState().selectWorkspace("ws-a");
+    const after = useAppStore.getState();
+    expect(after.diffContent).toBe("some content");
+    expect(after.diffSelectedFile).toBe("src/main.rs");
+    expect(after.selectedWorkspaceId).toBe("ws-a");
+    expect(after.diffContent).toBe(before.diffContent);
+  });
+
+  it("saves outgoing workspace diff selection and restores the incoming one", () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-a",
+      diffSelectedFile: "src/lib.rs",
+      diffSelectedLayer: "unstaged",
+      diffSelectionByWorkspace: {
+        "ws-b": { path: "src/main.rs", layer: "staged" },
+      },
+    });
+
+    useAppStore.getState().selectWorkspace("ws-b");
+
+    const s = useAppStore.getState();
+    expect(s.selectedWorkspaceId).toBe("ws-b");
+    expect(s.diffSelectionByWorkspace["ws-a"]).toEqual({
+      path: "src/lib.rs",
+      layer: "unstaged",
+    });
+    expect(s.diffSelectedFile).toBe("src/main.rs");
+    expect(s.diffSelectedLayer).toBe("staged");
+    expect(s.diffContent).toBeNull();
+    expect(s.diffError).toBeNull();
+  });
+
+  it("clears diff selection when switching to a workspace with no prior selection", () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-a",
+      diffSelectedFile: "src/foo.rs",
+      diffSelectedLayer: null,
+      diffSelectionByWorkspace: {},
+    });
+
+    useAppStore.getState().selectWorkspace("ws-b");
+
+    const s = useAppStore.getState();
+    expect(s.diffSelectedFile).toBeNull();
+    expect(s.diffSelectedLayer).toBeNull();
+  });
+});
+
+describe("clearDiff per-workspace cleanup", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-a",
+      diffSelectedFile: "src/lib.rs",
+      diffSelectedLayer: "unstaged",
+      diffSelectionByWorkspace: {
+        "ws-a": { path: "src/lib.rs", layer: "unstaged" },
+        "ws-b": { path: "src/main.rs", layer: "staged" },
+      },
+      diffFiles: [],
+      diffMergeBase: null,
+      diffStagedFiles: null,
+      diffContent: "content",
+      diffError: null,
+    });
+  });
+
+  it("removes only the current workspace's saved selection", () => {
+    useAppStore.getState().clearDiff();
+    const s = useAppStore.getState();
+    expect(s.diffSelectionByWorkspace["ws-a"]).toBeUndefined();
+    expect(s.diffSelectionByWorkspace["ws-b"]).toEqual({
+      path: "src/main.rs",
+      layer: "staged",
+    });
+  });
+
+  it("resets diff view state", () => {
+    useAppStore.getState().clearDiff();
+    const s = useAppStore.getState();
+    expect(s.diffSelectedFile).toBeNull();
+    expect(s.diffContent).toBeNull();
+  });
+});
+
+describe("removeWorkspace cleans up diffSelectionByWorkspace and chatDrafts", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [makeWorkspace("ws-a", "repo-1"), makeWorkspace("ws-b", "repo-1")],
+      selectedWorkspaceId: "ws-a",
+      diffSelectionByWorkspace: {
+        "ws-a": { path: "src/lib.rs", layer: null },
+        "ws-b": { path: "src/main.rs", layer: "staged" },
+      },
+      chatDrafts: { "ws-a": "hello", "ws-b": "world" },
+    });
+  });
+
+  it("removes the removed workspace's diff selection entry", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    const s = useAppStore.getState();
+    expect(s.diffSelectionByWorkspace["ws-a"]).toBeUndefined();
+    expect(s.diffSelectionByWorkspace["ws-b"]).toBeDefined();
+  });
+
+  it("removes the removed workspace's chat draft", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    const s = useAppStore.getState();
+    expect(s.chatDrafts["ws-a"]).toBeUndefined();
+    expect(s.chatDrafts["ws-b"]).toBe("world");
+  });
+});
+
+describe("removeRepository cleans up diffSelectionByWorkspace and chatDrafts", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      repositories: [makeRepository("repo-1"), makeRepository("repo-2")],
+      workspaces: [
+        makeWorkspace("ws-a", "repo-1"),
+        makeWorkspace("ws-b", "repo-1"),
+        makeWorkspace("ws-c", "repo-2"),
+      ],
+      selectedWorkspaceId: "ws-a",
+      diffSelectionByWorkspace: {
+        "ws-a": { path: "src/a.rs", layer: null },
+        "ws-b": { path: "src/b.rs", layer: "staged" },
+        "ws-c": { path: "src/c.rs", layer: null },
+      },
+      chatDrafts: { "ws-a": "draft-a", "ws-b": "draft-b", "ws-c": "draft-c" },
+    });
+  });
+
+  it("removes all workspace entries for the removed repo from diffSelectionByWorkspace", () => {
+    useAppStore.getState().removeRepository("repo-1");
+    const s = useAppStore.getState();
+    expect(s.diffSelectionByWorkspace["ws-a"]).toBeUndefined();
+    expect(s.diffSelectionByWorkspace["ws-b"]).toBeUndefined();
+    expect(s.diffSelectionByWorkspace["ws-c"]).toBeDefined();
+  });
+
+  it("removes all workspace entries for the removed repo from chatDrafts", () => {
+    useAppStore.getState().removeRepository("repo-1");
+    const s = useAppStore.getState();
+    expect(s.chatDrafts["ws-a"]).toBeUndefined();
+    expect(s.chatDrafts["ws-b"]).toBeUndefined();
+    expect(s.chatDrafts["ws-c"]).toBe("draft-c");
   });
 });


### PR DESCRIPTION
### Summary

Two pieces of UI state were silently reset whenever the user switched workspaces:

1. **Diff file selection** — `selectWorkspace` previously overwrote `diffSelectedFile`/`diffSelectedLayer` with `null` unconditionally. Now `selectWorkspace` saves the outgoing workspace's selection into a new `diffSelectionByWorkspace` map and restores the incoming workspace's last selection, so switching away and back lands on the same file.

2. **Chat input drafts** — the draft was stored in local `useState`, so it was lost whenever `ChatPanel` unmounted (e.g. switching to the diff view, which swaps the panel out entirely). Drafts are now stored in `chatDrafts` in the Zustand store and survive both panel unmounts and workspace switches.

Both maps are cleaned up in `removeWorkspace` to avoid unbounded growth.

Additionally, `ToolActivitiesSection`'s auto-collapse logic was moved from a `useEffect` into a render-time derived state update, eliminating the extra render cycle that caused a brief flicker when a new agent turn started.

### Complexity Notes

- **`selectWorkspace` atomicity** — the save-and-restore of `diffSelectionByWorkspace` happens inside a single `set((s) => ...)` callback, so there is no intermediate state where the old file is cleared before the new one is restored. Reviewers should verify `diffContent: null` is intentional here — it forces `DiffViewer` to reload content for the restored file rather than showing stale content from the previous workspace.
- **State-during-render pattern** — the `ToolActivitiesSection` change uses React's supported "derive state from props during render" pattern (`setPrevActivitiesLength` called conditionally during render). This is correct per React docs but looks unusual — it avoids a committed intermediate render at the cost of being less obvious.

### Test Steps

1. Open two workspaces, each with at least one changed file.
2. In workspace A, open the diff viewer and select a file.
3. Switch to workspace B — verify the diff panel shows B's state (no stale file from A).
4. Switch back to workspace A — verify the previously selected file is restored automatically.
5. In workspace A's chat input, type a partial message.
6. Click to the diff view (which swaps `ChatPanel` out of the layout) and back — verify the draft is still present.
7. Switch to workspace B and back — verify workspace A's draft is still intact.
8. Start an agent turn and watch the tool activities section — verify it collapses cleanly at the start of each turn without a visible flicker.

### Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
