### PR TITLE
fix(chat): attachment image previews, context menu, + dev-port auto-select

### DIFF
--- a/.claude/skills/claudette-debug/SKILL.md
+++ b/.claude/skills/claudette-debug/SKILL.md
@@ -8,7 +8,9 @@ allowed-tools: Bash Read Grep Glob
 
 # Claudette Debug
 
-Execute JavaScript inside the running Claudette Tauri webview via a TCP debug server on `127.0.0.1:19432`. Dev-build only (`#[cfg(debug_assertions)]`).
+Execute JavaScript inside the running Claudette Tauri webview via a TCP debug server on `127.0.0.1`. Dev-build only (`#[cfg(debug_assertions)]`).
+
+The server listens on port **19432 by default**, but the devshell `dev` helper auto-selects a free port (and writes a discovery file) so multiple dev instances can run in parallel against different branches. `debug-eval.sh` discovers the right instance automatically — you do not need to know the port. Details in [Port discovery](#port-discovery) below.
 
 ## Quick Start
 
@@ -26,11 +28,24 @@ Execute JavaScript inside the running Claudette Tauri webview via a TCP debug se
 
 ## Prerequisites
 
-- App running via `cargo tauri dev` (debug TCP server starts automatically)
-- Port 19432 available on localhost
+- App running via the devshell `dev` helper (or `cargo tauri dev`) — debug TCP server starts automatically
 - `python3` in PATH (used by eval helper)
 
-**Do NOT launch the installed app.** Never run `osascript -e 'tell application "Claudette" to activate'`, `open -a Claudette`, or double-click `/Applications/Claudette.app`. The debug TCP server on port 19432 only exists in dev builds (gated by `#[cfg(debug_assertions)]`); the installed release build has no debug server and eval calls against it will fail or silently target the wrong process. If the dev build is not already running, ask the user to start `cargo tauri dev` — do not start it yourself and do not fall back to the installed app.
+**Do NOT launch the installed app.** Never run `osascript -e 'tell application "Claudette" to activate'`, `open -a Claudette`, or double-click `/Applications/Claudette.app`. The debug TCP server only exists in dev builds (gated by `#[cfg(debug_assertions)]`); the installed release build has no debug server and eval calls against it will fail or silently target the wrong process. If the dev build is not already running, ask the user to start `dev` — do not start it yourself and do not fall back to the installed app.
+
+## Port discovery
+
+With the devshell `dev` helper, each dev instance probes for a free Vite port (starting at 1420) and a free debug port (starting at 19432), then writes `${TMPDIR:-/tmp}/claudette-dev/<pid>.json` with fields `{pid, debug_port, vite_port, cwd, branch, started_at}`. The file is removed on clean exit.
+
+`debug-eval.sh` resolves the port in this order:
+1. `$CLAUDETTE_DEBUG_PORT` (explicit override)
+2. Live discovery file whose `cwd` is an ancestor of the current `$PWD` (matches the worktree you're running the command from)
+3. The single live instance, if exactly one is running
+4. Legacy default `19432`
+
+If multiple instances are running and none match `$PWD`, the script exits with a list of `{pid, port, branch, cwd}` and asks the user to set `CLAUDETTE_DEBUG_PORT` or run from inside the target worktree. Stale files from crashed instances are cleaned up on access.
+
+To force a specific instance: `CLAUDETTE_DEBUG_PORT=19433 debug-eval.sh '...'`.
 
 ## Scripts
 
@@ -48,12 +63,13 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/`:
 ## Architecture
 
 ```
-Terminal ──TCP:19432──> debug server ──eval()──> webview JS context
-                                                      |
-Terminal <──TCP────── debug server <──invoke── webview (result callback)
+Terminal ──TCP:<port>──> debug server ──eval()──> webview JS context
+                                                       |
+Terminal <──TCP─────── debug server <──invoke── webview (result callback)
 ```
 
 - **TCP server**: `src-tauri/src/commands/debug.rs` — wraps JS in async IIFE, evals in webview, 10s timeout
+- **Port**: `19432` by default, overridable via `$CLAUDETTE_DEBUG_PORT` (set by the devshell `dev` helper per-instance)
 - **Input cap**: 1 MB max per eval request
 
 ## How to Execute JS

--- a/.claude/skills/claudette-debug/scripts/debug-eval.sh
+++ b/.claude/skills/claudette-debug/scripts/debug-eval.sh
@@ -2,11 +2,92 @@
 # Debug eval helper — sends JS to the running Claudette debug server.
 # Usage: ${CLAUDE_SKILL_DIR}/scripts/debug-eval.sh 'return 1 + 1'
 #        echo 'return document.title' | ${CLAUDE_SKILL_DIR}/scripts/debug-eval.sh
+#
+# Port selection:
+#   1. $CLAUDETTE_DEBUG_PORT overrides everything (explicit win).
+#   2. Otherwise, discover live `dev` instances via ${TMPDIR}/claudette-dev/*.json.
+#      Prefer the instance whose `cwd` is an ancestor of $PWD (match worktree).
+#      If exactly one instance is alive and no match, use it.
+#      If multiple instances are alive and no match, print the list and exit.
+#   3. Fall back to 19432 (legacy default).
 set -euo pipefail
 
-PORT="${CLAUDETTE_DEBUG_PORT:-19432}"
 HOST="127.0.0.1"
 TIMEOUT=12
+DISCOVERY_DIR="${TMPDIR:-/tmp}/claudette-dev"
+
+# --- Port discovery -------------------------------------------------------
+discover_port() {
+  if [[ -n "${CLAUDETTE_DEBUG_PORT:-}" ]]; then
+    echo "${CLAUDETTE_DEBUG_PORT}"
+    return
+  fi
+
+  [[ -d "$DISCOVERY_DIR" ]] || { echo 19432; return; }
+
+  # Collect live instances (pid still running, file readable).
+  local instances=()
+  shopt -s nullglob
+  for f in "$DISCOVERY_DIR"/*.json; do
+    # Tolerate missing jq — parse with python3 which we already require below.
+    local line
+    line=$(python3 -c "
+import json, os, sys
+try:
+    d = json.load(open('$f'))
+    pid = d.get('pid')
+    if pid is None: sys.exit(0)
+    # Check pid alive
+    os.kill(pid, 0)
+    print(f\"{pid}|{d.get('debug_port','')}|{d.get('cwd','')}|{d.get('branch','')}\")
+except (FileNotFoundError, json.JSONDecodeError, KeyError):
+    sys.exit(0)
+except ProcessLookupError:
+    # Stale file from a crashed instance — clean up.
+    try: os.unlink('$f')
+    except: pass
+    sys.exit(0)
+" 2>/dev/null) || continue
+    [[ -n "$line" ]] && instances+=("$line")
+  done
+  shopt -u nullglob
+
+  if [[ ${#instances[@]} -eq 0 ]]; then
+    echo 19432
+    return
+  fi
+
+  # Prefer an instance whose cwd is an ancestor of $PWD.
+  local pwd_real
+  pwd_real=$(cd "$PWD" && pwd -P)
+  for inst in "${instances[@]}"; do
+    IFS='|' read -r _pid port cwd _branch <<< "$inst"
+    [[ -z "$cwd" ]] && continue
+    if [[ "$pwd_real" == "$cwd" || "$pwd_real" == "$cwd"/* ]]; then
+      echo "$port"
+      return
+    fi
+  done
+
+  if [[ ${#instances[@]} -eq 1 ]]; then
+    IFS='|' read -r _pid port _cwd _branch <<< "${instances[0]}"
+    echo "$port"
+    return
+  fi
+
+  {
+    echo "ERROR: Multiple Claudette dev instances are running and none match \$PWD ($pwd_real)."
+    echo "Set CLAUDETTE_DEBUG_PORT=<port> to pick one, or run this from inside the target worktree."
+    echo "Instances:"
+    for inst in "${instances[@]}"; do
+      IFS='|' read -r pid port cwd branch <<< "$inst"
+      printf "  pid=%s  port=%s  branch=%s  cwd=%s\n" "$pid" "$port" "$branch" "$cwd"
+    done
+  } >&2
+  exit 2
+}
+
+PORT=$(discover_port)
 
 if [[ $# -gt 0 ]]; then
   JS="$*"
@@ -27,9 +108,9 @@ try:
     s.connect(('${HOST}', ${PORT}))
 except ConnectionRefusedError:
     print('ERROR: Cannot connect to debug server on ${HOST}:${PORT}', file=sys.stderr)
-    print('The dev build must be running via \`cargo tauri dev\`.', file=sys.stderr)
+    print('The dev build must be running via the devshell \`dev\` helper (or \`cargo tauri dev\`).', file=sys.stderr)
     print('Do NOT launch the installed /Applications/Claudette.app — it has no debug server.', file=sys.stderr)
-    print('Ask the user to start \`cargo tauri dev\` if it is not already running.', file=sys.stderr)
+    print('Ask the user to start \`dev\` if it is not already running.', file=sys.stderr)
     sys.exit(1)
 s.sendall(sys.stdin.buffer.read())
 s.shutdown(socket.SHUT_WR)

--- a/.claude/skills/claudette-debug/scripts/debug-eval.sh
+++ b/.claude/skills/claudette-debug/scripts/debug-eval.sh
@@ -30,24 +30,27 @@ discover_port() {
   shopt -s nullglob
   for f in "$DISCOVERY_DIR"/*.json; do
     # Tolerate missing jq — parse with python3 which we already require below.
+    # Pass the path via sys.argv rather than string-interpolating it into the
+    # Python source, so filenames containing quotes/backslashes don't break
+    # the parser (and can't be used for shell-injection).
     local line
-    line=$(python3 -c "
+    line=$(python3 -c '
 import json, os, sys
+path = sys.argv[1]
 try:
-    d = json.load(open('$f'))
-    pid = d.get('pid')
+    with open(path) as fh:
+        d = json.load(fh)
+    pid = d.get("pid")
     if pid is None: sys.exit(0)
-    # Check pid alive
-    os.kill(pid, 0)
-    print(f\"{pid}|{d.get('debug_port','')}|{d.get('cwd','')}|{d.get('branch','')}\")
+    os.kill(pid, 0)  # check alive
+    print("{}|{}|{}|{}".format(pid, d.get("debug_port",""), d.get("cwd",""), d.get("branch","")))
 except (FileNotFoundError, json.JSONDecodeError, KeyError):
     sys.exit(0)
 except ProcessLookupError:
-    # Stale file from a crashed instance — clean up.
-    try: os.unlink('$f')
-    except: pass
+    try: os.unlink(path)
+    except OSError: pass
     sys.exit(0)
-" 2>/dev/null) || continue
+' "$f" 2>/dev/null) || continue
     [[ -n "$line" ]] && instances+=("$line")
   done
   shopt -u nullglob

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ A single sandboxed Lua runtime (`src/plugin_runtime/`) serves multiple plugin ki
 
 ## Debugging (dev builds only)
 
-A debug TCP eval server runs on `127.0.0.1:19432` in dev builds. It executes JS in the webview and returns results over TCP. **Always use the `/claudette-debug` skill for debugging** — it has recipes for state inspection, store tracing, session monitoring, and UAT.
+A debug TCP eval server runs on `127.0.0.1` in dev builds (default port `19432`, overridable via `$CLAUDETTE_DEBUG_PORT` — `scripts/dev.sh` probes for a free port so multiple dev instances can coexist). It executes JS in the webview and returns results over TCP. **Always use the `/claudette-debug` skill for debugging** — it auto-discovers the right instance via `${TMPDIR:-/tmp}/claudette-dev/<pid>.json` and has recipes for state inspection, store tracing, session monitoring, and UAT.
 
 ```bash
 /claudette-debug state                    # Store overview

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ name = "claudette-tauri"
 version = "0.18.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "claudette",
  "claudette-server",

--- a/flake.nix
+++ b/flake.nix
@@ -535,8 +535,8 @@
             commands = [
               {
                 name = "dev";
-                command = "cd src/ui && bun install && cd ../.. && cargo tauri dev --features devtools,server";
-                help = "Start Tauri dev mode with hot-reload (includes embedded server)";
+                command = "exec ./scripts/dev.sh";
+                help = "Start Tauri dev mode with hot-reload (auto-selects free Vite + debug ports)";
                 category = "development";
               }
               {

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Claudette dev launcher.
+#
+# Probes for the first free Vite port (starting at 1420) and the first free
+# debug eval port (starting at 19432), exports them for the child processes,
+# then starts `cargo tauri dev` with an inline config override so the webview
+# loads from the port Vite actually bound.
+#
+# A discovery file is written to ${TMPDIR:-/tmp}/claudette-dev/<pid>.json so
+# helpers like `debug-eval.sh` can find the matching instance when multiple
+# dev builds run side-by-side. The file is cleaned up on exit.
+#
+# Env overrides:
+#   VITE_PORT_BASE         start port for Vite probe (default 1420)
+#   CLAUDETTE_DEBUG_PORT_BASE   start port for debug probe (default 19432)
+#   CARGO_TAURI_FEATURES   features to pass to tauri (default devtools,server)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+find_free_port() {
+  local p=$1
+  while lsof -iTCP:"$p" -sTCP:LISTEN -n -P >/dev/null 2>&1; do
+    p=$((p + 1))
+  done
+  echo "$p"
+}
+
+vite_port=$(find_free_port "${VITE_PORT_BASE:-1420}")
+debug_port=$(find_free_port "${CLAUDETTE_DEBUG_PORT_BASE:-19432}")
+
+export VITE_PORT="$vite_port"
+export CLAUDETTE_DEBUG_PORT="$debug_port"
+
+discovery_dir="${TMPDIR:-/tmp}/claudette-dev"
+mkdir -p "$discovery_dir"
+discovery_file="$discovery_dir/$$.json"
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+cwd="$(pwd)"
+started="$(date +%s)"
+
+# Emit JSON with a here-doc to avoid quoting headaches in paths.
+cat > "$discovery_file" <<EOF
+{"pid":$$,"debug_port":$debug_port,"vite_port":$vite_port,"cwd":"$cwd","branch":"$branch","started_at":$started}
+EOF
+
+cleanup() { rm -f "$discovery_file"; }
+trap cleanup EXIT INT TERM
+
+echo "▸ Branch:           $branch"
+echo "▸ Vite dev server:  http://localhost:$vite_port"
+echo "▸ Debug eval port:  $debug_port"
+echo "▸ Discovery file:   $discovery_file"
+
+(cd src/ui && bun install)
+
+features="${CARGO_TAURI_FEATURES:-devtools,server}"
+
+exec cargo tauri dev --features "$features" \
+  -c "{\"build\":{\"devUrl\":\"http://localhost:$vite_port\"}}"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -41,10 +41,23 @@ branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
 cwd="$(pwd)"
 started="$(date +%s)"
 
-# Emit JSON with a here-doc to avoid quoting headaches in paths.
-cat > "$discovery_file" <<EOF
-{"pid":$$,"debug_port":$debug_port,"vite_port":$vite_port,"cwd":"$cwd","branch":"$branch","started_at":$started}
-EOF
+# Build JSON via python3's json module so paths or branch names containing
+# quotes, backslashes, or newlines don't break the discovery file. `python3`
+# is already an explicit prerequisite of the debug eval helper, so making
+# the devshell depend on it too is consistent.
+python3 -c '
+import json, sys
+out, pid, debug_port, vite_port, started, cwd, branch = sys.argv[1:8]
+with open(out, "w") as f:
+    json.dump({
+        "pid": int(pid),
+        "debug_port": int(debug_port),
+        "vite_port": int(vite_port),
+        "cwd": cwd,
+        "branch": branch,
+        "started_at": int(started),
+    }, f)
+' "$discovery_file" "$$" "$debug_port" "$vite_port" "$started" "$cwd" "$branch"
 
 cleanup() { rm -f "$discovery_file"; }
 trap cleanup EXIT INT TERM

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ claudette = { path = ".." }
 claudette-server = { path = "../src-server", optional = true }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-dialog = "2"
+base64 = "0.22"
 
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-updater = "2"

--- a/src-tauri/src/commands/debug.rs
+++ b/src-tauri/src/commands/debug.rs
@@ -2,16 +2,26 @@
 /// — never compiled into release builds.
 ///
 /// Architecture:
-///   Terminal ──TCP:19432──▶ debug server ──eval()──▶ webview JS context
-///                                                        │
-///   Terminal ◀──TCP────── debug server ◀──event── webview (emit result)
+///   Terminal ──TCP:<port>──▶ debug server ──eval()──▶ webview JS context
+///                                                          │
+///   Terminal ◀──TCP──────── debug server ◀──event── webview (emit result)
+///
+/// The port defaults to 19432 but can be overridden via the
+/// `CLAUDETTE_DEBUG_PORT` env var so multiple dev instances can run side-by-side.
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter, Listener, Manager};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-/// Port for the debug TCP server. Only binds to 127.0.0.1.
-const DEBUG_PORT: u16 = 19432;
+/// Default port for the debug TCP server. Only binds to 127.0.0.1.
+const DEFAULT_DEBUG_PORT: u16 = 19432;
+
+fn debug_port() -> u16 {
+    std::env::var("CLAUDETTE_DEBUG_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_DEBUG_PORT)
+}
 
 /// Tauri command: eval JS in the webview and return the result.
 /// Called internally by the TCP server, but also registered as a Tauri command
@@ -97,17 +107,19 @@ pub async fn debug_eval_result(
     Ok(())
 }
 
-/// Start the debug TCP eval server on 127.0.0.1:19432.
+/// Start the debug TCP eval server on 127.0.0.1. Port is 19432 by default,
+/// or `$CLAUDETTE_DEBUG_PORT` when set.
 /// Call this from the Tauri `setup()` hook.
 pub fn start_debug_server(app: AppHandle) {
+    let port = debug_port();
     tauri::async_runtime::spawn(async move {
-        let listener = match tokio::net::TcpListener::bind(("127.0.0.1", DEBUG_PORT)).await {
+        let listener = match tokio::net::TcpListener::bind(("127.0.0.1", port)).await {
             Ok(l) => {
-                eprintln!("[debug] Eval server listening on 127.0.0.1:{DEBUG_PORT}");
+                eprintln!("[debug] Eval server listening on 127.0.0.1:{port}");
                 l
             }
             Err(e) => {
-                eprintln!("[debug] Failed to start eval server: {e}");
+                eprintln!("[debug] Failed to start eval server on port {port}: {e}");
                 return;
             }
         };

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use serde::Serialize;
 use tauri::State;
 use tokio::process::Command;
@@ -126,4 +128,164 @@ pub async fn read_workspace_file(
         size_bytes: read.size_bytes,
         truncated: read.truncated,
     })
+}
+
+/// Write raw bytes to a filesystem path chosen by the user via a save dialog.
+///
+/// The frontend opens the OS save dialog itself (via `@tauri-apps/plugin-dialog`)
+/// and passes the resulting absolute path plus the attachment bytes here. We
+/// reject relative paths defensively — the dialog only ever yields absolute
+/// paths, but accepting relatives would let callers write into the CWD of the
+/// running app, which is rarely what the user expects.
+pub fn write_bytes_to_absolute_path(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if !path.is_absolute() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path must be absolute",
+        ));
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, bytes)
+}
+
+#[tauri::command]
+pub async fn save_attachment_bytes(path: String, bytes: Vec<u8>) -> Result<(), String> {
+    let target = PathBuf::from(&path);
+    tokio::task::spawn_blocking(move || write_bytes_to_absolute_path(&target, &bytes))
+        .await
+        .map_err(|e| format!("join error: {e}"))?
+        .map_err(|e| format!("failed to save to {path}: {e}"))
+}
+
+/// Write attachment bytes to a temp HTML wrapper and open it with the system
+/// default handler (typically the user's browser).
+///
+/// Wrapping in HTML is deliberate: `open path.png` routes to the default image
+/// viewer (e.g. Preview on macOS), but `open path.html` routes to the browser
+/// on every platform we support. That matches the user's expectation of
+/// "Open in New Window" — a web page containing the image.
+pub fn write_image_as_html(
+    dir: &Path,
+    filename_stem: &str,
+    media_type: &str,
+    bytes: &[u8],
+) -> std::io::Result<PathBuf> {
+    use base64::Engine as _;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    let safe_stem = sanitize_stem(filename_stem);
+    let title = html_escape(filename_stem);
+    let html = format!(
+        "<!doctype html><meta charset=\"utf-8\"><title>{title}</title>\
+         <style>body{{margin:0;background:#111;display:flex;align-items:center;justify-content:center;min-height:100vh}}\
+         img{{max-width:100vw;max-height:100vh}}</style>\
+         <img src=\"data:{media_type};base64,{b64}\" alt=\"{title}\">"
+    );
+    let path = dir.join(format!("{safe_stem}.html"));
+    std::fs::write(&path, html)?;
+    Ok(path)
+}
+
+fn sanitize_stem(s: &str) -> String {
+    let stem: String = s
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if stem.is_empty() {
+        "attachment".to_string()
+    } else {
+        stem
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+#[tauri::command]
+pub async fn open_attachment_in_browser(
+    bytes: Vec<u8>,
+    filename: String,
+    media_type: String,
+) -> Result<(), String> {
+    let dir = std::env::temp_dir().join("claudette-attachments");
+    tokio::task::spawn_blocking(move || -> Result<PathBuf, String> {
+        std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;
+        let stem = Path::new(&filename)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("attachment");
+        write_image_as_html(&dir, stem, &media_type, &bytes).map_err(|e| format!("write html: {e}"))
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?
+    .and_then(|path| {
+        crate::commands::shell::opener::open(&path.to_string_lossy())
+            .map_err(|e| format!("open failed: {e}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_bytes_to_absolute_path_creates_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let nested = dir.path().join("sub").join("dir").join("out.bin");
+        write_bytes_to_absolute_path(&nested, b"hello").unwrap();
+        assert_eq!(std::fs::read(&nested).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn write_bytes_to_absolute_path_rejects_relative() {
+        let err = write_bytes_to_absolute_path(Path::new("relative.bin"), b"x").unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn write_bytes_to_absolute_path_overwrites_existing() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("file.bin");
+        write_bytes_to_absolute_path(&p, b"first").unwrap();
+        write_bytes_to_absolute_path(&p, b"second").unwrap();
+        assert_eq!(std::fs::read(&p).unwrap(), b"second");
+    }
+
+    #[test]
+    fn write_image_as_html_embeds_data_url() {
+        let dir = tempdir().unwrap();
+        let path =
+            write_image_as_html(dir.path(), "cat photo.png", "image/png", b"\x89PNG").unwrap();
+        assert_eq!(path.extension().unwrap(), "html");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("data:image/png;base64,iVBORw==")
+                || content.contains("data:image/png;base64,")
+        );
+        assert!(content.contains("<title>cat photo.png</title>"));
+    }
+
+    #[test]
+    fn sanitize_stem_replaces_unsafe_chars() {
+        assert_eq!(sanitize_stem("hello world.png"), "hello_world_png");
+        assert_eq!(sanitize_stem("../../etc/passwd"), "______etc_passwd");
+        assert_eq!(sanitize_stem(""), "attachment");
+    }
+
+    #[test]
+    fn html_escape_handles_special_chars() {
+        assert_eq!(html_escape(r#"a<b>&"c"#), "a&lt;b&gt;&amp;&quot;c");
+    }
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -176,13 +176,21 @@ pub fn write_image_as_html(
     let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
     let safe_stem = sanitize_stem(filename_stem);
     let title = html_escape(filename_stem);
+    let safe_media = html_escape(media_type);
+    // Include a unique suffix so opening the same attachment twice (or two
+    // differently-chatted files that share a filename stem) doesn't clobber
+    // the previous wrapper while it's still open in the user's browser.
+    let unique: u128 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
     let html = format!(
         "<!doctype html><meta charset=\"utf-8\"><title>{title}</title>\
          <style>body{{margin:0;background:#111;display:flex;align-items:center;justify-content:center;min-height:100vh}}\
          img{{max-width:100vw;max-height:100vh}}</style>\
-         <img src=\"data:{media_type};base64,{b64}\" alt=\"{title}\">"
+         <img src=\"data:{safe_media};base64,{b64}\" alt=\"{title}\">"
     );
-    let path = dir.join(format!("{safe_stem}.html"));
+    let path = dir.join(format!("{safe_stem}-{unique}.html"));
     std::fs::write(&path, html)?;
     Ok(path)
 }
@@ -275,6 +283,26 @@ mod tests {
                 || content.contains("data:image/png;base64,")
         );
         assert!(content.contains("<title>cat photo.png</title>"));
+    }
+
+    #[test]
+    fn write_image_as_html_escapes_hostile_media_type() {
+        let dir = tempdir().unwrap();
+        let path =
+            write_image_as_html(dir.path(), "x", "image/png\" onload=\"alert(1)", b"\x89PNG")
+                .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("onload=\"alert(1)"));
+        assert!(content.contains("&quot;"));
+    }
+
+    #[test]
+    fn write_image_as_html_uses_unique_suffix() {
+        let dir = tempdir().unwrap();
+        let p1 = write_image_as_html(dir.path(), "x", "image/png", b"a").unwrap();
+        std::thread::sleep(std::time::Duration::from_nanos(1));
+        let p2 = write_image_as_html(dir.path(), "x", "image/png", b"b").unwrap();
+        assert_ne!(p1, p2);
     }
 
     #[test]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use tauri::State;
+use tauri::{AppHandle, State, image::Image};
+use tauri_plugin_clipboard_manager::ClipboardExt as _;
 use tokio::process::Command;
 
 use claudette::db::Database;
@@ -210,6 +211,26 @@ fn html_escape(s: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+}
+
+/// Decode encoded image bytes (PNG/JPEG/etc) and copy the result to the
+/// system clipboard in a single IPC round-trip.
+///
+/// The equivalent three-step JS flow (`Image.fromBytes` → `writeImage` →
+/// `image.close`) ships the full byte buffer over the Tauri bridge three
+/// times and re-allocates on each hop. Doing the work end-to-end in Rust
+/// keeps the whole thing on one spawn_blocking task so the UI thread isn't
+/// blocked on PNG decode, and eliminates two serializations worth of lag.
+#[tauri::command]
+pub async fn copy_image_to_clipboard(app: AppHandle, bytes: Vec<u8>) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let image = Image::from_bytes(&bytes).map_err(|e| format!("decode image: {e}"))?;
+        app.clipboard()
+            .write_image(&image)
+            .map_err(|e| format!("clipboard write: {e}"))
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,8 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use tauri::{AppHandle, State, image::Image};
-use tauri_plugin_clipboard_manager::ClipboardExt as _;
+use tauri::State;
 use tokio::process::Command;
 
 use claudette::db::Database;
@@ -211,26 +210,6 @@ fn html_escape(s: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
-}
-
-/// Decode encoded image bytes (PNG/JPEG/etc) and copy the result to the
-/// system clipboard in a single IPC round-trip.
-///
-/// The equivalent three-step JS flow (`Image.fromBytes` → `writeImage` →
-/// `image.close`) ships the full byte buffer over the Tauri bridge three
-/// times and re-allocates on each hop. Doing the work end-to-end in Rust
-/// keeps the whole thing on one spawn_blocking task so the UI thread isn't
-/// blocked on PNG decode, and eliminates two serializations worth of lag.
-#[tauri::command]
-pub async fn copy_image_to_clipboard(app: AppHandle, bytes: Vec<u8>) -> Result<(), String> {
-    tokio::task::spawn_blocking(move || -> Result<(), String> {
-        let image = Image::from_bytes(&bytes).map_err(|e| format!("decode image: {e}"))?;
-        app.clipboard()
-            .write_image(&image)
-            .map_err(|e| format!("clipboard write: {e}"))
-    })
-    .await
-    .map_err(|e| format!("join error: {e}"))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -205,7 +205,7 @@ pub async fn open_url(url: String) -> Result<(), String> {
     Ok(())
 }
 
-mod opener {
+pub(crate) mod opener {
     use claudette::process::CommandWindowExt as _;
     use std::process::Command;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -405,6 +405,7 @@ fn main() {
             commands::files::read_workspace_file,
             commands::files::save_attachment_bytes,
             commands::files::open_attachment_in_browser,
+            commands::files::copy_image_to_clipboard,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::load_attachments_for_workspace,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -405,7 +405,6 @@ fn main() {
             commands::files::read_workspace_file,
             commands::files::save_attachment_bytes,
             commands::files::open_attachment_in_browser,
-            commands::files::copy_image_to_clipboard,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::load_attachments_for_workspace,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -403,6 +403,8 @@ fn main() {
             // Files
             commands::files::list_workspace_files,
             commands::files::read_workspace_file,
+            commands::files::save_attachment_bytes,
+            commands::files::open_attachment_in_browser,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::load_attachments_for_workspace,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,7 @@
             "dialog:default",
             "clipboard-manager:allow-write-text",
             "clipboard-manager:allow-read-text",
+            "clipboard-manager:allow-write-image",
             "updater:default",
             "process:default",
             "notification:default"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://github.com; img-src 'self' asset: http://asset.localhost data:; font-src 'self' data:",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://github.com; img-src 'self' asset: http://asset.localhost data: blob:; media-src 'self' blob:; font-src 'self' data:",
       "capabilities": [
         {
           "identifier": "main-capability",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,6 @@
             "dialog:default",
             "clipboard-manager:allow-write-text",
             "clipboard-manager:allow-read-text",
-            "clipboard-manager:allow-write-image",
             "updater:default",
             "process:default",
             "notification:default"

--- a/src/ui/src/components/chat/AttachmentContextMenu.module.css
+++ b/src/ui/src/components/chat/AttachmentContextMenu.module.css
@@ -2,11 +2,11 @@
   position: fixed;
   z-index: 10000;
   min-width: 220px;
-  background: var(--bg-elevated, #1e1e1e);
-  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
   border-radius: 8px;
   padding: 4px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
   font-size: 13px;
   user-select: none;
 }
@@ -19,15 +19,16 @@
   padding: 6px 10px;
   border: none;
   background: transparent;
-  color: var(--text-primary, #e6e6e6);
+  color: var(--text-primary);
   text-align: left;
   border-radius: 4px;
   cursor: pointer;
   font: inherit;
+  transition: background var(--transition-fast);
 }
 
 .item:hover:not(:disabled) {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  background: var(--hover-bg);
 }
 
 .item:disabled {
@@ -40,5 +41,5 @@
   align-items: center;
   width: 16px;
   height: 16px;
-  color: var(--text-secondary, #a0a0a0);
+  color: var(--text-muted);
 }

--- a/src/ui/src/components/chat/AttachmentContextMenu.module.css
+++ b/src/ui/src/components/chat/AttachmentContextMenu.module.css
@@ -1,0 +1,44 @@
+.menu {
+  position: fixed;
+  z-index: 10000;
+  min-width: 220px;
+  background: var(--bg-elevated, #1e1e1e);
+  border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  font-size: 13px;
+  user-select: none;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary, #e6e6e6);
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.item:hover:not(:disabled) {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+}
+
+.item:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  color: var(--text-secondary, #a0a0a0);
+}

--- a/src/ui/src/components/chat/AttachmentContextMenu.test.ts
+++ b/src/ui/src/components/chat/AttachmentContextMenu.test.ts
@@ -7,6 +7,13 @@ import { clampMenuToViewport } from "./AttachmentContextMenu";
 // we unit-test it in isolation — following the existing convention in
 // focusTargets.test.ts of pure-logic-only tests rather than pulling in a
 // DOM harness (jsdom / testing-library).
+//
+// The async "stay open while the action is in flight" behavior
+// (AttachmentContextMenuItem.onSelect returning a Promise holds the menu
+// open until it settles) is intentionally verified manually rather than
+// with a jsdom render harness: copy a large image and paste into another
+// app before the menu dismisses — the paste works because the menu only
+// closes after the clipboard write has actually resolved.
 
 describe("clampMenuToViewport", () => {
   it("passes through positions that already fit", () => {

--- a/src/ui/src/components/chat/AttachmentContextMenu.test.ts
+++ b/src/ui/src/components/chat/AttachmentContextMenu.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { clampMenuToViewport } from "./AttachmentContextMenu";
+
+// The component itself is thin wiring around a few DOM listeners and a
+// portal; its integration is verified manually in the running app. The
+// clamp logic is pure and carries the interesting edge-case behavior, so
+// we unit-test it in isolation — following the existing convention in
+// focusTargets.test.ts of pure-logic-only tests rather than pulling in a
+// DOM harness (jsdom / testing-library).
+
+describe("clampMenuToViewport", () => {
+  it("passes through positions that already fit", () => {
+    expect(clampMenuToViewport(100, 100, 220, 80, 1200, 800)).toEqual({
+      x: 100,
+      y: 100,
+    });
+  });
+
+  it("pulls the menu left when the click is near the right edge", () => {
+    const { x } = clampMenuToViewport(1190, 100, 220, 80, 1200, 800);
+    // maxX = 1200 - 220 - 8 = 972
+    expect(x).toBe(972);
+  });
+
+  it("pulls the menu up when the click is near the bottom edge", () => {
+    const { y } = clampMenuToViewport(100, 790, 220, 80, 1200, 800);
+    // maxY = 800 - 80 - 8 = 712
+    expect(y).toBe(712);
+  });
+
+  it("enforces a minimum margin on the top-left corner", () => {
+    expect(clampMenuToViewport(-10, -10, 220, 80, 1200, 800)).toEqual({
+      x: 8,
+      y: 8,
+    });
+  });
+
+  it("honors a custom margin", () => {
+    const { x } = clampMenuToViewport(5, 100, 220, 80, 1200, 800, 16);
+    expect(x).toBe(16);
+  });
+});

--- a/src/ui/src/components/chat/AttachmentContextMenu.tsx
+++ b/src/ui/src/components/chat/AttachmentContextMenu.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+import styles from "./AttachmentContextMenu.module.css";
+
+export interface AttachmentContextMenuItem {
+  label: string;
+  onSelect: () => void;
+  icon?: ReactNode;
+  disabled?: boolean;
+}
+
+interface AttachmentContextMenuProps {
+  x: number;
+  y: number;
+  items: AttachmentContextMenuItem[];
+  onClose: () => void;
+}
+
+// Keep the menu fully on-screen: if the click is close enough to the right or
+// bottom edge, shift the anchor so the menu opens up/left instead of clipping.
+// Exported for unit tests — the rendered component is thin enough that it
+// gets manual QA coverage in the running app.
+export function clampMenuToViewport(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin = 8,
+) {
+  const maxX = viewportWidth - width - margin;
+  const maxY = viewportHeight - height - margin;
+  return {
+    x: Math.max(margin, Math.min(x, maxX)),
+    y: Math.max(margin, Math.min(y, maxY)),
+  };
+}
+
+function clampToViewport(x: number, y: number, width: number, height: number) {
+  if (typeof window === "undefined") return { x, y };
+  return clampMenuToViewport(
+    x,
+    y,
+    width,
+    height,
+    window.innerWidth,
+    window.innerHeight,
+  );
+}
+
+export function AttachmentContextMenu({
+  x,
+  y,
+  items,
+  onClose,
+}: AttachmentContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Measure once rendered so we can clamp. Rough fallback for the first frame.
+  const estimated = useMemo(
+    () => ({ width: 220, height: items.length * 34 + 12 }),
+    [items.length],
+  );
+  const clamped = clampToViewport(x, y, estimated.width, estimated.height);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    function onOutside(e: MouseEvent) {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(e.target as Node)) onClose();
+    }
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("mousedown", onOutside, true);
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("mousedown", onOutside, true);
+    };
+  }, [onClose]);
+
+  const menu = (
+    <div
+      ref={menuRef}
+      className={styles.menu}
+      style={{ left: clamped.x, top: clamped.y }}
+      role="menu"
+      data-testid="attachment-context-menu"
+    >
+      {items.map((item, i) => (
+        <button
+          key={i}
+          type="button"
+          role="menuitem"
+          className={styles.item}
+          disabled={item.disabled}
+          onClick={() => {
+            if (item.disabled) return;
+            item.onSelect();
+            onClose();
+          }}
+        >
+          {item.icon ? <span className={styles.icon}>{item.icon}</span> : null}
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+
+  // Portal to body so parent `overflow: hidden` containers (message list,
+  // attachment strip) can't clip the menu.
+  return typeof document === "undefined"
+    ? menu
+    : createPortal(menu, document.body);
+}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -61,6 +61,9 @@ import { AttachmentContextMenu } from "./AttachmentContextMenu";
 import {
   downloadAttachment,
   openAttachmentInBrowser,
+  copyAttachmentToClipboard,
+  shareAttachment,
+  isShareSupported,
   type DownloadableAttachment,
 } from "../../utils/attachmentDownload";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
@@ -1065,6 +1068,14 @@ export function ChatPanel() {
               },
             },
             {
+              label: "Copy Image",
+              onSelect: () => {
+                copyAttachmentToClipboard(attachmentMenu.attachment).catch(
+                  (err) => console.error("Copy failed:", err),
+                );
+              },
+            },
+            {
               label: "Open in New Window",
               onSelect: () => {
                 openAttachmentInBrowser(attachmentMenu.attachment).catch(
@@ -1072,6 +1083,18 @@ export function ChatPanel() {
                 );
               },
             },
+            ...(isShareSupported()
+              ? [
+                  {
+                    label: "Share…",
+                    onSelect: () => {
+                      shareAttachment(attachmentMenu.attachment).catch((err) =>
+                        console.error("Share failed:", err),
+                      );
+                    },
+                  },
+                ]
+              : []),
           ]}
         />
       )}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -57,6 +57,12 @@ import { ContextPopover } from "./composer/ContextPopover";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { AttachMenu } from "./AttachMenu";
+import { AttachmentContextMenu } from "./AttachmentContextMenu";
+import {
+  downloadAttachment,
+  openAttachmentInBrowser,
+  type DownloadableAttachment,
+} from "../../utils/attachmentDownload";
 import { FileMentionPicker, matchFiles } from "./FileMentionPicker";
 import {
   describeSlashQuery,
@@ -197,6 +203,24 @@ export function ChatPanel() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [attachmentMenu, setAttachmentMenu] = useState<{
+    x: number;
+    y: number;
+    attachment: DownloadableAttachment;
+  } | null>(null);
+
+  const openAttachmentMenu = useCallback(
+    (e: React.MouseEvent, attachment: DownloadableAttachment) => {
+      e.preventDefault();
+      setAttachmentMenu({
+        x: e.clientX,
+        y: e.clientY,
+        attachment,
+      });
+    },
+    [],
+  );
 
   // Prompt history: stores past user inputs per workspace.
   const historyRef = useRef<Record<string, string[]>>({});
@@ -899,6 +923,7 @@ export function ChatPanel() {
                   workspaceId={selectedWorkspaceId}
                   isRunning={isRunning}
                   onForkTurn={isRemote ? undefined : handleFork}
+                  onAttachmentContextMenu={openAttachmentMenu}
                 />
               )}
 
@@ -1023,7 +1048,33 @@ export function ChatPanel() {
         historyRef={historyRef}
         historyIndexRef={historyIndexRef}
         draftRef={draftRef}
+        onAttachmentContextMenu={openAttachmentMenu}
       />
+      {attachmentMenu && (
+        <AttachmentContextMenu
+          x={attachmentMenu.x}
+          y={attachmentMenu.y}
+          onClose={() => setAttachmentMenu(null)}
+          items={[
+            {
+              label: "Download Image",
+              onSelect: () => {
+                downloadAttachment(attachmentMenu.attachment).catch((err) =>
+                  console.error("Download failed:", err),
+                );
+              },
+            },
+            {
+              label: "Open in New Window",
+              onSelect: () => {
+                openAttachmentInBrowser(attachmentMenu.attachment).catch(
+                  (err) => console.error("Open in browser failed:", err),
+                );
+              },
+            },
+          ]}
+        />
+      )}
     </div>
   );
 }
@@ -1386,6 +1437,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   workspaceId,
   isRunning,
   onForkTurn,
+  onAttachmentContextMenu,
 }: {
   messages: ChatMessage[];
   workspaceId: string;
@@ -1393,6 +1445,12 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   /** Handler invoked when the user forks a turn. Undefined disables the fork
    *  button (e.g. for remote workspaces where the command cannot run). */
   onForkTurn?: (checkpointId: string) => void;
+  /** Right-click handler on message-image attachments. Lifted to ChatPanel so
+   *  the context menu renders at the top of the component tree. */
+  onAttachmentContextMenu?: (
+    e: React.MouseEvent,
+    attachment: DownloadableAttachment,
+  ) => void;
 }) {
   const completedTurns = useAppStore(
     (s) => s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS
@@ -1643,6 +1701,13 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                         src={`data:${att.media_type};base64,${att.data_base64}`}
                         alt={att.filename}
                         className={styles.messageImage}
+                        onContextMenu={(e) =>
+                          onAttachmentContextMenu?.(e, {
+                            filename: att.filename,
+                            media_type: att.media_type,
+                            data_base64: att.data_base64,
+                          })
+                        }
                       />
                     ),
                   )}
@@ -1829,6 +1894,7 @@ function ChatInputArea({
   historyRef,
   historyIndexRef,
   draftRef,
+  onAttachmentContextMenu,
 }: {
   onSend: (
     content: string,
@@ -1844,6 +1910,10 @@ function ChatInputArea({
   historyRef: React.MutableRefObject<Record<string, string[]>>;
   historyIndexRef: React.MutableRefObject<number>;
   draftRef: React.MutableRefObject<string>;
+  onAttachmentContextMenu?: (
+    e: React.MouseEvent,
+    attachment: DownloadableAttachment,
+  ) => void;
 }) {
   const [chatInput, setChatInput] = useState("");
   const [cursorPos, setCursorPos] = useState(0);
@@ -2414,7 +2484,17 @@ function ChatInputArea({
                   </span>
                 </div>
               ) : (
-                <img src={att.preview_url} alt={att.filename} />
+                <img
+                  src={att.preview_url}
+                  alt={att.filename}
+                  onContextMenu={(e) =>
+                    onAttachmentContextMenu?.(e, {
+                      filename: att.filename,
+                      media_type: att.media_type,
+                      data_base64: att.data_base64,
+                    })
+                  }
+                />
               )}
               <button
                 className={styles.attachmentRemove}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -2218,6 +2218,12 @@ function ChatInputArea({
         // Skip text/plain — pasting text should insert into the textarea,
         // not create a file attachment.
         if (item.type === "text/plain") continue;
+        // Some clipboard writers (notably `navigator.clipboard.write` with
+        // a ClipboardItem) expose the image both as a "string" item (its
+        // data URL) and a "file" item. We must check the file variant —
+        // getAsFile() returns null for string items, which would
+        // silently drop the paste.
+        if (item.kind !== "file") continue;
         if (SUPPORTED_ATTACHMENT_TYPES.has(item.type)) {
           e.preventDefault();
           const file = item.getAsFile();

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -225,6 +225,10 @@ export function ChatPanel() {
     [],
   );
 
+  // navigator.canShare({ files: [probe] }) doesn't change across re-renders —
+  // it's a function of the platform / webview capabilities. Compute once.
+  const shareSupported = useMemo(() => isShareSupported(), []);
+
   // Prompt history: stores past user inputs per workspace.
   const historyRef = useRef<Record<string, string[]>>({});
   const historyIndexRef = useRef(-1);
@@ -1083,7 +1087,7 @@ export function ChatPanel() {
                 );
               },
             },
-            ...(isShareSupported()
+            ...(shareSupported
               ? [
                   {
                     label: "Share…",

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -3,6 +3,9 @@ import {
   extensionFor,
   downloadAttachment,
   openAttachmentInBrowser,
+  copyAttachmentToClipboard,
+  shareAttachment,
+  isShareSupported,
   type DownloadableAttachment,
 } from "./attachmentDownload";
 
@@ -100,5 +103,85 @@ describe("openAttachmentInBrowser", () => {
       filename: "screenshot.png",
       mediaType: "image/png",
     });
+  });
+});
+
+describe("copyAttachmentToClipboard", () => {
+  it("writes decoded bytes to the clipboard", async () => {
+    const writeImage = vi.fn().mockResolvedValue(undefined);
+    await copyAttachmentToClipboard(fixture, { writeImage });
+    expect(writeImage).toHaveBeenCalledWith([104, 101, 108, 108, 111]);
+  });
+
+  it("propagates clipboard errors", async () => {
+    const writeImage = vi.fn().mockRejectedValue(new Error("no clipboard"));
+    await expect(
+      copyAttachmentToClipboard(fixture, { writeImage }),
+    ).rejects.toThrow("no clipboard");
+  });
+});
+
+describe("isShareSupported", () => {
+  it("returns false when navigator has no share()", () => {
+    expect(isShareSupported({}, null)).toBe(false);
+  });
+
+  it("returns true when share exists and canShare is missing", () => {
+    expect(isShareSupported({ share: async () => {} }, null)).toBe(true);
+  });
+
+  it("asks canShare about a probe file when both exist", () => {
+    const canShare = vi.fn().mockReturnValue(true);
+    const probe = new File([new Uint8Array(0)], "x.png", { type: "image/png" });
+    expect(isShareSupported({ share: async () => {}, canShare }, probe)).toBe(
+      true,
+    );
+    expect(canShare).toHaveBeenCalledWith({ files: [probe] });
+  });
+
+  it("denies when canShare returns false for the probe", () => {
+    const probe = new File([new Uint8Array(0)], "x.png", { type: "image/png" });
+    expect(
+      isShareSupported(
+        { share: async () => {}, canShare: () => false },
+        probe,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("shareAttachment", () => {
+  it("calls navigator.share with a file and a title", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    await shareAttachment(fixture, { nav: { share } });
+
+    expect(share).toHaveBeenCalledOnce();
+    const arg = share.mock.calls[0][0];
+    expect(arg.title).toBe("screenshot.png");
+    expect(arg.files).toHaveLength(1);
+    expect((arg.files[0] as File).name).toBe("screenshot.png");
+    expect((arg.files[0] as File).type).toBe("image/png");
+  });
+
+  it("swallows AbortError (user dismissed the sheet)", async () => {
+    const share = vi
+      .fn()
+      .mockRejectedValue(new DOMException("user cancelled", "AbortError"));
+    await expect(
+      shareAttachment(fixture, { nav: { share } }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("surfaces non-Abort errors", async () => {
+    const share = vi.fn().mockRejectedValue(new Error("share backend down"));
+    await expect(
+      shareAttachment(fixture, { nav: { share } }),
+    ).rejects.toThrow("share backend down");
+  });
+
+  it("throws when navigator.share is unavailable", async () => {
+    await expect(shareAttachment(fixture, { nav: {} })).rejects.toThrow(
+      /not available/,
+    );
   });
 });

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -107,50 +107,20 @@ describe("openAttachmentInBrowser", () => {
 });
 
 describe("copyAttachmentToClipboard", () => {
-  function makeImageStub() {
-    const close = vi.fn().mockResolvedValue(undefined);
-    // Shaped enough to satisfy writeImage + finally-close; the real Image has
-    // a rid field and a Resource prototype but we only need the methods.
-    const image = { close } as unknown as import("@tauri-apps/api/image").Image;
-    return { image, close };
-  }
-
-  it("decodes bytes via Image.fromBytes before writing", async () => {
-    const writeImage = vi.fn().mockResolvedValue(undefined);
-    const { image, close } = makeImageStub();
-    const imageFromBytes = vi.fn().mockResolvedValue(image);
-
-    await copyAttachmentToClipboard(fixture, { writeImage, imageFromBytes });
-
-    expect(imageFromBytes).toHaveBeenCalledOnce();
-    // Called with the decoded bytes (hello = 104, 101, 108, 108, 111)
-    const passed = imageFromBytes.mock.calls[0][0];
-    expect(Array.from(passed)).toEqual([104, 101, 108, 108, 111]);
-    expect(writeImage).toHaveBeenCalledWith(image);
-    expect(close).toHaveBeenCalledOnce();
+  it("invokes copy_image_to_clipboard with the decoded bytes in one call", async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    await copyAttachmentToClipboard(fixture, { invoke });
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(invoke).toHaveBeenCalledWith("copy_image_to_clipboard", {
+      bytes: [104, 101, 108, 108, 111],
+    });
   });
 
-  it("closes the Image resource even if writeImage throws", async () => {
-    const writeImage = vi.fn().mockRejectedValue(new Error("no clipboard"));
-    const { image, close } = makeImageStub();
-    const imageFromBytes = vi.fn().mockResolvedValue(image);
-
+  it("propagates clipboard errors from the backend", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("clipboard unavailable"));
     await expect(
-      copyAttachmentToClipboard(fixture, { writeImage, imageFromBytes }),
-    ).rejects.toThrow("no clipboard");
-    expect(close).toHaveBeenCalledOnce();
-  });
-
-  it("propagates decode failures before ever calling writeImage", async () => {
-    const writeImage = vi.fn();
-    const imageFromBytes = vi
-      .fn()
-      .mockRejectedValue(new Error("unsupported format"));
-
-    await expect(
-      copyAttachmentToClipboard(fixture, { writeImage, imageFromBytes }),
-    ).rejects.toThrow("unsupported format");
-    expect(writeImage).not.toHaveBeenCalled();
+      copyAttachmentToClipboard(fixture, { invoke }),
+    ).rejects.toThrow("clipboard unavailable");
   });
 });
 

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -1,4 +1,22 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// vitest runs in Node; ClipboardItem is a browser global. Stub a minimal
+// constructor that records its input so the tests can assert on the data
+// the real browser/webview would see.
+beforeAll(() => {
+  if (typeof (globalThis as unknown as { ClipboardItem?: unknown }).ClipboardItem === "undefined") {
+    class FakeClipboardItem {
+      readonly types: string[];
+      readonly data: Record<string, Blob>;
+      constructor(data: Record<string, Blob>) {
+        this.data = data;
+        this.types = Object.keys(data);
+      }
+    }
+    (globalThis as unknown as { ClipboardItem: typeof FakeClipboardItem }).ClipboardItem =
+      FakeClipboardItem;
+  }
+});
 import {
   extensionFor,
   downloadAttachment,
@@ -107,20 +125,30 @@ describe("openAttachmentInBrowser", () => {
 });
 
 describe("copyAttachmentToClipboard", () => {
-  it("invokes copy_image_to_clipboard with the decoded bytes in one call", async () => {
-    const invoke = vi.fn().mockResolvedValue(undefined);
-    await copyAttachmentToClipboard(fixture, { invoke });
-    expect(invoke).toHaveBeenCalledOnce();
-    expect(invoke).toHaveBeenCalledWith("copy_image_to_clipboard", {
-      bytes: [104, 101, 108, 108, 111],
+  it("writes a ClipboardItem via navigator.clipboard.write", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    await copyAttachmentToClipboard(fixture, {
+      clipboard: { write } as unknown as Clipboard,
     });
+    expect(write).toHaveBeenCalledOnce();
+    const items = write.mock.calls[0][0] as ClipboardItem[];
+    expect(items).toHaveLength(1);
+    expect(items[0].types).toContain("image/png");
   });
 
-  it("propagates clipboard errors from the backend", async () => {
-    const invoke = vi.fn().mockRejectedValue(new Error("clipboard unavailable"));
+  it("throws when the clipboard API is unavailable", async () => {
     await expect(
-      copyAttachmentToClipboard(fixture, { invoke }),
-    ).rejects.toThrow("clipboard unavailable");
+      copyAttachmentToClipboard(fixture, { clipboard: undefined }),
+    ).rejects.toThrow(/not available/);
+  });
+
+  it("propagates errors from clipboard.write", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("denied"));
+    await expect(
+      copyAttachmentToClipboard(fixture, {
+        clipboard: { write } as unknown as Clipboard,
+      }),
+    ).rejects.toThrow("denied");
   });
 });
 

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -107,17 +107,50 @@ describe("openAttachmentInBrowser", () => {
 });
 
 describe("copyAttachmentToClipboard", () => {
-  it("writes decoded bytes to the clipboard", async () => {
+  function makeImageStub() {
+    const close = vi.fn().mockResolvedValue(undefined);
+    // Shaped enough to satisfy writeImage + finally-close; the real Image has
+    // a rid field and a Resource prototype but we only need the methods.
+    const image = { close } as unknown as import("@tauri-apps/api/image").Image;
+    return { image, close };
+  }
+
+  it("decodes bytes via Image.fromBytes before writing", async () => {
     const writeImage = vi.fn().mockResolvedValue(undefined);
-    await copyAttachmentToClipboard(fixture, { writeImage });
-    expect(writeImage).toHaveBeenCalledWith([104, 101, 108, 108, 111]);
+    const { image, close } = makeImageStub();
+    const imageFromBytes = vi.fn().mockResolvedValue(image);
+
+    await copyAttachmentToClipboard(fixture, { writeImage, imageFromBytes });
+
+    expect(imageFromBytes).toHaveBeenCalledOnce();
+    // Called with the decoded bytes (hello = 104, 101, 108, 108, 111)
+    const passed = imageFromBytes.mock.calls[0][0];
+    expect(Array.from(passed)).toEqual([104, 101, 108, 108, 111]);
+    expect(writeImage).toHaveBeenCalledWith(image);
+    expect(close).toHaveBeenCalledOnce();
   });
 
-  it("propagates clipboard errors", async () => {
+  it("closes the Image resource even if writeImage throws", async () => {
     const writeImage = vi.fn().mockRejectedValue(new Error("no clipboard"));
+    const { image, close } = makeImageStub();
+    const imageFromBytes = vi.fn().mockResolvedValue(image);
+
     await expect(
-      copyAttachmentToClipboard(fixture, { writeImage }),
+      copyAttachmentToClipboard(fixture, { writeImage, imageFromBytes }),
     ).rejects.toThrow("no clipboard");
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("propagates decode failures before ever calling writeImage", async () => {
+    const writeImage = vi.fn();
+    const imageFromBytes = vi
+      .fn()
+      .mockRejectedValue(new Error("unsupported format"));
+
+    await expect(
+      copyAttachmentToClipboard(fixture, { writeImage, imageFromBytes }),
+    ).rejects.toThrow("unsupported format");
+    expect(writeImage).not.toHaveBeenCalled();
   });
 });
 

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  extensionFor,
+  downloadAttachment,
+  openAttachmentInBrowser,
+  type DownloadableAttachment,
+} from "./attachmentDownload";
+
+const fixture: DownloadableAttachment = {
+  filename: "screenshot.png",
+  media_type: "image/png",
+  data_base64: "aGVsbG8=", // "hello"
+};
+
+describe("extensionFor", () => {
+  it("derives from media_type", () => {
+    expect(extensionFor(fixture)).toBe("png");
+  });
+
+  it("strips +xml / +json suffixes", () => {
+    expect(
+      extensionFor({ ...fixture, media_type: "image/svg+xml" }),
+    ).toBe("svg");
+  });
+
+  it("falls back to filename extension when media_type is opaque", () => {
+    expect(
+      extensionFor({
+        ...fixture,
+        filename: "doc.pdf",
+        media_type: "application/x-something totally weird",
+      }),
+    ).toBe("pdf");
+  });
+
+  it("falls back to bin as last resort", () => {
+    expect(
+      extensionFor({
+        filename: "noextension",
+        media_type: "application/x has a space",
+        data_base64: "",
+      }),
+    ).toBe("bin");
+  });
+});
+
+describe("downloadAttachment", () => {
+  it("returns null and skips invoke when user cancels the dialog", async () => {
+    const save = vi.fn().mockResolvedValue(null);
+    const invoke = vi.fn();
+
+    const result = await downloadAttachment(fixture, {
+      save,
+      invoke,
+    });
+
+    expect(result).toBeNull();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(save).toHaveBeenCalledOnce();
+    expect(save.mock.calls[0][0]).toMatchObject({
+      defaultPath: "screenshot.png",
+      filters: [{ name: "image/png", extensions: ["png"] }],
+    });
+  });
+
+  it("writes bytes to the chosen path and returns it", async () => {
+    const save = vi.fn().mockResolvedValue("/tmp/out.png");
+    const invoke = vi.fn().mockResolvedValue(undefined);
+
+    const result = await downloadAttachment(fixture, {
+      save,
+      invoke,
+    });
+
+    expect(result).toBe("/tmp/out.png");
+    expect(invoke).toHaveBeenCalledWith("save_attachment_bytes", {
+      path: "/tmp/out.png",
+      bytes: [104, 101, 108, 108, 111], // "hello"
+    });
+  });
+
+  it("propagates errors from invoke (e.g. disk full)", async () => {
+    const save = vi.fn().mockResolvedValue("/tmp/out.png");
+    const invoke = vi.fn().mockRejectedValue(new Error("ENOSPC"));
+
+    await expect(
+      downloadAttachment(fixture, { save, invoke }),
+    ).rejects.toThrow("ENOSPC");
+  });
+});
+
+describe("openAttachmentInBrowser", () => {
+  it("invokes the backend with decoded bytes, filename, and mediaType", async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+
+    await openAttachmentInBrowser(fixture, { invoke });
+
+    expect(invoke).toHaveBeenCalledWith("open_attachment_in_browser", {
+      bytes: [104, 101, 108, 108, 111],
+      filename: "screenshot.png",
+      mediaType: "image/png",
+    });
+  });
+});

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -1,4 +1,5 @@
 import { save } from "@tauri-apps/plugin-dialog";
+import { writeImage } from "@tauri-apps/plugin-clipboard-manager";
 import { invoke } from "@tauri-apps/api/core";
 
 import { base64ToBytes } from "./base64";
@@ -88,4 +89,83 @@ export async function openAttachmentInBrowser(
     filename: attachment.filename,
     mediaType: attachment.media_type,
   });
+}
+
+/**
+ * Copy the attachment image bytes to the system clipboard as an image (not
+ * as a file reference). Paste targets such as Messages, Keynote, or a web
+ * chat will receive the pixels directly.
+ */
+export async function copyAttachmentToClipboard(
+  attachment: DownloadableAttachment,
+  deps: { writeImage?: typeof writeImage } = {},
+): Promise<void> {
+  const writeImageFn = deps.writeImage ?? writeImage;
+  const bytes = base64ToBytes(attachment.data_base64);
+  await writeImageFn(Array.from(bytes));
+}
+
+/**
+ * Probe whether the current webview can invoke the native share sheet with
+ * a file. On macOS WKWebView the Web Share API is available; on Linux /
+ * Windows WebView2 it typically isn't, and we hide the Share menu item
+ * rather than offering a broken action.
+ *
+ * `nav` is injectable so the unit tests can exercise all three branches
+ * (no navigator.share, has navigator.share but no canShare, fully capable)
+ * deterministically — the real `navigator` is captured once at page load.
+ */
+export function isShareSupported(
+  nav: {
+    share?: (data: ShareData) => Promise<void>;
+    canShare?: (data: ShareData) => boolean;
+  } = typeof navigator === "undefined" ? {} : navigator,
+  probeFile: File | null = typeof File === "undefined"
+    ? null
+    : new File([new Uint8Array(0)], "probe.png", { type: "image/png" }),
+): boolean {
+  if (typeof nav.share !== "function") return false;
+  // canShare is advisory on some browsers. Assume yes if it's missing, since
+  // nav.share existing is a strong signal. Only deny when canShare
+  // explicitly returns false for our probe file.
+  if (typeof nav.canShare === "function" && probeFile) {
+    return nav.canShare({ files: [probeFile] });
+  }
+  return true;
+}
+
+/**
+ * Invoke the native share sheet with the attachment as a single file.
+ * Resolves when the sheet closes (success, cancel, or the user just
+ * dismissing). Throws only if the API itself is unavailable — the
+ * caller is expected to gate on `isShareSupported()` first.
+ */
+export async function shareAttachment(
+  attachment: DownloadableAttachment,
+  deps: {
+    nav?: { share?: (data: ShareData) => Promise<void> };
+  } = {},
+): Promise<void> {
+  const nav =
+    deps.nav ?? (typeof navigator === "undefined" ? {} : navigator);
+  if (typeof nav.share !== "function") {
+    throw new Error("Web Share API not available in this environment");
+  }
+  const bytes = base64ToBytes(attachment.data_base64);
+  // Share wants a File; construct it from the in-memory bytes. If the
+  // webview doesn't expose File (node test env without polyfills), let
+  // the caller's try/catch surface the error.
+  const file = new File([bytes], attachment.filename, {
+    type: attachment.media_type,
+  });
+  try {
+    await nav.share({
+      files: [file],
+      title: attachment.filename,
+    });
+  } catch (e) {
+    // AbortError = user dismissed the sheet; not a real failure.
+    if (e instanceof DOMException && e.name === "AbortError") return;
+    throw e;
+  }
 }

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -1,7 +1,5 @@
 import { save } from "@tauri-apps/plugin-dialog";
-import { writeImage } from "@tauri-apps/plugin-clipboard-manager";
 import { invoke } from "@tauri-apps/api/core";
-import { Image } from "@tauri-apps/api/image";
 
 import { base64ToBytes } from "./base64";
 
@@ -97,32 +95,22 @@ export async function openAttachmentInBrowser(
  * as a file reference). Paste targets such as Messages, Keynote, or a web
  * chat will receive the pixels directly.
  *
- * Tauri's `writeImage` expects either an `Image` resource or raw RGBA pixel
- * bytes — NOT encoded PNG/JPEG bytes. If you pass encoded bytes directly,
- * the Rust side interprets them as RGBA and writes garbage, which manifests
- * as "the first click does nothing, the second click works" because the OS
- * clipboard ends up with unreadable data that some apps recover from on
- * a repeated paste. So we decode via `Image.fromBytes` first — that lands
- * us with a real Image resource whose RGBA buffer writeImage can use.
+ * Routes through a single Tauri command (`copy_image_to_clipboard`) that
+ * decodes the PNG/JPEG bytes and writes to the OS clipboard in one
+ * spawn_blocking task. Going through the JS `Image.fromBytes` + `writeImage`
+ * dance instead costs three IPC round-trips and ships the byte buffer
+ * over the bridge twice, which was producing a very noticeable lag on
+ * realistic-sized screenshots.
  */
 export async function copyAttachmentToClipboard(
   attachment: DownloadableAttachment,
-  deps: {
-    writeImage?: typeof writeImage;
-    imageFromBytes?: (bytes: Uint8Array | number[]) => Promise<Image>;
-  } = {},
+  deps: { invoke?: typeof invoke } = {},
 ): Promise<void> {
-  const writeImageFn = deps.writeImage ?? writeImage;
-  const fromBytesFn =
-    deps.imageFromBytes ?? ((b) => Image.fromBytes(b as Uint8Array));
+  const invokeFn = deps.invoke ?? invoke;
   const bytes = base64ToBytes(attachment.data_base64);
-  const image = await fromBytesFn(bytes);
-  try {
-    await writeImageFn(image);
-  } finally {
-    // Image is a Tauri Resource; close so the Rust side drops its handle.
-    await image.close().catch(() => undefined);
-  }
+  await invokeFn("copy_image_to_clipboard", {
+    bytes: Array.from(bytes),
+  });
 }
 
 /**

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -1,6 +1,7 @@
 import { save } from "@tauri-apps/plugin-dialog";
 import { writeImage } from "@tauri-apps/plugin-clipboard-manager";
 import { invoke } from "@tauri-apps/api/core";
+import { Image } from "@tauri-apps/api/image";
 
 import { base64ToBytes } from "./base64";
 
@@ -95,14 +96,33 @@ export async function openAttachmentInBrowser(
  * Copy the attachment image bytes to the system clipboard as an image (not
  * as a file reference). Paste targets such as Messages, Keynote, or a web
  * chat will receive the pixels directly.
+ *
+ * Tauri's `writeImage` expects either an `Image` resource or raw RGBA pixel
+ * bytes — NOT encoded PNG/JPEG bytes. If you pass encoded bytes directly,
+ * the Rust side interprets them as RGBA and writes garbage, which manifests
+ * as "the first click does nothing, the second click works" because the OS
+ * clipboard ends up with unreadable data that some apps recover from on
+ * a repeated paste. So we decode via `Image.fromBytes` first — that lands
+ * us with a real Image resource whose RGBA buffer writeImage can use.
  */
 export async function copyAttachmentToClipboard(
   attachment: DownloadableAttachment,
-  deps: { writeImage?: typeof writeImage } = {},
+  deps: {
+    writeImage?: typeof writeImage;
+    imageFromBytes?: (bytes: Uint8Array | number[]) => Promise<Image>;
+  } = {},
 ): Promise<void> {
   const writeImageFn = deps.writeImage ?? writeImage;
+  const fromBytesFn =
+    deps.imageFromBytes ?? ((b) => Image.fromBytes(b as Uint8Array));
   const bytes = base64ToBytes(attachment.data_base64);
-  await writeImageFn(Array.from(bytes));
+  const image = await fromBytesFn(bytes);
+  try {
+    await writeImageFn(image);
+  } finally {
+    // Image is a Tauri Resource; close so the Rust side drops its handle.
+    await image.close().catch(() => undefined);
+  }
 }
 
 /**

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -1,0 +1,91 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+
+import { base64ToBytes } from "./base64";
+
+/**
+ * Minimal shape an attachment needs to expose for Download / Open In Browser.
+ * Accepts either the persisted `ChatAttachment` (data_base64) or the staged
+ * `PendingAttachment` (same field name) — both carry base64 bytes.
+ */
+export interface DownloadableAttachment {
+  filename: string;
+  media_type: string;
+  data_base64: string;
+}
+
+/**
+ * `image/png` → `png`. Falls back to the current filename's extension, then to
+ * `bin`. Keeps the save dialog's filter name accurate for uncommon types.
+ */
+export function extensionFor(attachment: DownloadableAttachment): string {
+  const fromMedia = attachment.media_type.split("/").pop();
+  if (fromMedia && /^[a-z0-9+.-]+$/i.test(fromMedia)) {
+    return fromMedia.replace("+xml", "").replace("+json", "");
+  }
+  const dot = attachment.filename.lastIndexOf(".");
+  if (dot > 0 && dot < attachment.filename.length - 1) {
+    return attachment.filename.slice(dot + 1);
+  }
+  return "bin";
+}
+
+/**
+ * Prompt the user with a native save dialog, then write the attachment bytes
+ * to the chosen path. Returns the saved path on success, or `null` if the
+ * user cancelled the dialog.
+ *
+ * `saveImpl` and `invokeImpl` are injectable so unit tests don't need to hit
+ * the real Tauri IPC; production code uses the module-level Tauri bindings.
+ */
+export async function downloadAttachment(
+  attachment: DownloadableAttachment,
+  deps: {
+    save?: typeof save;
+    invoke?: typeof invoke;
+  } = {},
+): Promise<string | null> {
+  const saveFn = deps.save ?? save;
+  const invokeFn = deps.invoke ?? invoke;
+
+  const ext = extensionFor(attachment);
+  const path = await saveFn({
+    defaultPath: attachment.filename,
+    filters: [
+      {
+        name: attachment.media_type || "File",
+        extensions: [ext],
+      },
+    ],
+  });
+
+  if (!path) {
+    return null;
+  }
+
+  const bytes = base64ToBytes(attachment.data_base64);
+  await invokeFn("save_attachment_bytes", {
+    path,
+    bytes: Array.from(bytes),
+  });
+  return path;
+}
+
+/**
+ * Write the attachment to a temp HTML wrapper and open it with the system
+ * default handler (routes to the user's browser because the wrapper is .html).
+ * Resolves once the open command has been dispatched; the backend is
+ * fire-and-forget after that.
+ */
+export async function openAttachmentInBrowser(
+  attachment: DownloadableAttachment,
+  deps: { invoke?: typeof invoke } = {},
+): Promise<void> {
+  const invokeFn = deps.invoke ?? invoke;
+  const bytes = base64ToBytes(attachment.data_base64);
+  await invokeFn("open_attachment_in_browser", {
+    bytes: Array.from(bytes),
+    filename: attachment.filename,
+    mediaType: attachment.media_type,
+  });
+}

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -91,26 +91,26 @@ export async function openAttachmentInBrowser(
 }
 
 /**
- * Copy the attachment image bytes to the system clipboard as an image (not
- * as a file reference). Paste targets such as Messages, Keynote, or a web
- * chat will receive the pixels directly.
- *
- * Routes through a single Tauri command (`copy_image_to_clipboard`) that
- * decodes the PNG/JPEG bytes and writes to the OS clipboard in one
- * spawn_blocking task. Going through the JS `Image.fromBytes` + `writeImage`
- * dance instead costs three IPC round-trips and ships the byte buffer
- * over the bridge twice, which was producing a very noticeable lag on
- * realistic-sized screenshots.
+ * Copy the attachment image to the system clipboard using the native
+ * `navigator.clipboard.write()` API. Zero IPC, zero base64→number[]
+ * serialization, zero Rust round-trip — the webview writes directly to
+ * the OS clipboard the same way any browser's "Copy Image" does.
  */
 export async function copyAttachmentToClipboard(
   attachment: DownloadableAttachment,
-  deps: { invoke?: typeof invoke } = {},
+  deps: { clipboard?: Clipboard } = {},
 ): Promise<void> {
-  const invokeFn = deps.invoke ?? invoke;
+  const clipboard =
+    deps.clipboard ??
+    (typeof navigator === "undefined" ? undefined : navigator.clipboard);
+  if (!clipboard) {
+    throw new Error("Clipboard API not available");
+  }
   const bytes = base64ToBytes(attachment.data_base64);
-  await invokeFn("copy_image_to_clipboard", {
-    bytes: Array.from(bytes),
-  });
+  const blob = new Blob([bytes], { type: attachment.media_type });
+  await clipboard.write([
+    new ClipboardItem({ [attachment.media_type]: blob }),
+  ]);
 }
 
 /**

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// Port is chosen by the devshell `dev` helper (which probes for the first
+// free port starting at 1420) and passed in via VITE_PORT. strictPort stays
+// true so a race between pre-flight and Vite startup fails loudly instead
+// of silently landing on a port Tauri isn't pointed at.
+const port = Number(process.env.VITE_PORT ?? 1420)
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 1420,
+    port,
     strictPort: true,
   },
 })

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -5,7 +5,11 @@ import react from '@vitejs/plugin-react'
 // free port starting at 1420) and passed in via VITE_PORT. strictPort stays
 // true so a race between pre-flight and Vite startup fails loudly instead
 // of silently landing on a port Tauri isn't pointed at.
-const port = Number(process.env.VITE_PORT ?? 1420)
+//
+// parseInt instead of Number so an empty/garbage VITE_PORT falls back to
+// 1420 instead of failing with "port NaN already in use".
+const parsed = parseInt(process.env.VITE_PORT ?? '', 10)
+const port = Number.isFinite(parsed) && parsed > 0 ? parsed : 1420
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary

Four related changes, all surfaced while verifying the image-attachment path:

1. **CSP `blob:` fix** — the composer attachment chip renders its pre-send thumbnail instead of an empty black square. Closes #305.
2. **Custom right-click menu** on chat attachment images (composer chip *and* rendered message images) with four working actions: Download, Copy, Open in New Window, Share…. The WebKit default "Download Image" was a no-op for `blob:` URLs and the other items needed Claudette-specific routing.
3. **Composer paste-handler fix** for a pre-existing bug that stopped images copied via the Web Clipboard API from being pasted back into Claudette.
4. **Devshell `dev` auto-selects free ports** so multiple dev instances can run side-by-side against different branches without the port-1420 collision that fails Vite. The `claudette-debug` skill auto-discovers the right instance.

---

## 1. CSP fix (`4863d32`)

`src-tauri/tauri.conf.json` — added `blob:` to the `img-src` CSP directive and introduced a `media-src 'self' blob:` directive for forward compatibility with video/audio attachments.

**Root cause:** the attachment chip uses `URL.createObjectURL()` → `blob:tauri://localhost/<uuid>`. The original CSP listed `'self' asset: http://asset.localhost data:` for `img-src` but not `blob:`, so the browser refused the load.

**Why safe:** `blob:` URLs are always same-origin (only the page itself can create them via `createObjectURL`). Scoped to `img-src` + `media-src` — `script-src`, `connect-src`, etc. are untouched.

## 2. Working attachment context menu

Right-clicking a chat attachment image opens a Claudette-owned menu with:

- **Download Image** — native save dialog, writes bytes to the chosen path
- **Copy Image** — writes the blob to the OS pasteboard via `navigator.clipboard.write(new ClipboardItem(...))`, the same mechanism Safari's own "Copy Image" uses. Pure web-standard, zero Tauri IPC.
- **Open in New Window** — writes a temp `.html` wrapper and opens with the system default handler (routes to the user's browser on every platform)
- **Share…** — invokes the native share sheet via the Web Share API on platforms where it's available (macOS WKWebView). Hidden on platforms where `navigator.canShare({ files })` reports no support, rather than offering a broken action.

**Implementation history:** early commits tried to route Copy through a Tauri command (`Image.fromBytes` + `writeImage`, then a single consolidated `copy_image_to_clipboard` Rust command) to work around what looked like byte-format issues. Both routes ultimately caused lag and a menu-dismissal race because they shipped the full byte buffer over the IPC bridge. Commit `9745969` simplified back to the native browser API, which turned out to be the right primitive all along. The Rust detour was removed in `5feb575`.

**Backend** (`src-tauri/src/commands/files.rs`):
- `save_attachment_bytes(path, bytes)` — rejects relative paths, creates parent dirs, writes bytes (6 unit tests with tempdirs).
- `open_attachment_in_browser(bytes, filename, media_type)` — writes a self-contained HTML wrapper under `${TMPDIR}/claudette-attachments/` and calls the existing cross-platform `opener::open`. The HTML wrapper is deliberate: `open path.png` routes to Preview on macOS; `open path.html` routes to the browser everywhere.

**Frontend** (`utils/attachmentDownload.ts`):
- `downloadAttachment()` — drives native save dialog + `save_attachment_bytes` IPC; returns saved path or null on cancel.
- `copyAttachmentToClipboard()` — `navigator.clipboard.write([new ClipboardItem({ [media_type]: blob })])`. That's it.
- `openAttachmentInBrowser()` — calls `open_attachment_in_browser`.
- `shareAttachment()` — calls `navigator.share({ files })`. Swallows `AbortError` (user dismissed).
- `isShareSupported()` — probes `navigator.share` + `navigator.canShare({ files })`.

All utilities accept injected deps so unit tests can mock save / invoke / clipboard / navigator without stubbing the real Tauri IPC.

**Menu component** (`components/chat/AttachmentContextMenu.tsx`):
- Portal-rendered, viewport-clamped, dismisses on Escape / outside-click.
- Clamp logic exported for unit tests (follows the existing convention in `focusTargets.test.ts` of pure-logic tests — no jsdom dep added).

**Wiring** (`ChatPanel.tsx`): menu state lives in `ChatPanel`; the handler is threaded into both `ChatInputArea` (composer chip) and `MessagesWithTurns` (sent-message image) so both surfaces share the same menu.

## 3. Composer paste-handler fix (`880ba4c`)

Pre-existing bug in `handlePaste` (`ChatPanel.tsx:2212`): the loop iterated `clipboardData.items` in order and matched on `type` alone. When the clipboard contains both a `string` and a `file` representation of the same image — notably after `navigator.clipboard.write(new ClipboardItem(...))` — the string item comes first, matches `SUPPORTED_ATTACHMENT_TYPES`, calls `preventDefault()`, and the handler returns before reaching the actual file. The paste silently dropped.

Never surfaced before because a Cmd-Shift-4 screenshot paste only puts a single `file` item on the clipboard. It only bit once Copy Image (change #2) started using the Web Clipboard API.

One-line guard: `if (item.kind !== "file") continue;` above the type check.

## 4. Devshell dev-port auto-select (`5316f90`)

`scripts/dev.sh` replaces the inline `dev` command in `flake.nix`:
- Probes for the first free Vite port (base 1420) and debug eval port (base 19432).
- Exports `VITE_PORT` (Vite config reads it) and `CLAUDETTE_DEBUG_PORT` (Rust debug server reads it).
- Passes `cargo tauri dev -c '{"build":{"devUrl":"http://localhost:<port>"}}'` so the webview loads from the port Vite actually bound.
- Writes `${TMPDIR:-/tmp}/claudette-dev/<pid>.json` with pid/ports/cwd/branch/started_at. Cleaned up on exit.

`claudette-debug`'s `debug-eval.sh` auto-discovers the right instance:
1. `$CLAUDETTE_DEBUG_PORT` (explicit override)
2. Live discovery file whose `cwd` is an ancestor of `$PWD`
3. Single live instance, if only one
4. Legacy default 19432

Stale files from crashed instances are swept on access.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --all-features` — claudette lib 696 passed
- [x] `cargo test -p claudette-tauri --features devtools,server --bin claudette` — 130 passed (6 in `commands::files::tests` new)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets` — clean (CI-linted crates)
- [x] `cd src/ui && bunx tsc -b` — clean
- [x] `cd src/ui && bun run test` — 687 passed (24 new across `attachmentDownload.test.ts` + `AttachmentContextMenu.test.ts`)
- [x] Manual: paste image into chat composer → thumbnail chip renders (was empty square on main)
- [x] Manual: right-click composer chip or message image → custom menu appears
- [x] Manual: Download Image → save dialog → file written
- [x] Manual: Copy Image → paste into Messages / Keynote / another Claudette composer → image appears
- [x] Manual: Open in New Window → opens in the system browser
- [ ] Manual: Share… on macOS → native share sheet appears
- [ ] Manual: two simultaneous `dev` instances → no port collision

## Migration / compatibility notes

- `blob:` + `media-src` CSP additions are additive; existing allowed origins are unchanged.
- The custom context menu only applies to chat-attachment `<img>` elements. All other right-clicks in the app retain the native WebKit menu.
- The dev-port auto-select is opt-in via the `dev` command; direct `cargo tauri dev` continues to use fixed ports 1420 / 19432.
- The paste-handler guard is a behavior *fix*, not a behavior change — it un-silences a previously-silent drop.

Closes #305.