### PR TITLE
fix(chat): elapsed timer resets when switching between workspaces

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -296,7 +296,7 @@ export function ChatPanel() {
   );
   const [elapsed, setElapsed] = useState(0);
   useEffect(() => {
-    if (!isRunning || !promptStartTime) return;
+    if (!isRunning || promptStartTime == null) return;
     setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
     setSpinnerIdx(0);
     const interval = setInterval(() => {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -291,27 +291,21 @@ export function ChatPanel() {
 
   // Spinner and elapsed timer for running agent.
   const [spinnerIdx, setSpinnerIdx] = useState(0);
+  const promptStartTime = useAppStore(
+    (s) => (selectedWorkspaceId ? s.promptStartTime[selectedWorkspaceId] ?? null : null)
+  );
   const [elapsed, setElapsed] = useState(0);
-  const startTimeRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!isRunning) {
-      startTimeRef.current = null;
-      return;
-    }
-    if (!startTimeRef.current) {
-      startTimeRef.current = Date.now();
-      setElapsed(0);
-      setSpinnerIdx(0);
-    }
+    if (!isRunning || !promptStartTime) return;
+    setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
+    setSpinnerIdx(0);
     const interval = setInterval(() => {
       setSpinnerIdx((i) => (i + 1) % SPINNER_FRAMES.length);
-      if (startTimeRef.current) {
-        const newElapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-        setElapsed((prev) => (prev === newElapsed ? prev : newElapsed));
-      }
+      const newElapsed = Math.floor((Date.now() - promptStartTime) / 1000);
+      setElapsed((prev) => (prev === newElapsed ? prev : newElapsed));
     }, SPINNER_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [isRunning]);
+  }, [isRunning, promptStartTime]);
 
   const formatElapsed = formatElapsedSeconds;
 
@@ -794,6 +788,7 @@ export function ChatPanel() {
       useAppStore.getState().addChatAttachments(selectedWorkspaceId, optimisticAtts);
     }
     updateWorkspace(selectedWorkspaceId, { agent_status: "Running" });
+    useAppStore.getState().setPromptStartTime(selectedWorkspaceId, Date.now());
     useAppStore.getState().clearUnreadCompletion(selectedWorkspaceId);
 
     try {
@@ -845,6 +840,7 @@ export function ChatPanel() {
       console.error("sendChatMessage failed:", errMsg);
       setError(errMsg);
       updateWorkspace(selectedWorkspaceId, { agent_status: "Idle" });
+      useAppStore.getState().clearPromptStartTime(selectedWorkspaceId);
     }
   };
 

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -81,6 +81,7 @@ export function useAgentStream() {
         turnFinalizedRef.current[wsId] = false;
         turnCheckpointIdRef.current[wsId] = undefined;
         updateWorkspace(wsId, { agent_status: "Idle" });
+        useAppStore.getState().clearPromptStartTime(wsId);
         setStreamingContent(wsId, "");
         clearStreamingThinking(wsId);
         blockToolMapRef.current = {};
@@ -388,6 +389,7 @@ export function useAgentStream() {
             turnMessageCountRef.current[wsId] = 0;
             turnFinalizedRef.current[wsId] = true;
             updateWorkspace(wsId, { agent_status: "Idle" });
+            useAppStore.getState().clearPromptStartTime(wsId);
             break;
           }
           case "user": {

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1081,6 +1081,48 @@ describe("clearLatestTurnUsage", () => {
   });
 });
 
+describe("promptStartTime (per-workspace)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ promptStartTime: {} });
+  });
+
+  it("setPromptStartTime stores timestamp keyed by workspace", () => {
+    useAppStore.getState().setPromptStartTime(WS_ID, 1700000000000);
+    expect(useAppStore.getState().promptStartTime[WS_ID]).toBe(1700000000000);
+  });
+
+  it("timestamps are isolated per workspace", () => {
+    useAppStore.getState().setPromptStartTime("ws-a", 1000);
+    useAppStore.getState().setPromptStartTime("ws-b", 2000);
+    expect(useAppStore.getState().promptStartTime["ws-a"]).toBe(1000);
+    expect(useAppStore.getState().promptStartTime["ws-b"]).toBe(2000);
+  });
+
+  it("overwrites previous timestamp for same workspace", () => {
+    useAppStore.getState().setPromptStartTime(WS_ID, 1000);
+    useAppStore.getState().setPromptStartTime(WS_ID, 2000);
+    expect(useAppStore.getState().promptStartTime[WS_ID]).toBe(2000);
+  });
+
+  it("clearPromptStartTime removes entry for that workspace only", () => {
+    useAppStore.getState().setPromptStartTime("ws-a", 1000);
+    useAppStore.getState().setPromptStartTime("ws-b", 2000);
+    useAppStore.getState().clearPromptStartTime("ws-a");
+    expect(useAppStore.getState().promptStartTime["ws-a"]).toBeUndefined();
+    expect(useAppStore.getState().promptStartTime["ws-b"]).toBe(2000);
+  });
+
+  it("clearPromptStartTime is a no-op for unknown workspace", () => {
+    useAppStore.getState().setPromptStartTime(WS_ID, 1000);
+    useAppStore.getState().clearPromptStartTime("ws-never-set");
+    expect(useAppStore.getState().promptStartTime[WS_ID]).toBe(1000);
+  });
+
+  it("defaults to empty (no timestamps)", () => {
+    expect(useAppStore.getState().promptStartTime[WS_ID]).toBeUndefined();
+  });
+});
+
 describe("compactionEvents slice", () => {
   beforeEach(() => {
     useAppStore.setState({ compactionEvents: {} });

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -160,6 +160,9 @@ interface AppState {
    *  rollback or empty load leaves no assistant message with token data —
    *  clearing hides the meter rather than leaving a stale value. */
   clearLatestTurnUsage: (wsId: string) => void;
+  promptStartTime: Record<string, number>;
+  setPromptStartTime: (wsId: string, time: number) => void;
+  clearPromptStartTime: (wsId: string) => void;
   /** Per-workspace compaction history, re-derived from the persisted
    *  COMPACTION:* sentinel messages on workspace load and updated live
    *  on compact_boundary events. This slice stores derived metadata
@@ -592,6 +595,18 @@ export const useAppStore = create<AppState>((set) => ({
       const next = { ...s.latestTurnUsage };
       delete next[wsId];
       return { latestTurnUsage: next };
+    }),
+  promptStartTime: {},
+  setPromptStartTime: (wsId, time) =>
+    set((s) => ({
+      promptStartTime: { ...s.promptStartTime, [wsId]: time },
+    })),
+  clearPromptStartTime: (wsId) =>
+    set((s) => {
+      if (!(wsId in s.promptStartTime)) return {};
+      const next = { ...s.promptStartTime };
+      delete next[wsId];
+      return { promptStartTime: next };
     }),
   compactionEvents: {},
   setCompactionEvents: (wsId, events) =>


### PR DESCRIPTION
## Summary

The elapsed time indicator at the bottom of the chat resets to 0:00 when switching workspaces and switching back. The root cause is a component-local `useRef` in `ChatPanel` that captures a fresh `Date.now()` on every remount.

This PR moves the prompt start timestamp into the Zustand store keyed by workspace ID. The timer now computes elapsed as `Date.now() - promptStartTime` on each tick, so switching away and back shows the correct wall-clock time.

- **`useAppStore.ts`** — Added `promptStartTime: Record<string, number>` with set/clear actions
- **`ChatPanel.tsx`** — Replaced `useRef`-based timer with store-backed `promptStartTime`; set on prompt send, clear on send failure
- **`useAgentStream.ts`** — Clear `promptStartTime` on `ProcessExited` and `result` events

## Complexity Notes

The timestamp is intentionally **not** reset during compaction (Running → Compacting → Running) since `isAgentBusy()` returns true for both states — the timer continues seamlessly across compaction pauses.

## Test Steps

1. Start a prompt in Workspace A — verify the elapsed timer counts up
2. Switch to Workspace B, wait ~15 seconds
3. Switch back to Workspace A — verify the timer shows ~15s (not 0:00)
4. Wait for the prompt to finish — verify the timer disappears normally
5. Start another prompt — verify the timer starts fresh from 0:00
6. (Edge case) If a prompt errors on send, verify no stale timer remains

## Checklist

- [x] Tests pass (608/608 vitest, tsc --noEmit clean)
- [ ] Manual testing with workspace switching

Closes #359