### PR TITLE
fix(sidebar): prevent filter menu selects from overflowing sidebar

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -5,6 +5,7 @@
 }
 
 .header {
+  position: relative;
   padding: 14px 16px 8px;
   display: flex;
   align-items: center;
@@ -47,10 +48,6 @@
   color: var(--text-muted);
 }
 
-.filterDropdown {
-  position: relative;
-}
-
 .filterToggle {
   background: none;
   border: none;
@@ -72,18 +69,19 @@
 .filterMenu {
   position: absolute;
   top: 100%;
-  right: 0;
+  left: 8px;
+  right: 8px;
   margin-top: 4px;
   background: var(--chat-input-bg);
   border: 1px solid var(--divider);
   border-radius: 8px;
   box-shadow: var(--shadow-md);
-  min-width: 240px;
   z-index: 100;
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  overflow: hidden;
 }
 
 .filterRow {
@@ -102,6 +100,7 @@
 
 .filterSelect {
   flex: 1;
+  min-width: 0;
   background-color: var(--input-bg, var(--hover-bg));
   color: var(--text-primary);
   border: 1px solid var(--divider);


### PR DESCRIPTION
## Summary

- Fix the workspace filter menu's `<select>` elements overflowing past the sidebar's right edge
- Move the menu's CSS containing block from the narrow `.filterDropdown` wrapper to the full-width `.header`, so `left`/`right` insets span the sidebar correctly
- Add `min-width: 0` on `.filterSelect` to override WebKit's intrinsic minimum width for `<select>` elements in flex layouts
- Add `overflow: hidden` on `.filterMenu` as a safety net to clip any residual overflow

## Test Steps

1. Run `cargo tauri dev`
2. Click the filter icon (funnel) in the sidebar header
3. Verify the filter menu (Group by, Repo, Show archived) fits entirely within the sidebar — no selects extending past the right edge
4. Test with a narrow sidebar width (drag the resize handle) to confirm the selects shrink gracefully
5. Change filter values (Group by → Repo, pick a specific repo) to confirm functionality is intact

## Checklist

- [x] Tests added/updated (CSS-only change — 621 frontend tests pass, TypeScript checks pass)
- [ ] Documentation updated (if applicable) — N/A