### PR TITLE
fix(sidebar): remove deleted workspace from sidebar and handle re-delete gracefully

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ cargo fmt --all --check                          # Check formatting
 
 # Frontend (React/TypeScript)
 cd src/ui && bun install                         # Install frontend dependencies
-cd src/ui && bun run build                       # Build frontend for production
-cd src/ui && bunx tsc --noEmit                   # TypeScript type check
+cd src/ui && bun run build                       # Build frontend (runs tsc -b && vite build)
+cd src/ui && bunx tsc -b                         # TypeScript type check (same as CI)
 cd src/ui && bun run test                        # Run frontend tests (vitest)
 cd src/ui && bun run test:watch                  # Run tests in watch mode
 
@@ -29,6 +29,8 @@ cargo tauri build                                # Release build
 ```
 
 IMPORTANT: CI sets `RUSTFLAGS="-Dwarnings"` — all compiler warnings are errors. Fix warnings before committing.
+
+IMPORTANT: Always run `cd src/ui && bunx tsc -b` after modifying TypeScript files (including tests). CI runs `tsc -b` via `bun run build` — `vitest` does **not** type-check (it uses esbuild), so tests can pass locally while types are broken. Run `tsc -b` as the final check before committing any frontend change.
 
 CI also enforces `bun install --frozen-lockfile` — do not modify `bun.lock` without intention. CI runs `cargo llvm-cov` for Rust test coverage (uploaded to Codecov). CI lints only the `claudette` and `claudette-server` crates (not `claudette-tauri`, which requires system libs).
 
@@ -118,7 +120,7 @@ src-server/             — Standalone + embeddable remote server
 ### Testing patterns
 
 - **Rust**: tests use `tempfile::tempdir()` to create ephemeral git repos — no fixtures or test databases. Async tests use `#[tokio::test]`. Test modules live at the bottom of each file (`#[cfg(test)] mod tests`).
-- **TypeScript**: vitest with `describe`/`it`/`expect`. Zustand tests reset state via `useAppStore.setState()` in `beforeEach`. No test database — frontend tests are pure state/logic tests.
+- **TypeScript**: vitest with `describe`/`it`/`expect`. Zustand tests reset state via `useAppStore.setState()` in `beforeEach`. No test database — frontend tests are pure state/logic tests. When constructing fixtures for store state, always read the actual type definition (e.g., `TerminalTab` in `types/terminal.ts`) — do not guess field names. Look for existing `make*` helpers in adjacent test files before creating new fixtures.
 
 ### Notification architecture
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -541,18 +541,14 @@ pub async fn delete_workspace(
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
     let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
-    let ws = workspaces
-        .iter()
-        .find(|w| w.id == id)
-        .ok_or("Workspace not found")?;
+    let Some(ws) = workspaces.iter().find(|w| w.id == id) else {
+        return Ok(());
+    };
 
     let repo_id = ws.repository_id.clone();
 
     let repos = db.list_repositories().map_err(|e| e.to_string())?;
-    let repo = repos
-        .iter()
-        .find(|r| r.id == repo_id)
-        .ok_or("Repository not found")?;
+    let repo = repos.iter().find(|r| r.id == repo_id);
 
     // Stop any running agent and clear session so tray state stays consistent.
     {
@@ -564,13 +560,15 @@ pub async fn delete_workspace(
         }
     }
 
-    // Remove worktree if active.
-    if let Some(ref wt_path) = ws.worktree_path {
-        let _ = git::remove_worktree(&repo.path, wt_path, true).await;
-    }
+    if let Some(repo) = repo {
+        // Remove worktree if active.
+        if let Some(ref wt_path) = ws.worktree_path {
+            let _ = git::remove_worktree(&repo.path, wt_path, true).await;
+        }
 
-    // Best-effort branch delete. Force-deletes even if unmerged commits exist.
-    let _ = git::branch_delete(&repo.path, &ws.branch_name).await;
+        // Best-effort branch delete. Force-deletes even if unmerged commits exist.
+        let _ = git::branch_delete(&repo.path, &ws.branch_name).await;
+    }
 
     // Cascade deletes chat messages and terminal tabs. Materializes a frozen
     // summary row into `deleted_workspace_summaries` in the same transaction so

--- a/src/db.rs
+++ b/src/db.rs
@@ -3465,6 +3465,21 @@ mod tests {
     }
 
     #[test]
+    fn test_delete_workspace_idempotent() {
+        let db = setup_db_with_workspace();
+        db.delete_workspace_with_summary("w1").unwrap();
+        // Second delete of the same workspace must succeed (no-op).
+        db.delete_workspace_with_summary("w1").unwrap();
+        assert_eq!(
+            count_rows(
+                &db,
+                "SELECT COUNT(*) FROM deleted_workspace_summaries WHERE workspace_id = 'w1'"
+            ),
+            1
+        );
+    }
+
+    #[test]
     fn test_archive_leaves_metrics_untouched() {
         let db = setup_db_with_workspace();
         db.insert_agent_session("s1", "w1", "r1").unwrap();

--- a/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
+++ b/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
@@ -17,10 +17,8 @@ export function DeleteWorkspaceModal() {
     setLoading(true);
     try {
       await deleteWorkspace(wsId);
-    } catch {
-      // Backend may fail (already deleted, DB error, etc.). Proceed with
-      // local removal — the user confirmed deletion and the workspace will
-      // reappear on next launch if the DB row actually survived.
+    } catch (e) {
+      console.error("delete_workspace failed, proceeding with local removal:", e);
     }
     removeWorkspace(wsId);
     closeModal();

--- a/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
+++ b/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
@@ -9,7 +9,6 @@ export function DeleteWorkspaceModal() {
   const modalData = useAppStore((s) => s.modalData);
   const removeWorkspace = useAppStore((s) => s.removeWorkspace);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const wsId = modalData.wsId as string;
   const wsName = modalData.wsName as string;
@@ -18,12 +17,13 @@ export function DeleteWorkspaceModal() {
     setLoading(true);
     try {
       await deleteWorkspace(wsId);
-      removeWorkspace(wsId);
-      closeModal();
-    } catch (e) {
-      setError(String(e));
-      setLoading(false);
+    } catch {
+      // Backend may fail (already deleted, DB error, etc.). Proceed with
+      // local removal — the user confirmed deletion and the workspace will
+      // reappear on next launch if the DB row actually survived.
     }
+    removeWorkspace(wsId);
+    closeModal();
   };
 
   return (
@@ -32,7 +32,6 @@ export function DeleteWorkspaceModal() {
         Are you sure you want to delete <strong>{wsName}</strong>? The branch
         and any unmerged commits will be permanently deleted.
       </div>
-      {error && <div className={shared.error}>{error}</div>}
       <div className={shared.actions}>
         <button className={shared.btn} onClick={closeModal}>
           Cancel

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1389,9 +1389,12 @@ describe("removeWorkspace", () => {
       workspaces: [makeWorkspace("ws-a"), makeWorkspace("ws-b")],
       selectedWorkspaceId: "ws-a",
       unreadCompletions: new Set(["ws-a", "ws-b"]),
-      terminalTabs: { "ws-a": [{ id: "t1", label: "shell" }], "ws-b": [{ id: "t2", label: "shell" }] },
-      activeTerminalTabId: { "ws-a": "t1", "ws-b": "t2" },
-      workspaceTerminalCommands: { "ws-a": ["ls"], "ws-b": ["pwd"] },
+      terminalTabs: { "ws-a": [{ id: 1, label: "shell" }], "ws-b": [{ id: 2, label: "shell" }] },
+      activeTerminalTabId: { "ws-a": 1, "ws-b": 2 },
+      workspaceTerminalCommands: {
+        "ws-a": { command: "ls", isRunning: false, exitCode: 0 },
+        "ws-b": { command: "pwd", isRunning: false, exitCode: 0 },
+      },
     });
   });
 

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -3,6 +3,7 @@ import { useAppStore } from "./useAppStore";
 import type { AgentQuestion } from "./useAppStore";
 import type { ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
+import type { Workspace } from "../types/workspace";
 import { applyPlanModeMountDefault } from "../components/chat/applyPlanModeMountDefault";
 
 const WS_ID = "test-workspace";
@@ -1364,5 +1365,65 @@ describe("selectWorkspace clears unreadCompletions", () => {
     useAppStore.getState().selectWorkspace(null);
     expect(useAppStore.getState().unreadCompletions.has("ws-a")).toBe(true);
     expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
+  });
+});
+
+function makeWorkspace(id: string, repoId: string = "r1"): Workspace {
+  return {
+    id,
+    repository_id: repoId,
+    name: `ws-${id}`,
+    branch_name: `branch-${id}`,
+    worktree_path: null,
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "2026-01-01T00:00:00Z",
+    remote_connection_id: null,
+  };
+}
+
+describe("removeWorkspace", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      workspaces: [makeWorkspace("ws-a"), makeWorkspace("ws-b")],
+      selectedWorkspaceId: "ws-a",
+      unreadCompletions: new Set(["ws-a", "ws-b"]),
+      terminalTabs: { "ws-a": [{ id: "t1", label: "shell" }], "ws-b": [{ id: "t2", label: "shell" }] },
+      activeTerminalTabId: { "ws-a": "t1", "ws-b": "t2" },
+      workspaceTerminalCommands: { "ws-a": ["ls"], "ws-b": ["pwd"] },
+    });
+  });
+
+  it("filters the workspace out of the array", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    const ids = useAppStore.getState().workspaces.map((w) => w.id);
+    expect(ids).toEqual(["ws-b"]);
+  });
+
+  it("clears selectedWorkspaceId when the selected workspace is removed", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
+  });
+
+  it("leaves selectedWorkspaceId unchanged when a different workspace is removed", () => {
+    useAppStore.getState().removeWorkspace("ws-b");
+    expect(useAppStore.getState().selectedWorkspaceId).toBe("ws-a");
+  });
+
+  it("cleans up per-workspace terminal state", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    const s = useAppStore.getState();
+    expect(s.terminalTabs["ws-a"]).toBeUndefined();
+    expect(s.activeTerminalTabId["ws-a"]).toBeUndefined();
+    expect(s.workspaceTerminalCommands["ws-a"]).toBeUndefined();
+    // Other workspace's state is untouched.
+    expect(s.terminalTabs["ws-b"]).toBeDefined();
+  });
+
+  it("removes workspace from unreadCompletions", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    expect(useAppStore.getState().unreadCompletions.has("ws-a")).toBe(false);
+    expect(useAppStore.getState().unreadCompletions.has("ws-b")).toBe(true);
   });
 });

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1389,7 +1389,10 @@ describe("removeWorkspace", () => {
       workspaces: [makeWorkspace("ws-a"), makeWorkspace("ws-b")],
       selectedWorkspaceId: "ws-a",
       unreadCompletions: new Set(["ws-a", "ws-b"]),
-      terminalTabs: { "ws-a": [{ id: 1, label: "shell" }], "ws-b": [{ id: 2, label: "shell" }] },
+      terminalTabs: {
+        "ws-a": [{ id: 1, workspace_id: "ws-a", title: "shell", is_script_output: false, sort_order: 1, created_at: "" }],
+        "ws-b": [{ id: 2, workspace_id: "ws-b", title: "shell", is_script_output: false, sort_order: 1, created_at: "" }],
+      },
       activeTerminalTabId: { "ws-a": 1, "ws-b": 2 },
       workspaceTerminalCommands: {
         "ws-a": { command: "ls", isRunning: false, exitCode: 0 },


### PR DESCRIPTION
## Summary

Fixes a bug where deleted workspaces persist in the sidebar and show a "Workspace not found" error when re-deleted.

- **Backend**: Make `delete_workspace` idempotent — return `Ok(())` if the workspace is already gone instead of erroring. Also handle missing repository gracefully by skipping git cleanup while still performing DB, agent, and tray cleanup.
- **Frontend**: Always remove the workspace from the Zustand store after the user confirms deletion, regardless of backend errors. The user's intent is unambiguous and the store is ephemeral (rebuilt from DB on launch).

Closes #374

## Complexity Notes

The backend change makes the repository lookup non-fatal (`find` returns `Option` instead of `ok_or`). Git operations (worktree removal, branch deletion) are conditionally skipped when the repo is missing, but DB cascade, agent cleanup, MCP supervisor cleanup, and tray rebuild still run. This handles the edge case where a workspace exists but its parent repository was already deleted.

## Test Steps

1. Create a workspace, then delete it → it should immediately disappear from the sidebar
2. Verify no "Workspace not found" errors appear in any scenario
3. Run `cargo test -p claudette -- test_delete_workspace_idempotent` → passes (DB-level idempotency)
4. Run `cd src/ui && bun run test` → all tests pass including new `removeWorkspace` store tests

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)