### PR TITLE
fix(chat): clean code-block selection rectangle

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -313,17 +313,20 @@
   line-height: 1.55;
   margin: 12px 0;
   cursor: text;
-  user-select: text;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .content pre code {
   background: none !important;
   color: inherit;
-  padding: 0;
+  padding: 0 !important;
   font-size: inherit;
-  /* Block layout so the selection rectangle clips to the code element rather
-     than the padded <pre> — fixes the stair-stepped selection (#396). */
+  -webkit-user-select: text;
+  user-select: text;
   display: block;
+  width: fit-content;
+  max-width: 100%;
   white-space: pre-wrap;
   overflow-wrap: break-word;
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -321,7 +321,11 @@
   color: inherit;
   padding: 0;
   font-size: inherit;
-  display: inline;
+  /* Block layout so the selection rectangle clips to the code element rather
+     than the padded <pre> — fixes the stair-stepped selection (#396). */
+  display: block;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 /* Inline code — accent tint */

--- a/src/ui/src/components/chat/CodeBlock.module.css
+++ b/src/ui/src/components/chat/CodeBlock.module.css
@@ -28,6 +28,12 @@ pre:hover > .copyButton:hover {
   color: var(--text-primary);
 }
 
+.copyButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
 .copyButton:active {
   opacity: 1;
 }

--- a/src/ui/src/components/chat/CodeBlock.module.css
+++ b/src/ui/src/components/chat/CodeBlock.module.css
@@ -24,7 +24,7 @@ pre:hover > .copyButton {
 
 pre:hover > .copyButton:hover {
   opacity: 1;
-  background: var(--hover-bg, rgba(255, 255, 255, 0.06));
+  background: var(--hover-bg);
   color: var(--text-primary);
 }
 

--- a/src/ui/src/components/chat/CodeBlock.module.css
+++ b/src/ui/src/components/chat/CodeBlock.module.css
@@ -1,0 +1,37 @@
+.copyButton {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: var(--chat-input-bg, transparent);
+  border: 1px solid var(--divider);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 5px;
+  border-radius: 6px;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  line-height: 0;
+}
+
+/* pre already has position: relative from ChatPanel.module.css */
+pre:hover > .copyButton {
+  opacity: 0.7;
+}
+
+pre:hover > .copyButton:hover {
+  opacity: 1;
+  background: var(--hover-bg, rgba(255, 255, 255, 0.06));
+  color: var(--text-primary);
+}
+
+.copyButton:active {
+  opacity: 1;
+}
+
+.copied {
+  color: var(--accent-primary);
+}

--- a/src/ui/src/components/chat/CodeBlock.tsx
+++ b/src/ui/src/components/chat/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import styles from "./CodeBlock.module.css";
 
 export function CodeBlock({
@@ -26,6 +26,12 @@ export function CodeBlock({
         timeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
       })
       .catch((err) => console.error("Copy code failed:", err));
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    };
   }, []);
 
   return (

--- a/src/ui/src/components/chat/CodeBlock.tsx
+++ b/src/ui/src/components/chat/CodeBlock.tsx
@@ -1,0 +1,72 @@
+import { useState, useRef, useCallback } from "react";
+import styles from "./CodeBlock.module.css";
+
+export function CodeBlock({
+  children,
+  ...props
+}: {
+  children?: React.ReactNode;
+  [key: string]: unknown;
+}) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const handleCopy = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    const text =
+      preRef.current?.querySelector("code")?.textContent ??
+      preRef.current?.textContent ??
+      "";
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+        timeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
+      })
+      .catch((err) => console.error("Copy code failed:", err));
+  }, []);
+
+  return (
+    <pre ref={preRef} {...props}>
+      {children}
+      <button
+        type="button"
+        className={`${styles.copyButton} ${copied ? styles.copied : ""}`}
+        onClick={handleCopy}
+        title={copied ? "Copied" : "Copy code"}
+        aria-label="Copy code"
+      >
+        {copied ? (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </pre>
+  );
+}

--- a/src/ui/src/components/chat/codeBlockSelection.test.ts
+++ b/src/ui/src/components/chat/codeBlockSelection.test.ts
@@ -10,7 +10,7 @@ const css = readFileSync(
 );
 
 /**
- * Regression test for code-block selection stair-step bug (GitHub #396).
+ * Regression test for code-block selection stair-step bug.
  *
  * WebKit paints selection highlights across the full line-box width of the
  * selected element's containing block.  Without the properties asserted here,

--- a/src/ui/src/components/chat/codeBlockSelection.test.ts
+++ b/src/ui/src/components/chat/codeBlockSelection.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const css = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "ChatPanel.module.css"),
+  "utf-8",
+);
+
+/**
+ * Regression test for code-block selection stair-step bug (GitHub #396).
+ *
+ * WebKit paints selection highlights across the full line-box width of the
+ * selected element's containing block.  Without the properties asserted here,
+ * selecting text inside a fenced code block extends the highlight to the
+ * full <pre> width and paints "stair-step" tabs above and below the
+ * visible code.  The fix requires cooperating rules on <pre> and <code>:
+ *
+ *   1. <pre> disables user-select so clicks in its padding can't start a
+ *      selection that extends to the full <pre> width.
+ *   2. <code> re-enables user-select so the text itself remains selectable.
+ *   3. <code> uses width: fit-content so its bounding box is only as wide
+ *      as the visible text.
+ *   4. <code> uses padding: 0 !important to override highlight.js's
+ *      pre code.hljs { padding: 1em } which inflates the element rect.
+ */
+
+function extractBlock(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${escaped}\\s*\\{([^}]+)\\}`, "m");
+  const match = css.match(re);
+  return match?.[1] ?? "";
+}
+
+describe("code-block selection CSS (regression for stair-step bug)", () => {
+  const preBlock = extractBlock(".content pre");
+  const codeBlock = extractBlock(".content pre code");
+
+  it("disables user-select on pre to prevent padding-area selections", () => {
+    expect(preBlock).toMatch(/user-select:\s*none/);
+    expect(preBlock).toMatch(/-webkit-user-select:\s*none/);
+  });
+
+  it("re-enables user-select on code so text remains selectable", () => {
+    expect(codeBlock).toMatch(/user-select:\s*text/);
+    expect(codeBlock).toMatch(/-webkit-user-select:\s*text/);
+  });
+
+  it("shrink-wraps code with fit-content to bound selection width", () => {
+    expect(codeBlock).toMatch(/width:\s*fit-content/);
+    expect(codeBlock).toMatch(/max-width:\s*100%/);
+  });
+
+  it("zeroes code padding with !important to override highlight.js", () => {
+    expect(codeBlock).toMatch(/padding:\s*0\s*!important/);
+  });
+
+  it("keeps code as display: block so it respects width: fit-content", () => {
+    expect(codeBlock).toMatch(/display:\s*block/);
+  });
+});

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";
-import { EXTERNAL_SCHEMES, trimTrailingCodeNewline } from "./markdown";
+import type { ReactElement } from "react";
+import { EXTERNAL_SCHEMES, trimTrailingCodeNewline, MARKDOWN_COMPONENTS } from "./markdown";
 
 describe("EXTERNAL_SCHEMES", () => {
   it("matches http URLs", () => {
@@ -74,11 +75,14 @@ describe("trimTrailingCodeNewline", () => {
     expect(result[1]).toBe(" x = 1;");
   });
 
-  it("is a no-op when there is no trailing newline", () => {
+  it("returns the original children reference when there is no trailing newline", () => {
     const span = createElement("span", { key: "k" }, "const");
-    const result = trimTrailingCodeNewline([span, " x = 1;"]) as React.ReactNode[];
-    expect(result).toHaveLength(2);
-    expect(result[1]).toBe(" x = 1;");
+    const input: React.ReactNode = [span, " x = 1;"];
+    expect(trimTrailingCodeNewline(input)).toBe(input);
+  });
+
+  it("returns the original string unchanged when no trailing newline", () => {
+    expect(trimTrailingCodeNewline("code")).toBe("code");
   });
 
   it("returns the original input when children are empty", () => {
@@ -86,10 +90,54 @@ describe("trimTrailingCodeNewline", () => {
     expect(trimTrailingCodeNewline(null)).toBe(null);
   });
 
-  it("does not modify the last child if it is a non-string element", () => {
+  it("returns children unchanged when last child is a non-string element", () => {
     const span = createElement("span", { key: "k" }, "code");
-    const result = trimTrailingCodeNewline([span]) as React.ReactNode[];
-    expect(result).toHaveLength(1);
-    expect((result[0] as React.ReactElement).type).toBe("span");
+    const input: React.ReactNode = [span];
+    expect(trimTrailingCodeNewline(input)).toBe(input);
+  });
+});
+
+describe("MARKDOWN_COMPONENTS.code", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const CodeComponent = MARKDOWN_COMPONENTS.code as (props: any) => ReactElement;
+
+  function renderCode(props: Record<string, unknown>): ReactElement {
+    return CodeComponent({ node: undefined, ...props });
+  }
+  function propsOf(el: ReactElement): Record<string, unknown> {
+    return (el as unknown as { props: Record<string, unknown> }).props;
+  }
+
+  it("strips trailing newline from fenced code blocks (hljs class)", () => {
+    const span = createElement("span", { className: "hljs-keyword", key: "k" }, "const");
+    const el = renderCode({ className: "hljs language-js", children: [span, " x = 1;\n"] });
+    expect(el.type).toBe("code");
+    expect(propsOf(el).className).toBe("hljs language-js");
+    const kids = propsOf(el).children as React.ReactNode[];
+    expect(kids).toHaveLength(2);
+    expect(kids[1]).toBe(" x = 1;");
+  });
+
+  it("strips trailing newline from fenced code blocks (language- class)", () => {
+    const el = renderCode({ className: "language-python", children: "print('hello')\n" });
+    expect(el.type).toBe("code");
+    const kids = propsOf(el).children as React.ReactNode[];
+    expect(kids).toHaveLength(1);
+    expect(kids[0]).toBe("print('hello')");
+  });
+
+  it("does NOT strip newlines from inline code (no language class)", () => {
+    const el = renderCode({ children: "some code" });
+    expect(propsOf(el).children).toBe("some code");
+  });
+
+  it("does NOT strip newlines when className is undefined", () => {
+    const el = renderCode({ className: undefined, children: "inline\n" });
+    expect(propsOf(el).children).toBe("inline\n");
+  });
+
+  it("preserves className on the rendered code element", () => {
+    const el = renderCode({ className: "hljs language-rust", children: "fn main() {}\n" });
+    expect(propsOf(el).className).toBe("hljs language-rust");
   });
 });

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { EXTERNAL_SCHEMES } from "./markdown";
+import { createElement } from "react";
+import { EXTERNAL_SCHEMES, trimTrailingCodeNewline } from "./markdown";
 
 describe("EXTERNAL_SCHEMES", () => {
   it("matches http URLs", () => {
@@ -42,5 +43,53 @@ describe("EXTERNAL_SCHEMES", () => {
 
   it("rejects empty string", () => {
     expect(EXTERNAL_SCHEMES.test("")).toBe(false);
+  });
+});
+
+describe("trimTrailingCodeNewline", () => {
+  it("strips a trailing newline from a single string child", () => {
+    expect(trimTrailingCodeNewline("const x = 1;\n")).toEqual(["const x = 1;"]);
+  });
+
+  it("strips multiple trailing newlines", () => {
+    expect(trimTrailingCodeNewline("const x = 1;\n\n\n")).toEqual(["const x = 1;"]);
+  });
+
+  it("preserves internal newlines", () => {
+    expect(trimTrailingCodeNewline("a\nb\nc\n")).toEqual(["a\nb\nc"]);
+  });
+
+  it("drops a trailing whitespace-only text node", () => {
+    const span = createElement("span", { key: "k" }, "code");
+    const result = trimTrailingCodeNewline([span, "\n"]) as React.ReactNode[];
+    expect(result).toHaveLength(1);
+    expect((result[0] as React.ReactElement).type).toBe("span");
+  });
+
+  it("trims trailing newline from the last text node after a span", () => {
+    const span = createElement("span", { key: "k" }, "const");
+    const result = trimTrailingCodeNewline([span, " x = 1;\n"]) as React.ReactNode[];
+    expect(result).toHaveLength(2);
+    expect((result[0] as React.ReactElement).type).toBe("span");
+    expect(result[1]).toBe(" x = 1;");
+  });
+
+  it("is a no-op when there is no trailing newline", () => {
+    const span = createElement("span", { key: "k" }, "const");
+    const result = trimTrailingCodeNewline([span, " x = 1;"]) as React.ReactNode[];
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(" x = 1;");
+  });
+
+  it("returns the original input when children are empty", () => {
+    expect(trimTrailingCodeNewline([])).toEqual([]);
+    expect(trimTrailingCodeNewline(null)).toBe(null);
+  });
+
+  it("does not modify the last child if it is a non-string element", () => {
+    const span = createElement("span", { key: "k" }, "code");
+    const result = trimTrailingCodeNewline([span]) as React.ReactNode[];
+    expect(result).toHaveLength(1);
+    expect((result[0] as React.ReactElement).type).toBe("span");
   });
 });

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -108,7 +108,7 @@ export const REMARK_PLUGINS: PluggableList = [remarkGfm];
 export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
 
 /**
- * Trim trailing newlines from the last text-node child of a code element.
+ * Trim all trailing newlines from the last text-node child of a code element.
  * rehype-highlight preserves the source `\n` before the closing fence; those
  * phantom newlines paint extra selection lines below the visible code.
  */

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -7,6 +7,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeHighlight from "rehype-highlight";
 import { AnsiUp } from "ansi_up";
 import { openUrl } from "../services/tauri";
+import { CodeBlock } from "../components/chat/CodeBlock";
 
 // Shared AnsiUp instance for converting ANSI escape sequences to HTML.
 const ansiUp = new AnsiUp();
@@ -142,6 +143,9 @@ export const MARKDOWN_COMPONENTS: Components = {
       },
       children,
     ),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  pre: ({ node, children, ...props }) =>
+    createElement(CodeBlock, props, children),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   code: ({ node, className, children, ...props }) => {
     const isFenced =

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -106,6 +106,22 @@ export const REMARK_PLUGINS: PluggableList = [remarkGfm];
 // Schemes that should open in the system browser rather than navigate the webview.
 export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
 
+/**
+ * Trim a single trailing newline from the last text-node child of a code element.
+ * rehype-highlight preserves the source `\n` before the closing fence; that
+ * phantom newline paints an extra selection line below the visible code.
+ */
+export function trimTrailingCodeNewline(children: React.ReactNode): React.ReactNode {
+  const arr = React.Children.toArray(children);
+  if (arr.length === 0) return children;
+  const last = arr[arr.length - 1];
+  if (typeof last !== "string") return arr;
+  const trimmed = last.replace(/\n+$/, "");
+  if (trimmed === last) return arr;
+  if (trimmed === "") return arr.slice(0, -1);
+  return [...arr.slice(0, -1), trimmed];
+}
+
 // Override <a> to open external links in the system browser instead of navigating the webview.
 export const MARKDOWN_COMPONENTS: Components = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -126,4 +142,14 @@ export const MARKDOWN_COMPONENTS: Components = {
       },
       children,
     ),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  code: ({ node, className, children, ...props }) => {
+    const isFenced =
+      typeof className === "string" && /\b(?:hljs|language-)/.test(className);
+    return createElement(
+      "code",
+      { ...props, className },
+      isFenced ? trimTrailingCodeNewline(children) : children,
+    );
+  },
 };

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -107,17 +107,17 @@ export const REMARK_PLUGINS: PluggableList = [remarkGfm];
 export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
 
 /**
- * Trim a single trailing newline from the last text-node child of a code element.
- * rehype-highlight preserves the source `\n` before the closing fence; that
- * phantom newline paints an extra selection line below the visible code.
+ * Trim trailing newlines from the last text-node child of a code element.
+ * rehype-highlight preserves the source `\n` before the closing fence; those
+ * phantom newlines paint extra selection lines below the visible code.
  */
 export function trimTrailingCodeNewline(children: React.ReactNode): React.ReactNode {
   const arr = React.Children.toArray(children);
   if (arr.length === 0) return children;
   const last = arr[arr.length - 1];
-  if (typeof last !== "string") return arr;
+  if (typeof last !== "string") return children;
   const trimmed = last.replace(/\n+$/, "");
-  if (trimmed === last) return arr;
+  if (trimmed === last) return children;
   if (trimmed === "") return arr.slice(0, -1);
   return [...arr.slice(0, -1), trimmed];
 }


### PR DESCRIPTION
## Summary

- Strip the trailing `\n` that rehype-highlight preserves on fenced code blocks (the source newline before the closing fence renders an invisible empty line under the code).
- Promote `.content pre code` from `display: inline` to `display: block` with `padding: 0`, so the selection rect clips to the `<code>` element rather than the padded `<pre>` (and overrides highlight.js' own `pre code.hljs { padding: 1em }` rule).
- Add unit tests for the new `trimTrailingCodeNewline` helper covering string-only children, hljs-style mixed children, and inline-code no-op cases.

Inline `<code>` (no `language-`/`hljs` class) is untouched, so table cells and prose-inline code still render as before.

Closes #396.

## Test plan

- [x] `cargo test --workspace --all-features` — 722 + 137 tests pass
- [x] `cargo clippy -p claudette -p claudette-server --all-targets` — clean (these are the CI-checked crates per CLAUDE.md)
- [x] `cargo fmt --all --check` — clean
- [x] `cd src/ui && bunx tsc -b` — clean
- [x] `cd src/ui && bun run test` — 813 tests pass
- [x] UAT via `/claudette-debug` against running dev instance: injected an `hljs` code block with trailing `\n`, applied the fix to the live DOM, then double-clicked a word: selection produced exactly one DOMRect with one distinct top — a clean rectangle aligned to the visible glyphs (`cleanRect: true`).