### PR TITLE
feat(chat): live token usage and compaction indicator

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -574,6 +574,18 @@
   font-family: var(--font-mono);
 }
 
+.compactingLabel {
+  color: var(--accent-primary);
+  font-size: 12px;
+  font-weight: 500;
+  animation: compactingPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes compactingPulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
 /* Tool activities — compact inline annotations */
 .toolActivities {
   display: flex;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -985,9 +985,16 @@ export function ChatPanel() {
                   ref={processingRef}
                   className={styles.processing}
                   role="status"
-                  aria-label={`Processing, ${formatElapsed(elapsed)} elapsed`}
+                  aria-label={
+                    ws?.agent_status === "Compacting"
+                      ? `Compacting context, ${formatElapsed(elapsed)} elapsed`
+                      : `Processing, ${formatElapsed(elapsed)} elapsed`
+                  }
                 >
                   <span className={styles.spinner} aria-hidden="true">{SPINNER_FRAMES[spinnerIdx]}</span>
+                  {ws?.agent_status === "Compacting" && (
+                    <span className={styles.compactingLabel}>Compacting context…</span>
+                  )}
                   <span className={styles.elapsed}>{formatElapsed(elapsed)}</span>
                 </div>
               )}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -187,6 +187,28 @@ export function useAgentStream() {
             const inner = streamEvent.event;
             if ("type" in inner) {
               switch (inner.type) {
+                case "message_delta": {
+                  // Live meter update during streaming. Usage here is
+                  // per-assistant-message cumulative — input_tokens reflects
+                  // the prompt size for the current API call (grows across
+                  // tool-use iterations as context accumulates), and
+                  // output_tokens grows as the model generates. The `result`
+                  // event later overwrites this with iterations[0] for the
+                  // canonical per-call end-of-turn reading; this case just
+                  // fills the gap in between so the meter doesn't sit stale.
+                  if (inner.usage) {
+                    const { setLatestTurnUsage } = useAppStore.getState();
+                    setLatestTurnUsage(wsId, {
+                      inputTokens: inner.usage.input_tokens,
+                      outputTokens: inner.usage.output_tokens,
+                      cacheReadTokens:
+                        inner.usage.cache_read_input_tokens ?? undefined,
+                      cacheCreationTokens:
+                        inner.usage.cache_creation_input_tokens ?? undefined,
+                    });
+                  }
+                  break;
+                }
                 case "content_block_delta": {
                   const delta = inner.delta;
                   if ("type" in delta && delta.type === "text_delta") {


### PR DESCRIPTION
## Summary

Two closely-related UX fixes for live feedback during a turn. Previously both token usage and compaction progress were invisible mid-turn — the meter sat stale, and compaction (often >60s) was indistinguishable from a normal running turn.

- **Live ContextMeter updates** — consume `message_delta.usage` from the CLI stream instead of waiting for `result.usage` at turn end. `input_tokens` now reflects the current API call's prompt size as it grows across tool-use iterations, and `output_tokens` increments as the model generates. The `result` handler still overwrites with `iterations[0]` so the end-of-turn resting value matches what it was before.
- **"Compacting context…" label** — the backend already flips `agent_status` to `Compacting` when the CLI emits `status: "compacting"`, but the processing indicator didn't distinguish it. Added a pulsing label next to the spinner and updated the aria-label for screen readers.

Both changes are purely frontend — the Rust bridge was already emitting the relevant events (see comment at `agent-events.ts:79-83` explicitly noting "Phase 1's frontend does not consume this").

## Test plan

- [ ] Send a prompt and watch the ContextMeter update during streaming (not just at turn end)
- [ ] Meter value at turn end matches previous behavior (no regression in resting-state reading)
- [ ] Trigger compaction (long session) and verify "Compacting context…" label appears next to the spinner while `agent_status === "Compacting"`
- [ ] Label disappears when `compact_boundary` fires and the sentinel divider renders
- [ ] `bunx tsc --noEmit` and `bun run test` both green