### PR TITLE
feat: persist SCM status to SQLite for instant display on app reload

### DIFF
--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -18,6 +18,7 @@ pub struct InitialData {
     pub default_branches: HashMap<String, String>,
     /// Most recent chat message per workspace (for dashboard display).
     pub last_messages: Vec<ChatMessage>,
+    pub scm_cache: Vec<claudette::db::ScmStatusCacheRow>,
 }
 
 #[tauri::command]
@@ -158,6 +159,7 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         .collect();
 
     let last_messages = db.last_message_per_workspace().map_err(|e| e.to_string())?;
+    let scm_cache = db.load_all_scm_status_cache().unwrap_or_default();
 
     Ok(InitialData {
         repositories,
@@ -165,5 +167,6 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         worktree_base_dir,
         default_branches,
         last_messages,
+        scm_cache,
     })
 }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -159,7 +159,7 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         .collect();
 
     let last_messages = db.last_message_per_workspace().map_err(|e| e.to_string())?;
-    let scm_cache = db.load_all_scm_status_cache().unwrap_or_default();
+    let scm_cache = db.load_all_scm_status_cache().map_err(|e| e.to_string())?;
 
     Ok(InitialData {
         repositories,

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -173,6 +173,11 @@ pub async fn load_scm_detail(
     {
         Some(name) => name,
         None => {
+            // Clear any stale cache row so old badges don't persist across restarts
+            // when the provider is no longer available (e.g. plugin removed).
+            if let Ok(db) = Database::open(&state.db_path) {
+                let _ = db.delete_scm_status_cache(&workspace_id);
+            }
             return Ok(ScmDetail {
                 workspace_id,
                 pull_request: None,
@@ -479,13 +484,24 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
         .await
         .ok()?;
 
-    let provider_name = resolve_provider_for_polling(
+    let provider_name = match resolve_provider_for_polling(
         &ctx.manual_override,
         &ctx.repo.path,
         ctx.repo.default_remote.as_deref(),
         app_state,
     )
-    .await?;
+    .await
+    {
+        Some(name) => name,
+        None => {
+            // Clear any stale cache row so old badges don't persist across restarts
+            // when the provider is no longer available (e.g. plugin removed).
+            if let Ok(db) = Database::open(&app_state.db_path) {
+                let _ = db.delete_scm_status_cache(workspace_id);
+            }
+            return None;
+        }
+    };
 
     let ws_info = make_workspace_info(&ctx.workspace, &ctx.repo);
     let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -80,6 +80,7 @@ async fn lookup_workspace_context(
     {
         if let Ok(db) = Database::open(db_path) {
             let _ = db.update_workspace_branch_name(&ctx.workspace.id, &actual);
+            let _ = db.delete_scm_status_cache(&ctx.workspace.id);
         }
         ctx.workspace.branch_name = actual;
     }
@@ -257,7 +258,7 @@ pub async fn load_scm_detail(
         let cached_error = error.clone();
         let mut cache = state.scm_cache.entries.write().await;
         cache.insert(
-            cache_key,
+            cache_key.clone(),
             ScmCacheEntry {
                 pull_request: pull_request.clone(),
                 ci_checks: ci_checks.clone(),
@@ -265,6 +266,22 @@ pub async fn load_scm_detail(
                 error: cached_error,
             },
         );
+    }
+
+    // Persist to SQLite for instant display on next app launch.
+    {
+        if let Ok(db) = Database::open(&state.db_path) {
+            let _ = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
+                workspace_id: workspace_id.clone(),
+                repo_id: cache_key.0.clone(),
+                branch_name: cache_key.1.clone(),
+                provider: Some(provider_name.clone()),
+                pr_json: serde_json::to_string(&pull_request).ok(),
+                ci_json: serde_json::to_string(&ci_checks).ok(),
+                error: error.clone(),
+                fetched_at: String::new(),
+            });
+        }
     }
 
     Ok(ScmDetail {
@@ -321,6 +338,9 @@ pub async fn scm_create_pr(
     // Invalidate cache
     let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
     state.scm_cache.entries.write().await.remove(&cache_key);
+    if let Ok(db) = Database::open(&state.db_path) {
+        let _ = db.delete_scm_status_cache(&workspace_id);
+    }
 
     serde_json::from_value(result).map_err(|e| e.to_string())
 }
@@ -361,6 +381,9 @@ pub async fn scm_merge_pr(
     // Invalidate cache
     let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
     state.scm_cache.entries.write().await.remove(&cache_key);
+    if let Ok(db) = Database::open(&state.db_path) {
+        let _ = db.delete_scm_status_cache(&workspace_id);
+    }
 
     Ok(result)
 }
@@ -374,6 +397,9 @@ pub async fn scm_refresh(
     let ctx = lookup_workspace_context(&state.db_path, &workspace_id).await?;
     let cache_key = (ctx.repo.id, ctx.workspace.branch_name);
     state.scm_cache.entries.write().await.remove(&cache_key);
+    if let Ok(db) = Database::open(&state.db_path) {
+        let _ = db.delete_scm_status_cache(&workspace_id);
+    }
 
     load_scm_detail(workspace_id, state).await
 }
@@ -521,7 +547,7 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
         let cached_error = error.clone();
         let mut cache = app_state.scm_cache.entries.write().await;
         cache.insert(
-            cache_key,
+            cache_key.clone(),
             ScmCacheEntry {
                 pull_request: pull_request.clone(),
                 ci_checks: ci_checks.clone(),
@@ -529,6 +555,22 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
                 error: cached_error,
             },
         );
+    }
+
+    // Persist to SQLite for instant display on next app launch.
+    {
+        if let Ok(db) = Database::open(&app_state.db_path) {
+            let _ = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
+                workspace_id: workspace_id.to_string(),
+                repo_id: cache_key.0.clone(),
+                branch_name: cache_key.1.clone(),
+                provider: Some(provider_name.clone()),
+                pr_json: serde_json::to_string(&pull_request).ok(),
+                ci_json: serde_json::to_string(&ci_checks).ok(),
+                error: error.clone(),
+                fetched_at: String::new(),
+            });
+        }
     }
 
     Some(ScmDetail {
@@ -685,6 +727,7 @@ async fn auto_archive_workspace(
 
         // Update DB status
         let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
+        let _ = db.delete_scm_status_cache(workspace_id);
         let _ = db.update_workspace_status(
             workspace_id,
             &claudette::model::WorkspaceStatus::Archived,

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -270,17 +270,26 @@ pub async fn load_scm_detail(
 
     // Persist to SQLite for instant display on next app launch.
     {
-        if let Ok(db) = Database::open(&state.db_path) {
-            let _ = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
-                workspace_id: workspace_id.clone(),
-                repo_id: cache_key.0.clone(),
-                branch_name: cache_key.1.clone(),
-                provider: Some(provider_name.clone()),
-                pr_json: serde_json::to_string(&pull_request).ok(),
-                ci_json: serde_json::to_string(&ci_checks).ok(),
-                error: error.clone(),
-                fetched_at: String::new(),
-            });
+        match Database::open(&state.db_path) {
+            Ok(db) => {
+                if let Err(e) = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
+                    workspace_id: workspace_id.clone(),
+                    repo_id: cache_key.0.clone(),
+                    branch_name: cache_key.1.clone(),
+                    provider: Some(provider_name.clone()),
+                    pr_json: serde_json::to_string(&pull_request).ok(),
+                    ci_json: serde_json::to_string(&ci_checks).ok(),
+                    error: error.clone(),
+                    fetched_at: String::new(),
+                }) {
+                    eprintln!(
+                        "[scm] Failed to persist SCM cache for workspace {workspace_id}: {e}"
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("[scm] Failed to open DB for SCM cache persistence: {e}");
+            }
         }
     }
 
@@ -559,17 +568,26 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
 
     // Persist to SQLite for instant display on next app launch.
     {
-        if let Ok(db) = Database::open(&app_state.db_path) {
-            let _ = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
-                workspace_id: workspace_id.to_string(),
-                repo_id: cache_key.0.clone(),
-                branch_name: cache_key.1.clone(),
-                provider: Some(provider_name.clone()),
-                pr_json: serde_json::to_string(&pull_request).ok(),
-                ci_json: serde_json::to_string(&ci_checks).ok(),
-                error: error.clone(),
-                fetched_at: String::new(),
-            });
+        match Database::open(&app_state.db_path) {
+            Ok(db) => {
+                if let Err(e) = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
+                    workspace_id: workspace_id.to_string(),
+                    repo_id: cache_key.0.clone(),
+                    branch_name: cache_key.1.clone(),
+                    provider: Some(provider_name.clone()),
+                    pr_json: serde_json::to_string(&pull_request).ok(),
+                    ci_json: serde_json::to_string(&ci_checks).ok(),
+                    error: error.clone(),
+                    fetched_at: String::new(),
+                }) {
+                    eprintln!(
+                        "[scm] Failed to persist SCM cache for workspace {workspace_id}: {e}"
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("[scm] Failed to open DB for SCM cache persistence: {e}");
+            }
         }
     }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -487,6 +487,7 @@ pub async fn archive_workspace(
 
     db.delete_terminal_tabs_for_workspace(&id)
         .map_err(|e| e.to_string())?;
+    let _ = db.delete_scm_status_cache(&id);
     db.update_workspace_status(&id, &WorkspaceStatus::Archived, None)
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -487,7 +487,7 @@ pub async fn archive_workspace(
 
     db.delete_terminal_tabs_for_workspace(&id)
         .map_err(|e| e.to_string())?;
-    let _ = db.delete_scm_status_cache(&id);
+    db.delete_scm_status_cache(&id).map_err(|e| e.to_string())?;
     db.update_workspace_status(&id, &WorkspaceStatus::Archived, None)
         .map_err(|e| e.to_string())?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1783,6 +1783,7 @@ impl Database {
 
     // --- SCM Status Cache ---
 
+    /// `row.fetched_at` is ignored; the database sets it to `datetime('now')` on every upsert.
     pub fn upsert_scm_status_cache(&self, row: &ScmStatusCacheRow) -> Result<(), rusqlite::Error> {
         self.conn.execute(
             "INSERT OR REPLACE INTO scm_status_cache

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,6 +26,19 @@ fn row_to_attachment(row: &rusqlite::Row) -> rusqlite::Result<Attachment> {
     })
 }
 
+/// Persisted SCM status for a workspace, loaded on app startup for instant display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScmStatusCacheRow {
+    pub workspace_id: String,
+    pub repo_id: String,
+    pub branch_name: String,
+    pub provider: Option<String>,
+    pub pr_json: Option<String>,
+    pub ci_json: Option<String>,
+    pub error: Option<String>,
+    pub fetched_at: String,
+}
+
 /// A saved MCP server configuration for a repository.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepositoryMcpServer {
@@ -1764,6 +1777,54 @@ impl Database {
         self.conn.execute(
             "UPDATE repository_mcp_servers SET enabled = ?1 WHERE id = ?2",
             params![enabled as i32, id],
+        )?;
+        Ok(())
+    }
+
+    // --- SCM Status Cache ---
+
+    pub fn upsert_scm_status_cache(&self, row: &ScmStatusCacheRow) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO scm_status_cache
+                (workspace_id, repo_id, branch_name, provider, pr_json, ci_json, error, fetched_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, datetime('now'))",
+            params![
+                row.workspace_id,
+                row.repo_id,
+                row.branch_name,
+                row.provider,
+                row.pr_json,
+                row.ci_json,
+                row.error
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn load_all_scm_status_cache(&self) -> Result<Vec<ScmStatusCacheRow>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT workspace_id, repo_id, branch_name, provider, pr_json, ci_json, error, fetched_at
+             FROM scm_status_cache",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ScmStatusCacheRow {
+                workspace_id: row.get(0)?,
+                repo_id: row.get(1)?,
+                branch_name: row.get(2)?,
+                provider: row.get(3)?,
+                pr_json: row.get(4)?,
+                ci_json: row.get(5)?,
+                error: row.get(6)?,
+                fetched_at: row.get(7)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn delete_scm_status_cache(&self, workspace_id: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM scm_status_cache WHERE workspace_id = ?1",
+            params![workspace_id],
         )?;
         Ok(())
     }
@@ -3600,6 +3661,24 @@ mod tests {
         }
     }
 
+    fn make_scm_cache(
+        workspace_id: &str,
+        repo_id: &str,
+        branch: &str,
+        pr_json: Option<&str>,
+    ) -> ScmStatusCacheRow {
+        ScmStatusCacheRow {
+            workspace_id: workspace_id.into(),
+            repo_id: repo_id.into(),
+            branch_name: branch.into(),
+            provider: Some("github".into()),
+            pr_json: pr_json.map(Into::into),
+            ci_json: Some("[]".into()),
+            error: None,
+            fetched_at: String::new(),
+        }
+    }
+
     #[test]
     fn test_migrations_timestamp_prefix_format() {
         for m in MIGRATIONS {
@@ -3731,5 +3810,85 @@ mod tests {
             !present,
             "failed migration must not leave tracking row in schema_migrations",
         );
+    }
+
+    #[test]
+    fn test_upsert_scm_status_cache() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+
+        let pr = r#"{"number":1,"title":"Fix","state":"open","url":"","author":"me","branch":"fix-bug","base":"main","draft":false,"ci_status":null}"#;
+        db.upsert_scm_status_cache(&make_scm_cache("w1", "r1", "fix-bug", Some(pr)))
+            .unwrap();
+
+        let rows = db.load_all_scm_status_cache().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].workspace_id, "w1");
+        assert_eq!(rows[0].provider, Some("github".into()));
+        assert!(rows[0].pr_json.is_some());
+        assert!(rows[0].error.is_none());
+
+        // Upsert same workspace — should replace, not duplicate.
+        db.upsert_scm_status_cache(&make_scm_cache("w1", "r1", "fix-bug", Some("null")))
+            .unwrap();
+        let rows = db.load_all_scm_status_cache().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pr_json, Some("null".into()));
+    }
+
+    #[test]
+    fn test_scm_status_cache_cascade_delete() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db.upsert_scm_status_cache(&make_scm_cache("w1", "r1", "fix-bug", Some("null")))
+            .unwrap();
+
+        db.delete_workspace("w1").unwrap();
+        let rows = db.load_all_scm_status_cache().unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn test_delete_scm_status_cache() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db.upsert_scm_status_cache(&make_scm_cache("w1", "r1", "fix-bug", Some("null")))
+            .unwrap();
+
+        db.delete_scm_status_cache("w1").unwrap();
+        let rows = db.load_all_scm_status_cache().unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn test_scm_status_cache_nullable_pr() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+
+        // NULL pr_json = never fetched
+        db.upsert_scm_status_cache(&make_scm_cache("w1", "r1", "fix-bug", None))
+            .unwrap();
+        let rows = db.load_all_scm_status_cache().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].pr_json.is_none());
+
+        // "null" string pr_json = fetched, no PR found
+        db.upsert_scm_status_cache(&make_scm_cache("w1", "r1", "fix-bug", Some("null")))
+            .unwrap();
+        let rows = db.load_all_scm_status_cache().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].pr_json, Some("null".into()));
     }
 }

--- a/src/migrations/20260423190000_scm_status_cache.sql
+++ b/src/migrations/20260423190000_scm_status_cache.sql
@@ -1,0 +1,10 @@
+CREATE TABLE scm_status_cache (
+    workspace_id  TEXT PRIMARY KEY REFERENCES workspaces(id) ON DELETE CASCADE,
+    repo_id       TEXT NOT NULL,
+    branch_name   TEXT NOT NULL,
+    provider      TEXT,
+    pr_json       TEXT,
+    ci_json       TEXT,
+    error         TEXT,
+    fetched_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -139,4 +139,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260423000001_repository_base_branch_and_default_remote.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260423190000_scm_status_cache",
+        sql: include_str!("20260423190000_scm_status_cache.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -51,6 +51,21 @@ function App() {
         msgMap[msg.workspace_id] = msg;
       }
       setLastMessages(msgMap);
+      // Hydrate SCM summaries from persisted cache for instant sidebar display.
+      for (const row of data.scm_cache) {
+        if (row.pr_json == null) continue;
+        try {
+          const pr: import("./types/plugin").PullRequest | null = JSON.parse(row.pr_json);
+          useAppStore.getState().setScmSummary(row.workspace_id, {
+            hasPr: pr !== null,
+            prState: pr?.state ?? null,
+            ciState: pr?.ci_status ?? null,
+            lastUpdated: new Date(row.fetched_at + "Z").getTime(),
+          });
+        } catch {
+          // Corrupted cache entry — skip silently, will be refreshed by polling.
+        }
+      }
     });
     getAppSetting("terminal_font_size")
       .then((val) => {

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -55,7 +55,16 @@ function App() {
       for (const row of data.scm_cache) {
         if (row.pr_json == null) continue;
         try {
-          const pr: import("./types/plugin").PullRequest | null = JSON.parse(row.pr_json);
+          const parsed: unknown = JSON.parse(row.pr_json);
+          const pr =
+            parsed !== null &&
+            typeof parsed === "object" &&
+            "number" in parsed &&
+            typeof (parsed as { number: unknown }).number === "number" &&
+            "state" in parsed &&
+            typeof (parsed as { state: unknown }).state === "string"
+              ? (parsed as import("./types/plugin").PullRequest)
+              : null;
           useAppStore.getState().setScmSummary(row.workspace_id, {
             hasPr: pr !== null,
             prState: pr?.state ?? null,

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -60,7 +60,7 @@ function App() {
             hasPr: pr !== null,
             prState: pr?.state ?? null,
             ciState: pr?.ci_status ?? null,
-            lastUpdated: new Date(row.fetched_at + "Z").getTime(),
+            lastUpdated: new Date(row.fetched_at.replace(" ", "T") + "Z").getTime(),
           });
         } catch {
           // Corrupted cache entry — skip silently, will be refreshed by polling.

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -42,6 +42,7 @@ export interface InitialData {
   worktree_base_dir: string;
   default_branches: Record<string, string>;
   last_messages: ChatMessage[];
+  scm_cache: ScmStatusCacheRow[];
 }
 
 export function loadInitialData(): Promise<InitialData> {
@@ -883,7 +884,7 @@ export function getAnalyticsMetrics(): Promise<AnalyticsMetrics> {
 
 // -- SCM Plugins --
 
-import type { PluginInfo, ScmDetail, PullRequest } from "../types/plugin";
+import type { PluginInfo, ScmDetail, PullRequest, ScmStatusCacheRow } from "../types/plugin";
 
 export function listScmProviders(): Promise<PluginInfo[]> {
   return invoke("list_scm_providers");

--- a/src/ui/src/types/plugin.ts
+++ b/src/ui/src/types/plugin.ts
@@ -41,3 +41,14 @@ export interface ScmSummary {
   ciState: "success" | "failure" | "pending" | null;
   lastUpdated: number;
 }
+
+export interface ScmStatusCacheRow {
+  workspace_id: string;
+  repo_id: string;
+  branch_name: string;
+  provider: string | null;
+  pr_json: string | null;
+  ci_json: string | null;
+  error: string | null;
+  fetched_at: string;
+}


### PR DESCRIPTION
## Summary

- Add `scm_status_cache` SQLite table (migration 25) to persist the last-known PR/CI status for each workspace, keyed by `workspace_id` with `ON DELETE CASCADE`
- Extend `load_initial_data` to return cached SCM data on startup so the sidebar renders PR badges immediately — no more 2-4s blank status while the background poller re-fetches from gh/glab CLI
- Write-through: every successful SCM fetch (both on-demand `load_scm_detail` and the 30s polling loop) upserts the result into SQLite alongside the existing in-memory cache

```mermaid
sequenceDiagram
    participant App as App Startup
    participant DB as SQLite
    participant Store as Zustand Store
    participant Sidebar as Sidebar UI
    participant Poller as SCM Poller (30s)
    participant CLI as gh/glab CLI

    App->>DB: load_initial_data (includes scm_status_cache)
    DB-->>App: cached PR/CI status per workspace
    App->>Store: setScmSummary() for each cached row
    Store-->>Sidebar: PR badges render immediately ✓
    Note over Poller: 5s delay, then every 30s
    Poller->>CLI: list_pull_requests + ci_status
    CLI-->>Poller: fresh data
    Poller->>DB: upsert_scm_status_cache (write-through)
    Poller->>Store: emit scm-data-updated event
    Store-->>Sidebar: badges update if data changed
```

### Cache invalidation

| Trigger | SQLite | In-memory |
|---|---|---|
| Workspace hard-delete | `ON DELETE CASCADE` (automatic) | Already handled |
| Workspace archive | `delete_scm_status_cache()` | Already handled |
| Auto-archive on PR merge | `delete_scm_status_cache()` | Already handled |
| Branch switch detected | `delete_scm_status_cache()` | Old key dropped, new key on next fetch |
| PR create / PR merge | `delete_scm_status_cache()` | Already handled |
| Force refresh | `delete_scm_status_cache()` | Already handled |

## Complexity Notes

- The `upsert_scm_status_cache` method takes `&ScmStatusCacheRow` (a struct) rather than individual args to stay within clippy's 7-argument limit. The `fetched_at` field in the struct is ignored by the SQL — `datetime('now')` is always used server-side.
- Stale JSON: if `PullRequest`/`CiCheck` structs gain new fields in the future, old cached JSON will fail to deserialize on the frontend. The hydration code has a `try/catch` that silently skips corrupted rows; the next poll cycle will overwrite them with fresh data.

## Test Steps

1. Run `cargo test --all-features` — all 535 tests pass (4 new SCM cache tests)
2. Run `cd src/ui && bun run test` — all 553 frontend tests pass
3. Run `cargo clippy -p claudette -p claudette-server --all-targets` — zero warnings
4. Run `cd src/ui && bunx tsc --noEmit` — clean
5. **Manual E2E**: Launch dev app → observe workspaces with PR badges → quit → relaunch → verify badges appear immediately (before first poll cycle at ~5s)

## Checklist

- [x] Tests added/updated (4 new unit tests for SCM cache CRUD + cascade)
- [ ] Documentation updated — N/A (internal implementation detail)

Closes #302