### PR TITLE
fix: update expired Discord invite links to permanent URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ All traffic is encrypted with TLS. The local app pins the server's certificate f
 
 ## Community
 
-Join us on [Discord](https://discord.gg/Ks9Ghnem) to ask questions, share feedback, and connect with other Claudette users.
+Join us on [Discord](https://discord.gg/aumGBKccmD) to ask questions, share feedback, and connect with other Claudette users.
 
 ## Contributing
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -23,7 +23,7 @@ export default defineConfig({
         {
           icon: 'discord',
           label: 'Discord',
-          href: 'https://discord.gg/Ks9Ghnem',
+          href: 'https://discord.gg/aumGBKccmD',
         },
       ],
       customCss: [

--- a/site/src/components/CTASection.astro
+++ b/site/src/components/CTASection.astro
@@ -7,7 +7,7 @@
   <p>Claudette is free and open source. Download it, try it out, and join the community.</p>
   <div class="cta-buttons">
     <a href="https://github.com/utensils/Claudette/releases" class="cta-btn cta-btn-primary">Download Now</a>
-    <a href="https://discord.gg/Ks9Ghnem" class="cta-btn cta-btn-outline">Join Discord</a>
+    <a href="https://discord.gg/aumGBKccmD" class="cta-btn cta-btn-outline">Join Discord</a>
     <a href="https://github.com/utensils/Claudette" class="cta-btn cta-btn-outline">View Source</a>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- Replace the expired Discord invite link (`discord.gg/Ks9Ghnem`) with the permanent invite (`discord.gg/aumGBKccmD`) across all three locations: README, site navigation bar, and site CTA section.

## Test Steps

1. Open the deployed site and verify the Discord link in the **navigation bar** points to `https://discord.gg/aumGBKccmD`
2. Scroll to the CTA section and verify the **"Join Discord"** button links to `https://discord.gg/aumGBKccmD`
3. Open `README.md` on GitHub and verify the **Community section** Discord link points to `https://discord.gg/aumGBKccmD`
4. Click each link and confirm they resolve to a valid, non-expired Discord invite

## Checklist

- [x] No code changes — link-only update
- [x] All three occurrences updated consistently