### PR TITLE
feat(chat): pin frequently-used slash commands in the composer

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod env;
 pub mod files;
 pub mod mcp;
 pub mod metrics;
+pub mod pinned_commands;
 pub mod plan;
 pub mod plugin;
 pub mod plugins_runtime;

--- a/src-tauri/src/commands/pinned_commands.rs
+++ b/src-tauri/src/commands/pinned_commands.rs
@@ -1,0 +1,43 @@
+use tauri::State;
+
+use claudette::db::Database;
+use claudette::model::PinnedCommand;
+
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn get_pinned_commands(
+    repo_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<PinnedCommand>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.list_pinned_commands(&repo_id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn pin_command(
+    repo_id: String,
+    command_name: String,
+    state: State<'_, AppState>,
+) -> Result<PinnedCommand, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.insert_pinned_command(&repo_id, &command_name)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn unpin_command(id: i64, state: State<'_, AppState>) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.delete_pinned_command(id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn reorder_pinned_commands(
+    repo_id: String,
+    ids: Vec<i64>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.reorder_pinned_commands(&repo_id, &ids)
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -460,6 +460,11 @@ fn main() {
             // Slash commands
             commands::slash_commands::list_slash_commands,
             commands::slash_commands::record_slash_command_usage,
+            // Pinned commands
+            commands::pinned_commands::get_pinned_commands,
+            commands::pinned_commands::pin_command,
+            commands::pinned_commands::unpin_command,
+            commands::pinned_commands::reorder_pinned_commands,
             // Files
             commands::files::list_workspace_files,
             commands::files::read_workspace_file,

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use crate::migrations::{MIGRATIONS, Migration};
 use crate::model::{
     AgentStatus, Attachment, AttachmentOrigin, ChatMessage, ChatSession, CheckpointFile,
-    CompletedTurnData, ConversationCheckpoint, RemoteConnection, Repository, TerminalTab,
-    TurnToolActivity, Workspace, WorkspaceStatus,
+    CompletedTurnData, ConversationCheckpoint, PinnedCommand, RemoteConnection, Repository,
+    TerminalTab, TurnToolActivity, Workspace, WorkspaceStatus,
 };
 
 fn row_to_attachment(row: &rusqlite::Row) -> rusqlite::Result<Attachment> {
@@ -2405,6 +2405,90 @@ impl Database {
             "DELETE FROM scm_status_cache WHERE workspace_id = ?1",
             params![workspace_id],
         )?;
+        Ok(())
+    }
+
+    // --- Pinned Commands ---
+
+    pub fn list_pinned_commands(
+        &self,
+        repo_id: &str,
+    ) -> Result<Vec<PinnedCommand>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT p.id, p.repo_id, p.command_name, p.sort_order, p.created_at,
+                    COALESCE((
+                        SELECT SUM(u.use_count)
+                        FROM slash_command_usage u
+                        JOIN workspaces w ON w.id = u.workspace_id
+                        WHERE w.repository_id = p.repo_id
+                          AND u.command_name = p.command_name
+                    ), 0) AS use_count
+             FROM pinned_commands p
+             WHERE p.repo_id = ?1
+             ORDER BY use_count DESC, p.sort_order, p.id",
+        )?;
+        let rows = stmt.query_map(params![repo_id], |row| {
+            Ok(PinnedCommand {
+                id: row.get(0)?,
+                repo_id: row.get(1)?,
+                command_name: row.get(2)?,
+                sort_order: row.get(3)?,
+                created_at: row.get(4)?,
+                use_count: row.get(5)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn insert_pinned_command(
+        &self,
+        repo_id: &str,
+        command_name: &str,
+    ) -> Result<PinnedCommand, rusqlite::Error> {
+        let max_order: i32 = self.conn.query_row(
+            "SELECT COALESCE(MAX(sort_order), -1) FROM pinned_commands WHERE repo_id = ?1",
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        let created_at: String = self
+            .conn
+            .query_row("SELECT datetime('now')", [], |row| row.get(0))?;
+        self.conn.execute(
+            "INSERT INTO pinned_commands (repo_id, command_name, sort_order, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![repo_id, command_name, max_order + 1, created_at],
+        )?;
+        Ok(PinnedCommand {
+            id: self.conn.last_insert_rowid(),
+            repo_id: repo_id.to_string(),
+            command_name: command_name.to_string(),
+            sort_order: max_order + 1,
+            created_at,
+            use_count: 0,
+        })
+    }
+
+    pub fn delete_pinned_command(&self, id: i64) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute("DELETE FROM pinned_commands WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    pub fn reorder_pinned_commands(
+        &self,
+        repo_id: &str,
+        ids: &[i64],
+    ) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "UPDATE pinned_commands SET sort_order = ?1 WHERE id = ?2 AND repo_id = ?3",
+            )?;
+            for (i, id) in ids.iter().enumerate() {
+                stmt.execute(params![i as i32, id, repo_id])?;
+            }
+        }
+        tx.commit()?;
         Ok(())
     }
 }
@@ -5019,5 +5103,92 @@ mod tests {
         );
         let actives = db.list_chat_sessions_for_workspace("w1", false).unwrap();
         assert_eq!(actives.len(), 1);
+    }
+
+    // --- Pinned command tests ---
+
+    #[test]
+    fn test_pinned_commands_crud() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+
+        let p1 = db.insert_pinned_command("r1", "review").unwrap();
+        let p2 = db.insert_pinned_command("r1", "run-tests").unwrap();
+
+        assert_eq!(p1.command_name, "review");
+        assert_eq!(p2.command_name, "run-tests");
+        assert!(p1.sort_order < p2.sort_order);
+
+        let pins = db.list_pinned_commands("r1").unwrap();
+        assert_eq!(pins.len(), 2);
+        assert_eq!(pins[0].command_name, "review");
+        assert_eq!(pins[1].command_name, "run-tests");
+
+        db.delete_pinned_command(p1.id).unwrap();
+        let pins = db.list_pinned_commands("r1").unwrap();
+        assert_eq!(pins.len(), 1);
+        assert_eq!(pins[0].command_name, "run-tests");
+    }
+
+    #[test]
+    fn test_pinned_commands_unique_constraint() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_pinned_command("r1", "review").unwrap();
+        let dup = db.insert_pinned_command("r1", "review");
+        assert!(dup.is_err());
+    }
+
+    #[test]
+    fn test_pinned_commands_per_repo() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_repository(&make_repo("r2", "/tmp/repo2", "repo2"))
+            .unwrap();
+
+        db.insert_pinned_command("r1", "review").unwrap();
+        db.insert_pinned_command("r2", "deploy").unwrap();
+
+        let r1_pins = db.list_pinned_commands("r1").unwrap();
+        let r2_pins = db.list_pinned_commands("r2").unwrap();
+        assert_eq!(r1_pins.len(), 1);
+        assert_eq!(r1_pins[0].command_name, "review");
+        assert_eq!(r2_pins.len(), 1);
+        assert_eq!(r2_pins[0].command_name, "deploy");
+    }
+
+    #[test]
+    fn test_pinned_commands_cascade_on_repo_delete() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_pinned_command("r1", "review").unwrap();
+        db.insert_pinned_command("r1", "run-tests").unwrap();
+
+        db.delete_repository("r1").unwrap();
+        let pins = db.list_pinned_commands("r1").unwrap();
+        assert!(pins.is_empty());
+    }
+
+    #[test]
+    fn test_pinned_commands_reorder() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+
+        let p1 = db.insert_pinned_command("r1", "alpha").unwrap();
+        let p2 = db.insert_pinned_command("r1", "beta").unwrap();
+        let p3 = db.insert_pinned_command("r1", "gamma").unwrap();
+
+        db.reorder_pinned_commands("r1", &[p3.id, p1.id, p2.id])
+            .unwrap();
+
+        let pins = db.list_pinned_commands("r1").unwrap();
+        assert_eq!(pins[0].command_name, "gamma");
+        assert_eq!(pins[1].command_name, "alpha");
+        assert_eq!(pins[2].command_name, "beta");
     }
 }

--- a/src/migrations/20260424044912_pinned_commands.sql
+++ b/src/migrations/20260424044912_pinned_commands.sql
@@ -1,0 +1,11 @@
+CREATE TABLE pinned_commands (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id      TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    command_name TEXT NOT NULL,
+    sort_order   INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(repo_id, command_name)
+);
+
+CREATE INDEX idx_pinned_commands_repo
+    ON pinned_commands(repo_id, sort_order);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -150,6 +150,11 @@ pub const MIGRATIONS: &[Migration] = &[
         legacy_version: None,
     },
     Migration {
+        id: "20260424044912_pinned_commands",
+        sql: include_str!("20260424044912_pinned_commands.sql"),
+        legacy_version: None,
+    },
+    Migration {
         id: "20260425003451_attachments_origin_and_tool_use",
         sql: include_str!("20260425003451_attachments_origin_and_tool_use.sql"),
         legacy_version: None,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,6 +5,7 @@ mod chat_session;
 mod checkpoint;
 pub mod diff;
 mod metrics;
+mod pinned_command;
 mod remote_connection;
 mod repository;
 mod terminal_tab;
@@ -22,6 +23,7 @@ pub use metrics::{
     AgentCommit, AgentSession, AnalyticsMetrics, DashboardMetrics, DeletedWorkspaceSummary,
     HeatmapCell, RepoLeaderRow, SessionDot, WorkspaceMetrics,
 };
+pub use pinned_command::PinnedCommand;
 pub use remote_connection::RemoteConnection;
 pub use repository::Repository;
 pub use terminal_tab::TerminalTab;

--- a/src/model/pinned_command.rs
+++ b/src/model/pinned_command.rs
@@ -1,0 +1,11 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PinnedCommand {
+    pub id: i64,
+    pub repo_id: String,
+    pub command_name: String,
+    pub sort_order: i32,
+    pub created_at: String,
+    pub use_count: i64,
+}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -57,6 +57,7 @@ import { SegmentedMeter } from "./composer/SegmentedMeter";
 import { ContextPopover } from "./composer/ContextPopover";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
+import { PinnedCommandsBar } from "./PinnedCommandsBar";
 import { AttachMenu } from "./AttachMenu";
 import {
   AttachmentContextMenu,
@@ -2441,6 +2442,11 @@ function ChatInputArea({
     return () => window.removeEventListener("keydown", onKey, true);
   }, [voice.state, voice.cancel]);
 
+  const handleInsertPinnedCommand = useCallback((commandText: string) => {
+    setChatInput((prev) => commandText + (prev ? " " + prev : ""));
+    textareaRef.current?.focus();
+  }, []);
+
   // Per-session draft storage: save input when switching away,
   // restore when switching back.
   const draftsRef = useRef<Record<string, string>>({});
@@ -3038,6 +3044,11 @@ function ChatInputArea({
           ))}
         </div>
       )}
+      <PinnedCommandsBar
+        repoId={repoId}
+        slashCommands={slashCommands}
+        onInsertCommand={handleInsertPinnedCommand}
+      />
       <div className={styles.inputTextWrap}>
         {showUltrathinkOverlay && (
           <div className={styles.inputHighlight} aria-hidden="true">

--- a/src/ui/src/components/chat/PinnedCommandsBar.module.css
+++ b/src/ui/src/components/chat/PinnedCommandsBar.module.css
@@ -1,0 +1,143 @@
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px 2px;
+  min-height: 28px;
+}
+
+.label {
+  color: var(--text-faint);
+  font-size: var(--fs-xs);
+  text-transform: lowercase;
+  letter-spacing: 0.03em;
+  user-select: none;
+  margin-right: 2px;
+}
+
+.hint {
+  color: var(--text-faint);
+  font-size: var(--fs-xs);
+  user-select: none;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 10px;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.18);
+  border-radius: var(--radius-pill);
+  background: var(--toolbar-active);
+  color: var(--toolbar-active-text);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--fs-sm);
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: filter var(--transition-fast);
+}
+
+.pill:hover {
+  filter: brightness(1.12);
+}
+
+.pillStale {
+  opacity: 0.45;
+}
+
+.slash {
+  color: var(--text-dim);
+  opacity: 0.5;
+}
+
+.unpin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 11px;
+  line-height: 1;
+  padding: 0 0 0 2px;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.pill:hover .unpin {
+  opacity: 0.55;
+}
+
+.unpin:hover {
+  opacity: 1 !important;
+}
+
+.addBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px dashed var(--divider);
+  border-radius: var(--radius-pill);
+  color: var(--text-dim);
+  font-size: var(--fs-sm);
+  line-height: 1;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.addBtn:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.inlinePicker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.pickerInput {
+  background: transparent;
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-pill);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--fs-sm);
+  line-height: 1;
+  padding: 3px 10px;
+  outline: none;
+  width: 160px;
+  transition: border-color var(--transition-fast);
+}
+
+.pickerInput:focus {
+  border-color: var(--accent-primary);
+}
+
+.pickerItem {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--hover-bg);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--fs-sm);
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.pickerItem:hover {
+  background: var(--selected-bg);
+  color: var(--text-primary);
+}

--- a/src/ui/src/components/chat/PinnedCommandsBar.module.css
+++ b/src/ui/src/components/chat/PinnedCommandsBar.module.css
@@ -25,8 +25,7 @@
 .pill {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  padding: 3px 10px;
+  gap: 0;
   border: 1px solid rgba(var(--accent-primary-rgb), 0.18);
   border-radius: var(--radius-pill);
   background: var(--toolbar-active);
@@ -35,12 +34,24 @@
   font-size: var(--fs-sm);
   line-height: 1;
   white-space: nowrap;
-  cursor: pointer;
   transition: filter var(--transition-fast);
 }
 
 .pill:hover {
   filter: brightness(1.12);
+}
+
+.pillAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 2px 3px 10px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  cursor: pointer;
 }
 
 .pillStale {
@@ -61,7 +72,7 @@
   color: inherit;
   font-size: 11px;
   line-height: 1;
-  padding: 0 0 0 2px;
+  padding: 0 6px 0 2px;
   margin: 0;
   opacity: 0;
   cursor: pointer;

--- a/src/ui/src/components/chat/PinnedCommandsBar.module.css
+++ b/src/ui/src/components/chat/PinnedCommandsBar.module.css
@@ -79,11 +79,13 @@
   transition: opacity var(--transition-fast);
 }
 
-.pill:hover .unpin {
+.pill:hover .unpin,
+.pill:focus-within .unpin {
   opacity: 0.55;
 }
 
-.unpin:hover {
+.unpin:hover,
+.unpin:focus-visible {
   opacity: 1 !important;
 }
 

--- a/src/ui/src/components/chat/PinnedCommandsBar.tsx
+++ b/src/ui/src/components/chat/PinnedCommandsBar.tsx
@@ -75,12 +75,13 @@ export function PinnedCommandsBar({
 
   const handleUnpin = useCallback((id: number) => {
     setPins((prev) => {
-      const removed = prev.find((p) => p.id === id);
+      const previousPins = prev;
+      const nextPins = prev.filter((p) => p.id !== id);
       unpinCommand(id).catch((e) => {
         console.error("Failed to unpin command:", e);
-        if (removed) setPins((cur) => [...cur, removed].sort((a, b) => a.sort_order - b.sort_order));
+        setPins(previousPins);
       });
-      return prev.filter((p) => p.id !== id);
+      return nextPins;
     });
   }, []);
 
@@ -93,12 +94,10 @@ export function PinnedCommandsBar({
         e.preventDefault();
         if (availableCommands.length > 0) {
           handlePin(availableCommands[0].name);
-        } else if (pickerQuery.trim() && slashCommands.length === 0) {
-          handlePin(pickerQuery.trim().replace(/^\//, ""));
         }
       }
     },
-    [availableCommands, handlePin, pickerQuery, slashCommands.length],
+    [availableCommands, handlePin],
   );
 
   useEffect(() => {
@@ -121,25 +120,28 @@ export function PinnedCommandsBar({
           slashCommands.length > 0 &&
           !slashCommands.some((c) => c.name === pin.command_name);
         return (
-          <button
+          <span
             key={pin.id}
             className={`${styles.pill}${isStale ? ` ${styles.pillStale}` : ""}`}
-            onClick={() => onInsertCommand("/" + pin.command_name)}
-            title={isStale ? `/${pin.command_name} (not available)` : `/${pin.command_name}`}
           >
-            <span className={styles.slash}>/</span>
-            {pin.command_name}
-            <span
+            <button
+              type="button"
+              className={styles.pillAction}
+              onClick={() => onInsertCommand(`/${pin.command_name} `)}
+              title={isStale ? `/${pin.command_name} (not available)` : `/${pin.command_name}`}
+            >
+              <span className={styles.slash}>/</span>
+              {pin.command_name}
+            </button>
+            <button
+              type="button"
               className={styles.unpin}
-              role="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleUnpin(pin.id);
-              }}
+              aria-label={`Unpin /${pin.command_name}`}
+              onClick={() => handleUnpin(pin.id)}
             >
               ✕
-            </span>
-          </button>
+            </button>
+          </span>
         );
       })}
 

--- a/src/ui/src/components/chat/PinnedCommandsBar.tsx
+++ b/src/ui/src/components/chat/PinnedCommandsBar.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SlashCommand, PinnedCommand } from "../../services/tauri";
+import { getPinnedCommands, pinCommand, unpinCommand } from "../../services/tauri";
+import styles from "./PinnedCommandsBar.module.css";
+
+interface PinnedCommandsBarProps {
+  repoId: string | undefined;
+  slashCommands: SlashCommand[];
+  onInsertCommand: (commandText: string) => void;
+}
+
+export function PinnedCommandsBar({
+  repoId,
+  slashCommands,
+  onInsertCommand,
+}: PinnedCommandsBarProps) {
+  const [pins, setPins] = useState<PinnedCommand[]>([]);
+  const [showPicker, setShowPicker] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState("");
+  const pickerInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!repoId) {
+      setPins([]);
+      return;
+    }
+    let cancelled = false;
+    getPinnedCommands(repoId)
+      .then((cmds) => {
+        if (!cancelled) setPins(cmds);
+      })
+      .catch((e) => console.error("Failed to load pinned commands:", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId]);
+
+  const pinnedNames = useMemo(
+    () => new Set(pins.map((p) => p.command_name)),
+    [pins],
+  );
+
+  const availableCommands = useMemo(() => {
+    const q = pickerQuery.toLowerCase();
+    return slashCommands.filter(
+      (cmd) => !pinnedNames.has(cmd.name) && (!q || cmd.name.toLowerCase().includes(q)),
+    );
+  }, [slashCommands, pinnedNames, pickerQuery]);
+
+  const handlePin = useCallback(
+    (name: string) => {
+      if (!repoId) return;
+      const temp: PinnedCommand = {
+        id: -Date.now(),
+        repo_id: repoId,
+        command_name: name,
+        sort_order: pins.length,
+        created_at: "",
+        use_count: 0,
+      };
+      setPins((prev) => [...prev, temp]);
+      setShowPicker(false);
+      setPickerQuery("");
+      pinCommand(repoId, name)
+        .then((saved) => {
+          setPins((prev) => prev.map((p) => (p.id === temp.id ? saved : p)));
+        })
+        .catch((e) => {
+          console.error("Failed to pin command:", e);
+          setPins((prev) => prev.filter((p) => p.id !== temp.id));
+        });
+    },
+    [repoId, pins.length],
+  );
+
+  const handleUnpin = useCallback((id: number) => {
+    setPins((prev) => {
+      const removed = prev.find((p) => p.id === id);
+      unpinCommand(id).catch((e) => {
+        console.error("Failed to unpin command:", e);
+        if (removed) setPins((cur) => [...cur, removed].sort((a, b) => a.sort_order - b.sort_order));
+      });
+      return prev.filter((p) => p.id !== id);
+    });
+  }, []);
+
+  const handlePickerKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        setShowPicker(false);
+        setPickerQuery("");
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        if (availableCommands.length > 0) {
+          handlePin(availableCommands[0].name);
+        } else if (pickerQuery.trim() && slashCommands.length === 0) {
+          handlePin(pickerQuery.trim().replace(/^\//, ""));
+        }
+      }
+    },
+    [availableCommands, handlePin, pickerQuery, slashCommands.length],
+  );
+
+  useEffect(() => {
+    if (showPicker) {
+      pickerInputRef.current?.focus();
+    }
+  }, [showPicker]);
+
+  if (!repoId) return null;
+
+  return (
+    <div className={styles.bar}>
+      {pins.length > 0 && <span className={styles.label}>pinned</span>}
+      {pins.length === 0 && !showPicker && (
+        <span className={styles.hint}>pin a command…</span>
+      )}
+
+      {pins.map((pin) => {
+        const isStale =
+          slashCommands.length > 0 &&
+          !slashCommands.some((c) => c.name === pin.command_name);
+        return (
+          <button
+            key={pin.id}
+            className={`${styles.pill}${isStale ? ` ${styles.pillStale}` : ""}`}
+            onClick={() => onInsertCommand("/" + pin.command_name)}
+            title={isStale ? `/${pin.command_name} (not available)` : `/${pin.command_name}`}
+          >
+            <span className={styles.slash}>/</span>
+            {pin.command_name}
+            <span
+              className={styles.unpin}
+              role="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleUnpin(pin.id);
+              }}
+            >
+              ✕
+            </span>
+          </button>
+        );
+      })}
+
+      {showPicker ? (
+        <div className={styles.inlinePicker}>
+          <input
+            ref={pickerInputRef}
+            className={styles.pickerInput}
+            value={pickerQuery}
+            onChange={(e) => setPickerQuery(e.target.value)}
+            onKeyDown={handlePickerKeyDown}
+            onBlur={() => {
+              setShowPicker(false);
+              setPickerQuery("");
+            }}
+            placeholder="search commands…"
+          />
+          {availableCommands.slice(0, 12).map((cmd) => (
+            <button
+              key={cmd.name}
+              className={styles.pickerItem}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handlePin(cmd.name);
+              }}
+            >
+              /{cmd.name}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <button
+          className={styles.addBtn}
+          onClick={() => setShowPicker(true)}
+          title="Pin a command"
+        >
+          +
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -243,6 +243,41 @@ export function recordSlashCommandUsage(
   });
 }
 
+// -- Pinned Commands --
+
+export interface PinnedCommand {
+  id: number;
+  repo_id: string;
+  command_name: string;
+  sort_order: number;
+  created_at: string;
+  use_count: number;
+}
+
+export function getPinnedCommands(
+  repoId: string,
+): Promise<PinnedCommand[]> {
+  return invoke("get_pinned_commands", { repoId });
+}
+
+export function pinCommand(
+  repoId: string,
+  commandName: string,
+): Promise<PinnedCommand> {
+  return invoke("pin_command", { repoId, commandName });
+}
+
+export function unpinCommand(id: number): Promise<void> {
+  return invoke("unpin_command", { id });
+}
+
+export function reorderPinnedCommands(
+  repoId: string,
+  ids: number[],
+): Promise<void> {
+  return invoke("reorder_pinned_commands", { repoId, ids });
+}
+
 // -- Plugins --
 
 export function listPlugins(


### PR DESCRIPTION
## Summary

Adds a per-repository bar of pinned slash commands above the chat composer, giving users one-click access to their most-used commands without opening the full picker.

- New `pinned_commands` table (per-repo, ordered, unique on `(repo_id, command_name)`) with cascade delete when a repository is removed.
- Pin/unpin from a dedicated inline picker ("+") in the pinned commands bar; pinned commands show as pills in a new `PinnedCommandsBar` component above the composer.
- Pinned commands are sorted by aggregated `use_count` from `slash_command_usage` (summed across all workspaces for that repo), with `sort_order` and `id` as tiebreakers — so the bar self-organizes around actual usage rather than insertion order.

```mermaid
erDiagram
    repositories ||--o{ pinned_commands : has
    repositories ||--o{ workspaces : has
    workspaces ||--o{ slash_command_usage : tracks
    pinned_commands {
        INTEGER id PK
        TEXT repo_id FK
        TEXT command_name
        INTEGER sort_order
        TEXT created_at
    }
    slash_command_usage {
        TEXT workspace_id FK
        TEXT command_name
        INTEGER use_count
        TEXT last_used_at
    }
```

## Complexity Notes

- **Migration system change** — this branch originally landed as a `PRAGMA user_version = 25` inline migration, but main refactored to the declarative `MIGRATIONS` array in `src/migrations/mod.rs`. The rebase converted it to a new `.sql` file with `legacy_version: None`. Reviewers should confirm the migration ID (`20260424044912_pinned_commands`) does not collide with any other in-flight branches.
- **Usage-ordered query** — `list_pinned_commands` joins `slash_command_usage` across all workspaces in the repo via a correlated subquery. Workspaces with heavy usage of a command will dominate the ordering; this is intentional but worth a look.
- **Picker interaction** — `PinnedCommandsBar.tsx` uses `onMouseDown` + `e.preventDefault()` on picker items because the inline picker input's `onBlur` closes the picker before `onClick` fires.

## Test Steps

1. Pull the branch and run `cargo tauri dev`.
2. Open a workspace in any repository and focus the chat composer.
3. Click the "+" button in the pinned commands bar to open the inline picker. Search for a command (e.g. `help`) and click it — it should appear as a pill in the bar.
4. Click a pinned command pill — it should insert `/command-name ` (with trailing space) into the composer.
5. Hover a pill and click the "✕" button to unpin — it should disappear. Verify keyboard focus works on the unpin button (Tab to it, Enter to activate).
6. Send a few different commands; verify the bar reorders by usage on next mount (close and reopen the workspace or trigger a refetch).
7. Pin commands in two different repositories; verify they are scoped per-repo and do not leak across.
8. Delete a repository with pins; confirm the `pinned_commands` rows cascade-delete (check via `/claudette-debug` or sqlite shell).
9. On a database pre-refactor (one still at `user_version = N`), confirm the new migration runs cleanly via the `schema_migrations` backfill path.

## Checklist

- [x] Tests added/updated (5 new `db.rs` tests covering CRUD, uniqueness, per-repo scoping, cascade delete, reorder)
- [ ] Documentation updated (if applicable)