### PR TITLE
fix(repository): show friendly message on duplicate repo path

### DIFF
--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use tauri::{AppHandle, State};
 
 use claudette::config;
-use claudette::db::Database;
+use claudette::db::{Database, is_duplicate_repository_path_error};
 use claudette::git;
 use claudette::model::Repository;
 
@@ -52,7 +52,13 @@ pub async fn add_repository(
     };
 
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    db.insert_repository(&repo).map_err(|e| e.to_string())?;
+    db.insert_repository(&repo).map_err(|e| {
+        if is_duplicate_repository_path_error(&e) {
+            "This repository is already in Claudette.".to_string()
+        } else {
+            e.to_string()
+        }
+    })?;
 
     crate::tray::rebuild_tray(&app);
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -166,6 +166,19 @@ impl Database {
     }
 }
 
+/// Returns true when `err` is the SQLite `UNIQUE` constraint failure on
+/// `repositories.path` — i.e. the caller tried to insert a repo whose path
+/// is already registered. Other constraint failures (including UNIQUE on
+/// other columns) return false.
+pub fn is_duplicate_repository_path_error(err: &rusqlite::Error) -> bool {
+    if let rusqlite::Error::SqliteFailure(code, Some(msg)) = err {
+        code.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+            && msg.contains("repositories.path")
+    } else {
+        false
+    }
+}
+
 impl Database {
     // --- Repositories ---
 
@@ -1772,7 +1785,25 @@ mod tests {
         db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
             .unwrap();
         let result = db.insert_repository(&make_repo("r2", "/tmp/repo1", "repo1-dup"));
-        assert!(result.is_err());
+        let err = result.expect_err("expected UNIQUE constraint failure");
+        assert!(
+            super::is_duplicate_repository_path_error(&err),
+            "expected duplicate-path error, got: {err:?}",
+        );
+    }
+
+    #[test]
+    fn test_duplicate_repo_id_not_flagged_as_duplicate_path() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        let err = db
+            .insert_repository(&make_repo("r1", "/tmp/repo2", "repo2"))
+            .expect_err("expected UNIQUE constraint failure on id");
+        assert!(
+            !super::is_duplicate_repository_path_error(&err),
+            "id collision should not be mapped to the duplicate-path branch: {err:?}",
+        );
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1799,7 +1799,7 @@ mod tests {
             .unwrap();
         let err = db
             .insert_repository(&make_repo("r1", "/tmp/repo2", "repo2"))
-            .expect_err("expected UNIQUE constraint failure on id");
+            .expect_err("expected PRIMARY KEY constraint failure on id");
         assert!(
             !super::is_duplicate_repository_path_error(&err),
             "id collision should not be mapped to the duplicate-path branch: {err:?}",


### PR DESCRIPTION
## Summary

- Adds `is_duplicate_repository_path_error` helper in `src/db.rs` that identifies the SQLite `UNIQUE` constraint failure on `repositories.path` (extended code `SQLITE_CONSTRAINT_UNIQUE` / 2067, message contains `repositories.path`).
- Uses it in the `add_repository` Tauri command to map the error to "This repository is already in Claudette." before the string hits the frontend. Other constraint failures pass through unchanged.
- Tightens the existing `test_duplicate_repo_path_rejected` test to assert the helper matches, and adds a negative test for the `id` UNIQUE collision so we don't accidentally widen the net.

Fixes #380

## Test plan

- [x] `cargo test --all-features` (566 passed)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -Dwarnings`
- [x] `cargo fmt --all --check`
- [x] `cd src/ui && bunx tsc --noEmit`
- [ ] Manual: try to add the same repository twice in the UI and confirm the toast shows the friendly message