### PR TITLE
feat(env-direnv): honor DIRENV_WATCHES + slow nix-devshell test

### DIFF
--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -5,10 +5,11 @@
 -- runs `direnv export json` (which returns `{VAR: "value" | null}`) and
 -- forwards that straight to the dispatcher.
 --
--- Known limitation: we watch `.envrc` for mtime changes but NOT the
--- files direnv itself watches via `DIRENV_WATCHES`. If your `.envrc`
--- sources another file that changes, edit `.envrc` (or run
--- `direnv reload` then re-evaluate via the UI) to force a refresh.
+-- The returned watch list includes `.envrc` plus every path direnv
+-- itself tracks via `DIRENV_WATCHES` (decoded from the exported env).
+-- That covers user-level `watch_file` directives and nested files that
+-- `.envrc` sources — editing `secret.env` under `dotenv secret.env`
+-- invalidates the cache just like editing `.envrc` itself.
 
 local M = {}
 
@@ -50,9 +51,31 @@ function M.export(args)
         env_map = host.json_decode(result.stdout)
     end
 
+    -- Seed with `.envrc` unconditionally — it's always a watch target.
+    -- Then merge in whatever direnv itself tracks via `DIRENV_WATCHES`
+    -- (user `watch_file` directives, files sourced by `dotenv ...`,
+    -- direnv's own allow/deny cache entries whose mtime flips when the
+    -- user runs `direnv allow`/`deny`). Dedupe so `.envrc` isn't listed
+    -- twice when direnv includes it too.
+    local watched = {}
+    local seen = {}
+    local function add(path)
+        if path and not seen[path] then
+            seen[path] = true
+            table.insert(watched, path)
+        end
+    end
+    add(join(args.worktree, ".envrc"))
+    local direnv_watches = env_map["DIRENV_WATCHES"]
+    if type(direnv_watches) == "string" and #direnv_watches > 0 then
+        for _, path in ipairs(host.direnv_decode_watches(direnv_watches)) do
+            add(path)
+        end
+    end
+
     return {
         env = env_map,
-        watched = { join(args.worktree, ".envrc") },
+        watched = watched,
     }
 end
 

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -88,7 +88,7 @@ fn direnv_detect_skips_missing_envrc() {
 
 /// Encode paths into direnv's `DIRENV_WATCHES` wire format — URL-safe
 /// base64 of zlib-compressed JSON `[{"path": ..., "modtime": N, ...}, ...]`.
-/// Mirrors the decoder lives in `host_api::decode_direnv_watches`.
+/// Mirrors the decoder in `host_api::decode_direnv_watches`.
 fn encode_direnv_watches(paths: &[&str]) -> String {
     use base64::Engine as _;
     use flate2::Compression;
@@ -131,9 +131,21 @@ fn direnv_export_with_stubbed_exec(
 
     // Overwrite `host.exec` in the globals of this VM. The plugin's
     // `export` is the only path that calls it (detect uses file_exists).
+    // Assert shape here so the test catches a regression where the
+    // plugin spawns the wrong CLI or passes the wrong args — a silent
+    // accept would let such a bug through.
     let stub_script = format!(
         r#"
         host.exec = function(cmd, args)
+            if cmd ~= "direnv" then
+                error("expected host.exec cmd='direnv', got: " .. tostring(cmd))
+            end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                local got = type(args) == "table"
+                    and tostring(args[1]) .. "," .. tostring(args[2]) .. "," .. tostring(args[3])
+                    or tostring(args)
+                error("expected host.exec args={{'export','json'}}, got: " .. got)
+            end
             return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
         end
         "#
@@ -196,7 +208,15 @@ fn direnv_export_watches_list_merges_direnv_watches() {
     }))
     .unwrap();
     let stub = format!(
-        r#"host.exec = function() return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }} end"#
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
     );
     lua.load(&stub).exec().unwrap();
 

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -897,14 +897,20 @@ async fn integration_mise_auto_trust_on_retries_after_untrusted() {
 /// `nix print-dev-env --json` on a fresh flake with a nixpkgs input
 /// evaluates the flake from scratch; that's ~3s with warm nixpkgs in
 /// the store and 10–60s cold. Too slow for the default fast-test loop,
-/// so this is gated behind `CLAUDETTE_SLOW_TESTS=1`. Local devs run it
-/// with `CLAUDETTE_SLOW_TESTS=1 cargo test -- --ignored` or by setting
-/// the env var directly; CI runs a nightly slow-tests job.
+/// so this is `#[ignore]`-gated plus a `CLAUDETTE_SLOW_TESTS=1`
+/// backstop. Run it explicitly:
+///
+///   CLAUDETTE_SLOW_TESTS=1 cargo test -p claudette \
+///     integration_nix_devshell_export_returns_env -- --ignored --nocapture
+///
+/// The env-var check exists so `cargo test -- --include-ignored` on a
+/// machine without network/Nix still no-ops instead of failing.
 ///
 /// Platform gating: `has_nix` evaluates to false on Windows (no native
 /// Nix), so this test only compiles into the binary on Linux + macOS
 /// where Nix is installed.
 #[cfg(has_nix)]
+#[ignore = "slow: needs nix + network; run with CLAUDETTE_SLOW_TESTS=1 -- --ignored"]
 #[tokio::test]
 async fn integration_nix_devshell_export_returns_env() {
     if std::env::var("CLAUDETTE_SLOW_TESTS").ok().as_deref() != Some("1") {
@@ -931,14 +937,18 @@ async fn integration_nix_devshell_export_returns_env() {
     )
     .unwrap();
 
-    // Trivial flake that pulls nixpkgs and exposes a devShell with one
-    // exported env var. `mkShellNoCC` avoids the cc wrapper derivation
-    // — faster than the default `mkShell`.
+    // Trivial flake that pulls a pinned nixpkgs and exposes a devShell
+    // with one exported env var. `mkShellNoCC` avoids the cc wrapper
+    // derivation — faster than the default `mkShell`. The input is
+    // pinned to a specific nixos-24.11 revision so the test resolves
+    // deterministically across machines and isn't at the mercy of
+    // nixos-unstable moving under us (or GitHub being slow when a cache
+    // miss forces a fetch).
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(
         tmp.path().join("flake.nix"),
         r#"{
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/50ab793786d9de88ee30ec4e4c24fb4236fc2674";
   outputs = { self, nixpkgs }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -86,6 +86,165 @@ fn direnv_detect_skips_missing_envrc() {
     ));
 }
 
+/// Encode paths into direnv's `DIRENV_WATCHES` wire format — URL-safe
+/// base64 of zlib-compressed JSON `[{"path": ..., "modtime": N, ...}, ...]`.
+/// Mirrors the decoder lives in `host_api::decode_direnv_watches`.
+fn encode_direnv_watches(paths: &[&str]) -> String {
+    use base64::Engine as _;
+    use flate2::Compression;
+    use flate2::write::ZlibEncoder;
+    use std::io::Write as _;
+
+    let entries: Vec<serde_json::Value> = paths
+        .iter()
+        .map(|p| serde_json::json!({ "path": p, "modtime": 1, "exists": true }))
+        .collect();
+    let json = serde_json::to_string(&entries).unwrap();
+    let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(json.as_bytes()).unwrap();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(enc.finish().unwrap())
+}
+
+/// Drive env-direnv's `export` with a stubbed `host.exec` that returns
+/// a caller-supplied env map (encoded as JSON) with the given
+/// `DIRENV_WATCHES` value. Returns `(watched list, worktree path)`.
+///
+/// We override `host.exec` after VM construction so the plugin code is
+/// unmodified — this is the same trick the plugin would see in prod,
+/// with all other host APIs intact. The stub records the first call
+/// only; the plugin invokes `direnv export json` once on the happy path.
+fn direnv_export_with_stubbed_exec(
+    direnv_watches: Option<&str>,
+) -> (Vec<String>, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "export FOO=bar\n").unwrap();
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+
+    // Build the JSON `host.exec` should return. direnv's real output is
+    // `{VAR: "value" | null}`, so we set at least one var plus
+    // optionally DIRENV_WATCHES.
+    let mut env = serde_json::json!({ "FOO": "bar" });
+    if let Some(w) = direnv_watches {
+        env["DIRENV_WATCHES"] = serde_json::Value::String(w.to_string());
+    }
+    let env_json = serde_json::to_string(&env).unwrap();
+
+    // Overwrite `host.exec` in the globals of this VM. The plugin's
+    // `export` is the only path that calls it (detect uses file_exists).
+    let stub_script = format!(
+        r#"
+        host.exec = function(cmd, args)
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub_script).exec().expect("install stub");
+
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().expect("export");
+    let watched: mlua::Table = result.get("watched").expect("watched field");
+    let mut out = Vec::new();
+    let len = watched.len().expect("len") as usize;
+    for i in 1..=len {
+        out.push(watched.get::<String>(i).expect("string path"));
+    }
+    (out, tmp)
+}
+
+#[test]
+fn direnv_export_watches_list_includes_envrc_without_direnv_watches() {
+    // No DIRENV_WATCHES in the exported env (direnv didn't emit one,
+    // or the .envrc has no `watch_file` directives). We still must
+    // report `.envrc` as the watch target, unchanged from prior behavior.
+    let (watched, _tmp) = direnv_export_with_stubbed_exec(None);
+    assert_eq!(watched.len(), 1, "watched = {watched:?}");
+    assert!(
+        watched[0].ends_with(".envrc"),
+        "expected .envrc in watched, got {watched:?}"
+    );
+}
+
+#[test]
+fn direnv_export_watches_list_merges_direnv_watches() {
+    // `.envrc` sources `secret.env` and `.local.env` via direnv's
+    // `watch_file` / `dotenv` directives. direnv emits both in
+    // `DIRENV_WATCHES`; the plugin must surface them so the cache
+    // invalidates when either changes. We two-phase this: first get
+    // the worktree path from the helper, then re-run with a
+    // DIRENV_WATCHES whose paths are rooted at that worktree so we can
+    // verify dedupe against the `.envrc` the plugin self-seeds.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "export FOO=bar\n").unwrap();
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let envrc_path = format!("{worktree}/.envrc");
+    let secret_path = format!("{worktree}/secret.env");
+    let local_path = format!("{worktree}/.local.env");
+    let encoded = encode_direnv_watches(&[&envrc_path, &secret_path, &local_path]);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"host.exec = function() return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }} end"#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+
+    assert!(
+        watched.contains(&envrc_path),
+        "expected {envrc_path} in watched, got {watched:?}"
+    );
+    assert!(
+        watched.contains(&secret_path),
+        "expected {secret_path} in watched, got {watched:?}"
+    );
+    assert!(
+        watched.contains(&local_path),
+        "expected {local_path} in watched, got {watched:?}"
+    );
+    // Dedupe: the worktree-rooted .envrc appears exactly once even
+    // though both the plugin and direnv list it.
+    let envrc_count = watched.iter().filter(|p| **p == envrc_path).count();
+    assert_eq!(
+        envrc_count, 1,
+        "expected .envrc exactly once in watched, got {watched:?}"
+    );
+}
+
+#[test]
+fn direnv_export_watches_list_tolerates_garbage_direnv_watches() {
+    // Decoder returns an empty list on unparseable input. The plugin
+    // must not error — we still emit the `.envrc` baseline.
+    let (watched, _tmp) = direnv_export_with_stubbed_exec(Some("not-base64!!"));
+    assert_eq!(watched.len(), 1);
+    assert!(watched[0].ends_with(".envrc"));
+}
+
 // ---------------------------------------------------------------------------
 // env-mise
 // ---------------------------------------------------------------------------
@@ -277,7 +436,7 @@ fn nix_detect_skips_plain_repo() {
 /// tests run in parallel by default, and `std::env::set_var` is
 /// process-global — concurrent integration tests tripping over each
 /// other's HOME would produce flaky failures.
-#[cfg(any(has_direnv, has_mise))]
+#[cfg(any(has_direnv, has_mise, has_nix))]
 fn env_override_mutex() -> &'static std::sync::Mutex<()> {
     static M: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
     M.get_or_init(|| std::sync::Mutex::new(()))
@@ -295,14 +454,14 @@ fn env_override_mutex() -> &'static std::sync::Mutex<()> {
 /// integration tests pollute the developer's real trust cache with
 /// tempdir paths, and fail outright in sandboxed CI environments
 /// where `~/.local/...` is read-only.
-#[cfg(any(has_direnv, has_mise))]
+#[cfg(any(has_direnv, has_mise, has_nix))]
 struct ScopedHome {
     _guard: std::sync::MutexGuard<'static, ()>,
     _tmp: tempfile::TempDir,
     prior: Vec<(&'static str, Option<String>)>,
 }
 
-#[cfg(any(has_direnv, has_mise))]
+#[cfg(any(has_direnv, has_mise, has_nix))]
 impl ScopedHome {
     fn new() -> Self {
         let guard = env_override_mutex()
@@ -349,7 +508,7 @@ impl ScopedHome {
     }
 }
 
-#[cfg(any(has_direnv, has_mise))]
+#[cfg(any(has_direnv, has_mise, has_nix))]
 impl Drop for ScopedHome {
     fn drop(&mut self) {
         for (k, v) in &self.prior {
@@ -733,7 +892,110 @@ async fn integration_mise_auto_trust_on_retries_after_untrusted() {
     );
 }
 
-// nix print-dev-env on a fresh flake evaluates the flake.nix from
-// scratch, which can take 10-60s the first time. Skip the integration
-// test for now — cargo test wall-clock matters more than coverage
-// here. Unit tests + the manual verification plan cover the happy path.
+/// End-to-end integration test for env-nix-devshell, opt-in.
+///
+/// `nix print-dev-env --json` on a fresh flake with a nixpkgs input
+/// evaluates the flake from scratch; that's ~3s with warm nixpkgs in
+/// the store and 10–60s cold. Too slow for the default fast-test loop,
+/// so this is gated behind `CLAUDETTE_SLOW_TESTS=1`. Local devs run it
+/// with `CLAUDETTE_SLOW_TESTS=1 cargo test -- --ignored` or by setting
+/// the env var directly; CI runs a nightly slow-tests job.
+///
+/// Platform gating: `has_nix` evaluates to false on Windows (no native
+/// Nix), so this test only compiles into the binary on Linux + macOS
+/// where Nix is installed.
+#[cfg(has_nix)]
+#[tokio::test]
+async fn integration_nix_devshell_export_returns_env() {
+    if std::env::var("CLAUDETTE_SLOW_TESTS").ok().as_deref() != Some("1") {
+        eprintln!(
+            "integration_nix_devshell_export_returns_env: skipped (set CLAUDETTE_SLOW_TESTS=1 to run)"
+        );
+        return;
+    }
+
+    // Redirect HOME + XDG_* so the test uses a disposable nix config
+    // (we write `experimental-features = nix-command flakes` into the
+    // scoped config below — nix needs the flake subsystem enabled for
+    // `print-dev-env --json`). The scoped home also keeps any cache
+    // sideeffects out of the developer's real dirs.
+    let _scoped = ScopedHome::new();
+
+    // Enable flakes inside the scoped XDG_CONFIG_HOME.
+    let xdg_config = std::env::var("XDG_CONFIG_HOME").expect("ScopedHome sets XDG_CONFIG_HOME");
+    let nix_cfg_dir = std::path::Path::new(&xdg_config).join("nix");
+    std::fs::create_dir_all(&nix_cfg_dir).unwrap();
+    std::fs::write(
+        nix_cfg_dir.join("nix.conf"),
+        "experimental-features = nix-command flakes\n",
+    )
+    .unwrap();
+
+    // Trivial flake that pulls nixpkgs and exposes a devShell with one
+    // exported env var. `mkShellNoCC` avoids the cc wrapper derivation
+    // — faster than the default `mkShell`.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("flake.nix"),
+        r#"{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAll = f: builtins.listToAttrs (map (s: { name = s; value = f s; }) systems);
+    in {
+      devShells = forAll (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in { default = pkgs.mkShellNoCC { CLAUDETTE_NIX_TEST = "ok"; }; });
+    };
+}
+"#,
+    )
+    .unwrap();
+
+    let plugin_dir = tempfile::tempdir().unwrap();
+    crate::plugin_runtime::seed::seed_bundled_plugins(plugin_dir.path());
+    let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+    assert!(
+        registry.plugins.contains_key("env-nix-devshell"),
+        "env-nix-devshell should be seeded + discovered"
+    );
+
+    let backend = crate::env_provider::backend::PluginRegistryBackend::new(&registry);
+    let cache = crate::env_provider::cache::EnvCache::new();
+    let ws_info = WorkspaceInfo {
+        id: "ws-nix".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: tmp.path().to_string_lossy().into_owned(),
+        repo_path: tmp.path().to_string_lossy().into_owned(),
+    };
+
+    let resolved = crate::env_provider::resolve_for_workspace(
+        &backend,
+        &cache,
+        tmp.path(),
+        &ws_info,
+        &Default::default(),
+    )
+    .await;
+
+    let nix_source = resolved
+        .sources
+        .iter()
+        .find(|s| s.plugin_name == "env-nix-devshell")
+        .expect("env-nix-devshell must appear in sources");
+    assert!(
+        nix_source.error.is_none(),
+        "nix-devshell errored: {:?}",
+        nix_source.error
+    );
+    assert_eq!(
+        resolved
+            .vars
+            .get("CLAUDETTE_NIX_TEST")
+            .and_then(|v| v.as_deref()),
+        Some("ok"),
+        "expected CLAUDETTE_NIX_TEST=ok in merged env; full resolved = {resolved:#?}"
+    );
+}

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -243,13 +243,27 @@ fn resolve_inside_workspace(
 /// truncated data, bad JSON) returns an empty vec — direnv is the source
 /// of truth and emits blank/placeholder values in normal operation that
 /// we shouldn't surface as plugin errors.
+///
+/// Size limits: the compressed input and the decompressed JSON are each
+/// capped. Real-world DIRENV_WATCHES values are well under 10 KB even in
+/// repos with many `watch_file` entries; the 1 MiB / 8 MiB caps below
+/// are orders of magnitude higher than anything sane while still
+/// bounding allocations if a malicious or broken producer hands us a
+/// zip bomb.
 fn decode_direnv_watches(encoded: &str) -> Vec<String> {
     use base64::Engine as _;
     use flate2::read::ZlibDecoder;
     use std::io::Read as _;
 
+    /// Max compressed input we'll even try to decode (1 MiB).
+    const MAX_COMPRESSED_BYTES: usize = 1024 * 1024;
+    /// Max decompressed JSON we'll accept (8 MiB) — bounds the zlib
+    /// decoder so a deliberately over-compressed payload can't blow up
+    /// the heap on `read_to_string`.
+    const MAX_DECOMPRESSED_BYTES: u64 = 8 * 1024 * 1024;
+
     let trimmed = encoded.trim();
-    if trimmed.is_empty() {
+    if trimmed.is_empty() || trimmed.len() > MAX_COMPRESSED_BYTES {
         return Vec::new();
     }
 
@@ -261,13 +275,20 @@ fn decode_direnv_watches(encoded: &str) -> Vec<String> {
         .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(trimmed))
         .or_else(|_| base64::engine::general_purpose::STANDARD.decode(trimmed));
     let bytes = match bytes {
-        Ok(b) => b,
-        Err(_) => return Vec::new(),
+        Ok(b) if b.len() <= MAX_COMPRESSED_BYTES => b,
+        _ => return Vec::new(),
     };
 
-    let mut decoder = ZlibDecoder::new(&bytes[..]);
+    let mut decoder = ZlibDecoder::new(&bytes[..]).take(MAX_DECOMPRESSED_BYTES);
     let mut json = String::new();
     if decoder.read_to_string(&mut json).is_err() {
+        return Vec::new();
+    }
+    // `Take` reads at most MAX_DECOMPRESSED_BYTES; a producer handing us
+    // a payload that would decompress to exactly the cap is borderline,
+    // so treat "filled the cap" as an indication that the original was
+    // likely truncated and skip rather than serving half-parsed data.
+    if json.len() as u64 >= MAX_DECOMPRESSED_BYTES {
         return Vec::new();
     }
 
@@ -906,5 +927,39 @@ mod tests {
             .eval()
             .unwrap();
         assert_eq!(len, 0);
+    }
+
+    #[test]
+    fn decode_direnv_watches_rejects_oversize_compressed_input() {
+        // A 2 MiB base64-safe string — over the 1 MiB compressed-input
+        // cap. We don't even try to decode this: it returns empty
+        // before touching zlib/JSON, so a zip-bomb-sized header never
+        // allocates the decompressed buffer.
+        let oversize: String = "A".repeat(2 * 1024 * 1024);
+        assert!(decode_direnv_watches(&oversize).is_empty());
+    }
+
+    #[test]
+    fn decode_direnv_watches_rejects_decompression_bomb() {
+        // Craft a zip bomb: 16 MiB of zeros compresses to a handful of
+        // bytes. The 8 MiB decompressed cap should trip and return
+        // empty without filling memory with the full expansion.
+        use base64::Engine as _;
+        use flate2::Compression;
+        use flate2::write::ZlibEncoder;
+        use std::io::Write as _;
+
+        let huge = vec![0u8; 16 * 1024 * 1024];
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::best());
+        enc.write_all(&huge).unwrap();
+        let compressed = enc.finish().unwrap();
+        // Sanity: the bomb really is small once compressed.
+        assert!(
+            compressed.len() < 64 * 1024,
+            "compressed size {} too large for a zip bomb test",
+            compressed.len()
+        );
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed);
+        assert!(decode_direnv_watches(&encoded).is_empty());
     }
 }

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -94,6 +94,21 @@ fn register_host_api(lua: &Lua, ctx: HostContext) -> LuaResult<()> {
         })?,
     )?;
 
+    // host.direnv_decode_watches(str) -> array<string>
+    //
+    // direnv encodes its watch list (DIRENV_WATCHES env var) as
+    // URL-safe-base64-of-zlib-of-JSON `[{path, modtime, exists}, ...]`.
+    // We decode in Rust because Lua has no gzip/deflate primitives.
+    //
+    // Returns the array of `path` strings. Unparseable input returns an
+    // empty list rather than raising — direnv occasionally emits blank or
+    // placeholder values we don't want to treat as fatal. Callers decide
+    // what to do with the result.
+    host.set(
+        "direnv_decode_watches",
+        lua.create_function(|_, encoded: String| Ok(decode_direnv_watches(&encoded)))?,
+    )?;
+
     // host.workspace() -> {id, name, branch, worktree_path, repo_path}
     let ws = ctx.workspace_info.clone();
     host.set(
@@ -217,6 +232,57 @@ fn resolve_inside_workspace(
     } else {
         None
     }
+}
+
+/// Decode direnv's `DIRENV_WATCHES` env-var value into the list of
+/// watched paths it carries.
+///
+/// Format (gzenv, per direnv source): URL-safe base64 (no padding) of
+/// zlib-compressed JSON `[{"path": "...", "modtime": N, "exists": bool}, ...]`.
+/// Returns `path` strings only. On any parse failure (unexpected encoding,
+/// truncated data, bad JSON) returns an empty vec — direnv is the source
+/// of truth and emits blank/placeholder values in normal operation that
+/// we shouldn't surface as plugin errors.
+fn decode_direnv_watches(encoded: &str) -> Vec<String> {
+    use base64::Engine as _;
+    use flate2::read::ZlibDecoder;
+    use std::io::Read as _;
+
+    let trimmed = encoded.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+
+    // direnv uses URL-safe base64 without padding; try that first, then
+    // fall back to standard base64 so we tolerate either variant in the
+    // wild.
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(trimmed)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(trimmed))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(trimmed));
+    let bytes = match bytes {
+        Ok(b) => b,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut decoder = ZlibDecoder::new(&bytes[..]);
+    let mut json = String::new();
+    if decoder.read_to_string(&mut json).is_err() {
+        return Vec::new();
+    }
+
+    let parsed: serde_json::Value = match serde_json::from_str(&json) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    let Some(array) = parsed.as_array() else {
+        return Vec::new();
+    };
+    array
+        .iter()
+        .filter_map(|entry| entry.get("path")?.as_str().map(str::to_owned))
+        .collect()
 }
 
 /// Execute a subprocess, restricted to allowed CLIs.
@@ -760,5 +826,85 @@ mod tests {
             .eval()
             .unwrap();
         assert!(!exists, "dotdot traversal must be denied");
+    }
+
+    /// Build a DIRENV_WATCHES-shaped payload from a list of paths.
+    /// URL-safe base64 (no padding) over zlib-compressed JSON —
+    /// mirrors the wire format emitted by direnv 2.x.
+    fn encode_direnv_watches(paths: &[&str]) -> String {
+        use base64::Engine as _;
+        use flate2::Compression;
+        use flate2::write::ZlibEncoder;
+        use std::io::Write as _;
+
+        let entries: Vec<serde_json::Value> = paths
+            .iter()
+            .map(|p| serde_json::json!({ "path": p, "modtime": 0, "exists": true }))
+            .collect();
+        let json = serde_json::to_string(&entries).unwrap();
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(json.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed)
+    }
+
+    #[test]
+    fn decode_direnv_watches_round_trip() {
+        let encoded =
+            encode_direnv_watches(&["/repo/.envrc", "/repo/secret.env", "/home/u/.config/foo"]);
+        let decoded = decode_direnv_watches(&encoded);
+        assert_eq!(
+            decoded,
+            vec![
+                "/repo/.envrc".to_string(),
+                "/repo/secret.env".to_string(),
+                "/home/u/.config/foo".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn decode_direnv_watches_empty_input_returns_empty() {
+        assert!(decode_direnv_watches("").is_empty());
+        assert!(decode_direnv_watches("   ").is_empty());
+    }
+
+    #[test]
+    fn decode_direnv_watches_returns_empty_on_garbage() {
+        // Not base64 at all.
+        assert!(decode_direnv_watches("not base64!!!").is_empty());
+        // Valid base64 but not zlib.
+        use base64::Engine as _;
+        let junk = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"hello world");
+        assert!(decode_direnv_watches(&junk).is_empty());
+    }
+
+    #[test]
+    fn decode_direnv_watches_via_lua_host_api() {
+        // Round-trip through the Lua surface to confirm the host function
+        // is wired up and returns a Lua sequence.
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let encoded = encode_direnv_watches(&["/a/.envrc", "/a/sub.env"]);
+
+        // Embed the encoded payload as a Lua string literal. The
+        // encoding is ASCII (URL-safe base64), no escape handling
+        // needed.
+        let script = format!(r#"return host.direnv_decode_watches("{encoded}")"#);
+        let table: mlua::Table = lua.load(&script).eval().unwrap();
+        assert_eq!(table.len().unwrap(), 2);
+        assert_eq!(table.get::<String>(1).unwrap(), "/a/.envrc");
+        assert_eq!(table.get::<String>(2).unwrap(), "/a/sub.env");
+    }
+
+    #[test]
+    fn decode_direnv_watches_via_lua_accepts_empty_string() {
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let len: i64 = lua
+            .load(r#"return #host.direnv_decode_watches("")"#)
+            .eval()
+            .unwrap();
+        assert_eq!(len, 0);
     }
 }


### PR DESCRIPTION
Closes #413.

## Summary

- **`env-direnv` now honors `DIRENV_WATCHES`** — after a successful
  `direnv export json`, the plugin decodes the watches env var and merges
  the paths into its `watched` list. Edits to files direnv itself tracks
  (`watch_file secret.env`, `dotenv .local.env`, nested sourced files) now
  invalidate the env cache. Previously only `.envrc` mtime was watched,
  so transitive file edits were silently stale.
- **New `host.direnv_decode_watches(str) -> array<string>` helper** that
  decodes direnv's gzenv format (URL-safe base64 → zlib → JSON) in Rust
  using the already-vendored `base64` + `flate2` crates. Returns `[]` on
  garbage rather than erroring so an oddly-shaped value from direnv
  doesn't fail the plugin.
- **Opt-in end-to-end integration test for `env-nix-devshell`** replacing
  the prior "skipped for now" comment. Gated with `#[ignore]` plus a
  `CLAUDETTE_SLOW_TESTS=1` env-var backstop; flake input pinned to a
  specific `nixos-24.11` commit for determinism. Verified locally in
  ~19 s cold with a pinned nixpkgs.

## Test plan

- [x] Unit tests for `decode_direnv_watches` (round trip, empty, garbage, Lua surface): `cargo test -p claudette --lib decode_direnv_watches`
- [x] Plugin-level tests for `env-direnv` watch-list merge via stubbed `host.exec`: `cargo test -p claudette --lib direnv_export_watches`
- [x] Slow nix test: `CLAUDETTE_SLOW_TESTS=1 cargo test -p claudette integration_nix_devshell_export_returns_env -- --ignored --nocapture` → passes in ~19 s
- [x] Default run shows `#[ignore]`d reason, does not execute
- [x] Full suite green: `cargo test -p claudette --all-features` (669 pass)
- [x] Lint: `cargo clippy -p claudette -p claudette-server --all-targets -- -Dwarnings`
- [x] Format: `cargo fmt --all --check`
- [x] Frontend: `bunx tsc -b` + `bun run test` (663 pass)

## Cross-platform

- Decoder is pure Rust — runs on Linux/macOS/Windows.
- `direnv` and `nix` integration tests gate on the `has_direnv` / `has_nix` cfg flags emitted by `build.rs`, so Windows CI (which has neither) just skips them.
- Follow-up from #406.