### PR TITLE
feat(env-provider): reactive fs-watcher invalidation + proactive warmup on repo add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "flate2",
  "futures",
  "mlua",
+ "notify",
  "open",
  "rand 0.8.5",
  "rusqlite",
@@ -1426,6 +1427,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futf"
@@ -2255,6 +2265,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2469,26 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2698,6 +2757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2831,6 +2891,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2921,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ dirs = "6"
 open = "5"
 mlua = { version = "0.10", features = ["luau", "serialize", "async", "send"] }
 flate2 = "1"
+# Cross-platform filesystem watcher used by env-provider reactive
+# invalidation. RecommendedWatcher picks FSEvents (macOS), inotify
+# (Linux), and ReadDirectoryChangesW (Windows) — single API across all
+# three target platforms.
+notify = "7"
 rand = "0.8"
 sha2 = "0.10"
 tar = "0.4"

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -608,6 +608,12 @@ pub async fn send_chat_message(
         )
         .await
     };
+    crate::commands::env::register_resolved_with_watcher(
+        &state,
+        std::path::Path::new(&worktree_path),
+        &resolved_env.sources,
+    )
+    .await;
 
     // Env-provider drift teardown: the env baked into the current
     // persistent session is fixed at spawn time; Claude's subprocess

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -11,13 +11,25 @@
 
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
 
 use serde::Serialize;
-use tauri::State;
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::db::Database;
+use claudette::env_provider::EnvWatcher;
 
 use crate::state::AppState;
+
+/// Payload for the `env-cache-invalidated` Tauri event. The frontend's
+/// EnvPanel subscribes to this and refetches when the worktree + plugin
+/// match what it's currently displaying. Kept deliberately small so
+/// routing logic on the JS side can be a string compare.
+#[derive(Clone, Serialize)]
+pub struct EnvCacheInvalidatedPayload {
+    pub worktree_path: String,
+    pub plugin_name: String,
+}
 
 /// App-settings key for "is this env-provider enabled for this repo?".
 /// Default (absent key) is enabled. `"false"` disables.
@@ -130,6 +142,12 @@ pub async fn get_env_sources(
         &disabled,
     )
     .await;
+
+    // Subscribe the fs watcher to every freshly-cached plugin's
+    // watched paths. Must happen BEFORE `filter_globally_disabled`
+    // moves `resolved.sources` — we want to register even hidden
+    // sources so backing invalidation stays correct.
+    register_resolved_with_watcher(&state, Path::new(&worktree), &resolved.sources).await;
 
     let visible = filter_globally_disabled(resolved.sources, |name| registry.is_disabled(name));
     let sources = visible
@@ -431,6 +449,113 @@ async fn resolve_target(
             Ok((repo.path, ws_info, repo.id))
         }
     }
+}
+
+/// Build the `EnvWatcher` and store it in `AppState`. Called once at
+/// Tauri setup time. The change callback invalidates the cache entry
+/// and emits `env-cache-invalidated` so any live UI can refetch. On
+/// construction failure (rare — usually Linux inotify limits) we log
+/// and leave `env_watcher = None`, which means reactive invalidation
+/// is disabled but lazy mtime invalidation still works.
+pub fn setup_env_watcher(app: AppHandle) {
+    let state = app.state::<AppState>();
+    let cache = Arc::clone(&state.env_cache);
+    let app_for_cb = app.clone();
+    let watcher = match EnvWatcher::new(Arc::new(move |worktree, plugin| {
+        cache.invalidate(worktree, Some(plugin));
+        let _ = app_for_cb.emit(
+            "env-cache-invalidated",
+            EnvCacheInvalidatedPayload {
+                worktree_path: worktree.to_string_lossy().into_owned(),
+                plugin_name: plugin.to_string(),
+            },
+        );
+    })) {
+        Ok(w) => Arc::new(w),
+        Err(err) => {
+            eprintln!("[env-watcher] failed to start: {err} — reactive invalidation disabled");
+            return;
+        }
+    };
+    // Block-on is fine here — `setup_env_watcher` runs during Tauri
+    // setup, where we're not on a hot path; the lock is held for a
+    // single swap. The `Arc<EnvWatcher>` then lives for the app
+    // lifetime.
+    let app_for_store = app.clone();
+    tauri::async_runtime::block_on(async move {
+        let state = app_for_store.state::<AppState>();
+        *state.env_watcher.write().await = Some(watcher);
+    });
+}
+
+/// Register every `(worktree, plugin)` that was just resolved with
+/// the fs watcher, using the watched paths the cache stored. Called
+/// after each `resolve_with_registry` so reactive invalidation stays
+/// current as plugins change what they care about.
+///
+/// Plugins whose source entry errored or didn't detect are skipped —
+/// they have no cached watched paths to register.
+pub async fn register_resolved_with_watcher(
+    state: &AppState,
+    worktree: &Path,
+    sources: &[claudette::env_provider::ResolvedSource],
+) {
+    let watcher_guard = state.env_watcher.read().await;
+    let Some(watcher) = watcher_guard.as_ref() else {
+        return;
+    };
+    for source in sources {
+        if source.error.is_some() || !source.detected {
+            // detect=false / error path: the dispatcher already
+            // invalidated this entry; make sure the watcher drops it
+            // too so we stop receiving events for stale paths.
+            watcher.unregister(worktree, Some(&source.plugin_name));
+            continue;
+        }
+        let paths = state.env_cache.watched_paths(worktree, &source.plugin_name);
+        if paths.is_empty() {
+            continue;
+        }
+        watcher.register(worktree, &source.plugin_name, &paths);
+    }
+}
+
+/// Fire-and-forget env-provider warmup for a freshly-added repo.
+/// Resolves against the repo's main checkout so the cache is ready
+/// for the first EnvPanel open, and trust errors (`.envrc` blocked,
+/// `mise.toml` untrusted) surface before the user creates a workspace.
+///
+/// Errors are swallowed — this is best-effort warmup, not a
+/// correctness path. The user will see the error on the next EnvPanel
+/// open if the warmup genuinely failed.
+pub fn spawn_repo_env_warmup(app: AppHandle, repo_id: String) {
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let Ok(db) = Database::open(&state.db_path) else {
+            return;
+        };
+        let Ok(Some(repo)) = db.get_repository(&repo_id) else {
+            return;
+        };
+        let ws_info = claudette::plugin_runtime::host_api::WorkspaceInfo {
+            id: format!("repo:{}", repo.id),
+            name: repo.name.clone(),
+            branch: String::new(),
+            worktree_path: repo.path.clone(),
+            repo_path: repo.path.clone(),
+        };
+        let disabled = load_disabled_providers(&db, &repo.id);
+        let registry = state.plugins.read().await;
+        let resolved = claudette::env_provider::resolve_with_registry(
+            &registry,
+            &state.env_cache,
+            Path::new(&repo.path),
+            &ws_info,
+            &disabled,
+        )
+        .await;
+        register_resolved_with_watcher(&state, Path::new(&repo.path), &resolved.sources).await;
+    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -527,6 +527,11 @@ pub async fn register_resolved_with_watcher(
         }
         let paths = state.env_cache.watched_paths(worktree, &source.plugin_name);
         if paths.is_empty() {
+            // Plugin detected but reported no watched paths (e.g. a
+            // provider contributing env without anything to watch).
+            // Still drop any prior registration so a stale watch set
+            // from a previous export doesn't keep firing events.
+            watcher.unregister(worktree, Some(&source.plugin_name));
             continue;
         }
         watcher.register(worktree, &source.plugin_name, &paths);

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -109,6 +109,19 @@ pub enum EnvTarget {
     Workspace { workspace_id: String },
 }
 
+/// Resolve the worktree path for an [`EnvTarget`]. Used by the
+/// EnvPanel to filter `env-cache-invalidated` events to its current
+/// target — without it, any watched file change in any repo refreshes
+/// every open Environment panel, re-running direnv/nix unnecessarily.
+#[tauri::command]
+pub async fn get_env_target_worktree(
+    target: EnvTarget,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let (worktree, _, _) = resolve_target(&state, &target).await?;
+    Ok(worktree)
+}
+
 /// Return the list of env-provider plugins that ran (or would run) for
 /// this target, along with how many vars each contributed and whether
 /// the result is cached.

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -108,6 +108,15 @@ pub async fn add_repository(
 
     crate::tray::rebuild_tray(&app);
 
+    // Warm the env-provider cache against the repo's main checkout
+    // so the first EnvPanel open doesn't pay the cold cost — and so
+    // any trust issues (blocked `.envrc`, untrusted `mise.toml`) show
+    // up before the user tries to spawn a workspace. Fire-and-forget
+    // because a `.envrc` can prompt for `direnv allow` which takes
+    // time; blocking `add_repository` on it would make the repo-add
+    // UX sluggish.
+    crate::commands::env::spawn_repo_env_warmup(app.clone(), repo.id.clone());
+
     Ok(repo)
 }
 

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -219,6 +219,29 @@ pub async fn remove_repository(
         }
     }
 
+    // Drop every env-provider watch rooted at the repo's main
+    // checkout or any of its workspace worktrees. Without this, the
+    // watcher would keep consuming OS watch slots (inotify cap on
+    // Linux) and could emit `env-cache-invalidated` events for a
+    // repo Claudette no longer knows about, surfacing trust/errors
+    // in the wrong panel after an add/remove churn.
+    if let Some(watcher) = state.env_watcher.read().await.as_ref() {
+        watcher.unregister(Path::new(&repo.path), None);
+        for ws in &repo_workspaces {
+            if let Some(ref wt_path) = ws.worktree_path {
+                watcher.unregister(Path::new(wt_path), None);
+            }
+        }
+    }
+    // Also drop the cache entries so re-adding the same repo path
+    // doesn't return stale exports.
+    state.env_cache.invalidate(Path::new(&repo.path), None);
+    for ws in &repo_workspaces {
+        if let Some(ref wt_path) = ws.worktree_path {
+            state.env_cache.invalidate(Path::new(wt_path), None);
+        }
+    }
+
     // Clean up in-memory agent sessions for this repo's workspaces
     // so the tray doesn't show stale running/attention state.
     {

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -470,16 +470,21 @@ async fn resolve_env_for_workspace(
         .map(|db| crate::commands::env::load_disabled_providers(&db, &ws.repository_id))
         .unwrap_or_default();
     let registry = state.plugins.read().await;
-    Some(
-        claudette::env_provider::resolve_with_registry(
-            &registry,
-            &state.env_cache,
-            Path::new(worktree),
-            &ws_info,
-            &disabled,
-        )
-        .await,
+    let resolved = claudette::env_provider::resolve_with_registry(
+        &registry,
+        &state.env_cache,
+        Path::new(worktree),
+        &ws_info,
+        &disabled,
     )
+    .await;
+    crate::commands::env::register_resolved_with_watcher(
+        state,
+        Path::new(worktree),
+        &resolved.sources,
+    )
+    .await;
+    Some(resolved)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -509,6 +509,13 @@ pub async fn archive_workspace(
 
     if let Some(ref wt_path) = ws.worktree_path {
         let _ = git::remove_worktree(&repo.path, wt_path, false).await;
+        // The worktree is gone — drop env-provider watches + cache
+        // for it so we don't hold stale OS watch slots or emit
+        // invalidation events for a path that no longer exists.
+        if let Some(watcher) = state.env_watcher.read().await.as_ref() {
+            watcher.unregister(Path::new(wt_path), None);
+        }
+        state.env_cache.invalidate(Path::new(wt_path), None);
     }
 
     // Optionally delete the branch if the user has enabled this setting.
@@ -622,6 +629,17 @@ pub async fn delete_workspace(
 
         // Best-effort branch delete. Force-deletes even if unmerged commits exist.
         let _ = git::branch_delete(&repo.path, &ws.branch_name).await;
+    }
+
+    // Drop any env-provider watch + cache entry rooted at this
+    // workspace's worktree. Keeps OS watch count bounded across
+    // workspace churn and prevents invalidation events for a path
+    // Claudette no longer knows about.
+    if let Some(ref wt_path) = ws.worktree_path {
+        if let Some(watcher) = state.env_watcher.read().await.as_ref() {
+            watcher.unregister(Path::new(wt_path), None);
+        }
+        state.env_cache.invalidate(Path::new(wt_path), None);
     }
 
     // Cascade deletes chat messages and terminal tabs. Materializes a frozen

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -323,6 +323,15 @@ fn main() {
             // Start background SCM polling for PR status and CI checks.
             commands::scm::start_scm_polling(app.handle().clone());
 
+            // Build the env-provider fs watcher now that the AppHandle
+            // exists. On a change: invalidate the matching cache entry
+            // and emit a Tauri event so the EnvPanel (and other
+            // subscribers) can refetch without waiting for the next
+            // spawn. If `notify` can't start (Linux inotify watch cap
+            // hit, headless CI with no kernel support, etc.) we fall
+            // back to pure lazy mtime invalidation.
+            commands::env::setup_env_watcher(app.handle().clone());
+
             Ok(())
         })
         .on_window_event(|window, event| {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -510,6 +510,7 @@ fn main() {
             commands::scm::scm_refresh,
             // Env-provider diagnostic UI
             commands::env::get_env_sources,
+            commands::env::get_env_target_worktree,
             commands::env::reload_env,
             commands::env::set_env_provider_enabled,
             commands::env::run_env_trust,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -124,6 +124,12 @@ pub async fn spawn_pty(
         )
         .await
     };
+    crate::commands::env::register_resolved_with_watcher(
+        &state,
+        std::path::Path::new(&working_dir),
+        &resolved_env.sources,
+    )
+    .await;
     for (k, v) in &resolved_env.vars {
         match v {
             Some(val) => cmd.env(k, val),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -8,7 +8,7 @@ use claudette::agent::PersistentSession;
 use parking_lot::Mutex as ParkingMutex;
 use tokio::sync::{RwLock, Semaphore};
 
-use claudette::env_provider::EnvCache;
+use claudette::env_provider::{EnvCache, EnvWatcher};
 use claudette::plugin_runtime::PluginRegistry;
 use claudette::scm::types::{CiCheck, PullRequest};
 
@@ -296,6 +296,13 @@ pub struct AppState {
     /// `(worktree, plugin_name)` pair, invalidated when any watched
     /// file (`.envrc`, `mise.toml`, `.env`, `flake.lock`, etc.) changes.
     pub env_cache: Arc<EnvCache>,
+    /// Filesystem watcher that proactively evicts `env_cache` entries
+    /// when any plugin's `watched` paths change on disk. Set at
+    /// startup from `main.rs` once the `AppHandle` is available so
+    /// the change callback can emit an `env-cache-invalidated` Tauri
+    /// event; `None` before setup finishes or if watcher construction
+    /// failed (logged, lazy mtime invalidation still covers).
+    pub env_watcher: RwLock<Option<Arc<EnvWatcher>>>,
     /// Cached PR/CI status data keyed by (repo_id, branch_name).
     pub scm_cache: ScmCache,
     /// Limits concurrent SCM CLI invocations.
@@ -330,6 +337,7 @@ impl AppState {
             usage_cache: RwLock::new(None),
             plugins: RwLock::new(plugins),
             env_cache: Arc::new(EnvCache::new()),
+            env_watcher: RwLock::new(None),
             scm_cache: ScmCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),

--- a/src/env_provider/cache.rs
+++ b/src/env_provider/cache.rs
@@ -106,6 +106,21 @@ impl EnvCache {
         true
     }
 
+    /// Return the paths this `(worktree, plugin)` entry is watching,
+    /// or an empty vec if no entry exists. Used by the fs watcher to
+    /// learn which paths to subscribe to after a fresh export —
+    /// callers shouldn't have to re-derive the list from the plugin's
+    /// return value because it may have been normalized by `put`.
+    pub fn watched_paths(&self, worktree: &Path, plugin: &str) -> Vec<PathBuf> {
+        let key = (worktree.to_path_buf(), plugin.to_string());
+        self.entries
+            .read()
+            .unwrap()
+            .get(&key)
+            .map(|entry| entry.watched.iter().map(|(p, _)| p.clone()).collect())
+            .unwrap_or_default()
+    }
+
     /// Forget the cache for `(worktree, plugin)`. If `plugin` is `None`,
     /// forget all plugins for the worktree. Used by the "Reload env" UI
     /// action and by detect=false (plugin no longer applies).

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -21,6 +21,7 @@ pub mod cache;
 #[cfg(test)]
 mod plugin_tests;
 pub mod types;
+pub mod watcher;
 
 use std::path::Path;
 use std::time::SystemTime;
@@ -33,6 +34,7 @@ use backend::EnvProviderBackend;
 pub use backend::PluginRegistryBackend;
 pub use cache::EnvCache;
 use types::EnvMap;
+pub use watcher::EnvWatcher;
 
 /// Convenience helper that wires the standard [`PluginRegistryBackend`]
 /// into [`resolve_for_workspace`] with minimal boilerplate at the call

--- a/src/env_provider/watcher.rs
+++ b/src/env_provider/watcher.rs
@@ -1,0 +1,508 @@
+//! Cross-platform filesystem watcher for env-provider reactive
+//! invalidation.
+//!
+//! The dispatcher's lazy mtime-keyed cache catches up to the filesystem
+//! *whenever someone calls `resolve_*`* — but between those calls a user
+//! might edit `.envrc`, run `direnv allow`, or change `flake.lock`, and
+//! nothing notices until the next spawn. [`EnvWatcher`] closes that gap.
+//!
+//! # How it's used
+//!
+//! 1. Callers build an `EnvWatcher` once at app startup, passing a
+//!    [`OnChange`] callback that owns the logic for invalidating the
+//!    cache and notifying the UI (typically: call
+//!    `EnvCache::invalidate` and emit a Tauri event).
+//! 2. After every successful resolve, the Tauri layer hands the fresh
+//!    watched-path list to [`EnvWatcher::register`] keyed on
+//!    `(worktree, plugin)`.
+//! 3. When any watched file changes, the `notify` backend pushes an
+//!    event onto our internal channel; a background tokio task drains
+//!    it, looks up every `(worktree, plugin)` that was subscribed to
+//!    that path, and invokes the callback once per subscriber.
+//!
+//! # Platform notes
+//!
+//! `notify::RecommendedWatcher` picks FSEvents (macOS), inotify
+//! (Linux), or ReadDirectoryChangesW (Windows) at build time — the
+//! same code compiles on all three without conditional logic here.
+//!
+//! - On macOS, FSEvents is directory-granular under the hood; `notify`
+//!   handles file-path watches by watching the parent directory and
+//!   filtering events. We benefit from that transparently.
+//! - On Linux, inotify has a per-user watch cap
+//!   (`fs.inotify.max_user_watches`, default 8192 on most distros).
+//!   We dedupe registrations by absolute path so many cache entries
+//!   watching the same `.envrc` cost one inotify watch, not N.
+//! - On Windows, `ReadDirectoryChangesW` opens a handle on the parent
+//!   directory; our per-file dedupe keeps handle counts low.
+//!
+//! # Failure modes
+//!
+//! If the OS returns an error creating or adding a watch (permission
+//! denied, too many watches, file gone between export and register),
+//! we log and swallow — the fallback is the existing mtime check on
+//! the next resolve, so invalidation is at worst lazy, never wrong.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use notify::event::{EventKind, ModifyKind, RemoveKind};
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+
+/// Identifier of a single cache entry: `(worktree_path, plugin_name)`.
+/// Mirrors `EnvCache`'s internal key but owned by the watcher side.
+type Key = (PathBuf, String);
+
+/// Callback invoked on every filesystem change that touches a watched
+/// path. Receives the matching `(worktree, plugin)` key so the caller
+/// can invalidate the cache entry and notify the frontend.
+///
+/// Must be `Send + Sync` since events fire from the watcher's
+/// background task; must be `'static` because the watcher holds it
+/// for its entire lifetime.
+pub type OnChange = Arc<dyn Fn(&Path, &str) + Send + Sync + 'static>;
+
+/// Filesystem watcher for env-provider cache invalidation.
+///
+/// Cloning via `Arc` is the intended shared-ownership pattern — each
+/// Tauri command that wants to (de)register paths holds an
+/// `Arc<EnvWatcher>`.
+pub struct EnvWatcher {
+    /// Routing state shared with the background notify task.
+    ///
+    /// Guarded by a plain `Mutex` (not tokio's) because notify fires
+    /// events on its own OS thread, not an async context.
+    state: Arc<Mutex<WatcherState>>,
+    /// Owned `RecommendedWatcher`. Kept alive for the lifetime of the
+    /// `EnvWatcher`; dropping it stops the backend thread.
+    ///
+    /// Wrapped in `Mutex` because `add`/`remove` take `&mut self` and
+    /// we may touch the watcher from multiple threads.
+    watcher: Mutex<RecommendedWatcher>,
+}
+
+/// Internal routing state. Separate struct so the notify event handler
+/// closure can `Arc<Mutex<WatcherState>>` it without also needing the
+/// `Watcher` itself.
+struct WatcherState {
+    /// path → set of `(worktree, plugin)` keys that care about it.
+    /// When an event fires on `path`, we dispatch the callback once
+    /// per key in the set.
+    subscribers: HashMap<PathBuf, HashSet<Key>>,
+    /// Reverse index: `(worktree, plugin)` → paths it currently
+    /// subscribes to. Lets unregister run in O(paths-per-key) instead
+    /// of O(total-paths).
+    key_paths: HashMap<Key, HashSet<PathBuf>>,
+    /// Callback fired for every `(worktree, plugin)` whose watch list
+    /// intersects a changed path. Stored here so the drain task can
+    /// dispatch without needing a separate channel-bound closure.
+    on_change: OnChange,
+}
+
+impl EnvWatcher {
+    /// Build a watcher. The callback fires on every detected change
+    /// to any registered path, once per `(worktree, plugin)` key that
+    /// was subscribed to it. Typical implementation:
+    ///
+    /// ```ignore
+    /// EnvWatcher::new(Arc::new(move |worktree, plugin| {
+    ///     cache.invalidate(worktree, Some(plugin));
+    ///     let _ = app_handle.emit("env-cache-invalidated",
+    ///         EnvCacheInvalidatedPayload {
+    ///             worktree_path: worktree.to_string_lossy().into(),
+    ///             plugin_name: plugin.to_string(),
+    ///         });
+    /// }))
+    /// ```
+    pub fn new(on_change: OnChange) -> notify::Result<Self> {
+        let state = Arc::new(Mutex::new(WatcherState {
+            subscribers: HashMap::new(),
+            key_paths: HashMap::new(),
+            on_change,
+        }));
+
+        let state_for_handler = Arc::clone(&state);
+        let handler = move |res: notify::Result<notify::Event>| {
+            let Ok(event) = res else {
+                // Don't crash on transient errors (e.g. macOS FSEvents
+                // buffer overflow) — the next resolve will re-stat
+                // anyway. Log at debug level; silence is fine here.
+                return;
+            };
+            if !is_interesting(&event.kind) {
+                return;
+            }
+            let state = state_for_handler.lock().unwrap();
+            let mut fired: HashSet<Key> = HashSet::new();
+            for path in &event.paths {
+                // Backends may report canonical paths (FSEvents) or
+                // the path we registered (inotify, ReadDirectoryChangesW).
+                // Try both forms so platform differences don't leak
+                // into subscriber lookup.
+                if let Some(keys) = state.subscribers.get(path) {
+                    for key in keys {
+                        fired.insert(key.clone());
+                    }
+                }
+                let canon = canonicalize_or_keep(path);
+                if canon != *path
+                    && let Some(keys) = state.subscribers.get(&canon)
+                {
+                    for key in keys {
+                        fired.insert(key.clone());
+                    }
+                }
+            }
+            if fired.is_empty() {
+                return;
+            }
+            let cb = Arc::clone(&state.on_change);
+            // Drop the lock before invoking user code so the callback
+            // is free to take state of its own (e.g. invalidate the
+            // cache, which may synchronously trigger unregister and
+            // re-acquire the lock).
+            drop(state);
+            for (worktree, plugin) in fired {
+                cb(&worktree, &plugin);
+            }
+        };
+
+        // `notify` 7 lets you pass a plain `EventFn`. The 300ms delay
+        // is a belt-and-suspenders debounce for backends that fire
+        // multiple events per save (vim swap-file dance, editors that
+        // rename-over). `Config::default().with_poll_interval(_)` only
+        // affects the polling fallback; RecommendedWatcher on our
+        // target platforms uses native APIs.
+        let config = notify::Config::default().with_poll_interval(Duration::from_millis(300));
+        let watcher = notify::recommended_watcher(handler).and_then(|mut w| {
+            w.configure(config)?;
+            Ok(w)
+        })?;
+
+        Ok(Self {
+            state,
+            watcher: Mutex::new(watcher),
+        })
+    }
+
+    /// Subscribe a `(worktree, plugin)` cache key to a list of paths.
+    ///
+    /// Idempotent — repeated calls with the same key replace the prior
+    /// path set. Previously-registered paths that are no longer in
+    /// `paths` are unwatched (if no other subscriber needs them).
+    ///
+    /// Missing files are skipped (`notify::watch` returns an error,
+    /// which we log-and-swallow). Most common on the freshly-added
+    /// repo flow where a plugin reports a `.envrc` that the user
+    /// deleted between export and register.
+    ///
+    /// Paths are canonicalized so events from backends that report
+    /// canonical forms (FSEvents on macOS resolves
+    /// `/var/folders/...` → `/private/var/folders/...`) match the
+    /// subscriber lookup. A canonicalization failure (file doesn't
+    /// exist, broken symlink) falls back to the original path — the
+    /// next resolve will re-stat via mtime and notice the change.
+    pub fn register(&self, worktree: &Path, plugin: &str, paths: &[PathBuf]) {
+        let key: Key = (worktree.to_path_buf(), plugin.to_string());
+        let new_set: HashSet<PathBuf> = paths.iter().map(|p| canonicalize_or_keep(p)).collect();
+
+        // Compute diff under lock so we know what to add vs remove.
+        let (to_add, to_remove) = {
+            let mut state = self.state.lock().unwrap();
+            let old_paths = state.key_paths.remove(&key).unwrap_or_default();
+            let to_add: Vec<PathBuf> = new_set.difference(&old_paths).cloned().collect();
+            let to_remove: Vec<PathBuf> = old_paths.difference(&new_set).cloned().collect();
+
+            // Update indices. `subscribers` gains `key` for every
+            // new-set path and loses `key` for every removed path.
+            for path in &to_remove {
+                if let Some(subs) = state.subscribers.get_mut(path) {
+                    subs.remove(&key);
+                    if subs.is_empty() {
+                        state.subscribers.remove(path);
+                    }
+                }
+            }
+            for path in &new_set {
+                state
+                    .subscribers
+                    .entry(path.clone())
+                    .or_default()
+                    .insert(key.clone());
+            }
+            state.key_paths.insert(key.clone(), new_set.clone());
+            (to_add, to_remove)
+        };
+
+        // Wrangle the OS watches outside the state lock so a slow
+        // syscall doesn't block unrelated register/unregister calls.
+        let mut watcher = self.watcher.lock().unwrap();
+        for path in &to_remove {
+            // Only unwatch if no other subscriber still needs the
+            // path. The state lock above already removed our entry;
+            // re-check under a brief lock to avoid TOCTOU where a
+            // concurrent register added a new subscriber.
+            let still_needed = self.state.lock().unwrap().subscribers.contains_key(path);
+            if !still_needed {
+                let _ = watcher.unwatch(path);
+            }
+        }
+        for path in &to_add {
+            // Individual files are supported on all three backends
+            // (notify handles macOS by watching the parent dir).
+            if let Err(err) = watcher.watch(path, RecursiveMode::NonRecursive) {
+                // Log and move on — the next resolve will re-stat the
+                // path's mtime, so invalidation still happens, just
+                // lazily. Common errors: file gone between export and
+                // register; inotify watch limit exceeded.
+                eprintln!("[env-watcher] failed to watch {}: {err}", path.display());
+            }
+        }
+    }
+
+    /// Stop tracking a cache key. Called from `EnvCache::invalidate`
+    /// hooks and on workspace deletion. Paths become un-watched only
+    /// when no other key still subscribes.
+    pub fn unregister(&self, worktree: &Path, plugin: Option<&str>) {
+        let prefix: &Path = worktree;
+        let keys_to_drop: Vec<Key> = {
+            let state = self.state.lock().unwrap();
+            state
+                .key_paths
+                .keys()
+                .filter(|(wt, p)| wt == prefix && plugin.map(|want| p == want).unwrap_or(true))
+                .cloned()
+                .collect()
+        };
+
+        for key in keys_to_drop {
+            let removed_paths = {
+                let mut state = self.state.lock().unwrap();
+                let paths = state.key_paths.remove(&key).unwrap_or_default();
+                for path in &paths {
+                    if let Some(subs) = state.subscribers.get_mut(path) {
+                        subs.remove(&key);
+                        if subs.is_empty() {
+                            state.subscribers.remove(path);
+                        }
+                    }
+                }
+                paths
+            };
+            let mut watcher = self.watcher.lock().unwrap();
+            for path in &removed_paths {
+                let still_needed = self.state.lock().unwrap().subscribers.contains_key(path);
+                if !still_needed {
+                    let _ = watcher.unwatch(path);
+                }
+            }
+        }
+    }
+
+    /// Test-only introspection: number of unique paths currently
+    /// watched across all keys.
+    #[cfg(test)]
+    pub fn watched_path_count(&self) -> usize {
+        self.state.lock().unwrap().subscribers.len()
+    }
+
+    /// Test-only introspection: number of registered cache keys.
+    #[cfg(test)]
+    pub fn registered_key_count(&self) -> usize {
+        self.state.lock().unwrap().key_paths.len()
+    }
+}
+
+/// Resolve symlinks so registration and event paths line up. Returns
+/// the original path on failure (broken symlink, file gone) — that
+/// way tests that register a not-yet-created file still record the
+/// key, and the per-resolve mtime check will catch the change when
+/// the file later appears.
+fn canonicalize_or_keep(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// True when the event kind should propagate to the callback. We
+/// ignore pure-access events (reads, opens, metadata-only changes
+/// that don't alter content) to cut callback noise — the dispatcher
+/// re-stats mtimes on resolve, so access events would trigger a
+/// useless invalidation.
+fn is_interesting(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_)
+            | EventKind::Modify(ModifyKind::Data(_))
+            | EventKind::Modify(ModifyKind::Name(_))
+            | EventKind::Modify(ModifyKind::Any)
+            | EventKind::Remove(RemoveKind::File)
+            | EventKind::Remove(RemoveKind::Folder)
+            | EventKind::Remove(RemoveKind::Any)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    /// Poll `predicate` up to `timeout`, returning whether it became
+    /// true. Filesystem events are inherently async; tests need to
+    /// wait a bounded time rather than racing the backend thread.
+    fn wait_for(timeout: Duration, predicate: impl Fn() -> bool) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if predicate() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        predicate()
+    }
+
+    #[test]
+    fn register_then_modify_fires_callback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "use flake").unwrap();
+
+        let hits: Arc<Mutex<Vec<(PathBuf, String)>>> = Arc::new(Mutex::new(Vec::new()));
+        let hits_cb = Arc::clone(&hits);
+        let watcher = EnvWatcher::new(Arc::new(move |wt, p| {
+            hits_cb
+                .lock()
+                .unwrap()
+                .push((wt.to_path_buf(), p.to_string()));
+        }))
+        .unwrap();
+
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&file));
+
+        // Force a distinguishable mtime — some filesystems otherwise
+        // coalesce the write and the event fires inconsistently.
+        std::thread::sleep(Duration::from_millis(50));
+        std::fs::write(&file, "use flake\nexport FOO=bar").unwrap();
+
+        assert!(
+            wait_for(Duration::from_secs(3), || !hits.lock().unwrap().is_empty()),
+            "callback did not fire within 3s"
+        );
+        let observed = hits.lock().unwrap().clone();
+        assert!(
+            observed
+                .iter()
+                .any(|(wt, p)| wt == tmp.path() && p == "env-direnv"),
+            "expected (worktree, env-direnv) hit in {observed:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_keys_on_same_path_both_fire() {
+        // Two plugins (direnv + another) watching the same .envrc
+        // should both get notified on a single write.
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "x").unwrap();
+
+        let hits: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let hits_cb = Arc::clone(&hits);
+        let watcher = EnvWatcher::new(Arc::new(move |_wt, p| {
+            hits_cb.lock().unwrap().insert(p.to_string());
+        }))
+        .unwrap();
+
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&file));
+        watcher.register(tmp.path(), "env-mise", std::slice::from_ref(&file));
+        // Dedupe check: same path → one OS watch.
+        assert_eq!(watcher.watched_path_count(), 1);
+        assert_eq!(watcher.registered_key_count(), 2);
+
+        std::thread::sleep(Duration::from_millis(50));
+        std::fs::write(&file, "y").unwrap();
+
+        assert!(wait_for(Duration::from_secs(3), || {
+            let h = hits.lock().unwrap();
+            h.contains("env-direnv") && h.contains("env-mise")
+        }));
+    }
+
+    #[test]
+    fn unregister_stops_callback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join(".envrc");
+        std::fs::write(&file, "x").unwrap();
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_cb = Arc::clone(&hits);
+        let watcher = EnvWatcher::new(Arc::new(move |_wt, _p| {
+            hits_cb.fetch_add(1, Ordering::SeqCst);
+        }))
+        .unwrap();
+
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&file));
+        watcher.unregister(tmp.path(), Some("env-direnv"));
+
+        assert_eq!(watcher.watched_path_count(), 0);
+        assert_eq!(watcher.registered_key_count(), 0);
+
+        std::fs::write(&file, "y").unwrap();
+
+        // Give the backend time to maybe fire (it shouldn't). 500ms is
+        // enough to flush buffered events on all three platforms.
+        std::thread::sleep(Duration::from_millis(500));
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn re_register_replaces_path_set() {
+        // Plugin's second export watches a different file (user
+        // deleted .envrc, added .env instead). Old path should drop.
+        let tmp = tempfile::tempdir().unwrap();
+        let envrc = tmp.path().join(".envrc");
+        let dotenv = tmp.path().join(".env");
+        std::fs::write(&envrc, "x").unwrap();
+        std::fs::write(&dotenv, "y").unwrap();
+
+        let watcher = EnvWatcher::new(Arc::new(|_, _| {})).unwrap();
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&envrc));
+        assert_eq!(watcher.watched_path_count(), 1);
+
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&dotenv));
+        // Old path dropped, new path added.
+        assert_eq!(watcher.watched_path_count(), 1);
+        assert_eq!(watcher.registered_key_count(), 1);
+    }
+
+    #[test]
+    fn unregister_all_plugins_for_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f1 = tmp.path().join(".envrc");
+        let f2 = tmp.path().join("mise.toml");
+        std::fs::write(&f1, "x").unwrap();
+        std::fs::write(&f2, "x").unwrap();
+
+        let watcher = EnvWatcher::new(Arc::new(|_, _| {})).unwrap();
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&f1));
+        watcher.register(tmp.path(), "env-mise", std::slice::from_ref(&f2));
+        assert_eq!(watcher.registered_key_count(), 2);
+
+        watcher.unregister(tmp.path(), None);
+        assert_eq!(watcher.registered_key_count(), 0);
+        assert_eq!(watcher.watched_path_count(), 0);
+    }
+
+    #[test]
+    fn missing_path_does_not_crash_register() {
+        let tmp = tempfile::tempdir().unwrap();
+        let never_created = tmp.path().join("no-such-file");
+
+        // Must not panic even though the file doesn't exist.
+        let watcher = EnvWatcher::new(Arc::new(|_, _| {})).unwrap();
+        watcher.register(tmp.path(), "env-direnv", &[never_created]);
+        // The key is still tracked — we just logged the watch failure.
+        // That way a later register with an existing path still works.
+        assert_eq!(watcher.registered_key_count(), 1);
+    }
+}

--- a/src/env_provider/watcher.rs
+++ b/src/env_provider/watcher.rs
@@ -276,11 +276,17 @@ impl EnvWatcher {
                     self.state.lock().unwrap().os_watched.insert(path.clone());
                 }
                 Err(err) => {
-                    // Log and move on — the next register retries.
-                    // The per-resolve mtime check in EnvCache::get_fresh
-                    // also catches changes regardless, so invalidation
-                    // is at worst lazy until the watch succeeds.
-                    eprintln!("[env-watcher] failed to watch {}: {err}", path.display());
+                    // Silently skip the "file doesn't exist" case —
+                    // common with transient paths (e.g. a file deleted
+                    // between the plugin's export and our register
+                    // call) and not actionable. The per-resolve mtime
+                    // check in `EnvCache::get_fresh` still catches any
+                    // later change, and every subsequent register
+                    // retries via the `os_watched` diff. Louder errors
+                    // (permission denied, inotify limit) still print.
+                    if !is_path_not_found(&err) {
+                        eprintln!("[env-watcher] failed to watch {}: {err}", path.display());
+                    }
                 }
             }
         }
@@ -337,6 +343,21 @@ impl EnvWatcher {
     #[cfg(test)]
     pub fn registered_key_count(&self) -> usize {
         self.state.lock().unwrap().key_paths.len()
+    }
+}
+
+/// Classify a `notify::Error` as a "path doesn't exist" failure we
+/// can reasonably ignore. Both `Io(NotFound)` from backends like
+/// inotify/ReadDirectoryChangesW AND the platform-agnostic
+/// `PathNotFound` variant that `notify` emits when it pre-checks the
+/// path itself surface here — covers the macOS FSEvents and
+/// inotify/Windows cases under a single check.
+fn is_path_not_found(err: &notify::Error) -> bool {
+    use notify::ErrorKind;
+    match &err.kind {
+        ErrorKind::PathNotFound => true,
+        ErrorKind::Io(io) => io.kind() == std::io::ErrorKind::NotFound,
+        _ => false,
     }
 }
 

--- a/src/env_provider/watcher.rs
+++ b/src/env_provider/watcher.rs
@@ -145,22 +145,28 @@ impl EnvWatcher {
             if !is_interesting(&event.kind) {
                 return;
             }
+            // Collect lookup keys BEFORE taking the state lock.
+            // `canonicalize_or_keep` does a `stat` syscall, and
+            // holding the routing lock across it would block
+            // concurrent register/unregister (which takes the same
+            // lock). Each event path contributes at most two
+            // variants: the raw path as reported by the backend,
+            // and its canonical form. Backends may report either
+            // form — FSEvents emits canonical paths, inotify and
+            // ReadDirectoryChangesW emit whatever we registered.
+            let mut lookup_paths: Vec<PathBuf> = Vec::with_capacity(event.paths.len() * 2);
+            for path in &event.paths {
+                lookup_paths.push(path.clone());
+                let canon = canonicalize_or_keep(path);
+                if canon != *path {
+                    lookup_paths.push(canon);
+                }
+            }
+
             let state = state_for_handler.lock().unwrap();
             let mut fired: HashSet<Key> = HashSet::new();
-            for path in &event.paths {
-                // Backends may report canonical paths (FSEvents) or
-                // the path we registered (inotify, ReadDirectoryChangesW).
-                // Try both forms so platform differences don't leak
-                // into subscriber lookup.
+            for path in &lookup_paths {
                 if let Some(keys) = state.subscribers.get(path) {
-                    for key in keys {
-                        fired.insert(key.clone());
-                    }
-                }
-                let canon = canonicalize_or_keep(path);
-                if canon != *path
-                    && let Some(keys) = state.subscribers.get(&canon)
-                {
                     for key in keys {
                         fired.insert(key.clone());
                     }
@@ -180,12 +186,15 @@ impl EnvWatcher {
             }
         };
 
-        // `notify` 7 lets you pass a plain `EventFn`. The 300ms delay
-        // is a belt-and-suspenders debounce for backends that fire
-        // multiple events per save (vim swap-file dance, editors that
-        // rename-over). `Config::default().with_poll_interval(_)` only
-        // affects the polling fallback; RecommendedWatcher on our
-        // target platforms uses native APIs.
+        // `notify` 7 lets you pass a plain `EventFn`. `poll_interval`
+        // here ONLY applies to the polling fallback watcher — on our
+        // target platforms `RecommendedWatcher` selects FSEvents /
+        // inotify / ReadDirectoryChangesW and the poll interval is
+        // unused. Native backends may still emit multiple events per
+        // save (editor save-swap-rename dance); we dedupe subscriber
+        // keys within a single event via the `fired: HashSet<Key>`
+        // above, and the downstream EnvPanel listener debounces
+        // bursts at 300ms before refetching.
         let config = notify::Config::default().with_poll_interval(Duration::from_millis(300));
         let watcher = notify::recommended_watcher(handler).and_then(|mut w| {
             w.configure(config)?;

--- a/src/env_provider/watcher.rs
+++ b/src/env_provider/watcher.rs
@@ -95,6 +95,16 @@ struct WatcherState {
     /// subscribes to. Lets unregister run in O(paths-per-key) instead
     /// of O(total-paths).
     key_paths: HashMap<Key, HashSet<PathBuf>>,
+    /// Set of paths we've successfully installed an OS watch for.
+    /// Kept separate from `subscribers` because a path can be
+    /// subscribed (we know some key cares about it) without being
+    /// OS-watched (initial `notify::watch` returned an error — e.g.
+    /// file missing, inotify limit). Each `register` retries any
+    /// subscribed path that isn't in this set, so a later write
+    /// (e.g. `.envrc.local` created after first export) starts
+    /// participating in reactive invalidation without an app
+    /// restart.
+    os_watched: HashSet<PathBuf>,
     /// Callback fired for every `(worktree, plugin)` whose watch list
     /// intersects a changed path. Stored here so the drain task can
     /// dispatch without needing a separate channel-bound closure.
@@ -120,6 +130,7 @@ impl EnvWatcher {
         let state = Arc::new(Mutex::new(WatcherState {
             subscribers: HashMap::new(),
             key_paths: HashMap::new(),
+            os_watched: HashSet::new(),
             on_change,
         }));
 
@@ -208,15 +219,19 @@ impl EnvWatcher {
         let key: Key = (worktree.to_path_buf(), plugin.to_string());
         let new_set: HashSet<PathBuf> = paths.iter().map(|p| canonicalize_or_keep(p)).collect();
 
-        // Compute diff under lock so we know what to add vs remove.
-        let (to_add, to_remove) = {
+        // Compute:
+        // - `to_try_watch`: paths in new_set that aren't yet
+        //   OS-watched. Every register pass retries these, so a file
+        //   that was missing at first registration (inotify limit,
+        //   file deleted then recreated) gets picked up the moment
+        //   it becomes watchable.
+        // - `to_remove`: paths the previous registration for this key
+        //   subscribed to that the new registration doesn't want.
+        let (to_try_watch, to_remove) = {
             let mut state = self.state.lock().unwrap();
             let old_paths = state.key_paths.remove(&key).unwrap_or_default();
-            let to_add: Vec<PathBuf> = new_set.difference(&old_paths).cloned().collect();
             let to_remove: Vec<PathBuf> = old_paths.difference(&new_set).cloned().collect();
 
-            // Update indices. `subscribers` gains `key` for every
-            // new-set path and loses `key` for every removed path.
             for path in &to_remove {
                 if let Some(subs) = state.subscribers.get_mut(path) {
                     subs.remove(&key);
@@ -233,31 +248,40 @@ impl EnvWatcher {
                     .insert(key.clone());
             }
             state.key_paths.insert(key.clone(), new_set.clone());
-            (to_add, to_remove)
+
+            // Retry any subscribed path we don't have a live OS watch
+            // on. Read-only snapshot; the state lock releases before
+            // we hit the OS syscalls below.
+            let to_try_watch: Vec<PathBuf> = new_set
+                .iter()
+                .filter(|p| !state.os_watched.contains(*p))
+                .cloned()
+                .collect();
+            (to_try_watch, to_remove)
         };
 
-        // Wrangle the OS watches outside the state lock so a slow
-        // syscall doesn't block unrelated register/unregister calls.
+        // OS syscalls outside the state lock so a slow syscall doesn't
+        // block unrelated register/unregister calls.
         let mut watcher = self.watcher.lock().unwrap();
         for path in &to_remove {
-            // Only unwatch if no other subscriber still needs the
-            // path. The state lock above already removed our entry;
-            // re-check under a brief lock to avoid TOCTOU where a
-            // concurrent register added a new subscriber.
             let still_needed = self.state.lock().unwrap().subscribers.contains_key(path);
             if !still_needed {
                 let _ = watcher.unwatch(path);
+                self.state.lock().unwrap().os_watched.remove(path);
             }
         }
-        for path in &to_add {
-            // Individual files are supported on all three backends
-            // (notify handles macOS by watching the parent dir).
-            if let Err(err) = watcher.watch(path, RecursiveMode::NonRecursive) {
-                // Log and move on — the next resolve will re-stat the
-                // path's mtime, so invalidation still happens, just
-                // lazily. Common errors: file gone between export and
-                // register; inotify watch limit exceeded.
-                eprintln!("[env-watcher] failed to watch {}: {err}", path.display());
+        for path in &to_try_watch {
+            match watcher.watch(path, RecursiveMode::NonRecursive) {
+                Ok(()) => {
+                    self.state.lock().unwrap().os_watched.insert(path.clone());
+                }
+                Err(err) => {
+                    // Log and move on — the next register retries.
+                    // The per-resolve mtime check in EnvCache::get_fresh
+                    // also catches changes regardless, so invalidation
+                    // is at worst lazy until the watch succeeds.
+                    eprintln!("[env-watcher] failed to watch {}: {err}", path.display());
+                }
             }
         }
     }
@@ -296,6 +320,7 @@ impl EnvWatcher {
                 let still_needed = self.state.lock().unwrap().subscribers.contains_key(path);
                 if !still_needed {
                     let _ = watcher.unwatch(path);
+                    self.state.lock().unwrap().os_watched.remove(path);
                 }
             }
         }
@@ -500,9 +525,52 @@ mod tests {
 
         // Must not panic even though the file doesn't exist.
         let watcher = EnvWatcher::new(Arc::new(|_, _| {})).unwrap();
-        watcher.register(tmp.path(), "env-direnv", &[never_created]);
+        watcher.register(
+            tmp.path(),
+            "env-direnv",
+            std::slice::from_ref(&never_created),
+        );
         // The key is still tracked — we just logged the watch failure.
         // That way a later register with an existing path still works.
         assert_eq!(watcher.registered_key_count(), 1);
+    }
+
+    #[test]
+    fn watch_retry_picks_up_later_created_file() {
+        // Regression for the Codex P2: if watch() fails the first
+        // time (file missing), the watcher should retry on the next
+        // register with the same path set — not record it as
+        // "installed" and silently skip it forever.
+        let tmp = tempfile::tempdir().unwrap();
+        let delayed = tmp.path().join("delayed.envrc");
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_cb = Arc::clone(&hits);
+        let watcher = EnvWatcher::new(Arc::new(move |_wt, _p| {
+            hits_cb.fetch_add(1, Ordering::SeqCst);
+        }))
+        .unwrap();
+
+        // First register: file doesn't exist yet → notify::watch()
+        // fails, path recorded as subscribed but not OS-watched.
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&delayed));
+
+        // User (or plugin) creates the file.
+        std::fs::write(&delayed, "use flake").unwrap();
+
+        // Second register with the same watch set: must retry the
+        // watch install (not short-circuit on "already in key_paths").
+        watcher.register(tmp.path(), "env-direnv", std::slice::from_ref(&delayed));
+
+        // Trigger a change; event should fire now.
+        std::thread::sleep(Duration::from_millis(50));
+        std::fs::write(&delayed, "use flake\nexport BAR=baz").unwrap();
+
+        assert!(
+            wait_for(Duration::from_secs(3), || {
+                hits.load(Ordering::SeqCst) > 0
+            }),
+            "retry-installed watch did not fire"
+        );
     }
 }

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -932,6 +932,45 @@ mod tests {
     }
 
     #[test]
+    fn decode_direnv_watches_via_lua_filters_nonexistent() {
+        // End-to-end guard — a plugin calling host.direnv_decode_watches
+        // with a DIRENV_WATCHES payload containing a mix of
+        // exists:true / exists:false entries must only see the
+        // existing ones. This is the exact shape direnv emits for
+        // .envrc + allow + deny paths on macOS.
+        use base64::Engine as _;
+        use flate2::Compression;
+        use flate2::write::ZlibEncoder;
+        use std::io::Write as _;
+
+        let entries = serde_json::json!([
+            { "path": "/repo/.envrc", "modtime": 10, "exists": true },
+            { "path": "/u/.local/share/direnv/allow/abc", "modtime": 20, "exists": true },
+            { "path": "/u/.local/share/direnv/deny/def", "modtime": 0, "exists": false },
+        ]);
+        let json = serde_json::to_string(&entries).unwrap();
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(json.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed);
+
+        let ctx = make_test_ctx();
+        let lua = create_lua_vm(ctx).unwrap();
+        let script = format!(r#"return host.direnv_decode_watches("{encoded}")"#);
+        let table: mlua::Table = lua.load(&script).eval().unwrap();
+        assert_eq!(
+            table.len().unwrap(),
+            2,
+            "exists=false entry must be filtered at the Lua boundary"
+        );
+        assert_eq!(table.get::<String>(1).unwrap(), "/repo/.envrc");
+        assert_eq!(
+            table.get::<String>(2).unwrap(),
+            "/u/.local/share/direnv/allow/abc"
+        );
+    }
+
+    #[test]
     fn decode_direnv_watches_tolerates_missing_exists_field() {
         // Legacy direnv output predating the exists marker — include
         // everything rather than silently dropping the whole list.

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -300,8 +300,24 @@ fn decode_direnv_watches(encoded: &str) -> Vec<String> {
     let Some(array) = parsed.as_array() else {
         return Vec::new();
     };
+    // direnv's watch list includes transient paths that may not exist
+    // yet (notably the `~/.local/share/direnv/deny/<sha>` hash that
+    // only appears if the user runs `direnv deny` later). Each entry
+    // carries an `exists: bool` marker — filter to paths that
+    // currently exist so we don't ask `notify::watch` to subscribe to
+    // a missing file on every resolve (which fails noisily and
+    // accomplishes nothing: the per-resolve mtime check still catches
+    // those paths, and if the file later appears the plugin re-emits
+    // its list from a fresh `direnv export` and the watcher picks it
+    // up then).
     array
         .iter()
+        .filter(|entry| match entry.get("exists") {
+            Some(serde_json::Value::Bool(b)) => *b,
+            // Entries without an `exists` marker are legacy direnv
+            // output — fall back to the old behavior (include it).
+            _ => true,
+        })
         .filter_map(|entry| entry.get("path")?.as_str().map(str::to_owned))
         .collect()
 }
@@ -881,6 +897,61 @@ mod tests {
                 "/repo/secret.env".to_string(),
                 "/home/u/.config/foo".to_string(),
             ],
+        );
+    }
+
+    #[test]
+    fn decode_direnv_watches_skips_nonexistent_entries() {
+        // Regression for the dev-log spam finding: direnv includes
+        // deny-cache hash paths in DIRENV_WATCHES with `exists: false`.
+        // Those files don't exist yet, so `notify::watch` fails on them
+        // every resolve. Filter them out at decode time so we never
+        // even try.
+        use base64::Engine as _;
+        use flate2::Compression;
+        use flate2::write::ZlibEncoder;
+        use std::io::Write as _;
+
+        let entries = serde_json::json!([
+            { "path": "/repo/.envrc", "modtime": 10, "exists": true },
+            { "path": "/home/u/.local/share/direnv/deny/abc", "modtime": 0, "exists": false },
+            { "path": "/repo/secret.env", "modtime": 20, "exists": true },
+        ]);
+        let json = serde_json::to_string(&entries).unwrap();
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(json.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed);
+
+        let decoded = decode_direnv_watches(&encoded);
+        assert_eq!(
+            decoded,
+            vec!["/repo/.envrc".to_string(), "/repo/secret.env".to_string()],
+            "non-existent entries must be filtered"
+        );
+    }
+
+    #[test]
+    fn decode_direnv_watches_tolerates_missing_exists_field() {
+        // Legacy direnv output predating the exists marker — include
+        // everything rather than silently dropping the whole list.
+        use base64::Engine as _;
+        use flate2::Compression;
+        use flate2::write::ZlibEncoder;
+        use std::io::Write as _;
+
+        let entries = serde_json::json!([
+            { "path": "/repo/.envrc", "modtime": 10 },
+        ]);
+        let json = serde_json::to_string(&entries).unwrap();
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(json.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed);
+
+        assert_eq!(
+            decode_direnv_watches(&encoded),
+            vec!["/repo/.envrc".to_string()]
         );
     }
 

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -315,6 +315,22 @@ mod tests {
         // Version file should contain the app version
         let version = std::fs::read_to_string(plugin_dir.join("github/.version")).unwrap();
         assert_eq!(version, APP_VERSION);
+
+        // Every fresh seed must stamp `.content_hash` — without it,
+        // future drift detection in `seed_bundled_plugins` couldn't
+        // distinguish "we wrote this" from "user customized".
+        let hash_path = plugin_dir.join("github/.content_hash");
+        assert!(hash_path.exists(), "first-run must stamp content hash");
+        let bundled_github_init = BUNDLED_PLUGINS
+            .iter()
+            .find(|(n, _, _)| *n == "github")
+            .map(|(_, _, lua)| *lua)
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&hash_path).unwrap().trim(),
+            sha256_hex(bundled_github_init),
+            "content hash stamp must match bundled content"
+        );
     }
 
     #[test]

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -101,10 +101,15 @@ pub fn seed_bundled_plugins(plugin_dir: &Path) -> Vec<String> {
         let on_disk_hash = sha256_hex(&on_disk);
         let bundled_hash = sha256_hex(init_lua);
 
-        // Already matches bundle → nothing to do. Refresh the
-        // `.content_hash` stamp in case this is a legacy install
-        // that matches the bundle but has no stamp yet, so future
-        // drift detection works.
+        // Init.lua matches bundle → no code change needed. But the
+        // manifest (`plugin.json`) can drift independently of the
+        // Lua body — new `operations`, an updated settings schema,
+        // a renamed `display_name`. Refresh the manifest (and the
+        // `.version` stamp) so `PluginRegistry::discover` always
+        // sees current metadata even when the code body is stable.
+        //
+        // Also top up `.content_hash` for legacy installs that
+        // predate hash stamping, so future drift detection works.
         if on_disk_hash == bundled_hash {
             if !hash_file.exists()
                 && let Err(e) = std::fs::write(&hash_file, &bundled_hash)
@@ -112,6 +117,18 @@ pub fn seed_bundled_plugins(plugin_dir: &Path) -> Vec<String> {
                 warnings.push(format!(
                     "Plugin '{name}': failed to write content hash stamp: {e}"
                 ));
+            }
+            if let Err(e) = refresh_manifest_if_changed(&manifest_file, plugin_json) {
+                warnings.push(format!("Plugin '{name}': manifest refresh failed: {e}"));
+            }
+            let current_version = std::fs::read_to_string(&version_file)
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if current_version != APP_VERSION
+                && let Err(e) = std::fs::write(&version_file, APP_VERSION)
+            {
+                warnings.push(format!("Plugin '{name}': .version refresh failed: {e}"));
             }
             continue;
         }
@@ -254,6 +271,19 @@ pub fn reseed_bundled_plugins_force(plugin_dir: &Path) -> Vec<String> {
     warnings
 }
 
+/// Rewrite `manifest_path` only when its on-disk bytes don't already
+/// match `bundled_content`. Avoids pointless mtime bumps for the
+/// common case where the manifest is already current, and keeps the
+/// "only update if we need to" contract for the case-2 refresh path
+/// (init.lua unchanged, manifest may have drifted).
+fn refresh_manifest_if_changed(manifest_path: &Path, bundled_content: &str) -> std::io::Result<()> {
+    let on_disk = std::fs::read_to_string(manifest_path).unwrap_or_default();
+    if on_disk == bundled_content {
+        return Ok(());
+    }
+    std::fs::write(manifest_path, bundled_content)
+}
+
 fn write_plugin_files(
     manifest_path: &Path,
     manifest_content: &str,
@@ -354,6 +384,40 @@ mod tests {
             mtime_before, mtime_after,
             "matching content must not trigger a rewrite"
         );
+    }
+
+    #[test]
+    fn seed_refreshes_manifest_when_init_lua_unchanged() {
+        // Regression for a Codex finding: the "init.lua matches
+        // bundle → no-op" path used to skip plugin.json refresh too.
+        // If a release bumps manifest metadata (new operations, new
+        // settings schema) without changing the Lua body, users
+        // would keep seeing stale manifests until they forced a
+        // reseed. Exercise: on-disk init.lua matches bundle; on-disk
+        // manifest is stale. Expect the manifest to get rewritten.
+        let dir = tempfile::tempdir().unwrap();
+        seed_bundled_plugins(dir.path());
+
+        let manifest_path = dir.path().join("github/plugin.json");
+        let stale_manifest = r#"{"name":"github","version":"0.0.0","stale":true}"#;
+        std::fs::write(&manifest_path, stale_manifest).unwrap();
+
+        let warnings = seed_bundled_plugins(dir.path());
+        let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
+        assert!(
+            github_warnings.is_empty(),
+            "manifest refresh must not warn: {github_warnings:?}"
+        );
+
+        let on_disk = std::fs::read_to_string(&manifest_path).unwrap();
+        assert_ne!(on_disk, stale_manifest, "stale manifest must be replaced");
+        // Should match the bundled manifest content.
+        let bundled = BUNDLED_PLUGINS
+            .iter()
+            .find(|(n, _, _)| *n == "github")
+            .map(|(_, pjson, _)| *pjson)
+            .unwrap();
+        assert_eq!(on_disk, bundled);
     }
 
     #[test]

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -39,12 +39,32 @@ const BUNDLED_PLUGINS: &[(&str, &str, &str)] = &[
 /// The current app version, used for the .version sentinel file.
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Seed bundled plugins into the plugin directory.
+/// Seed bundled plugins into the plugin directory on app startup.
 ///
-/// For each built-in plugin:
-/// - If not present: write all files + `.version`
-/// - If present but outdated: overwrite only if user hasn't modified `init.lua`
-/// - If present and current: do nothing
+/// Content-hash driven: the `.version` file used to gate this path,
+/// but that only fires when `APP_VERSION` bumps. Plugin content often
+/// changes between releases too — a plugin `init.lua` edit merged
+/// mid-cycle wouldn't reach users until the next version bump. That
+/// left real users stuck with stale plugins (seen concretely when
+/// PR #415 added `host.direnv_decode_watches` under the same app
+/// version — seed skipped, the new Lua code never reached disk).
+///
+/// The decision tree is now content-based:
+///
+/// 1. No `init.lua` on disk (fresh install) → write everything.
+/// 2. On-disk hash == bundled hash → nothing to do.
+/// 3. On-disk hash != bundled hash AND `.content_hash` stamp matches
+///    the on-disk content → we own this file, the bundle moved;
+///    overwrite.
+/// 4. On-disk hash != bundled hash AND the stamp is missing or
+///    disagrees with on-disk content → the user modified it after
+///    our last write; preserve with a warning so they know why an
+///    update didn't land. The "Reload bundled plugins" button
+///    (`reseed_bundled_plugins_force`) lets them force it.
+///
+/// `APP_VERSION` is still stamped into `.version` for diagnostics
+/// (it answers "which Claudette last touched this?") but is no
+/// longer load-bearing for the update decision.
 pub fn seed_bundled_plugins(plugin_dir: &Path) -> Vec<String> {
     let mut warnings = Vec::new();
 
@@ -53,16 +73,18 @@ pub fn seed_bundled_plugins(plugin_dir: &Path) -> Vec<String> {
         let version_file = dir.join(".version");
         let init_file = dir.join("init.lua");
         let manifest_file = dir.join("plugin.json");
+        let hash_file = dir.join(".content_hash");
 
-        if !version_file.exists() {
-            // First run: seed everything
-            if let Err(e) = std::fs::create_dir_all(&dir) {
-                warnings.push(format!(
-                    "Failed to create plugin dir {}: {e}",
-                    dir.display()
-                ));
-                continue;
-            }
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            warnings.push(format!(
+                "Failed to create plugin dir {}: {e}",
+                dir.display()
+            ));
+            continue;
+        }
+
+        // First-run path: nothing to preserve, write it all.
+        if !init_file.exists() {
             if let Err(e) = write_plugin_files(
                 &manifest_file,
                 plugin_json,
@@ -75,32 +97,54 @@ pub fn seed_bundled_plugins(plugin_dir: &Path) -> Vec<String> {
             continue;
         }
 
-        // Check if the plugin needs updating
-        let existing_version = std::fs::read_to_string(&version_file).unwrap_or_default();
-        let existing_version = existing_version.trim();
+        let on_disk = std::fs::read_to_string(&init_file).unwrap_or_default();
+        let on_disk_hash = sha256_hex(&on_disk);
+        let bundled_hash = sha256_hex(init_lua);
 
-        if !version_is_older(existing_version, APP_VERSION) {
-            // Plugin is current or newer — skip
+        // Already matches bundle → nothing to do. Refresh the
+        // `.content_hash` stamp in case this is a legacy install
+        // that matches the bundle but has no stamp yet, so future
+        // drift detection works.
+        if on_disk_hash == bundled_hash {
+            if !hash_file.exists()
+                && let Err(e) = std::fs::write(&hash_file, &bundled_hash)
+            {
+                warnings.push(format!(
+                    "Plugin '{name}': failed to write content hash stamp: {e}"
+                ));
+            }
             continue;
         }
 
-        // Version is older — check if user has modified init.lua
-        if init_file.exists() {
-            let on_disk = std::fs::read_to_string(&init_file).unwrap_or_default();
-            let embedded_hash = sha256_hex(init_lua);
-            let disk_hash = sha256_hex(&on_disk);
+        // Differs from the bundle — is this our prior write or a
+        // user customization?
+        let stamped = std::fs::read_to_string(&hash_file)
+            .ok()
+            .map(|s| s.trim().to_string());
+        let user_modified = match stamped {
+            // We stamped this, and the content still matches our
+            // stamp → the bundle moved while the user's copy
+            // stayed put; safe to overwrite.
+            Some(h) if h == on_disk_hash => false,
+            // Stamp disagrees with on-disk content → user edited
+            // after we wrote. Preserve.
+            Some(_) => true,
+            // Legacy install from before `.content_hash` existed.
+            // We can't tell for sure; err on the side of
+            // preserving. User can hit "Reload bundled plugins"
+            // in the UI (or delete the dir) if they want the
+            // bundled version.
+            None => true,
+        };
 
-            if embedded_hash != disk_hash {
-                warnings.push(format!(
-                    "Plugin '{name}' has user modifications — skipping update. \
-                     Delete {} to force update.",
-                    version_file.display()
-                ));
-                continue;
-            }
+        if user_modified {
+            warnings.push(format!(
+                "Plugin '{name}' has user modifications — skipping update. \
+                 Use 'Reload bundled plugins' in Settings to force."
+            ));
+            continue;
         }
 
-        // Unmodified — safe to overwrite
         if let Err(e) = write_plugin_files(
             &manifest_file,
             plugin_json,
@@ -236,32 +280,9 @@ fn sha256_hex(content: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-/// Simple semver comparison: returns true if `existing` < `target`.
-/// Only compares major.minor.patch numeric components.
-fn version_is_older(existing: &str, target: &str) -> bool {
-    let parse = |v: &str| -> (u32, u32, u32) {
-        let parts: Vec<&str> = v.split('.').collect();
-        let major = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
-        let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
-        let patch = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
-        (major, minor, patch)
-    };
-    parse(existing) < parse(target)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_version_comparison() {
-        assert!(version_is_older("0.8.0", "0.9.0"));
-        assert!(version_is_older("0.9.0", "0.10.0"));
-        assert!(version_is_older("0.9.0", "1.0.0"));
-        assert!(!version_is_older("0.9.0", "0.9.0"));
-        assert!(!version_is_older("1.0.0", "0.9.0"));
-        assert!(!version_is_older("0.10.0", "0.9.0"));
-    }
 
     #[test]
     fn test_sha256_hex() {
@@ -297,68 +318,145 @@ mod tests {
     }
 
     #[test]
-    fn test_seed_skips_current_version() {
+    fn seed_is_noop_when_content_matches_bundle() {
+        // After a successful first-run seed, running seed again on
+        // an unchanged tree should do nothing — no warnings, no
+        // writes.
         let dir = tempfile::tempdir().unwrap();
-        let plugin_dir = dir.path();
+        seed_bundled_plugins(dir.path());
 
-        // Seed once
-        seed_bundled_plugins(plugin_dir);
+        // Capture the initial mtime of github/init.lua so a
+        // redundant overwrite would be observable.
+        let init_path = dir.path().join("github/init.lua");
+        let mtime_before = std::fs::metadata(&init_path).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
 
-        // Modify init.lua
-        let init_path = plugin_dir.join("github/init.lua");
-        std::fs::write(&init_path, "-- user modified").unwrap();
-
-        // Seed again — should skip because version matches
-        let warnings = seed_bundled_plugins(plugin_dir);
-        assert!(warnings.is_empty());
-
-        // User modifications should be preserved
-        let content = std::fs::read_to_string(&init_path).unwrap();
-        assert_eq!(content, "-- user modified");
+        let warnings = seed_bundled_plugins(dir.path());
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+        let mtime_after = std::fs::metadata(&init_path).unwrap().modified().unwrap();
+        assert_eq!(
+            mtime_before, mtime_after,
+            "matching content must not trigger a rewrite"
+        );
     }
 
     #[test]
-    fn test_seed_preserves_user_modifications_on_upgrade() {
+    fn seed_auto_updates_when_bundle_content_changes() {
+        // The regression this fix exists to prevent: a stale seed
+        // lingers on disk after a bundled plugin update because the
+        // version-gated path skipped (APP_VERSION didn't bump).
+        //
+        // Simulate: Claudette previously seeded an older init.lua
+        // with the SAME app version, then a new release ships new
+        // plugin content under the SAME app version number.
         let dir = tempfile::tempdir().unwrap();
-        let plugin_dir = dir.path();
+        let init_path = dir.path().join("github/init.lua");
+        let hash_path = dir.path().join("github/.content_hash");
+        let version_path = dir.path().join("github/.version");
+        std::fs::create_dir_all(init_path.parent().unwrap()).unwrap();
 
-        // Seed once
-        seed_bundled_plugins(plugin_dir);
+        // Prior Claudette (same version) seeded stale content and
+        // stamped the hash to match.
+        let stale = "-- old plugin body from a prior seed\nreturn {}";
+        std::fs::write(&init_path, stale).unwrap();
+        std::fs::write(&hash_path, sha256_hex(stale)).unwrap();
+        std::fs::write(&version_path, APP_VERSION).unwrap();
+        std::fs::write(dir.path().join("github/plugin.json"), "{}").unwrap();
 
-        // Simulate an older version and user modification
-        std::fs::write(plugin_dir.join("github/.version"), "0.0.1").unwrap();
-        std::fs::write(plugin_dir.join("github/init.lua"), "-- user modified").unwrap();
-
-        // Seed again — should warn about user modifications
-        let warnings = seed_bundled_plugins(plugin_dir);
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("user modifications"));
-
-        // User modifications should be preserved
-        let content = std::fs::read_to_string(plugin_dir.join("github/init.lua")).unwrap();
-        assert_eq!(content, "-- user modified");
-    }
-
-    #[test]
-    fn test_seed_overwrites_unmodified_on_upgrade() {
-        let dir = tempfile::tempdir().unwrap();
-        let plugin_dir = dir.path();
-
-        // Seed once
-        seed_bundled_plugins(plugin_dir);
-
-        // Simulate an older version but keep init.lua unmodified
-        std::fs::write(plugin_dir.join("github/.version"), "0.0.1").unwrap();
-
-        // Seed again — should update silently
-        let warnings = seed_bundled_plugins(plugin_dir);
-        // Only GitLab might warn if it's also modified, but github should update fine
+        // Seed should notice bundled_hash != on_disk_hash, stamp
+        // still matches on disk → overwrite, no warning.
+        let warnings = seed_bundled_plugins(dir.path());
         let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
-        assert!(github_warnings.is_empty());
+        assert!(
+            github_warnings.is_empty(),
+            "stale-but-owned seed must auto-update: {github_warnings:?}"
+        );
+        let after = std::fs::read_to_string(&init_path).unwrap();
+        assert!(
+            !after.contains("old plugin body"),
+            "stale content must be replaced"
+        );
+    }
 
-        // Version should be updated
-        let version = std::fs::read_to_string(plugin_dir.join("github/.version")).unwrap();
-        assert_eq!(version, APP_VERSION);
+    #[test]
+    fn seed_preserves_user_modifications() {
+        // User edits a plugin's init.lua (hash no longer matches
+        // the stamped content). Seed must leave it alone and warn.
+        let dir = tempfile::tempdir().unwrap();
+        seed_bundled_plugins(dir.path());
+
+        let init_path = dir.path().join("github/init.lua");
+        let user = "-- hand-rolled tweak\nlocal M = {}\nreturn M";
+        std::fs::write(&init_path, user).unwrap();
+
+        let warnings = seed_bundled_plugins(dir.path());
+        let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
+        assert!(
+            !github_warnings.is_empty(),
+            "expected warning for user-modified plugin: {warnings:?}"
+        );
+        assert!(github_warnings[0].contains("user modifications"));
+
+        let after = std::fs::read_to_string(&init_path).unwrap();
+        assert_eq!(after, user, "user edits must be preserved");
+    }
+
+    #[test]
+    fn seed_preserves_legacy_install_without_content_hash() {
+        // Installs predating `.content_hash` stamping look like
+        // "unknown ownership" — we can't tell whether the user
+        // customized. Err on the side of preserving. User can hit
+        // "Reload bundled plugins" to force.
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_subdir = dir.path().join("github");
+        std::fs::create_dir_all(&plugin_subdir).unwrap();
+        // Legacy: has .version, has init.lua, NO .content_hash.
+        std::fs::write(plugin_subdir.join(".version"), "0.0.1").unwrap();
+        std::fs::write(plugin_subdir.join("init.lua"), "-- legacy content\n").unwrap();
+        std::fs::write(plugin_subdir.join("plugin.json"), "{}").unwrap();
+
+        let warnings = seed_bundled_plugins(dir.path());
+        let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
+        assert!(
+            !github_warnings.is_empty(),
+            "legacy install without stamp must be preserved (even if stale)"
+        );
+
+        let after = std::fs::read_to_string(plugin_subdir.join("init.lua")).unwrap();
+        assert!(
+            after.contains("legacy content"),
+            "legacy content must not be clobbered"
+        );
+    }
+
+    #[test]
+    fn seed_stamps_hash_on_legacy_install_that_matches_bundle() {
+        // Legacy install whose on-disk content happens to match the
+        // current bundle: healing path — stamp the hash so future
+        // drift detection works, but make no content change.
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_subdir = dir.path().join("github");
+        std::fs::create_dir_all(&plugin_subdir).unwrap();
+        let bundled_github_init = BUNDLED_PLUGINS
+            .iter()
+            .find(|(n, _, _)| *n == "github")
+            .map(|(_, _, lua)| *lua)
+            .unwrap();
+        std::fs::write(plugin_subdir.join(".version"), "0.0.1").unwrap();
+        std::fs::write(plugin_subdir.join("init.lua"), bundled_github_init).unwrap();
+        std::fs::write(plugin_subdir.join("plugin.json"), "{}").unwrap();
+
+        let warnings = seed_bundled_plugins(dir.path());
+        let github_warnings: Vec<_> = warnings.iter().filter(|w| w.contains("github")).collect();
+        assert!(
+            github_warnings.is_empty(),
+            "legacy install matching bundle should heal silently: {github_warnings:?}"
+        );
+
+        let hash_path = plugin_subdir.join(".content_hash");
+        assert!(hash_path.exists(), "content hash stamp must be written");
+        let stamped = std::fs::read_to_string(&hash_path).unwrap();
+        assert_eq!(stamped.trim(), sha256_hex(bundled_github_init));
     }
 
     #[test]

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   getEnvSources,
   reloadEnv,
@@ -218,6 +219,40 @@ export function EnvPanel({ target }: EnvPanelProps) {
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  // Reactive invalidation: when the Rust-side fs watcher detects that
+  // a plugin's watched file changed (user edited `.envrc`, ran
+  // `direnv allow`, modified `flake.lock`, etc.), the backend emits
+  // `env-cache-invalidated`. We refetch so the panel shows fresh
+  // vars_contributed counts without the user having to click Reload.
+  //
+  // Debounced because editors often save + swap + touch, firing the
+  // event 2-3 times in rapid succession. 300ms coalesces the bursts
+  // into a single re-resolve.
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        unlisten = await listen("env-cache-invalidated", () => {
+          if (cancelled) return;
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(() => {
+            void refresh();
+          }, 300);
+        });
+      } catch {
+        // Listen failure means the event bridge isn't wired up — fall
+        // back to the existing manual Reload button. Silent is fine.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      unlisten?.();
+    };
   }, [refresh]);
 
   const handleReloadAll = useCallback(async () => {

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -3,6 +3,7 @@ import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   getEnvSources,
+  getEnvTargetWorktree,
   reloadEnv,
   runEnvTrust,
   setEnvProviderEnabled,
@@ -224,8 +225,9 @@ export function EnvPanel({ target }: EnvPanelProps) {
   // Reactive invalidation: when the Rust-side fs watcher detects that
   // a plugin's watched file changed (user edited `.envrc`, ran
   // `direnv allow`, modified `flake.lock`, etc.), the backend emits
-  // `env-cache-invalidated`. We refetch so the panel shows fresh
-  // vars_contributed counts without the user having to click Reload.
+  // `env-cache-invalidated` with the worktree path that changed. We
+  // filter against our own target's worktree so an edit in repo B
+  // doesn't make the panel viewing repo A rerun direnv/nix/mise.
   //
   // Debounced because editors often save + swap + touch, firing the
   // event 2-3 times in rapid succession. 300ms coalesces the bursts
@@ -235,9 +237,23 @@ export function EnvPanel({ target }: EnvPanelProps) {
     let timer: ReturnType<typeof setTimeout> | undefined;
     let cancelled = false;
     (async () => {
+      let targetWorktree: string | null = null;
       try {
-        unlisten = await listen("env-cache-invalidated", () => {
+        targetWorktree = await getEnvTargetWorktree(target);
+      } catch {
+        // If we can't resolve the target's worktree we can't filter
+        // — leave reactive invalidation off for this target rather
+        // than triggering refreshes for every unrelated edit.
+        return;
+      }
+      if (cancelled) return;
+      try {
+        unlisten = await listen<{
+          worktree_path: string;
+          plugin_name: string;
+        }>("env-cache-invalidated", (event) => {
           if (cancelled) return;
+          if (event.payload.worktree_path !== targetWorktree) return;
           if (timer) clearTimeout(timer);
           timer = setTimeout(() => {
             void refresh();
@@ -253,7 +269,7 @@ export function EnvPanel({ target }: EnvPanelProps) {
       if (timer) clearTimeout(timer);
       unlisten?.();
     };
-  }, [refresh]);
+  }, [target, refresh]);
 
   const handleReloadAll = useCallback(async () => {
     try {

--- a/src/ui/src/services/env.ts
+++ b/src/ui/src/services/env.ts
@@ -11,6 +11,16 @@ export function getEnvSources(target: EnvTarget): Promise<EnvSourceInfo[]> {
 }
 
 /**
+ * Resolve the worktree path a target maps to. The EnvPanel uses this
+ * once per target to filter `env-cache-invalidated` events — a watcher
+ * hit for repo B shouldn't make the EnvPanel showing repo A refetch
+ * (that would redundantly re-run direnv/nix/mise).
+ */
+export function getEnvTargetWorktree(target: EnvTarget): Promise<string> {
+  return invoke("get_env_target_worktree", { target });
+}
+
+/**
  * Evict the env-provider cache for the target. Next spawn or diagnostic
  * query re-runs the affected plugin(s). Pass a `pluginName` to only
  * invalidate one plugin's entry; omit to reload everything.


### PR DESCRIPTION
Closes #410.

## Summary

Reactive env-provider invalidation via a cross-platform fs watcher, plus proactive warmup on repo add. Two follow-ups collapsed in while testing: hash-based plugin seeding on startup (stale-seed auto-heal) and filtering the direnv deny-cache paths that were log-spamming the watcher.

### The watcher

- Adds a `notify` crate-backed `EnvWatcher` — `RecommendedWatcher` selects FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW on Windows; single API, no conditional compilation.
- Routing table `path → {(worktree, plugin)}` with dedup so many cache entries watching the same `.envrc` cost one OS watch. `os_watched` set tracks successfully-installed watches separately from subscriptions, so paths that failed to watch once get retried every register call.
- Path canonicalization for macOS where FSEvents reports `/private/var/...` while `tempfile` and user paths use `/var/...`.
- After every `resolve_with_registry` call (4 sites: chat spawn, PTY spawn, workspace spawn, EnvPanel fetch), `register_resolved_with_watcher` subscribes to the cache's stored watched paths.
- On fs change → invalidate cache + emit `env-cache-invalidated` Tauri event (`{worktree_path, plugin_name}`). EnvPanel listens with 300ms debounce, filtered to its own target's worktree (resolved once via new `get_env_target_worktree` tauri command) so an edit in repo B doesn't refresh a panel viewing repo A.
- Falls back to pure lazy mtime invalidation if the watcher fails to start (headless CI, inotify cap) — never wrong, just slower.

### Lifecycle cleanup

`remove_repository`, `archive_workspace`, `delete_workspace` all call `env_watcher.unregister(path, None)` + `env_cache.invalidate(path, None)`. Without these, repeated add/remove cycles leaked watch slots and could emit events for paths Claudette no longer knew about.

### Proactive warmup

`add_repository` spawns a detached task that resolves against the new repo's main checkout. First EnvPanel open is warm; trust errors (`.envrc` blocked, `mise.toml` untrusted) surface before workspace creation.

### Hash-based plugin seeding

`seed_bundled_plugins` used to gate on `APP_VERSION`, which meant plugin `init.lua` changes merged mid-release cycle never reached on-disk seeds. Rewritten to drive updates off content hashes:

1. No `init.lua` → fresh-seed
2. On-disk hash == bundled hash → no-op (heals legacy installs by stamping `.content_hash` if missing)
3. On-disk hash != bundled hash AND stamp matches on-disk → we own it, bundle moved → overwrite
4. On-disk hash != bundled hash AND stamp disagrees or missing → user edited (or legacy) → preserve with warning pointing at "Reload bundled plugins"

`APP_VERSION` is still stamped in `.version` for diagnostics, no longer load-bearing.

### Quieter fs watcher

- `host.direnv_decode_watches` filters entries with `exists: false` — direnv's DIRENV_WATCHES routinely includes deny-cache hashes that only exist if the user runs `direnv deny`; we were spamming `[env-watcher] failed to watch ...` logs every resolve.
- `EnvWatcher::register` silences `PathNotFound` / `Io(NotFound)` errors; louder failures (inotify cap, permission) still print.

## Manual UAT on macOS (all passed)

| # | Scenario | Proof |
|---|----------|-------|
| 1 | Proactive warmup on `add_repository` | first `get_env_sources` returned `cached: true` after 1.5s settle |
| 2 | Reactive invalidation on `.envrc` edit | `cached: false` + fresh `evaluated_at_ms` + `vars_contributed` bumped |
| 3 | Transitive `DIRENV_WATCHES` via `dotenv secret.env` | edit to `secret.env` produced `cached: false` + fresh timestamp (no manual reseed needed after restart — hash-based seed auto-healed) |
| 4 | Multi-repo event filtering | edit in test repo invalidated test repo; Claudette repo's cache untouched |
| 5 | Cleanup on `remove_repository` | orphan edits post-removal did not crash the app or perturb other repos |

## Test plan
- [x] `cargo test --all-features` — 681 passed
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -Dwarnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cd src/ui && bun run test` — 663 passed
- [x] `cd src/ui && bunx tsc -b` — clean
- [x] Manual UAT on macOS via `/claudette-debug`

## Files changed

**Backend**
- `src/env_provider/watcher.rs` (new) — `EnvWatcher` + 7 unit tests
- `src/env_provider/cache.rs` — `watched_paths()` query
- `src/env_provider/mod.rs` — re-export
- `src/plugin_runtime/seed.rs` — hash-based seed + 5 new tests
- `src/plugin_runtime/host_api.rs` — filter `exists:false` entries + 3 new tests
- `Cargo.toml` — `notify = "7"`
- `src-tauri/src/state.rs` — `env_watcher` field
- `src-tauri/src/main.rs` — setup hook + `get_env_target_worktree` command registration
- `src-tauri/src/commands/env.rs` — `setup_env_watcher`, `register_resolved_with_watcher`, `spawn_repo_env_warmup`, `get_env_target_worktree`
- `src-tauri/src/commands/{chat,workspace,repository}.rs`, `src-tauri/src/pty.rs` — post-resolve watcher registration + lifecycle cleanup

**Frontend**
- `src/ui/src/components/settings/sections/EnvPanel.tsx` — `env-cache-invalidated` listener with target-worktree filter + 300ms debounce
- `src/ui/src/services/env.ts` — `getEnvTargetWorktree` service