### PR TITLE
feat(sidebar): show badge-check icon when agent completes work

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -47,7 +47,6 @@ import {
   maxSizeFor,
   isTextFile,
 } from "../../utils/attachmentValidation";
-import { useAgentStream } from "../../hooks/useAgentStream";
 import { useTypewriter } from "../../hooks/useTypewriter";
 import { extractToolSummary } from "../../hooks/toolSummary";
 import { AgentQuestionCard } from "./AgentQuestionCard";
@@ -204,8 +203,6 @@ export function ChatPanel() {
   const historyRef = useRef<Record<string, string[]>>({});
   const historyIndexRef = useRef(-1);
   const draftRef = useRef("");
-
-  useAgentStream();
 
   const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
 

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -13,6 +13,7 @@ import { SettingsPage } from "../settings/SettingsPage";
 import { ResizeHandle } from "./ResizeHandle";
 import { ToastContainer } from "./Toast";
 import { useAgentStream } from "../../hooks/useAgentStream";
+import { isAgentBusy } from "../../utils/agentStatus";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useBranchRefresh } from "../../hooks/useBranchRefresh";
 import { useAutoUpdater } from "../../hooks/useAutoUpdater";
@@ -40,22 +41,24 @@ export function AppLayout() {
   useAutoUpdater();
 
   useEffect(() => {
-    const prevStatuses: Record<string, string> = {};
+    const prevBusy = new Map<string, boolean>();
     for (const ws of useAppStore.getState().workspaces) {
-      prevStatuses[ws.id] = typeof ws.agent_status === "string" ? ws.agent_status : "Error";
+      prevBusy.set(ws.id, isAgentBusy(ws.agent_status));
     }
-    return useAppStore.subscribe((state) => {
+    return useAppStore.subscribe((state, prev) => {
+      if (state.workspaces === prev.workspaces) return;
+      const currentIds = new Set<string>();
       for (const ws of state.workspaces) {
-        const prev = prevStatuses[ws.id];
-        prevStatuses[ws.id] = typeof ws.agent_status === "string" ? ws.agent_status : "Error";
-        if (
-          prev &&
-          (prev === "Running" || prev === "Compacting") &&
-          ws.agent_status !== "Running" &&
-          ws.agent_status !== "Compacting"
-        ) {
+        currentIds.add(ws.id);
+        const wasBusy = prevBusy.get(ws.id);
+        const busy = isAgentBusy(ws.agent_status);
+        prevBusy.set(ws.id, busy);
+        if (wasBusy && !busy) {
           state.markWorkspaceAsUnread(ws.id);
         }
+      }
+      for (const id of prevBusy.keys()) {
+        if (!currentIds.has(id)) prevBusy.delete(id);
       }
     });
   }, []);

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ import { ModalRouter } from "../modals/ModalRouter";
 import { SettingsPage } from "../settings/SettingsPage";
 import { ResizeHandle } from "./ResizeHandle";
 import { ToastContainer } from "./Toast";
+import { useAgentStream } from "../../hooks/useAgentStream";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useBranchRefresh } from "../../hooks/useBranchRefresh";
 import { useAutoUpdater } from "../../hooks/useAutoUpdater";
@@ -33,9 +34,31 @@ export function AppLayout() {
   const fuzzyFinderOpen = useAppStore((s) => s.fuzzyFinderOpen);
   const commandPaletteOpen = useAppStore((s) => s.commandPaletteOpen);
 
+  useAgentStream();
   useKeyboardShortcuts();
   useBranchRefresh();
   useAutoUpdater();
+
+  useEffect(() => {
+    const prevStatuses: Record<string, string> = {};
+    for (const ws of useAppStore.getState().workspaces) {
+      prevStatuses[ws.id] = typeof ws.agent_status === "string" ? ws.agent_status : "Error";
+    }
+    return useAppStore.subscribe((state) => {
+      for (const ws of state.workspaces) {
+        const prev = prevStatuses[ws.id];
+        prevStatuses[ws.id] = typeof ws.agent_status === "string" ? ws.agent_status : "Error";
+        if (
+          prev &&
+          (prev === "Running" || prev === "Compacting") &&
+          ws.agent_status !== "Running" &&
+          ws.agent_status !== "Compacting"
+        ) {
+          state.markWorkspaceAsUnread(ws.id);
+        }
+      }
+    });
+  }, []);
 
   const showDiff = diffSelectedFile !== null;
 

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -91,11 +91,9 @@ export function useAgentStream() {
         // fires before the user has a chance to answer. The question is
         // cleared when the user responds (onRespond) or sends a new message.
 
-        // Notification: mark workspace as unread if not currently selected
-        const { selectedWorkspaceId, markWorkspaceAsUnread } = useAppStore.getState();
-        if (wsId !== selectedWorkspaceId) {
-          markWorkspaceAsUnread(wsId);
-        }
+        // Badge-check notification is handled by a store subscription
+        // in AppLayout (watching Running→Idle/Stopped transitions) rather
+        // than here, because this closure can go stale under HMR.
 
         // Notification sound + command are handled on the Rust side
         // (in ProcessExited handler) so they work even when the webview

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1326,3 +1326,37 @@ describe("rollbackConversation updates latestTurnUsage", () => {
     expect(useAppStore.getState().latestTurnUsage.ws1).toBeUndefined();
   });
 });
+
+describe("selectWorkspace clears unreadCompletions", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      unreadCompletions: new Set<string>(),
+      selectedWorkspaceId: null,
+    });
+  });
+
+  it("clears unread for the selected workspace", () => {
+    useAppStore.getState().markWorkspaceAsUnread("ws-a");
+    expect(useAppStore.getState().unreadCompletions.has("ws-a")).toBe(true);
+
+    useAppStore.getState().selectWorkspace("ws-a");
+    expect(useAppStore.getState().unreadCompletions.has("ws-a")).toBe(false);
+    expect(useAppStore.getState().selectedWorkspaceId).toBe("ws-a");
+  });
+
+  it("does not clear unread for other workspaces", () => {
+    useAppStore.getState().markWorkspaceAsUnread("ws-a");
+    useAppStore.getState().markWorkspaceAsUnread("ws-b");
+
+    useAppStore.getState().selectWorkspace("ws-b");
+    expect(useAppStore.getState().unreadCompletions.has("ws-a")).toBe(true);
+    expect(useAppStore.getState().unreadCompletions.has("ws-b")).toBe(false);
+  });
+
+  it("handles selecting null (dashboard) without error", () => {
+    useAppStore.getState().markWorkspaceAsUnread("ws-a");
+    useAppStore.getState().selectWorkspace(null);
+    expect(useAppStore.getState().unreadCompletions.has("ws-a")).toBe(true);
+    expect(useAppStore.getState().selectedWorkspaceId).toBeNull();
+  });
+});

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -561,9 +561,16 @@ export const useAppStore = create<AppState>((set) => ({
         workspaceTerminalCommands: newWorkspaceTerminalCommands,
       };
     }),
-  selectWorkspace: (id) => {
-    set({ selectedWorkspaceId: id, rightSidebarTab: "changes" });
-  },
+  selectWorkspace: (id) =>
+    set((s) => {
+      const updates: Partial<AppState> = { selectedWorkspaceId: id, rightSidebarTab: "changes" };
+      if (id && s.unreadCompletions.has(id)) {
+        const next = new Set(s.unreadCompletions);
+        next.delete(id);
+        updates.unreadCompletions = next;
+      }
+      return updates;
+    }),
 
   // -- Chat --
   chatMessages: {},


### PR DESCRIPTION
## Summary

- Moved `useAgentStream` from `ChatPanel` to `AppLayout` so the Tauri event listener stays active on dashboard and diff views
- Added a Zustand store subscription in `AppLayout` that watches for `Running → Idle/Stopped` transitions and calls `markWorkspaceAsUnread` — avoids stale closure issues with the `useEffect`-based Tauri listener
- Expanded `selectWorkspace` to clear `unreadCompletions` for the navigated-to workspace, so the badge dismisses on view

## Test plan

- [ ] Start an agent in workspace A, switch to workspace B before it finishes — badge-check appears on A
- [ ] Click workspace A — badge clears immediately
- [ ] Repeat from the dashboard view (no workspace selected) — badge still appears
- [ ] Repeat with the diff viewer open — badge still appears
- [ ] Verify notification sound still plays alongside the badge
- [ ] `cd src/ui && bun run test` passes
- [ ] `cd src/ui && bunx tsc --noEmit` passes