### PR TITLE
fix(notifications): defer attention notify until UI has the prompt event

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -19,6 +19,14 @@ use claudette::{base64_decode, base64_encode};
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
 
+/// How long to wait between emitting `agent-permission-prompt` and firing the
+/// attention system notification. This is the window in which the webview
+/// picks up the event, runs the Zustand setter, and paints the question/plan
+/// card. 300ms is a compromise: long enough to cover typical React render
+/// plus a macOS window-show animation (when the user had the window hidden),
+/// short enough that the notification still feels tied to the trigger.
+const ATTENTION_NOTIFY_DELAY_MS: u64 = 300;
+
 async fn fire_completion_notification(
     db_path: &std::path::Path,
     cesp_playback: &std::sync::Mutex<claudette::cesp::SoundPlaybackState>,
@@ -839,10 +847,8 @@ pub async fn send_chat_message(
         // to None after each persistence so per-message counts stay distinct
         // across multi-message turns.
         let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
-        let mut pending_attention_kind: Option<crate::state::AttentionKind>;
         let mut notified_via_result = false;
         while let Some(event) = rx.recv().await {
-            pending_attention_kind = None;
             // Track whether the CLI initialized successfully.
             if let AgentEvent::Stream(StreamEvent::System { subtype, .. }) = &event
                 && subtype == "init"
@@ -930,6 +936,29 @@ pub async fn send_chat_message(
                         "input": input,
                     });
                     let _ = app.emit("agent-permission-prompt", &payload);
+
+                    // Fire the system notification after the frontend has the
+                    // data it needs to render the card. We emit
+                    // `agent-permission-prompt` synchronously above; the
+                    // short sleep gives the webview time to pick up the event
+                    // and paint before the notification sound/banner arrives.
+                    // Tied to ControlRequest (not the earlier ContentBlockStart)
+                    // because the card is driven by this event, not the
+                    // streaming tool_use block.
+                    let kind = if tool_name == "AskUserQuestion" {
+                        crate::state::AttentionKind::Ask
+                    } else {
+                        crate::state::AttentionKind::Plan
+                    };
+                    let app_for_notify = app.clone();
+                    let ws_id_for_notify = ws_id.clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            ATTENTION_NOTIFY_DELAY_MS,
+                        ))
+                        .await;
+                        crate::tray::notify_attention(&app_for_notify, &ws_id_for_notify, kind);
+                    });
                 } else {
                     let app_state = app.state::<AppState>();
                     let agents = app_state.agents.read().await;
@@ -964,9 +993,10 @@ pub async fn send_chat_message(
             }
 
             // Detect tool calls that require user input (question, plan approval).
-            // Capture whether we need to notify — the actual notification is
-            // deferred until after the event is emitted to the frontend so the
-            // UI updates before the system notification appears.
+            // The tray state flip happens here (on ContentBlockStart) so the
+            // icon/menu update is immediate. The *notification* itself fires
+            // later, from the ControlRequest branch, once the frontend has the
+            // data it needs to render the question/plan card.
             if let AgentEvent::Stream(StreamEvent::Stream {
                 event:
                     InnerStreamEvent::ContentBlockStart {
@@ -983,7 +1013,6 @@ pub async fn send_chat_message(
                 };
                 let app_state = app.state::<AppState>();
                 let mut agents = app_state.agents.write().await;
-                let already_notified = agents.get(&ws_id).is_some_and(|s| s.needs_attention);
                 if let Some(session) = agents.get_mut(&ws_id) {
                     session.needs_attention = true;
                     session.attention_kind = Some(kind);
@@ -993,12 +1022,6 @@ pub async fn send_chat_message(
                     if name == "ExitPlanMode" {
                         session.session_exited_plan = true;
                     }
-                }
-                drop(agents);
-                // Only send notification once per attention cycle — skip if
-                // we already notified the user about this workspace.
-                if !already_notified {
-                    pending_attention_kind = Some(kind);
                 }
             }
 
@@ -1361,14 +1384,6 @@ pub async fn send_chat_message(
                 event,
             };
             let _ = app.emit("agent-stream", &payload);
-
-            // Send attention notification AFTER emitting the event to the
-            // frontend — this gives the UI time to update before the system
-            // notification / sound fires, so the badge is already visible
-            // when the user sees the notification.
-            if let Some(kind) = pending_attention_kind {
-                crate::tray::notify_attention(&app, &ws_id, kind);
-            }
         }
     });
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -392,6 +392,7 @@ pub async fn send_chat_message(
                 custom_instructions: instructions.clone(),
                 needs_attention: false,
                 attention_kind: None,
+                attention_notification_sent: false,
                 persistent_session: None,
                 mcp_config_dirty: false,
                 session_plan_mode: false,
@@ -409,6 +410,7 @@ pub async fn send_chat_message(
             custom_instructions: instructions,
             needs_attention: false,
             attention_kind: None,
+            attention_notification_sent: false,
             persistent_session: None,
             mcp_config_dirty: false,
             session_plan_mode: false,
@@ -945,6 +947,15 @@ pub async fn send_chat_message(
                     // Tied to ControlRequest (not the earlier ContentBlockStart)
                     // because the card is driven by this event, not the
                     // streaming tool_use block.
+                    //
+                    // The task is detached, so it must defend against state
+                    // changes during the sleep:
+                    //   - If the user already responded (or the session was
+                    //     stopped/cleared), the matching pending_permission is
+                    //     gone and a notification would be misleading.
+                    //   - If a different pending prompt in the same cycle has
+                    //     already triggered the notification, dedupe via
+                    //     `attention_notification_sent`.
                     let kind = if tool_name == "AskUserQuestion" {
                         crate::state::AttentionKind::Ask
                     } else {
@@ -952,12 +963,41 @@ pub async fn send_chat_message(
                     };
                     let app_for_notify = app.clone();
                     let ws_id_for_notify = ws_id.clone();
+                    let tool_use_id_for_notify = tool_use_id.clone();
+                    let request_id_for_notify = request_id.clone();
+                    let tool_name_for_notify = tool_name.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(std::time::Duration::from_millis(
                             ATTENTION_NOTIFY_DELAY_MS,
                         ))
                         .await;
-                        crate::tray::notify_attention(&app_for_notify, &ws_id_for_notify, kind);
+
+                        let app_state = app_for_notify.state::<AppState>();
+                        let should_notify = {
+                            let mut agents = app_state.agents.write().await;
+                            let Some(session) = agents.get_mut(&ws_id_for_notify) else {
+                                return;
+                            };
+                            if session.attention_notification_sent {
+                                false
+                            } else {
+                                let still_pending = session
+                                    .pending_permissions
+                                    .get(&tool_use_id_for_notify)
+                                    .is_some_and(|p| {
+                                        p.request_id == request_id_for_notify
+                                            && p.tool_name == tool_name_for_notify
+                                    });
+                                if still_pending {
+                                    session.attention_notification_sent = true;
+                                }
+                                still_pending
+                            }
+                        };
+
+                        if should_notify {
+                            crate::tray::notify_attention(&app_for_notify, &ws_id_for_notify, kind);
+                        }
                     });
                 } else {
                     let app_state = app.state::<AppState>();
@@ -1842,6 +1882,7 @@ pub async fn submit_agent_answer(
             .expect("checked above");
         session.needs_attention = false;
         session.attention_kind = None;
+        session.attention_notification_sent = false;
         (pending, ps)
     };
 
@@ -1910,6 +1951,7 @@ pub async fn submit_plan_approval(
             .expect("checked above");
         session.needs_attention = false;
         session.attention_kind = None;
+        session.attention_notification_sent = false;
         (pending, ps)
     };
 
@@ -2443,6 +2485,7 @@ mod tests {
             custom_instructions: None,
             needs_attention: false,
             attention_kind: None,
+            attention_notification_sent: false,
             persistent_session: None,
             mcp_config_dirty: false,
             session_plan_mode: false,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -52,6 +52,11 @@ pub struct AgentSessionState {
     pub needs_attention: bool,
     /// What kind of input the agent needs, if any.
     pub attention_kind: Option<AttentionKind>,
+    /// Set when the deferred attention notification has been fired for the
+    /// current attention cycle. Cleared whenever `needs_attention` is cleared
+    /// (i.e. when the user responds). Prevents repeated banner/sound when
+    /// multiple `can_use_tool` prompts queue inside a single cycle.
+    pub attention_notification_sent: bool,
     /// Long-lived process that persists MCP servers across turns.
     /// When present, subsequent turns write to this process's stdin instead of
     /// spawning new processes.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -739,6 +739,7 @@ mod tests {
             } else {
                 None
             },
+            attention_notification_sent: false,
             persistent_session: None,
             mcp_config_dirty: false,
             session_plan_mode: false,


### PR DESCRIPTION
## Summary
- Fixes #331: system notifications for AskUserQuestion / ExitPlanMode arrived before the UI rendered the question/plan card.
- Moves the `notify_attention` call from the `agent-stream` ContentBlockStart path (which fires when the model starts streaming the tool_use block) to the `ControlRequest::CanUseTool` path (which is what drives `agent-permission-prompt`, the event the frontend uses to actually render the card).
- Defers the notification by 300 ms via `tokio::spawn` so the webview has time to process the event and paint the card before the banner / sound arrives.
- Tray icon / menu state still flips immediately on ContentBlockStart, so the at-a-glance signal is unchanged.

## Why this approach
The issue suggested three options (delay, frontend ack, hybrid). This is the hybrid: tying the trigger to the same event that drives the card render eliminates the largest gap (the CLI delay between ContentBlockStart and ControlRequest), and the small async sleep covers React render + macOS show-window animation without a frontend round-trip.

## Test plan
- [x] `cargo test --all-features` (566 passed)
- [x] `cargo clippy --workspace --all-targets` (no new warnings; one pre-existing in `files.rs` unaffected)
- [x] `cargo fmt --all --check`
- [x] `bunx tsc --noEmit` in `src/ui`
- [x] `bun run test` in `src/ui` (624 passed)
- [ ] Manual: hide window, trigger an AskUserQuestion, confirm the notification arrives at-or-after the card is visible when the window comes back to focus.