### PR TITLE
fix(chat): correct turn footer rollback and fork actions

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -676,6 +676,10 @@
   font-variant-numeric: tabular-nums;
 }
 
+.messageTurnFooter {
+  margin: -2px 0 6px;
+}
+
 .turnFooterElapsed {
   font-family: var(--font-mono);
   color: var(--text-dim);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -74,6 +74,11 @@ import {
   resolveNativeHandler,
 } from "./nativeSlashCommands";
 import { checkpointHasFileChanges, clearAllHasFileChanges, buildRollbackMap } from "../../utils/checkpointUtils";
+import {
+  assistantTextForTurn,
+  buildPlainTurnFooters,
+  findTriggeringUserIndex,
+} from "../../utils/chatTurnFooter";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { CompactionDivider } from "./CompactionDivider";
 import { SyntheticContinuationMessage } from "./SyntheticContinuationMessage";
@@ -1319,6 +1324,7 @@ function TurnFooter({
   assistantText,
   onFork,
   onRollback,
+  className,
 }: {
   durationMs?: number;
   inputTokens?: number;
@@ -1326,6 +1332,7 @@ function TurnFooter({
   assistantText?: string;
   onFork?: () => void;
   onRollback?: () => void;
+  className?: string;
 }) {
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<number | null>(null);
@@ -1437,7 +1444,10 @@ function TurnFooter({
   const hasMetadata = !!(tokensNode || elapsedNode);
 
   return (
-    <div className={styles.turnFooter} onClick={(e) => e.stopPropagation()}>
+    <div
+      className={`${styles.turnFooter}${className ? ` ${className}` : ""}`}
+      onClick={(e) => e.stopPropagation()}
+    >
       {tokensNode}
       {tokensNode && elapsedNode && (
         <span className={styles.turnFooterDot} aria-hidden="true">·</span>
@@ -1483,6 +1493,15 @@ function TaskProgressBar({
  * per-message selectors and redundant re-renders during streaming.
  */
 const EMPTY_CHECKPOINTS: import("../../types/checkpoint").ConversationCheckpoint[] = [];
+
+type RollbackModalData = {
+  workspaceId: string;
+  checkpointId: string | null;
+  messageId: string;
+  messagePreview: string;
+  messageContent: string;
+  hasFileChanges: boolean;
+};
 
 const MessagesWithTurns = memo(function MessagesWithTurns({
   messages,
@@ -1553,65 +1572,33 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
     return map;
   }, [completedTurns]);
 
-  // Joined assistant text per turn, used by the "Copy output" action in the
-  // turn footer. A turn's slice is [prevTurn.afterMessageIndex, afterMessageIndex).
-  const assistantTextByTurnId = useMemo(() => {
-    const map = new Map<string, string>();
-    let prevBoundary = 0;
-    for (const turn of completedTurns) {
-      const text = messages
-        .slice(prevBoundary, turn.afterMessageIndex)
-        .filter((m) => m.role === "Assistant")
-        .map((m) => m.content)
-        .join("\n\n")
-        .trim();
-      map.set(turn.id, text);
-      prevBoundary = turn.afterMessageIndex;
-    }
-    return map;
-  }, [completedTurns, messages]);
+  const completedTurnPositions = useMemo(
+    () => new Set(completedTurns.map((turn) => turn.afterMessageIndex)),
+    [completedTurns],
+  );
 
-  // Map user message index → checkpoint for the preceding turn.
-  // Checks the message immediately before this user message (assistant or
-  // user for tool-only turns) for a matching checkpoint. Index 0 always
-  // maps to null (clear-all) when any checkpoints exist.
+  const findTriggeringUserIdx = useCallback(
+    (afterMessageIndex: number) => {
+      return findTriggeringUserIndex(messages, afterMessageIndex);
+    },
+    [messages],
+  );
+
+  // Map user message index → checkpoint for rollback buttons.
+  // Each user message maps to the latest preceding checkpoint, with the first
+  // user message mapping to null so it can clear the whole conversation.
   const rollbackCheckpointByIdx = useMemo(
     () => buildRollbackMap(messages, checkpoints),
     [messages, checkpoints],
   );
 
-  // Per-turn rollback data, keyed by turn.id. A turn's rollback target is
-  // the checkpoint captured just before the triggering user message ran.
-  // A turn's triggering user message is the first User message in its range
-  // [prevBoundary, afterMessageIndex) — the checkpoint itself is anchored to
-  // the last assistant message of the turn, so we can't use cp.message_id.
-  const rollbackByTurnId = useMemo(() => {
-    const result = new Map<
-      string,
-      {
-        workspaceId: string;
-        checkpointId: string | null;
-        messageId: string;
-        messagePreview: string;
-        messageContent: string;
-        hasFileChanges: boolean;
-      }
-    >();
-    let prevBoundary = 0;
-    for (const turn of completedTurns) {
-      let userIdx = -1;
-      for (let i = prevBoundary; i < turn.afterMessageIndex && i < messages.length; i++) {
-        if (messages[i].role === "User") {
-          userIdx = i;
-          break;
-        }
-      }
-      prevBoundary = turn.afterMessageIndex;
-      if (userIdx === -1) continue;
-      if (!rollbackCheckpointByIdx.has(userIdx)) continue;
+  const buildRollbackData = useCallback(
+    (userIdx: number): RollbackModalData | null => {
+      if (!rollbackCheckpointByIdx.has(userIdx)) return null;
       const target = rollbackCheckpointByIdx.get(userIdx) ?? null;
       const userMsg = messages[userIdx];
-      result.set(turn.id, {
+      if (!userMsg) return null;
+      return {
         workspaceId,
         checkpointId: target ? target.id : null,
         messageId: userMsg.id,
@@ -1620,16 +1607,99 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
         hasFileChanges: target
           ? checkpointHasFileChanges(target, checkpoints)
           : clearAllHasFileChanges(checkpoints),
-      });
+      };
+    },
+    [checkpoints, messages, rollbackCheckpointByIdx, workspaceId],
+  );
+
+  // Joined assistant text per turn, used by the "Copy output" action in the
+  // turn footer. CompletedTurn is only persisted for tool-using turns, so the
+  // slice starts at the nearest preceding user message instead of the previous
+  // CompletedTurn boundary.
+  const assistantTextByTurnId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const turn of completedTurns) {
+      const userIdx = findTriggeringUserIdx(turn.afterMessageIndex);
+      if (userIdx === -1) {
+        map.set(turn.id, "");
+        continue;
+      }
+      map.set(
+        turn.id,
+        assistantTextForTurn(messages, userIdx, turn.afterMessageIndex),
+      );
+    }
+    return map;
+  }, [completedTurns, findTriggeringUserIdx, messages]);
+
+  // Per-turn rollback data, keyed by turn.id. Completed turns are only
+  // persisted for tool-using turns, so the triggering user is the nearest
+  // user message before the completed turn boundary.
+  const rollbackByTurnId = useMemo(() => {
+    const result = new Map<string, RollbackModalData>();
+    for (const turn of completedTurns) {
+      const userIdx = findTriggeringUserIdx(turn.afterMessageIndex);
+      if (userIdx === -1) continue;
+      const data = buildRollbackData(userIdx);
+      if (data) result.set(turn.id, data);
     }
     return result;
-  }, [completedTurns, checkpoints, messages, workspaceId, rollbackCheckpointByIdx]);
+  }, [buildRollbackData, completedTurns, findTriggeringUserIdx]);
 
   const buildOnRollback = (turnId: string) => {
     if (isRunning) return undefined;
     const data = rollbackByTurnId.get(turnId);
     if (!data) return undefined;
     return () => openModal("rollback", data);
+  };
+
+  const plainTurnFootersByPosition = useMemo(() => {
+    return buildPlainTurnFooters(
+      messages,
+      rollbackCheckpointByIdx,
+      completedTurnPositions,
+      checkpoints,
+    );
+  }, [checkpoints, completedTurnPositions, messages, rollbackCheckpointByIdx]);
+
+  const renderPlainTurnFooter = (position: number) => {
+    const data = plainTurnFootersByPosition.get(position);
+    if (!data) return null;
+    const rollbackData = buildRollbackData(data.userIdx);
+    const onRollback =
+      !isRunning && rollbackData
+        ? () => openModal("rollback", rollbackData)
+        : undefined;
+    const onFork =
+      data.forkCheckpointId && onForkTurn
+        ? () => onForkTurn(data.forkCheckpointId!)
+        : undefined;
+    const hasRenderableTokens =
+      typeof data.inputTokens === "number" &&
+      typeof data.outputTokens === "number";
+
+    if (
+      !data.assistantText &&
+      !data.durationMs &&
+      !hasRenderableTokens &&
+      !onFork &&
+      !onRollback
+    ) {
+      return null;
+    }
+
+    return (
+      <TurnFooter
+        key={`plain-turn-footer-${data.position}`}
+        durationMs={data.durationMs}
+        inputTokens={data.inputTokens}
+        outputTokens={data.outputTokens}
+        assistantText={data.assistantText}
+        onFork={onFork}
+        onRollback={onRollback}
+        className={styles.messageTurnFooter}
+      />
+    );
   };
 
   // Compute cumulative task progress at each turn index in a single O(n) pass.
@@ -1796,6 +1866,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
             </div>
           </div>
           )}
+          {renderPlainTurnFooter(idx + 1)}
         </React.Fragment>
         );
       })}

--- a/src/ui/src/utils/chatTurnFooter.test.ts
+++ b/src/ui/src/utils/chatTurnFooter.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { ConversationCheckpoint } from "../types/checkpoint";
+import type { ChatMessage } from "../types/chat";
+import {
+  assistantTextForTurn,
+  buildPlainTurnFooters,
+  findTriggeringUserIndex,
+} from "./chatTurnFooter";
+
+function msg(
+  id: string,
+  role: "User" | "Assistant" | "System",
+  content = "",
+): ChatMessage {
+  return {
+    id,
+    workspace_id: "ws",
+    role,
+    content,
+    cost_usd: null,
+    duration_ms: null,
+    created_at: "",
+    thinking: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cache_creation_tokens: null,
+  };
+}
+
+function cp(id: string, messageId: string): ConversationCheckpoint {
+  return {
+    id,
+    workspace_id: "ws",
+    message_id: messageId,
+    commit_hash: null,
+    has_file_state: false,
+    turn_index: 0,
+    message_count: 1,
+    created_at: "",
+  };
+}
+
+describe("chat turn footer derivation", () => {
+  it("builds footer data for plain assistant turns without tool summaries", () => {
+    const messages = [
+      msg("m1", "User", "question"),
+      {
+        ...msg("m2", "Assistant", "answer"),
+        duration_ms: 1_500,
+        input_tokens: 100,
+        output_tokens: 25,
+      },
+    ];
+    const rollbackMap = new Map<number, ConversationCheckpoint | null>([
+      [0, null],
+    ]);
+
+    const result = buildPlainTurnFooters(messages, rollbackMap, new Set());
+
+    expect(result.get(2)).toEqual({
+      position: 2,
+      userIdx: 0,
+      rollbackCheckpointId: null,
+      forkCheckpointId: null,
+      assistantText: "answer",
+      durationMs: 1_500,
+      inputTokens: 100,
+      outputTokens: 25,
+    });
+  });
+
+  it("does not duplicate footer data when a completed tool turn owns that position", () => {
+    const messages = [
+      msg("m1", "User", "read the file"),
+      msg("m2", "Assistant", "done"),
+    ];
+    const rollbackMap = new Map<number, ConversationCheckpoint | null>([
+      [0, null],
+    ]);
+
+    const result = buildPlainTurnFooters(messages, rollbackMap, new Set([2]));
+
+    expect(result.size).toBe(0);
+  });
+
+  it("builds copy footer data even when rollback is unavailable", () => {
+    const messages = [
+      msg("m1", "User", "first"),
+      msg("m2", "Assistant", "first answer"),
+      msg("m3", "User", "second"),
+      msg("m4", "Assistant", "second answer"),
+    ];
+    const rollbackMap = new Map<number, ConversationCheckpoint | null>([
+      [0, null],
+    ]);
+
+    const result = buildPlainTurnFooters(messages, rollbackMap, new Set());
+
+    expect(result.get(4)).toMatchObject({
+      position: 4,
+      userIdx: 2,
+      rollbackCheckpointId: null,
+      forkCheckpointId: null,
+      assistantText: "second answer",
+    });
+  });
+
+  it("keeps the nearest prior user as a completed turn trigger after a plain turn", () => {
+    const messages = [
+      msg("m1", "User", "plain question"),
+      msg("m2", "Assistant", "plain answer"),
+      msg("m3", "User", "tool request"),
+      msg("m4", "Assistant", "tool answer"),
+    ];
+
+    const userIdx = findTriggeringUserIndex(messages, 4);
+
+    expect(userIdx).toBe(2);
+    expect(assistantTextForTurn(messages, userIdx, 4)).toBe("tool answer");
+  });
+
+  it("uses the current turn checkpoint for fork, not the rollback checkpoint", () => {
+    const messages = [
+      msg("m1", "User", "first"),
+      msg("m2", "Assistant", "first answer"),
+      msg("m3", "User", "second"),
+      msg("m4", "Assistant", "second answer"),
+    ];
+    const rollbackMap = new Map<number, ConversationCheckpoint | null>([
+      [0, null],
+      [2, cp("cp1", "m2")],
+    ]);
+
+    const result = buildPlainTurnFooters(
+      messages,
+      rollbackMap,
+      new Set(),
+      [cp("cp1", "m2"), cp("cp2", "m4")],
+    );
+
+    expect(result.get(4)?.rollbackCheckpointId).toBe("cp1");
+    expect(result.get(4)?.forkCheckpointId).toBe("cp2");
+  });
+});

--- a/src/ui/src/utils/chatTurnFooter.ts
+++ b/src/ui/src/utils/chatTurnFooter.ts
@@ -1,0 +1,103 @@
+import type { ConversationCheckpoint } from "../types/checkpoint";
+import type { ChatMessage } from "../types/chat";
+
+export type PlainTurnFooterData = {
+  position: number;
+  userIdx: number;
+  rollbackCheckpointId: string | null;
+  forkCheckpointId: string | null;
+  assistantText: string;
+  durationMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+export function findTriggeringUserIndex(
+  messages: ChatMessage[],
+  afterMessageIndex: number,
+): number {
+  for (
+    let i = Math.min(afterMessageIndex, messages.length) - 1;
+    i >= 0;
+    i--
+  ) {
+    if (messages[i].role === "User") return i;
+  }
+  return -1;
+}
+
+export function assistantTextForTurn(
+  messages: ChatMessage[],
+  userIdx: number,
+  afterMessageIndex: number,
+): string {
+  if (userIdx < 0) return "";
+  return messages
+    .slice(userIdx + 1, afterMessageIndex)
+    .filter((m) => m.role === "Assistant")
+    .map((m) => m.content)
+    .join("\n\n")
+    .trim();
+}
+
+export function buildPlainTurnFooters(
+  messages: ChatMessage[],
+  rollbackCheckpointByIdx: Map<number, ConversationCheckpoint | null>,
+  completedTurnPositions: Set<number>,
+  checkpoints: ConversationCheckpoint[] = [],
+): Map<number, PlainTurnFooterData> {
+  const map = new Map<number, PlainTurnFooterData>();
+  const checkpointByMessageId = new Map(
+    checkpoints.map((checkpoint) => [checkpoint.message_id, checkpoint]),
+  );
+
+  for (let userIdx = 0; userIdx < messages.length; userIdx++) {
+    if (messages[userIdx].role !== "User") continue;
+
+    let endExclusive = messages.length;
+    for (let i = userIdx + 1; i < messages.length; i++) {
+      if (messages[i].role === "User") {
+        endExclusive = i;
+        break;
+      }
+    }
+    if (completedTurnPositions.has(endExclusive)) continue;
+
+    const assistantMessages = messages
+      .slice(userIdx + 1, endExclusive)
+      .filter((m) => m.role === "Assistant");
+    if (assistantMessages.length === 0) continue;
+
+    const durationMs =
+      assistantMessages.reduce((sum, m) => sum + (m.duration_ms ?? 0), 0) ||
+      undefined;
+    const inputTokens =
+      assistantMessages.reduce((sum, m) => sum + (m.input_tokens ?? 0), 0) ||
+      undefined;
+    const outputTokens =
+      assistantMessages.reduce((sum, m) => sum + (m.output_tokens ?? 0), 0) ||
+      undefined;
+    const rollbackTarget = rollbackCheckpointByIdx.get(userIdx) ?? null;
+    let forkTarget: ConversationCheckpoint | undefined;
+    for (let i = endExclusive - 1; i > userIdx; i--) {
+      const checkpoint = checkpointByMessageId.get(messages[i].id);
+      if (checkpoint) {
+        forkTarget = checkpoint;
+        break;
+      }
+    }
+
+    map.set(endExclusive, {
+      position: endExclusive,
+      userIdx,
+      rollbackCheckpointId: rollbackTarget ? rollbackTarget.id : null,
+      forkCheckpointId: forkTarget ? forkTarget.id : null,
+      assistantText: assistantTextForTurn(messages, userIdx, endExclusive),
+      durationMs,
+      inputTokens,
+      outputTokens,
+    });
+  }
+
+  return map;
+}


### PR DESCRIPTION
## Summary
- render the existing chat turn footer for plain assistant turns, so copy/fork/rollback are not limited to tool-using turns
- derive footer data from message boundaries and keep tool-turn summaries as the owner when a CompletedTurn exists
- use separate checkpoint targets: rollback uses the checkpoint before the triggering user message, while fork uses the checkpoint created by the selected turn
- add regression coverage for plain-turn footer rendering, unavailable rollback data, and fork-vs-rollback checkpoint selection

## Verification
- PASS: nix develop -c bash -lc 'cd src/ui && bunx tsc -b'
- PASS: nix develop -c bash -lc 'cd src/ui && bunx vitest run src/utils/chatTurnFooter.test.ts'
- PASS: nix develop -c bash -lc 'cd src/ui && bun run test'
- PASS: nix develop -c bash -lc 'cd src/ui && bun run lint:css'
- PASS: nix develop -c bash -lc 'cd src/ui && bun run build'
- PASS: cargo fmt --all --check
- PASS: cargo test --all-features
- PASS: RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-server --all-targets
- PASS with existing warnings: cargo clippy --workspace --all-targets
- NOTE: nix develop -c bash -lc 'cd src/ui && bun run lint' still reports existing repo-wide ESLint issues unrelated to this patch.