### PR TITLE
feat(chat): add /compact slash command and fix context meter buttons

### DIFF
--- a/src/slash_commands.rs
+++ b/src/slash_commands.rs
@@ -151,6 +151,14 @@ pub fn native_command_registry(plugin_management_enabled: bool) -> Vec<SlashComm
         kind: Some(NativeKind::LocalAction),
     });
     commands.push(SlashCommand {
+        name: "compact".to_string(),
+        description: "Compact the conversation context".to_string(),
+        source: "builtin".to_string(),
+        aliases: Vec::new(),
+        argument_hint: None,
+        kind: Some(NativeKind::PromptExpansion),
+    });
+    commands.push(SlashCommand {
         name: "plan".to_string(),
         description: "Show, toggle, or open the current plan".to_string(),
         source: "builtin".to_string(),
@@ -783,6 +791,7 @@ mod tests {
         assert!(names.contains(&"version"));
         // Workspace-control commands are unconditional too.
         assert!(names.contains(&"clear"));
+        assert!(names.contains(&"compact"));
         assert!(names.contains(&"plan"));
         assert!(names.contains(&"model"));
         assert!(names.contains(&"permissions"));

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -24,7 +24,6 @@ import {
   setAppSetting,
   listWorkspaceFiles,
   clearConversation,
-  resetAgentSession,
   readPlanFile,
   loadDiffFiles,
   forkWorkspaceAtCheckpoint,
@@ -2496,8 +2495,8 @@ function ChatInputArea({
             <ContextPopover
               workspaceId={selectedWorkspaceId}
               onClose={() => setContextPopoverOpen(false)}
-              onCompact={() => resetAgentSession(selectedWorkspaceId)}
-              onClear={() => clearConversation(selectedWorkspaceId, false)}
+              onCompact={() => { onSend("/compact"); }}
+              onClear={() => { onSend("/clear"); }}
             />
           )}
         </div>

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -634,6 +634,53 @@ describe("/clear handler", () => {
   });
 });
 
+describe("/compact handler", () => {
+  it("is registered as prompt_expansion with no aliases", () => {
+    const handler = resolveNativeHandler("compact")!;
+    expect(handler).toBeDefined();
+    expect(handler.name).toBe("compact");
+    expect(handler.kind).toBe("prompt_expansion");
+    expect(handler.aliases).toEqual([]);
+  });
+
+  it("expands to /compact prompt text for the CLI", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("compact")!;
+    const result = await handler.execute(ctx, "");
+    expect(result).toEqual({
+      kind: "expand",
+      canonicalName: "compact",
+      prompt: "/compact",
+    });
+  });
+
+  it("does not add a local message on success", async () => {
+    const ctx = makeCtx();
+    await resolveNativeHandler("compact")!.execute(ctx, "");
+    expect(ctx.addLocalMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects any argument without expanding", async () => {
+    const ctx = makeCtx();
+    const handler = resolveNativeHandler("compact")!;
+    const result = await handler.execute(ctx, "extra args");
+    expect(result).toEqual({ kind: "handled", canonicalName: "compact" });
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("does not accept arguments"),
+    );
+  });
+
+  it("bails out gracefully if no workspace is selected", async () => {
+    const ctx = makeCtx({ workspaceId: null });
+    const handler = resolveNativeHandler("compact")!;
+    const result = await handler.execute(ctx, "");
+    expect(result).toEqual({ kind: "handled", canonicalName: "compact" });
+    expect(ctx.addLocalMessage).toHaveBeenCalledWith(
+      expect.stringContaining("no active workspace"),
+    );
+  });
+});
+
 describe("/plan handler", () => {
   it("toggles plan mode off when invoked with no args and plan mode is currently on", async () => {
     const ctx = makeCtx({ planMode: true });

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -395,6 +395,23 @@ const clearHandler: NativeHandler = {
   },
 };
 
+const compactHandler: NativeHandler = {
+  name: "compact",
+  aliases: [],
+  kind: "prompt_expansion",
+  execute: (ctx, args) => {
+    if (!ctx.workspaceId) {
+      ctx.addLocalMessage("/compact: no active workspace");
+      return { kind: "handled" as const, canonicalName: "compact" };
+    }
+    if (args.trim() !== "") {
+      ctx.addLocalMessage("/compact: does not accept arguments. Usage: /compact");
+      return { kind: "handled" as const, canonicalName: "compact" };
+    }
+    return { kind: "expand" as const, canonicalName: "compact", prompt: "/compact" };
+  },
+};
+
 const planHandler: NativeHandler = {
   name: "plan",
   aliases: [],
@@ -765,6 +782,7 @@ export const NATIVE_HANDLERS: NativeHandler[] = [
   releaseNotesHandler,
   versionHandler,
   clearHandler,
+  compactHandler,
   planHandler,
   modelHandler,
   permissionsHandler,


### PR DESCRIPTION
## Summary

- Register `/compact` as a native slash command (Rust registry + TypeScript handler) so it appears in autocomplete and triggers CLI-native context compaction via the existing event bridge
- Fix the context meter popover's **Compact** button — was calling `resetAgentSession` (full session kill) instead of actual compaction
- Fix the popover's **Clear** button — was calling `clearConversation` directly, bypassing the `/clear` handler's cleanup (rollback, turns/attachments/diff reload). Both buttons now route through `onSend()` for consistent lifecycle handling

## Complexity Notes

`/compact` uses `PromptExpansion` (not `LocalAction`) because compaction must flow through the CLI subprocess. There is no Tauri command for compaction — the only trigger is sending `/compact` as prompt text through `send_chat_message`, which runs the event bridge that persists `COMPACTION:` and `SYNTHETIC_SUMMARY:` sentinels to the DB. `PromptExpansion` achieves this by returning `{ kind: "expand", prompt: "/compact" }`, which falls through `handleSend` into the normal agent send pipeline.

## Test Steps

1. Type `/comp` in the chat input → autocomplete should surface `/compact` with description "Compact the conversation context"
2. Select `/compact` and send → agent status should briefly show "Compacting", then a CompactionDivider should appear in the chat timeline
3. Click the context meter (segmented bar) → popover opens → click **Compact** → same compaction behavior as step 2
4. Click the context meter → click **Clear** → conversation should clear with "Conversation cleared." message, diff/turns/attachments should reload
5. Run `cargo test -p claudette native_command` → 13 tests pass
6. Run `cd src/ui && bunx vitest run nativeSlashCommands` → 135 tests pass (5 new for `/compact`)

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable) — N/A, no user-facing docs affected

Closes #342, Closes #355