### PR TITLE
docs: highlight Windows/Linux/macOS cross-platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.reddit.com/r/ClaudetteApp"><img src="https://img.shields.io/reddit/subreddit-subscribers/ClaudetteApp?style=social" alt="Reddit"/></a>
 </p>
 
-Claudette is a cross-platform desktop application built with [Tauri 2](https://tauri.app) (Rust backend) and React/TypeScript (frontend). It provides a lightweight interface for managing and orchestrating Claude Code sessions, similar in spirit to [Conductor.build](https://conductor.build) but with a focused feature set.
+Claudette is a cross-platform desktop application built with [Tauri 2](https://tauri.app) (Rust backend) and React/TypeScript (frontend). It provides a lightweight interface for managing and orchestrating Claude Code sessions, similar in spirit to [Conductor.build](https://conductor.build) but with a focused feature set. Unlike most similar tools, Claudette runs natively on **macOS** (Apple Silicon + Intel), **Linux** (x86_64, Wayland + X11), and **Windows** (x86_64 + ARM64).
 
 ## Prerequisites
 

--- a/site/src/components/FeatureCards.astro
+++ b/site/src/components/FeatureCards.astro
@@ -9,6 +9,7 @@ const features = [
   { icon: 'palette', title: 'Theming', desc: '12 built-in themes plus custom theme support. Make it yours.' },
   { icon: 'zap', title: 'Lightweight', desc: 'Under 30MB binary, under 2s cold start. Native Rust performance without Electron bloat.' },
   { icon: 'settings', title: 'Per-repo Settings', desc: 'Custom instructions, setup scripts, and branch preferences tailored to each repository.' },
+  { icon: 'monitor', title: 'Truly Cross-Platform', desc: 'Native builds for macOS (Apple Silicon + Intel), Linux (x86_64, Wayland + X11), and Windows (x86_64 + ARM64) — unlike most comparable tools.' },
 ];
 
 const icons: Record<string, string> = {
@@ -21,6 +22,7 @@ const icons: Record<string, string> = {
   'palette': '<circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2Z"/>',
   'zap': '<path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/>',
   'settings': '<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
+  'monitor': '<rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/>',
 };
 ---
 

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -12,13 +12,13 @@ Claudette is available as a pre-built binary from [GitHub Releases](https://gith
 | macOS | Apple Silicon (aarch64) | `.dmg` |
 | macOS | Intel (x86_64) | `.dmg` |
 | Linux | x86_64 | `.AppImage`, `.deb` |
-| Windows | x86_64 | `.msi`, `.exe` |
-| Windows | ARM64 | `.msi`, `.exe` |
+| Windows | x86_64 | `.zip` |
+| Windows | ARM64 | `.zip` |
 
 1. Download the appropriate binary for your platform from the [latest release](https://github.com/utensils/Claudette/releases/latest)
 2. **macOS**: Open the `.dmg` and drag Claudette to your Applications folder
 3. **Linux**: Run the `.AppImage` directly or install the `.deb` package
-4. **Windows**: Run the `.msi` installer or the standalone `.exe`
+4. **Windows**: Extract the `.zip` archive and run `claudette.exe`
 
 ## Prerequisites
 

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Download and install Claudette on macOS or Linux.
+description: Download and install Claudette on macOS, Linux, or Windows.
 ---
 
 ## Download
@@ -12,10 +12,13 @@ Claudette is available as a pre-built binary from [GitHub Releases](https://gith
 | macOS | Apple Silicon (aarch64) | `.dmg` |
 | macOS | Intel (x86_64) | `.dmg` |
 | Linux | x86_64 | `.AppImage`, `.deb` |
+| Windows | x86_64 | `.msi`, `.exe` |
+| Windows | ARM64 | `.msi`, `.exe` |
 
 1. Download the appropriate binary for your platform from the [latest release](https://github.com/utensils/Claudette/releases/latest)
 2. **macOS**: Open the `.dmg` and drag Claudette to your Applications folder
 3. **Linux**: Run the `.AppImage` directly or install the `.deb` package
+4. **Windows**: Run the `.msi` installer or the standalone `.exe`
 
 ## Prerequisites
 
@@ -52,6 +55,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
     sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
       libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
     ```
+  </TabItem>
+  <TabItem label="Windows">
+    Install [Visual Studio C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the **Desktop development with C++** workload, then install the Rust toolchain via [rustup](https://rustup.rs/).
   </TabItem>
 </Tabs>
 

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Claudette — Claude's Missing Better Half
-description: A beautiful desktop orchestrator for parallel Claude Code agents. Git worktrees, remote workspaces, integrated terminal, and more.
+description: A beautiful desktop orchestrator for parallel Claude Code agents. Runs natively on macOS, Linux, and Windows. Git worktrees, remote workspaces, integrated terminal, and more.
 template: splash
 hero:
   title: Claudette
-  tagline: Claude's missing better half — a beautiful desktop orchestrator for running parallel Claude Code agents. Manage workspaces, review diffs, and ship faster.
+  tagline: Claude's missing better half — a beautiful desktop orchestrator for running parallel Claude Code agents. Runs natively on macOS, Linux, and Windows. Manage workspaces, review diffs, and ship faster.
   image:
     alt: Claudette — a cute pixel art pig with a pink bow
     file: ../../assets/hero-mascot.png


### PR DESCRIPTION
## Summary

- Updated README intro to explicitly call out macOS, Linux, and Windows as first-class native platforms, framing it as a differentiator vs. comparable tools
- Updated site hero tagline and SEO `description` to mention all three platforms
- Added Windows rows (x86_64 + ARM64) to the installation platform table, Windows install step, and a Windows build-from-source tab with MSVC toolchain instructions
- Added a new **Truly Cross-Platform** feature card on the landing page with a monitor icon

## Test Steps

1. Browse to the site landing page — confirm the hero tagline now reads "Runs natively on macOS, Linux, and Windows"
2. Check the **Features** section for the new "Truly Cross-Platform" card
3. Navigate to **Getting Started → Installation** — confirm the platform table shows Windows x86_64 and ARM64 rows, the installation steps list a Windows step (#4), and the build-from-source tabs include a Windows tab
4. Inspect the page `<meta name="description">` to confirm it mentions all three platforms

## Checklist

- [x] Documentation updated