### PR TITLE
fix(metrics): resize heatmap grid row correctly on window maximize

### DIFF
--- a/src/ui/src/components/metrics/primitives/Heatmap.test.tsx
+++ b/src/ui/src/components/metrics/primitives/Heatmap.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { renderToString } from "react-dom/server";
+import { Heatmap } from "./Heatmap";
+
+describe("Heatmap", () => {
+  it("renders an svg with an explicit aspect-ratio matching its viewBox", () => {
+    const html = renderToString(<Heatmap cells={[]} />);
+    const width = 13 * (11 + 2) - 2;
+    const height = 7 * (11 + 2) - 2;
+    expect(html).toContain(`viewBox="0 0 ${width} ${height}"`);
+    expect(html).toMatch(/aspect-ratio:\s*167\s*\/\s*89/);
+  });
+
+  it("propagates aspect-ratio when custom dimensions are supplied", () => {
+    const html = renderToString(
+      <Heatmap cells={[]} weeks={4} days={7} cellSize={10} gap={1} />
+    );
+    const width = 4 * (10 + 1) - 1;
+    const height = 7 * (10 + 1) - 1;
+    expect(html).toContain(`viewBox="0 0 ${width} ${height}"`);
+    expect(html).toMatch(
+      new RegExp(`aspect-ratio:\\s*${width}\\s*/\\s*${height}`)
+    );
+  });
+});

--- a/src/ui/src/components/metrics/primitives/Heatmap.test.tsx
+++ b/src/ui/src/components/metrics/primitives/Heatmap.test.tsx
@@ -8,7 +8,9 @@ describe("Heatmap", () => {
     const width = 13 * (11 + 2) - 2;
     const height = 7 * (11 + 2) - 2;
     expect(html).toContain(`viewBox="0 0 ${width} ${height}"`);
-    expect(html).toMatch(/aspect-ratio:\s*167\s*\/\s*89/);
+    expect(html).toMatch(
+      new RegExp(`aspect-ratio:\\s*${width}\\s*/\\s*${height}`)
+    );
   });
 
   it("propagates aspect-ratio when custom dimensions are supplied", () => {

--- a/src/ui/src/components/metrics/primitives/Heatmap.tsx
+++ b/src/ui/src/components/metrics/primitives/Heatmap.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import styles from "../metrics.module.css";
 import type { HeatmapCell } from "../../../types/metrics";
 
@@ -19,6 +20,24 @@ export function Heatmap({
   const max = cells.reduce((m, c) => (c.count > m ? c.count : m), 0);
   const width = weeks * (cellSize + gap) - gap;
   const height = days * (cellSize + gap) - gap;
+
+  // Pin the SVG to an explicit pixel height derived from its measured width.
+  // `aspect-ratio` alone gives the right *size* but leaves the CSS Grid row
+  // using a stale track height after window resize — an explicit pixel height
+  // provides a concrete intrinsic block-size so the grid row refits cleanly.
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [pxHeight, setPxHeight] = useState<number | null>(null);
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w > 0) setPxHeight((w * height) / width);
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [width, height]);
+
   const lookup = new Map<string, number>();
   for (const c of cells) {
     lookup.set(`${c.week}:${c.dow}`, c.count);
@@ -49,11 +68,16 @@ export function Heatmap({
 
   return (
     <svg
+      ref={svgRef}
       className={styles.svg}
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="xMinYMid meet"
       role="img"
       aria-label="session heatmap"
+      style={{
+        aspectRatio: `${width} / ${height}`,
+        ...(pxHeight !== null ? { height: `${pxHeight}px` } : null),
+      }}
     >
       {rects}
     </svg>


### PR DESCRIPTION
## Summary

- The activity heatmap SVG relied on `width: 100%; height: auto` with a viewBox-derived aspect ratio; Chromium's CSS Grid auto-row algorithm did not re-resolve the width/height dependency on window resize, so the heatmap stayed tiny and left-anchored after maximizing until the user forced a style invalidation via `cmd +/-`.
- Pinned the SVG to an explicit pixel height derived from a `ResizeObserver` measuring its width. Concrete intrinsic block-size lets the grid track algorithm refit the row on every resize. Inline `aspect-ratio` is kept as a first-paint fallback.
- Added `Heatmap.test.tsx` using `react-dom/server` to lock in the `aspect-ratio` + viewBox invariants.

## Verified in the running dev build

| | Pre-max | Post-max (before fix) | Post-max (after fix) |
|---|---|---|---|
| Panel height | 185 | **185** ❌ | **262** ✅ |
| SVG height | 99 | 213 (overflowing) | 213 |
| Overflow below panel | 0 | **+64 px** ❌ | **−13 px** ✅ |
| Needs cmd +/-? | — | yes | **no** |

Measurements captured via the debug eval server before and after a native window maximize.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 621 passing (2 new for Heatmap)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --all-features` — 531 passing
- [x] Manual UAT in `cargo tauri dev`: launch unmaximized, then double-click title bar — heatmap scales and the panel row grows without needing `cmd +/-`.