### PR TITLE
fix(chat): remove horizontal scrollbar from input composer

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -940,6 +940,7 @@
   resize: none;
   min-height: 52px;
   max-height: 160px;
+  overflow-x: hidden;
 }
 
 .input:focus-visible {


### PR DESCRIPTION
## Summary
- Add `overflow-x: hidden` to the `.input` textarea rule in `ChatPanel.module.css` so the browser no longer reserves a horizontal scrollbar track at the bottom of the composer. The textarea wraps long content, so horizontal scrolling was never usable — the track was pure visual noise (most visible on macOS with "Show scrollbars: Always").

Closes #388

## Test plan
- [x] `cargo test --all-features` — 566 passed
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -D warnings` — clean (CI-linted crates)
- [x] `cargo fmt --all --check` — clean
- [x] `cd src/ui && bunx tsc --noEmit` — clean
- [x] `cd src/ui && bun run test` — 624 passed
- [x] Visual verification via Playwright: injected before/after textarea fixtures with the same dimensions/styling as the composer; confirmed computed `overflow-x` flips from `auto` to `hidden`.