### PR TITLE
feat(settings): auto-delete workspace record when branch is deleted on archive

### DIFF
--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -810,9 +810,7 @@ async fn auto_archive_workspace(
     }
 
     // Delete the local branch when the setting is enabled.
-    if delete_record
-        && let Some(repo_path) = &repo_path
-    {
+    if delete_record && let Some(repo_path) = &repo_path {
         let _ = claudette::git::branch_delete(repo_path, &branch_name).await;
     }
 

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -825,25 +825,36 @@ async fn auto_archive_workspace(
     }
 
     // Now that async cleanup is done, persist the archive/delete mutation.
-    {
-        if let Ok(db) = Database::open(&app_state.db_path) {
+    // Check the result so we don't emit frontend events for a state change
+    // that didn't actually land in the DB.
+    let mutation_ok = Database::open(&app_state.db_path)
+        .ok()
+        .map(|db| {
             if delete_record {
-                let _ = db.delete_workspace_with_summary(&ws_id);
+                db.delete_workspace_with_summary(&ws_id).is_ok()
             } else {
                 let _ = db.delete_terminal_tabs_for_workspace(&ws_id);
                 let _ = db.delete_scm_status_cache(&ws_id);
-                let _ = db.update_workspace_status(
+                db.update_workspace_status(
                     &ws_id,
                     &claudette::model::WorkspaceStatus::Archived,
                     None,
-                );
+                )
+                .is_ok()
             }
-        }
+        })
+        .unwrap_or(false);
+
+    if !mutation_ok {
+        eprintln!("[scm] DB mutation failed while auto-archiving workspace '{ws_name}' ({ws_id})");
+        return;
     }
+
+    let deleted = delete_record;
 
     // If the workspace record was fully deleted and no workspaces remain for this
     // repo, clean up MCP supervisor state.
-    if delete_record {
+    if deleted {
         let supervisor = handle.state::<Arc<McpSupervisor>>();
         let remaining = Database::open(&app_state.db_path)
             .map(|db| db.list_workspaces().unwrap_or_default())
@@ -857,7 +868,7 @@ async fn auto_archive_workspace(
     // Rebuild tray and notify frontend
     crate::tray::rebuild_tray(handle);
 
-    let verb = if delete_record { "deleted" } else { "archived" };
+    let verb = if deleted { "deleted" } else { "archived" };
     let body = match pr_number {
         Some(num) => {
             format!("Workspace \u{2018}{ws_name}\u{2019} {verb} \u{2014} PR #{num} merged")
@@ -876,7 +887,7 @@ async fn auto_archive_workspace(
     let mut payload = serde_json::json!({
         "workspace_id": ws_id,
         "workspace_name": ws_name,
-        "deleted": delete_record,
+        "deleted": deleted,
     });
     if let Some(num) = pr_number {
         payload["pr_number"] = serde_json::json!(num);

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Instant;
 
 use futures::stream::{self, StreamExt};
@@ -5,6 +6,7 @@ use serde::Serialize;
 use tauri::{Emitter, Manager, State};
 
 use claudette::db::Database;
+use claudette::mcp_supervisor::McpSupervisor;
 use claudette::plugin_runtime::host_api::WorkspaceInfo;
 use claudette::scm::detect;
 use claudette::scm::types::{CiCheck, PullRequest};
@@ -716,6 +718,9 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
 /// Performs the same core steps as the `archive_workspace` Tauri command:
 /// removes the worktree, updates the DB status, stops any running agent,
 /// and emits a `workspace-auto-archived` event to the frontend.
+///
+/// When `git_delete_branch_on_archive` is enabled, fully deletes the workspace
+/// record (preserving lifetime stats) instead of moving it to Archived status.
 async fn auto_archive_workspace(
     handle: &tauri::AppHandle,
     app_state: &AppState,
@@ -726,8 +731,10 @@ async fn auto_archive_workspace(
     struct ArchiveInfo {
         ws_id: String,
         ws_name: String,
+        repo_id: String,
         worktree_path: Option<String>,
         repo_path: Option<String>,
+        delete_record: bool,
         resolved: crate::tray::ResolvedSound,
     }
     let archive_info: Option<ArchiveInfo> = {
@@ -753,26 +760,39 @@ async fn auto_archive_workspace(
             .flatten()
             .map(|r| r.path);
 
+        let delete_record = db
+            .get_app_setting("git_delete_branch_on_archive")
+            .ok()
+            .flatten()
+            .as_deref()
+            == Some("true");
+
         let resolved = crate::tray::resolve_notification(
             &db,
             &app_state.cesp_playback,
             crate::tray::NotificationEvent::Finished,
         );
 
-        // Update DB status
-        let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
-        let _ = db.delete_scm_status_cache(workspace_id);
-        let _ = db.update_workspace_status(
-            workspace_id,
-            &claudette::model::WorkspaceStatus::Archived,
-            None,
-        );
+        if delete_record {
+            // Fully remove the record; lifetime stats are frozen in a summary row.
+            let _ = db.delete_workspace_with_summary(workspace_id);
+        } else {
+            let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
+            let _ = db.delete_scm_status_cache(workspace_id);
+            let _ = db.update_workspace_status(
+                workspace_id,
+                &claudette::model::WorkspaceStatus::Archived,
+                None,
+            );
+        }
 
         Some(ArchiveInfo {
             ws_id: ws.id.clone(),
             ws_name: ws.name.clone(),
+            repo_id: ws.repository_id.clone(),
             worktree_path: ws.worktree_path.clone(),
             repo_path,
+            delete_record,
             resolved,
         })
     };
@@ -780,8 +800,10 @@ async fn auto_archive_workspace(
     let Some(ArchiveInfo {
         ws_id,
         ws_name,
+        repo_id,
         worktree_path: wt_path,
         repo_path,
+        delete_record,
         resolved,
     }) = archive_info
     else {
@@ -803,14 +825,28 @@ async fn auto_archive_workspace(
         }
     }
 
+    // If the workspace record was fully deleted and no workspaces remain for this
+    // repo, clean up MCP supervisor state.
+    if delete_record {
+        let supervisor = handle.state::<Arc<McpSupervisor>>();
+        let remaining = Database::open(&app_state.db_path)
+            .map(|db| db.list_workspaces().unwrap_or_default())
+            .unwrap_or_default();
+        if !remaining.iter().any(|w| w.repository_id == repo_id) {
+            supervisor.remove_repo(&repo_id).await;
+            let _ = handle.emit("mcp-status-cleared", &repo_id);
+        }
+    }
+
     // Rebuild tray and notify frontend
     crate::tray::rebuild_tray(handle);
 
+    let verb = if delete_record { "deleted" } else { "archived" };
     let body = match pr_number {
         Some(num) => {
-            format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR #{num} merged")
+            format!("Workspace \u{2018}{ws_name}\u{2019} {verb} \u{2014} PR #{num} merged")
         }
-        None => format!("Workspace \u{2018}{ws_name}\u{2019} archived \u{2014} PR merged"),
+        None => format!("Workspace \u{2018}{ws_name}\u{2019} {verb} \u{2014} PR merged"),
     };
     crate::tray::send_notification(
         handle,
@@ -824,10 +860,11 @@ async fn auto_archive_workspace(
     let mut payload = serde_json::json!({
         "workspace_id": ws_id,
         "workspace_name": ws_name,
+        "deleted": delete_record,
     });
     if let Some(num) = pr_number {
         payload["pr_number"] = serde_json::json!(num);
     }
     let _ = handle.emit("workspace-auto-archived", payload);
-    eprintln!("[scm] Auto-archived workspace '{ws_name}' ({ws_id})");
+    eprintln!("[scm] Auto-{verb} workspace '{ws_name}' ({ws_id})");
 }

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -719,19 +719,24 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
 /// removes the worktree, updates the DB status, stops any running agent,
 /// and emits a `workspace-auto-archived` event to the frontend.
 ///
-/// When `git_delete_branch_on_archive` is enabled, fully deletes the workspace
-/// record (preserving lifetime stats) instead of moving it to Archived status.
+/// When `git_delete_branch_on_archive` is enabled, also deletes the local
+/// branch and fully removes the workspace record (preserving lifetime stats)
+/// instead of moving it to Archived status.
 async fn auto_archive_workspace(
     handle: &tauri::AppHandle,
     app_state: &AppState,
     workspace_id: &str,
     pr_number: Option<u64>,
 ) {
-    // All DB work in a block (Database is not Send — must not hold across .await)
+    // Read-only DB block — capture workspace/repo info and settings.
+    // DB mutations are deferred until after async cleanup so the workspace row
+    // remains available while worktree removal and agent stop run, and the
+    // frozen summary snapshot reflects a fully-quiesced workspace.
     struct ArchiveInfo {
         ws_id: String,
         ws_name: String,
         repo_id: String,
+        branch_name: String,
         worktree_path: Option<String>,
         repo_path: Option<String>,
         delete_record: bool,
@@ -773,23 +778,11 @@ async fn auto_archive_workspace(
             crate::tray::NotificationEvent::Finished,
         );
 
-        if delete_record {
-            // Fully remove the record; lifetime stats are frozen in a summary row.
-            let _ = db.delete_workspace_with_summary(workspace_id);
-        } else {
-            let _ = db.delete_terminal_tabs_for_workspace(workspace_id);
-            let _ = db.delete_scm_status_cache(workspace_id);
-            let _ = db.update_workspace_status(
-                workspace_id,
-                &claudette::model::WorkspaceStatus::Archived,
-                None,
-            );
-        }
-
         Some(ArchiveInfo {
             ws_id: ws.id.clone(),
             ws_name: ws.name.clone(),
             repo_id: ws.repository_id.clone(),
+            branch_name: ws.branch_name.clone(),
             worktree_path: ws.worktree_path.clone(),
             repo_path,
             delete_record,
@@ -801,6 +794,7 @@ async fn auto_archive_workspace(
         ws_id,
         ws_name,
         repo_id,
+        branch_name,
         worktree_path: wt_path,
         repo_path,
         delete_record,
@@ -815,6 +809,13 @@ async fn auto_archive_workspace(
         let _ = claudette::git::remove_worktree(repo_path, wt_path, false).await;
     }
 
+    // Delete the local branch when the setting is enabled.
+    if delete_record
+        && let Some(repo_path) = &repo_path
+    {
+        let _ = claudette::git::branch_delete(repo_path, &branch_name).await;
+    }
+
     // Stop any running agent
     {
         let mut agents = app_state.agents.write().await;
@@ -822,6 +823,23 @@ async fn auto_archive_workspace(
             && let Some(pid) = session.active_pid
         {
             let _ = claudette::agent::stop_agent(pid).await;
+        }
+    }
+
+    // Now that async cleanup is done, persist the archive/delete mutation.
+    {
+        if let Ok(db) = Database::open(&app_state.db_path) {
+            if delete_record {
+                let _ = db.delete_workspace_with_summary(&ws_id);
+            } else {
+                let _ = db.delete_terminal_tabs_for_workspace(&ws_id);
+                let _ = db.delete_scm_status_cache(&ws_id);
+                let _ = db.update_workspace_status(
+                    &ws_id,
+                    &claudette::model::WorkspaceStatus::Archived,
+                    None,
+                );
+            }
         }
     }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -439,7 +439,8 @@ pub async fn archive_workspace(
     id: String,
     app: AppHandle,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+    supervisor: State<'_, Arc<McpSupervisor>>,
+) -> Result<bool, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
     let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
@@ -453,6 +454,8 @@ pub async fn archive_workspace(
         .iter()
         .find(|r| r.id == ws.repository_id)
         .ok_or("Repository not found")?;
+
+    let repo_id = ws.repository_id.clone();
 
     if let Some(ref wt_path) = ws.worktree_path {
         let _ = git::remove_worktree(&repo.path, wt_path, false).await;
@@ -485,6 +488,23 @@ pub async fn archive_workspace(
         let _ = db.end_agent_session(sid, true);
     }
 
+    if delete_branch {
+        // Branch is gone — nothing left to restore. Fully delete the record while
+        // preserving lifetime stats in `deleted_workspace_summaries`.
+        db.delete_workspace_with_summary(&id)
+            .map_err(|e| e.to_string())?;
+
+        // If this was the last workspace for the repo, clean up MCP supervisor state.
+        let remaining = db.list_workspaces().unwrap_or_default();
+        if !remaining.iter().any(|w| w.repository_id == repo_id) {
+            supervisor.remove_repo(&repo_id).await;
+            let _ = app.emit("mcp-status-cleared", &repo_id);
+        }
+
+        crate::tray::rebuild_tray(&app);
+        return Ok(true);
+    }
+
     db.delete_terminal_tabs_for_workspace(&id)
         .map_err(|e| e.to_string())?;
     db.delete_scm_status_cache(&id).map_err(|e| e.to_string())?;
@@ -493,7 +513,7 @@ pub async fn archive_workspace(
 
     crate::tray::rebuild_tray(&app);
 
-    Ok(())
+    Ok(false)
 }
 
 #[tauri::command]

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -230,16 +230,22 @@ function App() {
     });
 
     // Listen for workspace auto-archived events (e.g. PR merged with archive_on_merge).
-    const unlistenAutoArchived = listen<{ workspace_id: string; workspace_name: string; pr_number?: number }>("workspace-auto-archived", (event) => {
-      const { workspace_id, workspace_name, pr_number } = event.payload;
+    // When `deleted` is true the workspace record was fully removed; otherwise it moved to Archived.
+    const unlistenAutoArchived = listen<{ workspace_id: string; workspace_name: string; pr_number?: number; deleted?: boolean }>("workspace-auto-archived", (event) => {
+      const { workspace_id, workspace_name, pr_number, deleted } = event.payload;
       const store = useAppStore.getState();
-      store.updateWorkspace(workspace_id, { status: "Archived" as const });
+      if (deleted) {
+        store.removeWorkspace(workspace_id);
+      } else {
+        store.updateWorkspace(workspace_id, { status: "Archived" as const });
+      }
       if (store.selectedWorkspaceId === workspace_id) {
         store.selectWorkspace(null);
       }
+      const verb = deleted ? "deleted" : "archived";
       const msg = pr_number != null
-        ? `Workspace \u201c${workspace_name}\u201d archived \u2014 PR #${pr_number} merged`
-        : `Workspace \u201c${workspace_name}\u201d archived \u2014 PR merged`;
+        ? `Workspace \u201c${workspace_name}\u201d ${verb} \u2014 PR #${pr_number} merged`
+        : `Workspace \u201c${workspace_name}\u201d ${verb} \u2014 PR merged`;
       store.addToast(msg);
     });
 

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -53,6 +53,7 @@ export const Sidebar = memo(function Sidebar() {
   const openModal = useAppStore((s) => s.openModal);
   const openSettings = useAppStore((s) => s.openSettings);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
+  const removeWorkspace = useAppStore((s) => s.removeWorkspace);
   const unreadCompletions = useAppStore((s) => s.unreadCompletions);
   const agentQuestions = useAppStore((s) => s.agentQuestions);
   const planApprovals = useAppStore((s) => s.planApprovals);
@@ -225,19 +226,23 @@ export const Sidebar = memo(function Sidebar() {
     if (archivingRef.current.has(wsId)) return;
     archivingRef.current.add(wsId);
     try {
-      await archiveWorkspace(wsId);
-      updateWorkspace(wsId, {
-        status: "Archived",
-        worktree_path: null,
-        agent_status: "Stopped",
-      });
+      const deleted = await archiveWorkspace(wsId);
+      if (deleted) {
+        removeWorkspace(wsId);
+      } else {
+        updateWorkspace(wsId, {
+          status: "Archived",
+          worktree_path: null,
+          agent_status: "Stopped",
+        });
+      }
       if (useAppStore.getState().selectedWorkspaceId === wsId) selectWorkspace(null);
     } catch (e) {
       console.error("Failed to archive workspace:", e);
     } finally {
       archivingRef.current.delete(wsId);
     }
-  }, [updateWorkspace, selectWorkspace]);
+  }, [updateWorkspace, removeWorkspace, selectWorkspace]);
 
   const handleRestore = useCallback(async (wsId: string) => {
     if (restoringRef.current.has(wsId)) return;

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -139,7 +139,7 @@ export function runWorkspaceSetup(
   return invoke("run_workspace_setup", { workspaceId });
 }
 
-export function archiveWorkspace(id: string): Promise<void> {
+export function archiveWorkspace(id: string): Promise<boolean> {
   return invoke("archive_workspace", { id });
 }
 


### PR DESCRIPTION
## Summary

When both "Archive on Merge" and "Delete branch on archive" are enabled, archived workspace records silently accumulated in the database with no user touchpoint — the branch was deleted but the DB record persisted as clutter. This PR extends the existing `git_delete_branch_on_archive` setting to also fully remove the workspace DB record (via `delete_workspace_with_summary`, preserving lifetime stats in a frozen summary row).

- **Manual archive path** (`archive_workspace` command): now returns `bool` — `true` when the record was deleted, `false` when it was moved to Archived. Frontend branches on this to call `removeWorkspace` vs `updateWorkspace`.
- **Auto-archive path** (`auto_archive_workspace` in SCM polling): checks the same setting and takes the delete path when enabled, including MCP supervisor cleanup. Adds `deleted: boolean` to the `workspace-auto-archived` event payload.
- **MCP supervisor cleanup** applied in both paths: when the last workspace for a repo is removed, cleans up supervisor state and emits `mcp-status-cleared`.

```mermaid
flowchart TD
    A[Archive triggered] --> B{delete_branch_on_archive?}
    B -- No --> C[Update status → Archived]
    B -- Yes --> D[Delete branch]
    D --> E[delete_workspace_with_summary]
    E --> F{Last workspace for repo?}
    F -- Yes --> G[MCP supervisor cleanup]
    F -- No --> H[Done — return true]
    G --> H
    C --> I[Done — return false]
```

Closes #373
Closes #324

## Complexity Notes

- `archive_workspace` return type changed from `Result<(), String>` to `Result<bool, String>`, requiring a new `McpSupervisor` state parameter. Downstream callers (frontend `archiveWorkspace`) updated accordingly.
- The `auto_archive_workspace` function opens a fresh DB connection for MCP cleanup outside the main DB block (since `Database` is not `Send` and can't be held across `.await` points).

## Test Steps

1. Enable **Settings → Git → Delete branch on archive**
2. Create a workspace, then click Archive in the sidebar → workspace should disappear entirely (not move to Archived)
3. Toggle **Show archived** → the workspace should NOT appear in the archived list
4. Disable "Delete branch on archive", archive another workspace → it should appear under Archived as before
5. Enable both "Archive on Merge" and "Delete branch on archive", merge a PR → workspace should be auto-deleted (check sidebar + toast message says "deleted" not "archived")
6. Verify the **Usage** dashboard still shows lifetime stats for deleted workspaces (frozen summary)

## Checklist

- [x] Tests pass (`cargo test --all-features`, `bun run test`)
- [x] Lint clean (`cargo clippy`, `cargo fmt --check`, `bunx tsc -b`)
- [ ] Manual testing of archive + auto-archive paths