### PR TITLE
feat(notifications): add OpenPeon community sound pack support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",
+ "flate2",
  "futures",
  "mlua",
  "open",
@@ -638,6 +639,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ which = "7"
 dirs = "6"
 open = "5"
 mlua = { version = "0.10", features = ["luau", "serialize", "async", "send"] }
+flate2 = "1"
 rand = "0.8"
 sha2 = "0.10"
+tar = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/cesp.rs
+++ b/src-tauri/src/commands/cesp.rs
@@ -20,6 +20,10 @@ pub async fn cesp_fetch_registry() -> Result<Vec<RegistryPack>, String> {
         .send()
         .await
         .map_err(|e| format!("Failed to fetch registry: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("Registry returned HTTP {status}"));
+    }
     let index: RegistryIndex = resp
         .json()
         .await
@@ -41,11 +45,16 @@ pub async fn cesp_install_pack(
 ) -> Result<InstalledPack, String> {
     let tarball_url =
         format!("https://github.com/{source_repo}/archive/refs/tags/{source_ref}.tar.gz");
-    let bytes = http_client()
+    let resp = http_client()
         .get(&tarball_url)
         .send()
         .await
-        .map_err(|e| format!("Failed to download pack: {e}"))?
+        .map_err(|e| format!("Failed to download pack: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("Failed to download pack: HTTP {status}"));
+    }
+    let bytes = resp
         .bytes()
         .await
         .map_err(|e| format!("Failed to read pack data: {e}"))?;
@@ -109,8 +118,9 @@ pub async fn cesp_preview_sound(
         .pick_sound(&preview_category, sounds, std::time::Duration::ZERO)
         .ok_or("No sound available")?;
 
-    let file_path = cesp::resolve_sound_file(&pack_dir, sound);
-    cesp::play_audio_file(&file_path, volume);
+    if let Some(file_path) = cesp::resolve_sound_file(&pack_dir, sound) {
+        cesp::play_audio_file(&file_path, volume);
+    }
     Ok(())
 }
 
@@ -161,8 +171,9 @@ pub async fn cesp_play_for_event(
     if let Some(sound) =
         playback.pick_sound(category, sounds, std::time::Duration::from_millis(500))
     {
-        let file_path = cesp::resolve_sound_file(&pack_dir, sound);
-        cesp::play_audio_file(&file_path, volume);
+        if let Some(file_path) = cesp::resolve_sound_file(&pack_dir, sound) {
+            cesp::play_audio_file(&file_path, volume);
+        }
     }
 
     Ok(())

--- a/src-tauri/src/commands/cesp.rs
+++ b/src-tauri/src/commands/cesp.rs
@@ -1,0 +1,169 @@
+use tauri::State;
+
+use claudette::cesp;
+use claudette::db::Database;
+use claudette::model::cesp::{InstalledPack, RegistryIndex, RegistryPack};
+
+use crate::state::AppState;
+
+const REGISTRY_URL: &str = "https://peonping.github.io/registry/index.json";
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+#[tauri::command]
+pub async fn cesp_fetch_registry() -> Result<Vec<RegistryPack>, String> {
+    let resp = http_client()
+        .get(REGISTRY_URL)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch registry: {e}"))?;
+    let index: RegistryIndex = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse registry: {e}"))?;
+    Ok(index.packs)
+}
+
+#[tauri::command]
+pub async fn cesp_list_installed() -> Result<Vec<InstalledPack>, String> {
+    cesp::list_installed()
+}
+
+#[tauri::command]
+pub async fn cesp_install_pack(
+    name: String,
+    source_repo: String,
+    source_ref: String,
+    source_path: String,
+) -> Result<InstalledPack, String> {
+    let tarball_url =
+        format!("https://github.com/{source_repo}/archive/refs/tags/{source_ref}.tar.gz");
+    let bytes = http_client()
+        .get(&tarball_url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to download pack: {e}"))?
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read pack data: {e}"))?;
+
+    let entry = RegistryPack {
+        name,
+        display_name: String::new(),
+        description: None,
+        language: None,
+        source_repo,
+        source_ref,
+        source_path,
+        categories: Vec::new(),
+        sound_count: 0,
+        total_size_bytes: 0,
+    };
+
+    cesp::install_pack(&entry, &bytes)
+}
+
+#[tauri::command]
+pub async fn cesp_update_pack(
+    name: String,
+    source_repo: String,
+    source_ref: String,
+    source_path: String,
+) -> Result<InstalledPack, String> {
+    cesp_install_pack(name, source_repo, source_ref, source_path).await
+}
+
+#[tauri::command]
+pub async fn cesp_delete_pack(name: String) -> Result<(), String> {
+    cesp::delete_pack(&name)
+}
+
+#[tauri::command]
+pub async fn cesp_preview_sound(
+    pack_name: String,
+    category: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let volume: f64 = db
+        .get_app_setting("cesp_volume")
+        .ok()
+        .flatten()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+
+    let pack_dir = cesp::packs_dir().join(&pack_name);
+    let manifest = cesp::load_manifest(&pack_dir)?;
+    let sounds = cesp::resolve_category(&manifest, &category)
+        .ok_or_else(|| format!("No sounds for category '{category}'"))?;
+
+    let mut playback = state
+        .cesp_playback
+        .lock()
+        .map_err(|e| format!("Lock error: {e}"))?;
+    let preview_category = format!("preview:{category}");
+    let sound = playback
+        .pick_sound(&preview_category, sounds, std::time::Duration::ZERO)
+        .ok_or("No sound available")?;
+
+    let file_path = cesp::resolve_sound_file(&pack_dir, sound);
+    cesp::play_audio_file(&file_path, volume);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn cesp_play_for_event(
+    event_name: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    let db_get = |key: &str| -> Option<String> { db.get_app_setting(key).ok().flatten() };
+
+    let sound_source = db_get("sound_source").unwrap_or_else(|| "system".to_string());
+    if sound_source != "openpeon" {
+        return Ok(());
+    }
+
+    let muted = db_get("cesp_muted").unwrap_or_else(|| "false".to_string());
+    if muted == "true" {
+        return Ok(());
+    }
+
+    let pack_name = match db_get("cesp_active_pack") {
+        Some(name) if !name.is_empty() => name,
+        _ => return Ok(()),
+    };
+
+    let volume: f64 = db_get("cesp_volume")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+
+    let pack_dir = cesp::packs_dir().join(&pack_name);
+    let manifest = match cesp::load_manifest(&pack_dir) {
+        Ok(m) => m,
+        Err(_) => return Ok(()),
+    };
+
+    let category = cesp::notification_event_to_cesp_category(&event_name);
+    let sounds = match cesp::resolve_category(&manifest, category) {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    let mut playback = state
+        .cesp_playback
+        .lock()
+        .map_err(|e| format!("Lock error: {e}"))?;
+    if let Some(sound) =
+        playback.pick_sound(category, sounds, std::time::Duration::from_millis(500))
+    {
+        let file_path = cesp::resolve_sound_file(&pack_dir, sound);
+        cesp::play_audio_file(&file_path, volume);
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/commands/cesp.rs
+++ b/src-tauri/src/commands/cesp.rs
@@ -104,6 +104,7 @@ pub async fn cesp_preview_sound(
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0);
 
+    cesp::validate_pack_name(&pack_name)?;
     let pack_dir = cesp::packs_dir().join(&pack_name);
     let manifest = cesp::load_manifest(&pack_dir)?;
     let sounds = cesp::resolve_category(&manifest, &category)
@@ -152,6 +153,9 @@ pub async fn cesp_play_for_event(
         .and_then(|v| v.parse().ok())
         .unwrap_or(1.0);
 
+    if cesp::validate_pack_name(&pack_name).is_err() {
+        return Ok(());
+    }
     let pack_dir = cesp::packs_dir().join(&pack_name);
     let manifest = match cesp::load_manifest(&pack_dir) {
         Ok(m) => m,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -19,6 +19,45 @@ use claudette::{base64_decode, base64_encode};
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
 
+async fn fire_completion_notification(
+    db_path: &std::path::Path,
+    cesp_playback: &std::sync::Mutex<claudette::cesp::SoundPlaybackState>,
+    event: crate::tray::NotificationEvent,
+    ws_id: &str,
+) {
+    let Ok(db) = Database::open(db_path) else {
+        return;
+    };
+    let resolved = crate::tray::resolve_notification(&db, cesp_playback, event);
+    if resolved.sound != "None" {
+        crate::commands::settings::play_notification_sound(resolved.sound, Some(resolved.volume));
+    }
+    if let Ok(Some(cmd)) = db.get_app_setting("notification_command")
+        && !cmd.is_empty()
+        && let Some(fresh_ws) = db
+            .list_workspaces()
+            .ok()
+            .and_then(|wss| wss.into_iter().find(|w| w.id == ws_id))
+    {
+        let repo_path = db
+            .get_repository(&fresh_ws.repository_id)
+            .ok()
+            .flatten()
+            .map(|r| r.path)
+            .unwrap_or_default();
+        let default_branch = git::default_branch(&repo_path)
+            .await
+            .unwrap_or_else(|_| "main".into());
+        let fresh_env = WorkspaceEnv::from_workspace(&fresh_ws, &repo_path, default_branch);
+        if let Some(mut command) =
+            crate::commands::settings::build_notification_command(&cmd, &fresh_env)
+            && let Ok(child) = command.spawn()
+        {
+            crate::commands::settings::spawn_and_reap(child);
+        }
+    }
+}
+
 /// Frontend-facing input for a file attachment (base64-encoded).
 #[derive(Clone, Deserialize)]
 pub struct AttachmentInput {
@@ -1031,9 +1070,9 @@ pub async fn send_chat_message(
             // When a persistent turn completes (Result event), clear active_pid
             // so the workspace shows as idle. The persistent process stays alive
             // for the next turn — only active_pid is cleared, not persistent_session.
-            if let AgentEvent::Stream(StreamEvent::Result { .. }) = &event {
+            if let AgentEvent::Stream(StreamEvent::Result { subtype, .. }) = &event {
                 let app_state = app.state::<AppState>();
-                let session_id_for_capture = {
+                let (session_id_for_capture, needs_attention) = {
                     let mut agents = app_state.agents.write().await;
                     if let Some(session) = agents.get_mut(&ws_id)
                         && session.active_pid == Some(spawned_pid)
@@ -1041,10 +1080,12 @@ pub async fn send_chat_message(
                     {
                         session.active_pid = None;
                     }
-                    agents
+                    let sid = agents
                         .get(&ws_id)
                         .map(|s| s.session_id.clone())
-                        .unwrap_or_default()
+                        .unwrap_or_default();
+                    let attn = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
+                    (sid, attn)
                 };
                 // Rebuild tray so it reflects the idle state. Without this,
                 // the tray stays stuck on "Running" because the persistent
@@ -1065,6 +1106,15 @@ pub async fn send_chat_message(
                     &wt_path,
                 )
                 .await;
+                if !needs_attention {
+                    let event = if subtype == "success" {
+                        crate::tray::NotificationEvent::Finished
+                    } else {
+                        crate::tray::NotificationEvent::Error
+                    };
+                    fire_completion_notification(&db_path, &app_state.cesp_playback, event, &ws_id)
+                        .await;
+                }
             }
 
             // Track per-assistant-message cumulative usage as the CLI streams it.
@@ -1141,64 +1191,16 @@ pub async fn send_chat_message(
                     )
                     .await;
                 }
-                // Play notification sound + run command if the window is not focused.
-                // This runs on the Rust side so it works even when the webview
-                // is suspended (window hidden / close-to-tray).
                 let needs_attention_now = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
                 let app_state = app.state::<crate::state::AppState>();
-                let viewing_this =
-                    app_state.viewing_workspace_id.read().await.as_deref() == Some(ws_id.as_str());
-                let window_focused = app
-                    .get_webview_window("main")
-                    .and_then(|w| w.is_focused().ok())
-                    .unwrap_or(false);
-                // Skip if user is actively viewing this workspace (window
-                // focused AND this workspace selected) or if this is an
-                // attention event (notify_attention already handled it).
-                if !(window_focused && viewing_this)
-                    && !needs_attention_now
-                    && let Ok(db) = Database::open(&db_path)
-                {
-                    let resolved = crate::tray::resolve_notification(
-                        &db,
-                        &app_state.cesp_playback,
-                        crate::tray::NotificationEvent::Finished,
-                    );
-                    if resolved.sound != "None" {
-                        crate::commands::settings::play_notification_sound(
-                            resolved.sound,
-                            Some(resolved.volume),
-                        );
-                    }
-                    // Run notification command if configured — uses the same
-                    // tested helper as the settings test button and tray path.
-                    // Rebuild WorkspaceEnv from the DB so it reflects any
-                    // renames that happened during the turn (try_auto_rename).
-                    if let Ok(Some(cmd)) = db.get_app_setting("notification_command")
-                        && !cmd.is_empty()
-                        && let Some(fresh_ws) = db
-                            .list_workspaces()
-                            .ok()
-                            .and_then(|wss| wss.into_iter().find(|w| w.id == ws_id))
-                    {
-                        let repo_path = db
-                            .get_repository(&fresh_ws.repository_id)
-                            .ok()
-                            .flatten()
-                            .map(|r| r.path)
-                            .unwrap_or_default();
-                        let default_branch = git::default_branch(&repo_path)
-                            .await
-                            .unwrap_or_else(|_| "main".into());
-                        let fresh_env =
-                            WorkspaceEnv::from_workspace(&fresh_ws, &repo_path, default_branch);
-                        if let Some(mut command) =
-                            crate::commands::settings::build_notification_command(&cmd, &fresh_env)
-                            && let Ok(child) = command.spawn()
-                        {
-                            crate::commands::settings::spawn_and_reap(child);
-                        }
-                    }
+                if !needs_attention_now {
+                    let event = if exit_code == Some(0) {
+                        crate::tray::NotificationEvent::Finished
+                    } else {
+                        crate::tray::NotificationEvent::Error
+                    };
+                    fire_completion_notification(&db_path, &app_state.cesp_playback, event, &ws_id)
+                        .await;
                 }
 
                 drop(agents);
@@ -1792,6 +1794,8 @@ pub async fn submit_agent_answer(
             .pending_permissions
             .remove(&tool_use_id)
             .expect("checked above");
+        session.needs_attention = false;
+        session.attention_kind = None;
         (pending, ps)
     };
 
@@ -1858,6 +1862,8 @@ pub async fn submit_plan_approval(
             .pending_permissions
             .remove(&tool_use_id)
             .expect("checked above");
+        session.needs_attention = false;
+        session.attention_kind = None;
         (pending, ps)
     };
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1173,9 +1173,14 @@ pub async fn send_chat_message(
                             .flatten()
                             .unwrap_or_else(|| "system".to_string());
                         if sound_source == "openpeon" {
-                            claudette::cesp::play_cesp_sound_for_event("finished", &|key| {
-                                db.get_app_setting(key).ok().flatten()
-                            });
+                            let app_state = app_handle.state::<crate::state::AppState>();
+                            if let Ok(mut playback) = app_state.cesp_playback.lock() {
+                                claudette::cesp::play_cesp_sound_for_event_with_state(
+                                    "finished",
+                                    &mut playback,
+                                    &|key| db.get_app_setting(key).ok().flatten(),
+                                );
+                            }
                         } else {
                             let sound = crate::tray::resolve_notification_sound(
                                 &db,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1155,44 +1155,17 @@ pub async fn send_chat_message(
                     && !needs_attention_now
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    let muted = db
-                        .get_app_setting("cesp_muted")
-                        .ok()
-                        .flatten()
-                        .is_some_and(|v| v == "true");
-                    let volume: f64 = db
-                        .get_app_setting("cesp_volume")
-                        .ok()
-                        .flatten()
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(1.0);
-                    if !muted && volume > 0.0 {
-                        let sound_source = db
-                            .get_app_setting("sound_source")
-                            .ok()
-                            .flatten()
-                            .unwrap_or_else(|| "system".to_string());
-                        if sound_source == "openpeon" {
-                            let app_state = app_handle.state::<crate::state::AppState>();
-                            if let Ok(mut playback) = app_state.cesp_playback.lock() {
-                                claudette::cesp::play_cesp_sound_for_event_with_state(
-                                    "finished",
-                                    &mut playback,
-                                    &|key| db.get_app_setting(key).ok().flatten(),
-                                );
-                            }
-                        } else {
-                            let sound = crate::tray::resolve_notification_sound(
-                                &db,
-                                crate::tray::NotificationEvent::Finished,
-                            );
-                            if sound != "None" {
-                                crate::commands::settings::play_notification_sound(
-                                    sound,
-                                    Some(volume),
-                                );
-                            }
-                        }
+                    let app_state = app_handle.state::<crate::state::AppState>();
+                    let resolved = crate::tray::resolve_notification(
+                        &db,
+                        &app_state.cesp_playback,
+                        crate::tray::NotificationEvent::Finished,
+                    );
+                    if resolved.sound != "None" {
+                        crate::commands::settings::play_notification_sound(
+                            resolved.sound,
+                            Some(resolved.volume),
+                        );
                     }
                     // Run notification command if configured — uses the same
                     // tested helper as the settings test button and tray path.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1145,17 +1145,20 @@ pub async fn send_chat_message(
                 // This runs on the Rust side so it works even when the webview
                 // is suspended (window hidden / close-to-tray).
                 let needs_attention_now = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
+                let app_state = app.state::<crate::state::AppState>();
+                let viewing_this =
+                    app_state.viewing_workspace_id.read().await.as_deref() == Some(ws_id.as_str());
                 let window_focused = app
                     .get_webview_window("main")
                     .and_then(|w| w.is_focused().ok())
                     .unwrap_or(false);
-                // Skip if user is actively watching (window focused) or if this
-                // is an attention event (notify_attention already handled it).
-                if !window_focused
+                // Skip if user is actively viewing this workspace (window
+                // focused AND this workspace selected) or if this is an
+                // attention event (notify_attention already handled it).
+                if !(window_focused && viewing_this)
                     && !needs_attention_now
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    let app_state = app.state::<crate::state::AppState>();
                     let resolved = crate::tray::resolve_notification(
                         &db,
                         &app_state.cesp_playback,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -832,6 +832,7 @@ pub async fn send_chat_message(
         // across multi-message turns.
         let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
         let mut pending_attention_kind: Option<crate::state::AttentionKind>;
+        let mut notified_via_result = false;
         while let Some(event) = rx.recv().await {
             pending_attention_kind = None;
             // Track whether the CLI initialized successfully.
@@ -1114,6 +1115,7 @@ pub async fn send_chat_message(
                     };
                     fire_completion_notification(&db_path, &app_state.cesp_playback, event, &ws_id)
                         .await;
+                    notified_via_result = true;
                 }
             }
 
@@ -1193,7 +1195,7 @@ pub async fn send_chat_message(
                 }
                 let needs_attention_now = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
                 let app_state = app.state::<crate::state::AppState>();
-                if !needs_attention_now {
+                if !needs_attention_now && !notified_via_result {
                     let event = if exit_code == Some(0) {
                         crate::tray::NotificationEvent::Finished
                     } else {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1155,12 +1155,39 @@ pub async fn send_chat_message(
                     && !needs_attention_now
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    let sound = crate::tray::resolve_notification_sound(
-                        &db,
-                        crate::tray::NotificationEvent::Finished,
-                    );
-                    if sound != "None" {
-                        crate::commands::settings::play_notification_sound(sound);
+                    let muted = db
+                        .get_app_setting("cesp_muted")
+                        .ok()
+                        .flatten()
+                        .is_some_and(|v| v == "true");
+                    let volume: f64 = db
+                        .get_app_setting("cesp_volume")
+                        .ok()
+                        .flatten()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(1.0);
+                    if !muted && volume > 0.0 {
+                        let sound_source = db
+                            .get_app_setting("sound_source")
+                            .ok()
+                            .flatten()
+                            .unwrap_or_else(|| "system".to_string());
+                        if sound_source == "openpeon" {
+                            claudette::cesp::play_cesp_sound_for_event("finished", &|key| {
+                                db.get_app_setting(key).ok().flatten()
+                            });
+                        } else {
+                            let sound = crate::tray::resolve_notification_sound(
+                                &db,
+                                crate::tray::NotificationEvent::Finished,
+                            );
+                            if sound != "None" {
+                                crate::commands::settings::play_notification_sound(
+                                    sound,
+                                    Some(volume),
+                                );
+                            }
+                        }
                     }
                     // Run notification command if configured — uses the same
                     // tested helper as the settings test button and tray path.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1155,7 +1155,7 @@ pub async fn send_chat_message(
                     && !needs_attention_now
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    let app_state = app_handle.state::<crate::state::AppState>();
+                    let app_state = app.state::<crate::state::AppState>();
                     let resolved = crate::tray::resolve_notification(
                         &db,
                         &app_state.cesp_playback,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod apps;
+pub mod cesp;
 pub mod chat;
 pub mod data;
 #[cfg(debug_assertions)]

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -660,9 +660,13 @@ async fn auto_archive_workspace(
         let sound = if muted || volume <= 0.0 {
             "None".to_string()
         } else if sound_source == "openpeon" {
-            claudette::cesp::play_cesp_sound_for_event("finished", &|key| {
-                db.get_app_setting(key).ok().flatten()
-            });
+            if let Ok(mut playback) = app_state.cesp_playback.lock() {
+                claudette::cesp::play_cesp_sound_for_event_with_state(
+                    "finished",
+                    &mut playback,
+                    &|key| db.get_app_setting(key).ok().flatten(),
+                );
+            }
             "None".to_string()
         } else {
             crate::tray::resolve_notification_sound(&db, crate::tray::NotificationEvent::Finished)

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -617,7 +617,8 @@ async fn auto_archive_workspace(
     pr_number: Option<u64>,
 ) {
     // All DB work in a block (Database is not Send — must not hold across .await)
-    let archive_info: Option<(String, String, Option<String>, Option<String>, String)> = {
+    #[allow(clippy::type_complexity)]
+    let archive_info: Option<(String, String, Option<String>, Option<String>, String, f64)> = {
         let db = match Database::open(&app_state.db_path) {
             Ok(db) => db,
             Err(e) => {
@@ -640,8 +641,32 @@ async fn auto_archive_workspace(
             .flatten()
             .map(|r| r.path);
 
-        let sound =
-            crate::tray::resolve_notification_sound(&db, crate::tray::NotificationEvent::Finished);
+        let muted = db
+            .get_app_setting("cesp_muted")
+            .ok()
+            .flatten()
+            .is_some_and(|v| v == "true");
+        let volume: f64 = db
+            .get_app_setting("cesp_volume")
+            .ok()
+            .flatten()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1.0);
+        let sound_source = db
+            .get_app_setting("sound_source")
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| "system".to_string());
+        let sound = if muted || volume <= 0.0 {
+            "None".to_string()
+        } else if sound_source == "openpeon" {
+            claudette::cesp::play_cesp_sound_for_event("finished", &|key| {
+                db.get_app_setting(key).ok().flatten()
+            });
+            "None".to_string()
+        } else {
+            crate::tray::resolve_notification_sound(&db, crate::tray::NotificationEvent::Finished)
+        };
 
         // Update DB status
         let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
@@ -657,10 +682,11 @@ async fn auto_archive_workspace(
             ws.worktree_path.clone(),
             repo_path,
             sound,
+            volume,
         ))
     };
 
-    let Some((ws_id, ws_name, wt_path, repo_path, sound)) = archive_info else {
+    let Some((ws_id, ws_name, wt_path, repo_path, sound, volume)) = archive_info else {
         return;
     };
 
@@ -688,7 +714,7 @@ async fn auto_archive_workspace(
         }
         None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
     };
-    crate::tray::send_notification(handle, "", "Claudette", &body, &sound);
+    crate::tray::send_notification(handle, "", "Claudette", &body, &sound, volume);
 
     let mut payload = serde_json::json!({
         "workspace_id": ws_id,

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -617,8 +617,13 @@ async fn auto_archive_workspace(
     pr_number: Option<u64>,
 ) {
     // All DB work in a block (Database is not Send — must not hold across .await)
-    #[allow(clippy::type_complexity)]
-    let archive_info: Option<(String, String, Option<String>, Option<String>, String, f64)> = {
+    let archive_info: Option<(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        crate::tray::ResolvedSound,
+    )> = {
         let db = match Database::open(&app_state.db_path) {
             Ok(db) => db,
             Err(e) => {
@@ -641,36 +646,11 @@ async fn auto_archive_workspace(
             .flatten()
             .map(|r| r.path);
 
-        let muted = db
-            .get_app_setting("cesp_muted")
-            .ok()
-            .flatten()
-            .is_some_and(|v| v == "true");
-        let volume: f64 = db
-            .get_app_setting("cesp_volume")
-            .ok()
-            .flatten()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(1.0);
-        let sound_source = db
-            .get_app_setting("sound_source")
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| "system".to_string());
-        let sound = if muted || volume <= 0.0 {
-            "None".to_string()
-        } else if sound_source == "openpeon" {
-            if let Ok(mut playback) = app_state.cesp_playback.lock() {
-                claudette::cesp::play_cesp_sound_for_event_with_state(
-                    "finished",
-                    &mut playback,
-                    &|key| db.get_app_setting(key).ok().flatten(),
-                );
-            }
-            "None".to_string()
-        } else {
-            crate::tray::resolve_notification_sound(&db, crate::tray::NotificationEvent::Finished)
-        };
+        let resolved = crate::tray::resolve_notification(
+            &db,
+            &app_state.cesp_playback,
+            crate::tray::NotificationEvent::Finished,
+        );
 
         // Update DB status
         let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
@@ -685,12 +665,11 @@ async fn auto_archive_workspace(
             ws.name.clone(),
             ws.worktree_path.clone(),
             repo_path,
-            sound,
-            volume,
+            resolved,
         ))
     };
 
-    let Some((ws_id, ws_name, wt_path, repo_path, sound, volume)) = archive_info else {
+    let Some((ws_id, ws_name, wt_path, repo_path, resolved)) = archive_info else {
         return;
     };
 
@@ -718,7 +697,14 @@ async fn auto_archive_workspace(
         }
         None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
     };
-    crate::tray::send_notification(handle, "", "Claudette", &body, &sound, volume);
+    crate::tray::send_notification(
+        handle,
+        "",
+        "Claudette",
+        &body,
+        &resolved.sound,
+        resolved.volume,
+    );
 
     let mut payload = serde_json::json!({
         "workspace_id": ws_id,

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -175,8 +175,12 @@ pub async fn list_system_fonts() -> Vec<String> {
 
 /// Play a notification sound by name (for settings preview and agent-finished events).
 #[tauri::command]
-pub fn play_notification_sound(sound: String) {
+pub fn play_notification_sound(sound: String, volume: Option<f64>) {
     if sound == "None" {
+        return;
+    }
+    let vol = volume.unwrap_or(1.0).clamp(0.0, 1.0);
+    if vol <= 0.0 {
         return;
     }
     #[cfg(target_os = "macos")]
@@ -186,26 +190,31 @@ pub fn play_notification_sound(sound: String) {
         } else {
             format!("/System/Library/Sounds/{sound}.aiff")
         };
-        if let Ok(child) = std::process::Command::new("afplay").arg(&path).spawn() {
+        if let Ok(child) = std::process::Command::new("afplay")
+            .arg("-v")
+            .arg(format!("{vol}"))
+            .arg(&path)
+            .spawn()
+        {
             spawn_and_reap(child);
         }
     }
     #[cfg(target_os = "linux")]
     {
-        // On Linux, play the system "bell" or "message" sound via paplay/canberra.
-        // "Default" maps to the desktop notification sound; named sounds are
-        // looked up via the XDG sound theme.
         let sound_name = if sound == "Default" {
             "bell".to_string()
         } else {
             sound.to_lowercase()
         };
+        let pa_volume = (vol * 65536.0) as u32;
         if let Ok(child) = std::process::Command::new("canberra-gtk-play")
             .arg("-i")
             .arg(&sound_name)
             .spawn()
             .or_else(|_| {
                 std::process::Command::new("paplay")
+                    .arg("--volume")
+                    .arg(pa_volume.to_string())
                     .arg(format!(
                         "/usr/share/sounds/freedesktop/stereo/{sound_name}.oga"
                     ))
@@ -217,7 +226,7 @@ pub fn play_notification_sound(sound: String) {
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
-        let _ = sound;
+        let _ = (sound, vol);
     }
 }
 
@@ -378,7 +387,7 @@ mod tests {
     #[test]
     fn test_play_notification_sound_none_is_noop() {
         // Should not panic or spawn any process.
-        play_notification_sound("None".to_string());
+        play_notification_sound("None".to_string(), None);
     }
 
     // --- Notification command tests ---

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -173,17 +173,6 @@ pub async fn list_system_fonts() -> Vec<String> {
     result
 }
 
-/// Tell the backend which workspace the user is currently looking at.
-#[tauri::command]
-pub async fn set_viewing_workspace(
-    workspace_id: Option<String>,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
-    let mut viewing = state.viewing_workspace_id.write().await;
-    *viewing = workspace_id;
-    Ok(())
-}
-
 /// Play a notification sound by name (for settings preview and agent-finished events).
 #[tauri::command]
 pub fn play_notification_sound(sound: String, volume: Option<f64>) {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -179,7 +179,10 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
     if sound == "None" {
         return;
     }
-    let vol = volume.unwrap_or(1.0).clamp(0.0, 1.0);
+    let vol = volume
+        .filter(|v| v.is_finite())
+        .unwrap_or(1.0)
+        .clamp(0.0, 1.0);
     if vol <= 0.0 {
         return;
     }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -173,6 +173,17 @@ pub async fn list_system_fonts() -> Vec<String> {
     result
 }
 
+/// Tell the backend which workspace the user is currently looking at.
+#[tauri::command]
+pub async fn set_viewing_workspace(
+    workspace_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let mut viewing = state.viewing_workspace_id.write().await;
+    *viewing = workspace_id;
+    Ok(())
+}
+
 /// Play a notification sound by name (for settings preview and agent-finished events).
 #[tauri::command]
 pub fn play_notification_sound(sound: String, volume: Option<f64>) {

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::process::Command as TokioCommand;
 
 use claudette::agent;

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -156,6 +156,16 @@ pub async fn create_workspace(
 
     crate::tray::rebuild_tray(&app);
 
+    let app_state = app.state::<crate::state::AppState>();
+    let resolved = crate::tray::resolve_notification(
+        &db,
+        &app_state.cesp_playback,
+        crate::tray::NotificationEvent::SessionStart,
+    );
+    if resolved.sound != "None" {
+        crate::commands::settings::play_notification_sound(resolved.sound, Some(resolved.volume));
+    }
+
     Ok(CreateWorkspaceResult {
         workspace: ws,
         setup_result,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -417,6 +417,14 @@ fn main() {
             commands::plugin::load_plugin_configuration,
             commands::plugin::save_plugin_top_level_configuration,
             commands::plugin::save_plugin_channel_configuration,
+            // Sound Packs (CESP)
+            commands::cesp::cesp_fetch_registry,
+            commands::cesp::cesp_list_installed,
+            commands::cesp::cesp_install_pack,
+            commands::cesp::cesp_update_pack,
+            commands::cesp::cesp_delete_pack,
+            commands::cesp::cesp_preview_sound,
+            commands::cesp::cesp_play_for_event,
             // Shell Integration
             commands::shell::setup_shell_integration,
             commands::shell::apply_shell_integration,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -398,7 +398,6 @@ fn main() {
             commands::settings::play_notification_sound,
             commands::settings::run_notification_command,
             commands::settings::get_git_username,
-            commands::settings::set_viewing_workspace,
             // Updater
             commands::updater::check_for_updates_with_channel,
             commands::updater::install_pending_update,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -398,6 +398,7 @@ fn main() {
             commands::settings::play_notification_sound,
             commands::settings::run_notification_command,
             commands::settings::get_git_username,
+            commands::settings::set_viewing_workspace,
             // Updater
             commands::updater::check_for_updates_with_channel,
             commands::updater::install_pending_update,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -280,9 +280,6 @@ pub struct AppState {
     pub pending_update: tokio::sync::Mutex<Option<tauri_plugin_updater::Update>>,
     /// CESP sound pack playback state (no-repeat + debounce tracking).
     pub cesp_playback: Mutex<claudette::cesp::SoundPlaybackState>,
-    /// The workspace the user is currently viewing in the UI.
-    /// Updated from the frontend via the `set_viewing_workspace` command.
-    pub viewing_workspace_id: RwLock<Option<String>>,
 }
 
 impl AppState {
@@ -304,7 +301,6 @@ impl AppState {
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),
             cesp_playback: Mutex::new(claudette::cesp::SoundPlaybackState::new()),
-            viewing_workspace_id: RwLock::new(None),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -278,6 +278,8 @@ pub struct AppState {
     /// call. The Update struct holds the downloaded payload + signature context
     /// and is not Serialize, so it lives here instead of crossing the IPC boundary.
     pub pending_update: tokio::sync::Mutex<Option<tauri_plugin_updater::Update>>,
+    /// CESP sound pack playback state (no-repeat + debounce tracking).
+    pub cesp_playback: Mutex<claudette::cesp::SoundPlaybackState>,
 }
 
 impl AppState {
@@ -298,6 +300,7 @@ impl AppState {
             scm_cache: ScmCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),
+            cesp_playback: Mutex::new(claudette::cesp::SoundPlaybackState::new()),
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -280,6 +280,9 @@ pub struct AppState {
     pub pending_update: tokio::sync::Mutex<Option<tauri_plugin_updater::Update>>,
     /// CESP sound pack playback state (no-repeat + debounce tracking).
     pub cesp_playback: Mutex<claudette::cesp::SoundPlaybackState>,
+    /// The workspace the user is currently viewing in the UI.
+    /// Updated from the frontend via the `set_viewing_workspace` command.
+    pub viewing_workspace_id: RwLock<Option<String>>,
 }
 
 impl AppState {
@@ -301,6 +304,7 @@ impl AppState {
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),
             cesp_playback: Mutex::new(claudette::cesp::SoundPlaybackState::new()),
+            viewing_workspace_id: RwLock::new(None),
         }
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -13,6 +13,10 @@ pub enum NotificationEvent {
     Ask,
     Plan,
     Finished,
+    #[allow(dead_code)]
+    Error,
+    #[allow(dead_code)]
+    SessionStart,
 }
 
 impl NotificationEvent {
@@ -21,6 +25,8 @@ impl NotificationEvent {
             Self::Ask => "notification_sound_ask",
             Self::Plan => "notification_sound_plan",
             Self::Finished => "notification_sound_finished",
+            Self::Error => "notification_sound_error",
+            Self::SessionStart => "notification_sound_session_start",
         }
     }
 }
@@ -375,12 +381,42 @@ pub fn notify_attention(app: &AppHandle, workspace_id: &str, kind: AttentionKind
         .map(|w| w.name.clone())
         .unwrap_or_else(|| "An agent".to_string());
 
-    let sound = resolve_notification_sound(&db, NotificationEvent::from(kind));
+    let muted = db
+        .get_app_setting("cesp_muted")
+        .ok()
+        .flatten()
+        .is_some_and(|v| v == "true");
+    let volume: f64 = db
+        .get_app_setting("cesp_volume")
+        .ok()
+        .flatten()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+
+    let sound_source = db
+        .get_app_setting("sound_source")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "system".to_string());
+    let sound = if muted || volume <= 0.0 {
+        "None".to_string()
+    } else if sound_source == "openpeon" {
+        let event_name = match kind {
+            AttentionKind::Ask => "ask",
+            AttentionKind::Plan => "plan",
+        };
+        claudette::cesp::play_cesp_sound_for_event(event_name, &|key| {
+            db.get_app_setting(key).ok().flatten()
+        });
+        "None".to_string()
+    } else {
+        resolve_notification_sound(&db, NotificationEvent::from(kind))
+    };
 
     let title = "Claudette — Input Required";
     let body = format!("{ws_name} is waiting for your response");
 
-    send_notification(app, workspace_id, title, &body, &sound);
+    send_notification(app, workspace_id, title, &body, &sound, volume);
 
     // Run user-configured notification command (if set).
     // Build a best-effort WorkspaceEnv even when the workspace lookup fails
@@ -583,6 +619,7 @@ pub(crate) fn send_notification(
     title: &str,
     body: &str,
     sound: &str,
+    #[cfg_attr(target_os = "macos", allow(unused))] volume: f64,
 ) {
     // On macOS, use mac-notification-sys directly so we can block for the
     // click response. When the user clicks the notification, show the window
@@ -631,7 +668,7 @@ pub(crate) fn send_notification(
         use tauri_plugin_notification::NotificationExt;
         let _ = app.notification().builder().title(title).body(body).show();
         if sound != "None" {
-            crate::commands::settings::play_notification_sound(sound.to_string());
+            crate::commands::settings::play_notification_sound(sound.to_string(), Some(volume));
         }
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -29,6 +29,16 @@ impl NotificationEvent {
             Self::SessionStart => "notification_sound_session_start",
         }
     }
+
+    fn cesp_event_name(&self) -> &'static str {
+        match self {
+            Self::Ask => "ask",
+            Self::Plan => "plan",
+            Self::Finished => "finished",
+            Self::Error => "error",
+            Self::SessionStart => "session_start",
+        }
+    }
 }
 
 impl From<AttentionKind> for NotificationEvent {
@@ -58,6 +68,44 @@ where
 /// Fallback: per-event key -> global `notification_sound` -> legacy `audio_notifications` -> "Default"
 pub fn resolve_notification_sound(db: &Database, event: NotificationEvent) -> String {
     resolve_notification_sound_with(|key| db.get_app_setting(key).ok().flatten(), event)
+}
+
+pub struct ResolvedSound {
+    pub sound: String,
+    pub volume: f64,
+}
+
+/// Read muted/volume/source settings from the DB, play a CESP sound if that
+/// source is active (via the shared playback state), or return the system
+/// sound name. Callers only need to handle the system-sound path.
+pub fn resolve_notification(
+    db: &Database,
+    cesp_playback: &std::sync::Mutex<claudette::cesp::SoundPlaybackState>,
+    event: NotificationEvent,
+) -> ResolvedSound {
+    let db_get = |key: &str| db.get_app_setting(key).ok().flatten();
+
+    let muted = db_get("cesp_muted").is_some_and(|v| v == "true");
+    let volume: f64 = db_get("cesp_volume")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+
+    let sound = if muted || volume <= 0.0 {
+        "None".to_string()
+    } else if db_get("sound_source").as_deref() == Some("openpeon") {
+        if let Ok(mut playback) = cesp_playback.lock() {
+            claudette::cesp::play_cesp_sound_for_event_with_state(
+                event.cesp_event_name(),
+                &mut playback,
+                &db_get,
+            );
+        }
+        "None".to_string()
+    } else {
+        resolve_notification_sound(db, event)
+    };
+
+    ResolvedSound { sound, volume }
 }
 
 // Baseline tray icons (the ones shipped for the Auto style).
@@ -381,47 +429,21 @@ pub fn notify_attention(app: &AppHandle, workspace_id: &str, kind: AttentionKind
         .map(|w| w.name.clone())
         .unwrap_or_else(|| "An agent".to_string());
 
-    let muted = db
-        .get_app_setting("cesp_muted")
-        .ok()
-        .flatten()
-        .is_some_and(|v| v == "true");
-    let volume: f64 = db
-        .get_app_setting("cesp_volume")
-        .ok()
-        .flatten()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(1.0);
-
-    let sound_source = db
-        .get_app_setting("sound_source")
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| "system".to_string());
-    let sound = if muted || volume <= 0.0 {
-        "None".to_string()
-    } else if sound_source == "openpeon" {
-        let event_name = match kind {
-            AttentionKind::Ask => "ask",
-            AttentionKind::Plan => "plan",
-        };
-        let app_state = app.state::<AppState>();
-        if let Ok(mut playback) = app_state.cesp_playback.lock() {
-            claudette::cesp::play_cesp_sound_for_event_with_state(
-                event_name,
-                &mut playback,
-                &|key| db.get_app_setting(key).ok().flatten(),
-            );
-        }
-        "None".to_string()
-    } else {
-        resolve_notification_sound(&db, NotificationEvent::from(kind))
-    };
+    let app_state = app.state::<AppState>();
+    let resolved =
+        resolve_notification(&db, &app_state.cesp_playback, NotificationEvent::from(kind));
 
     let title = "Claudette — Input Required";
     let body = format!("{ws_name} is waiting for your response");
 
-    send_notification(app, workspace_id, title, &body, &sound, volume);
+    send_notification(
+        app,
+        workspace_id,
+        title,
+        &body,
+        &resolved.sound,
+        resolved.volume,
+    );
 
     // Run user-configured notification command (if set).
     // Build a best-effort WorkspaceEnv even when the workspace lookup fails

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -405,9 +405,14 @@ pub fn notify_attention(app: &AppHandle, workspace_id: &str, kind: AttentionKind
             AttentionKind::Ask => "ask",
             AttentionKind::Plan => "plan",
         };
-        claudette::cesp::play_cesp_sound_for_event(event_name, &|key| {
-            db.get_app_setting(key).ok().flatten()
-        });
+        let app_state = app.state::<AppState>();
+        if let Ok(mut playback) = app_state.cesp_playback.lock() {
+            claudette::cesp::play_cesp_sound_for_event_with_state(
+                event_name,
+                &mut playback,
+                &|key| db.get_app_setting(key).ok().flatten(),
+            );
+        }
         "None".to_string()
     } else {
         resolve_notification_sound(&db, NotificationEvent::from(kind))

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -13,7 +13,6 @@ pub enum NotificationEvent {
     Ask,
     Plan,
     Finished,
-    #[allow(dead_code)]
     Error,
     SessionStart,
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -15,7 +15,6 @@ pub enum NotificationEvent {
     Finished,
     #[allow(dead_code)]
     Error,
-    #[allow(dead_code)]
     SessionStart,
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -86,7 +86,9 @@ pub fn resolve_notification(
     let muted = db_get("cesp_muted").is_some_and(|v| v == "true");
     let volume: f64 = db_get("cesp_volume")
         .and_then(|v| v.parse().ok())
-        .unwrap_or(1.0);
+        .filter(|v: &f64| v.is_finite())
+        .unwrap_or(1.0)
+        .clamp(0.0, 1.0);
 
     let sound = if muted || volume <= 0.0 {
         "None".to_string()

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -233,21 +233,17 @@ fn extract_tarball(data: &[u8], target_dir: &Path, source_path: &str) -> Result<
             continue;
         }
 
-        let dest = target_dir.join(&relative);
+        // Reject any component that escapes the target directory
+        for component in relative.components() {
+            match component {
+                std::path::Component::Normal(_) => {}
+                _ => return Err(format!("Path traversal detected: {}", inner_str)),
+            }
+        }
 
-        // Path traversal guard
-        let canonical_target = target_dir
-            .canonicalize()
-            .unwrap_or_else(|_| target_dir.to_path_buf());
+        let dest = target_dir.join(&relative);
         let dest_parent = dest.parent().unwrap_or(target_dir);
         let _ = std::fs::create_dir_all(dest_parent);
-        let canonical_dest = dest
-            .parent()
-            .and_then(|p| p.canonicalize().ok())
-            .unwrap_or_else(|| dest_parent.to_path_buf());
-        if !canonical_dest.starts_with(&canonical_target) {
-            return Err(format!("Path traversal detected: {}", inner_str));
-        }
 
         if entry.header().entry_type().is_dir() {
             let _ = std::fs::create_dir_all(&dest);
@@ -363,12 +359,26 @@ impl Default for SoundPlaybackState {
     }
 }
 
-pub fn resolve_sound_file(pack_dir: &Path, sound: &CespSound) -> PathBuf {
+pub fn resolve_sound_file(pack_dir: &Path, sound: &CespSound) -> Option<PathBuf> {
     let file = &sound.file;
-    if file.contains('/') {
+    if file.is_empty() || file.contains('\\') {
+        return None;
+    }
+    let path = Path::new(file);
+    for component in path.components() {
+        if !matches!(component, std::path::Component::Normal(_)) {
+            return None;
+        }
+    }
+    let resolved = if file.contains('/') {
         pack_dir.join(file)
     } else {
         pack_dir.join("sounds").join(file)
+    };
+    if resolved.starts_with(pack_dir) {
+        Some(resolved)
+    } else {
+        None
     }
 }
 
@@ -473,7 +483,7 @@ pub fn play_cesp_sound_for_event_with_state(
     }
 
     let pack_name = match db_get("cesp_active_pack") {
-        Some(name) if !name.is_empty() => name,
+        Some(name) if !name.is_empty() && validate_pack_name(&name).is_ok() => name,
         _ => return,
     };
 
@@ -493,8 +503,9 @@ pub fn play_cesp_sound_for_event_with_state(
         None => return,
     };
 
-    if let Some(sound) = playback.pick_sound(category, sounds, Duration::from_millis(500)) {
-        let file_path = resolve_sound_file(&pack_dir, sound);
+    if let Some(sound) = playback.pick_sound(category, sounds, Duration::from_millis(500))
+        && let Some(file_path) = resolve_sound_file(&pack_dir, sound)
+    {
         play_audio_file(&file_path, volume);
     }
 }
@@ -667,7 +678,10 @@ mod tests {
             label: None,
         };
         let result = resolve_sound_file(Path::new("/packs/peon"), &sound);
-        assert_eq!(result, PathBuf::from("/packs/peon/sounds/hello.wav"));
+        assert_eq!(
+            result.unwrap(),
+            PathBuf::from("/packs/peon/sounds/hello.wav")
+        );
     }
 
     #[test]
@@ -677,7 +691,10 @@ mod tests {
             label: None,
         };
         let result = resolve_sound_file(Path::new("/packs/peon"), &sound);
-        assert_eq!(result, PathBuf::from("/packs/peon/sounds/hello.wav"));
+        assert_eq!(
+            result.unwrap(),
+            PathBuf::from("/packs/peon/sounds/hello.wav")
+        );
     }
 
     #[test]

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, VecDeque};
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -11,6 +11,18 @@ const MANIFEST_FILE: &str = "openpeon.json";
 const META_FILE: &str = "_meta.json";
 const MAX_ALIAS_DEPTH: usize = 5;
 const NO_REPEAT_WINDOW: usize = 3;
+
+fn validate_pack_name(name: &str) -> Result<(), String> {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || name.starts_with('.')
+    {
+        return Err(format!("Invalid pack name: {name:?}"));
+    }
+    Ok(())
+}
 
 pub fn packs_dir() -> PathBuf {
     let base = dirs::home_dir()
@@ -68,6 +80,7 @@ pub fn list_installed() -> Result<Vec<InstalledPack>, String> {
             Ok(m) => m,
             Err(_) => continue,
         };
+        let meta = load_meta(&path);
         let sound_count: u32 = manifest
             .categories
             .values()
@@ -84,6 +97,7 @@ pub fn list_installed() -> Result<Vec<InstalledPack>, String> {
             version: manifest.version.clone(),
             categories,
             sound_count,
+            installed_ref: meta.map(|m| m.source_ref),
             update_available: false,
         });
     }
@@ -91,23 +105,43 @@ pub fn list_installed() -> Result<Vec<InstalledPack>, String> {
     Ok(packs)
 }
 
+fn load_meta(pack_dir: &Path) -> Option<InstalledPackMeta> {
+    let data = std::fs::read_to_string(pack_dir.join(META_FILE)).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
 pub fn install_pack(
     registry_entry: &RegistryPack,
     tarball_bytes: &[u8],
 ) -> Result<InstalledPack, String> {
-    let pack_dir = packs_dir().join(&registry_entry.name);
-    if pack_dir.exists() {
-        std::fs::remove_dir_all(&pack_dir)
-            .map_err(|e| format!("Failed to remove existing pack: {e}"))?;
+    validate_pack_name(&registry_entry.name)?;
+
+    let base = packs_dir();
+    let pack_dir = base.join(&registry_entry.name);
+    let staging_dir = base.join(format!("_staging_{}", registry_entry.name));
+
+    if staging_dir.exists() {
+        let _ = std::fs::remove_dir_all(&staging_dir);
     }
-    std::fs::create_dir_all(&pack_dir).map_err(|e| format!("Failed to create pack dir: {e}"))?;
+    std::fs::create_dir_all(&staging_dir)
+        .map_err(|e| format!("Failed to create staging dir: {e}"))?;
 
-    extract_tarball(tarball_bytes, &pack_dir, &registry_entry.source_path)?;
+    let cleanup_staging = || {
+        let _ = std::fs::remove_dir_all(&staging_dir);
+    };
 
-    let manifest = load_manifest(&pack_dir).map_err(|e| {
-        let _ = std::fs::remove_dir_all(&pack_dir);
-        format!("Pack missing valid {MANIFEST_FILE}: {e}")
-    })?;
+    if let Err(e) = extract_tarball(tarball_bytes, &staging_dir, &registry_entry.source_path) {
+        cleanup_staging();
+        return Err(e);
+    }
+
+    let manifest = match load_manifest(&staging_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            cleanup_staging();
+            return Err(format!("Pack missing valid {MANIFEST_FILE}: {e}"));
+        }
+    };
 
     let meta = InstalledPackMeta {
         source_repo: registry_entry.source_repo.clone(),
@@ -116,8 +150,19 @@ pub fn install_pack(
     };
     let meta_json = serde_json::to_string_pretty(&meta)
         .map_err(|e| format!("Failed to serialize meta: {e}"))?;
-    std::fs::write(pack_dir.join(META_FILE), meta_json)
-        .map_err(|e| format!("Failed to write {META_FILE}: {e}"))?;
+    if let Err(e) = std::fs::write(staging_dir.join(META_FILE), meta_json) {
+        cleanup_staging();
+        return Err(format!("Failed to write {META_FILE}: {e}"));
+    }
+
+    if pack_dir.exists() {
+        std::fs::remove_dir_all(&pack_dir)
+            .map_err(|e| format!("Failed to remove existing pack: {e}"))?;
+    }
+    std::fs::rename(&staging_dir, &pack_dir).map_err(|e| {
+        cleanup_staging();
+        format!("Failed to finalize pack install: {e}")
+    })?;
 
     let sound_count: u32 = manifest
         .categories
@@ -136,12 +181,20 @@ pub fn install_pack(
         version: manifest.version,
         categories,
         sound_count,
+        installed_ref: Some(registry_entry.source_ref.clone()),
         update_available: false,
     })
 }
 
 pub fn delete_pack(name: &str) -> Result<(), String> {
-    let pack_dir = packs_dir().join(name);
+    validate_pack_name(name)?;
+    let base = packs_dir();
+    let pack_dir = base.join(name);
+    let canonical_base = base.canonicalize().unwrap_or_else(|_| base.clone());
+    let canonical_pack = pack_dir.canonicalize().unwrap_or_else(|_| pack_dir.clone());
+    if !canonical_pack.starts_with(&canonical_base) {
+        return Err(format!("Invalid pack path for '{name}'"));
+    }
     if !pack_dir.exists() {
         return Err(format!("Pack '{name}' is not installed"));
     }
@@ -199,11 +252,9 @@ fn extract_tarball(data: &[u8], target_dir: &Path, source_path: &str) -> Result<
         if entry.header().entry_type().is_dir() {
             let _ = std::fs::create_dir_all(&dest);
         } else if entry.header().entry_type().is_file() {
-            let mut buf = Vec::new();
-            entry
-                .read_to_end(&mut buf)
-                .map_err(|e| format!("Failed to read entry {}: {e}", inner_str))?;
-            std::fs::write(&dest, &buf)
+            let mut out = std::fs::File::create(&dest)
+                .map_err(|e| format!("Failed to create {}: {e}", dest.display()))?;
+            std::io::copy(&mut entry, &mut out)
                 .map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
         }
     }
@@ -322,7 +373,11 @@ pub fn resolve_sound_file(pack_dir: &Path, sound: &CespSound) -> PathBuf {
 }
 
 pub fn play_audio_file(path: &Path, volume: f64) {
-    if volume <= 0.0 || !path.exists() {
+    if !volume.is_finite() || !path.exists() {
+        return;
+    }
+    let volume = volume.clamp(0.0, 1.0);
+    if volume <= 0.0 {
         return;
     }
 
@@ -402,7 +457,11 @@ fn spawn_and_reap(mut child: std::process::Child) {
     });
 }
 
-pub fn play_cesp_sound_for_event(event: &str, db_get: &dyn Fn(&str) -> Option<String>) {
+pub fn play_cesp_sound_for_event_with_state(
+    event: &str,
+    playback: &mut SoundPlaybackState,
+    db_get: &dyn Fn(&str) -> Option<String>,
+) {
     let sound_source = db_get("sound_source").unwrap_or_else(|| "system".to_string());
     if sound_source != "openpeon" {
         return;
@@ -434,11 +493,15 @@ pub fn play_cesp_sound_for_event(event: &str, db_get: &dyn Fn(&str) -> Option<St
         None => return,
     };
 
-    let mut rng = rand::thread_rng();
-    if let Some(sound) = sounds.choose(&mut rng) {
+    if let Some(sound) = playback.pick_sound(category, sounds, Duration::from_millis(500)) {
         let file_path = resolve_sound_file(&pack_dir, sound);
         play_audio_file(&file_path, volume);
     }
+}
+
+pub fn play_cesp_sound_for_event(event: &str, db_get: &dyn Fn(&str) -> Option<String>) {
+    let mut playback = SoundPlaybackState::new();
+    play_cesp_sound_for_event_with_state(event, &mut playback, db_get);
 }
 
 #[cfg(test)]
@@ -664,5 +727,20 @@ mod tests {
     fn epoch_days_to_date_known_values() {
         assert_eq!(epoch_days_to_date(0), (1970, 1, 1));
         assert_eq!(epoch_days_to_date(18627), (2020, 12, 31));
+    }
+
+    #[test]
+    fn validate_pack_name_rejects_traversal() {
+        assert!(validate_pack_name("../escape").is_err());
+        assert!(validate_pack_name("foo/bar").is_err());
+        assert!(validate_pack_name("foo\\bar").is_err());
+        assert!(validate_pack_name(".hidden").is_err());
+        assert!(validate_pack_name("").is_err());
+    }
+
+    #[test]
+    fn validate_pack_name_accepts_valid() {
+        assert!(validate_pack_name("peon-classic").is_ok());
+        assert!(validate_pack_name("glados_v2").is_ok());
     }
 }

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -1,0 +1,668 @@
+use std::collections::{HashMap, VecDeque};
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use rand::seq::SliceRandom;
+
+use crate::model::cesp::{CespManifest, CespSound, InstalledPack, InstalledPackMeta, RegistryPack};
+
+const MANIFEST_FILE: &str = "openpeon.json";
+const META_FILE: &str = "_meta.json";
+const MAX_ALIAS_DEPTH: usize = 5;
+const NO_REPEAT_WINDOW: usize = 3;
+
+pub fn packs_dir() -> PathBuf {
+    let base = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".claudette")
+        .join("packs");
+    let _ = std::fs::create_dir_all(&base);
+    base
+}
+
+pub fn load_manifest(pack_dir: &Path) -> Result<CespManifest, String> {
+    let path = pack_dir.join(MANIFEST_FILE);
+    let data = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse {}: {e}", path.display()))
+}
+
+pub fn resolve_category<'a>(manifest: &'a CespManifest, category: &str) -> Option<&'a [CespSound]> {
+    if let Some(cat) = manifest.categories.get(category)
+        && !cat.sounds.is_empty()
+    {
+        return Some(&cat.sounds);
+    }
+    let mut target = category.to_string();
+    for _ in 0..MAX_ALIAS_DEPTH {
+        match manifest.category_aliases.get(&target) {
+            Some(alias_target) => {
+                if let Some(cat) = manifest.categories.get(alias_target)
+                    && !cat.sounds.is_empty()
+                {
+                    return Some(&cat.sounds);
+                }
+                target = alias_target.clone();
+            }
+            None => return None,
+        }
+    }
+    None
+}
+
+pub fn list_installed() -> Result<Vec<InstalledPack>, String> {
+    let dir = packs_dir();
+    let entries = std::fs::read_dir(&dir).map_err(|e| format!("Cannot read packs dir: {e}"))?;
+    let mut packs = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.starts_with('_') => n.to_string(),
+            _ => continue,
+        };
+        let manifest = match load_manifest(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let sound_count: u32 = manifest
+            .categories
+            .values()
+            .map(|c| c.sounds.len() as u32)
+            .sum();
+        let categories: Vec<String> = manifest.categories.keys().cloned().collect();
+        let display_name = manifest
+            .display_name
+            .clone()
+            .unwrap_or_else(|| manifest.name.clone());
+        packs.push(InstalledPack {
+            name,
+            display_name,
+            version: manifest.version.clone(),
+            categories,
+            sound_count,
+            update_available: false,
+        });
+    }
+    packs.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+    Ok(packs)
+}
+
+pub fn install_pack(
+    registry_entry: &RegistryPack,
+    tarball_bytes: &[u8],
+) -> Result<InstalledPack, String> {
+    let pack_dir = packs_dir().join(&registry_entry.name);
+    if pack_dir.exists() {
+        std::fs::remove_dir_all(&pack_dir)
+            .map_err(|e| format!("Failed to remove existing pack: {e}"))?;
+    }
+    std::fs::create_dir_all(&pack_dir).map_err(|e| format!("Failed to create pack dir: {e}"))?;
+
+    extract_tarball(tarball_bytes, &pack_dir, &registry_entry.source_path)?;
+
+    let manifest = load_manifest(&pack_dir).map_err(|e| {
+        let _ = std::fs::remove_dir_all(&pack_dir);
+        format!("Pack missing valid {MANIFEST_FILE}: {e}")
+    })?;
+
+    let meta = InstalledPackMeta {
+        source_repo: registry_entry.source_repo.clone(),
+        source_ref: registry_entry.source_ref.clone(),
+        installed_at: chrono_now_iso(),
+    };
+    let meta_json = serde_json::to_string_pretty(&meta)
+        .map_err(|e| format!("Failed to serialize meta: {e}"))?;
+    std::fs::write(pack_dir.join(META_FILE), meta_json)
+        .map_err(|e| format!("Failed to write {META_FILE}: {e}"))?;
+
+    let sound_count: u32 = manifest
+        .categories
+        .values()
+        .map(|c| c.sounds.len() as u32)
+        .sum();
+    let categories: Vec<String> = manifest.categories.keys().cloned().collect();
+    let display_name = manifest
+        .display_name
+        .clone()
+        .unwrap_or_else(|| manifest.name.clone());
+
+    Ok(InstalledPack {
+        name: registry_entry.name.clone(),
+        display_name,
+        version: manifest.version,
+        categories,
+        sound_count,
+        update_available: false,
+    })
+}
+
+pub fn delete_pack(name: &str) -> Result<(), String> {
+    let pack_dir = packs_dir().join(name);
+    if !pack_dir.exists() {
+        return Err(format!("Pack '{name}' is not installed"));
+    }
+    std::fs::remove_dir_all(&pack_dir).map_err(|e| format!("Failed to delete pack: {e}"))
+}
+
+fn extract_tarball(data: &[u8], target_dir: &Path, source_path: &str) -> Result<(), String> {
+    let decoder = flate2::read::GzDecoder::new(Cursor::new(data));
+    let mut archive = tar::Archive::new(decoder);
+
+    for entry in archive.entries().map_err(|e| format!("Bad tarball: {e}"))? {
+        let mut entry = entry.map_err(|e| format!("Bad tarball entry: {e}"))?;
+        let raw_path = entry
+            .path()
+            .map_err(|e| format!("Bad path in tarball: {e}"))?
+            .into_owned();
+
+        let components: Vec<_> = raw_path.components().collect();
+        if components.len() <= 1 {
+            continue;
+        }
+        // Strip top-level directory (GitHub tarball wrapping)
+        let inner: PathBuf = components[1..].iter().collect();
+        let inner_str = inner.to_string_lossy();
+
+        // Only extract files under the source_path subdirectory
+        let relative = if source_path.is_empty() || source_path == "." {
+            inner.clone()
+        } else if let Ok(rel) = inner.strip_prefix(source_path) {
+            rel.to_path_buf()
+        } else {
+            continue;
+        };
+
+        if relative.as_os_str().is_empty() {
+            continue;
+        }
+
+        let dest = target_dir.join(&relative);
+
+        // Path traversal guard
+        let canonical_target = target_dir
+            .canonicalize()
+            .unwrap_or_else(|_| target_dir.to_path_buf());
+        let dest_parent = dest.parent().unwrap_or(target_dir);
+        let _ = std::fs::create_dir_all(dest_parent);
+        let canonical_dest = dest
+            .parent()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| dest_parent.to_path_buf());
+        if !canonical_dest.starts_with(&canonical_target) {
+            return Err(format!("Path traversal detected: {}", inner_str));
+        }
+
+        if entry.header().entry_type().is_dir() {
+            let _ = std::fs::create_dir_all(&dest);
+        } else if entry.header().entry_type().is_file() {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .map_err(|e| format!("Failed to read entry {}: {e}", inner_str))?;
+            std::fs::write(&dest, &buf)
+                .map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn chrono_now_iso() -> String {
+    use std::time::SystemTime;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let days = secs / 86400;
+    let day_secs = secs % 86400;
+    let hours = day_secs / 3600;
+    let mins = (day_secs % 3600) / 60;
+    let s = day_secs % 60;
+    // Approximate date from epoch days (good enough for a timestamp)
+    let (year, month, day) = epoch_days_to_date(days);
+    format!("{year:04}-{month:02}-{day:02}T{hours:02}:{mins:02}:{s:02}Z")
+}
+
+fn epoch_days_to_date(days: u64) -> (u64, u64, u64) {
+    // Algorithm from Howard Hinnant's civil_from_days
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+pub fn notification_event_to_cesp_category(event: &str) -> &str {
+    match event {
+        "ask" => "input.required",
+        "plan" => "task.acknowledge",
+        "finished" => "task.complete",
+        "error" => "task.error",
+        "session_start" => "session.start",
+        _ => "input.required",
+    }
+}
+
+pub struct SoundPlaybackState {
+    recent: HashMap<String, VecDeque<usize>>,
+    last_played: HashMap<String, Instant>,
+}
+
+impl SoundPlaybackState {
+    pub fn new() -> Self {
+        Self {
+            recent: HashMap::new(),
+            last_played: HashMap::new(),
+        }
+    }
+
+    pub fn pick_sound<'a>(
+        &mut self,
+        category: &str,
+        sounds: &'a [CespSound],
+        debounce: Duration,
+    ) -> Option<&'a CespSound> {
+        if sounds.is_empty() {
+            return None;
+        }
+
+        if let Some(last) = self.last_played.get(category)
+            && last.elapsed() < debounce
+        {
+            return None;
+        }
+
+        let recent = self.recent.entry(category.to_string()).or_default();
+
+        let mut candidates: Vec<usize> =
+            (0..sounds.len()).filter(|i| !recent.contains(i)).collect();
+
+        if candidates.is_empty() {
+            recent.clear();
+            candidates = (0..sounds.len()).collect();
+        }
+
+        let mut rng = rand::thread_rng();
+        let &idx = candidates.choose(&mut rng)?;
+
+        while recent.len() >= NO_REPEAT_WINDOW {
+            recent.pop_front();
+        }
+        recent.push_back(idx);
+        self.last_played
+            .insert(category.to_string(), Instant::now());
+
+        Some(&sounds[idx])
+    }
+}
+
+impl Default for SoundPlaybackState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn resolve_sound_file(pack_dir: &Path, sound: &CespSound) -> PathBuf {
+    let file = &sound.file;
+    if file.contains('/') {
+        pack_dir.join(file)
+    } else {
+        pack_dir.join("sounds").join(file)
+    }
+}
+
+pub fn play_audio_file(path: &Path, volume: f64) {
+    if volume <= 0.0 || !path.exists() {
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        let result = if ext == "ogg" || ext == "oga" {
+            std::process::Command::new("ffplay")
+                .args(["-nodisp", "-autoexit", "-volume"])
+                .arg(format!("{}", (volume * 100.0) as u32))
+                .arg(path)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+        } else {
+            std::process::Command::new("afplay")
+                .arg("-v")
+                .arg(format!("{volume}"))
+                .arg(path)
+                .spawn()
+        };
+        if let Ok(child) = result {
+            spawn_and_reap(child);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        let result = if ext == "mp3" {
+            std::process::Command::new("ffplay")
+                .args(["-nodisp", "-autoexit", "-volume"])
+                .arg(format!("{}", (volume * 100.0) as u32))
+                .arg(path)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+        } else {
+            let pa_volume = (volume * 65536.0) as u32;
+            std::process::Command::new("paplay")
+                .arg("--volume")
+                .arg(pa_volume.to_string())
+                .arg(path)
+                .spawn()
+                .or_else(|_| {
+                    std::process::Command::new("ffplay")
+                        .args(["-nodisp", "-autoexit", "-volume"])
+                        .arg(format!("{}", (volume * 100.0) as u32))
+                        .arg(path)
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn()
+                })
+        };
+        if let Ok(child) = result {
+            spawn_and_reap(child);
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (path, volume);
+    }
+}
+
+fn spawn_and_reap(mut child: std::process::Child) {
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+}
+
+pub fn play_cesp_sound_for_event(event: &str, db_get: &dyn Fn(&str) -> Option<String>) {
+    let sound_source = db_get("sound_source").unwrap_or_else(|| "system".to_string());
+    if sound_source != "openpeon" {
+        return;
+    }
+
+    let muted = db_get("cesp_muted").unwrap_or_else(|| "false".to_string());
+    if muted == "true" {
+        return;
+    }
+
+    let pack_name = match db_get("cesp_active_pack") {
+        Some(name) if !name.is_empty() => name,
+        _ => return,
+    };
+
+    let volume: f64 = db_get("cesp_volume")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+
+    let pack_dir = packs_dir().join(&pack_name);
+    let manifest = match load_manifest(&pack_dir) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    let category = notification_event_to_cesp_category(event);
+    let sounds = match resolve_category(&manifest, category) {
+        Some(s) => s,
+        None => return,
+    };
+
+    let mut rng = rand::thread_rng();
+    if let Some(sound) = sounds.choose(&mut rng) {
+        let file_path = resolve_sound_file(&pack_dir, sound);
+        play_audio_file(&file_path, volume);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::cesp::{CespCategorySounds, CespSound};
+
+    fn make_manifest() -> CespManifest {
+        let mut categories = HashMap::new();
+        categories.insert(
+            "task.complete".to_string(),
+            CespCategorySounds {
+                sounds: vec![
+                    CespSound {
+                        file: "sounds/done1.wav".to_string(),
+                        label: Some("Done 1".to_string()),
+                    },
+                    CespSound {
+                        file: "sounds/done2.wav".to_string(),
+                        label: Some("Done 2".to_string()),
+                    },
+                    CespSound {
+                        file: "sounds/done3.wav".to_string(),
+                        label: Some("Done 3".to_string()),
+                    },
+                    CespSound {
+                        file: "sounds/done4.wav".to_string(),
+                        label: Some("Done 4".to_string()),
+                    },
+                ],
+            },
+        );
+        categories.insert(
+            "input.required".to_string(),
+            CespCategorySounds {
+                sounds: vec![CespSound {
+                    file: "sounds/what.wav".to_string(),
+                    label: None,
+                }],
+            },
+        );
+        let mut aliases = HashMap::new();
+        aliases.insert("complete".to_string(), "task.complete".to_string());
+        aliases.insert("greeting".to_string(), "session.start".to_string());
+
+        CespManifest {
+            cesp_version: "1.0".to_string(),
+            name: "test-pack".to_string(),
+            display_name: Some("Test Pack".to_string()),
+            version: "1.0.0".to_string(),
+            categories,
+            category_aliases: aliases,
+        }
+    }
+
+    #[test]
+    fn resolve_direct_category() {
+        let m = make_manifest();
+        let sounds = resolve_category(&m, "task.complete").unwrap();
+        assert_eq!(sounds.len(), 4);
+    }
+
+    #[test]
+    fn resolve_via_alias() {
+        let m = make_manifest();
+        let sounds = resolve_category(&m, "complete").unwrap();
+        assert_eq!(sounds.len(), 4);
+    }
+
+    #[test]
+    fn resolve_missing_category_returns_none() {
+        let m = make_manifest();
+        assert!(resolve_category(&m, "session.end").is_none());
+    }
+
+    #[test]
+    fn resolve_alias_to_missing_category_returns_none() {
+        let m = make_manifest();
+        assert!(resolve_category(&m, "greeting").is_none());
+    }
+
+    #[test]
+    fn pick_sound_no_repeat() {
+        let sounds: Vec<CespSound> = (0..4)
+            .map(|i| CespSound {
+                file: format!("s{i}.wav"),
+                label: None,
+            })
+            .collect();
+        let mut state = SoundPlaybackState::new();
+        let debounce = Duration::from_millis(0);
+
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..20 {
+            let s = state.pick_sound("cat", &sounds, debounce).unwrap();
+            seen.insert(s.file.clone());
+        }
+        assert_eq!(seen.len(), 4);
+    }
+
+    #[test]
+    fn pick_sound_single_sound_always_works() {
+        let sounds = vec![CespSound {
+            file: "only.wav".to_string(),
+            label: None,
+        }];
+        let mut state = SoundPlaybackState::new();
+        let debounce = Duration::from_millis(0);
+
+        for _ in 0..5 {
+            let s = state.pick_sound("cat", &sounds, debounce).unwrap();
+            assert_eq!(s.file, "only.wav");
+        }
+    }
+
+    #[test]
+    fn pick_sound_debounce() {
+        let sounds = vec![CespSound {
+            file: "a.wav".to_string(),
+            label: None,
+        }];
+        let mut state = SoundPlaybackState::new();
+
+        let first = state.pick_sound("cat", &sounds, Duration::from_secs(10));
+        assert!(first.is_some());
+
+        let second = state.pick_sound("cat", &sounds, Duration::from_secs(10));
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn pick_sound_empty_sounds() {
+        let mut state = SoundPlaybackState::new();
+        assert!(
+            state
+                .pick_sound("cat", &[], Duration::from_millis(0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn event_to_category_mapping() {
+        assert_eq!(notification_event_to_cesp_category("ask"), "input.required");
+        assert_eq!(
+            notification_event_to_cesp_category("plan"),
+            "task.acknowledge"
+        );
+        assert_eq!(
+            notification_event_to_cesp_category("finished"),
+            "task.complete"
+        );
+        assert_eq!(notification_event_to_cesp_category("error"), "task.error");
+        assert_eq!(
+            notification_event_to_cesp_category("session_start"),
+            "session.start"
+        );
+    }
+
+    #[test]
+    fn resolve_sound_file_with_slash() {
+        let sound = CespSound {
+            file: "sounds/hello.wav".to_string(),
+            label: None,
+        };
+        let result = resolve_sound_file(Path::new("/packs/peon"), &sound);
+        assert_eq!(result, PathBuf::from("/packs/peon/sounds/hello.wav"));
+    }
+
+    #[test]
+    fn resolve_sound_file_without_slash() {
+        let sound = CespSound {
+            file: "hello.wav".to_string(),
+            label: None,
+        };
+        let result = resolve_sound_file(Path::new("/packs/peon"), &sound);
+        assert_eq!(result, PathBuf::from("/packs/peon/sounds/hello.wav"));
+    }
+
+    #[test]
+    fn extract_tarball_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("extracted");
+        std::fs::create_dir_all(&target).unwrap();
+
+        // Build a minimal tarball with a top-level wrapper dir
+        let mut builder = tar::Builder::new(Vec::new());
+        let data = b"test content";
+        let mut header = tar::Header::new_gnu();
+        header.set_path("repo-v1.0.0/mypack/openpeon.json").unwrap();
+        header.set_size(data.len() as u64);
+        header.set_cksum();
+        builder.append(&header, &data[..]).unwrap();
+
+        let data2 = b"wav bytes";
+        let mut header2 = tar::Header::new_gnu();
+        header2
+            .set_path("repo-v1.0.0/mypack/sounds/hello.wav")
+            .unwrap();
+        header2.set_size(data2.len() as u64);
+        header2.set_cksum();
+        builder.append(&header2, &data2[..]).unwrap();
+
+        let raw = builder.into_inner().unwrap();
+
+        // Compress
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(&raw).unwrap();
+        let gz = encoder.finish().unwrap();
+
+        extract_tarball(&gz, &target, "mypack").unwrap();
+
+        assert!(target.join("openpeon.json").exists());
+        assert!(target.join("sounds/hello.wav").exists());
+        assert_eq!(
+            std::fs::read_to_string(target.join("openpeon.json")).unwrap(),
+            "test content"
+        );
+    }
+
+    #[test]
+    fn epoch_days_to_date_known_values() {
+        assert_eq!(epoch_days_to_date(0), (1970, 1, 1));
+        assert_eq!(epoch_days_to_date(18627), (2020, 12, 31));
+    }
+}

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -12,7 +12,7 @@ const META_FILE: &str = "_meta.json";
 const MAX_ALIAS_DEPTH: usize = 5;
 const NO_REPEAT_WINDOW: usize = 3;
 
-fn validate_pack_name(name: &str) -> Result<(), String> {
+pub fn validate_pack_name(name: &str) -> Result<(), String> {
     if name.is_empty()
         || name.contains('/')
         || name.contains('\\')
@@ -155,9 +155,11 @@ pub fn install_pack(
         return Err(format!("Failed to write {META_FILE}: {e}"));
     }
 
-    if pack_dir.exists() {
-        std::fs::remove_dir_all(&pack_dir)
-            .map_err(|e| format!("Failed to remove existing pack: {e}"))?;
+    if pack_dir.exists()
+        && let Err(e) = std::fs::remove_dir_all(&pack_dir)
+    {
+        cleanup_staging();
+        return Err(format!("Failed to remove existing pack: {e}"));
     }
     std::fs::rename(&staging_dir, &pack_dir).map_err(|e| {
         cleanup_staging();

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -203,9 +203,14 @@ pub fn delete_pack(name: &str) -> Result<(), String> {
     std::fs::remove_dir_all(&pack_dir).map_err(|e| format!("Failed to delete pack: {e}"))
 }
 
+const MAX_EXTRACT_BYTES: u64 = 50 * 1024 * 1024; // 50 MB
+const MAX_EXTRACT_FILES: usize = 1_000;
+
 fn extract_tarball(data: &[u8], target_dir: &Path, source_path: &str) -> Result<(), String> {
     let decoder = flate2::read::GzDecoder::new(Cursor::new(data));
     let mut archive = tar::Archive::new(decoder);
+    let mut total_bytes: u64 = 0;
+    let mut file_count: usize = 0;
 
     for entry in archive.entries().map_err(|e| format!("Bad tarball: {e}"))? {
         let mut entry = entry.map_err(|e| format!("Bad tarball entry: {e}"))?;
@@ -250,10 +255,23 @@ fn extract_tarball(data: &[u8], target_dir: &Path, source_path: &str) -> Result<
         if entry.header().entry_type().is_dir() {
             let _ = std::fs::create_dir_all(&dest);
         } else if entry.header().entry_type().is_file() {
+            file_count += 1;
+            if file_count > MAX_EXTRACT_FILES {
+                return Err(format!(
+                    "Pack exceeds maximum file count ({MAX_EXTRACT_FILES})"
+                ));
+            }
             let mut out = std::fs::File::create(&dest)
                 .map_err(|e| format!("Failed to create {}: {e}", dest.display()))?;
-            std::io::copy(&mut entry, &mut out)
+            let written = std::io::copy(&mut entry, &mut out)
                 .map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
+            total_bytes += written;
+            if total_bytes > MAX_EXTRACT_BYTES {
+                return Err(format!(
+                    "Pack exceeds maximum extracted size ({} MB)",
+                    MAX_EXTRACT_BYTES / (1024 * 1024)
+                ));
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod cesp;
 pub mod config;
 pub mod db;
 pub mod diff;

--- a/src/model/cesp.rs
+++ b/src/model/cesp.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CespSound {
+    pub file: String,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CespCategorySounds {
+    pub sounds: Vec<CespSound>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CespManifest {
+    pub cesp_version: String,
+    pub name: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    pub version: String,
+    #[serde(default)]
+    pub categories: HashMap<String, CespCategorySounds>,
+    #[serde(default)]
+    pub category_aliases: HashMap<String, String>,
+}
+
+/// Top-level registry index envelope (`index.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryIndex {
+    #[serde(default)]
+    pub version: u32,
+    pub packs: Vec<RegistryPack>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegistryPack {
+    pub name: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    pub source_repo: String,
+    pub source_ref: String,
+    pub source_path: String,
+    #[serde(default)]
+    pub categories: Vec<String>,
+    #[serde(default)]
+    pub sound_count: u32,
+    #[serde(default)]
+    pub total_size_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledPackMeta {
+    pub source_repo: String,
+    pub source_ref: String,
+    pub installed_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledPack {
+    pub name: String,
+    pub display_name: String,
+    pub version: String,
+    pub categories: Vec<String>,
+    pub sound_count: u32,
+    pub update_available: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_manifest_minimal() {
+        let json = r#"{
+            "cesp_version": "1.0",
+            "name": "test",
+            "version": "1.0.0",
+            "categories": {}
+        }"#;
+        let m: CespManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.name, "test");
+        assert_eq!(m.cesp_version, "1.0");
+        assert!(m.display_name.is_none());
+        assert!(m.category_aliases.is_empty());
+    }
+
+    #[test]
+    fn parse_manifest_full() {
+        let json = r#"{
+            "cesp_version": "1.0",
+            "name": "peon",
+            "display_name": "Warcraft Peon",
+            "version": "1.0.0",
+            "categories": {
+                "session.start": {
+                    "sounds": [
+                        { "file": "sounds/Hello.wav", "label": "Something need doing?" },
+                        { "file": "sounds/ReadyToWork.wav", "label": "Ready to work!" }
+                    ]
+                },
+                "task.complete": {
+                    "sounds": [
+                        { "file": "sounds/JobsDone.wav", "label": "Job's done!" }
+                    ]
+                }
+            },
+            "category_aliases": {
+                "greeting": "session.start",
+                "complete": "task.complete"
+            }
+        }"#;
+        let m: CespManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.display_name.as_deref(), Some("Warcraft Peon"));
+        assert_eq!(m.categories.len(), 2);
+        assert_eq!(m.categories["session.start"].sounds.len(), 2);
+        assert_eq!(m.category_aliases["greeting"], "session.start");
+    }
+
+    #[test]
+    fn parse_registry_pack() {
+        let json = r#"{
+            "name": "glados",
+            "display_name": "GLaDOS",
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.1.0",
+            "source_path": "glados",
+            "categories": ["session.start", "task.complete", "task.error", "input.required"],
+            "sound_count": 28,
+            "total_size_bytes": 1843200
+        }"#;
+        let p: RegistryPack = serde_json::from_str(json).unwrap();
+        assert_eq!(p.name, "glados");
+        assert_eq!(p.sound_count, 28);
+        assert_eq!(p.categories.len(), 4);
+    }
+}

--- a/src/model/cesp.rs
+++ b/src/model/cesp.rs
@@ -68,6 +68,8 @@ pub struct InstalledPack {
     pub version: String,
     pub categories: Vec<String>,
     pub sound_count: u32,
+    #[serde(default)]
+    pub installed_ref: Option<String>,
     pub update_available: bool,
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,5 @@
 mod attachment;
+pub mod cesp;
 mod chat_message;
 mod checkpoint;
 pub mod diff;
@@ -9,6 +10,10 @@ mod terminal_tab;
 mod workspace;
 
 pub use attachment::Attachment;
+pub use cesp::{
+    CespCategorySounds, CespManifest, CespSound, InstalledPack, InstalledPackMeta, RegistryIndex,
+    RegistryPack,
+};
 pub use chat_message::{ChatMessage, ChatRole};
 pub use checkpoint::{CheckpointFile, CompletedTurnData, ConversationCheckpoint, TurnToolActivity};
 pub use metrics::{

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1182,15 +1182,15 @@
   padding: 20px 24px;
   margin: 8px 0;
   border-radius: var(--radius-lg);
-  background: rgba(139, 92, 246, 0.08);
-  border: 1px solid rgba(139, 92, 246, 0.20);
+  background: var(--purple-bg);
+  border: 1px solid var(--purple-border);
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .emptyStateCard:hover {
-  background: rgba(139, 92, 246, 0.13);
-  border-color: rgba(139, 92, 246, 0.35);
+  background: var(--purple-bg-hover);
+  border-color: var(--purple-border-hover);
 }
 
 .emptyStateTitle {
@@ -1212,8 +1212,8 @@
   padding: 6px 14px;
   border: none;
   border-radius: var(--radius-md);
-  background: rgba(139, 92, 246, 0.20);
-  color: #c4b5fd;
+  background: var(--purple-btn-bg);
+  color: var(--purple-text);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -1222,7 +1222,7 @@
 }
 
 .emptyStateCta:hover {
-  background: rgba(139, 92, 246, 0.30);
+  background: var(--purple-btn-bg-hover);
 }
 
 /* ── Browse more link (Mode C: text link next to pack dropdown) ── */

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -429,6 +429,7 @@
   border-radius: 10px;
   background: color-mix(in srgb, var(--sidebar-bg) 78%, transparent);
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .pluginCardSelected {
@@ -454,6 +455,17 @@
   align-items: center;
   color: var(--text-primary);
   font-weight: 500;
+}
+
+.packNameLink {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+
+.packNameLink:hover {
+  text-decoration: underline;
+  color: var(--accent-primary);
 }
 
 .pluginBadge {
@@ -1022,6 +1034,45 @@
 
 .mcpToggleOn .mcpToggleKnob {
   transform: translateX(16px);
+}
+
+/* ── Sound pack browser list (scrollable) ── */
+
+.packBrowserList {
+  composes: pluginList;
+  max-height: 480px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+/* ── Volume slider ── */
+
+.volumeSlider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 140px;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--divider);
+  outline: none;
+  cursor: pointer;
+}
+
+.volumeSlider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  cursor: pointer;
+}
+
+.volumeValue {
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: var(--text-dim);
+  min-width: 36px;
+  text-align: right;
 }
 
 /* ── Placeholder ── */

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1156,3 +1156,95 @@
   margin-top: var(--space-1);
   max-width: 260px;
 }
+
+/* ── Mode-specific block (animated height) ── */
+
+.modeBlock {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 180ms ease;
+}
+
+.modeBlockCollapsed {
+  grid-template-rows: 0fr;
+}
+
+.modeBlockInner {
+  overflow: hidden;
+}
+
+/* ── Empty-state card (Mode B: sound packs, none installed) ── */
+
+.emptyStateCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px 24px;
+  margin: 8px 0;
+  border-radius: var(--radius-lg);
+  background: rgba(139, 92, 246, 0.08);
+  border: 1px solid rgba(139, 92, 246, 0.20);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.emptyStateCard:hover {
+  background: rgba(139, 92, 246, 0.13);
+  border-color: rgba(139, 92, 246, 0.35);
+}
+
+.emptyStateTitle {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.emptyStateSubtitle {
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.emptyStateCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  padding: 6px 14px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: rgba(139, 92, 246, 0.20);
+  color: #c4b5fd;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: flex-start;
+  transition: background 0.15s ease;
+}
+
+.emptyStateCta:hover {
+  background: rgba(139, 92, 246, 0.30);
+}
+
+/* ── Browse more link (Mode C: text link next to pack dropdown) ── */
+
+.browseMoreLink {
+  color: var(--text-dim);
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 0;
+  transition: color 0.12s ease;
+  white-space: nowrap;
+}
+
+.browseMoreLink:hover {
+  color: var(--text-muted);
+}
+
+/* ── De-emphasized event rows (Mode B: no pack installed) ── */
+
+.eventRowDisabled {
+  opacity: 0.45;
+  pointer-events: none;
+}

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -308,6 +308,7 @@ export function NotificationsSettings() {
               max={100}
               value={volume}
               onChange={(e) => handleVolumeChange(Number(e.target.value))}
+              aria-label="Notification volume"
             />
             <span className={styles.volumeValue}>{volume}%</span>
           </div>
@@ -329,6 +330,7 @@ export function NotificationsSettings() {
             onClick={handleMuteToggle}
             role="switch"
             aria-checked={muted}
+            aria-label="Mute all sounds"
           >
             <span className={styles.toggleKnob} />
           </button>

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -107,7 +107,12 @@ export function NotificationsSettings() {
     }
     getAppSetting("cesp_volume")
       .then((val) => {
-        if (val) setVolume(Math.round(parseFloat(val) * 100));
+        if (val) {
+          const parsed = parseFloat(val);
+          if (Number.isFinite(parsed)) {
+            setVolume(Math.round(Math.min(1, Math.max(0, parsed)) * 100));
+          }
+        }
       })
       .catch(() => {});
     getAppSetting("cesp_muted")
@@ -127,7 +132,14 @@ export function NotificationsSettings() {
   }, [loadInstalled]);
 
   useEffect(() => {
-    if (installed.length > 0 && !activePack) {
+    if (installed.length === 0) {
+      if (activePack) {
+        setActivePack("");
+        setAppSetting("cesp_active_pack", "").catch(() => {});
+      }
+      return;
+    }
+    if (!installed.some((p) => p.name === activePack)) {
       const first = installed[0].name;
       setActivePack(first);
       setAppSetting("cesp_active_pack", first).catch(() => {});

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -1,15 +1,20 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   getAppSetting,
   setAppSetting,
   listNotificationSounds,
   playNotificationSound,
   runNotificationCommand,
+  cespListInstalled,
+  cespPreviewSound,
 } from "../../../services/tauri";
+import type { InstalledSoundPack } from "../../../types/soundpacks";
+import { SoundPackBrowser } from "./SoundPackBrowser";
 import styles from "../Settings.module.css";
 
 interface SoundEvent {
   key: string;
+  cespCategory: string;
   label: string;
   description: string;
 }
@@ -17,18 +22,33 @@ interface SoundEvent {
 const SOUND_EVENTS: SoundEvent[] = [
   {
     key: "notification_sound_ask",
+    cespCategory: "input.required",
     label: "Agent question",
     description: "Sound when an agent needs your input",
   },
   {
     key: "notification_sound_plan",
+    cespCategory: "task.acknowledge",
     label: "Plan ready",
     description: "Sound when an agent has a plan for review",
   },
   {
     key: "notification_sound_finished",
+    cespCategory: "task.complete",
     label: "Work complete",
     description: "Sound when an agent finishes its task",
+  },
+  {
+    key: "notification_sound_error",
+    cespCategory: "task.error",
+    label: "Error",
+    description: "Sound when an agent encounters an error",
+  },
+  {
+    key: "notification_sound_session_start",
+    cespCategory: "session.start",
+    label: "Session start",
+    description: "Sound when a new session begins",
   },
 ];
 
@@ -43,19 +63,40 @@ async function resolveSound(eventKey: string): Promise<string> {
 }
 
 export function NotificationsSettings() {
+  const [soundSource, setSoundSource] = useState<"system" | "openpeon">(
+    "system",
+  );
   const [sounds, setSounds] = useState<Record<string, string>>({
     notification_sound_ask: "Default",
     notification_sound_plan: "Default",
     notification_sound_finished: "Default",
+    notification_sound_error: "Default",
+    notification_sound_session_start: "Default",
   });
   const [availableSounds, setAvailableSounds] = useState<string[]>([
     "Default",
     "None",
   ]);
+  const [volume, setVolume] = useState(100);
+  const [muted, setMuted] = useState(false);
+  const [activePack, setActivePack] = useState("");
+  const [installed, setInstalled] = useState<InstalledSoundPack[]>([]);
+  const [showBrowser, setShowBrowser] = useState(false);
   const [notificationCommand, setNotificationCommand] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  const loadInstalled = useCallback(() => {
+    cespListInstalled()
+      .then(setInstalled)
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
+    getAppSetting("sound_source")
+      .then((val) => {
+        if (val === "openpeon") setSoundSource("openpeon");
+      })
+      .catch(() => {});
     listNotificationSounds().then(setAvailableSounds).catch(() => {});
     for (const event of SOUND_EVENTS) {
       resolveSound(event.key)
@@ -64,12 +105,75 @@ export function NotificationsSettings() {
         )
         .catch(() => {});
     }
+    getAppSetting("cesp_volume")
+      .then((val) => {
+        if (val) setVolume(Math.round(parseFloat(val) * 100));
+      })
+      .catch(() => {});
+    getAppSetting("cesp_muted")
+      .then((val) => setMuted(val === "true"))
+      .catch(() => {});
+    getAppSetting("cesp_active_pack")
+      .then((val) => {
+        if (val) setActivePack(val);
+      })
+      .catch(() => {});
+    loadInstalled();
     getAppSetting("notification_command")
       .then((val) => {
         if (val) setNotificationCommand(val);
       })
       .catch(() => {});
-  }, []);
+  }, [loadInstalled]);
+
+  useEffect(() => {
+    if (installed.length > 0 && !activePack) {
+      const first = installed[0].name;
+      setActivePack(first);
+      setAppSetting("cesp_active_pack", first).catch(() => {});
+    }
+  }, [installed, activePack]);
+
+  const handleSoundSourceChange = async (
+    source: "system" | "openpeon",
+  ) => {
+    setSoundSource(source);
+    try {
+      setError(null);
+      await setAppSetting("sound_source", source);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handlePackChange = async (name: string) => {
+    setActivePack(name);
+    try {
+      setError(null);
+      await setAppSetting("cesp_active_pack", name);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handleVolumeChange = async (val: number) => {
+    setVolume(val);
+    try {
+      await setAppSetting("cesp_volume", (val / 100).toFixed(2));
+    } catch {
+      // best-effort
+    }
+  };
+
+  const handleMuteToggle = async () => {
+    const next = !muted;
+    setMuted(next);
+    try {
+      await setAppSetting("cesp_muted", next ? "true" : "false");
+    } catch {
+      // best-effort
+    }
+  };
 
   const handleSoundChange = async (key: string, sound: string) => {
     const prev = sounds[key];
@@ -79,6 +183,21 @@ export function NotificationsSettings() {
       await setAppSetting(key, sound);
     } catch (e) {
       setSounds((s) => ({ ...s, [key]: prev }));
+      setError(String(e));
+    }
+  };
+
+  const handlePreview = async (event: SoundEvent) => {
+    try {
+      setError(null);
+      if (soundSource === "openpeon") {
+        if (activePack) {
+          await cespPreviewSound(activePack, event.cespCategory);
+        }
+      } else {
+        await playNotificationSound(sounds[event.key], volume / 100);
+      }
+    } catch (e) {
       setError(String(e));
     }
   };
@@ -113,33 +232,152 @@ export function NotificationsSettings() {
     <div>
       <h2 className={styles.sectionTitle}>Notifications</h2>
 
-      {SOUND_EVENTS.map((event) => (
-        <div key={event.key} className={styles.settingRow}>
+      {/* 1. Sound source */}
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Sound source</div>
+          <div className={styles.settingDescription}>
+            Choose between system notification sounds or community sound packs.
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <label className={styles.radioLabel}>
+            <input
+              type="radio"
+              name="sound-source"
+              checked={soundSource === "system"}
+              onChange={() => handleSoundSourceChange("system")}
+            />
+            System sounds
+          </label>
+          <label className={styles.radioLabel}>
+            <input
+              type="radio"
+              name="sound-source"
+              checked={soundSource === "openpeon"}
+              onChange={() => handleSoundSourceChange("openpeon")}
+            />
+            Sound packs (OpenPeon)
+          </label>
+        </div>
+      </div>
+
+      {/* 2. Active pack (OpenPeon only) */}
+      {soundSource === "openpeon" && (
+        <div className={styles.settingRow}>
           <div className={styles.settingInfo}>
-            <div className={styles.settingLabel}>{event.label}</div>
+            <div className={styles.settingLabel}>Active pack</div>
             <div className={styles.settingDescription}>
-              {event.description}
+              {installed.length === 0
+                ? "No sound packs installed. Browse packs to get started."
+                : "Choose which installed sound pack to use."}
             </div>
           </div>
           <div className={styles.settingControl}>
+            <select
+              className={styles.select}
+              value={activePack}
+              onChange={(e) => handlePackChange(e.target.value)}
+              disabled={installed.length === 0}
+            >
+              {installed.length === 0 && <option value="">None</option>}
+              {installed.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.display_name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {/* 3. Volume */}
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Volume</div>
+          <div className={styles.settingDescription}>
+            Master volume for notification sound playback.
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <div className={styles.inlineControl}>
+            <input
+              type="range"
+              className={styles.volumeSlider}
+              min={0}
+              max={100}
+              value={volume}
+              onChange={(e) => handleVolumeChange(Number(e.target.value))}
+            />
+            <span className={styles.volumeValue}>{volume}%</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 4. Mute all sounds */}
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Mute all sounds</div>
+          <div className={styles.settingDescription}>
+            Silence all notification sounds without changing other settings.
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            data-checked={muted}
+            onClick={handleMuteToggle}
+            role="switch"
+            aria-checked={muted}
+          >
+            <span className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
+
+      {/* 5. Event sounds */}
+      <div className={styles.settingRow} style={{ borderBottom: "none", paddingBottom: 4 }}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Event sounds</div>
+          <div className={styles.settingDescription}>
+            Configure the sound played for each notification event.
+          </div>
+        </div>
+      </div>
+      {SOUND_EVENTS.map((event) => (
+        <div key={event.key} className={styles.settingRow} style={{ padding: "10px 0" }}>
+          <div className={styles.settingInfo}>
+            <div className={styles.settingLabel} style={{ fontSize: 13 }}>
+              {event.label}
+            </div>
+            <div className={styles.settingDescription}>{event.description}</div>
+          </div>
+          <div className={styles.settingControl}>
             <div className={styles.inlineControl}>
-              <select
-                className={styles.select}
-                value={sounds[event.key]}
-                onChange={(e) =>
-                  handleSoundChange(event.key, e.target.value)
-                }
-              >
-                {availableSounds.map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
+              {soundSource === "system" ? (
+                <select
+                  className={styles.select}
+                  value={sounds[event.key]}
+                  onChange={(e) =>
+                    handleSoundChange(event.key, e.target.value)
+                  }
+                >
+                  {availableSounds.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <span className={styles.settingDescription} style={{ margin: 0 }}>
+                  From active pack
+                </span>
+              )}
               <button
                 className={styles.iconBtn}
-                onClick={() => playNotificationSound(sounds[event.key])}
-                title="Preview sound"
+                onClick={() => handlePreview(event)}
+                disabled={soundSource === "openpeon" && !activePack}
+                title={`Preview ${event.label}`}
                 aria-label={`Preview ${event.label} sound`}
               >
                 &#9654;
@@ -149,6 +387,9 @@ export function NotificationsSettings() {
         </div>
       ))}
 
+      {error && <div className={styles.error}>{error}</div>}
+
+      {/* 6. Notification command */}
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>
           <div className={styles.settingLabel}>Notification command</div>
@@ -157,7 +398,6 @@ export function NotificationsSettings() {
             environment variables ($CLAUDETTE_WORKSPACE_NAME,
             $CLAUDETTE_WORKSPACE_PATH, etc.) are set.
           </div>
-          {error && <div className={styles.error}>{error}</div>}
         </div>
         <div className={styles.settingControl}>
           <div className={styles.inlineControl}>
@@ -183,6 +423,35 @@ export function NotificationsSettings() {
           </div>
         </div>
       </div>
+
+      {/* 7. Sound pack registry (OpenPeon only) */}
+      {soundSource === "openpeon" && (
+        <>
+          <div className={styles.settingRow}>
+            <div className={styles.settingInfo}>
+              <div className={styles.settingLabel}>
+                {showBrowser ? "Sound pack registry" : "Browse & install packs"}
+              </div>
+              <div className={styles.settingDescription}>
+                {showBrowser
+                  ? "Install, update, or remove sound packs from the OpenPeon registry."
+                  : "Browse 100+ community sound packs."}
+              </div>
+            </div>
+            <div className={styles.settingControl}>
+              <button
+                className={styles.iconBtn}
+                onClick={() => setShowBrowser(!showBrowser)}
+              >
+                {showBrowser ? "Close" : "Browse packs"}
+              </button>
+            </div>
+          </div>
+          {showBrowser && (
+            <SoundPackBrowser installed={installed} onChanged={loadInstalled} />
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -243,6 +243,10 @@ export function NotificationsSettings() {
     }
   };
 
+  const isOpenPeon = soundSource === "openpeon";
+  const hasPacks = installed.length > 0;
+  const noPacks = isOpenPeon && !hasPacks;
+
   return (
     <div>
       <h2 className={styles.sectionTitle}>Notifications</h2>
@@ -260,7 +264,7 @@ export function NotificationsSettings() {
             <input
               type="radio"
               name="sound-source"
-              checked={soundSource === "system"}
+              checked={!isOpenPeon}
               onChange={() => handleSoundSourceChange("system")}
             />
             System sounds
@@ -269,7 +273,7 @@ export function NotificationsSettings() {
             <input
               type="radio"
               name="sound-source"
-              checked={soundSource === "openpeon"}
+              checked={isOpenPeon}
               onChange={() => handleSoundSourceChange("openpeon")}
             />
             Sound packs (OpenPeon)
@@ -277,34 +281,98 @@ export function NotificationsSettings() {
         </div>
       </div>
 
-      {/* 2. Active pack (OpenPeon only) */}
-      {soundSource === "openpeon" && (
-        <div className={styles.settingRow}>
-          <div className={styles.settingInfo}>
-            <div className={styles.settingLabel}>Active pack</div>
-            <div className={styles.settingDescription}>
-              {installed.length === 0
-                ? "No sound packs installed. Browse packs to get started."
-                : "Choose which installed sound pack to use."}
-            </div>
-          </div>
-          <div className={styles.settingControl}>
-            <select
-              className={styles.select}
-              value={activePack}
-              onChange={(e) => handlePackChange(e.target.value)}
-              disabled={installed.length === 0}
+      {/* 2. Mode-specific block */}
+      <div
+        className={`${styles.modeBlock} ${!isOpenPeon ? styles.modeBlockCollapsed : ""}`}
+      >
+        <div className={styles.modeBlockInner}>
+          {isOpenPeon && !hasPacks ? (
+            /* Mode B: empty-state card */
+            <div
+              className={styles.emptyStateCard}
+              onClick={() => setShowBrowser(true)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setShowBrowser(true);
+                }
+              }}
             >
-              {installed.length === 0 && <option value="">None</option>}
-              {installed.map((p) => (
-                <option key={p.name} value={p.name}>
-                  {p.display_name}
-                </option>
-              ))}
-            </select>
-          </div>
+              <div className={styles.emptyStateTitle}>
+                No sound packs installed yet
+              </div>
+              <div className={styles.emptyStateSubtitle}>
+                Browse 100+ community sound packs to customize your
+                notifications.
+              </div>
+              <span className={styles.emptyStateCta}>Browse packs →</span>
+            </div>
+          ) : isOpenPeon ? (
+            /* Mode C: active pack selector + browse link */
+            <div className={styles.settingRow}>
+              <div className={styles.settingInfo}>
+                <div className={styles.settingLabel}>Active pack</div>
+                <div className={styles.settingDescription}>
+                  Choose which installed sound pack to use.
+                </div>
+              </div>
+              <div className={styles.settingControl}>
+                <div className={styles.inlineControl}>
+                  <select
+                    className={styles.select}
+                    value={activePack}
+                    onChange={(e) => handlePackChange(e.target.value)}
+                  >
+                    {installed.map((p) => (
+                      <option key={p.name} value={p.name}>
+                        {p.display_name}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    className={styles.browseMoreLink}
+                    onClick={() => setShowBrowser(true)}
+                  >
+                    Browse more →
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+          {isOpenPeon && showBrowser && (
+            <>
+              <div
+                className={styles.settingRow}
+                style={{ borderBottom: "none", paddingBottom: 0 }}
+              >
+                <div className={styles.settingInfo}>
+                  <div className={styles.settingLabel}>
+                    Sound pack registry
+                  </div>
+                  <div className={styles.settingDescription}>
+                    Install, update, or remove sound packs from the OpenPeon
+                    registry.
+                  </div>
+                </div>
+                <div className={styles.settingControl}>
+                  <button
+                    className={styles.iconBtn}
+                    onClick={() => setShowBrowser(false)}
+                  >
+                    Close
+                  </button>
+                </div>
+              </div>
+              <SoundPackBrowser
+                installed={installed}
+                onChanged={loadInstalled}
+              />
+            </>
+          )}
         </div>
-      )}
+      </div>
 
       {/* 3. Volume */}
       <div className={styles.settingRow}>
@@ -354,21 +422,32 @@ export function NotificationsSettings() {
       </div>
 
       {/* 5. Event sounds */}
-      <div className={styles.settingRow} style={{ borderBottom: "none", paddingBottom: 4 }}>
+      <div
+        className={styles.settingRow}
+        style={{ borderBottom: "none", paddingBottom: 4 }}
+      >
         <div className={styles.settingInfo}>
           <div className={styles.settingLabel}>Event sounds</div>
           <div className={styles.settingDescription}>
-            Configure the sound played for each notification event.
+            {noPacks
+              ? "Install a pack to configure event sounds."
+              : "Configure the sound played for each notification event."}
           </div>
         </div>
       </div>
       {SOUND_EVENTS.map((event) => (
-        <div key={event.key} className={styles.settingRow} style={{ padding: "10px 0" }}>
+        <div
+          key={event.key}
+          className={`${styles.settingRow} ${noPacks ? styles.eventRowDisabled : ""}`}
+          style={{ padding: "10px 0" }}
+        >
           <div className={styles.settingInfo}>
             <div className={styles.settingLabel} style={{ fontSize: 13 }}>
               {event.label}
             </div>
-            <div className={styles.settingDescription}>{event.description}</div>
+            <div className={styles.settingDescription}>
+              {event.description}
+            </div>
           </div>
           <div className={styles.settingControl}>
             <div className={styles.inlineControl}>
@@ -387,19 +466,24 @@ export function NotificationsSettings() {
                   ))}
                 </select>
               ) : (
-                <span className={styles.settingDescription} style={{ margin: 0 }}>
-                  From active pack
+                <span
+                  className={styles.settingDescription}
+                  style={{ margin: 0 }}
+                >
+                  {noPacks ? "— no pack —" : "From active pack"}
                 </span>
               )}
-              <button
-                className={styles.iconBtn}
-                onClick={() => handlePreview(event)}
-                disabled={soundSource === "openpeon" && !activePack}
-                title={`Preview ${event.label}`}
-                aria-label={`Preview ${event.label} sound`}
-              >
-                &#9654;
-              </button>
+              {!noPacks && (
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => handlePreview(event)}
+                  disabled={isOpenPeon && !activePack}
+                  title={`Preview ${event.label}`}
+                  aria-label={`Preview ${event.label} sound`}
+                >
+                  &#9654;
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -441,35 +525,6 @@ export function NotificationsSettings() {
           </div>
         </div>
       </div>
-
-      {/* 7. Sound pack registry (OpenPeon only) */}
-      {soundSource === "openpeon" && (
-        <>
-          <div className={styles.settingRow}>
-            <div className={styles.settingInfo}>
-              <div className={styles.settingLabel}>
-                {showBrowser ? "Sound pack registry" : "Browse & install packs"}
-              </div>
-              <div className={styles.settingDescription}>
-                {showBrowser
-                  ? "Install, update, or remove sound packs from the OpenPeon registry."
-                  : "Browse 100+ community sound packs."}
-              </div>
-            </div>
-            <div className={styles.settingControl}>
-              <button
-                className={styles.iconBtn}
-                onClick={() => setShowBrowser(!showBrowser)}
-              >
-                {showBrowser ? "Close" : "Browse packs"}
-              </button>
-            </div>
-          </div>
-          {showBrowser && (
-            <SoundPackBrowser installed={installed} onChanged={loadInstalled} />
-          )}
-        </>
-      )}
     </div>
   );
 }

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -168,10 +168,13 @@ export function NotificationsSettings() {
     }
   };
 
-  const handleVolumeChange = async (val: number) => {
+  const handleVolumeChange = (val: number) => {
     setVolume(val);
+  };
+
+  const handleVolumeCommit = async () => {
     try {
-      await setAppSetting("cesp_volume", (val / 100).toFixed(2));
+      await setAppSetting("cesp_volume", (volume / 100).toFixed(2));
     } catch {
       // best-effort
     }
@@ -320,6 +323,7 @@ export function NotificationsSettings() {
               max={100}
               value={volume}
               onChange={(e) => handleVolumeChange(Number(e.target.value))}
+              onPointerUp={handleVolumeCommit}
               aria-label="Notification volume"
             />
             <span className={styles.volumeValue}>{volume}%</span>

--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -203,6 +203,7 @@ export function NotificationsSettings() {
   };
 
   const handlePreview = async (event: SoundEvent) => {
+    if (muted) return;
     try {
       setError(null);
       if (soundSource === "openpeon") {
@@ -392,6 +393,7 @@ export function NotificationsSettings() {
               value={volume}
               onChange={(e) => handleVolumeChange(Number(e.target.value))}
               onPointerUp={handleVolumeCommit}
+              onKeyUp={handleVolumeCommit}
               aria-label="Notification volume"
             />
             <span className={styles.volumeValue}>{volume}%</span>

--- a/src/ui/src/components/settings/sections/SoundPackBrowser.tsx
+++ b/src/ui/src/components/settings/sections/SoundPackBrowser.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  cespFetchRegistry,
+  cespInstallPack,
+  cespUpdatePack,
+  cespDeletePack,
+  openUrl,
+} from "../../../services/tauri";
+import type {
+  RegistryPack,
+  InstalledSoundPack,
+} from "../../../types/soundpacks";
+import styles from "../Settings.module.css";
+
+const REGISTRY_BASE = "https://peonping.github.io/registry/packs/";
+
+function packRegistryUrl(name: string): string {
+  return `${REGISTRY_BASE}${encodeURIComponent(name)}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  en: "English",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  it: "Italian",
+  pt: "Portuguese",
+  ja: "Japanese",
+  ko: "Korean",
+  zh: "Chinese",
+  ru: "Russian",
+  ar: "Arabic",
+  nl: "Dutch",
+  pl: "Polish",
+  sv: "Swedish",
+  tr: "Turkish",
+  multi: "Multilingual",
+};
+
+function languageLabel(code: string): string {
+  return LANGUAGE_LABELS[code] ?? code.toUpperCase();
+}
+
+interface Props {
+  installed: InstalledSoundPack[];
+  onChanged: () => void;
+}
+
+export function SoundPackBrowser({ installed, onChanged }: Props) {
+  const [registry, setRegistry] = useState<RegistryPack[]>([]);
+  const [search, setSearch] = useState("");
+  const [language, setLanguage] = useState("all");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    cespFetchRegistry()
+      .then(setRegistry)
+      .catch((e) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const languages = useMemo(() => {
+    const codes = new Set<string>();
+    for (const p of registry) {
+      if (p.language) codes.add(p.language);
+    }
+    return [...codes].sort((a, b) => languageLabel(a).localeCompare(languageLabel(b)));
+  }, [registry]);
+
+  const installedNames = new Set(installed.map((p) => p.name));
+
+  const filtered = useMemo(() => {
+    return registry.filter((p) => {
+      if (language !== "all" && p.language !== language) return false;
+      const q = search.toLowerCase();
+      return (
+        !q ||
+        p.display_name.toLowerCase().includes(q) ||
+        p.name.toLowerCase().includes(q) ||
+        (p.description?.toLowerCase().includes(q) ?? false) ||
+        p.categories.some((c) => c.toLowerCase().includes(q))
+      );
+    });
+  }, [registry, search, language]);
+
+  const handleInstall = async (pack: RegistryPack) => {
+    setBusy(pack.name);
+    setError(null);
+    try {
+      await cespInstallPack(
+        pack.name,
+        pack.source_repo,
+        pack.source_ref,
+        pack.source_path,
+      );
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleUpdate = async (pack: RegistryPack) => {
+    setBusy(pack.name);
+    setError(null);
+    try {
+      await cespUpdatePack(
+        pack.name,
+        pack.source_repo,
+        pack.source_ref,
+        pack.source_path,
+      );
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    setBusy(name);
+    setError(null);
+    try {
+      await cespDeletePack(name);
+      onChanged();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) {
+    return <div className={styles.placeholder}>Loading sound pack registry…</div>;
+  }
+
+  return (
+    <div>
+      <div className={styles.pluginToolbar}>
+        <div className={styles.pluginFormRow}>
+          <input
+            className={styles.input}
+            placeholder="Search packs…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck={false}
+          />
+          <select
+            className={styles.select}
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+          >
+            <option value="all">All languages</option>
+            {languages.map((code) => (
+              <option key={code} value={code}>
+                {languageLabel(code)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <span className={styles.pluginMeta}>
+          {filtered.length} of {registry.length} packs
+        </span>
+      </div>
+
+      {error && <div className={styles.pluginError}>{error}</div>}
+
+      <div className={styles.packBrowserList}>
+        {filtered.length === 0 && (
+          <div className={styles.placeholder}>
+            {registry.length === 0
+              ? "No packs available in the registry."
+              : "No packs match your filters."}
+          </div>
+        )}
+
+        {filtered.map((pack) => {
+          const isInstalled = installedNames.has(pack.name);
+          const installedPack = installed.find((p) => p.name === pack.name);
+          const isBusy = busy === pack.name;
+
+          return (
+            <div key={pack.name} className={styles.pluginCard}>
+              <div className={styles.pluginCardHeader}>
+                <div className={styles.pluginCardBody}>
+                  <div className={styles.pluginCardTitle}>
+                    <a
+                      className={styles.packNameLink}
+                      href={packRegistryUrl(pack.name)}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        void openUrl(packRegistryUrl(pack.name));
+                      }}
+                    >
+                      {pack.display_name}
+                    </a>
+                    {isInstalled && (
+                      <span className={styles.pluginBadge}>installed</span>
+                    )}
+                    {installedPack?.update_available && (
+                      <span className={styles.pluginBadge}>update</span>
+                    )}
+                    <span className={styles.pluginBadge}>
+                      {pack.source_ref}
+                    </span>
+                  </div>
+                  {pack.description && (
+                    <div className={styles.settingDescription}>
+                      {pack.description}
+                    </div>
+                  )}
+                  <div className={styles.pluginMeta}>
+                    {[
+                      `${pack.sound_count} sounds`,
+                      formatBytes(pack.total_size_bytes),
+                      pack.language ? languageLabel(pack.language) : null,
+                      pack.categories.join(", "),
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </div>
+                </div>
+                <div className={styles.pluginActions}>
+                  {isInstalled ? (
+                    <>
+                      {installedPack?.update_available && (
+                        <button
+                          className={styles.iconBtn}
+                          disabled={isBusy}
+                          onClick={() => handleUpdate(pack)}
+                        >
+                          {isBusy ? "Updating…" : "Update"}
+                        </button>
+                      )}
+                      <button
+                        className={styles.iconBtn}
+                        disabled={isBusy}
+                        onClick={() => handleDelete(pack.name)}
+                      >
+                        {isBusy ? "Removing…" : "Uninstall"}
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className={styles.iconBtn}
+                      disabled={isBusy}
+                      onClick={() => handleInstall(pack)}
+                    >
+                      {isBusy ? "Installing…" : "Install"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/sections/SoundPackBrowser.tsx
+++ b/src/ui/src/components/settings/sections/SoundPackBrowser.tsx
@@ -77,6 +77,7 @@ export function SoundPackBrowser({ installed, onChanged }: Props) {
     return [...codes].sort((a, b) => languageLabel(a).localeCompare(languageLabel(b)));
   }, [registry]);
 
+  const installedByName = new Map(installed.map((p) => [p.name, p]));
   const installedNames = new Set(installed.map((p) => p.name));
 
   const filtered = useMemo(() => {
@@ -190,7 +191,11 @@ export function SoundPackBrowser({ installed, onChanged }: Props) {
 
         {filtered.map((pack) => {
           const isInstalled = installedNames.has(pack.name);
-          const installedPack = installed.find((p) => p.name === pack.name);
+          const installedPack = installedByName.get(pack.name);
+          const hasUpdate =
+            isInstalled &&
+            installedPack?.installed_ref != null &&
+            installedPack.installed_ref !== pack.source_ref;
           const isBusy = busy === pack.name;
 
           return (
@@ -211,7 +216,7 @@ export function SoundPackBrowser({ installed, onChanged }: Props) {
                     {isInstalled && (
                       <span className={styles.pluginBadge}>installed</span>
                     )}
-                    {installedPack?.update_available && (
+                    {hasUpdate && (
                       <span className={styles.pluginBadge}>update</span>
                     )}
                     <span className={styles.pluginBadge}>
@@ -237,7 +242,7 @@ export function SoundPackBrowser({ installed, onChanged }: Props) {
                 <div className={styles.pluginActions}>
                   {isInstalled ? (
                     <>
-                      {installedPack?.update_available && (
+                      {hasUpdate && (
                         <button
                           className={styles.iconBtn}
                           disabled={isBusy}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -651,12 +651,6 @@ export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
 
-export function setViewingWorkspace(
-  workspaceId: string | null,
-): Promise<void> {
-  return invoke("set_viewing_workspace", { workspaceId });
-}
-
 // -- Updater --
 
 export type UpdateChannel = "stable" | "nightly";

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -694,8 +694,11 @@ export function listSystemFonts(): Promise<string[]> {
   return invoke("list_system_fonts");
 }
 
-export function playNotificationSound(sound: string): Promise<void> {
-  return invoke("play_notification_sound", { sound });
+export function playNotificationSound(
+  sound: string,
+  volume?: number,
+): Promise<void> {
+  return invoke("play_notification_sound", { sound, volume });
 }
 
 export function runNotificationCommand(
@@ -714,6 +717,47 @@ export function runNotificationCommand(
     defaultBranch,
     branchName,
   });
+}
+
+// -- Sound Packs (CESP) --
+
+import type { RegistryPack, InstalledSoundPack } from "../types/soundpacks";
+
+export function cespFetchRegistry(): Promise<RegistryPack[]> {
+  return invoke("cesp_fetch_registry");
+}
+
+export function cespListInstalled(): Promise<InstalledSoundPack[]> {
+  return invoke("cesp_list_installed");
+}
+
+export function cespInstallPack(
+  name: string,
+  sourceRepo: string,
+  sourceRef: string,
+  sourcePath: string,
+): Promise<InstalledSoundPack> {
+  return invoke("cesp_install_pack", { name, sourceRepo, sourceRef, sourcePath });
+}
+
+export function cespUpdatePack(
+  name: string,
+  sourceRepo: string,
+  sourceRef: string,
+  sourcePath: string,
+): Promise<InstalledSoundPack> {
+  return invoke("cesp_update_pack", { name, sourceRepo, sourceRef, sourcePath });
+}
+
+export function cespDeletePack(name: string): Promise<void> {
+  return invoke("cesp_delete_pack", { name });
+}
+
+export function cespPreviewSound(
+  packName: string,
+  category: string,
+): Promise<void> {
+  return invoke("cesp_preview_sound", { packName, category });
 }
 
 // -- Remote --

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -651,6 +651,12 @@ export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
 
+export function setViewingWorkspace(
+  workspaceId: string | null,
+): Promise<void> {
+  return invoke("set_viewing_workspace", { workspaceId });
+}
+
 // -- Updater --
 
 export type UpdateChannel = "stable" | "nightly";

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -34,7 +34,6 @@ import {
   getAnalyticsMetrics,
   getDashboardMetrics,
   getWorkspaceMetricsBatch,
-  setViewingWorkspace,
 } from "../services/tauri";
 import type { SlashCommand } from "../services/tauri";
 import type {
@@ -561,7 +560,6 @@ export const useAppStore = create<AppState>((set) => ({
     }),
   selectWorkspace: (id) => {
     set({ selectedWorkspaceId: id, rightSidebarTab: "changes" });
-    setViewingWorkspace(id).catch(() => {});
   },
 
   // -- Chat --

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -34,6 +34,7 @@ import {
   getAnalyticsMetrics,
   getDashboardMetrics,
   getWorkspaceMetricsBatch,
+  setViewingWorkspace,
 } from "../services/tauri";
 import type { SlashCommand } from "../services/tauri";
 import type {
@@ -558,8 +559,10 @@ export const useAppStore = create<AppState>((set) => ({
         workspaceTerminalCommands: newWorkspaceTerminalCommands,
       };
     }),
-  selectWorkspace: (id) =>
-    set({ selectedWorkspaceId: id, rightSidebarTab: "changes" }),
+  selectWorkspace: (id) => {
+    set({ selectedWorkspaceId: id, rightSidebarTab: "changes" });
+    setViewingWorkspace(id).catch(() => {});
+  },
 
   // -- Chat --
   chatMessages: {},

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -26,6 +26,15 @@
      our bright/medium accents; light themes override below. */
   --on-accent:           #1c1815;
 
+  /* ---- Purple accent (empty-state cards) ---- */
+  --purple-bg:           rgba(139, 92, 246, 0.08);
+  --purple-bg-hover:     rgba(139, 92, 246, 0.13);
+  --purple-border:       rgba(139, 92, 246, 0.20);
+  --purple-border-hover: rgba(139, 92, 246, 0.35);
+  --purple-btn-bg:       rgba(139, 92, 246, 0.20);
+  --purple-btn-bg-hover: rgba(139, 92, 246, 0.30);
+  --purple-text:         #c4b5fd;
+
   /* ---- Mascot pink (the bow) ---- */
   --mascot-pink:         #f5a0b8;
   --mascot-pink-dim:     #d97a95;

--- a/src/ui/src/types/soundpacks.ts
+++ b/src/ui/src/types/soundpacks.ts
@@ -1,0 +1,21 @@
+export interface RegistryPack {
+  name: string;
+  display_name: string;
+  description: string | null;
+  language: string | null;
+  source_repo: string;
+  source_ref: string;
+  source_path: string;
+  categories: string[];
+  sound_count: number;
+  total_size_bytes: number;
+}
+
+export interface InstalledSoundPack {
+  name: string;
+  display_name: string;
+  version: string;
+  categories: string[];
+  sound_count: number;
+  update_available: boolean;
+}

--- a/src/ui/src/types/soundpacks.ts
+++ b/src/ui/src/types/soundpacks.ts
@@ -17,5 +17,6 @@ export interface InstalledSoundPack {
   version: string;
   categories: string[];
   sound_count: number;
+  installed_ref: string | null;
   update_available: boolean;
 }


### PR DESCRIPTION
## Summary

Adds **OpenPeon / CESP (Community Event Sound Packs)** as an alternative notification sound source alongside existing system sounds. Users can now browse, install, and manage community-created sound packs from a public registry, with per-event category mapping, volume control, and mute toggle — all unified in a redesigned Notifications settings panel.

```mermaid
flowchart LR
    A[Notification Event] --> B{sound_source?}
    B -->|system| C[System Sound via afplay/paplay]
    B -->|openpeon| D[CESP Engine]
    D --> E[Load manifest]
    E --> F[Resolve category + alias]
    F --> G[Pick sound no-repeat/debounce]
    G --> H[Play audio file]
```

### What changed

- **New `cesp` module** (`src/cesp.rs`, `src/model/cesp.rs`) — pack install/delete/list, manifest parsing, tarball extraction (via `flate2` + `tar`), audio playback with no-repeat window and debounce, category alias resolution
- **New Tauri commands** (`src-tauri/src/commands/cesp.rs`) — `cesp_fetch_registry`, `cesp_install_pack`, `cesp_update_pack`, `cesp_delete_pack`, `cesp_preview_sound`, `cesp_play_for_event`
- **Notification path integration** — `tray.rs`, `chat.rs`, `scm.rs` all check `sound_source` setting and route to CESP when set to `"openpeon"`
- **Volume support** — `play_notification_sound` now accepts a volume parameter; uses `afplay -v` on macOS, `paplay --volume` on Linux
- **Frontend** — Redesigned `NotificationsSettings` with sound source radio, active pack selector, volume slider, mute toggle, and 5 canonical events (Agent question, Plan ready, Work complete, Error, Session start); new `SoundPackBrowser` component with search, language filter, install/update/uninstall

## Complexity Notes

- **Three notification paths** (`tray.rs` for attention, `chat.rs` for agent-finished, `scm.rs` for auto-archive) all independently read `sound_source`/`cesp_muted`/`cesp_volume` from the DB and dispatch to CESP or system sounds. The pattern is duplicated because `Database` is not `Send` and each path has different async constraints — reviewers should verify all three stay consistent.
- **Tarball extraction** includes a path-traversal guard (`canonical_dest.starts_with(canonical_target)`) — worth verifying the security boundary.
- **`SoundPlaybackState`** lives in `AppState` behind a `std::sync::Mutex` (not tokio) because playback decisions are fast, synchronous, and called from both sync and async contexts.

## Test Steps

1. `cargo test --all-features` — 512 tests pass (includes new CESP tests for manifest parsing, category resolution, alias chains, no-repeat/debounce, tarball extraction roundtrip, epoch date conversion)
2. `cd src/ui && bun run test` — 579 tests pass
3. `cargo clippy -p claudette -p claudette-server --all-targets` — zero warnings
4. `cd src/ui && bunx tsc --noEmit` — clean
5. **Manual**: Open Settings → Notifications → switch to "Sound packs (OpenPeon)" → browse packs → install one → select it as active → click preview buttons for each event → adjust volume slider → toggle mute → switch back to "System sounds" and verify system sounds still work

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)