### PR TITLE
fix(chat): preserve session context when stopping agent

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1367,6 +1367,32 @@ pub async fn send_chat_message(
     Ok(())
 }
 
+/// What `take_stop_snapshot` hands back: permissions to deny, pid to kill,
+/// and the session id to mark ended in the DB.
+type StopSnapshot = (
+    Option<(Arc<PersistentSession>, Vec<PendingPermission>)>,
+    Option<u32>,
+    Option<String>,
+);
+
+/// Mutations performed on an agent session when the user clicks Stop.
+///
+/// Stop interrupts the in-flight turn — it takes `active_pid` so the caller
+/// can kill the process and drains pending permission requests so the caller
+/// can deny them. It deliberately does NOT clear `session_id`, `turn_count`,
+/// or `persistent_session`: those are owned by `reset_agent_session` and
+/// `clear_conversation`. Preserving them is what lets the next
+/// `send_chat_message` resume via `--resume` instead of spawning a fresh
+/// conversation. The now-dead `persistent_session` handle is fine — on the
+/// next turn `send_turn` detects the broken pipe and respawns with
+/// `--resume <session_id>`.
+fn take_stop_snapshot(session: &mut AgentSessionState) -> StopSnapshot {
+    let drained = drain_pending_permissions(session);
+    let ended_sid = Some(session.session_id.clone());
+    let pid = session.active_pid.take();
+    (drained, pid, ended_sid)
+}
+
 #[tauri::command]
 pub async fn stop_agent(
     workspace_id: String,
@@ -1379,16 +1405,7 @@ pub async fn stop_agent(
     let (to_deny_stop, pid_to_kill, ended_sid) = {
         let mut agents = state.agents.write().await;
         match agents.get_mut(&workspace_id) {
-            Some(session) => {
-                let drained = drain_pending_permissions(session);
-                let ended_sid = Some(session.session_id.clone());
-                // Clear persistent session and reset session state so the next
-                // turn starts completely fresh (not --resume with a stale ID).
-                session.persistent_session = None;
-                session.turn_count = 0;
-                session.session_id = String::new();
-                (drained, session.active_pid.take(), ended_sid)
-            }
+            Some(session) => take_stop_snapshot(session),
             None => (None, None, None),
         }
     };
@@ -1400,11 +1417,10 @@ pub async fn stop_agent(
         agent::stop_agent(pid).await?;
     }
 
-    // Clear persisted session from DB too. `stop_agent` aborts an in-flight
-    // turn (SIGTERM on the live pid + deny mid-turn permission prompts), so
-    // the session did not complete successfully — record it as a failure.
+    // Record the interrupted turn as a failure for analytics, but leave the
+    // workspace's session_id / turn_count rows intact so an app restart after
+    // stop still resumes via --resume.
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let _ = db.clear_agent_session(&workspace_id);
     if let Some(sid) = ended_sid.as_deref().filter(|s| !s.is_empty()) {
         let _ = db.end_agent_session(sid, false);
     }
@@ -2385,5 +2401,64 @@ mod tests {
         let input = json!({});
         let response = build_permission_response(&s(&["*", "Read"]), false, false, "Edit", &input);
         assert_eq!(response["behavior"], "deny");
+    }
+
+    use super::take_stop_snapshot;
+    use crate::state::AgentSessionState;
+    use std::collections::HashMap;
+
+    fn fresh_session(session_id: &str, turn_count: u32, pid: Option<u32>) -> AgentSessionState {
+        AgentSessionState {
+            session_id: session_id.to_string(),
+            turn_count,
+            active_pid: pid,
+            custom_instructions: None,
+            needs_attention: false,
+            attention_kind: None,
+            persistent_session: None,
+            mcp_config_dirty: false,
+            session_plan_mode: false,
+            session_allowed_tools: Vec::new(),
+            session_disable_1m_context: false,
+            pending_permissions: HashMap::new(),
+            session_exited_plan: false,
+        }
+    }
+
+    #[test]
+    fn take_stop_snapshot_preserves_session_identity_for_resume() {
+        // Regression guard for the bug where Stop wiped session_id/turn_count,
+        // causing the next send to start a brand-new conversation instead of
+        // resuming. Stop must leave those fields intact so send_chat_message
+        // can spawn the CLI with --resume <session_id>.
+        let mut session = fresh_session("sess-abc", 7, Some(12345));
+
+        let (drained, pid, ended_sid) = take_stop_snapshot(&mut session);
+
+        // Caller receives the pid to kill and the sid to log.
+        assert!(drained.is_none(), "no pending permissions to drain");
+        assert_eq!(pid, Some(12345));
+        assert_eq!(ended_sid.as_deref(), Some("sess-abc"));
+
+        // Session identity is preserved — this is the fix.
+        assert_eq!(session.session_id, "sess-abc");
+        assert_eq!(session.turn_count, 7);
+        assert!(session.persistent_session.is_none());
+
+        // active_pid is consumed so the caller can kill without racing.
+        assert!(session.active_pid.is_none());
+    }
+
+    #[test]
+    fn take_stop_snapshot_is_idempotent_when_already_stopped() {
+        // A double-stop (e.g. user clicks Stop twice) must not corrupt state.
+        let mut session = fresh_session("sess-abc", 7, None);
+
+        let (_, pid, ended_sid) = take_stop_snapshot(&mut session);
+
+        assert!(pid.is_none());
+        assert_eq!(ended_sid.as_deref(), Some("sess-abc"));
+        assert_eq!(session.session_id, "sess-abc");
+        assert_eq!(session.turn_count, 7);
     }
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -731,6 +731,7 @@ pub async fn send_chat_message(
         // IGNORE), then bump turn_count + last_message_at. Runs for every
         // turn so resumed-from-DB sessions get their row lazily created too.
         let _ = db.insert_agent_session(&session.session_id, &workspace_id, &ws.repository_id);
+        let _ = db.reopen_agent_session(&session.session_id);
         let _ = db.update_agent_session_turn(&session.session_id, session.turn_count);
         if db
             .get_app_setting("first_session_at")
@@ -1390,6 +1391,8 @@ fn take_stop_snapshot(session: &mut AgentSessionState) -> StopSnapshot {
     let drained = drain_pending_permissions(session);
     let ended_sid = Some(session.session_id.clone());
     let pid = session.active_pid.take();
+    session.needs_attention = false;
+    session.attention_kind = None;
     (drained, pid, ended_sid)
 }
 
@@ -2460,5 +2463,19 @@ mod tests {
         assert_eq!(ended_sid.as_deref(), Some("sess-abc"));
         assert_eq!(session.session_id, "sess-abc");
         assert_eq!(session.turn_count, 7);
+    }
+
+    #[test]
+    fn take_stop_snapshot_clears_attention_flags() {
+        use crate::state::AttentionKind;
+
+        let mut session = fresh_session("sess-abc", 3, Some(999));
+        session.needs_attention = true;
+        session.attention_kind = Some(AttentionKind::Ask);
+
+        take_stop_snapshot(&mut session);
+
+        assert!(!session.needs_attention);
+        assert!(session.attention_kind.is_none());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -549,6 +549,19 @@ impl Database {
         Ok(())
     }
 
+    /// Re-open a previously ended session so that `update_agent_session_turn`
+    /// can track resumed turns. Called on the `--resume` path when a user
+    /// sends a new message after stopping mid-turn.
+    pub fn reopen_agent_session(&self, session_id: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE agent_sessions
+             SET ended_at = NULL
+             WHERE id = ?1 AND ended_at IS NOT NULL",
+            params![session_id],
+        )?;
+        Ok(())
+    }
+
     // --- Metrics: agent commits ---
 
     /// Insert commits observed during an agent session. Idempotent per
@@ -3218,6 +3231,33 @@ mod tests {
             )
             .unwrap();
         assert_eq!(tc_after, 3);
+
+        // Reopen clears ended_at so resumed turns can update metrics.
+        db.reopen_agent_session("s1").unwrap();
+        let ended_after_reopen: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT ended_at FROM agent_sessions WHERE id = 's1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(ended_after_reopen.is_none());
+
+        // Turn bump works again after reopen.
+        db.update_agent_session_turn("s1", 10).unwrap();
+        let tc_reopened: i64 = db
+            .conn
+            .query_row(
+                "SELECT turn_count FROM agent_sessions WHERE id = 's1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(tc_reopened, 10);
+
+        // Reopen on an already-open session is a no-op.
+        db.reopen_agent_session("s1").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When a user clicks the **Stop** button to interrupt a running agent, the next message they send starts a brand-new Claude CLI conversation — prior context is lost from the agent's perspective, even though the chat UI still shows the message history.

**Root cause:** `stop_agent` was clearing `session_id`, `turn_count`, and `persistent_session` in both memory and the database. The next `send_chat_message` saw `saved_turn_count=0`, computed `is_resume=false`, generated a fresh UUID, and spawned the CLI with `--session-id <new-uuid>` instead of `--resume <old-uuid>`.

**Fix:** Narrow `stop_agent` to only interrupt the in-flight turn (kill the process, drain pending permissions) without resetting session identity. Session state is preserved so the next message resumes via `--resume`. Users who want a fresh start already have `clear_conversation` and `reset_agent_session`.

This aligns the local Tauri handler with the remote-server handler in `src-server/src/handler.rs`, which already preserved session state correctly on stop.

```mermaid
sequenceDiagram
    participant U as User
    participant FE as Frontend
    participant BE as Tauri Backend
    participant CLI as Claude CLI

    U->>FE: Click Stop
    FE->>BE: stop_agent(workspace_id)
    BE->>CLI: kill process
    Note over BE: ❌ Before: clear session_id, turn_count, DB
    Note over BE: ✅ After: preserve session_id, turn_count, DB

    U->>FE: Send next message
    FE->>BE: send_chat_message(...)
    Note over BE: ❌ Before: is_resume=false → --session-id <new-uuid>
    Note over BE: ✅ After: is_resume=true → --resume <old-session-id>
    BE->>CLI: spawn with --resume
    CLI-->>BE: Continues with full context
```

## Complexity Notes

- The now-dead `persistent_session` handle (an `Arc<PersistentSession>` pointing to a killed process) is intentionally left in place. On the next turn, `send_turn` writes to the dead stdin, detects the broken-pipe error, and falls through to the existing respawn-with-`--resume` path (`chat.rs:602-655`). No new recovery logic needed.
- If the CLI's on-disk transcript is corrupted from the SIGKILL, `--resume` will fail and the existing catch blocks at `chat.rs:621-625` / `chat.rs:682-695` log the error and fall back to a fresh session — same as current behavior in the worst case.

## Test Steps

1. `cargo tauri dev`
2. Create a workspace, send a message, wait for a reply
3. Send a second message and click **Stop** mid-response
4. Send a third message referencing something from the first reply (e.g., "what did you just tell me about X?")
5. **Expected:** Agent answers with knowledge of turn 1
6. **Before fix:** Agent responds as if it has no prior context
7. Also verify: quit the app after stopping, relaunch, send a message — should resume (DB row preserved)

## Checklist

- [x] Tests added/updated (2 regression tests for `take_stop_snapshot`)
- [ ] Documentation updated (if applicable) — N/A, no user-facing docs affected