### PR TITLE
refactor(sidebar): use Archive icon for archived workspace status

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -313,6 +313,13 @@ export const Sidebar = memo(function Sidebar() {
             {spinnerChar}
           </span>
         ) : (() => {
+          if (ws.status === "Archived") {
+            return (
+              <span className={styles.statusIcon} title="Archived">
+                <Archive size={14} style={{ color: "var(--text-dim)" }} />
+              </span>
+            );
+          }
           const summary = scmSummary[ws.id];
           if (summary?.hasPr) {
             const prState = summary.prState;


### PR DESCRIPTION
## Summary

- Replace `CircleDashed` with `Archive` icon for archived workspaces in the sidebar status indicator
- Creates a clear visual association between the archive action button and the resulting archived state
- Archived status check takes precedence over PR/agent-status icon logic

Closes #325

## Test Steps

1. Run `cargo tauri dev` to start the app
2. Create a workspace and archive it via the sidebar action button
3. Enable "Show archived" in the sidebar filter menu
4. Verify archived workspaces display the Archive (box with down arrow) icon instead of the dashed circle
5. Verify active workspaces still show their normal status icons (spinner, PR state, or dashed circle)

## Checklist

- [x] Tests added/updated (existing 608 frontend tests pass; no new tests needed for icon swap)
- [ ] Documentation updated (if applicable) — N/A