### PR TITLE
fix(notifications): prevent active sound pack from resetting on restart

### DIFF
--- a/src/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/src/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -80,6 +80,7 @@ export function NotificationsSettings() {
   const [volume, setVolume] = useState(100);
   const [muted, setMuted] = useState(false);
   const [activePack, setActivePack] = useState("");
+  const [activePackLoaded, setActivePackLoaded] = useState(false);
   const [installed, setInstalled] = useState<InstalledSoundPack[]>([]);
   const [showBrowser, setShowBrowser] = useState(false);
   const [notificationCommand, setNotificationCommand] = useState("");
@@ -122,7 +123,8 @@ export function NotificationsSettings() {
       .then((val) => {
         if (val) setActivePack(val);
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setActivePackLoaded(true));
     loadInstalled();
     getAppSetting("notification_command")
       .then((val) => {
@@ -132,6 +134,7 @@ export function NotificationsSettings() {
   }, [loadInstalled]);
 
   useEffect(() => {
+    if (!activePackLoaded) return;
     if (installed.length === 0) {
       if (activePack) {
         setActivePack("");
@@ -144,7 +147,7 @@ export function NotificationsSettings() {
       setActivePack(first);
       setAppSetting("cesp_active_pack", first).catch(() => {});
     }
-  }, [installed, activePack]);
+  }, [installed, activePack, activePackLoaded]);
 
   const handleSoundSourceChange = async (
     source: "system" | "openpeon",


### PR DESCRIPTION
## Summary

Fixes the OpenPeon sound pack selection resetting to the alphabetically first pack (e.g. "Army of Darkness") after every app restart, even when the user had selected a different pack (e.g. "Ron Burgundy").

**Root cause:** A race condition between two `useEffect` hooks in `NotificationsSettings.tsx`. On mount, `cespListInstalled()` and `getAppSetting("cesp_active_pack")` fire in parallel. The installed-list IPC resolves first, triggering a correction effect that sees `activePack` as `""` (the DB value hasn't loaded yet), interprets it as "not in installed list", and overwrites the database with `installed[0]` — the alphabetically first pack.

**Fix:** Add an `activePackLoaded` loading sentinel that gates the correction effect until the persisted value has been loaded (or confirmed absent via `.finally()`).

## Complexity Notes

The fix is intentionally minimal (3 lines changed) to avoid restructuring the init flow. The `.finally()` ensures the guard is released even if `getAppSetting` fails, so the correction effect can still auto-select a default pack when the DB is empty.

## Test Steps

1. `cargo tauri dev`
2. Open Settings → Notifications → select "Sound packs (OpenPeon)"
3. Install 2+ sound packs from the registry
4. Select a pack that is **not** first alphabetically
5. Quit the app completely (`Cmd+Q`)
6. Relaunch with `cargo tauri dev`
7. Open Settings → Notifications → verify the selected pack persists
8. Also verify: uninstall all packs → confirm the selection clears gracefully

## Checklist

- [x] Tests added/updated (existing 621 tests pass; no new test needed — this is a timing fix in React init logic)
- [ ] Documentation updated (if applicable)