### PR TITLE
feat(chat): group tool calls into segments and separate subagents

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1862,8 +1862,8 @@ impl Database {
         let tx = self.conn.unchecked_transaction()?;
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order, group_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             )?;
             for a in activities {
                 stmt.execute(params![
@@ -1875,6 +1875,7 @@ impl Database {
                     a.result_text,
                     a.summary,
                     a.sort_order,
+                    a.group_id,
                 ])?;
             }
         }
@@ -1908,8 +1909,8 @@ impl Database {
         )?;
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order, group_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             )?;
             for a in activities {
                 stmt.execute(params![
@@ -1921,6 +1922,7 @@ impl Database {
                     a.result_text,
                     a.summary,
                     a.sort_order,
+                    a.group_id,
                 ])?;
             }
         }
@@ -1940,7 +1942,8 @@ impl Database {
         // Then load all activities for this workspace in one query.
         let mut stmt = self.conn.prepare(
             "SELECT ta.id, ta.checkpoint_id, ta.tool_use_id, ta.tool_name,
-                    ta.input_json, ta.result_text, ta.summary, ta.sort_order
+                    ta.input_json, ta.result_text, ta.summary, ta.sort_order,
+                    ta.group_id
              FROM turn_tool_activities ta
              JOIN conversation_checkpoints cp ON ta.checkpoint_id = cp.id
              WHERE cp.workspace_id = ?1
@@ -1957,6 +1960,7 @@ impl Database {
                     result_text: row.get(5)?,
                     summary: row.get(6)?,
                     sort_order: row.get(7)?,
+                    group_id: row.get(8)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -2034,7 +2038,8 @@ impl Database {
 
         let mut stmt = self.conn.prepare(
             "SELECT ta.id, ta.checkpoint_id, ta.tool_use_id, ta.tool_name,
-                    ta.input_json, ta.result_text, ta.summary, ta.sort_order
+                    ta.input_json, ta.result_text, ta.summary, ta.sort_order,
+                    ta.group_id, ta.anchor_ordinal
              FROM turn_tool_activities ta
              JOIN conversation_checkpoints cp ON ta.checkpoint_id = cp.id
              WHERE cp.chat_session_id = ?1
@@ -2051,6 +2056,8 @@ impl Database {
                     result_text: row.get(5)?,
                     summary: row.get(6)?,
                     sort_order: row.get(7)?,
+                    group_id: row.get(8)?,
+                    anchor_ordinal: row.get(9)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -3847,6 +3854,7 @@ mod tests {
             result_text: "ok".into(),
             summary: format!("{tool} test.rs"),
             sort_order: order,
+            group_id: None,
         }
     }
 
@@ -3885,6 +3893,49 @@ mod tests {
 
         let turns = db.list_completed_turns("w1").unwrap();
         assert!(turns.is_empty());
+    }
+
+    #[test]
+    fn test_tool_activity_group_id_round_trip() {
+        // `group_id` is a new (2026-04-24) column backing the turn-segment
+        // feature. Inserting with assorted values — `Some(i)`, `None`, and a
+        // repeated index — must read back identically; any loss here would
+        // collapse segments in the UI (all rows grouped together).
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+
+        let mk = |id: &str, order: i32, group: Option<i32>| TurnToolActivity {
+            id: id.into(),
+            checkpoint_id: "cp1".into(),
+            tool_use_id: format!("tu_{id}"),
+            tool_name: "Read".into(),
+            input_json: "{}".into(),
+            result_text: "".into(),
+            summary: "".into(),
+            sort_order: order,
+            group_id: group,
+        };
+
+        db.insert_turn_tool_activities(&[
+            mk("a1", 0, Some(0)),
+            mk("a2", 1, Some(0)),
+            mk("a3", 2, Some(1)),
+            mk("a4", 3, None), // legacy-style row; nullable column
+        ])
+        .unwrap();
+
+        let turns = db.list_completed_turns("w1").unwrap();
+        assert_eq!(turns.len(), 1);
+        let acts = &turns[0].activities;
+        assert_eq!(acts.len(), 4);
+        // Row-by-row: ordering preserved by sort_order, group_id preserved verbatim.
+        assert_eq!(acts[0].group_id, Some(0));
+        assert_eq!(acts[1].group_id, Some(0));
+        assert_eq!(acts[2].group_id, Some(1));
+        assert_eq!(acts[3].group_id, None);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1862,8 +1862,8 @@ impl Database {
         let tx = self.conn.unchecked_transaction()?;
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order, group_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order, group_id, anchor_ordinal)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             )?;
             for a in activities {
                 stmt.execute(params![
@@ -1876,6 +1876,7 @@ impl Database {
                     a.summary,
                     a.sort_order,
                     a.group_id,
+                    a.anchor_ordinal,
                 ])?;
             }
         }
@@ -1909,8 +1910,8 @@ impl Database {
         )?;
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order, group_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO turn_tool_activities (id, checkpoint_id, tool_use_id, tool_name, input_json, result_text, summary, sort_order, group_id, anchor_ordinal)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             )?;
             for a in activities {
                 stmt.execute(params![
@@ -1923,6 +1924,7 @@ impl Database {
                     a.summary,
                     a.sort_order,
                     a.group_id,
+                    a.anchor_ordinal,
                 ])?;
             }
         }
@@ -1943,7 +1945,7 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT ta.id, ta.checkpoint_id, ta.tool_use_id, ta.tool_name,
                     ta.input_json, ta.result_text, ta.summary, ta.sort_order,
-                    ta.group_id
+                    ta.group_id, ta.anchor_ordinal
              FROM turn_tool_activities ta
              JOIN conversation_checkpoints cp ON ta.checkpoint_id = cp.id
              WHERE cp.workspace_id = ?1
@@ -1961,6 +1963,7 @@ impl Database {
                     summary: row.get(6)?,
                     sort_order: row.get(7)?,
                     group_id: row.get(8)?,
+                    anchor_ordinal: row.get(9)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -3855,6 +3858,7 @@ mod tests {
             summary: format!("{tool} test.rs"),
             sort_order: order,
             group_id: None,
+            anchor_ordinal: None,
         }
     }
 
@@ -3917,6 +3921,7 @@ mod tests {
             summary: "".into(),
             sort_order: order,
             group_id: group,
+            anchor_ordinal: None,
         };
 
         db.insert_turn_tool_activities(&[

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -373,6 +373,7 @@ fn copy_history(
                     result_text: a.result_text.clone(),
                     summary: a.summary.clone(),
                     sort_order: a.sort_order,
+                    group_id: a.group_id,
                 })
                 .collect();
             db.insert_turn_tool_activities(&remapped)?;
@@ -553,6 +554,7 @@ mod tests {
             result_text: "ok".into(),
             summary: "read file".into(),
             sort_order: 0,
+            group_id: None,
         }])
         .unwrap();
         db.insert_turn_tool_activities(&[TurnToolActivity {
@@ -564,6 +566,7 @@ mod tests {
             result_text: "ok".into(),
             summary: "edit file".into(),
             sort_order: 0,
+            group_id: None,
         }])
         .unwrap();
         db

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -374,6 +374,7 @@ fn copy_history(
                     summary: a.summary.clone(),
                     sort_order: a.sort_order,
                     group_id: a.group_id,
+                    anchor_ordinal: a.anchor_ordinal,
                 })
                 .collect();
             db.insert_turn_tool_activities(&remapped)?;
@@ -555,6 +556,7 @@ mod tests {
             summary: "read file".into(),
             sort_order: 0,
             group_id: None,
+            anchor_ordinal: None,
         }])
         .unwrap();
         db.insert_turn_tool_activities(&[TurnToolActivity {
@@ -567,6 +569,7 @@ mod tests {
             summary: "edit file".into(),
             sort_order: 0,
             group_id: None,
+            anchor_ordinal: None,
         }])
         .unwrap();
         db

--- a/src/migrations/20260424170614_turn_tool_activity_group_id.sql
+++ b/src/migrations/20260424170614_turn_tool_activity_group_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE turn_tool_activities ADD COLUMN group_id INTEGER;

--- a/src/migrations/20260425180000_turn_tool_activity_anchor_ordinal.sql
+++ b/src/migrations/20260425180000_turn_tool_activity_anchor_ordinal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE turn_tool_activities ADD COLUMN anchor_ordinal INTEGER;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -159,4 +159,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260425003451_attachments_origin_and_tool_use.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260424170614_turn_tool_activity_group_id",
+        sql: include_str!("20260424170614_turn_tool_activity_group_id.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -164,4 +164,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260424170614_turn_tool_activity_group_id.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260425180000_turn_tool_activity_anchor_ordinal",
+        sql: include_str!("20260425180000_turn_tool_activity_anchor_ordinal.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/model/checkpoint.rs
+++ b/src/model/checkpoint.rs
@@ -35,6 +35,12 @@ pub struct TurnToolActivity {
     pub result_text: String,
     pub summary: String,
     pub sort_order: i32,
+    /// Index of the segment this activity belongs to within its turn. Rows
+    /// sharing a `group_id` are rendered as one tool-group; distinct values
+    /// become distinct groups or subagent cards. `None` on pre-migration rows
+    /// — the reader treats those as a single group covering the whole turn.
+    #[serde(default)]
+    pub group_id: Option<i32>,
 }
 
 /// Grouped checkpoint + activities for loading completed turns.

--- a/src/model/checkpoint.rs
+++ b/src/model/checkpoint.rs
@@ -41,6 +41,12 @@ pub struct TurnToolActivity {
     /// — the reader treats those as a single group covering the whole turn.
     #[serde(default)]
     pub group_id: Option<i32>,
+    /// 0-based index of the committed segment group within the turn. The Nth
+    /// group anchors to the Nth assistant message in the turn's message span.
+    /// Used to reconstruct inline segment rendering on reload. `None` on
+    /// legacy rows — falls back to aggregated TurnSummary rendering.
+    #[serde(default)]
+    pub anchor_ordinal: Option<i32>,
 }
 
 /// Grouped checkpoint + activities for loading completed turns.

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -714,6 +714,85 @@
   margin: 0;
 }
 
+/*
+ * Segmented body: when a turn contains more than one tool-group (because text
+ * or thinking interleaved) or any subagent call, each segment renders as its
+ * own mini sub-box under the turn-level header.
+ */
+.turnSegments {
+  border-top: 1px solid var(--divider);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.toolGroupBox {
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.toolGroupHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: transparent;
+  font-size: 11px;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.toolGroupHeader:hover {
+  background: var(--hover-bg-subtle);
+}
+
+.toolGroupBody {
+  border-top: 1px solid var(--divider);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.subagentCard {
+  border: 1px solid var(--accent-dim, var(--divider));
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--hover-bg-subtle);
+}
+
+.subagentHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.subagentHeader:hover {
+  background: var(--hover-bg-subtle);
+}
+
+.subagentLabel {
+  font-weight: 600;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.subagentSummary {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 /* Footer below a completed turn: elapsed time + copy + fork actions. */
 .turnFooter {
   display: flex;

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -644,6 +644,13 @@
   50% { opacity: 1; }
 }
 
+.inlineSegments {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 0;
+}
+
 /* Tool activities — compact inline annotations */
 .toolActivities {
   display: flex;
@@ -791,6 +798,36 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+
+.subagentSpinner {
+  animation: spin 1s linear infinite;
+  color: var(--text-faint);
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.subagentBody {
+  border-top: 1px solid var(--divider);
+  padding: 8px 10px;
+  font-size: 12px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.subagentPrompt {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--divider);
+}
+
+.subagentResult {
+  color: var(--text-primary);
+  line-height: 1.5;
 }
 
 /* Footer below a completed turn: elapsed time + copy + fork actions. */

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -4,7 +4,8 @@ import { HighlightedPlainText } from "./HighlightedPlainText";
 import { ChatSearchBar } from "./ChatSearchBar";
 import { AlertCircle, FileText, GitBranch, LoaderCircle, Mic, Plus, RotateCcw, Send, Split, Square, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
-import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
+import type { ToolActivity, CompletedTurn, TurnSegment } from "../../stores/useAppStore";
+import { isSubagentTool } from "../../utils/toolClassification";
 import {
   loadChatHistory,
   loadAttachmentsForSession,
@@ -247,6 +248,7 @@ const ScrollContext = createContext<{
 // causing Object.is to return false and triggering unnecessary component re-renders.
 const EMPTY_COMPLETED_TURNS: CompletedTurn[] = [];
 const EMPTY_ACTIVITIES: ToolActivity[] = [];
+const EMPTY_TURN_SEGMENTS: TurnSegment[] = [];
 const EMPTY_ATTACHMENTS: ChatAttachment[] = [];
 
 export function ChatPanel() {
@@ -1391,6 +1393,218 @@ const StreamingMessage = memo(function StreamingMessage({
 /**
  * Render a single completed turn summary (collapsible tool call list).
  */
+/** Flat one-line row for a single tool call inside a tool-group or the
+ *  legacy flat turn body. Extracted so both renderers share the exact markup
+ *  they used to inline. */
+function ToolActivityRow({
+  act,
+  searchQuery,
+}: {
+  act: ToolActivity;
+  searchQuery?: string;
+}) {
+  const text = act.summary || extractToolSummary(act.toolName, act.inputJson);
+  return (
+    <div className={styles.toolActivity}>
+      <div className={styles.toolHeader}>
+        <span
+          className={styles.toolName}
+          style={{ color: toolColor(act.toolName) }}
+        >
+          {act.toolName}
+        </span>
+        {(act.summary || act.inputJson) && (
+          <span className={styles.toolSummary}>
+            <HighlightedPlainText text={text} query={searchQuery ?? ""} />
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** A tool-group segment: a mini sub-box with its own collapse chevron
+ *  holding every tool call that belongs to this group. */
+function ToolGroupBox({
+  activities,
+  searchQuery,
+}: {
+  activities: ToolActivity[];
+  searchQuery?: string;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  // Force-expand when the active search query matches inside any of this
+  // group's activity summaries — otherwise marks would land in detached
+  // DOM and the search counter would tick up with nothing visible.
+  const queryHasMatch =
+    !!searchQuery &&
+    activities.some(
+      (a) =>
+        a.summary &&
+        a.summary.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+  const isExpanded = !collapsed || queryHasMatch;
+  return (
+    <div className={styles.toolGroupBox}>
+      <div
+        className={styles.toolGroupHeader}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        onClick={(e) => {
+          e.stopPropagation();
+          setCollapsed((c) => !c);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            setCollapsed((c) => !c);
+          }
+        }}
+      >
+        <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
+        <span>
+          {activities.length} tool call{activities.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+      {isExpanded && (
+        <div className={styles.toolGroupBody}>
+          {activities.map((act) => (
+            <ToolActivityRow
+              key={act.toolUseId}
+              act={act}
+              searchQuery={searchQuery}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A subagent segment: a standalone card for a `Task` or `Agent` tool call.
+ *  Currently renders the same input/summary that a tool-group row would;
+ *  the distinct card is the mount point for future per-subagent streaming. */
+function SubagentCard({ activity }: { activity: ToolActivity }) {
+  const summary =
+    activity.summary ||
+    extractToolSummary(activity.toolName, activity.inputJson);
+  return (
+    <div className={styles.subagentCard}>
+      <div className={styles.subagentHeader}>
+        <span
+          className={styles.subagentLabel}
+          style={{ color: toolColor(activity.toolName) }}
+        >
+          {activity.toolName}
+        </span>
+        {summary && <span className={styles.subagentSummary}>{summary}</span>}
+      </div>
+    </div>
+  );
+}
+
+/** Render the body of a turn (completed or in-progress) as its ordered
+ *  segments. When `segments` is undefined — legacy turns without the
+ *  `group_id` column populated — falls back to a single flat tool list so
+ *  older history still displays sensibly. When there is exactly one
+ *  tool-group covering every activity the renderer also uses the flat list
+ *  to keep visual parity with the pre-segment UI. */
+function TurnSegmentedBody({
+  segments,
+  activities,
+  searchQuery,
+}: {
+  segments?: TurnSegment[];
+  activities: ToolActivity[];
+  searchQuery?: string;
+}) {
+  const byId = useMemo(() => {
+    const m = new Map<string, ToolActivity>();
+    for (const a of activities) m.set(a.toolUseId, a);
+    return m;
+  }, [activities]);
+
+  const flatten =
+    !segments ||
+    segments.length === 0 ||
+    (segments.length === 1 &&
+      segments[0].kind === "tool-group" &&
+      segments[0].toolUseIds.length === activities.length);
+
+  if (flatten) {
+    return (
+      <div className={styles.turnActivities}>
+        {activities.map((act) => (
+          <ToolActivityRow
+            key={act.toolUseId}
+            act={act}
+            searchQuery={searchQuery}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.turnSegments}>
+      {segments!.map((seg) => {
+        if (seg.kind === "subagent") {
+          const act = byId.get(seg.toolUseId);
+          if (!act) return null;
+          return <SubagentCard key={seg.id} activity={act} />;
+        }
+        const acts = seg.toolUseIds
+          .map((id) => byId.get(id))
+          .filter((a): a is ToolActivity => !!a);
+        if (acts.length === 0) return null;
+        return (
+          <ToolGroupBox
+            key={seg.id}
+            activities={acts}
+            searchQuery={searchQuery}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/** Synthesise segments for an in-progress turn when the live stream hasn't
+ *  populated `turnSegments` yet (e.g. early in a new turn before the first
+ *  tool_use arrives, or for workspaces whose state pre-dates this slice
+ *  being tracked). Keeps the live renderer from blank-flashing while the
+ *  stream catches up. */
+function synthesiseLiveSegments(activities: ToolActivity[]): TurnSegment[] {
+  if (activities.length === 0) return [];
+  const segments: TurnSegment[] = [];
+  let currentIds: string[] = [];
+  const flush = () => {
+    if (currentIds.length === 0) return;
+    segments.push({
+      kind: "tool-group",
+      id: `live-grp-${currentIds[0]}`,
+      toolUseIds: [...currentIds],
+    });
+    currentIds = [];
+  };
+  for (const a of activities) {
+    if (isSubagentTool(a.toolName)) {
+      flush();
+      segments.push({
+        kind: "subagent",
+        id: `live-sub-${a.toolUseId}`,
+        toolUseId: a.toolUseId,
+      });
+    } else {
+      currentIds.push(a.toolUseId);
+    }
+  }
+  flush();
+  return segments;
+}
+
 function TurnSummary({
   turn,
   collapsed,
@@ -1464,25 +1678,11 @@ function TurnSummary({
           </span>
         </div>
         {isExpanded && (
-          <div className={styles.turnActivities}>
-            {turn.activities.map((act: ToolActivity) => (
-              <div key={act.toolUseId} className={styles.toolActivity}>
-                <div className={styles.toolHeader}>
-                  <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
-                    {act.toolName}
-                  </span>
-                  {(act.summary || act.inputJson) && (
-                    <span className={styles.toolSummary}>
-                      <HighlightedPlainText
-                        text={act.summary || extractToolSummary(act.toolName, act.inputJson)}
-                        query={searchQuery}
-                      />
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+          <TurnSegmentedBody
+            segments={turn.segments}
+            activities={turn.activities}
+            searchQuery={searchQuery}
+          />
         )}
       </div>
       {taskProgress && taskProgress.totalCount > 0 && (
@@ -2192,6 +2392,9 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
   const activities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES
   );
+  const liveSegments = useAppStore(
+    (s) => s.turnSegments[sessionId] ?? EMPTY_TURN_SEGMENTS,
+  );
   const [collapsed, setCollapsed] = useState(true);
 
   // Auto-collapse when a new turn starts (activities goes from 0 to non-zero)
@@ -2217,6 +2420,23 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
     );
   const isExpanded = !collapsed || queryHasMatch;
 
+  // Prefer segments the stream handler built live. Fall back to synthesis if
+  // the store has no segments yet (race early in turn) OR if segments don't
+  // yet cover every activity (segment update lags behind a freshly-appended
+  // tool entry — the missing tool would otherwise vanish from the UI).
+  const segmentToolUseIds = new Set(
+    liveSegments.flatMap((seg) =>
+      seg.kind === "tool-group" ? seg.toolUseIds : [seg.toolUseId],
+    ),
+  );
+  const segmentsCoverAll = activities.every((a) =>
+    segmentToolUseIds.has(a.toolUseId),
+  );
+  const segments =
+    liveSegments.length > 0 && segmentsCoverAll
+      ? liveSegments
+      : synthesiseLiveSegments(activities);
+
   return (
     <div className={styles.toolActivities} aria-live="polite" aria-atomic="true">
       <div className={styles.turnSummary}>
@@ -2241,20 +2461,11 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
           </span>
         </div>
         {isExpanded && (
-          <div className={styles.turnActivities}>
-            {activities.map((act: ToolActivity) => (
-              <div key={act.toolUseId} className={styles.toolActivity}>
-                <div className={styles.toolHeader}>
-                  <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>{act.toolName}</span>
-                  {act.summary && (
-                    <span className={styles.toolSummary}>
-                      <HighlightedPlainText text={act.summary} query={searchQuery} />
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+          <TurnSegmentedBody
+            segments={segments}
+            activities={activities}
+            searchQuery={searchQuery}
+          />
         )}
       </div>
     </div>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -250,6 +250,11 @@ const EMPTY_COMPLETED_TURNS: CompletedTurn[] = [];
 const EMPTY_ACTIVITIES: ToolActivity[] = [];
 const EMPTY_TURN_SEGMENTS: TurnSegment[] = [];
 const EMPTY_ATTACHMENTS: ChatAttachment[] = [];
+const EMPTY_COMMITTED: Array<{
+  afterMessageId: string;
+  segments: TurnSegment[];
+  activities: ToolActivity[];
+}> = [];
 
 export function ChatPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -372,9 +377,21 @@ export function ChatPanel() {
   const showThinkingBlocks = useAppStore(
     (s) => activeSessionId ? s.showThinkingBlocks[activeSessionId] === true : false
   );
-  // Subscribe only to count — avoids re-render on tool activity content changes
   const activitiesCount = useAppStore(
-    (s) => (activeSessionId ? (s.toolActivities[activeSessionId] || []).length : 0)
+    (s) => {
+      if (!activeSessionId) return 0;
+      const all = s.toolActivities[activeSessionId] ?? [];
+      const committed = s.committedSegmentGroups[activeSessionId] ?? [];
+      if (committed.length === 0) return all.length;
+      // Don't double-count tools that are already shown inline via committed
+      // segment groups — only the trailing (uncommitted) tools are "in
+      // progress" from the running indicator's perspective.
+      const ids = new Set<string>();
+      for (const g of committed) {
+        for (const a of g.activities) ids.add(a.toolUseId);
+      }
+      return all.filter((a) => !ids.has(a.toolUseId)).length;
+    }
   );
   const completedTurnsCount = useAppStore(
     (s) => (activeSessionId ? (s.completedTurns[activeSessionId] || []).length : 0)
@@ -1483,24 +1500,85 @@ function ToolGroupBox({
   );
 }
 
-/** A subagent segment: a standalone card for a `Task` or `Agent` tool call.
- *  Currently renders the same input/summary that a tool-group row would;
- *  the distinct card is the mount point for future per-subagent streaming. */
-function SubagentCard({ activity }: { activity: ToolActivity }) {
+function SubagentCard({
+  activity,
+  searchQuery,
+}: {
+  activity: ToolActivity;
+  searchQuery?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
   const summary =
     activity.summary ||
     extractToolSummary(activity.toolName, activity.inputJson);
+
+  const parsed = useMemo(() => {
+    try {
+      const obj = JSON.parse(activity.inputJson);
+      return {
+        description: obj.description as string | undefined,
+        prompt: obj.prompt as string | undefined,
+      };
+    } catch {
+      return { description: undefined, prompt: undefined };
+    }
+  }, [activity.inputJson]);
+
+  const headerText = parsed.description || summary;
+  const hasBody = !!(parsed.prompt || activity.resultText);
+  const isInteractive = hasBody;
+
   return (
     <div className={styles.subagentCard}>
-      <div className={styles.subagentHeader}>
+      <div
+        className={styles.subagentHeader}
+        role={isInteractive ? "button" : undefined}
+        tabIndex={isInteractive ? 0 : undefined}
+        aria-expanded={isInteractive ? expanded : undefined}
+        // Hover/cursor:pointer styling lives in CSS; suppress it when there's
+        // nothing to expand so the card doesn't imply clickability.
+        style={isInteractive ? undefined : { cursor: "default" }}
+        onClick={() => isInteractive && setExpanded(!expanded)}
+        onKeyDown={(e) => {
+          if (isInteractive && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            setExpanded(!expanded);
+          }
+        }}
+      >
+        {hasBody && (
+          <span className={styles.toolChevron}>
+            {expanded ? "⌄" : "›"}
+          </span>
+        )}
         <span
           className={styles.subagentLabel}
           style={{ color: toolColor(activity.toolName) }}
         >
           {activity.toolName}
         </span>
-        {summary && <span className={styles.subagentSummary}>{summary}</span>}
+        {headerText && (
+          <span className={styles.subagentSummary}>{headerText}</span>
+        )}
+        {!activity.resultText && (
+          <LoaderCircle size={12} className={styles.subagentSpinner} />
+        )}
       </div>
+      {expanded && (
+        <div className={styles.subagentBody}>
+          {parsed.prompt && (
+            <div className={styles.subagentPrompt}>{parsed.prompt}</div>
+          )}
+          {activity.resultText && (
+            <div className={styles.subagentResult}>
+              <HighlightedMessageMarkdown
+                content={activity.resultText}
+                query={searchQuery ?? ""}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -1603,6 +1681,110 @@ function synthesiseLiveSegments(activities: ToolActivity[]): TurnSegment[] {
   }
   flush();
   return segments;
+}
+
+function InlineToolGroup({
+  activities,
+  isRunning,
+  searchQuery,
+}: {
+  activities: ToolActivity[];
+  isRunning?: boolean;
+  searchQuery?: string;
+}) {
+  const [collapsed, setCollapsed] = useState(true);
+  // Force-expand when the active search query matches inside any of this
+  // group's activity summaries — otherwise marks would be silently hidden
+  // behind the collapsed header and the user would see a non-zero counter
+  // with no visible highlight.
+  const queryHasMatch =
+    !!searchQuery &&
+    activities.some(
+      (a) =>
+        a.summary &&
+        a.summary.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+  const isExpanded = !collapsed || queryHasMatch;
+  return (
+    <div className={styles.toolActivities}>
+      <div className={styles.turnSummary}>
+        <div
+          className={styles.turnHeader}
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
+          onClick={() => setCollapsed(!collapsed)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setCollapsed(!collapsed);
+            }
+          }}
+        >
+          <span className={styles.toolChevron}>
+            {isExpanded ? "⌄" : "›"}
+          </span>
+          <span className={styles.turnLabel}>
+            {activities.length} tool call{activities.length !== 1 ? "s" : ""}
+            {isRunning && <span className={styles.inProgressNote}> in progress</span>}
+          </span>
+        </div>
+        {isExpanded && (
+          <div className={styles.turnActivities}>
+            {activities.map((act) => (
+              <ToolActivityRow
+                key={act.toolUseId}
+                act={act}
+                searchQuery={searchQuery}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function InlineSegments({
+  segments,
+  activities,
+  isRunning,
+  searchQuery,
+}: {
+  segments: TurnSegment[];
+  activities: ToolActivity[];
+  isRunning?: boolean;
+  searchQuery?: string;
+}) {
+  const byId = useMemo(() => {
+    const m = new Map<string, ToolActivity>();
+    for (const a of activities) m.set(a.toolUseId, a);
+    return m;
+  }, [activities]);
+
+  return (
+    <div className={styles.inlineSegments}>
+      {segments.map((seg) => {
+        if (seg.kind === "subagent") {
+          const act = byId.get(seg.toolUseId);
+          if (!act) return null;
+          return <SubagentCard key={seg.id} activity={act} />;
+        }
+        const acts = seg.toolUseIds
+          .map((id) => byId.get(id))
+          .filter((a): a is ToolActivity => !!a);
+        if (acts.length === 0) return null;
+        return (
+          <InlineToolGroup
+            key={seg.id}
+            activities={acts}
+            isRunning={isRunning}
+            searchQuery={searchQuery}
+          />
+        );
+      })}
+    </div>
+  );
 }
 
 function TurnSummary({
@@ -1894,6 +2076,18 @@ type RollbackModalData = {
   hasFileChanges: boolean;
 };
 
+function CommittedSegmentsCard({
+  segments,
+  activities,
+}: {
+  segments: TurnSegment[];
+  activities: ToolActivity[];
+}) {
+  return (
+    <InlineSegments segments={segments} activities={activities} />
+  );
+}
+
 const MessagesWithTurns = memo(function MessagesWithTurns({
   messages,
   workspaceId,
@@ -1954,6 +2148,9 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   const chatAttachments = useAppStore(
     (s) => s.chatAttachments[sessionId] ?? EMPTY_ATTACHMENTS
   );
+  const committedGroups = useAppStore(
+    (s) => s.committedSegmentGroups[sessionId] ?? EMPTY_COMMITTED,
+  );
 
   // Pre-build a Map keyed by message_id for O(1) lookup in the render loop.
   //
@@ -1987,6 +2184,101 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
     }
     return map;
   }, [chatAttachments, messages]);
+
+  const committedByMessageId = useMemo(() => {
+    const map = new Map<
+      string,
+      { segments: TurnSegment[]; activities: ToolActivity[] }
+    >();
+    for (const g of committedGroups) {
+      const existing = map.get(g.afterMessageId);
+      if (existing) {
+        existing.segments.push(...g.segments);
+        existing.activities.push(...g.activities);
+      } else {
+        map.set(g.afterMessageId, {
+          segments: [...g.segments],
+          activities: [...g.activities],
+        });
+      }
+    }
+    return map;
+  }, [committedGroups]);
+
+  const renderCommittedSegments = (messageId: string) => {
+    const group = committedByMessageId.get(messageId);
+    if (!group || group.activities.length === 0) return null;
+    return (
+      <CommittedSegmentsCard
+        key={`committed-${messageId}`}
+        segments={group.segments}
+        activities={group.activities}
+      />
+    );
+  };
+
+  const completedInlineByMessageId = useMemo(() => {
+    const map = new Map<
+      string,
+      Array<{
+        segments: TurnSegment[];
+        activities: ToolActivity[];
+        turnId: string;
+        isLastGroup: boolean;
+        turn: CompletedTurn;
+        globalIdx: number;
+      }>
+    >();
+    completedTurns.forEach((turn, globalIdx) => {
+      if (!turn.segmentGroups) return;
+      const actByToolUseId = new Map(
+        turn.activities.map((a) => [a.toolUseId, a]),
+      );
+      turn.segmentGroups.forEach((g, idx) => {
+        const acts = g.activityToolUseIds
+          .map((id) => actByToolUseId.get(id))
+          .filter((a): a is ToolActivity => !!a);
+        const entry = {
+          segments: g.segments,
+          activities: acts,
+          turnId: turn.id,
+          isLastGroup: idx === turn.segmentGroups!.length - 1,
+          turn,
+          globalIdx,
+        };
+        const list = map.get(g.afterMessageId) ?? [];
+        list.push(entry);
+        map.set(g.afterMessageId, list);
+      });
+    });
+    return map;
+  }, [completedTurns]);
+
+  const renderCompletedInlineSegments = (messageId: string) => {
+    const entries = completedInlineByMessageId.get(messageId);
+    if (!entries || entries.length === 0) return null;
+    return entries.map((data) => (
+      <React.Fragment key={`completed-inline-${data.turnId}-${messageId}`}>
+        <InlineSegments
+          segments={data.segments}
+          activities={data.activities}
+        />
+        {data.isLastGroup && (
+          <TurnFooter
+            durationMs={data.turn.durationMs}
+            inputTokens={data.turn.inputTokens}
+            outputTokens={data.turn.outputTokens}
+            assistantText={assistantTextByTurnId.get(data.turnId) ?? ""}
+            onFork={
+              onForkTurn ? () => onForkTurn(data.turn.id) : undefined
+            }
+            onRollback={buildOnRollback(data.turnId)}
+            className={styles.messageTurnFooter}
+          />
+        )}
+      </React.Fragment>
+    ));
+  };
 
   // Build an index: afterMessageIndex → array of (turn, globalIndex) pairs.
   // Only recomputed when completedTurns changes, not on every streaming update.
@@ -2170,7 +2462,9 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   const renderTurns = (position: number) => {
     const entries = turnsByPosition[position];
     if (!entries) return null;
-    return entries.map(({ turn, globalIdx }) => (
+    return entries
+      .filter(({ turn }) => !turn.segmentGroups?.length)
+      .map(({ turn, globalIdx }) => (
       <TurnSummary
         key={turn.id}
         turn={turn}
@@ -2351,6 +2645,8 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
             </div>
           </div>
           )}
+          {renderCommittedSegments(msg.id)}
+          {renderCompletedInlineSegments(msg.id)}
           {renderPlainTurnFooter(idx + 1)}
         </React.Fragment>
         );
@@ -2359,6 +2655,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
       {completedTurns
         .map((turn, globalIdx) => ({ turn, globalIdx }))
         .filter(({ turn }) => turn.afterMessageIndex >= messages.length)
+        .filter(({ turn }) => !turn.segmentGroups?.length)
         .map(({ turn, globalIdx }) => (
           <TurnSummary
             key={turn.id}
@@ -2389,36 +2686,31 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
   isRunning: boolean;
   searchQuery: string;
 }) {
-  const activities = useAppStore(
+  const allActivities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES
   );
   const liveSegments = useAppStore(
     (s) => s.turnSegments[sessionId] ?? EMPTY_TURN_SEGMENTS,
   );
-  const [collapsed, setCollapsed] = useState(true);
+  const committedGroups = useAppStore(
+    (s) => s.committedSegmentGroups[sessionId] ?? EMPTY_COMMITTED,
+  );
 
-  // Auto-collapse when a new turn starts (activities goes from 0 to non-zero)
-  const prevLengthRef = useRef(0);
-  useEffect(() => {
-    if (isRunning && activities.length > 0 && prevLengthRef.current === 0) {
-      setCollapsed(true);
+  const committedIds = useMemo(() => {
+    if (committedGroups.length === 0) return null;
+    const ids = new Set<string>();
+    for (const g of committedGroups) {
+      for (const a of g.activities) ids.add(a.toolUseId);
     }
-    prevLengthRef.current = activities.length;
-  }, [isRunning, activities.length]);
+    return ids;
+  }, [committedGroups]);
+
+  const activities = useMemo(() => {
+    if (!committedIds) return allActivities;
+    return allActivities.filter((a) => !committedIds.has(a.toolUseId));
+  }, [allActivities, committedIds]);
 
   if (activities.length === 0) return null;
-
-  // Force-expand when the active search query matches inside any of this
-  // section's activity summaries — otherwise marks would be silently
-  // hidden behind the collapsed header and the user would see a non-zero
-  // counter with no visible highlight.
-  const queryHasMatch =
-    !!searchQuery &&
-    activities.some(
-      (a) =>
-        a.summary && a.summary.toLowerCase().includes(searchQuery.toLowerCase()),
-    );
-  const isExpanded = !collapsed || queryHasMatch;
 
   // Prefer segments the stream handler built live. Fall back to synthesis if
   // the store has no segments yet (race early in turn) OR if segments don't
@@ -2438,37 +2730,13 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
       : synthesiseLiveSegments(activities);
 
   return (
-    <div className={styles.toolActivities} aria-live="polite" aria-atomic="true">
-      <div className={styles.turnSummary}>
-        <div
-          className={styles.turnHeader}
-          role="button"
-          tabIndex={0}
-          onClick={() => setCollapsed(!collapsed)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              setCollapsed(!collapsed);
-            }
-          }}
-        >
-          <span className={styles.toolChevron}>
-            {isExpanded ? "⌄" : "›"}
-          </span>
-          <span className={styles.turnLabel}>
-            {activities.length} tool call{activities.length !== 1 ? "s" : ""}
-            {isRunning && <span className={styles.inProgressNote}> in progress</span>}
-          </span>
-        </div>
-        {isExpanded && (
-          <TurnSegmentedBody
-            segments={segments}
-            activities={activities}
-            searchQuery={searchQuery}
-          />
-        )}
-      </div>
-    </div>
+    <InlineSegments
+      segments={segments}
+      activities={activities}
+      isRunning={isRunning}
+      searchQuery={searchQuery}
+    />
+
   );
 });
 

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -11,6 +11,7 @@ import { debugChat } from "../utils/chatDebug";
 import { extractLatestCallUsage } from "../utils/extractLatestCallUsage";
 import { buildCompactionSentinel } from "../utils/compactionSentinel";
 import { pickMeterUsageFromResult } from "./pickMeterUsageFromResult";
+import { isSubagentTool } from "../utils/toolClassification";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 
@@ -26,6 +27,8 @@ export function useAgentStream() {
   const appendToolActivityInput = useAppStore(
     (s) => s.appendToolActivityInput
   );
+  const appendToolSegment = useAppStore((s) => s.appendToolSegment);
+  const markSegmentBreak = useAppStore((s) => s.markSegmentBreak);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const updateChatSession = useAppStore((s) => s.updateChatSession);
   const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
@@ -226,6 +229,9 @@ export function useAgentStream() {
                   const delta = inner.delta;
                   if ("type" in delta && delta.type === "text_delta") {
                     appendStreamingContent(sessionId, delta.text);
+                    // Text arriving between tools breaks the current
+                    // tool-group segment; the next tool starts a new one.
+                    markSegmentBreak(sessionId);
                   }
                   if (
                     "type" in delta &&
@@ -262,6 +268,7 @@ export function useAgentStream() {
                     delta.thinking
                   ) {
                     appendStreamingThinking(sessionId, delta.thinking);
+                    markSegmentBreak(sessionId);
                   }
                   break;
                 }
@@ -292,6 +299,11 @@ export function useAgentStream() {
                       collapsed: true,
                       summary: "",
                     });
+                    appendToolSegment(
+                      wsId,
+                      inner.content_block.id,
+                      isSubagentTool(inner.content_block.name),
+                    );
                     // Detect plan mode changes from agent tool calls.
                     if (inner.content_block.name === "EnterPlanMode") {
                       setPlanMode(sessionId, true);
@@ -464,6 +476,8 @@ export function useAgentStream() {
     addToolActivity,
     updateToolActivity,
     appendToolActivityInput,
+    appendToolSegment,
+    markSegmentBreak,
     updateWorkspace,
     setAgentQuestion,
     setPlanApproval,
@@ -600,6 +614,18 @@ export function useAgentStream() {
       const savePromise = currentActivities.length > 0
         ? (() => {
             const messageCount = turnMessageCountRef.current[sessionId] || 0;
+            // Build toolUseId → group_id (segment index) so each persisted
+            // activity can be grouped back together on reload.
+            const liveSegments =
+              useAppStore.getState().turnSegments[sessionId] ?? [];
+            const groupByToolUseId = new Map<string, number>();
+            liveSegments.forEach((seg, idx) => {
+              if (seg.kind === "tool-group") {
+                for (const id of seg.toolUseIds) groupByToolUseId.set(id, idx);
+              } else {
+                groupByToolUseId.set(seg.toolUseId, idx);
+              }
+            });
             const activities = currentActivities.map((a, i) => ({
               id: crypto.randomUUID(),
               checkpoint_id: checkpoint.id,
@@ -609,6 +635,7 @@ export function useAgentStream() {
               result_text: a.resultText,
               summary: a.summary,
               sort_order: i,
+              group_id: groupByToolUseId.get(a.toolUseId) ?? null,
             }));
             return saveTurnToolActivities(checkpoint.id, messageCount, activities);
           })()

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -29,6 +29,7 @@ export function useAgentStream() {
   );
   const appendToolSegment = useAppStore((s) => s.appendToolSegment);
   const markSegmentBreak = useAppStore((s) => s.markSegmentBreak);
+  const commitSegments = useAppStore((s) => s.commitSegments);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const updateChatSession = useAppStore((s) => s.updateChatSession);
   const setAgentQuestion = useAppStore((s) => s.setAgentQuestion);
@@ -300,7 +301,7 @@ export function useAgentStream() {
                       summary: "",
                     });
                     appendToolSegment(
-                      wsId,
+                      sessionId,
                       inner.content_block.id,
                       isSubagentTool(inner.content_block.name),
                     );
@@ -399,6 +400,7 @@ export function useAgentStream() {
               // block doesn't vanish between streamingContent clearing and the
               // completed message unhiding. It's cleared atomically with
               // pendingTypewriter at drain-complete via finishTypewriterDrain.
+              commitSegments(sessionId, messageId);
             }
             setStreamingContent(sessionId, "");
             break;
@@ -448,7 +450,14 @@ export function useAgentStream() {
                 const text =
                   typeof block.content === "string"
                     ? block.content
-                    : JSON.stringify(block.content);
+                    : Array.isArray(block.content)
+                      ? block.content
+                          .filter(
+                            (b: { type: string }) => b.type === "text",
+                          )
+                          .map((b: { text: string }) => b.text)
+                          .join("\n")
+                      : String(block.content ?? "");
                 updateToolActivity(sessionId, block.tool_use_id, {
                   resultText: text,
                 });
@@ -478,6 +487,7 @@ export function useAgentStream() {
     appendToolActivityInput,
     appendToolSegment,
     markSegmentBreak,
+    commitSegments,
     updateWorkspace,
     setAgentQuestion,
     setPlanApproval,
@@ -614,17 +624,44 @@ export function useAgentStream() {
       const savePromise = currentActivities.length > 0
         ? (() => {
             const messageCount = turnMessageCountRef.current[sessionId] || 0;
-            // Build toolUseId → group_id (segment index) so each persisted
-            // activity can be grouped back together on reload.
-            const liveSegments =
+            // Build toolUseId → group_id (segment index) AND anchor_ordinal
+            // (which committed group, i.e. which assistant message the tool
+            // landed under). Read both committed groups and trailing live
+            // segments so a checkpoint-created event that fires after
+            // commitSegments has already run still maps every activity.
+            const committed =
+              useAppStore.getState().committedSegmentGroups[sessionId] ?? [];
+            const trailing =
               useAppStore.getState().turnSegments[sessionId] ?? [];
             const groupByToolUseId = new Map<string, number>();
-            liveSegments.forEach((seg, idx) => {
-              if (seg.kind === "tool-group") {
-                for (const id of seg.toolUseIds) groupByToolUseId.set(id, idx);
-              } else {
-                groupByToolUseId.set(seg.toolUseId, idx);
+            const anchorByToolUseId = new Map<string, number>();
+            let groupIdx = 0;
+            committed.forEach((g, ordinal) => {
+              for (const seg of g.segments) {
+                if (seg.kind === "tool-group") {
+                  for (const id of seg.toolUseIds) {
+                    groupByToolUseId.set(id, groupIdx);
+                    anchorByToolUseId.set(id, ordinal);
+                  }
+                } else {
+                  groupByToolUseId.set(seg.toolUseId, groupIdx);
+                  anchorByToolUseId.set(seg.toolUseId, ordinal);
+                }
+                groupIdx++;
               }
+            });
+            const trailingOrdinal = committed.length;
+            trailing.forEach((seg) => {
+              if (seg.kind === "tool-group") {
+                for (const id of seg.toolUseIds) {
+                  groupByToolUseId.set(id, groupIdx);
+                  anchorByToolUseId.set(id, trailingOrdinal);
+                }
+              } else {
+                groupByToolUseId.set(seg.toolUseId, groupIdx);
+                anchorByToolUseId.set(seg.toolUseId, trailingOrdinal);
+              }
+              groupIdx++;
             });
             const activities = currentActivities.map((a, i) => ({
               id: crypto.randomUUID(),
@@ -636,6 +673,7 @@ export function useAgentStream() {
               summary: a.summary,
               sort_order: i,
               group_id: groupByToolUseId.get(a.toolUseId) ?? null,
+              anchor_ordinal: anchorByToolUseId.get(a.toolUseId) ?? null,
             }));
             return saveTurnToolActivities(checkpoint.id, messageCount, activities);
           })()

--- a/src/ui/src/stores/useAppStore.segments.test.ts
+++ b/src/ui/src/stores/useAppStore.segments.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "./useAppStore";
+
+const WS_ID = "ws-segments";
+
+function resetSegmentState() {
+  useAppStore.setState({
+    toolActivities: { [WS_ID]: [] },
+    turnSegments: { [WS_ID]: [] },
+    segmentBreakPending: { [WS_ID]: false },
+    chatMessages: { [WS_ID]: [] },
+    completedTurns: { [WS_ID]: [] },
+  });
+}
+
+/** Helper: register a tool activity in the store the way useAgentStream does
+ *  — needed because finalizeTurn is a no-op when `toolActivities` is empty. */
+function registerTool(toolUseId: string, toolName: string) {
+  useAppStore.setState((s) => ({
+    toolActivities: {
+      ...s.toolActivities,
+      [WS_ID]: [
+        ...(s.toolActivities[WS_ID] ?? []),
+        {
+          toolUseId,
+          toolName,
+          inputJson: "{}",
+          resultText: "",
+          collapsed: true,
+          summary: "",
+        },
+      ],
+    },
+  }));
+}
+
+describe("appendToolSegment / markSegmentBreak", () => {
+  beforeEach(() => {
+    resetSegmentState();
+  });
+
+  it("consecutive tools without a break merge into one tool-group", () => {
+    const { appendToolSegment } = useAppStore.getState();
+    appendToolSegment(WS_ID, "t1", false);
+    appendToolSegment(WS_ID, "t2", false);
+    appendToolSegment(WS_ID, "t3", false);
+
+    const segs = useAppStore.getState().turnSegments[WS_ID];
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t1", "t2", "t3"],
+    });
+  });
+
+  it("text/thinking between tools breaks the group", () => {
+    const { appendToolSegment, markSegmentBreak } = useAppStore.getState();
+    appendToolSegment(WS_ID, "t1", false);
+    appendToolSegment(WS_ID, "t2", false);
+    markSegmentBreak(WS_ID);
+    appendToolSegment(WS_ID, "t3", false);
+
+    const segs = useAppStore.getState().turnSegments[WS_ID];
+    expect(segs).toHaveLength(2);
+    expect(segs[0]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t1", "t2"],
+    });
+    expect(segs[1]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t3"],
+    });
+  });
+
+  it("subagent calls always get their own segment, never merged", () => {
+    const { appendToolSegment } = useAppStore.getState();
+    appendToolSegment(WS_ID, "t1", false);
+    appendToolSegment(WS_ID, "sub1", true);
+    appendToolSegment(WS_ID, "t2", false);
+
+    const segs = useAppStore.getState().turnSegments[WS_ID];
+    expect(segs).toHaveLength(3);
+    expect(segs[0]).toMatchObject({ kind: "tool-group", toolUseIds: ["t1"] });
+    expect(segs[1]).toMatchObject({ kind: "subagent", toolUseId: "sub1" });
+    expect(segs[2]).toMatchObject({ kind: "tool-group", toolUseIds: ["t2"] });
+  });
+
+  it("a non-subagent tool after a subagent opens a new tool-group", () => {
+    // Because the trailing segment is `subagent`, the merging rule's
+    // "append to last tool-group" branch doesn't apply.
+    const { appendToolSegment } = useAppStore.getState();
+    appendToolSegment(WS_ID, "sub1", true);
+    appendToolSegment(WS_ID, "t1", false);
+
+    const segs = useAppStore.getState().turnSegments[WS_ID];
+    expect(segs).toHaveLength(2);
+    expect(segs[0].kind).toBe("subagent");
+    expect(segs[1]).toMatchObject({ kind: "tool-group", toolUseIds: ["t1"] });
+  });
+
+  it("markSegmentBreak is idempotent — repeated breaks before any tool only break once", () => {
+    const { appendToolSegment, markSegmentBreak } = useAppStore.getState();
+    appendToolSegment(WS_ID, "t1", false);
+    markSegmentBreak(WS_ID);
+    markSegmentBreak(WS_ID);
+    markSegmentBreak(WS_ID);
+    appendToolSegment(WS_ID, "t2", false);
+
+    const segs = useAppStore.getState().turnSegments[WS_ID];
+    expect(segs).toHaveLength(2);
+    expect(segs[0]).toMatchObject({ kind: "tool-group", toolUseIds: ["t1"] });
+  });
+
+  it("appending a tool clears the pending break flag", () => {
+    const { appendToolSegment, markSegmentBreak } = useAppStore.getState();
+    markSegmentBreak(WS_ID);
+    appendToolSegment(WS_ID, "t1", false);
+
+    expect(useAppStore.getState().segmentBreakPending[WS_ID]).toBe(false);
+  });
+});
+
+describe("finalizeTurn snapshots segments", () => {
+  beforeEach(() => {
+    resetSegmentState();
+  });
+
+  it("copies live segments onto the CompletedTurn and clears the slice", () => {
+    const { appendToolSegment, markSegmentBreak, finalizeTurn } =
+      useAppStore.getState();
+    registerTool("t1", "Read");
+    appendToolSegment(WS_ID, "t1", false);
+    registerTool("t2", "Read");
+    appendToolSegment(WS_ID, "t2", false);
+    markSegmentBreak(WS_ID);
+    registerTool("t3", "Bash");
+    appendToolSegment(WS_ID, "t3", false);
+
+    finalizeTurn(WS_ID, 1);
+
+    const turn = useAppStore.getState().completedTurns[WS_ID][0];
+    expect(turn.segments).toHaveLength(2);
+    expect(turn.segments![0]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t1", "t2"],
+    });
+    expect(turn.segments![1]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t3"],
+    });
+    // Slice is cleared after finalization.
+    expect(useAppStore.getState().turnSegments[WS_ID]).toEqual([]);
+    expect(useAppStore.getState().segmentBreakPending[WS_ID]).toBe(false);
+  });
+
+  it("falls back to a single tool-group when no live segments were captured", () => {
+    // Simulates a hydration / stream-bypass path where toolActivities exist
+    // but the stream handler never invoked appendToolSegment.
+    const { finalizeTurn } = useAppStore.getState();
+    registerTool("t1", "Read");
+    registerTool("t2", "Read");
+
+    finalizeTurn(WS_ID, 1);
+
+    const turn = useAppStore.getState().completedTurns[WS_ID][0];
+    expect(turn.segments).toHaveLength(1);
+    expect(turn.segments![0]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t1", "t2"],
+    });
+  });
+});

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -86,9 +86,26 @@ export interface ToolActivity {
   summary: string;
 }
 
+/**
+ * Ordered render unit inside a turn. Groups of consecutive non-subagent tool
+ * calls render as a single `tool-group`; subagents (Task/Agent) always get
+ * their own `subagent` segment so per-agent status UI can be attached later.
+ * Text or thinking arriving between tools "breaks" the current group so the
+ * next tool starts a fresh segment. Text and thinking themselves are rendered
+ * via the existing `ChatMessage` bubbles and streaming components — they are
+ * not stored as segments; only their boundary effect on tool grouping matters.
+ */
+export type TurnSegment =
+  | { kind: "tool-group"; id: string; toolUseIds: string[] }
+  | { kind: "subagent"; id: string; toolUseId: string };
+
 export interface CompletedTurn {
   id: string;
   activities: ToolActivity[];
+  /** Ordered segments for this turn. Absent on legacy (pre-segment-column)
+   *  rows — the renderer treats an undefined `segments` as "one tool-group
+   *  containing every activity" so older turns still display sensibly. */
+  segments?: TurnSegment[];
   messageCount: number;
   collapsed: boolean;
   /** Index into chatMessages at the time of finalization — used to render
@@ -208,6 +225,13 @@ interface AppState {
   pendingTypewriter: Record<string, { messageId: string; text: string } | null>;
   showThinkingBlocks: Record<string, boolean>;
   toolActivities: Record<string, ToolActivity[]>;
+  /** Per-workspace ordered segments for the *in-progress* turn. Finalized
+   *  into `CompletedTurn.segments` by `finalizeTurn` and cleared. */
+  turnSegments: Record<string, TurnSegment[]>;
+  /** Transient flag: text or thinking has arrived since the last tool call,
+   *  so the next tool must start a fresh tool-group segment. Cleared when
+   *  the next tool is appended or when the turn finalizes. */
+  segmentBreakPending: Record<string, boolean>;
   completedTurns: Record<string, CompletedTurn[]>;
   /** Latest `result.usage` values per workspace — kept in sync with every
    *  turn end, including tool-free turns that don't produce a CompletedTurn.
@@ -270,6 +294,17 @@ interface AppState {
     toolUseId: string,
     partialJson: string,
   ) => void;
+  /** Append a tool call to the in-progress turn's segment list. A subagent
+   *  call, or any call after a pending break, starts a new segment; otherwise
+   *  the call extends the trailing `tool-group`. Clears `segmentBreakPending`. */
+  appendToolSegment: (
+    wsId: string,
+    toolUseId: string,
+    isSubagent: boolean,
+  ) => void;
+  /** Mark that text or thinking has arrived, so the next tool call will
+   *  start a new segment rather than merging into the trailing tool-group. */
+  markSegmentBreak: (wsId: string) => void;
 
   // -- Agent Questions (per-session) --
   agentQuestions: Record<string, AgentQuestion>;
@@ -807,6 +842,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   pendingTypewriter: {},
   showThinkingBlocks: {},
   toolActivities: {},
+  turnSegments: {},
+  segmentBreakPending: {},
   completedTurns: {},
   latestTurnUsage: {},
   setLatestTurnUsage: (wsId, usage) =>
@@ -934,6 +971,44 @@ export const useAppStore = create<AppState>((set, get) => ({
         ),
       },
     })),
+  appendToolSegment: (wsId, toolUseId, isSubagent) =>
+    set((s) => {
+      const segs = s.turnSegments[wsId] ?? [];
+      const last = segs[segs.length - 1];
+      const breakPending = s.segmentBreakPending[wsId] === true;
+      let next: TurnSegment[];
+      if (isSubagent) {
+        next = [
+          ...segs,
+          { kind: "subagent", id: crypto.randomUUID(), toolUseId },
+        ];
+      } else if (!breakPending && last?.kind === "tool-group") {
+        next = segs.slice(0, -1).concat({
+          ...last,
+          toolUseIds: [...last.toolUseIds, toolUseId],
+        });
+      } else {
+        next = [
+          ...segs,
+          {
+            kind: "tool-group",
+            id: crypto.randomUUID(),
+            toolUseIds: [toolUseId],
+          },
+        ];
+      }
+      return {
+        turnSegments: { ...s.turnSegments, [wsId]: next },
+        segmentBreakPending: { ...s.segmentBreakPending, [wsId]: false },
+      };
+    }),
+  markSegmentBreak: (wsId) =>
+    set((s) => {
+      if (s.segmentBreakPending[wsId] === true) return {};
+      return {
+        segmentBreakPending: { ...s.segmentBreakPending, [wsId]: true },
+      };
+    }),
   finalizeTurn: (
     wsId,
     messageCount,
@@ -963,6 +1038,23 @@ export const useAppStore = create<AppState>((set, get) => ({
         });
         return {};
       }
+      const liveSegments = s.turnSegments[wsId] ?? [];
+      const segments: TurnSegment[] = liveSegments.length > 0
+        ? liveSegments.map((seg) =>
+            seg.kind === "tool-group"
+              ? { ...seg, toolUseIds: [...seg.toolUseIds] }
+              : { ...seg },
+          )
+        : // No live segments captured (e.g. hydration path or a turn that
+          // bypassed the stream handler) — fall back to one tool-group with
+          // every activity so the renderer still has a structure to iterate.
+          [
+            {
+              kind: "tool-group",
+              id: crypto.randomUUID(),
+              toolUseIds: activities.map((a) => a.toolUseId),
+            },
+          ];
       const turn: CompletedTurn = {
         id: turnId ?? crypto.randomUUID(),
         activities: activities.map((a) => ({
@@ -973,6 +1065,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           collapsed: true,
           summary: a.summary,
         })),
+        segments,
         messageCount,
         collapsed: true,
         afterMessageIndex: (s.chatMessages[wsId] || []).length,
@@ -999,6 +1092,8 @@ export const useAppStore = create<AppState>((set, get) => ({
           [wsId]: [...(s.completedTurns[wsId] || []), turn],
         },
         toolActivities: { ...s.toolActivities, [wsId]: [] },
+        turnSegments: { ...s.turnSegments, [wsId]: [] },
+        segmentBreakPending: { ...s.segmentBreakPending, [wsId]: false },
       };
     }),
   hydrateCompletedTurns: (wsId, turns) =>
@@ -1221,6 +1316,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         lastMessages: updatedLastMessages,
         completedTurns: { ...s.completedTurns, [sessionId]: [] },
         toolActivities: { ...s.toolActivities, [sessionId]: [] },
+        turnSegments: { ...s.turnSegments, [sessionId]: [] },
+        segmentBreakPending: { ...s.segmentBreakPending, [sessionId]: false },
         streamingContent: { ...s.streamingContent, [sessionId]: "" },
         streamingThinking: { ...s.streamingThinking, [sessionId]: "" },
         agentQuestions: restQuestions,

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -136,6 +136,15 @@ export interface CompletedTurn {
   /** Turn-total cache-creation tokens. Same max-based reconstruction semantics
    *  as `cacheReadTokens`. */
   cacheCreationTokens?: number;
+  /** Per-message segment positioning. Each entry maps a committed segment
+   *  group to the assistant message it appeared after. When present, segments
+   *  render inline after their message instead of aggregated in TurnSummary.
+   *  Absent on legacy turns or single-message turns. */
+  segmentGroups?: Array<{
+    afterMessageId: string;
+    segments: TurnSegment[];
+    activityToolUseIds: string[];
+  }>;
 }
 
 export interface AgentQuestionItem {
@@ -232,6 +241,20 @@ interface AppState {
    *  so the next tool must start a fresh tool-group segment. Cleared when
    *  the next tool is appended or when the turn finalizes. */
   segmentBreakPending: Record<string, boolean>;
+  /** Segments that have been "committed" to a specific message position.
+   *  When an assistant message finalizes mid-turn, the current
+   *  `turnSegments` are snapshotted here with their matching activities.
+   *  `MessagesWithTurns` subscribes to this (infrequently-changing) slice
+   *  to render segments inline after the message they belong to.
+   *  Cleared on turn finalization. */
+  committedSegmentGroups: Record<
+    string,
+    Array<{
+      afterMessageId: string;
+      segments: TurnSegment[];
+      activities: ToolActivity[];
+    }>
+  >;
   completedTurns: Record<string, CompletedTurn[]>;
   /** Latest `result.usage` values per workspace — kept in sync with every
    *  turn end, including tool-free turns that don't produce a CompletedTurn.
@@ -305,6 +328,12 @@ interface AppState {
   /** Mark that text or thinking has arrived, so the next tool call will
    *  start a new segment rather than merging into the trailing tool-group. */
   markSegmentBreak: (wsId: string) => void;
+  /** Snapshot the current `turnSegments` and their matching
+   *  `toolActivities` into `committedSegmentGroups`, anchored to the
+   *  just-finalized assistant message. Called from useAgentStream on the
+   *  `assistant` event. Resets `turnSegments` and `segmentBreakPending`
+   *  so the next message's tool calls start from a clean slate. */
+  commitSegments: (wsId: string, messageId: string) => void;
 
   // -- Agent Questions (per-session) --
   agentQuestions: Record<string, AgentQuestion>;
@@ -844,6 +873,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   toolActivities: {},
   turnSegments: {},
   segmentBreakPending: {},
+  committedSegmentGroups: {},
   completedTurns: {},
   latestTurnUsage: {},
   setLatestTurnUsage: (wsId, usage) =>
@@ -1004,9 +1034,43 @@ export const useAppStore = create<AppState>((set, get) => ({
     }),
   markSegmentBreak: (wsId) =>
     set((s) => {
-      if (s.segmentBreakPending[wsId] === true) return {};
+      if (s.segmentBreakPending[wsId] === true) return s;
       return {
         segmentBreakPending: { ...s.segmentBreakPending, [wsId]: true },
+      };
+    }),
+  commitSegments: (wsId, messageId) =>
+    set((s) => {
+      const segs = s.turnSegments[wsId] ?? [];
+      if (segs.length === 0) return {};
+      const allActivities = s.toolActivities[wsId] ?? [];
+      const toolIdsInSegs = new Set<string>();
+      for (const seg of segs) {
+        if (seg.kind === "tool-group") {
+          for (const id of seg.toolUseIds) toolIdsInSegs.add(id);
+        } else {
+          toolIdsInSegs.add(seg.toolUseId);
+        }
+      }
+      const snapshotActivities = allActivities
+        .filter((a) => toolIdsInSegs.has(a.toolUseId))
+        .map((a) => ({ ...a }));
+      const entry = {
+        afterMessageId: messageId,
+        segments: segs.map((seg) =>
+          seg.kind === "tool-group"
+            ? { ...seg, toolUseIds: [...seg.toolUseIds] }
+            : { ...seg },
+        ),
+        activities: snapshotActivities,
+      };
+      return {
+        committedSegmentGroups: {
+          ...s.committedSegmentGroups,
+          [wsId]: [...(s.committedSegmentGroups[wsId] ?? []), entry],
+        },
+        turnSegments: { ...s.turnSegments, [wsId]: [] },
+        segmentBreakPending: { ...s.segmentBreakPending, [wsId]: false },
       };
     }),
   finalizeTurn: (
@@ -1020,12 +1084,6 @@ export const useAppStore = create<AppState>((set, get) => ({
     cacheCreationTokens,
   ) =>
     set((s) => {
-      // Phase 2.5: finalizeTurn no longer writes latestTurnUsage. The
-      // meter needs per-call values, not the turn-aggregate we receive
-      // here — useAgentStream's result handler calls setLatestTurnUsage
-      // separately with the correct per-call data. The tokens we DO
-      // receive here stay as CompletedTurn aggregate fields for the
-      // TurnFooter's "turn-total work" view.
       const activities = s.toolActivities[wsId] || [];
       if (activities.length === 0) {
         debugChat("store", "finalizeTurn skipped", {
@@ -1038,23 +1096,44 @@ export const useAppStore = create<AppState>((set, get) => ({
         });
         return {};
       }
-      const liveSegments = s.turnSegments[wsId] ?? [];
-      const segments: TurnSegment[] = liveSegments.length > 0
-        ? liveSegments.map((seg) =>
+      const committed = s.committedSegmentGroups[wsId] ?? [];
+      const trailing = s.turnSegments[wsId] ?? [];
+      const allSegments: TurnSegment[] = [
+        ...committed.flatMap((g) =>
+          g.segments.map((seg) =>
             seg.kind === "tool-group"
               ? { ...seg, toolUseIds: [...seg.toolUseIds] }
               : { ...seg },
-          )
-        : // No live segments captured (e.g. hydration path or a turn that
-          // bypassed the stream handler) — fall back to one tool-group with
-          // every activity so the renderer still has a structure to iterate.
-          [
-            {
-              kind: "tool-group",
-              id: crypto.randomUUID(),
-              toolUseIds: activities.map((a) => a.toolUseId),
-            },
-          ];
+          ),
+        ),
+        ...trailing.map((seg) =>
+          seg.kind === "tool-group"
+            ? { ...seg, toolUseIds: [...seg.toolUseIds] }
+            : { ...seg },
+        ),
+      ];
+      const segments: TurnSegment[] =
+        allSegments.length > 0
+          ? allSegments
+          : [
+              {
+                kind: "tool-group",
+                id: crypto.randomUUID(),
+                toolUseIds: activities.map((a) => a.toolUseId),
+              },
+            ];
+      const segmentGroups =
+        committed.length > 0
+          ? committed.map((g) => ({
+              afterMessageId: g.afterMessageId,
+              segments: g.segments.map((seg) =>
+                seg.kind === "tool-group"
+                  ? { ...seg, toolUseIds: [...seg.toolUseIds] }
+                  : { ...seg },
+              ),
+              activityToolUseIds: g.activities.map((a) => a.toolUseId),
+            }))
+          : undefined;
       const turn: CompletedTurn = {
         id: turnId ?? crypto.randomUUID(),
         activities: activities.map((a) => ({
@@ -1066,6 +1145,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           summary: a.summary,
         })),
         segments,
+        segmentGroups,
         messageCount,
         collapsed: true,
         afterMessageIndex: (s.chatMessages[wsId] || []).length,
@@ -1094,6 +1174,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         toolActivities: { ...s.toolActivities, [wsId]: [] },
         turnSegments: { ...s.turnSegments, [wsId]: [] },
         segmentBreakPending: { ...s.segmentBreakPending, [wsId]: false },
+        committedSegmentGroups: {
+          ...s.committedSegmentGroups,
+          [wsId]: [],
+        },
       };
     }),
   hydrateCompletedTurns: (wsId, turns) =>
@@ -1318,6 +1402,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         toolActivities: { ...s.toolActivities, [sessionId]: [] },
         turnSegments: { ...s.turnSegments, [sessionId]: [] },
         segmentBreakPending: { ...s.segmentBreakPending, [sessionId]: false },
+        committedSegmentGroups: {
+          ...s.committedSegmentGroups,
+          [sessionId]: [],
+        },
         streamingContent: { ...s.streamingContent, [sessionId]: "" },
         streamingThinking: { ...s.streamingThinking, [sessionId]: "" },
         agentQuestions: restQuestions,

--- a/src/ui/src/types/checkpoint.ts
+++ b/src/ui/src/types/checkpoint.ts
@@ -18,6 +18,11 @@ export interface TurnToolActivityData {
   result_text: string;
   summary: string;
   sort_order: number;
+  /** Index of the segment this activity belongs to within its turn. Activities
+   *  sharing a `group_id` render as a single tool-group; distinct values
+   *  become distinct groups or subagent cards. Null on legacy rows persisted
+   *  before the segment column existed — the reader treats those as one group. */
+  group_id?: number | null;
 }
 
 export interface CompletedTurnData {

--- a/src/ui/src/types/checkpoint.ts
+++ b/src/ui/src/types/checkpoint.ts
@@ -23,6 +23,10 @@ export interface TurnToolActivityData {
    *  become distinct groups or subagent cards. Null on legacy rows persisted
    *  before the segment column existed — the reader treats those as one group. */
   group_id?: number | null;
+  /** 0-based index of the committed segment group within the turn. The Nth
+   *  group anchors to the Nth assistant message in the turn's message span.
+   *  Null on legacy rows — falls back to aggregated TurnSummary rendering. */
+  anchor_ordinal?: number | null;
 }
 
 export interface CompletedTurnData {

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -243,6 +243,132 @@ describe("reconstructCompletedTurns", () => {
     expect(result[0].commitHash).toBe("abc123");
   });
 
+  it("leaves segments undefined when every activity has null group_id (legacy rows)", () => {
+    // Legacy turns persisted before the group_id column existed. The renderer
+    // treats absent `segments` as "one flat tool-group" — preserving the
+    // pre-migration visual exactly.
+    const messages = [makeMsg("m1")];
+    const turnData = [makeTurnData("cp1", "m1", 3)];
+    // `makeTurnData` doesn't set group_id → all activities get undefined.
+    const result = reconstructCompletedTurns(messages, turnData);
+    expect(result[0].segments).toBeUndefined();
+  });
+
+  it("derives one tool-group segment per distinct group_id, preserving order", () => {
+    const messages = [makeMsg("m1")];
+    const turnData: CompletedTurnData[] = [
+      {
+        checkpoint_id: "cp1",
+        message_id: "m1",
+        turn_index: 0,
+        message_count: 1,
+        commit_hash: null,
+        activities: [
+          {
+            id: "act-1",
+            checkpoint_id: "cp1",
+            tool_use_id: "t1",
+            tool_name: "Read",
+            input_json: "{}",
+            result_text: "",
+            summary: "",
+            sort_order: 0,
+            group_id: 0,
+          },
+          {
+            id: "act-2",
+            checkpoint_id: "cp1",
+            tool_use_id: "t2",
+            tool_name: "Read",
+            input_json: "{}",
+            result_text: "",
+            summary: "",
+            sort_order: 1,
+            group_id: 0,
+          },
+          {
+            id: "act-3",
+            checkpoint_id: "cp1",
+            tool_use_id: "t3",
+            tool_name: "Read",
+            input_json: "{}",
+            result_text: "",
+            summary: "",
+            sort_order: 2,
+            group_id: 1,
+          },
+        ],
+      },
+    ];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+    const segs = result[0].segments!;
+    expect(segs).toHaveLength(2);
+    expect(segs[0]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t1", "t2"],
+    });
+    expect(segs[1]).toMatchObject({
+      kind: "tool-group",
+      toolUseIds: ["t3"],
+    });
+  });
+
+  it("reconstructs a solo Task/Agent group as a subagent segment", () => {
+    const messages = [makeMsg("m1")];
+    const turnData: CompletedTurnData[] = [
+      {
+        checkpoint_id: "cp1",
+        message_id: "m1",
+        turn_index: 0,
+        message_count: 1,
+        commit_hash: null,
+        activities: [
+          {
+            id: "act-1",
+            checkpoint_id: "cp1",
+            tool_use_id: "t1",
+            tool_name: "Read",
+            input_json: "{}",
+            result_text: "",
+            summary: "",
+            sort_order: 0,
+            group_id: 0,
+          },
+          {
+            id: "act-2",
+            checkpoint_id: "cp1",
+            tool_use_id: "t2",
+            tool_name: "Task",
+            input_json: "{}",
+            result_text: "",
+            summary: "",
+            sort_order: 1,
+            group_id: 1,
+          },
+          {
+            id: "act-3",
+            checkpoint_id: "cp1",
+            tool_use_id: "t3",
+            tool_name: "Agent",
+            input_json: "{}",
+            result_text: "",
+            summary: "",
+            sort_order: 2,
+            group_id: 2,
+          },
+        ],
+      },
+    ];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+    const segs = result[0].segments!;
+    expect(segs).toHaveLength(3);
+    expect(segs[0]).toMatchObject({ kind: "tool-group" });
+    expect(segs[1]).toMatchObject({ kind: "subagent", toolUseId: "t2" });
+    expect(segs[2]).toMatchObject({ kind: "subagent", toolUseId: "t3" });
+  });
+
   it("maps activity fields correctly", () => {
     const messages = [makeMsg("m1")];
     const turnData: CompletedTurnData[] = [

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -1,7 +1,69 @@
-import type { CompletedTurn } from "../stores/useAppStore";
+import type { CompletedTurn, TurnSegment } from "../stores/useAppStore";
 import type { ChatMessage } from "../types/chat";
-import type { CompletedTurnData } from "../types/checkpoint";
+import type {
+  CompletedTurnData,
+  TurnToolActivityData,
+} from "../types/checkpoint";
 import { debugChat } from "./chatDebug";
+import { isSubagentTool } from "./toolClassification";
+
+/**
+ * Rebuild the segment list for a completed turn from the persisted
+ * `group_id` on each activity. Rows that share a `group_id` collapse into
+ * one tool-group (or a subagent segment if the group is a lone Task/Agent
+ * call). Legacy rows — all `group_id` missing/null — fall back to a single
+ * tool-group covering every activity so pre-migration turns still render.
+ */
+function deriveSegmentsFromActivities(
+  activities: TurnToolActivityData[],
+): TurnSegment[] | undefined {
+  if (activities.length === 0) return undefined;
+
+  const anyGroupId = activities.some(
+    (a) => a.group_id !== null && a.group_id !== undefined,
+  );
+  if (!anyGroupId) return undefined;
+
+  const segments: TurnSegment[] = [];
+  let currentKey: number | null = null;
+  let currentBucket: TurnToolActivityData[] = [];
+
+  const flush = () => {
+    if (currentBucket.length === 0) return;
+    const first = currentBucket[0];
+    const isSoloSubagent =
+      currentBucket.length === 1 && isSubagentTool(first.tool_name);
+    if (isSoloSubagent) {
+      segments.push({
+        kind: "subagent",
+        id: `seg-sub-${first.tool_use_id}`,
+        toolUseId: first.tool_use_id,
+      });
+    } else {
+      segments.push({
+        kind: "tool-group",
+        id: `seg-grp-${first.tool_use_id}`,
+        toolUseIds: currentBucket.map((a) => a.tool_use_id),
+      });
+    }
+    currentBucket = [];
+  };
+
+  for (const a of activities) {
+    const key = a.group_id ?? null;
+    if (currentBucket.length === 0 || key === currentKey) {
+      currentBucket.push(a);
+      currentKey = key;
+    } else {
+      flush();
+      currentBucket.push(a);
+      currentKey = key;
+    }
+  }
+  flush();
+
+  return segments.length > 0 ? segments : undefined;
+}
 
 /**
  * Reconstruct CompletedTurn[] from persisted turn data and loaded messages.
@@ -77,6 +139,7 @@ export function reconstructCompletedTurns(
         collapsed: true,
         summary: a.summary,
       })),
+      segments: deriveSegmentsFromActivities(td.activities),
       messageCount: td.message_count,
       collapsed: true,
       afterMessageIndex,

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -129,6 +129,36 @@ export function reconstructCompletedTurns(
         0,
       ) || undefined;
 
+    const anyAnchor = td.activities.some(
+      (a) => a.anchor_ordinal != null,
+    );
+    let segmentGroups: CompletedTurn["segmentGroups"] = undefined;
+    if (anyAnchor) {
+      const byOrdinal = new Map<number, TurnToolActivityData[]>();
+      for (const a of td.activities) {
+        const ord = a.anchor_ordinal ?? 0;
+        const bucket = byOrdinal.get(ord);
+        if (bucket) bucket.push(a);
+        else byOrdinal.set(ord, [a]);
+      }
+      segmentGroups = [...byOrdinal.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([ordinal, acts]) => {
+          const anchorMsg = turnAssistantMessages[ordinal];
+          return {
+            afterMessageId: anchorMsg?.id ?? td.message_id,
+            segments: deriveSegmentsFromActivities(acts) ?? [
+              {
+                kind: "tool-group" as const,
+                id: `seg-grp-${acts[0].tool_use_id}`,
+                toolUseIds: acts.map((a) => a.tool_use_id),
+              },
+            ],
+            activityToolUseIds: acts.map((a) => a.tool_use_id),
+          };
+        });
+    }
+
     return {
       id: td.checkpoint_id,
       activities: td.activities.map((a) => ({
@@ -140,6 +170,7 @@ export function reconstructCompletedTurns(
         summary: a.summary,
       })),
       segments: deriveSegmentsFromActivities(td.activities),
+      segmentGroups,
       messageCount: td.message_count,
       collapsed: true,
       afterMessageIndex,

--- a/src/ui/src/utils/toolClassification.ts
+++ b/src/ui/src/utils/toolClassification.ts
@@ -1,0 +1,8 @@
+export const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "Task",
+  "Agent",
+]);
+
+export function isSubagentTool(toolName: string): boolean {
+  return SUBAGENT_TOOL_NAMES.has(toolName);
+}


### PR DESCRIPTION
## Summary

- Consecutive tool calls during a turn now merge into collapsible **tool-group segments** that break when text or thinking arrives between them, so tool grouping reflects the actual interleaving in the conversation
- `Task` and `Agent` tool calls render as standalone **subagent cards** — preparing a mount point for per-agent streaming UI
- Grouping persists across app restarts via a new `group_id` column on `turn_tool_activities`; legacy rows (NULL) fall back to the existing single-group rendering

## Changes

### Rust (persistence)
- **Migration** `20260424170614_turn_tool_activity_group_id.sql` — `ALTER TABLE turn_tool_activities ADD COLUMN group_id INTEGER`
- **`model/checkpoint.rs`** — `group_id: Option<i32>` on `TurnToolActivity`
- **`db.rs`** — write and read `group_id` in `insert_turn_tool_activities`, `save_turn_tool_activities`, `list_completed_turns`
- **`fork.rs`** — preserves `group_id` across checkpoint remaps

### TypeScript (state + streaming)
- **`toolClassification.ts`** (new) — `isSubagentTool("Task" | "Agent")`
- **`useAppStore.ts`** — `TurnSegment` type, `turnSegments`/`segmentBreakPending` slices, `appendToolSegment`/`markSegmentBreak` actions, `finalizeTurn` snapshots segments
- **`useAgentStream.ts`** — text/thinking deltas mark segment breaks; `tool_use` blocks call `appendToolSegment`; persistence path writes `group_id` from live segments
- **`reconstructTurns.ts`** — derives `segments` from persisted `group_id` values on reload
- **`checkpoint.ts`** — `group_id?: number | null` on `TurnToolActivityData`

### UI (rendering)
- **`ChatPanel.tsx`** — `ToolGroupBox`, `SubagentCard`, `TurnSegmentedBody` components; both `TurnSummary` (completed) and `ToolActivitiesSection` (live) render via segments
- **`ChatPanel.module.css`** — styles for `.turnSegments`, `.toolGroupBox`, `.subagentCard`

### Tests
- `useAppStore.segments.test.ts` — 8 tests: grouping, breaks, subagent isolation, finalize snapshot/fallback
- `reconstructTurns.test.ts` — 3 new tests: legacy-null fallback, group_id grouping, subagent reconstruction
- `db.rs` — `test_tool_activity_group_id_round_trip` (Rust)

## Test plan

- [ ] `cargo test --all-features` passes (680 tests)
- [ ] `cd src/ui && bunx tsc -b` clean
- [ ] `cd src/ui && bun run test` passes (674 tests)
- [ ] `cargo clippy --workspace --all-targets` clean on `claudette`/`claudette-server`
- [ ] Manual: run a prompt that emits text → tool → text → tool; confirm groups split at text boundaries
- [ ] Manual: run a prompt that spawns a subagent (Task tool); confirm it renders as a distinct card
- [ ] Manual: restart app, reopen workspace; confirm grouping is preserved on reload
- [ ] Manual: load a workspace with pre-migration history; confirm legacy turns render as before (single flat list)