### PR TITLE
feat(terminal): open clicked URLs in the default browser

### DIFF
--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -9,6 +9,7 @@ import {
   createTerminalTab,
   deleteTerminalTab,
   listTerminalTabs,
+  openUrl,
   spawnPty,
   writePty,
   resizePty,
@@ -217,7 +218,9 @@ export const TerminalPanel = memo(function TerminalPanel() {
         theme: getTerminalTheme(),
       });
       const fit = new FitAddon();
-      const links = new WebLinksAddon();
+      const links = new WebLinksAddon((_event, url) => {
+        void openUrl(url);
+      });
       term.loadAddon(fit);
       term.loadAddon(links);
 


### PR DESCRIPTION
## Summary

- Wire the existing `WebLinksAddon` click handler to call `openUrl` (Tauri shell API) so terminal URLs open in the system default browser
- The addon was already installed and loaded but had no custom handler, causing clicks to silently fail in the Tauri webview sandbox

Closes #356

## Test plan

- [ ] Run `cargo tauri dev`, open a workspace terminal
- [ ] Run a command that prints a URL (e.g., `echo http://example.com`)
- [ ] Hover over the URL — verify it shows an underline
- [ ] Click the URL — verify it opens in the default browser
- [ ] Test with `http://`, `https://`, and `localhost:PORT` URLs