### PR TITLE
feat(plugins): plugin runtime kinds + env-provider system + repo-level env panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Feature flags in `claudette-tauri`:
 
 ### Tauri commands
 
-Commands in `src-tauri/src/commands/` are organized by domain: `chat`, `workspace`, `repository`, `terminal`, `diff`, `settings`, `plugin`, `mcp`, `remote`, `usage`, `files`, `shell`, `slash_commands`, `plan`, `apps`, `data`, `debug`. Each is a thin wrapper — business logic belongs in the `claudette` crate.
+Commands in `src-tauri/src/commands/` are organized by domain: `chat`, `workspace`, `repository`, `scm`, `terminal`, `diff`, `settings`, `plugin`, `mcp`, `remote`, `usage`, `metrics`, `files`, `shell`, `slash_commands`, `plan`, `apps`, `data`, `cesp`, `updater`, `debug`. Each is a thin wrapper — business logic belongs in the `claudette` crate.
 
 ## Project structure
 
@@ -92,10 +92,23 @@ Cargo.toml              — workspace root + claudette lib crate
 src/
   lib.rs                — library entry point, re-exports backend modules
   db.rs                 — SQLite database: connection, migrations, CRUD
+  migrations/           — versioned .sql files + MIGRATIONS registry
   git.rs                — async git worktree operations
   diff.rs               — diff parsing and git diff operations
   agent.rs              — Claude CLI subprocess + JSON streaming
-  model/                — data types (no UI or IO logic)
+  fork.rs               — session forking / checkpoint branching
+  snapshot.rs           — workspace snapshots
+  process.rs            — cross-platform process spawning helpers
+  mcp.rs / mcp_supervisor.rs — MCP server config + lifecycle supervision
+  plugin.rs             — Claude-Code plugin marketplace integration
+  plugin_runtime/       — sandboxed Lua runtime (mlua) shared across plugin kinds
+  permissions.rs        — tool/permission policy
+  scm/                  — SCM consumer of plugin_runtime: PR/CI types + host/URL detection
+  env_provider/         — env-provider consumer: dispatcher, mtime cache, merged ResolvedEnv
+  slash_commands.rs     — slash command loading and dispatch
+  cesp.rs               — CESP (Claudette event stream protocol)
+  config.rs / env.rs / path.rs / file_expand.rs — config, env, path helpers
+  model/                — data types (no UI or IO logic); all derive Serialize
   names/                — random workspace name generator
   ui/                   — React/Vite frontend (see src/ui/package.json)
 src-tauri/              — Tauri binary crate
@@ -104,8 +117,22 @@ src-tauri/              — Tauri binary crate
   src/pty.rs            — PTY management via portable-pty
   src/tray.rs           — system tray: icon/menu/tooltip, notifications
   src/transport/        — Remote transport trait + WebSocket client
+  src/remote.rs         — embedded remote server wiring
+  src/mdns.rs           — mDNS advertisement for remote discovery
+  src/osc133.rs         — OSC 133 terminal prompt-marker parsing
 src-server/             — Standalone + embeddable remote server
+plugins/                — bundled Lua plugins (compiled in via include_str!)
+  scm-github/           — GitHub PR / CI provider
+  scm-gitlab/           — GitLab PR / CI provider
+  env-direnv/           — direnv env activation
+  env-mise/             — mise env activation
+  env-dotenv/           — `.env` in-process parser
+  env-nix-devshell/     — `nix print-dev-env` env activation
 ```
+
+### Plugin system
+
+A single sandboxed Lua runtime (`src/plugin_runtime/`) serves multiple plugin kinds declared via `plugin.json`'s `kind` field (`scm` | `env-provider`, defaults to `scm`). Each kind has its own domain consumer (`src/scm/`, `src/env_provider/`) that dispatches operations on top of the shared runtime. Bundled plugins live in `plugins/*/` and are seeded into the user's plugin dir on first run. Users can drop their own plugins into `~/.claudette/plugins/<name>/` (one `plugin.json` + one `init.lua`); discovery picks them up at startup.
 
 ### Guidelines for new code
 
@@ -121,6 +148,11 @@ src-server/             — Standalone + embeddable remote server
 
 - **Rust**: tests use `tempfile::tempdir()` to create ephemeral git repos — no fixtures or test databases. Async tests use `#[tokio::test]`. Test modules live at the bottom of each file (`#[cfg(test)] mod tests`).
 - **TypeScript**: vitest with `describe`/`it`/`expect`. Zustand tests reset state via `useAppStore.setState()` in `beforeEach`. No test database — frontend tests are pure state/logic tests. When constructing fixtures for store state, always read the actual type definition (e.g., `TerminalTab` in `types/terminal.ts`) — do not guess field names. Look for existing `make*` helpers in adjacent test files before creating new fixtures.
+
+### Windows specifics
+
+- `AGENTS.md` is a symlink to `CLAUDE.md` for Codex/other agent-tool compatibility — edit `CLAUDE.md`, never `AGENTS.md`.
+- Windows builds use MSVC toolchain; `[target.'cfg(windows)'.dependencies]` in `Cargo.toml` pulls in Windows-only crates. Gate Windows-specific code with `#[cfg(windows)]` / `#[cfg(not(windows))]` rather than Unix-only paths.
 
 ### Notification architecture
 
@@ -147,7 +179,7 @@ src-server/             — Standalone + embeddable remote server
 - See GitHub Issue #5 for the full MVP PRD
 - See GitHub Issue #11 for the Workspace Management TDD
 - P0 features: workspace management, agent chat, diff viewer, integrated terminal, checkpoints, git/GitHub integration, scripts, repo settings
-- Target platforms: macOS (Apple Silicon + Intel) and Linux (x86_64, Wayland + X11)
+- Target platforms: macOS (Apple Silicon + Intel), Linux (x86_64, Wayland + X11), and Windows (x86_64 + ARM64)
 
 ## Debugging (dev builds only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Feature flags in `claudette-tauri`:
 
 ### Tauri commands
 
-Commands in `src-tauri/src/commands/` are organized by domain: `chat`, `workspace`, `repository`, `scm`, `terminal`, `diff`, `settings`, `plugin`, `mcp`, `remote`, `usage`, `metrics`, `files`, `shell`, `slash_commands`, `plan`, `apps`, `data`, `cesp`, `updater`, `debug`. Each is a thin wrapper — business logic belongs in the `claudette` crate.
+Commands in `src-tauri/src/commands/` are organized by domain: `apps`, `auth`, `cesp`, `chat`, `data`, `debug`, `diff`, `env`, `files`, `mcp`, `metrics`, `plan`, `plugin`, `plugins_runtime`, `remote`, `repository`, `scm`, `settings`, `shell`, `slash_commands`, `terminal`, `updater`, `usage`, `workspace`. Each is a thin wrapper — business logic belongs in the `claudette` crate.
 
 ## Project structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,12 @@ plugins/                — bundled Lua plugins (compiled in via include_str!)
 
 A single sandboxed Lua runtime (`src/plugin_runtime/`) serves multiple plugin kinds declared via `plugin.json`'s `kind` field (`scm` | `env-provider`, defaults to `scm`). Each kind has its own domain consumer (`src/scm/`, `src/env_provider/`) that dispatches operations on top of the shared runtime. Bundled plugins live in `plugins/*/` and are seeded into the user's plugin dir on first run. Users can drop their own plugins into `~/.claudette/plugins/<name>/` (one `plugin.json` + one `init.lua`); discovery picks them up at startup.
 
+**Plugin settings** (`manifest.settings: Vec<PluginSettingField>`) let a plugin declare typed user-configurable fields (boolean/text/select) that the Plugins settings section renders as a form. Values persist in `app_settings` as `plugin:{name}:setting:{key}` and are piped into the Lua `host.config("<key>")` surface at invocation time. Manifest defaults apply when no override is set. Global on/off state persists as `plugin:{name}:enabled = "false"` (absent key = enabled).
+
+**Settings UI** separates two plugin concepts:
+- **Plugins** (`src/ui/src/components/settings/sections/PluginsSettings.tsx`) — Claudette's own Lua plugins (SCM + env-provider). Always visible. Shows status, per-plugin toggle, and the manifest-declared settings form.
+- **Claude Code Plugins** (`ClaudeCodePluginsSettings.tsx`, route key `claude-code-plugins`) — the Claude CLI marketplace integration from `src/plugin.rs` (marketplaces, channels, install/uninstall). Gated behind the `pluginManagementEnabled` experimental flag.
+
 ### Guidelines for new code
 
 - **Data types** go in `model/` — keep them free of UI and IO dependencies. All model types must derive `Serialize`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,8 @@ winreg = "0.55"
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[build-dependencies]
+# Probes PATH for direnv/mise/nix so env-provider integration tests
+# can compile-out when the tool isn't installed on the build host.
+which = "7"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+//! Build script — emits `cargo:rustc-cfg` flags so env-provider
+//! integration tests that require external CLIs (`direnv`, `mise`,
+//! `nix`) can compile-out when the tool isn't installed.
+//!
+//! These flags are **only used by tests** — production code never
+//! gates on them. The design is: ship unit tests that exercise detect
+//! logic with synthetic filesystems (no CLI needed), plus integration
+//! tests that actually invoke the CLI (gated on availability).
+//!
+//! Rationale: CI hosts may not have direnv/mise/nix; dev machines
+//! usually do. We don't want CI to fail just because a tool isn't
+//! installed — the unit tests still cover the Lua detect/parse paths.
+
+fn main() {
+    // Declare the cfg names we emit so rustc 1.80+ doesn't warn about
+    // unknown --cfg values (edition 2024).
+    println!("cargo:rustc-check-cfg=cfg(has_direnv)");
+    println!("cargo:rustc-check-cfg=cfg(has_mise)");
+    println!("cargo:rustc-check-cfg=cfg(has_nix)");
+
+    // Re-run only if PATH changes — we're probing PATH, not any input file.
+    println!("cargo:rerun-if-env-changed=PATH");
+
+    for tool in &["direnv", "mise", "nix"] {
+        if which::which(tool).is_ok() {
+            println!("cargo:rustc-cfg=has_{tool}");
+        }
+    }
+}

--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -22,6 +22,20 @@ end
 
 function M.export(args)
     local result = host.exec("direnv", { "export", "json" })
+
+    -- If the .envrc is blocked and the user has opted into auto-allow,
+    -- run `direnv allow` once and retry. direnv normally hashes the
+    -- .envrc path so each worktree must be allowed independently —
+    -- opting in consciously trades that per-path safeguard for zero-
+    -- friction activation. Retry only once to avoid infinite loops if
+    -- `allow` somehow fails to unblock.
+    if result.code ~= 0
+        and host.config("auto_allow") == true
+        and (result.stderr or ""):match("is blocked") then
+        host.exec("direnv", { "allow" })
+        result = host.exec("direnv", { "export", "json" })
+    end
+
     if result.code ~= 0 then
         -- Non-zero exit from `direnv export json` usually means the
         -- `.envrc` hasn't been allowed yet. Propagate the stderr so the

--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -1,0 +1,45 @@
+-- env-direnv plugin for Claudette.
+--
+-- Activates direnv-managed environment for workspace subprocesses.
+-- Detects when a `.envrc` file exists in the worktree root. On export,
+-- runs `direnv export json` (which returns `{VAR: "value" | null}`) and
+-- forwards that straight to the dispatcher.
+--
+-- Known limitation: we watch `.envrc` for mtime changes but NOT the
+-- files direnv itself watches via `DIRENV_WATCHES`. If your `.envrc`
+-- sources another file that changes, edit `.envrc` (or run
+-- `direnv reload` then re-evaluate via the UI) to force a refresh.
+
+local M = {}
+
+local function join(dir, name)
+    return dir .. "/" .. name
+end
+
+function M.detect(args)
+    return host.file_exists(join(args.worktree, ".envrc"))
+end
+
+function M.export(args)
+    local result = host.exec("direnv", { "export", "json" })
+    if result.code ~= 0 then
+        -- Non-zero exit from `direnv export json` usually means the
+        -- `.envrc` hasn't been allowed yet. Propagate the stderr so the
+        -- UI can surface a "run direnv allow" hint.
+        error("direnv export failed: " .. (result.stderr or result.stdout or "unknown error"))
+    end
+
+    -- Empty stdout = no vars to export (e.g. `.envrc` exists but is
+    -- empty, or direnv is silently allowing without any exports).
+    local env_map = {}
+    if result.stdout and #result.stdout > 0 then
+        env_map = host.json_decode(result.stdout)
+    end
+
+    return {
+        env = env_map,
+        watched = { join(args.worktree, ".envrc") },
+    }
+end
+
+return M

--- a/plugins/env-direnv/plugin.json
+++ b/plugins/env-direnv/plugin.json
@@ -5,5 +5,14 @@
   "description": "Activate direnv-managed environment for workspace subprocesses",
   "kind": "env-provider",
   "required_clis": ["direnv"],
-  "operations": ["detect", "export"]
+  "operations": ["detect", "export"],
+  "settings": [
+    {
+      "type": "boolean",
+      "key": "auto_allow",
+      "label": "Always allow .envrc",
+      "description": "When direnv reports an .envrc as blocked, run `direnv allow` automatically. Note: direnv normally hashes the .envrc path so each worktree must be allowed separately — enabling this bypasses that per-path safeguard.",
+      "default": false
+    }
+  ]
 }

--- a/plugins/env-direnv/plugin.json
+++ b/plugins/env-direnv/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "env-direnv",
+  "display_name": "direnv",
+  "version": "1.0.0",
+  "description": "Activate direnv-managed environment for workspace subprocesses",
+  "kind": "env-provider",
+  "required_clis": ["direnv"],
+  "operations": ["detect", "export"]
+}

--- a/plugins/env-dotenv/init.lua
+++ b/plugins/env-dotenv/init.lua
@@ -1,0 +1,73 @@
+-- env-dotenv plugin for Claudette.
+--
+-- The no-external-dependency fallback: parses `.env` in-process using
+-- `host.read_file` and a small KEY=VALUE parser. Useful for projects
+-- that don't adopt direnv or mise but still keep secrets / config in a
+-- `.env` file (e.g. Next.js, Django, Docker Compose conventions).
+--
+-- v1 scope:
+-- - blank lines and lines starting with `#` are ignored
+-- - optional `export` prefix is stripped (bash-compatible syntax)
+-- - values wrapped in `"..."` or `'...'` are unquoted
+-- - inline `  # comment` on an unquoted value is stripped
+-- - NO interpolation: `${FOO}` / `$FOO` are passed through literally
+-- - NO multi-line values (values that span physical lines)
+--
+-- Deliberately lowest precedence in the dispatcher: if you have direnv
+-- or mise configured, those wrap your `.env` anyway.
+
+local M = {}
+
+local function join(dir, name)
+    return dir .. "/" .. name
+end
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- Parse dotenv-style content. Returns a flat `{KEY: "value"}` table.
+-- Exposed at module level so it can be unit-tested via the host API.
+function M._parse(text)
+    local env = {}
+    for line in text:gmatch("[^\r\n]+") do
+        local t = trim(line)
+        if t ~= "" and not t:match("^#") then
+            -- Strip optional `export` prefix
+            local content = t:gsub("^export%s+", "")
+            local key, value = content:match("^([A-Za-z_][A-Za-z0-9_]*)%s*=%s*(.*)$")
+            if key then
+                -- Quoted values: return contents verbatim (no comment stripping).
+                local dquoted = value:match('^"(.-)"$')
+                local squoted = value:match("^'(.-)'$")
+                local stripped
+                if dquoted then
+                    stripped = dquoted
+                elseif squoted then
+                    stripped = squoted
+                else
+                    -- Unquoted: strip trailing inline comment (whitespace + `#`).
+                    stripped = value:match("^(.-)%s+#") or value
+                    stripped = trim(stripped)
+                end
+                env[key] = stripped
+            end
+        end
+    end
+    return env
+end
+
+function M.detect(args)
+    return host.file_exists(join(args.worktree, ".env"))
+end
+
+function M.export(args)
+    local path = join(args.worktree, ".env")
+    local contents = host.read_file(path)
+    return {
+        env = M._parse(contents),
+        watched = { path },
+    }
+end
+
+return M

--- a/plugins/env-dotenv/plugin.json
+++ b/plugins/env-dotenv/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "env-dotenv",
+  "display_name": "dotenv",
+  "version": "1.0.0",
+  "description": "Parse .env file and apply KEY=VALUE entries to workspace subprocesses",
+  "kind": "env-provider",
+  "required_clis": [],
+  "operations": ["detect", "export"]
+}

--- a/plugins/env-mise/init.lua
+++ b/plugins/env-mise/init.lua
@@ -1,0 +1,50 @@
+-- env-mise plugin for Claudette.
+--
+-- Detects any of `mise.toml`, `.mise.toml`, `.tool-versions` in the
+-- worktree root. On export, runs `mise env --json` which returns a flat
+-- `{VAR: "value"}` map (including the merged PATH).
+
+local M = {}
+
+local function join(dir, name)
+    return dir .. "/" .. name
+end
+
+-- Config files in order of mise's own precedence.
+local CONFIG_FILES = { "mise.toml", ".mise.toml", ".tool-versions" }
+
+function M.detect(args)
+    for _, name in ipairs(CONFIG_FILES) do
+        if host.file_exists(join(args.worktree, name)) then
+            return true
+        end
+    end
+    return false
+end
+
+function M.export(args)
+    local result = host.exec("mise", { "env", "--json" })
+    if result.code ~= 0 then
+        -- Common causes: config not trusted (run `mise trust`) or
+        -- malformed TOML. Surface stderr verbatim.
+        error("mise env failed: " .. (result.stderr or result.stdout or "unknown error"))
+    end
+
+    local env_map = host.json_decode(result.stdout)
+
+    -- Watch all known config files — mise may use whichever is present.
+    local watched = {}
+    for _, name in ipairs(CONFIG_FILES) do
+        local path = join(args.worktree, name)
+        if host.file_exists(path) then
+            table.insert(watched, path)
+        end
+    end
+
+    return {
+        env = env_map,
+        watched = watched,
+    }
+end
+
+return M

--- a/plugins/env-mise/init.lua
+++ b/plugins/env-mise/init.lua
@@ -24,6 +24,18 @@ end
 
 function M.export(args)
     local result = host.exec("mise", { "env", "--json" })
+
+    -- Auto-trust opt-in: when mise reports config files as not trusted
+    -- and the user has enabled auto_trust, run `mise trust` once and
+    -- retry. Single retry avoids an infinite loop if trust fails for
+    -- another reason.
+    if result.code ~= 0
+        and host.config("auto_trust") == true
+        and (result.stderr or ""):match("not trusted") then
+        host.exec("mise", { "trust" })
+        result = host.exec("mise", { "env", "--json" })
+    end
+
     if result.code ~= 0 then
         -- Common causes: config not trusted (run `mise trust`) or
         -- malformed TOML. Surface stderr verbatim.

--- a/plugins/env-mise/plugin.json
+++ b/plugins/env-mise/plugin.json
@@ -5,5 +5,14 @@
   "description": "Activate mise-managed environment (tools + env vars) for workspace subprocesses",
   "kind": "env-provider",
   "required_clis": ["mise"],
-  "operations": ["detect", "export"]
+  "operations": ["detect", "export"],
+  "settings": [
+    {
+      "type": "boolean",
+      "key": "auto_trust",
+      "label": "Always trust mise config",
+      "description": "When mise reports config files as not trusted, run `mise trust` automatically. mise normally requires per-path trust — enabling this bypasses that for zero-friction activation.",
+      "default": false
+    }
+  ]
 }

--- a/plugins/env-mise/plugin.json
+++ b/plugins/env-mise/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "env-mise",
+  "display_name": "mise",
+  "version": "1.0.0",
+  "description": "Activate mise-managed environment (tools + env vars) for workspace subprocesses",
+  "kind": "env-provider",
+  "required_clis": ["mise"],
+  "operations": ["detect", "export"]
+}

--- a/plugins/env-nix-devshell/init.lua
+++ b/plugins/env-nix-devshell/init.lua
@@ -28,7 +28,21 @@ function M.detect(args)
 end
 
 function M.export(args)
-    local result = host.exec("nix", { "print-dev-env", "--json" })
+    -- `nix print-dev-env --json` auto-discovers only flake.nix. For
+    -- legacy `shell.nix`-only repos we must pass `-f shell.nix`
+    -- explicitly; otherwise nix errors with "could not find a
+    -- flake.nix" even though detect said the repo was eligible.
+    local flake_path = join(args.worktree, "flake.nix")
+    local shell_path = join(args.worktree, "shell.nix")
+    local result
+    if host.file_exists(flake_path) then
+        result = host.exec("nix", { "print-dev-env", "--json" })
+    elseif host.file_exists(shell_path) then
+        result = host.exec("nix", { "print-dev-env", "--json", "-f", shell_path })
+    else
+        error("nix print-dev-env failed: neither flake.nix nor shell.nix present at export time")
+    end
+
     if result.code ~= 0 then
         error("nix print-dev-env failed: " .. (result.stderr or result.stdout or "unknown error"))
     end

--- a/plugins/env-nix-devshell/init.lua
+++ b/plugins/env-nix-devshell/init.lua
@@ -1,12 +1,15 @@
 -- env-nix-devshell plugin for Claudette.
 --
 -- Activates a Nix devshell for users who keep their toolchain in a
--- `flake.nix` (or legacy `shell.nix`) *without* the direnv wrapper.
+-- `flake.nix` (or legacy `shell.nix`).
 --
--- Detection policy: only activate when NO `.envrc` is present. If
--- direnv is in play, it already wraps the flake (via `use flake` in
--- `.envrc`), and the `env-direnv` plugin wins on precedence. We stay
--- out of its way to avoid evaluating the flake twice.
+-- Detection is a pure function of what's on disk: if `flake.nix` or
+-- `shell.nix` exists, we detect. We deliberately do NOT back off when
+-- `.envrc` is present — instead, precedence handles the overlap:
+-- `env-direnv` outranks `env-nix-devshell`, so when an `.envrc` does
+-- `use flake` and both plugins export, direnv's values win on key
+-- collisions at merge time. Users who want only one can toggle the
+-- other off in the Environment settings panel.
 --
 -- Export: runs `nix print-dev-env --json` which emits
 -- `{ variables: { NAME: { type, value } } }`. We keep only
@@ -20,10 +23,6 @@ local function join(dir, name)
 end
 
 function M.detect(args)
-    -- direnv wraps the flake — let env-direnv handle it.
-    if host.file_exists(join(args.worktree, ".envrc")) then
-        return false
-    end
     return host.file_exists(join(args.worktree, "flake.nix"))
         or host.file_exists(join(args.worktree, "shell.nix"))
 end

--- a/plugins/env-nix-devshell/init.lua
+++ b/plugins/env-nix-devshell/init.lua
@@ -1,0 +1,67 @@
+-- env-nix-devshell plugin for Claudette.
+--
+-- Activates a Nix devshell for users who keep their toolchain in a
+-- `flake.nix` (or legacy `shell.nix`) *without* the direnv wrapper.
+--
+-- Detection policy: only activate when NO `.envrc` is present. If
+-- direnv is in play, it already wraps the flake (via `use flake` in
+-- `.envrc`), and the `env-direnv` plugin wins on precedence. We stay
+-- out of its way to avoid evaluating the flake twice.
+--
+-- Export: runs `nix print-dev-env --json` which emits
+-- `{ variables: { NAME: { type, value } } }`. We keep only
+-- `exported`/`var`-typed string values — array and associative types
+-- (Bash-specific) don't round-trip cleanly to a child process env.
+
+local M = {}
+
+local function join(dir, name)
+    return dir .. "/" .. name
+end
+
+function M.detect(args)
+    -- direnv wraps the flake — let env-direnv handle it.
+    if host.file_exists(join(args.worktree, ".envrc")) then
+        return false
+    end
+    return host.file_exists(join(args.worktree, "flake.nix"))
+        or host.file_exists(join(args.worktree, "shell.nix"))
+end
+
+function M.export(args)
+    local result = host.exec("nix", { "print-dev-env", "--json" })
+    if result.code ~= 0 then
+        error("nix print-dev-env failed: " .. (result.stderr or result.stdout or "unknown error"))
+    end
+
+    local parsed = host.json_decode(result.stdout)
+
+    local env_map = {}
+    if parsed.variables then
+        for name, info in pairs(parsed.variables) do
+            -- Only scalar strings — skip Bash arrays and associatives,
+            -- which can't be represented as plain env vars anyway.
+            if type(info) == "table"
+                and type(info.value) == "string"
+                and (info.type == "exported" or info.type == "var")
+            then
+                env_map[name] = info.value
+            end
+        end
+    end
+
+    local watched = {}
+    for _, name in ipairs({ "flake.nix", "flake.lock", "shell.nix" }) do
+        local path = join(args.worktree, name)
+        if host.file_exists(path) then
+            table.insert(watched, path)
+        end
+    end
+
+    return {
+        env = env_map,
+        watched = watched,
+    }
+end
+
+return M

--- a/plugins/env-nix-devshell/plugin.json
+++ b/plugins/env-nix-devshell/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "env-nix-devshell",
+  "display_name": "Nix devshell",
+  "version": "1.0.0",
+  "description": "Activate a Nix flake or shell.nix devshell for workspace subprocesses",
+  "kind": "env-provider",
+  "required_clis": ["nix"],
+  "operations": ["detect", "export"]
+}

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -445,6 +445,11 @@ async fn handle_send_chat_message(
         &agent_settings,
         &[], // Attachments not yet supported over remote transport
         Some(&ws_env),
+        // Env-provider activation is not wired into the remote server path in
+        // v1 — it requires a PluginRegistry + EnvCache in ServerState, which
+        // is a separate follow-up. Local desktop agents already get it via
+        // claudette-tauri's AppState.
+        None,
     )
     .await?;
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -590,6 +590,11 @@ pub async fn send_chat_message(
         worktree_path: worktree_path.clone(),
         repo_path: repo_path.to_string(),
     };
+    let disabled_env_providers = {
+        let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+        let repo_id = repo.as_ref().map(|r| r.id.as_str()).unwrap_or("");
+        crate::commands::env::load_disabled_providers(&db, repo_id)
+    };
     let resolved_env = {
         let registry = state.plugins.read().await;
         claudette::env_provider::resolve_with_registry(
@@ -597,6 +602,7 @@ pub async fn send_chat_message(
             &state.env_cache,
             std::path::Path::new(&worktree_path),
             &ws_info_for_env,
+            &disabled_env_providers,
         )
         .await
     };

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -400,6 +400,7 @@ pub async fn send_chat_message(
                 session_disable_1m_context: false,
                 pending_permissions: std::collections::HashMap::new(),
                 session_exited_plan: false,
+                session_resolved_env: Default::default(),
             };
         }
 
@@ -418,6 +419,7 @@ pub async fn send_chat_message(
             session_disable_1m_context: false,
             pending_permissions: std::collections::HashMap::new(),
             session_exited_plan: false,
+            session_resolved_env: Default::default(),
         }
     });
 
@@ -607,6 +609,42 @@ pub async fn send_chat_message(
         .await
     };
 
+    // Env-provider drift teardown: the env baked into the current
+    // persistent session is fixed at spawn time; Claude's subprocess
+    // won't see `.envrc` / `mise.toml` / `direnv allow` changes until
+    // it's respawned. Compare the freshly-resolved vars against the
+    // snapshot stored at spawn and teardown on any divergence. The
+    // mtime-keyed cache makes this re-resolve nearly free on quiet
+    // turns, so the check costs nothing in the common case.
+    if session.persistent_session.is_some() && session.session_resolved_env != resolved_env.vars {
+        eprintln!(
+            "[chat] env-provider output changed ({} vars before, {} after) — tearing down persistent session for {workspace_id}",
+            session.session_resolved_env.len(),
+            resolved_env.vars.len(),
+        );
+        let to_deny_env = drain_pending_permissions(session);
+        let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
+        session.persistent_session = None;
+        session.active_pid = None;
+        session.session_exited_plan = false;
+        if stale_pid.is_some() || to_deny_env.is_some() {
+            drop(agents);
+            if let Some((ref ps, drained)) = to_deny_env {
+                deny_drained_permissions(
+                    drained,
+                    ps,
+                    "Session restarted because workspace env changed.",
+                )
+                .await;
+            }
+            if let Some(pid) = stale_pid {
+                let _ = agent::stop_agent_graceful(pid).await;
+            }
+            agents = state.agents.write().await;
+        }
+    }
+    let session = agents.get_mut(&workspace_id).ok_or("Session lost")?;
+
     // Use persistent session to keep MCP servers alive across turns.
     // First turn or after restart: start a PersistentSession.
     // Subsequent turns in same session: reuse the existing process via stdin.
@@ -699,6 +737,7 @@ pub async fn send_chat_message(
                 // spawn-time flags above so the latch can't leak across
                 // respawns (including paths that skip the drift branch).
                 session.session_exited_plan = false;
+                session.session_resolved_env = resolved_env.vars.clone();
                 handle
             }
         }
@@ -766,6 +805,7 @@ pub async fn send_chat_message(
         session.session_disable_1m_context = agent_settings.disable_1m_context;
         // See the sibling reset above — fresh process, fresh latch.
         session.session_exited_plan = false;
+        session.session_resolved_env = resolved_env.vars.clone();
         let _ = db.save_agent_session(&workspace_id, &final_sid, session.turn_count);
         handle
     };

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -579,6 +579,28 @@ pub async fn send_chat_message(
     };
     let ws_env = WorkspaceEnv::from_workspace(ws, repo_path, default_branch);
 
+    // Resolve the env-provider layer (direnv / mise / dotenv / nix-devshell)
+    // once per turn. The mtime-keyed cache makes this essentially free on
+    // turns where nothing changed; on the first turn or after the user
+    // edits `.envrc` / `mise.toml` / etc., it re-runs the affected plugin.
+    let ws_info_for_env = claudette::plugin_runtime::host_api::WorkspaceInfo {
+        id: ws.id.clone(),
+        name: ws.name.clone(),
+        branch: ws.branch_name.clone(),
+        worktree_path: worktree_path.clone(),
+        repo_path: repo_path.to_string(),
+    };
+    let resolved_env = {
+        let registry = state.plugins.read().await;
+        claudette::env_provider::resolve_with_registry(
+            &registry,
+            &state.env_cache,
+            std::path::Path::new(&worktree_path),
+            &ws_info_for_env,
+        )
+        .await
+    };
+
     // Use persistent session to keep MCP servers alive across turns.
     // First turn or after restart: start a PersistentSession.
     // Subsequent turns in same session: reuse the existing process via stdin.
@@ -588,6 +610,7 @@ pub async fn send_chat_message(
 
     // Helper: start a persistent session, using --resume for restored sessions.
     let ws_env_for_persistent = ws_env.clone();
+    let resolved_env_for_persistent = resolved_env.clone();
     let start_persistent = |worktree: String,
                             sid: String,
                             is_resume: bool,
@@ -595,6 +618,7 @@ pub async fn send_chat_message(
                             instructions: Option<String>,
                             settings: AgentSettings| {
         let env = ws_env_for_persistent.clone();
+        let resolved = resolved_env_for_persistent.clone();
         async move {
             let ps = Arc::new(
                 PersistentSession::start(
@@ -605,6 +629,7 @@ pub async fn send_chat_message(
                     instructions.as_deref(),
                     &settings,
                     Some(&env),
+                    Some(&resolved),
                 )
                 .await?,
             );

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2564,6 +2564,7 @@ mod tests {
             session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
             session_exited_plan: false,
+            session_resolved_env: Default::default(),
         }
     }
 

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -189,51 +189,138 @@ pub async fn reload_env(
     Ok(())
 }
 
+/// Env-provider CLI trust/state pass-through. direnv and mise look
+/// up their trust cache under XDG_*_HOME (falling back to $HOME-based
+/// defaults), and some users point those at non-default locations.
+/// `host_exec`'s env-provider hermetic path and `run_env_trust` must
+/// both preserve these vars so what Claudette reads/writes matches
+/// what the user's terminal sees.
+const ENV_PROVIDER_PASSTHROUGH_KEYS: &[&str] = &[
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+];
+
 /// Run a plugin's trust command (`direnv allow`, `mise trust`) in the
 /// target's worktree directory. Hard-coded dispatch by plugin name so
 /// a malicious plugin manifest can't declare arbitrary commands for
-/// us to auto-run. Inherits `HOME`/`USER`/`LOGNAME`/`SHELL`/`TERM`
-/// from the app process so the tool writes to the user's existing
-/// trust cache.
+/// us to auto-run.
+///
+/// direnv and mise hash the target path into their allow-cache keys,
+/// so a single approval doesn't cover sibling worktrees. When the
+/// target is a repo (from `RepoSettings`), we fan out: run the
+/// command in the repo's main checkout AND every existing workspace
+/// worktree under it. That way one click blesses every path the
+/// agent, setup script, or PTY will actually spawn in.
 #[tauri::command]
 pub async fn run_env_trust(
     target: EnvTarget,
     plugin_name: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let (worktree, _, _) = resolve_target(&state, &target).await?;
-
     let cmd: &[&str] = match plugin_name.as_str() {
         "env-direnv" => &["direnv", "allow"],
         "env-mise" => &["mise", "trust"],
         _ => return Err(format!("no trust command defined for '{plugin_name}'")),
     };
 
-    let mut command = tokio::process::Command::new(cmd[0]);
-    command.args(&cmd[1..]);
-    command.current_dir(&worktree);
-    command.env("PATH", claudette::env::enriched_path());
-    for key in ["HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL"] {
-        if let Ok(val) = std::env::var(key) {
-            command.env(key, val);
+    // Collect every path we need to approve. For a Workspace target
+    // it's just that workspace. For a Repo target it's repo.path +
+    // every workspace.worktree_path that exists for that repo.
+    let paths = resolve_trust_paths(&state, &target).await?;
+    if paths.is_empty() {
+        return Err("no worktrees to run trust against".to_string());
+    }
+
+    let mut errors: Vec<String> = Vec::new();
+    for path in &paths {
+        let mut command = tokio::process::Command::new(cmd[0]);
+        command.args(&cmd[1..]);
+        command.current_dir(path);
+        command.env("PATH", claudette::env::enriched_path());
+        for key in ENV_PROVIDER_PASSTHROUGH_KEYS {
+            if let Ok(val) = std::env::var(key) {
+                command.env(key, val);
+            }
+        }
+
+        let output = command
+            .output()
+            .await
+            .map_err(|e| format!("failed to spawn {}: {e}", cmd[0]))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            errors.push(format!(
+                "{}: {} failed: {}",
+                path,
+                cmd.join(" "),
+                stderr.trim()
+            ));
+            continue;
+        }
+
+        // Trust state changed → evict this path's cache entry so the
+        // next resolve re-runs export with the now-allowed config.
+        state
+            .env_cache
+            .invalidate(Path::new(path), Some(&plugin_name));
+    }
+
+    if !errors.is_empty() && errors.len() == paths.len() {
+        return Err(errors.join("; "));
+    }
+    // Partial success is fine — the caller's refresh will show which
+    // paths are now trusted and which still need attention.
+    Ok(())
+}
+
+/// Gather every on-disk path we should run the trust command against.
+/// `Workspace` → the workspace's worktree. `Repo` → repo.path plus
+/// every workspace.worktree_path that currently exists for the repo.
+async fn resolve_trust_paths(state: &AppState, target: &EnvTarget) -> Result<Vec<String>, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    match target {
+        EnvTarget::Workspace { workspace_id } => {
+            let ws = db
+                .list_workspaces()
+                .map_err(|e| e.to_string())?
+                .into_iter()
+                .find(|w| w.id == *workspace_id)
+                .ok_or("Workspace not found")?;
+            let worktree = ws
+                .worktree_path
+                .clone()
+                .ok_or("Workspace has no worktree")?;
+            Ok(vec![worktree])
+        }
+        EnvTarget::Repo { repo_id } => {
+            let repo = db
+                .get_repository(repo_id)
+                .map_err(|e| e.to_string())?
+                .ok_or("Repository not found")?;
+            let mut paths = vec![repo.path.clone()];
+            let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+            for ws in workspaces {
+                if ws.repository_id == *repo_id {
+                    if let Some(wt) = ws.worktree_path {
+                        if wt != repo.path {
+                            paths.push(wt);
+                        }
+                    }
+                }
+            }
+            Ok(paths)
         }
     }
-
-    let output = command
-        .output()
-        .await
-        .map_err(|e| format!("failed to spawn {}: {e}", cmd[0]))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("{} failed: {}", cmd.join(" "), stderr.trim()));
-    }
-
-    // Trust state changed → evict so the next resolve re-runs export.
-    state
-        .env_cache
-        .invalidate(Path::new(&worktree), Some(&plugin_name));
-    Ok(())
 }
 
 /// Build a [`WorkspaceInfo`] for the given target, returning

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -9,6 +9,7 @@
 //! Nothing here mutates the workspace or database state — reload just
 //! evicts the in-memory cache, and the next spawn/resolve recomputes.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use serde::Serialize;
@@ -18,6 +19,35 @@ use claudette::db::Database;
 
 use crate::state::AppState;
 
+/// App-settings key for "is this env-provider enabled for this repo?".
+/// Default (absent key) is enabled. `"false"` disables.
+fn enabled_key(repo_id: &str, plugin_name: &str) -> String {
+    format!("repo:{repo_id}:env_provider:{plugin_name}:enabled")
+}
+
+/// Load the set of env-provider plugin names that have been explicitly
+/// disabled for a repo. Absent settings = enabled (default), so the
+/// returned set contains only names with the setting set to `"false"`.
+pub(crate) fn load_disabled_providers(db: &Database, repo_id: &str) -> HashSet<String> {
+    // We list all app settings with the repo+env_provider prefix.
+    // Pattern is precise; rusqlite does this cheaply via LIKE.
+    let prefix = format!("repo:{repo_id}:env_provider:");
+    db.list_app_settings_with_prefix(&prefix)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(key, value)| {
+            if value == "false" {
+                // key = "repo:{repo_id}:env_provider:{plugin_name}:enabled"
+                let rest = key.strip_prefix(&prefix)?;
+                let plugin_name = rest.strip_suffix(":enabled")?;
+                Some(plugin_name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Snapshot of one plugin's contribution for a workspace.
 ///
 /// Mirrors [`claudette::env_provider::ResolvedSource`] but uses
@@ -26,7 +56,9 @@ use crate::state::AppState;
 #[derive(Serialize)]
 pub struct EnvSourceInfo {
     pub plugin_name: String,
+    pub display_name: String,
     pub detected: bool,
+    pub enabled: bool,
     pub vars_contributed: usize,
     pub cached: bool,
     /// Milliseconds since the Unix epoch. Frontend formats this
@@ -47,33 +79,83 @@ pub async fn get_workspace_env_sources(
     workspace_id: String,
     state: State<'_, AppState>,
 ) -> Result<Vec<EnvSourceInfo>, String> {
-    let (worktree, ws_info) = lookup_ws_context(&state, &workspace_id).await?;
+    let (worktree, ws_info, repo_id) = lookup_ws_context(&state, &workspace_id).await?;
+    let disabled = {
+        let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+        load_disabled_providers(&db, &repo_id)
+    };
     let registry = state.plugins.read().await;
+    // Look up display_name for each plugin from the registry so the UI
+    // shows "direnv" instead of the internal "env-direnv" name.
+    let display_names: std::collections::HashMap<String, String> = registry
+        .plugins
+        .iter()
+        .map(|(name, p)| (name.clone(), p.manifest.display_name.clone()))
+        .collect();
     let resolved = claudette::env_provider::resolve_with_registry(
         &registry,
         &state.env_cache,
         Path::new(&worktree),
         &ws_info,
+        &disabled,
     )
     .await;
 
     let sources = resolved
         .sources
         .into_iter()
-        .map(|s| EnvSourceInfo {
-            plugin_name: s.plugin_name,
-            detected: s.detected,
-            vars_contributed: s.vars_contributed,
-            cached: s.cached,
-            evaluated_at_ms: s
-                .evaluated_at
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis())
-                .unwrap_or(0),
-            error: s.error,
+        .map(|s| {
+            let display_name = display_names
+                .get(&s.plugin_name)
+                .cloned()
+                .unwrap_or_else(|| s.plugin_name.clone());
+            let enabled = !disabled.contains(&s.plugin_name);
+            EnvSourceInfo {
+                plugin_name: s.plugin_name,
+                display_name,
+                detected: s.detected,
+                enabled,
+                vars_contributed: s.vars_contributed,
+                cached: s.cached,
+                evaluated_at_ms: s
+                    .evaluated_at
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0),
+                error: s.error,
+            }
         })
         .collect();
     Ok(sources)
+}
+
+/// Toggle whether an env-provider plugin runs for a workspace's repo.
+/// Disabling evicts any cached result for every workspace under the
+/// repo so the next spawn reflects the change immediately.
+#[tauri::command]
+pub async fn set_env_provider_enabled(
+    workspace_id: String,
+    plugin_name: String,
+    enabled: bool,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let (worktree, _, repo_id) = lookup_ws_context(&state, &workspace_id).await?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let key = enabled_key(&repo_id, &plugin_name);
+    // We persist only the "disabled" case; absent key = enabled (default).
+    if enabled {
+        db.delete_app_setting(&key).map_err(|e| e.to_string())?;
+    } else {
+        db.set_app_setting(&key, "false")
+            .map_err(|e| e.to_string())?;
+    }
+    // Invalidate the cache entry for this (worktree, plugin) regardless
+    // of direction — enabling should re-run the plugin on next resolve,
+    // disabling should stop applying a stale cached result.
+    state
+        .env_cache
+        .invalidate(Path::new(&worktree), Some(&plugin_name));
+    Ok(())
 }
 
 /// Evict the env-provider cache for a workspace, forcing a fresh
@@ -88,7 +170,7 @@ pub async fn reload_workspace_env(
     plugin_name: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let (worktree, _) = lookup_ws_context(&state, &workspace_id).await?;
+    let (worktree, _, _) = lookup_ws_context(&state, &workspace_id).await?;
     state
         .env_cache
         .invalidate(Path::new(&worktree), plugin_name.as_deref());
@@ -100,7 +182,14 @@ pub async fn reload_workspace_env(
 async fn lookup_ws_context(
     state: &AppState,
     workspace_id: &str,
-) -> Result<(String, claudette::plugin_runtime::host_api::WorkspaceInfo), String> {
+) -> Result<
+    (
+        String,
+        claudette::plugin_runtime::host_api::WorkspaceInfo,
+        String,
+    ),
+    String,
+> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let ws = db
         .list_workspaces()
@@ -116,6 +205,7 @@ async fn lookup_ws_context(
         .get_repository(&ws.repository_id)
         .map_err(|e| e.to_string())?
         .ok_or("Repository not found")?;
+    let repo_id = ws.repository_id.clone();
 
     let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
         id: ws.id.clone(),
@@ -124,5 +214,5 @@ async fn lookup_ws_context(
         worktree_path: worktree.clone(),
         repo_path: repo.path,
     };
-    Ok((worktree, ws_info))
+    Ok((worktree, ws_info, repo_id))
 }

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -160,8 +160,10 @@ pub async fn get_env_sources(
 }
 
 /// Toggle whether an env-provider plugin runs for the target's repo.
-/// Disabling evicts any cached result for every workspace under the
-/// repo so the next spawn reflects the change immediately.
+/// The toggle is persisted per-repo, so the change applies to every
+/// worktree under that repo. This evicts the cache for the repo's
+/// main checkout AND every workspace worktree beneath it so the next
+/// spawn in any of them reflects the new state immediately.
 #[tauri::command]
 pub async fn set_env_provider_enabled(
     target: EnvTarget,
@@ -169,7 +171,7 @@ pub async fn set_env_provider_enabled(
     enabled: bool,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let (worktree, _, repo_id) = resolve_target(&state, &target).await?;
+    let (_, _, repo_id) = resolve_target(&state, &target).await?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let key = enabled_key(&repo_id, &plugin_name);
     // We persist only the "disabled" case; absent key = enabled (default).
@@ -179,13 +181,40 @@ pub async fn set_env_provider_enabled(
         db.set_app_setting(&key, "false")
             .map_err(|e| e.to_string())?;
     }
-    // Invalidate the cache entry for this (worktree, plugin) regardless
-    // of direction — enabling should re-run the plugin on next resolve,
-    // disabling should stop applying a stale cached result.
-    state
-        .env_cache
-        .invalidate(Path::new(&worktree), Some(&plugin_name));
+    // Per-repo setting → fan-out cache eviction across the repo's main
+    // checkout + every workspace worktree. Re-enabling forces a fresh
+    // eval on next resolve; disabling stops a stale cached value from
+    // being applied.
+    for path in repo_worktree_paths(&db, &repo_id) {
+        state
+            .env_cache
+            .invalidate(Path::new(&path), Some(&plugin_name));
+    }
     Ok(())
+}
+
+/// Every on-disk worktree path associated with a repo: the main
+/// checkout plus each workspace.worktree_path. Silently drops
+/// database errors — if we can't list workspaces, we just invalidate
+/// what we can (or nothing), and stale cache entries will expire on
+/// the next mtime change anyway.
+fn repo_worktree_paths(db: &Database, repo_id: &str) -> Vec<String> {
+    let Ok(Some(repo)) = db.get_repository(repo_id) else {
+        return Vec::new();
+    };
+    let mut paths = vec![repo.path.clone()];
+    if let Ok(workspaces) = db.list_workspaces() {
+        for ws in workspaces {
+            if ws.repository_id == repo_id {
+                if let Some(wt) = ws.worktree_path {
+                    if wt != repo.path {
+                        paths.push(wt);
+                    }
+                }
+            }
+        }
+    }
+    paths
 }
 
 /// Evict the env-provider cache for the target, forcing a fresh

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -48,6 +48,24 @@ pub(crate) fn load_disabled_providers(db: &Database, repo_id: &str) -> HashSet<S
         .collect()
 }
 
+/// Strip sources whose plugin is globally disabled in the Plugins
+/// settings section. The env panel is a per-repo/per-workspace view —
+/// surfacing globally-off plugins there is noise (they're managed
+/// elsewhere and won't run regardless), and showing them with the
+/// `error: "disabled"` marker was being rendered as a confusing ERROR
+/// badge. Resolution still runs them through `resolve_with_registry`
+/// upstream (the dispatcher needs to record them for cache
+/// invalidation), so we filter at the UI boundary only.
+pub(crate) fn filter_globally_disabled(
+    sources: Vec<claudette::env_provider::ResolvedSource>,
+    is_globally_disabled: impl Fn(&str) -> bool,
+) -> Vec<claudette::env_provider::ResolvedSource> {
+    sources
+        .into_iter()
+        .filter(|s| !is_globally_disabled(&s.plugin_name))
+        .collect()
+}
+
 /// Snapshot of one plugin's contribution for a workspace.
 ///
 /// Mirrors [`claudette::env_provider::ResolvedSource`] but uses
@@ -113,8 +131,8 @@ pub async fn get_env_sources(
     )
     .await;
 
-    let sources = resolved
-        .sources
+    let visible = filter_globally_disabled(resolved.sources, |name| registry.is_disabled(name));
+    let sources = visible
         .into_iter()
         .map(|s| {
             let display_name = display_names
@@ -383,5 +401,59 @@ async fn resolve_target(
             };
             Ok((repo.path, ws_info, repo.id))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claudette::env_provider::ResolvedSource;
+    use std::collections::HashSet;
+    use std::time::SystemTime;
+
+    fn src(name: &str) -> ResolvedSource {
+        ResolvedSource {
+            plugin_name: name.to_string(),
+            detected: true,
+            vars_contributed: 1,
+            cached: false,
+            evaluated_at: SystemTime::now(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn filter_globally_disabled_hides_globally_disabled_sources() {
+        let sources = vec![src("env-direnv"), src("env-mise"), src("env-dotenv")];
+        let globally_off: HashSet<&str> = ["env-mise"].into_iter().collect();
+
+        let visible = filter_globally_disabled(sources, |n| globally_off.contains(n));
+
+        let names: Vec<&str> = visible.iter().map(|s| s.plugin_name.as_str()).collect();
+        assert_eq!(names, vec!["env-direnv", "env-dotenv"]);
+    }
+
+    #[test]
+    fn filter_globally_disabled_keeps_per_repo_disabled_with_reason() {
+        // Per-repo disable stamps `error: Some("disabled")`. That must
+        // still be visible — the user can re-enable it right there via
+        // the toggle. Only GLOBAL disables (from Plugins settings) are
+        // hidden.
+        let mut s = src("env-direnv");
+        s.error = Some("disabled".to_string());
+        s.detected = false;
+        s.vars_contributed = 0;
+        let sources = vec![s];
+
+        let visible = filter_globally_disabled(sources, |_| false);
+
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].error.as_deref(), Some("disabled"));
+    }
+
+    #[test]
+    fn filter_globally_disabled_empty_passes_through() {
+        let visible = filter_globally_disabled(Vec::new(), |_| true);
+        assert!(visible.is_empty());
     }
 }

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -67,19 +67,31 @@ pub struct EnvSourceInfo {
     pub error: Option<String>,
 }
 
+/// Identifies what to resolve env for. `Repo` resolves against the
+/// repository's main checkout (useful before any workspace exists);
+/// `Workspace` resolves against the workspace's worktree (existing
+/// behavior). Per-provider toggles persist at repo scope, so both
+/// targets under the same repo share their enable/disable state.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum EnvTarget {
+    Repo { repo_id: String },
+    Workspace { workspace_id: String },
+}
+
 /// Return the list of env-provider plugins that ran (or would run) for
-/// this workspace, along with how many vars each contributed and
-/// whether the result is cached.
+/// this target, along with how many vars each contributed and whether
+/// the result is cached.
 ///
 /// Side effect: this triggers a full `resolve_for_workspace` pass,
 /// which respects the mtime cache — so repeated calls during a quiet
 /// period are cheap.
 #[tauri::command]
-pub async fn get_workspace_env_sources(
-    workspace_id: String,
+pub async fn get_env_sources(
+    target: EnvTarget,
     state: State<'_, AppState>,
 ) -> Result<Vec<EnvSourceInfo>, String> {
-    let (worktree, ws_info, repo_id) = lookup_ws_context(&state, &workspace_id).await?;
+    let (worktree, ws_info, repo_id) = resolve_target(&state, &target).await?;
     let disabled = {
         let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
         load_disabled_providers(&db, &repo_id)
@@ -129,17 +141,17 @@ pub async fn get_workspace_env_sources(
     Ok(sources)
 }
 
-/// Toggle whether an env-provider plugin runs for a workspace's repo.
+/// Toggle whether an env-provider plugin runs for the target's repo.
 /// Disabling evicts any cached result for every workspace under the
 /// repo so the next spawn reflects the change immediately.
 #[tauri::command]
 pub async fn set_env_provider_enabled(
-    workspace_id: String,
+    target: EnvTarget,
     plugin_name: String,
     enabled: bool,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let (worktree, _, repo_id) = lookup_ws_context(&state, &workspace_id).await?;
+    let (worktree, _, repo_id) = resolve_target(&state, &target).await?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let key = enabled_key(&repo_id, &plugin_name);
     // We persist only the "disabled" case; absent key = enabled (default).
@@ -158,30 +170,77 @@ pub async fn set_env_provider_enabled(
     Ok(())
 }
 
-/// Evict the env-provider cache for a workspace, forcing a fresh
+/// Evict the env-provider cache for the target, forcing a fresh
 /// `export` call on the next spawn / diagnostic query.
 ///
 /// If `plugin_name` is provided, only that plugin's cache entry is
 /// dropped. Otherwise every plugin's entry for this worktree is
 /// dropped.
 #[tauri::command]
-pub async fn reload_workspace_env(
-    workspace_id: String,
+pub async fn reload_env(
+    target: EnvTarget,
     plugin_name: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let (worktree, _, _) = lookup_ws_context(&state, &workspace_id).await?;
+    let (worktree, _, _) = resolve_target(&state, &target).await?;
     state
         .env_cache
         .invalidate(Path::new(&worktree), plugin_name.as_deref());
     Ok(())
 }
 
-/// Load workspace + repo from the DB and build a [`WorkspaceInfo`] for
-/// env-provider invocation. Shared by all commands in this module.
-async fn lookup_ws_context(
+/// Run a plugin's trust command (`direnv allow`, `mise trust`) in the
+/// target's worktree directory. Hard-coded dispatch by plugin name so
+/// a malicious plugin manifest can't declare arbitrary commands for
+/// us to auto-run. Inherits `HOME`/`USER`/`LOGNAME`/`SHELL`/`TERM`
+/// from the app process so the tool writes to the user's existing
+/// trust cache.
+#[tauri::command]
+pub async fn run_env_trust(
+    target: EnvTarget,
+    plugin_name: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let (worktree, _, _) = resolve_target(&state, &target).await?;
+
+    let cmd: &[&str] = match plugin_name.as_str() {
+        "env-direnv" => &["direnv", "allow"],
+        "env-mise" => &["mise", "trust"],
+        _ => return Err(format!("no trust command defined for '{plugin_name}'")),
+    };
+
+    let mut command = tokio::process::Command::new(cmd[0]);
+    command.args(&cmd[1..]);
+    command.current_dir(&worktree);
+    command.env("PATH", claudette::env::enriched_path());
+    for key in ["HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL"] {
+        if let Ok(val) = std::env::var(key) {
+            command.env(key, val);
+        }
+    }
+
+    let output = command
+        .output()
+        .await
+        .map_err(|e| format!("failed to spawn {}: {e}", cmd[0]))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("{} failed: {}", cmd.join(" "), stderr.trim()));
+    }
+
+    // Trust state changed → evict so the next resolve re-runs export.
+    state
+        .env_cache
+        .invalidate(Path::new(&worktree), Some(&plugin_name));
+    Ok(())
+}
+
+/// Build a [`WorkspaceInfo`] for the given target, returning
+/// `(worktree_path, ws_info, repo_id)`.
+async fn resolve_target(
     state: &AppState,
-    workspace_id: &str,
+    target: &EnvTarget,
 ) -> Result<
     (
         String,
@@ -190,29 +249,52 @@ async fn lookup_ws_context(
     ),
     String,
 > {
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let ws = db
-        .list_workspaces()
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .find(|w| w.id == workspace_id)
-        .ok_or("Workspace not found")?;
-    let worktree = ws
-        .worktree_path
-        .clone()
-        .ok_or("Workspace has no worktree")?;
-    let repo = db
-        .get_repository(&ws.repository_id)
-        .map_err(|e| e.to_string())?
-        .ok_or("Repository not found")?;
-    let repo_id = ws.repository_id.clone();
-
-    let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
-        id: ws.id.clone(),
-        name: ws.name.clone(),
-        branch: ws.branch_name.clone(),
-        worktree_path: worktree.clone(),
-        repo_path: repo.path,
-    };
-    Ok((worktree, ws_info, repo_id))
+    match target {
+        EnvTarget::Workspace { workspace_id } => {
+            let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+            let ws = db
+                .list_workspaces()
+                .map_err(|e| e.to_string())?
+                .into_iter()
+                .find(|w| w.id == *workspace_id)
+                .ok_or("Workspace not found")?;
+            let worktree = ws
+                .worktree_path
+                .clone()
+                .ok_or("Workspace has no worktree")?;
+            let repo = db
+                .get_repository(&ws.repository_id)
+                .map_err(|e| e.to_string())?
+                .ok_or("Repository not found")?;
+            let repo_id = ws.repository_id.clone();
+            let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
+                id: ws.id.clone(),
+                name: ws.name.clone(),
+                branch: ws.branch_name.clone(),
+                worktree_path: worktree.clone(),
+                repo_path: repo.path,
+            };
+            Ok((worktree, ws_info, repo_id))
+        }
+        EnvTarget::Repo { repo_id } => {
+            let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+            let repo = db
+                .get_repository(repo_id)
+                .map_err(|e| e.to_string())?
+                .ok_or("Repository not found")?;
+            // The repo's main checkout IS a git worktree — safe to
+            // use as a resolution target. Synthetic WorkspaceInfo
+            // uses "repo:{id}" as id (guaranteed not to collide with
+            // any real workspace id) and an empty branch string
+            // (none of our plugins consume `args.branch`).
+            let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
+                id: format!("repo:{}", repo.id),
+                name: repo.name.clone(),
+                branch: String::new(),
+                worktree_path: repo.path.clone(),
+                repo_path: repo.path.clone(),
+            };
+            Ok((repo.path, ws_info, repo.id))
+        }
+    }
 }

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -1,0 +1,128 @@
+//! Tauri commands for the env-provider diagnostic UI.
+//!
+//! The env-provider system runs silently in the background — every
+//! workspace spawn already gets the merged env without asking. These
+//! commands expose read + reload surfaces so the UI can tell the user
+//! *why* a variable is (or isn't) set, and let them force a
+//! re-evaluation (e.g. after running `direnv allow`).
+//!
+//! Nothing here mutates the workspace or database state — reload just
+//! evicts the in-memory cache, and the next spawn/resolve recomputes.
+
+use std::path::Path;
+
+use serde::Serialize;
+use tauri::State;
+
+use claudette::db::Database;
+
+use crate::state::AppState;
+
+/// Snapshot of one plugin's contribution for a workspace.
+///
+/// Mirrors [`claudette::env_provider::ResolvedSource`] but uses
+/// serializable timestamps (ms since epoch) since `SystemTime` isn't
+/// directly serde-friendly across the IPC boundary.
+#[derive(Serialize)]
+pub struct EnvSourceInfo {
+    pub plugin_name: String,
+    pub detected: bool,
+    pub vars_contributed: usize,
+    pub cached: bool,
+    /// Milliseconds since the Unix epoch. Frontend formats this
+    /// relative to `Date.now()` ("evaluated 3s ago").
+    pub evaluated_at_ms: u128,
+    pub error: Option<String>,
+}
+
+/// Return the list of env-provider plugins that ran (or would run) for
+/// this workspace, along with how many vars each contributed and
+/// whether the result is cached.
+///
+/// Side effect: this triggers a full `resolve_for_workspace` pass,
+/// which respects the mtime cache — so repeated calls during a quiet
+/// period are cheap.
+#[tauri::command]
+pub async fn get_workspace_env_sources(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<EnvSourceInfo>, String> {
+    let (worktree, ws_info) = lookup_ws_context(&state, &workspace_id).await?;
+    let registry = state.plugins.read().await;
+    let resolved = claudette::env_provider::resolve_with_registry(
+        &registry,
+        &state.env_cache,
+        Path::new(&worktree),
+        &ws_info,
+    )
+    .await;
+
+    let sources = resolved
+        .sources
+        .into_iter()
+        .map(|s| EnvSourceInfo {
+            plugin_name: s.plugin_name,
+            detected: s.detected,
+            vars_contributed: s.vars_contributed,
+            cached: s.cached,
+            evaluated_at_ms: s
+                .evaluated_at
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0),
+            error: s.error,
+        })
+        .collect();
+    Ok(sources)
+}
+
+/// Evict the env-provider cache for a workspace, forcing a fresh
+/// `export` call on the next spawn / diagnostic query.
+///
+/// If `plugin_name` is provided, only that plugin's cache entry is
+/// dropped. Otherwise every plugin's entry for this worktree is
+/// dropped.
+#[tauri::command]
+pub async fn reload_workspace_env(
+    workspace_id: String,
+    plugin_name: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let (worktree, _) = lookup_ws_context(&state, &workspace_id).await?;
+    state
+        .env_cache
+        .invalidate(Path::new(&worktree), plugin_name.as_deref());
+    Ok(())
+}
+
+/// Load workspace + repo from the DB and build a [`WorkspaceInfo`] for
+/// env-provider invocation. Shared by all commands in this module.
+async fn lookup_ws_context(
+    state: &AppState,
+    workspace_id: &str,
+) -> Result<(String, claudette::plugin_runtime::host_api::WorkspaceInfo), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let ws = db
+        .list_workspaces()
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree = ws
+        .worktree_path
+        .clone()
+        .ok_or("Workspace has no worktree")?;
+    let repo = db
+        .get_repository(&ws.repository_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Repository not found")?;
+
+    let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
+        id: ws.id.clone(),
+        name: ws.name.clone(),
+        branch: ws.branch_name.clone(),
+        worktree_path: worktree.clone(),
+        repo_path: repo.path,
+    };
+    Ok((worktree, ws_info))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod mcp;
 pub mod metrics;
 pub mod plan;
 pub mod plugin;
+pub mod plugins_runtime;
 pub mod remote;
 pub mod repository;
 pub mod scm;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod data;
 #[cfg(debug_assertions)]
 pub mod debug;
 pub mod diff;
+pub mod env;
 pub mod files;
 pub mod mcp;
 pub mod metrics;

--- a/src-tauri/src/commands/plugins_runtime.rs
+++ b/src-tauri/src/commands/plugins_runtime.rs
@@ -123,13 +123,13 @@ pub async fn set_claudette_plugin_enabled(
         .read()
         .await
         .set_disabled(&plugin_name, !enabled);
-    // When the state flips, we also want to evict any env-provider
-    // cache entries that might be keyed by this plugin across all
-    // worktrees. Simple approach: the env cache is in state; re-enable
-    // will force re-resolve on next spawn anyway, so we do nothing
-    // here — the existing invalidation paths in `set_env_provider_enabled`
-    // handle per-repo toggles, and `call_operation` now respects the
-    // global disabled flag on read.
+    // Global enable/disable changes can leave stale env-provider exports
+    // cached across worktrees. Invalidate any entries for this plugin on
+    // BOTH transitions: disabling means stale values must not continue
+    // applying, and re-enabling after out-of-band trust changes (e.g.
+    // the user ran `direnv allow` while the plugin was off) means the
+    // watched-mtime cache key wouldn't catch the change on its own.
+    state.env_cache.invalidate_plugin_everywhere(&plugin_name);
     Ok(())
 }
 

--- a/src-tauri/src/commands/plugins_runtime.rs
+++ b/src-tauri/src/commands/plugins_runtime.rs
@@ -109,6 +109,17 @@ pub async fn set_claudette_plugin_enabled(
     enabled: bool,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
+    // Validate the plugin exists before touching the DB — otherwise a
+    // typo (or stale UI state) would accumulate stray
+    // `plugin:{name}:enabled` rows in `app_settings` that would unexpectedly
+    // take effect if a plugin with that name is later installed.
+    {
+        let registry = state.plugins.read().await;
+        if !registry.plugins.contains_key(&plugin_name) {
+            return Err(format!("unknown plugin: {plugin_name}"));
+        }
+    }
+
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let key = format!("plugin:{plugin_name}:enabled");
     // Persist only the "disabled" case; absent key = enabled.

--- a/src-tauri/src/commands/plugins_runtime.rs
+++ b/src-tauri/src/commands/plugins_runtime.rs
@@ -1,0 +1,206 @@
+//! Tauri commands for the **Plugins** settings section — Claudette's
+//! own Lua plugins (SCM + env-provider), not the Claude Code
+//! marketplace plugins (those live in `commands/plugin.rs`).
+//!
+//! Surfaces:
+//!   * `list_claudette_plugins` — snapshot of every discovered plugin
+//!     with manifest metadata, enabled state, current setting values.
+//!   * `set_claudette_plugin_enabled` — global on/off toggle.
+//!   * `set_claudette_plugin_setting` — persist a value for one of
+//!     the plugin's declared settings fields.
+//!   * `reseed_bundled_plugins` — reseed in-binary plugins over any
+//!     unmodified on-disk copies. Escape hatch for when users are
+//!     stuck on an older seeded `init.lua` because we haven't bumped
+//!     `APP_VERSION` yet.
+//!
+//! Persistence keys in `app_settings`:
+//!   * `plugin:{name}:enabled = "false"` — plugin globally disabled.
+//!     Absent (or "true") means enabled. We only store the negative
+//!     so enabled-by-default stays cheap.
+//!   * `plugin:{name}:setting:{key} = <json>` — user override for a
+//!     manifest-declared setting field. Stored as JSON so the type
+//!     shape (bool/string) round-trips through the `host.config`
+//!     surface cleanly.
+
+use serde::Serialize;
+use tauri::State;
+
+use claudette::db::Database;
+use claudette::plugin_runtime::manifest::{PluginKind, PluginSettingField};
+
+use crate::state::AppState;
+
+#[derive(Serialize)]
+pub struct ClaudettePluginInfo {
+    pub name: String,
+    pub display_name: String,
+    pub version: String,
+    pub description: String,
+    pub kind: PluginKind,
+    pub required_clis: Vec<String>,
+    pub cli_available: bool,
+    pub enabled: bool,
+    pub settings_schema: Vec<PluginSettingField>,
+    /// Current effective value for each declared setting key (after
+    /// merging manifest defaults + user overrides). Null means no
+    /// value is set.
+    pub setting_values: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[tauri::command]
+pub async fn list_claudette_plugins(
+    state: State<'_, AppState>,
+) -> Result<Vec<ClaudettePluginInfo>, String> {
+    let registry = state.plugins.read().await;
+    let mut out: Vec<ClaudettePluginInfo> = registry
+        .plugins
+        .iter()
+        .map(|(name, plugin)| {
+            let effective = registry.effective_config(name);
+            let setting_values: std::collections::HashMap<String, serde_json::Value> = plugin
+                .manifest
+                .settings
+                .iter()
+                .map(|field| {
+                    let key = field.key().to_string();
+                    let value = effective
+                        .get(&key)
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    (key, value)
+                })
+                .collect();
+            ClaudettePluginInfo {
+                name: plugin.manifest.name.clone(),
+                display_name: plugin.manifest.display_name.clone(),
+                version: plugin.manifest.version.clone(),
+                description: plugin.manifest.description.clone(),
+                kind: plugin.manifest.kind,
+                required_clis: plugin.manifest.required_clis.clone(),
+                cli_available: plugin.cli_available,
+                enabled: !registry.is_disabled(name),
+                settings_schema: plugin.manifest.settings.clone(),
+                setting_values,
+            }
+        })
+        .collect();
+    // Stable order: by kind first (Scm, EnvProvider), then by name.
+    // This matches how the UI groups them.
+    out.sort_by(|a, b| {
+        (kind_sort_key(a.kind), a.name.as_str()).cmp(&(kind_sort_key(b.kind), b.name.as_str()))
+    });
+    Ok(out)
+}
+
+fn kind_sort_key(kind: PluginKind) -> u8 {
+    match kind {
+        PluginKind::Scm => 0,
+        PluginKind::EnvProvider => 1,
+    }
+}
+
+/// Globally enable or disable a plugin. Writes to `app_settings` and
+/// updates the registry's in-memory state so the change takes effect
+/// immediately (next `call_operation` will short-circuit with
+/// `PluginDisabled` if disabled).
+#[tauri::command]
+pub async fn set_claudette_plugin_enabled(
+    plugin_name: String,
+    enabled: bool,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let key = format!("plugin:{plugin_name}:enabled");
+    // Persist only the "disabled" case; absent key = enabled.
+    if enabled {
+        db.delete_app_setting(&key).map_err(|e| e.to_string())?;
+    } else {
+        db.set_app_setting(&key, "false")
+            .map_err(|e| e.to_string())?;
+    }
+    state
+        .plugins
+        .read()
+        .await
+        .set_disabled(&plugin_name, !enabled);
+    // When the state flips, we also want to evict any env-provider
+    // cache entries that might be keyed by this plugin across all
+    // worktrees. Simple approach: the env cache is in state; re-enable
+    // will force re-resolve on next spawn anyway, so we do nothing
+    // here — the existing invalidation paths in `set_env_provider_enabled`
+    // handle per-repo toggles, and `call_operation` now respects the
+    // global disabled flag on read.
+    Ok(())
+}
+
+/// Persist a user override for one of a plugin's declared settings
+/// fields. Pass `value: null` to clear the override (reverts to the
+/// manifest default).
+#[tauri::command]
+pub async fn set_claudette_plugin_setting(
+    plugin_name: String,
+    key: String,
+    value: serde_json::Value,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let storage_key = format!("plugin:{plugin_name}:setting:{key}");
+
+    let registry = state.plugins.read().await;
+    if value.is_null() {
+        db.delete_app_setting(&storage_key)
+            .map_err(|e| e.to_string())?;
+        registry.set_setting(&plugin_name, &key, None);
+    } else {
+        let serialized = serde_json::to_string(&value).map_err(|e| e.to_string())?;
+        db.set_app_setting(&storage_key, &serialized)
+            .map_err(|e| e.to_string())?;
+        registry.set_setting(&plugin_name, &key, Some(value));
+    }
+
+    // Settings can affect future exports (e.g. `auto_allow` turning on
+    // means the next export retries with `direnv allow`). Invalidate
+    // any env-cache entries whose plugin name matches so the next
+    // resolve picks up the new behavior.
+    state.env_cache.invalidate_plugin_everywhere(&plugin_name);
+    Ok(())
+}
+
+/// Reseed all bundled plugins from the in-binary tarball over any
+/// unmodified on-disk copies. Skips any plugin whose `init.lua` has
+/// been user-modified (hash mismatch). Useful as an escape hatch when
+/// we've shipped plugin tree changes between releases and haven't
+/// bumped APP_VERSION yet (or for users who want to revert a failed
+/// customization).
+#[tauri::command]
+pub async fn reseed_bundled_plugins(state: State<'_, AppState>) -> Result<Vec<String>, String> {
+    let registry = state.plugins.read().await;
+    let plugin_dir = registry.plugin_dir.clone();
+    drop(registry);
+
+    let warnings = claudette::plugin_runtime::seed::reseed_bundled_plugins_force(&plugin_dir);
+
+    // After a reseed, rediscover so the registry picks up any new
+    // manifest fields (e.g. settings schemas added between versions).
+    // This replaces the registry entirely — setting_overrides are re-
+    // hydrated from app_settings below so user preferences survive.
+    let new_registry = claudette::plugin_runtime::PluginRegistry::discover(&plugin_dir);
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    if let Ok(entries) = db.list_app_settings_with_prefix("plugin:") {
+        for (key, value) in entries {
+            let rest = &key["plugin:".len()..];
+            if let Some((plugin_name, tail)) = rest.split_once(':') {
+                if tail == "enabled" && value == "false" {
+                    new_registry.set_disabled(plugin_name, true);
+                } else if let Some(setting_key) = tail.strip_prefix("setting:") {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&value) {
+                        new_registry.set_setting(plugin_name, setting_key, Some(v));
+                    }
+                }
+            }
+        }
+    }
+    *state.plugins.write().await = new_registry;
+
+    Ok(warnings)
+}

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -466,6 +466,9 @@ async fn resolve_env_for_workspace(
         worktree_path: worktree.to_string(),
         repo_path: repo_path.to_string(),
     };
+    let disabled = Database::open(&state.db_path)
+        .map(|db| crate::commands::env::load_disabled_providers(&db, &ws.repository_id))
+        .unwrap_or_default();
     let registry = state.plugins.read().await;
     Some(
         claudette::env_provider::resolve_with_registry(
@@ -473,6 +476,7 @@ async fn resolve_env_for_workspace(
             &state.env_cache,
             Path::new(worktree),
             &ws_info,
+            &disabled,
         )
         .await,
     )

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -153,6 +153,7 @@ pub async fn create_workspace(
     let setup_result = if skip_setup.unwrap_or(false) {
         None
     } else {
+        let resolved_env = resolve_env_for_workspace(&state, &ws, &repo_path).await;
         resolve_and_run_setup(
             &ws,
             Path::new(&repo_path),
@@ -160,6 +161,7 @@ pub async fn create_workspace(
             settings_setup_script.as_deref(),
             repo_base_branch.as_deref(),
             repo_default_remote.as_deref(),
+            resolved_env.as_ref(),
         )
         .await
     };
@@ -238,6 +240,7 @@ async fn resolve_and_run_setup(
     settings_script: Option<&str>,
     base_branch: Option<&str>,
     default_remote: Option<&str>,
+    resolved_env: Option<&claudette::env_provider::ResolvedEnv>,
 ) -> Option<SetupResult> {
     // 1. Check .claudette.json
     let (script, source) = match config::load_config(repo_path) {
@@ -302,6 +305,13 @@ async fn resolve_and_run_setup(
         .stderr(std::process::Stdio::piped());
     #[cfg(unix)]
     cmd.process_group(0);
+    // Env-provider layer (direnv/mise/dotenv/nix-devshell) first so the
+    // user's setup commands can rely on tools/vars from those sources
+    // (e.g. `bun install` finding `node` from a mise-managed toolchain),
+    // then WorkspaceEnv on top so CLAUDETTE_* markers always win.
+    if let Some(env) = resolved_env {
+        env.apply(&mut cmd);
+    }
     ws_env.apply(&mut cmd);
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -421,6 +431,7 @@ pub async fn run_workspace_setup(
         .find(|r| r.id == ws.repository_id)
         .ok_or("Repository not found")?;
 
+    let resolved_env = resolve_env_for_workspace(&state, ws, &repo.path).await;
     let result = resolve_and_run_setup(
         ws,
         Path::new(&repo.path),
@@ -428,10 +439,43 @@ pub async fn run_workspace_setup(
         repo.setup_script.as_deref(),
         repo.base_branch.as_deref(),
         repo.default_remote.as_deref(),
+        resolved_env.as_ref(),
     )
     .await;
 
     Ok(result)
+}
+
+/// Resolve the env-provider layer for a workspace, producing a
+/// [`claudette::env_provider::ResolvedEnv`] merged from all detected
+/// providers (direnv, mise, dotenv, nix-devshell).
+///
+/// Returns `None` when the workspace has no worktree path yet (which
+/// shouldn't happen by the time we're about to spawn, but keeps the
+/// call sites defensive).
+async fn resolve_env_for_workspace(
+    state: &AppState,
+    ws: &Workspace,
+    repo_path: &str,
+) -> Option<claudette::env_provider::ResolvedEnv> {
+    let worktree = ws.worktree_path.as_deref()?;
+    let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
+        id: ws.id.clone(),
+        name: ws.name.clone(),
+        branch: ws.branch_name.clone(),
+        worktree_path: worktree.to_string(),
+        repo_path: repo_path.to_string(),
+    };
+    let registry = state.plugins.read().await;
+    Some(
+        claudette::env_provider::resolve_with_registry(
+            &registry,
+            &state.env_cache,
+            Path::new(worktree),
+            &ws_info,
+        )
+        .await,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -480,6 +480,7 @@ fn main() {
             // Env-provider diagnostic UI
             commands::env::get_workspace_env_sources,
             commands::env::reload_workspace_env,
+            commands::env::set_env_provider_enabled,
             // Local server
             commands::remote::start_local_server,
             commands::remote::stop_local_server,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -477,6 +477,9 @@ fn main() {
             commands::scm::scm_create_pr,
             commands::scm::scm_merge_pr,
             commands::scm::scm_refresh,
+            // Env-provider diagnostic UI
+            commands::env::get_workspace_env_sources,
+            commands::env::reload_workspace_env,
             // Local server
             commands::remote::start_local_server,
             commands::remote::stop_local_server,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -105,6 +105,27 @@ fn main() {
             .join(", ")
     );
 
+    // Hydrate the registry's in-memory state (globally disabled plugins,
+    // user setting overrides) from app_settings so the very first call
+    // after startup reflects what the user configured previously. Any
+    // failure here is non-fatal: the registry just runs with defaults.
+    if let Ok(db) = Database::open(&db_path) {
+        if let Ok(entries) = db.list_app_settings_with_prefix("plugin:") {
+            for (key, value) in entries {
+                let rest = &key["plugin:".len()..];
+                if let Some((plugin_name, tail)) = rest.split_once(':') {
+                    if tail == "enabled" && value == "false" {
+                        plugins.set_disabled(plugin_name, true);
+                    } else if let Some(setting_key) = tail.strip_prefix("setting:") {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&value) {
+                            plugins.set_setting(plugin_name, setting_key, Some(v));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let app_state = state::AppState::new(db_path, worktree_base_dir, plugins);
     let remote_manager = remote::RemoteConnectionManager::new();
     let mcp_supervisor = std::sync::Arc::new(claudette::mcp_supervisor::McpSupervisor::new());
@@ -478,9 +499,15 @@ fn main() {
             commands::scm::scm_merge_pr,
             commands::scm::scm_refresh,
             // Env-provider diagnostic UI
-            commands::env::get_workspace_env_sources,
-            commands::env::reload_workspace_env,
+            commands::env::get_env_sources,
+            commands::env::reload_env,
             commands::env::set_env_provider_enabled,
+            commands::env::run_env_trust,
+            // Claudette Lua plugins (SCM + env-provider) settings surface
+            commands::plugins_runtime::list_claudette_plugins,
+            commands::plugins_runtime::set_claudette_plugin_enabled,
+            commands::plugins_runtime::set_claudette_plugin_setting,
+            commands::plugins_runtime::reseed_bundled_plugins,
             // Local server
             commands::remote::start_local_server,
             commands::remote::stop_local_server,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -89,26 +89,29 @@ pub async fn spawn_pty(
         repo_path: root_path.clone(),
     };
     let disabled_env_providers = {
-        // Look up the repo_id from the DB so we can honor per-repo
-        // user disables of env providers.
+        // Look up repo_id + per-repo env-provider disables in a single
+        // DB open — this runs on every PTY spawn, so avoid duplicate
+        // opens and workspace-list scans.
         use claudette::db::Database;
-        let repo_id = Database::open(&state.db_path)
+        Database::open(&state.db_path)
             .ok()
-            .and_then(|db| {
-                db.list_workspaces()
-                    .ok()?
-                    .into_iter()
-                    .find(|w| w.id == workspace_id)
-                    .map(|w| w.repository_id)
+            .map(|db| {
+                let repo_id = db
+                    .list_workspaces()
+                    .ok()
+                    .and_then(|ws| {
+                        ws.into_iter()
+                            .find(|w| w.id == workspace_id)
+                            .map(|w| w.repository_id)
+                    })
+                    .unwrap_or_default();
+                if repo_id.is_empty() {
+                    Default::default()
+                } else {
+                    crate::commands::env::load_disabled_providers(&db, &repo_id)
+                }
             })
-            .unwrap_or_default();
-        if repo_id.is_empty() {
-            Default::default()
-        } else {
-            claudette::db::Database::open(&state.db_path)
-                .map(|db| crate::commands::env::load_disabled_providers(&db, &repo_id))
-                .unwrap_or_default()
-        }
+            .unwrap_or_default()
     };
     let resolved_env = {
         let registry = state.plugins.read().await;

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -88,6 +88,28 @@ pub async fn spawn_pty(
         worktree_path: working_dir.clone(),
         repo_path: root_path.clone(),
     };
+    let disabled_env_providers = {
+        // Look up the repo_id from the DB so we can honor per-repo
+        // user disables of env providers.
+        use claudette::db::Database;
+        let repo_id = Database::open(&state.db_path)
+            .ok()
+            .and_then(|db| {
+                db.list_workspaces()
+                    .ok()?
+                    .into_iter()
+                    .find(|w| w.id == workspace_id)
+                    .map(|w| w.repository_id)
+            })
+            .unwrap_or_default();
+        if repo_id.is_empty() {
+            Default::default()
+        } else {
+            claudette::db::Database::open(&state.db_path)
+                .map(|db| crate::commands::env::load_disabled_providers(&db, &repo_id))
+                .unwrap_or_default()
+        }
+    };
     let resolved_env = {
         let registry = state.plugins.read().await;
         claudette::env_provider::resolve_with_registry(
@@ -95,16 +117,18 @@ pub async fn spawn_pty(
             &state.env_cache,
             std::path::Path::new(&working_dir),
             &ws_info,
+            &disabled_env_providers,
         )
         .await
     };
     for (k, v) in &resolved_env.vars {
         match v {
             Some(val) => cmd.env(k, val),
-            // portable-pty's CommandBuilder has no env_remove — but since
-            // the PTY inherits only what we explicitly set, simply omitting
-            // a key is the "unset" semantic here. Skip None-valued entries.
-            None => continue,
+            // portable-pty's CommandBuilder inherits the base env, so
+            // None-valued entries must be explicitly removed rather
+            // than just skipped — otherwise the interactive shell
+            // silently picks up the parent-process value.
+            None => cmd.env_remove(k),
         }
     }
 

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -74,7 +74,42 @@ pub async fn spawn_pty(
     cmd.cwd(&working_dir);
     configure_pty_env(&mut cmd);
 
-    // Set workspace context env vars for scripts and tools.
+    // Resolve the env-provider layer for this workspace.
+    // Unlike the agent spawn path, the PTY hosts an interactive shell that
+    // runs the user's profile — so ~/.zprofile / ~/.bashrc / direnv shell
+    // hooks will ALSO layer env on top of whatever we set here. The result
+    // is: our CLAUDETTE_* markers + direnv/mise/dotenv/nix-devshell env is
+    // the "base" the shell inherits; the user's shell profile runs after
+    // and can override/add if they want.
+    let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
+        id: workspace_id.clone(),
+        name: workspace_name.clone(),
+        branch: branch_name.clone(),
+        worktree_path: working_dir.clone(),
+        repo_path: root_path.clone(),
+    };
+    let resolved_env = {
+        let registry = state.plugins.read().await;
+        claudette::env_provider::resolve_with_registry(
+            &registry,
+            &state.env_cache,
+            std::path::Path::new(&working_dir),
+            &ws_info,
+        )
+        .await
+    };
+    for (k, v) in &resolved_env.vars {
+        match v {
+            Some(val) => cmd.env(k, val),
+            // portable-pty's CommandBuilder has no env_remove — but since
+            // the PTY inherits only what we explicitly set, simply omitting
+            // a key is the "unset" semantic here. Skip None-valued entries.
+            None => continue,
+        }
+    }
+
+    // Set workspace context env vars for scripts and tools. Applied AFTER
+    // resolved_env so CLAUDETTE_* markers always win.
     let ws_env = claudette::env::WorkspaceEnv {
         workspace_name,
         workspace_id,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,6 +8,7 @@ use claudette::agent::PersistentSession;
 use parking_lot::Mutex as ParkingMutex;
 use tokio::sync::{RwLock, Semaphore};
 
+use claudette::env_provider::EnvCache;
 use claudette::plugin_runtime::PluginRegistry;
 use claudette::scm::types::{CiCheck, PullRequest};
 
@@ -283,6 +284,10 @@ pub struct AppState {
     pub usage_cache: RwLock<Option<UsageCacheEntry>>,
     /// SCM provider plugin registry.
     pub plugins: RwLock<PluginRegistry>,
+    /// mtime-keyed cache of env-provider exports. One entry per
+    /// `(worktree, plugin_name)` pair, invalidated when any watched
+    /// file (`.envrc`, `mise.toml`, `.env`, `flake.lock`, etc.) changes.
+    pub env_cache: Arc<EnvCache>,
     /// Cached PR/CI status data keyed by (repo_id, branch_name).
     pub scm_cache: ScmCache,
     /// Limits concurrent SCM CLI invocations.
@@ -316,6 +321,7 @@ impl AppState {
             next_tray_seq: AtomicU64::new(1),
             usage_cache: RwLock::new(None),
             plugins: RwLock::new(plugins),
+            env_cache: Arc::new(EnvCache::new()),
             scm_cache: ScmCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -88,6 +88,14 @@ pub struct AgentSessionState {
     /// `plan_mode=false` on the next turn, so we force a teardown regardless
     /// of the requested flag. Reset after teardown.
     pub session_exited_plan: bool,
+    /// Snapshot of the env-provider resolved env `vars` map baked into
+    /// the current persistent session at spawn. Each new turn re-resolves
+    /// and compares; any divergence (user edited `.envrc`, ran
+    /// `direnv allow`, toggled a provider, changed a plugin setting)
+    /// forces a teardown so the fresh env reaches the agent subprocess.
+    /// Stored as a plain map because `EnvMap` already is one; keeping a
+    /// snapshot lets the comparison be a single equality check.
+    pub session_resolved_env: claudette::env_provider::types::EnvMap,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -747,6 +747,7 @@ mod tests {
             session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
             session_exited_plan: false,
+            session_resolved_env: Default::default(),
         }
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -791,6 +791,7 @@ pub async fn run_turn(
     settings: &AgentSettings,
     attachments: &[FileAttachment],
     ws_env: Option<&WorkspaceEnv>,
+    resolved_env: Option<&crate::env_provider::ResolvedEnv>,
 ) -> Result<TurnHandle, String> {
     let has_attachments = !attachments.is_empty();
     let args = build_claude_args(
@@ -829,6 +830,14 @@ pub async fn run_turn(
     }
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+    // Apply user-provided env-provider output (direnv / mise / nix-devshell /
+    // dotenv) BEFORE the workspace's CLAUDETTE_* markers so those always win,
+    // and BEFORE the settings-driven 1M-context toggle so the UI choice
+    // cannot be overridden by a provider that happens to export the same key.
+    if let Some(env) = resolved_env {
+        env.apply(&mut cmd);
+    }
 
     cmd.env_remove("CLAUDE_CODE_DISABLE_1M_CONTEXT");
     if settings.disable_1m_context {
@@ -1066,6 +1075,7 @@ impl PersistentSession {
         custom_instructions: Option<&str>,
         settings: &AgentSettings,
         ws_env: Option<&WorkspaceEnv>,
+        resolved_env: Option<&crate::env_provider::ResolvedEnv>,
     ) -> Result<Self, String> {
         let args = build_persistent_args(
             session_id,
@@ -1093,6 +1103,12 @@ impl PersistentSession {
         }
         cmd.env_remove("CLAUDECODE");
         cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+
+        // See run_turn for layering rationale — env-provider output under
+        // the CLAUDETTE_* markers, under the settings-driven context toggle.
+        if let Some(env) = resolved_env {
+            env.apply(&mut cmd);
+        }
 
         cmd.env_remove("CLAUDE_CODE_DISABLE_1M_CONTEXT");
         if settings.disable_1m_context {

--- a/src/db.rs
+++ b/src/db.rs
@@ -396,6 +396,41 @@ impl Database {
         Ok(())
     }
 
+    /// Delete a single app setting. Returns Ok(()) whether the key
+    /// existed or not — callers using "absent means default" semantics
+    /// (e.g. env-provider enable/disable) don't care.
+    pub fn delete_app_setting(&self, key: &str) -> Result<(), rusqlite::Error> {
+        self.conn
+            .execute("DELETE FROM app_settings WHERE key = ?1", params![key])?;
+        Ok(())
+    }
+
+    /// Return every `(key, value)` whose key starts with `prefix`.
+    /// Used by features that namespace many related settings under one
+    /// prefix (e.g. per-provider env-provider enable flags) and need to
+    /// enumerate them efficiently.
+    pub fn list_app_settings_with_prefix(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<(String, String)>, rusqlite::Error> {
+        // Escape LIKE metacharacters so a prefix containing % or _ doesn't
+        // accidentally match unrelated keys. ESCAPE '\' designates the
+        // backslash as the literal-escape marker.
+        let escaped: String = prefix
+            .chars()
+            .flat_map(|c| match c {
+                '%' | '_' | '\\' => vec!['\\', c],
+                _ => vec![c],
+            })
+            .collect();
+        let pattern = format!("{escaped}%");
+        let mut stmt = self.conn.prepare(
+            "SELECT key, value FROM app_settings WHERE key LIKE ?1 ESCAPE '\\' ORDER BY key",
+        )?;
+        let rows = stmt.query_map(params![pattern], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        rows.collect()
+    }
+
     // --- Workspaces ---
 
     pub fn insert_workspace(&self, ws: &Workspace) -> Result<(), rusqlite::Error> {

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -120,22 +120,28 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
             ))
         })?;
 
-        let env = obj
-            .get("env")
-            .and_then(|v| v.as_object())
-            .map(|m| {
-                m.iter()
-                    .map(|(k, v)| {
-                        let val = match v {
-                            serde_json::Value::Null => None,
-                            serde_json::Value::String(s) => Some(s.clone()),
-                            other => Some(other.to_string()),
-                        };
-                        (k.clone(), val)
-                    })
-                    .collect::<EnvMap>()
-            })
-            .unwrap_or_default();
+        let env = match obj.get("env").and_then(|v| v.as_object()) {
+            Some(m) => {
+                let mut env = EnvMap::new();
+                for (k, v) in m.iter() {
+                    let val = match v {
+                        serde_json::Value::Null => None,
+                        serde_json::Value::String(s) => Some(s.clone()),
+                        // OS env vars are strings. Silently stringifying
+                        // objects/arrays/numbers would hide plugin bugs —
+                        // surface them as a clear parse error instead.
+                        _ => {
+                            return Err(PluginError::ParseError(format!(
+                                "{plugin}: export().env[{k:?}] must be a string or null"
+                            )));
+                        }
+                    };
+                    env.insert(k.clone(), val);
+                }
+                env
+            }
+            None => EnvMap::default(),
+        };
 
         let watched: Vec<PathBuf> = obj
             .get("watched")

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -28,6 +28,17 @@ pub trait EnvProviderBackend: Send + Sync {
     /// `kind = "env-provider"`.
     fn env_provider_names(&self) -> Vec<String>;
 
+    /// True when the plugin is globally disabled and must not run,
+    /// regardless of per-repo toggle state. The dispatcher checks this
+    /// alongside the caller-supplied `disabled` HashSet and treats a
+    /// hit identically — invalidates the cache and records a
+    /// `disabled` source. Keeping the check on the backend (rather
+    /// than relying on callers to merge in the registry's state) makes
+    /// direct uses of [`resolve_for_workspace`] safe too.
+    fn is_plugin_disabled(&self, _plugin: &str) -> bool {
+        false
+    }
+
     /// Run the plugin's `detect` operation. Returns `true` if the
     /// plugin wants to contribute env for this worktree.
     fn detect(
@@ -66,6 +77,10 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
             .filter(|(_, p)| p.manifest.kind == PluginKind::EnvProvider)
             .map(|(name, _)| name.clone())
             .collect()
+    }
+
+    fn is_plugin_disabled(&self, plugin: &str) -> bool {
+        self.registry.is_disabled(plugin)
     }
 
     async fn detect(
@@ -154,6 +169,8 @@ pub(crate) mod mock {
         /// Counts per plugin: (detect_calls, export_calls). Used by tests to
         /// assert cache behavior (e.g., that export was NOT called on a cache hit).
         pub calls: Mutex<HashMap<String, (usize, usize)>>,
+        /// Plugin names that should report as globally disabled.
+        pub globally_disabled: std::collections::HashSet<String>,
     }
 
     impl MockBackend {
@@ -163,7 +180,13 @@ pub(crate) mod mock {
                 detect_results: HashMap::new(),
                 export_results: HashMap::new(),
                 calls: Mutex::new(HashMap::new()),
+                globally_disabled: std::collections::HashSet::new(),
             }
+        }
+
+        pub fn with_globally_disabled(mut self, name: &str) -> Self {
+            self.globally_disabled.insert(name.to_string());
+            self
         }
 
         pub fn with_plugin(mut self, name: &str) -> Self {
@@ -200,6 +223,10 @@ pub(crate) mod mock {
     impl EnvProviderBackend for MockBackend {
         fn env_provider_names(&self) -> Vec<String> {
             self.plugins.clone()
+        }
+
+        fn is_plugin_disabled(&self, plugin: &str) -> bool {
+            self.globally_disabled.contains(plugin)
         }
 
         async fn detect(

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -1,0 +1,243 @@
+//! Backend trait abstracting plugin invocation for the env-provider
+//! dispatcher.
+//!
+//! The dispatcher is generic over this trait so unit tests can drive it
+//! with a synthetic [`mock::MockBackend`] without spinning up a real
+//! [`PluginRegistry`] (which needs a Lua VM per call, making unit tests
+//! expensive).
+//!
+//! The real implementation [`PluginRegistryBackend`] wraps a
+//! `&PluginRegistry` and forwards calls to `call_operation`.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+
+use crate::plugin_runtime::host_api::WorkspaceInfo;
+use crate::plugin_runtime::manifest::PluginKind;
+use crate::plugin_runtime::{PluginError, PluginRegistry};
+
+use super::types::{EnvMap, ProviderExport};
+
+/// Abstraction over the plugin runtime for the env-provider dispatcher.
+///
+/// Two impls:
+/// - [`PluginRegistryBackend`]: production — calls into the real Lua runtime.
+/// - `mock::MockBackend`: tests — returns canned results synchronously.
+pub trait EnvProviderBackend: Send + Sync {
+    /// Names of all loaded plugins whose manifest declares
+    /// `kind = "env-provider"`.
+    fn env_provider_names(&self) -> Vec<String>;
+
+    /// Run the plugin's `detect` operation. Returns `true` if the
+    /// plugin wants to contribute env for this worktree.
+    fn detect(
+        &self,
+        plugin: &str,
+        worktree: &Path,
+        ws_info: &WorkspaceInfo,
+    ) -> impl Future<Output = Result<bool, PluginError>> + Send;
+
+    /// Run the plugin's `export` operation. Only called when `detect`
+    /// returned `true`.
+    fn export(
+        &self,
+        plugin: &str,
+        worktree: &Path,
+        ws_info: &WorkspaceInfo,
+    ) -> impl Future<Output = Result<ProviderExport, PluginError>> + Send;
+}
+
+/// Production backend wrapping a [`PluginRegistry`].
+pub struct PluginRegistryBackend<'a> {
+    pub registry: &'a PluginRegistry,
+}
+
+impl<'a> PluginRegistryBackend<'a> {
+    pub fn new(registry: &'a PluginRegistry) -> Self {
+        Self { registry }
+    }
+}
+
+impl EnvProviderBackend for PluginRegistryBackend<'_> {
+    fn env_provider_names(&self) -> Vec<String> {
+        self.registry
+            .plugins
+            .iter()
+            .filter(|(_, p)| p.manifest.kind == PluginKind::EnvProvider)
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
+    async fn detect(
+        &self,
+        plugin: &str,
+        worktree: &Path,
+        ws_info: &WorkspaceInfo,
+    ) -> Result<bool, PluginError> {
+        let args = serde_json::json!({
+            "worktree": worktree.to_string_lossy(),
+        });
+        let result = self
+            .registry
+            .call_operation(plugin, "detect", args, ws_info.clone())
+            .await?;
+        Ok(result.as_bool().unwrap_or(false))
+    }
+
+    async fn export(
+        &self,
+        plugin: &str,
+        worktree: &Path,
+        ws_info: &WorkspaceInfo,
+    ) -> Result<ProviderExport, PluginError> {
+        let args = serde_json::json!({
+            "worktree": worktree.to_string_lossy(),
+        });
+        let result = self
+            .registry
+            .call_operation(plugin, "export", args, ws_info.clone())
+            .await?;
+
+        // Expected shape: { env: { KEY: "value" | nil, ... }, watched: ["path", ...] }
+        let obj = result.as_object().ok_or_else(|| {
+            PluginError::ParseError(format!(
+                "{plugin}: export() must return a table with `env` and `watched` fields"
+            ))
+        })?;
+
+        let env = obj
+            .get("env")
+            .and_then(|v| v.as_object())
+            .map(|m| {
+                m.iter()
+                    .map(|(k, v)| {
+                        let val = match v {
+                            serde_json::Value::Null => None,
+                            serde_json::Value::String(s) => Some(s.clone()),
+                            other => Some(other.to_string()),
+                        };
+                        (k.clone(), val)
+                    })
+                    .collect::<EnvMap>()
+            })
+            .unwrap_or_default();
+
+        let watched: Vec<PathBuf> = obj
+            .get("watched")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(PathBuf::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(ProviderExport { env, watched })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod mock {
+    //! Synthetic backend for dispatcher unit tests.
+
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    pub struct MockBackend {
+        pub plugins: Vec<String>,
+        /// Controls what each plugin's detect returns. Default (absent): false.
+        pub detect_results: HashMap<String, Result<bool, String>>,
+        /// Controls what each plugin's export returns.
+        pub export_results: HashMap<String, Result<ProviderExport, String>>,
+        /// Counts per plugin: (detect_calls, export_calls). Used by tests to
+        /// assert cache behavior (e.g., that export was NOT called on a cache hit).
+        pub calls: Mutex<HashMap<String, (usize, usize)>>,
+    }
+
+    impl MockBackend {
+        pub fn new() -> Self {
+            Self {
+                plugins: vec![],
+                detect_results: HashMap::new(),
+                export_results: HashMap::new(),
+                calls: Mutex::new(HashMap::new()),
+            }
+        }
+
+        pub fn with_plugin(mut self, name: &str) -> Self {
+            self.plugins.push(name.to_string());
+            self
+        }
+
+        pub fn detects(mut self, name: &str, value: bool) -> Self {
+            self.detect_results.insert(name.to_string(), Ok(value));
+            self
+        }
+
+        pub fn exports(mut self, name: &str, export: ProviderExport) -> Self {
+            self.export_results.insert(name.to_string(), Ok(export));
+            self
+        }
+
+        pub fn export_fails(mut self, name: &str, msg: &str) -> Self {
+            self.export_results
+                .insert(name.to_string(), Err(msg.to_string()));
+            self
+        }
+
+        pub fn call_counts(&self, name: &str) -> (usize, usize) {
+            self.calls
+                .lock()
+                .unwrap()
+                .get(name)
+                .copied()
+                .unwrap_or((0, 0))
+        }
+    }
+
+    impl EnvProviderBackend for MockBackend {
+        fn env_provider_names(&self) -> Vec<String> {
+            self.plugins.clone()
+        }
+
+        async fn detect(
+            &self,
+            plugin: &str,
+            _worktree: &Path,
+            _ws_info: &WorkspaceInfo,
+        ) -> Result<bool, PluginError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .entry(plugin.to_string())
+                .or_default()
+                .0 += 1;
+            match self.detect_results.get(plugin) {
+                Some(Ok(v)) => Ok(*v),
+                Some(Err(e)) => Err(PluginError::ScriptError(e.clone())),
+                None => Ok(false),
+            }
+        }
+
+        async fn export(
+            &self,
+            plugin: &str,
+            _worktree: &Path,
+            _ws_info: &WorkspaceInfo,
+        ) -> Result<ProviderExport, PluginError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .entry(plugin.to_string())
+                .or_default()
+                .1 += 1;
+            match self.export_results.get(plugin) {
+                Some(Ok(v)) => Ok(v.clone()),
+                Some(Err(e)) => Err(PluginError::ScriptError(e.clone())),
+                None => Err(PluginError::OperationNotSupported("export".into())),
+            }
+        }
+    }
+}

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -143,13 +143,23 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
             None => EnvMap::default(),
         };
 
+        // Normalize every watched entry to an absolute path. Plugin
+        // authors naturally return relative names (".envrc",
+        // "mise.toml", "flake.lock"), and our bundled plugins already
+        // join to worktree — but third-party plugins shouldn't have to
+        // think about this, and without the join EnvCache would stat
+        // relative paths against the app's CWD and silently never
+        // invalidate.
         let watched: Vec<PathBuf> = obj
             .get("watched")
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
                     .filter_map(|v| v.as_str())
-                    .map(PathBuf::from)
+                    .map(|s| {
+                        let p = PathBuf::from(s);
+                        if p.is_relative() { worktree.join(p) } else { p }
+                    })
                     .collect()
             })
             .unwrap_or_default();

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -68,22 +68,42 @@ impl EnvCache {
 
     /// Store (or overwrite) the cache entry for `(worktree, plugin)`.
     ///
-    /// `ProviderExport.watched` is snapshotted: each path's current
-    /// mtime is recorded alongside it, so future `get_fresh` calls can
-    /// detect changes.
-    pub fn put(&self, worktree: &Path, plugin: &str, export: &ProviderExport) {
-        let key = (worktree.to_path_buf(), plugin.to_string());
-        let watched = export
+    /// Returns `true` if the entry was stored, `false` if it was dropped
+    /// because a watched file's mtime changed between the two snapshots
+    /// we take (before-store and after-store). The race we're guarding:
+    ///
+    ///   t0: plugin's `export()` captures env based on on-disk content
+    ///   t1: we snapshot mtimes ("first")
+    ///   t2: we snapshot mtimes again ("second")
+    ///   t3: caller stores the entry
+    ///
+    /// If a file changes during [t1, t2] we see it here and refuse to
+    /// cache — the next resolve will re-run `export()` and pick up the
+    /// fresh state. A change during [t0, t1] still slips through (we
+    /// cache stale env under the post-change mtime), but the window is
+    /// microseconds and — being bounded above by the slowest syscall —
+    /// small enough that not-caching-at-all would be more wasteful than
+    /// the occasional stale turn. File-content hashing would fully close
+    /// this and is v2 work.
+    pub fn put(&self, worktree: &Path, plugin: &str, export: &ProviderExport) -> bool {
+        let first: Vec<(PathBuf, Option<SystemTime>)> = export
             .watched
             .iter()
             .map(|p| (p.clone(), mtime(p)))
             .collect();
+        let second: Vec<Option<SystemTime>> = export.watched.iter().map(|p| mtime(p)).collect();
+        if first.iter().zip(second.iter()).any(|((_, a), b)| a != b) {
+            return false;
+        }
+
+        let key = (worktree.to_path_buf(), plugin.to_string());
         let entry = CacheEntry {
             env: export.env.clone(),
-            watched,
+            watched: first,
             evaluated_at: SystemTime::now(),
         };
         self.entries.write().unwrap().insert(key, entry);
+        true
     }
 
     /// Forget the cache for `(worktree, plugin)`. If `plugin` is `None`,

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -121,6 +121,14 @@ impl EnvCache {
         }
     }
 
+    /// Forget every cache entry for a given plugin, across all
+    /// worktrees. Called when a plugin's global enable state or
+    /// settings change — any cached export is potentially stale.
+    pub fn invalidate_plugin_everywhere(&self, plugin: &str) {
+        let mut guard = self.entries.write().unwrap();
+        guard.retain(|(_, p), _| p != plugin);
+    }
+
     #[cfg(test)]
     pub fn len(&self) -> usize {
         self.entries.read().unwrap().len()
@@ -226,6 +234,29 @@ mod tests {
         assert_eq!(cache.len(), 1);
         assert!(cache.get_fresh(tmp.path(), "env-direnv").is_none());
         assert!(cache.get_fresh(tmp.path(), "env-mise").is_some());
+    }
+
+    #[test]
+    fn invalidate_plugin_everywhere_drops_all_worktrees_for_plugin() {
+        let tmp_a = tempfile::tempdir().unwrap();
+        let tmp_b = tempfile::tempdir().unwrap();
+        let file_a = tmp_a.path().join(".envrc");
+        let file_b = tmp_b.path().join(".envrc");
+        std::fs::write(&file_a, "x").unwrap();
+        std::fs::write(&file_b, "x").unwrap();
+
+        let cache = EnvCache::new();
+        cache.put(tmp_a.path(), "env-direnv", &export_with_watched(&file_a));
+        cache.put(tmp_a.path(), "env-mise", &export_with_watched(&file_a));
+        cache.put(tmp_b.path(), "env-direnv", &export_with_watched(&file_b));
+        assert_eq!(cache.len(), 3);
+
+        cache.invalidate_plugin_everywhere("env-direnv");
+
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get_fresh(tmp_a.path(), "env-direnv").is_none());
+        assert!(cache.get_fresh(tmp_b.path(), "env-direnv").is_none());
+        assert!(cache.get_fresh(tmp_a.path(), "env-mise").is_some());
     }
 
     #[test]

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -1,0 +1,223 @@
+//! In-memory cache for env-provider exports, keyed by `(worktree, plugin_name)`.
+//!
+//! The cache stores each plugin's last [`ProviderExport`] alongside the
+//! mtimes of the files it reported as `watched`. On lookup, we re-stat
+//! those files; if all mtimes are unchanged, the cached entry is
+//! returned and the plugin's `export` operation is skipped (no Lua VM
+//! spin-up, no subprocess).
+//!
+//! Scope of invalidation covered by v1:
+//! - `.envrc` / `mise.toml` / `.env` / `flake.lock` edits → mtime
+//!   changes → cache miss → re-export.
+//! - File deletion → stat fails → treated as "mtime changed" → miss.
+//!
+//! Not covered (v2+ work):
+//! - A plugin starts watching a *new* file on a later call (e.g. user
+//!   adds `.envrc.local`). We only know what the previous export told
+//!   us to watch. Acceptable because direnv's `DIRENV_WATCHES` updates
+//!   inside `.envrc` — the `.envrc` mtime changing forces a re-eval.
+//! - User runs `direnv deny` without editing `.envrc` → cache stays
+//!   fresh until next `.envrc` mtime change. Workaround: UI "Reload".
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::SystemTime;
+
+use super::types::{EnvMap, ProviderExport};
+
+/// Cache entry for a single `(worktree, plugin)` pair.
+#[derive(Debug, Clone)]
+pub struct CacheEntry {
+    /// Exported env. Kept separate from `ProviderExport` so we can
+    /// clone cheaply without re-walking the watched list.
+    pub env: EnvMap,
+    /// Files we watch for invalidation, paired with their mtime at the
+    /// time of the last successful export.
+    pub watched: Vec<(PathBuf, Option<SystemTime>)>,
+    /// When this entry was written.
+    pub evaluated_at: SystemTime,
+}
+
+type Key = (PathBuf, String);
+
+#[derive(Default, Debug)]
+pub struct EnvCache {
+    entries: RwLock<HashMap<Key, CacheEntry>>,
+}
+
+impl EnvCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached entry if all watched files' current mtimes
+    /// match the stored values. Any change → stale → returns `None`.
+    pub fn get_fresh(&self, worktree: &Path, plugin: &str) -> Option<CacheEntry> {
+        let key = (worktree.to_path_buf(), plugin.to_string());
+        let guard = self.entries.read().unwrap();
+        let entry = guard.get(&key)?.clone();
+        drop(guard);
+
+        if all_mtimes_match(&entry.watched) {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    /// Store (or overwrite) the cache entry for `(worktree, plugin)`.
+    ///
+    /// `ProviderExport.watched` is snapshotted: each path's current
+    /// mtime is recorded alongside it, so future `get_fresh` calls can
+    /// detect changes.
+    pub fn put(&self, worktree: &Path, plugin: &str, export: &ProviderExport) {
+        let key = (worktree.to_path_buf(), plugin.to_string());
+        let watched = export
+            .watched
+            .iter()
+            .map(|p| (p.clone(), mtime(p)))
+            .collect();
+        let entry = CacheEntry {
+            env: export.env.clone(),
+            watched,
+            evaluated_at: SystemTime::now(),
+        };
+        self.entries.write().unwrap().insert(key, entry);
+    }
+
+    /// Forget the cache for `(worktree, plugin)`. If `plugin` is `None`,
+    /// forget all plugins for the worktree. Used by the "Reload env" UI
+    /// action and by detect=false (plugin no longer applies).
+    pub fn invalidate(&self, worktree: &Path, plugin: Option<&str>) {
+        let mut guard = self.entries.write().unwrap();
+        match plugin {
+            Some(p) => {
+                guard.remove(&(worktree.to_path_buf(), p.to_string()));
+            }
+            None => {
+                guard.retain(|(wt, _), _| wt != worktree);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.read().unwrap().len()
+    }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.read().unwrap().is_empty()
+    }
+}
+
+/// Read a file's mtime, returning `None` if the file is missing or
+/// unreadable. A missing file on lookup counts as "mtime changed" vs.
+/// its previous `Some(_)` — it will not match, so the cache misses.
+fn mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+fn all_mtimes_match(watched: &[(PathBuf, Option<SystemTime>)]) -> bool {
+    watched.iter().all(|(p, stored)| mtime(p) == *stored)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn export_with_watched(path: &Path) -> ProviderExport {
+        let mut env = EnvMap::new();
+        env.insert("FOO".into(), Some("bar".into()));
+        ProviderExport {
+            env,
+            watched: vec![path.to_path_buf()],
+        }
+    }
+
+    #[test]
+    fn put_then_get_returns_fresh_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "use flake").unwrap();
+
+        let cache = EnvCache::new();
+        let export = export_with_watched(&file);
+        cache.put(tmp.path(), "env-direnv", &export);
+
+        let entry = cache.get_fresh(tmp.path(), "env-direnv").unwrap();
+        assert_eq!(entry.env.get("FOO").unwrap().as_deref(), Some("bar"));
+    }
+
+    #[test]
+    fn get_fresh_returns_none_when_mtime_changes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "use flake").unwrap();
+
+        let cache = EnvCache::new();
+        cache.put(tmp.path(), "env-direnv", &export_with_watched(&file));
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        // Force a distinguishable mtime. Sleep is unavoidable on
+        // filesystems with second-level mtime resolution (most of ext4,
+        // HFS+). 1100ms is enough to cross the boundary reliably.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&file, "export FOO=baz").unwrap();
+
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "mtime change must invalidate"
+        );
+    }
+
+    #[test]
+    fn get_fresh_returns_none_when_watched_file_is_deleted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "use flake").unwrap();
+
+        let cache = EnvCache::new();
+        cache.put(tmp.path(), "env-direnv", &export_with_watched(&file));
+        std::fs::remove_file(&file).unwrap();
+
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_none());
+    }
+
+    #[test]
+    fn get_fresh_returns_none_when_no_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = EnvCache::new();
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_none());
+    }
+
+    #[test]
+    fn invalidate_single_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "x").unwrap();
+        let cache = EnvCache::new();
+        cache.put(tmp.path(), "env-direnv", &export_with_watched(&file));
+        cache.put(tmp.path(), "env-mise", &export_with_watched(&file));
+        assert_eq!(cache.len(), 2);
+
+        cache.invalidate(tmp.path(), Some("env-direnv"));
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_none());
+        assert!(cache.get_fresh(tmp.path(), "env-mise").is_some());
+    }
+
+    #[test]
+    fn invalidate_entire_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "x").unwrap();
+        let cache = EnvCache::new();
+        cache.put(tmp.path(), "env-direnv", &export_with_watched(&file));
+        cache.put(tmp.path(), "env-mise", &export_with_watched(&file));
+
+        cache.invalidate(tmp.path(), None);
+        assert_eq!(cache.len(), 0);
+    }
+}

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -30,8 +30,22 @@ use serde::Serialize;
 use crate::plugin_runtime::host_api::WorkspaceInfo;
 
 use backend::EnvProviderBackend;
-use cache::EnvCache;
+pub use backend::PluginRegistryBackend;
+pub use cache::EnvCache;
 use types::EnvMap;
+
+/// Convenience helper that wires the standard [`PluginRegistryBackend`]
+/// into [`resolve_for_workspace`] with minimal boilerplate at the call
+/// site. The tauri layer uses this from spawn command handlers.
+pub async fn resolve_with_registry(
+    registry: &crate::plugin_runtime::PluginRegistry,
+    cache: &EnvCache,
+    worktree: &Path,
+    ws_info: &WorkspaceInfo,
+) -> ResolvedEnv {
+    let backend = PluginRegistryBackend::new(registry);
+    resolve_for_workspace(&backend, cache, worktree, ws_info).await
+}
 
 /// The merged env contributed by all detected env-provider plugins.
 #[derive(Debug, Default, Clone)]

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -38,10 +38,9 @@ use types::EnvMap;
 /// into [`resolve_for_workspace`] with minimal boilerplate at the call
 /// site. The tauri layer uses this from spawn command handlers.
 ///
-/// Merges the per-repo `disabled` set with the registry's globally-
-/// disabled plugin names so the dispatcher sees a single "skip this"
-/// set and globally-off plugins show up in the UI as cleanly disabled
-/// (rather than as a `PluginDisabled` error surfaced through detect).
+/// The dispatcher consults the backend directly for global-disable
+/// state (via [`EnvProviderBackend::is_plugin_disabled`]), so callers
+/// only need to pass their per-repo disabled set here.
 pub async fn resolve_with_registry(
     registry: &crate::plugin_runtime::PluginRegistry,
     cache: &EnvCache,
@@ -50,13 +49,7 @@ pub async fn resolve_with_registry(
     disabled: &std::collections::HashSet<String>,
 ) -> ResolvedEnv {
     let backend = PluginRegistryBackend::new(registry);
-    let mut merged_disabled = disabled.clone();
-    for name in backend.env_provider_names() {
-        if registry.is_disabled(&name) {
-            merged_disabled.insert(name);
-        }
-    }
-    resolve_for_workspace(&backend, cache, worktree, ws_info, &merged_disabled).await
+    resolve_for_workspace(&backend, cache, worktree, ws_info, disabled).await
 }
 
 /// The merged env contributed by all detected env-provider plugins.
@@ -181,9 +174,14 @@ pub async fn resolve_for_workspace(
     let mut sources = Vec::with_capacity(names.len());
 
     for name in names {
-        if disabled.contains(&name) {
-            // User explicitly turned this provider off — drop any cached
-            // result so re-enabling it forces a fresh evaluation.
+        // "Disabled" means either:
+        //   - the user toggled it off per-repo (Environment panel), or
+        //   - the plugin is globally disabled in the Plugins settings
+        //     section (via `backend.is_plugin_disabled`).
+        // Both surface the same way to the UI (`error: "disabled"`)
+        // and drop any stale cache entry so re-enabling forces a
+        // fresh evaluation on the next resolve.
+        if disabled.contains(&name) || backend.is_plugin_disabled(&name) {
             cache.invalidate(worktree, Some(&name));
             sources.push(ResolvedSource {
                 plugin_name: name,
@@ -730,6 +728,60 @@ mod tests {
         assert!(
             cache.get_fresh(tmp.path(), "env-direnv").is_none(),
             "detect=false must evict the stale cache entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn globally_disabled_skips_even_with_warm_cache() {
+        // Regression for the Codex finding: even when a plugin had a
+        // previously-cached export, flipping it off globally must stop
+        // its vars from reaching the merged env on the next resolve.
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = EnvCache::new();
+
+        // Seed a warm cache entry for env-direnv pointing at a real
+        // file so the mtime check would otherwise keep it fresh.
+        let watched = tmp.path().join(".envrc");
+        std::fs::write(&watched, "x").unwrap();
+        let export = ProviderExport {
+            env: {
+                let mut m = EnvMap::new();
+                m.insert("SHOULD_NOT_SHOW".into(), Some("leaked".into()));
+                m
+            },
+            watched: vec![watched.clone()],
+        };
+        cache.put(tmp.path(), "env-direnv", &export);
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .with_globally_disabled("env-direnv")
+            .detects("env-direnv", true)
+            .exports("env-direnv", export.clone());
+
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+
+        assert!(
+            !resolved.vars.contains_key("SHOULD_NOT_SHOW"),
+            "globally-disabled plugin must not contribute vars (warm cache leak)"
+        );
+        let source = resolved
+            .sources
+            .iter()
+            .find(|s| s.plugin_name == "env-direnv")
+            .expect("plugin must appear in sources");
+        assert_eq!(source.error.as_deref(), Some("disabled"));
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "disable must invalidate the cache entry"
         );
     }
 

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -42,9 +42,10 @@ pub async fn resolve_with_registry(
     cache: &EnvCache,
     worktree: &Path,
     ws_info: &WorkspaceInfo,
+    disabled: &std::collections::HashSet<String>,
 ) -> ResolvedEnv {
     let backend = PluginRegistryBackend::new(registry);
-    resolve_for_workspace(&backend, cache, worktree, ws_info).await
+    resolve_for_workspace(&backend, cache, worktree, ws_info, disabled).await
 }
 
 /// The merged env contributed by all detected env-provider plugins.
@@ -142,20 +143,47 @@ pub fn precedence_of(name: &str) -> i32 {
 /// Iterates in ascending precedence order; later (higher) providers
 /// overwrite earlier (lower) ones on key collision. `None` values unset
 /// the key from the merged map.
+///
+/// When a plugin name appears in `disabled`, it's skipped entirely —
+/// `detect` is not called, the cache is not consulted, and the source
+/// entry records `detected=false` with an `"disabled"` error string so
+/// the UI can distinguish user-disabled from not-applicable.
 pub async fn resolve_for_workspace(
     backend: &impl EnvProviderBackend,
     cache: &EnvCache,
     worktree: &Path,
     ws_info: &WorkspaceInfo,
+    disabled: &std::collections::HashSet<String>,
 ) -> ResolvedEnv {
     let mut names = backend.env_provider_names();
-    // Sort ascending: lowest precedence first, so higher overwrites on merge.
-    names.sort_by_key(|n| precedence_of(n));
+    // Sort: primary by precedence (ascending, so higher overwrites on
+    // merge); secondary by name so unknown providers with tied
+    // precedence collide deterministically instead of by HashMap
+    // iteration order.
+    names.sort_by(|a, b| {
+        precedence_of(a)
+            .cmp(&precedence_of(b))
+            .then_with(|| a.cmp(b))
+    });
 
     let mut merged = EnvMap::new();
     let mut sources = Vec::with_capacity(names.len());
 
     for name in names {
+        if disabled.contains(&name) {
+            // User explicitly turned this provider off — drop any cached
+            // result so re-enabling it forces a fresh evaluation.
+            cache.invalidate(worktree, Some(&name));
+            sources.push(ResolvedSource {
+                plugin_name: name,
+                detected: false,
+                vars_contributed: 0,
+                cached: false,
+                evaluated_at: SystemTime::now(),
+                error: Some("disabled".to_string()),
+            });
+            continue;
+        }
         let source = resolve_one(backend, cache, &name, worktree, ws_info, &mut merged).await;
         sources.push(source);
     }
@@ -283,8 +311,14 @@ mod tests {
     async fn resolve_empty_no_plugins() {
         let backend = MockBackend::new();
         let cache = EnvCache::new();
-        let resolved =
-            resolve_for_workspace(&backend, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            std::path::Path::new("/tmp"),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
         assert!(resolved.vars.is_empty());
         assert!(resolved.sources.is_empty());
     }
@@ -302,7 +336,14 @@ mod tests {
                 export_of(&[("FOO", Some("bar"))], vec![tmp.path().join(".envrc")]),
             );
         let cache = EnvCache::new();
-        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         assert_eq!(resolved.vars.get("FOO").unwrap().as_deref(), Some("bar"));
         assert_eq!(resolved.sources.len(), 1);
@@ -318,8 +359,14 @@ mod tests {
             .with_plugin("env-direnv")
             .detects("env-direnv", false);
         let cache = EnvCache::new();
-        let resolved =
-            resolve_for_workspace(&backend, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            std::path::Path::new("/tmp"),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         assert!(resolved.vars.is_empty());
         let (detects, exports) = backend.call_counts("env-direnv");
@@ -353,7 +400,14 @@ mod tests {
                 ),
             );
         let cache = EnvCache::new();
-        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         assert_eq!(
             resolved.vars.get("KEY").unwrap().as_deref(),
@@ -386,7 +440,14 @@ mod tests {
                 export_of(&[("UNWANTED", None)], vec![tmp.path().join(".envrc")]),
             );
         let cache = EnvCache::new();
-        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         // The merged map DOES contain the key, but its value is None —
         // which tells apply() to env_remove it from the spawned process.
@@ -409,9 +470,23 @@ mod tests {
         let cache = EnvCache::new();
 
         // First resolve: cold cache.
-        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let _ = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
         // Second resolve: should be a cache hit.
-        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         assert!(
             resolved.sources[0].cached,
@@ -436,13 +511,27 @@ mod tests {
                 export_of(&[("FOO", Some("bar"))], vec![envrc.clone()]),
             );
         let cache = EnvCache::new();
-        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let _ = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         // Touch the watched file — forces a distinguishable mtime.
         std::thread::sleep(std::time::Duration::from_millis(1100));
         std::fs::write(&envrc, "y").unwrap();
 
-        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let _ = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         let (_, exports) = backend.call_counts("env-direnv");
         assert_eq!(exports, 2, "mtime change must re-export");
@@ -457,8 +546,14 @@ mod tests {
         b.detect_results
             .insert("env-direnv".into(), Err("direnv not allowed".into()));
         let cache = EnvCache::new();
-        let resolved =
-            resolve_for_workspace(&b, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &b,
+            &cache,
+            std::path::Path::new("/tmp"),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
         assert_eq!(resolved.sources.len(), 1);
         assert!(resolved.sources[0].error.is_some());
         assert!(resolved.vars.is_empty());
@@ -471,8 +566,14 @@ mod tests {
             .detects("env-direnv", true)
             .export_fails("env-direnv", "something broke");
         let cache = EnvCache::new();
-        let resolved =
-            resolve_for_workspace(&backend, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            std::path::Path::new("/tmp"),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         assert!(resolved.sources[0].detected);
         assert!(resolved.sources[0].error.is_some());
@@ -518,6 +619,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_provider_is_skipped_and_cache_invalidated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let envrc = tmp.path().join(".envrc");
+        std::fs::write(&envrc, "x").unwrap();
+
+        // Seed a cache entry as if direnv previously detected + exported.
+        let cache = EnvCache::new();
+        cache.put(
+            tmp.path(),
+            "env-direnv",
+            &export_of(&[("FOO", Some("bar"))], vec![envrc.clone()]),
+        );
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        // Now the user disables it. Expect:
+        // - detect is NOT called
+        // - export is NOT called
+        // - cache entry is dropped so re-enabling re-runs the plugin
+        // - source records a "disabled" reason
+        let backend = MockBackend::new().with_plugin("env-direnv");
+        let mut disabled = std::collections::HashSet::new();
+        disabled.insert("env-direnv".to_string());
+        let resolved =
+            resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info(), &disabled).await;
+
+        let (detects, exports) = backend.call_counts("env-direnv");
+        assert_eq!(detects, 0, "disabled provider must not be detected");
+        assert_eq!(exports, 0, "disabled provider must not be exported");
+        assert!(resolved.vars.is_empty());
+        assert_eq!(resolved.sources.len(), 1);
+        assert_eq!(resolved.sources[0].error.as_deref(), Some("disabled"));
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "disabling must evict cached env so re-enable re-runs fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn precedence_tie_break_is_deterministic_by_name() {
+        // Two unknown providers share precedence 10. Without a secondary
+        // sort key the merge order would follow HashMap iteration, so
+        // which "FOO" wins depends on hash state. With the name tiebreak,
+        // "aaa" sorts before "bbb" in ascending order — so "bbb" merges
+        // last and wins on key collision.
+        let backend = MockBackend::new()
+            .with_plugin("aaa")
+            .with_plugin("bbb")
+            .detects("aaa", true)
+            .detects("bbb", true)
+            .exports("aaa", export_of(&[("FOO", Some("from-aaa"))], vec![]))
+            .exports("bbb", export_of(&[("FOO", Some("from-bbb"))], vec![]));
+        let cache = EnvCache::new();
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            std::path::Path::new("/tmp"),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+
+        assert_eq!(
+            resolved.vars.get("FOO").and_then(|v| v.as_deref()),
+            Some("from-bbb"),
+            "tied-precedence plugins must resolve by ascending name — bbb sorts later, wins merge"
+        );
+    }
+
+    #[tokio::test]
     async fn detect_false_invalidates_stale_cache() {
         let tmp = tempfile::tempdir().unwrap();
         let envrc = tmp.path().join(".envrc");
@@ -537,7 +707,14 @@ mod tests {
         let backend = MockBackend::new()
             .with_plugin("env-direnv")
             .detects("env-direnv", false);
-        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        let _ = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
 
         assert!(
             cache.get_fresh(tmp.path(), "env-direnv").is_none(),

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -1,0 +1,531 @@
+//! Env-provider dispatcher.
+//!
+//! Glues the plugin runtime's `kind = "env-provider"` plugins together
+//! into a single merged env that the agent, setup script, PTY, and any
+//! other subprocess spawned in a workspace can inherit.
+//!
+//! Flow per resolve:
+//! 1. Ask the backend which plugins are env-providers.
+//! 2. For each, check the mtime-keyed cache. Fresh hit → use cached env.
+//! 3. Cache miss → call `detect`. False → skip + invalidate any stale cache.
+//! 4. `detect` true → call `export` → store in cache.
+//! 5. Merge all plugin results in precedence order (highest wins on key
+//!    collisions). `None`-valued entries unset the key from the merge.
+//!
+//! Errors from any single provider are captured in [`ResolvedSource`]
+//! but do not fail the whole resolve — the agent still spawns with
+//! whatever other providers contributed.
+
+pub mod backend;
+pub mod cache;
+pub mod types;
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use serde::Serialize;
+
+use crate::plugin_runtime::host_api::WorkspaceInfo;
+
+use backend::EnvProviderBackend;
+use cache::EnvCache;
+use types::EnvMap;
+
+/// The merged env contributed by all detected env-provider plugins.
+#[derive(Debug, Default, Clone)]
+pub struct ResolvedEnv {
+    /// Final merged env. `None`-valued entries should be unset from the
+    /// spawned command via `Command::env_remove`.
+    pub vars: EnvMap,
+    /// Per-plugin audit trail — surfaced in the settings UI and useful
+    /// for debugging "why isn't FOO set?" questions.
+    pub sources: Vec<ResolvedSource>,
+}
+
+/// Result of asking one plugin to contribute env.
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolvedSource {
+    pub plugin_name: String,
+    pub detected: bool,
+    pub vars_contributed: usize,
+    pub cached: bool,
+    pub evaluated_at: SystemTime,
+    /// Present when the plugin errored or was skipped with a reason.
+    pub error: Option<String>,
+}
+
+impl ResolvedEnv {
+    /// Apply the merged env to a `tokio::process::Command`. `None`
+    /// values trigger `env_remove` so providers can model "direnv
+    /// unexported this var" correctly.
+    pub fn apply(&self, cmd: &mut tokio::process::Command) {
+        for (k, v) in &self.vars {
+            match v {
+                Some(val) => {
+                    cmd.env(k, val);
+                }
+                None => {
+                    cmd.env_remove(k);
+                }
+            }
+        }
+    }
+
+    /// Sibling to [`apply`] for `std::process::Command` (setup script
+    /// spawn, non-async code paths).
+    pub fn apply_std(&self, cmd: &mut std::process::Command) {
+        for (k, v) in &self.vars {
+            match v {
+                Some(val) => {
+                    cmd.env(k, val);
+                }
+                None => {
+                    cmd.env_remove(k);
+                }
+            }
+        }
+    }
+
+    /// Apply to a `HashMap` env (used by the PTY code path, which
+    /// builds its env map separately before handing to `portable-pty`).
+    pub fn apply_to_map(&self, map: &mut std::collections::HashMap<String, String>) {
+        for (k, v) in &self.vars {
+            match v {
+                Some(val) => {
+                    map.insert(k.clone(), val.clone());
+                }
+                None => {
+                    map.remove(k);
+                }
+            }
+        }
+    }
+}
+
+/// Hardcoded precedence for v1. Higher value = wins on key collision.
+/// Unknown plugin names get a low default so user-added providers are
+/// merged last (overridden by any of the built-ins that also detected).
+///
+/// See the plan for rationale — direnv wraps most other tools
+/// (`use flake`, `use mise`, `use devbox`), so when both a direnv and
+/// a raw provider (mise, nix-devshell) both detect, the direnv export
+/// already includes the underlying tool's env, and its values win.
+pub fn precedence_of(name: &str) -> i32 {
+    match name {
+        "env-direnv" => 100,
+        "env-mise" => 80,
+        "env-shadowenv" => 60,
+        "env-nix-devshell" => 40,
+        "env-dotenv" => 20,
+        _ => 10,
+    }
+}
+
+/// Resolve the full env a workspace should spawn with.
+///
+/// Iterates in ascending precedence order; later (higher) providers
+/// overwrite earlier (lower) ones on key collision. `None` values unset
+/// the key from the merged map.
+pub async fn resolve_for_workspace(
+    backend: &impl EnvProviderBackend,
+    cache: &EnvCache,
+    worktree: &Path,
+    ws_info: &WorkspaceInfo,
+) -> ResolvedEnv {
+    let mut names = backend.env_provider_names();
+    // Sort ascending: lowest precedence first, so higher overwrites on merge.
+    names.sort_by_key(|n| precedence_of(n));
+
+    let mut merged = EnvMap::new();
+    let mut sources = Vec::with_capacity(names.len());
+
+    for name in names {
+        let source = resolve_one(backend, cache, &name, worktree, ws_info, &mut merged).await;
+        sources.push(source);
+    }
+
+    ResolvedEnv {
+        vars: merged,
+        sources,
+    }
+}
+
+async fn resolve_one(
+    backend: &impl EnvProviderBackend,
+    cache: &EnvCache,
+    name: &str,
+    worktree: &Path,
+    ws_info: &WorkspaceInfo,
+    merged: &mut EnvMap,
+) -> ResolvedSource {
+    // 1. Fast path: cache hit → skip detect AND export.
+    if let Some(entry) = cache.get_fresh(worktree, name) {
+        let contributed = entry.env.len();
+        merge_into(merged, &entry.env);
+        return ResolvedSource {
+            plugin_name: name.to_string(),
+            detected: true,
+            vars_contributed: contributed,
+            cached: true,
+            evaluated_at: entry.evaluated_at,
+            error: None,
+        };
+    }
+
+    // 2. Slow path: run detect.
+    let detected = match backend.detect(name, worktree, ws_info).await {
+        Ok(v) => v,
+        Err(e) => {
+            return ResolvedSource {
+                plugin_name: name.to_string(),
+                detected: false,
+                vars_contributed: 0,
+                cached: false,
+                evaluated_at: SystemTime::now(),
+                error: Some(format!("detect: {e}")),
+            };
+        }
+    };
+
+    if !detected {
+        // Drop any stale cache for this (worktree, plugin) — plugin no
+        // longer applies (e.g. user deleted `.envrc`).
+        cache.invalidate(worktree, Some(name));
+        return ResolvedSource {
+            plugin_name: name.to_string(),
+            detected: false,
+            vars_contributed: 0,
+            cached: false,
+            evaluated_at: SystemTime::now(),
+            error: None,
+        };
+    }
+
+    // 3. Run export, store result in cache.
+    match backend.export(name, worktree, ws_info).await {
+        Ok(export) => {
+            let contributed = export.env.len();
+            cache.put(worktree, name, &export);
+            merge_into(merged, &export.env);
+            ResolvedSource {
+                plugin_name: name.to_string(),
+                detected: true,
+                vars_contributed: contributed,
+                cached: false,
+                evaluated_at: SystemTime::now(),
+                error: None,
+            }
+        }
+        Err(e) => ResolvedSource {
+            plugin_name: name.to_string(),
+            detected: true,
+            vars_contributed: 0,
+            cached: false,
+            evaluated_at: SystemTime::now(),
+            error: Some(format!("export: {e}")),
+        },
+    }
+}
+
+/// Merge `incoming` into `merged`. `None` entries *unset* the key; the
+/// last writer wins on collisions (callers iterate in ascending
+/// precedence order so this naturally implements "highest wins").
+fn merge_into(merged: &mut EnvMap, incoming: &EnvMap) {
+    for (k, v) in incoming {
+        merged.insert(k.clone(), v.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use backend::mock::MockBackend;
+    use types::ProviderExport;
+
+    fn ws_info() -> WorkspaceInfo {
+        WorkspaceInfo {
+            id: "ws-1".into(),
+            name: "test".into(),
+            branch: "main".into(),
+            worktree_path: "/tmp".into(),
+            repo_path: "/tmp".into(),
+        }
+    }
+
+    fn export_of(
+        pairs: &[(&str, Option<&str>)],
+        watched: Vec<std::path::PathBuf>,
+    ) -> ProviderExport {
+        let env = pairs
+            .iter()
+            .map(|(k, v)| ((*k).into(), v.map(|s| s.into())))
+            .collect();
+        ProviderExport { env, watched }
+    }
+
+    #[tokio::test]
+    async fn resolve_empty_no_plugins() {
+        let backend = MockBackend::new();
+        let cache = EnvCache::new();
+        let resolved =
+            resolve_for_workspace(&backend, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+        assert!(resolved.vars.is_empty());
+        assert!(resolved.sources.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_single_plugin_detects_and_exports() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".envrc"), "x").unwrap();
+
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .detects("env-direnv", true)
+            .exports(
+                "env-direnv",
+                export_of(&[("FOO", Some("bar"))], vec![tmp.path().join(".envrc")]),
+            );
+        let cache = EnvCache::new();
+        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        assert_eq!(resolved.vars.get("FOO").unwrap().as_deref(), Some("bar"));
+        assert_eq!(resolved.sources.len(), 1);
+        assert_eq!(resolved.sources[0].plugin_name, "env-direnv");
+        assert!(resolved.sources[0].detected);
+        assert_eq!(resolved.sources[0].vars_contributed, 1);
+        assert!(!resolved.sources[0].cached);
+    }
+
+    #[tokio::test]
+    async fn resolve_plugin_detects_false_skips_export() {
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .detects("env-direnv", false);
+        let cache = EnvCache::new();
+        let resolved =
+            resolve_for_workspace(&backend, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+
+        assert!(resolved.vars.is_empty());
+        let (detects, exports) = backend.call_counts("env-direnv");
+        assert_eq!(detects, 1);
+        assert_eq!(exports, 0, "export must not run when detect=false");
+    }
+
+    #[tokio::test]
+    async fn precedence_direnv_overrides_mise() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".envrc"), "x").unwrap();
+        std::fs::write(tmp.path().join("mise.toml"), "x").unwrap();
+
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .with_plugin("env-mise")
+            .detects("env-direnv", true)
+            .detects("env-mise", true)
+            .exports(
+                "env-direnv",
+                export_of(
+                    &[("KEY", Some("from-direnv"))],
+                    vec![tmp.path().join(".envrc")],
+                ),
+            )
+            .exports(
+                "env-mise",
+                export_of(
+                    &[("KEY", Some("from-mise"))],
+                    vec![tmp.path().join("mise.toml")],
+                ),
+            );
+        let cache = EnvCache::new();
+        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        assert_eq!(
+            resolved.vars.get("KEY").unwrap().as_deref(),
+            Some("from-direnv"),
+            "direnv precedence should override mise"
+        );
+    }
+
+    #[tokio::test]
+    async fn null_value_unsets_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("mise.toml"), "x").unwrap();
+        std::fs::write(tmp.path().join(".envrc"), "x").unwrap();
+
+        let backend = MockBackend::new()
+            .with_plugin("env-mise")
+            .with_plugin("env-direnv")
+            .detects("env-mise", true)
+            .detects("env-direnv", true)
+            .exports(
+                "env-mise",
+                export_of(
+                    &[("UNWANTED", Some("x"))],
+                    vec![tmp.path().join("mise.toml")],
+                ),
+            )
+            .exports(
+                "env-direnv",
+                // direnv (higher precedence) emits null → unsets the key
+                export_of(&[("UNWANTED", None)], vec![tmp.path().join(".envrc")]),
+            );
+        let cache = EnvCache::new();
+        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        // The merged map DOES contain the key, but its value is None —
+        // which tells apply() to env_remove it from the spawned process.
+        assert_eq!(resolved.vars.get("UNWANTED"), Some(&None));
+    }
+
+    #[tokio::test]
+    async fn cache_hit_skips_detect_and_export() {
+        let tmp = tempfile::tempdir().unwrap();
+        let envrc = tmp.path().join(".envrc");
+        std::fs::write(&envrc, "x").unwrap();
+
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .detects("env-direnv", true)
+            .exports(
+                "env-direnv",
+                export_of(&[("FOO", Some("bar"))], vec![envrc.clone()]),
+            );
+        let cache = EnvCache::new();
+
+        // First resolve: cold cache.
+        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+        // Second resolve: should be a cache hit.
+        let resolved = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        assert!(
+            resolved.sources[0].cached,
+            "second resolve should hit cache"
+        );
+        let (detects, exports) = backend.call_counts("env-direnv");
+        assert_eq!(detects, 1, "cache hit must skip detect");
+        assert_eq!(exports, 1, "cache hit must skip export");
+    }
+
+    #[tokio::test]
+    async fn cache_miss_on_mtime_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let envrc = tmp.path().join(".envrc");
+        std::fs::write(&envrc, "x").unwrap();
+
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .detects("env-direnv", true)
+            .exports(
+                "env-direnv",
+                export_of(&[("FOO", Some("bar"))], vec![envrc.clone()]),
+            );
+        let cache = EnvCache::new();
+        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        // Touch the watched file — forces a distinguishable mtime.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&envrc, "y").unwrap();
+
+        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        let (_, exports) = backend.call_counts("env-direnv");
+        assert_eq!(exports, 2, "mtime change must re-export");
+    }
+
+    #[tokio::test]
+    async fn detect_error_captured_in_source() {
+        let backend = MockBackend::new().with_plugin("env-direnv");
+        // detect_results has no entry → backend returns Ok(false) by
+        // default. We want to cover the Err branch.
+        let mut b = backend;
+        b.detect_results
+            .insert("env-direnv".into(), Err("direnv not allowed".into()));
+        let cache = EnvCache::new();
+        let resolved =
+            resolve_for_workspace(&b, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+        assert_eq!(resolved.sources.len(), 1);
+        assert!(resolved.sources[0].error.is_some());
+        assert!(resolved.vars.is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_error_does_not_fail_resolve() {
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .detects("env-direnv", true)
+            .export_fails("env-direnv", "something broke");
+        let cache = EnvCache::new();
+        let resolved =
+            resolve_for_workspace(&backend, &cache, std::path::Path::new("/tmp"), &ws_info()).await;
+
+        assert!(resolved.sources[0].detected);
+        assert!(resolved.sources[0].error.is_some());
+        assert_eq!(resolved.sources[0].vars_contributed, 0);
+        assert!(resolved.vars.is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_sets_and_unsets_vars_on_command() {
+        // We can't easily inspect tokio Command's env after the fact, so
+        // we use a std Command (same semantics) and run a shell that
+        // prints its env to stdout. This exercises the full apply path.
+        // Skipped on Windows — `sh` isn't present, and the semantics we
+        // care about (env_remove) are shared across platforms anyway.
+        #[cfg(unix)]
+        {
+            let mut env = EnvMap::new();
+            env.insert("CLAUDETTE_TEST_SET".into(), Some("yes".into()));
+            env.insert("CLAUDETTE_TEST_UNSET".into(), None);
+            let resolved = ResolvedEnv {
+                vars: env,
+                sources: vec![],
+            };
+
+            let mut cmd = std::process::Command::new("sh");
+            cmd.arg("-c")
+                .arg("echo set=$CLAUDETTE_TEST_SET; echo unset=${CLAUDETTE_TEST_UNSET:-MISSING}");
+            // Pre-set the unset var in the parent env so we can observe
+            // env_remove actually taking effect.
+            unsafe {
+                std::env::set_var("CLAUDETTE_TEST_UNSET", "from-parent");
+            }
+            resolved.apply_std(&mut cmd);
+
+            let output = cmd.output().unwrap();
+            let stdout = String::from_utf8(output.stdout).unwrap();
+            assert!(stdout.contains("set=yes"), "stdout was: {stdout}");
+            assert!(
+                stdout.contains("unset=MISSING"),
+                "env_remove failed; stdout was: {stdout}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn detect_false_invalidates_stale_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let envrc = tmp.path().join(".envrc");
+        std::fs::write(&envrc, "x").unwrap();
+
+        // Seed the cache as if direnv previously detected + exported.
+        let cache = EnvCache::new();
+        cache.put(
+            tmp.path(),
+            "env-direnv",
+            &export_of(&[("STALE", Some("yes"))], vec![envrc.clone()]),
+        );
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        // Now simulate the user deleting .envrc — detect returns false.
+        std::fs::remove_file(&envrc).unwrap();
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .detects("env-direnv", false);
+        let _ = resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info()).await;
+
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "detect=false must evict the stale cache entry"
+        );
+    }
+}

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -18,6 +18,8 @@
 
 pub mod backend;
 pub mod cache;
+#[cfg(test)]
+mod plugin_tests;
 pub mod types;
 
 use std::path::Path;

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -37,6 +37,11 @@ use types::EnvMap;
 /// Convenience helper that wires the standard [`PluginRegistryBackend`]
 /// into [`resolve_for_workspace`] with minimal boilerplate at the call
 /// site. The tauri layer uses this from spawn command handlers.
+///
+/// Merges the per-repo `disabled` set with the registry's globally-
+/// disabled plugin names so the dispatcher sees a single "skip this"
+/// set and globally-off plugins show up in the UI as cleanly disabled
+/// (rather than as a `PluginDisabled` error surfaced through detect).
 pub async fn resolve_with_registry(
     registry: &crate::plugin_runtime::PluginRegistry,
     cache: &EnvCache,
@@ -45,7 +50,13 @@ pub async fn resolve_with_registry(
     disabled: &std::collections::HashSet<String>,
 ) -> ResolvedEnv {
     let backend = PluginRegistryBackend::new(registry);
-    resolve_for_workspace(&backend, cache, worktree, ws_info, disabled).await
+    let mut merged_disabled = disabled.clone();
+    for name in backend.env_provider_names() {
+        if registry.is_disabled(&name) {
+            merged_disabled.insert(name);
+        }
+    }
+    resolve_for_workspace(&backend, cache, worktree, ws_info, &merged_disabled).await
 }
 
 /// The merged env contributed by all detected env-provider plugins.
@@ -720,5 +731,61 @@ mod tests {
             cache.get_fresh(tmp.path(), "env-direnv").is_none(),
             "detect=false must evict the stale cache entry"
         );
+    }
+
+    #[tokio::test]
+    async fn resolve_with_registry_treats_globally_disabled_as_disabled() {
+        // Regression guard for the UAT finding: globally-disabled plugins
+        // used to surface as `detect` errors with "Plugin '...' is
+        // disabled" in the UI. Now they merge into the dispatcher's
+        // `disabled` set so the source shows error="disabled" cleanly.
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_dir = tempfile::tempdir().unwrap();
+        // Seed a minimal env-provider plugin so the registry discovers it.
+        let pdir = plugin_dir.path().join("env-testprov");
+        std::fs::create_dir_all(&pdir).unwrap();
+        std::fs::write(
+            pdir.join("plugin.json"),
+            r#"{
+                "name": "env-testprov",
+                "display_name": "TestProv",
+                "version": "1.0.0",
+                "description": "test",
+                "kind": "env-provider",
+                "operations": ["detect", "export"]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            pdir.join("init.lua"),
+            r#"
+            local M = {}
+            function M.detect() return true end
+            function M.export() return { env = {}, watched = {} } end
+            return M
+            "#,
+        )
+        .unwrap();
+
+        let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+        registry.set_disabled("env-testprov", true);
+        let cache = EnvCache::new();
+
+        let resolved = resolve_with_registry(
+            &registry,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+
+        let source = resolved
+            .sources
+            .iter()
+            .find(|s| s.plugin_name == "env-testprov")
+            .expect("plugin must appear in sources");
+        assert_eq!(source.error.as_deref(), Some("disabled"));
+        assert!(!source.detected);
     }
 }

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -273,11 +273,104 @@ fn nix_detect_skips_plain_repo() {
 // Integration: real CLIs (gated behind build.rs probes)
 // ---------------------------------------------------------------------------
 
+/// Serialize HOME/XDG env overrides across integration tests. Tokio
+/// tests run in parallel by default, and `std::env::set_var` is
+/// process-global — concurrent integration tests tripping over each
+/// other's HOME would produce flaky failures.
+#[cfg(any(has_direnv, has_mise))]
+fn env_override_mutex() -> &'static std::sync::Mutex<()> {
+    static M: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    M.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+/// RAII guard that redirects HOME + XDG_*_HOME to a tempdir for the
+/// duration of an integration test. Restores the prior values on drop
+/// so subsequent tests (and the rest of the test binary) see the real
+/// user env. Holds the serialization mutex across the whole test so
+/// env overrides never overlap.
+///
+/// Why this matters: `direnv allow` and `mise trust` write their
+/// trust-cache entries under `$XDG_DATA_HOME` / `$XDG_STATE_HOME`
+/// (falling back to `$HOME/.local/share`). Without isolation, the
+/// integration tests pollute the developer's real trust cache with
+/// tempdir paths, and fail outright in sandboxed CI environments
+/// where `~/.local/...` is read-only.
+#[cfg(any(has_direnv, has_mise))]
+struct ScopedHome {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    _tmp: tempfile::TempDir,
+    prior: Vec<(&'static str, Option<String>)>,
+}
+
+#[cfg(any(has_direnv, has_mise))]
+impl ScopedHome {
+    fn new() -> Self {
+        let guard = env_override_mutex()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let xdg_data = home.join(".local/share");
+        let xdg_state = home.join(".local/state");
+        let xdg_cache = home.join(".cache");
+        let xdg_config = home.join(".config");
+        for p in [&xdg_data, &xdg_state, &xdg_cache, &xdg_config] {
+            std::fs::create_dir_all(p).unwrap();
+        }
+
+        let keys = [
+            ("HOME", home.to_string_lossy().into_owned()),
+            ("XDG_DATA_HOME", xdg_data.to_string_lossy().into_owned()),
+            ("XDG_STATE_HOME", xdg_state.to_string_lossy().into_owned()),
+            ("XDG_CACHE_HOME", xdg_cache.to_string_lossy().into_owned()),
+            ("XDG_CONFIG_HOME", xdg_config.to_string_lossy().into_owned()),
+        ];
+
+        let prior: Vec<(&'static str, Option<String>)> = keys
+            .iter()
+            .map(|(k, _)| (*k, std::env::var(*k).ok()))
+            .collect();
+
+        for (k, v) in keys {
+            // SAFETY: set_var is unsafe in edition 2024 because it can
+            // race with other threads reading env. `env_override_mutex`
+            // serializes all integration tests that mutate these keys,
+            // and the keys are restored before the mutex releases.
+            unsafe {
+                std::env::set_var(k, v);
+            }
+        }
+
+        Self {
+            _guard: guard,
+            _tmp: tmp,
+            prior,
+        }
+    }
+}
+
+#[cfg(any(has_direnv, has_mise))]
+impl Drop for ScopedHome {
+    fn drop(&mut self) {
+        for (k, v) in &self.prior {
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+}
+
 #[cfg(has_direnv)]
 #[tokio::test]
 async fn integration_direnv_export_returns_env() {
-    // Write an .envrc that exports a var, then go through the dispatcher
-    // using the real PluginRegistryBackend against a real direnv CLI.
+    // Redirect HOME + XDG_*_HOME into a tempdir so `direnv allow`
+    // writes to a disposable cache instead of the developer's real
+    // `~/.local/share/direnv/allow/`.
+    let _scoped = ScopedHome::new();
+
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(
         tmp.path().join(".envrc"),
@@ -285,8 +378,8 @@ async fn integration_direnv_export_returns_env() {
     )
     .unwrap();
 
-    // direnv requires the .envrc to be allowed. We drive that via the
-    // CLI since direnv's own allow-list lives under XDG_DATA_HOME.
+    // direnv requires the .envrc to be allowed. direnv reads HOME for
+    // its allow-cache location, which we've redirected above.
     let status = std::process::Command::new("direnv")
         .arg("allow")
         .current_dir(tmp.path())
@@ -344,6 +437,10 @@ async fn integration_direnv_export_returns_env() {
 #[cfg(has_mise)]
 #[tokio::test]
 async fn integration_mise_export_returns_env() {
+    // See ScopedHome for why this matters — `mise trust` writes to
+    // `$XDG_STATE_HOME/mise/trusted-configs/` (or equivalents).
+    let _scoped = ScopedHome::new();
+
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(
         tmp.path().join("mise.toml"),

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -307,8 +307,14 @@ async fn integration_direnv_export_returns_env() {
         repo_path: tmp.path().to_string_lossy().into_owned(),
     };
 
-    let resolved =
-        crate::env_provider::resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info).await;
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
     let direnv_source = resolved
         .sources
         .iter()
@@ -361,8 +367,14 @@ async fn integration_mise_export_returns_env() {
         repo_path: tmp.path().to_string_lossy().into_owned(),
     };
 
-    let resolved =
-        crate::env_provider::resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info).await;
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
     let mise_source = resolved
         .sources
         .iter()

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -238,13 +238,17 @@ fn nix_detect_finds_shell_nix() {
 }
 
 #[test]
-fn nix_detect_skips_when_direnv_present() {
-    // Even with flake.nix present, if .envrc exists, env-direnv wins —
-    // nix-devshell must back off to avoid double-evaluating the flake.
+fn nix_detect_finds_flake_even_with_envrc() {
+    // Detection is a pure function of what's on disk — if flake.nix
+    // exists, env-nix-devshell detects regardless of whether direnv is
+    // also configured. Precedence handles the overlap at merge time
+    // (direnv > nix-devshell, so direnv's vars win on collisions when
+    // both plugins export), and the per-provider toggle lets users
+    // disable either one if they want a single-source setup.
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join("flake.nix"), "{}").unwrap();
     std::fs::write(tmp.path().join(".envrc"), "use flake").unwrap();
-    assert!(!run_detect(
+    assert!(run_detect(
         "env-nix-devshell",
         NIX_SRC,
         &["nix"],

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -19,6 +19,7 @@ use mlua::Lua;
 use std::path::Path;
 
 use crate::plugin_runtime::host_api::{HostContext, WorkspaceInfo, create_lua_vm};
+use crate::plugin_runtime::manifest::PluginKind;
 
 const DIRENV_SRC: &str = include_str!("../../plugins/env-direnv/init.lua");
 const MISE_SRC: &str = include_str!("../../plugins/env-mise/init.lua");
@@ -29,6 +30,7 @@ const NIX_SRC: &str = include_str!("../../plugins/env-nix-devshell/init.lua");
 fn make_vm(plugin: &str, allowed: &[&str], worktree: &Path) -> Lua {
     let ctx = HostContext {
         plugin_name: plugin.to_string(),
+        kind: PluginKind::EnvProvider,
         allowed_clis: allowed.iter().map(|s| s.to_string()).collect(),
         workspace_info: WorkspaceInfo {
             id: "ws-1".into(),

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -1,0 +1,388 @@
+//! Unit tests for the bundled env-provider Lua plugins.
+//!
+//! These tests load each plugin's `init.lua` into a sandboxed Lua VM
+//! and invoke its `detect` / `export` operations directly — they don't
+//! go through `PluginRegistry::call_operation`, so they run faster and
+//! don't depend on plugin discovery on the filesystem. The full
+//! registry path is exercised by the dispatcher integration test at
+//! the bottom of this file.
+//!
+//! External CLIs (`direnv`, `mise`, `nix`) are needed only for the
+//! `export` integration tests — unit tests cover the detect and parse
+//! branches synthetically. Integration tests are gated behind
+//! `has_direnv` / `has_mise` / `has_nix` cfg flags emitted by
+//! `build.rs`, so CI without those tools silently skips them.
+
+#![cfg(test)]
+
+use mlua::Lua;
+use std::path::Path;
+
+use crate::plugin_runtime::host_api::{HostContext, WorkspaceInfo, create_lua_vm};
+
+const DIRENV_SRC: &str = include_str!("../../plugins/env-direnv/init.lua");
+const MISE_SRC: &str = include_str!("../../plugins/env-mise/init.lua");
+const DOTENV_SRC: &str = include_str!("../../plugins/env-dotenv/init.lua");
+const NIX_SRC: &str = include_str!("../../plugins/env-nix-devshell/init.lua");
+
+/// Build a VM configured for the given plugin's `required_clis`.
+fn make_vm(plugin: &str, allowed: &[&str], worktree: &Path) -> Lua {
+    let ctx = HostContext {
+        plugin_name: plugin.to_string(),
+        allowed_clis: allowed.iter().map(|s| s.to_string()).collect(),
+        workspace_info: WorkspaceInfo {
+            id: "ws-1".into(),
+            name: "test".into(),
+            branch: "main".into(),
+            worktree_path: worktree.to_string_lossy().into_owned(),
+            repo_path: worktree.to_string_lossy().into_owned(),
+        },
+        config: Default::default(),
+    };
+    create_lua_vm(ctx).expect("create vm")
+}
+
+/// Run `detect(args)` against the given plugin source.
+fn run_detect(plugin: &str, src: &str, allowed: &[&str], worktree: &Path) -> bool {
+    let lua = make_vm(plugin, allowed, worktree);
+    let path = worktree.to_string_lossy().into_owned();
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.detect({{ worktree = "{path}" }})
+        "#,
+        src = src,
+        path = path.replace('\\', "\\\\")
+    );
+    lua.load(&script).eval::<bool>().expect("detect call")
+}
+
+// ---------------------------------------------------------------------------
+// env-direnv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direnv_detect_finds_envrc() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake").unwrap();
+    assert!(run_detect(
+        "env-direnv",
+        DIRENV_SRC,
+        &["direnv"],
+        tmp.path()
+    ));
+}
+
+#[test]
+fn direnv_detect_skips_missing_envrc() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(!run_detect(
+        "env-direnv",
+        DIRENV_SRC,
+        &["direnv"],
+        tmp.path()
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// env-mise
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mise_detect_finds_mise_toml() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("mise.toml"), "[tools]\nnode = \"20\"").unwrap();
+    assert!(run_detect("env-mise", MISE_SRC, &["mise"], tmp.path()));
+}
+
+#[test]
+fn mise_detect_finds_hidden_mise_toml() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".mise.toml"), "[tools]").unwrap();
+    assert!(run_detect("env-mise", MISE_SRC, &["mise"], tmp.path()));
+}
+
+#[test]
+fn mise_detect_finds_tool_versions() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".tool-versions"), "node 20").unwrap();
+    assert!(run_detect("env-mise", MISE_SRC, &["mise"], tmp.path()));
+}
+
+#[test]
+fn mise_detect_skips_when_no_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(!run_detect("env-mise", MISE_SRC, &["mise"], tmp.path()));
+}
+
+// ---------------------------------------------------------------------------
+// env-dotenv (the only plugin that parses in-process)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dotenv_detect_finds_env_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".env"), "FOO=bar").unwrap();
+    assert!(run_detect("env-dotenv", DOTENV_SRC, &[], tmp.path()));
+}
+
+#[test]
+fn dotenv_detect_skips_missing_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(!run_detect("env-dotenv", DOTENV_SRC, &[], tmp.path()));
+}
+
+/// Drive `_parse(text)` directly so we cover quoting / comment /
+/// `export`-prefix corners without touching the filesystem.
+fn parse_dotenv_text(text: &str) -> std::collections::HashMap<String, String> {
+    let tmp = tempfile::tempdir().unwrap();
+    let lua = make_vm("env-dotenv", &[], tmp.path());
+    // Escape backslashes for Lua string literal
+    let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M._parse("{txt}")
+        "#,
+        src = DOTENV_SRC,
+        txt = escaped.replace('\n', "\\n").replace('\r', "\\r")
+    );
+    let table: mlua::Table = lua.load(&script).eval().expect("_parse call");
+    let mut out = std::collections::HashMap::new();
+    for pair in table.pairs::<String, String>() {
+        let (k, v) = pair.unwrap();
+        out.insert(k, v);
+    }
+    out
+}
+
+#[test]
+fn dotenv_parse_simple_kv() {
+    let env = parse_dotenv_text("FOO=bar\nBAZ=qux\n");
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("bar"));
+    assert_eq!(env.get("BAZ").map(|s| s.as_str()), Some("qux"));
+}
+
+#[test]
+fn dotenv_parse_strips_export_prefix() {
+    let env = parse_dotenv_text("export FOO=bar\n");
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("bar"));
+}
+
+#[test]
+fn dotenv_parse_handles_double_quoted_values() {
+    let env = parse_dotenv_text(r#"FOO="hello world""#);
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("hello world"));
+}
+
+#[test]
+fn dotenv_parse_handles_single_quoted_values() {
+    let env = parse_dotenv_text("FOO='hello world'");
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("hello world"));
+}
+
+#[test]
+fn dotenv_parse_ignores_comment_lines() {
+    let env = parse_dotenv_text("# this is a comment\nFOO=bar\n# another\n");
+    assert_eq!(env.len(), 1);
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("bar"));
+}
+
+#[test]
+fn dotenv_parse_strips_inline_comment_on_unquoted_value() {
+    let env = parse_dotenv_text("FOO=bar  # trailing comment");
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("bar"));
+}
+
+#[test]
+fn dotenv_parse_preserves_hash_in_quoted_value() {
+    // Quoted `#` is data, not a comment.
+    let env = parse_dotenv_text(r#"TOKEN="abc#def""#);
+    assert_eq!(env.get("TOKEN").map(|s| s.as_str()), Some("abc#def"));
+}
+
+#[test]
+fn dotenv_parse_skips_blank_lines_and_malformed() {
+    let env = parse_dotenv_text("\n\nFOO=bar\nmalformed line\n  \nBAZ=qux\n");
+    assert_eq!(env.get("FOO").map(|s| s.as_str()), Some("bar"));
+    assert_eq!(env.get("BAZ").map(|s| s.as_str()), Some("qux"));
+    assert_eq!(env.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// env-nix-devshell
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nix_detect_finds_flake() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("flake.nix"), "{}").unwrap();
+    assert!(run_detect(
+        "env-nix-devshell",
+        NIX_SRC,
+        &["nix"],
+        tmp.path()
+    ));
+}
+
+#[test]
+fn nix_detect_finds_shell_nix() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("shell.nix"), "{}").unwrap();
+    assert!(run_detect(
+        "env-nix-devshell",
+        NIX_SRC,
+        &["nix"],
+        tmp.path()
+    ));
+}
+
+#[test]
+fn nix_detect_skips_when_direnv_present() {
+    // Even with flake.nix present, if .envrc exists, env-direnv wins —
+    // nix-devshell must back off to avoid double-evaluating the flake.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("flake.nix"), "{}").unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake").unwrap();
+    assert!(!run_detect(
+        "env-nix-devshell",
+        NIX_SRC,
+        &["nix"],
+        tmp.path()
+    ));
+}
+
+#[test]
+fn nix_detect_skips_plain_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(!run_detect(
+        "env-nix-devshell",
+        NIX_SRC,
+        &["nix"],
+        tmp.path()
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Integration: real CLIs (gated behind build.rs probes)
+// ---------------------------------------------------------------------------
+
+#[cfg(has_direnv)]
+#[tokio::test]
+async fn integration_direnv_export_returns_env() {
+    // Write an .envrc that exports a var, then go through the dispatcher
+    // using the real PluginRegistryBackend against a real direnv CLI.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".envrc"),
+        "export CLAUDETTE_DIRENV_TEST=hello\n",
+    )
+    .unwrap();
+
+    // direnv requires the .envrc to be allowed. We drive that via the
+    // CLI since direnv's own allow-list lives under XDG_DATA_HOME.
+    let status = std::process::Command::new("direnv")
+        .arg("allow")
+        .current_dir(tmp.path())
+        .status()
+        .expect("direnv allow");
+    assert!(status.success(), "direnv allow failed");
+
+    // Seed the plugin into a temp plugin dir and discover.
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+    assert!(
+        registry.plugins.contains_key("env-direnv"),
+        "env-direnv should be seeded + discovered"
+    );
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-int".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved =
+        crate::env_provider::resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info).await;
+    let direnv_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-direnv")
+        .expect("env-direnv must appear in sources");
+    assert!(
+        direnv_source.error.is_none(),
+        "direnv errored: {:?}",
+        direnv_source.error
+    );
+    assert_eq!(
+        resolved
+            .vars
+            .get("CLAUDETTE_DIRENV_TEST")
+            .and_then(|v| v.as_deref()),
+        Some("hello"),
+        "expected CLAUDETTE_DIRENV_TEST=hello in merged env; full resolved = {resolved:#?}"
+    );
+}
+
+#[cfg(has_mise)]
+#[tokio::test]
+async fn integration_mise_export_returns_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mise.toml"),
+        "[env]\nCLAUDETTE_MISE_TEST = \"world\"\n",
+    )
+    .unwrap();
+
+    // mise requires explicit trust for per-project config.
+    let status = std::process::Command::new("mise")
+        .arg("trust")
+        .current_dir(tmp.path())
+        .status()
+        .expect("mise trust");
+    assert!(status.success(), "mise trust failed");
+
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-int".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved =
+        crate::env_provider::resolve_for_workspace(&backend, &cache, tmp.path(), &ws_info).await;
+    let mise_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-mise")
+        .expect("env-mise must appear in sources");
+    assert!(
+        mise_source.error.is_none(),
+        "mise errored: {:?}",
+        mise_source.error
+    );
+    assert_eq!(
+        resolved
+            .vars
+            .get("CLAUDETTE_MISE_TEST")
+            .and_then(|v| v.as_deref()),
+        Some("world"),
+    );
+}
+
+// nix print-dev-env on a fresh flake evaluates the flake.nix from
+// scratch, which can take 10-60s the first time. Skip the integration
+// test for now — cargo test wall-clock matters more than coverage
+// here. Unit tests + the manual verification plan cover the happy path.

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -497,6 +497,242 @@ async fn integration_mise_export_returns_env() {
     );
 }
 
+/// auto_allow default (unset / false): an unallowed .envrc must stay
+/// blocked. The plugin reports the error as-is; no retry is attempted,
+/// and no vars are contributed. This is the "safe by default" path that
+/// honors direnv's per-path trust model.
+#[cfg(has_direnv)]
+#[tokio::test]
+async fn integration_direnv_auto_allow_off_surfaces_blocked_error() {
+    let _scoped = ScopedHome::new();
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".envrc"),
+        "export CLAUDETTE_DIRENV_DENY=oops\n",
+    )
+    .unwrap();
+
+    // Intentionally DO NOT `direnv allow` — the .envrc must stay blocked.
+
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+    // Explicit default — make sure auto_allow=false behaves the same as
+    // "never configured" (manifest default).
+    registry.set_setting("env-direnv", "auto_allow", Some(serde_json::json!(false)));
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-deny".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
+    let direnv_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-direnv")
+        .expect("env-direnv must appear in sources");
+    assert!(
+        direnv_source.error.is_some(),
+        "auto_allow=false must surface the blocked error, got sources={:#?}",
+        resolved.sources
+    );
+    let err = direnv_source.error.as_ref().unwrap();
+    assert!(
+        err.contains("blocked") || err.contains("allow"),
+        "error should describe a blocked .envrc; got: {err}"
+    );
+    assert_eq!(direnv_source.vars_contributed, 0);
+    assert!(
+        !resolved.vars.contains_key("CLAUDETTE_DIRENV_DENY"),
+        "no vars should leak from a blocked .envrc"
+    );
+}
+
+/// auto_allow=true must retry after `direnv allow` when the .envrc is
+/// blocked. After the retry the plugin reports success and vars flow
+/// through.
+#[cfg(has_direnv)]
+#[tokio::test]
+async fn integration_direnv_auto_allow_on_retries_after_blocked() {
+    let _scoped = ScopedHome::new();
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join(".envrc"),
+        "export CLAUDETTE_DIRENV_AUTO=yes\n",
+    )
+    .unwrap();
+
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+    registry.set_setting("env-direnv", "auto_allow", Some(serde_json::json!(true)));
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-auto".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
+    let direnv_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-direnv")
+        .expect("env-direnv must appear in sources");
+    assert!(
+        direnv_source.error.is_none(),
+        "auto_allow=true must retry past the blocked error; got {:?}",
+        direnv_source.error
+    );
+    assert_eq!(
+        resolved
+            .vars
+            .get("CLAUDETTE_DIRENV_AUTO")
+            .and_then(|v| v.as_deref()),
+        Some("yes"),
+    );
+}
+
+/// auto_trust default (unset / false): an untrusted mise.toml must stay
+/// blocked — errors surface as-is, no retry, no vars contributed.
+#[cfg(has_mise)]
+#[tokio::test]
+async fn integration_mise_auto_trust_off_surfaces_untrusted_error() {
+    let _scoped = ScopedHome::new();
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mise.toml"),
+        "[env]\nCLAUDETTE_MISE_DENY = \"nope\"\n",
+    )
+    .unwrap();
+
+    // Intentionally DO NOT `mise trust` — mise.toml must stay untrusted.
+
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+    registry.set_setting("env-mise", "auto_trust", Some(serde_json::json!(false)));
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-mise-deny".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
+    let mise_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-mise")
+        .expect("env-mise must appear in sources");
+    assert!(
+        mise_source.error.is_some(),
+        "auto_trust=false must surface untrusted error; sources={:#?}",
+        resolved.sources
+    );
+    let err = mise_source.error.as_ref().unwrap();
+    assert!(
+        err.contains("trust") || err.contains("not trusted"),
+        "error should mention trust; got: {err}"
+    );
+    assert_eq!(mise_source.vars_contributed, 0);
+    assert!(!resolved.vars.contains_key("CLAUDETTE_MISE_DENY"));
+}
+
+/// auto_trust=true must retry after `mise trust` when the mise.toml is
+/// untrusted, and then report success with vars flowing through.
+#[cfg(has_mise)]
+#[tokio::test]
+async fn integration_mise_auto_trust_on_retries_after_untrusted() {
+    let _scoped = ScopedHome::new();
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("mise.toml"),
+        "[env]\nCLAUDETTE_MISE_AUTO = \"yes\"\n",
+    )
+    .unwrap();
+
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+    registry.set_setting("env-mise", "auto_trust", Some(serde_json::json!(true)));
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-mise-auto".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
+    let mise_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-mise")
+        .expect("env-mise must appear in sources");
+    assert!(
+        mise_source.error.is_none(),
+        "auto_trust=true must retry past the untrusted error; got {:?}",
+        mise_source.error
+    );
+    assert_eq!(
+        resolved
+            .vars
+            .get("CLAUDETTE_MISE_AUTO")
+            .and_then(|v| v.as_deref()),
+        Some("yes"),
+    );
+}
+
 // nix print-dev-env on a fresh flake evaluates the flake.nix from
 // scratch, which can take 10-60s the first time. Skip the integration
 // test for now — cargo test wall-clock matters more than coverage

--- a/src/env_provider/types.rs
+++ b/src/env_provider/types.rs
@@ -1,0 +1,26 @@
+//! Data types for env-provider results.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Environment-variable map. A value of `None` signals "unset this
+/// variable in the merged env" — matching `direnv export json`'s
+/// semantics where direnv uses `null` to unset vars its `.envrc`
+/// previously exported.
+pub type EnvMap = HashMap<String, Option<String>>;
+
+/// Result of a single env-provider plugin's `export` operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderExport {
+    /// Variables the plugin wants applied to subprocesses spawned in
+    /// the workspace. `None`-valued entries are unset rather than set.
+    pub env: EnvMap,
+
+    /// Paths the plugin watches for re-evaluation. When any of these
+    /// paths' mtimes change, the cached export is invalidated and the
+    /// plugin is called again on next resolve.
+    ///
+    /// Providers should include the primary config file(s) they depend
+    /// on (`.envrc`, `mise.toml`, `.env`, `flake.lock`, etc.).
+    pub watched: Vec<PathBuf>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod db;
 pub mod diff;
 pub mod env;
+pub mod env_provider;
 pub mod file_expand;
 pub mod fork;
 pub mod git;

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -127,48 +127,94 @@ fn register_host_api(lua: &Lua, ctx: HostContext) -> LuaResult<()> {
         })?,
     )?;
 
+    // Canonicalize the workspace root once per VM creation. Both
+    // `host.file_exists` and `host.read_file` use it as the confinement
+    // boundary: any path they resolve (after following symlinks) must
+    // descend from this root, or the operation fails. Stored as
+    // Option<PathBuf> so plugins whose worktree no longer exists fail
+    // closed (deny everything) rather than panicking.
+    let confinement = std::path::Path::new(&ctx.workspace_info.worktree_path)
+        .canonicalize()
+        .ok();
+
     // host.file_exists(path) -> bool
     //
-    // Sandbox-safe: takes an explicit path string from the plugin. The
-    // sandbox removed `io`/`os`, so plugins can't probe the filesystem
-    // on their own — this host-provided helper is the only way to check
-    // for the presence of config files (`.envrc`, `mise.toml`, `.env`,
-    // `flake.nix`, etc.) that env providers detect on.
+    // Returns true only when the path resolves to something that exists
+    // AND is inside the workspace root (after canonicalization — symlinks
+    // that escape the workspace resolve to false, not true).
     //
-    // Returns true for both files and directories — providers that need
-    // finer distinction can call `host.read_file` (which errors on dirs).
+    // Deliberately returns `false` (not error) for paths outside the
+    // workspace so a malicious plugin can't probe the filesystem by
+    // observing whether the call succeeds or errors.
+    let file_exists_root = confinement.clone();
     host.set(
         "file_exists",
-        lua.create_function(|_, path: String| {
+        lua.create_function(move |_, path: String| {
             if path.contains('\0') {
                 return Err(LuaError::external("path must not contain null bytes"));
             }
-            Ok(std::path::Path::new(&path).exists())
+            Ok(resolve_inside_workspace(&path, file_exists_root.as_deref()).is_some())
         })?,
     )?;
 
     // host.read_file(path) -> string
     //
-    // Reads the file at `path` as UTF-8. Used by env providers that
-    // parse config files in-process (e.g. dotenv's `.env` parser) rather
-    // than shelling out to an external tool.
-    //
-    // Raises a Lua error on missing files, unreadable files, or non-UTF-8
-    // contents. Plugins can wrap calls in `pcall` if they need to handle
-    // the failure themselves.
+    // Reads the file at `path` as UTF-8. Rejects paths that escape the
+    // workspace (`../../etc/passwd`, absolute paths outside, symlinks
+    // pointing out) with a Lua error. Used by env providers that parse
+    // config files in-process (e.g. dotenv's `.env` parser).
+    let read_file_root = confinement;
     host.set(
         "read_file",
-        lua.create_function(|_, path: String| {
+        lua.create_function(move |_, path: String| {
             if path.contains('\0') {
                 return Err(LuaError::external("path must not contain null bytes"));
             }
-            std::fs::read_to_string(&path)
+            let canonical =
+                resolve_inside_workspace(&path, read_file_root.as_deref()).ok_or_else(|| {
+                    LuaError::external(format!(
+                        "path '{path}' is outside the workspace or does not exist"
+                    ))
+                })?;
+            std::fs::read_to_string(&canonical)
                 .map_err(|e| LuaError::external(format!("failed to read '{path}': {e}")))
         })?,
     )?;
 
     lua.globals().set("host", host)?;
     Ok(())
+}
+
+/// Resolve `path` (absolute or relative to `workspace_root`) into a
+/// canonical path, confirming it exists and is descended from the
+/// canonical `workspace_root`. Returns `None` if:
+///   - `workspace_root` is `None` (fail closed — no confinement possible)
+///   - the path doesn't exist
+///   - the path's canonical form escapes the workspace root (symlink
+///     traversal, absolute paths outside, `..` components that land
+///     outside)
+///
+/// Canonicalization follows symlinks, so a repo-local `.env -> /etc/passwd`
+/// resolves to `/etc/passwd` which doesn't start with the workspace root
+/// → confinement fails. This is the primary mitigation for malicious
+/// plugins or repos attempting to read outside the worktree.
+fn resolve_inside_workspace(
+    path: &str,
+    workspace_root: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    let root = workspace_root?;
+    let input = std::path::Path::new(path);
+    let candidate = if input.is_absolute() {
+        input.to_path_buf()
+    } else {
+        root.join(input)
+    };
+    let canonical = candidate.canonicalize().ok()?;
+    if canonical.starts_with(root) {
+        Some(canonical)
+    } else {
+        None
+    }
 }
 
 /// Execute a subprocess, restricted to allowed CLIs.
@@ -530,5 +576,137 @@ mod tests {
             .load(r#"return host.read_file("/tmp/file\0injected")"#)
             .eval();
         assert!(result.is_err());
+    }
+
+    /// Build a context whose workspace root is the given tempdir. Used
+    /// by the confinement tests below so they can assert that paths
+    /// outside that tempdir are rejected.
+    fn ctx_with_worktree(worktree: &std::path::Path) -> HostContext {
+        HostContext {
+            plugin_name: "test".to_string(),
+            allowed_clis: vec![],
+            workspace_info: WorkspaceInfo {
+                id: "ws-1".into(),
+                name: "test".into(),
+                branch: "main".into(),
+                worktree_path: worktree.to_string_lossy().into_owned(),
+                repo_path: worktree.to_string_lossy().into_owned(),
+            },
+            config: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_file_exists_rejects_absolute_path_outside_workspace() {
+        // Absolute path to a file the OS is guaranteed to have at a
+        // predictable location. On all supported platforms this is NOT
+        // under the narrow tempdir workspace, so confinement should deny.
+        let workspace = tempfile::tempdir().unwrap();
+        let ctx = ctx_with_worktree(workspace.path());
+        let lua = create_lua_vm(ctx).unwrap();
+
+        // Use the Rust binary's path — exists for sure on every host
+        // that runs this test, and is clearly outside the tempdir.
+        let outside = std::env::current_exe().unwrap();
+        let outside_s = outside.to_string_lossy().replace('\\', "\\\\");
+        let exists: bool = lua
+            .load(format!(r#"return host.file_exists("{outside_s}")"#))
+            .eval()
+            .unwrap();
+        assert!(
+            !exists,
+            "path outside workspace must report as not existing"
+        );
+    }
+
+    #[test]
+    fn test_read_file_rejects_absolute_path_outside_workspace() {
+        let workspace = tempfile::tempdir().unwrap();
+        let ctx = ctx_with_worktree(workspace.path());
+        let lua = create_lua_vm(ctx).unwrap();
+
+        let outside = std::env::current_exe().unwrap();
+        let outside_s = outside.to_string_lossy().replace('\\', "\\\\");
+        let result: LuaResult<String> = lua
+            .load(format!(r#"return host.read_file("{outside_s}")"#))
+            .eval();
+        assert!(
+            result.is_err(),
+            "read_file must reject path outside workspace"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("outside the workspace"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_read_file_rejects_symlink_escaping_workspace() {
+        // A `.env` inside the workspace that symlinks to a file outside
+        // must not be readable — this is the path-traversal escape Codex
+        // flagged as the primary attack for a malicious `.env`.
+        let workspace = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let secret = outside_dir.path().join("secret.txt");
+        std::fs::write(&secret, "sensitive").unwrap();
+
+        let link = workspace.path().join(".env");
+        std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+        let ctx = ctx_with_worktree(workspace.path());
+        let lua = create_lua_vm(ctx).unwrap();
+
+        // file_exists follows the symlink → resolves outside → false.
+        let exists: bool = lua
+            .load(r#"return host.file_exists(".env")"#)
+            .eval()
+            .unwrap();
+        assert!(!exists, "symlink escape must report as not existing");
+
+        // read_file follows the symlink → resolves outside → error.
+        let result: LuaResult<String> = lua.load(r#"return host.read_file(".env")"#).eval();
+        assert!(
+            result.is_err(),
+            "symlink escape must be rejected by read_file"
+        );
+    }
+
+    #[test]
+    fn test_file_exists_allows_path_inside_workspace() {
+        // Sanity check that the confinement doesn't over-restrict legit
+        // workspace files — plugins MUST still be able to detect on
+        // `.envrc` / `mise.toml` / etc.
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join(".envrc"), "use flake").unwrap();
+        let ctx = ctx_with_worktree(workspace.path());
+        let lua = create_lua_vm(ctx).unwrap();
+
+        let exists: bool = lua
+            .load(r#"return host.file_exists(".envrc")"#)
+            .eval()
+            .unwrap();
+        assert!(exists, "file inside workspace must be visible");
+
+        let contents: String = lua
+            .load(r#"return host.read_file(".envrc")"#)
+            .eval()
+            .unwrap();
+        assert_eq!(contents, "use flake");
+    }
+
+    #[test]
+    fn test_file_exists_rejects_dotdot_traversal() {
+        // `..` in a relative path must not let a plugin escape upward.
+        let workspace = tempfile::tempdir().unwrap();
+        let ctx = ctx_with_worktree(workspace.path());
+        let lua = create_lua_vm(ctx).unwrap();
+
+        let exists: bool = lua
+            .load(r#"return host.file_exists("../../../etc/passwd")"#)
+            .eval()
+            .unwrap();
+        assert!(!exists, "dotdot traversal must be denied");
     }
 }

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use crate::plugin_runtime::manifest::PluginKind;
 use crate::process::CommandWindowExt as _;
 use mlua::LuaSerdeExt;
 use mlua::prelude::*;
@@ -10,6 +11,7 @@ use tokio::process::Command;
 #[derive(Debug, Clone)]
 pub struct HostContext {
     pub plugin_name: String,
+    pub kind: PluginKind,
     pub allowed_clis: Vec<String>,
     pub workspace_info: WorkspaceInfo,
     pub config: HashMap<String, serde_json::Value>,
@@ -254,11 +256,32 @@ async fn host_exec(
     command.no_console_window();
     command.args(&args);
     command.current_dir(&ctx.workspace_info.worktree_path);
-    // macOS GUI apps inherit a minimal launchd PATH, so binaries like
-    // `gh`/`glab` (typically in /opt/homebrew/bin) wouldn't be found.
-    // Pass the enriched PATH so the child — and anything it shells out
-    // to (git, credential helpers, editors) — can resolve them.
-    command.env("PATH", crate::env::enriched_path());
+
+    // Env-provider plugins run hermetically: we clear the inherited env
+    // and set only a minimal, stable baseline. This matters for tools
+    // like `direnv export json` which compute a *diff* against the
+    // current env — if Claudette was launched from a terminal that
+    // already had the workspace's env loaded, direnv would emit only
+    // the delta (handful of vars), not the full set. A hermetic baseline
+    // makes the exported set deterministic and independent of how
+    // Claudette was launched. SCM plugins keep inheriting the full env
+    // because they depend on user-state vars like `GH_TOKEN`,
+    // `SSH_AUTH_SOCK`, `XDG_CONFIG_HOME`, etc.
+    if ctx.kind == PluginKind::EnvProvider {
+        command.env_clear();
+        command.env("PATH", crate::env::enriched_path());
+        for key in ["HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL"] {
+            if let Ok(val) = std::env::var(key) {
+                command.env(key, val);
+            }
+        }
+    } else {
+        // macOS GUI apps inherit a minimal launchd PATH, so binaries like
+        // `gh`/`glab` (typically in /opt/homebrew/bin) wouldn't be found.
+        // Pass the enriched PATH so the child — and anything it shells out
+        // to (git, credential helpers, editors) — can resolve them.
+        command.env("PATH", crate::env::enriched_path());
+    }
     command.kill_on_drop(true);
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
@@ -306,6 +329,7 @@ mod tests {
         let tmp = std::env::temp_dir().to_string_lossy().into_owned();
         HostContext {
             plugin_name: "test".to_string(),
+            kind: PluginKind::Scm,
             // `cargo` is cross-platform, guaranteed to be in PATH on
             // any Rust CI host, and produces stable human-readable
             // output. `echo` would be simpler but is a `cmd.exe`
@@ -584,6 +608,7 @@ mod tests {
     fn ctx_with_worktree(worktree: &std::path::Path) -> HostContext {
         HostContext {
             plugin_name: "test".to_string(),
+            kind: PluginKind::Scm,
             allowed_clis: vec![],
             workspace_info: WorkspaceInfo {
                 id: "ws-1".into(),

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -270,7 +270,25 @@ async fn host_exec(
     if ctx.kind == PluginKind::EnvProvider {
         command.env_clear();
         command.env("PATH", crate::env::enriched_path());
-        for key in ["HOME", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL"] {
+        // XDG_*_HOME vars matter: direnv/mise store their allow/trust
+        // caches under XDG_DATA_HOME (defaulting to $HOME/.local/share
+        // when unset). Users who point those at non-default paths
+        // would otherwise see their pre-approved worktrees reported
+        // as blocked because we'd be looking at the default location
+        // while their terminal wrote to the override.
+        for key in [
+            "HOME",
+            "USER",
+            "LOGNAME",
+            "SHELL",
+            "TERM",
+            "LANG",
+            "LC_ALL",
+            "XDG_DATA_HOME",
+            "XDG_STATE_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_CONFIG_HOME",
+        ] {
             if let Ok(val) = std::env::var(key) {
                 command.env(key, val);
             }

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -26,9 +26,6 @@ pub struct WorkspaceInfo {
 
 const EXEC_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// CLIs that are always allowed regardless of manifest declarations.
-const ALWAYS_ALLOWED_CLIS: &[&str] = &["git"];
-
 /// Create a sandboxed Lua VM with the host API registered.
 pub fn create_lua_vm(ctx: HostContext) -> LuaResult<Lua> {
     let lua = Lua::new();
@@ -42,13 +39,23 @@ pub fn create_lua_vm(ctx: HostContext) -> LuaResult<Lua> {
     Ok(lua)
 }
 
-/// Remove os and io standard libraries from the Lua VM.
+/// Remove stdlib functions that give a plugin filesystem/network/process
+/// access outside the host-mediated API. The sandbox is defense-in-depth
+/// — a plugin is compiled code the user opted to install, not adversarial
+/// input — but we minimize the reachable surface anyway.
+///
+/// Includes `package`/`require`: mlua's Luau backend disables `require`
+/// by default, but we clear them unconditionally so a future mlua
+/// change (or a different Lua backend) doesn't silently re-enable
+/// file-backed module loading.
 fn sandbox_stdlib(lua: &Lua) -> LuaResult<()> {
     let globals = lua.globals();
     globals.set("os", LuaNil)?;
     globals.set("io", LuaNil)?;
     globals.set("loadfile", LuaNil)?;
     globals.set("dofile", LuaNil)?;
+    globals.set("package", LuaNil)?;
+    globals.set("require", LuaNil)?;
     Ok(())
 }
 
@@ -171,10 +178,13 @@ async fn host_exec(
     args_table: LuaTable,
     ctx: &HostContext,
 ) -> LuaResult<LuaTable> {
-    // Validate command is in the allowlist
-    let is_always_allowed = ALWAYS_ALLOWED_CLIS.contains(&cmd);
+    // Validate command is in this plugin's manifest-declared allowlist.
+    // Previously `git` was always-allowed as a convenience, but that let
+    // plugins execute arbitrary shell via `git -c alias.x='!...'` without
+    // declaring it — the user's install-time trust decision about which
+    // CLIs this plugin may run must be the sole authority.
     let is_declared = ctx.allowed_clis.iter().any(|c| c == cmd);
-    if !is_always_allowed && !is_declared {
+    if !is_declared {
         return Err(LuaError::external(format!(
             "Command '{cmd}' is not in this plugin's allowed CLIs: {:?}",
             ctx.allowed_clis
@@ -392,19 +402,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_exec_git_always_allowed() {
+    async fn test_exec_git_no_longer_always_allowed() {
+        // `git` was previously in an always-allowed list, which let a
+        // plugin exploit `git -c alias.x='!sh ...' x` to run arbitrary
+        // shell without declaring it. With the constant removed, plugins
+        // must declare every CLI they use — the manifest is the sole
+        // allowlist authority.
         let ctx = make_test_ctx();
         let lua = create_lua_vm(ctx).unwrap();
 
-        // git should work even though it's not in allowed_clis
-        let result: LuaTable = lua
+        let result: LuaResult<LuaTable> = lua
             .load(r#"return host.exec("git", {"--version"})"#)
             .eval_async()
-            .await
-            .unwrap();
+            .await;
 
-        let stdout: String = result.get("stdout").unwrap();
-        assert!(stdout.contains("git version"));
+        assert!(
+            result.is_err(),
+            "git must not be allowed without declaration"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not in this plugin's allowed CLIs"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -120,6 +120,46 @@ fn register_host_api(lua: &Lua, ctx: HostContext) -> LuaResult<()> {
         })?,
     )?;
 
+    // host.file_exists(path) -> bool
+    //
+    // Sandbox-safe: takes an explicit path string from the plugin. The
+    // sandbox removed `io`/`os`, so plugins can't probe the filesystem
+    // on their own — this host-provided helper is the only way to check
+    // for the presence of config files (`.envrc`, `mise.toml`, `.env`,
+    // `flake.nix`, etc.) that env providers detect on.
+    //
+    // Returns true for both files and directories — providers that need
+    // finer distinction can call `host.read_file` (which errors on dirs).
+    host.set(
+        "file_exists",
+        lua.create_function(|_, path: String| {
+            if path.contains('\0') {
+                return Err(LuaError::external("path must not contain null bytes"));
+            }
+            Ok(std::path::Path::new(&path).exists())
+        })?,
+    )?;
+
+    // host.read_file(path) -> string
+    //
+    // Reads the file at `path` as UTF-8. Used by env providers that
+    // parse config files in-process (e.g. dotenv's `.env` parser) rather
+    // than shelling out to an external tool.
+    //
+    // Raises a Lua error on missing files, unreadable files, or non-UTF-8
+    // contents. Plugins can wrap calls in `pcall` if they need to handle
+    // the failure themselves.
+    host.set(
+        "read_file",
+        lua.create_function(|_, path: String| {
+            if path.contains('\0') {
+                return Err(LuaError::external("path must not contain null bytes"));
+            }
+            std::fs::read_to_string(&path)
+                .map_err(|e| LuaError::external(format!("failed to read '{path}': {e}")))
+        })?,
+    )?;
+
     lua.globals().set("host", host)?;
     Ok(())
 }
@@ -384,5 +424,91 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("null bytes"));
+    }
+
+    #[test]
+    fn test_host_file_exists_true() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("marker.txt");
+        std::fs::write(&file, "hi").unwrap();
+
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let path = file.to_string_lossy().into_owned();
+        let exists: bool = lua
+            .load(format!(r#"return host.file_exists("{path}")"#))
+            .eval()
+            .unwrap();
+        assert!(exists, "existing file should return true");
+    }
+
+    #[test]
+    fn test_host_file_exists_false() {
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        // Cross-platform nonexistent path: tempdir + a child that never got created.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist.xyz");
+        let path = missing.to_string_lossy().into_owned();
+        let exists: bool = lua
+            .load(format!(r#"return host.file_exists("{path}")"#))
+            .eval()
+            .unwrap();
+        assert!(!exists, "missing file should return false");
+    }
+
+    #[test]
+    fn test_host_file_exists_directory_returns_true() {
+        // Documented behavior: file_exists returns true for directories too.
+        // Providers that need file-vs-dir distinction can use host.read_file
+        // (which errors on directories) to disambiguate.
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let path = tmp.path().to_string_lossy().into_owned();
+        let exists: bool = lua
+            .load(format!(r#"return host.file_exists("{path}")"#))
+            .eval()
+            .unwrap();
+        assert!(exists, "existing directory should return true");
+    }
+
+    #[test]
+    fn test_host_read_file_returns_contents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("data.env");
+        std::fs::write(&file, "FOO=bar\nBAZ=qux\n").unwrap();
+
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let path = file.to_string_lossy().into_owned();
+        let contents: String = lua
+            .load(format!(r#"return host.read_file("{path}")"#))
+            .eval()
+            .unwrap();
+        assert_eq!(contents, "FOO=bar\nBAZ=qux\n");
+    }
+
+    #[test]
+    fn test_host_read_file_errors_on_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope.txt");
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let path = missing.to_string_lossy().into_owned();
+        let result: LuaResult<String> = lua
+            .load(format!(r#"return host.read_file("{path}")"#))
+            .eval();
+        assert!(result.is_err(), "missing file should raise Lua error");
+    }
+
+    #[test]
+    fn test_host_read_file_rejects_null_byte_in_path() {
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let result: LuaResult<String> = lua
+            .load(r#"return host.read_file("/tmp/file\0injected")"#)
+            .eval();
+        assert!(result.is_err());
     }
 }

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -534,6 +534,15 @@ mod tests {
         assert!(err.contains("null bytes"));
     }
 
+    /// Escape a filesystem path for embedding inside a Lua double-quoted
+    /// string literal. On Windows, paths like `C:\Users\...` contain
+    /// backslashes that Lua interprets as escape sequences (`\U` etc.)
+    /// — without escaping them to `\\` the path gets silently mangled.
+    /// POSIX paths have no backslashes, so this is a no-op there.
+    fn lua_escape(path: &std::path::Path) -> String {
+        path.to_string_lossy().replace('\\', "\\\\")
+    }
+
     #[test]
     fn test_host_file_exists_true() {
         let tmp = tempfile::tempdir().unwrap();
@@ -542,7 +551,7 @@ mod tests {
 
         let ctx = make_test_ctx();
         let lua = create_lua_vm(ctx).unwrap();
-        let path = file.to_string_lossy().into_owned();
+        let path = lua_escape(&file);
         let exists: bool = lua
             .load(format!(r#"return host.file_exists("{path}")"#))
             .eval()
@@ -557,7 +566,7 @@ mod tests {
         // Cross-platform nonexistent path: tempdir + a child that never got created.
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("does-not-exist.xyz");
-        let path = missing.to_string_lossy().into_owned();
+        let path = lua_escape(&missing);
         let exists: bool = lua
             .load(format!(r#"return host.file_exists("{path}")"#))
             .eval()
@@ -573,7 +582,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let ctx = make_test_ctx();
         let lua = create_lua_vm(ctx).unwrap();
-        let path = tmp.path().to_string_lossy().into_owned();
+        let path = lua_escape(tmp.path());
         let exists: bool = lua
             .load(format!(r#"return host.file_exists("{path}")"#))
             .eval()
@@ -589,7 +598,7 @@ mod tests {
 
         let ctx = make_test_ctx();
         let lua = create_lua_vm(ctx).unwrap();
-        let path = file.to_string_lossy().into_owned();
+        let path = lua_escape(&file);
         let contents: String = lua
             .load(format!(r#"return host.read_file("{path}")"#))
             .eval()
@@ -603,7 +612,7 @@ mod tests {
         let missing = tmp.path().join("nope.txt");
         let ctx = make_test_ctx();
         let lua = create_lua_vm(ctx).unwrap();
-        let path = missing.to_string_lossy().into_owned();
+        let path = lua_escape(&missing);
         let result: LuaResult<String> = lua
             .load(format!(r#"return host.read_file("{path}")"#))
             .eval();
@@ -651,7 +660,7 @@ mod tests {
         // Use the Rust binary's path — exists for sure on every host
         // that runs this test, and is clearly outside the tempdir.
         let outside = std::env::current_exe().unwrap();
-        let outside_s = outside.to_string_lossy().replace('\\', "\\\\");
+        let outside_s = lua_escape(&outside);
         let exists: bool = lua
             .load(format!(r#"return host.file_exists("{outside_s}")"#))
             .eval()
@@ -669,7 +678,7 @@ mod tests {
         let lua = create_lua_vm(ctx).unwrap();
 
         let outside = std::env::current_exe().unwrap();
-        let outside_s = outside.to_string_lossy().replace('\\', "\\\\");
+        let outside_s = lua_escape(&outside);
         let result: LuaResult<String> = lua
             .load(format!(r#"return host.read_file("{outside_s}")"#))
             .eval();

--- a/src/plugin_runtime/manifest.rs
+++ b/src/plugin_runtime/manifest.rs
@@ -3,6 +3,18 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+/// Plugin kind — drives which dispatcher consumes the plugin.
+///
+/// Defaults to [`PluginKind::Scm`] for backwards compatibility with
+/// manifests written before this field existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum PluginKind {
+    #[default]
+    Scm,
+    EnvProvider,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginManifest {
     pub name: String,
@@ -16,6 +28,8 @@ pub struct PluginManifest {
     pub operations: Vec<String>,
     #[serde(default)]
     pub config_schema: HashMap<String, ConfigField>,
+    #[serde(default)]
+    pub kind: PluginKind,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,5 +116,70 @@ mod tests {
         }"#;
         let result: Result<PluginManifest, _> = serde_json::from_str(json);
         assert!(result.is_err()); // missing description and operations
+    }
+
+    #[test]
+    fn test_manifest_defaults_to_scm_kind() {
+        // Existing manifests in the wild don't have a `kind` field — parsing
+        // must succeed and default to Scm for backwards compatibility.
+        let json = r#"{
+            "name": "legacy",
+            "display_name": "Legacy",
+            "version": "1.0.0",
+            "description": "No kind field",
+            "operations": ["list_pull_requests"]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.kind, PluginKind::Scm);
+    }
+
+    #[test]
+    fn test_manifest_parses_env_provider_kind() {
+        let json = r#"{
+            "name": "env-direnv",
+            "display_name": "direnv",
+            "version": "1.0.0",
+            "description": "direnv env provider",
+            "kind": "env-provider",
+            "operations": ["detect", "export"]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.kind, PluginKind::EnvProvider);
+    }
+
+    #[test]
+    fn test_manifest_rejects_unknown_kind() {
+        let json = r#"{
+            "name": "weird",
+            "display_name": "Weird",
+            "version": "1.0.0",
+            "description": "Unknown kind",
+            "kind": "frobnicator",
+            "operations": []
+        }"#;
+        let result: Result<PluginManifest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "unknown kind should fail to parse");
+    }
+
+    #[test]
+    fn test_manifest_roundtrips_env_provider_kind() {
+        let manifest = PluginManifest {
+            name: "env-mise".into(),
+            display_name: "mise".into(),
+            version: "1.0.0".into(),
+            description: "mise env provider".into(),
+            required_clis: vec!["mise".into()],
+            remote_patterns: vec![],
+            operations: vec!["detect".into(), "export".into()],
+            config_schema: HashMap::new(),
+            kind: PluginKind::EnvProvider,
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(
+            json.contains(r#""kind":"env-provider""#),
+            "serialized kind should be kebab-case: {json}"
+        );
+        let round: PluginManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(round.kind, PluginKind::EnvProvider);
     }
 }

--- a/src/plugin_runtime/manifest.rs
+++ b/src/plugin_runtime/manifest.rs
@@ -30,6 +30,12 @@ pub struct PluginManifest {
     pub config_schema: HashMap<String, ConfigField>,
     #[serde(default)]
     pub kind: PluginKind,
+    /// User-facing settings the Plugins UI renders a form for. Values
+    /// are persisted in `app_settings` as `plugin:{name}:setting:{key}`
+    /// and piped into `HostContext.config` at invocation time so plugin
+    /// scripts read them via `host.config("auto_allow")`.
+    #[serde(default)]
+    pub settings: Vec<PluginSettingField>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,6 +50,71 @@ pub struct ConfigField {
     pub default: serde_json::Value,
     #[serde(default)]
     pub options: Vec<String>,
+}
+
+/// User-facing plugin setting — rendered as a typed input in the
+/// Plugins settings section. The Lua plugin reads its own values via
+/// `host.config("<key>")`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PluginSettingField {
+    Boolean {
+        key: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default)]
+        default: bool,
+    },
+    Text {
+        key: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        placeholder: Option<String>,
+    },
+    Select {
+        key: String,
+        label: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default: Option<String>,
+        options: Vec<SelectOption>,
+    },
+}
+
+impl PluginSettingField {
+    pub fn key(&self) -> &str {
+        match self {
+            Self::Boolean { key, .. } | Self::Text { key, .. } | Self::Select { key, .. } => key,
+        }
+    }
+
+    /// Default value rendered as a serde_json::Value so it can feed
+    /// `HostContext.config` with the same type shape plugins will read.
+    pub fn default_value(&self) -> serde_json::Value {
+        match self {
+            Self::Boolean { default, .. } => serde_json::Value::Bool(*default),
+            Self::Text { default, .. } => default
+                .clone()
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+            Self::Select { default, .. } => default
+                .clone()
+                .map(serde_json::Value::String)
+                .unwrap_or(serde_json::Value::Null),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SelectOption {
+    pub value: String,
+    pub label: String,
 }
 
 /// Parse a plugin manifest from a `plugin.json` file.
@@ -173,6 +244,7 @@ mod tests {
             operations: vec!["detect".into(), "export".into()],
             config_schema: HashMap::new(),
             kind: PluginKind::EnvProvider,
+            settings: vec![],
         };
         let json = serde_json::to_string(&manifest).unwrap();
         assert!(
@@ -181,5 +253,147 @@ mod tests {
         );
         let round: PluginManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(round.kind, PluginKind::EnvProvider);
+    }
+
+    #[test]
+    fn manifest_defaults_to_empty_settings() {
+        let json = r#"{
+            "name": "legacy",
+            "display_name": "Legacy",
+            "version": "1.0.0",
+            "description": "No settings",
+            "operations": []
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.settings.is_empty());
+    }
+
+    #[test]
+    fn manifest_parses_boolean_setting() {
+        let json = r#"{
+            "name": "env-direnv",
+            "display_name": "direnv",
+            "version": "1.0.0",
+            "description": "direnv env provider",
+            "kind": "env-provider",
+            "operations": ["detect", "export"],
+            "settings": [
+                {
+                    "type": "boolean",
+                    "key": "auto_allow",
+                    "label": "Always allow .envrc",
+                    "description": "Run direnv allow automatically",
+                    "default": false
+                }
+            ]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.settings.len(), 1);
+        match &manifest.settings[0] {
+            PluginSettingField::Boolean {
+                key,
+                label,
+                description,
+                default,
+            } => {
+                assert_eq!(key, "auto_allow");
+                assert_eq!(label, "Always allow .envrc");
+                assert_eq!(
+                    description.as_deref(),
+                    Some("Run direnv allow automatically")
+                );
+                assert!(!*default);
+            }
+            other => panic!("expected boolean, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn manifest_parses_multiple_setting_types() {
+        let json = r#"{
+            "name": "demo", "display_name": "Demo", "version": "1.0.0",
+            "description": "d", "operations": [],
+            "settings": [
+                { "type": "boolean", "key": "a", "label": "A", "default": true },
+                { "type": "text", "key": "b", "label": "B", "placeholder": "x" },
+                { "type": "select", "key": "c", "label": "C",
+                  "options": [
+                      { "value": "v1", "label": "V1" },
+                      { "value": "v2", "label": "V2" }
+                  ] }
+            ]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.settings.len(), 3);
+        assert!(matches!(
+            manifest.settings[0],
+            PluginSettingField::Boolean { .. }
+        ));
+        assert!(matches!(
+            manifest.settings[1],
+            PluginSettingField::Text { .. }
+        ));
+        match &manifest.settings[2] {
+            PluginSettingField::Select { options, .. } => assert_eq!(options.len(), 2),
+            other => panic!("expected select, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn manifest_rejects_unknown_setting_type() {
+        let json = r#"{
+            "name": "bad", "display_name": "B", "version": "1.0.0",
+            "description": "b", "operations": [],
+            "settings": [ { "type": "weirdo", "key": "x", "label": "X" } ]
+        }"#;
+        let result: Result<PluginManifest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "unknown setting type should fail to parse");
+    }
+
+    #[test]
+    fn setting_field_default_value_helper() {
+        let b = PluginSettingField::Boolean {
+            key: "k".into(),
+            label: "l".into(),
+            description: None,
+            default: true,
+        };
+        assert_eq!(b.default_value(), serde_json::Value::Bool(true));
+        assert_eq!(b.key(), "k");
+
+        let t_with = PluginSettingField::Text {
+            key: "k".into(),
+            label: "l".into(),
+            description: None,
+            default: Some("hi".into()),
+            placeholder: None,
+        };
+        assert_eq!(
+            t_with.default_value(),
+            serde_json::Value::String("hi".into())
+        );
+
+        let t_no_default = PluginSettingField::Text {
+            key: "k".into(),
+            label: "l".into(),
+            description: None,
+            default: None,
+            placeholder: None,
+        };
+        assert_eq!(t_no_default.default_value(), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn setting_field_roundtrips() {
+        let field = PluginSettingField::Boolean {
+            key: "auto_allow".into(),
+            label: "Auto allow".into(),
+            description: Some("Auto-run".into()),
+            default: false,
+        };
+        let json = serde_json::to_string(&field).unwrap();
+        assert!(json.contains(r#""type":"boolean""#), "got {json}");
+        let back: PluginSettingField = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, field);
     }
 }

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -171,6 +171,7 @@ impl PluginRegistry {
 
         let ctx = HostContext {
             plugin_name: plugin_name.to_string(),
+            kind: plugin.manifest.kind,
             allowed_clis: plugin.manifest.required_clis.clone(),
             workspace_info,
             config: plugin.config.clone(),

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -160,8 +160,12 @@ impl PluginRegistry {
 
     /// Set or clear a user setting override for a plugin. Pass `None` to
     /// revert to the manifest's default value. No-op if the plugin
-    /// isn't registered.
+    /// isn't registered — we don't want unknown plugin names to
+    /// silently accumulate override entries.
     pub fn set_setting(&self, plugin_name: &str, key: &str, value: Option<serde_json::Value>) {
+        if !self.plugins.contains_key(plugin_name) {
+            return;
+        }
         let mut guard = self.setting_overrides.write().unwrap();
         match value {
             Some(v) => {
@@ -650,5 +654,22 @@ mod tests {
             .unwrap();
         assert_eq!(result["flag"], false);
         assert_eq!(result["name"], "bob");
+    }
+
+    #[test]
+    fn set_setting_ignores_unknown_plugin_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = PluginRegistry::discover(dir.path());
+
+        registry.set_setting(
+            "does-not-exist",
+            "some_key",
+            Some(serde_json::Value::String("x".into())),
+        );
+
+        // Unknown plugin names must NOT silently accumulate override
+        // entries in the map.
+        let overrides = registry.setting_overrides.read().unwrap();
+        assert!(!overrides.contains_key("does-not-exist"));
     }
 }

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -221,7 +221,17 @@ impl PluginRegistry {
     /// `PluginDisabled` from `call_operation`; dispatchers that prefer
     /// silent filtering (env-provider resolution) check `is_disabled`
     /// first.
+    ///
+    /// No-op for plugin names that aren't registered — parallels
+    /// `set_setting`, and keeps startup hydration from app_settings
+    /// silently dropping entries for removed/renamed plugins instead of
+    /// ghost-disabling them. Callers at the API boundary (e.g.
+    /// `set_claudette_plugin_enabled`) should validate unknown names
+    /// explicitly and surface an error to the user.
     pub fn set_disabled(&self, plugin_name: &str, disabled: bool) {
+        if !self.plugins.contains_key(plugin_name) {
+            return;
+        }
         let mut guard = self.disabled.write().unwrap();
         if disabled {
             guard.insert(plugin_name.to_string());
@@ -604,12 +614,23 @@ mod tests {
     #[test]
     fn set_disabled_and_is_disabled_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
+        let registry = make_plugin_with_settings_manifest(dir.path());
+        assert!(!registry.is_disabled("settings-demo"));
+        registry.set_disabled("settings-demo", true);
+        assert!(registry.is_disabled("settings-demo"));
+        registry.set_disabled("settings-demo", false);
+        assert!(!registry.is_disabled("settings-demo"));
+    }
+
+    #[test]
+    fn set_disabled_ignores_unknown_plugin_name() {
+        let dir = tempfile::tempdir().unwrap();
         let registry = PluginRegistry::discover(dir.path());
-        assert!(!registry.is_disabled("x"));
-        registry.set_disabled("x", true);
-        assert!(registry.is_disabled("x"));
-        registry.set_disabled("x", false);
-        assert!(!registry.is_disabled("x"));
+        registry.set_disabled("does-not-exist", true);
+        assert!(
+            !registry.is_disabled("does-not-exist"),
+            "unknown plugin names must not accumulate in the disabled set"
+        );
     }
 
     #[tokio::test]

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -2,9 +2,10 @@ pub mod host_api;
 pub mod manifest;
 pub mod seed;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 use std::time::Duration;
 
 use host_api::{HostContext, WorkspaceInfo};
@@ -40,6 +41,7 @@ pub enum PluginError {
     NoProvider,
     OperationNotSupported(String),
     PluginNotFound(String),
+    PluginDisabled(String),
 }
 
 impl fmt::Display for PluginError {
@@ -58,6 +60,7 @@ impl fmt::Display for PluginError {
             Self::NoProvider => write!(f, "No provider configured for this repository"),
             Self::OperationNotSupported(op) => write!(f, "Operation '{op}' is not supported"),
             Self::PluginNotFound(name) => write!(f, "Plugin '{name}' not found"),
+            Self::PluginDisabled(name) => write!(f, "Plugin '{name}' is disabled"),
         }
     }
 }
@@ -73,6 +76,20 @@ impl serde::Serialize for PluginError {
 pub struct PluginRegistry {
     pub plugins: HashMap<String, LoadedPlugin>,
     pub plugin_dir: PathBuf,
+    /// User-persisted setting overrides, keyed by plugin name → setting
+    /// key → JSON value. Populated from `app_settings` at app start
+    /// and updated by the Plugins settings UI. Takes precedence over
+    /// manifest defaults and any static `plugin.config`.
+    ///
+    /// The lock is independent of `plugins`, so concurrent reads (from
+    /// `call_operation` building its HostContext) don't contend with
+    /// writes from the UI layer.
+    setting_overrides: RwLock<HashMap<String, HashMap<String, serde_json::Value>>>,
+    /// Globally-disabled plugin names. `call_operation` short-circuits
+    /// with `PluginDisabled` for any name in this set; dispatchers that
+    /// want to skip silently (e.g. env-provider resolution) should call
+    /// `is_disabled` and filter.
+    disabled: RwLock<HashSet<String>>,
 }
 
 impl PluginRegistry {
@@ -92,6 +109,8 @@ impl PluginRegistry {
                 return Self {
                     plugins,
                     plugin_dir: plugin_dir.to_path_buf(),
+                    setting_overrides: RwLock::new(HashMap::new()),
+                    disabled: RwLock::new(HashSet::new()),
                 };
             }
         };
@@ -134,7 +153,81 @@ impl PluginRegistry {
         Self {
             plugins,
             plugin_dir: plugin_dir.to_path_buf(),
+            setting_overrides: RwLock::new(HashMap::new()),
+            disabled: RwLock::new(HashSet::new()),
         }
+    }
+
+    /// Set or clear a user setting override for a plugin. Pass `None` to
+    /// revert to the manifest's default value. No-op if the plugin
+    /// isn't registered.
+    pub fn set_setting(&self, plugin_name: &str, key: &str, value: Option<serde_json::Value>) {
+        let mut guard = self.setting_overrides.write().unwrap();
+        match value {
+            Some(v) => {
+                guard
+                    .entry(plugin_name.to_string())
+                    .or_default()
+                    .insert(key.to_string(), v);
+            }
+            None => {
+                if let Some(entry) = guard.get_mut(plugin_name) {
+                    entry.remove(key);
+                    if entry.is_empty() {
+                        guard.remove(plugin_name);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Return the effective config map a plugin's Lua VM will see.
+    /// Precedence (lowest → highest): manifest `settings[].default` →
+    /// static `plugin.config` → user setting overrides.
+    ///
+    /// Returns an empty map for unknown plugin names rather than an
+    /// error; `call_operation` is the surface that rejects unknown
+    /// plugins.
+    pub fn effective_config(&self, plugin_name: &str) -> HashMap<String, serde_json::Value> {
+        let mut out: HashMap<String, serde_json::Value> = HashMap::new();
+
+        if let Some(plugin) = self.plugins.get(plugin_name) {
+            for field in &plugin.manifest.settings {
+                let default = field.default_value();
+                if !default.is_null() {
+                    out.insert(field.key().to_string(), default);
+                }
+            }
+            for (k, v) in &plugin.config {
+                out.insert(k.clone(), v.clone());
+            }
+        }
+
+        let overrides = self.setting_overrides.read().unwrap();
+        if let Some(plugin_overrides) = overrides.get(plugin_name) {
+            for (k, v) in plugin_overrides {
+                out.insert(k.clone(), v.clone());
+            }
+        }
+
+        out
+    }
+
+    /// Globally enable/disable a plugin. Disabled plugins return
+    /// `PluginDisabled` from `call_operation`; dispatchers that prefer
+    /// silent filtering (env-provider resolution) check `is_disabled`
+    /// first.
+    pub fn set_disabled(&self, plugin_name: &str, disabled: bool) {
+        let mut guard = self.disabled.write().unwrap();
+        if disabled {
+            guard.insert(plugin_name.to_string());
+        } else {
+            guard.remove(plugin_name);
+        }
+    }
+
+    pub fn is_disabled(&self, plugin_name: &str) -> bool {
+        self.disabled.read().unwrap().contains(plugin_name)
     }
 
     /// Execute an operation on a plugin.
@@ -152,6 +245,10 @@ impl PluginRegistry {
             .plugins
             .get(plugin_name)
             .ok_or_else(|| PluginError::PluginNotFound(plugin_name.to_string()))?;
+
+        if self.is_disabled(plugin_name) {
+            return Err(PluginError::PluginDisabled(plugin_name.to_string()));
+        }
 
         if !plugin.cli_available {
             let cli_list = plugin.manifest.required_clis.join(", ");
@@ -174,7 +271,7 @@ impl PluginRegistry {
             kind: plugin.manifest.kind,
             allowed_clis: plugin.manifest.required_clis.clone(),
             workspace_info,
-            config: plugin.config.clone(),
+            config: self.effective_config(plugin_name),
         };
 
         let lua =
@@ -434,5 +531,124 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(PluginError::OperationNotSupported(_))));
+    }
+
+    fn make_plugin_with_settings_manifest(dir: &Path) -> PluginRegistry {
+        let plugin_dir = dir.join("settings-demo");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{
+                "name": "settings-demo",
+                "display_name": "Settings Demo",
+                "version": "1.0.0",
+                "description": "demo",
+                "operations": ["read_config"],
+                "settings": [
+                    { "type": "boolean", "key": "flag", "label": "Flag", "default": false },
+                    { "type": "text", "key": "name", "label": "Name", "default": "alice" }
+                ]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            plugin_dir.join("init.lua"),
+            r#"
+            local M = {}
+            function M.read_config(args)
+                return { flag = host.config("flag"), name = host.config("name") }
+            end
+            return M
+            "#,
+        )
+        .unwrap();
+        PluginRegistry::discover(dir)
+    }
+
+    #[test]
+    fn effective_config_uses_manifest_defaults_when_no_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = make_plugin_with_settings_manifest(dir.path());
+        let cfg = registry.effective_config("settings-demo");
+        assert_eq!(cfg.get("flag"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(
+            cfg.get("name"),
+            Some(&serde_json::Value::String("alice".into()))
+        );
+    }
+
+    #[test]
+    fn set_setting_overrides_manifest_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = make_plugin_with_settings_manifest(dir.path());
+        registry.set_setting("settings-demo", "flag", Some(serde_json::Value::Bool(true)));
+        let cfg = registry.effective_config("settings-demo");
+        assert_eq!(cfg.get("flag"), Some(&serde_json::Value::Bool(true)));
+        // Unset override reverts to manifest default.
+        registry.set_setting("settings-demo", "flag", None);
+        let cfg = registry.effective_config("settings-demo");
+        assert_eq!(cfg.get("flag"), Some(&serde_json::Value::Bool(false)));
+    }
+
+    #[test]
+    fn effective_config_empty_for_unknown_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = PluginRegistry::discover(dir.path());
+        assert!(registry.effective_config("no-such-plugin").is_empty());
+    }
+
+    #[test]
+    fn set_disabled_and_is_disabled_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = PluginRegistry::discover(dir.path());
+        assert!(!registry.is_disabled("x"));
+        registry.set_disabled("x", true);
+        assert!(registry.is_disabled("x"));
+        registry.set_disabled("x", false);
+        assert!(!registry.is_disabled("x"));
+    }
+
+    #[tokio::test]
+    async fn call_operation_errors_for_disabled_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = make_plugin_with_settings_manifest(dir.path());
+        registry.set_disabled("settings-demo", true);
+
+        let ws = WorkspaceInfo {
+            id: "ws-1".into(),
+            name: "test".into(),
+            branch: "main".into(),
+            worktree_path: "/tmp".into(),
+            repo_path: "/tmp".into(),
+        };
+        let result = registry
+            .call_operation("settings-demo", "read_config", serde_json::json!({}), ws)
+            .await;
+        assert!(matches!(result, Err(PluginError::PluginDisabled(_))));
+    }
+
+    #[tokio::test]
+    async fn call_operation_populates_host_config_from_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = make_plugin_with_settings_manifest(dir.path());
+        registry.set_setting(
+            "settings-demo",
+            "name",
+            Some(serde_json::Value::String("bob".into())),
+        );
+
+        let ws = WorkspaceInfo {
+            id: "ws-1".into(),
+            name: "test".into(),
+            branch: "main".into(),
+            worktree_path: "/tmp".into(),
+            repo_path: "/tmp".into(),
+        };
+        let result = registry
+            .call_operation("settings-demo", "read_config", serde_json::json!({}), ws)
+            .await
+            .unwrap();
+        assert_eq!(result["flag"], false);
+        assert_eq!(result["name"], "bob");
     }
 }

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -133,6 +133,7 @@ pub fn reseed_bundled_plugins_force(plugin_dir: &Path) -> Vec<String> {
         let init_file = dir.join("init.lua");
         let manifest_file = dir.join("plugin.json");
         let version_file = dir.join(".version");
+        let content_hash_file = dir.join(".content_hash");
 
         if let Err(e) = std::fs::create_dir_all(&dir) {
             warnings.push(format!(
@@ -142,17 +143,21 @@ pub fn reseed_bundled_plugins_force(plugin_dir: &Path) -> Vec<String> {
             continue;
         }
 
-        // Ownership check: presence of `.version` is our signal that
-        // Claudette seeded this directory. If present, overwriting is
-        // safe — we own the file regardless of whether the content
-        // matches the *current* embedded hash (this is the whole
-        // point of reseed: a plugin seeded from an older Claudette
-        // version has different content but is still ours to update).
+        // Layered ownership check:
         //
-        // If `.version` is absent but `init.lua` exists, the directory
-        // was created by the user (or a user's tool), so we skip.
-        // This is stricter than the previous hash-based check: we no
-        // longer need to guess based on matching hashes.
+        // 1. No `.version` at all + `init.lua` exists → user created
+        //    this plugin directory; never touch.
+        // 2. `.content_hash` exists + matches the on-disk init.lua →
+        //    this is the content we last wrote; safe to overwrite
+        //    (the current embed may differ from the stored hash,
+        //    which is exactly the stale-seeded case reseed is for).
+        // 3. `.content_hash` exists + differs from the on-disk
+        //    init.lua → user customized it after we seeded; preserve.
+        // 4. `.content_hash` missing + `.version` present (legacy
+        //    install predating hash-stamping): fall back to hashing
+        //    against the current embed. This restores the pre-hash
+        //    behavior for existing installs without clobbering
+        //    customizations.
         let has_version_stamp = version_file.exists();
         if init_file.exists() && !has_version_stamp {
             warnings.push(format!(
@@ -161,6 +166,34 @@ pub fn reseed_bundled_plugins_force(plugin_dir: &Path) -> Vec<String> {
                 dir.display()
             ));
             continue;
+        }
+
+        if init_file.exists() {
+            let on_disk = std::fs::read_to_string(&init_file).unwrap_or_default();
+            let on_disk_hash = sha256_hex(&on_disk);
+            let preserved_as_user_edit = if content_hash_file.exists() {
+                let stamped = std::fs::read_to_string(&content_hash_file)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                stamped != on_disk_hash
+            } else {
+                // Legacy install without a content hash. Only preserve
+                // if the on-disk content clearly diverges from what we
+                // would write now — this retains customizations made
+                // before this code existed. Stale-seeded-but-unmodified
+                // copies (identical to the current embed) pass through
+                // and get restamped with a proper hash below.
+                sha256_hex(init_lua) != on_disk_hash && !on_disk.is_empty()
+            };
+            if preserved_as_user_edit {
+                warnings.push(format!(
+                    "Plugin '{name}': init.lua has user modifications — skipping update. \
+                     Delete {} to force a reseed.",
+                    dir.display()
+                ));
+                continue;
+            }
         }
 
         if let Err(e) = write_plugin_files(
@@ -187,6 +220,13 @@ fn write_plugin_files(
     std::fs::write(manifest_path, manifest_content)?;
     std::fs::write(init_path, init_content)?;
     std::fs::write(version_path, APP_VERSION)?;
+    // Stamp the content hash alongside .version so reseed can later
+    // detect whether the on-disk `init.lua` is still what we wrote
+    // (regardless of which Claudette version wrote it). Mismatch
+    // between this stamp and the on-disk hash means the user has
+    // customized the file, so force-reseed preserves it.
+    let hash_path = version_path.with_file_name(".content_hash");
+    std::fs::write(hash_path, sha256_hex(init_content))?;
     Ok(())
 }
 
@@ -323,21 +363,22 @@ mod tests {
 
     #[test]
     fn force_reseed_rewrites_stale_version_content() {
-        // Regression guard for the Codex finding: when a plugin was
-        // seeded by an older Claudette build, its on-disk init.lua
-        // doesn't match the current embedded hash. The previous
-        // hash-based gate would misclassify this as "user modified"
-        // and refuse to overwrite — exactly the case the Reload
-        // button is supposed to repair. Using `.version` presence
-        // as the ownership signal fixes it.
+        // Stale-seeded scenario: plugin was seeded by an older
+        // Claudette build, its on-disk init.lua no longer matches
+        // the current embed, but the `.content_hash` stamp still
+        // matches the on-disk content (we own it, user didn't
+        // modify). The Reload button must overwrite.
         let dir = tempfile::tempdir().unwrap();
         seed_bundled_plugins(dir.path());
 
         let init_path = dir.path().join("github/init.lua");
-        // Simulate a stale seeded copy: different content than the
-        // current embed, but `.version` is still present (seeded by
-        // a prior Claudette build).
-        std::fs::write(&init_path, "-- stale content from older version").unwrap();
+        let hash_path = dir.path().join("github/.content_hash");
+        let stale = "-- stale content from older version";
+        std::fs::write(&init_path, stale).unwrap();
+        // Restamp the hash to match the stale content — this is
+        // what a prior reseed from that older version would have
+        // written.
+        std::fs::write(&hash_path, sha256_hex(stale)).unwrap();
 
         let warnings = reseed_bundled_plugins_force(dir.path());
         let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
@@ -349,6 +390,35 @@ mod tests {
         assert!(
             !after.contains("stale content"),
             "stale content must be replaced with embedded plugin"
+        );
+    }
+
+    #[test]
+    fn force_reseed_preserves_user_edits_via_hash_stamp() {
+        // Regression guard for the Codex re-review finding: when
+        // `.content_hash` exists but differs from the on-disk
+        // init.lua hash, the user has customized a seeded plugin.
+        // Force-reseed must preserve those edits.
+        let dir = tempfile::tempdir().unwrap();
+        seed_bundled_plugins(dir.path());
+
+        let init_path = dir.path().join("github/init.lua");
+        // Simulate a user edit — change content WITHOUT updating
+        // `.content_hash`, which is exactly what happens when a
+        // user edits the file directly.
+        let user_content = "-- user customization\nlocal M = {}\nreturn M";
+        std::fs::write(&init_path, user_content).unwrap();
+
+        let warnings = reseed_bundled_plugins_force(dir.path());
+        let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
+        assert!(
+            !github_warnings.is_empty(),
+            "user edit must be preserved with a warning: {warnings:?}"
+        );
+        let after = std::fs::read_to_string(&init_path).unwrap();
+        assert!(
+            after.contains("user customization"),
+            "user edits must survive reseed"
         );
     }
 

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -142,27 +142,25 @@ pub fn reseed_bundled_plugins_force(plugin_dir: &Path) -> Vec<String> {
             continue;
         }
 
-        // If a user has modified init.lua we refuse to clobber. Hash
-        // match with the embedded version is our "safe to overwrite"
-        // signal.
-        if init_file.exists() {
-            let on_disk = std::fs::read_to_string(&init_file).unwrap_or_default();
-            let embedded_hash = sha256_hex(init_lua);
-            let disk_hash = sha256_hex(&on_disk);
-            if embedded_hash != disk_hash && !on_disk.is_empty() {
-                // If the on-disk content differs from the current
-                // embedded one, we need another signal that the user
-                // hasn't customized — compare against `plugin_json`
-                // content. But plugin.json is likely to have been
-                // re-rendered on disk (pretty-printed by us), so we
-                // still respect user-edited init.lua.
-                warnings.push(format!(
-                    "Plugin '{name}': init.lua has user modifications — skipping update. \
-                     Delete {} to force a reseed.",
-                    dir.display()
-                ));
-                continue;
-            }
+        // Ownership check: presence of `.version` is our signal that
+        // Claudette seeded this directory. If present, overwriting is
+        // safe — we own the file regardless of whether the content
+        // matches the *current* embedded hash (this is the whole
+        // point of reseed: a plugin seeded from an older Claudette
+        // version has different content but is still ours to update).
+        //
+        // If `.version` is absent but `init.lua` exists, the directory
+        // was created by the user (or a user's tool), so we skip.
+        // This is stricter than the previous hash-based check: we no
+        // longer need to guess based on matching hashes.
+        let has_version_stamp = version_file.exists();
+        if init_file.exists() && !has_version_stamp {
+            warnings.push(format!(
+                "Plugin '{name}': no .version file — directory appears user-created, skipping. \
+                 Delete {} to force a reseed.",
+                dir.display()
+            ));
+            continue;
         }
 
         if let Err(e) = write_plugin_files(
@@ -324,35 +322,58 @@ mod tests {
     }
 
     #[test]
-    fn force_reseed_overwrites_unmodified_current_version() {
-        // Even when .version matches APP_VERSION, force reseed should
-        // still rewrite on-disk init.lua that matches the embedded hash.
-        // (Use case: user stuck on a stale init.lua because we shipped
-        // tree changes between version bumps.)
+    fn force_reseed_rewrites_stale_version_content() {
+        // Regression guard for the Codex finding: when a plugin was
+        // seeded by an older Claudette build, its on-disk init.lua
+        // doesn't match the current embedded hash. The previous
+        // hash-based gate would misclassify this as "user modified"
+        // and refuse to overwrite — exactly the case the Reload
+        // button is supposed to repair. Using `.version` presence
+        // as the ownership signal fixes it.
         let dir = tempfile::tempdir().unwrap();
         seed_bundled_plugins(dir.path());
 
-        // Swap init.lua with a *previously-embedded* content (simulated
-        // by overwriting with the same bytes so the hash matches the
-        // current embed — we can't easily simulate "previous embed"
-        // without shipping a second copy).
-        // What we can assert: force reseed writes the current content
-        // even if .version says we're on APP_VERSION (vs the gated
-        // seed which would skip).
         let init_path = dir.path().join("github/init.lua");
-        let before = std::fs::read_to_string(&init_path).unwrap();
-        // Overwrite with whitespace added so hash differs from on-disk
-        // but this mimics user modification — should be preserved.
-        std::fs::write(&init_path, format!("{before}\n-- added")).unwrap();
+        // Simulate a stale seeded copy: different content than the
+        // current embed, but `.version` is still present (seeded by
+        // a prior Claudette build).
+        std::fs::write(&init_path, "-- stale content from older version").unwrap();
+
+        let warnings = reseed_bundled_plugins_force(dir.path());
+        let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
+        assert!(
+            github_warnings.is_empty(),
+            "stale seeded copy must be overwritten without warning: {github_warnings:?}"
+        );
+        let after = std::fs::read_to_string(&init_path).unwrap();
+        assert!(
+            !after.contains("stale content"),
+            "stale content must be replaced with embedded plugin"
+        );
+    }
+
+    #[test]
+    fn force_reseed_skips_user_created_plugin_dir() {
+        // A user-created plugin directory has no `.version` stamp.
+        // The reseed must refuse to clobber it.
+        let dir = tempfile::tempdir().unwrap();
+        let user_dir = dir.path().join("github");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        std::fs::write(
+            user_dir.join("init.lua"),
+            "-- user-authored plugin (never seeded)",
+        )
+        .unwrap();
+        std::fs::write(user_dir.join("plugin.json"), "{}").unwrap();
+        // NO .version file — this is the user-ownership signal.
 
         let warnings = reseed_bundled_plugins_force(dir.path());
         assert!(
             warnings.iter().any(|w| w.contains("github")),
-            "user-modified init.lua should be preserved with a warning: {warnings:?}"
+            "user-created plugin dir must be preserved with a warning: {warnings:?}"
         );
-        // Content should be unchanged (we preserved user edits).
-        let after = std::fs::read_to_string(&init_path).unwrap();
-        assert!(after.contains("-- added"));
+        let preserved = std::fs::read_to_string(user_dir.join("init.lua")).unwrap();
+        assert!(preserved.contains("user-authored"));
     }
 
     #[test]

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -14,6 +14,26 @@ const BUNDLED_PLUGINS: &[(&str, &str, &str)] = &[
         include_str!("../../plugins/scm-gitlab/plugin.json"),
         include_str!("../../plugins/scm-gitlab/init.lua"),
     ),
+    (
+        "env-direnv",
+        include_str!("../../plugins/env-direnv/plugin.json"),
+        include_str!("../../plugins/env-direnv/init.lua"),
+    ),
+    (
+        "env-mise",
+        include_str!("../../plugins/env-mise/plugin.json"),
+        include_str!("../../plugins/env-mise/init.lua"),
+    ),
+    (
+        "env-dotenv",
+        include_str!("../../plugins/env-dotenv/plugin.json"),
+        include_str!("../../plugins/env-dotenv/init.lua"),
+    ),
+    (
+        "env-nix-devshell",
+        include_str!("../../plugins/env-nix-devshell/plugin.json"),
+        include_str!("../../plugins/env-nix-devshell/init.lua"),
+    ),
 ];
 
 /// The current app version, used for the .version sentinel file.

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -115,6 +115,70 @@ pub fn seed_bundled_plugins(plugin_dir: &Path) -> Vec<String> {
     warnings
 }
 
+/// Reseed all bundled plugins regardless of the current `.version`
+/// stamp. Used by the "Reload bundled plugins" button to pick up
+/// in-tree plugin changes between Claudette releases (since the
+/// version-gated path in [`seed_bundled_plugins`] only runs on
+/// APP_VERSION bumps).
+///
+/// Preserves user-modified `init.lua` files by comparing SHA-256
+/// hashes — if the on-disk content doesn't match *any* content the
+/// bundled seed function has ever written, we skip that plugin and
+/// return a warning so the user sees why it wasn't updated.
+pub fn reseed_bundled_plugins_force(plugin_dir: &Path) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    for (name, plugin_json, init_lua) in BUNDLED_PLUGINS {
+        let dir = plugin_dir.join(name);
+        let init_file = dir.join("init.lua");
+        let manifest_file = dir.join("plugin.json");
+        let version_file = dir.join(".version");
+
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            warnings.push(format!(
+                "Failed to create plugin dir {}: {e}",
+                dir.display()
+            ));
+            continue;
+        }
+
+        // If a user has modified init.lua we refuse to clobber. Hash
+        // match with the embedded version is our "safe to overwrite"
+        // signal.
+        if init_file.exists() {
+            let on_disk = std::fs::read_to_string(&init_file).unwrap_or_default();
+            let embedded_hash = sha256_hex(init_lua);
+            let disk_hash = sha256_hex(&on_disk);
+            if embedded_hash != disk_hash && !on_disk.is_empty() {
+                // If the on-disk content differs from the current
+                // embedded one, we need another signal that the user
+                // hasn't customized — compare against `plugin_json`
+                // content. But plugin.json is likely to have been
+                // re-rendered on disk (pretty-printed by us), so we
+                // still respect user-edited init.lua.
+                warnings.push(format!(
+                    "Plugin '{name}': init.lua has user modifications — skipping update. \
+                     Delete {} to force a reseed.",
+                    dir.display()
+                ));
+                continue;
+            }
+        }
+
+        if let Err(e) = write_plugin_files(
+            &manifest_file,
+            plugin_json,
+            &init_file,
+            init_lua,
+            &version_file,
+        ) {
+            warnings.push(format!("Failed to reseed plugin '{name}': {e}"));
+        }
+    }
+
+    warnings
+}
+
 fn write_plugin_files(
     manifest_path: &Path,
     manifest_content: &str,
@@ -257,5 +321,54 @@ mod tests {
         // Version should be updated
         let version = std::fs::read_to_string(plugin_dir.join("github/.version")).unwrap();
         assert_eq!(version, APP_VERSION);
+    }
+
+    #[test]
+    fn force_reseed_overwrites_unmodified_current_version() {
+        // Even when .version matches APP_VERSION, force reseed should
+        // still rewrite on-disk init.lua that matches the embedded hash.
+        // (Use case: user stuck on a stale init.lua because we shipped
+        // tree changes between version bumps.)
+        let dir = tempfile::tempdir().unwrap();
+        seed_bundled_plugins(dir.path());
+
+        // Swap init.lua with a *previously-embedded* content (simulated
+        // by overwriting with the same bytes so the hash matches the
+        // current embed — we can't easily simulate "previous embed"
+        // without shipping a second copy).
+        // What we can assert: force reseed writes the current content
+        // even if .version says we're on APP_VERSION (vs the gated
+        // seed which would skip).
+        let init_path = dir.path().join("github/init.lua");
+        let before = std::fs::read_to_string(&init_path).unwrap();
+        // Overwrite with whitespace added so hash differs from on-disk
+        // but this mimics user modification — should be preserved.
+        std::fs::write(&init_path, format!("{before}\n-- added")).unwrap();
+
+        let warnings = reseed_bundled_plugins_force(dir.path());
+        assert!(
+            warnings.iter().any(|w| w.contains("github")),
+            "user-modified init.lua should be preserved with a warning: {warnings:?}"
+        );
+        // Content should be unchanged (we preserved user edits).
+        let after = std::fs::read_to_string(&init_path).unwrap();
+        assert!(after.contains("-- added"));
+    }
+
+    #[test]
+    fn force_reseed_rewrites_unmodified_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_bundled_plugins(dir.path());
+
+        // Delete init.lua so force-reseed has to restore it.
+        let init_path = dir.path().join("github/init.lua");
+        std::fs::remove_file(&init_path).unwrap();
+
+        let warnings = reseed_bundled_plugins_force(dir.path());
+        assert!(
+            warnings.is_empty(),
+            "unmodified reseed should have no warnings: {warnings:?}"
+        );
+        assert!(init_path.exists(), "init.lua must be restored");
     }
 }

--- a/src/scm/detect.rs
+++ b/src/scm/detect.rs
@@ -231,6 +231,7 @@ mod tests {
                 remote_patterns: patterns.iter().map(|s| s.to_string()).collect(),
                 operations: vec![],
                 config_schema: std::collections::HashMap::new(),
+                kind: crate::plugin_runtime::manifest::PluginKind::Scm,
             },
             dir: std::path::PathBuf::new(),
             config: std::collections::HashMap::new(),

--- a/src/scm/detect.rs
+++ b/src/scm/detect.rs
@@ -232,6 +232,7 @@ mod tests {
                 operations: vec![],
                 config_schema: std::collections::HashMap::new(),
                 kind: crate::plugin_runtime::manifest::PluginKind::Scm,
+                settings: vec![],
             },
             dir: std::path::PathBuf::new(),
             config: std::collections::HashMap::new(),

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1032,7 +1032,7 @@
   margin: 4px 8px 8px 22px;
   padding: 10px 12px;
   border-left: 2px solid var(--status-stopped);
-  background: var(--error-hover, rgba(220, 60, 60, 0.08));
+  background: var(--error-hover);
   border-radius: 0 4px 4px 0;
   display: flex;
   flex-direction: column;

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1085,6 +1085,64 @@
   background: var(--accent-bg);
 }
 
+.pluginSettingsForm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.pluginSettingRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.pluginSettingLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.textInput {
+  margin-top: 4px;
+  width: 100%;
+  font-size: 12px;
+  padding: 5px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--sidebar-border);
+  background: var(--input-bg, var(--selected-bg));
+  color: var(--text-primary);
+  font-family: inherit;
+}
+
+.textInput:focus {
+  outline: none;
+  border-color: var(--accent-color, var(--text-primary));
+}
+
+.envErrorRunBtn {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 3px;
+  border: 1px solid var(--accent-color, var(--text-primary));
+  background: var(--accent-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-weight: 500;
+}
+
+.envErrorRunBtn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.envErrorRunBtn:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
 .envErrorDetails {
   font-size: 11px;
   color: var(--text-dim);

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -1012,6 +1012,109 @@
   color: var(--text-dim);
 }
 
+/* ── Env-provider error card ── */
+
+.envDetailsBtn {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--sidebar-border);
+  background: none;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.envDetailsBtn:hover {
+  background: var(--accent-bg);
+}
+
+.envErrorCard {
+  margin: 4px 8px 8px 22px;
+  padding: 10px 12px;
+  border-left: 2px solid var(--status-stopped);
+  background: var(--error-hover, rgba(220, 60, 60, 0.08));
+  border-radius: 0 4px 4px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.envErrorSummary {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.envErrorHint {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.envErrorCmdRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.envErrorCmd {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  padding: 5px 8px;
+  background: var(--selected-bg);
+  border-radius: 3px;
+  color: var(--text-primary);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.envErrorCopyBtn {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 3px;
+  border: 1px solid var(--sidebar-border);
+  background: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.envErrorCopyBtn:hover {
+  background: var(--accent-bg);
+}
+
+.envErrorDetails {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.envErrorDetails summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 2px 0;
+}
+
+.envErrorDetails summary:hover {
+  color: var(--text-primary);
+}
+
+.envErrorPre {
+  margin: 6px 0;
+  padding: 8px 10px;
+  background: var(--selected-bg);
+  border-radius: 3px;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
 /* Group label for MCP source sections */
 .mcpGroupLabel {
   padding: 8px 8px 4px;

--- a/src/ui/src/components/settings/SettingsPage.tsx
+++ b/src/ui/src/components/settings/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { RepoSettings } from "./sections/RepoSettings";
 import { ExperimentalSettings } from "./sections/ExperimentalSettings";
 import { UsageSettings } from "./sections/UsageSettings";
 import { PluginsSettings } from "./sections/PluginsSettings";
+import { ClaudeCodePluginsSettings } from "./sections/ClaudeCodePluginsSettings";
 import styles from "./Settings.module.css";
 
 function SectionContent({ section }: { section: string | null }) {
@@ -19,8 +20,13 @@ function SectionContent({ section }: { section: string | null }) {
   if (section === "appearance") return <AppearanceSettings />;
   if (section === "notifications") return <NotificationsSettings />;
   if (section === "git") return <GitSettings />;
-  if (section === "plugins") {
-    return pluginManagementEnabled ? <PluginsSettings /> : <ExperimentalSettings />;
+  if (section === "plugins") return <PluginsSettings />;
+  if (section === "claude-code-plugins") {
+    return pluginManagementEnabled ? (
+      <ClaudeCodePluginsSettings />
+    ) : (
+      <ExperimentalSettings />
+    );
   }
   if (section === "experimental") return <ExperimentalSettings />;
   if (section.startsWith("repo:"))

--- a/src/ui/src/components/settings/SettingsSidebar.test.ts
+++ b/src/ui/src/components/settings/SettingsSidebar.test.ts
@@ -3,11 +3,26 @@ import { describe, expect, it } from "vitest";
 import { getAppSections } from "./SettingsSidebar";
 
 describe("getAppSections", () => {
-  it("hides the plugins section when plugin management is disabled", () => {
-    expect(getAppSections(false).map((section) => section.id)).not.toContain("plugins");
+  it("always shows the Plugins (Claudette) section", () => {
+    // Claudette's own plugin list is always visible — it's just
+    // diagnostic info plus toggles, no marketplace dependency.
+    expect(getAppSections(false).map((section) => section.id)).toContain(
+      "plugins",
+    );
+    expect(getAppSections(true).map((section) => section.id)).toContain(
+      "plugins",
+    );
   });
 
-  it("shows the plugins section when plugin management is enabled", () => {
-    expect(getAppSections(true).map((section) => section.id)).toContain("plugins");
+  it("hides the Claude Code Plugins section when plugin management is disabled", () => {
+    expect(getAppSections(false).map((section) => section.id)).not.toContain(
+      "claude-code-plugins",
+    );
+  });
+
+  it("shows the Claude Code Plugins section when plugin management is enabled", () => {
+    expect(getAppSections(true).map((section) => section.id)).toContain(
+      "claude-code-plugins",
+    );
   });
 });

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -10,6 +10,11 @@ const APP_SECTIONS = [
   { id: "notifications", label: "Notifications", icon: Bell },
   { id: "git", label: "Git", icon: GitBranch },
   { id: "plugins", label: "Plugins", icon: Puzzle },
+  {
+    id: "claude-code-plugins",
+    label: "Claude Code Plugins",
+    icon: Puzzle,
+  },
 ];
 
 const MORE_SECTIONS = [
@@ -17,8 +22,9 @@ const MORE_SECTIONS = [
 ];
 
 export function getAppSections(pluginManagementEnabled: boolean) {
-  return APP_SECTIONS.filter((section) =>
-    section.id !== "plugins" || pluginManagementEnabled,
+  return APP_SECTIONS.filter(
+    (section) =>
+      section.id !== "claude-code-plugins" || pluginManagementEnabled,
   );
 }
 

--- a/src/ui/src/components/settings/sections/ClaudeCodePluginsSettings.tsx
+++ b/src/ui/src/components/settings/sections/ClaudeCodePluginsSettings.tsx
@@ -1,0 +1,1209 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { ensureAndValidateMcps } from "../../../services/mcp";
+import {
+  addPluginMarketplace,
+  disablePlugin,
+  enablePlugin,
+  installPlugin,
+  listPluginCatalog,
+  listPluginMarketplaces,
+  loadPluginConfiguration,
+  removePluginMarketplace,
+  savePluginChannelConfiguration,
+  savePluginTopLevelConfiguration,
+  uninstallPlugin,
+  updateAllPlugins,
+  updatePlugin,
+  updatePluginMarketplace,
+} from "../../../services/tauri";
+import { useAppStore } from "../../../stores/useAppStore";
+import type {
+  AvailablePlugin,
+  EditablePluginScope,
+  InstalledPlugin,
+  PluginConfigSection,
+  PluginConfiguration,
+  PluginMarketplace,
+  PluginSettingsAction,
+  PluginScope,
+} from "../../../types/plugins";
+import {
+  availablePluginLinks,
+  canInstallAvailablePluginAtScope,
+  formatInstallCount,
+  marketplaceSourceLink,
+  matchesAvailablePlugin,
+  matchesInstalledPlugin,
+  matchesMarketplace,
+  primaryInstalledScope,
+  sortAvailablePlugins,
+  summarizeAvailablePlugins,
+  summarizeInstalledPlugins,
+} from "./pluginCatalog";
+import styles from "../Settings.module.css";
+import { openUrl } from "../../../services/tauri";
+
+type DraftValues = Record<string, string | boolean>;
+
+function scopeNeedsRepo(scope: EditablePluginScope): boolean {
+  return scope === "project" || scope === "local";
+}
+
+function hasConfig(plugin: InstalledPlugin): boolean {
+  return (
+    Object.keys(plugin.user_config_schema).length > 0
+    || plugin.channels.some((channel) => Object.keys(channel.config_schema).length > 0)
+  );
+}
+
+function buildDraft(section: PluginConfigSection): DraftValues {
+  const draft: DraftValues = {};
+  for (const [key, field] of Object.entries(section.schema)) {
+    if (field.sensitive) {
+      draft[key] = "";
+      continue;
+    }
+    const value = section.state.values[key];
+    if (field.type === "boolean") {
+      draft[key] = value === true;
+    } else if (field.multiple && Array.isArray(value)) {
+      draft[key] = value.join("\n");
+    } else if (value === undefined || value === null) {
+      draft[key] = "";
+    } else {
+      draft[key] = String(value);
+    }
+  }
+  return draft;
+}
+
+function buildPayload(
+  section: PluginConfigSection,
+  draft: DraftValues,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(section.schema)) {
+    const value = draft[key];
+    if (field.sensitive) {
+      if (typeof value === "string" && value.trim() !== "") {
+        payload[key] = field.multiple
+          ? value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+          : value;
+      }
+      continue;
+    }
+    if (field.type === "boolean") {
+      payload[key] = value === true;
+      continue;
+    }
+    if (field.multiple) {
+      payload[key] = typeof value === "string"
+        ? value
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+        : [];
+      continue;
+    }
+    payload[key] = typeof value === "string" ? value : "";
+  }
+  return payload;
+}
+
+function installedPluginSelectionKey(plugin: Pick<InstalledPlugin, "plugin_id" | "scope">): string {
+  return `${plugin.plugin_id}::${plugin.scope}`;
+}
+
+function repoAvailabilityDetail(scope: PluginScope, hasRepoContext: boolean): string | null {
+  if (!hasRepoContext) return null;
+  if (scope === "user" || scope === "managed") {
+    return `available in this repo via ${scope} scope`;
+  }
+  return null;
+}
+
+function matchesPluginTarget(plugin: InstalledPlugin, target: string): boolean {
+  const normalizedTarget = target.trim().toLowerCase();
+  if (!normalizedTarget) return false;
+  return (
+    normalizedTarget === plugin.plugin_id.toLowerCase()
+    || normalizedTarget === plugin.name.toLowerCase()
+  );
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function ConfigEditor({
+  title,
+  section,
+  draft,
+  onDraftChange,
+  onSave,
+  busy,
+}: {
+  title: string;
+  section: PluginConfigSection;
+  draft: DraftValues;
+  onDraftChange: (key: string, value: string | boolean) => void;
+  onSave: () => void;
+  busy: boolean;
+}) {
+  return (
+    <div className={styles.pluginConfigSection}>
+      <div className={styles.pluginConfigHeader}>
+        <div>
+          <div className={styles.settingLabel}>{title}</div>
+          <div className={styles.settingDescription}>
+            Sensitive fields are masked and blank values keep the existing secret.
+          </div>
+        </div>
+        <button className={styles.iconBtn} onClick={onSave} disabled={busy}>
+          Save
+        </button>
+      </div>
+
+      <div className={styles.pluginConfigFields}>
+        {Object.entries(section.schema).map(([key, field]) => {
+          const savedSensitive = section.state.saved_sensitive_keys.includes(key);
+          return (
+            <label key={key} className={styles.pluginField}>
+              <span className={styles.fieldLabel}>{field.title}</span>
+              <span className={styles.fieldHint}>{field.description}</span>
+              {field.type === "boolean" ? (
+                <input
+                  type="checkbox"
+                  checked={draft[key] === true}
+                  onChange={(event) => onDraftChange(key, event.target.checked)}
+                />
+              ) : field.multiple ? (
+                <textarea
+                  className={styles.textarea}
+                  value={String(draft[key] ?? "")}
+                  onChange={(event) => onDraftChange(key, event.target.value)}
+                  placeholder={field.sensitive && savedSensitive ? "Saved" : ""}
+                />
+              ) : (
+                <input
+                  className={styles.input}
+                  type={field.sensitive ? "password" : field.type === "number" ? "number" : "text"}
+                  min={field.min ?? undefined}
+                  max={field.max ?? undefined}
+                  value={String(draft[key] ?? "")}
+                  onChange={(event) => onDraftChange(key, event.target.value)}
+                  placeholder={field.sensitive && savedSensitive ? "Saved" : ""}
+                />
+              )}
+              <span className={styles.pluginFieldMeta}>
+                {field.required ? "Required" : "Optional"}
+                {field.sensitive ? " · Sensitive" : ""}
+                {savedSensitive && field.sensitive ? " · Secret saved" : ""}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function PluginStatCard({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className={styles.pluginStatCard}>
+      <div className={styles.pluginStatValue}>{value}</div>
+      <div className={styles.pluginStatLabel}>{label}</div>
+      <div className={styles.pluginStatDetail}>{detail}</div>
+    </div>
+  );
+}
+
+function ExternalBrowserLink({
+  detail,
+  href,
+  label,
+  meta,
+}: {
+  detail: string;
+  href: string;
+  label: string;
+  meta: string | null;
+}) {
+  return (
+    <button
+      type="button"
+      className={styles.pluginLink}
+      onClick={(event) => {
+        event.preventDefault();
+        void openUrl(href).catch((nextError) =>
+          console.error("Failed to open plugin link:", href, nextError),
+        );
+      }}
+    >
+      <span className={styles.pluginLinkLabel}>{label}</span>
+      <span className={styles.pluginLinkDetail}>{detail}</span>
+      {meta && <span className={styles.pluginLinkMeta}>{meta}</span>}
+    </button>
+  );
+}
+
+export function ClaudeCodePluginsSettings() {
+  const repositories = useAppStore((state) => state.repositories);
+  const pluginSettingsTab = useAppStore((state) => state.pluginSettingsTab);
+  const setPluginSettingsTab = useAppStore((state) => state.setPluginSettingsTab);
+  const pluginSettingsRepoId = useAppStore((state) => state.pluginSettingsRepoId);
+  const setPluginSettingsRepoId = useAppStore((state) => state.setPluginSettingsRepoId);
+  const pluginSettingsIntent = useAppStore((state) => state.pluginSettingsIntent);
+  const clearPluginSettingsIntent = useAppStore((state) => state.clearPluginSettingsIntent);
+  const pluginRefreshToken = useAppStore((state) => state.pluginRefreshToken);
+  const bumpPluginRefreshToken = useAppStore((state) => state.bumpPluginRefreshToken);
+  const setMcpStatus = useAppStore((state) => state.setMcpStatus);
+
+  const localRepositories = useMemo(
+    () => repositories.filter((repo) => repo.remote_connection_id === null),
+    [repositories],
+  );
+
+  const [installedPlugins, setInstalledPlugins] = useState<InstalledPlugin[]>([]);
+  const [availablePlugins, setAvailablePlugins] = useState<AvailablePlugin[]>([]);
+  const [marketplaces, setMarketplaces] = useState<PluginMarketplace[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  const [installTarget, setInstallTarget] = useState("");
+  const [installScope, setInstallScope] = useState<EditablePluginScope>("user");
+  const [availableFilter, setAvailableFilter] = useState("");
+  const [pluginFilter, setPluginFilter] = useState("");
+  const [selectedPluginKey, setSelectedPluginKey] = useState<string | null>(null);
+  const [config, setConfig] = useState<PluginConfiguration | null>(null);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [configLoading, setConfigLoading] = useState(false);
+  const [topLevelDraft, setTopLevelDraft] = useState<DraftValues>({});
+  const [channelDrafts, setChannelDrafts] = useState<Record<string, DraftValues>>({});
+  const [pendingActionHint, setPendingActionHint] = useState<PluginSettingsAction | null>(null);
+  const [pendingTargetHint, setPendingTargetHint] = useState<string | null>(null);
+
+  const [marketplaceSource, setMarketplaceSource] = useState("");
+  const [marketplaceScope, setMarketplaceScope] = useState<EditablePluginScope>("user");
+  const [marketplaceFilter, setMarketplaceFilter] = useState("");
+
+  const installedSummary = useMemo(
+    () => summarizeInstalledPlugins(installedPlugins),
+    [installedPlugins],
+  );
+  const availableSummary = useMemo(
+    () => summarizeAvailablePlugins(availablePlugins),
+    [availablePlugins],
+  );
+  const filteredInstalled = useMemo(
+    () => installedPlugins.filter((plugin) => matchesInstalledPlugin(plugin, pluginFilter)),
+    [installedPlugins, pluginFilter],
+  );
+  const filteredAvailable = useMemo(
+    () => sortAvailablePlugins(
+      availablePlugins.filter((plugin) => matchesAvailablePlugin(plugin, availableFilter)),
+    ),
+    [availableFilter, availablePlugins],
+  );
+  const filteredMarketplaces = useMemo(
+    () => marketplaces.filter((marketplace) => matchesMarketplace(marketplace, marketplaceFilter)),
+    [marketplaceFilter, marketplaces],
+  );
+  const availablePluginsById = useMemo(
+    () => new Map(availablePlugins.map((plugin) => [plugin.plugin_id, plugin])),
+    [availablePlugins],
+  );
+  const selectedInstalledPlugin = useMemo(
+    () => installedPlugins.find((plugin) => installedPluginSelectionKey(plugin) === selectedPluginKey) ?? null,
+    [installedPlugins, selectedPluginKey],
+  );
+  const globallyInstalledPlugins = useMemo(
+    () => installedPlugins.filter((plugin) => plugin.scope === "user" || plugin.scope === "managed"),
+    [installedPlugins],
+  );
+
+  useEffect(() => {
+    if (!pluginSettingsRepoId) return;
+    if (localRepositories.some((repo) => repo.id === pluginSettingsRepoId)) return;
+    setPluginSettingsRepoId(null);
+  }, [localRepositories, pluginSettingsRepoId, setPluginSettingsRepoId]);
+
+  useEffect(() => {
+    if (!pluginSettingsIntent) return;
+
+    setPluginSettingsTab(pluginSettingsIntent.tab);
+    if (pluginSettingsIntent.repoId) {
+      setPluginSettingsRepoId(pluginSettingsIntent.repoId);
+    }
+    setPendingActionHint(pluginSettingsIntent.action);
+    setPendingTargetHint(pluginSettingsIntent.target ?? pluginSettingsIntent.source);
+
+    if (pluginSettingsIntent.tab === "available") {
+      setInstallScope(pluginSettingsIntent.scope);
+      if (pluginSettingsIntent.source) {
+        setInstallTarget(pluginSettingsIntent.source);
+      }
+      if (pluginSettingsIntent.target) {
+        setAvailableFilter(pluginSettingsIntent.target);
+      }
+    } else if (pluginSettingsIntent.tab === "installed") {
+      if (pluginSettingsIntent.target) {
+        setPluginFilter(pluginSettingsIntent.target);
+        setSelectedPluginKey(null);
+      }
+    } else {
+      setMarketplaceScope(pluginSettingsIntent.scope);
+      if (pluginSettingsIntent.source) {
+        setMarketplaceSource(pluginSettingsIntent.source);
+      }
+      if (pluginSettingsIntent.target) {
+        setMarketplaceFilter(pluginSettingsIntent.target);
+      }
+    }
+
+    clearPluginSettingsIntent();
+  }, [
+    clearPluginSettingsIntent,
+    pluginSettingsIntent,
+    setPluginSettingsRepoId,
+    setPluginSettingsTab,
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      listPluginCatalog(pluginSettingsRepoId ?? undefined),
+      listPluginMarketplaces(pluginSettingsRepoId ?? undefined),
+    ])
+      .then(([catalog, nextMarketplaces]) => {
+        if (cancelled) return;
+        setInstalledPlugins(catalog.installed);
+        setAvailablePlugins(catalog.available);
+        setMarketplaces(nextMarketplaces);
+      })
+      .catch((nextError) => {
+        if (!cancelled) setError(String(nextError));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginRefreshToken, pluginSettingsRepoId]);
+
+  useEffect(() => {
+    if (!selectedInstalledPlugin) {
+      setConfig(null);
+      setTopLevelDraft({});
+      setChannelDrafts({});
+      setConfigError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setConfigLoading(true);
+    setConfigError(null);
+    loadPluginConfiguration(selectedInstalledPlugin.plugin_id, pluginSettingsRepoId ?? undefined)
+      .then((result) => {
+        if (cancelled) return;
+        setConfig(result);
+        setTopLevelDraft(result.top_level ? buildDraft(result.top_level) : {});
+        const nextChannelDrafts: Record<string, DraftValues> = {};
+        for (const channel of result.channels) {
+          nextChannelDrafts[channel.server] = buildDraft(channel.section);
+        }
+        setChannelDrafts(nextChannelDrafts);
+      })
+      .catch((nextError) => {
+        if (!cancelled) setConfigError(String(nextError));
+      })
+      .finally(() => {
+        if (!cancelled) setConfigLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginSettingsRepoId, selectedInstalledPlugin]);
+
+  async function refreshAffectedMcps(scope: EditablePluginScope | "managed" | null) {
+    const repoIds = scope === "project" || scope === "local"
+      ? pluginSettingsRepoId ? [pluginSettingsRepoId] : []
+      : localRepositories.map((repo) => repo.id);
+
+    await Promise.all(repoIds.map(async (repoId) => {
+      try {
+        const snapshot = await ensureAndValidateMcps(repoId);
+        setMcpStatus(repoId, snapshot);
+      } catch (nextError) {
+        console.error(`Failed to refresh MCPs for ${repoId}:`, nextError);
+      }
+    }));
+  }
+
+  async function afterMutation(scope: EditablePluginScope | "managed" | null, nextMessage: string) {
+    bumpPluginRefreshToken();
+    await refreshAffectedMcps(scope);
+    setMessage(nextMessage);
+  }
+
+  function requireRepoForScope(scope: EditablePluginScope): string | null {
+    if (!scopeNeedsRepo(scope)) return null;
+    return pluginSettingsRepoId;
+  }
+
+  async function withBusy(key: string, work: () => Promise<void>) {
+    setBusyKey(key);
+    setError(null);
+    setMessage(null);
+    try {
+      await work();
+    } catch (nextError) {
+      setError(String(nextError));
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  function repoIdForPluginScope(scope: PluginScope): string | undefined {
+    if (scope === "project" || scope === "local") {
+      return pluginSettingsRepoId ?? undefined;
+    }
+    return undefined;
+  }
+
+  function openInstalledPlugin(pluginId: string) {
+    setPluginSettingsTab("installed");
+    setPluginFilter(pluginId);
+    const matchingPlugins = installedPlugins.filter((plugin) => plugin.plugin_id === pluginId);
+    const primaryScope = primaryInstalledScope(matchingPlugins.map((plugin) => plugin.scope));
+    const targetPlugin = matchingPlugins.find((plugin) => plugin.scope === primaryScope)
+      ?? matchingPlugins[0]
+      ?? null;
+    setSelectedPluginKey(targetPlugin ? installedPluginSelectionKey(targetPlugin) : null);
+  }
+
+  async function handleInstall(targetOverride?: string) {
+    const target = (targetOverride ?? installTarget).trim();
+    if (!target) {
+      setError("Enter a plugin identifier to install.");
+      return;
+    }
+    if (installScope !== "user") {
+      const globalInstall = globallyInstalledPlugins.find((plugin) => matchesPluginTarget(plugin, target));
+      if (globalInstall) {
+        setError(
+          `${globalInstall.plugin_id} is already installed at ${globalInstall.scope} scope and is already available in this repository.`,
+        );
+        return;
+      }
+    }
+    const repoId = requireRepoForScope(installScope);
+    if (scopeNeedsRepo(installScope) && !repoId) {
+      setError("Select a local repository for project/local scope.");
+      return;
+    }
+
+    await withBusy(targetOverride ? `install:${target}` : "install", async () => {
+      await installPlugin(target, installScope, repoId ?? undefined);
+      await afterMutation(installScope, `Installed ${target} at ${installScope} scope.`);
+      if (!targetOverride) {
+        setInstallTarget("");
+      }
+      setPendingActionHint(null);
+      setPendingTargetHint(null);
+    });
+  }
+
+  async function handlePluginAction(
+    plugin: InstalledPlugin,
+    action: "enable" | "disable" | "uninstall" | "update",
+  ) {
+    const repoId = repoIdForPluginScope(plugin.scope);
+
+    await withBusy(`${action}:${plugin.plugin_id}:${plugin.scope}`, async () => {
+      if (action === "enable") {
+        await enablePlugin(plugin.plugin_id, plugin.scope as EditablePluginScope, repoId);
+      } else if (action === "disable") {
+        await disablePlugin(plugin.plugin_id, plugin.scope as EditablePluginScope, repoId);
+      } else if (action === "uninstall") {
+        await uninstallPlugin(plugin.plugin_id, plugin.scope as EditablePluginScope, false, repoId);
+        if (selectedPluginKey === installedPluginSelectionKey(plugin)) {
+          setSelectedPluginKey(null);
+        }
+      } else {
+        await updatePlugin(plugin.plugin_id, plugin.scope, repoId);
+      }
+      await afterMutation(plugin.scope, `${action} completed for ${plugin.plugin_id}.`);
+      setPendingActionHint(null);
+      setPendingTargetHint(null);
+    });
+  }
+
+  async function handleUpdateAllInstalled() {
+    await withBusy("update-all", async () => {
+      const result = await updateAllPlugins(pluginSettingsRepoId ?? undefined);
+      if (result.succeeded > 0) {
+        const refreshScope = installedPlugins.some((plugin) => plugin.scope === "managed" || plugin.scope === "user")
+          ? "user"
+          : installedPlugins.some((plugin) => plugin.scope === "project")
+            ? "project"
+            : installedPlugins.some((plugin) => plugin.scope === "local")
+              ? "local"
+              : null;
+        bumpPluginRefreshToken();
+        await refreshAffectedMcps(refreshScope);
+      }
+
+      if (result.attempted === 0) {
+        setMessage("No plugins need update checks in this context.");
+      } else {
+        setMessage(`Checked ${pluralize(result.attempted, "plugin")}; ${pluralize(result.succeeded, "update")} completed.`);
+      }
+
+      if (result.failed.length > 0) {
+        const visibleFailures = result.failed.slice(0, 3).join("\n");
+        const extraFailures = result.failed.length > 3
+          ? `\n… ${result.failed.length - 3} more`
+          : "";
+        setError(`Some plugin updates failed:\n${visibleFailures}${extraFailures}`);
+      }
+
+      setPendingActionHint(null);
+      setPendingTargetHint(null);
+    });
+  }
+
+  async function handleRefreshMarketplaceMetadata(messageText: string) {
+    await withBusy("marketplace-refresh", async () => {
+      await updatePluginMarketplace(undefined, pluginSettingsRepoId ?? undefined);
+      bumpPluginRefreshToken();
+      setMessage(messageText);
+    });
+  }
+
+  async function handleMarketplaceAdd() {
+    if (!marketplaceSource.trim()) {
+      setError("Enter a marketplace source.");
+      return;
+    }
+    const repoId = requireRepoForScope(marketplaceScope);
+    if (scopeNeedsRepo(marketplaceScope) && !repoId) {
+      setError("Select a local repository for project/local scope.");
+      return;
+    }
+    await withBusy("marketplace-add", async () => {
+      await addPluginMarketplace(marketplaceSource.trim(), marketplaceScope, repoId ?? undefined);
+      bumpPluginRefreshToken();
+      setMessage(`Added marketplace ${marketplaceSource.trim()}.`);
+      setPendingActionHint(null);
+      setPendingTargetHint(null);
+    });
+  }
+
+  async function handleSaveTopLevel() {
+    const topLevelSection = config?.top_level;
+    if (!topLevelSection || !selectedInstalledPlugin) return;
+    await withBusy(`config:${selectedInstalledPlugin.plugin_id}:top`, async () => {
+      await savePluginTopLevelConfiguration(
+        selectedInstalledPlugin.plugin_id,
+        buildPayload(topLevelSection, topLevelDraft),
+        pluginSettingsRepoId ?? undefined,
+      );
+      await afterMutation("user", `Saved configuration for ${selectedInstalledPlugin.plugin_id}.`);
+      const refreshed = await loadPluginConfiguration(
+        selectedInstalledPlugin.plugin_id,
+        pluginSettingsRepoId ?? undefined,
+      );
+      setConfig(refreshed);
+      setTopLevelDraft(refreshed.top_level ? buildDraft(refreshed.top_level) : {});
+    });
+  }
+
+  async function handleSaveChannel(serverName: string) {
+    if (!config || !selectedInstalledPlugin) return;
+    const channel = config.channels.find((entry) => entry.server === serverName);
+    if (!channel) return;
+    await withBusy(`config:${selectedInstalledPlugin.plugin_id}:${serverName}`, async () => {
+      await savePluginChannelConfiguration(
+        selectedInstalledPlugin.plugin_id,
+        serverName,
+        buildPayload(channel.section, channelDrafts[serverName] ?? {}),
+        pluginSettingsRepoId ?? undefined,
+      );
+      await afterMutation("user", `Saved ${serverName} configuration.`);
+      const refreshed = await loadPluginConfiguration(
+        selectedInstalledPlugin.plugin_id,
+        pluginSettingsRepoId ?? undefined,
+      );
+      setConfig(refreshed);
+      const nextChannelDrafts: Record<string, DraftValues> = {};
+      for (const entry of refreshed.channels) {
+        nextChannelDrafts[entry.server] = buildDraft(entry.section);
+      }
+      setChannelDrafts(nextChannelDrafts);
+    });
+  }
+
+  return (
+    <div>
+      <h1 className={styles.sectionTitle}>Plugins</h1>
+      <div className={styles.settingDescription}>
+        Browse marketplace plugins, manage installed ones, and refresh marketplace metadata using the real Claude CLI.
+      </div>
+
+      <div className={styles.pluginToolbar}>
+        <div className={styles.inlineControl}>
+          <label className={styles.settingLabel} htmlFor="plugin-repo-select">Repository</label>
+          <select
+            id="plugin-repo-select"
+            className={styles.select}
+            value={pluginSettingsRepoId ?? ""}
+            onChange={(event) => setPluginSettingsRepoId(event.target.value || null)}
+          >
+            <option value="">Global only</option>
+            {localRepositories.map((repo) => (
+              <option key={repo.id} value={repo.id}>{repo.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.pluginTabs}>
+          <button
+            className={pluginSettingsTab === "available" ? styles.pluginTabActive : styles.pluginTab}
+            onClick={() => setPluginSettingsTab("available")}
+          >
+            Available
+          </button>
+          <button
+            className={pluginSettingsTab === "installed" ? styles.pluginTabActive : styles.pluginTab}
+            onClick={() => setPluginSettingsTab("installed")}
+          >
+            Installed
+          </button>
+          <button
+            className={pluginSettingsTab === "marketplaces" ? styles.pluginTabActive : styles.pluginTab}
+            onClick={() => setPluginSettingsTab("marketplaces")}
+          >
+            Marketplaces
+          </button>
+        </div>
+      </div>
+
+      {pendingActionHint && pendingTargetHint && (
+        <div className={styles.pluginNotice}>
+          Pending action: <strong>{pendingActionHint}</strong> for <code>{pendingTargetHint}</code>.
+        </div>
+      )}
+      {message && <div className={styles.pluginSuccess}>{message}</div>}
+      {error && <div className={styles.pluginError}>{error}</div>}
+
+      {pluginSettingsTab === "available" && (
+        <div className={styles.pluginPanel}>
+          <div className={styles.pluginSummaryGrid}>
+            <PluginStatCard
+              label="Marketplace catalog"
+              value={String(availableSummary.total)}
+              detail={pluralize(marketplaces.length, "marketplace")}
+            />
+            <PluginStatCard
+              label="Ready to install"
+              value={String(availableSummary.discoverable)}
+              detail="Not installed in this context"
+            />
+            <PluginStatCard
+              label="Installed here"
+              value={String(availableSummary.installed)}
+              detail={pluralize(installedSummary.pluginCount, "distinct plugin")}
+            />
+            <PluginStatCard
+              label="Known updates"
+              value={String(installedSummary.updatesAvailable)}
+              detail={installedSummary.unknownVersionCount > 0
+                ? `${pluralize(installedSummary.unknownVersionCount, "plugin")} without version metadata`
+                : "All installed plugins publish version metadata"}
+            />
+          </div>
+
+          <div className={styles.pluginInlineNote}>
+            Claude Code treats user and managed installs as global, so this browser does not offer redundant project or local installs for plugins that are already available everywhere. Refresh marketplaces to recalculate update badges.
+          </div>
+
+          <div className={styles.pluginFormRow}>
+            <input
+              className={styles.input}
+              placeholder="Search marketplace plugins"
+              value={availableFilter}
+              onChange={(event) => setAvailableFilter(event.target.value)}
+            />
+            <select
+              className={styles.select}
+              value={installScope}
+              onChange={(event) => setInstallScope(event.target.value as EditablePluginScope)}
+            >
+              <option value="user">Install to user</option>
+              <option value="project">Install to project</option>
+              <option value="local">Install to local</option>
+            </select>
+            <button
+              className={styles.iconBtn}
+              onClick={() => void handleRefreshMarketplaceMetadata("Refreshed marketplace metadata.")}
+              disabled={busyKey === "marketplace-refresh"}
+            >
+              Refresh Marketplaces
+            </button>
+          </div>
+
+          <div className={styles.pluginFormRow}>
+            <input
+              className={styles.input}
+              placeholder="Install custom plugin target or plugin@marketplace"
+              value={installTarget}
+              onChange={(event) => setInstallTarget(event.target.value)}
+            />
+            <button className={styles.iconBtn} onClick={() => void handleInstall()} disabled={busyKey === "install"}>
+              Install
+            </button>
+          </div>
+
+          {loading ? (
+            <div className={styles.settingDescription}>Loading plugin catalog…</div>
+          ) : filteredAvailable.length === 0 ? (
+            <div className={styles.settingDescription}>No marketplace plugins match this view.</div>
+          ) : (
+            <div className={styles.pluginList}>
+              {filteredAvailable.map((plugin) => {
+                const installableAtScope = canInstallAvailablePluginAtScope(plugin, installScope);
+                const installCount = formatInstallCount(plugin.install_count);
+                const links = availablePluginLinks(plugin);
+                return (
+                  <div key={plugin.plugin_id} className={styles.pluginCard}>
+                    <div className={styles.pluginCardHeader}>
+                      <div className={styles.pluginCardBody}>
+                        <div className={styles.pluginCardTitle}>
+                          <span>{plugin.name}</span>
+                          <span className={styles.pluginBadge}>{plugin.marketplace}</span>
+                          {plugin.category && <span className={styles.pluginBadge}>{plugin.category}</span>}
+                          {plugin.version && <span className={styles.pluginBadge}>v{plugin.version}</span>}
+                          {plugin.installed && <span className={styles.pluginBadge}>installed</span>}
+                          {plugin.enabled && <span className={styles.pluginBadge}>enabled</span>}
+                          {plugin.update_available && <span className={styles.pluginBadge}>update available</span>}
+                          {plugin.installed_scopes.map((scope) => (
+                            <span key={`${plugin.plugin_id}:${scope}`} className={styles.pluginBadge}>
+                              {scope}
+                            </span>
+                          ))}
+                        </div>
+                        <div className={styles.settingDescription}>
+                          {plugin.description ?? "No description provided."}
+                        </div>
+                        {installCount && (
+                          <div className={styles.pluginMeta}>{installCount}</div>
+                        )}
+                        {links.length > 0 && (
+                          <div className={styles.pluginLinkRow}>
+                            {links.map((link) => (
+                              <ExternalBrowserLink
+                                key={`${plugin.plugin_id}:${link.label}:${link.url}`}
+                                detail={link.detail}
+                                href={link.url}
+                                label={link.label}
+                                meta={link.meta}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className={styles.pluginActions}>
+                        {plugin.installed && (
+                          <button
+                            className={styles.iconBtn}
+                            onClick={() => openInstalledPlugin(plugin.plugin_id)}
+                          >
+                            Manage
+                          </button>
+                        )}
+                        {installableAtScope && (
+                          <button
+                            className={styles.iconBtn}
+                            onClick={() => void handleInstall(plugin.plugin_id)}
+                            disabled={
+                              (scopeNeedsRepo(installScope) && !pluginSettingsRepoId)
+                              || busyKey === `install:${plugin.plugin_id}`
+                            }
+                          >
+                            Install to {installScope}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {pluginSettingsTab === "installed" && (
+        <div className={styles.pluginPanel}>
+          <div className={styles.pluginSummaryGrid}>
+            <PluginStatCard
+              label="Installations"
+              value={String(installedSummary.installationCount)}
+              detail={pluralize(installedSummary.pluginCount, "distinct plugin")}
+            />
+            <PluginStatCard
+              label="Known updates"
+              value={String(installedSummary.updatesAvailable)}
+              detail="Based on refreshed marketplace versions"
+            />
+            <PluginStatCard
+              label="Unknown version status"
+              value={String(installedSummary.unknownVersionCount)}
+              detail="These still work with Update All"
+            />
+            <PluginStatCard
+              label="Configured marketplaces"
+              value={String(marketplaces.length)}
+              detail="Refresh them to check for new versions"
+            />
+          </div>
+
+          <div className={styles.pluginInlineNote}>
+            Claude Code’s interactive plugin tools do not expose a native one-shot update-all command. Claudette now runs the per-plugin update flow across this installed set and surfaces concrete update badges when metadata is available.
+          </div>
+
+          <div className={styles.pluginFormRow}>
+            <input
+              className={styles.input}
+              placeholder="Filter installed plugins"
+              value={pluginFilter}
+              onChange={(event) => setPluginFilter(event.target.value)}
+            />
+            <button
+              className={styles.iconBtn}
+              onClick={() => void handleUpdateAllInstalled()}
+              disabled={busyKey === "update-all"}
+            >
+              Update All
+            </button>
+            <button
+              className={styles.iconBtn}
+              onClick={() => void handleRefreshMarketplaceMetadata("Refreshed marketplace metadata for update checks.")}
+              disabled={busyKey === "marketplace-refresh"}
+            >
+              Refresh Marketplaces
+            </button>
+          </div>
+
+          {loading ? (
+            <div className={styles.settingDescription}>Loading installed plugins…</div>
+          ) : filteredInstalled.length === 0 ? (
+            <div className={styles.settingDescription}>No installed plugins match this view.</div>
+          ) : (
+            <div className={styles.pluginList}>
+              {filteredInstalled.map((plugin) => {
+                const catalogPlugin = availablePluginsById.get(plugin.plugin_id);
+                const links = catalogPlugin ? availablePluginLinks(catalogPlugin) : [];
+                return (
+                  <div
+                    key={`${plugin.plugin_id}:${plugin.scope}`}
+                    className={`${styles.pluginCard}${selectedPluginKey === installedPluginSelectionKey(plugin) ? ` ${styles.pluginCardSelected}` : ""}`}
+                  >
+                    <div className={styles.pluginCardHeader}>
+                      <div className={styles.pluginCardBody}>
+                        <div className={styles.pluginCardTitle}>
+                          <span>{plugin.plugin_id}</span>
+                          <span className={styles.pluginBadge}>{plugin.scope}</span>
+                          <span className={styles.pluginBadge}>{plugin.enabled ? "enabled" : "disabled"}</span>
+                          {plugin.update_available && plugin.latest_known_version && (
+                            <span className={styles.pluginBadge}>update → v{plugin.latest_known_version}</span>
+                          )}
+                          {plugin.command_count > 0 && <span className={styles.pluginBadge}>{plugin.command_count} cmds</span>}
+                          {plugin.skill_count > 0 && <span className={styles.pluginBadge}>{plugin.skill_count} skills</span>}
+                          {plugin.mcp_servers.length > 0 && <span className={styles.pluginBadge}>{plugin.mcp_servers.length} mcp</span>}
+                        </div>
+                        <div className={styles.settingDescription}>
+                          {plugin.description ?? "No description provided."}
+                        </div>
+                        <div className={styles.pluginMeta}>
+                          {[
+                            `v${plugin.version}`,
+                            plugin.latest_known_version && !plugin.update_available
+                              ? `latest v${plugin.latest_known_version}`
+                              : null,
+                            repoAvailabilityDetail(plugin.scope, pluginSettingsRepoId !== null),
+                            plugin.install_path,
+                          ].filter((value): value is string => Boolean(value)).join(" · ")}
+                        </div>
+                        {links.length > 0 && (
+                          <div className={styles.pluginLinkRow}>
+                            {links.map((link) => (
+                              <ExternalBrowserLink
+                                key={`${plugin.plugin_id}:${plugin.scope}:${link.label}:${link.url}`}
+                                detail={link.detail}
+                                href={link.url}
+                                label={link.label}
+                                meta={link.meta}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className={styles.pluginActions}>
+                        {plugin.scope !== "managed" && (
+                          plugin.enabled ? (
+                            <button
+                              className={styles.iconBtn}
+                              onClick={() => void handlePluginAction(plugin, "disable")}
+                              disabled={busyKey === `disable:${plugin.plugin_id}:${plugin.scope}`}
+                            >
+                              Disable
+                            </button>
+                          ) : (
+                            <button
+                              className={styles.iconBtn}
+                              onClick={() => void handlePluginAction(plugin, "enable")}
+                              disabled={busyKey === `enable:${plugin.plugin_id}:${plugin.scope}`}
+                            >
+                              Enable
+                            </button>
+                          )
+                        )}
+                        <button
+                          className={styles.iconBtn}
+                          onClick={() => void handlePluginAction(plugin, "update")}
+                          disabled={busyKey === `update:${plugin.plugin_id}:${plugin.scope}`}
+                        >
+                          Update
+                        </button>
+                        {plugin.scope !== "managed" && (
+                          <button
+                            className={styles.iconBtn}
+                            onClick={() => void handlePluginAction(plugin, "uninstall")}
+                            disabled={busyKey === `uninstall:${plugin.plugin_id}:${plugin.scope}`}
+                          >
+                            Uninstall
+                          </button>
+                        )}
+                        {hasConfig(plugin) && (
+                          <button
+                            className={styles.iconBtn}
+                            onClick={() => setSelectedPluginKey((current) =>
+                              current === installedPluginSelectionKey(plugin)
+                                ? null
+                                : installedPluginSelectionKey(plugin)
+                            )}
+                          >
+                            Configure
+                          </button>
+                        )}
+                      </div>
+                    </div>
+
+                    {selectedPluginKey === installedPluginSelectionKey(plugin) && (
+                      <div className={styles.pluginConfigPanel}>
+                        {configLoading ? (
+                          <div className={styles.settingDescription}>Loading configuration…</div>
+                        ) : configError ? (
+                          <div className={styles.pluginError}>{configError}</div>
+                        ) : config ? (
+                          <>
+                            {config.top_level && (
+                              <ConfigEditor
+                                title="Plugin options"
+                                section={config.top_level}
+                                draft={topLevelDraft}
+                                onDraftChange={(key, value) => setTopLevelDraft((draft) => ({ ...draft, [key]: value }))}
+                                onSave={() => void handleSaveTopLevel()}
+                                busy={busyKey === `config:${plugin.plugin_id}:top`}
+                              />
+                            )}
+                            {config.channels.map((channel) => (
+                              <ConfigEditor
+                                key={channel.server}
+                                title={channel.display_name ?? channel.server}
+                                section={channel.section}
+                                draft={channelDrafts[channel.server] ?? {}}
+                                onDraftChange={(key, value) => setChannelDrafts((drafts) => ({
+                                  ...drafts,
+                                  [channel.server]: {
+                                    ...drafts[channel.server],
+                                    [key]: value,
+                                  },
+                                }))}
+                                onSave={() => void handleSaveChannel(channel.server)}
+                                busy={busyKey === `config:${plugin.plugin_id}:${channel.server}`}
+                              />
+                            ))}
+                            {!config.top_level && config.channels.length === 0 && (
+                              <div className={styles.settingDescription}>This plugin does not expose configurable fields.</div>
+                            )}
+                          </>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {pluginSettingsTab === "marketplaces" && (
+        <div className={styles.pluginPanel}>
+          <div className={styles.pluginSummaryGrid}>
+            <PluginStatCard
+              label="Configured marketplaces"
+              value={String(marketplaces.length)}
+              detail="Visible in this repo context"
+            />
+            <PluginStatCard
+              label="Catalog entries"
+              value={String(availableSummary.total)}
+              detail="Powered by local marketplace clones"
+            />
+            <PluginStatCard
+              label="Known plugin updates"
+              value={String(installedSummary.updatesAvailable)}
+              detail="Recomputed after marketplace refresh"
+            />
+            <PluginStatCard
+              label="Direct installs"
+              value={String(availableSummary.discoverable)}
+              detail="Plugins not yet installed here"
+            />
+          </div>
+
+          <div className={styles.pluginInlineNote}>
+            Refreshing marketplaces updates the available-plugin catalog and the version metadata used for per-plugin update badges.
+          </div>
+
+          <div className={styles.pluginFormRow}>
+            <input
+              className={styles.input}
+              placeholder="github:owner/repo, URL, or local path"
+              value={marketplaceSource}
+              onChange={(event) => setMarketplaceSource(event.target.value)}
+            />
+            <select
+              className={styles.select}
+              value={marketplaceScope}
+              onChange={(event) => setMarketplaceScope(event.target.value as EditablePluginScope)}
+            >
+              <option value="user">User</option>
+              <option value="project">Project</option>
+              <option value="local">Local</option>
+            </select>
+            <button className={styles.iconBtn} onClick={() => void handleMarketplaceAdd()} disabled={busyKey === "marketplace-add"}>
+              Add
+            </button>
+            <button
+              className={styles.iconBtn}
+              onClick={() => void handleRefreshMarketplaceMetadata("Updated all marketplaces.")}
+              disabled={busyKey === "marketplace-refresh"}
+            >
+              Update All
+            </button>
+          </div>
+
+          <div className={styles.pluginFormRow}>
+            <input
+              className={styles.input}
+              placeholder="Filter marketplaces"
+              value={marketplaceFilter}
+              onChange={(event) => setMarketplaceFilter(event.target.value)}
+            />
+          </div>
+
+          {loading ? (
+            <div className={styles.settingDescription}>Loading marketplaces…</div>
+          ) : filteredMarketplaces.length === 0 ? (
+            <div className={styles.settingDescription}>No marketplaces match this view.</div>
+          ) : (
+            <div className={styles.pluginList}>
+              {filteredMarketplaces.map((marketplace) => {
+                const sourceLink = marketplaceSourceLink(marketplace);
+                return (
+                  <div key={marketplace.name} className={styles.pluginCard}>
+                    <div className={styles.pluginCardHeader}>
+                      <div className={styles.pluginCardBody}>
+                        <div className={styles.pluginCardTitle}>
+                          <span>{marketplace.name}</span>
+                          {marketplace.scope && <span className={styles.pluginBadge}>{marketplace.scope}</span>}
+                          <span className={styles.pluginBadge}>{marketplace.source_kind}</span>
+                        </div>
+                        <div className={styles.settingDescription}>
+                          {sourceLink ? `${marketplace.source_kind} marketplace source` : marketplace.source_label}
+                        </div>
+                        {sourceLink && (
+                          <div className={styles.pluginLinkRow}>
+                            <ExternalBrowserLink
+                              detail={sourceLink.detail}
+                              href={sourceLink.url}
+                              label={sourceLink.label}
+                              meta={sourceLink.meta}
+                            />
+                          </div>
+                        )}
+                        {marketplace.install_location && (
+                          <div className={styles.pluginMeta}>{marketplace.install_location}</div>
+                        )}
+                      </div>
+                      <div className={styles.pluginActions}>
+                        <button
+                          className={styles.iconBtn}
+                          onClick={() => void withBusy(`marketplace-update:${marketplace.name}`, async () => {
+                            await updatePluginMarketplace(marketplace.name, pluginSettingsRepoId ?? undefined);
+                            bumpPluginRefreshToken();
+                            setMessage(`Updated ${marketplace.name}.`);
+                          })}
+                          disabled={busyKey === `marketplace-update:${marketplace.name}`}
+                        >
+                          Update
+                        </button>
+                        <button
+                          className={styles.iconBtn}
+                          onClick={() => void withBusy(`marketplace-remove:${marketplace.name}`, async () => {
+                            await removePluginMarketplace(marketplace.name, pluginSettingsRepoId ?? undefined);
+                            bumpPluginRefreshToken();
+                            setMessage(`Removed ${marketplace.name}.`);
+                            setPendingActionHint(null);
+                            setPendingTargetHint(null);
+                          })}
+                          disabled={busyKey === `marketplace-remove:${marketplace.name}`}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -6,6 +6,7 @@ import {
   runEnvTrust,
   setEnvProviderEnabled,
 } from "../../../services/env";
+import { listClaudettePlugins } from "../../../services/claudettePlugins";
 import type { EnvSourceInfo, EnvTarget } from "../../../types/env";
 import styles from "../Settings.module.css";
 
@@ -29,14 +30,17 @@ interface ErrorInsight {
  * have a canned hint.
  */
 function analyzeError(pluginName: string, err: string): ErrorInsight {
-  if (/not trusted|mise trust/i.test(err)) {
+  // Gate the canned "Run this to fix it" hints on the plugin id so a
+  // third-party plugin whose error text happens to contain "not trusted"
+  // or "is blocked" doesn't get a wrong mise/direnv suggestion.
+  if (pluginName === "env-mise" && /not trusted|mise trust/i.test(err)) {
     return {
       summary: "mise config files in this workspace are not trusted.",
       suggestedCommand: "mise trust",
       suggestedDescription: "Run in the workspace to authorize mise config:",
     };
   }
-  if (/is blocked|direnv allow/i.test(err)) {
+  if (pluginName === "env-direnv" && /is blocked|direnv allow/i.test(err)) {
     return {
       summary: ".envrc is blocked — direnv needs explicit permission.",
       suggestedCommand: "direnv allow",
@@ -157,6 +161,42 @@ export function EnvPanel({ target }: EnvPanelProps) {
     }
   }, [target]);
 
+  // Kick off a cheap registry-only fetch in parallel with the resolve
+  // pass so the toggle rows appear instantly, even on a fresh mount
+  // where the full resolve (direnv/nix/mise) can take seconds. The
+  // resolve result replaces the placeholder rows once it completes.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const plugins = await listClaudettePlugins();
+        if (cancelled) return;
+        setSources((prev) => {
+          // If the resolve pass already populated us (fast repo), keep it.
+          if (prev !== null) return prev;
+          return plugins
+            .filter((p) => p.kind === "env-provider" && p.enabled)
+            .map<EnvSourceInfo>((p) => ({
+              plugin_name: p.name,
+              display_name: p.display_name,
+              detected: false,
+              enabled: true,
+              vars_contributed: 0,
+              cached: false,
+              evaluated_at_ms: 0,
+              error: null,
+            }));
+        });
+      } catch {
+        // Listing is best-effort scaffolding; the real resolve path
+        // below will surface any fetch error.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [target]);
+
   useEffect(() => {
     void refresh();
   }, [refresh]);
@@ -206,6 +246,10 @@ export function EnvPanel({ target }: EnvPanelProps) {
     );
   }
 
+  // Only show the blanking "Loading…" in the edge case where BOTH the
+  // placeholder-list fetch and the resolve fetch are still pending —
+  // otherwise the placeholder rows let the user see + toggle providers
+  // immediately.
   if (loading && sources === null) {
     return <div className={styles.settingDescription}>Loading…</div>;
   }

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import {
-  getWorkspaceEnvSources,
-  reloadWorkspaceEnv,
+  getEnvSources,
+  reloadEnv,
+  runEnvTrust,
   setEnvProviderEnabled,
 } from "../../../services/env";
-import type { EnvSourceInfo } from "../../../types/env";
+import type { EnvSourceInfo, EnvTarget } from "../../../types/env";
 import styles from "../Settings.module.css";
 
 interface ErrorInsight {
@@ -57,8 +58,26 @@ function analyzeError(pluginName: string, err: string): ErrorInsight {
   return { summary: core.slice(0, 240) };
 }
 
-interface WorkspaceEnvPanelProps {
-  workspaceId: string;
+interface EnvPanelProps {
+  target: EnvTarget;
+}
+
+/**
+ * Pattern-match an error to a plugin name that supports the one-click
+ * trust Run button. Returns `null` for plugins/errors we don't have a
+ * canned fix for — the UI still shows the Copy button in those cases.
+ */
+function trustablePluginFromError(
+  pluginName: string,
+  error: string,
+): "env-direnv" | "env-mise" | null {
+  if (pluginName === "env-mise" && /not trusted|mise trust/i.test(error)) {
+    return "env-mise";
+  }
+  if (pluginName === "env-direnv" && /is blocked|direnv allow/i.test(error)) {
+    return "env-direnv";
+  }
+  return null;
 }
 
 /**
@@ -108,11 +127,13 @@ function formatRelativeTime(ms: number): string {
  * in this workspace — useful after running `direnv allow` / `mise trust`
  * outside Claudette and wanting the new state reflected immediately.
  */
-export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
+export function EnvPanel({ target }: EnvPanelProps) {
   const [sources, setSources] = useState<EnvSourceInfo[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [runningTrust, setRunningTrust] = useState<string | null>(null);
+  const [trustError, setTrustError] = useState<string | null>(null);
 
   const toggleExpanded = useCallback((name: string) => {
     setExpanded((prev) => {
@@ -127,14 +148,14 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
     setLoading(true);
     setFetchError(null);
     try {
-      const result = await getWorkspaceEnvSources(workspaceId);
+      const result = await getEnvSources(target);
       setSources(result);
     } catch (e) {
       setFetchError(String(e));
     } finally {
       setLoading(false);
     }
-  }, [workspaceId]);
+  }, [target]);
 
   useEffect(() => {
     void refresh();
@@ -142,23 +163,39 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
 
   const handleReloadAll = useCallback(async () => {
     try {
-      await reloadWorkspaceEnv(workspaceId);
+      await reloadEnv(target);
       await refresh();
     } catch (e) {
       setFetchError(String(e));
     }
-  }, [workspaceId, refresh]);
+  }, [target, refresh]);
 
   const handleToggle = useCallback(
     async (pluginName: string, nextEnabled: boolean) => {
       try {
-        await setEnvProviderEnabled(workspaceId, pluginName, nextEnabled);
+        await setEnvProviderEnabled(target, pluginName, nextEnabled);
         await refresh();
       } catch (e) {
         setFetchError(String(e));
       }
     },
-    [workspaceId, refresh],
+    [target, refresh],
+  );
+
+  const handleRunTrust = useCallback(
+    async (pluginName: string) => {
+      setRunningTrust(pluginName);
+      setTrustError(null);
+      try {
+        await runEnvTrust(target, pluginName);
+        await refresh();
+      } catch (e) {
+        setTrustError(String(e));
+      } finally {
+        setRunningTrust(null);
+      }
+    },
+    [target, refresh],
   );
 
   if (fetchError) {
@@ -249,12 +286,24 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
                 <ErrorCard
                   pluginName={source.plugin_name}
                   error={source.error!}
+                  trustablePlugin={trustablePluginFromError(
+                    source.plugin_name,
+                    source.error!,
+                  )}
+                  running={runningTrust === source.plugin_name}
+                  onRunTrust={() => handleRunTrust(source.plugin_name)}
                 />
               )}
             </div>
           );
         })}
       </div>
+
+      {trustError && (
+        <div className={styles.mcpError} role="alert">
+          Trust command failed: {trustError}
+        </div>
+      )}
 
       <div className={styles.buttonRow}>
         <button
@@ -273,9 +322,15 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
 function ErrorCard({
   pluginName,
   error,
+  trustablePlugin,
+  running,
+  onRunTrust,
 }: {
   pluginName: string;
   error: string;
+  trustablePlugin: "env-direnv" | "env-mise" | null;
+  running: boolean;
+  onRunTrust: () => void;
 }) {
   const insight = analyzeError(pluginName, error);
   const [copiedCmd, setCopiedCmd] = useState(false);
@@ -309,6 +364,17 @@ function ErrorCard({
             <code className={styles.envErrorCmd}>
               {insight.suggestedCommand}
             </code>
+            {trustablePlugin && (
+              <button
+                type="button"
+                className={styles.envErrorRunBtn}
+                onClick={onRunTrust}
+                disabled={running}
+                title="Run this command in the workspace from Claudette"
+              >
+                {running ? "Running…" : "Run"}
+              </button>
+            )}
             <button
               type="button"
               className={styles.envErrorCopyBtn}

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -138,6 +138,12 @@ export function EnvPanel({ target }: EnvPanelProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [runningTrust, setRunningTrust] = useState<string | null>(null);
   const [trustError, setTrustError] = useState<string | null>(null);
+  // Becomes true after the first successful `getEnvSources` resolve for
+  // the current target. While false, any rows we're showing came from
+  // the cheap placeholder fetch and don't yet reflect per-repo toggle
+  // state — so we lock per-row toggles to avoid the user acting on a
+  // placeholder value.
+  const [resolvedOnce, setResolvedOnce] = useState(false);
 
   const toggleExpanded = useCallback((name: string) => {
     setExpanded((prev) => {
@@ -154,6 +160,7 @@ export function EnvPanel({ target }: EnvPanelProps) {
     try {
       const result = await getEnvSources(target);
       setSources(result);
+      setResolvedOnce(true);
     } catch (e) {
       setFetchError(String(e));
     } finally {
@@ -165,6 +172,12 @@ export function EnvPanel({ target }: EnvPanelProps) {
   // pass so the toggle rows appear instantly, even on a fresh mount
   // where the full resolve (direnv/nix/mise) can take seconds. The
   // resolve result replaces the placeholder rows once it completes.
+  // Reset the "first resolve landed" flag whenever the target changes;
+  // the next refresh() call will flip it back to true.
+  useEffect(() => {
+    setResolvedOnce(false);
+  }, [target]);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -266,9 +279,10 @@ export function EnvPanel({ target }: EnvPanelProps) {
     <>
       <div className={styles.settingDescription}>
         Tools whose env is merged into every subprocess Claudette spawns
-        for this workspace. Cached results invalidate automatically when
-        watched files (<code>.envrc</code>, <code>mise.toml</code>,{" "}
-        <code>.env</code>, <code>flake.lock</code>) change.
+        for this {target.kind === "repo" ? "repository" : "workspace"}.
+        Cached results invalidate automatically when watched files
+        (<code>.envrc</code>, <code>mise.toml</code>, <code>.env</code>,{" "}
+        <code>flake.lock</code>) change.
       </div>
 
       <div className={styles.mcpList}>
@@ -321,6 +335,12 @@ export function EnvPanel({ target }: EnvPanelProps) {
                     role="switch"
                     aria-checked={source.enabled}
                     aria-label={`${source.enabled ? "Disable" : "Enable"} ${source.display_name}`}
+                    disabled={!resolvedOnce}
+                    title={
+                      !resolvedOnce
+                        ? "Resolving environment providers…"
+                        : undefined
+                    }
                   >
                     <span className={styles.mcpToggleKnob} />
                   </button>

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import {
   getEnvSources,
@@ -172,10 +172,16 @@ export function EnvPanel({ target }: EnvPanelProps) {
   // pass so the toggle rows appear instantly, even on a fresh mount
   // where the full resolve (direnv/nix/mise) can take seconds. The
   // resolve result replaces the placeholder rows once it completes.
-  // Reset the "first resolve landed" flag whenever the target changes;
-  // the next refresh() call will flip it back to true.
+  // Reset panel state whenever the target changes. Without this, rows
+  // from the previous repo/workspace linger until refresh() resolves,
+  // and the placeholder fetch won't replace them because it only fills
+  // when sources===null. Clearing expanded/trustError too avoids
+  // surfacing error details from a different target.
   useEffect(() => {
     setResolvedOnce(false);
+    setSources(null);
+    setExpanded(new Set());
+    setTrustError(null);
   }, [target]);
 
   useEffect(() => {
@@ -399,13 +405,39 @@ function ErrorCard({
   const insight = analyzeError(pluginName, error);
   const [copiedCmd, setCopiedCmd] = useState(false);
   const [copiedRaw, setCopiedRaw] = useState(false);
+  // Track the "Copied" flag reset timer per-flag so a fast second copy
+  // (or an unmount from collapsing/target-change) cancels the pending
+  // setState instead of firing after the component is gone.
+  const cmdResetRef = useRef<number | null>(null);
+  const rawResetRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (cmdResetRef.current !== null) {
+        window.clearTimeout(cmdResetRef.current);
+      }
+      if (rawResetRef.current !== null) {
+        window.clearTimeout(rawResetRef.current);
+      }
+    };
+  }, []);
 
   const copy = useCallback(
-    async (text: string, setFlag: (v: boolean) => void) => {
+    async (
+      text: string,
+      setFlag: (v: boolean) => void,
+      timerRef: React.MutableRefObject<number | null>,
+    ) => {
       try {
         await writeText(text);
         setFlag(true);
-        setTimeout(() => setFlag(false), 1500);
+        if (timerRef.current !== null) {
+          window.clearTimeout(timerRef.current);
+        }
+        timerRef.current = window.setTimeout(() => {
+          setFlag(false);
+          timerRef.current = null;
+        }, 1500);
       } catch {
         // Clipboard access can fail in hardened webviews; silently no-op —
         // the raw text is still visible in the <pre> for manual selection.
@@ -442,7 +474,9 @@ function ErrorCard({
             <button
               type="button"
               className={styles.envErrorCopyBtn}
-              onClick={() => copy(insight.suggestedCommand!, setCopiedCmd)}
+              onClick={() =>
+                copy(insight.suggestedCommand!, setCopiedCmd, cmdResetRef)
+              }
             >
               {copiedCmd ? "Copied" : "Copy"}
             </button>
@@ -455,7 +489,7 @@ function ErrorCard({
         <button
           type="button"
           className={styles.envErrorCopyBtn}
-          onClick={() => copy(error, setCopiedRaw)}
+          onClick={() => copy(error, setCopiedRaw, rawResetRef)}
         >
           {copiedRaw ? "Copied" : "Copy full error"}
         </button>

--- a/src/ui/src/components/settings/sections/PluginsSettings.tsx
+++ b/src/ui/src/components/settings/sections/PluginsSettings.tsx
@@ -1,1209 +1,373 @@
-import { useEffect, useMemo, useState } from "react";
-
-import { ensureAndValidateMcps } from "../../../services/mcp";
+import { useCallback, useEffect, useState } from "react";
 import {
-  addPluginMarketplace,
-  disablePlugin,
-  enablePlugin,
-  installPlugin,
-  listPluginCatalog,
-  listPluginMarketplaces,
-  loadPluginConfiguration,
-  removePluginMarketplace,
-  savePluginChannelConfiguration,
-  savePluginTopLevelConfiguration,
-  uninstallPlugin,
-  updateAllPlugins,
-  updatePlugin,
-  updatePluginMarketplace,
-} from "../../../services/tauri";
-import { useAppStore } from "../../../stores/useAppStore";
+  listClaudettePlugins,
+  reseedBundledPlugins,
+  setClaudettePluginEnabled,
+  setClaudettePluginSetting,
+} from "../../../services/claudettePlugins";
 import type {
-  AvailablePlugin,
-  EditablePluginScope,
-  InstalledPlugin,
-  PluginConfigSection,
-  PluginConfiguration,
-  PluginMarketplace,
-  PluginSettingsAction,
-  PluginScope,
-} from "../../../types/plugins";
-import {
-  availablePluginLinks,
-  canInstallAvailablePluginAtScope,
-  formatInstallCount,
-  marketplaceSourceLink,
-  matchesAvailablePlugin,
-  matchesInstalledPlugin,
-  matchesMarketplace,
-  primaryInstalledScope,
-  sortAvailablePlugins,
-  summarizeAvailablePlugins,
-  summarizeInstalledPlugins,
-} from "./pluginCatalog";
+  ClaudettePluginInfo,
+  ClaudettePluginKind,
+  PluginSettingField,
+} from "../../../types/claudettePlugins";
 import styles from "../Settings.module.css";
-import { openUrl } from "../../../services/tauri";
 
-type DraftValues = Record<string, string | boolean>;
+const KIND_LABELS: Record<ClaudettePluginKind, string> = {
+  scm: "Source control",
+  "env-provider": "Environment providers",
+};
 
-function scopeNeedsRepo(scope: EditablePluginScope): boolean {
-  return scope === "project" || scope === "local";
-}
+const KIND_ORDER: ClaudettePluginKind[] = ["scm", "env-provider"];
 
-function hasConfig(plugin: InstalledPlugin): boolean {
-  return (
-    Object.keys(plugin.user_config_schema).length > 0
-    || plugin.channels.some((channel) => Object.keys(channel.config_schema).length > 0)
-  );
-}
-
-function buildDraft(section: PluginConfigSection): DraftValues {
-  const draft: DraftValues = {};
-  for (const [key, field] of Object.entries(section.schema)) {
-    if (field.sensitive) {
-      draft[key] = "";
-      continue;
-    }
-    const value = section.state.values[key];
-    if (field.type === "boolean") {
-      draft[key] = value === true;
-    } else if (field.multiple && Array.isArray(value)) {
-      draft[key] = value.join("\n");
-    } else if (value === undefined || value === null) {
-      draft[key] = "";
-    } else {
-      draft[key] = String(value);
-    }
-  }
-  return draft;
-}
-
-function buildPayload(
-  section: PluginConfigSection,
-  draft: DraftValues,
-): Record<string, unknown> {
-  const payload: Record<string, unknown> = {};
-  for (const [key, field] of Object.entries(section.schema)) {
-    const value = draft[key];
-    if (field.sensitive) {
-      if (typeof value === "string" && value.trim() !== "") {
-        payload[key] = field.multiple
-          ? value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
-          : value;
-      }
-      continue;
-    }
-    if (field.type === "boolean") {
-      payload[key] = value === true;
-      continue;
-    }
-    if (field.multiple) {
-      payload[key] = typeof value === "string"
-        ? value
-          .split(/\r?\n/)
-          .map((line) => line.trim())
-          .filter(Boolean)
-        : [];
-      continue;
-    }
-    payload[key] = typeof value === "string" ? value : "";
-  }
-  return payload;
-}
-
-function installedPluginSelectionKey(plugin: Pick<InstalledPlugin, "plugin_id" | "scope">): string {
-  return `${plugin.plugin_id}::${plugin.scope}`;
-}
-
-function repoAvailabilityDetail(scope: PluginScope, hasRepoContext: boolean): string | null {
-  if (!hasRepoContext) return null;
-  if (scope === "user" || scope === "managed") {
-    return `available in this repo via ${scope} scope`;
-  }
-  return null;
-}
-
-function matchesPluginTarget(plugin: InstalledPlugin, target: string): boolean {
-  const normalizedTarget = target.trim().toLowerCase();
-  if (!normalizedTarget) return false;
-  return (
-    normalizedTarget === plugin.plugin_id.toLowerCase()
-    || normalizedTarget === plugin.name.toLowerCase()
-  );
-}
-
-function pluralize(count: number, singular: string, plural = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function ConfigEditor({
-  title,
-  section,
-  draft,
-  onDraftChange,
-  onSave,
-  busy,
-}: {
-  title: string;
-  section: PluginConfigSection;
-  draft: DraftValues;
-  onDraftChange: (key: string, value: string | boolean) => void;
-  onSave: () => void;
-  busy: boolean;
-}) {
-  return (
-    <div className={styles.pluginConfigSection}>
-      <div className={styles.pluginConfigHeader}>
-        <div>
-          <div className={styles.settingLabel}>{title}</div>
-          <div className={styles.settingDescription}>
-            Sensitive fields are masked and blank values keep the existing secret.
-          </div>
-        </div>
-        <button className={styles.iconBtn} onClick={onSave} disabled={busy}>
-          Save
-        </button>
-      </div>
-
-      <div className={styles.pluginConfigFields}>
-        {Object.entries(section.schema).map(([key, field]) => {
-          const savedSensitive = section.state.saved_sensitive_keys.includes(key);
-          return (
-            <label key={key} className={styles.pluginField}>
-              <span className={styles.fieldLabel}>{field.title}</span>
-              <span className={styles.fieldHint}>{field.description}</span>
-              {field.type === "boolean" ? (
-                <input
-                  type="checkbox"
-                  checked={draft[key] === true}
-                  onChange={(event) => onDraftChange(key, event.target.checked)}
-                />
-              ) : field.multiple ? (
-                <textarea
-                  className={styles.textarea}
-                  value={String(draft[key] ?? "")}
-                  onChange={(event) => onDraftChange(key, event.target.value)}
-                  placeholder={field.sensitive && savedSensitive ? "Saved" : ""}
-                />
-              ) : (
-                <input
-                  className={styles.input}
-                  type={field.sensitive ? "password" : field.type === "number" ? "number" : "text"}
-                  min={field.min ?? undefined}
-                  max={field.max ?? undefined}
-                  value={String(draft[key] ?? "")}
-                  onChange={(event) => onDraftChange(key, event.target.value)}
-                  placeholder={field.sensitive && savedSensitive ? "Saved" : ""}
-                />
-              )}
-              <span className={styles.pluginFieldMeta}>
-                {field.required ? "Required" : "Optional"}
-                {field.sensitive ? " · Sensitive" : ""}
-                {savedSensitive && field.sensitive ? " · Secret saved" : ""}
-              </span>
-            </label>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function PluginStatCard({
-  label,
-  value,
-  detail,
-}: {
-  label: string;
-  value: string;
-  detail: string;
-}) {
-  return (
-    <div className={styles.pluginStatCard}>
-      <div className={styles.pluginStatValue}>{value}</div>
-      <div className={styles.pluginStatLabel}>{label}</div>
-      <div className={styles.pluginStatDetail}>{detail}</div>
-    </div>
-  );
-}
-
-function ExternalBrowserLink({
-  detail,
-  href,
-  label,
-  meta,
-}: {
-  detail: string;
-  href: string;
-  label: string;
-  meta: string | null;
-}) {
-  return (
-    <button
-      type="button"
-      className={styles.pluginLink}
-      onClick={(event) => {
-        event.preventDefault();
-        void openUrl(href).catch((nextError) =>
-          console.error("Failed to open plugin link:", href, nextError),
-        );
-      }}
-    >
-      <span className={styles.pluginLinkLabel}>{label}</span>
-      <span className={styles.pluginLinkDetail}>{detail}</span>
-      {meta && <span className={styles.pluginLinkMeta}>{meta}</span>}
-    </button>
-  );
-}
-
+/**
+ * Plugins settings section — shows Claudette's own Lua plugins (SCM
+ * providers + env providers) with global enable/disable toggles and
+ * per-plugin setting forms.
+ *
+ * Distinct from the "Claude Code Plugins" section, which manages
+ * the Claude Code marketplace. These plugins are bundled with
+ * Claudette (or dropped into `~/.claudette/plugins/`) and run inside
+ * Claudette's sandboxed Lua VM.
+ */
 export function PluginsSettings() {
-  const repositories = useAppStore((state) => state.repositories);
-  const pluginSettingsTab = useAppStore((state) => state.pluginSettingsTab);
-  const setPluginSettingsTab = useAppStore((state) => state.setPluginSettingsTab);
-  const pluginSettingsRepoId = useAppStore((state) => state.pluginSettingsRepoId);
-  const setPluginSettingsRepoId = useAppStore((state) => state.setPluginSettingsRepoId);
-  const pluginSettingsIntent = useAppStore((state) => state.pluginSettingsIntent);
-  const clearPluginSettingsIntent = useAppStore((state) => state.clearPluginSettingsIntent);
-  const pluginRefreshToken = useAppStore((state) => state.pluginRefreshToken);
-  const bumpPluginRefreshToken = useAppStore((state) => state.bumpPluginRefreshToken);
-  const setMcpStatus = useAppStore((state) => state.setMcpStatus);
-
-  const localRepositories = useMemo(
-    () => repositories.filter((repo) => repo.remote_connection_id === null),
-    [repositories],
-  );
-
-  const [installedPlugins, setInstalledPlugins] = useState<InstalledPlugin[]>([]);
-  const [availablePlugins, setAvailablePlugins] = useState<AvailablePlugin[]>([]);
-  const [marketplaces, setMarketplaces] = useState<PluginMarketplace[]>([]);
+  const [plugins, setPlugins] = useState<ClaudettePluginInfo[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
-  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [reseedMessage, setReseedMessage] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const [installTarget, setInstallTarget] = useState("");
-  const [installScope, setInstallScope] = useState<EditablePluginScope>("user");
-  const [availableFilter, setAvailableFilter] = useState("");
-  const [pluginFilter, setPluginFilter] = useState("");
-  const [selectedPluginKey, setSelectedPluginKey] = useState<string | null>(null);
-  const [config, setConfig] = useState<PluginConfiguration | null>(null);
-  const [configError, setConfigError] = useState<string | null>(null);
-  const [configLoading, setConfigLoading] = useState(false);
-  const [topLevelDraft, setTopLevelDraft] = useState<DraftValues>({});
-  const [channelDrafts, setChannelDrafts] = useState<Record<string, DraftValues>>({});
-  const [pendingActionHint, setPendingActionHint] = useState<PluginSettingsAction | null>(null);
-  const [pendingTargetHint, setPendingTargetHint] = useState<string | null>(null);
-
-  const [marketplaceSource, setMarketplaceSource] = useState("");
-  const [marketplaceScope, setMarketplaceScope] = useState<EditablePluginScope>("user");
-  const [marketplaceFilter, setMarketplaceFilter] = useState("");
-
-  const installedSummary = useMemo(
-    () => summarizeInstalledPlugins(installedPlugins),
-    [installedPlugins],
-  );
-  const availableSummary = useMemo(
-    () => summarizeAvailablePlugins(availablePlugins),
-    [availablePlugins],
-  );
-  const filteredInstalled = useMemo(
-    () => installedPlugins.filter((plugin) => matchesInstalledPlugin(plugin, pluginFilter)),
-    [installedPlugins, pluginFilter],
-  );
-  const filteredAvailable = useMemo(
-    () => sortAvailablePlugins(
-      availablePlugins.filter((plugin) => matchesAvailablePlugin(plugin, availableFilter)),
-    ),
-    [availableFilter, availablePlugins],
-  );
-  const filteredMarketplaces = useMemo(
-    () => marketplaces.filter((marketplace) => matchesMarketplace(marketplace, marketplaceFilter)),
-    [marketplaceFilter, marketplaces],
-  );
-  const availablePluginsById = useMemo(
-    () => new Map(availablePlugins.map((plugin) => [plugin.plugin_id, plugin])),
-    [availablePlugins],
-  );
-  const selectedInstalledPlugin = useMemo(
-    () => installedPlugins.find((plugin) => installedPluginSelectionKey(plugin) === selectedPluginKey) ?? null,
-    [installedPlugins, selectedPluginKey],
-  );
-  const globallyInstalledPlugins = useMemo(
-    () => installedPlugins.filter((plugin) => plugin.scope === "user" || plugin.scope === "managed"),
-    [installedPlugins],
-  );
-
-  useEffect(() => {
-    if (!pluginSettingsRepoId) return;
-    if (localRepositories.some((repo) => repo.id === pluginSettingsRepoId)) return;
-    setPluginSettingsRepoId(null);
-  }, [localRepositories, pluginSettingsRepoId, setPluginSettingsRepoId]);
-
-  useEffect(() => {
-    if (!pluginSettingsIntent) return;
-
-    setPluginSettingsTab(pluginSettingsIntent.tab);
-    if (pluginSettingsIntent.repoId) {
-      setPluginSettingsRepoId(pluginSettingsIntent.repoId);
-    }
-    setPendingActionHint(pluginSettingsIntent.action);
-    setPendingTargetHint(pluginSettingsIntent.target ?? pluginSettingsIntent.source);
-
-    if (pluginSettingsIntent.tab === "available") {
-      setInstallScope(pluginSettingsIntent.scope);
-      if (pluginSettingsIntent.source) {
-        setInstallTarget(pluginSettingsIntent.source);
-      }
-      if (pluginSettingsIntent.target) {
-        setAvailableFilter(pluginSettingsIntent.target);
-      }
-    } else if (pluginSettingsIntent.tab === "installed") {
-      if (pluginSettingsIntent.target) {
-        setPluginFilter(pluginSettingsIntent.target);
-        setSelectedPluginKey(null);
-      }
-    } else {
-      setMarketplaceScope(pluginSettingsIntent.scope);
-      if (pluginSettingsIntent.source) {
-        setMarketplaceSource(pluginSettingsIntent.source);
-      }
-      if (pluginSettingsIntent.target) {
-        setMarketplaceFilter(pluginSettingsIntent.target);
-      }
-    }
-
-    clearPluginSettingsIntent();
-  }, [
-    clearPluginSettingsIntent,
-    pluginSettingsIntent,
-    setPluginSettingsRepoId,
-    setPluginSettingsTab,
-  ]);
-
-  useEffect(() => {
-    let cancelled = false;
+  const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
-
-    Promise.all([
-      listPluginCatalog(pluginSettingsRepoId ?? undefined),
-      listPluginMarketplaces(pluginSettingsRepoId ?? undefined),
-    ])
-      .then(([catalog, nextMarketplaces]) => {
-        if (cancelled) return;
-        setInstalledPlugins(catalog.installed);
-        setAvailablePlugins(catalog.available);
-        setMarketplaces(nextMarketplaces);
-      })
-      .catch((nextError) => {
-        if (!cancelled) setError(String(nextError));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [pluginRefreshToken, pluginSettingsRepoId]);
+    try {
+      const result = await listClaudettePlugins();
+      setPlugins(result);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    if (!selectedInstalledPlugin) {
-      setConfig(null);
-      setTopLevelDraft({});
-      setChannelDrafts({});
-      setConfigError(null);
-      return;
-    }
+    void refresh();
+  }, [refresh]);
 
-    let cancelled = false;
-    setConfigLoading(true);
-    setConfigError(null);
-    loadPluginConfiguration(selectedInstalledPlugin.plugin_id, pluginSettingsRepoId ?? undefined)
-      .then((result) => {
-        if (cancelled) return;
-        setConfig(result);
-        setTopLevelDraft(result.top_level ? buildDraft(result.top_level) : {});
-        const nextChannelDrafts: Record<string, DraftValues> = {};
-        for (const channel of result.channels) {
-          nextChannelDrafts[channel.server] = buildDraft(channel.section);
-        }
-        setChannelDrafts(nextChannelDrafts);
-      })
-      .catch((nextError) => {
-        if (!cancelled) setConfigError(String(nextError));
-      })
-      .finally(() => {
-        if (!cancelled) setConfigLoading(false);
-      });
+  const toggleExpanded = useCallback((name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [pluginSettingsRepoId, selectedInstalledPlugin]);
-
-  async function refreshAffectedMcps(scope: EditablePluginScope | "managed" | null) {
-    const repoIds = scope === "project" || scope === "local"
-      ? pluginSettingsRepoId ? [pluginSettingsRepoId] : []
-      : localRepositories.map((repo) => repo.id);
-
-    await Promise.all(repoIds.map(async (repoId) => {
+  const handleToggle = useCallback(
+    async (pluginName: string, nextEnabled: boolean) => {
       try {
-        const snapshot = await ensureAndValidateMcps(repoId);
-        setMcpStatus(repoId, snapshot);
-      } catch (nextError) {
-        console.error(`Failed to refresh MCPs for ${repoId}:`, nextError);
+        await setClaudettePluginEnabled(pluginName, nextEnabled);
+        await refresh();
+      } catch (e) {
+        setError(String(e));
       }
-    }));
-  }
+    },
+    [refresh],
+  );
 
-  async function afterMutation(scope: EditablePluginScope | "managed" | null, nextMessage: string) {
-    bumpPluginRefreshToken();
-    await refreshAffectedMcps(scope);
-    setMessage(nextMessage);
-  }
+  const handleSettingChange = useCallback(
+    async (pluginName: string, key: string, value: unknown) => {
+      try {
+        await setClaudettePluginSetting(pluginName, key, value);
+        await refresh();
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [refresh],
+  );
 
-  function requireRepoForScope(scope: EditablePluginScope): string | null {
-    if (!scopeNeedsRepo(scope)) return null;
-    return pluginSettingsRepoId;
-  }
-
-  async function withBusy(key: string, work: () => Promise<void>) {
-    setBusyKey(key);
-    setError(null);
-    setMessage(null);
+  const handleReseed = useCallback(async () => {
+    setReseedMessage(null);
     try {
-      await work();
-    } catch (nextError) {
-      setError(String(nextError));
-    } finally {
-      setBusyKey(null);
-    }
-  }
-
-  function repoIdForPluginScope(scope: PluginScope): string | undefined {
-    if (scope === "project" || scope === "local") {
-      return pluginSettingsRepoId ?? undefined;
-    }
-    return undefined;
-  }
-
-  function openInstalledPlugin(pluginId: string) {
-    setPluginSettingsTab("installed");
-    setPluginFilter(pluginId);
-    const matchingPlugins = installedPlugins.filter((plugin) => plugin.plugin_id === pluginId);
-    const primaryScope = primaryInstalledScope(matchingPlugins.map((plugin) => plugin.scope));
-    const targetPlugin = matchingPlugins.find((plugin) => plugin.scope === primaryScope)
-      ?? matchingPlugins[0]
-      ?? null;
-    setSelectedPluginKey(targetPlugin ? installedPluginSelectionKey(targetPlugin) : null);
-  }
-
-  async function handleInstall(targetOverride?: string) {
-    const target = (targetOverride ?? installTarget).trim();
-    if (!target) {
-      setError("Enter a plugin identifier to install.");
-      return;
-    }
-    if (installScope !== "user") {
-      const globalInstall = globallyInstalledPlugins.find((plugin) => matchesPluginTarget(plugin, target));
-      if (globalInstall) {
-        setError(
-          `${globalInstall.plugin_id} is already installed at ${globalInstall.scope} scope and is already available in this repository.`,
-        );
-        return;
-      }
-    }
-    const repoId = requireRepoForScope(installScope);
-    if (scopeNeedsRepo(installScope) && !repoId) {
-      setError("Select a local repository for project/local scope.");
-      return;
-    }
-
-    await withBusy(targetOverride ? `install:${target}` : "install", async () => {
-      await installPlugin(target, installScope, repoId ?? undefined);
-      await afterMutation(installScope, `Installed ${target} at ${installScope} scope.`);
-      if (!targetOverride) {
-        setInstallTarget("");
-      }
-      setPendingActionHint(null);
-      setPendingTargetHint(null);
-    });
-  }
-
-  async function handlePluginAction(
-    plugin: InstalledPlugin,
-    action: "enable" | "disable" | "uninstall" | "update",
-  ) {
-    const repoId = repoIdForPluginScope(plugin.scope);
-
-    await withBusy(`${action}:${plugin.plugin_id}:${plugin.scope}`, async () => {
-      if (action === "enable") {
-        await enablePlugin(plugin.plugin_id, plugin.scope as EditablePluginScope, repoId);
-      } else if (action === "disable") {
-        await disablePlugin(plugin.plugin_id, plugin.scope as EditablePluginScope, repoId);
-      } else if (action === "uninstall") {
-        await uninstallPlugin(plugin.plugin_id, plugin.scope as EditablePluginScope, false, repoId);
-        if (selectedPluginKey === installedPluginSelectionKey(plugin)) {
-          setSelectedPluginKey(null);
-        }
-      } else {
-        await updatePlugin(plugin.plugin_id, plugin.scope, repoId);
-      }
-      await afterMutation(plugin.scope, `${action} completed for ${plugin.plugin_id}.`);
-      setPendingActionHint(null);
-      setPendingTargetHint(null);
-    });
-  }
-
-  async function handleUpdateAllInstalled() {
-    await withBusy("update-all", async () => {
-      const result = await updateAllPlugins(pluginSettingsRepoId ?? undefined);
-      if (result.succeeded > 0) {
-        const refreshScope = installedPlugins.some((plugin) => plugin.scope === "managed" || plugin.scope === "user")
-          ? "user"
-          : installedPlugins.some((plugin) => plugin.scope === "project")
-            ? "project"
-            : installedPlugins.some((plugin) => plugin.scope === "local")
-              ? "local"
-              : null;
-        bumpPluginRefreshToken();
-        await refreshAffectedMcps(refreshScope);
-      }
-
-      if (result.attempted === 0) {
-        setMessage("No plugins need update checks in this context.");
-      } else {
-        setMessage(`Checked ${pluralize(result.attempted, "plugin")}; ${pluralize(result.succeeded, "update")} completed.`);
-      }
-
-      if (result.failed.length > 0) {
-        const visibleFailures = result.failed.slice(0, 3).join("\n");
-        const extraFailures = result.failed.length > 3
-          ? `\n… ${result.failed.length - 3} more`
-          : "";
-        setError(`Some plugin updates failed:\n${visibleFailures}${extraFailures}`);
-      }
-
-      setPendingActionHint(null);
-      setPendingTargetHint(null);
-    });
-  }
-
-  async function handleRefreshMarketplaceMetadata(messageText: string) {
-    await withBusy("marketplace-refresh", async () => {
-      await updatePluginMarketplace(undefined, pluginSettingsRepoId ?? undefined);
-      bumpPluginRefreshToken();
-      setMessage(messageText);
-    });
-  }
-
-  async function handleMarketplaceAdd() {
-    if (!marketplaceSource.trim()) {
-      setError("Enter a marketplace source.");
-      return;
-    }
-    const repoId = requireRepoForScope(marketplaceScope);
-    if (scopeNeedsRepo(marketplaceScope) && !repoId) {
-      setError("Select a local repository for project/local scope.");
-      return;
-    }
-    await withBusy("marketplace-add", async () => {
-      await addPluginMarketplace(marketplaceSource.trim(), marketplaceScope, repoId ?? undefined);
-      bumpPluginRefreshToken();
-      setMessage(`Added marketplace ${marketplaceSource.trim()}.`);
-      setPendingActionHint(null);
-      setPendingTargetHint(null);
-    });
-  }
-
-  async function handleSaveTopLevel() {
-    const topLevelSection = config?.top_level;
-    if (!topLevelSection || !selectedInstalledPlugin) return;
-    await withBusy(`config:${selectedInstalledPlugin.plugin_id}:top`, async () => {
-      await savePluginTopLevelConfiguration(
-        selectedInstalledPlugin.plugin_id,
-        buildPayload(topLevelSection, topLevelDraft),
-        pluginSettingsRepoId ?? undefined,
+      const warnings = await reseedBundledPlugins();
+      setReseedMessage(
+        warnings.length === 0
+          ? "Bundled plugins reseeded."
+          : `Reseeded with ${warnings.length} warning(s): ${warnings.join("; ")}`,
       );
-      await afterMutation("user", `Saved configuration for ${selectedInstalledPlugin.plugin_id}.`);
-      const refreshed = await loadPluginConfiguration(
-        selectedInstalledPlugin.plugin_id,
-        pluginSettingsRepoId ?? undefined,
-      );
-      setConfig(refreshed);
-      setTopLevelDraft(refreshed.top_level ? buildDraft(refreshed.top_level) : {});
-    });
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [refresh]);
+
+  if (error) {
+    return (
+      <div>
+        <h2 className={styles.sectionTitle}>Plugins</h2>
+        <div className={styles.mcpError} role="alert">
+          Failed to load plugins: {error}
+        </div>
+      </div>
+    );
   }
 
-  async function handleSaveChannel(serverName: string) {
-    if (!config || !selectedInstalledPlugin) return;
-    const channel = config.channels.find((entry) => entry.server === serverName);
-    if (!channel) return;
-    await withBusy(`config:${selectedInstalledPlugin.plugin_id}:${serverName}`, async () => {
-      await savePluginChannelConfiguration(
-        selectedInstalledPlugin.plugin_id,
-        serverName,
-        buildPayload(channel.section, channelDrafts[serverName] ?? {}),
-        pluginSettingsRepoId ?? undefined,
-      );
-      await afterMutation("user", `Saved ${serverName} configuration.`);
-      const refreshed = await loadPluginConfiguration(
-        selectedInstalledPlugin.plugin_id,
-        pluginSettingsRepoId ?? undefined,
-      );
-      setConfig(refreshed);
-      const nextChannelDrafts: Record<string, DraftValues> = {};
-      for (const entry of refreshed.channels) {
-        nextChannelDrafts[entry.server] = buildDraft(entry.section);
-      }
-      setChannelDrafts(nextChannelDrafts);
-    });
+  if (loading && plugins === null) {
+    return (
+      <div>
+        <h2 className={styles.sectionTitle}>Plugins</h2>
+        <div className={styles.settingDescription}>Loading…</div>
+      </div>
+    );
   }
+
+  const items = plugins ?? [];
+  const grouped = KIND_ORDER.map((kind) => ({
+    kind,
+    items: items.filter((p) => p.kind === kind),
+  })).filter((g) => g.items.length > 0);
 
   return (
     <div>
-      <h1 className={styles.sectionTitle}>Plugins</h1>
+      <h2 className={styles.sectionTitle}>Plugins</h2>
       <div className={styles.settingDescription}>
-        Browse marketplace plugins, manage installed ones, and refresh marketplace metadata using the real Claude CLI.
+        Claudette's built-in plugins — source-control providers and
+        environment activators. Toggle a plugin off to disable it
+        globally; open a row to configure its behaviour.{" "}
+        <em>(Not to be confused with Claude Code Plugins, which manages
+        marketplace extensions for the Claude CLI itself.)</em>
       </div>
 
-      <div className={styles.pluginToolbar}>
-        <div className={styles.inlineControl}>
-          <label className={styles.settingLabel} htmlFor="plugin-repo-select">Repository</label>
-          <select
-            id="plugin-repo-select"
-            className={styles.select}
-            value={pluginSettingsRepoId ?? ""}
-            onChange={(event) => setPluginSettingsRepoId(event.target.value || null)}
-          >
-            <option value="">Global only</option>
-            {localRepositories.map((repo) => (
-              <option key={repo.id} value={repo.id}>{repo.name}</option>
+      {grouped.length === 0 && (
+        <div className={styles.settingDescription}>
+          No plugins discovered. This shouldn't happen — bundled plugins
+          are seeded on first run. Try the Reseed button below.
+        </div>
+      )}
+
+      {grouped.map(({ kind, items }) => (
+        <div key={kind} className={styles.fieldGroup}>
+          <div className={styles.mcpGroupLabel}>{KIND_LABELS[kind]}</div>
+          <div className={styles.mcpList}>
+            {items.map((plugin) => (
+              <PluginRow
+                key={plugin.name}
+                plugin={plugin}
+                expanded={expanded.has(plugin.name)}
+                onToggleExpand={() => toggleExpanded(plugin.name)}
+                onToggleEnabled={(next) => handleToggle(plugin.name, next)}
+                onSettingChange={(key, value) =>
+                  handleSettingChange(plugin.name, key, value)
+                }
+              />
             ))}
-          </select>
+          </div>
         </div>
+      ))}
 
-        <div className={styles.pluginTabs}>
-          <button
-            className={pluginSettingsTab === "available" ? styles.pluginTabActive : styles.pluginTab}
-            onClick={() => setPluginSettingsTab("available")}
+      <div className={styles.buttonRow}>
+        <button
+          type="button"
+          className={styles.iconBtn}
+          onClick={handleReseed}
+        >
+          Reload bundled plugins
+        </button>
+        {reseedMessage && (
+          <span className={styles.settingDescription}>{reseedMessage}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface PluginRowProps {
+  plugin: ClaudettePluginInfo;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  onSettingChange: (key: string, value: unknown) => void;
+}
+
+function PluginRow({
+  plugin,
+  expanded,
+  onToggleExpand,
+  onToggleEnabled,
+  onSettingChange,
+}: PluginRowProps) {
+  const hasSettings = plugin.settings_schema.length > 0;
+  const hasCliIssue = !plugin.cli_available;
+  const dotColor = !plugin.enabled
+    ? "var(--text-faint)"
+    : hasCliIssue
+      ? "var(--status-stopped)"
+      : "var(--status-running)";
+  const badge = !plugin.enabled
+    ? "disabled"
+    : hasCliIssue
+      ? "cli missing"
+      : "loaded";
+
+  return (
+    <div>
+      <div className={styles.mcpRow}>
+        <div className={styles.mcpInfo}>
+          <span
+            className={styles.mcpStatusDot}
+            style={{ background: dotColor }}
+            title={badge}
+          />
+          <span
+            className={`${styles.mcpName} ${!plugin.enabled ? styles.mcpNameDisabled : ""}`}
           >
-            Available
-          </button>
+            {plugin.display_name}
+          </span>
+          <span className={styles.mcpBadge}>{badge}</span>
+          <span className={styles.settingDescription}>
+            v{plugin.version}
+          </span>
+        </div>
+        <div className={styles.mcpActions}>
+          {(hasSettings || hasCliIssue) && (
+            <button
+              type="button"
+              className={styles.envDetailsBtn}
+              onClick={onToggleExpand}
+              aria-expanded={expanded}
+            >
+              {expanded ? "Hide details" : "Details"}
+            </button>
+          )}
           <button
-            className={pluginSettingsTab === "installed" ? styles.pluginTabActive : styles.pluginTab}
-            onClick={() => setPluginSettingsTab("installed")}
+            type="button"
+            className={`${styles.mcpToggle} ${plugin.enabled ? styles.mcpToggleOn : ""}`}
+            onClick={() => onToggleEnabled(!plugin.enabled)}
+            role="switch"
+            aria-checked={plugin.enabled}
+            aria-label={`${plugin.enabled ? "Disable" : "Enable"} ${plugin.display_name}`}
           >
-            Installed
-          </button>
-          <button
-            className={pluginSettingsTab === "marketplaces" ? styles.pluginTabActive : styles.pluginTab}
-            onClick={() => setPluginSettingsTab("marketplaces")}
-          >
-            Marketplaces
+            <span className={styles.mcpToggleKnob} />
           </button>
         </div>
       </div>
-
-      {pendingActionHint && pendingTargetHint && (
-        <div className={styles.pluginNotice}>
-          Pending action: <strong>{pendingActionHint}</strong> for <code>{pendingTargetHint}</code>.
-        </div>
-      )}
-      {message && <div className={styles.pluginSuccess}>{message}</div>}
-      {error && <div className={styles.pluginError}>{error}</div>}
-
-      {pluginSettingsTab === "available" && (
-        <div className={styles.pluginPanel}>
-          <div className={styles.pluginSummaryGrid}>
-            <PluginStatCard
-              label="Marketplace catalog"
-              value={String(availableSummary.total)}
-              detail={pluralize(marketplaces.length, "marketplace")}
-            />
-            <PluginStatCard
-              label="Ready to install"
-              value={String(availableSummary.discoverable)}
-              detail="Not installed in this context"
-            />
-            <PluginStatCard
-              label="Installed here"
-              value={String(availableSummary.installed)}
-              detail={pluralize(installedSummary.pluginCount, "distinct plugin")}
-            />
-            <PluginStatCard
-              label="Known updates"
-              value={String(installedSummary.updatesAvailable)}
-              detail={installedSummary.unknownVersionCount > 0
-                ? `${pluralize(installedSummary.unknownVersionCount, "plugin")} without version metadata`
-                : "All installed plugins publish version metadata"}
-            />
+      {expanded && (
+        <div className={styles.envErrorCard}>
+          <div className={styles.settingDescription}>
+            {plugin.description}
           </div>
-
-          <div className={styles.pluginInlineNote}>
-            Claude Code treats user and managed installs as global, so this browser does not offer redundant project or local installs for plugins that are already available everywhere. Refresh marketplaces to recalculate update badges.
-          </div>
-
-          <div className={styles.pluginFormRow}>
-            <input
-              className={styles.input}
-              placeholder="Search marketplace plugins"
-              value={availableFilter}
-              onChange={(event) => setAvailableFilter(event.target.value)}
-            />
-            <select
-              className={styles.select}
-              value={installScope}
-              onChange={(event) => setInstallScope(event.target.value as EditablePluginScope)}
-            >
-              <option value="user">Install to user</option>
-              <option value="project">Install to project</option>
-              <option value="local">Install to local</option>
-            </select>
-            <button
-              className={styles.iconBtn}
-              onClick={() => void handleRefreshMarketplaceMetadata("Refreshed marketplace metadata.")}
-              disabled={busyKey === "marketplace-refresh"}
-            >
-              Refresh Marketplaces
-            </button>
-          </div>
-
-          <div className={styles.pluginFormRow}>
-            <input
-              className={styles.input}
-              placeholder="Install custom plugin target or plugin@marketplace"
-              value={installTarget}
-              onChange={(event) => setInstallTarget(event.target.value)}
-            />
-            <button className={styles.iconBtn} onClick={() => void handleInstall()} disabled={busyKey === "install"}>
-              Install
-            </button>
-          </div>
-
-          {loading ? (
-            <div className={styles.settingDescription}>Loading plugin catalog…</div>
-          ) : filteredAvailable.length === 0 ? (
-            <div className={styles.settingDescription}>No marketplace plugins match this view.</div>
-          ) : (
-            <div className={styles.pluginList}>
-              {filteredAvailable.map((plugin) => {
-                const installableAtScope = canInstallAvailablePluginAtScope(plugin, installScope);
-                const installCount = formatInstallCount(plugin.install_count);
-                const links = availablePluginLinks(plugin);
-                return (
-                  <div key={plugin.plugin_id} className={styles.pluginCard}>
-                    <div className={styles.pluginCardHeader}>
-                      <div className={styles.pluginCardBody}>
-                        <div className={styles.pluginCardTitle}>
-                          <span>{plugin.name}</span>
-                          <span className={styles.pluginBadge}>{plugin.marketplace}</span>
-                          {plugin.category && <span className={styles.pluginBadge}>{plugin.category}</span>}
-                          {plugin.version && <span className={styles.pluginBadge}>v{plugin.version}</span>}
-                          {plugin.installed && <span className={styles.pluginBadge}>installed</span>}
-                          {plugin.enabled && <span className={styles.pluginBadge}>enabled</span>}
-                          {plugin.update_available && <span className={styles.pluginBadge}>update available</span>}
-                          {plugin.installed_scopes.map((scope) => (
-                            <span key={`${plugin.plugin_id}:${scope}`} className={styles.pluginBadge}>
-                              {scope}
-                            </span>
-                          ))}
-                        </div>
-                        <div className={styles.settingDescription}>
-                          {plugin.description ?? "No description provided."}
-                        </div>
-                        {installCount && (
-                          <div className={styles.pluginMeta}>{installCount}</div>
-                        )}
-                        {links.length > 0 && (
-                          <div className={styles.pluginLinkRow}>
-                            {links.map((link) => (
-                              <ExternalBrowserLink
-                                key={`${plugin.plugin_id}:${link.label}:${link.url}`}
-                                detail={link.detail}
-                                href={link.url}
-                                label={link.label}
-                                meta={link.meta}
-                              />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-
-                      <div className={styles.pluginActions}>
-                        {plugin.installed && (
-                          <button
-                            className={styles.iconBtn}
-                            onClick={() => openInstalledPlugin(plugin.plugin_id)}
-                          >
-                            Manage
-                          </button>
-                        )}
-                        {installableAtScope && (
-                          <button
-                            className={styles.iconBtn}
-                            onClick={() => void handleInstall(plugin.plugin_id)}
-                            disabled={
-                              (scopeNeedsRepo(installScope) && !pluginSettingsRepoId)
-                              || busyKey === `install:${plugin.plugin_id}`
-                            }
-                          >
-                            Install to {installScope}
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+          {plugin.required_clis.length > 0 && (
+            <div className={styles.envErrorHint}>
+              Requires:{" "}
+              {plugin.required_clis.map((cli, i) => (
+                <span key={cli}>
+                  {i > 0 && ", "}
+                  <code>{cli}</code>
+                </span>
+              ))}
+              {hasCliIssue && (
+                <>
+                  {" "}
+                  <strong style={{ color: "var(--status-stopped)" }}>
+                    (not found on PATH)
+                  </strong>
+                </>
+              )}
+            </div>
+          )}
+          {hasSettings && (
+            <div className={styles.pluginSettingsForm}>
+              {plugin.settings_schema.map((field) => (
+                <SettingInput
+                  key={field.key}
+                  field={field}
+                  value={plugin.setting_values[field.key]}
+                  onChange={(value) => onSettingChange(field.key, value)}
+                />
+              ))}
             </div>
           )}
         </div>
       )}
+    </div>
+  );
+}
 
-      {pluginSettingsTab === "installed" && (
-        <div className={styles.pluginPanel}>
-          <div className={styles.pluginSummaryGrid}>
-            <PluginStatCard
-              label="Installations"
-              value={String(installedSummary.installationCount)}
-              detail={pluralize(installedSummary.pluginCount, "distinct plugin")}
-            />
-            <PluginStatCard
-              label="Known updates"
-              value={String(installedSummary.updatesAvailable)}
-              detail="Based on refreshed marketplace versions"
-            />
-            <PluginStatCard
-              label="Unknown version status"
-              value={String(installedSummary.unknownVersionCount)}
-              detail="These still work with Update All"
-            />
-            <PluginStatCard
-              label="Configured marketplaces"
-              value={String(marketplaces.length)}
-              detail="Refresh them to check for new versions"
-            />
-          </div>
-
-          <div className={styles.pluginInlineNote}>
-            Claude Code’s interactive plugin tools do not expose a native one-shot update-all command. Claudette now runs the per-plugin update flow across this installed set and surfaces concrete update badges when metadata is available.
-          </div>
-
-          <div className={styles.pluginFormRow}>
-            <input
-              className={styles.input}
-              placeholder="Filter installed plugins"
-              value={pluginFilter}
-              onChange={(event) => setPluginFilter(event.target.value)}
-            />
-            <button
-              className={styles.iconBtn}
-              onClick={() => void handleUpdateAllInstalled()}
-              disabled={busyKey === "update-all"}
-            >
-              Update All
-            </button>
-            <button
-              className={styles.iconBtn}
-              onClick={() => void handleRefreshMarketplaceMetadata("Refreshed marketplace metadata for update checks.")}
-              disabled={busyKey === "marketplace-refresh"}
-            >
-              Refresh Marketplaces
-            </button>
-          </div>
-
-          {loading ? (
-            <div className={styles.settingDescription}>Loading installed plugins…</div>
-          ) : filteredInstalled.length === 0 ? (
-            <div className={styles.settingDescription}>No installed plugins match this view.</div>
-          ) : (
-            <div className={styles.pluginList}>
-              {filteredInstalled.map((plugin) => {
-                const catalogPlugin = availablePluginsById.get(plugin.plugin_id);
-                const links = catalogPlugin ? availablePluginLinks(catalogPlugin) : [];
-                return (
-                  <div
-                    key={`${plugin.plugin_id}:${plugin.scope}`}
-                    className={`${styles.pluginCard}${selectedPluginKey === installedPluginSelectionKey(plugin) ? ` ${styles.pluginCardSelected}` : ""}`}
-                  >
-                    <div className={styles.pluginCardHeader}>
-                      <div className={styles.pluginCardBody}>
-                        <div className={styles.pluginCardTitle}>
-                          <span>{plugin.plugin_id}</span>
-                          <span className={styles.pluginBadge}>{plugin.scope}</span>
-                          <span className={styles.pluginBadge}>{plugin.enabled ? "enabled" : "disabled"}</span>
-                          {plugin.update_available && plugin.latest_known_version && (
-                            <span className={styles.pluginBadge}>update → v{plugin.latest_known_version}</span>
-                          )}
-                          {plugin.command_count > 0 && <span className={styles.pluginBadge}>{plugin.command_count} cmds</span>}
-                          {plugin.skill_count > 0 && <span className={styles.pluginBadge}>{plugin.skill_count} skills</span>}
-                          {plugin.mcp_servers.length > 0 && <span className={styles.pluginBadge}>{plugin.mcp_servers.length} mcp</span>}
-                        </div>
-                        <div className={styles.settingDescription}>
-                          {plugin.description ?? "No description provided."}
-                        </div>
-                        <div className={styles.pluginMeta}>
-                          {[
-                            `v${plugin.version}`,
-                            plugin.latest_known_version && !plugin.update_available
-                              ? `latest v${plugin.latest_known_version}`
-                              : null,
-                            repoAvailabilityDetail(plugin.scope, pluginSettingsRepoId !== null),
-                            plugin.install_path,
-                          ].filter((value): value is string => Boolean(value)).join(" · ")}
-                        </div>
-                        {links.length > 0 && (
-                          <div className={styles.pluginLinkRow}>
-                            {links.map((link) => (
-                              <ExternalBrowserLink
-                                key={`${plugin.plugin_id}:${plugin.scope}:${link.label}:${link.url}`}
-                                detail={link.detail}
-                                href={link.url}
-                                label={link.label}
-                                meta={link.meta}
-                              />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-
-                      <div className={styles.pluginActions}>
-                        {plugin.scope !== "managed" && (
-                          plugin.enabled ? (
-                            <button
-                              className={styles.iconBtn}
-                              onClick={() => void handlePluginAction(plugin, "disable")}
-                              disabled={busyKey === `disable:${plugin.plugin_id}:${plugin.scope}`}
-                            >
-                              Disable
-                            </button>
-                          ) : (
-                            <button
-                              className={styles.iconBtn}
-                              onClick={() => void handlePluginAction(plugin, "enable")}
-                              disabled={busyKey === `enable:${plugin.plugin_id}:${plugin.scope}`}
-                            >
-                              Enable
-                            </button>
-                          )
-                        )}
-                        <button
-                          className={styles.iconBtn}
-                          onClick={() => void handlePluginAction(plugin, "update")}
-                          disabled={busyKey === `update:${plugin.plugin_id}:${plugin.scope}`}
-                        >
-                          Update
-                        </button>
-                        {plugin.scope !== "managed" && (
-                          <button
-                            className={styles.iconBtn}
-                            onClick={() => void handlePluginAction(plugin, "uninstall")}
-                            disabled={busyKey === `uninstall:${plugin.plugin_id}:${plugin.scope}`}
-                          >
-                            Uninstall
-                          </button>
-                        )}
-                        {hasConfig(plugin) && (
-                          <button
-                            className={styles.iconBtn}
-                            onClick={() => setSelectedPluginKey((current) =>
-                              current === installedPluginSelectionKey(plugin)
-                                ? null
-                                : installedPluginSelectionKey(plugin)
-                            )}
-                          >
-                            Configure
-                          </button>
-                        )}
-                      </div>
-                    </div>
-
-                    {selectedPluginKey === installedPluginSelectionKey(plugin) && (
-                      <div className={styles.pluginConfigPanel}>
-                        {configLoading ? (
-                          <div className={styles.settingDescription}>Loading configuration…</div>
-                        ) : configError ? (
-                          <div className={styles.pluginError}>{configError}</div>
-                        ) : config ? (
-                          <>
-                            {config.top_level && (
-                              <ConfigEditor
-                                title="Plugin options"
-                                section={config.top_level}
-                                draft={topLevelDraft}
-                                onDraftChange={(key, value) => setTopLevelDraft((draft) => ({ ...draft, [key]: value }))}
-                                onSave={() => void handleSaveTopLevel()}
-                                busy={busyKey === `config:${plugin.plugin_id}:top`}
-                              />
-                            )}
-                            {config.channels.map((channel) => (
-                              <ConfigEditor
-                                key={channel.server}
-                                title={channel.display_name ?? channel.server}
-                                section={channel.section}
-                                draft={channelDrafts[channel.server] ?? {}}
-                                onDraftChange={(key, value) => setChannelDrafts((drafts) => ({
-                                  ...drafts,
-                                  [channel.server]: {
-                                    ...drafts[channel.server],
-                                    [key]: value,
-                                  },
-                                }))}
-                                onSave={() => void handleSaveChannel(channel.server)}
-                                busy={busyKey === `config:${plugin.plugin_id}:${channel.server}`}
-                              />
-                            ))}
-                            {!config.top_level && config.channels.length === 0 && (
-                              <div className={styles.settingDescription}>This plugin does not expose configurable fields.</div>
-                            )}
-                          </>
-                        ) : null}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+function SettingInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: PluginSettingField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  if (field.type === "boolean") {
+    const checked = value === true;
+    return (
+      <label className={styles.pluginSettingRow}>
+        <button
+          type="button"
+          className={`${styles.mcpToggle} ${checked ? styles.mcpToggleOn : ""}`}
+          onClick={() => onChange(!checked)}
+          role="switch"
+          aria-checked={checked}
+          aria-label={field.label}
+        >
+          <span className={styles.mcpToggleKnob} />
+        </button>
+        <div>
+          <div className={styles.pluginSettingLabel}>{field.label}</div>
+          {field.description && (
+            <div className={styles.envErrorHint}>{field.description}</div>
           )}
         </div>
-      )}
+      </label>
+    );
+  }
 
-      {pluginSettingsTab === "marketplaces" && (
-        <div className={styles.pluginPanel}>
-          <div className={styles.pluginSummaryGrid}>
-            <PluginStatCard
-              label="Configured marketplaces"
-              value={String(marketplaces.length)}
-              detail="Visible in this repo context"
-            />
-            <PluginStatCard
-              label="Catalog entries"
-              value={String(availableSummary.total)}
-              detail="Powered by local marketplace clones"
-            />
-            <PluginStatCard
-              label="Known plugin updates"
-              value={String(installedSummary.updatesAvailable)}
-              detail="Recomputed after marketplace refresh"
-            />
-            <PluginStatCard
-              label="Direct installs"
-              value={String(availableSummary.discoverable)}
-              detail="Plugins not yet installed here"
-            />
-          </div>
-
-          <div className={styles.pluginInlineNote}>
-            Refreshing marketplaces updates the available-plugin catalog and the version metadata used for per-plugin update badges.
-          </div>
-
-          <div className={styles.pluginFormRow}>
-            <input
-              className={styles.input}
-              placeholder="github:owner/repo, URL, or local path"
-              value={marketplaceSource}
-              onChange={(event) => setMarketplaceSource(event.target.value)}
-            />
-            <select
-              className={styles.select}
-              value={marketplaceScope}
-              onChange={(event) => setMarketplaceScope(event.target.value as EditablePluginScope)}
-            >
-              <option value="user">User</option>
-              <option value="project">Project</option>
-              <option value="local">Local</option>
-            </select>
-            <button className={styles.iconBtn} onClick={() => void handleMarketplaceAdd()} disabled={busyKey === "marketplace-add"}>
-              Add
-            </button>
-            <button
-              className={styles.iconBtn}
-              onClick={() => void handleRefreshMarketplaceMetadata("Updated all marketplaces.")}
-              disabled={busyKey === "marketplace-refresh"}
-            >
-              Update All
-            </button>
-          </div>
-
-          <div className={styles.pluginFormRow}>
-            <input
-              className={styles.input}
-              placeholder="Filter marketplaces"
-              value={marketplaceFilter}
-              onChange={(event) => setMarketplaceFilter(event.target.value)}
-            />
-          </div>
-
-          {loading ? (
-            <div className={styles.settingDescription}>Loading marketplaces…</div>
-          ) : filteredMarketplaces.length === 0 ? (
-            <div className={styles.settingDescription}>No marketplaces match this view.</div>
-          ) : (
-            <div className={styles.pluginList}>
-              {filteredMarketplaces.map((marketplace) => {
-                const sourceLink = marketplaceSourceLink(marketplace);
-                return (
-                  <div key={marketplace.name} className={styles.pluginCard}>
-                    <div className={styles.pluginCardHeader}>
-                      <div className={styles.pluginCardBody}>
-                        <div className={styles.pluginCardTitle}>
-                          <span>{marketplace.name}</span>
-                          {marketplace.scope && <span className={styles.pluginBadge}>{marketplace.scope}</span>}
-                          <span className={styles.pluginBadge}>{marketplace.source_kind}</span>
-                        </div>
-                        <div className={styles.settingDescription}>
-                          {sourceLink ? `${marketplace.source_kind} marketplace source` : marketplace.source_label}
-                        </div>
-                        {sourceLink && (
-                          <div className={styles.pluginLinkRow}>
-                            <ExternalBrowserLink
-                              detail={sourceLink.detail}
-                              href={sourceLink.url}
-                              label={sourceLink.label}
-                              meta={sourceLink.meta}
-                            />
-                          </div>
-                        )}
-                        {marketplace.install_location && (
-                          <div className={styles.pluginMeta}>{marketplace.install_location}</div>
-                        )}
-                      </div>
-                      <div className={styles.pluginActions}>
-                        <button
-                          className={styles.iconBtn}
-                          onClick={() => void withBusy(`marketplace-update:${marketplace.name}`, async () => {
-                            await updatePluginMarketplace(marketplace.name, pluginSettingsRepoId ?? undefined);
-                            bumpPluginRefreshToken();
-                            setMessage(`Updated ${marketplace.name}.`);
-                          })}
-                          disabled={busyKey === `marketplace-update:${marketplace.name}`}
-                        >
-                          Update
-                        </button>
-                        <button
-                          className={styles.iconBtn}
-                          onClick={() => void withBusy(`marketplace-remove:${marketplace.name}`, async () => {
-                            await removePluginMarketplace(marketplace.name, pluginSettingsRepoId ?? undefined);
-                            bumpPluginRefreshToken();
-                            setMessage(`Removed ${marketplace.name}.`);
-                            setPendingActionHint(null);
-                            setPendingTargetHint(null);
-                          })}
-                          disabled={busyKey === `marketplace-remove:${marketplace.name}`}
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+  if (field.type === "text") {
+    const stringValue = typeof value === "string" ? value : (field.default ?? "");
+    return (
+      <div className={styles.pluginSettingRow}>
+        <div>
+          <div className={styles.pluginSettingLabel}>{field.label}</div>
+          {field.description && (
+            <div className={styles.envErrorHint}>{field.description}</div>
           )}
+          <input
+            type="text"
+            value={stringValue}
+            placeholder={field.placeholder ?? ""}
+            onChange={(e) => onChange(e.target.value || null)}
+            className={styles.textInput}
+          />
         </div>
-      )}
+      </div>
+    );
+  }
+
+  // select
+  const stringValue = typeof value === "string" ? value : (field.default ?? "");
+  return (
+    <div className={styles.pluginSettingRow}>
+      <div>
+        <div className={styles.pluginSettingLabel}>{field.label}</div>
+        {field.description && (
+          <div className={styles.envErrorHint}>{field.description}</div>
+        )}
+        <select
+          value={stringValue}
+          onChange={(e) => onChange(e.target.value || null)}
+          className={styles.textInput}
+        >
+          {field.options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 }

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -14,6 +14,7 @@ import type { SavedMcpServer, McpSource } from "../../../types/mcp";
 import { MCP_SOURCE_LABELS } from "../../../types/mcp";
 import { RepoIcon } from "../../shared/RepoIcon";
 import { IconPicker } from "../../modals/IconPicker";
+import { WorkspaceEnvPanel } from "./WorkspaceEnvPanel";
 import styles from "../Settings.module.css";
 
 interface RepoSettingsProps {
@@ -27,8 +28,16 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const repositories = useAppStore((s) => s.repositories);
   const mcpStatus = useAppStore((s) => s.mcpStatus);
   const setMcpStatus = useAppStore((s) => s.setMcpStatus);
+  const workspaces = useAppStore((s) => s.workspaces);
 
   const repo = repositories.find((r) => r.id === repoId);
+  // Env-provider resolution is per-worktree, not per-repo — we preview
+  // using the first active workspace for this repo. If there are no
+  // workspaces yet, the panel is skipped (nothing useful to show until
+  // a worktree exists).
+  const previewWorkspace = workspaces.find(
+    (w) => w.repository_id === repoId && w.worktree_path,
+  );
   const repoMcpStatus = mcpStatus[repoId];
 
   const [name, setName] = useState(repo?.name ?? "");
@@ -409,6 +418,13 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           Skip confirmation when running setup scripts
         </label>
       </div>
+
+      {previewWorkspace && (
+        <div className={styles.fieldGroup}>
+          <div className={styles.fieldLabel}>Environment</div>
+          <WorkspaceEnvPanel workspaceId={previewWorkspace.id} />
+        </div>
+      )}
 
       <div className={styles.fieldGroup}>
         <div className={styles.fieldLabel}>Custom instructions</div>

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { updateRepositorySettings, getRepoConfig, getAppSetting, setAppSetting, listGitRemotes, listGitRemoteBranches, getDefaultBranch } from "../../../services/tauri";
 import {
@@ -31,6 +31,14 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
 
   const repo = repositories.find((r) => r.id === repoId);
   const repoMcpStatus = mcpStatus[repoId];
+
+  // Stable reference for EnvPanel so its effects (keyed on the target
+  // object) don't re-fire on every RepoSettings re-render. Only the
+  // repoId string matters for resolution.
+  const envTarget = useMemo(
+    () => ({ kind: "repo" as const, repo_id: repoId }),
+    [repoId],
+  );
 
   const [name, setName] = useState(repo?.name ?? "");
   const [icon, setIcon] = useState(repo?.icon ?? "");
@@ -413,7 +421,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
 
       <div className={styles.fieldGroup}>
         <div className={styles.fieldLabel}>Environment</div>
-        <EnvPanel target={{ kind: "repo", repo_id: repoId }} />
+        <EnvPanel target={envTarget} />
       </div>
 
       <div className={styles.fieldGroup}>

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -14,7 +14,7 @@ import type { SavedMcpServer, McpSource } from "../../../types/mcp";
 import { MCP_SOURCE_LABELS } from "../../../types/mcp";
 import { RepoIcon } from "../../shared/RepoIcon";
 import { IconPicker } from "../../modals/IconPicker";
-import { WorkspaceEnvPanel } from "./WorkspaceEnvPanel";
+import { EnvPanel } from "./EnvPanel";
 import styles from "../Settings.module.css";
 
 interface RepoSettingsProps {
@@ -28,16 +28,8 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
   const repositories = useAppStore((s) => s.repositories);
   const mcpStatus = useAppStore((s) => s.mcpStatus);
   const setMcpStatus = useAppStore((s) => s.setMcpStatus);
-  const workspaces = useAppStore((s) => s.workspaces);
 
   const repo = repositories.find((r) => r.id === repoId);
-  // Env-provider resolution is per-worktree, not per-repo — we preview
-  // using the first active workspace for this repo. If there are no
-  // workspaces yet, the panel is skipped (nothing useful to show until
-  // a worktree exists).
-  const previewWorkspace = workspaces.find(
-    (w) => w.repository_id === repoId && w.worktree_path,
-  );
   const repoMcpStatus = mcpStatus[repoId];
 
   const [name, setName] = useState(repo?.name ?? "");
@@ -419,12 +411,10 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         </label>
       </div>
 
-      {previewWorkspace && (
-        <div className={styles.fieldGroup}>
-          <div className={styles.fieldLabel}>Environment</div>
-          <WorkspaceEnvPanel workspaceId={previewWorkspace.id} />
-        </div>
-      )}
+      <div className={styles.fieldGroup}>
+        <div className={styles.fieldLabel}>Environment</div>
+        <EnvPanel target={{ kind: "repo", repo_id: repoId }} />
+      </div>
 
       <div className={styles.fieldGroup}>
         <div className={styles.fieldLabel}>Custom instructions</div>

--- a/src/ui/src/components/settings/sections/WorkspaceEnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/WorkspaceEnvPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   getWorkspaceEnvSources,
   reloadWorkspaceEnv,
+  setEnvProviderEnabled,
 } from "../../../services/env";
 import type { EnvSourceInfo } from "../../../types/env";
 import styles from "../Settings.module.css";
@@ -11,15 +12,51 @@ interface WorkspaceEnvPanelProps {
 }
 
 /**
- * Diagnostic panel showing which env-provider plugins activated for a
- * workspace (direnv, mise, dotenv, nix-devshell) and how many vars
- * each contributed. Used to answer "why is (or isn't) FOO set when
- * the agent runs Bash?"
+ * Per-provider status color. Matches the MCP server row palette so the
+ * Environment section reads with the same visual grammar:
  *
- * Clicking Reload evicts the backend's mtime cache for this workspace
- * so the next spawn / fetch re-runs every provider — the escape hatch
- * for when a user ran `direnv allow` outside Claudette and wants the
- * new env picked up immediately.
+ *   green  — active + fresh eval
+ *   blue   — active + cache hit (same semantic as MCP "connected")
+ *   red    — error (direnv blocked, mise untrusted, flake eval failed)
+ *   dim    — not detected (plugin's detect() returned false) OR disabled
+ */
+function stateColor(source: EnvSourceInfo): string {
+  if (!source.enabled) return "var(--text-faint)";
+  if (source.error) return "var(--status-stopped)";
+  if (!source.detected) return "var(--text-faint)";
+  return source.cached ? "var(--status-idle)" : "var(--status-running)";
+}
+
+function stateBadge(source: EnvSourceInfo): string {
+  if (!source.enabled) return "disabled";
+  if (source.error) return "error";
+  if (!source.detected) return "not detected";
+  return source.cached ? "cached" : "fresh";
+}
+
+function formatRelativeTime(ms: number): string {
+  if (!ms) return "";
+  const now = Date.now();
+  const diff = Math.max(0, now - ms);
+  if (diff < 5_000) return "just now";
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+/**
+ * Environment providers panel for a workspace.
+ *
+ * Mirrors the MCP servers list pattern (mcpRow/mcpInfo/mcpActions + toggle
+ * switch) so the Settings page reads consistently. Each row represents one
+ * env-provider plugin; users can toggle individual providers off (e.g. a
+ * repo has both mise.toml and flake.nix but the user only wants the Nix
+ * devshell active) without touching the others.
+ *
+ * The "Reload" footer button evicts the backend cache for every provider
+ * in this workspace — useful after running `direnv allow` / `mise trust`
+ * outside Claudette and wanting the new state reflected immediately.
  */
 export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
   const [sources, setSources] = useState<EnvSourceInfo[] | null>(null);
@@ -34,7 +71,6 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
       setSources(result);
     } catch (e) {
       setFetchError(String(e));
-      setSources(null);
     } finally {
       setLoading(false);
     }
@@ -44,7 +80,7 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
     void refresh();
   }, [refresh]);
 
-  const handleReload = useCallback(async () => {
+  const handleReloadAll = useCallback(async () => {
     try {
       await reloadWorkspaceEnv(workspaceId);
       await refresh();
@@ -53,76 +89,106 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
     }
   }, [workspaceId, refresh]);
 
+  const handleToggle = useCallback(
+    async (pluginName: string, nextEnabled: boolean) => {
+      try {
+        await setEnvProviderEnabled(workspaceId, pluginName, nextEnabled);
+        await refresh();
+      } catch (e) {
+        setFetchError(String(e));
+      }
+    },
+    [workspaceId, refresh],
+  );
+
   if (fetchError) {
     return (
-      <div className={styles.settingRow}>
-        <div className={styles.settingInfo}>
-          <div className={styles.settingLabel}>Environment</div>
-          <div className={styles.settingDescription} role="alert">
-            Failed to load: {fetchError}
-          </div>
-        </div>
+      <div className={styles.mcpError} role="alert">
+        Failed to load environment providers: {fetchError}
       </div>
     );
   }
 
   if (loading && sources === null) {
+    return <div className={styles.settingDescription}>Loading…</div>;
+  }
+
+  if (!sources || sources.length === 0) {
     return (
-      <div className={styles.settingRow}>
-        <div className={styles.settingInfo}>
-          <div className={styles.settingLabel}>Environment</div>
-          <div className={styles.settingDescription}>Loading…</div>
-        </div>
+      <div className={styles.settingDescription}>
+        No environment providers installed.
       </div>
     );
   }
 
-  const active = sources?.filter((s) => s.detected) ?? [];
-  const errored = sources?.filter((s) => s.error) ?? [];
-
   return (
-    <div className={styles.settingRow}>
-      <div className={styles.settingInfo}>
-        <div className={styles.settingLabel}>Environment providers</div>
-        <div className={styles.settingDescription}>
-          Tools whose env is merged into every subprocess spawned in this
-          workspace. Cache is invalidated automatically when watched files
-          (<code>.envrc</code>, <code>mise.toml</code>, <code>.env</code>,{" "}
-          <code>flake.lock</code>, etc.) change.
-        </div>
-        {active.length === 0 && errored.length === 0 ? (
-          <div className={styles.settingDescription}>
-            No providers detected for this worktree.
-          </div>
-        ) : (
-          <ul>
-            {active.map((s) => (
-              <li key={s.plugin_name}>
-                <strong>{s.plugin_name}</strong>
-                {" — "}
-                {s.vars_contributed} var
-                {s.vars_contributed === 1 ? "" : "s"}
-                {s.cached ? " (cached)" : " (fresh)"}
-              </li>
-            ))}
-            {errored.map((s) => (
-              <li key={`err-${s.plugin_name}`} role="alert">
-                <strong>{s.plugin_name}</strong>: {s.error}
-              </li>
-            ))}
-          </ul>
-        )}
+    <>
+      <div className={styles.settingDescription}>
+        Tools whose env is merged into every subprocess Claudette spawns
+        for this workspace. Cached results invalidate automatically when
+        watched files (<code>.envrc</code>, <code>mise.toml</code>,{" "}
+        <code>.env</code>, <code>flake.lock</code>) change.
       </div>
-      <div className={styles.settingControl}>
+
+      <div className={styles.mcpList}>
+        {sources.map((source) => (
+          <div key={source.plugin_name} className={styles.mcpRow}>
+            <div className={styles.mcpInfo}>
+              <span
+                className={styles.mcpStatusDot}
+                style={{ background: stateColor(source) }}
+                title={stateBadge(source)}
+              />
+              <span
+                className={`${styles.mcpName} ${!source.enabled ? styles.mcpNameDisabled : ""}`}
+              >
+                {source.display_name}
+              </span>
+              <span className={styles.mcpBadge}>{stateBadge(source)}</span>
+              {source.enabled && source.detected && !source.error && (
+                <span className={styles.settingDescription}>
+                  {source.vars_contributed} var
+                  {source.vars_contributed === 1 ? "" : "s"}
+                  {source.evaluated_at_ms > 0 && (
+                    <> · {formatRelativeTime(source.evaluated_at_ms)}</>
+                  )}
+                </span>
+              )}
+              {source.enabled && source.error && source.error !== "disabled" && (
+                <span
+                  className={styles.mcpError}
+                  title={source.error}
+                >
+                  {source.error.slice(0, 60)}
+                </span>
+              )}
+            </div>
+            <div className={styles.mcpActions}>
+              <button
+                type="button"
+                className={`${styles.mcpToggle} ${source.enabled ? styles.mcpToggleOn : ""}`}
+                onClick={() => handleToggle(source.plugin_name, !source.enabled)}
+                role="switch"
+                aria-checked={source.enabled}
+                aria-label={`${source.enabled ? "Disable" : "Enable"} ${source.display_name}`}
+              >
+                <span className={styles.mcpToggleKnob} />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.buttonRow}>
         <button
           type="button"
-          onClick={handleReload}
+          className={styles.iconBtn}
+          onClick={handleReloadAll}
           disabled={loading}
-          aria-label="Reload environment providers"
         >
           {loading ? "Reloading…" : "Reload"}
         </button>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/ui/src/components/settings/sections/WorkspaceEnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/WorkspaceEnvPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import {
   getWorkspaceEnvSources,
   reloadWorkspaceEnv,
@@ -6,6 +7,55 @@ import {
 } from "../../../services/env";
 import type { EnvSourceInfo } from "../../../types/env";
 import styles from "../Settings.module.css";
+
+interface ErrorInsight {
+  summary: string;
+  suggestedCommand?: string;
+  suggestedDescription?: string;
+}
+
+/**
+ * Extract a human summary + optional fix suggestion from a raw Lua runtime
+ * error string. Handles the common remediable cases surfaced by bundled
+ * env providers:
+ *
+ *   - mise: `are not trusted` → suggest `mise trust`
+ *   - direnv: `.envrc is blocked` → suggest `direnv allow`
+ *   - nix-devshell: flake eval failure → no suggestion, just the core message
+ *
+ * Falls back to the first meaningful line of the error with Lua traceback
+ * boilerplate stripped, so users see a readable message even when we don't
+ * have a canned hint.
+ */
+function analyzeError(pluginName: string, err: string): ErrorInsight {
+  if (/not trusted|mise trust/i.test(err)) {
+    return {
+      summary: "mise config files in this workspace are not trusted.",
+      suggestedCommand: "mise trust",
+      suggestedDescription: "Run in the workspace to authorize mise config:",
+    };
+  }
+  if (/is blocked|direnv allow/i.test(err)) {
+    return {
+      summary: ".envrc is blocked — direnv needs explicit permission.",
+      suggestedCommand: "direnv allow",
+      suggestedDescription: "Run in the workspace to allow direnv:",
+    };
+  }
+  if (pluginName === "env-nix-devshell" && /flake|nix/i.test(err)) {
+    return {
+      summary: "`nix print-dev-env` failed to evaluate the devshell.",
+    };
+  }
+
+  const cleaned = err
+    .replace(/^\[string "[^"]*"\]:\d+:\s*/, "")
+    .replace(/^plugin script error:\s*runtime error:\s*/i, "")
+    .trim();
+  const afterFailed = /(?:failed|error):\s*(.+)/is.exec(cleaned);
+  const core = (afterFailed ? afterFailed[1] : cleaned).split("\n")[0];
+  return { summary: core.slice(0, 240) };
+}
 
 interface WorkspaceEnvPanelProps {
   workspaceId: string;
@@ -62,6 +112,16 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
   const [sources, setSources] = useState<EnvSourceInfo[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -131,52 +191,69 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
       </div>
 
       <div className={styles.mcpList}>
-        {sources.map((source) => (
-          <div key={source.plugin_name} className={styles.mcpRow}>
-            <div className={styles.mcpInfo}>
-              <span
-                className={styles.mcpStatusDot}
-                style={{ background: stateColor(source) }}
-                title={stateBadge(source)}
-              />
-              <span
-                className={`${styles.mcpName} ${!source.enabled ? styles.mcpNameDisabled : ""}`}
-              >
-                {source.display_name}
-              </span>
-              <span className={styles.mcpBadge}>{stateBadge(source)}</span>
-              {source.enabled && source.detected && !source.error && (
-                <span className={styles.settingDescription}>
-                  {source.vars_contributed} var
-                  {source.vars_contributed === 1 ? "" : "s"}
-                  {source.evaluated_at_ms > 0 && (
-                    <> · {formatRelativeTime(source.evaluated_at_ms)}</>
+        {sources.map((source) => {
+          const hasError =
+            source.enabled && !!source.error && source.error !== "disabled";
+          const isOpen = expanded.has(source.plugin_name);
+          return (
+            <div key={source.plugin_name}>
+              <div className={styles.mcpRow}>
+                <div className={styles.mcpInfo}>
+                  <span
+                    className={styles.mcpStatusDot}
+                    style={{ background: stateColor(source) }}
+                    title={stateBadge(source)}
+                  />
+                  <span
+                    className={`${styles.mcpName} ${!source.enabled ? styles.mcpNameDisabled : ""}`}
+                  >
+                    {source.display_name}
+                  </span>
+                  <span className={styles.mcpBadge}>{stateBadge(source)}</span>
+                  {source.enabled && source.detected && !source.error && (
+                    <span className={styles.settingDescription}>
+                      {source.vars_contributed} var
+                      {source.vars_contributed === 1 ? "" : "s"}
+                      {source.evaluated_at_ms > 0 && (
+                        <> · {formatRelativeTime(source.evaluated_at_ms)}</>
+                      )}
+                    </span>
                   )}
-                </span>
-              )}
-              {source.enabled && source.error && source.error !== "disabled" && (
-                <span
-                  className={styles.mcpError}
-                  title={source.error}
-                >
-                  {source.error.slice(0, 60)}
-                </span>
+                </div>
+                <div className={styles.mcpActions}>
+                  {hasError && (
+                    <button
+                      type="button"
+                      className={styles.envDetailsBtn}
+                      onClick={() => toggleExpanded(source.plugin_name)}
+                      aria-expanded={isOpen}
+                    >
+                      {isOpen ? "Hide details" : "Show details"}
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className={`${styles.mcpToggle} ${source.enabled ? styles.mcpToggleOn : ""}`}
+                    onClick={() =>
+                      handleToggle(source.plugin_name, !source.enabled)
+                    }
+                    role="switch"
+                    aria-checked={source.enabled}
+                    aria-label={`${source.enabled ? "Disable" : "Enable"} ${source.display_name}`}
+                  >
+                    <span className={styles.mcpToggleKnob} />
+                  </button>
+                </div>
+              </div>
+              {hasError && isOpen && (
+                <ErrorCard
+                  pluginName={source.plugin_name}
+                  error={source.error!}
+                />
               )}
             </div>
-            <div className={styles.mcpActions}>
-              <button
-                type="button"
-                className={`${styles.mcpToggle} ${source.enabled ? styles.mcpToggleOn : ""}`}
-                onClick={() => handleToggle(source.plugin_name, !source.enabled)}
-                role="switch"
-                aria-checked={source.enabled}
-                aria-label={`${source.enabled ? "Disable" : "Enable"} ${source.display_name}`}
-              >
-                <span className={styles.mcpToggleKnob} />
-              </button>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       <div className={styles.buttonRow}>
@@ -190,5 +267,69 @@ export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
         </button>
       </div>
     </>
+  );
+}
+
+function ErrorCard({
+  pluginName,
+  error,
+}: {
+  pluginName: string;
+  error: string;
+}) {
+  const insight = analyzeError(pluginName, error);
+  const [copiedCmd, setCopiedCmd] = useState(false);
+  const [copiedRaw, setCopiedRaw] = useState(false);
+
+  const copy = useCallback(
+    async (text: string, setFlag: (v: boolean) => void) => {
+      try {
+        await writeText(text);
+        setFlag(true);
+        setTimeout(() => setFlag(false), 1500);
+      } catch {
+        // Clipboard access can fail in hardened webviews; silently no-op —
+        // the raw text is still visible in the <pre> for manual selection.
+      }
+    },
+    [],
+  );
+
+  return (
+    <div className={styles.envErrorCard} role="alert">
+      <div className={styles.envErrorSummary}>{insight.summary}</div>
+      {insight.suggestedCommand && (
+        <>
+          {insight.suggestedDescription && (
+            <div className={styles.envErrorHint}>
+              {insight.suggestedDescription}
+            </div>
+          )}
+          <div className={styles.envErrorCmdRow}>
+            <code className={styles.envErrorCmd}>
+              {insight.suggestedCommand}
+            </code>
+            <button
+              type="button"
+              className={styles.envErrorCopyBtn}
+              onClick={() => copy(insight.suggestedCommand!, setCopiedCmd)}
+            >
+              {copiedCmd ? "Copied" : "Copy"}
+            </button>
+          </div>
+        </>
+      )}
+      <details className={styles.envErrorDetails}>
+        <summary>Raw error output</summary>
+        <pre className={styles.envErrorPre}>{error}</pre>
+        <button
+          type="button"
+          className={styles.envErrorCopyBtn}
+          onClick={() => copy(error, setCopiedRaw)}
+        >
+          {copiedRaw ? "Copied" : "Copy full error"}
+        </button>
+      </details>
+    </div>
   );
 }

--- a/src/ui/src/components/settings/sections/WorkspaceEnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/WorkspaceEnvPanel.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  getWorkspaceEnvSources,
+  reloadWorkspaceEnv,
+} from "../../../services/env";
+import type { EnvSourceInfo } from "../../../types/env";
+import styles from "../Settings.module.css";
+
+interface WorkspaceEnvPanelProps {
+  workspaceId: string;
+}
+
+/**
+ * Diagnostic panel showing which env-provider plugins activated for a
+ * workspace (direnv, mise, dotenv, nix-devshell) and how many vars
+ * each contributed. Used to answer "why is (or isn't) FOO set when
+ * the agent runs Bash?"
+ *
+ * Clicking Reload evicts the backend's mtime cache for this workspace
+ * so the next spawn / fetch re-runs every provider — the escape hatch
+ * for when a user ran `direnv allow` outside Claudette and wants the
+ * new env picked up immediately.
+ */
+export function WorkspaceEnvPanel({ workspaceId }: WorkspaceEnvPanelProps) {
+  const [sources, setSources] = useState<EnvSourceInfo[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const result = await getWorkspaceEnvSources(workspaceId);
+      setSources(result);
+    } catch (e) {
+      setFetchError(String(e));
+      setSources(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleReload = useCallback(async () => {
+    try {
+      await reloadWorkspaceEnv(workspaceId);
+      await refresh();
+    } catch (e) {
+      setFetchError(String(e));
+    }
+  }, [workspaceId, refresh]);
+
+  if (fetchError) {
+    return (
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Environment</div>
+          <div className={styles.settingDescription} role="alert">
+            Failed to load: {fetchError}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading && sources === null) {
+    return (
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>Environment</div>
+          <div className={styles.settingDescription}>Loading…</div>
+        </div>
+      </div>
+    );
+  }
+
+  const active = sources?.filter((s) => s.detected) ?? [];
+  const errored = sources?.filter((s) => s.error) ?? [];
+
+  return (
+    <div className={styles.settingRow}>
+      <div className={styles.settingInfo}>
+        <div className={styles.settingLabel}>Environment providers</div>
+        <div className={styles.settingDescription}>
+          Tools whose env is merged into every subprocess spawned in this
+          workspace. Cache is invalidated automatically when watched files
+          (<code>.envrc</code>, <code>mise.toml</code>, <code>.env</code>,{" "}
+          <code>flake.lock</code>, etc.) change.
+        </div>
+        {active.length === 0 && errored.length === 0 ? (
+          <div className={styles.settingDescription}>
+            No providers detected for this worktree.
+          </div>
+        ) : (
+          <ul>
+            {active.map((s) => (
+              <li key={s.plugin_name}>
+                <strong>{s.plugin_name}</strong>
+                {" — "}
+                {s.vars_contributed} var
+                {s.vars_contributed === 1 ? "" : "s"}
+                {s.cached ? " (cached)" : " (fresh)"}
+              </li>
+            ))}
+            {errored.map((s) => (
+              <li key={`err-${s.plugin_name}`} role="alert">
+                <strong>{s.plugin_name}</strong>: {s.error}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className={styles.settingControl}>
+        <button
+          type="button"
+          onClick={handleReload}
+          disabled={loading}
+          aria-label="Reload environment providers"
+        >
+          {loading ? "Reloading…" : "Reload"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/services/claudettePlugins.ts
+++ b/src/ui/src/services/claudettePlugins.ts
@@ -1,0 +1,45 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { ClaudettePluginInfo } from "../types/claudettePlugins";
+
+/**
+ * Snapshot of every discovered Claudette Lua plugin, ordered by kind
+ * (SCM first, then env-provider) and then by name. Cheap — reads
+ * in-memory registry state plus an app_settings scan. No plugin VMs
+ * are spun up.
+ */
+export function listClaudettePlugins(): Promise<ClaudettePluginInfo[]> {
+  return invoke("list_claudette_plugins");
+}
+
+/** Globally enable/disable a plugin. Takes effect immediately. */
+export function setClaudettePluginEnabled(
+  pluginName: string,
+  enabled: boolean,
+): Promise<void> {
+  return invoke("set_claudette_plugin_enabled", { pluginName, enabled });
+}
+
+/**
+ * Persist a user override for a manifest-declared setting. Pass
+ * `null` to clear the override (reverts to the manifest default).
+ */
+export function setClaudettePluginSetting(
+  pluginName: string,
+  key: string,
+  value: unknown,
+): Promise<void> {
+  return invoke("set_claudette_plugin_setting", {
+    pluginName,
+    key,
+    value,
+  });
+}
+
+/**
+ * Reseed bundled plugins from the in-binary tarball, preserving any
+ * user-modified `init.lua` files. Returns per-plugin warning strings
+ * so the UI can surface which plugins were skipped (and why).
+ */
+export function reseedBundledPlugins(): Promise<string[]> {
+  return invoke("reseed_bundled_plugins");
+}

--- a/src/ui/src/services/env.test.ts
+++ b/src/ui/src/services/env.test.ts
@@ -10,6 +10,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 import {
   getWorkspaceEnvSources,
   reloadWorkspaceEnv,
+  setEnvProviderEnabled,
 } from "./env";
 
 describe("env service", () => {
@@ -59,6 +60,28 @@ describe("env service", () => {
       expect(invokeMock).toHaveBeenCalledWith("reload_workspace_env", {
         workspaceId: "ws-2",
         pluginName: "env-direnv",
+      });
+    });
+  });
+
+  describe("setEnvProviderEnabled", () => {
+    it("forwards enabled=true when re-enabling a provider", async () => {
+      invokeMock.mockResolvedValueOnce(undefined);
+      await setEnvProviderEnabled("ws-1", "env-mise", true);
+      expect(invokeMock).toHaveBeenCalledWith("set_env_provider_enabled", {
+        workspaceId: "ws-1",
+        pluginName: "env-mise",
+        enabled: true,
+      });
+    });
+
+    it("forwards enabled=false when disabling a provider", async () => {
+      invokeMock.mockResolvedValueOnce(undefined);
+      await setEnvProviderEnabled("ws-1", "env-mise", false);
+      expect(invokeMock).toHaveBeenCalledWith("set_env_provider_enabled", {
+        workspaceId: "ws-1",
+        pluginName: "env-mise",
+        enabled: false,
       });
     });
   });

--- a/src/ui/src/services/env.test.ts
+++ b/src/ui/src/services/env.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Tauri bridge before importing the service under test.
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
+}));
+
+// Now import — the mock is in place before `invoke` is captured.
+import {
+  getWorkspaceEnvSources,
+  reloadWorkspaceEnv,
+} from "./env";
+
+describe("env service", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  describe("getWorkspaceEnvSources", () => {
+    it("invokes the right command with the workspace id", async () => {
+      invokeMock.mockResolvedValueOnce([]);
+      await getWorkspaceEnvSources("ws-abc");
+      expect(invokeMock).toHaveBeenCalledWith("get_workspace_env_sources", {
+        workspaceId: "ws-abc",
+      });
+    });
+
+    it("returns the backend payload unchanged", async () => {
+      const payload = [
+        {
+          plugin_name: "env-direnv",
+          detected: true,
+          vars_contributed: 3,
+          cached: false,
+          evaluated_at_ms: 1_700_000_000_000,
+          error: null,
+        },
+      ];
+      invokeMock.mockResolvedValueOnce(payload);
+      const result = await getWorkspaceEnvSources("ws-xyz");
+      expect(result).toEqual(payload);
+    });
+  });
+
+  describe("reloadWorkspaceEnv", () => {
+    it("passes undefined plugin_name when invalidating everything", async () => {
+      invokeMock.mockResolvedValueOnce(undefined);
+      await reloadWorkspaceEnv("ws-1");
+      expect(invokeMock).toHaveBeenCalledWith("reload_workspace_env", {
+        workspaceId: "ws-1",
+        pluginName: undefined,
+      });
+    });
+
+    it("forwards plugin_name when invalidating a single provider", async () => {
+      invokeMock.mockResolvedValueOnce(undefined);
+      await reloadWorkspaceEnv("ws-2", "env-direnv");
+      expect(invokeMock).toHaveBeenCalledWith("reload_workspace_env", {
+        workspaceId: "ws-2",
+        pluginName: "env-direnv",
+      });
+    });
+  });
+});

--- a/src/ui/src/services/env.test.ts
+++ b/src/ui/src/services/env.test.ts
@@ -1,15 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the Tauri bridge before importing the service under test.
 const invokeMock = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
 }));
 
-// Now import — the mock is in place before `invoke` is captured.
 import {
-  getWorkspaceEnvSources,
-  reloadWorkspaceEnv,
+  envTargetFromRepo,
+  envTargetFromWorkspace,
+  getEnvSources,
+  reloadEnv,
+  runEnvTrust,
   setEnvProviderEnabled,
 } from "./env";
 
@@ -18,12 +19,33 @@ describe("env service", () => {
     invokeMock.mockReset();
   });
 
-  describe("getWorkspaceEnvSources", () => {
-    it("invokes the right command with the workspace id", async () => {
+  describe("envTargetFromRepo / envTargetFromWorkspace", () => {
+    it("constructs kind=repo targets", () => {
+      expect(envTargetFromRepo("r-1")).toEqual({ kind: "repo", repo_id: "r-1" });
+    });
+
+    it("constructs kind=workspace targets", () => {
+      expect(envTargetFromWorkspace("w-1")).toEqual({
+        kind: "workspace",
+        workspace_id: "w-1",
+      });
+    });
+  });
+
+  describe("getEnvSources", () => {
+    it("invokes with a repo target", async () => {
       invokeMock.mockResolvedValueOnce([]);
-      await getWorkspaceEnvSources("ws-abc");
-      expect(invokeMock).toHaveBeenCalledWith("get_workspace_env_sources", {
-        workspaceId: "ws-abc",
+      await getEnvSources({ kind: "repo", repo_id: "r-1" });
+      expect(invokeMock).toHaveBeenCalledWith("get_env_sources", {
+        target: { kind: "repo", repo_id: "r-1" },
+      });
+    });
+
+    it("invokes with a workspace target", async () => {
+      invokeMock.mockResolvedValueOnce([]);
+      await getEnvSources({ kind: "workspace", workspace_id: "w-1" });
+      expect(invokeMock).toHaveBeenCalledWith("get_env_sources", {
+        target: { kind: "workspace", workspace_id: "w-1" },
       });
     });
 
@@ -31,7 +53,9 @@ describe("env service", () => {
       const payload = [
         {
           plugin_name: "env-direnv",
+          display_name: "direnv",
           detected: true,
+          enabled: true,
           vars_contributed: 3,
           cached: false,
           evaluated_at_ms: 1_700_000_000_000,
@@ -39,26 +63,26 @@ describe("env service", () => {
         },
       ];
       invokeMock.mockResolvedValueOnce(payload);
-      const result = await getWorkspaceEnvSources("ws-xyz");
+      const result = await getEnvSources({ kind: "repo", repo_id: "r-1" });
       expect(result).toEqual(payload);
     });
   });
 
-  describe("reloadWorkspaceEnv", () => {
+  describe("reloadEnv", () => {
     it("passes undefined plugin_name when invalidating everything", async () => {
       invokeMock.mockResolvedValueOnce(undefined);
-      await reloadWorkspaceEnv("ws-1");
-      expect(invokeMock).toHaveBeenCalledWith("reload_workspace_env", {
-        workspaceId: "ws-1",
+      await reloadEnv({ kind: "workspace", workspace_id: "w-1" });
+      expect(invokeMock).toHaveBeenCalledWith("reload_env", {
+        target: { kind: "workspace", workspace_id: "w-1" },
         pluginName: undefined,
       });
     });
 
     it("forwards plugin_name when invalidating a single provider", async () => {
       invokeMock.mockResolvedValueOnce(undefined);
-      await reloadWorkspaceEnv("ws-2", "env-direnv");
-      expect(invokeMock).toHaveBeenCalledWith("reload_workspace_env", {
-        workspaceId: "ws-2",
+      await reloadEnv({ kind: "repo", repo_id: "r-1" }, "env-direnv");
+      expect(invokeMock).toHaveBeenCalledWith("reload_env", {
+        target: { kind: "repo", repo_id: "r-1" },
         pluginName: "env-direnv",
       });
     });
@@ -67,9 +91,13 @@ describe("env service", () => {
   describe("setEnvProviderEnabled", () => {
     it("forwards enabled=true when re-enabling a provider", async () => {
       invokeMock.mockResolvedValueOnce(undefined);
-      await setEnvProviderEnabled("ws-1", "env-mise", true);
+      await setEnvProviderEnabled(
+        { kind: "repo", repo_id: "r-1" },
+        "env-mise",
+        true,
+      );
       expect(invokeMock).toHaveBeenCalledWith("set_env_provider_enabled", {
-        workspaceId: "ws-1",
+        target: { kind: "repo", repo_id: "r-1" },
         pluginName: "env-mise",
         enabled: true,
       });
@@ -77,11 +105,38 @@ describe("env service", () => {
 
     it("forwards enabled=false when disabling a provider", async () => {
       invokeMock.mockResolvedValueOnce(undefined);
-      await setEnvProviderEnabled("ws-1", "env-mise", false);
+      await setEnvProviderEnabled(
+        { kind: "workspace", workspace_id: "w-1" },
+        "env-mise",
+        false,
+      );
       expect(invokeMock).toHaveBeenCalledWith("set_env_provider_enabled", {
-        workspaceId: "ws-1",
+        target: { kind: "workspace", workspace_id: "w-1" },
         pluginName: "env-mise",
         enabled: false,
+      });
+    });
+  });
+
+  describe("runEnvTrust", () => {
+    it("invokes run_env_trust for env-direnv", async () => {
+      invokeMock.mockResolvedValueOnce(undefined);
+      await runEnvTrust({ kind: "repo", repo_id: "r-1" }, "env-direnv");
+      expect(invokeMock).toHaveBeenCalledWith("run_env_trust", {
+        target: { kind: "repo", repo_id: "r-1" },
+        pluginName: "env-direnv",
+      });
+    });
+
+    it("invokes run_env_trust for env-mise", async () => {
+      invokeMock.mockResolvedValueOnce(undefined);
+      await runEnvTrust(
+        { kind: "workspace", workspace_id: "w-1" },
+        "env-mise",
+      );
+      expect(invokeMock).toHaveBeenCalledWith("run_env_trust", {
+        target: { kind: "workspace", workspace_id: "w-1" },
+        pluginName: "env-mise",
       });
     });
   });

--- a/src/ui/src/services/env.ts
+++ b/src/ui/src/services/env.ts
@@ -27,3 +27,21 @@ export function reloadWorkspaceEnv(
 ): Promise<void> {
   return invoke("reload_workspace_env", { workspaceId, pluginName });
 }
+
+/**
+ * Enable or disable a specific env-provider plugin for the workspace's
+ * repo. Disabling persists across app restarts. The backend invalidates
+ * the plugin's cache entry so the state change takes effect on the
+ * next spawn — no need for an explicit reload.
+ */
+export function setEnvProviderEnabled(
+  workspaceId: string,
+  pluginName: string,
+  enabled: boolean,
+): Promise<void> {
+  return invoke("set_env_provider_enabled", {
+    workspaceId,
+    pluginName,
+    enabled,
+  });
+}

--- a/src/ui/src/services/env.ts
+++ b/src/ui/src/services/env.ts
@@ -1,0 +1,29 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { EnvSourceInfo } from "../types/env";
+
+/**
+ * Fetch the list of env-provider plugins that ran (or were considered)
+ * for a workspace. Cheap after the first call — respects the backend's
+ * mtime-keyed cache.
+ */
+export function getWorkspaceEnvSources(
+  workspaceId: string,
+): Promise<EnvSourceInfo[]> {
+  return invoke("get_workspace_env_sources", { workspaceId });
+}
+
+/**
+ * Evict the env-provider cache for a workspace. Next spawn or diagnostic
+ * query re-runs the affected plugin(s). Pass a `pluginName` to only
+ * invalidate one plugin's entry; omit to reload everything.
+ *
+ * Typical use: after the user runs `direnv allow` / `mise trust` on a
+ * worktree that previously errored, they hit "Reload" to pick up the
+ * freshly-allowed config without restarting Claudette.
+ */
+export function reloadWorkspaceEnv(
+  workspaceId: string,
+  pluginName?: string,
+): Promise<void> {
+  return invoke("reload_workspace_env", { workspaceId, pluginName });
+}

--- a/src/ui/src/services/env.ts
+++ b/src/ui/src/services/env.ts
@@ -1,19 +1,17 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { EnvSourceInfo } from "../types/env";
+import type { EnvSourceInfo, EnvTarget } from "../types/env";
 
 /**
  * Fetch the list of env-provider plugins that ran (or were considered)
- * for a workspace. Cheap after the first call — respects the backend's
+ * for the target. Cheap after the first call — respects the backend's
  * mtime-keyed cache.
  */
-export function getWorkspaceEnvSources(
-  workspaceId: string,
-): Promise<EnvSourceInfo[]> {
-  return invoke("get_workspace_env_sources", { workspaceId });
+export function getEnvSources(target: EnvTarget): Promise<EnvSourceInfo[]> {
+  return invoke("get_env_sources", { target });
 }
 
 /**
- * Evict the env-provider cache for a workspace. Next spawn or diagnostic
+ * Evict the env-provider cache for the target. Next spawn or diagnostic
  * query re-runs the affected plugin(s). Pass a `pluginName` to only
  * invalidate one plugin's entry; omit to reload everything.
  *
@@ -21,27 +19,51 @@ export function getWorkspaceEnvSources(
  * worktree that previously errored, they hit "Reload" to pick up the
  * freshly-allowed config without restarting Claudette.
  */
-export function reloadWorkspaceEnv(
-  workspaceId: string,
+export function reloadEnv(
+  target: EnvTarget,
   pluginName?: string,
 ): Promise<void> {
-  return invoke("reload_workspace_env", { workspaceId, pluginName });
+  return invoke("reload_env", { target, pluginName });
 }
 
 /**
- * Enable or disable a specific env-provider plugin for the workspace's
+ * Enable or disable a specific env-provider plugin for the target's
  * repo. Disabling persists across app restarts. The backend invalidates
  * the plugin's cache entry so the state change takes effect on the
  * next spawn — no need for an explicit reload.
  */
 export function setEnvProviderEnabled(
-  workspaceId: string,
+  target: EnvTarget,
   pluginName: string,
   enabled: boolean,
 ): Promise<void> {
   return invoke("set_env_provider_enabled", {
-    workspaceId,
+    target,
     pluginName,
     enabled,
   });
+}
+
+/**
+ * Run a plugin's trust command (`direnv allow`, `mise trust`) against
+ * the target's worktree. Inherits `HOME`/`PATH` from Claudette so the
+ * trust cache update lands in the user's normal location. Invalidates
+ * the provider's cache entry on success so the next resolve picks up
+ * the freshly-trusted state.
+ */
+export function runEnvTrust(
+  target: EnvTarget,
+  pluginName: string,
+): Promise<void> {
+  return invoke("run_env_trust", { target, pluginName });
+}
+
+/** Convenience helper for call sites that have a repo id in hand. */
+export function envTargetFromRepo(repoId: string): EnvTarget {
+  return { kind: "repo", repo_id: repoId };
+}
+
+/** Convenience helper for call sites that have a workspace id in hand. */
+export function envTargetFromWorkspace(workspaceId: string): EnvTarget {
+  return { kind: "workspace", workspace_id: workspaceId };
 }

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -159,7 +159,7 @@ describe("plugin settings routing", () => {
 
     const state = useAppStore.getState();
     expect(state.settingsOpen).toBe(true);
-    expect(state.settingsSection).toBe("plugins");
+    expect(state.settingsSection).toBe("claude-code-plugins");
     expect(state.pluginSettingsTab).toBe("installed");
     expect(state.pluginSettingsRepoId).toBe("repo-1");
     expect(state.pluginSettingsIntent).toEqual({
@@ -194,7 +194,7 @@ describe("plugin settings routing", () => {
     });
   });
 
-  it("manual plugins settings entry resets to global available view", () => {
+  it("manual claude-code-plugins settings entry resets to global available view", () => {
     useAppStore.setState({
       pluginSettingsRepoId: "repo-1",
       pluginSettingsIntent: {
@@ -208,10 +208,10 @@ describe("plugin settings routing", () => {
       pluginSettingsTab: "installed",
     });
 
-    useAppStore.getState().setSettingsSection("plugins");
+    useAppStore.getState().setSettingsSection("claude-code-plugins");
 
     const state = useAppStore.getState();
-    expect(state.settingsSection).toBe("plugins");
+    expect(state.settingsSection).toBe("claude-code-plugins");
     expect(state.pluginSettingsRepoId).toBeNull();
     expect(state.pluginSettingsIntent).toBeNull();
     expect(state.pluginSettingsTab).toBe("available");
@@ -222,15 +222,23 @@ describe("plugin settings routing", () => {
     expect(useAppStore.getState().pluginManagementEnabled).toBe(false);
   });
 
-  it("redirects plugin settings section to experimental when disabled", () => {
+  it("redirects claude-code-plugins section to experimental when management disabled", () => {
     useAppStore.setState({ pluginManagementEnabled: false });
 
-    useAppStore.getState().setSettingsSection("plugins");
+    useAppStore.getState().setSettingsSection("claude-code-plugins");
 
     const state = useAppStore.getState();
     expect(state.settingsSection).toBe("experimental");
     expect(state.pluginSettingsIntent).toBeNull();
     expect(state.pluginSettingsRepoId).toBeNull();
+  });
+
+  it("keeps the new plugins (Claudette) section accessible regardless of management flag", () => {
+    useAppStore.setState({ pluginManagementEnabled: false });
+
+    useAppStore.getState().setSettingsSection("plugins");
+
+    expect(useAppStore.getState().settingsSection).toBe("plugins");
   });
 
   it("ignores openPluginSettings when plugin management is disabled", () => {

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -1195,14 +1195,26 @@ export const useAppStore = create<AppState>((set) => ({
     }),
   setSettingsSection: (section) =>
     set((state) => {
-      const nextSection = section === "plugins" && !state.pluginManagementEnabled
-        ? "experimental"
-        : section;
+      // Claude Code Plugins requires plugin management to be on; when
+      // disabled, fall through to the experimental pane so the setting
+      // stays reachable. The new "plugins" section (Claudette's own
+      // Lua plugins) is always available.
+      const nextSection =
+        section === "claude-code-plugins" && !state.pluginManagementEnabled
+          ? "experimental"
+          : section;
+      const resetMarketplaceIntent = nextSection === "claude-code-plugins";
       return {
         settingsSection: nextSection,
-        pluginSettingsIntent: nextSection === "plugins" ? null : state.pluginSettingsIntent,
-        pluginSettingsRepoId: nextSection === "plugins" ? null : state.pluginSettingsRepoId,
-        pluginSettingsTab: nextSection === "plugins" ? "available" : state.pluginSettingsTab,
+        pluginSettingsIntent: resetMarketplaceIntent
+          ? null
+          : state.pluginSettingsIntent,
+        pluginSettingsRepoId: resetMarketplaceIntent
+          ? null
+          : state.pluginSettingsRepoId,
+        pluginSettingsTab: resetMarketplaceIntent
+          ? "available"
+          : state.pluginSettingsTab,
       };
     }),
   pluginSettingsTab: "available",
@@ -1224,7 +1236,7 @@ export const useAppStore = create<AppState>((set) => ({
       };
       return {
         settingsOpen: true,
-        settingsSection: "plugins",
+        settingsSection: "claude-code-plugins",
         pluginSettingsTab: mergedIntent.tab,
         pluginSettingsRepoId: mergedIntent.repoId,
         pluginSettingsIntent: mergedIntent,
@@ -1385,9 +1397,10 @@ export const useAppStore = create<AppState>((set) => ({
   setPluginManagementEnabled: (enabled) =>
     set((state) => ({
       pluginManagementEnabled: enabled,
-      settingsSection: !enabled && state.settingsSection === "plugins"
-        ? "experimental"
-        : state.settingsSection,
+      settingsSection:
+        !enabled && state.settingsSection === "claude-code-plugins"
+          ? "experimental"
+          : state.settingsSection,
       pluginSettingsIntent: enabled ? state.pluginSettingsIntent : null,
       pluginSettingsRepoId: enabled ? state.pluginSettingsRepoId : null,
       pluginSettingsTab: enabled ? state.pluginSettingsTab : "available",

--- a/src/ui/src/types/claudettePlugins.ts
+++ b/src/ui/src/types/claudettePlugins.ts
@@ -1,0 +1,56 @@
+/**
+ * Types for Claudette's own Lua plugins (SCM providers + env
+ * providers). Distinct from the Claude Code marketplace plugins in
+ * `src/ui/src/types/plugins.ts`.
+ */
+
+export type ClaudettePluginKind = "scm" | "env-provider";
+
+/**
+ * Mirrors the Rust `PluginSettingField` enum. The `type` discriminant
+ * tells the UI which input to render.
+ */
+export type PluginSettingField =
+  | {
+      type: "boolean";
+      key: string;
+      label: string;
+      description?: string | null;
+      default?: boolean;
+    }
+  | {
+      type: "text";
+      key: string;
+      label: string;
+      description?: string | null;
+      default?: string | null;
+      placeholder?: string | null;
+    }
+  | {
+      type: "select";
+      key: string;
+      label: string;
+      description?: string | null;
+      default?: string | null;
+      options: Array<{ value: string; label: string }>;
+    };
+
+export interface ClaudettePluginInfo {
+  name: string;
+  display_name: string;
+  version: string;
+  description: string;
+  kind: ClaudettePluginKind;
+  required_clis: string[];
+  /** `false` when a required CLI (e.g. `direnv`) isn't on PATH. */
+  cli_available: boolean;
+  /** `true` unless the user has globally disabled this plugin. */
+  enabled: boolean;
+  settings_schema: PluginSettingField[];
+  /**
+   * Current effective value for each declared setting key, after
+   * merging manifest defaults + user overrides. Missing/unset values
+   * are `null`.
+   */
+  setting_values: Record<string, unknown>;
+}

--- a/src/ui/src/types/env.ts
+++ b/src/ui/src/types/env.ts
@@ -4,9 +4,14 @@
  * the workspace (detected or not).
  */
 export interface EnvSourceInfo {
+  /** Internal plugin id, e.g. `env-direnv`. Used for API calls. */
   plugin_name: string;
+  /** Human-friendly name from the manifest, e.g. `direnv`. Used in the UI. */
+  display_name: string;
   /** Whether the plugin declared it applies to this workspace. */
   detected: boolean;
+  /** Whether the user has this provider enabled for the workspace's repo. */
+  enabled: boolean;
   /** How many env vars this plugin contributed to the merged result. */
   vars_contributed: number;
   /** `true` when this plugin's contribution came from the mtime cache. */

--- a/src/ui/src/types/env.ts
+++ b/src/ui/src/types/env.ts
@@ -1,7 +1,19 @@
 /**
- * Matches `EnvSourceInfo` serialized by the Rust `get_workspace_env_sources`
- * Tauri command. One entry per env-provider plugin that was considered for
- * the workspace (detected or not).
+ * What to resolve env-provider state for. Mirrors the Rust `EnvTarget`
+ * enum with `#[serde(tag = "kind", rename_all = "snake_case")]`.
+ *
+ * Use `{ kind: "repo", repo_id }` in Repo Settings so the panel works
+ * before a workspace exists. Use `{ kind: "workspace", workspace_id }`
+ * from a workspace-scoped view.
+ */
+export type EnvTarget =
+  | { kind: "repo"; repo_id: string }
+  | { kind: "workspace"; workspace_id: string };
+
+/**
+ * Matches `EnvSourceInfo` serialized by the Rust `get_env_sources`
+ * Tauri command. One entry per env-provider plugin that was considered
+ * for the target (detected or not).
  */
 export interface EnvSourceInfo {
   /** Internal plugin id, e.g. `env-direnv`. Used for API calls. */

--- a/src/ui/src/types/env.ts
+++ b/src/ui/src/types/env.ts
@@ -1,0 +1,18 @@
+/**
+ * Matches `EnvSourceInfo` serialized by the Rust `get_workspace_env_sources`
+ * Tauri command. One entry per env-provider plugin that was considered for
+ * the workspace (detected or not).
+ */
+export interface EnvSourceInfo {
+  plugin_name: string;
+  /** Whether the plugin declared it applies to this workspace. */
+  detected: boolean;
+  /** How many env vars this plugin contributed to the merged result. */
+  vars_contributed: number;
+  /** `true` when this plugin's contribution came from the mtime cache. */
+  cached: boolean;
+  /** Milliseconds since Unix epoch — format via `new Date(...).toLocaleString()`. */
+  evaluated_at_ms: number;
+  /** Set when detect or export errored (e.g. "direnv not allowed"). */
+  error: string | null;
+}


### PR DESCRIPTION
## Summary

This branch lands a broad but coherent chunk of work around the plugin runtime and settings surface:

- **Plugin runtime kinds** — `plugin_runtime` grew a `PluginKind` distinction (`scm` vs `env-provider`) with different exec semantics per kind (hermetic env for env-providers so `direnv`/`mise` see a clean baseline instead of the app's full env).
- **Env-provider system** — new `src/env_provider/` module: dispatcher, mtime-watched cache, merged `ResolvedEnv`, 4 bundled Lua plugins (`direnv`, `mise`, `dotenv`, `nix-devshell`), wired into every spawn site (agent, PTY, setup scripts, scm host invocations).
- **Plugin settings schema** — manifests can declare typed user-configurable fields (`boolean`/`text`/`select`); values persist in `app_settings` and flow into the Lua `host.config()` surface.
- **Repo-level Environment panel** — `EnvTarget { Repo | Workspace }` abstraction lets the Environment section live in repo settings even before any workspace exists.
- **Trust UX** — one-click Run button for `direnv allow` / `mise trust` with fan-out across the repo's main checkout + every existing workspace worktree; optional per-plugin auto-allow/auto-trust setting that retries on the "blocked/untrusted" error path.
- **Settings split** — what was previously **Plugins** (Claude Code marketplace) is now **Claude Code Plugins**; new **Plugins** section exposes Claudette's own Lua plugins with per-plugin enable toggle + settings form + "Reload bundled plugins" button that re-stamps plugins with a two-file ownership marker (`.version` + `.content_hash`) so user-edited plugins are preserved.
- **Env-drift teardown** — persistent agent sessions snapshot their resolved env; a divergence on a subsequent turn forces respawn so stale `DIRENV_FILE`/`PATH`/etc. don't leak across worktree edits.
- **Globally-disabled filter** (this session) — globally-off plugins are hidden from the per-workspace Environment panel rather than rendered as a confusing ERROR badge. Per-repo disabled entries still appear with their toggle.

## Test plan

- [x] `cargo test --all-features` (646 tests, all pass)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -Dwarnings` (clean)
- [x] `cargo fmt --all --check` (clean)
- [x] `bun run test` (642 frontend tests pass)
- [x] `bunx tsc -b` (clean)
- [x] UAT via `/claudette-debug` against a running dev build:
  - [x] Globally disable `env-mise` → disappears from repo env panel
  - [x] Re-enable globally → reappears
  - [x] Per-repo disabled plugins still visible with `disabled` badge + toggle
  - [x] Real error (mise untrusted) still surfaces with `ERROR` badge + Run/Copy actions
  - [x] Workspace target honors the filter too
- [x] Codex peer review — two rounds, all findings addressed (shell.nix branch, trust path fan-out, reseed content-hash, XDG passthrough, warm-cache leak, persistent-session drift)

## Key files

- `src/plugin_runtime/` — runtime + manifest settings schema + seed
- `src/env_provider/` — dispatcher, cache, backend trait, bundled-plugin integration tests
- `plugins/env-*` — bundled Lua plugins
- `src-tauri/src/commands/env.rs` — `EnvTarget` + tauri commands + globally-disabled filter
- `src-tauri/src/commands/plugins_runtime.rs` — list/toggle/setting/reseed commands
- `src/ui/src/components/settings/sections/EnvPanel.tsx` — repo + workspace env panel
- `src/ui/src/components/settings/sections/PluginsSettings.tsx` — Claudette's Lua plugin list
- `src/ui/src/components/settings/sections/ClaudeCodePluginsSettings.tsx` — renamed Claude Code marketplace UI

## Stats

53 files changed, 6936 insertions(+), 1793 deletions(-), 16 commits.

Closes #322.