### PR TITLE
feat(windows): native Windows support + CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,71 @@ jobs:
       - run: bun run lint:css
       - run: bun run build
       - run: bun run test
+
+  # Native Windows build check on both supported targets. We compile the
+  # full workspace (including the Tauri bin, which pulls in WebView2 +
+  # Win32 APIs) and run the library tests so Windows-specific code paths
+  # — process/PTY spawning, verbatim-path handling, registry PATH reads —
+  # are exercised on a real Windows host. The matrix runs on first-party
+  # GitHub runners; `windows-11-arm` is GA and ships a native ARM64
+  # MSVC toolchain so this is a native build, not cross-compilation.
+  windows-check:
+    name: Windows Check (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            label: x86_64
+          - platform: windows-11-arm
+            rust-target: aarch64-pc-windows-msvc
+            label: aarch64
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+          targets: ${{ matrix.rust-target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-${{ matrix.label }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "latest"
+
+      - name: Install frontend dependencies
+        shell: bash
+        run: cd src/ui && bun install --frozen-lockfile
+
+      # `tauri::generate_context!()` checks that `frontendDist` exists at
+      # compile time, and the release build actually embeds the files,
+      # so we need a built frontend before any `cargo` command that
+      # touches claudette-tauri.
+      - name: Build frontend
+        shell: bash
+        run: cd src/ui && bun run build
+
+      - name: Generate icons
+        shell: bash
+        run: npx @tauri-apps/cli icon assets/logo.png
+
+      - name: cargo check (full workspace)
+        shell: bash
+        run: cargo check --workspace --target ${{ matrix.rust-target }}
+
+      # Release-mode build of just the Tauri bin, so the asset-embedding
+      # path (tauri_build + custom-protocol) is exercised on Windows.
+      # Without this the check job can miss regressions that only fire
+      # under the release profile or the embedded-frontend codegen.
+      - name: cargo build --release (claudette-tauri)
+        shell: bash
+        run: cargo build --release -p claudette-tauri --features tauri/custom-protocol --target ${{ matrix.rust-target }}
+
+      - name: cargo test (library crates)
+        shell: bash
+        run: cargo test -p claudette -p claudette-server --target ${{ matrix.rust-target }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,6 +116,19 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             bundles: appimage,deb
             label: linux-x86_64
+          # Windows ships bare `.exe` assets only (no MSI/NSIS bundle).
+          # The tauri-action step is skipped on Windows and we drive
+          # cargo directly against the native MSVC toolchain baked into
+          # GitHub's Windows runners. `windows-11-arm` is GA and native,
+          # so ARM64 builds aren't cross-compiled.
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            bundles: ""
+            label: windows-x86_64
+          - platform: windows-11-arm
+            rust-target: aarch64-pc-windows-msvc
+            bundles: ""
+            label: windows-aarch64
 
     name: Build (${{ matrix.label }})
     runs-on: ${{ matrix.platform }}
@@ -164,12 +177,16 @@ jobs:
           bun-version: "latest"
 
       - name: Install frontend dependencies
+        shell: bash
         run: cd src/ui && bun install --frozen-lockfile
 
       - name: Generate icons
+        shell: bash
         run: npx @tauri-apps/cli icon assets/logo.png
 
-      - name: Build and upload desktop app
+      # ---- macOS + Linux: tauri-action drives the bundled build ------------
+      - name: Build and upload desktop app (non-Windows)
+        if: ${{ !startsWith(matrix.platform, 'windows') }}
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -188,16 +205,65 @@ jobs:
           prerelease: true
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
+      # ---- Windows: direct cargo build, ship the bare .exe -----------------
+      # `custom-protocol` is the feature flag that tells tauri-build to
+      # embed `frontendDist` (otherwise the release binary tries to
+      # contact the devUrl at startup and shows "localhost refused to
+      # connect"). `tauri-action` sets this automatically via
+      # `cargo tauri build`; since we're bypassing it on Windows, we
+      # pass the flag explicitly.
+      - name: Build desktop exe (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        run: |
+          cd src/ui && bun run build && cd ../..
+          cargo build --release -p claudette-tauri \
+            --features tauri/custom-protocol \
+            --target ${{ matrix.rust-target }}
+
+      # Zip the bare .exe before upload. Raw unsigned .exe downloads
+      # trigger aggressive SmartScreen + browser warnings ("file not
+      # commonly downloaded / could harm your device"); shipping inside
+      # a .zip is the customary Windows distribution shape and keeps
+      # Mark-of-the-Web attached to the archive rather than the binary.
+      # `Compress-Archive` is a built-in PowerShell cmdlet on every
+      # Windows runner — no external deps.
+      - name: Upload desktop exe (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BIN="target/${{ matrix.rust-target }}/release/claudette.exe"
+          ASSET="claudette-${{ matrix.label }}.zip"
+          cp "$BIN" claudette.exe
+          powershell -NoProfile -Command "Compress-Archive -Path 'claudette.exe' -DestinationPath '$ASSET' -Force"
+          gh release upload nightly "$ASSET" --clobber
+
       - name: Build headless server
+        shell: bash
         run: cargo build --release -p claudette-server --target ${{ matrix.rust-target }}
 
-      - name: Upload headless server binary
+      - name: Upload headless server binary (non-Windows)
+        if: ${{ !startsWith(matrix.platform, 'windows') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BIN="target/${{ matrix.rust-target }}/release/claudette-server"
           ASSET="claudette-server-${{ matrix.label }}"
           cp "$BIN" "$ASSET"
+          gh release upload nightly "$ASSET" --clobber
+
+      - name: Upload headless server binary (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BIN="target/${{ matrix.rust-target }}/release/claudette-server.exe"
+          ASSET="claudette-server-${{ matrix.label }}.zip"
+          cp "$BIN" claudette-server.exe
+          powershell -NoProfile -Command "Compress-Archive -Path 'claudette-server.exe' -DestinationPath '$ASSET' -Force"
           gh release upload nightly "$ASSET" --clobber
 
   # Nightly builds are not announced to Discord — too noisy. Stable releases only.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,6 +78,19 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             bundles: appimage,deb
             label: linux-x86_64
+          # Windows ships bare `.exe` assets only (no MSI/NSIS bundle).
+          # The tauri-action step is skipped on Windows and we drive
+          # cargo directly against the native MSVC toolchain baked into
+          # GitHub's Windows runners. `windows-11-arm` is GA and native,
+          # so ARM64 builds aren't cross-compiled.
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            bundles: ""
+            label: windows-x86_64
+          - platform: windows-11-arm
+            rust-target: aarch64-pc-windows-msvc
+            bundles: ""
+            label: windows-aarch64
 
     name: Build (${{ matrix.label }})
     runs-on: ${{ matrix.platform }}
@@ -118,12 +131,16 @@ jobs:
           bun-version: "latest"
 
       - name: Install frontend dependencies
+        shell: bash
         run: cd src/ui && bun install --frozen-lockfile
 
       - name: Generate icons
+        shell: bash
         run: npx @tauri-apps/cli icon assets/logo.png
 
-      - name: Build and upload desktop app
+      # ---- macOS + Linux: tauri-action drives the bundled build ------------
+      - name: Build and upload desktop app (non-Windows)
+        if: ${{ !startsWith(matrix.platform, 'windows') }}
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -141,16 +158,65 @@ jobs:
           releaseDraft: true
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
+      # ---- Windows: direct cargo build, ship the bare .exe -----------------
+      # `custom-protocol` is the feature flag that tells tauri-build to
+      # embed `frontendDist` (otherwise the release binary tries to
+      # contact the devUrl at startup and shows "localhost refused to
+      # connect"). `tauri-action` sets this automatically via
+      # `cargo tauri build`; since we're bypassing it on Windows, we
+      # pass the flag explicitly.
+      - name: Build desktop exe (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        run: |
+          cd src/ui && bun run build && cd ../..
+          cargo build --release -p claudette-tauri \
+            --features tauri/custom-protocol \
+            --target ${{ matrix.rust-target }}
+
+      # Zip the bare .exe before upload. Raw unsigned .exe downloads
+      # trigger aggressive SmartScreen + browser warnings ("file not
+      # commonly downloaded / could harm your device"); shipping inside
+      # a .zip is the customary Windows distribution shape and keeps
+      # Mark-of-the-Web attached to the archive rather than the binary.
+      # `Compress-Archive` is a built-in PowerShell cmdlet on every
+      # Windows runner — no external deps.
+      - name: Upload desktop exe (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BIN="target/${{ matrix.rust-target }}/release/claudette.exe"
+          ASSET="claudette-${{ matrix.label }}.zip"
+          cp "$BIN" claudette.exe
+          powershell -NoProfile -Command "Compress-Archive -Path 'claudette.exe' -DestinationPath '$ASSET' -Force"
+          gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
+
       - name: Build headless server
+        shell: bash
         run: cargo build --release -p claudette-server --target ${{ matrix.rust-target }}
 
-      - name: Upload headless server binary
+      - name: Upload headless server binary (non-Windows)
+        if: ${{ !startsWith(matrix.platform, 'windows') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BIN="target/${{ matrix.rust-target }}/release/claudette-server"
           ASSET="claudette-server-${{ matrix.label }}"
           cp "$BIN" "$ASSET"
+          gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
+
+      - name: Upload headless server binary (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BIN="target/${{ matrix.rust-target }}/release/claudette-server.exe"
+          ASSET="claudette-server-${{ matrix.label }}.zip"
+          cp "$BIN" claudette-server.exe
+          powershell -NoProfile -Command "Compress-Archive -Path 'claudette-server.exe' -DestinationPath '$ASSET' -Force"
           gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
 
   publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "url",
  "uuid",
  "which",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,12 @@ rand = "0.8"
 sha2 = "0.10"
 tar = "0.4"
 
+[target.'cfg(windows)'.dependencies]
+# Read fresh PATH from HKCU + HKLM Environment registry keys so we pick up
+# PATH updates made after claudette started (winget/installer edits) without
+# forcing the user to log out and back in.
+winreg = "0.55"
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/flake.nix
+++ b/flake.nix
@@ -600,6 +600,33 @@
                 category = "windows";
               }
               {
+                name = "deploy-win-arm64";
+                command = ''
+                  set -euo pipefail
+                  # Build, then stop any running instance on the test VM and
+                  # copy the fresh .exe over. The remote process has a file
+                  # lock on claudette.exe while running, so scp cannot
+                  # overwrite it without the Stop-Process step.
+                  #
+                  # Host and remote path are overridable for cases where the
+                  # VM's DHCP lease changes or someone else tests against a
+                  # different machine. Defaults match the project's shared
+                  # Windows-on-ARM test VM (see project memory).
+                  HOST=''${CLAUDETTE_WIN_HOST:-brink@172.16.52.129}
+                  REMOTE_PATH=''${CLAUDETTE_WIN_REMOTE_PATH:-OneDrive/Desktop/claudette.exe}
+                  build-win-arm64
+                  echo ""
+                  echo "Stopping running claudette on $HOST (if any)..."
+                  ssh "$HOST" 'Stop-Process -Name claudette -Force -ErrorAction SilentlyContinue'
+                  echo "Copying to $HOST:$REMOTE_PATH ..."
+                  scp target/aarch64-pc-windows-msvc/release/claudette.exe "$HOST:$REMOTE_PATH"
+                  echo ""
+                  echo "Deployed. Double-click claudette.exe on the VM desktop to run."
+                '';
+                help = "Build + deploy aarch64-pc-windows-msvc exe to the test VM (overridable via CLAUDETTE_WIN_HOST / CLAUDETTE_WIN_REMOTE_PATH)";
+                category = "windows";
+              }
+              {
                 name = "build-win-x64";
                 command = ''
                   set -euo pipefail

--- a/flake.nix
+++ b/flake.nix
@@ -347,7 +347,7 @@
               # above, so no separate lld package is needed.
               #
               # clangXwinShim wraps plain `clang` (see its definition above)
-              # to rewrite `/imsvc` → `-imsvc`; `lib.hiPrio` lets it win the
+              # to rewrite `/imsvc` → `-isystem`; `lib.hiPrio` lets it win the
               # buildEnv symlink conflict over clang-unwrapped's own
               # `bin/clang`, while clang-unwrapped's other binaries
               # (clang-cl, clang++, ...) pass through unchanged.

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,13 @@
             fenixPkgs.latest.rust-src
             fenixPkgs.latest.rustc
             fenixPkgs.latest.rustfmt
+            # Windows MSVC cross-compile targets (consumed via cargo-xwin in
+            # the devshell). aarch64 is the priority per project plan;
+            # x86_64 included so both Windows architectures are available.
+            # rust-std ships the Windows stdlib binaries; the MS CRT and
+            # Windows SDK headers are fetched on demand by cargo-xwin.
+            fenixPkgs.targets.aarch64-pc-windows-msvc.latest.rust-std
+            fenixPkgs.targets.x86_64-pc-windows-msvc.latest.rust-std
           ];
 
           craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
@@ -301,6 +308,22 @@
               pkgs.cmake
               pkgs.perl
               pkgs.cargo-llvm-cov
+              # Windows cross-compile toolchain. cargo-xwin shells out to
+              # clang-cl (the MSVC-compatible driver) and llvm-lib / llvm-ar
+              # as the archiver; rust-lld is bundled with the fenix rustc
+              # above, so no separate lld package is needed.
+              #
+              # We intentionally use clang-unwrapped here rather than
+              # llvmPackages.clang: the cc-wrapper variant only exposes the
+              # `clang` / `clang++` entry points and hides the `clang-cl`
+              # symlink that cargo-xwin looks up on PATH. llvmPackages.llvm
+              # gives the raw LLVM binaries (llvm-lib, llvm-ar, llvm-rc);
+              # we avoid llvmPackages.bintools because its wrapper symlinks
+              # (`strip`, `ar`, ...) collide with same-named symlinks
+              # elsewhere in the devshell's buildEnv.
+              pkgs.cargo-xwin
+              pkgs.llvmPackages.clang-unwrapped
+              pkgs.llvmPackages.llvm
             ]
             ++ darwinBuildInputs
             ++ linuxBuildInputs
@@ -319,6 +342,16 @@
               {
                 name = "RUST_SRC_PATH";
                 value = "${fenixPkgs.latest.rust-src}/lib/rustlib/src/rust/library";
+              }
+              {
+                # cargo-xwin downloads the Microsoft CRT + Windows SDK
+                # headers on first Windows cross-build. Setting this to "1"
+                # signals acceptance of the Microsoft Software License Terms
+                # (https://go.microsoft.com/fwlink/?LinkID=2109288) so the
+                # download is non-interactive. The cache lives under
+                # ~/.cache/cargo-xwin/xwin and is reused across builds.
+                name = "XWIN_ACCEPT_LICENSE";
+                value = "1";
               }
             ]
             ++ lib.optionals pkgs.stdenv.isLinux [
@@ -486,6 +519,42 @@
                 command = "cargo test --workspace --all-features";
                 help = "Run all Rust tests";
                 category = "quality";
+              }
+              {
+                name = "build-win-arm64";
+                command = ''
+                  # TODO(you): implement — this is the first Windows
+                  # cross-build command. arm64 is the initial test target.
+                  #
+                  # Wiring already in place:
+                  #   - cargo-xwin is on PATH and XWIN_ACCEPT_LICENSE=1 is set,
+                  #     so `cargo xwin build --target aarch64-pc-windows-msvc ...`
+                  #     will fetch MS CRT + SDK on first use (~few hundred MB,
+                  #     cached under ~/.cache/cargo-xwin) and handle linker +
+                  #     include paths automatically.
+                  #   - rust-std for aarch64-pc-windows-msvc ships in the
+                  #     fenix toolchain.
+                  #   - clang-cl, llvm-lib, llvm-ar, lld-link are on PATH
+                  #     via llvmPackages.clang + llvmPackages.bintools.
+                  #
+                  # Decisions that shape the command (5–10 lines of shell):
+                  #   - Rebuild the frontend first? tauri-build bakes
+                  #     src/ui/dist/ into the .exe via include_str!(), so a
+                  #     stale dist silently produces a stale binary. Running
+                  #     `cd src/ui && bun install --frozen-lockfile && bun run build`
+                  #     is slow but safe; skipping is fast but footgun-prone.
+                  #   - --release or leave to debug? Release matches what
+                  #     you'd ship / test, debug iterates faster.
+                  #   - Build just -p claudette-tauri, or also
+                  #     -p claudette-server (useful standalone on Windows)?
+                  #   - Echo the final .exe path at the end so it can be
+                  #     scp'd to the ARM64 Windows test box without hunting
+                  #     through target/aarch64-pc-windows-msvc/<profile>/.
+                  echo "build-win-arm64: not implemented — fill in flake.nix"
+                  exit 1
+                '';
+                help = "Cross-compile claudette.exe for aarch64-pc-windows-msvc (Windows on ARM)";
+                category = "windows";
               }
               {
                 name = "coverage";

--- a/flake.nix
+++ b/flake.nix
@@ -564,15 +564,34 @@
                 name = "build-win-arm64";
                 command = ''
                   set -euo pipefail
-                  # Rebuild the frontend — tauri-build bakes src/ui/dist/
-                  # into the .exe via include_str!(), so a stale dist
-                  # silently produces a stale binary.
+                  # Rebuild the frontend — tauri-codegen bakes src/ui/dist/
+                  # into the .exe at build time, so a stale dist silently
+                  # produces a stale binary.
                   (cd src/ui && bun install --frozen-lockfile && bun run build)
-                  # Cross-compile the Tauri binary. Default clang-cl mode:
-                  # the devshell's clangXwinShim rewrites /imsvc → -imsvc
-                  # so ring's direct-clang .S compile doesn't choke on the
-                  # MSVC-style flags cargo-xwin injects into CFLAGS.
+                  # Cross-compile the Tauri binary. Three things make this
+                  # the correct invocation:
+                  #
+                  # 1. --features tauri/custom-protocol — without this,
+                  #    tauri-build emits cargo:rustc-cfg=dev and the
+                  #    resulting binary loads http://localhost:1420 at
+                  #    runtime instead of the embedded asset protocol.
+                  #    `cargo tauri build` passes this automatically;
+                  #    plain `cargo build`/`cargo xwin build` do not.
+                  # 2. Default cargo-xwin mode (clang-cl) — the devshell's
+                  #    clangXwinShim rewrites /imsvc → -isystem so ring's
+                  #    direct-clang .S assembly compile doesn't choke on
+                  #    MSVC-style include flags leaked into CFLAGS.
+                  # 3. --release — tauri-codegen embeds the frontend only
+                  #    when the binary isn't in debug profile.
+                  #
+                  # We skip `cargo tauri build --runner` because tauri-cli
+                  # shells out to rustup to verify the target is installed,
+                  # and our fenix toolchain supplies the rust-std outside
+                  # rustup's knowledge. Driving `cargo xwin build` directly
+                  # sidesteps the check; asset embedding is handled by
+                  # the feature flag above.
                   cargo xwin build --release \
+                    --features tauri/custom-protocol \
                     --target aarch64-pc-windows-msvc -p claudette-tauri
                   echo ""
                   echo "Built: $PWD/target/aarch64-pc-windows-msvc/release/claudette.exe"
@@ -586,6 +605,7 @@
                   set -euo pipefail
                   (cd src/ui && bun install --frozen-lockfile && bun run build)
                   cargo xwin build --release \
+                    --features tauri/custom-protocol \
                     --target x86_64-pc-windows-msvc -p claudette-tauri
                   echo ""
                   echo "Built: $PWD/target/x86_64-pc-windows-msvc/release/claudette.exe"

--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,39 @@
             pkgs.libiconv
           ];
 
+          # Wrapper around `clang` that rewrites the MSVC-style `/imsvc`
+          # include flag to the GNU-driver-compatible `-isystem` form.
+          #
+          # cargo-xwin's default (and correct-for-STL) mode is clang-cl: it
+          # injects `/imsvc <path>` pairs into CFLAGS_<target> so that clang-cl
+          # sees the MSVC CRT + SDK + C++ STL under xwin/crt/include (which
+          # actually contains <iterator>, <vector>, ... — the alternative
+          # "sysroot" mode ships a sysroot whose include/c++/stl/ directory
+          # is empty on aarch64, so clang-cl mode is the only workable one).
+          #
+          # The snag: `ring`'s build script compiles Windows ARM64 `.S`
+          # assembly by invoking `clang` directly (not clang-cl, because
+          # clang-cl doesn't parse GAS syntax). The GNU-driver `clang` then
+          # rejects `/imsvc` (treated as a filename) and also rejects
+          # `-imsvc` (clang-cl-only spelling). The only spelling accepted by
+          # both drivers is `-isystem`, which carries the same semantics we
+          # need here (mark the directory as a system header root, suppress
+          # diagnostics from headers within it).
+          #
+          # Wrapping `clang` specifically (not clang-cl, not clang++) is
+          # sufficient because that is the exact binary ring shells out to
+          # for the .S pregenerated files.
+          clangXwinShim = pkgs.writeShellScriptBin "clang" ''
+            args=()
+            for arg in "$@"; do
+              case "$arg" in
+                /imsvc) args+=("-isystem") ;;
+                *) args+=("$arg") ;;
+              esac
+            done
+            exec ${pkgs.llvmPackages.clang-unwrapped}/bin/clang "''${args[@]}"
+          '';
+
           # Linux native deps for webkit + GTK stack.
           # NOTE: cairo / pango / harfbuzz / atk / gdk-pixbuf are propagated by
           # gtk3, so nixpkgs' pkg-config setup hook picks them up automatically
@@ -313,7 +346,13 @@
               # as the archiver; rust-lld is bundled with the fenix rustc
               # above, so no separate lld package is needed.
               #
-              # We intentionally use clang-unwrapped here rather than
+              # clangXwinShim wraps plain `clang` (see its definition above)
+              # to rewrite `/imsvc` → `-imsvc`; `lib.hiPrio` lets it win the
+              # buildEnv symlink conflict over clang-unwrapped's own
+              # `bin/clang`, while clang-unwrapped's other binaries
+              # (clang-cl, clang++, ...) pass through unchanged.
+              #
+              # We intentionally use clang-unwrapped rather than
               # llvmPackages.clang: the cc-wrapper variant only exposes the
               # `clang` / `clang++` entry points and hides the `clang-cl`
               # symlink that cargo-xwin looks up on PATH. llvmPackages.llvm
@@ -322,6 +361,7 @@
               # (`strip`, `ar`, ...) collide with same-named symlinks
               # elsewhere in the devshell's buildEnv.
               pkgs.cargo-xwin
+              (lib.hiPrio clangXwinShim)
               pkgs.llvmPackages.clang-unwrapped
               pkgs.llvmPackages.llvm
             ]
@@ -528,9 +568,12 @@
                   # into the .exe via include_str!(), so a stale dist
                   # silently produces a stale binary.
                   (cd src/ui && bun install --frozen-lockfile && bun run build)
-                  # Cross-compile the Tauri binary. cargo-xwin handles
-                  # MS CRT + SDK download, linker, and include paths.
-                  cargo xwin build --release --target aarch64-pc-windows-msvc -p claudette-tauri
+                  # Cross-compile the Tauri binary. Default clang-cl mode:
+                  # the devshell's clangXwinShim rewrites /imsvc → -imsvc
+                  # so ring's direct-clang .S compile doesn't choke on the
+                  # MSVC-style flags cargo-xwin injects into CFLAGS.
+                  cargo xwin build --release \
+                    --target aarch64-pc-windows-msvc -p claudette-tauri
                   echo ""
                   echo "Built: $PWD/target/aarch64-pc-windows-msvc/release/claudette.exe"
                 '';
@@ -542,7 +585,8 @@
                 command = ''
                   set -euo pipefail
                   (cd src/ui && bun install --frozen-lockfile && bun run build)
-                  cargo xwin build --release --target x86_64-pc-windows-msvc -p claudette-tauri
+                  cargo xwin build --release \
+                    --target x86_64-pc-windows-msvc -p claudette-tauri
                   echo ""
                   echo "Built: $PWD/target/x86_64-pc-windows-msvc/release/claudette.exe"
                 '';

--- a/flake.nix
+++ b/flake.nix
@@ -523,37 +523,30 @@
               {
                 name = "build-win-arm64";
                 command = ''
-                  # TODO(you): implement — this is the first Windows
-                  # cross-build command. arm64 is the initial test target.
-                  #
-                  # Wiring already in place:
-                  #   - cargo-xwin is on PATH and XWIN_ACCEPT_LICENSE=1 is set,
-                  #     so `cargo xwin build --target aarch64-pc-windows-msvc ...`
-                  #     will fetch MS CRT + SDK on first use (~few hundred MB,
-                  #     cached under ~/.cache/cargo-xwin) and handle linker +
-                  #     include paths automatically.
-                  #   - rust-std for aarch64-pc-windows-msvc ships in the
-                  #     fenix toolchain.
-                  #   - clang-cl, llvm-lib, llvm-ar, lld-link are on PATH
-                  #     via llvmPackages.clang + llvmPackages.bintools.
-                  #
-                  # Decisions that shape the command (5–10 lines of shell):
-                  #   - Rebuild the frontend first? tauri-build bakes
-                  #     src/ui/dist/ into the .exe via include_str!(), so a
-                  #     stale dist silently produces a stale binary. Running
-                  #     `cd src/ui && bun install --frozen-lockfile && bun run build`
-                  #     is slow but safe; skipping is fast but footgun-prone.
-                  #   - --release or leave to debug? Release matches what
-                  #     you'd ship / test, debug iterates faster.
-                  #   - Build just -p claudette-tauri, or also
-                  #     -p claudette-server (useful standalone on Windows)?
-                  #   - Echo the final .exe path at the end so it can be
-                  #     scp'd to the ARM64 Windows test box without hunting
-                  #     through target/aarch64-pc-windows-msvc/<profile>/.
-                  echo "build-win-arm64: not implemented — fill in flake.nix"
-                  exit 1
+                  set -euo pipefail
+                  # Rebuild the frontend — tauri-build bakes src/ui/dist/
+                  # into the .exe via include_str!(), so a stale dist
+                  # silently produces a stale binary.
+                  (cd src/ui && bun install --frozen-lockfile && bun run build)
+                  # Cross-compile the Tauri binary. cargo-xwin handles
+                  # MS CRT + SDK download, linker, and include paths.
+                  cargo xwin build --release --target aarch64-pc-windows-msvc -p claudette-tauri
+                  echo ""
+                  echo "Built: $PWD/target/aarch64-pc-windows-msvc/release/claudette.exe"
                 '';
                 help = "Cross-compile claudette.exe for aarch64-pc-windows-msvc (Windows on ARM)";
+                category = "windows";
+              }
+              {
+                name = "build-win-x64";
+                command = ''
+                  set -euo pipefail
+                  (cd src/ui && bun install --frozen-lockfile && bun run build)
+                  cargo xwin build --release --target x86_64-pc-windows-msvc -p claudette-tauri
+                  echo ""
+                  echo "Built: $PWD/target/x86_64-pc-windows-msvc/release/claudette.exe"
+                '';
+                help = "Cross-compile claudette.exe for x86_64-pc-windows-msvc";
                 category = "windows";
               }
               {

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -241,7 +241,8 @@ pub async fn detect_installed_apps(state: State<'_, AppState>) -> Result<Vec<Det
 /// Launch an app using macOS `open -a` command.
 #[cfg(target_os = "macos")]
 async fn open_macos_app(app_name: &str, worktree_path: &str) -> Result<(), String> {
-    tokio::process::Command::new("open").no_console_window()
+    tokio::process::Command::new("open")
+        .no_console_window()
         .args(["-a", app_name, worktree_path])
         .spawn()
         .map_err(|e| format!("Failed to launch {app_name}: {e}"))?;
@@ -286,7 +287,8 @@ end run"#
         other => return Err(format!("No AppleScript handler for app '{other}'")),
     };
 
-    tokio::process::Command::new("osascript").no_console_window()
+    tokio::process::Command::new("osascript")
+        .no_console_window()
         .arg("-e")
         .arg(script)
         .arg("--")
@@ -369,7 +371,8 @@ end run"#,
         )
     };
 
-    tokio::process::Command::new("osascript").no_console_window()
+    tokio::process::Command::new("osascript")
+        .no_console_window()
         .arg("-e")
         .arg(script)
         .arg("--")
@@ -522,7 +525,8 @@ pub async fn open_workspace_in_app(
         .map(|a| a.replace("{}", &worktree_path))
         .collect();
 
-    tokio::process::Command::new(&detected.detected_path).no_console_window()
+    tokio::process::Command::new(&detected.detected_path)
+        .no_console_window()
         .args(&args)
         .spawn()
         .map_err(|e| format!("Failed to launch {}: {e}", entry.name))?;

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::state::AppState;
+use claudette::process::CommandWindowExt as _;
 
 const DEFAULT_APPS_JSON: &str = include_str!("../../default-apps.json");
 
@@ -240,7 +241,7 @@ pub async fn detect_installed_apps(state: State<'_, AppState>) -> Result<Vec<Det
 /// Launch an app using macOS `open -a` command.
 #[cfg(target_os = "macos")]
 async fn open_macos_app(app_name: &str, worktree_path: &str) -> Result<(), String> {
-    tokio::process::Command::new("open")
+    tokio::process::Command::new("open").no_console_window()
         .args(["-a", app_name, worktree_path])
         .spawn()
         .map_err(|e| format!("Failed to launch {app_name}: {e}"))?;
@@ -285,7 +286,7 @@ end run"#
         other => return Err(format!("No AppleScript handler for app '{other}'")),
     };
 
-    tokio::process::Command::new("osascript")
+    tokio::process::Command::new("osascript").no_console_window()
         .arg("-e")
         .arg(script)
         .arg("--")
@@ -368,7 +369,7 @@ end run"#,
         )
     };
 
-    tokio::process::Command::new("osascript")
+    tokio::process::Command::new("osascript").no_console_window()
         .arg("-e")
         .arg(script)
         .arg("--")
@@ -428,6 +429,7 @@ async fn open_in_terminal(
 
     // Build: terminal_binary [terminal_open_args with {} -> path] [exec_separator] editor_binary [editor_open_args]
     let mut cmd = tokio::process::Command::new(&terminal.detected_path);
+    cmd.no_console_window();
 
     for arg in &terminal_entry.open_args {
         cmd.arg(arg.replace("{}", worktree_path));
@@ -520,7 +522,7 @@ pub async fn open_workspace_in_app(
         .map(|a| a.replace("{}", &worktree_path))
         .collect();
 
-    tokio::process::Command::new(&detected.detected_path)
+    tokio::process::Command::new(&detected.detected_path).no_console_window()
         .args(&args)
         .spawn()
         .map_err(|e| format!("Failed to launch {}: {e}", entry.name))?;

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -6,6 +6,7 @@ use claudette::db::Database;
 use claudette::file_expand;
 
 use crate::state::AppState;
+use claudette::process::CommandWindowExt as _;
 
 const MAX_FILES: usize = 10_000;
 
@@ -44,7 +45,7 @@ pub async fn list_workspace_files(
         .as_ref()
         .ok_or("Workspace has no worktree")?;
 
-    let output = Command::new("git")
+    let output = Command::new("git").no_console_window()
         .args(["-C", worktree_path])
         .args(["ls-files", "--cached", "--others", "--exclude-standard"])
         .output()

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -45,7 +45,7 @@ pub async fn list_workspace_files(
         .as_ref()
         .ok_or("Workspace has no worktree")?;
 
-    let output = Command::new("git").no_console_window()
+    let output = Command::new(&claudette::git::resolve_git_path_blocking()).no_console_window()
         .args(["-C", worktree_path])
         .args(["ls-files", "--cached", "--others", "--exclude-standard"])
         .output()

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -45,7 +45,8 @@ pub async fn list_workspace_files(
         .as_ref()
         .ok_or("Workspace has no worktree")?;
 
-    let output = Command::new(&claudette::git::resolve_git_path_blocking()).no_console_window()
+    let output = Command::new(&claudette::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["-C", worktree_path])
         .args(["ls-files", "--cached", "--others", "--exclude-standard"])
         .output()

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -10,6 +10,7 @@ use crate::state::LocalServerState;
 use crate::transport::ws::WebSocketTransport;
 #[cfg(feature = "server")]
 use tokio::io::{AsyncBufReadExt, BufReader};
+use claudette::process::CommandWindowExt as _;
 
 #[derive(Serialize)]
 pub struct PairResult {
@@ -280,7 +281,7 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
         let server_bin = std::env::current_exe()
             .map_err(|e| format!("Failed to locate current executable: {e}"))?;
 
-        let mut child = tokio::process::Command::new(&server_bin)
+        let mut child = tokio::process::Command::new(&server_bin).no_console_window()
             .arg("--server")
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -8,9 +8,9 @@ use crate::state::AppState;
 #[cfg(feature = "server")]
 use crate::state::LocalServerState;
 use crate::transport::ws::WebSocketTransport;
+use claudette::process::CommandWindowExt as _;
 #[cfg(feature = "server")]
 use tokio::io::{AsyncBufReadExt, BufReader};
-use claudette::process::CommandWindowExt as _;
 
 #[derive(Serialize)]
 pub struct PairResult {
@@ -281,7 +281,8 @@ pub async fn start_local_server(state: State<'_, AppState>) -> Result<LocalServe
         let server_bin = std::env::current_exe()
             .map_err(|e| format!("Failed to locate current executable: {e}"))?;
 
-        let mut child = tokio::process::Command::new(&server_bin).no_console_window()
+        let mut child = tokio::process::Command::new(&server_bin)
+            .no_console_window()
             .arg("--server")
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -124,17 +124,15 @@ pub async fn list_system_fonts() -> Vec<String> {
     }
     // `mut` is only reached from the per-target blocks below; Windows has
     // neither branch, so the binding stays immutable there.
-    #[cfg_attr(
-        not(any(target_os = "macos", target_os = "linux")),
-        allow(unused_mut)
-    )]
+    #[cfg_attr(not(any(target_os = "macos", target_os = "linux")), allow(unused_mut))]
     let mut families = std::collections::BTreeSet::<String>::new();
 
     #[cfg(target_os = "macos")]
     {
         // Swift is always available on macOS; NSFontManager is the canonical API.
         let script = r#"import AppKit; NSFontManager.shared.availableFontFamilies.sorted().forEach { print($0) }"#;
-        if let Ok(output) = tokio::process::Command::new("/usr/bin/swift").no_console_window()
+        if let Ok(output) = tokio::process::Command::new("/usr/bin/swift")
+            .no_console_window()
             .arg("-e")
             .arg(script)
             .output()
@@ -153,7 +151,8 @@ pub async fn list_system_fonts() -> Vec<String> {
     #[cfg(target_os = "linux")]
     {
         // fontconfig is standard on all Linux desktops.
-        if let Ok(output) = tokio::process::Command::new("fc-list").no_console_window()
+        if let Ok(output) = tokio::process::Command::new("fc-list")
+            .no_console_window()
             .args([":", "family"])
             .output()
             .await
@@ -200,7 +199,8 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
         } else {
             format!("/System/Library/Sounds/{sound}.aiff")
         };
-        if let Ok(child) = std::process::Command::new("afplay").no_console_window()
+        if let Ok(child) = std::process::Command::new("afplay")
+            .no_console_window()
             .arg("-v")
             .arg(format!("{vol}"))
             .arg(&path)
@@ -217,12 +217,14 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
             sound.to_lowercase()
         };
         let pa_volume = (vol * 65536.0) as u32;
-        if let Ok(child) = std::process::Command::new("canberra-gtk-play").no_console_window()
+        if let Ok(child) = std::process::Command::new("canberra-gtk-play")
+            .no_console_window()
             .arg("-i")
             .arg(&sound_name)
             .spawn()
             .or_else(|_| {
-                std::process::Command::new("paplay").no_console_window()
+                std::process::Command::new("paplay")
+                    .no_console_window()
                     .arg("--volume")
                     .arg(pa_volume.to_string())
                     .arg(format!(

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -6,6 +6,7 @@ use tauri::{AppHandle, State};
 use claudette::db::Database;
 
 use crate::state::AppState;
+use claudette::process::CommandWindowExt as _;
 
 /// Spawn a short-lived process and reap it in a background thread to prevent zombies.
 pub(crate) fn spawn_and_reap(mut child: std::process::Child) {
@@ -133,7 +134,7 @@ pub async fn list_system_fonts() -> Vec<String> {
     {
         // Swift is always available on macOS; NSFontManager is the canonical API.
         let script = r#"import AppKit; NSFontManager.shared.availableFontFamilies.sorted().forEach { print($0) }"#;
-        if let Ok(output) = tokio::process::Command::new("/usr/bin/swift")
+        if let Ok(output) = tokio::process::Command::new("/usr/bin/swift").no_console_window()
             .arg("-e")
             .arg(script)
             .output()
@@ -152,7 +153,7 @@ pub async fn list_system_fonts() -> Vec<String> {
     #[cfg(target_os = "linux")]
     {
         // fontconfig is standard on all Linux desktops.
-        if let Ok(output) = tokio::process::Command::new("fc-list")
+        if let Ok(output) = tokio::process::Command::new("fc-list").no_console_window()
             .args([":", "family"])
             .output()
             .await
@@ -199,7 +200,7 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
         } else {
             format!("/System/Library/Sounds/{sound}.aiff")
         };
-        if let Ok(child) = std::process::Command::new("afplay")
+        if let Ok(child) = std::process::Command::new("afplay").no_console_window()
             .arg("-v")
             .arg(format!("{vol}"))
             .arg(&path)
@@ -216,12 +217,12 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
             sound.to_lowercase()
         };
         let pa_volume = (vol * 65536.0) as u32;
-        if let Ok(child) = std::process::Command::new("canberra-gtk-play")
+        if let Ok(child) = std::process::Command::new("canberra-gtk-play").no_console_window()
             .arg("-i")
             .arg(&sound_name)
             .spawn()
             .or_else(|_| {
-                std::process::Command::new("paplay")
+                std::process::Command::new("paplay").no_console_window()
                     .arg("--volume")
                     .arg(pa_volume.to_string())
                     .arg(format!(
@@ -255,6 +256,7 @@ pub(crate) fn build_notification_command(
         return None;
     }
     let mut command = std::process::Command::new("sh");
+    command.no_console_window();
     command.arg("-c").arg(cmd);
     ws_env.apply_std(&mut command);
     Some(command)

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -121,6 +121,12 @@ pub async fn list_system_fonts() -> Vec<String> {
     if let Some(cached) = SYSTEM_FONTS.get() {
         return cached.clone();
     }
+    // `mut` is only reached from the per-target blocks below; Windows has
+    // neither branch, so the binding stays immutable there.
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "linux")),
+        allow(unused_mut)
+    )]
     let mut families = std::collections::BTreeSet::<String>::new();
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -214,10 +214,16 @@ mod opener {
         let cmd = Command::new("open").no_console_window().arg(path).spawn();
 
         #[cfg(target_os = "linux")]
-        let cmd = Command::new("xdg-open").no_console_window().arg(path).spawn();
+        let cmd = Command::new("xdg-open")
+            .no_console_window()
+            .arg(path)
+            .spawn();
 
         #[cfg(target_os = "windows")]
-        let cmd = Command::new("cmd").no_console_window().args(["/C", "start", "", path]).spawn();
+        let cmd = Command::new("cmd")
+            .no_console_window()
+            .args(["/C", "start", "", path])
+            .spawn();
 
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         let cmd = Err(std::io::Error::new(

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -206,17 +206,18 @@ pub async fn open_url(url: String) -> Result<(), String> {
 }
 
 mod opener {
+    use claudette::process::CommandWindowExt as _;
     use std::process::Command;
 
     pub fn open(path: &str) -> std::io::Result<()> {
         #[cfg(target_os = "macos")]
-        let cmd = Command::new("open").arg(path).spawn();
+        let cmd = Command::new("open").no_console_window().arg(path).spawn();
 
         #[cfg(target_os = "linux")]
-        let cmd = Command::new("xdg-open").arg(path).spawn();
+        let cmd = Command::new("xdg-open").no_console_window().arg(path).spawn();
 
         #[cfg(target_os = "windows")]
-        let cmd = Command::new("cmd").args(["/C", "start", "", path]).spawn();
+        let cmd = Command::new("cmd").no_console_window().args(["/C", "start", "", path]).spawn();
 
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         let cmd = Err(std::io::Error::new(

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -2,6 +2,7 @@ use tauri::State;
 
 use crate::state::AppState;
 use crate::usage::{self, ClaudeCodeUsage};
+use claudette::process::CommandWindowExt as _;
 
 #[tauri::command]
 pub async fn get_claude_code_usage(state: State<'_, AppState>) -> Result<ClaudeCodeUsage, String> {
@@ -21,21 +22,21 @@ pub async fn open_release_notes() -> Result<(), String> {
 async fn open_external_url(url: &str) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        tokio::process::Command::new("open")
+        tokio::process::Command::new("open").no_console_window()
             .arg(url)
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;
     }
     #[cfg(target_os = "windows")]
     {
-        tokio::process::Command::new("cmd")
+        tokio::process::Command::new("cmd").no_console_window()
             .args(["/C", "start", url])
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        tokio::process::Command::new("xdg-open")
+        tokio::process::Command::new("xdg-open").no_console_window()
             .arg(url)
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -22,21 +22,24 @@ pub async fn open_release_notes() -> Result<(), String> {
 async fn open_external_url(url: &str) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        tokio::process::Command::new("open").no_console_window()
+        tokio::process::Command::new("open")
+            .no_console_window()
             .arg(url)
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;
     }
     #[cfg(target_os = "windows")]
     {
-        tokio::process::Command::new("cmd").no_console_window()
+        tokio::process::Command::new("cmd")
+            .no_console_window()
             .args(["/C", "start", url])
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        tokio::process::Command::new("xdg-open").no_console_window()
+        tokio::process::Command::new("xdg-open")
+            .no_console_window()
             .arg(url)
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -898,7 +898,8 @@ pub async fn open_workspace_in_terminal(worktree_path: String) -> Result<(), Str
             end tell"#
         );
 
-        tokio::process::Command::new("osascript").no_console_window()
+        tokio::process::Command::new("osascript")
+            .no_console_window()
             .arg("-e")
             .arg(&script)
             .spawn()

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -17,6 +17,7 @@ use claudette::model::{AgentStatus, Workspace, WorkspaceStatus};
 use claudette::names::NameGenerator;
 
 use crate::state::AppState;
+use claudette::process::CommandWindowExt as _;
 
 #[derive(Serialize, Clone)]
 pub struct SetupResult {
@@ -278,6 +279,7 @@ async fn resolve_and_run_setup(
     //    scripts won't spawn there without a user-installed shell — the
     //    grandchild-leak on timeout is moot until that is addressed.
     let mut cmd = TokioCommand::new("sh");
+    cmd.no_console_window();
     cmd.arg("-c")
         .arg(&script)
         .current_dir(worktree_path)
@@ -860,6 +862,7 @@ pub async fn open_workspace_in_terminal(worktree_path: String) -> Result<(), Str
         let mut errors = Vec::new();
         for (terminal, args) in &terminals {
             let mut cmd = tokio::process::Command::new(terminal);
+            cmd.no_console_window();
             for arg in args {
                 cmd.arg(arg);
             }
@@ -895,7 +898,7 @@ pub async fn open_workspace_in_terminal(worktree_path: String) -> Result<(), Str
             end tell"#
         );
 
-        tokio::process::Command::new("osascript")
+        tokio::process::Command::new("osascript").no_console_window()
             .arg("-e")
             .arg(&script)
             .spawn()

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -272,14 +272,20 @@ async fn resolve_and_run_setup(
 
     // 3. Execute the script in its own process group so we can kill the
     //    entire tree on timeout (prevents orphan grandchild processes).
+    //    `process_group` is a Unix-only extension; on Windows the timeout
+    //    path falls back to `child.kill().await` which only terminates the
+    //    immediate child. Windows also lacks a built-in `sh`, so setup
+    //    scripts won't spawn there without a user-installed shell — the
+    //    grandchild-leak on timeout is moot until that is addressed.
     let mut cmd = TokioCommand::new("sh");
     cmd.arg("-c")
         .arg(&script)
         .current_dir(worktree_path)
         .env("PATH", claudette::env::enriched_path())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .process_group(0);
+        .stderr(std::process::Stdio::piped());
+    #[cfg(unix)]
+    cmd.process_group(0);
     ws_env.apply(&mut cmd);
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -295,6 +301,8 @@ async fn resolve_and_run_setup(
         }
     };
 
+    // Only used on Unix to send SIGKILL to the process group on timeout.
+    #[cfg(unix)]
     let pid = child.id();
 
     // 3. Read stdout/stderr concurrently with waiting to avoid pipe buffer
@@ -350,7 +358,11 @@ async fn resolve_and_run_setup(
             timed_out: false,
         }),
         Err(_) => {
-            // Timeout — kill the entire process group, then reap the child.
+            // Timeout — kill the entire process group on Unix (SIGKILL to
+            // -pgid hits every descendant). Windows has no process-group
+            // signal; `child.kill()` below calls `TerminateProcess` on
+            // the immediate child only.
+            #[cfg(unix)]
             if let Some(pgid) = pid {
                 unsafe {
                     libc::kill(-(pgid as i32), libc::SIGKILL);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -286,6 +286,14 @@ fn main() {
             // (tokio runtime may not be available during setup).
             std::thread::spawn(usage::warm_user_agent_cache_sync);
 
+            // Pre-warm the login-shell PATH cache. On Unix, `shell_path()`
+            // spawns `$SHELL -l -c 'echo $PATH'` with a 5-second timeout —
+            // fine to pay once at startup on a std thread, but lethal if
+            // it ever runs inline on a Tokio worker (stalls every async
+            // handler that touches `enriched_path` until the probe
+            // returns). On Windows this is a no-op.
+            std::thread::spawn(claudette::env::prewarm_shell_path);
+
             // Set up the system tray icon (respects tray_enabled setting).
             if let Err(e) = tray::setup_tray(app.handle()) {
                 eprintln!("[tray] Failed to setup tray: {e}");

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -62,6 +62,14 @@ pub async fn spawn_pty(
         })
         .map_err(|e| format!("Failed to open PTY: {e}"))?;
 
+    // On Windows, worktree paths created before the `\\?\`-stripping fix
+    // landed may still be stored in the DB as verbatim paths. `cmd.exe`
+    // refuses to chdir into a verbatim path and falls back to C:\Windows,
+    // which is exactly the symptom we just fixed at creation time. Strip
+    // here too so existing workspaces open in the right directory without
+    // a data migration.
+    let working_dir = claudette::path::strip_verbatim_prefix(&working_dir).to_string();
+
     let mut cmd = CommandBuilder::new_default_prog();
     cmd.cwd(&working_dir);
     configure_pty_env(&mut cmd);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -321,12 +321,13 @@ impl AppState {
 #[cfg(unix)]
 mod tests {
     use super::*;
+    use claudette::process::CommandWindowExt as _;
 
     /// Helper: spawn a long-running `sleep` process and return its PID.
     fn spawn_sleep() -> (tokio::process::Child, u32) {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let child = tokio::process::Command::new("sleep")
+            let child = tokio::process::Command::new("sleep").no_console_window()
                 .arg("3600")
                 .kill_on_drop(true)
                 .spawn()
@@ -384,7 +385,7 @@ mod tests {
     fn local_server_state_drop_kills_child() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let (child, pid) = rt.block_on(async {
-            let child = tokio::process::Command::new("sleep")
+            let child = tokio::process::Command::new("sleep").no_console_window()
                 .arg("3600")
                 .kill_on_drop(true)
                 .spawn()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -327,7 +327,8 @@ mod tests {
     fn spawn_sleep() -> (tokio::process::Child, u32) {
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let child = tokio::process::Command::new("sleep").no_console_window()
+            let child = tokio::process::Command::new("sleep")
+                .no_console_window()
                 .arg("3600")
                 .kill_on_drop(true)
                 .spawn()
@@ -385,7 +386,8 @@ mod tests {
     fn local_server_state_drop_kills_child() {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let (child, pid) = rt.block_on(async {
-            let child = tokio::process::Command::new("sleep").no_console_window()
+            let child = tokio::process::Command::new("sleep")
+                .no_console_window()
                 .arg("3600")
                 .kill_on_drop(true)
                 .spawn()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -109,7 +109,11 @@ pub struct LocalServerState {
     pub child: tokio::process::Child,
     /// The PID captured at spawn time for reliable synchronous cleanup.
     /// `tokio::process::Child::id()` returns `None` after the child is reaped,
-    /// so we store the PID eagerly.
+    /// so we store the PID eagerly. Only read on Unix, where `Drop` passes
+    /// it to `kill_process_sync` to send SIGTERM/SIGKILL + reap; on Windows
+    /// `child.start_kill()` alone suffices and this field is held only to
+    /// keep the struct layout consistent across platforms.
+    #[cfg_attr(windows, allow(dead_code))]
     pub pid: u32,
     /// The connection string printed by the server on startup.
     pub connection_string: String,
@@ -124,10 +128,13 @@ impl Drop for LocalServerState {
             eprintln!("[cleanup] Server process already exited");
             return;
         }
-        // Best-effort tokio-level kill (may fail if runtime is gone).
+        // Best-effort tokio-level kill (may fail if runtime is gone). On
+        // Windows this invokes `TerminateProcess`, which is immediate and
+        // leaves no zombie state — so the extra synchronous cleanup below
+        // is only meaningful on Unix where SIGTERM → grace → SIGKILL →
+        // `waitpid` is needed to reap the child.
         let _ = self.child.start_kill();
-        // Synchronous POSIX kill — works even during process teardown when the
-        // tokio runtime is no longer available.
+        #[cfg(unix)]
         kill_process_sync(self.pid);
     }
 }
@@ -139,6 +146,7 @@ impl Drop for LocalServerState {
 /// `SIGKILL` and reaps the process. This is safe to call from `Drop` impls
 /// and the `RunEvent::Exit` handler where async code cannot run. Uses raw
 /// libc calls so it does not depend on the tokio runtime.
+#[cfg(unix)]
 pub fn kill_process_sync(pid: u32) {
     use std::time::{Duration, Instant};
     let pid = pid as i32;

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -1,8 +1,8 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use claudette::process::CommandWindowExt as _;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use claudette::process::CommandWindowExt as _;
 
 // ---------------------------------------------------------------------------
 // Credential types (stored in macOS Keychain / Linux credentials file)
@@ -134,7 +134,8 @@ static USER_AGENT_CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new(
 /// (sync) and is intended to run on a background `std::thread`, not tokio,
 /// since the tokio runtime may not be available during Tauri's `setup()`.
 pub fn warm_user_agent_cache_sync() {
-    let output = std::process::Command::new("claude").no_console_window()
+    let output = std::process::Command::new("claude")
+        .no_console_window()
         .arg("--version")
         .env("PATH", claudette::env::enriched_path())
         .output();
@@ -169,7 +170,8 @@ const ENV_AUTH_ERROR: &str = "ENV_AUTH:";
 async fn read_credentials_platform() -> Result<CredentialFile, String> {
     // Claude Code stores credentials under $USER, not a fixed account name.
     let user = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
-    let output = tokio::process::Command::new("security").no_console_window()
+    let output = tokio::process::Command::new("security")
+        .no_console_window()
         .args([
             "find-generic-password",
             "-s",

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -2,6 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
+use claudette::process::CommandWindowExt as _;
 
 // ---------------------------------------------------------------------------
 // Credential types (stored in macOS Keychain / Linux credentials file)
@@ -133,7 +134,7 @@ static USER_AGENT_CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new(
 /// (sync) and is intended to run on a background `std::thread`, not tokio,
 /// since the tokio runtime may not be available during Tauri's `setup()`.
 pub fn warm_user_agent_cache_sync() {
-    let output = std::process::Command::new("claude")
+    let output = std::process::Command::new("claude").no_console_window()
         .arg("--version")
         .env("PATH", claudette::env::enriched_path())
         .output();
@@ -168,7 +169,7 @@ const ENV_AUTH_ERROR: &str = "ENV_AUTH:";
 async fn read_credentials_platform() -> Result<CredentialFile, String> {
     // Claude Code stores credentials under $USER, not a fixed account name.
     let user = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
-    let output = tokio::process::Command::new("security")
+    let output = tokio::process::Command::new("security").no_console_window()
         .args([
             "find-generic-password",
             "-s",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -919,11 +919,12 @@ pub async fn run_turn(
 }
 
 /// Stop an agent process by killing it.
+///
+/// Platform-specific: `kill -9 <pid>` on Unix, `taskkill /PID <pid> /T /F`
+/// on Windows. The `/T` flag terminates the whole process tree so MCP
+/// server children are reaped alongside the parent claude process.
 pub async fn stop_agent(pid: u32) -> Result<(), String> {
-    let output = tokio::process::Command::new("kill")
-        .no_console_window()
-        .args(["-9", &pid.to_string()])
-        .output()
+    let output = stop_agent_force(pid)
         .await
         .map_err(|e| format!("Failed to kill agent: {e}"))?;
 
@@ -937,35 +938,101 @@ pub async fn stop_agent(pid: u32) -> Result<(), String> {
     }
 }
 
-/// Gracefully stop an agent process (SIGTERM → wait → SIGKILL).
+/// Platform-specific force-kill invocation. Returns the raw `Output` so
+/// callers can shape their own error messages (or ignore exit status
+/// when probing liveness, as `stop_agent_graceful` does on Unix).
+async fn stop_agent_force(pid: u32) -> std::io::Result<std::process::Output> {
+    #[cfg(unix)]
+    {
+        tokio::process::Command::new("kill")
+            .no_console_window()
+            .args(["-9", &pid.to_string()])
+            .output()
+            .await
+    }
+    #[cfg(windows)]
+    {
+        tokio::process::Command::new("taskkill")
+            .no_console_window()
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .output()
+            .await
+    }
+}
+
+/// Gracefully stop an agent process.
 ///
-/// Sends SIGTERM first and allows up to 500 ms for the process to exit.
-/// Falls back to SIGKILL if the deadline expires. Suitable for tearing
-/// down idle persistent sessions at turn boundaries where we don't need
-/// an instant kill.
+/// On Unix this is SIGTERM → poll up to 500 ms → SIGKILL. On Windows we
+/// issue `taskkill /PID <pid> /T` (no `/F`) first, which sends
+/// `WM_CLOSE` / a CTRL_CLOSE_EVENT equivalent and lets the child exit
+/// cleanly; if it's still alive after the poll window we escalate to
+/// `/F`. Used at idle-session teardown where we don't need an instant
+/// kill.
 pub async fn stop_agent_graceful(pid: u32) -> Result<(), String> {
-    // Send SIGTERM for graceful shutdown.
+    // Send the graceful signal. Errors here are non-fatal — the force
+    // escalation below covers any "process didn't respond" case.
+    #[cfg(unix)]
     let _ = tokio::process::Command::new("kill")
         .no_console_window()
         .args(["-15", &pid.to_string()])
         .output()
         .await;
+    #[cfg(windows)]
+    let _ = tokio::process::Command::new("taskkill")
+        .no_console_window()
+        .args(["/PID", &pid.to_string(), "/T"])
+        .output()
+        .await;
 
-    // Poll for up to 500 ms.
+    // Poll for up to 500 ms. On Unix we use `kill -0` (permission-only
+    // probe, no signal sent) which exits non-zero once the pid is gone.
+    // On Windows `tasklist /FI "PID eq <pid>"` prints a header line
+    // plus one row while the process exists; once the process exits,
+    // it prints an "INFO: No tasks..." line to stderr, so we check for
+    // the pid in stdout.
     for _ in 0..10 {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        if !pid_is_alive(pid).await {
+            return Ok(());
+        }
+    }
+
+    // Escalate to force-kill.
+    stop_agent(pid).await
+}
+
+/// Best-effort liveness probe. Returns `true` if the pid appears to
+/// still be running, `false` if the probe indicates it's gone (or if
+/// the probe itself fails — a failed probe is treated as "dead" so
+/// `stop_agent_graceful` doesn't loop forever on a misbehaving OS).
+async fn pid_is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
         let probe = tokio::process::Command::new("kill")
             .no_console_window()
             .args(["-0", &pid.to_string()])
             .output()
             .await;
-        if probe.is_ok_and(|o| !o.status.success()) {
-            return Ok(());
+        probe.is_ok_and(|o| o.status.success())
+    }
+    #[cfg(windows)]
+    {
+        let probe = tokio::process::Command::new("tasklist")
+            .no_console_window()
+            .args(["/FI", &format!("PID eq {pid}"), "/NH", "/FO", "CSV"])
+            .output()
+            .await;
+        match probe {
+            Ok(o) if o.status.success() => {
+                // /NH suppresses the header; /FO CSV gives one row per
+                // match. An alive pid appears in stdout; a dead one
+                // yields an "INFO: No tasks..." message on stderr and
+                // an empty stdout.
+                !String::from_utf8_lossy(&o.stdout).trim().is_empty()
+            }
+            _ => false,
         }
     }
-
-    // Escalate to SIGKILL.
-    stop_agent(pid).await
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -920,7 +920,8 @@ pub async fn run_turn(
 
 /// Stop an agent process by killing it.
 pub async fn stop_agent(pid: u32) -> Result<(), String> {
-    let output = tokio::process::Command::new("kill").no_console_window()
+    let output = tokio::process::Command::new("kill")
+        .no_console_window()
         .args(["-9", &pid.to_string()])
         .output()
         .await
@@ -944,7 +945,8 @@ pub async fn stop_agent(pid: u32) -> Result<(), String> {
 /// an instant kill.
 pub async fn stop_agent_graceful(pid: u32) -> Result<(), String> {
     // Send SIGTERM for graceful shutdown.
-    let _ = tokio::process::Command::new("kill").no_console_window()
+    let _ = tokio::process::Command::new("kill")
+        .no_console_window()
         .args(["-15", &pid.to_string()])
         .output()
         .await;
@@ -952,7 +954,8 @@ pub async fn stop_agent_graceful(pid: u32) -> Result<(), String> {
     // Poll for up to 500 ms.
     for _ in 0..10 {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let probe = tokio::process::Command::new("kill").no_console_window()
+        let probe = tokio::process::Command::new("kill")
+            .no_console_window()
             .args(["-0", &pid.to_string()])
             .output()
             .await;
@@ -2451,12 +2454,8 @@ mod tests {
         let home = PathBuf::from(r"C:\Users\user");
         let expected = home.join(r".local\bin\claude.exe");
         let expected_clone = expected.clone();
-        let result = resolve_claude_path_inner(
-            Some(home),
-            None,
-            || None,
-            move |p| p == expected_clone,
-        );
+        let result =
+            resolve_claude_path_inner(Some(home), None, || None, move |p| p == expected_clone);
         assert_eq!(result, expected.into_os_string());
     }
 
@@ -2469,12 +2468,8 @@ mod tests {
         let home = PathBuf::from(r"C:\Users\user");
         let expected = home.join(r"AppData\Roaming\npm\claude.cmd");
         let expected_clone = expected.clone();
-        let result = resolve_claude_path_inner(
-            Some(home),
-            None,
-            || None,
-            move |p| p == expected_clone,
-        );
+        let result =
+            resolve_claude_path_inner(Some(home), None, || None, move |p| p == expected_clone);
         assert_eq!(result, expected.into_os_string());
     }
 
@@ -2937,7 +2932,8 @@ mod tests {
     #[tokio::test]
     async fn test_stop_agent_graceful_stops_process_before_escalation() {
         // Spawn a process that traps SIGTERM and exits cleanly.
-        let mut child = tokio::process::Command::new("sh").no_console_window()
+        let mut child = tokio::process::Command::new("sh")
+            .no_console_window()
             .args(["-c", "trap 'exit 0' TERM; sleep 5"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
@@ -2958,7 +2954,8 @@ mod tests {
             .expect("failed to reap child");
 
         // kill -0 should fail for a dead process.
-        let probe = tokio::process::Command::new("kill").no_console_window()
+        let probe = tokio::process::Command::new("kill")
+            .no_console_window()
             .args(["-0", &pid.to_string()])
             .output()
             .await;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -551,31 +551,46 @@ pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> Stri
 /// a slow shell probe that timed out on first call).
 ///
 /// The login-shell probe uses `std::process::Command` (blocking) with a
-/// 5-second timeout that kills the subprocess on expiry. We run the entire
-/// resolution inside `spawn_blocking` to avoid stalling async workers.
+/// 5-second timeout that kills the subprocess on expiry. On Unix we run
+/// the whole resolution inside `spawn_blocking` so a cold `SHELL_PATH`
+/// cache never stalls a Tokio worker — `enriched_path()` transitively
+/// calls `login_shell_path_probe()` on first use, and that probe can
+/// block for up to 5 s on slow shell-init files. (Startup also calls
+/// [`crate::env::prewarm_shell_path`] to warm the cache up front, but we
+/// keep the `spawn_blocking` wrapper as a belt-and-braces guard.)
+/// On Windows the base PATH comes from the registry — a handful of
+/// `Path::is_file` probes plus one registry read, sub-millisecond — so
+/// we run it inline.
 async fn resolve_claude_path() -> OsString {
     static RESOLVED: OnceLock<OsString> = OnceLock::new();
     if let Some(cached) = RESOLVED.get() {
         return cached.clone();
     }
-    // `enriched_path()` picks up fresh values from the Windows registry on
-    // Windows, and merges the login-shell PATH on Unix. This way an install
-    // made after claudette started (e.g. winget) is findable without a
-    // logout/restart. The work is a handful of Path::is_file probes plus one
-    // registry read, so we run it inline rather than going through
-    // spawn_blocking.
-    let resolved = resolve_claude_path_inner(
-        dirs::home_dir(),
-        Some(crate::env::enriched_path()),
-        login_shell_path,
-        is_executable_file,
-    );
+    #[cfg(unix)]
+    let resolved = tokio::task::spawn_blocking(resolve_claude_path_sync)
+        .await
+        .unwrap_or_else(|_| OsString::from("claude"));
+    #[cfg(not(unix))]
+    let resolved = resolve_claude_path_sync();
+
     // Only cache absolute paths — the bare "claude" fallback should allow
     // retries on subsequent calls in case the environment improves.
     if Path::new(&resolved).is_absolute() {
         let _ = RESOLVED.set(resolved.clone());
     }
     resolved
+}
+
+/// Synchronous core of [`resolve_claude_path`]. Extracted so it can run
+/// inside `tokio::task::spawn_blocking` on Unix without juggling async
+/// boundaries inside the resolver itself.
+fn resolve_claude_path_sync() -> OsString {
+    resolve_claude_path_inner(
+        dirs::home_dir(),
+        Some(crate::env::enriched_path()),
+        login_shell_path,
+        is_executable_file,
+    )
 }
 
 /// Check that a path is a regular file with execute permission.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -10,6 +10,7 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 
 use crate::env::WorkspaceEnv;
+use crate::process::CommandWindowExt as _;
 
 // ---------------------------------------------------------------------------
 // Stream event types — maps to Claude CLI `--output-format stream-json`
@@ -539,7 +540,7 @@ pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> Stri
 /// Resolve the full path to the `claude` CLI binary (async-safe).
 ///
 /// GUI apps on macOS (and some Linux desktop environments) don't inherit the
-/// user's shell PATH, so a bare `Command::new("claude")` fails with ENOENT.
+/// user's shell PATH, so a bare `Command::new("claude").no_console_window()` fails with ENOENT.
 /// We first check the current process PATH, then ask the user's login shell
 /// for its PATH, then try well-known install locations, and finally fall back
 /// to a bare `claude` command.
@@ -711,6 +712,7 @@ pub async fn run_turn(
 
     let claude_path = resolve_claude_path().await;
     let mut cmd = Command::new(&claude_path);
+    cmd.no_console_window();
     cmd.args(&args)
         .current_dir(working_dir)
         .stdout(std::process::Stdio::piped())
@@ -825,7 +827,7 @@ pub async fn run_turn(
 
 /// Stop an agent process by killing it.
 pub async fn stop_agent(pid: u32) -> Result<(), String> {
-    let output = tokio::process::Command::new("kill")
+    let output = tokio::process::Command::new("kill").no_console_window()
         .args(["-9", &pid.to_string()])
         .output()
         .await
@@ -849,7 +851,7 @@ pub async fn stop_agent(pid: u32) -> Result<(), String> {
 /// an instant kill.
 pub async fn stop_agent_graceful(pid: u32) -> Result<(), String> {
     // Send SIGTERM for graceful shutdown.
-    let _ = tokio::process::Command::new("kill")
+    let _ = tokio::process::Command::new("kill").no_console_window()
         .args(["-15", &pid.to_string()])
         .output()
         .await;
@@ -857,7 +859,7 @@ pub async fn stop_agent_graceful(pid: u32) -> Result<(), String> {
     // Poll for up to 500 ms.
     for _ in 0..10 {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let probe = tokio::process::Command::new("kill")
+        let probe = tokio::process::Command::new("kill").no_console_window()
             .args(["-0", &pid.to_string()])
             .output()
             .await;
@@ -912,6 +914,7 @@ impl PersistentSession {
 
         let claude_path = resolve_claude_path().await;
         let mut cmd = Command::new(&claude_path);
+        cmd.no_console_window();
         cmd.args(&args)
             .current_dir(working_dir)
             .stdin(std::process::Stdio::piped())
@@ -1275,6 +1278,7 @@ pub async fn generate_branch_name(
 
     let claude_path = resolve_claude_path().await;
     let mut cmd = Command::new(&claude_path);
+    cmd.no_console_window();
     cmd.stdin(std::process::Stdio::null())
         .env("PATH", crate::env::enriched_path());
     // Run in the user's worktree so the CLI loads *their* project context.
@@ -2762,7 +2766,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_agent_graceful_stops_process_before_escalation() {
         // Spawn a process that traps SIGTERM and exits cleanly.
-        let mut child = tokio::process::Command::new("sh")
+        let mut child = tokio::process::Command::new("sh").no_console_window()
             .args(["-c", "trap 'exit 0' TERM; sleep 5"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
@@ -2783,7 +2787,7 @@ mod tests {
             .expect("failed to reap child");
 
         // kill -0 should fail for a dead process.
-        let probe = tokio::process::Command::new("kill")
+        let probe = tokio::process::Command::new("kill").no_console_window()
             .args(["-0", &pid.to_string()])
             .output()
             .await;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -558,16 +558,18 @@ async fn resolve_claude_path() -> OsString {
     if let Some(cached) = RESOLVED.get() {
         return cached.clone();
     }
-    let resolved = tokio::task::spawn_blocking(|| {
-        resolve_claude_path_inner(
-            dirs::home_dir(),
-            std::env::var_os("PATH"),
-            login_shell_path,
-            is_executable_file,
-        )
-    })
-    .await
-    .unwrap_or_else(|_| OsString::from("claude"));
+    // `enriched_path()` picks up fresh values from the Windows registry on
+    // Windows, and merges the login-shell PATH on Unix. This way an install
+    // made after claudette started (e.g. winget) is findable without a
+    // logout/restart. The work is a handful of Path::is_file probes plus one
+    // registry read, so we run it inline rather than going through
+    // spawn_blocking.
+    let resolved = resolve_claude_path_inner(
+        dirs::home_dir(),
+        Some(crate::env::enriched_path()),
+        login_shell_path,
+        is_executable_file,
+    );
     // Only cache absolute paths — the bare "claude" fallback should allow
     // retries on subsequent calls in case the environment improves.
     if Path::new(&resolved).is_absolute() {
@@ -633,20 +635,7 @@ fn resolve_claude_path_inner(
     }
 
     // 3. Well-known install locations as static fallbacks.
-    let mut fallback_candidates: Vec<PathBuf> = Vec::new();
-    if let Some(ref home) = home {
-        fallback_candidates.extend([
-            home.join(".local/bin/claude"),
-            home.join(".claude/local/claude"),
-            home.join(".nix-profile/bin/claude"), // Nix single-user
-        ]);
-    }
-    fallback_candidates.extend([
-        PathBuf::from("/usr/local/bin/claude"),
-        PathBuf::from("/opt/homebrew/bin/claude"), // macOS Homebrew
-        PathBuf::from("/run/current-system/sw/bin/claude"), // NixOS system
-        PathBuf::from("/nix/var/nix/profiles/default/bin/claude"), // Nix multi-user
-    ]);
+    let fallback_candidates = claude_fallback_paths(home.as_deref());
     for p in &fallback_candidates {
         if exists(p) {
             return p.clone().into_os_string();
@@ -654,19 +643,108 @@ fn resolve_claude_path_inner(
     }
 
     // 4. Nothing found — bare name as absolute last resort.
-    OsString::from("claude")
+    //    On Windows this is `claude.exe` so `CreateProcessW` doesn't add an
+    //    unwanted `.com`/`.bat` match from PATHEXT resolution.
+    OsString::from(claude_bare_name())
 }
 
-/// Search colon-separated PATH directories for a `claude` binary.
-/// Skips non-absolute entries to prevent repo-local execution.
+/// Binary filename variants for the `claude` CLI on the current target.
+///
+/// On Windows, the official Anthropic native installer ships `claude.exe`,
+/// while `npm i -g @anthropic-ai/claude-code` produces `.cmd` and `.ps1`
+/// launcher shims in `%APPDATA%\npm\`. We probe all three so both install
+/// flows resolve. On Unix there's only the bare `claude` executable.
+#[cfg(windows)]
+fn claude_binary_variants() -> &'static [&'static str] {
+    &["claude.exe", "claude.cmd", "claude.ps1"]
+}
+
+#[cfg(not(windows))]
+fn claude_binary_variants() -> &'static [&'static str] {
+    &["claude"]
+}
+
+#[cfg(windows)]
+fn claude_bare_name() -> &'static str {
+    "claude.exe"
+}
+
+#[cfg(not(windows))]
+fn claude_bare_name() -> &'static str {
+    "claude"
+}
+
+/// Well-known install locations for the `claude` CLI on the current target.
+/// Checked in order; first extant path wins. Pure function, no IO — takes
+/// `home` as a parameter so tests can inject a fixed path.
+fn claude_fallback_paths(home: Option<&Path>) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+
+    #[cfg(windows)]
+    {
+        if let Some(home) = home {
+            // Official Anthropic Windows installer drops here; this is the
+            // most likely hit on a fresh machine.
+            out.push(home.join(".local").join("bin").join("claude.exe"));
+            // npm global install — shims live under %APPDATA%\npm, which is
+            // `$HOME/AppData/Roaming/npm` by default.
+            out.push(
+                home.join("AppData")
+                    .join("Roaming")
+                    .join("npm")
+                    .join("claude.cmd"),
+            );
+            out.push(
+                home.join("AppData")
+                    .join("Roaming")
+                    .join("npm")
+                    .join("claude.ps1"),
+            );
+            // Hypothetical future MSI target — cheap to check and harmless
+            // if absent.
+            out.push(
+                home.join("AppData")
+                    .join("Local")
+                    .join("Programs")
+                    .join("claude")
+                    .join("claude.exe"),
+            );
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(home) = home {
+            out.push(home.join(".local/bin/claude"));
+            out.push(home.join(".claude/local/claude"));
+            out.push(home.join(".nix-profile/bin/claude"));
+        }
+        out.push(PathBuf::from("/usr/local/bin/claude"));
+        out.push(PathBuf::from("/opt/homebrew/bin/claude"));
+        out.push(PathBuf::from("/run/current-system/sw/bin/claude"));
+        out.push(PathBuf::from("/nix/var/nix/profiles/default/bin/claude"));
+    }
+
+    out
+}
+
+/// Search PATH directories for a `claude` binary, trying each platform
+/// filename variant (`claude.exe`/`claude.cmd`/`claude.ps1` on Windows,
+/// bare `claude` elsewhere).
+///
+/// Skips non-absolute entries to prevent repo-local execution
+/// (e.g. a `.` entry would otherwise let a malicious repo provide its own
+/// `claude` binary).
 fn search_path_dirs(path: &std::ffi::OsStr, exists: &impl Fn(&Path) -> bool) -> Option<OsString> {
     for dir in std::env::split_paths(path) {
         if !dir.is_absolute() {
             continue;
         }
-        let candidate = dir.join("claude");
-        if exists(&candidate) {
-            return Some(candidate.into_os_string());
+        for name in claude_binary_variants() {
+            let candidate = dir.join(name);
+            if exists(&candidate) {
+                return Some(candidate.into_os_string());
+            }
         }
     }
     None
@@ -2167,6 +2245,7 @@ mod tests {
         None
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_process_path_wins() {
         // Process PATH is checked first and should win over everything.
@@ -2184,6 +2263,7 @@ mod tests {
         assert_eq!(result, OsString::from("/custom/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_shell_path_before_well_known() {
         // When process PATH misses, shell probe runs before well-known paths.
@@ -2197,6 +2277,7 @@ mod tests {
         assert_eq!(result, OsString::from("/shell/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_shell_probe_deferred() {
         // Shell probe should NOT run if process PATH already found claude.
@@ -2214,6 +2295,7 @@ mod tests {
         assert!(!probed.load(std::sync::atomic::Ordering::SeqCst));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_falls_back_to_well_known_home() {
         let home = PathBuf::from("/home/user");
@@ -2222,6 +2304,7 @@ mod tests {
         assert_eq!(result, expected.into_os_string());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_falls_back_to_claude_local() {
         let home = PathBuf::from("/home/user");
@@ -2230,6 +2313,7 @@ mod tests {
         assert_eq!(result, expected.into_os_string());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_falls_back_to_system() {
         let result = resolve_claude_path_inner(None, None, no_shell, |p| {
@@ -2238,6 +2322,7 @@ mod tests {
         assert_eq!(result, OsString::from("/usr/local/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_falls_back_to_homebrew() {
         let result = resolve_claude_path_inner(None, None, no_shell, |p| {
@@ -2246,6 +2331,7 @@ mod tests {
         assert_eq!(result, OsString::from("/opt/homebrew/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_finds_nix_profile() {
         let home = PathBuf::from("/home/user");
@@ -2254,6 +2340,7 @@ mod tests {
         assert_eq!(result, expected.into_os_string());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_finds_nixos_system() {
         let result = resolve_claude_path_inner(None, None, no_shell, |p| {
@@ -2262,6 +2349,7 @@ mod tests {
         assert_eq!(result, OsString::from("/run/current-system/sw/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_home_before_system_in_fallbacks() {
         // Within the well-known fallbacks, home paths are checked before system.
@@ -2273,12 +2361,14 @@ mod tests {
         assert_eq!(result, home_path.into_os_string());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_bare_fallback() {
         let result = resolve_claude_path_inner(None, None, no_shell, |_| false);
         assert_eq!(result, OsString::from("claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_skips_relative_in_process_path() {
         let result = resolve_claude_path_inner(
@@ -2294,6 +2384,7 @@ mod tests {
         assert_eq!(result, OsString::from("/abs/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_skips_empty_path_entry() {
         let result =
@@ -2303,6 +2394,7 @@ mod tests {
         assert_eq!(result, OsString::from("/good/bin/claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_resolve_all_relative_falls_through_to_bare() {
         let result = resolve_claude_path_inner(
@@ -2314,6 +2406,7 @@ mod tests {
         assert_eq!(result, OsString::from("claude"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_search_path_dirs_skips_relative() {
         let path = OsString::from(".:/tmp/evil:/good/bin");
@@ -2323,11 +2416,74 @@ mod tests {
         assert_eq!(result, Some(OsString::from("/tmp/evil/claude")));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_search_path_dirs_returns_none_for_all_relative() {
         let path = OsString::from(".:relative:./bin");
         let result = search_path_dirs(path.as_os_str(), &|_| true);
         assert_eq!(result, None);
+    }
+
+    // --- Windows-specific resolve tests ---
+
+    /// `.local\bin\claude.exe` is the location the official Anthropic
+    /// Windows installer drops the binary into. If this lookup ever
+    /// regresses, users who ran `irm https://claude.ai/install.ps1` will
+    /// see "program not found" despite the file being right there.
+    #[cfg(windows)]
+    #[test]
+    fn test_resolve_falls_back_to_anthropic_native_windows() {
+        let home = PathBuf::from(r"C:\Users\user");
+        let expected = home.join(r".local\bin\claude.exe");
+        let expected_clone = expected.clone();
+        let result = resolve_claude_path_inner(
+            Some(home),
+            None,
+            || None,
+            move |p| p == expected_clone,
+        );
+        assert_eq!(result, expected.into_os_string());
+    }
+
+    /// `%APPDATA%\npm\claude.cmd` is what `npm i -g @anthropic-ai/claude-code`
+    /// produces on Windows — a `.cmd` shim, not a `.exe`. Our resolver must
+    /// accept both variants.
+    #[cfg(windows)]
+    #[test]
+    fn test_resolve_falls_back_to_npm_shim_windows() {
+        let home = PathBuf::from(r"C:\Users\user");
+        let expected = home.join(r"AppData\Roaming\npm\claude.cmd");
+        let expected_clone = expected.clone();
+        let result = resolve_claude_path_inner(
+            Some(home),
+            None,
+            || None,
+            move |p| p == expected_clone,
+        );
+        assert_eq!(result, expected.into_os_string());
+    }
+
+    /// `search_path_dirs` must probe each Windows filename variant in order
+    /// within a single directory — a user who has only `claude.cmd` on PATH
+    /// (npm install) should resolve just like one with `claude.exe` (native
+    /// install).
+    #[cfg(windows)]
+    #[test]
+    fn test_search_path_dirs_tries_each_variant_windows() {
+        let path = OsString::from(r"C:\tools\npm");
+        let expected = PathBuf::from(r"C:\tools\npm\claude.cmd");
+        let expected_clone = expected.clone();
+        let result = search_path_dirs(path.as_os_str(), &move |p| p == expected_clone);
+        assert_eq!(result, Some(expected.into_os_string()));
+    }
+
+    /// The bare-name last-resort fallback must be `claude.exe` on Windows,
+    /// not `claude` — otherwise `CreateProcessW` may not resolve it even
+    /// with PATHEXT configured, depending on the caller's settings.
+    #[cfg(windows)]
+    #[test]
+    fn test_bare_name_is_exe_on_windows() {
+        assert_eq!(claude_bare_name(), "claude.exe");
     }
 
     // --- build_claude_args attachment tests ---

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -424,7 +424,8 @@ pub fn play_audio_file(path: &Path, volume: f64) {
             .unwrap_or("")
             .to_lowercase();
         let result = if ext == "ogg" || ext == "oga" {
-            std::process::Command::new("ffplay").no_console_window()
+            std::process::Command::new("ffplay")
+                .no_console_window()
                 .args(["-nodisp", "-autoexit", "-volume"])
                 .arg(format!("{}", (volume * 100.0) as u32))
                 .arg(path)
@@ -432,7 +433,8 @@ pub fn play_audio_file(path: &Path, volume: f64) {
                 .stderr(std::process::Stdio::null())
                 .spawn()
         } else {
-            std::process::Command::new("afplay").no_console_window()
+            std::process::Command::new("afplay")
+                .no_console_window()
                 .arg("-v")
                 .arg(format!("{volume}"))
                 .arg(path)
@@ -451,7 +453,8 @@ pub fn play_audio_file(path: &Path, volume: f64) {
             .unwrap_or("")
             .to_lowercase();
         let result = if ext == "mp3" {
-            std::process::Command::new("ffplay").no_console_window()
+            std::process::Command::new("ffplay")
+                .no_console_window()
                 .args(["-nodisp", "-autoexit", "-volume"])
                 .arg(format!("{}", (volume * 100.0) as u32))
                 .arg(path)
@@ -460,13 +463,15 @@ pub fn play_audio_file(path: &Path, volume: f64) {
                 .spawn()
         } else {
             let pa_volume = (volume * 65536.0) as u32;
-            std::process::Command::new("paplay").no_console_window()
+            std::process::Command::new("paplay")
+                .no_console_window()
                 .arg("--volume")
                 .arg(pa_volume.to_string())
                 .arg(path)
                 .spawn()
                 .or_else(|_| {
-                    std::process::Command::new("ffplay").no_console_window()
+                    std::process::Command::new("ffplay")
+                        .no_console_window()
                         .args(["-nodisp", "-autoexit", "-volume"])
                         .arg(format!("{}", (volume * 100.0) as u32))
                         .arg(path)

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -6,6 +6,11 @@ use std::time::{Duration, Instant};
 use rand::seq::SliceRandom;
 
 use crate::model::cesp::{CespManifest, CespSound, InstalledPack, InstalledPackMeta, RegistryPack};
+// Sound-playback spawns only live under macOS/Linux cfg branches — the
+// trait import is likewise macOS/Linux-only so Windows doesn't flag it
+// as unused.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use crate::process::CommandWindowExt as _;
 
 const MANIFEST_FILE: &str = "openpeon.json";
 const META_FILE: &str = "_meta.json";
@@ -419,7 +424,7 @@ pub fn play_audio_file(path: &Path, volume: f64) {
             .unwrap_or("")
             .to_lowercase();
         let result = if ext == "ogg" || ext == "oga" {
-            std::process::Command::new("ffplay")
+            std::process::Command::new("ffplay").no_console_window()
                 .args(["-nodisp", "-autoexit", "-volume"])
                 .arg(format!("{}", (volume * 100.0) as u32))
                 .arg(path)
@@ -427,7 +432,7 @@ pub fn play_audio_file(path: &Path, volume: f64) {
                 .stderr(std::process::Stdio::null())
                 .spawn()
         } else {
-            std::process::Command::new("afplay")
+            std::process::Command::new("afplay").no_console_window()
                 .arg("-v")
                 .arg(format!("{volume}"))
                 .arg(path)
@@ -446,7 +451,7 @@ pub fn play_audio_file(path: &Path, volume: f64) {
             .unwrap_or("")
             .to_lowercase();
         let result = if ext == "mp3" {
-            std::process::Command::new("ffplay")
+            std::process::Command::new("ffplay").no_console_window()
                 .args(["-nodisp", "-autoexit", "-volume"])
                 .arg(format!("{}", (volume * 100.0) as u32))
                 .arg(path)
@@ -455,13 +460,13 @@ pub fn play_audio_file(path: &Path, volume: f64) {
                 .spawn()
         } else {
             let pa_volume = (volume * 65536.0) as u32;
-            std::process::Command::new("paplay")
+            std::process::Command::new("paplay").no_console_window()
                 .arg("--volume")
                 .arg(pa_volume.to_string())
                 .arg(path)
                 .spawn()
                 .or_else(|_| {
-                    std::process::Command::new("ffplay")
+                    std::process::Command::new("ffplay").no_console_window()
                         .args(["-nodisp", "-autoexit", "-volume"])
                         .arg(format!("{}", (volume * 100.0) as u32))
                         .arg(path)

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -481,6 +481,7 @@ pub fn play_audio_file(path: &Path, volume: f64) {
     }
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn spawn_and_reap(mut child: std::process::Child) {
     std::thread::spawn(move || {
         let _ = child.wait();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -45,7 +45,7 @@ fn validate_file_path(file_path: &str) -> Result<(), DiffError> {
 }
 
 async fn run_git(path: &str, args: &[&str]) -> Result<String, DiffError> {
-    let output = Command::new("git").no_console_window()
+    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
         .args(["-C", path])
         .args(args)
         .output()
@@ -271,7 +271,7 @@ pub async fn file_diff(
     if !ls_output.trim().is_empty() {
         // Untracked file — diff against /dev/null
         let full_path = Path::new(worktree_path).join(file_path);
-        let output = Command::new("git").no_console_window()
+        let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["-C", worktree_path])
             .args([
                 "diff",
@@ -323,7 +323,7 @@ pub async fn file_diff_for_layer(
         Some("untracked") => {
             // Diff against /dev/null for untracked files
             let full_path = Path::new(worktree_path).join(file_path);
-            let output = Command::new("git").no_console_window()
+            let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
                 .args(["-C", worktree_path])
                 .args([
                     "diff",
@@ -833,7 +833,7 @@ mod integration_tests {
     use std::process::Command as StdCommand;
 
     fn git_cmd(dir: &Path, args: &[&str]) -> String {
-        let output = StdCommand::new("git").no_console_window()
+        let output = StdCommand::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["-C", dir.to_str().unwrap()])
             .args(args)
             .output()

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -31,7 +31,14 @@ fn validate_file_path(file_path: &str) -> Result<(), DiffError> {
             "Invalid file path: contains null byte".into(),
         ));
     }
-    if Path::new(file_path).is_absolute() {
+    // Reject platform-absolute paths AND Unix-style rooted paths on any
+    // platform. `Path::is_absolute` on Windows considers only
+    // drive-letter and UNC forms absolute — so `/etc/passwd` would pass
+    // through `is_absolute()` as `false` on a Windows build, defeating
+    // the path-traversal guard. Checking the leading byte directly
+    // closes that gap regardless of host OS.
+    let first_byte = file_path.as_bytes().first().copied();
+    if Path::new(file_path).is_absolute() || first_byte == Some(b'/') || first_byte == Some(b'\\') {
         return Err(DiffError::CommandFailed(
             "Invalid file path: absolute paths are not allowed".into(),
         ));
@@ -849,6 +856,14 @@ mod integration_tests {
         git_cmd(dir, &["init", "-b", "main"]);
         git_cmd(dir, &["config", "user.email", "test@test.com"]);
         git_cmd(dir, &["config", "user.name", "Test"]);
+        // Force LF line endings in the working tree. Git for Windows
+        // defaults to `core.autocrlf=true` globally, which rewrites LF to
+        // CRLF on checkout and would make the revert assertions compare
+        // "keep\r\n" against "keep\n". The production worktree this
+        // module manages is a git worktree created by the app, where we
+        // control the config — so mirroring that in tests is closer to
+        // real conditions, not less accurate.
+        git_cmd(dir, &["config", "core.autocrlf", "false"]);
 
         // Create initial file and commit on main
         std::fs::write(dir.join("file.txt"), "line 1\nline 2\nline 3\n").unwrap();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::path::Path;
 
 use tokio::process::Command;
+use crate::process::CommandWindowExt as _;
 
 use crate::model::diff::{
     DiffFile, DiffHunk, DiffLine, DiffLineType, FileDiff, FileStatus, StagedDiffFiles,
@@ -44,7 +45,7 @@ fn validate_file_path(file_path: &str) -> Result<(), DiffError> {
 }
 
 async fn run_git(path: &str, args: &[&str]) -> Result<String, DiffError> {
-    let output = Command::new("git")
+    let output = Command::new("git").no_console_window()
         .args(["-C", path])
         .args(args)
         .output()
@@ -270,7 +271,7 @@ pub async fn file_diff(
     if !ls_output.trim().is_empty() {
         // Untracked file — diff against /dev/null
         let full_path = Path::new(worktree_path).join(file_path);
-        let output = Command::new("git")
+        let output = Command::new("git").no_console_window()
             .args(["-C", worktree_path])
             .args([
                 "diff",
@@ -322,7 +323,7 @@ pub async fn file_diff_for_layer(
         Some("untracked") => {
             // Diff against /dev/null for untracked files
             let full_path = Path::new(worktree_path).join(file_path);
-            let output = Command::new("git")
+            let output = Command::new("git").no_console_window()
                 .args(["-C", worktree_path])
                 .args([
                     "diff",
@@ -832,7 +833,7 @@ mod integration_tests {
     use std::process::Command as StdCommand;
 
     fn git_cmd(dir: &Path, args: &[&str]) -> String {
-        let output = StdCommand::new("git")
+        let output = StdCommand::new("git").no_console_window()
             .args(["-C", dir.to_str().unwrap()])
             .args(args)
             .output()

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::path::Path;
 
-use tokio::process::Command;
 use crate::process::CommandWindowExt as _;
+use tokio::process::Command;
 
 use crate::model::diff::{
     DiffFile, DiffHunk, DiffLine, DiffLineType, FileDiff, FileStatus, StagedDiffFiles,
@@ -45,7 +45,8 @@ fn validate_file_path(file_path: &str) -> Result<(), DiffError> {
 }
 
 async fn run_git(path: &str, args: &[&str]) -> Result<String, DiffError> {
-    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+    let output = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["-C", path])
         .args(args)
         .output()
@@ -271,7 +272,8 @@ pub async fn file_diff(
     if !ls_output.trim().is_empty() {
         // Untracked file — diff against /dev/null
         let full_path = Path::new(worktree_path).join(file_path);
-        let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        let output = Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["-C", worktree_path])
             .args([
                 "diff",
@@ -323,7 +325,8 @@ pub async fn file_diff_for_layer(
         Some("untracked") => {
             // Diff against /dev/null for untracked files
             let full_path = Path::new(worktree_path).join(file_path);
-            let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+            let output = Command::new(crate::git::resolve_git_path_blocking())
+                .no_console_window()
                 .args(["-C", worktree_path])
                 .args([
                     "diff",
@@ -833,7 +836,8 @@ mod integration_tests {
     use std::process::Command as StdCommand;
 
     fn git_cmd(dir: &Path, args: &[&str]) -> String {
-        let output = StdCommand::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        let output = StdCommand::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["-C", dir.to_str().unwrap()])
             .args(args)
             .output()

--- a/src/env.rs
+++ b/src/env.rs
@@ -14,6 +14,7 @@
 use std::ffi::OsString;
 use std::path::Path;
 use std::sync::OnceLock;
+use crate::process::CommandWindowExt as _;
 
 /// Cached login-shell PATH, resolved once per process lifetime.
 static SHELL_PATH: OnceLock<Option<OsString>> = OnceLock::new();
@@ -83,7 +84,7 @@ fn login_shell_path_probe() -> Option<OsString> {
         r#"printf '%s\n' "$PATH""#
     };
 
-    let mut child = std::process::Command::new(&shell)
+    let mut child = std::process::Command::new(&shell).no_console_window()
         .args(["-l", "-c", cmd_arg])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -304,6 +305,7 @@ mod tests {
     fn apply_std_sets_env_on_command() {
         let env = sample_env();
         let mut cmd = std::process::Command::new("echo");
+        cmd.no_console_window();
         env.apply_std(&mut cmd);
 
         let envs: Vec<_> = cmd.get_envs().collect();

--- a/src/env.rs
+++ b/src/env.rs
@@ -33,22 +33,29 @@ pub fn shell_path() -> Option<&'static OsString> {
 
 /// Build a PATH string that merges the login-shell PATH with the process PATH.
 ///
-/// If the login shell probe succeeded, its PATH is used as the base with any
-/// additional process-PATH entries appended (deduped). If it failed, the
-/// process PATH is returned unchanged.
+/// On Unix, the login shell is probed once (cached) and its PATH becomes the
+/// base — this catches GUI-launched apps that don't inherit the user's shell
+/// profile.
 ///
-/// This ensures that both user-installed tools (from shell profile) and any
-/// extra entries set by the launching context (e.g. Tauri dev server) are
-/// available.
+/// On Windows, we instead read the current `HKCU\Environment\Path` +
+/// `HKLM\...\Environment\Path` from the registry on every call. That gives us
+/// "fresh" PATH values after a `winget` / installer update without requiring
+/// the user to log out and back in — the process env block we inherited at
+/// launch is frozen, but the registry always reflects the current truth.
+///
+/// Process PATH is then appended (deduped) so any entries the launching
+/// context added beyond the registry (e.g. Tauri dev server) are preserved.
 pub fn enriched_path() -> OsString {
     let process_path = std::env::var_os("PATH").unwrap_or_default();
-    let Some(shell) = shell_path() else {
-        return process_path;
+
+    let base = match base_path() {
+        Some(p) => p,
+        None => return process_path,
     };
 
-    // Start with shell PATH entries, then append any non-empty process-PATH
-    // entries that aren't already present.
-    let mut merged_dirs: Vec<std::path::PathBuf> = std::env::split_paths(shell)
+    // Start with the base (login-shell on Unix, registry on Windows) and
+    // append any non-empty process-PATH entries not already present.
+    let mut merged_dirs: Vec<std::path::PathBuf> = std::env::split_paths(&base)
         .filter(|dir| !dir.as_os_str().is_empty())
         .collect();
 
@@ -59,6 +66,101 @@ pub fn enriched_path() -> OsString {
     }
 
     std::env::join_paths(&merged_dirs).unwrap_or(process_path)
+}
+
+#[cfg(unix)]
+fn base_path() -> Option<OsString> {
+    shell_path().cloned()
+}
+
+#[cfg(windows)]
+fn base_path() -> Option<OsString> {
+    windows_registry_path()
+}
+
+/// Read the current `Path` value from `HKCU\Environment` +
+/// `HKLM\...\Environment`, expand any `%VAR%` references against the current
+/// process env, and return the merged string.
+///
+/// We do NOT cache this — the whole point is to see changes made after
+/// claudette started (winget installs, user edits via System Properties).
+/// The cost is two registry reads + string operations, which is
+/// sub-millisecond and only runs on subprocess-spawn paths.
+///
+/// Returns `None` only when both keys fail to open (pathological state; we
+/// fall back to the frozen process PATH in that case).
+#[cfg(windows)]
+pub fn windows_registry_path() -> Option<OsString> {
+    use winreg::RegKey;
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+
+    // Machine PATH first, user PATH after — matches how Windows itself
+    // builds the effective PATH when a new session starts.
+    let machine = hklm
+        .open_subkey(r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment")
+        .and_then(|k| k.get_value::<String, _>("Path"))
+        .ok();
+    let user = hkcu
+        .open_subkey("Environment")
+        .and_then(|k| k.get_value::<String, _>("Path"))
+        .ok();
+
+    if machine.is_none() && user.is_none() {
+        return None;
+    }
+
+    let combined = match (machine, user) {
+        (Some(m), Some(u)) if !u.is_empty() => format!("{m};{u}"),
+        (Some(m), _) => m,
+        (None, Some(u)) => u,
+        (None, None) => unreachable!(),
+    };
+
+    Some(OsString::from(expand_env_vars_windows(&combined)))
+}
+
+/// Expand `%VAR%` placeholders against the current process env.
+/// Case-insensitive match on the var name (Windows convention). Unknown
+/// placeholders are left as-is so the string is still usable for diagnosis.
+#[cfg(windows)]
+fn expand_env_vars_windows(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if let Some(end) = bytes[i + 1..].iter().position(|&b| b == b'%') {
+                let name = &input[i + 1..i + 1 + end];
+                // Case-insensitive lookup — Windows env-var names are
+                // case-insensitive so `%PATH%` and `%Path%` must resolve
+                // the same way.
+                let matched = std::env::vars_os().find_map(|(k, v)| {
+                    if k.to_string_lossy().eq_ignore_ascii_case(name) {
+                        Some(v)
+                    } else {
+                        None
+                    }
+                });
+                match matched {
+                    Some(v) => out.push_str(&v.to_string_lossy()),
+                    None => {
+                        // Unknown var — leave the original `%NAME%` in place.
+                        out.push('%');
+                        out.push_str(name);
+                        out.push('%');
+                    }
+                }
+                i += 1 + end + 1;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
 }
 
 /// Probe the login shell for its PATH.
@@ -317,5 +419,73 @@ mod tests {
             std::ffi::OsStr::new("CLAUDETTE_ROOT_PATH"),
             Some(std::ffi::OsStr::new("/home/user/repo"))
         )));
+    }
+
+    // -----------------------------------------------------------------------
+    // Windows env-var expansion tests
+    // -----------------------------------------------------------------------
+    //
+    // The registry stores PATH entries like `%SystemRoot%\System32`
+    // unexpanded (REG_EXPAND_SZ). Since Rust's `std::env::split_paths`
+    // does not expand `%VAR%` references, we have to do it ourselves
+    // before handing the value back. These tests exercise the corner
+    // cases of that hand-rolled expander without requiring a real
+    // Windows environment.
+
+    /// Bare strings with no `%VAR%` references must pass through byte-for-
+    /// byte — that's the overwhelmingly common case on most machines.
+    #[cfg(windows)]
+    #[test]
+    fn expand_passthrough_without_vars() {
+        assert_eq!(
+            expand_env_vars_windows(r"C:\Windows;C:\Users\user\.local\bin"),
+            r"C:\Windows;C:\Users\user\.local\bin"
+        );
+    }
+
+    /// A defined env var must be substituted. We lean on `SystemRoot`,
+    /// which is guaranteed to exist on any real Windows session that
+    /// could reach this code.
+    #[cfg(windows)]
+    #[test]
+    fn expand_replaces_defined_var() {
+        let system_root = std::env::var("SystemRoot")
+            .expect("SystemRoot must be defined in a Windows test env");
+        let expanded = expand_env_vars_windows(r"%SystemRoot%\System32");
+        assert_eq!(expanded, format!(r"{system_root}\System32"));
+    }
+
+    /// Case-insensitive match: Windows env-var names are not
+    /// case-sensitive, so `%systemroot%` and `%SystemRoot%` must resolve
+    /// to the same value.
+    #[cfg(windows)]
+    #[test]
+    fn expand_is_case_insensitive() {
+        let upper = expand_env_vars_windows(r"%SYSTEMROOT%\System32");
+        let lower = expand_env_vars_windows(r"%systemroot%\System32");
+        assert_eq!(upper, lower);
+    }
+
+    /// An unknown var must be left as-is rather than turning into an
+    /// empty string — a user reading the resolved PATH should still be
+    /// able to see *which* var failed to resolve.
+    #[cfg(windows)]
+    #[test]
+    fn expand_leaves_unknown_var_intact() {
+        let nonce = "CLAUDETTE_TEST_NONEXISTENT_VAR_XYZ_9876";
+        // Safety: the env-var name is unique to this test so clearing
+        // it is guaranteed not to race with other tests.
+        // (And we don't rely on any prior value.)
+        let out = expand_env_vars_windows(&format!(r"prefix;%{nonce}%;suffix"));
+        assert_eq!(out, format!(r"prefix;%{nonce}%;suffix"));
+    }
+
+    /// A lone `%` at end-of-string is not a var reference and must be
+    /// preserved. Without this guard the expander could read past the
+    /// input or emit empty output.
+    #[cfg(windows)]
+    #[test]
+    fn expand_tolerates_unmatched_percent() {
+        assert_eq!(expand_env_vars_windows(r"C:\foo%"), r"C:\foo%");
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -11,10 +11,10 @@
 //! It also defines [`WorkspaceEnv`], the set of `CLAUDETTE_*` environment
 //! variables injected into every subprocess.
 
+use crate::process::CommandWindowExt as _;
 use std::ffi::OsString;
 use std::path::Path;
 use std::sync::OnceLock;
-use crate::process::CommandWindowExt as _;
 
 /// Cached login-shell PATH, resolved once per process lifetime.
 static SHELL_PATH: OnceLock<Option<OsString>> = OnceLock::new();
@@ -237,7 +237,8 @@ fn login_shell_path_probe() -> Option<OsString> {
         r#"printf '%s\n' "$PATH""#
     };
 
-    let mut child = std::process::Command::new(&shell).no_console_window()
+    let mut child = std::process::Command::new(&shell)
+        .no_console_window()
         .args(["-l", "-c", cmd_arg])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -615,8 +616,8 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn expand_replaces_defined_var() {
-        let system_root = std::env::var("SystemRoot")
-            .expect("SystemRoot must be defined in a Windows test env");
+        let system_root =
+            std::env::var("SystemRoot").expect("SystemRoot must be defined in a Windows test env");
         let expanded = expand_env_vars_windows(r"%SystemRoot%\System32");
         assert_eq!(expanded, format!(r"{system_root}\System32"));
     }
@@ -678,8 +679,8 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn expand_preserves_non_ascii_around_var_substitution() {
-        let system_root = std::env::var("SystemRoot")
-            .expect("SystemRoot must be defined in a Windows test env");
+        let system_root =
+            std::env::var("SystemRoot").expect("SystemRoot must be defined in a Windows test env");
         let out = expand_env_vars_windows(r"前%SystemRoot%後");
         assert_eq!(out, format!("前{system_root}後"));
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -31,6 +31,26 @@ pub fn shell_path() -> Option<&'static OsString> {
     SHELL_PATH.get_or_init(login_shell_path_probe).as_ref()
 }
 
+/// Force the login-shell PATH probe to run to completion, populating the
+/// [`SHELL_PATH`] cache. Call this once at app startup from a thread
+/// where a 5-second block is acceptable (a plain `std::thread::spawn` at
+/// Tauri setup time — never the Tokio runtime) so later async callers
+/// of [`enriched_path`] never pay the probe cost on a worker thread.
+///
+/// Idempotent: the `OnceLock::get_or_init` inside [`shell_path`]
+/// guarantees only the first call runs the probe, so repeated
+/// invocations are cheap no-ops.
+///
+/// On Windows this is a no-op — the Windows "base PATH" comes from the
+/// registry and is read fresh on every `enriched_path()` call, there is
+/// no shell probe to warm.
+pub fn prewarm_shell_path() {
+    #[cfg(unix)]
+    {
+        let _ = shell_path();
+    }
+}
+
 /// Build a PATH string that merges the login-shell PATH with the process PATH.
 ///
 /// On Unix, the login shell is probed once (cached) and its PATH becomes the
@@ -127,38 +147,69 @@ pub fn windows_registry_path() -> Option<OsString> {
 /// placeholders are left as-is so the string is still usable for diagnosis.
 #[cfg(windows)]
 fn expand_env_vars_windows(input: &str) -> String {
+    // Case-insensitive lookup — Windows env-var names are
+    // case-insensitive so `%PATH%` and `%Path%` must resolve the same
+    // way.
+    expand_env_vars_with_lookup(input, |name| {
+        std::env::vars_os().find_map(|(k, v)| {
+            if k.to_string_lossy().eq_ignore_ascii_case(name) {
+                Some(v.to_string_lossy().into_owned())
+            } else {
+                None
+            }
+        })
+    })
+}
+
+/// Pure, platform-agnostic implementation of `%VAR%` expansion.
+/// Accepting the env lookup as a closure lets the Unicode-correctness and
+/// boundary-handling tests run on every CI target (Linux/macOS) rather
+/// than being gated behind `#[cfg(windows)]` and effectively never
+/// executed. The Windows wrapper supplies a real case-insensitive
+/// `std::env::vars_os` lookup on top of this.
+///
+/// Implementation note: we operate on byte indices so we can slice out
+/// `%NAME%` spans, but we copy literal text via `&input[..]` slices —
+/// never by casting a single byte to `char`. An earlier version did
+/// `out.push(bytes[i] as char)`, which mojibakes any non-ASCII byte
+/// (e.g. `é` (`0xC3 0xA9`) became `Ã©`), so `which_in_enriched_path`
+/// stopped finding binaries under non-ASCII user-profile paths.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn expand_env_vars_with_lookup<F>(input: &str, lookup: F) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'%' {
-            if let Some(end) = bytes[i + 1..].iter().position(|&b| b == b'%') {
-                let name = &input[i + 1..i + 1 + end];
-                // Case-insensitive lookup — Windows env-var names are
-                // case-insensitive so `%PATH%` and `%Path%` must resolve
-                // the same way.
-                let matched = std::env::vars_os().find_map(|(k, v)| {
-                    if k.to_string_lossy().eq_ignore_ascii_case(name) {
-                        Some(v)
-                    } else {
-                        None
-                    }
-                });
-                match matched {
-                    Some(v) => out.push_str(&v.to_string_lossy()),
-                    None => {
-                        // Unknown var — leave the original `%NAME%` in place.
-                        out.push('%');
-                        out.push_str(name);
-                        out.push('%');
-                    }
+        if bytes[i] == b'%'
+            && let Some(end) = bytes[i + 1..].iter().position(|&b| b == b'%')
+        {
+            let name = &input[i + 1..i + 1 + end];
+            match lookup(name) {
+                Some(value) => out.push_str(&value),
+                None => {
+                    // Unknown var — leave the original `%NAME%` in place.
+                    out.push('%');
+                    out.push_str(name);
+                    out.push('%');
                 }
-                i += 1 + end + 1;
-                continue;
             }
+            i += 1 + end + 1;
+            continue;
         }
-        out.push(bytes[i] as char);
-        i += 1;
+        // Copy the next UTF-8 scalar via its byte range — never cast a
+        // single byte to `char`. `char_indices` gives us the next char
+        // boundary; combined with the `input[i..j]` slice this is a
+        // zero-cost copy of the exact UTF-8 bytes.
+        let ch = input[i..]
+            .chars()
+            .next()
+            .expect("i is within bytes.len() so at least one char remains");
+        let ch_len = ch.len_utf8();
+        out.push_str(&input[i..i + ch_len]);
+        i += ch_len;
     }
     out
 }
@@ -432,6 +483,121 @@ mod tests {
     // cases of that hand-rolled expander without requiring a real
     // Windows environment.
 
+    // ---- Pre-warm guarantees ---------------------------------------------
+
+    /// `prewarm_shell_path` must be safe to call repeatedly — startup
+    /// code is allowed to fire it on a std thread and forget about it,
+    /// so any re-entrancy (two callers racing, a caller that also calls
+    /// `shell_path` directly) must not panic or re-run the underlying
+    /// probe. We assert both invariants here.
+    #[test]
+    fn prewarm_shell_path_is_idempotent() {
+        prewarm_shell_path();
+        prewarm_shell_path();
+        // A follow-up direct call must still succeed without panicking
+        // — `shell_path` returns `Option<&'static OsString>`, and the
+        // underlying `OnceLock` value is frozen by the first invocation.
+        let _ = shell_path();
+    }
+
+    /// After prewarm runs to completion on Unix, further calls into
+    /// `enriched_path` must not need to spawn a shell. We can't observe
+    /// the probe directly, but we can assert the `SHELL_PATH` cache is
+    /// populated (either with `Some(path)` or `None` if the probe
+    /// failed) — both states stop future callers from re-probing.
+    #[cfg(unix)]
+    #[test]
+    fn prewarm_populates_shell_path_cache_on_unix() {
+        prewarm_shell_path();
+        assert!(
+            SHELL_PATH.get().is_some(),
+            "prewarm must populate the SHELL_PATH OnceLock on Unix",
+        );
+    }
+
+    // ---- Platform-agnostic expansion tests --------------------------------
+    //
+    // `expand_env_vars_windows` is Windows-gated (it reads the real process
+    // env), but the expansion *logic* is shared with
+    // `expand_env_vars_with_lookup`, which takes the env lookup as a
+    // closure. Testing the inner function lets CI (which runs on Linux and
+    // macOS) catch regressions in boundary handling, Unicode preservation,
+    // and edge cases — otherwise these guards would silently never execute.
+
+    /// Regression guard for the original mojibake bug: the expander must
+    /// preserve multi-byte UTF-8 literal text byte-for-byte. The earlier
+    /// `bytes[i] as char` cast would corrupt every non-ASCII code point
+    /// (`é` (`0xC3 0xA9`) turned into `Ã©`), so Windows user profiles with
+    /// accents, umlauts, CJK, or emoji stopped being searchable.
+    #[test]
+    fn expand_lookup_preserves_non_ascii_literal() {
+        let input = r"C:\Users\éßΩ漢\bin;D:\🎉\tools";
+        assert_eq!(
+            expand_env_vars_with_lookup(input, |_| None),
+            input,
+            "non-ASCII literal text must round-trip byte-for-byte"
+        );
+    }
+
+    /// Non-ASCII inside a variable's *value* must also survive — makes
+    /// sure the substitution path (not just literal copy) is UTF-8 clean.
+    #[test]
+    fn expand_lookup_preserves_non_ascii_in_value() {
+        let out = expand_env_vars_with_lookup(r"%HOME%\bin", |name| {
+            if name.eq_ignore_ascii_case("HOME") {
+                Some(r"C:\Users\éß漢".to_string())
+            } else {
+                None
+            }
+        });
+        assert_eq!(out, r"C:\Users\éß漢\bin");
+    }
+
+    /// Non-ASCII literal text both *before* and *after* a `%VAR%` span
+    /// exercises the boundary between literal-copy and substitution
+    /// modes — the mojibake bug was on the literal-copy path, so this is
+    /// the scenario that would have caught it in the wild.
+    #[test]
+    fn expand_lookup_non_ascii_around_substitution() {
+        let out = expand_env_vars_with_lookup("前%X%後", |name| {
+            (name == "X").then(|| "MID".to_string())
+        });
+        assert_eq!(out, "前MID後");
+    }
+
+    /// A defined var must substitute its value.
+    #[test]
+    fn expand_lookup_replaces_defined_var() {
+        let out = expand_env_vars_with_lookup(r"%FOO%\bin", |name| {
+            (name == "FOO").then(|| r"C:\x".to_string())
+        });
+        assert_eq!(out, r"C:\x\bin");
+    }
+
+    /// An unknown var must pass through as-is so the resolved PATH is
+    /// still human-readable for diagnosis.
+    #[test]
+    fn expand_lookup_leaves_unknown_var_intact() {
+        let out = expand_env_vars_with_lookup("%MISSING%", |_| None);
+        assert_eq!(out, "%MISSING%");
+    }
+
+    /// A lone trailing `%` is not a var reference and must be preserved.
+    #[test]
+    fn expand_lookup_tolerates_unmatched_percent() {
+        let out = expand_env_vars_with_lookup(r"C:\foo%", |_| None);
+        assert_eq!(out, r"C:\foo%");
+    }
+
+    /// Empty input must return empty output (no panic on the char
+    /// advance path).
+    #[test]
+    fn expand_lookup_handles_empty_input() {
+        assert_eq!(expand_env_vars_with_lookup("", |_| None), "");
+    }
+
+    // ---- Windows-only (reads real process env) ----------------------------
+
     /// Bare strings with no `%VAR%` references must pass through byte-for-
     /// byte — that's the overwhelmingly common case on most machines.
     #[cfg(windows)]
@@ -487,5 +653,34 @@ mod tests {
     #[test]
     fn expand_tolerates_unmatched_percent() {
         assert_eq!(expand_env_vars_windows(r"C:\foo%"), r"C:\foo%");
+    }
+
+    /// Regression guard: an earlier version cast UTF-8 bytes to `char`
+    /// one-at-a-time while copying the literal text between `%VAR%`
+    /// references, which corrupted every non-ASCII code point into
+    /// mojibake (`é` → `Ã©`). Windows user profiles routinely contain
+    /// non-ASCII characters — Spanish, German, CJK, emoji in new
+    /// installs — so this must round-trip cleanly.
+    #[cfg(windows)]
+    #[test]
+    fn expand_preserves_non_ascii_literal_text() {
+        // Multi-byte chars in the literal spans (both sides of %VAR%
+        // and around it). We don't resolve any var here — the point is
+        // that passthrough text itself is byte-correct.
+        let input = r"C:\Users\éßΩ漢\bin;D:\🎉\tools";
+        assert_eq!(expand_env_vars_windows(input), input);
+    }
+
+    /// Non-ASCII inside the *value* of an expanded var must survive too.
+    /// We prepend a short ASCII string, interpolate a real env var
+    /// (SystemRoot), and append a CJK tail so the boundary handling
+    /// between UTF-8 literal text and var expansion gets exercised.
+    #[cfg(windows)]
+    #[test]
+    fn expand_preserves_non_ascii_around_var_substitution() {
+        let system_root = std::env::var("SystemRoot")
+            .expect("SystemRoot must be defined in a Windows test env");
+        let out = expand_env_vars_windows(r"前%SystemRoot%後");
+        assert_eq!(out, format!("前{system_root}後"));
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -31,6 +31,22 @@ pub fn shell_path() -> Option<&'static OsString> {
     SHELL_PATH.get_or_init(login_shell_path_probe).as_ref()
 }
 
+/// Is the login-shell PATH cache already populated?
+///
+/// Used by async-context callers (`resolve_git_path_blocking`) that want
+/// to benefit from the enriched PATH when available but must avoid
+/// triggering the 5-second shell probe inline on a Tokio worker. On
+/// Windows there is no shell probe to warm, so this is always `true`.
+#[cfg(unix)]
+pub fn shell_path_is_cached() -> bool {
+    SHELL_PATH.get().is_some()
+}
+
+#[cfg(not(unix))]
+pub fn shell_path_is_cached() -> bool {
+    true
+}
+
 /// Force the login-shell PATH probe to run to completion, populating the
 /// [`SHELL_PATH`] cache. Call this once at app startup from a thread
 /// where a 5-second block is acceptable (a plain `std::thread::spawn` at
@@ -363,6 +379,12 @@ impl WorkspaceEnv {
 mod tests {
     use super::*;
 
+    /// `/usr/bin` is a Unix-only expectation. On Windows PATH has a
+    /// completely different shape (`C:\Windows\System32;...`) — the
+    /// `enriched_path_is_nonempty` / `..._contains_no_empty_entries`
+    /// tests below give us the platform-agnostic invariants we
+    /// actually care about.
+    #[cfg(unix)]
     #[test]
     fn enriched_path_includes_process_path() {
         let enriched = enriched_path();
@@ -514,6 +536,29 @@ mod tests {
             SHELL_PATH.get().is_some(),
             "prewarm must populate the SHELL_PATH OnceLock on Unix",
         );
+    }
+
+    /// `shell_path_is_cached` is the signal async callers
+    /// (`resolve_git_path_blocking`) use to decide whether they can
+    /// safely call `enriched_path()` without risking the 5 s shell
+    /// probe. On Windows it must always be `true` — no shell probe
+    /// exists on that platform, so there's nothing to wait for.
+    #[cfg(not(unix))]
+    #[test]
+    fn shell_path_is_cached_is_always_true_on_non_unix() {
+        assert!(shell_path_is_cached());
+    }
+
+    /// On Unix the answer depends on whether the probe has run yet.
+    /// Since these tests share a process-wide `OnceLock`, the truthful
+    /// post-prewarm state is the only one we can assert without races
+    /// — but we at least verify the function returns and the value is
+    /// monotonically `true` after the first `prewarm_shell_path()`.
+    #[cfg(unix)]
+    #[test]
+    fn shell_path_is_cached_is_true_after_prewarm() {
+        prewarm_shell_path();
+        assert!(shell_path_is_cached());
     }
 
     // ---- Platform-agnostic expansion tests --------------------------------

--- a/src/git.rs
+++ b/src/git.rs
@@ -28,12 +28,34 @@ pub fn resolve_git_path_blocking() -> OsString {
     let resolved = resolve_git_path_inner(
         dirs::home_dir(),
         Some(crate::env::enriched_path()),
-        |p| p.is_file(),
+        is_executable_file,
     );
     if Path::new(&resolved).is_absolute() {
         let _ = RESOLVED.set(resolved.clone());
     }
     resolved
+}
+
+/// Regular-file + execute-permission check. Without the execute bit a
+/// PATH hit can be a package-manager placeholder (pip-installed
+/// launcher, empty `git` wrapper script dropped during a broken
+/// upgrade, etc.) — caching that path would then make every git-backed
+/// feature fail with `PermissionDenied` even though a real executable
+/// exists further down PATH. On Windows the underlying FS doesn't
+/// expose a POSIX exec bit, so we fall back to `is_file`.
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.is_file()
+        && path
+            .metadata()
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(windows)]
@@ -360,11 +382,7 @@ pub async fn create_worktree(
     )
     .await?;
 
-    // Return the absolute worktree path
-    let abs_path = std::path::Path::new(worktree_path)
-        .canonicalize()
-        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
-    Ok(abs_path.to_string_lossy().to_string())
+    canonicalize_worktree_path(worktree_path)
 }
 
 /// Create a worktree + new branch rooted at an explicit git ref (commit hash,
@@ -391,10 +409,7 @@ pub async fn create_worktree_from_ref(
     )
     .await?;
 
-    let abs_path = std::path::Path::new(worktree_path)
-        .canonicalize()
-        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
-    Ok(abs_path.to_string_lossy().to_string())
+    canonicalize_worktree_path(worktree_path)
 }
 
 /// Restore a worktree for an existing branch (no -b flag).
@@ -408,10 +423,18 @@ pub async fn restore_worktree(
         &["worktree", "add", worktree_path, "--", branch_name],
     )
     .await?;
+    canonicalize_worktree_path(worktree_path)
+}
+
+/// Canonicalize a freshly-created worktree path and strip Windows verbatim
+/// `\\?\` prefixes so the result is a plain drive-letter path. The stored
+/// path is later passed to shells as a CWD; `cmd.exe` refuses verbatim
+/// paths, so we must normalize at the source.
+fn canonicalize_worktree_path(worktree_path: &str) -> Result<String, GitError> {
     let abs_path = std::path::Path::new(worktree_path)
         .canonicalize()
         .map_err(|e| GitError::CommandFailed(e.to_string()))?;
-    Ok(abs_path.to_string_lossy().to_string())
+    Ok(crate::path::strip_verbatim_prefix(&abs_path.to_string_lossy()).to_string())
 }
 
 pub async fn remove_worktree(
@@ -1304,5 +1327,82 @@ mod tests {
     fn test_resolve_git_bare_name_is_exe_on_windows() {
         let result = resolve_git_path_inner(None, None, |_| false);
         assert_eq!(result, OsString::from("git.exe"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Executable-bit check on Unix
+    //
+    // Regression guard: `is_executable_file` must reject regular files that
+    // lack the execute bit. Without this, a non-exec placeholder earlier on
+    // PATH (empty script left behind by a broken package upgrade, a build
+    // artefact like `/target/git/Cargo.toml`, etc.) would beat the real
+    // binary and poison the `OnceLock` cache — every subsequent git call
+    // would then fail with `PermissionDenied`.
+    // -----------------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn is_executable_file_rejects_non_exec_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let placeholder = dir.path().join("git");
+        std::fs::write(&placeholder, b"").unwrap();
+        // Readable/writable but not executable — the exact shape of a
+        // "leftover wrapper" file.
+        std::fs::set_permissions(&placeholder, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            !is_executable_file(&placeholder),
+            "non-exec regular file must be rejected",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn is_executable_file_accepts_exec_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("git");
+        std::fs::write(&real, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            is_executable_file(&real),
+            "regular file with exec bit set must be accepted",
+        );
+    }
+
+    /// End-to-end guard: with the production `is_executable_file` predicate
+    /// wired in, a non-exec placeholder earlier in PATH must be skipped in
+    /// favour of a real binary later in PATH. Before the executability
+    /// check, `resolve_git_path_inner` returned the placeholder because
+    /// `Path::is_file` was true, which is exactly the caching hazard we
+    /// are guarding against.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_git_skips_non_executable_placeholder() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+
+        let broken_dir = dir.path().join("broken");
+        let real_dir = dir.path().join("real");
+        std::fs::create_dir(&broken_dir).unwrap();
+        std::fs::create_dir(&real_dir).unwrap();
+
+        // Non-exec placeholder — what a corrupted install leaves behind.
+        let broken = broken_dir.join("git");
+        std::fs::write(&broken, b"").unwrap();
+        std::fs::set_permissions(&broken, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        // Real executable further down PATH.
+        let real = real_dir.join("git");
+        std::fs::write(&real, b"#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let path = std::env::join_paths([&broken_dir, &real_dir]).unwrap();
+        let resolved = resolve_git_path_inner(None, Some(path), is_executable_file);
+        assert_eq!(
+            resolved,
+            real.into_os_string(),
+            "resolver must skip the non-exec placeholder and pick the real binary",
+        );
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -25,11 +25,22 @@ pub fn resolve_git_path_blocking() -> OsString {
     if let Some(cached) = RESOLVED.get() {
         return cached.clone();
     }
-    let resolved = resolve_git_path_inner(
-        dirs::home_dir(),
-        Some(crate::env::enriched_path()),
-        is_executable_file,
-    );
+    // On Unix, `enriched_path()` triggers `login_shell_path_probe()` the
+    // first time it runs — that probe spawns `$SHELL -l -c ...` with a
+    // 5 s timeout. `resolve_git_path_blocking` is called inline from
+    // async code paths (every `run_git`), so we must not pay that cost
+    // on a Tokio worker. When the cache is cold we fall back to the
+    // process PATH — git is almost always in `/usr/bin` or
+    // `/usr/local/bin` (both in process PATH on macOS/Linux), and the
+    // well-known fallbacks below cover nix profiles, Homebrew, etc.
+    // After the startup prewarm thread completes, subsequent calls hit
+    // the enriched path.
+    let path = if crate::env::shell_path_is_cached() {
+        Some(crate::env::enriched_path())
+    } else {
+        std::env::var_os("PATH")
+    };
+    let resolved = resolve_git_path_inner(dirs::home_dir(), path, is_executable_file);
     if Path::new(&resolved).is_absolute() {
         let _ = RESOLVED.set(resolved.clone());
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,9 +1,142 @@
+use std::ffi::OsString;
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use serde::Serialize;
 use tokio::process::Command;
 use crate::process::CommandWindowExt as _;
+
+/// Resolve the `git` binary once and reuse the absolute path for every
+/// subsequent call. Caching matters because git is invoked dozens of times
+/// per user action (status / log / diff / branch / worktree / etc.) — doing
+/// the PATH walk each time would dominate the cost on Windows where the
+/// registry-backed PATH lookup is heavier than Unix.
+///
+/// Kept sync on purpose: the work is a handful of `Path::is_file` probes
+/// plus one Windows registry read, all sub-millisecond, so `spawn_blocking`
+/// would be more overhead than the operation itself.
+///
+/// The cache is only populated for absolute paths — a bare `"git"` (our
+/// last-resort fallback) is re-evaluated on every call so retrying after
+/// the user installs git actually works.
+pub fn resolve_git_path_blocking() -> OsString {
+    static RESOLVED: OnceLock<OsString> = OnceLock::new();
+    if let Some(cached) = RESOLVED.get() {
+        return cached.clone();
+    }
+    let resolved = resolve_git_path_inner(
+        dirs::home_dir(),
+        Some(crate::env::enriched_path()),
+        |p| p.is_file(),
+    );
+    if Path::new(&resolved).is_absolute() {
+        let _ = RESOLVED.set(resolved.clone());
+    }
+    resolved
+}
+
+#[cfg(windows)]
+fn git_binary_variants() -> &'static [&'static str] {
+    &["git.exe", "git.cmd"]
+}
+
+#[cfg(not(windows))]
+fn git_binary_variants() -> &'static [&'static str] {
+    &["git"]
+}
+
+#[cfg(windows)]
+fn git_bare_name() -> &'static str {
+    "git.exe"
+}
+
+#[cfg(not(windows))]
+fn git_bare_name() -> &'static str {
+    "git"
+}
+
+/// Well-known git install locations per platform. Checked in order after
+/// the PATH-based search misses.
+fn git_fallback_paths(home: Option<&Path>) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+
+    #[cfg(windows)]
+    {
+        // Git for Windows system installer (most common on both x64 and
+        // ARM64 — the ARM64 installer also drops here).
+        out.push(PathBuf::from(r"C:\Program Files\Git\cmd\git.exe"));
+        // 32-bit installer on 64-bit Windows — rare today but still seen.
+        out.push(PathBuf::from(r"C:\Program Files (x86)\Git\cmd\git.exe"));
+        if let Some(home) = home {
+            // Git for Windows user-scope installer.
+            out.push(
+                home.join("AppData")
+                    .join("Local")
+                    .join("Programs")
+                    .join("Git")
+                    .join("cmd")
+                    .join("git.exe"),
+            );
+            // Scoop.
+            out.push(
+                home.join("scoop")
+                    .join("apps")
+                    .join("git")
+                    .join("current")
+                    .join("cmd")
+                    .join("git.exe"),
+            );
+        }
+        // Chocolatey — default install location.
+        out.push(PathBuf::from(r"C:\ProgramData\chocolatey\bin\git.exe"));
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(home) = home {
+            out.push(home.join(".nix-profile/bin/git"));
+        }
+        out.push(PathBuf::from("/usr/local/bin/git"));
+        out.push(PathBuf::from("/opt/homebrew/bin/git")); // macOS Homebrew
+        out.push(PathBuf::from("/usr/bin/git"));
+        out.push(PathBuf::from("/run/current-system/sw/bin/git"));
+        out.push(PathBuf::from("/nix/var/nix/profiles/default/bin/git"));
+    }
+
+    out
+}
+
+/// Pure resolution logic — identical shape to `resolve_claude_path_inner`.
+/// 1. PATH search (enriched PATH passed by caller — registry on Windows,
+///    login-shell + process PATH on Unix).
+/// 2. Well-known install locations.
+/// 3. Bare `git` / `git.exe` as the last-resort fallback.
+fn resolve_git_path_inner(
+    home: Option<PathBuf>,
+    process_path: Option<OsString>,
+    exists: impl Fn(&Path) -> bool,
+) -> OsString {
+    if let Some(process_path) = process_path {
+        for dir in std::env::split_paths(&process_path) {
+            if !dir.is_absolute() {
+                continue;
+            }
+            for name in git_binary_variants() {
+                let candidate = dir.join(name);
+                if exists(&candidate) {
+                    return candidate.into_os_string();
+                }
+            }
+        }
+    }
+    for p in git_fallback_paths(home.as_deref()) {
+        if exists(&p) {
+            return p.into_os_string();
+        }
+    }
+    OsString::from(git_bare_name())
+}
 
 #[derive(Debug, Clone)]
 pub enum GitError {
@@ -23,7 +156,7 @@ impl fmt::Display for GitError {
 impl std::error::Error for GitError {}
 
 async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
-    let output = Command::new("git").no_console_window()
+    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
         .args(["-C", repo_path])
         .args(args)
         .output()
@@ -41,7 +174,7 @@ async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
 /// Read `git config user.name` from global config (no repo required).
 /// Returns `None` if not configured.
 pub async fn get_git_username() -> Result<Option<String>, GitError> {
-    let output = Command::new("git").no_console_window()
+    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
         .args(["config", "--global", "user.name"])
         .output()
         .await
@@ -169,7 +302,7 @@ pub async fn fetch_remote(repo_path: &str) -> Result<(), GitError> {
     };
 
     // Spawn with kill_on_drop so the child is terminated if the timeout fires.
-    let mut child = match Command::new("git").no_console_window()
+    let mut child = match Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
         .args(["-C", repo_path, "fetch", &remote])
         .kill_on_drop(true)
         .stdout(std::process::Stdio::null())
@@ -831,7 +964,7 @@ mod tests {
         // Clone from bare remote.
         let clone_dir = tempfile::tempdir().unwrap();
         let clone_path = clone_dir.path().to_str().unwrap();
-        let output = tokio::process::Command::new("git").no_console_window()
+        let output = tokio::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["clone", remote_path, clone_path])
             .output()
             .await
@@ -863,7 +996,7 @@ mod tests {
         // Push a new commit directly to the bare remote via a temp worktree.
         let pusher = tempfile::tempdir().unwrap();
         let pusher_path = pusher.path().to_str().unwrap();
-        let out = tokio::process::Command::new("git").no_console_window()
+        let out = tokio::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["clone", remote_path, pusher_path])
             .output()
             .await
@@ -1101,5 +1234,75 @@ mod tests {
             ensure_utc_tz("2026-04-18T03:36:10"),
             "2026-04-18T03:36:10 UTC"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_git_path_inner tests
+    // -----------------------------------------------------------------------
+
+    /// Happy path on Unix: process PATH hit wins before any fallback is
+    /// consulted.
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_git_process_path_wins_unix() {
+        let result = resolve_git_path_inner(
+            Some(PathBuf::from("/home/user")),
+            Some(OsString::from("/usr/bin:/usr/local/bin")),
+            |p| p == Path::new("/usr/bin/git"),
+        );
+        assert_eq!(result, OsString::from("/usr/bin/git"));
+    }
+
+    /// Fallback to a well-known system location when PATH misses.
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_git_falls_back_system_unix() {
+        let result = resolve_git_path_inner(None, None, |p| {
+            p == Path::new("/usr/local/bin/git")
+        });
+        assert_eq!(result, OsString::from("/usr/local/bin/git"));
+    }
+
+    /// Last resort: nothing exists anywhere — we return the bare name so
+    /// the caller can surface a legible "git not installed" error instead
+    /// of a phantom absolute path.
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_git_falls_back_bare_name_unix() {
+        let result = resolve_git_path_inner(None, None, |_| false);
+        assert_eq!(result, OsString::from("git"));
+    }
+
+    /// On Windows, Git for Windows is by far the most likely install; its
+    /// default location is `C:\Program Files\Git\cmd\git.exe` regardless
+    /// of whether the user ran the x64 or ARM64 installer.
+    #[cfg(windows)]
+    #[test]
+    fn test_resolve_git_falls_back_program_files_windows() {
+        let expected = Path::new(r"C:\Program Files\Git\cmd\git.exe");
+        let result = resolve_git_path_inner(None, None, |p| p == expected);
+        assert_eq!(result, expected.as_os_str().to_os_string());
+    }
+
+    /// Scoop installs git under `%USERPROFILE%\scoop\apps\git\current\cmd`.
+    /// Users who prefer Scoop shouldn't have to install Git for Windows
+    /// just to use claudette.
+    #[cfg(windows)]
+    #[test]
+    fn test_resolve_git_falls_back_scoop_windows() {
+        let home = PathBuf::from(r"C:\Users\user");
+        let expected = home.join(r"scoop\apps\git\current\cmd\git.exe");
+        let expected_clone = expected.clone();
+        let result = resolve_git_path_inner(Some(home), None, move |p| p == expected_clone);
+        assert_eq!(result, expected.into_os_string());
+    }
+
+    /// Last-resort on Windows must be `git.exe`, not `git` — a bare `"git"`
+    /// handed to `CreateProcessW` without PATHEXT completion would fail.
+    #[cfg(windows)]
+    #[test]
+    fn test_resolve_git_bare_name_is_exe_on_windows() {
+        let result = resolve_git_path_inner(None, None, |_| false);
+        assert_eq!(result, OsString::from("git.exe"));
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,9 +3,9 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use crate::process::CommandWindowExt as _;
 use serde::Serialize;
 use tokio::process::Command;
-use crate::process::CommandWindowExt as _;
 
 /// Resolve the `git` binary once and reuse the absolute path for every
 /// subsequent call. Caching matters because git is invoked dozens of times
@@ -178,7 +178,8 @@ impl fmt::Display for GitError {
 impl std::error::Error for GitError {}
 
 async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
-    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+    let output = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["-C", repo_path])
         .args(args)
         .output()
@@ -196,7 +197,8 @@ async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
 /// Read `git config user.name` from global config (no repo required).
 /// Returns `None` if not configured.
 pub async fn get_git_username() -> Result<Option<String>, GitError> {
-    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+    let output = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["config", "--global", "user.name"])
         .output()
         .await
@@ -324,7 +326,8 @@ pub async fn fetch_remote(repo_path: &str) -> Result<(), GitError> {
     };
 
     // Spawn with kill_on_drop so the child is terminated if the timeout fires.
-    let mut child = match Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+    let mut child = match Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["-C", repo_path, "fetch", &remote])
         .kill_on_drop(true)
         .stdout(std::process::Stdio::null())
@@ -987,7 +990,8 @@ mod tests {
         // Clone from bare remote.
         let clone_dir = tempfile::tempdir().unwrap();
         let clone_path = clone_dir.path().to_str().unwrap();
-        let output = tokio::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        let output = tokio::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["clone", remote_path, clone_path])
             .output()
             .await
@@ -1019,7 +1023,8 @@ mod tests {
         // Push a new commit directly to the bare remote via a temp worktree.
         let pusher = tempfile::tempdir().unwrap();
         let pusher_path = pusher.path().to_str().unwrap();
-        let out = tokio::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        let out = tokio::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["clone", remote_path, pusher_path])
             .output()
             .await
@@ -1280,9 +1285,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn test_resolve_git_falls_back_system_unix() {
-        let result = resolve_git_path_inner(None, None, |p| {
-            p == Path::new("/usr/local/bin/git")
-        });
+        let result = resolve_git_path_inner(None, None, |p| p == Path::new("/usr/local/bin/git"));
         assert_eq!(result, OsString::from("/usr/local/bin/git"));
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use serde::Serialize;
 use tokio::process::Command;
+use crate::process::CommandWindowExt as _;
 
 #[derive(Debug, Clone)]
 pub enum GitError {
@@ -22,7 +23,7 @@ impl fmt::Display for GitError {
 impl std::error::Error for GitError {}
 
 async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
-    let output = Command::new("git")
+    let output = Command::new("git").no_console_window()
         .args(["-C", repo_path])
         .args(args)
         .output()
@@ -40,7 +41,7 @@ async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
 /// Read `git config user.name` from global config (no repo required).
 /// Returns `None` if not configured.
 pub async fn get_git_username() -> Result<Option<String>, GitError> {
-    let output = Command::new("git")
+    let output = Command::new("git").no_console_window()
         .args(["config", "--global", "user.name"])
         .output()
         .await
@@ -168,7 +169,7 @@ pub async fn fetch_remote(repo_path: &str) -> Result<(), GitError> {
     };
 
     // Spawn with kill_on_drop so the child is terminated if the timeout fires.
-    let mut child = match Command::new("git")
+    let mut child = match Command::new("git").no_console_window()
         .args(["-C", repo_path, "fetch", &remote])
         .kill_on_drop(true)
         .stdout(std::process::Stdio::null())
@@ -830,7 +831,7 @@ mod tests {
         // Clone from bare remote.
         let clone_dir = tempfile::tempdir().unwrap();
         let clone_path = clone_dir.path().to_str().unwrap();
-        let output = tokio::process::Command::new("git")
+        let output = tokio::process::Command::new("git").no_console_window()
             .args(["clone", remote_path, clone_path])
             .output()
             .await
@@ -862,7 +863,7 @@ mod tests {
         // Push a new commit directly to the bare remote via a temp worktree.
         let pusher = tempfile::tempdir().unwrap();
         let pusher_path = pusher.path().to_str().unwrap();
-        let out = tokio::process::Command::new("git")
+        let out = tokio::process::Command::new("git").no_console_window()
             .args(["clone", remote_path, pusher_path])
             .output()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mcp_supervisor;
 pub mod metrics;
 pub mod model;
 pub mod names;
+pub mod path;
 pub mod permissions;
 pub mod plugin;
 pub mod process;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod model;
 pub mod names;
 pub mod permissions;
 pub mod plugin;
+pub mod process;
 pub mod scm_provider;
 pub mod slash_commands;
 pub mod snapshot;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -466,7 +466,7 @@ fn detect_repo_local_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
 
 /// Check if a file is explicitly gitignored (returns true if ignored).
 fn is_gitignored(repo_path: &Path, file: &str) -> bool {
-    std::process::Command::new("git").no_console_window()
+    std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
         .args(["check-ignore", "-q", file])
         .current_dir(repo_path)
         .stdout(std::process::Stdio::null())
@@ -487,7 +487,7 @@ mod tests {
         let repo = dir.path();
 
         // Init git repo
-        std::process::Command::new("git").no_console_window()
+        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["init"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -502,14 +502,14 @@ mod tests {
         fs::write(repo.join(".claude.json"), mcp_json).unwrap();
 
         // Stage and commit .gitignore so git is functional
-        std::process::Command::new("git").no_console_window()
+        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["add", ".gitignore"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
             .unwrap();
-        std::process::Command::new("git").no_console_window()
+        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["commit", "-m", "init", "--allow-empty"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -547,7 +547,7 @@ mod tests {
         let repo = dir.path();
 
         // Init git repo WITHOUT .gitignore
-        std::process::Command::new("git").no_console_window()
+        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["init"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -670,7 +670,7 @@ mod tests {
     #[test]
     fn test_is_gitignored_false_not_ignored() {
         let dir = TempDir::new().unwrap();
-        std::process::Command::new("git").no_console_window()
+        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["init"])
             .current_dir(dir.path())
             .stdout(std::process::Stdio::null())

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -13,6 +13,7 @@
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use crate::process::CommandWindowExt as _;
 
 /// A detected MCP server with its full configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -465,7 +466,7 @@ fn detect_repo_local_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
 
 /// Check if a file is explicitly gitignored (returns true if ignored).
 fn is_gitignored(repo_path: &Path, file: &str) -> bool {
-    std::process::Command::new("git")
+    std::process::Command::new("git").no_console_window()
         .args(["check-ignore", "-q", file])
         .current_dir(repo_path)
         .stdout(std::process::Stdio::null())
@@ -486,7 +487,7 @@ mod tests {
         let repo = dir.path();
 
         // Init git repo
-        std::process::Command::new("git")
+        std::process::Command::new("git").no_console_window()
             .args(["init"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -501,14 +502,14 @@ mod tests {
         fs::write(repo.join(".claude.json"), mcp_json).unwrap();
 
         // Stage and commit .gitignore so git is functional
-        std::process::Command::new("git")
+        std::process::Command::new("git").no_console_window()
             .args(["add", ".gitignore"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
             .unwrap();
-        std::process::Command::new("git")
+        std::process::Command::new("git").no_console_window()
             .args(["commit", "-m", "init", "--allow-empty"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -546,7 +547,7 @@ mod tests {
         let repo = dir.path();
 
         // Init git repo WITHOUT .gitignore
-        std::process::Command::new("git")
+        std::process::Command::new("git").no_console_window()
             .args(["init"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -669,7 +670,7 @@ mod tests {
     #[test]
     fn test_is_gitignored_false_not_ignored() {
         let dir = TempDir::new().unwrap();
-        std::process::Command::new("git")
+        std::process::Command::new("git").no_console_window()
             .args(["init"])
             .current_dir(dir.path())
             .stdout(std::process::Stdio::null())

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -12,8 +12,8 @@
 
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
 use crate::process::CommandWindowExt as _;
+use serde::{Deserialize, Serialize};
 
 /// A detected MCP server with its full configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -466,7 +466,8 @@ fn detect_repo_local_mcps(repo_path: &Path) -> Option<Vec<McpServer>> {
 
 /// Check if a file is explicitly gitignored (returns true if ignored).
 fn is_gitignored(repo_path: &Path, file: &str) -> bool {
-    std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+    std::process::Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["check-ignore", "-q", file])
         .current_dir(repo_path)
         .stdout(std::process::Stdio::null())
@@ -487,7 +488,8 @@ mod tests {
         let repo = dir.path();
 
         // Init git repo
-        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        std::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["init"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -502,14 +504,16 @@ mod tests {
         fs::write(repo.join(".claude.json"), mcp_json).unwrap();
 
         // Stage and commit .gitignore so git is functional
-        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        std::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["add", ".gitignore"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
             .unwrap();
-        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        std::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["commit", "-m", "init", "--allow-empty"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -547,7 +551,8 @@ mod tests {
         let repo = dir.path();
 
         // Init git repo WITHOUT .gitignore
-        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        std::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["init"])
             .current_dir(repo)
             .stdout(std::process::Stdio::null())
@@ -670,7 +675,8 @@ mod tests {
     #[test]
     fn test_is_gitignored_false_not_ignored() {
         let dir = TempDir::new().unwrap();
-        std::process::Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        std::process::Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["init"])
             .current_dir(dir.path())
             .stdout(std::process::Stdio::null())

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,94 @@
+//! Path-normalization helpers for cross-platform subprocess handoff.
+//!
+//! On Windows, `std::fs::canonicalize` / `tokio::fs::canonicalize` return a
+//! *verbatim* path — `\\?\C:\Users\...`. The `\\?\` prefix disables
+//! Win32 name normalization and enables long-path support, which is great
+//! for Win32 file APIs but breaks anything that interprets the path as a
+//! command-line CWD. In particular, `cmd.exe` sees the leading `\\`,
+//! classifies it as a UNC share, refuses to `chdir` into it, and falls back
+//! to `C:\Windows` with the warning:
+//!
+//! ```text
+//! '\\?\C:\Users\foo\workspace'
+//! CMD.EXE was started with the above path as the current directory.
+//! UNC paths are not supported. Defaulting to Windows directory.
+//! ```
+//!
+//! We hand canonical paths to `portable-pty` as the child CWD, which
+//! eventually reaches `cmd.exe` (or any shell a user configures), so we
+//! must strip the prefix before it leaves the Rust side.
+
+/// Strip the `\\?\` verbatim-path prefix when it hides a plain
+/// drive-letter path (`\\?\C:\...`). Leaves the string untouched when the
+/// prefix is absent or when stripping would change semantics — notably
+/// `\\?\UNC\server\share\...`, which is a *real* UNC path that must keep
+/// its verbatim form to stay valid.
+///
+/// Pure string manipulation — testable on every platform, even though it
+/// only has practical effect on Windows-origin paths.
+pub fn strip_verbatim_prefix(s: &str) -> &str {
+    let Some(rest) = s.strip_prefix(r"\\?\") else {
+        return s;
+    };
+    let bytes = rest.as_bytes();
+    // Drive-letter form: ASCII letter followed by ':'. Reject anything
+    // else (including `\\?\UNC\...` and the empty tail) so we never
+    // rewrite a UNC verbatim path into a broken shorter one.
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        rest
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_drive_letter_verbatim_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\C:\Users\brink\workspace"),
+            r"C:\Users\brink\workspace",
+        );
+    }
+
+    #[test]
+    fn strips_lowercase_drive_letter() {
+        assert_eq!(strip_verbatim_prefix(r"\\?\c:\foo"), r"c:\foo");
+    }
+
+    #[test]
+    fn strips_bare_drive_root() {
+        // The shortest legal drive-letter verbatim path — just `\\?\C:` with
+        // no trailing component. Stripping still yields a valid drive spec.
+        assert_eq!(strip_verbatim_prefix(r"\\?\C:"), r"C:");
+    }
+
+    #[test]
+    fn preserves_real_unc_verbatim_path() {
+        // `\\?\UNC\server\share\...` is the verbatim form of `\\server\share\...`
+        // and must keep the prefix — dropping it would produce `UNC\server\share`,
+        // which is not a valid UNC path at all.
+        let unc = r"\\?\UNC\server\share\file.txt";
+        assert_eq!(strip_verbatim_prefix(unc), unc);
+    }
+
+    #[test]
+    fn preserves_non_verbatim_paths_unchanged() {
+        assert_eq!(strip_verbatim_prefix(r"C:\Users\brink"), r"C:\Users\brink");
+        assert_eq!(strip_verbatim_prefix("/home/brink"), "/home/brink");
+        assert_eq!(strip_verbatim_prefix(""), "");
+    }
+
+    #[test]
+    fn preserves_malformed_verbatim_prefix() {
+        // `\\?\` with a single-character tail — no colon, not a drive spec.
+        // Stripping would hand `X` downstream, which is just a relative name.
+        assert_eq!(strip_verbatim_prefix(r"\\?\X"), r"\\?\X");
+        // Empty tail after the prefix — same reasoning.
+        assert_eq!(strip_verbatim_prefix(r"\\?\"), r"\\?\");
+        // Digit "drive" — real Windows drive letters are A–Z only.
+        assert_eq!(strip_verbatim_prefix(r"\\?\1:\foo"), r"\\?\1:\foo");
+    }
+}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use crate::process::CommandWindowExt as _;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
@@ -359,7 +360,7 @@ pub async fn run_claude_plugin_command(
         crate::env::which_in_enriched_path("claude").unwrap_or_else(|_| PathBuf::from("claude"));
     let current_dir = plugin_command_cwd(repo_path);
 
-    let output = tokio::process::Command::new(&claude_path)
+    let output = tokio::process::Command::new(&claude_path).no_console_window()
         .args(args)
         .current_dir(current_dir)
         .stdout(std::process::Stdio::piped())
@@ -1252,7 +1253,7 @@ fn read_secure_storage_object() -> Result<Value, String> {
     #[cfg(target_os = "macos")]
     {
         let account = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
-        let output = std::process::Command::new("security")
+        let output = std::process::Command::new("security").no_console_window()
             .args([
                 "find-generic-password",
                 "-s",
@@ -1291,7 +1292,7 @@ fn write_secure_storage_object(value: &Value) -> Result<(), String> {
         let account = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
         let json = serde_json::to_string(value)
             .map_err(|e| format!("Failed to serialize keychain payload: {e}"))?;
-        let output = std::process::Command::new("security")
+        let output = std::process::Command::new("security").no_console_window()
             .args([
                 "add-generic-password",
                 "-U",

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,9 +2,9 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use crate::process::CommandWindowExt as _;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use crate::process::CommandWindowExt as _;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
@@ -360,7 +360,8 @@ pub async fn run_claude_plugin_command(
         crate::env::which_in_enriched_path("claude").unwrap_or_else(|_| PathBuf::from("claude"));
     let current_dir = plugin_command_cwd(repo_path);
 
-    let output = tokio::process::Command::new(&claude_path).no_console_window()
+    let output = tokio::process::Command::new(&claude_path)
+        .no_console_window()
         .args(args)
         .current_dir(current_dir)
         .stdout(std::process::Stdio::piped())
@@ -1253,7 +1254,8 @@ fn read_secure_storage_object() -> Result<Value, String> {
     #[cfg(target_os = "macos")]
     {
         let account = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
-        let output = std::process::Command::new("security").no_console_window()
+        let output = std::process::Command::new("security")
+            .no_console_window()
             .args([
                 "find-generic-password",
                 "-s",
@@ -1292,7 +1294,8 @@ fn write_secure_storage_object(value: &Value) -> Result<(), String> {
         let account = std::env::var("USER").unwrap_or_else(|_| "root".to_string());
         let json = serde_json::to_string(value)
             .map_err(|e| format!("Failed to serialize keychain payload: {e}"))?;
-        let output = std::process::Command::new("security").no_console_window()
+        let output = std::process::Command::new("security")
+            .no_console_window()
             .args([
                 "add-generic-password",
                 "-U",

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,122 @@
+//! Windows-safe subprocess spawning.
+//!
+//! When a GUI process (one linked with no attached console) spawns a child
+//! via `CreateProcessW`, Windows allocates a fresh console window for the
+//! child unless told otherwise. For a quiet background invocation — `git`,
+//! `claude`, setup scripts, MCP servers — this surfaces as a cmd.exe window
+//! that pops up, lives for the lifetime of the child, and disappears. For
+//! a Tauri app that runs many short subprocesses, the flicker storm is
+//! unacceptable.
+//!
+//! The fix is the `CREATE_NO_WINDOW` creation flag (0x08000000). This
+//! trait adds a single chainable method — `.no_console_window()` — that
+//! applies the flag on Windows and is a no-op on other platforms, so the
+//! call site reads the same everywhere.
+
+/// Extension trait for the two `Command` types used in this codebase
+/// (`std::process::Command` and `tokio::process::Command`) that hides the
+/// platform-specific incantation for suppressing the transient console
+/// window Windows creates for GUI-spawned children.
+///
+/// Call it anywhere in the builder chain before a terminating
+/// `.spawn()`/`.output()`/`.status()`:
+///
+/// ```ignore
+/// use claudette::process::CommandWindowExt;
+///
+/// let out = tokio::process::Command::new("git")
+///     .args(["status", "--porcelain"])
+///     .no_console_window()
+///     .output()
+///     .await?;
+/// ```
+pub trait CommandWindowExt {
+    /// Suppress the cmd.exe console window Windows would otherwise create
+    /// for this child. No-op on Unix-likes.
+    fn no_console_window(&mut self) -> &mut Self;
+}
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+impl CommandWindowExt for std::process::Command {
+    fn no_console_window(&mut self) -> &mut Self {
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.creation_flags(CREATE_NO_WINDOW);
+        }
+        self
+    }
+}
+
+impl CommandWindowExt for tokio::process::Command {
+    fn no_console_window(&mut self) -> &mut Self {
+        // tokio's `Command` exposes `creation_flags` as an inherent method
+        // on Windows — no `CommandExt` trait import needed here, unlike
+        // the std impl above.
+        #[cfg(windows)]
+        self.creation_flags(CREATE_NO_WINDOW);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The trait must be callable on a newly-constructed `std::process::Command`
+    /// and return `&mut Self` so it fits mid-chain with `.arg()` / `.output()`.
+    /// We don't actually spawn — that would require a known-present Unix/Windows
+    /// binary and makes tests flaky. The compile-and-mutate check is enough to
+    /// catch breakage of the trait's shape (return type, method name, impls).
+    #[test]
+    fn std_command_chain_typechecks() {
+        let mut cmd = std::process::Command::new("true");
+        // If this compiles, the `&mut Self` return lets us keep chaining.
+        let _ref: &mut std::process::Command = cmd.no_console_window().arg("-x");
+    }
+
+    #[test]
+    fn tokio_command_chain_typechecks() {
+        let mut cmd = tokio::process::Command::new("true");
+        let _ref: &mut tokio::process::Command = cmd.no_console_window().arg("-x");
+    }
+
+    /// The trait must be idempotent: calling it twice on the same command
+    /// mustn't panic, change the program name, or otherwise corrupt state.
+    /// (On Windows the second call just re-OR's the same creation flag.)
+    #[test]
+    fn repeat_application_is_safe() {
+        let mut cmd = std::process::Command::new("true");
+        cmd.no_console_window();
+        cmd.no_console_window();
+        assert_eq!(cmd.get_program(), "true");
+    }
+
+    /// On Windows, `CREATE_NO_WINDOW` is the exact flag we want — nothing
+    /// else. This guards against an accidental change to the constant (e.g.
+    /// mixing up `DETACHED_PROCESS = 0x0000_0008` — close in hex but wrong
+    /// semantics) without having to spawn a subprocess.
+    #[cfg(windows)]
+    #[test]
+    fn windows_flag_is_create_no_window() {
+        assert_eq!(CREATE_NO_WINDOW, 0x0800_0000);
+    }
+
+    /// On Windows, spawning a child with the flag set should succeed exactly
+    /// like spawning without it — the flag only controls the console-window
+    /// allocation, not the process itself. This also exercises the cfg-gated
+    /// `CommandExt::creation_flags` code path end-to-end.
+    #[cfg(windows)]
+    #[test]
+    fn windows_spawn_with_flag_succeeds() {
+        // `cmd /C exit 0` is always available on Windows.
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "exit", "0"])
+            .no_console_window()
+            .status()
+            .expect("cmd.exe should be spawnable");
+        assert!(status.success());
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -85,7 +85,9 @@ mod tests {
 
     /// The trait must be idempotent: calling it twice on the same command
     /// mustn't panic, change the program name, or otherwise corrupt state.
-    /// (On Windows the second call just re-OR's the same creation flag.)
+    /// (`CommandExt::creation_flags` *sets* the value rather than OR-ing,
+    /// so the second call just writes the same flag back — no bit
+    /// accumulation, but the post-state is identical either way.)
     #[test]
     fn repeat_application_is_safe() {
         let mut cmd = std::process::Command::new("true");

--- a/src/scm_provider/host_api.rs
+++ b/src/scm_provider/host_api.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use crate::process::CommandWindowExt as _;
 use mlua::LuaSerdeExt;
 use mlua::prelude::*;
 use tokio::process::Command;
-use crate::process::CommandWindowExt as _;
 
 /// Context passed to the Lua host API functions.
 #[derive(Debug, Clone)]

--- a/src/scm_provider/host_api.rs
+++ b/src/scm_provider/host_api.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use mlua::LuaSerdeExt;
 use mlua::prelude::*;
 use tokio::process::Command;
+use crate::process::CommandWindowExt as _;
 
 /// Context passed to the Lua host API functions.
 #[derive(Debug, Clone)]
@@ -154,6 +155,7 @@ async fn host_exec(
     // Build and execute the command with kill_on_drop so timed-out
     // processes don't leak.
     let mut command = Command::new(cmd);
+    command.no_console_window();
     command.args(&args);
     command.current_dir(&ctx.workspace_info.worktree_path);
     // macOS GUI apps inherit a minimal launchd PATH, so binaries like

--- a/src/scm_provider/host_api.rs
+++ b/src/scm_provider/host_api.rs
@@ -201,16 +201,27 @@ async fn host_exec(
 mod tests {
     use super::*;
 
+    /// Build a context whose `worktree_path` is a real directory so
+    /// `Command::current_dir` actually works. Hardcoding `/tmp` worked
+    /// on Unix but fails on Windows (no `/tmp` → `ERROR_DIRECTORY`).
+    /// `std::env::temp_dir()` resolves per-platform — `/tmp` on Unix,
+    /// `%TEMP%` on Windows.
     fn make_test_ctx() -> HostContext {
+        let tmp = std::env::temp_dir().to_string_lossy().into_owned();
         HostContext {
             plugin_name: "test".to_string(),
-            allowed_clis: vec!["echo".to_string()],
+            // `cargo` is cross-platform, guaranteed to be in PATH on
+            // any Rust CI host, and produces stable human-readable
+            // output. `echo` would be simpler but is a `cmd.exe`
+            // builtin on Windows — there's no `echo.exe` on PATH, so
+            // spawning it directly via `Command::new` fails.
+            allowed_clis: vec!["cargo".to_string()],
             workspace_info: WorkspaceInfo {
                 id: "ws-1".to_string(),
                 name: "test-workspace".to_string(),
                 branch: "main".to_string(),
-                worktree_path: "/tmp".to_string(),
-                repo_path: "/tmp".to_string(),
+                worktree_path: tmp.clone(),
+                repo_path: tmp,
             },
             config: HashMap::new(),
         }
@@ -312,13 +323,16 @@ mod tests {
         let lua = create_lua_vm(ctx).unwrap();
 
         let result: LuaTable = lua
-            .load(r#"return host.exec("echo", {"hello", "world"})"#)
+            .load(r#"return host.exec("cargo", {"--version"})"#)
             .eval_async()
             .await
             .unwrap();
 
         let stdout: String = result.get("stdout").unwrap();
-        assert!(stdout.trim().contains("hello world"));
+        assert!(
+            stdout.trim().starts_with("cargo "),
+            "expected `cargo --version` stdout to start with \"cargo \", got: {stdout:?}",
+        );
         assert_eq!(result.get::<i32>("code").unwrap(), 0);
     }
 
@@ -358,8 +372,12 @@ mod tests {
         let ctx = make_test_ctx();
         let lua = create_lua_vm(ctx).unwrap();
 
+        // Use the allowed cmd — the null-byte check must fire *after*
+        // the allowlist check, so using a non-allowed cmd would hit the
+        // earlier error path and never exercise the branch we want to
+        // cover.
         let result: LuaResult<LuaTable> = lua
-            .load(r#"return host.exec("echo", {"hello\0world"})"#)
+            .load(r#"return host.exec("cargo", {"--version\0"})"#)
             .eval_async()
             .await;
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -44,7 +44,7 @@ impl From<std::io::Error> for SnapshotError {
 /// Enumerate all files in a worktree that git tracks or would track
 /// (respects .gitignore). Returns NUL-separated paths.
 async fn list_worktree_files(worktree_path: &str) -> Result<Vec<String>, SnapshotError> {
-    let output = Command::new("git").no_console_window()
+    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
         .args(["-C", worktree_path])
         .args([
             "ls-files",
@@ -271,17 +271,17 @@ mod tests {
     async fn setup_test_repo() -> TempDir {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_str().unwrap();
-        Command::new("git").no_console_window()
+        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["init", path])
             .output()
             .await
             .unwrap();
-        Command::new("git").no_console_window()
+        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["-C", path, "config", "user.email", "test@test.com"])
             .output()
             .await
             .unwrap();
-        Command::new("git").no_console_window()
+        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["-C", path, "config", "user.name", "Test"])
             .output()
             .await
@@ -298,7 +298,7 @@ mod tests {
         tokio::fs::write(dir.path().join("hello.txt"), b"hello")
             .await
             .unwrap();
-        Command::new("git").no_console_window()
+        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
             .args(["-C", dir_str, "add", "hello.txt"])
             .output()
             .await

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use tokio::process::Command;
 
 use crate::model::CheckpointFile;
+use crate::process::CommandWindowExt as _;
 
 /// Maximum file size to include in a snapshot (10 MB).
 const MAX_SNAPSHOT_FILE_SIZE: u64 = 10 * 1024 * 1024;
@@ -43,7 +44,7 @@ impl From<std::io::Error> for SnapshotError {
 /// Enumerate all files in a worktree that git tracks or would track
 /// (respects .gitignore). Returns NUL-separated paths.
 async fn list_worktree_files(worktree_path: &str) -> Result<Vec<String>, SnapshotError> {
-    let output = Command::new("git")
+    let output = Command::new("git").no_console_window()
         .args(["-C", worktree_path])
         .args([
             "ls-files",
@@ -270,17 +271,17 @@ mod tests {
     async fn setup_test_repo() -> TempDir {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_str().unwrap();
-        Command::new("git")
+        Command::new("git").no_console_window()
             .args(["init", path])
             .output()
             .await
             .unwrap();
-        Command::new("git")
+        Command::new("git").no_console_window()
             .args(["-C", path, "config", "user.email", "test@test.com"])
             .output()
             .await
             .unwrap();
-        Command::new("git")
+        Command::new("git").no_console_window()
             .args(["-C", path, "config", "user.name", "Test"])
             .output()
             .await
@@ -297,7 +298,7 @@ mod tests {
         tokio::fs::write(dir.path().join("hello.txt"), b"hello")
             .await
             .unwrap();
-        Command::new("git")
+        Command::new("git").no_console_window()
             .args(["-C", dir_str, "add", "hello.txt"])
             .output()
             .await

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -293,6 +293,23 @@ mod tests {
         dir
     }
 
+    /// Return a fresh SQLite DB in a sibling tempdir to the worktree,
+    /// matching production layout (the app's DB lives under
+    /// `~/.claudette/`, never inside a managed worktree). Putting the
+    /// test DB *inside* `setup_test_repo`'s worktree would make
+    /// `restore_snapshot` — which lists and deletes every non-snapshot
+    /// file under the worktree — try to delete `test.db` while the test
+    /// still holds an open rusqlite connection to it. On Windows that
+    /// triggers `ERROR_USER_MAPPED_FILE` (1224) because SQLite
+    /// memory-maps part of the DB; on Unix the unlink silently
+    /// succeeds and masks the fact that the test was doing something
+    /// unrealistic. Either way, the DB doesn't belong in the worktree.
+    fn make_db_outside_worktree() -> (TempDir, std::path::PathBuf) {
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        (db_dir, db_path)
+    }
+
     #[tokio::test]
     async fn test_collect_worktree_files() {
         let dir = setup_test_repo().await;
@@ -378,7 +395,7 @@ mod tests {
             .unwrap();
 
         // Save snapshot to DB
-        let db_path = dir.path().join("test.db");
+        let (_db_dir, db_path) = make_db_outside_worktree();
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 
@@ -426,7 +443,7 @@ mod tests {
             .await
             .unwrap();
 
-        let db_path = dir.path().join("test.db");
+        let (_db_dir, db_path) = make_db_outside_worktree();
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 
@@ -454,7 +471,7 @@ mod tests {
             .await
             .unwrap();
 
-        let db_path = dir.path().join("test.db");
+        let (_db_dir, db_path) = make_db_outside_worktree();
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 
@@ -489,7 +506,7 @@ mod tests {
             .await
             .unwrap();
 
-        let db_path = dir.path().join("test.db");
+        let (_db_dir, db_path) = make_db_outside_worktree();
         let db = crate::db::Database::open(&db_path).unwrap();
         db.execute_batch(TEST_SEED_SQL).unwrap();
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -44,7 +44,8 @@ impl From<std::io::Error> for SnapshotError {
 /// Enumerate all files in a worktree that git tracks or would track
 /// (respects .gitignore). Returns NUL-separated paths.
 async fn list_worktree_files(worktree_path: &str) -> Result<Vec<String>, SnapshotError> {
-    let output = Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+    let output = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
         .args(["-C", worktree_path])
         .args([
             "ls-files",
@@ -271,17 +272,20 @@ mod tests {
     async fn setup_test_repo() -> TempDir {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().to_str().unwrap();
-        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["init", path])
             .output()
             .await
             .unwrap();
-        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["-C", path, "config", "user.email", "test@test.com"])
             .output()
             .await
             .unwrap();
-        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["-C", path, "config", "user.name", "Test"])
             .output()
             .await
@@ -298,7 +302,8 @@ mod tests {
         tokio::fs::write(dir.path().join("hello.txt"), b"hello")
             .await
             .unwrap();
-        Command::new(&crate::git::resolve_git_path_blocking()).no_console_window()
+        Command::new(crate::git::resolve_git_path_blocking())
+            .no_console_window()
             .args(["-C", dir_str, "add", "hello.txt"])
             .output()
             .await


### PR DESCRIPTION
## Summary

- Cross-compile + native-runner CI for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`
- Windows-safe subprocess spawning (CREATE_NO_WINDOW), registry-backed PATH, common-install fallbacks for `git`/`claude`
- Fix terminal opening in `C:\Windows` under verbatim (`\\?\C:\...`) worktree paths
- Fix Unicode mojibake in Windows PATH expansion, add exec-bit check to git resolver, move login-shell probe off Tokio workers (all from Codex review)
- Release assets: bare `claudette.exe` + `claudette-server.exe` shipped inside `.zip` archives to avoid SmartScreen warnings on unsigned downloads

## Test plan

- [x] Cross-compile from aarch64-darwin host, manually deployed to Windows-on-ARM VM — dashboard loads, git operations work, terminal opens in the right workspace directory
- [x] x64 cross-compiled `.exe` deployed alongside ARM64 build on the same VM for emulation test
- [x] `cargo test --all-features` (local) — 555 lib tests pass, up from 537 at branch base (+18 new tests for the path stripper, UTF-8 expander, exec-bit predicate, and prewarm idempotence)
- [x] `cargo clippy --workspace` clean
- [x] `actionlint` clean on all three modified workflows (only a pre-existing SC2129 style note in `nightly.yml:42` remains)
- [ ] CI passes on GitHub (new `windows-check` matrix job)
- [ ] Nightly release produces `claudette-windows-x86_64.zip` + `claudette-windows-aarch64.zip` (plus matching `-server-*` zips) alongside existing macOS/Linux assets

## Notable changes

| Area | File(s) |
|---|---|
| Windows subprocess flag helper | `src/process.rs` (new trait `CommandWindowExt`) |
| Verbatim-path strip helper | `src/path.rs` (new, 6 tests) |
| Registry-backed PATH + fallback resolvers | `src/env.rs`, `src/agent.rs`, `src/git.rs` |
| Cross-platform UTF-8-safe env-var expansion | `src/env.rs` (refactored to `expand_env_vars_with_lookup`, 7 cross-platform tests) |
| Pre-warm login-shell PATH at startup (Unix) | `src/env.rs`, `src-tauri/src/main.rs` |
| Git resolver: require exec bit | `src/git.rs` (mirrors `resolve_claude_path_inner` hygiene) |
| Cross-compile toolchain in Nix devshell | `flake.nix` |
| GitHub Actions Windows matrix | `.github/workflows/{ci,nightly,release-please}.yml` |