### PR TITLE
feat(chat): lightbox preview for attachment images (single-click → full-size)

### DIFF
--- a/src/ui/src/components/chat/AttachmentLightbox.module.css
+++ b/src/ui/src/components/chat/AttachmentLightbox.module.css
@@ -1,0 +1,70 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  background: var(--overlay-bg-heavy);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 32px 24px;
+  gap: 12px;
+  user-select: none;
+}
+
+.imageWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: calc(100vw - 64px);
+  max-height: calc(100vh - 128px);
+  outline: none;
+}
+
+.image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  cursor: default;
+}
+
+.caption {
+  color: var(--text-primary);
+  font-size: 13px;
+  text-align: center;
+  max-width: calc(100vw - 64px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-shadow: var(--shadow-sm);
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  border: none;
+  background: var(--overlay-bg-heavy);
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: background var(--transition-fast);
+}
+
+.closeBtn:hover,
+.closeBtn:focus-visible {
+  background: var(--overlay-bg-heavy);
+  outline: 1px solid var(--text-primary);
+  outline-offset: 1px;
+}

--- a/src/ui/src/components/chat/AttachmentLightbox.test.ts
+++ b/src/ui/src/components/chat/AttachmentLightbox.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  isBackdropDismiss,
+  nextFocusTarget,
+} from "./AttachmentLightbox";
+
+// The lightbox component is thin DOM wiring around two pure decisions:
+// should a mousedown close the overlay, and where should focus go on Tab.
+// Both are unit-tested here without a jsdom harness — following the same
+// convention as AttachmentContextMenu.test.ts.
+
+describe("isBackdropDismiss", () => {
+  it("returns true when the target is the backdrop element itself", () => {
+    const backdrop = {} as HTMLElement;
+    expect(isBackdropDismiss(backdrop, backdrop)).toBe(true);
+  });
+
+  it("returns false for clicks on descendants of the backdrop", () => {
+    const backdrop = {} as HTMLElement;
+    const inner = {} as HTMLElement;
+    expect(isBackdropDismiss(inner, backdrop)).toBe(false);
+  });
+
+  it("returns false when backdrop ref is null", () => {
+    expect(isBackdropDismiss({} as HTMLElement, null)).toBe(false);
+  });
+
+  it("returns false when target is null", () => {
+    expect(isBackdropDismiss(null, {} as HTMLElement)).toBe(false);
+  });
+});
+
+describe("nextFocusTarget", () => {
+  const close = { id: "close" } as unknown as HTMLElement;
+  const wrap = { id: "wrap" } as unknown as HTMLElement;
+
+  it("Tab from close moves focus to the image wrapper", () => {
+    expect(nextFocusTarget(close, false, close, wrap)).toBe(wrap);
+  });
+
+  it("Tab from wrap cycles back to the close button", () => {
+    expect(nextFocusTarget(wrap, false, close, wrap)).toBe(close);
+  });
+
+  it("Shift+Tab from close moves focus to the image wrapper", () => {
+    expect(nextFocusTarget(close, true, close, wrap)).toBe(wrap);
+  });
+
+  it("Shift+Tab from wrap moves focus back to the close button", () => {
+    expect(nextFocusTarget(wrap, true, close, wrap)).toBe(close);
+  });
+
+  it("Tab from an element outside the trap pulls focus back to close", () => {
+    expect(nextFocusTarget(null, false, close, wrap)).toBe(close);
+    const stray = {} as HTMLElement;
+    expect(nextFocusTarget(stray, false, close, wrap)).toBe(close);
+  });
+
+  it("Shift+Tab from an element outside the trap also pulls focus to close", () => {
+    expect(nextFocusTarget(null, true, close, wrap)).toBe(close);
+  });
+});

--- a/src/ui/src/components/chat/AttachmentLightbox.tsx
+++ b/src/ui/src/components/chat/AttachmentLightbox.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+import type { DownloadableAttachment } from "../../utils/attachmentDownload";
+import styles from "./AttachmentLightbox.module.css";
+
+interface AttachmentLightboxProps {
+  attachment: DownloadableAttachment;
+  /** Element to return focus to on close — typically the originating <img>. */
+  returnFocusTo?: HTMLElement | null;
+  onClose: () => void;
+}
+
+export function AttachmentLightbox({
+  attachment,
+  returnFocusTo,
+  onClose,
+}: AttachmentLightboxProps) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const imageWrapRef = useRef<HTMLDivElement>(null);
+
+  // Focus the close button on open, restore to the trigger on close.
+  useEffect(() => {
+    const previouslyFocused = returnFocusTo ?? null;
+    closeBtnRef.current?.focus();
+    return () => {
+      previouslyFocused?.focus?.();
+    };
+  }, [returnFocusTo]);
+
+  // Escape, Tab trap. Capture phase so we swallow Escape before any
+  // underlying context-menu handler also bound at capture.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        // Two focusable targets — cycle between them so focus can't escape
+        // the overlay while it's open.
+        const close = closeBtnRef.current;
+        const wrap = imageWrapRef.current;
+        if (!close || !wrap) return;
+        const active = document.activeElement;
+        if (e.shiftKey) {
+          if (active === close) {
+            e.preventDefault();
+            wrap.focus();
+          }
+        } else if (active === wrap) {
+          e.preventDefault();
+          close.focus();
+        }
+      }
+    }
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  // Prevent background scroll while open.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  function onBackdropMouseDown(e: React.MouseEvent<HTMLDivElement>) {
+    // Only dismiss when the click lands on the backdrop itself, not on the
+    // image, caption, or close button.
+    if (e.target === backdropRef.current) onClose();
+  }
+
+  const src = `data:${attachment.media_type};base64,${attachment.data_base64}`;
+
+  const overlay = (
+    <div
+      ref={backdropRef}
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-label={attachment.filename}
+      onMouseDown={onBackdropMouseDown}
+      data-testid="attachment-lightbox"
+    >
+      <button
+        ref={closeBtnRef}
+        type="button"
+        className={styles.closeBtn}
+        aria-label="Close image preview"
+        onClick={onClose}
+      >
+        <X size={18} />
+      </button>
+      <div ref={imageWrapRef} className={styles.imageWrap} tabIndex={-1}>
+        <img
+          src={src}
+          alt={attachment.filename}
+          className={styles.image}
+          draggable={false}
+        />
+      </div>
+      <div className={styles.caption}>{attachment.filename}</div>
+    </div>
+  );
+
+  return typeof document === "undefined"
+    ? overlay
+    : createPortal(overlay, document.body);
+}

--- a/src/ui/src/components/chat/AttachmentLightbox.tsx
+++ b/src/ui/src/components/chat/AttachmentLightbox.tsx
@@ -12,6 +12,42 @@ interface AttachmentLightboxProps {
   onClose: () => void;
 }
 
+/**
+ * Pure two-target focus-trap decision: given the active element and a Tab
+ * keypress, return which of the two targets should receive focus next, or
+ * `null` if the native tab order already cycles correctly.
+ *
+ * Exported for unit tests — keeps the component body focused on wiring.
+ */
+export function nextFocusTarget(
+  active: Element | null,
+  shift: boolean,
+  close: HTMLElement,
+  wrap: HTMLElement,
+): HTMLElement | null {
+  if (shift) {
+    // Shift+Tab: wrap → close, close → wrap (cycle backward).
+    if (active === wrap) return close;
+    if (active === close) return wrap;
+    return close;
+  }
+  // Tab: close → wrap, wrap → close (cycle forward).
+  if (active === close) return wrap;
+  if (active === wrap) return close;
+  return close;
+}
+
+/**
+ * Pure: should a mousedown on the overlay dismiss the lightbox? Yes iff the
+ * click lands on the backdrop element itself, not on a descendant.
+ */
+export function isBackdropDismiss(
+  target: EventTarget | null,
+  backdrop: HTMLElement | null,
+): boolean {
+  return target !== null && target === backdrop;
+}
+
 export function AttachmentLightbox({
   attachment,
   returnFocusTo,
@@ -30,7 +66,7 @@ export function AttachmentLightbox({
     };
   }, [returnFocusTo]);
 
-  // Escape, Tab trap. Capture phase so we swallow Escape before any
+  // Escape + Tab trap. Capture phase so we swallow Escape before any
   // underlying context-menu handler also bound at capture.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -41,20 +77,18 @@ export function AttachmentLightbox({
         return;
       }
       if (e.key === "Tab") {
-        // Two focusable targets — cycle between them so focus can't escape
-        // the overlay while it's open.
         const close = closeBtnRef.current;
         const wrap = imageWrapRef.current;
         if (!close || !wrap) return;
-        const active = document.activeElement;
-        if (e.shiftKey) {
-          if (active === close) {
-            e.preventDefault();
-            wrap.focus();
-          }
-        } else if (active === wrap) {
+        const target = nextFocusTarget(
+          document.activeElement,
+          e.shiftKey,
+          close,
+          wrap,
+        );
+        if (target) {
           e.preventDefault();
-          close.focus();
+          target.focus();
         }
       }
     }
@@ -72,9 +106,7 @@ export function AttachmentLightbox({
   }, []);
 
   function onBackdropMouseDown(e: React.MouseEvent<HTMLDivElement>) {
-    // Only dismiss when the click lands on the backdrop itself, not on the
-    // image, caption, or close button.
-    if (e.target === backdropRef.current) onClose();
+    if (isBackdropDismiss(e.target, backdropRef.current)) onClose();
   }
 
   const src = `data:${attachment.media_type};base64,${attachment.data_base64}`;
@@ -98,7 +130,7 @@ export function AttachmentLightbox({
       >
         <X size={18} />
       </button>
-      <div ref={imageWrapRef} className={styles.imageWrap} tabIndex={-1}>
+      <div ref={imageWrapRef} className={styles.imageWrap} tabIndex={0}>
         <img
           src={src}
           alt={attachment.filename}

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -1038,6 +1038,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  cursor: pointer;
 }
 
 .attachmentRemove {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -2563,13 +2563,18 @@ function ChatInputArea({
                 <img
                   src={att.preview_url}
                   alt={att.filename}
-                  onClick={(e) =>
+                  onClick={(e) => {
+                    // PDFs also render as an <img> here (preview_url is a blob
+                    // URL of the first-page thumbnail), but their data_base64
+                    // is PDF bytes — not renderable inside an <img>. Only open
+                    // the lightbox for actual image MIME types.
+                    if (!att.media_type.startsWith("image/")) return;
                     onAttachmentClick?.(e, {
                       filename: att.filename,
                       media_type: att.media_type,
                       data_base64: att.data_base64,
-                    })
-                  }
+                    });
+                  }}
                   onContextMenu={(e) =>
                     onAttachmentContextMenu?.(e, {
                       filename: att.filename,

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -58,6 +58,7 @@ import { WorkspaceActions } from "./WorkspaceActions";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { AttachMenu } from "./AttachMenu";
 import { AttachmentContextMenu } from "./AttachmentContextMenu";
+import { AttachmentLightbox } from "./AttachmentLightbox";
 import {
   downloadAttachment,
   openAttachmentInBrowser,
@@ -220,6 +221,21 @@ export function ChatPanel() {
         x: e.clientX,
         y: e.clientY,
         attachment,
+      });
+    },
+    [],
+  );
+
+  const [lightbox, setLightbox] = useState<{
+    attachment: DownloadableAttachment;
+    returnFocus: HTMLElement | null;
+  } | null>(null);
+
+  const openLightbox = useCallback(
+    (e: React.MouseEvent, attachment: DownloadableAttachment) => {
+      setLightbox({
+        attachment,
+        returnFocus: (e.currentTarget as HTMLElement) ?? null,
       });
     },
     [],
@@ -931,6 +947,7 @@ export function ChatPanel() {
                   isRunning={isRunning}
                   onForkTurn={isRemote ? undefined : handleFork}
                   onAttachmentContextMenu={openAttachmentMenu}
+                  onAttachmentClick={openLightbox}
                 />
               )}
 
@@ -1056,6 +1073,7 @@ export function ChatPanel() {
         historyIndexRef={historyIndexRef}
         draftRef={draftRef}
         onAttachmentContextMenu={openAttachmentMenu}
+        onAttachmentClick={openLightbox}
       />
       {attachmentMenu && (
         <AttachmentContextMenu
@@ -1100,6 +1118,13 @@ export function ChatPanel() {
                 ]
               : []),
           ]}
+        />
+      )}
+      {lightbox && (
+        <AttachmentLightbox
+          attachment={lightbox.attachment}
+          returnFocusTo={lightbox.returnFocus}
+          onClose={() => setLightbox(null)}
         />
       )}
     </div>
@@ -1465,6 +1490,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   isRunning,
   onForkTurn,
   onAttachmentContextMenu,
+  onAttachmentClick,
 }: {
   messages: ChatMessage[];
   workspaceId: string;
@@ -1475,6 +1501,11 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   /** Right-click handler on message-image attachments. Lifted to ChatPanel so
    *  the context menu renders at the top of the component tree. */
   onAttachmentContextMenu?: (
+    e: React.MouseEvent,
+    attachment: DownloadableAttachment,
+  ) => void;
+  /** Left-click handler on message-image attachments — opens the lightbox. */
+  onAttachmentClick?: (
     e: React.MouseEvent,
     attachment: DownloadableAttachment,
   ) => void;
@@ -1728,6 +1759,13 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                         src={`data:${att.media_type};base64,${att.data_base64}`}
                         alt={att.filename}
                         className={styles.messageImage}
+                        onClick={(e) =>
+                          onAttachmentClick?.(e, {
+                            filename: att.filename,
+                            media_type: att.media_type,
+                            data_base64: att.data_base64,
+                          })
+                        }
                         onContextMenu={(e) =>
                           onAttachmentContextMenu?.(e, {
                             filename: att.filename,
@@ -1922,6 +1960,7 @@ function ChatInputArea({
   historyIndexRef,
   draftRef,
   onAttachmentContextMenu,
+  onAttachmentClick,
 }: {
   onSend: (
     content: string,
@@ -1938,6 +1977,10 @@ function ChatInputArea({
   historyIndexRef: React.MutableRefObject<number>;
   draftRef: React.MutableRefObject<string>;
   onAttachmentContextMenu?: (
+    e: React.MouseEvent,
+    attachment: DownloadableAttachment,
+  ) => void;
+  onAttachmentClick?: (
     e: React.MouseEvent,
     attachment: DownloadableAttachment,
   ) => void;
@@ -2520,6 +2563,13 @@ function ChatInputArea({
                 <img
                   src={att.preview_url}
                   alt={att.filename}
+                  onClick={(e) =>
+                    onAttachmentClick?.(e, {
+                      filename: att.filename,
+                      media_type: att.media_type,
+                      data_base64: att.data_base64,
+                    })
+                  }
                   onContextMenu={(e) =>
                     onAttachmentContextMenu?.(e, {
                       filename: att.filename,
@@ -2531,7 +2581,10 @@ function ChatInputArea({
               )}
               <button
                 className={styles.attachmentRemove}
-                onClick={() => removeAttachment(att.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeAttachment(att.id);
+                }}
                 title="Remove"
               >
                 <X size={12} />


### PR DESCRIPTION
## Summary

- Single-left-click on an attachment image now opens a portal-rendered lightbox: dark backdrop, centered image, filename caption, close via × / Escape / backdrop click.
- Works for both rendered message images (`styles.messageImage`) and composer chip thumbnails (`styles.attachmentThumb img`).
- Right-click still opens the `AttachmentContextMenu` added in #422 — the two handlers are independent.

### Implementation notes

- New `AttachmentLightbox.tsx` + `.module.css` mirrors the `AttachmentContextMenu` portal pattern.
- Lightbox state lives in `ChatPanel` next to `attachmentMenu`, threaded through `MessagesWithTurns` and `ChatInputArea` via a new `onAttachmentClick` prop (parallels the existing `onAttachmentContextMenu`).
- Reuses `DownloadableAttachment` so both persisted `ChatAttachment` and in-flight `PendingAttachment` surfaces work with no extra mapping.
- Accessibility: `role="dialog"`, `aria-modal="true"`, `aria-label={filename}`; focus moves to × on open, two-target Tab trap between × and image wrapper, focus returns to the originating `<img>` on close, `body { overflow: hidden }` while open.
- Composer-chip `×` remove button stops propagation so removing a chip doesn't also trigger the lightbox.
- Theme-token-compliant: `--overlay-bg-heavy`, `--shadow-sm`, `--shadow-lg`, `--radius-pill`, `--text-primary`.

Closes #424.

## Test plan

- [x] `nix develop -c cargo fmt --all --check`
- [x] `cd src/ui && nix develop -c bunx tsc -b`
- [x] `cd src/ui && nix develop -c bun run test` (776 tests)
- [x] `cd src/ui && nix develop -c bun run lint:css`
- [x] Manual UAT: click message image → lightbox; click composer chip → lightbox; Escape / backdrop click / × all dismiss; right-click still opens context menu; chip × still removes without opening lightbox.