### PR TITLE
feat(ux): dialog with install guidance when a required CLI is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,8 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "windows-sys 0.61.2",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/scripts/build-win.sh
+++ b/scripts/build-win.sh
@@ -18,6 +18,14 @@ case "${1:-}" in
 esac
 
 (cd src/ui && bun install --frozen-lockfile && bun run build)
+
+# Regenerate platform icons from the PNG master. `icon.ico` / `icon.icns` are
+# listed in `tauri.conf.json` but gitignored — tauri-build requires the .ico
+# at link time on Windows to embed the PE resource, so it must exist before
+# we invoke `cargo xwin`. CI does the equivalent in ci.yml / nightly.yml /
+# release-please.yml via `npx @tauri-apps/cli icon`.
+cargo tauri icon assets/logo.png
+
 cargo xwin build --release \
   --features tauri/custom-protocol \
   --target "$TRIPLE" -p claudette-tauri

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,16 @@ url = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6"
 
+[target.'cfg(windows)'.dependencies]
+# Registry probe for WebView2 Runtime + MessageBoxW fallback. Kept as direct
+# deps (not transitive via `claudette`) so main.rs can run the probe before
+# any lib-crate code that might depend on a working webview.
+winreg = "0.55"
+windows-sys = { version = "0.61", features = [
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Foundation",
+] }
+
 [features]
 default = ["server"]
 devtools = ["tauri/devtools"]

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -57,7 +57,12 @@ pub async fn claude_auth_login(app: AppHandle, state: State<'_, AppState>) -> Re
         .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
-        .map_err(|e| format!("Failed to spawn `claude auth login`: {e}"))?;
+        .map_err(|e| {
+            let err = claudette::missing_cli::map_spawn_err(&e, "claude", || {
+                format!("Failed to spawn `claude auth login`: {e}")
+            });
+            crate::missing_cli::handle_err(&app, &err).unwrap_or(err)
+        })?;
 
     let stdout = child
         .stdout

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -653,31 +653,34 @@ pub async fn send_chat_message(
     let saved_turn_count = session.turn_count;
 
     // Helper: start a persistent session, using --resume for restored sessions.
+    // Routes claude-missing errors through the missing-CLI dialog emitter so
+    // both the initial-start and respawn paths surface the same guidance.
     let ws_env_for_persistent = ws_env.clone();
     let resolved_env_for_persistent = resolved_env.clone();
-    let start_persistent = |worktree: String,
-                            sid: String,
-                            is_resume: bool,
-                            tools: Vec<String>,
-                            instructions: Option<String>,
-                            settings: AgentSettings| {
+    let app_for_persistent = app.clone();
+    let start_persistent = move |worktree: String,
+                                 sid: String,
+                                 is_resume: bool,
+                                 tools: Vec<String>,
+                                 instructions: Option<String>,
+                                 settings: AgentSettings| {
         let env = ws_env_for_persistent.clone();
         let resolved = resolved_env_for_persistent.clone();
+        let app = app_for_persistent.clone();
         async move {
-            let ps = Arc::new(
-                PersistentSession::start(
-                    std::path::Path::new(&worktree),
-                    &sid,
-                    is_resume,
-                    &tools,
-                    instructions.as_deref(),
-                    &settings,
-                    Some(&env),
-                    Some(&resolved),
-                )
-                .await?,
-            );
-            Ok::<Arc<PersistentSession>, String>(ps)
+            let started = PersistentSession::start(
+                std::path::Path::new(&worktree),
+                &sid,
+                is_resume,
+                &tools,
+                instructions.as_deref(),
+                &settings,
+                Some(&env),
+                Some(&resolved),
+            )
+            .await
+            .map_err(|e| crate::missing_cli::handle_err(&app, &e).unwrap_or(e))?;
+            Ok::<Arc<PersistentSession>, String>(Arc::new(started))
         }
     };
 
@@ -791,6 +794,7 @@ pub async fn send_chat_message(
                     session.session_id = String::new();
                 }
                 drop(agents);
+                let e = crate::missing_cli::handle_err(&app, &e).unwrap_or(e);
                 return Err(e);
             }
         };

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -60,7 +60,10 @@ pub async fn add_repository(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Repository, String> {
-    git::validate_repo(&path).await.map_err(|e| e.to_string())?;
+    git::validate_repo(&path).await.map_err(|e| {
+        let err = e.to_string();
+        crate::missing_cli::handle_err(&app, &err).unwrap_or(err)
+    })?;
 
     let canon = std::fs::canonicalize(&path).map_err(|e| format!("Invalid path: {e}"))?;
     let canon_str = canon.to_string_lossy().to_string();
@@ -168,9 +171,13 @@ pub async fn set_setup_script_auto_run(
 pub async fn relink_repository(
     id: String,
     path: String,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    git::validate_repo(&path).await.map_err(|e| e.to_string())?;
+    git::validate_repo(&path).await.map_err(|e| {
+        let err = e.to_string();
+        crate::missing_cli::handle_err(&app, &err).unwrap_or(err)
+    })?;
 
     let canon = std::fs::canonicalize(&path).map_err(|e| format!("Invalid path: {e}"))?;
     let canon_str = canon.to_string_lossy().to_string();

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use futures::stream::{self, StreamExt};
 use serde::Serialize;
-use tauri::{Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::db::Database;
 use claudette::plugin_runtime::host_api::WorkspaceInfo;
@@ -315,6 +315,7 @@ pub async fn scm_create_pr(
     body: String,
     base: String,
     draft: bool,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<PullRequest, String> {
     let ctx = lookup_workspace_context(&state.db_path, &workspace_id).await?;
@@ -347,7 +348,10 @@ pub async fn scm_create_pr(
     let result = registry
         .call_operation(&provider, "create_pull_request", args, ws_info)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            let err = e.to_string();
+            crate::missing_cli::handle_err(&app, &err).unwrap_or(err)
+        })?;
 
     // Invalidate cache
     let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
@@ -364,6 +368,7 @@ pub async fn scm_create_pr(
 pub async fn scm_merge_pr(
     workspace_id: String,
     pr_number: u64,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<serde_json::Value, String> {
     let ctx = lookup_workspace_context(&state.db_path, &workspace_id).await?;
@@ -390,7 +395,10 @@ pub async fn scm_merge_pr(
     let result = registry
         .call_operation(&provider, "merge_pull_request", args, ws_info)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            let err = e.to_string();
+            crate::missing_cli::handle_err(&app, &err).unwrap_or(err)
+        })?;
 
     // Invalidate cache
     let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 
 mod commands;
 mod mdns;
+mod missing_cli;
 mod osc133;
 mod pty;
 mod remote;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ mod state;
 mod transport;
 mod tray;
 mod usage;
+mod webview2_check;
 
 use std::path::PathBuf;
 
@@ -41,6 +42,12 @@ fn main() {
         });
         return;
     }
+
+    // Windows only: if the WebView2 Runtime is missing, Tauri's webview
+    // initialization would fail with a generic system error dialog and exit.
+    // Probe the runtime registry up-front and show a native MessageBox with
+    // a download link instead. No-op on macOS/Linux.
+    webview2_check::ensure_installed();
 
     // Determine database and worktree paths.
     let data_dir = dirs::data_dir()

--- a/src-tauri/src/missing_cli.rs
+++ b/src-tauri/src/missing_cli.rs
@@ -1,0 +1,51 @@
+//! Tauri-side glue for the missing-CLI dialog.
+//!
+//! The `claudette` crate reports missing-CLI failures via the sentinel
+//! [`claudette::missing_cli::format_err`] string so its error signatures stay
+//! simple (`Result<_, String>` / `GitError::CliNotFound`). This module
+//! intercepts those sentinels at the Tauri boundary, emits a structured
+//! `missing-dependency` event that the frontend listens for to show the
+//! install-guidance dialog, and rewrites the error into a short, friendly
+//! message so any UI that surfaces the raw `Err` string is still readable.
+
+use tauri::{AppHandle, Emitter};
+
+use claudette::missing_cli::{self, MissingCli};
+
+/// Event name the frontend listens for. Payload: [`MissingCli`].
+pub const MISSING_DEPENDENCY_EVENT: &str = "missing-dependency";
+
+/// If `err` carries the missing-CLI sentinel, emit the dialog event and return
+/// `Some(friendly_message)` suitable for the original `Result::Err`. Returns
+/// `None` for unrelated errors, letting callers fall through with the original.
+pub fn handle_err(app: &AppHandle, err: &str) -> Option<String> {
+    let tool = missing_cli::parse_err(err)?;
+    let guidance = missing_cli::guidance_for(tool);
+    emit(app, &guidance);
+    Some(friendly_message(&guidance))
+}
+
+fn emit(app: &AppHandle, guidance: &MissingCli) {
+    if let Err(e) = app.emit(MISSING_DEPENDENCY_EVENT, guidance) {
+        eprintln!("[missing-cli] failed to emit {MISSING_DEPENDENCY_EVENT}: {e}");
+    }
+}
+
+fn friendly_message(guidance: &MissingCli) -> String {
+    format!(
+        "{} is not installed. See the install guide that just opened for options.",
+        guidance.display_name
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn friendly_message_uses_display_name() {
+        let g = missing_cli::guidance_for("claude");
+        let msg = friendly_message(&g);
+        assert!(msg.starts_with("Claude CLI is not installed."));
+    }
+}

--- a/src-tauri/src/missing_cli.rs
+++ b/src-tauri/src/missing_cli.rs
@@ -32,8 +32,12 @@ fn emit(app: &AppHandle, guidance: &MissingCli) {
 }
 
 fn friendly_message(guidance: &MissingCli) -> String {
+    // We only emit the Tauri event here — the actual dialog is rendered by
+    // `MissingCliModal` on the frontend. Phrase the message neutrally so it
+    // still reads correctly if the event listener isn't mounted yet or the
+    // `emit` call above failed (see [`emit`]).
     format!(
-        "{} is not installed. See the install guide that just opened for options.",
+        "{} is not installed. See the install options dialog.",
         guidance.display_name
     )
 }

--- a/src-tauri/src/webview2_check.rs
+++ b/src-tauri/src/webview2_check.rs
@@ -50,32 +50,33 @@ mod imp {
     /// for a different user only. In that case Tauri/wry will still surface
     /// its own system dialog — see follow-up issue for a more thorough probe.
     fn is_runtime_installed() -> bool {
-        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
-        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-        let paths: [(RegKey, String); 3] = [
-            (
-                hklm.clone(),
-                format!(r"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
-            ),
-            (
-                hklm,
-                format!(r"SOFTWARE\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
-            ),
-            (
-                hkcu,
-                format!(r"Software\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
-            ),
+        let hklm_paths = [
+            format!(r"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
+            format!(r"SOFTWARE\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
         ];
-        for (root, path) in paths {
-            if let Ok(key) = root.open_subkey(&path)
-                && let Ok(pv) = key.get_value::<String, _>("pv")
-                && !pv.is_empty()
-                && pv != "0.0.0.0"
-            {
+        let hkcu_path = format!(r"Software\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}");
+
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        for path in &hklm_paths {
+            if has_valid_pv(&hklm, path) {
                 return true;
             }
         }
-        false
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        has_valid_pv(&hkcu, &hkcu_path)
+    }
+
+    /// Returns `true` iff `hive\path` exists and has a non-empty `pv` value
+    /// that isn't the placeholder `"0.0.0.0"` EdgeUpdate stamps when it
+    /// hasn't finished registering a runtime.
+    fn has_valid_pv(hive: &RegKey, path: &str) -> bool {
+        let Ok(key) = hive.open_subkey(path) else {
+            return false;
+        };
+        let Ok(pv) = key.get_value::<String, _>("pv") else {
+            return false;
+        };
+        !pv.is_empty() && pv != "0.0.0.0"
     }
 
     fn show_missing_dialog_and_exit() -> ! {

--- a/src-tauri/src/webview2_check.rs
+++ b/src-tauri/src/webview2_check.rs
@@ -1,0 +1,134 @@
+//! Pre-webview probe for the Microsoft Edge WebView2 Runtime.
+//!
+//! Claudette is a Tauri app that renders its UI in an embedded WebView2
+//! surface. On Windows, if the runtime isn't installed, Tauri's internal
+//! initialization fails with a generic "Could not find the WebView2 Runtime"
+//! system dialog and the process exits — the user has no path forward.
+//!
+//! This module probes the well-known Evergreen Runtime registry keys *before*
+//! Tauri starts. If the runtime is missing, we show a native `MessageBoxW`
+//! (no webview required) with a button that opens Microsoft's download page,
+//! then exit cleanly so the shell doesn't surface a crash.
+//!
+//! No-op on non-Windows targets.
+
+/// Run the WebView2 probe. On Windows, exits the process with a native error
+/// dialog if the runtime isn't installed. No-op elsewhere.
+pub fn ensure_installed() {
+    #[cfg(windows)]
+    imp::ensure_installed();
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        IDOK, MB_ICONERROR, MB_OKCANCEL, MB_SETFOREGROUND, MB_SYSTEMMODAL, MessageBoxW,
+    };
+    use winreg::RegKey;
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+
+    /// Evergreen WebView2 Runtime app ID, per Microsoft's distribution docs.
+    const EVERGREEN_GUID: &str = "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+
+    const DOWNLOAD_URL: &str = "https://developer.microsoft.com/en-us/microsoft-edge/webview2/";
+
+    pub fn ensure_installed() {
+        if is_runtime_installed() {
+            return;
+        }
+        show_missing_dialog_and_exit();
+    }
+
+    /// Check the three registry locations where the Evergreen Runtime stamps
+    /// its product version. Any populated `pv != "0.0.0.0"` means the runtime
+    /// is registered on this machine.
+    ///
+    /// Note: this does not detect the edge case where the runtime is installed
+    /// for a different user only. In that case Tauri/wry will still surface
+    /// its own system dialog — see follow-up issue for a more thorough probe.
+    fn is_runtime_installed() -> bool {
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let paths: [(RegKey, String); 3] = [
+            (
+                hklm.clone(),
+                format!(r"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
+            ),
+            (
+                hklm,
+                format!(r"SOFTWARE\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
+            ),
+            (
+                hkcu,
+                format!(r"Software\Microsoft\EdgeUpdate\Clients\{EVERGREEN_GUID}"),
+            ),
+        ];
+        for (root, path) in paths {
+            if let Ok(key) = root.open_subkey(&path)
+                && let Ok(pv) = key.get_value::<String, _>("pv")
+                && !pv.is_empty()
+                && pv != "0.0.0.0"
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn show_missing_dialog_and_exit() -> ! {
+        let title = to_wide("Claudette — WebView2 Runtime required");
+        let body = to_wide(
+            "Claudette needs the Microsoft Edge WebView2 Runtime, which isn't installed \
+            on this system.\n\n\
+            Click OK to open Microsoft's download page. After installing the \
+            Evergreen Runtime, relaunch Claudette.\n\n\
+            Click Cancel to quit.",
+        );
+        // SAFETY: MessageBoxW with null hWnd is always safe; the pointers are
+        // to local, NUL-terminated UTF-16 buffers that outlive the call.
+        let result = unsafe {
+            MessageBoxW(
+                std::ptr::null_mut(),
+                body.as_ptr(),
+                title.as_ptr(),
+                MB_OKCANCEL | MB_ICONERROR | MB_SYSTEMMODAL | MB_SETFOREGROUND,
+            )
+        };
+        if result == IDOK as i32 {
+            let _ = std::process::Command::new("cmd")
+                .args(["/C", "start", "", DOWNLOAD_URL])
+                .spawn();
+        }
+        std::process::exit(1);
+    }
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        OsStr::new(s)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn to_wide_is_nul_terminated() {
+            let w = to_wide("abc");
+            assert_eq!(w, vec![b'a' as u16, b'b' as u16, b'c' as u16, 0]);
+        }
+
+        #[test]
+        fn evergreen_guid_is_well_formed() {
+            // Microsoft-documented runtime app ID — guard against typos that
+            // would make `is_runtime_installed` silently always-false.
+            assert_eq!(EVERGREEN_GUID.len(), 38);
+            assert!(EVERGREEN_GUID.starts_with('{'));
+            assert!(EVERGREEN_GUID.ends_with('}'));
+        }
+    }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -903,9 +903,11 @@ pub async fn run_turn(
         env.apply(&mut cmd);
     }
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to spawn claude at {:?}: {e}", claude_path))?;
+    let mut child = cmd.spawn().map_err(|e| {
+        crate::missing_cli::map_spawn_err(&e, "claude", || {
+            format!("Failed to spawn claude at {:?}: {e}", claude_path)
+        })
+    })?;
 
     let pid = child
         .id()
@@ -1175,10 +1177,12 @@ impl PersistentSession {
         }
 
         let mut child = cmd.spawn().map_err(|e| {
-            format!(
-                "Failed to spawn persistent session at {:?}: {e}",
-                claude_path
-            )
+            crate::missing_cli::map_spawn_err(&e, "claude", || {
+                format!(
+                    "Failed to spawn persistent session at {:?}: {e}",
+                    claude_path
+                )
+            })
         })?;
 
         let pid = child
@@ -1558,10 +1562,12 @@ pub async fn generate_branch_name(
     }
 
     let output = cmd.output().await.map_err(|e| {
-        format!(
-            "Failed to spawn claude at {:?} for branch name: {e}",
-            claude_path
-        )
+        crate::missing_cli::map_spawn_err(&e, "claude", || {
+            format!(
+                "Failed to spawn claude at {:?} for branch name: {e}",
+                claude_path
+            )
+        })
     })?;
 
     if !output.status.success() {

--- a/src/git.rs
+++ b/src/git.rs
@@ -175,6 +175,23 @@ fn resolve_git_path_inner(
 pub enum GitError {
     NotAGitRepo,
     CommandFailed(String),
+    /// The `git` executable could not be located on PATH. The `Display` form
+    /// uses the shared [`crate::missing_cli::format_err`] sentinel so Tauri
+    /// wrappers can detect it via [`crate::missing_cli::parse_err`].
+    CliNotFound,
+}
+
+impl GitError {
+    /// Map an `io::Error` from a git-subprocess spawn/output call, preserving
+    /// the `NotFound` signal as [`GitError::CliNotFound`] instead of folding
+    /// it into a generic `CommandFailed` string.
+    pub fn from_spawn_io(err: std::io::Error) -> Self {
+        if crate::missing_cli::is_not_found(&err) {
+            Self::CliNotFound
+        } else {
+            Self::CommandFailed(err.to_string())
+        }
+    }
 }
 
 impl fmt::Display for GitError {
@@ -182,6 +199,7 @@ impl fmt::Display for GitError {
         match self {
             Self::NotAGitRepo => write!(f, "Not a git repository"),
             Self::CommandFailed(msg) => write!(f, "Git command failed: {msg}"),
+            Self::CliNotFound => write!(f, "{}", crate::missing_cli::format_err("git")),
         }
     }
 }
@@ -195,7 +213,7 @@ async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, GitError> {
         .args(args)
         .output()
         .await
-        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
+        .map_err(GitError::from_spawn_io)?;
 
     if output.status.success() {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -213,7 +231,7 @@ pub async fn get_git_username() -> Result<Option<String>, GitError> {
         .args(["config", "--global", "user.name"])
         .output()
         .await
-        .map_err(|e| GitError::CommandFailed(e.to_string()))?;
+        .map_err(GitError::from_spawn_io)?;
 
     if output.status.success() {
         let name = String::from_utf8_lossy(&output.stdout).trim().to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mcp;
 pub mod mcp_supervisor;
 pub mod metrics;
 pub mod migrations;
+pub mod missing_cli;
 pub mod model;
 pub mod names;
 pub mod path;

--- a/src/missing_cli.rs
+++ b/src/missing_cli.rs
@@ -1,0 +1,301 @@
+//! Detection + UX data for "required CLI is not installed" failures.
+//!
+//! When `Command::new("claude" | "git" | ...)`.spawn()` fails with
+//! `io::ErrorKind::NotFound`, the raw OS error ("No such file or directory /
+//! program not found") is useless to a new user. This module provides:
+//!
+//! 1. A sentinel error format ([`format_err`] / [`parse_err`]) that spawn sites
+//!    return so the Tauri layer can detect the failure and surface a structured
+//!    dialog instead of leaking the subprocess error.
+//! 2. Per-tool × per-OS install guidance ([`guidance_for`]) rendered by the
+//!    `MissingCliModal` on the frontend.
+
+use serde::Serialize;
+
+/// Prefix on error strings returned by spawn sites when the underlying cause
+/// is `io::ErrorKind::NotFound`. Format: `"MISSING_CLI:<tool>"` (optionally
+/// followed by `: <original error>` — the parser ignores anything after the
+/// tool token).
+pub const SPAWN_ERR_PREFIX: &str = "MISSING_CLI:";
+
+/// Produce the sentinel error string for a spawn site that failed because the
+/// named CLI is not on PATH.
+pub fn format_err(tool: &str) -> String {
+    format!("{SPAWN_ERR_PREFIX}{tool}")
+}
+
+/// If `err` carries the sentinel [`SPAWN_ERR_PREFIX`], return the tool token.
+pub fn parse_err(err: &str) -> Option<&str> {
+    let rest = err.strip_prefix(SPAWN_ERR_PREFIX)?;
+    // Tool token ends at the first `:` or end-of-string.
+    let end = rest.find(':').unwrap_or(rest.len());
+    Some(&rest[..end])
+}
+
+/// Returns `true` when the I/O error's root cause is "executable not found".
+pub fn is_not_found(err: &std::io::Error) -> bool {
+    err.kind() == std::io::ErrorKind::NotFound
+}
+
+/// Map an `io::Error` from a `.spawn()` / `.output()` call to either the
+/// sentinel missing-CLI error (when `kind == NotFound`) or `fallback()`
+/// otherwise. Keeps the call-site clean:
+///
+/// ```ignore
+/// cmd.spawn().map_err(|e| missing_cli::map_spawn_err(&e, "claude",
+///     || format!("Failed to spawn claude at {:?}: {e}", path)))?;
+/// ```
+pub fn map_spawn_err(
+    err: &std::io::Error,
+    tool: &str,
+    fallback: impl FnOnce() -> String,
+) -> String {
+    if is_not_found(err) {
+        format_err(tool)
+    } else {
+        fallback()
+    }
+}
+
+/// One install method shown in the dialog. Either `command` (copy-paste) or
+/// `url` (open in browser) is populated — the UI renders whichever is present.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct InstallOption {
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+impl InstallOption {
+    fn cmd(label: &str, command: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            command: Some(command.to_string()),
+            url: None,
+        }
+    }
+    fn link(label: &str, url: &str) -> Self {
+        Self {
+            label: label.to_string(),
+            command: None,
+            url: Some(url.to_string()),
+        }
+    }
+}
+
+/// Structured payload for the `missing-dependency` Tauri event.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct MissingCli {
+    /// Raw executable token — `"claude"`, `"git"`, `"gh"`.
+    pub tool: String,
+    /// Human-friendly name for the dialog title — `"Claude CLI"`.
+    pub display_name: String,
+    /// One-sentence explanation of why Claudette needs this tool.
+    pub purpose: String,
+    /// `"macos"`, `"linux"`, or `"windows"` — drives which install options the
+    /// frontend shows most prominently.
+    pub platform: String,
+    /// Install options — ordered by recommendation. Common options (e.g. `npm`)
+    /// appear on all platforms; platform-native options (`brew`, `winget`)
+    /// appear only where relevant.
+    pub install_options: Vec<InstallOption>,
+}
+
+/// Current OS token used in the payload.
+pub fn current_platform() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "linux"
+    }
+}
+
+/// Build the guidance payload for a given tool, targeting [`current_platform`].
+/// Unknown tools fall back to a minimal "not found" entry so the dialog still
+/// renders something useful.
+pub fn guidance_for(tool: &str) -> MissingCli {
+    let platform = current_platform().to_string();
+    match tool {
+        "claude" => MissingCli {
+            tool: tool.to_string(),
+            display_name: "Claude CLI".to_string(),
+            purpose: "Claudette orchestrates Claude Code agents by running the \
+                `claude` CLI as a subprocess — it needs to be installed and on PATH."
+                .to_string(),
+            platform,
+            install_options: claude_options(),
+        },
+        "git" => MissingCli {
+            tool: tool.to_string(),
+            display_name: "Git".to_string(),
+            purpose: "Claudette uses Git for repository detection, worktrees, \
+                diffs, and checkpoints."
+                .to_string(),
+            platform,
+            install_options: git_options(),
+        },
+        "gh" => MissingCli {
+            tool: tool.to_string(),
+            display_name: "GitHub CLI".to_string(),
+            purpose: "Some Claudette features talk to GitHub through the `gh` CLI \
+                (for example the GitHub SCM plugin)."
+                .to_string(),
+            platform,
+            install_options: gh_options(),
+        },
+        other => MissingCli {
+            tool: other.to_string(),
+            display_name: other.to_string(),
+            purpose: format!("Claudette needs `{other}` on PATH, but it wasn't found."),
+            platform,
+            install_options: Vec::new(),
+        },
+    }
+}
+
+fn claude_options() -> Vec<InstallOption> {
+    let mut opts = vec![InstallOption::cmd(
+        "Install with npm",
+        "npm install -g @anthropic-ai/claude-code",
+    )];
+    if cfg!(target_os = "windows") {
+        opts.push(InstallOption::link(
+            "Official installer",
+            "https://claude.com/product/claude-code",
+        ));
+    } else {
+        opts.push(InstallOption::link(
+            "Installation guide",
+            "https://docs.claude.com/en/docs/claude-code/setup",
+        ));
+    }
+    opts
+}
+
+fn git_options() -> Vec<InstallOption> {
+    if cfg!(target_os = "macos") {
+        vec![
+            InstallOption::cmd("Install Xcode Command Line Tools", "xcode-select --install"),
+            InstallOption::cmd("Install with Homebrew", "brew install git"),
+            InstallOption::link("git-scm.com", "https://git-scm.com/download/mac"),
+        ]
+    } else if cfg!(target_os = "windows") {
+        vec![
+            InstallOption::cmd("Install with winget", "winget install --id Git.Git -e"),
+            InstallOption::link("Git for Windows", "https://git-scm.com/download/win"),
+        ]
+    } else {
+        vec![
+            InstallOption::cmd("Debian / Ubuntu", "sudo apt install git"),
+            InstallOption::cmd("Fedora / RHEL", "sudo dnf install git"),
+            InstallOption::cmd("Arch", "sudo pacman -S git"),
+            InstallOption::link("Other distros", "https://git-scm.com/download/linux"),
+        ]
+    }
+}
+
+fn gh_options() -> Vec<InstallOption> {
+    if cfg!(target_os = "macos") {
+        vec![
+            InstallOption::cmd("Install with Homebrew", "brew install gh"),
+            InstallOption::link("cli.github.com", "https://cli.github.com/"),
+        ]
+    } else if cfg!(target_os = "windows") {
+        vec![
+            InstallOption::cmd("Install with winget", "winget install --id GitHub.cli -e"),
+            InstallOption::link("cli.github.com", "https://cli.github.com/"),
+        ]
+    } else {
+        vec![
+            InstallOption::cmd("Debian / Ubuntu", "sudo apt install gh"),
+            InstallOption::cmd("Fedora / RHEL", "sudo dnf install gh"),
+            InstallOption::cmd("Arch", "sudo pacman -S github-cli"),
+            InstallOption::link("Install guide", "https://github.com/cli/cli#installation"),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_and_parse_roundtrip() {
+        let s = format_err("claude");
+        assert_eq!(parse_err(&s), Some("claude"));
+        let s2 = format!("{s}: some suffix");
+        assert_eq!(parse_err(&s2), Some("claude"));
+    }
+
+    #[test]
+    fn parse_err_rejects_non_sentinel() {
+        assert_eq!(parse_err("Failed to spawn"), None);
+        assert_eq!(parse_err(""), None);
+    }
+
+    #[test]
+    fn is_not_found_maps_errorkind() {
+        let not_found = std::io::Error::new(std::io::ErrorKind::NotFound, "program not found");
+        assert!(is_not_found(&not_found));
+        let other = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "nope");
+        assert!(!is_not_found(&other));
+    }
+
+    #[test]
+    fn map_spawn_err_returns_sentinel_on_not_found() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "x");
+        let out = map_spawn_err(&err, "claude", || "fallback".to_string());
+        assert_eq!(out, format_err("claude"));
+    }
+
+    #[test]
+    fn map_spawn_err_returns_fallback_otherwise() {
+        let err = std::io::Error::other("boom");
+        let out = map_spawn_err(&err, "claude", || "fallback".to_string());
+        assert_eq!(out, "fallback");
+    }
+
+    #[test]
+    fn guidance_for_claude_has_npm_option() {
+        let g = guidance_for("claude");
+        assert_eq!(g.tool, "claude");
+        assert_eq!(g.display_name, "Claude CLI");
+        assert!(!g.purpose.is_empty());
+        assert!(
+            g.install_options
+                .iter()
+                .any(|o| o.command.as_deref() == Some("npm install -g @anthropic-ai/claude-code"))
+        );
+    }
+
+    #[test]
+    fn guidance_for_git_has_platform_option() {
+        let g = guidance_for("git");
+        assert_eq!(g.tool, "git");
+        assert!(!g.install_options.is_empty());
+    }
+
+    #[test]
+    fn guidance_for_gh_has_entries() {
+        let g = guidance_for("gh");
+        assert_eq!(g.tool, "gh");
+        assert!(!g.install_options.is_empty());
+    }
+
+    #[test]
+    fn guidance_for_unknown_tool_returns_fallback() {
+        let g = guidance_for("fakebin");
+        assert_eq!(g.tool, "fakebin");
+        assert!(g.install_options.is_empty());
+    }
+
+    #[test]
+    fn current_platform_is_one_of_three() {
+        let p = current_platform();
+        assert!(matches!(p, "macos" | "linux" | "windows"));
+    }
+}

--- a/src/missing_cli.rs
+++ b/src/missing_cli.rs
@@ -27,9 +27,14 @@ pub fn format_err(tool: &str) -> String {
 /// If `err` carries the sentinel [`SPAWN_ERR_PREFIX`], return the tool token.
 pub fn parse_err(err: &str) -> Option<&str> {
     let rest = err.strip_prefix(SPAWN_ERR_PREFIX)?;
-    // Tool token ends at the first `:` or end-of-string.
-    let end = rest.find(':').unwrap_or(rest.len());
-    Some(&rest[..end])
+    // The optional original-error suffix (produced by [`format_err`] callers
+    // that append context) is documented as `": <original error>"`. Split only
+    // on that unambiguous delimiter so colons inside the tool token — e.g.
+    // Windows drive letters in absolute paths (`C:\Tools\gh.exe`) — are
+    // preserved. Host-side normalization in `host_exec` usually collapses
+    // paths to bare names before emitting the sentinel, but parsing has to
+    // stay robust for legacy/hand-crafted payloads.
+    Some(rest.split_once(": ").map(|(tool, _)| tool).unwrap_or(rest))
 }
 
 /// Returns `true` when the I/O error's root cause is "executable not found".
@@ -235,6 +240,22 @@ mod tests {
     fn parse_err_rejects_non_sentinel() {
         assert_eq!(parse_err("Failed to spawn"), None);
         assert_eq!(parse_err(""), None);
+    }
+
+    #[test]
+    fn parse_err_preserves_windows_absolute_path_tool() {
+        // Regression for Copilot review on PR #417: splitting on the first
+        // `:` truncated Windows absolute paths (`MISSING_CLI:C:\Tools\gh.exe`
+        // parsed as `tool=C`). `parse_err` now splits only on the documented
+        // `": "` suffix delimiter.
+        assert_eq!(
+            parse_err(r"MISSING_CLI:C:\Tools\gh.exe"),
+            Some(r"C:\Tools\gh.exe")
+        );
+        assert_eq!(
+            parse_err(r"MISSING_CLI:C:\Tools\gh.exe: No such file or directory"),
+            Some(r"C:\Tools\gh.exe")
+        );
     }
 
     #[test]

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -391,9 +391,16 @@ async fn host_exec(
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
 
-    let child = command
-        .spawn()
-        .map_err(|e| LuaError::external(format!("Failed to execute '{cmd}': {e}")))?;
+    let child = command.spawn().map_err(|e| {
+        // Preserve `NotFound` via the missing-CLI sentinel so a Tauri-layer
+        // interceptor (e.g. around scm/env-provider commands) can surface
+        // the MissingCli dialog instead of the raw subprocess error when a
+        // plugin's declared CLI (like `gh`) isn't installed.
+        let msg = crate::missing_cli::map_spawn_err(&e, cmd, || {
+            format!("Failed to execute '{cmd}': {e}")
+        });
+        LuaError::external(msg)
+    })?;
 
     // Run with timeout — kill_on_drop ensures the child is killed if
     // the future is dropped on timeout.

--- a/src/plugin_runtime/host_api.rs
+++ b/src/plugin_runtime/host_api.rs
@@ -322,6 +322,25 @@ fn decode_direnv_watches(encoded: &str) -> Vec<String> {
         .collect()
 }
 
+/// Collapse a CLI identifier (which plugins may declare as a bare name
+/// like `"gh"` or as a full path like `"C:\\Tools\\gh.exe"`) to a stable
+/// tool token suitable for the missing-CLI sentinel. Strips the directory
+/// and the trailing extension. Falls back to the original string when no
+/// sensible stem can be extracted.
+///
+/// Handles both `/` and `\` as separators regardless of the host platform —
+/// a plugin declared on a Windows install can be carried in a manifest
+/// that's loaded on macOS/Linux for tests, and `Path::file_stem` on Unix
+/// treats backslashes as regular characters.
+fn normalize_cli_name(cmd: &str) -> &str {
+    let basename = cmd.rsplit(['/', '\\']).next().unwrap_or(cmd);
+    let stem = basename
+        .rsplit_once('.')
+        .map(|(stem, _ext)| stem)
+        .unwrap_or(basename);
+    if stem.is_empty() { cmd } else { stem }
+}
+
 /// Execute a subprocess, restricted to allowed CLIs.
 async fn host_exec(
     lua: &Lua,
@@ -412,7 +431,14 @@ async fn host_exec(
         // interceptor (e.g. around scm/env-provider commands) can surface
         // the MissingCli dialog instead of the raw subprocess error when a
         // plugin's declared CLI (like `gh`) isn't installed.
-        let msg = crate::missing_cli::map_spawn_err(&e, cmd, || {
+        //
+        // Normalize `cmd` to its basename sans extension before emitting the
+        // sentinel — a plugin that declares a full path (`C:\Tools\gh.exe`)
+        // would otherwise produce `MISSING_CLI:C:\Tools\gh.exe`, which the
+        // Tauri-side `guidance_for` lookup can't match to the `gh` entry
+        // (and whose drive-letter colon would also confuse a naive parser).
+        let tool = normalize_cli_name(cmd);
+        let msg = crate::missing_cli::map_spawn_err(&e, tool, || {
             format!("Failed to execute '{cmd}': {e}")
         });
         LuaError::external(msg)
@@ -1078,5 +1104,29 @@ mod tests {
         );
         let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&compressed);
         assert!(decode_direnv_watches(&encoded).is_empty());
+    }
+
+    #[test]
+    fn normalize_cli_name_keeps_bare_name() {
+        assert_eq!(normalize_cli_name("gh"), "gh");
+        assert_eq!(normalize_cli_name("git"), "git");
+    }
+
+    #[test]
+    fn normalize_cli_name_strips_extension_and_directory() {
+        // Regression for Copilot review on PR #417: plugins that declare a
+        // full path (common on Windows) must still produce a tool token that
+        // matches `missing_cli::guidance_for`.
+        assert_eq!(normalize_cli_name(r"C:\Tools\gh.exe"), "gh");
+        assert_eq!(normalize_cli_name("/usr/local/bin/gh"), "gh");
+        assert_eq!(normalize_cli_name("gh.exe"), "gh");
+    }
+
+    #[test]
+    fn normalize_cli_name_falls_back_to_input_when_empty() {
+        // Path::file_stem returns None for `"/"` — the fallback must keep
+        // callers from silently emitting an empty tool token.
+        assert_eq!(normalize_cli_name("/"), "/");
+        assert_eq!(normalize_cli_name(""), "");
     }
 }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -229,6 +229,16 @@ function App() {
       }
     });
 
+    // Listen for missing-CLI events (claude/git/gh not on PATH). Routes to the
+    // MissingCliModal so users see platform-specific install guidance instead
+    // of a raw subprocess error.
+    const unlistenMissingCli = listen<import("./components/modals/MissingCliModal").MissingCliData>(
+      "missing-dependency",
+      (event) => {
+        useAppStore.getState().openModal("missingCli", event.payload as unknown as Record<string, unknown>);
+      },
+    );
+
     // Listen for workspace auto-archived events (e.g. PR merged with archive_on_merge).
     const unlistenAutoArchived = listen<{ workspace_id: string; workspace_name: string; pr_number?: number }>("workspace-auto-archived", (event) => {
       const { workspace_id, workspace_name, pr_number } = event.payload;
@@ -257,6 +267,7 @@ function App() {
       unlistenResetZoom.then((fn) => fn());
       unlistenScmUpdate.then((fn) => fn());
       unlistenAutoArchived.then((fn) => fn());
+      unlistenMissingCli.then((fn) => fn());
     };
   }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setPluginManagementEnabled, setAppVersion]);
 

--- a/src/ui/src/components/modals/MissingCliModal.module.css
+++ b/src/ui/src/components/modals/MissingCliModal.module.css
@@ -1,0 +1,69 @@
+.purpose {
+  font-size: 13px;
+  color: var(--text-primary);
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.platformLine {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.optionList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.option {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.optionLabel {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.commandRow {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.code {
+  flex: 1;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow-x: auto;
+  display: flex;
+  align-items: center;
+}
+
+.linkButton {
+  background: transparent;
+  border: none;
+  color: var(--accent-fg, var(--text-primary));
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  padding: 0;
+  text-decoration: underline;
+  word-break: break-all;
+}
+
+.linkButton:hover {
+  opacity: 0.8;
+}

--- a/src/ui/src/components/modals/MissingCliModal.tsx
+++ b/src/ui/src/components/modals/MissingCliModal.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useAppStore } from "../../stores/useAppStore";
+import { openUrl } from "../../services/tauri";
+import { Modal } from "./Modal";
+import shared from "./shared.module.css";
+import styles from "./MissingCliModal.module.css";
+
+export interface InstallOption {
+  label: string;
+  command?: string;
+  url?: string;
+}
+
+export interface MissingCliData {
+  tool: string;
+  display_name: string;
+  purpose: string;
+  platform: string;
+  install_options: InstallOption[];
+}
+
+const PLATFORM_LABEL: Record<string, string> = {
+  macos: "macOS",
+  linux: "Linux",
+  windows: "Windows",
+};
+
+function isMissingCliData(value: unknown): value is MissingCliData {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.tool === "string" &&
+    typeof v.display_name === "string" &&
+    typeof v.purpose === "string" &&
+    typeof v.platform === "string" &&
+    Array.isArray(v.install_options)
+  );
+}
+
+export function MissingCliModal() {
+  const closeModal = useAppStore((s) => s.closeModal);
+  const modalData = useAppStore((s) => s.modalData);
+  const [copied, setCopied] = useState<number | null>(null);
+
+  const data = isMissingCliData(modalData) ? modalData : null;
+  if (!data) return null;
+
+  const platformLabel = PLATFORM_LABEL[data.platform] ?? data.platform;
+
+  const handleCopy = async (cmd: string, idx: number) => {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(idx);
+      setTimeout(() => setCopied((c) => (c === idx ? null : c)), 1500);
+    } catch {
+      // Clipboard API can reject in some sandboxes — silently ignore.
+    }
+  };
+
+  const handleOpen = (url: string) => {
+    void openUrl(url).catch(() => {});
+  };
+
+  return (
+    <Modal title={`${data.display_name} not installed`} onClose={closeModal}>
+      <p className={styles.purpose}>{data.purpose}</p>
+      <div className={styles.platformLine}>
+        Detected platform: <strong>{platformLabel}</strong>
+      </div>
+      {data.install_options.length > 0 ? (
+        <ul className={styles.optionList}>
+          {data.install_options.map((opt, idx) => (
+            <li key={idx} className={styles.option}>
+              <div className={styles.optionLabel}>{opt.label}</div>
+              {opt.command && (
+                <div className={styles.commandRow}>
+                  <code className={styles.code}>{opt.command}</code>
+                  <button
+                    type="button"
+                    className={shared.btn}
+                    onClick={() => void handleCopy(opt.command!, idx)}
+                  >
+                    {copied === idx ? "Copied" : "Copy"}
+                  </button>
+                </div>
+              )}
+              {opt.url && (
+                <button
+                  type="button"
+                  className={styles.linkButton}
+                  onClick={() => handleOpen(opt.url!)}
+                >
+                  {opt.url}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className={shared.warning}>
+          No installation guidance is available for this tool — please consult
+          its documentation.
+        </div>
+      )}
+      <div className={shared.actions}>
+        <button className={shared.btnPrimary} onClick={closeModal}>
+          Close
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/modals/MissingCliModal.tsx
+++ b/src/ui/src/components/modals/MissingCliModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { openUrl } from "../../services/tauri";
 import { Modal } from "./Modal";
@@ -25,6 +25,16 @@ const PLATFORM_LABEL: Record<string, string> = {
   windows: "Windows",
 };
 
+function isInstallOption(value: unknown): value is InstallOption {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.label === "string" &&
+    (v.command === undefined || typeof v.command === "string") &&
+    (v.url === undefined || typeof v.url === "string")
+  );
+}
+
 function isMissingCliData(value: unknown): value is MissingCliData {
   if (value === null || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
@@ -33,7 +43,8 @@ function isMissingCliData(value: unknown): value is MissingCliData {
     typeof v.display_name === "string" &&
     typeof v.purpose === "string" &&
     typeof v.platform === "string" &&
-    Array.isArray(v.install_options)
+    Array.isArray(v.install_options) &&
+    v.install_options.every(isInstallOption)
   );
 }
 
@@ -41,6 +52,20 @@ export function MissingCliModal() {
   const closeModal = useAppStore((s) => s.closeModal);
   const modalData = useAppStore((s) => s.modalData);
   const [copied, setCopied] = useState<number | null>(null);
+  // Track the pending "Copied" reset so it can be cancelled on unmount and
+  // on repeat clicks — otherwise a timer could fire after the modal closes
+  // and call setState on an unmounted component.
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+        copyTimerRef.current = null;
+      }
+    },
+    [],
+  );
 
   const data = isMissingCliData(modalData) ? modalData : null;
   if (!data) return null;
@@ -51,7 +76,13 @@ export function MissingCliModal() {
     try {
       await navigator.clipboard.writeText(cmd);
       setCopied(idx);
-      setTimeout(() => setCopied((c) => (c === idx ? null : c)), 1500);
+      if (copyTimerRef.current !== null) {
+        clearTimeout(copyTimerRef.current);
+      }
+      copyTimerRef.current = setTimeout(() => {
+        copyTimerRef.current = null;
+        setCopied((c) => (c === idx ? null : c));
+      }, 1500);
     } catch {
       // Clipboard API can reject in some sandboxes — silently ignore.
     }

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -10,6 +10,7 @@ import { ConfirmSetupScriptModal } from "./ConfirmSetupScriptModal";
 import { McpSelectionModal } from "./McpSelectionModal";
 import { ImportWorktreesModal } from "./ImportWorktreesModal";
 import { ConfirmNightlyChannelModal } from "./ConfirmNightlyChannelModal";
+import { MissingCliModal } from "./MissingCliModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -37,6 +38,8 @@ export function ModalRouter() {
       return <ImportWorktreesModal />;
     case "confirmNightlyChannel":
       return <ConfirmNightlyChannelModal />;
+    case "missingCli":
+      return <MissingCliModal />;
     default:
       return null;
   }


### PR DESCRIPTION
Closes #382.

Two related changes to the Windows / first-run UX when a required dependency is missing. See follow-up #418 for the installer/bundler track.

## Summary

### 1. Missing-CLI install-guidance dialog (primary)

- Adds `claudette::missing_cli` — a sentinel error format (`MISSING_CLI:<tool>`), platform detection, and a per-tool × per-OS install-guidance table covering `claude`, `git`, and `gh`.
- Wraps the `claude` spawn sites in `src/agent.rs` (run_turn, persistent session, branch-rename) and all `git` sites in `src/git.rs` (via `GitError::CliNotFound`) so an `io::ErrorKind::NotFound` is preserved instead of being folded into a generic "command failed" string.
- Tauri-layer `crate::missing_cli::handle_err` intercepts the sentinel at the most user-visible entry points (`send_chat_message`, `claude_auth_login`, `add_repository`, `relink_repository`), emits a structured `missing-dependency` event with the `MissingCli` payload, and rewrites the returned `Err` into a short friendly message.
- New `MissingCliModal` renders the payload with copy buttons for commands and browser-open buttons for URLs, keyed by the user's OS. `App.tsx` listens for the event and opens the modal via the existing Zustand `openModal` pipe.

This is the reactive (MVP) path from the issue — a proactive startup probe can land on top of the same payload shape later.

### 2. Pre-webview probe for missing WebView2 Runtime (Windows-only)

The missing-CLI dialog can't help if Claudette itself never loads. On Windows, when the Edge WebView2 Runtime isn't installed, Tauri's webview initialization fails with a generic system error dialog ("Could not find the WebView2 Runtime") and the process exits.

- New `src-tauri/src/webview2_check.rs` probes the Evergreen Runtime registry keys (HKLM x86-64 + HKLM native + HKCU) at the top of `main()`, before any Tauri code runs.
- If the runtime is missing, surface a native `MessageBoxW` with a short explanation and an OK/Cancel prompt; OK opens Microsoft's download page via `start`, then we exit cleanly. No webview required.
- `#[cfg(windows)]` gated — macOS/Linux builds are unaffected (`ensure_installed()` is an empty fn). Skipped for `--server` subcommand, which doesn't need the webview.
- Adds two direct Windows-only deps (`winreg`, `windows-sys` with `Win32_UI_WindowsAndMessaging` + `Win32_Foundation`). Both were already transitive — Cargo.lock grew by two lines.
- Full installer + `bundle.windows.webviewInstallMode` track (option 1 from the design discussion) is out of scope for this PR — see #418.

## Test plan

- [x] `cargo test --all-features` — 680 passed, incl. 10 new `missing_cli` tests (roundtrip, parse, platform, guidance tables); Windows-only `webview2_check` tests are `#[cfg(windows)]` and will run in Windows CI
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cd src/ui && bunx tsc -b` — clean
- [x] `cd src/ui && bun run test` — 663 passed
- [ ] Windows CI validates the WebView2 probe compilation (can't cross-compile locally from macOS)
- [ ] Manual UAT on macOS: rename `claude` on PATH, click Send in a workspace chat, verify the dialog appears with npm + docs entries
- [ ] Manual UAT on Windows: uninstall WebView2 Runtime, launch Claudette, verify the native MessageBox appears and the OK button opens the Microsoft download page
- [ ] Manual UAT on Windows: install WebView2 Runtime, launch Claudette, verify the probe is silent and the app starts normally