### PR TITLE
feat(sidebar): allow renaming workspaces via double-click

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -551,6 +551,35 @@ pub async fn delete_workspace(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn rename_workspace(
+    id: String,
+    new_name: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let trimmed = new_name.trim().to_string();
+    if !is_valid_workspace_name(&trimmed) {
+        return Err("Invalid workspace name. Use letters, numbers, and hyphens only.".into());
+    }
+    if trimmed.len() > 60 {
+        return Err("Workspace name must be 60 characters or fewer".into());
+    }
+
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.update_workspace_name(&id, &trimmed).map_err(|e| {
+        if e.to_string().contains("UNIQUE constraint failed") {
+            "A workspace with this name already exists in this repository".into()
+        } else {
+            e.to_string()
+        }
+    })?;
+
+    crate::tray::rebuild_tray(&app);
+
+    Ok(())
+}
+
 #[derive(Serialize)]
 pub struct GeneratedWorkspaceName {
     /// Safe for branch names and file paths

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -341,6 +341,7 @@ fn main() {
             commands::workspace::run_workspace_setup,
             commands::workspace::archive_workspace,
             commands::workspace::restore_workspace,
+            commands::workspace::rename_workspace,
             commands::workspace::delete_workspace,
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1125,6 +1125,17 @@ impl Database {
         Ok(())
     }
 
+    pub fn update_workspace_name(&self, id: &str, new_name: &str) -> Result<(), rusqlite::Error> {
+        let rows_affected = self.conn.execute(
+            "UPDATE workspaces SET name = ?1 WHERE id = ?2",
+            params![new_name, id],
+        )?;
+        if rows_affected != 1 {
+            return Err(rusqlite::Error::StatementChangedRows(rows_affected));
+        }
+        Ok(())
+    }
+
     pub fn delete_workspace(&self, id: &str) -> Result<(), rusqlite::Error> {
         self.conn
             .execute("DELETE FROM workspaces WHERE id = ?1", params![id])?;
@@ -2145,6 +2156,55 @@ mod tests {
         // Renaming a workspace that doesn't exist should fail.
         let result = db.rename_workspace("no-such-id", "new-name", "claudette/new-name");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_workspace_name() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "old-name"))
+            .unwrap();
+        db.update_workspace_name("w1", "new-name").unwrap();
+        let workspaces = db.list_workspaces().unwrap();
+        assert_eq!(workspaces[0].name, "new-name");
+        assert_eq!(workspaces[0].branch_name, "claudette/old-name");
+    }
+
+    #[test]
+    fn test_update_workspace_name_unique_conflict() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "name-a"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "name-b"))
+            .unwrap();
+        let result = db.update_workspace_name("w1", "name-b");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_workspace_name_nonexistent() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        let result = db.update_workspace_name("no-such-id", "new-name");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_workspace_name_cross_repo_ok() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_repository(&make_repo("r2", "/tmp/repo2", "repo2"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "shared-name"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r2", "other-name"))
+            .unwrap();
+        db.update_workspace_name("w2", "shared-name").unwrap();
     }
 
     #[test]

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -403,6 +403,19 @@
   gap: 6px;
 }
 
+.wsNameInput {
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--chat-input-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--accent-primary);
+  border-radius: 4px;
+  padding: 0 4px;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .badgeDone,
 .badgePlan,
 .badgeAsk {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -101,6 +101,7 @@ export const Sidebar = memo(function Sidebar() {
   const [renamingWsId, setRenamingWsId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const renameCancelledRef = useRef(false);
 
   const creatingRef = useRef(false);
   const archivingRef = useRef<Set<string>>(new Set());
@@ -346,10 +347,19 @@ export const Sidebar = memo(function Sidebar() {
               className={styles.wsNameInput}
               value={renameValue}
               onChange={(e) => setRenameValue(e.target.value)}
-              onBlur={() => handleRenameSubmit(ws.id)}
+              onBlur={() => {
+                if (renameCancelledRef.current) {
+                  renameCancelledRef.current = false;
+                  return;
+                }
+                handleRenameSubmit(ws.id);
+              }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleRenameSubmit(ws.id);
-                if (e.key === "Escape") setRenamingWsId(null);
+                if (e.key === "Escape") {
+                  renameCancelledRef.current = true;
+                  setRenamingWsId(null);
+                }
               }}
               autoFocus
               onClick={(e) => e.stopPropagation()}

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import {
   archiveWorkspace,
   reorderRepositories,
+  renameWorkspace,
   restoreWorkspace,
   generateWorkspaceName,
   createWorkspace,
@@ -96,6 +97,10 @@ export const Sidebar = memo(function Sidebar() {
     [workspaces],
   );
   const spinnerChar = useSpinnerFrame(anyRunning);
+
+  const [renamingWsId, setRenamingWsId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const renameInputRef = useRef<HTMLInputElement>(null);
 
   const creatingRef = useRef(false);
   const archivingRef = useRef<Set<string>>(new Set());
@@ -256,6 +261,22 @@ export const Sidebar = memo(function Sidebar() {
     }
   }, [updateWorkspace]);
 
+  const handleRenameSubmit = useCallback(async (wsId: string) => {
+    const trimmed = renameValue.trim();
+    const ws = workspaces.find((w) => w.id === wsId);
+    if (!trimmed || trimmed === ws?.name) {
+      setRenamingWsId(null);
+      return;
+    }
+    try {
+      await renameWorkspace(wsId, trimmed);
+      updateWorkspace(wsId, { name: trimmed });
+    } catch (e) {
+      console.error("Failed to rename workspace:", e);
+    }
+    setRenamingWsId(null);
+  }, [renameValue, workspaces, updateWorkspace]);
+
   const renderWorkspace = (ws: typeof workspaces[number]) => {
     const badge: "ask" | "plan" | "done" | null =
       agentQuestions[ws.id] ? "ask" :
@@ -319,9 +340,34 @@ export const Sidebar = memo(function Sidebar() {
           );
         })()}
         <div className={styles.wsInfo}>
-          <span className={styles.wsName}>
-            {ws.name}
-          </span>
+          {renamingWsId === ws.id ? (
+            <input
+              ref={renameInputRef}
+              className={styles.wsNameInput}
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onBlur={() => handleRenameSubmit(ws.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleRenameSubmit(ws.id);
+                if (e.key === "Escape") setRenamingWsId(null);
+              }}
+              autoFocus
+              onClick={(e) => e.stopPropagation()}
+              onMouseDown={(e) => e.stopPropagation()}
+              aria-label="Rename workspace"
+            />
+          ) : (
+            <span
+              className={styles.wsName}
+              onDoubleClick={(e) => {
+                e.stopPropagation();
+                setRenamingWsId(ws.id);
+                setRenameValue(ws.name);
+              }}
+            >
+              {ws.name}
+            </span>
+          )}
           <span className={styles.wsBranch}>{ws.branch_name}</span>
           {(() => {
             const commandState = workspaceTerminalCommands[ws.id];

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -134,6 +134,10 @@ export function restoreWorkspace(id: string): Promise<string> {
   return invoke("restore_workspace", { id });
 }
 
+export function renameWorkspace(id: string, newName: string): Promise<void> {
+  return invoke("rename_workspace", { id, newName });
+}
+
 export function deleteWorkspace(id: string): Promise<void> {
   return invoke("delete_workspace", { id });
 }


### PR DESCRIPTION
## Summary

- Add inline workspace rename: double-click a workspace name in the sidebar to edit it in-place
- Only the display name changes — git branches remain untouched, avoiding disruption to CI/collaborators
- Adds `update_workspace_name` DB function, `rename_workspace` Tauri command, and frontend inline edit UI

## Complexity Notes

- **Validation**: Reuses existing `is_valid_workspace_name()` slug validation (alphanumeric + hyphens). This keeps names safe for worktree paths, env vars, and tray menus. A future `display_name` column could decouple display from slug if needed.
- **Auto-rename race**: If a user renames a workspace before the first-turn auto-rename fires, the auto-rename may overwrite the user's choice. This is acceptable — the user can rename again. The existing `workspace-renamed` event listener already handles store updates.
- **`onMouseDown` stopPropagation**: Required on the rename input to prevent the sidebar's pointer-based drag reorder from activating when clicking inside the text field.

## Test Steps

1. Run `cargo tauri dev`
2. Double-click a workspace name in the sidebar → an input field should appear with the current name selected
3. Type a new name (e.g., `fix-shipping-bug`) and press Enter → name updates in sidebar and system tray
4. Double-click another name, then press Escape → edit is cancelled, original name preserved
5. Try renaming to an existing workspace name in the same repo → error logged, old name restored
6. Try renaming with invalid characters (spaces, underscores) → rejected by validation
7. Rename an archived workspace → should work the same way
8. Run `cargo test -p claudette update_workspace_name` → 4 new DB tests pass

## Checklist

- [x] Tests added/updated (4 new DB unit tests: basic rename, unique conflict, nonexistent ID, cross-repo OK)
- [x] Clippy clean, `cargo fmt` clean, `tsc --noEmit` clean
- [ ] Documentation updated (if applicable)