### PR TITLE
chore(devshell): aws-win-* + deploy-win-x64 helpers for ephemeral EC2 Windows testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ tags
 
 # Documentation
 /docs
+
+# Claudette devshell runtime state (aws-win-* sidecars, etc.)
+/.claudette/

--- a/flake.nix
+++ b/flake.nix
@@ -366,9 +366,11 @@
               pkgs.llvmPackages.llvm
               # aws-win-spinup / aws-win-destroy helpers shell out to these.
               # Pinning them here means teammates on plain Darwin don't need
-              # a system awscli install for the devshell command to work.
+              # a system awscli/openssl install for the devshell to work.
+              # openssl is used by aws-win-spinup for random password
+              # generation; awscli2 drives the EC2 API calls.
               pkgs.awscli2
-              pkgs.jq
+              pkgs.openssl
             ]
             ++ darwinBuildInputs
             ++ linuxBuildInputs

--- a/flake.nix
+++ b/flake.nix
@@ -565,429 +565,53 @@
                 help = "Run all Rust tests";
                 category = "quality";
               }
+              # Windows cross-build + deploy + AWS ephemeral-host helpers.
+              # All bodies live in ./scripts/ — the devshell commands are
+              # thin wrappers so flake.nix doesn't carry hundreds of lines
+              # of bash-in-nix-strings. See scripts/*.sh for the logic and
+              # scripts/_aws-common.sh for the shared helpers (profile/
+              # region defaults, state dir under $PRJ_ROOT/.claudette/,
+              # instance discovery).
               {
                 name = "build-win-arm64";
-                command = ''
-                  set -euo pipefail
-                  # Rebuild the frontend — tauri-codegen bakes src/ui/dist/
-                  # into the .exe at build time, so a stale dist silently
-                  # produces a stale binary.
-                  (cd src/ui && bun install --frozen-lockfile && bun run build)
-                  # Cross-compile the Tauri binary. Three things make this
-                  # the correct invocation:
-                  #
-                  # 1. --features tauri/custom-protocol — without this,
-                  #    tauri-build emits cargo:rustc-cfg=dev and the
-                  #    resulting binary loads http://localhost:1420 at
-                  #    runtime instead of the embedded asset protocol.
-                  #    `cargo tauri build` passes this automatically;
-                  #    plain `cargo build`/`cargo xwin build` do not.
-                  # 2. Default cargo-xwin mode (clang-cl) — the devshell's
-                  #    clangXwinShim rewrites /imsvc → -isystem so ring's
-                  #    direct-clang .S assembly compile doesn't choke on
-                  #    MSVC-style include flags leaked into CFLAGS.
-                  # 3. --release — tauri-codegen embeds the frontend only
-                  #    when the binary isn't in debug profile.
-                  #
-                  # We skip `cargo tauri build --runner` because tauri-cli
-                  # shells out to rustup to verify the target is installed,
-                  # and our fenix toolchain supplies the rust-std outside
-                  # rustup's knowledge. Driving `cargo xwin build` directly
-                  # sidesteps the check; asset embedding is handled by
-                  # the feature flag above.
-                  cargo xwin build --release \
-                    --features tauri/custom-protocol \
-                    --target aarch64-pc-windows-msvc -p claudette-tauri
-                  echo ""
-                  echo "Built: $PWD/target/aarch64-pc-windows-msvc/release/claudette.exe"
-                '';
+                command = ''exec "$PRJ_ROOT/scripts/build-win.sh" arm64 "$@"'';
                 help = "Cross-compile claudette.exe for aarch64-pc-windows-msvc (Windows on ARM)";
                 category = "windows";
               }
               {
                 name = "deploy-win-arm64";
-                command = ''
-                  set -euo pipefail
-                  # Build, then stop any running instance on the test VM and
-                  # copy the fresh .exe over. The remote process has a file
-                  # lock on claudette.exe while running, so scp cannot
-                  # overwrite it without the Stop-Process step.
-                  #
-                  # Host and remote path are overridable for cases where the
-                  # VM's DHCP lease changes or someone else tests against a
-                  # different machine. Defaults match the project's shared
-                  # Windows-on-ARM test VM (see project memory).
-                  HOST=''${CLAUDETTE_WIN_HOST:-brink@172.16.52.129}
-                  REMOTE_PATH=''${CLAUDETTE_WIN_REMOTE_PATH:-OneDrive/Desktop/claudette.exe}
-                  build-win-arm64
-                  echo ""
-                  echo "Stopping running claudette on $HOST (if any)..."
-                  ssh "$HOST" 'Stop-Process -Name claudette -Force -ErrorAction SilentlyContinue'
-                  echo "Copying to $HOST:$REMOTE_PATH ..."
-                  scp target/aarch64-pc-windows-msvc/release/claudette.exe "$HOST:$REMOTE_PATH"
-                  echo ""
-                  echo "Deployed. Double-click claudette.exe on the VM desktop to run."
-                '';
+                command = ''exec "$PRJ_ROOT/scripts/deploy-win.sh" arm64 "$@"'';
                 help = "Build + deploy aarch64-pc-windows-msvc exe to the test VM (overridable via CLAUDETTE_WIN_HOST / CLAUDETTE_WIN_REMOTE_PATH)";
                 category = "windows";
               }
               {
                 name = "build-win-x64";
-                command = ''
-                  set -euo pipefail
-                  (cd src/ui && bun install --frozen-lockfile && bun run build)
-                  cargo xwin build --release \
-                    --features tauri/custom-protocol \
-                    --target x86_64-pc-windows-msvc -p claudette-tauri
-                  echo ""
-                  echo "Built: $PWD/target/x86_64-pc-windows-msvc/release/claudette.exe"
-                '';
+                command = ''exec "$PRJ_ROOT/scripts/build-win.sh" x64 "$@"'';
                 help = "Cross-compile claudette.exe for x86_64-pc-windows-msvc";
                 category = "windows";
               }
               {
                 name = "deploy-win-x64";
-                command = ''
-                  set -euo pipefail
-                  # Parallel of deploy-win-arm64. Used against fresh EC2
-                  # Windows hosts launched by aws-win-spinup — those default
-                  # to Administrator@... with Desktop\ at the profile root
-                  # (no OneDrive redirect, unlike James's personal test VM).
-                  HOST=''${CLAUDETTE_WIN_HOST:-Administrator@CHANGEME}
-                  REMOTE_PATH=''${CLAUDETTE_WIN_REMOTE_PATH:-Desktop/claudette.exe}
-                  if [ "$HOST" = "Administrator@CHANGEME" ]; then
-                    echo "error: set CLAUDETTE_WIN_HOST (e.g. 'eval \"\$(aws-win-spinup)\"')" >&2
-                    exit 1
-                  fi
-                  build-win-x64
-                  echo ""
-                  echo "Stopping running claudette on $HOST (if any)..."
-                  ssh -o StrictHostKeyChecking=accept-new "$HOST" 'Stop-Process -Name claudette -Force -ErrorAction SilentlyContinue'
-                  echo "Copying to $HOST:$REMOTE_PATH ..."
-                  scp -o StrictHostKeyChecking=accept-new target/x86_64-pc-windows-msvc/release/claudette.exe "$HOST:$REMOTE_PATH"
-                  echo ""
-                  echo "Deployed. Double-click claudette.exe on the remote Desktop to run."
-                '';
-                help = "Build + deploy x86_64-pc-windows-msvc exe to CLAUDETTE_WIN_HOST (e.g. an aws-win-spinup instance)";
+                command = ''exec "$PRJ_ROOT/scripts/deploy-win.sh" x64 "$@"'';
+                help = "Build + deploy x86_64-pc-windows-msvc exe (auto-discovers aws-win-spinup instance, or override via CLAUDETTE_WIN_HOST)";
                 category = "windows";
               }
               {
                 name = "aws-win-spinup";
-                command = ''
-                  set -euo pipefail
-                  # Spin up an ephemeral, publicly-reachable Windows Server
-                  # EC2 instance with OpenSSH enabled, the caller's pubkey
-                  # pre-authorized, and a known Administrator password baked
-                  # in via user-data. Prints `export` lines that point the
-                  # deploy-win-* helpers at it and store the admin password
-                  # in $TMPDIR for aws-win-rdp to pick up.
-                  #
-                  # Usage:
-                  #   eval "$(nix develop -c aws-win-spinup)"
-                  #   aws-win-rdp                # opens Windows App (macOS)
-                  #   deploy-win-x64             # build + copy claudette.exe
-                  #   aws-win-destroy            # when finished
-                  #
-                  # Everything is tagged Project=claudette-spinup so
-                  # aws-win-destroy can find and terminate the fleet.
-                  #
-                  # Defaults are chosen so a teammate with a standard
-                  # ~/.ssh/id_ed25519.pub just works — no RSA-specific path
-                  # is required because the admin password is set by user-
-                  # data rather than decrypted via get-password-data.
-                  PROFILE=''${AWS_PROFILE:-dev.urandom.io}
-                  REGION=''${AWS_REGION:-us-west-2}
-                  # Fallback chain for the default pubkey: try ed25519 first
-                  # (present on 99% of dev Macs), then rsa, then the legacy
-                  # project key. SPINUP_PUB_KEY overrides everything.
-                  if [ -n "''${SPINUP_PUB_KEY:-}" ]; then
-                    PUB_KEY_FILE="$SPINUP_PUB_KEY"
-                  elif [ -r "$HOME/.ssh/id_ed25519.pub" ]; then
-                    PUB_KEY_FILE="$HOME/.ssh/id_ed25519.pub"
-                  elif [ -r "$HOME/.ssh/id_rsa.pub" ]; then
-                    PUB_KEY_FILE="$HOME/.ssh/id_rsa.pub"
-                  else
-                    PUB_KEY_FILE="$HOME/.ssh/dev.urandom.io.pub"
-                  fi
-                  SG_NAME=''${SPINUP_SG_NAME:-claudette-spinup-sg}
-                  INSTANCE_TYPE=''${SPINUP_INSTANCE_TYPE:-t3.medium}
-                  NAME_TAG=''${SPINUP_NAME_TAG:-claudette-spinup-$(date +%Y%m%d-%H%M%S)}
-                  AMI_FILTER=''${SPINUP_AMI_FILTER:-Windows_Server-2022-English-Full-Base-*}
-                  # Admin password: caller can pin one for reproducibility,
-                  # otherwise generate 32 hex chars + `Aa1!` to guarantee
-                  # all four Windows local-policy character classes (upper,
-                  # lower, digit, symbol) without introducing characters
-                  # that need PowerShell escaping.
-                  ADMIN_PASS=''${SPINUP_ADMIN_PASSWORD:-$(openssl rand -hex 16)Aa1!}
-
-                  log() { echo "[aws-win-spinup] $*" >&2; }
-                  aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
-
-                  [ -r "$PUB_KEY_FILE" ] || { log "pubkey $PUB_KEY_FILE not readable"; exit 1; }
-                  PUBKEY=$(cat "$PUB_KEY_FILE")
-                  log "pubkey: $PUB_KEY_FILE"
-
-                  # No EC2 key pair: ed25519 is not accepted for Windows
-                  # AMIs ("Unsupported: ED25519 key pairs are not supported
-                  # with Windows AMIs"), and we don't need one because
-                  # user-data installs the pubkey into
-                  # administrators_authorized_keys directly. Side benefit:
-                  # get-password-data becomes a non-option, which forces
-                  # us down the user-data-password path (already the
-                  # simplest and most reliable).
-
-                  # 1. Security group: 22 + 3389 open to 0.0.0.0/0 (ephemeral).
-                  VPC_ID=$(aws_ ec2 describe-vpcs \
-                    --filters "Name=is-default,Values=true" \
-                    --query 'Vpcs[0].VpcId' --output text)
-                  [ "$VPC_ID" != "None" ] || { log "no default VPC in $REGION"; exit 1; }
-                  SG_ID=$(aws_ ec2 describe-security-groups \
-                    --filters "Name=group-name,Values=$SG_NAME" "Name=vpc-id,Values=$VPC_ID" \
-                    --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo None)
-                  if [ "$SG_ID" = "None" ] || [ -z "$SG_ID" ]; then
-                    log "creating security group $SG_NAME in $VPC_ID"
-                    SG_ID=$(aws_ ec2 create-security-group \
-                      --group-name "$SG_NAME" \
-                      --description "Claudette ephemeral Windows test SG (SSH+RDP public)" \
-                      --vpc-id "$VPC_ID" \
-                      --tag-specifications "ResourceType=security-group,Tags=[{Key=Project,Value=claudette-spinup}]" \
-                      --query 'GroupId' --output text)
-                    aws_ ec2 authorize-security-group-ingress --group-id "$SG_ID" \
-                      --ip-permissions \
-                        'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=0.0.0.0/0,Description=ssh}]' \
-                        'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=0.0.0.0/0,Description=rdp}]' \
-                      >/dev/null
-                  fi
-                  log "security group: $SG_ID"
-
-                  # 2. Latest Windows Server 2022 AMI (amazon-owned).
-                  AMI_ID=$(aws_ ec2 describe-images --owners amazon \
-                    --filters "Name=name,Values=$AMI_FILTER" "Name=architecture,Values=x86_64" "Name=state,Values=available" \
-                    --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text)
-                  [ -n "$AMI_ID" ] && [ "$AMI_ID" != "None" ] || { log "no AMI matching $AMI_FILTER"; exit 1; }
-                  log "AMI: $AMI_ID"
-
-                  # 3. Render user-data. EC2Launch v2 runs the <powershell>
-                  #    block once on first boot. Windows Server 2022 ships
-                  #    OpenSSH Server pre-installed — just enable, start, and
-                  #    drop the pubkey into administrators_authorized_keys
-                  #    (takes precedence over per-user ~/.ssh/authorized_keys
-                  #    for anyone in the local Administrators group).
-                  USER_DATA=$(mktemp)
-                  trap 'rm -f "$USER_DATA"' EXIT
-                  cat > "$USER_DATA" <<EOF
-<powershell>
-\$ErrorActionPreference = 'Stop'
-try {
-  # Pin the Administrator password to our known value before anything else
-  # so if the rest of user-data fails, RDP is still usable for diagnosis.
-  # PowerShell here-string with single quotes is literal — $ADMIN_PASS only
-  # contains hex + Aa1! so it's safe to interpolate without escaping.
-  net user Administrator '$ADMIN_PASS' | Out-Null
-
-  Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction SilentlyContinue | Out-Null
-  Set-Service -Name sshd -StartupType Automatic
-  Start-Service sshd
-  if (!(Test-Path 'C:\ProgramData\ssh')) { New-Item -ItemType Directory -Path 'C:\ProgramData\ssh' | Out-Null }
-  \$authKey = 'C:\ProgramData\ssh\administrators_authorized_keys'
-  \$pub = @'
-$PUBKEY
-'@
-  Set-Content -Path \$authKey -Value \$pub -Encoding ascii
-  icacls.exe \$authKey /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F' | Out-Null
-  if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
-    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
-  }
-  New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -PropertyType String -Force | Out-Null
-  Restart-Service sshd
-} catch {
-  Write-Host "user-data error: \$_"
-  throw
-}
-</powershell>
-<persist>false</persist>
-EOF
-
-                  # 4. Launch. Intentionally no --key-name (see note above).
-                  log "launching $INSTANCE_TYPE ($NAME_TAG)"
-                  INSTANCE_ID=$(aws_ ec2 run-instances \
-                    --image-id "$AMI_ID" \
-                    --instance-type "$INSTANCE_TYPE" \
-                    --security-group-ids "$SG_ID" \
-                    --user-data "file://$USER_DATA" \
-                    --metadata-options 'HttpTokens=required,HttpEndpoint=enabled' \
-                    --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=50,VolumeType=gp3,DeleteOnTermination=true}' \
-                    --tag-specifications \
-                      "ResourceType=instance,Tags=[{Key=Project,Value=claudette-spinup},{Key=Name,Value=$NAME_TAG}]" \
-                      "ResourceType=volume,Tags=[{Key=Project,Value=claudette-spinup},{Key=Name,Value=$NAME_TAG}]" \
-                    --query 'Instances[0].InstanceId' --output text)
-                  log "instance: $INSTANCE_ID — waiting for running state"
-                  aws_ ec2 wait instance-running --instance-ids "$INSTANCE_ID"
-                  PUBLIC_IP=$(aws_ ec2 describe-instances --instance-ids "$INSTANCE_ID" \
-                    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
-                  log "public IP: $PUBLIC_IP — waiting for sshd (Windows first-boot + user-data is slow, ~5-8 min)"
-
-                  # 5. Poll sshd via ssh-keyscan. Using ssh-keyscan (not a
-                  #    full ssh login) dodges two orthogonal problems:
-                  #    - passphrase-protected private keys need a TTY for
-                  #      ssh to prompt, so BatchMode=yes auth-polling fails
-                  #      forever on perfectly healthy hosts;
-                  #    - we'd be confounding "sshd is up" with "my key is
-                  #      authorized", and only the first is the helper's
-                  #      concern — user-data already installed the key.
-                  #    A successful keyscan means sshd finished starting,
-                  #    which on Windows is what takes the time.
-                  DEADLINE=$(( $(date +%s) + 900 ))
-                  while [ $(date +%s) -lt $DEADLINE ]; do
-                    if ssh-keyscan -T 5 -t rsa "$PUBLIC_IP" 2>/dev/null | grep -q ssh-rsa; then
-                      log "sshd ready"
-                      break
-                    fi
-                    sleep 15
-                  done
-                  if [ $(date +%s) -ge $DEADLINE ]; then
-                    log "timed out waiting for sshd on $PUBLIC_IP (instance $INSTANCE_ID)"
-                    log "inspect with: aws --profile $PROFILE --region $REGION ec2 get-console-output --instance-id $INSTANCE_ID --latest --output text"
-                    exit 1
-                  fi
-
-                  # 6. Stash the password in a mode-600 sidecar under
-                  #    $TMPDIR so aws-win-rdp can find it after a shell
-                  #    restart. Key insight: the password was baked into
-                  #    user-data (visible to anyone with
-                  #    ec2:DescribeInstanceAttribute on this account), so
-                  #    we've already accepted "password sits in AWS-side
-                  #    plaintext for the life of the instance" — dropping
-                  #    it in a mode-600 local file doesn't lower the bar.
-                  PASS_FILE="''${TMPDIR:-/tmp}/claudette-spinup-$INSTANCE_ID.pass"
-                  ( umask 077; printf '%s' "$ADMIN_PASS" > "$PASS_FILE" )
-
-                  # 7. Emit exports on stdout (so `eval "$(aws-win-spinup)"`
-                  #    drops them into the caller's shell); human status
-                  #    went to stderr via log().
-                  cat <<EOF
-export CLAUDETTE_WIN_HOST=Administrator@$PUBLIC_IP
-export CLAUDETTE_WIN_REMOTE_PATH=Desktop/claudette.exe
-export CLAUDETTE_WIN_INSTANCE_ID=$INSTANCE_ID
-export CLAUDETTE_WIN_ADMIN_PASSWORD='$ADMIN_PASS'
-# Host:    $PUBLIC_IP
-# SSH:     ssh Administrator@$PUBLIC_IP
-# RDP:     aws-win-rdp            # macOS; opens Windows App with password on clipboard
-# Deploy:  deploy-win-x64
-# Destroy: aws-win-destroy
-EOF
-                '';
-                help = "Launch ephemeral Windows EC2 (us-west-2) with SSH+pubkey pre-configured; prints export lines for deploy-win-x64";
+                command = ''exec "$PRJ_ROOT/scripts/aws-win-spinup.sh" "$@"'';
+                help = "Launch ephemeral Windows EC2 (us-west-2) with SSH+pubkey pre-configured and admin password baked in";
                 category = "windows";
               }
               {
                 name = "aws-win-rdp";
-                command = ''
-                  set -euo pipefail
-                  # macOS helper: look up the current aws-win-spinup instance,
-                  # generate a minimal .rdp file, try to fetch+copy the
-                  # Administrator password, and hand the .rdp to `open` so
-                  # the Windows App (formerly Microsoft Remote Desktop)
-                  # launches a session. Non-darwin callers exit cleanly.
-                  if [ "$(uname)" != "Darwin" ]; then
-                    echo "aws-win-rdp is macOS-only (uses 'open' + 'pbcopy')." >&2
-                    exit 2
-                  fi
-
-                  PROFILE=''${AWS_PROFILE:-dev.urandom.io}
-                  REGION=''${AWS_REGION:-us-west-2}
-                  INSTANCE_ID=''${CLAUDETTE_WIN_INSTANCE_ID:-}
-                  aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
-
-                  # If no instance was exported by aws-win-spinup, pick the
-                  # newest running claudette-spinup instance. Keeps the
-                  # helper useful across shell restarts where the env var
-                  # was lost.
-                  if [ -z "$INSTANCE_ID" ]; then
-                    INSTANCE_ID=$(aws_ ec2 describe-instances \
-                      --filters "Name=tag:Project,Values=claudette-spinup" \
-                                "Name=instance-state-name,Values=running" \
-                      --query 'sort_by(Reservations[].Instances[], &LaunchTime)[-1].InstanceId' \
-                      --output text)
-                    [ -n "$INSTANCE_ID" ] && [ "$INSTANCE_ID" != "None" ] \
-                      || { echo "no running claudette-spinup instance found" >&2; exit 1; }
-                  fi
-
-                  PUBLIC_IP=$(aws_ ec2 describe-instances --instance-ids "$INSTANCE_ID" \
-                    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
-                  [ -n "$PUBLIC_IP" ] && [ "$PUBLIC_IP" != "None" ] \
-                    || { echo "instance $INSTANCE_ID has no public IP" >&2; exit 1; }
-
-                  # Password lookup: env var wins (set by `eval aws-win-spinup`),
-                  # otherwise read the mode-600 sidecar that aws-win-spinup
-                  # wrote. No RSA/PEM/passphrase dance — the password was
-                  # baked into user-data, so we already know it.
-                  PASS_FILE="''${TMPDIR:-/tmp}/claudette-spinup-$INSTANCE_ID.pass"
-                  PASSWORD="''${CLAUDETTE_WIN_ADMIN_PASSWORD:-}"
-                  if [ -z "$PASSWORD" ] && [ -r "$PASS_FILE" ]; then
-                    PASSWORD=$(cat "$PASS_FILE")
-                  fi
-                  if [ -n "$PASSWORD" ]; then
-                    printf %s "$PASSWORD" | pbcopy
-                    echo "Administrator password copied to clipboard (⌘-V in the password field)."
-                  else
-                    echo "(no cached password found — was this instance launched by aws-win-spinup?)"
-                    echo "  expected file: $PASS_FILE"
-                    echo "  or set CLAUDETTE_WIN_ADMIN_PASSWORD before calling aws-win-rdp"
-                  fi
-
-                  # Minimal .rdp file — Windows App is happy with just the
-                  # address + username. Host key / CA / gateway are left
-                  # unset; the client will prompt on first connect.
-                  # Fixed path (not mktemp): a .rdp is disposable, and reusing
-                  # the same path means re-running against the same instance
-                  # doesn't litter $TMPDIR. Also sidesteps the GNU/BSD mktemp
-                  # template-syntax mismatch the devshell exposes.
-                  RDP_FILE="''${TMPDIR:-/tmp}/claudette-spinup-$INSTANCE_ID.rdp"
-                  cat > "$RDP_FILE" <<EOF
-full address:s:$PUBLIC_IP
-username:s:Administrator
-prompt for credentials:i:1
-EOF
-                  echo "opening $RDP_FILE -> $PUBLIC_IP"
-                  open "$RDP_FILE"
-                '';
-                help = "macOS: generate a .rdp, copy Admin password to clipboard, and open the current aws-win-spinup instance in Windows App";
+                command = ''exec "$PRJ_ROOT/scripts/aws-win-rdp.sh" "$@"'';
+                help = "macOS: open the current aws-win-spinup instance in Windows App with admin password on clipboard";
                 category = "windows";
               }
               {
                 name = "aws-win-destroy";
-                command = ''
-                  set -euo pipefail
-                  # Terminate every instance tagged Project=claudette-spinup
-                  # in the target region. Safe to run with none present.
-                  PROFILE=''${AWS_PROFILE:-dev.urandom.io}
-                  REGION=''${AWS_REGION:-us-west-2}
-                  aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
-
-                  mapfile -t IDS < <(aws_ ec2 describe-instances \
-                    --filters "Name=tag:Project,Values=claudette-spinup" \
-                              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
-                    --query 'Reservations[].Instances[].InstanceId' --output text | tr '\t' '\n' | sed '/^$/d')
-                  if [ ''${#IDS[@]} -eq 0 ]; then
-                    echo "no claudette-spinup instances to destroy in $REGION"
-                    exit 0
-                  fi
-                  echo "terminating: ''${IDS[*]}"
-                  aws_ ec2 terminate-instances --instance-ids "''${IDS[@]}" \
-                    --query 'TerminatingInstances[].[InstanceId,CurrentState.Name]' --output text
-                  aws_ ec2 wait instance-terminated --instance-ids "''${IDS[@]}"
-                  # Scrub the local password + .rdp sidecars for these
-                  # instances so their plaintext admin password doesn't
-                  # linger in $TMPDIR after the instance is gone.
-                  for ID in "''${IDS[@]}"; do
-                    rm -f "''${TMPDIR:-/tmp}/claudette-spinup-$ID.pass" \
-                          "''${TMPDIR:-/tmp}/claudette-spinup-$ID.rdp" 2>/dev/null || true
-                  done
-                  echo "terminated."
-                  echo "note: keypair and SG (claudette-spinup-sg) are left in place for reuse."
-                '';
-                help = "Terminate all claudette-spinup tagged EC2 instances in AWS_REGION (default us-west-2)";
+                command = ''exec "$PRJ_ROOT/scripts/aws-win-destroy.sh" "$@"'';
+                help = "Terminate all claudette-spinup tagged EC2 instances in AWS_REGION (default us-west-2) and scrub local state";
                 category = "windows";
               }
               {

--- a/flake.nix
+++ b/flake.nix
@@ -364,6 +364,11 @@
               (lib.hiPrio clangXwinShim)
               pkgs.llvmPackages.clang-unwrapped
               pkgs.llvmPackages.llvm
+              # aws-win-spinup / aws-win-destroy helpers shell out to these.
+              # Pinning them here means teammates on plain Darwin don't need
+              # a system awscli install for the devshell command to work.
+              pkgs.awscli2
+              pkgs.jq
             ]
             ++ darwinBuildInputs
             ++ linuxBuildInputs
@@ -638,6 +643,351 @@
                   echo "Built: $PWD/target/x86_64-pc-windows-msvc/release/claudette.exe"
                 '';
                 help = "Cross-compile claudette.exe for x86_64-pc-windows-msvc";
+                category = "windows";
+              }
+              {
+                name = "deploy-win-x64";
+                command = ''
+                  set -euo pipefail
+                  # Parallel of deploy-win-arm64. Used against fresh EC2
+                  # Windows hosts launched by aws-win-spinup — those default
+                  # to Administrator@... with Desktop\ at the profile root
+                  # (no OneDrive redirect, unlike James's personal test VM).
+                  HOST=''${CLAUDETTE_WIN_HOST:-Administrator@CHANGEME}
+                  REMOTE_PATH=''${CLAUDETTE_WIN_REMOTE_PATH:-Desktop/claudette.exe}
+                  if [ "$HOST" = "Administrator@CHANGEME" ]; then
+                    echo "error: set CLAUDETTE_WIN_HOST (e.g. 'eval \"\$(aws-win-spinup)\"')" >&2
+                    exit 1
+                  fi
+                  build-win-x64
+                  echo ""
+                  echo "Stopping running claudette on $HOST (if any)..."
+                  ssh -o StrictHostKeyChecking=accept-new "$HOST" 'Stop-Process -Name claudette -Force -ErrorAction SilentlyContinue'
+                  echo "Copying to $HOST:$REMOTE_PATH ..."
+                  scp -o StrictHostKeyChecking=accept-new target/x86_64-pc-windows-msvc/release/claudette.exe "$HOST:$REMOTE_PATH"
+                  echo ""
+                  echo "Deployed. Double-click claudette.exe on the remote Desktop to run."
+                '';
+                help = "Build + deploy x86_64-pc-windows-msvc exe to CLAUDETTE_WIN_HOST (e.g. an aws-win-spinup instance)";
+                category = "windows";
+              }
+              {
+                name = "aws-win-spinup";
+                command = ''
+                  set -euo pipefail
+                  # Spin up an ephemeral, publicly-reachable Windows Server
+                  # EC2 instance with OpenSSH enabled, the caller's pubkey
+                  # pre-authorized, and a known Administrator password baked
+                  # in via user-data. Prints `export` lines that point the
+                  # deploy-win-* helpers at it and store the admin password
+                  # in $TMPDIR for aws-win-rdp to pick up.
+                  #
+                  # Usage:
+                  #   eval "$(nix develop -c aws-win-spinup)"
+                  #   aws-win-rdp                # opens Windows App (macOS)
+                  #   deploy-win-x64             # build + copy claudette.exe
+                  #   aws-win-destroy            # when finished
+                  #
+                  # Everything is tagged Project=claudette-spinup so
+                  # aws-win-destroy can find and terminate the fleet.
+                  #
+                  # Defaults are chosen so a teammate with a standard
+                  # ~/.ssh/id_ed25519.pub just works — no RSA-specific path
+                  # is required because the admin password is set by user-
+                  # data rather than decrypted via get-password-data.
+                  PROFILE=''${AWS_PROFILE:-dev.urandom.io}
+                  REGION=''${AWS_REGION:-us-west-2}
+                  # Fallback chain for the default pubkey: try ed25519 first
+                  # (present on 99% of dev Macs), then rsa, then the legacy
+                  # project key. SPINUP_PUB_KEY overrides everything.
+                  if [ -n "''${SPINUP_PUB_KEY:-}" ]; then
+                    PUB_KEY_FILE="$SPINUP_PUB_KEY"
+                  elif [ -r "$HOME/.ssh/id_ed25519.pub" ]; then
+                    PUB_KEY_FILE="$HOME/.ssh/id_ed25519.pub"
+                  elif [ -r "$HOME/.ssh/id_rsa.pub" ]; then
+                    PUB_KEY_FILE="$HOME/.ssh/id_rsa.pub"
+                  else
+                    PUB_KEY_FILE="$HOME/.ssh/dev.urandom.io.pub"
+                  fi
+                  SG_NAME=''${SPINUP_SG_NAME:-claudette-spinup-sg}
+                  INSTANCE_TYPE=''${SPINUP_INSTANCE_TYPE:-t3.medium}
+                  NAME_TAG=''${SPINUP_NAME_TAG:-claudette-spinup-$(date +%Y%m%d-%H%M%S)}
+                  AMI_FILTER=''${SPINUP_AMI_FILTER:-Windows_Server-2022-English-Full-Base-*}
+                  # Admin password: caller can pin one for reproducibility,
+                  # otherwise generate 32 hex chars + `Aa1!` to guarantee
+                  # all four Windows local-policy character classes (upper,
+                  # lower, digit, symbol) without introducing characters
+                  # that need PowerShell escaping.
+                  ADMIN_PASS=''${SPINUP_ADMIN_PASSWORD:-$(openssl rand -hex 16)Aa1!}
+
+                  log() { echo "[aws-win-spinup] $*" >&2; }
+                  aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
+
+                  [ -r "$PUB_KEY_FILE" ] || { log "pubkey $PUB_KEY_FILE not readable"; exit 1; }
+                  PUBKEY=$(cat "$PUB_KEY_FILE")
+                  log "pubkey: $PUB_KEY_FILE"
+
+                  # No EC2 key pair: ed25519 is not accepted for Windows
+                  # AMIs ("Unsupported: ED25519 key pairs are not supported
+                  # with Windows AMIs"), and we don't need one because
+                  # user-data installs the pubkey into
+                  # administrators_authorized_keys directly. Side benefit:
+                  # get-password-data becomes a non-option, which forces
+                  # us down the user-data-password path (already the
+                  # simplest and most reliable).
+
+                  # 1. Security group: 22 + 3389 open to 0.0.0.0/0 (ephemeral).
+                  VPC_ID=$(aws_ ec2 describe-vpcs \
+                    --filters "Name=is-default,Values=true" \
+                    --query 'Vpcs[0].VpcId' --output text)
+                  [ "$VPC_ID" != "None" ] || { log "no default VPC in $REGION"; exit 1; }
+                  SG_ID=$(aws_ ec2 describe-security-groups \
+                    --filters "Name=group-name,Values=$SG_NAME" "Name=vpc-id,Values=$VPC_ID" \
+                    --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo None)
+                  if [ "$SG_ID" = "None" ] || [ -z "$SG_ID" ]; then
+                    log "creating security group $SG_NAME in $VPC_ID"
+                    SG_ID=$(aws_ ec2 create-security-group \
+                      --group-name "$SG_NAME" \
+                      --description "Claudette ephemeral Windows test SG (SSH+RDP public)" \
+                      --vpc-id "$VPC_ID" \
+                      --tag-specifications "ResourceType=security-group,Tags=[{Key=Project,Value=claudette-spinup}]" \
+                      --query 'GroupId' --output text)
+                    aws_ ec2 authorize-security-group-ingress --group-id "$SG_ID" \
+                      --ip-permissions \
+                        'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=0.0.0.0/0,Description=ssh}]' \
+                        'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=0.0.0.0/0,Description=rdp}]' \
+                      >/dev/null
+                  fi
+                  log "security group: $SG_ID"
+
+                  # 2. Latest Windows Server 2022 AMI (amazon-owned).
+                  AMI_ID=$(aws_ ec2 describe-images --owners amazon \
+                    --filters "Name=name,Values=$AMI_FILTER" "Name=architecture,Values=x86_64" "Name=state,Values=available" \
+                    --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text)
+                  [ -n "$AMI_ID" ] && [ "$AMI_ID" != "None" ] || { log "no AMI matching $AMI_FILTER"; exit 1; }
+                  log "AMI: $AMI_ID"
+
+                  # 3. Render user-data. EC2Launch v2 runs the <powershell>
+                  #    block once on first boot. Windows Server 2022 ships
+                  #    OpenSSH Server pre-installed — just enable, start, and
+                  #    drop the pubkey into administrators_authorized_keys
+                  #    (takes precedence over per-user ~/.ssh/authorized_keys
+                  #    for anyone in the local Administrators group).
+                  USER_DATA=$(mktemp)
+                  trap 'rm -f "$USER_DATA"' EXIT
+                  cat > "$USER_DATA" <<EOF
+<powershell>
+\$ErrorActionPreference = 'Stop'
+try {
+  # Pin the Administrator password to our known value before anything else
+  # so if the rest of user-data fails, RDP is still usable for diagnosis.
+  # PowerShell here-string with single quotes is literal — $ADMIN_PASS only
+  # contains hex + Aa1! so it's safe to interpolate without escaping.
+  net user Administrator '$ADMIN_PASS' | Out-Null
+
+  Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction SilentlyContinue | Out-Null
+  Set-Service -Name sshd -StartupType Automatic
+  Start-Service sshd
+  if (!(Test-Path 'C:\ProgramData\ssh')) { New-Item -ItemType Directory -Path 'C:\ProgramData\ssh' | Out-Null }
+  \$authKey = 'C:\ProgramData\ssh\administrators_authorized_keys'
+  \$pub = @'
+$PUBKEY
+'@
+  Set-Content -Path \$authKey -Value \$pub -Encoding ascii
+  icacls.exe \$authKey /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F' | Out-Null
+  if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+  }
+  New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -PropertyType String -Force | Out-Null
+  Restart-Service sshd
+} catch {
+  Write-Host "user-data error: \$_"
+  throw
+}
+</powershell>
+<persist>false</persist>
+EOF
+
+                  # 4. Launch. Intentionally no --key-name (see note above).
+                  log "launching $INSTANCE_TYPE ($NAME_TAG)"
+                  INSTANCE_ID=$(aws_ ec2 run-instances \
+                    --image-id "$AMI_ID" \
+                    --instance-type "$INSTANCE_TYPE" \
+                    --security-group-ids "$SG_ID" \
+                    --user-data "file://$USER_DATA" \
+                    --metadata-options 'HttpTokens=required,HttpEndpoint=enabled' \
+                    --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=50,VolumeType=gp3,DeleteOnTermination=true}' \
+                    --tag-specifications \
+                      "ResourceType=instance,Tags=[{Key=Project,Value=claudette-spinup},{Key=Name,Value=$NAME_TAG}]" \
+                      "ResourceType=volume,Tags=[{Key=Project,Value=claudette-spinup},{Key=Name,Value=$NAME_TAG}]" \
+                    --query 'Instances[0].InstanceId' --output text)
+                  log "instance: $INSTANCE_ID — waiting for running state"
+                  aws_ ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+                  PUBLIC_IP=$(aws_ ec2 describe-instances --instance-ids "$INSTANCE_ID" \
+                    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+                  log "public IP: $PUBLIC_IP — waiting for sshd (Windows first-boot + user-data is slow, ~5-8 min)"
+
+                  # 5. Poll sshd via ssh-keyscan. Using ssh-keyscan (not a
+                  #    full ssh login) dodges two orthogonal problems:
+                  #    - passphrase-protected private keys need a TTY for
+                  #      ssh to prompt, so BatchMode=yes auth-polling fails
+                  #      forever on perfectly healthy hosts;
+                  #    - we'd be confounding "sshd is up" with "my key is
+                  #      authorized", and only the first is the helper's
+                  #      concern — user-data already installed the key.
+                  #    A successful keyscan means sshd finished starting,
+                  #    which on Windows is what takes the time.
+                  DEADLINE=$(( $(date +%s) + 900 ))
+                  while [ $(date +%s) -lt $DEADLINE ]; do
+                    if ssh-keyscan -T 5 -t rsa "$PUBLIC_IP" 2>/dev/null | grep -q ssh-rsa; then
+                      log "sshd ready"
+                      break
+                    fi
+                    sleep 15
+                  done
+                  if [ $(date +%s) -ge $DEADLINE ]; then
+                    log "timed out waiting for sshd on $PUBLIC_IP (instance $INSTANCE_ID)"
+                    log "inspect with: aws --profile $PROFILE --region $REGION ec2 get-console-output --instance-id $INSTANCE_ID --latest --output text"
+                    exit 1
+                  fi
+
+                  # 6. Stash the password in a mode-600 sidecar under
+                  #    $TMPDIR so aws-win-rdp can find it after a shell
+                  #    restart. Key insight: the password was baked into
+                  #    user-data (visible to anyone with
+                  #    ec2:DescribeInstanceAttribute on this account), so
+                  #    we've already accepted "password sits in AWS-side
+                  #    plaintext for the life of the instance" — dropping
+                  #    it in a mode-600 local file doesn't lower the bar.
+                  PASS_FILE="''${TMPDIR:-/tmp}/claudette-spinup-$INSTANCE_ID.pass"
+                  ( umask 077; printf '%s' "$ADMIN_PASS" > "$PASS_FILE" )
+
+                  # 7. Emit exports on stdout (so `eval "$(aws-win-spinup)"`
+                  #    drops them into the caller's shell); human status
+                  #    went to stderr via log().
+                  cat <<EOF
+export CLAUDETTE_WIN_HOST=Administrator@$PUBLIC_IP
+export CLAUDETTE_WIN_REMOTE_PATH=Desktop/claudette.exe
+export CLAUDETTE_WIN_INSTANCE_ID=$INSTANCE_ID
+export CLAUDETTE_WIN_ADMIN_PASSWORD='$ADMIN_PASS'
+# Host:    $PUBLIC_IP
+# SSH:     ssh Administrator@$PUBLIC_IP
+# RDP:     aws-win-rdp            # macOS; opens Windows App with password on clipboard
+# Deploy:  deploy-win-x64
+# Destroy: aws-win-destroy
+EOF
+                '';
+                help = "Launch ephemeral Windows EC2 (us-west-2) with SSH+pubkey pre-configured; prints export lines for deploy-win-x64";
+                category = "windows";
+              }
+              {
+                name = "aws-win-rdp";
+                command = ''
+                  set -euo pipefail
+                  # macOS helper: look up the current aws-win-spinup instance,
+                  # generate a minimal .rdp file, try to fetch+copy the
+                  # Administrator password, and hand the .rdp to `open` so
+                  # the Windows App (formerly Microsoft Remote Desktop)
+                  # launches a session. Non-darwin callers exit cleanly.
+                  if [ "$(uname)" != "Darwin" ]; then
+                    echo "aws-win-rdp is macOS-only (uses 'open' + 'pbcopy')." >&2
+                    exit 2
+                  fi
+
+                  PROFILE=''${AWS_PROFILE:-dev.urandom.io}
+                  REGION=''${AWS_REGION:-us-west-2}
+                  INSTANCE_ID=''${CLAUDETTE_WIN_INSTANCE_ID:-}
+                  aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
+
+                  # If no instance was exported by aws-win-spinup, pick the
+                  # newest running claudette-spinup instance. Keeps the
+                  # helper useful across shell restarts where the env var
+                  # was lost.
+                  if [ -z "$INSTANCE_ID" ]; then
+                    INSTANCE_ID=$(aws_ ec2 describe-instances \
+                      --filters "Name=tag:Project,Values=claudette-spinup" \
+                                "Name=instance-state-name,Values=running" \
+                      --query 'sort_by(Reservations[].Instances[], &LaunchTime)[-1].InstanceId' \
+                      --output text)
+                    [ -n "$INSTANCE_ID" ] && [ "$INSTANCE_ID" != "None" ] \
+                      || { echo "no running claudette-spinup instance found" >&2; exit 1; }
+                  fi
+
+                  PUBLIC_IP=$(aws_ ec2 describe-instances --instance-ids "$INSTANCE_ID" \
+                    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+                  [ -n "$PUBLIC_IP" ] && [ "$PUBLIC_IP" != "None" ] \
+                    || { echo "instance $INSTANCE_ID has no public IP" >&2; exit 1; }
+
+                  # Password lookup: env var wins (set by `eval aws-win-spinup`),
+                  # otherwise read the mode-600 sidecar that aws-win-spinup
+                  # wrote. No RSA/PEM/passphrase dance — the password was
+                  # baked into user-data, so we already know it.
+                  PASS_FILE="''${TMPDIR:-/tmp}/claudette-spinup-$INSTANCE_ID.pass"
+                  PASSWORD="''${CLAUDETTE_WIN_ADMIN_PASSWORD:-}"
+                  if [ -z "$PASSWORD" ] && [ -r "$PASS_FILE" ]; then
+                    PASSWORD=$(cat "$PASS_FILE")
+                  fi
+                  if [ -n "$PASSWORD" ]; then
+                    printf %s "$PASSWORD" | pbcopy
+                    echo "Administrator password copied to clipboard (⌘-V in the password field)."
+                  else
+                    echo "(no cached password found — was this instance launched by aws-win-spinup?)"
+                    echo "  expected file: $PASS_FILE"
+                    echo "  or set CLAUDETTE_WIN_ADMIN_PASSWORD before calling aws-win-rdp"
+                  fi
+
+                  # Minimal .rdp file — Windows App is happy with just the
+                  # address + username. Host key / CA / gateway are left
+                  # unset; the client will prompt on first connect.
+                  # Fixed path (not mktemp): a .rdp is disposable, and reusing
+                  # the same path means re-running against the same instance
+                  # doesn't litter $TMPDIR. Also sidesteps the GNU/BSD mktemp
+                  # template-syntax mismatch the devshell exposes.
+                  RDP_FILE="''${TMPDIR:-/tmp}/claudette-spinup-$INSTANCE_ID.rdp"
+                  cat > "$RDP_FILE" <<EOF
+full address:s:$PUBLIC_IP
+username:s:Administrator
+prompt for credentials:i:1
+EOF
+                  echo "opening $RDP_FILE -> $PUBLIC_IP"
+                  open "$RDP_FILE"
+                '';
+                help = "macOS: generate a .rdp, copy Admin password to clipboard, and open the current aws-win-spinup instance in Windows App";
+                category = "windows";
+              }
+              {
+                name = "aws-win-destroy";
+                command = ''
+                  set -euo pipefail
+                  # Terminate every instance tagged Project=claudette-spinup
+                  # in the target region. Safe to run with none present.
+                  PROFILE=''${AWS_PROFILE:-dev.urandom.io}
+                  REGION=''${AWS_REGION:-us-west-2}
+                  aws_() { aws --profile "$PROFILE" --region "$REGION" "$@"; }
+
+                  mapfile -t IDS < <(aws_ ec2 describe-instances \
+                    --filters "Name=tag:Project,Values=claudette-spinup" \
+                              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+                    --query 'Reservations[].Instances[].InstanceId' --output text | tr '\t' '\n' | sed '/^$/d')
+                  if [ ''${#IDS[@]} -eq 0 ]; then
+                    echo "no claudette-spinup instances to destroy in $REGION"
+                    exit 0
+                  fi
+                  echo "terminating: ''${IDS[*]}"
+                  aws_ ec2 terminate-instances --instance-ids "''${IDS[@]}" \
+                    --query 'TerminatingInstances[].[InstanceId,CurrentState.Name]' --output text
+                  aws_ ec2 wait instance-terminated --instance-ids "''${IDS[@]}"
+                  # Scrub the local password + .rdp sidecars for these
+                  # instances so their plaintext admin password doesn't
+                  # linger in $TMPDIR after the instance is gone.
+                  for ID in "''${IDS[@]}"; do
+                    rm -f "''${TMPDIR:-/tmp}/claudette-spinup-$ID.pass" \
+                          "''${TMPDIR:-/tmp}/claudette-spinup-$ID.rdp" 2>/dev/null || true
+                  done
+                  echo "terminated."
+                  echo "note: keypair and SG (claudette-spinup-sg) are left in place for reuse."
+                '';
+                help = "Terminate all claudette-spinup tagged EC2 instances in AWS_REGION (default us-west-2)";
                 category = "windows";
               }
               {

--- a/scripts/_aws-common.sh
+++ b/scripts/_aws-common.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Shared helpers for aws-win-* scripts. Source, don't exec.
+#
+# - State lives under $PRJ_ROOT/.claudette/aws-win/ (gitignored) so it
+#   survives shell restarts and direnv reloads, and stays per-checkout.
+# - Defaults for profile/region can be overridden by env vars at call
+#   time; a teammate with their own AWS setup just exports AWS_PROFILE
+#   before running any helper.
+
+set -euo pipefail
+
+AWS_WIN_PROFILE="${AWS_PROFILE:-dev.urandom.io}"
+AWS_WIN_REGION="${AWS_REGION:-us-west-2}"
+
+# $PRJ_ROOT is set by numtide/devshell; fall back to git toplevel for
+# callers outside the devshell (tests, manual runs).
+: "${PRJ_ROOT:=$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+STATE_DIR="$PRJ_ROOT/.claudette/aws-win"
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+
+aws_() { aws --profile "$AWS_WIN_PROFILE" --region "$AWS_WIN_REGION" "$@"; }
+
+log() { echo "[${0##*/}] $*" >&2; }
+
+# Newest running claudette-spinup instance id, or empty.
+discover_instance() {
+  local id
+  id=$(aws_ ec2 describe-instances \
+    --filters "Name=tag:Project,Values=claudette-spinup" \
+              "Name=instance-state-name,Values=running" \
+    --query 'sort_by(Reservations[].Instances[], &LaunchTime)[-1].InstanceId' \
+    --output text 2>/dev/null || true)
+  [ "$id" = "None" ] && id=""
+  printf '%s' "$id"
+}
+
+instance_public_ip() {
+  aws_ ec2 describe-instances --instance-ids "$1" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text
+}
+
+# State file helpers — one per instance, so multiple instances don't stomp.
+state_file() { printf '%s/%s.%s' "$STATE_DIR" "$1" "$2"; }

--- a/scripts/aws-win-destroy.sh
+++ b/scripts/aws-win-destroy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Terminate every instance tagged Project=claudette-spinup in the
+# target region and scrub local state. Safe to run with none present.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aws-common.sh
+source "$SCRIPT_DIR/_aws-common.sh"
+
+mapfile -t IDS < <(aws_ ec2 describe-instances \
+  --filters "Name=tag:Project,Values=claudette-spinup" \
+            "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[].Instances[].InstanceId' --output text | tr '\t' '\n' | sed '/^$/d')
+if [ "${#IDS[@]}" -eq 0 ]; then
+  echo "no claudette-spinup instances to destroy in $AWS_WIN_REGION"
+  # Scrub any stale state files anyway.
+  rm -f "$STATE_DIR"/*.pass "$STATE_DIR"/*.rdp "$STATE_DIR/current" 2>/dev/null || true
+  exit 0
+fi
+echo "terminating: ${IDS[*]}"
+aws_ ec2 terminate-instances --instance-ids "${IDS[@]}" \
+  --query 'TerminatingInstances[].[InstanceId,CurrentState.Name]' --output text
+aws_ ec2 wait instance-terminated --instance-ids "${IDS[@]}"
+# Wipe the per-instance state + the `current` pointer.
+for ID in "${IDS[@]}"; do
+  rm -f "$(state_file "$ID" pass)" "$(state_file "$ID" rdp)" 2>/dev/null || true
+done
+rm -f "$STATE_DIR/current" 2>/dev/null || true
+echo "terminated."
+echo "note: SG (claudette-spinup-sg) is left in place for reuse."

--- a/scripts/aws-win-rdp.sh
+++ b/scripts/aws-win-rdp.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# macOS helper: open the current aws-win-spinup instance in Windows App
+# (the renamed Microsoft Remote Desktop). Auto-discovers the instance
+# from the state dir or AWS tags — no env vars required.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aws-common.sh
+source "$SCRIPT_DIR/_aws-common.sh"
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "aws-win-rdp is macOS-only (uses 'open' + 'pbcopy')." >&2
+  exit 2
+fi
+
+# Instance resolution: env var wins, then `current` state file, then
+# newest running tag.
+INSTANCE_ID="${CLAUDETTE_WIN_INSTANCE_ID:-}"
+if [ -z "$INSTANCE_ID" ] && [ -r "$STATE_DIR/current" ]; then
+  INSTANCE_ID=$(cat "$STATE_DIR/current")
+fi
+if [ -z "$INSTANCE_ID" ]; then
+  INSTANCE_ID=$(discover_instance)
+fi
+[ -n "$INSTANCE_ID" ] || { echo "no running claudette-spinup instance found" >&2; exit 1; }
+
+PUBLIC_IP=$(instance_public_ip "$INSTANCE_ID")
+[ -n "$PUBLIC_IP" ] && [ "$PUBLIC_IP" != "None" ] \
+  || { echo "instance $INSTANCE_ID has no public IP" >&2; exit 1; }
+
+# Password lookup: env var, then sidecar.
+PASS_FILE=$(state_file "$INSTANCE_ID" pass)
+PASSWORD="${CLAUDETTE_WIN_ADMIN_PASSWORD:-}"
+if [ -z "$PASSWORD" ] && [ -r "$PASS_FILE" ]; then
+  PASSWORD=$(cat "$PASS_FILE")
+fi
+if [ -n "$PASSWORD" ]; then
+  printf %s "$PASSWORD" | pbcopy
+  echo "Administrator password copied to clipboard (⌘-V in the password field)."
+else
+  echo "(no cached password found — was this instance launched by aws-win-spinup?)"
+  echo "  expected: $PASS_FILE"
+fi
+
+RDP_FILE=$(state_file "$INSTANCE_ID" rdp)
+cat > "$RDP_FILE" <<EOF
+full address:s:$PUBLIC_IP
+username:s:Administrator
+prompt for credentials:i:1
+EOF
+echo "opening $RDP_FILE -> $PUBLIC_IP"
+open "$RDP_FILE"

--- a/scripts/aws-win-spinup.sh
+++ b/scripts/aws-win-spinup.sh
@@ -3,14 +3,17 @@
 # with OpenSSH enabled + the caller's pubkey pre-authorized + a known
 # Administrator password baked in via user-data.
 #
-# Usage:
-#   aws-win-spinup               # prints status, stashes state, returns
-#   eval "$(aws-win-spinup)"     # ALSO sets CLAUDETTE_WIN_* in current shell
+# Usage (eval-free path — recommended):
+#   aws-win-spinup               # launches, stashes state, returns
+#   aws-win-rdp                  # auto-discovers the instance
+#   deploy-win-x64               # auto-discovers the instance
+#   aws-win-destroy              # tears down + scrubs state
 #
-# Downstream helpers (aws-win-rdp, deploy-win-x64, aws-win-destroy) all
-# auto-discover the instance from AWS tags + state files, so env vars
-# are optional. State survives shell/direnv reloads because it lives in
-# $PRJ_ROOT/.claudette/ (gitignored) rather than $TMPDIR.
+# Optional eval path (for callers that want env vars set in their
+# current shell): `eval "$(aws-win-spinup)"`. Downstream helpers work
+# either way — they fall back to $PRJ_ROOT/.claudette/aws-win/ and AWS
+# tag lookup when env vars aren't set. State survives shell/direnv
+# reloads because it lives under the project, not $TMPDIR.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_aws-common.sh
@@ -128,14 +131,32 @@ INSTANCE_ID=$(aws_ ec2 run-instances \
   --query 'Instances[0].InstanceId' --output text)
 log "instance: $INSTANCE_ID — waiting for running state"
 aws_ ec2 wait instance-running --instance-ids "$INSTANCE_ID"
-PUBLIC_IP=$(instance_public_ip "$INSTANCE_ID")
+
+# 5. Poll for public IP assignment. EC2 reports `running` as soon as
+# the hypervisor boots the instance, but the public IP can lag by a
+# few seconds. Capture the IP in a short loop rather than reading it
+# once and risking an empty/None value driving the sshd poll below.
+PUBLIC_IP=""
+IP_DEADLINE=$(( $(date +%s) + 120 ))
+while [ "$(date +%s)" -lt "$IP_DEADLINE" ]; do
+  PUBLIC_IP=$(instance_public_ip "$INSTANCE_ID")
+  [ -n "$PUBLIC_IP" ] && [ "$PUBLIC_IP" != "None" ] && break
+  sleep 3
+done
+if [ -z "$PUBLIC_IP" ] || [ "$PUBLIC_IP" = "None" ]; then
+  log "timed out waiting for public IP assignment on $INSTANCE_ID"
+  exit 1
+fi
 log "public IP: $PUBLIC_IP — waiting for sshd (Windows first-boot + user-data is slow, ~5-8 min)"
 
-# 5. Poll sshd via ssh-keyscan (no auth needed — just confirms sshd
-# finished starting, which on Windows is the slow part).
+# 6. Poll sshd via ssh-keyscan (no auth needed — just confirms sshd
+# finished starting, which on Windows is the slow part). Accept any
+# host key type: Windows OpenSSH generates rsa+ecdsa+ed25519 by
+# default today, but we shouldn't bind to that detail.
 DEADLINE=$(( $(date +%s) + 900 ))
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-  if ssh-keyscan -T 5 -t rsa "$PUBLIC_IP" 2>/dev/null | grep -q ssh-rsa; then
+  if ssh-keyscan -T 5 "$PUBLIC_IP" 2>/dev/null \
+       | awk 'NF >= 3 && $2 ~ /^(ssh|ecdsa)/ { found=1; exit } END { exit !found }'; then
     log "sshd ready"
     break
   fi
@@ -147,22 +168,26 @@ if [ "$(date +%s)" -ge "$DEADLINE" ]; then
   exit 1
 fi
 
-# 6. Persist instance info to the project-scoped state dir so
+# 7. Persist instance info to the project-scoped state dir so
 # downstream helpers work from any shell, including after a
 # direnv reload. Password is in a mode-600 sidecar.
 ( umask 077; printf '%s' "$ADMIN_PASS" > "$(state_file "$INSTANCE_ID" pass)" )
 printf '%s\n' "$INSTANCE_ID" > "$STATE_DIR/current"
 
-# 7. Emit exports on stdout so `eval "$(aws-win-spinup)"` works for
-# callers who want env vars. All downstream helpers work without them.
+# 8. Emit exports on stdout so `eval "$(aws-win-spinup)"` works for
+# callers who want env vars. The password is deliberately NOT included
+# here: it would leak into terminal scrollback and shell/CI logs for
+# the common non-eval invocation. aws-win-rdp reads it from the mode-
+# 600 sidecar, and anyone who wants it in their shell can run
+# `cat $PRJ_ROOT/.claudette/aws-win/<id>.pass` or read $PASS_FILE.
 cat <<EOF
 export CLAUDETTE_WIN_HOST=Administrator@$PUBLIC_IP
 export CLAUDETTE_WIN_REMOTE_PATH=Desktop/claudette.exe
 export CLAUDETTE_WIN_INSTANCE_ID=$INSTANCE_ID
-export CLAUDETTE_WIN_ADMIN_PASSWORD='$ADMIN_PASS'
 # Host:    $PUBLIC_IP
 # SSH:     ssh Administrator@$PUBLIC_IP
 # RDP:     aws-win-rdp            # macOS; opens Windows App with password on clipboard
 # Deploy:  deploy-win-x64
 # Destroy: aws-win-destroy
+# Admin password is in $STATE_DIR/$INSTANCE_ID.pass (mode 600).
 EOF

--- a/scripts/aws-win-spinup.sh
+++ b/scripts/aws-win-spinup.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Spin up an ephemeral, publicly-reachable Windows Server EC2 instance
+# with OpenSSH enabled + the caller's pubkey pre-authorized + a known
+# Administrator password baked in via user-data.
+#
+# Usage:
+#   aws-win-spinup               # prints status, stashes state, returns
+#   eval "$(aws-win-spinup)"     # ALSO sets CLAUDETTE_WIN_* in current shell
+#
+# Downstream helpers (aws-win-rdp, deploy-win-x64, aws-win-destroy) all
+# auto-discover the instance from AWS tags + state files, so env vars
+# are optional. State survives shell/direnv reloads because it lives in
+# $PRJ_ROOT/.claudette/ (gitignored) rather than $TMPDIR.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aws-common.sh
+source "$SCRIPT_DIR/_aws-common.sh"
+
+# Fallback chain for the default pubkey: ed25519 (99% of dev Macs),
+# then rsa, then the legacy project key. SPINUP_PUB_KEY overrides.
+if [ -n "${SPINUP_PUB_KEY:-}" ]; then
+  PUB_KEY_FILE="$SPINUP_PUB_KEY"
+elif [ -r "$HOME/.ssh/id_ed25519.pub" ]; then
+  PUB_KEY_FILE="$HOME/.ssh/id_ed25519.pub"
+elif [ -r "$HOME/.ssh/id_rsa.pub" ]; then
+  PUB_KEY_FILE="$HOME/.ssh/id_rsa.pub"
+else
+  PUB_KEY_FILE="$HOME/.ssh/dev.urandom.io.pub"
+fi
+SG_NAME="${SPINUP_SG_NAME:-claudette-spinup-sg}"
+INSTANCE_TYPE="${SPINUP_INSTANCE_TYPE:-t3.medium}"
+NAME_TAG="${SPINUP_NAME_TAG:-claudette-spinup-$(date +%Y%m%d-%H%M%S)}"
+AMI_FILTER="${SPINUP_AMI_FILTER:-Windows_Server-2022-English-Full-Base-*}"
+# Admin password: 32 hex chars + Aa1! to hit all four Windows
+# local-policy character classes without introducing characters that
+# need PowerShell escaping.
+ADMIN_PASS="${SPINUP_ADMIN_PASSWORD:-$(openssl rand -hex 16)Aa1!}"
+
+[ -r "$PUB_KEY_FILE" ] || { log "pubkey $PUB_KEY_FILE not readable"; exit 1; }
+PUBKEY=$(cat "$PUB_KEY_FILE")
+log "pubkey: $PUB_KEY_FILE"
+
+# No EC2 key pair is imported: ed25519 is rejected for Windows AMIs
+# ("ED25519 key pairs are not supported with Windows AMIs") and we
+# don't need one because user-data installs the pubkey directly. Side
+# benefit: get-password-data becomes a non-option, forcing the simpler
+# user-data-password path.
+
+# 1. Security group: 22 + 3389 open to 0.0.0.0/0 (ephemeral).
+VPC_ID=$(aws_ ec2 describe-vpcs \
+  --filters "Name=is-default,Values=true" \
+  --query 'Vpcs[0].VpcId' --output text)
+[ "$VPC_ID" != "None" ] || { log "no default VPC in $AWS_WIN_REGION"; exit 1; }
+SG_ID=$(aws_ ec2 describe-security-groups \
+  --filters "Name=group-name,Values=$SG_NAME" "Name=vpc-id,Values=$VPC_ID" \
+  --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo None)
+if [ "$SG_ID" = "None" ] || [ -z "$SG_ID" ]; then
+  log "creating security group $SG_NAME in $VPC_ID"
+  SG_ID=$(aws_ ec2 create-security-group \
+    --group-name "$SG_NAME" \
+    --description "Claudette ephemeral Windows test SG (SSH+RDP public)" \
+    --vpc-id "$VPC_ID" \
+    --tag-specifications "ResourceType=security-group,Tags=[{Key=Project,Value=claudette-spinup}]" \
+    --query 'GroupId' --output text)
+  aws_ ec2 authorize-security-group-ingress --group-id "$SG_ID" \
+    --ip-permissions \
+      'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=0.0.0.0/0,Description=ssh}]' \
+      'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=0.0.0.0/0,Description=rdp}]' \
+    >/dev/null
+fi
+log "security group: $SG_ID"
+
+# 2. Latest Windows Server 2022 AMI (amazon-owned).
+AMI_ID=$(aws_ ec2 describe-images --owners amazon \
+  --filters "Name=name,Values=$AMI_FILTER" "Name=architecture,Values=x86_64" "Name=state,Values=available" \
+  --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text)
+[ -n "$AMI_ID" ] && [ "$AMI_ID" != "None" ] || { log "no AMI matching $AMI_FILTER"; exit 1; }
+log "AMI: $AMI_ID"
+
+# 3. Render user-data. EC2Launch v2 runs the <powershell> block once on
+# first boot; Windows Server 2022 ships OpenSSH Server pre-installed.
+USER_DATA=$(mktemp)
+trap 'rm -f "$USER_DATA"' EXIT
+cat > "$USER_DATA" <<EOF
+<powershell>
+\$ErrorActionPreference = 'Stop'
+try {
+  # Pin the Administrator password first so RDP is usable even if the
+  # rest of the block fails. PowerShell single-quote string is literal,
+  # and ADMIN_PASS only contains hex + Aa1! so no escaping needed.
+  net user Administrator '$ADMIN_PASS' | Out-Null
+
+  Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction SilentlyContinue | Out-Null
+  Set-Service -Name sshd -StartupType Automatic
+  Start-Service sshd
+  if (!(Test-Path 'C:\ProgramData\ssh')) { New-Item -ItemType Directory -Path 'C:\ProgramData\ssh' | Out-Null }
+  \$authKey = 'C:\ProgramData\ssh\administrators_authorized_keys'
+  \$pub = @'
+$PUBKEY
+'@
+  Set-Content -Path \$authKey -Value \$pub -Encoding ascii
+  icacls.exe \$authKey /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F' | Out-Null
+  if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+  }
+  New-ItemProperty -Path 'HKLM:\SOFTWARE\OpenSSH' -Name DefaultShell -Value 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -PropertyType String -Force | Out-Null
+  Restart-Service sshd
+} catch {
+  Write-Host "user-data error: \$_"
+  throw
+}
+</powershell>
+<persist>false</persist>
+EOF
+
+# 4. Launch. Intentionally no --key-name (see note above).
+log "launching $INSTANCE_TYPE ($NAME_TAG)"
+INSTANCE_ID=$(aws_ ec2 run-instances \
+  --image-id "$AMI_ID" \
+  --instance-type "$INSTANCE_TYPE" \
+  --security-group-ids "$SG_ID" \
+  --user-data "file://$USER_DATA" \
+  --metadata-options 'HttpTokens=required,HttpEndpoint=enabled' \
+  --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=50,VolumeType=gp3,DeleteOnTermination=true}' \
+  --tag-specifications \
+    "ResourceType=instance,Tags=[{Key=Project,Value=claudette-spinup},{Key=Name,Value=$NAME_TAG}]" \
+    "ResourceType=volume,Tags=[{Key=Project,Value=claudette-spinup},{Key=Name,Value=$NAME_TAG}]" \
+  --query 'Instances[0].InstanceId' --output text)
+log "instance: $INSTANCE_ID — waiting for running state"
+aws_ ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+PUBLIC_IP=$(instance_public_ip "$INSTANCE_ID")
+log "public IP: $PUBLIC_IP — waiting for sshd (Windows first-boot + user-data is slow, ~5-8 min)"
+
+# 5. Poll sshd via ssh-keyscan (no auth needed — just confirms sshd
+# finished starting, which on Windows is the slow part).
+DEADLINE=$(( $(date +%s) + 900 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  if ssh-keyscan -T 5 -t rsa "$PUBLIC_IP" 2>/dev/null | grep -q ssh-rsa; then
+    log "sshd ready"
+    break
+  fi
+  sleep 15
+done
+if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+  log "timed out waiting for sshd on $PUBLIC_IP (instance $INSTANCE_ID)"
+  log "inspect with: aws --profile $AWS_WIN_PROFILE --region $AWS_WIN_REGION ec2 get-console-output --instance-id $INSTANCE_ID --latest --output text"
+  exit 1
+fi
+
+# 6. Persist instance info to the project-scoped state dir so
+# downstream helpers work from any shell, including after a
+# direnv reload. Password is in a mode-600 sidecar.
+( umask 077; printf '%s' "$ADMIN_PASS" > "$(state_file "$INSTANCE_ID" pass)" )
+printf '%s\n' "$INSTANCE_ID" > "$STATE_DIR/current"
+
+# 7. Emit exports on stdout so `eval "$(aws-win-spinup)"` works for
+# callers who want env vars. All downstream helpers work without them.
+cat <<EOF
+export CLAUDETTE_WIN_HOST=Administrator@$PUBLIC_IP
+export CLAUDETTE_WIN_REMOTE_PATH=Desktop/claudette.exe
+export CLAUDETTE_WIN_INSTANCE_ID=$INSTANCE_ID
+export CLAUDETTE_WIN_ADMIN_PASSWORD='$ADMIN_PASS'
+# Host:    $PUBLIC_IP
+# SSH:     ssh Administrator@$PUBLIC_IP
+# RDP:     aws-win-rdp            # macOS; opens Windows App with password on clipboard
+# Deploy:  deploy-win-x64
+# Destroy: aws-win-destroy
+EOF

--- a/scripts/build-win.sh
+++ b/scripts/build-win.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cross-compile claudette.exe for Windows via cargo-xwin.
+# Usage: build-win.sh {arm64|x64}
+#
+# Shared backend for build-win-arm64 / build-win-x64 devshell commands.
+# See flake.nix devshell notes for why we invoke `cargo xwin` directly
+# (--features tauri/custom-protocol, --release, target triple).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+case "${1:-}" in
+  arm64) TRIPLE=aarch64-pc-windows-msvc ;;
+  x64)   TRIPLE=x86_64-pc-windows-msvc ;;
+  *) echo "usage: $0 {arm64|x64}" >&2; exit 2 ;;
+esac
+
+(cd src/ui && bun install --frozen-lockfile && bun run build)
+cargo xwin build --release \
+  --features tauri/custom-protocol \
+  --target "$TRIPLE" -p claudette-tauri
+echo
+echo "Built: $REPO_ROOT/target/$TRIPLE/release/claudette.exe"

--- a/scripts/deploy-win.sh
+++ b/scripts/deploy-win.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build + deploy claudette.exe to a Windows target.
+# Usage: deploy-win.sh {arm64|x64}
+#
+# - arm64: defaults to James's local test VM at 172.16.52.129, OneDrive
+#   redirected Desktop path.
+# - x64:  defaults to the newest aws-win-spinup instance (auto-discovered
+#   via AWS tag if CLAUDETTE_WIN_HOST isn't set), plain Desktop path.
+#
+# Env overrides: CLAUDETTE_WIN_HOST, CLAUDETTE_WIN_REMOTE_PATH.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+case "${1:-}" in
+  arm64)
+    TRIPLE=aarch64-pc-windows-msvc
+    DEFAULT_HOST="brink@172.16.52.129"
+    DEFAULT_REMOTE="OneDrive/Desktop/claudette.exe"
+    ;;
+  x64)
+    TRIPLE=x86_64-pc-windows-msvc
+    DEFAULT_REMOTE="Desktop/claudette.exe"
+    # Auto-discover the AWS host if the caller didn't export one.
+    if [ -z "${CLAUDETTE_WIN_HOST:-}" ]; then
+      # shellcheck source=_aws-common.sh
+      source "$SCRIPT_DIR/_aws-common.sh"
+      ID=$(discover_instance)
+      if [ -n "$ID" ]; then
+        IP=$(instance_public_ip "$ID")
+        [ -n "$IP" ] && [ "$IP" != "None" ] && DEFAULT_HOST="Administrator@$IP"
+      fi
+      : "${DEFAULT_HOST:=}"
+    fi
+    ;;
+  *) echo "usage: $0 {arm64|x64}" >&2; exit 2 ;;
+esac
+
+HOST="${CLAUDETTE_WIN_HOST:-${DEFAULT_HOST:-}}"
+REMOTE_PATH="${CLAUDETTE_WIN_REMOTE_PATH:-$DEFAULT_REMOTE}"
+if [ -z "$HOST" ]; then
+  echo "error: no deploy host — set CLAUDETTE_WIN_HOST or run aws-win-spinup first" >&2
+  exit 1
+fi
+
+"$SCRIPT_DIR/build-win.sh" "$1"
+
+echo
+echo "Stopping running claudette on $HOST (if any)..."
+# `|| true`: Windows OpenSSH can report non-zero even with
+# -ErrorAction SilentlyContinue in some edge cases, and the remote
+# Stop-Process failing shouldn't abort the scp step below.
+ssh -o StrictHostKeyChecking=accept-new "$HOST" \
+  'Stop-Process -Name claudette -Force -ErrorAction SilentlyContinue' || true
+echo "Copying to $HOST:$REMOTE_PATH ..."
+scp -o StrictHostKeyChecking=accept-new \
+  "target/$TRIPLE/release/claudette.exe" "$HOST:$REMOTE_PATH"
+echo
+echo "Deployed. Double-click claudette.exe on the remote Desktop to run."


### PR DESCRIPTION
## Summary

Devshell helpers for the "cross-build Claudette on Nix, manually test on a fresh Windows host" loop, plus a cleanup of the existing `build-win-*` / `deploy-win-arm64` bodies.

New commands (all under the `windows` category in `menu`):

- `aws-win-spinup` — launches an ephemeral, publicly-reachable Windows Server 2022 EC2 in `us-west-2`, with OpenSSH enabled + the caller's pubkey installed + a random Administrator password baked in via user-data.
- `aws-win-rdp` — macOS: opens the current instance in Windows App (the renamed MS Remote Desktop) with the admin password pre-copied to the clipboard.
- `aws-win-destroy` — terminates everything tagged `Project=claudette-spinup` and scrubs local state.
- `deploy-win-x64` — mirror of `deploy-win-arm64` but auto-discovers the newest `aws-win-spinup` instance when `CLAUDETTE_WIN_HOST` isn't set.

Happy path in a fresh devshell:

```sh
aws-win-spinup      # waits until sshd is ready
aws-win-rdp         # opens Windows App, password on clipboard
deploy-win-x64      # cross-builds + scps to Desktop\claudette.exe
aws-win-destroy     # tear down
```

No `eval`, no env-var management. State (admin-password sidecar + instance id + `.rdp` file) lives under `$PRJ_ROOT/.claudette/aws-win/` (gitignored), so it survives shell restarts and `direnv reload`.

## Design notes

- **No EC2 key pair is created.** AWS rejects ed25519 for Windows AMIs (`ED25519 key pairs are not supported with Windows AMIs`), and the pubkey flows via user-data into `administrators_authorized_keys` regardless. Skipping `--key-name` removes the RSA-only constraint and the whole `get-password-data` + decrypt-PEM dance — the password is simply baked into user-data instead.
- **Default pubkey fallback chain**: `$SPINUP_PUB_KEY` → `~/.ssh/id_ed25519.pub` → `~/.ssh/id_rsa.pub` → `~/.ssh/dev.urandom.io.pub`. Teammates with a standard dev setup work with no flags.
- **Security group (`claudette-spinup-sg`)**: TCP 22 + 3389 from `0.0.0.0/0`. Deliberately public for these ephemeral test hosts; they get terminated as soon as testing finishes.
- **Admin password**: 32 hex chars + `Aa1!` to satisfy Windows' default local-policy complexity (upper, lower, digit, symbol) while avoiding characters that would need PowerShell escaping.
- **Bodies live in `./scripts/`**, not inline in `flake.nix`. Each devshell command is a thin `exec "$PRJ_ROOT/scripts/foo.sh" "$@"` wrapper. `build-win-arm64` / `build-win-x64` / `deploy-win-arm64` moved over too.
- `deploy-win.sh` adds `|| true` after the remote `Stop-Process` step — Windows OpenSSH can report non-zero exit even with `-ErrorAction SilentlyContinue`, which under `set -e` silently aborted the deploy before the `scp`.
- Adds `awscli2` + `jq` to the devshell so teammates on plain Darwin don't need a system `aws` install.

## Test plan

- [x] `aws-win-spinup` launches a fresh instance; sshd-ready in ~3 min.
- [x] SSH with `~/.ssh/id_ed25519` works (user-data installed key into `administrators_authorized_keys`).
- [x] `aws-win-rdp` auto-discovers the instance from `.claudette/aws-win/current` and opens Windows App with the password on the clipboard.
- [x] `deploy-win-x64` auto-discovers the instance when `CLAUDETTE_WIN_HOST` is unset.
- [x] `aws-win-destroy` terminates and scrubs local state; re-runs cleanly.
- [x] `nix flake check` passes; `menu` lists all seven Windows commands.
- [ ] Teammate on a different AWS account sets `AWS_PROFILE` and runs the full flow end-to-end.