### PR TITLE
chore: ignore .agents/ Codex skills export directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ tags
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 
+# OpenAI Codex (skills exported from .claude/skills/ via codex-export)
+.agents/
+
 # Superpowers brainstorm
 .superpowers/
 


### PR DESCRIPTION
## Summary
- Add `.agents/` to `.gitignore` so the OpenAI Codex CLI skills directory stays local.
- Tools like `codex-export` mirror `.claude/skills/` into `.agents/skills/` for Codex's discovery convention (Codex scans `.agents/skills` from cwd up to the repo root). The exported copies are derived from `.claude/skills/`, so versioning them would create two sources of truth.

## Test plan
- [x] `git check-ignore -v .agents/skills/claudette-debug/SKILL.md` matches the new rule
- [x] `git status` no longer reports `.agents/` as untracked