### PR TITLE
chore(windows): share claude resolver and add empty-title to start

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -30,9 +30,14 @@ async fn open_external_url(url: &str) -> Result<(), String> {
     }
     #[cfg(target_os = "windows")]
     {
+        // `start` treats its first quoted argument as a window title, so an
+        // unquoted target containing spaces or quotes can be misparsed as a
+        // title with no real target. The empty `""` slot neutralises that
+        // quirk — current callers pass controlled URLs, but the defensive
+        // form costs nothing and protects future callers.
         tokio::process::Command::new("cmd")
             .no_console_window()
-            .args(["/C", "start", url])
+            .args(["/C", "start", "", url])
             .spawn()
             .map_err(|e| format!("Failed to open URL: {e}"))?;
     }

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -133,8 +133,16 @@ static USER_AGENT_CACHE: std::sync::OnceLock<String> = std::sync::OnceLock::new(
 /// Pre-warm the User-Agent cache at startup. Uses `std::process::Command`
 /// (sync) and is intended to run on a background `std::thread`, not tokio,
 /// since the tokio runtime may not be available during Tauri's `setup()`.
+///
+/// Goes through `claudette::agent::resolve_claude_path_blocking` instead of
+/// a bare `Command::new("claude")` so npm-installed Windows shims
+/// (`claude.cmd` / `claude.ps1`) and the official installer paths under
+/// `%LOCALAPPDATA%` are honoured. Without the resolver the warm step
+/// silently no-ops on those installs and every later usage call pays the
+/// full UA detection cost on the first hit.
 pub fn warm_user_agent_cache_sync() {
-    let output = std::process::Command::new("claude")
+    let claude_path = claudette::agent::resolve_claude_path_blocking();
+    let output = std::process::Command::new(&claude_path)
         .no_console_window()
         .arg("--version")
         .env("PATH", claudette::env::enriched_path())

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -607,8 +607,24 @@ pub fn resolve_claude_path_blocking() -> OsString {
     } else {
         std::env::var_os("PATH")
     };
-    let resolved =
-        resolve_claude_path_inner(dirs::home_dir(), path, login_shell_path, is_executable_file);
+    // Also gate the lazy shell-path probe inside the resolver: even with
+    // `enriched_path()` skipped above, the `login_shell_path` closure
+    // would still invoke `crate::env::shell_path()` (and pay the 5 s
+    // probe) on a process-PATH miss. Returning `None` when the cache is
+    // cold keeps the blocking helper truly non-stalling — well-known
+    // fallback paths still cover typical installs.
+    let resolved = resolve_claude_path_inner(
+        dirs::home_dir(),
+        path,
+        || {
+            if crate::env::shell_path_is_cached() {
+                login_shell_path()
+            } else {
+                None
+            }
+        },
+        is_executable_file,
+    );
     if Path::new(&resolved).is_absolute() {
         let _ = RESOLVED_CLAUDE_PATH.set(resolved.clone());
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -562,24 +562,63 @@ pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> Stri
 /// `Path::is_file` probes plus one registry read, sub-millisecond — so
 /// we run it inline.
 pub async fn resolve_claude_path() -> OsString {
-    static RESOLVED: OnceLock<OsString> = OnceLock::new();
-    if let Some(cached) = RESOLVED.get() {
+    if let Some(cached) = RESOLVED_CLAUDE_PATH.get() {
         return cached.clone();
     }
     #[cfg(unix)]
     let resolved = tokio::task::spawn_blocking(resolve_claude_path_sync)
         .await
-        .unwrap_or_else(|_| OsString::from("claude"));
+        .unwrap_or_else(|_| OsString::from(claude_bare_name()));
     #[cfg(not(unix))]
     let resolved = resolve_claude_path_sync();
 
     // Only cache absolute paths — the bare "claude" fallback should allow
     // retries on subsequent calls in case the environment improves.
     if Path::new(&resolved).is_absolute() {
-        let _ = RESOLVED.set(resolved.clone());
+        let _ = RESOLVED_CLAUDE_PATH.set(resolved.clone());
     }
     resolved
 }
+
+/// Resolve the `claude` CLI path from a synchronous (non-async) context.
+///
+/// Mirrors [`crate::git::resolve_git_path_blocking`] so callers that can't
+/// `.await` (e.g. background `std::thread` startup tasks like the User-Agent
+/// cache warmer) get the same lookup order — process PATH, login-shell PATH,
+/// well-known install locations — instead of a bare `Command::new("claude")`
+/// that misses Windows npm shims (`claude.cmd`/`claude.ps1`) and the official
+/// installer paths under `%LOCALAPPDATA%`.
+///
+/// Shares the same `OnceLock` cache as [`resolve_claude_path`], so the first
+/// call from either side populates it and subsequent calls are free.
+///
+/// On a cold shell-path cache we skip [`crate::env::enriched_path`] and use
+/// the raw process PATH instead, matching `resolve_git_path_blocking`'s
+/// behaviour: this avoids stalling for up to 5 s on the login-shell probe
+/// when the caller can't afford that wait. The fallback well-known paths
+/// (npm shims, `%LOCALAPPDATA%\Programs\claude`, `~/.local/bin`, etc.) still
+/// run, so most installs resolve even without the enriched PATH.
+pub fn resolve_claude_path_blocking() -> OsString {
+    if let Some(cached) = RESOLVED_CLAUDE_PATH.get() {
+        return cached.clone();
+    }
+    let path = if crate::env::shell_path_is_cached() {
+        Some(crate::env::enriched_path())
+    } else {
+        std::env::var_os("PATH")
+    };
+    let resolved =
+        resolve_claude_path_inner(dirs::home_dir(), path, login_shell_path, is_executable_file);
+    if Path::new(&resolved).is_absolute() {
+        let _ = RESOLVED_CLAUDE_PATH.set(resolved.clone());
+    }
+    resolved
+}
+
+/// Shared cache for [`resolve_claude_path`] and [`resolve_claude_path_blocking`].
+/// Only populated for absolute paths — the bare-`claude` fallback stays
+/// uncached so the next call gets a chance to find a real install.
+static RESOLVED_CLAUDE_PATH: OnceLock<OsString> = OnceLock::new();
 
 /// Synchronous core of [`resolve_claude_path`]. Extracted so it can run
 /// inside `tokio::task::spawn_blocking` on Unix without juggling async


### PR DESCRIPTION
## Summary

Two deferred Windows-polish items from PR #383's Copilot review:

- `warm_user_agent_cache_sync` (`src-tauri/src/usage.rs`) now goes through a new `claudette::agent::resolve_claude_path_blocking` helper instead of `Command::new("claude")`. The bare command misses npm-installed Windows shims (`claude.cmd` / `claude.ps1`) and the official installer paths under `%LOCALAPPDATA%`, leaving the UA cache cold and forcing every later usage call to pay full detection cost.
- `cmd /C start <url>` in `open_external_url` (`src-tauri/src/commands/usage.rs`) now passes an explicit empty title (`cmd /C start "" <url>`) so the target can never be misparsed as a window title. Audited the other `cmd /C start` site in `shell.rs::open`; it already had the empty title.

The new `resolve_claude_path_blocking` mirrors `resolve_git_path_blocking`: shares an `OnceLock` cache with the async `resolve_claude_path` and gates `enriched_path()` on `shell_path_is_cached()` so cold callers never stall on the 5 s login-shell probe.

Closes #387.

## Test plan

- [x] `cargo test --workspace --all-features` (579 + 120 = 699 tests pass)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -D warnings` (matches CI scope)
- [x] `cargo fmt --all --check`
- [x] `cd src/ui && bunx tsc -b`
- [x] `cd src/ui && bun run test` (650 tests pass)
- [ ] Manual smoke on a Windows machine with npm-installed claude (`%APPDATA%\npm\claude.cmd`) to confirm the UA cache warms

### Note on workspace clippy

`cargo clippy --workspace --all-targets -- -D warnings` surfaces a pre-existing lint in `src-tauri/src/commands/files.rs:48` (`needless_borrows_for_generic_args` on `Command::new(&claudette::git::resolve_git_path_blocking())`) — unrelated to this change and present on `main`. CI lints only `claudette` and `claudette-server` per CLAUDE.md, so it does not block CI; left for a follow-up.