### PR TITLE
fix(settings): constrain radio label click area to content width

### DIFF
--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -741,6 +741,7 @@
   font-size: 13px;
   color: var(--text-primary);
   cursor: pointer;
+  width: fit-content;
 }
 
 .radioLabel input[type="radio"] {


### PR DESCRIPTION
## Summary

- Adds `width: fit-content` to the `.radioLabel` CSS class so only the radio button and its label text are clickable, not the entire row width
- Fixes accidental selection changes when clicking empty space to the right of branch prefix radio options in Settings → Git

Closes #327

## Test Steps

1. Open Settings → Git
2. Locate the "Branch name prefix" radio buttons (Git username / Custom / None)
3. Click the radio circle or label text — selection should change ✓
4. Click empty whitespace to the right of a label — selection should **not** change ✓
5. Verify radio button alignment and spacing looks unchanged

## Checklist

- [x] Tests added/updated (CSS-only change, existing tests pass — 608 frontend, 508 backend)
- [ ] Documentation updated (not applicable)