### PR TITLE
fix(chat): attachment context menus + SVG lightbox preview

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -252,7 +252,11 @@ fn extension_for_media_type(media_type: &str) -> &str {
         .split_once('+')
         .map(|p| p.0)
         .unwrap_or(after_slash);
-    if !bare.is_empty() && bare.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.') {
+    if !bare.is_empty()
+        && bare
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
+    {
         bare
     } else {
         "bin"
@@ -391,10 +395,7 @@ mod tests {
     #[test]
     fn extension_for_media_type_strips_xml_json_suffixes() {
         assert_eq!(extension_for_media_type("image/svg+xml"), "svg");
-        assert_eq!(
-            extension_for_media_type("application/ld+json"),
-            "ld"
-        );
+        assert_eq!(extension_for_media_type("application/ld+json"), "ld");
     }
 
     #[test]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -246,27 +246,76 @@ pub async fn open_attachment_in_browser(
 /// Pick a sensible file extension for a media type. Used when staging an
 /// attachment to a temp file so the OS routes the open-with handler to the
 /// right app (e.g. `.pdf` → Preview / Adobe / etc).
-fn extension_for_media_type(media_type: &str) -> &str {
+///
+/// Common types that have a canonical extension different from their MIME
+/// subtype (`text/plain` → `txt`, `image/jpeg` → `jpg`, `+json` types → `json`)
+/// get an explicit mapping. Everything else falls back to the subtype with
+/// any `+xml` / `+json` suffix stripped.
+fn extension_for_media_type(media_type: &str) -> &'static str {
+    match media_type {
+        "text/plain" => return "txt",
+        "text/html" => return "html",
+        "text/css" => return "css",
+        "text/javascript" | "application/javascript" => return "js",
+        "image/jpeg" => return "jpg",
+        "image/svg+xml" => return "svg",
+        "application/pdf" => return "pdf",
+        "application/json" => return "json",
+        "application/zip" => return "zip",
+        _ => {}
+    }
+    // `+json` suffixed types (application/ld+json, application/vnd.api+json…)
+    // route to the json viewer naturally.
+    if media_type.ends_with("+json") {
+        return "json";
+    }
+    if media_type.ends_with("+xml") {
+        return "xml";
+    }
+    // Last-resort fallback: trust the subtype iff it looks safe.
     let after_slash = media_type.rsplit_once('/').map(|p| p.1).unwrap_or("");
-    let bare = after_slash
-        .split_once('+')
-        .map(|p| p.0)
-        .unwrap_or(after_slash);
-    if !bare.is_empty()
-        && bare
+    if !after_slash.is_empty()
+        && after_slash
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
     {
-        bare
+        // SAFETY: we matched the explicit cases above; for the catch-all we
+        // need a 'static lifetime, so leak the small string into a static
+        // pool. In practice this branch only fires for types we haven't
+        // mapped yet — adding them above is the long-term fix.
+        leak_static_str(after_slash)
     } else {
         "bin"
     }
+}
+
+/// Cache `&'static str`s for media subtypes so [`extension_for_media_type`]
+/// can return them by reference. The set of distinct media types Claudette
+/// sees in a session is bounded by the user's attachments; leaking is
+/// fine. Lazy-initialized so non-test runs pay nothing if every type hits
+/// the explicit map.
+fn leak_static_str(s: &str) -> &'static str {
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<String, &'static str>>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    let mut guard = cache.lock().expect("extension cache mutex poisoned");
+    if let Some(&existing) = guard.get(s) {
+        return existing;
+    }
+    let leaked: &'static str = Box::leak(s.to_string().into_boxed_str());
+    guard.insert(s.to_string(), leaked);
+    leaked
 }
 
 /// Write attachment bytes to a temp file using the natural file extension
 /// for the media type. Unlike [`write_image_as_html`], this writes the raw
 /// bytes (no wrapper) so `open` routes to the system default handler for
 /// the format — Preview / Adobe Reader for PDFs, etc.
+///
+/// On Unix the file is created with `0o600` (owner read/write only) so
+/// other local accounts can't peek at potentially sensitive content
+/// stashed under the shared temp dir.
 pub fn write_attachment_to_temp_file(
     dir: &Path,
     filename: &str,
@@ -286,13 +335,94 @@ pub fn write_attachment_to_temp_file(
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let path = dir.join(format!("{safe_stem}-{unique}.{ext}"));
-    std::fs::write(&path, bytes)?;
+    write_owner_only(&path, bytes)?;
     Ok(path)
+}
+
+/// Write `bytes` to `path`, creating the file with restrictive permissions
+/// on Unix (`0o600`). On Windows ACLs handle this differently — a regular
+/// `fs::write` is fine.
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(bytes)?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, bytes)
+    }
+}
+
+/// Create the staging directory with restrictive permissions on Unix
+/// (`0o700`) so other accounts can't list or read the staged files.
+fn create_staging_dir(dir: &Path) -> std::io::Result<()> {
+    if dir.exists() {
+        return Ok(());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(dir)
+    }
+}
+
+/// Remove staged attachments older than `max_age` from `dir`. Used to keep
+/// the temp staging directory from growing unboundedly across sessions —
+/// PDFs in particular can be 10+ MB each. Errors during cleanup are
+/// swallowed: a stale file that we couldn't delete this run will be tried
+/// again on the next open.
+pub fn cleanup_stale_attachments(dir: &Path, max_age: std::time::Duration) {
+    cleanup_stale_attachments_at(dir, max_age, std::time::SystemTime::now());
+}
+
+/// Testable variant of [`cleanup_stale_attachments`] — `now` is injected
+/// so the test doesn't need to manipulate file mtimes.
+fn cleanup_stale_attachments_at(
+    dir: &Path,
+    max_age: std::time::Duration,
+    now: std::time::SystemTime,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        let Ok(age) = now.duration_since(modified) else {
+            continue;
+        };
+        if age >= max_age {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// Open an attachment with the system's default handler for its media
 /// type (e.g. PDF → Preview on macOS, the user's PDF reader on Linux /
-/// Windows). Bytes are staged to a temp file under the OS temp dir.
+/// Windows). Bytes are staged to a temp file under the OS temp dir with
+/// owner-only permissions; stale stages older than 24 h are reaped on
+/// each open so the directory doesn't grow without bound.
 #[tauri::command]
 pub async fn open_attachment_with_default_app(
     bytes: Vec<u8>,
@@ -301,7 +431,11 @@ pub async fn open_attachment_with_default_app(
 ) -> Result<(), String> {
     let dir = std::env::temp_dir().join("claudette-attachments");
     tokio::task::spawn_blocking(move || -> Result<PathBuf, String> {
-        std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;
+        create_staging_dir(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;
+        // Reap files older than a day — keeps the directory bounded
+        // without yanking the rug out from under an app the user may
+        // still have open. Cleanup errors are non-fatal.
+        cleanup_stale_attachments(&dir, std::time::Duration::from_secs(24 * 60 * 60));
         write_attachment_to_temp_file(&dir, &filename, &media_type, &bytes)
             .map_err(|e| format!("write attachment: {e}"))
     })
@@ -393,9 +527,19 @@ mod tests {
     }
 
     #[test]
-    fn extension_for_media_type_strips_xml_json_suffixes() {
+    fn extension_for_media_type_uses_real_extensions_not_subtypes() {
+        // text/plain → txt (not "plain"); subtypes that aren't valid file
+        // extensions get a sensible mapping so the OS routes to the right
+        // viewer/editor.
+        assert_eq!(extension_for_media_type("text/plain"), "txt");
+        assert_eq!(extension_for_media_type("application/json"), "json");
+        assert_eq!(extension_for_media_type("application/ld+json"), "json");
+        assert_eq!(extension_for_media_type("text/html"), "html");
+    }
+
+    #[test]
+    fn extension_for_media_type_strips_xml_suffix() {
         assert_eq!(extension_for_media_type("image/svg+xml"), "svg");
-        assert_eq!(extension_for_media_type("application/ld+json"), "ld");
     }
 
     #[test]
@@ -444,5 +588,55 @@ mod tests {
         let p2 =
             write_attachment_to_temp_file(dir.path(), "doc.pdf", "application/pdf", b"b").unwrap();
         assert_ne!(p1, p2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_attachment_to_temp_file_uses_owner_only_perms() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempdir().unwrap();
+        let path =
+            write_attachment_to_temp_file(dir.path(), "secret.pdf", "application/pdf", b"%PDF")
+                .unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        // Only the owner should be able to read the staged file — these
+        // can contain user data that other local accounts shouldn't see.
+        assert_eq!(mode, 0o600, "expected 0o600, got {mode:o}");
+    }
+
+    #[test]
+    fn cleanup_stale_attachments_removes_old_files() {
+        use std::time::Duration;
+        let dir = tempdir().unwrap();
+        let old_path = dir.path().join("old.pdf");
+        let fresh_path = dir.path().join("fresh.pdf");
+        std::fs::write(&old_path, b"old").unwrap();
+        // Sleep so the fresh file has a strictly newer mtime than the old
+        // one (file system mtime resolution is ~1 ms on most platforms).
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(&fresh_path, b"fresh").unwrap();
+
+        // Pretend "now" is far in the future, just past the fresh file's
+        // mtime — the old file lands beyond the cleanup threshold while
+        // the fresh one is still inside it.
+        let fresh_mtime = std::fs::metadata(&fresh_path).unwrap().modified().unwrap();
+        let now = fresh_mtime + Duration::from_millis(5);
+        cleanup_stale_attachments_at(dir.path(), Duration::from_millis(15), now);
+
+        assert!(!old_path.exists(), "old file should be removed");
+        assert!(fresh_path.exists(), "fresh file should be kept");
+    }
+
+    #[test]
+    fn cleanup_stale_attachments_is_noop_when_dir_missing() {
+        // Must not panic / error when the staging directory hasn't been
+        // created yet (first ever open after install).
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        cleanup_stale_attachments_at(
+            &missing,
+            std::time::Duration::from_secs(0),
+            std::time::SystemTime::now(),
+        );
     }
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -251,26 +251,31 @@ pub async fn open_attachment_in_browser(
 /// subtype (`text/plain` → `txt`, `image/jpeg` → `jpg`, `+json` types → `json`)
 /// get an explicit mapping. Everything else falls back to the subtype with
 /// any `+xml` / `+json` suffix stripped.
-fn extension_for_media_type(media_type: &str) -> &'static str {
+///
+/// Returns a `Cow<'static, str>` so the explicit-map cases (the common
+/// path) cost nothing, while the catch-all case yields an owned `String`
+/// without leaking memory across sessions.
+fn extension_for_media_type(media_type: &str) -> std::borrow::Cow<'static, str> {
+    use std::borrow::Cow;
     match media_type {
-        "text/plain" => return "txt",
-        "text/html" => return "html",
-        "text/css" => return "css",
-        "text/javascript" | "application/javascript" => return "js",
-        "image/jpeg" => return "jpg",
-        "image/svg+xml" => return "svg",
-        "application/pdf" => return "pdf",
-        "application/json" => return "json",
-        "application/zip" => return "zip",
+        "text/plain" => return Cow::Borrowed("txt"),
+        "text/html" => return Cow::Borrowed("html"),
+        "text/css" => return Cow::Borrowed("css"),
+        "text/javascript" | "application/javascript" => return Cow::Borrowed("js"),
+        "image/jpeg" => return Cow::Borrowed("jpg"),
+        "image/svg+xml" => return Cow::Borrowed("svg"),
+        "application/pdf" => return Cow::Borrowed("pdf"),
+        "application/json" => return Cow::Borrowed("json"),
+        "application/zip" => return Cow::Borrowed("zip"),
         _ => {}
     }
     // `+json` suffixed types (application/ld+json, application/vnd.api+json…)
     // route to the json viewer naturally.
     if media_type.ends_with("+json") {
-        return "json";
+        return Cow::Borrowed("json");
     }
     if media_type.ends_with("+xml") {
-        return "xml";
+        return Cow::Borrowed("xml");
     }
     // Last-resort fallback: trust the subtype iff it looks safe.
     let after_slash = media_type.rsplit_once('/').map(|p| p.1).unwrap_or("");
@@ -279,33 +284,10 @@ fn extension_for_media_type(media_type: &str) -> &'static str {
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.')
     {
-        // SAFETY: we matched the explicit cases above; for the catch-all we
-        // need a 'static lifetime, so leak the small string into a static
-        // pool. In practice this branch only fires for types we haven't
-        // mapped yet — adding them above is the long-term fix.
-        leak_static_str(after_slash)
+        Cow::Owned(after_slash.to_string())
     } else {
-        "bin"
+        Cow::Borrowed("bin")
     }
-}
-
-/// Cache `&'static str`s for media subtypes so [`extension_for_media_type`]
-/// can return them by reference. The set of distinct media types Claudette
-/// sees in a session is bounded by the user's attachments; leaking is
-/// fine. Lazy-initialized so non-test runs pay nothing if every type hits
-/// the explicit map.
-fn leak_static_str(s: &str) -> &'static str {
-    use std::sync::{Mutex, OnceLock};
-    static CACHE: OnceLock<Mutex<std::collections::HashMap<String, &'static str>>> =
-        OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
-    let mut guard = cache.lock().expect("extension cache mutex poisoned");
-    if let Some(&existing) = guard.get(s) {
-        return existing;
-    }
-    let leaked: &'static str = Box::leak(s.to_string().into_boxed_str());
-    guard.insert(s.to_string(), leaked);
-    leaked
 }
 
 /// Write attachment bytes to a temp file using the natural file extension
@@ -328,8 +310,9 @@ pub fn write_attachment_to_temp_file(
         .unwrap_or("attachment");
     let safe_stem = sanitize_stem(stem);
     let ext = extension_for_media_type(media_type);
-    // Unique suffix so re-opening the same file twice doesn't clobber a
-    // wrapper still open in the system viewer.
+    // Unique nanosecond suffix so re-opening the same attachment twice
+    // doesn't overwrite a staged file that the system viewer may still
+    // be holding open.
     let unique: u128 = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
@@ -363,9 +346,34 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 }
 
 /// Create the staging directory with restrictive permissions on Unix
-/// (`0o700`) so other accounts can't list or read the staged files.
+/// (`0o700`) so other accounts can't list or read the staged files. If
+/// the path already exists we verify it's a real directory (not a file
+/// or symlink that could redirect writes elsewhere) and re-tighten the
+/// permissions on Unix in case a previous run created it with a wider
+/// umask.
 fn create_staging_dir(dir: &Path) -> std::io::Result<()> {
     if dir.exists() {
+        // `symlink_metadata` doesn't follow symlinks — it tells us
+        // whether the *path entry* is a directory, so a malicious link
+        // to /etc can't satisfy the check.
+        let meta = std::fs::symlink_metadata(dir)?;
+        if !meta.file_type().is_dir() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!(
+                    "staging path {} exists and is not a directory",
+                    dir.display()
+                ),
+            ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = meta.permissions().mode() & 0o777;
+            if mode != 0o700 {
+                std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+            }
+        }
         return Ok(());
     }
     #[cfg(unix)]
@@ -638,5 +646,38 @@ mod tests {
             std::time::Duration::from_secs(0),
             std::time::SystemTime::now(),
         );
+    }
+
+    #[test]
+    fn create_staging_dir_creates_when_missing() {
+        let parent = tempdir().unwrap();
+        let target = parent.path().join("claudette-staging");
+        assert!(!target.exists());
+        create_staging_dir(&target).unwrap();
+        assert!(target.is_dir());
+    }
+
+    #[test]
+    fn create_staging_dir_rejects_a_regular_file_at_the_path() {
+        let parent = tempdir().unwrap();
+        let target = parent.path().join("not-a-dir");
+        std::fs::write(&target, b"oops").unwrap();
+        let err = create_staging_dir(&target).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_staging_dir_tightens_permissions_on_existing_dir() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let parent = tempdir().unwrap();
+        let target = parent.path().join("loose-dir");
+        // Pre-create with a wider mode (e.g. a previous run with a
+        // permissive umask).
+        std::fs::create_dir(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+        create_staging_dir(&target).unwrap();
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "expected 0o700, got {mode:o}");
     }
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -243,6 +243,72 @@ pub async fn open_attachment_in_browser(
     })
 }
 
+/// Pick a sensible file extension for a media type. Used when staging an
+/// attachment to a temp file so the OS routes the open-with handler to the
+/// right app (e.g. `.pdf` → Preview / Adobe / etc).
+fn extension_for_media_type(media_type: &str) -> &str {
+    let after_slash = media_type.rsplit_once('/').map(|p| p.1).unwrap_or("");
+    let bare = after_slash
+        .split_once('+')
+        .map(|p| p.0)
+        .unwrap_or(after_slash);
+    if !bare.is_empty() && bare.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.') {
+        bare
+    } else {
+        "bin"
+    }
+}
+
+/// Write attachment bytes to a temp file using the natural file extension
+/// for the media type. Unlike [`write_image_as_html`], this writes the raw
+/// bytes (no wrapper) so `open` routes to the system default handler for
+/// the format — Preview / Adobe Reader for PDFs, etc.
+pub fn write_attachment_to_temp_file(
+    dir: &Path,
+    filename: &str,
+    media_type: &str,
+    bytes: &[u8],
+) -> std::io::Result<PathBuf> {
+    let stem = Path::new(filename)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("attachment");
+    let safe_stem = sanitize_stem(stem);
+    let ext = extension_for_media_type(media_type);
+    // Unique suffix so re-opening the same file twice doesn't clobber a
+    // wrapper still open in the system viewer.
+    let unique: u128 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let path = dir.join(format!("{safe_stem}-{unique}.{ext}"));
+    std::fs::write(&path, bytes)?;
+    Ok(path)
+}
+
+/// Open an attachment with the system's default handler for its media
+/// type (e.g. PDF → Preview on macOS, the user's PDF reader on Linux /
+/// Windows). Bytes are staged to a temp file under the OS temp dir.
+#[tauri::command]
+pub async fn open_attachment_with_default_app(
+    bytes: Vec<u8>,
+    filename: String,
+    media_type: String,
+) -> Result<(), String> {
+    let dir = std::env::temp_dir().join("claudette-attachments");
+    tokio::task::spawn_blocking(move || -> Result<PathBuf, String> {
+        std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;
+        write_attachment_to_temp_file(&dir, &filename, &media_type, &bytes)
+            .map_err(|e| format!("write attachment: {e}"))
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?
+    .and_then(|path| {
+        crate::commands::shell::opener::open(&path.to_string_lossy())
+            .map_err(|e| format!("open failed: {e}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,5 +381,67 @@ mod tests {
     #[test]
     fn html_escape_handles_special_chars() {
         assert_eq!(html_escape(r#"a<b>&"c"#), "a&lt;b&gt;&amp;&quot;c");
+    }
+
+    #[test]
+    fn extension_for_media_type_picks_pdf_for_pdf_type() {
+        assert_eq!(extension_for_media_type("application/pdf"), "pdf");
+    }
+
+    #[test]
+    fn extension_for_media_type_strips_xml_json_suffixes() {
+        assert_eq!(extension_for_media_type("image/svg+xml"), "svg");
+        assert_eq!(
+            extension_for_media_type("application/ld+json"),
+            "ld"
+        );
+    }
+
+    #[test]
+    fn extension_for_media_type_falls_back_to_bin_for_opaque_types() {
+        assert_eq!(
+            extension_for_media_type("application/x-something weird"),
+            "bin"
+        );
+    }
+
+    #[test]
+    fn write_attachment_to_temp_file_uses_natural_extension() {
+        let dir = tempdir().unwrap();
+        let path = write_attachment_to_temp_file(
+            dir.path(),
+            "claude-system-card.pdf",
+            "application/pdf",
+            b"%PDF-1.4 fake",
+        )
+        .unwrap();
+        assert_eq!(path.extension().unwrap(), "pdf");
+        assert_eq!(std::fs::read(&path).unwrap(), b"%PDF-1.4 fake");
+    }
+
+    #[test]
+    fn write_attachment_to_temp_file_sanitizes_filename() {
+        let dir = tempdir().unwrap();
+        let path = write_attachment_to_temp_file(
+            dir.path(),
+            "hello world.pdf",
+            "application/pdf",
+            b"%PDF",
+        )
+        .unwrap();
+        let stem = path.file_stem().unwrap().to_str().unwrap();
+        assert!(!stem.contains(' '));
+        assert!(stem.starts_with("hello_world"));
+    }
+
+    #[test]
+    fn write_attachment_to_temp_file_uses_unique_suffix() {
+        let dir = tempdir().unwrap();
+        let p1 =
+            write_attachment_to_temp_file(dir.path(), "doc.pdf", "application/pdf", b"a").unwrap();
+        std::thread::sleep(std::time::Duration::from_nanos(1));
+        let p2 =
+            write_attachment_to_temp_file(dir.path(), "doc.pdf", "application/pdf", b"b").unwrap();
+        assert_ne!(p1, p2);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -454,6 +454,7 @@ fn main() {
             commands::files::read_workspace_file,
             commands::files::save_attachment_bytes,
             commands::files::open_attachment_in_browser,
+            commands::files::open_attachment_with_default_app,
             // Chat
             commands::chat::load_chat_history,
             commands::chat::load_attachments_for_workspace,

--- a/src/ui/src/components/chat/AttachmentContextMenu.module.css
+++ b/src/ui/src/components/chat/AttachmentContextMenu.module.css
@@ -2,7 +2,7 @@
   position: fixed;
   /* Higher than the lightbox backdrop (10001) so right-click while a
      preview is open lands the menu above the overlay rather than behind
-     it. See issue #433. */
+     it. See issue 433. */
   z-index: 10002;
   min-width: 220px;
   background: var(--sidebar-bg);

--- a/src/ui/src/components/chat/AttachmentContextMenu.module.css
+++ b/src/ui/src/components/chat/AttachmentContextMenu.module.css
@@ -1,6 +1,9 @@
 .menu {
   position: fixed;
-  z-index: 10000;
+  /* Higher than the lightbox backdrop (10001) so right-click while a
+     preview is open lands the menu above the overlay rather than behind
+     it. See issue #433. */
+  z-index: 10002;
   min-width: 220px;
   background: var(--sidebar-bg);
   border: 1px solid var(--sidebar-border);

--- a/src/ui/src/components/chat/AttachmentContextMenu.test.ts
+++ b/src/ui/src/components/chat/AttachmentContextMenu.test.ts
@@ -55,7 +55,7 @@ describe("clampMenuToViewport", () => {
 describe("attachmentNounFor", () => {
   // The default-image labels read awkwardly for PDFs and text files
   // ("Download Image" for a PDF). Map media types to a sensible noun so
-  // the menu labels match the artifact kind. See issue #430.
+  // the menu labels match the artifact kind. See issue 430.
 
   it("returns 'Image' for raster image types", () => {
     expect(attachmentNounFor("image/png")).toBe("Image");

--- a/src/ui/src/components/chat/AttachmentContextMenu.test.ts
+++ b/src/ui/src/components/chat/AttachmentContextMenu.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { clampMenuToViewport } from "./AttachmentContextMenu";
+import {
+  attachmentNounFor,
+  buildAttachmentMenuLabels,
+  clampMenuToViewport,
+} from "./AttachmentContextMenu";
 
 // The component itself is thin wiring around a few DOM listeners and a
 // portal; its integration is verified manually in the running app. The
@@ -45,5 +49,58 @@ describe("clampMenuToViewport", () => {
   it("honors a custom margin", () => {
     const { x } = clampMenuToViewport(5, 100, 220, 80, 1200, 800, 16);
     expect(x).toBe(16);
+  });
+});
+
+describe("attachmentNounFor", () => {
+  // The default-image labels read awkwardly for PDFs and text files
+  // ("Download Image" for a PDF). Map media types to a sensible noun so
+  // the menu labels match the artifact kind. See issue #430.
+
+  it("returns 'Image' for raster image types", () => {
+    expect(attachmentNounFor("image/png")).toBe("Image");
+    expect(attachmentNounFor("image/jpeg")).toBe("Image");
+    expect(attachmentNounFor("image/gif")).toBe("Image");
+    expect(attachmentNounFor("image/webp")).toBe("Image");
+    expect(attachmentNounFor("image/svg+xml")).toBe("Image");
+  });
+
+  it("returns 'PDF' for application/pdf", () => {
+    expect(attachmentNounFor("application/pdf")).toBe("PDF");
+  });
+
+  it("returns 'File' for text/plain", () => {
+    expect(attachmentNounFor("text/plain")).toBe("File");
+  });
+
+  it("falls back to 'File' for anything else", () => {
+    expect(attachmentNounFor("application/octet-stream")).toBe("File");
+    expect(attachmentNounFor("")).toBe("File");
+  });
+});
+
+describe("buildAttachmentMenuLabels", () => {
+  it("uses 'Image' verbs for image attachments", () => {
+    expect(buildAttachmentMenuLabels("image/png")).toEqual({
+      download: "Download Image",
+      copy: "Copy Image",
+      open: "Open in New Window",
+    });
+  });
+
+  it("uses 'PDF' verbs for PDFs", () => {
+    expect(buildAttachmentMenuLabels("application/pdf")).toEqual({
+      download: "Download PDF",
+      copy: "Copy PDF",
+      open: "Open in New Window",
+    });
+  });
+
+  it("uses 'File' verbs for text/plain", () => {
+    expect(buildAttachmentMenuLabels("text/plain")).toEqual({
+      download: "Download File",
+      copy: "Copy File",
+      open: "Open in New Window",
+    });
   });
 });

--- a/src/ui/src/components/chat/AttachmentContextMenu.tsx
+++ b/src/ui/src/components/chat/AttachmentContextMenu.tsx
@@ -41,7 +41,7 @@ export function clampMenuToViewport(
 /**
  * Pick a human-readable noun for an attachment's media type. Used to label
  * the context menu actions so a PDF doesn't show "Download Image". See
- * issue #430.
+ * issue 430.
  */
 export function attachmentNounFor(mediaType: string): "Image" | "PDF" | "File" {
   if (mediaType.startsWith("image/")) return "Image";

--- a/src/ui/src/components/chat/AttachmentContextMenu.tsx
+++ b/src/ui/src/components/chat/AttachmentContextMenu.tsx
@@ -38,6 +38,38 @@ export function clampMenuToViewport(
   };
 }
 
+/**
+ * Pick a human-readable noun for an attachment's media type. Used to label
+ * the context menu actions so a PDF doesn't show "Download Image". See
+ * issue #430.
+ */
+export function attachmentNounFor(mediaType: string): "Image" | "PDF" | "File" {
+  if (mediaType.startsWith("image/")) return "Image";
+  if (mediaType === "application/pdf") return "PDF";
+  return "File";
+}
+
+/**
+ * Build the labels for the standard attachment context menu items, picking
+ * a noun that matches the media type. The menu *items* (with their handlers)
+ * are still assembled at the call site so each handler closes over the
+ * caller's helpers — this just produces the strings.
+ */
+export function buildAttachmentMenuLabels(mediaType: string): {
+  download: string;
+  copy: string;
+  open: string;
+} {
+  const noun = attachmentNounFor(mediaType);
+  return {
+    download: `Download ${noun}`,
+    copy: `Copy ${noun}`,
+    // "New Window" is media-agnostic — the OS opens whichever app handles
+    // the type. Keeping a single label avoids drift across platforms.
+    open: "Open in New Window",
+  };
+}
+
 function clampToViewport(x: number, y: number, width: number, height: number) {
   if (typeof window === "undefined") return { x, y };
   return clampMenuToViewport(

--- a/src/ui/src/components/chat/AttachmentLightbox.module.css
+++ b/src/ui/src/components/chat/AttachmentLightbox.module.css
@@ -32,6 +32,15 @@
   cursor: default;
 }
 
+/* SVGs that only declare a viewBox (no width/height attrs on <svg>) have no
+   intrinsic pixel dimensions when loaded through <img>, so the lightbox
+   collapses to 0×0. Force a generous floor so the rendered SVG fills the
+   wrap and scales up via the existing max-width/max-height ceiling. */
+.imageSvg {
+  min-width: min(480px, calc(100vw - 64px));
+  min-height: min(480px, calc(100vh - 128px));
+}
+
 .caption {
   color: var(--text-primary);
   font-size: 13px;

--- a/src/ui/src/components/chat/AttachmentLightbox.test.ts
+++ b/src/ui/src/components/chat/AttachmentLightbox.test.ts
@@ -66,7 +66,7 @@ describe("needsSvgFallbackSize", () => {
   // SVGs with only a viewBox (no width/height attributes on <svg>) have no
   // intrinsic pixel dimensions when loaded through <img>, so the lightbox
   // collapses to 0×0. Other image types always carry intrinsic pixel
-  // dimensions, so they don't need the fallback. See issue #432.
+  // dimensions, so they don't need the fallback. See issue 432.
 
   it("returns true for image/svg+xml", () => {
     expect(needsSvgFallbackSize("image/svg+xml")).toBe(true);

--- a/src/ui/src/components/chat/AttachmentLightbox.test.ts
+++ b/src/ui/src/components/chat/AttachmentLightbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isBackdropDismiss,
+  needsSvgFallbackSize,
   nextFocusTarget,
 } from "./AttachmentLightbox";
 
@@ -58,5 +59,28 @@ describe("nextFocusTarget", () => {
 
   it("Shift+Tab from an element outside the trap also pulls focus to close", () => {
     expect(nextFocusTarget(null, true, close, wrap)).toBe(close);
+  });
+});
+
+describe("needsSvgFallbackSize", () => {
+  // SVGs with only a viewBox (no width/height attributes on <svg>) have no
+  // intrinsic pixel dimensions when loaded through <img>, so the lightbox
+  // collapses to 0×0. Other image types always carry intrinsic pixel
+  // dimensions, so they don't need the fallback. See issue #432.
+
+  it("returns true for image/svg+xml", () => {
+    expect(needsSvgFallbackSize("image/svg+xml")).toBe(true);
+  });
+
+  it("returns false for raster image types", () => {
+    expect(needsSvgFallbackSize("image/png")).toBe(false);
+    expect(needsSvgFallbackSize("image/jpeg")).toBe(false);
+    expect(needsSvgFallbackSize("image/gif")).toBe(false);
+    expect(needsSvgFallbackSize("image/webp")).toBe(false);
+  });
+
+  it("returns false for non-image types", () => {
+    expect(needsSvgFallbackSize("application/pdf")).toBe(false);
+    expect(needsSvgFallbackSize("text/plain")).toBe(false);
   });
 });

--- a/src/ui/src/components/chat/AttachmentLightbox.tsx
+++ b/src/ui/src/components/chat/AttachmentLightbox.tsx
@@ -53,13 +53,18 @@ export function isBackdropDismiss(
 }
 
 /**
- * Pure: does this attachment need the SVG fallback minimum size in the
- * lightbox? SVGs that only declare a viewBox (no width/height on the root
- * <svg>) collapse to 0×0 when loaded through <img>, because the data URL
- * sandbox doesn't expose intrinsic dimensions. Force a floor for those.
+ * Pure: should the lightbox apply the SVG fallback minimum size to this
+ * attachment? Returns true for *any* `image/svg+xml` regardless of
+ * whether the root `<svg>` declares explicit width/height — detecting the
+ * viewBox-only subset would require decoding the data URL and parsing
+ * the markup, which is more work than the value justifies. The
+ * `min-width`/`min-height` floor is a no-op for SVGs that already render
+ * larger than the floor (max-width / max-height still cap them), so
+ * applying it broadly is safe.
  *
- * Raster types always carry intrinsic pixel dimensions, so they don't need
- * the fallback — applying it would also blow up tiny pixel-art images.
+ * Raster types always carry intrinsic pixel dimensions, so they don't
+ * need the fallback — and applying a 480px floor would visibly upscale
+ * tiny pixel-art images.
  */
 export function needsSvgFallbackSize(mediaType: string): boolean {
   return mediaType === "image/svg+xml";

--- a/src/ui/src/components/chat/AttachmentLightbox.tsx
+++ b/src/ui/src/components/chat/AttachmentLightbox.tsx
@@ -12,7 +12,7 @@ interface AttachmentLightboxProps {
   onClose: () => void;
   /** Right-click handler for the previewed image. When set, suppresses the
    *  WebKit default image context menu (Open in New Window, Copy Image, …)
-   *  and lets the caller surface its own attachment menu. See issue #433. */
+   *  and lets the caller surface its own attachment menu. See issue 433. */
   onContextMenu?: (e: React.MouseEvent) => void;
 }
 

--- a/src/ui/src/components/chat/AttachmentLightbox.tsx
+++ b/src/ui/src/components/chat/AttachmentLightbox.tsx
@@ -10,6 +10,10 @@ interface AttachmentLightboxProps {
   /** Element to return focus to on close — typically the originating <img>. */
   returnFocusTo?: HTMLElement | null;
   onClose: () => void;
+  /** Right-click handler for the previewed image. When set, suppresses the
+   *  WebKit default image context menu (Open in New Window, Copy Image, …)
+   *  and lets the caller surface its own attachment menu. See issue #433. */
+  onContextMenu?: (e: React.MouseEvent) => void;
 }
 
 /**
@@ -48,10 +52,24 @@ export function isBackdropDismiss(
   return target !== null && target === backdrop;
 }
 
+/**
+ * Pure: does this attachment need the SVG fallback minimum size in the
+ * lightbox? SVGs that only declare a viewBox (no width/height on the root
+ * <svg>) collapse to 0×0 when loaded through <img>, because the data URL
+ * sandbox doesn't expose intrinsic dimensions. Force a floor for those.
+ *
+ * Raster types always carry intrinsic pixel dimensions, so they don't need
+ * the fallback — applying it would also blow up tiny pixel-art images.
+ */
+export function needsSvgFallbackSize(mediaType: string): boolean {
+  return mediaType === "image/svg+xml";
+}
+
 export function AttachmentLightbox({
   attachment,
   returnFocusTo,
   onClose,
+  onContextMenu,
 }: AttachmentLightboxProps) {
   const backdropRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
@@ -134,8 +152,13 @@ export function AttachmentLightbox({
         <img
           src={src}
           alt={attachment.filename}
-          className={styles.image}
+          className={
+            needsSvgFallbackSize(attachment.media_type)
+              ? `${styles.image} ${styles.imageSvg}`
+              : styles.image
+          }
           draggable={false}
+          onContextMenu={onContextMenu}
         />
       </div>
       <div className={styles.caption}>{attachment.filename}</div>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -144,7 +144,7 @@ function PdfThumbnail({ dataBase64, attachmentId, filename, className, onClick, 
   onClick?: () => void;
   /** Right-click handler. Wired so PDF thumbnails get the same Claudette
    *  context menu (Download / Copy / Open) as image attachments rather than
-   *  WebKit's default image menu. See issue #430. */
+   *  WebKit's default image menu. See issue 430. */
   onContextMenu?: (e: React.MouseEvent) => void;
 }) {
   const [src, setSrc] = useState<string | null>(null);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -168,9 +168,31 @@ function PdfThumbnail({ dataBase64, attachmentId, filename, className, onClick, 
     return () => { cancelled = true; };
   }, [dataBase64, attachmentId]);
 
+  // Both the loading-state pill and the rendered first-page thumbnail
+  // need to be keyboard-actionable when an onClick is wired — without
+  // role/tabIndex/Enter+Space handling, non-mouse users can't open the
+  // PDF.
+  const interactiveProps = onClick
+    ? {
+        role: "button" as const,
+        tabIndex: 0,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick();
+          }
+        },
+        "aria-label": `Open ${filename}`,
+      }
+    : {};
   if (!src) {
     return (
-      <div className={styles.messagePdf} onClick={onClick} onContextMenu={onContextMenu}>
+      <div
+        className={styles.messagePdf}
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        {...interactiveProps}
+      >
         <FileText size={16} />
         <span>{filename}</span>
       </div>
@@ -184,6 +206,7 @@ function PdfThumbnail({ dataBase64, attachmentId, filename, className, onClick, 
       onClick={onClick}
       onContextMenu={onContextMenu}
       style={onClick ? { cursor: "zoom-in" } : undefined}
+      {...interactiveProps}
     />
   );
 }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -65,6 +65,7 @@ import { AttachmentLightbox } from "./AttachmentLightbox";
 import {
   downloadAttachment,
   openAttachmentInBrowser,
+  openAttachmentWithDefaultApp,
   copyAttachmentToClipboard,
   shareAttachment,
   isShareSupported,
@@ -133,11 +134,14 @@ function formatDurationMs(ms: number): string {
  * (fetches the body from the backend on demand). Shows a loading pill with
  * the filename while the thumbnail generates.
  */
-function PdfThumbnail({ dataBase64, attachmentId, filename, className, onContextMenu }: {
+function PdfThumbnail({ dataBase64, attachmentId, filename, className, onClick, onContextMenu }: {
   dataBase64?: string;
   attachmentId?: string;
   filename: string;
   className?: string;
+  /** Left-click handler. Used to open the PDF with the system's default
+   *  PDF viewer rather than the lightbox (which only renders images). */
+  onClick?: () => void;
   /** Right-click handler. Wired so PDF thumbnails get the same Claudette
    *  context menu (Download / Copy / Open) as image attachments rather than
    *  WebKit's default image menu. See issue #430. */
@@ -166,13 +170,22 @@ function PdfThumbnail({ dataBase64, attachmentId, filename, className, onContext
 
   if (!src) {
     return (
-      <div className={styles.messagePdf} onContextMenu={onContextMenu}>
+      <div className={styles.messagePdf} onClick={onClick} onContextMenu={onContextMenu}>
         <FileText size={16} />
         <span>{filename}</span>
       </div>
     );
   }
-  return <img src={src} alt={filename} className={className} onContextMenu={onContextMenu} />;
+  return (
+    <img
+      src={src}
+      alt={filename}
+      className={className}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      style={onClick ? { cursor: "zoom-in" } : undefined}
+    />
+  );
 }
 
 /** Semantic colors for tool names — makes tool activity scannable at a glance. */
@@ -229,16 +242,38 @@ export function ChatPanel() {
     x: number;
     y: number;
     attachment: DownloadableAttachment;
+    /** Persisted PDFs hydrate without data_base64 (it's stripped to keep
+     *  the initial IPC small). When the menu fires for one, hold the row
+     *  id so each action can lazy-load the bytes via loadAttachmentData
+     *  before downloading / copying. */
+    attachmentId?: string;
   } | null>(null);
 
   const openAttachmentMenu = useCallback(
-    (e: React.MouseEvent, attachment: DownloadableAttachment) => {
+    (e: React.MouseEvent, attachment: DownloadableAttachment, attachmentId?: string) => {
       e.preventDefault();
       setAttachmentMenu({
         x: e.clientX,
         y: e.clientY,
         attachment,
+        attachmentId,
       });
+    },
+    [],
+  );
+
+  /** Resolves an attachment's data_base64, fetching from the backend on
+   *  demand if it was stripped during hydration. Returns a fresh object
+   *  so callers can pass it straight into download / copy helpers. */
+  const ensureAttachmentBytes = useCallback(
+    async (
+      attachment: DownloadableAttachment,
+      attachmentId?: string,
+    ): Promise<DownloadableAttachment> => {
+      if (attachment.data_base64 || !attachmentId) return attachment;
+      const { loadAttachmentData } = await import("../../services/tauri");
+      const data_base64 = await loadAttachmentData(attachmentId);
+      return { ...attachment, data_base64 };
     },
     [],
   );
@@ -1100,9 +1135,18 @@ export function ChatPanel() {
         onAttachmentClick={openLightbox}
       />
       {attachmentMenu && (() => {
-        const labels = buildAttachmentMenuLabels(
-          attachmentMenu.attachment.media_type,
-        );
+        const mt = attachmentMenu.attachment.media_type;
+        const labels = buildAttachmentMenuLabels(mt);
+        // The browser-wrapper path renders bytes inside <img>, which is
+        // broken for PDFs (and would be broken for any non-image type we
+        // add later). Drop "Open in New Window" for non-images — left-
+        // click already opens the PDF in the system default viewer.
+        const isImage = mt.startsWith("image/");
+        const withBytes = () =>
+          ensureAttachmentBytes(
+            attachmentMenu.attachment,
+            attachmentMenu.attachmentId,
+          );
         return (
           <AttachmentContextMenu
             x={attachmentMenu.x}
@@ -1112,35 +1156,41 @@ export function ChatPanel() {
               {
                 label: labels.download,
                 onSelect: () => {
-                  downloadAttachment(attachmentMenu.attachment).catch((err) =>
-                    console.error("Download failed:", err),
-                  );
+                  withBytes()
+                    .then(downloadAttachment)
+                    .catch((err) => console.error("Download failed:", err));
                 },
               },
               {
                 label: labels.copy,
                 onSelect: () => {
-                  copyAttachmentToClipboard(attachmentMenu.attachment).catch(
-                    (err) => console.error("Copy failed:", err),
-                  );
+                  withBytes()
+                    .then(copyAttachmentToClipboard)
+                    .catch((err) => console.error("Copy failed:", err));
                 },
               },
-              {
-                label: labels.open,
-                onSelect: () => {
-                  openAttachmentInBrowser(attachmentMenu.attachment).catch(
-                    (err) => console.error("Open in browser failed:", err),
-                  );
-                },
-              },
+              ...(isImage
+                ? [
+                    {
+                      label: labels.open,
+                      onSelect: () => {
+                        withBytes()
+                          .then(openAttachmentInBrowser)
+                          .catch((err) =>
+                            console.error("Open in browser failed:", err),
+                          );
+                      },
+                    },
+                  ]
+                : []),
               ...(shareSupported
                 ? [
                     {
                       label: "Share…",
                       onSelect: () => {
-                        shareAttachment(attachmentMenu.attachment).catch((err) =>
-                          console.error("Share failed:", err),
-                        );
+                        withBytes()
+                          .then(shareAttachment)
+                          .catch((err) => console.error("Share failed:", err));
                       },
                     },
                   ]
@@ -1543,10 +1593,13 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
    *  button (e.g. for remote workspaces where the command cannot run). */
   onForkTurn?: (checkpointId: string) => void;
   /** Right-click handler on message-image attachments. Lifted to ChatPanel so
-   *  the context menu renders at the top of the component tree. */
+   *  the context menu renders at the top of the component tree. The third
+   *  argument is the persisted attachment id, used to lazy-load bytes for
+   *  PDFs (whose data_base64 is stripped on hydration). */
   onAttachmentContextMenu?: (
     e: React.MouseEvent,
     attachment: DownloadableAttachment,
+    attachmentId?: string,
   ) => void;
   /** Left-click handler on message-image attachments — opens the lightbox. */
   onAttachmentClick?: (
@@ -1859,12 +1912,36 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                         attachmentId={att.id}
                         filename={att.filename}
                         className={styles.messageImage}
+                        onClick={() => {
+                          (async () => {
+                            // Persisted attachments strip data_base64 on first
+                            // load to avoid IPC bloat — fetch on demand.
+                            let b64 = att.data_base64;
+                            if (!b64) {
+                              const { loadAttachmentData } = await import(
+                                "../../services/tauri"
+                              );
+                              b64 = await loadAttachmentData(att.id);
+                            }
+                            await openAttachmentWithDefaultApp({
+                              filename: att.filename,
+                              media_type: att.media_type,
+                              data_base64: b64,
+                            });
+                          })().catch((err) =>
+                            console.error("Failed to open PDF:", err),
+                          );
+                        }}
                         onContextMenu={(e) =>
-                          onAttachmentContextMenu?.(e, {
-                            filename: att.filename,
-                            media_type: att.media_type,
-                            data_base64: att.data_base64,
-                          })
+                          onAttachmentContextMenu?.(
+                            e,
+                            {
+                              filename: att.filename,
+                              media_type: att.media_type,
+                              data_base64: att.data_base64,
+                            },
+                            att.id,
+                          )
                         }
                       />
                     ) : att.media_type === "text/plain" ? (
@@ -1872,11 +1949,15 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                         key={att.id}
                         className={styles.messagePdf}
                         onContextMenu={(e) =>
-                          onAttachmentContextMenu?.(e, {
-                            filename: att.filename,
-                            media_type: att.media_type,
-                            data_base64: att.data_base64,
-                          })
+                          onAttachmentContextMenu?.(
+                            e,
+                            {
+                              filename: att.filename,
+                              media_type: att.media_type,
+                              data_base64: att.data_base64,
+                            },
+                            att.id,
+                          )
                         }
                       >
                         <FileText size={14} />
@@ -1901,11 +1982,15 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                           })
                         }
                         onContextMenu={(e) =>
-                          onAttachmentContextMenu?.(e, {
-                            filename: att.filename,
-                            media_type: att.media_type,
-                            data_base64: att.data_base64,
-                          })
+                          onAttachmentContextMenu?.(
+                            e,
+                            {
+                              filename: att.filename,
+                              media_type: att.media_type,
+                              data_base64: att.data_base64,
+                            },
+                            att.id,
+                          )
                         }
                       />
                     ),

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -57,7 +57,10 @@ import { ContextPopover } from "./composer/ContextPopover";
 import { WorkspaceActions } from "./WorkspaceActions";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { AttachMenu } from "./AttachMenu";
-import { AttachmentContextMenu } from "./AttachmentContextMenu";
+import {
+  AttachmentContextMenu,
+  buildAttachmentMenuLabels,
+} from "./AttachmentContextMenu";
 import { AttachmentLightbox } from "./AttachmentLightbox";
 import {
   downloadAttachment,
@@ -130,11 +133,15 @@ function formatDurationMs(ms: number): string {
  * (fetches the body from the backend on demand). Shows a loading pill with
  * the filename while the thumbnail generates.
  */
-function PdfThumbnail({ dataBase64, attachmentId, filename, className }: {
+function PdfThumbnail({ dataBase64, attachmentId, filename, className, onContextMenu }: {
   dataBase64?: string;
   attachmentId?: string;
   filename: string;
   className?: string;
+  /** Right-click handler. Wired so PDF thumbnails get the same Claudette
+   *  context menu (Download / Copy / Open) as image attachments rather than
+   *  WebKit's default image menu. See issue #430. */
+  onContextMenu?: (e: React.MouseEvent) => void;
 }) {
   const [src, setSrc] = useState<string | null>(null);
   useEffect(() => {
@@ -159,13 +166,13 @@ function PdfThumbnail({ dataBase64, attachmentId, filename, className }: {
 
   if (!src) {
     return (
-      <div className={styles.messagePdf}>
+      <div className={styles.messagePdf} onContextMenu={onContextMenu}>
         <FileText size={16} />
         <span>{filename}</span>
       </div>
     );
   }
-  return <img src={src} alt={filename} className={className} />;
+  return <img src={src} alt={filename} className={className} onContextMenu={onContextMenu} />;
 }
 
 /** Semantic colors for tool names — makes tool activity scannable at a glance. */
@@ -1092,56 +1099,62 @@ export function ChatPanel() {
         onAttachmentContextMenu={openAttachmentMenu}
         onAttachmentClick={openLightbox}
       />
-      {attachmentMenu && (
-        <AttachmentContextMenu
-          x={attachmentMenu.x}
-          y={attachmentMenu.y}
-          onClose={() => setAttachmentMenu(null)}
-          items={[
-            {
-              label: "Download Image",
-              onSelect: () => {
-                downloadAttachment(attachmentMenu.attachment).catch((err) =>
-                  console.error("Download failed:", err),
-                );
+      {attachmentMenu && (() => {
+        const labels = buildAttachmentMenuLabels(
+          attachmentMenu.attachment.media_type,
+        );
+        return (
+          <AttachmentContextMenu
+            x={attachmentMenu.x}
+            y={attachmentMenu.y}
+            onClose={() => setAttachmentMenu(null)}
+            items={[
+              {
+                label: labels.download,
+                onSelect: () => {
+                  downloadAttachment(attachmentMenu.attachment).catch((err) =>
+                    console.error("Download failed:", err),
+                  );
+                },
               },
-            },
-            {
-              label: "Copy Image",
-              onSelect: () => {
-                copyAttachmentToClipboard(attachmentMenu.attachment).catch(
-                  (err) => console.error("Copy failed:", err),
-                );
+              {
+                label: labels.copy,
+                onSelect: () => {
+                  copyAttachmentToClipboard(attachmentMenu.attachment).catch(
+                    (err) => console.error("Copy failed:", err),
+                  );
+                },
               },
-            },
-            {
-              label: "Open in New Window",
-              onSelect: () => {
-                openAttachmentInBrowser(attachmentMenu.attachment).catch(
-                  (err) => console.error("Open in browser failed:", err),
-                );
+              {
+                label: labels.open,
+                onSelect: () => {
+                  openAttachmentInBrowser(attachmentMenu.attachment).catch(
+                    (err) => console.error("Open in browser failed:", err),
+                  );
+                },
               },
-            },
-            ...(shareSupported
-              ? [
-                  {
-                    label: "Share…",
-                    onSelect: () => {
-                      shareAttachment(attachmentMenu.attachment).catch((err) =>
-                        console.error("Share failed:", err),
-                      );
+              ...(shareSupported
+                ? [
+                    {
+                      label: "Share…",
+                      onSelect: () => {
+                        shareAttachment(attachmentMenu.attachment).catch((err) =>
+                          console.error("Share failed:", err),
+                        );
+                      },
                     },
-                  },
-                ]
-              : []),
-          ]}
-        />
-      )}
+                  ]
+                : []),
+            ]}
+          />
+        );
+      })()}
       {lightbox && (
         <AttachmentLightbox
           attachment={lightbox.attachment}
           returnFocusTo={lightbox.returnFocus}
           onClose={() => setLightbox(null)}
+          onContextMenu={(e) => openAttachmentMenu(e, lightbox.attachment)}
         />
       )}
     </div>
@@ -1846,9 +1859,26 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                         attachmentId={att.id}
                         filename={att.filename}
                         className={styles.messageImage}
+                        onContextMenu={(e) =>
+                          onAttachmentContextMenu?.(e, {
+                            filename: att.filename,
+                            media_type: att.media_type,
+                            data_base64: att.data_base64,
+                          })
+                        }
                       />
                     ) : att.media_type === "text/plain" ? (
-                      <div key={att.id} className={styles.messagePdf}>
+                      <div
+                        key={att.id}
+                        className={styles.messagePdf}
+                        onContextMenu={(e) =>
+                          onAttachmentContextMenu?.(e, {
+                            filename: att.filename,
+                            media_type: att.media_type,
+                            data_base64: att.data_base64,
+                          })
+                        }
+                      >
                         <FileText size={14} />
                         <span>{att.filename}</span>
                         <span className={styles.textFileSize}>

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -21,6 +21,7 @@ import {
   extensionFor,
   downloadAttachment,
   openAttachmentInBrowser,
+  openAttachmentWithDefaultApp,
   copyAttachmentToClipboard,
   shareAttachment,
   isShareSupported,
@@ -120,6 +121,27 @@ describe("openAttachmentInBrowser", () => {
       bytes: [104, 101, 108, 108, 111],
       filename: "screenshot.png",
       mediaType: "image/png",
+    });
+  });
+});
+
+describe("openAttachmentWithDefaultApp", () => {
+  // The HTML-wrapper path renders bytes inside <img>, which produces a
+  // broken page for PDFs (and anything else that isn't an image). This
+  // helper stages the bytes to a real file and lets the OS route to the
+  // appropriate viewer (Preview, Adobe, etc).
+  it("invokes open_attachment_with_default_app with decoded bytes", async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const pdf: DownloadableAttachment = {
+      filename: "doc.pdf",
+      media_type: "application/pdf",
+      data_base64: "JVBERi0=", // %PDF-
+    };
+    await openAttachmentWithDefaultApp(pdf, { invoke });
+    expect(invoke).toHaveBeenCalledWith("open_attachment_with_default_app", {
+      bytes: [37, 80, 68, 70, 45],
+      filename: "doc.pdf",
+      mediaType: "application/pdf",
     });
   });
 });

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -150,6 +150,25 @@ describe("copyAttachmentToClipboard", () => {
       }),
     ).rejects.toThrow("denied");
   });
+
+  // WebKit silently drops image/svg+xml ClipboardItems, so a copied SVG
+  // would never reach the system clipboard. Production routes SVGs
+  // through Tauri's writeText, which bypasses the WKWebView allowlist.
+  it("writes SVG attachments via the injected writeText (Tauri clipboard)", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const svgFixture: DownloadableAttachment = {
+      filename: "drawing.svg",
+      data_base64: "PHN2Zy8+", // base64 of '<svg/>'
+      media_type: "image/svg+xml",
+    };
+    await copyAttachmentToClipboard(svgFixture, {
+      clipboard: { write } as unknown as Clipboard,
+      writeText,
+    });
+    expect(writeText).toHaveBeenCalledWith("<svg/>");
+    expect(write).not.toHaveBeenCalled();
+  });
 });
 
 describe("isShareSupported", () => {

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -137,17 +137,15 @@ export async function copyAttachmentToClipboard(
   const clipboard =
     deps.clipboard ??
     (typeof navigator === "undefined" ? undefined : navigator.clipboard);
-  if (!clipboard) {
-    throw new Error("Clipboard API not available");
-  }
   const bytes = base64ToBytes(attachment.data_base64);
   if (attachment.media_type === "image/svg+xml") {
     // WKWebView silently drops `image/svg+xml` ClipboardItems, so writing
     // an SVG via navigator.clipboard.write succeeds but the system
     // clipboard receives nothing. Since SVG is XML, route through the
     // Tauri clipboard plugin's writeText, which bypasses the webview's
-    // ClipboardItem allowlist entirely. Falls back to the W3C path for
-    // non-Tauri environments (e.g. unit tests with a stubbed clipboard).
+    // ClipboardItem allowlist entirely. Falls back to the W3C path only
+    // when neither a writeText injection nor a window context is
+    // available (i.e. tests with a stubbed clipboard).
     const text = new TextDecoder("utf-8").decode(bytes);
     if (deps.writeText) {
       await deps.writeText(text);
@@ -158,9 +156,17 @@ export async function copyAttachmentToClipboard(
       await mod.writeText(text);
       return;
     }
+    if (!clipboard) {
+      throw new Error("Clipboard API not available");
+    }
     const blob = new Blob([text], { type: "text/plain" });
     await clipboard.write([new ClipboardItem({ "text/plain": blob })]);
     return;
+  }
+  // Non-SVG path uses the W3C ClipboardItem API directly — this is the
+  // only branch that requires `navigator.clipboard.write`.
+  if (!clipboard) {
+    throw new Error("Clipboard API not available");
   }
   const blob = new Blob([bytes], { type: attachment.media_type });
   await clipboard.write([

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -95,10 +95,23 @@ export async function openAttachmentInBrowser(
  * `navigator.clipboard.write()` API. Zero IPC, zero base64→number[]
  * serialization, zero Rust round-trip — the webview writes directly to
  * the OS clipboard the same way any browser's "Copy Image" does.
+ *
+ * SVG is special-cased: WebKit's ClipboardItem implementation silently
+ * drops `image/svg+xml`, so a copied SVG would never reach the system
+ * clipboard. Since SVG is XML, write it as `text/plain` (the markup
+ * itself) — that survives the round-trip and pastes correctly into any
+ * text editor, into GitHub comments, and back into Claudette's composer.
  */
 export async function copyAttachmentToClipboard(
   attachment: DownloadableAttachment,
-  deps: { clipboard?: Clipboard } = {},
+  deps: {
+    clipboard?: Clipboard;
+    /** Injectable text-clipboard writer — bypasses the W3C clipboard
+     *  permission gate. Production wires this to Tauri's plugin so SVGs
+     *  reach the system clipboard reliably. Defaults to the Tauri plugin
+     *  in browser/webview contexts; tests pass a stub. */
+    writeText?: (text: string) => Promise<void>;
+  } = {},
 ): Promise<void> {
   const clipboard =
     deps.clipboard ??
@@ -107,6 +120,27 @@ export async function copyAttachmentToClipboard(
     throw new Error("Clipboard API not available");
   }
   const bytes = base64ToBytes(attachment.data_base64);
+  if (attachment.media_type === "image/svg+xml") {
+    // WKWebView silently drops `image/svg+xml` ClipboardItems, so writing
+    // an SVG via navigator.clipboard.write succeeds but the system
+    // clipboard receives nothing. Since SVG is XML, route through the
+    // Tauri clipboard plugin's writeText, which bypasses the webview's
+    // ClipboardItem allowlist entirely. Falls back to the W3C path for
+    // non-Tauri environments (e.g. unit tests with a stubbed clipboard).
+    const text = new TextDecoder("utf-8").decode(bytes);
+    if (deps.writeText) {
+      await deps.writeText(text);
+      return;
+    }
+    if (typeof window !== "undefined") {
+      const mod = await import("@tauri-apps/plugin-clipboard-manager");
+      await mod.writeText(text);
+      return;
+    }
+    const blob = new Blob([text], { type: "text/plain" });
+    await clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+    return;
+  }
   const blob = new Blob([bytes], { type: attachment.media_type });
   await clipboard.write([
     new ClipboardItem({ [attachment.media_type]: blob }),

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -91,6 +91,27 @@ export async function openAttachmentInBrowser(
 }
 
 /**
+ * Stage the attachment to a temp file with its natural extension and open
+ * it with the system default handler (e.g. PDFs → Preview on macOS,
+ * whichever PDF reader is registered on Linux/Windows). The HTML-wrapper
+ * path used by `openAttachmentInBrowser` only renders inside `<img>`, so
+ * it produces a broken page for PDFs — this command is the right path
+ * for non-image previewing.
+ */
+export async function openAttachmentWithDefaultApp(
+  attachment: DownloadableAttachment,
+  deps: { invoke?: typeof invoke } = {},
+): Promise<void> {
+  const invokeFn = deps.invoke ?? invoke;
+  const bytes = base64ToBytes(attachment.data_base64);
+  await invokeFn("open_attachment_with_default_app", {
+    bytes: Array.from(bytes),
+    filename: attachment.filename,
+    mediaType: attachment.media_type,
+  });
+}
+
+/**
  * Copy the attachment image to the system clipboard using the native
  * `navigator.clipboard.write()` API. Zero IPC, zero base64→number[]
  * serialization, zero Rust round-trip — the webview writes directly to


### PR DESCRIPTION
## Summary

Fixes three follow-up issues from #431.

- **#430** — non-image attachments fall back to WebKit's default context menu. `PdfThumbnail` and the `text/plain` row now wire `onContextMenu` to the shared menu, and labels are media-type aware ("Download PDF" / "Download File" / "Download Image").
- **#432** — SVG lightbox preview was blank. SVGs that only declare a `viewBox` (no `width`/`height`) have no intrinsic pixel dimensions inside `<img>`, so they collapsed to 0×0. Added a `min-width`/`min-height` fallback applied via the `imageSvg` class only to `image/svg+xml`.
- **#433** — lightbox right-click fell through to WebKit's "Open Image in New Window" / Inspect Element menu. Added an `onContextMenu` prop to `AttachmentLightbox` and wired it from `ChatPanel` to the same handler the inline thumbnails use.

UAT (in the running dev app via `claudette-debug`) caught a fourth bug as a side effect of #433: the menu's `z-index: 10000` was lower than the lightbox backdrop's `10001`, so the menu rendered with the right layout but was unreachable behind the overlay (`elementFromPoint` at the menu center returned the lightbox image). Bumped to `10002`.

## Test plan

- [x] New unit tests for `needsSvgFallbackSize`, `attachmentNounFor`, `buildAttachmentMenuLabels` (pure helpers — match existing test style)
- [x] Full vitest suite: 815/815 passing
- [x] `tsc -b` clean
- [x] UAT via `claudette-debug`:
  - SVG lightbox renders 480×480 with `imageSvg` class applied
  - Lightbox right-click on PNG opens Claudette menu (z-index now above backdrop, `elementFromPoint` lands on a `menuitem` button)
  - PDF context menu shows "Download PDF" / "Copy PDF"
  - PNG / SVG context menus retain "Download Image" / "Copy Image"
  - End-to-end download path: invoked `save_attachment_bytes` with PDF bytes from a real agent attachment → verified 14 MB file at `~/Downloads/uat-claude-opus-4.6-system-card.pdf`, magic bytes `%PDF-` confirmed by `file(1)`

Closes #430, closes #432, closes #433.