### PR TITLE
fix(sidebar): persist external branch renames to DB and refresh on select

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -644,26 +644,28 @@ pub fn generate_workspace_name() -> GeneratedWorkspaceName {
     }
 }
 
+/// Re-read the current branch for every active workspace and return the set
+/// of workspaces whose stored `branch_name` is now stale. Any drift is also
+/// persisted back to the DB so external branch renames (`git branch -m`,
+/// `git checkout -b`, etc.) made from the integrated terminal or elsewhere
+/// stop the DB from diverging from git reality.
 #[tauri::command]
 pub async fn refresh_branches(state: State<'_, AppState>) -> Result<Vec<(String, String)>, String> {
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    claudette::workspace_sync::reconcile_all_workspace_branches(&state.db_path).await
+}
 
-    let mut updates = Vec::new();
-
-    for ws in &workspaces {
-        if ws.status != WorkspaceStatus::Active {
-            continue;
-        }
-        if let Some(ref wt_path) = ws.worktree_path
-            && let Ok(branch) = git::current_branch(wt_path).await
-            && branch != ws.branch_name
-        {
-            updates.push((ws.id.clone(), branch));
-        }
-    }
-
-    Ok(updates)
+/// Re-read the current branch for a single workspace, persist any change, and
+/// return the new branch name (or `None` if nothing changed or the workspace
+/// isn't active). Used for event-driven refreshes — e.g. when the user selects
+/// a workspace or focuses its terminal panel — so sidebar state tracks
+/// external `git` operations without waiting on the 5s poll.
+#[tauri::command]
+pub async fn refresh_workspace_branch(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<Option<String>, String> {
+    claudette::workspace_sync::reconcile_single_workspace_branch(&state.db_path, &workspace_id)
+        .await
 }
 
 #[derive(Serialize)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -355,6 +355,7 @@ fn main() {
             commands::workspace::delete_workspace,
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
+            commands::workspace::refresh_workspace_branch,
             commands::workspace::discover_worktrees,
             commands::workspace::import_worktrees,
             commands::workspace::open_workspace_in_terminal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod process;
 pub mod scm;
 pub mod slash_commands;
 pub mod snapshot;
+pub mod workspace_sync;
 
 use base64::Engine;
 

--- a/src/ui/src/hooks/useBranchRefresh.test.ts
+++ b/src/ui/src/hooks/useBranchRefresh.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockRefreshBranches, mockRefreshWorkspaceBranch } = vi.hoisted(() => ({
+  mockRefreshBranches: vi.fn(),
+  mockRefreshWorkspaceBranch: vi.fn(),
+}));
+
+vi.mock("../services/tauri", () => ({
+  refreshBranches: mockRefreshBranches,
+  refreshWorkspaceBranch: mockRefreshWorkspaceBranch,
+}));
+
+import {
+  pollAndApplyBranchUpdates,
+  refreshSelectedWorkspaceBranch,
+} from "./useBranchRefresh";
+
+describe("pollAndApplyBranchUpdates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies every drift returned by the backend", async () => {
+    mockRefreshBranches.mockResolvedValue([
+      ["w1", "user/renamed"],
+      ["w2", "feature/new"],
+    ]);
+    const updateWorkspace = vi.fn();
+
+    await pollAndApplyBranchUpdates(updateWorkspace);
+
+    expect(updateWorkspace).toHaveBeenCalledTimes(2);
+    expect(updateWorkspace).toHaveBeenNthCalledWith(1, "w1", {
+      branch_name: "user/renamed",
+    });
+    expect(updateWorkspace).toHaveBeenNthCalledWith(2, "w2", {
+      branch_name: "feature/new",
+    });
+  });
+
+  it("makes no store writes when the backend returns no drift", async () => {
+    mockRefreshBranches.mockResolvedValue([]);
+    const updateWorkspace = vi.fn();
+
+    await pollAndApplyBranchUpdates(updateWorkspace);
+
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors so the polling loop keeps running", async () => {
+    mockRefreshBranches.mockRejectedValue(new Error("IPC down"));
+    const updateWorkspace = vi.fn();
+
+    await expect(
+      pollAndApplyBranchUpdates(updateWorkspace),
+    ).resolves.toBeUndefined();
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshSelectedWorkspaceBranch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes the fresh branch to the store when the backend reports drift", async () => {
+    mockRefreshWorkspaceBranch.mockResolvedValue("user/renamed");
+    const updateWorkspace = vi.fn();
+
+    const result = await refreshSelectedWorkspaceBranch("w1", updateWorkspace);
+
+    expect(result).toBe("user/renamed");
+    expect(mockRefreshWorkspaceBranch).toHaveBeenCalledWith("w1");
+    expect(updateWorkspace).toHaveBeenCalledWith("w1", {
+      branch_name: "user/renamed",
+    });
+  });
+
+  it("leaves the store untouched when there is no drift", async () => {
+    mockRefreshWorkspaceBranch.mockResolvedValue(null);
+    const updateWorkspace = vi.fn();
+
+    const result = await refreshSelectedWorkspaceBranch("w1", updateWorkspace);
+
+    expect(result).toBeNull();
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns null and skips the write on backend failure", async () => {
+    mockRefreshWorkspaceBranch.mockRejectedValue(
+      new Error("workspace gone"),
+    );
+    const updateWorkspace = vi.fn();
+
+    const result = await refreshSelectedWorkspaceBranch("w1", updateWorkspace);
+
+    expect(result).toBeNull();
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -5,9 +5,11 @@ import type { Workspace } from "../types/workspace";
 
 type UpdateWorkspace = (id: string, updates: Partial<Workspace>) => void;
 
-/// Poll all active workspaces for external branch-name drift and mirror any
-/// detected changes into the Zustand store. Errors are swallowed so a
-/// transient git/IPC failure doesn't break the polling loop.
+/**
+ * Poll all active workspaces for external branch-name drift and mirror any
+ * detected changes into the Zustand store. Errors are swallowed so a
+ * transient git/IPC failure doesn't break the polling loop.
+ */
 export async function pollAndApplyBranchUpdates(
   updateWorkspace: UpdateWorkspace,
 ): Promise<void> {
@@ -21,9 +23,11 @@ export async function pollAndApplyBranchUpdates(
   }
 }
 
-/// Immediate refresh for a single workspace — called when the user selects
-/// one so external renames appear without waiting on the 5s poll. Returns
-/// the new branch name if one was applied (useful for tests).
+/**
+ * Immediate refresh for a single workspace — called when the user selects
+ * one so external renames appear without waiting on the 5s poll. Returns
+ * the new branch name if one was applied (useful for tests).
+ */
 export async function refreshSelectedWorkspaceBranch(
   workspaceId: string,
   updateWorkspace: UpdateWorkspace,

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import { useAppStore } from "../stores/useAppStore";
-import { refreshBranches } from "../services/tauri";
+import { refreshBranches, refreshWorkspaceBranch } from "../services/tauri";
 
 export function useBranchRefresh() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
 
   useEffect(() => {
     const refresh = async () => {
@@ -22,4 +23,22 @@ export function useBranchRefresh() {
     const interval = setInterval(refresh, 5000);
     return () => clearInterval(interval);
   }, [updateWorkspace]);
+
+  // Immediate refresh when the user selects a workspace — picks up branch
+  // renames done in the integrated terminal without waiting for the next
+  // poll tick.
+  useEffect(() => {
+    if (!selectedWorkspaceId) return;
+    const wsId = selectedWorkspaceId;
+    (async () => {
+      try {
+        const branch = await refreshWorkspaceBranch(wsId);
+        if (branch !== null) {
+          updateWorkspace(wsId, { branch_name: branch });
+        }
+      } catch {
+        // Silently ignore refresh errors
+      }
+    })();
+  }, [selectedWorkspaceId, updateWorkspace]);
 }

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -1,22 +1,50 @@
 import { useEffect } from "react";
 import { useAppStore } from "../stores/useAppStore";
 import { refreshBranches, refreshWorkspaceBranch } from "../services/tauri";
+import type { Workspace } from "../types/workspace";
+
+type UpdateWorkspace = (id: string, updates: Partial<Workspace>) => void;
+
+/// Poll all active workspaces for external branch-name drift and mirror any
+/// detected changes into the Zustand store. Errors are swallowed so a
+/// transient git/IPC failure doesn't break the polling loop.
+export async function pollAndApplyBranchUpdates(
+  updateWorkspace: UpdateWorkspace,
+): Promise<void> {
+  try {
+    const updates = await refreshBranches();
+    for (const [wsId, branchName] of updates) {
+      updateWorkspace(wsId, { branch_name: branchName });
+    }
+  } catch {
+    // Silently ignore refresh errors
+  }
+}
+
+/// Immediate refresh for a single workspace — called when the user selects
+/// one so external renames appear without waiting on the 5s poll. Returns
+/// the new branch name if one was applied (useful for tests).
+export async function refreshSelectedWorkspaceBranch(
+  workspaceId: string,
+  updateWorkspace: UpdateWorkspace,
+): Promise<string | null> {
+  try {
+    const branch = await refreshWorkspaceBranch(workspaceId);
+    if (branch !== null) {
+      updateWorkspace(workspaceId, { branch_name: branch });
+    }
+    return branch;
+  } catch {
+    return null;
+  }
+}
 
 export function useBranchRefresh() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
 
   useEffect(() => {
-    const refresh = async () => {
-      try {
-        const updates = await refreshBranches();
-        for (const [wsId, branchName] of updates) {
-          updateWorkspace(wsId, { branch_name: branchName });
-        }
-      } catch {
-        // Silently ignore refresh errors
-      }
-    };
+    const refresh = () => pollAndApplyBranchUpdates(updateWorkspace);
 
     // Run immediately on mount, then poll.
     refresh();
@@ -29,16 +57,6 @@ export function useBranchRefresh() {
   // poll tick.
   useEffect(() => {
     if (!selectedWorkspaceId) return;
-    const wsId = selectedWorkspaceId;
-    (async () => {
-      try {
-        const branch = await refreshWorkspaceBranch(wsId);
-        if (branch !== null) {
-          updateWorkspace(wsId, { branch_name: branch });
-        }
-      } catch {
-        // Silently ignore refresh errors
-      }
-    })();
+    refreshSelectedWorkspaceBranch(selectedWorkspaceId, updateWorkspace);
   }, [selectedWorkspaceId, updateWorkspace]);
 }

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -168,6 +168,12 @@ export function refreshBranches(): Promise<[string, string][]> {
   return invoke("refresh_branches");
 }
 
+export function refreshWorkspaceBranch(
+  workspaceId: string,
+): Promise<string | null> {
+  return invoke("refresh_workspace_branch", { workspaceId });
+}
+
 export function openWorkspaceInTerminal(worktreePath: string): Promise<void> {
   return invoke("open_workspace_in_terminal", { worktreePath });
 }

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -1,0 +1,267 @@
+//! Sync workspace metadata with the on-disk git state.
+//!
+//! The DB stores each workspace's `branch_name` at creation time, but users
+//! can rename the branch in the integrated terminal (`git branch -m`) or
+//! switch branches with `git checkout -b`. Those external operations bypass
+//! the auto-rename path in the chat command, so the DB drifts from reality.
+//!
+//! These helpers re-read the current branch from git and persist any drift
+//! back to the DB, keeping the sidebar and other DB-backed UI in sync. They
+//! are driven from the Tauri command layer both periodically and on workspace
+//! selection.
+
+use std::path::Path;
+
+use crate::db::Database;
+use crate::git;
+use crate::model::WorkspaceStatus;
+
+/// Re-read the current branch for every active workspace. For each workspace
+/// whose stored `branch_name` no longer matches the worktree's HEAD, persist
+/// the fresh value to the DB and return the `(workspace_id, new_branch)` pair
+/// so the caller can mirror the change into in-memory UI state.
+///
+/// DB access is split into short synchronous blocks around the async git
+/// calls, because `rusqlite::Connection` is not `Send`.
+pub async fn reconcile_all_workspace_branches(
+    db_path: &Path,
+) -> Result<Vec<(String, String)>, String> {
+    let workspaces = {
+        let db = Database::open(db_path).map_err(|e| e.to_string())?;
+        db.list_workspaces().map_err(|e| e.to_string())?
+    };
+
+    let mut updates = Vec::new();
+    for ws in &workspaces {
+        if ws.status != WorkspaceStatus::Active {
+            continue;
+        }
+        if let Some(ref wt_path) = ws.worktree_path
+            && let Ok(branch) = git::current_branch(wt_path).await
+            && branch != ws.branch_name
+        {
+            updates.push((ws.id.clone(), branch));
+        }
+    }
+
+    if !updates.is_empty() {
+        let db = Database::open(db_path).map_err(|e| e.to_string())?;
+        for (id, branch) in &updates {
+            let _ = db.update_workspace_branch_name(id, branch);
+        }
+    }
+
+    Ok(updates)
+}
+
+/// Re-read the current branch for a single workspace. Returns the new branch
+/// name if the DB was stale (and was just updated), or `None` when nothing
+/// needed to change, the workspace isn't active, or the worktree is missing.
+pub async fn reconcile_single_workspace_branch(
+    db_path: &Path,
+    workspace_id: &str,
+) -> Result<Option<String>, String> {
+    let ws = {
+        let db = Database::open(db_path).map_err(|e| e.to_string())?;
+        db.list_workspaces()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .find(|w| w.id == workspace_id)
+            .ok_or("Workspace not found")?
+    };
+
+    if ws.status != WorkspaceStatus::Active {
+        return Ok(None);
+    }
+    let Some(wt_path) = ws.worktree_path.as_ref() else {
+        return Ok(None);
+    };
+    let Ok(branch) = git::current_branch(wt_path).await else {
+        return Ok(None);
+    };
+    if branch == ws.branch_name {
+        return Ok(None);
+    }
+
+    let db = Database::open(db_path).map_err(|e| e.to_string())?;
+    db.update_workspace_branch_name(&ws.id, &branch)
+        .map_err(|e| e.to_string())?;
+    Ok(Some(branch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AgentStatus, Repository, Workspace};
+    use std::process::Command;
+
+    fn init_git_repo(path: &Path, branch: &str) {
+        Command::new("git")
+            .args(["init", "-b", branch])
+            .current_dir(path)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(path)
+            .output()
+            .expect("git config");
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(path)
+            .output()
+            .expect("git config");
+        std::fs::write(path.join("README.md"), "# test").unwrap();
+        Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(path)
+            .output()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(path)
+            .output()
+            .expect("git commit");
+    }
+
+    fn rename_branch(path: &Path, new_name: &str) {
+        Command::new("git")
+            .args(["branch", "-m", new_name])
+            .current_dir(path)
+            .output()
+            .expect("git branch -m");
+    }
+
+    fn make_ws(id: &str, repo_id: &str, branch: &str, worktree: &Path) -> Workspace {
+        Workspace {
+            id: id.into(),
+            repository_id: repo_id.into(),
+            name: id.into(),
+            branch_name: branch.into(),
+            worktree_path: Some(worktree.to_string_lossy().to_string()),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+        }
+    }
+
+    fn make_repo(id: &str, path: &Path) -> Repository {
+        Repository {
+            id: id.into(),
+            path: path.to_string_lossy().to_string(),
+            name: id.into(),
+            path_slug: id.into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_all_persists_external_rename() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_git_repo(repo_dir.path(), "claudette/original");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", repo_dir.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "claudette/original", repo_dir.path()))
+            .unwrap();
+        drop(db);
+
+        // First pass: DB already matches git, no updates expected.
+        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        assert!(updates.is_empty());
+
+        // Simulate the user renaming the branch externally.
+        rename_branch(repo_dir.path(), "user/renamed-branch");
+
+        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        assert_eq!(
+            updates,
+            vec![("w1".to_string(), "user/renamed-branch".to_string())]
+        );
+
+        // DB now reflects the new branch name — the fix that closes #354.
+        let db = Database::open(&db_path).unwrap();
+        let ws = db
+            .list_workspaces()
+            .unwrap()
+            .into_iter()
+            .find(|w| w.id == "w1")
+            .unwrap();
+        assert_eq!(ws.branch_name, "user/renamed-branch");
+    }
+
+    #[tokio::test]
+    async fn reconcile_single_returns_none_when_unchanged() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_git_repo(repo_dir.path(), "main");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", repo_dir.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "main", repo_dir.path()))
+            .unwrap();
+        drop(db);
+
+        let result = reconcile_single_workspace_branch(&db_path, "w1")
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn reconcile_single_persists_on_drift() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_git_repo(repo_dir.path(), "main");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", repo_dir.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "main", repo_dir.path()))
+            .unwrap();
+        drop(db);
+
+        rename_branch(repo_dir.path(), "feature/new");
+
+        let result = reconcile_single_workspace_branch(&db_path, "w1")
+            .await
+            .unwrap();
+        assert_eq!(result, Some("feature/new".to_string()));
+
+        let db = Database::open(&db_path).unwrap();
+        let ws = db
+            .list_workspaces()
+            .unwrap()
+            .into_iter()
+            .find(|w| w.id == "w1")
+            .unwrap();
+        assert_eq!(ws.branch_name, "feature/new");
+    }
+
+    #[tokio::test]
+    async fn reconcile_single_missing_workspace_errors() {
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let _db = Database::open(&db_path).unwrap();
+        let err = reconcile_single_workspace_branch(&db_path, "nope")
+            .await
+            .unwrap_err();
+        assert!(err.contains("not found"));
+    }
+}

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -47,7 +47,8 @@ pub async fn reconcile_all_workspace_branches(
     if !updates.is_empty() {
         let db = Database::open(db_path).map_err(|e| e.to_string())?;
         for (id, branch) in &updates {
-            let _ = db.update_workspace_branch_name(id, branch);
+            db.update_workspace_branch_name(id, branch)
+                .map_err(|e| e.to_string())?;
         }
     }
 
@@ -95,41 +96,40 @@ mod tests {
     use crate::model::{AgentStatus, Repository, Workspace};
     use std::process::Command;
 
+    fn run_git(path: &Path, args: &[&str], action: &str) {
+        let git_path = crate::git::resolve_git_path_blocking();
+        let output = Command::new(&git_path)
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|e| panic!("{action}: failed to spawn git: {e}"));
+        assert!(
+            output.status.success(),
+            "{action} failed ({:?}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
     fn init_git_repo(path: &Path, branch: &str) {
-        Command::new("git")
-            .args(["init", "-b", branch])
-            .current_dir(path)
-            .output()
-            .expect("git init");
-        Command::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(path)
-            .output()
-            .expect("git config");
-        Command::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(path)
-            .output()
-            .expect("git config");
+        run_git(path, &["init", "-b", branch], "git init");
+        run_git(
+            path,
+            &["config", "user.email", "test@test.com"],
+            "git config user.email",
+        );
+        run_git(
+            path,
+            &["config", "user.name", "Test"],
+            "git config user.name",
+        );
         std::fs::write(path.join("README.md"), "# test").unwrap();
-        Command::new("git")
-            .args(["add", "-A"])
-            .current_dir(path)
-            .output()
-            .expect("git add");
-        Command::new("git")
-            .args(["commit", "-m", "initial"])
-            .current_dir(path)
-            .output()
-            .expect("git commit");
+        run_git(path, &["add", "-A"], "git add");
+        run_git(path, &["commit", "-m", "initial"], "git commit");
     }
 
     fn rename_branch(path: &Path, new_name: &str) {
-        Command::new("git")
-            .args(["branch", "-m", new_name])
-            .current_dir(path)
-            .output()
-            .expect("git branch -m");
+        run_git(path, &["branch", "-m", new_name], "git branch -m");
     }
 
     fn make_ws(id: &str, repo_id: &str, branch: &str, worktree: &Path) -> Workspace {
@@ -364,18 +364,26 @@ mod tests {
         init_git_repo(repo_dir.path(), "main");
 
         // Detach HEAD at the current commit.
-        let head_sha = std::process::Command::new("git")
+        let git_path = crate::git::resolve_git_path_blocking();
+        let rev_parse = Command::new(&git_path)
             .args(["rev-parse", "HEAD"])
             .current_dir(repo_dir.path())
             .output()
+            .expect("spawn git rev-parse");
+        assert!(
+            rev_parse.status.success(),
+            "git rev-parse failed: {}",
+            String::from_utf8_lossy(&rev_parse.stderr),
+        );
+        let head_sha = String::from_utf8(rev_parse.stdout)
             .unwrap()
-            .stdout;
-        let head_sha = String::from_utf8(head_sha).unwrap().trim().to_string();
-        std::process::Command::new("git")
-            .args(["checkout", "--detach", &head_sha])
-            .current_dir(repo_dir.path())
-            .output()
-            .unwrap();
+            .trim()
+            .to_string();
+        run_git(
+            repo_dir.path(),
+            &["checkout", "--detach", &head_sha],
+            "git checkout --detach",
+        );
 
         let db_dir = tempfile::tempdir().unwrap();
         let db_path = db_dir.path().join("test.db");

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -264,4 +264,140 @@ mod tests {
             .unwrap_err();
         assert!(err.contains("not found"));
     }
+
+    #[tokio::test]
+    async fn reconcile_all_skips_archived_workspaces() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_git_repo(repo_dir.path(), "claudette/stale");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", repo_dir.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "claudette/stale", repo_dir.path()))
+            .unwrap();
+        // Archive the workspace — subsequent reconciles should ignore it.
+        db.update_workspace_status("w1", &WorkspaceStatus::Archived, None)
+            .unwrap();
+        drop(db);
+
+        // Rename the branch on disk; an archived workspace must not drive an update.
+        rename_branch(repo_dir.path(), "something/else");
+
+        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        assert!(updates.is_empty());
+
+        let db = Database::open(&db_path).unwrap();
+        let ws = db
+            .list_workspaces()
+            .unwrap()
+            .into_iter()
+            .find(|w| w.id == "w1")
+            .unwrap();
+        assert_eq!(ws.branch_name, "claudette/stale");
+    }
+
+    #[tokio::test]
+    async fn reconcile_all_handles_missing_worktree_path() {
+        // Archived-style workspaces typically null out worktree_path, but a
+        // workspace with no path must never panic or reach git.
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", std::path::Path::new("/tmp/nonexistent")))
+            .unwrap();
+        let mut ws = make_ws("w1", "r1", "claudette/x", std::path::Path::new("/tmp"));
+        ws.worktree_path = None;
+        db.insert_workspace(&ws).unwrap();
+        drop(db);
+
+        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        assert!(updates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reconcile_all_updates_only_drifted_workspaces() {
+        // Two workspaces pointed at two separate repos; only one has been
+        // renamed externally. The return value and the DB should only
+        // reflect the drifted one.
+        let stable = tempfile::tempdir().unwrap();
+        init_git_repo(stable.path(), "claudette/stable");
+        let drifted = tempfile::tempdir().unwrap();
+        init_git_repo(drifted.path(), "claudette/original");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", stable.path()))
+            .unwrap();
+        db.insert_repository(&make_repo("r2", drifted.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "claudette/stable", stable.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w2", "r2", "claudette/original", drifted.path()))
+            .unwrap();
+        drop(db);
+
+        rename_branch(drifted.path(), "user/renamed");
+
+        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        assert_eq!(
+            updates,
+            vec![("w2".to_string(), "user/renamed".to_string())]
+        );
+
+        let db = Database::open(&db_path).unwrap();
+        let all = db.list_workspaces().unwrap();
+        let w1 = all.iter().find(|w| w.id == "w1").unwrap();
+        let w2 = all.iter().find(|w| w.id == "w2").unwrap();
+        assert_eq!(w1.branch_name, "claudette/stable");
+        assert_eq!(w2.branch_name, "user/renamed");
+    }
+
+    #[tokio::test]
+    async fn reconcile_single_tolerates_detached_head() {
+        // After `git checkout <sha>` the worktree is in detached HEAD and
+        // `current_branch` returns an error. The reconcile must swallow that
+        // and leave the DB alone — not propagate the error or blank the row.
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_git_repo(repo_dir.path(), "main");
+
+        // Detach HEAD at the current commit.
+        let head_sha = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo_dir.path())
+            .output()
+            .unwrap()
+            .stdout;
+        let head_sha = String::from_utf8(head_sha).unwrap().trim().to_string();
+        std::process::Command::new("git")
+            .args(["checkout", "--detach", &head_sha])
+            .current_dir(repo_dir.path())
+            .output()
+            .unwrap();
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", repo_dir.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "main", repo_dir.path()))
+            .unwrap();
+        drop(db);
+
+        let result = reconcile_single_workspace_branch(&db_path, "w1")
+            .await
+            .unwrap();
+        assert!(result.is_none());
+
+        let db = Database::open(&db_path).unwrap();
+        let ws = db
+            .list_workspaces()
+            .unwrap()
+            .into_iter()
+            .find(|w| w.id == "w1")
+            .unwrap();
+        assert_eq!(ws.branch_name, "main");
+    }
 }


### PR DESCRIPTION
## Summary

- Extracts branch-reconciliation logic into `claudette::workspace_sync` with real-git unit tests, and persists drift to the DB on every poll so `workspaces.branch_name` stays in sync when users run `git branch -m` or `git checkout -b` from the integrated terminal
- Adds a `refresh_workspace_branch` command; the `useBranchRefresh` hook now calls it immediately on workspace selection so externally-renamed branches appear in the sidebar without waiting on the 5s poll
- No new runtime dependencies

## Test plan

- [x] `cargo test --all-features` (570 pass, includes 4 new tests in `workspace_sync::tests`)
- [x] `cargo clippy --workspace --all-targets` (claudette / claudette-server clean; the one remaining warning is pre-existing in `src-tauri/src/commands/files.rs` and outside the CI-enforced crates)
- [x] `cargo fmt --all --check`
- [x] `bunx tsc --noEmit`
- [x] `bun run test` (624 pass)
- [ ] Manual UAT: rename a branch via the integrated terminal, confirm sidebar updates within one poll cycle (or immediately on re-selecting the workspace)

Closes #354