### PR TITLE
feat(chat): hide 1M context models when CLAUDE_CODE_DISABLE_1M_CONTEXT is set

### DIFF
--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -576,6 +576,23 @@ pub fn spawn_repo_env_warmup(app: AppHandle, repo_id: String) {
     });
 }
 
+/// Flags derived from the host process environment that the frontend needs
+/// to adjust UI behaviour.
+#[derive(Serialize)]
+pub struct HostEnvFlags {
+    pub disable_1m_context: bool,
+}
+
+/// Return environment-derived flags from the host process. Unlike app
+/// settings (stored in the database), these reflect the environment in
+/// which Claudette was launched and cannot be changed at runtime.
+#[tauri::command]
+pub fn get_host_env_flags() -> HostEnvFlags {
+    HostEnvFlags {
+        disable_1m_context: std::env::var("CLAUDE_CODE_DISABLE_1M_CONTEXT").is_ok(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -574,6 +574,7 @@ fn main() {
             commands::env::reload_env,
             commands::env::set_env_provider_enabled,
             commands::env::run_env_trust,
+            commands::env::get_host_env_flags,
             // Claudette Lua plugins (SCM + env-provider) settings surface
             commands::plugins_runtime::list_claudette_plugins,
             commands::plugins_runtime::set_claudette_plugin_enabled,

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -143,7 +143,7 @@ function App() {
       .then((val) => { if (val === "true") setPluginManagementEnabled(true); })
       .catch(() => {});
     getHostEnvFlags()
-      .then(({ disable1mContext }) => { if (disable1mContext) setDisable1mContext(true); })
+      .then(({ disable_1m_context }) => { if (disable_1m_context) setDisable1mContext(true); })
       .catch(() => {});
 
     // Listen for terminal command events

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData, getAppSetting, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, clearAttention, detectInstalledApps, listSystemFonts } from "./services/tauri";
+import { loadInitialData, getAppSetting, getHostEnvFlags, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, clearAttention, detectInstalledApps, listSystemFonts } from "./services/tauri";
 import { applyTheme, applyUserFonts, loadAllThemes, findTheme } from "./utils/theme";
 import { adjustUiFontSize, resetUiFontSize } from "./utils/fontSettings";
 import { useMcpStatus } from "./hooks/useMcpStatus";
@@ -29,6 +29,7 @@ function App() {
   const setDetectedApps = useAppStore((s) => s.setDetectedApps);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
   const setPluginManagementEnabled = useAppStore((s) => s.setPluginManagementEnabled);
+  const setDisable1mContext = useAppStore((s) => s.setDisable1mContext);
   const setAppVersion = useAppStore((s) => s.setAppVersion);
 
   // Listen for MCP supervisor status events from the Rust backend.
@@ -140,6 +141,9 @@ function App() {
       .catch(() => {});
     getAppSetting("plugin_management_enabled")
       .then((val) => { if (val === "true") setPluginManagementEnabled(true); })
+      .catch(() => {});
+    getHostEnvFlags()
+      .then(({ disable1mContext }) => { if (disable1mContext) setDisable1mContext(true); })
       .catch(() => {});
 
     // Listen for terminal command events
@@ -275,7 +279,7 @@ function App() {
       unlistenAutoArchived.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setPluginManagementEnabled, setAppVersion]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setPluginManagementEnabled, setDisable1mContext, setAppVersion]);
 
   return <AppLayout />;
 }

--- a/src/ui/src/components/chat/ModelSelector.tsx
+++ b/src/ui/src/components/chat/ModelSelector.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { CircleDollarSign, ChevronRight } from "lucide-react";
 import styles from "./ModelSelector.module.css";
-import { MODELS, is1mContextModel, type Model } from "./modelRegistry";
+import { MODELS, type Model } from "./modelRegistry";
 import { useAppStore } from "../../stores/useAppStore";
 
-export { MODELS, is1mContextModel } from "./modelRegistry";
+export { MODELS, is1mContextModel, get1mFallback } from "./modelRegistry";
 
 interface ModelSelectorProps {
   selected: string;
@@ -19,7 +19,7 @@ export function ModelSelector({
 }: ModelSelectorProps) {
   const disable1mContext = useAppStore((s) => s.disable1mContext);
   const visibleModels = disable1mContext
-    ? MODELS.filter((m) => !is1mContextModel(m.id))
+    ? MODELS.filter((m) => m.contextWindowTokens < 1_000_000)
     : MODELS;
   const primary = visibleModels.filter((m) => !m.legacy);
   const legacy = visibleModels.filter((m) => m.legacy);

--- a/src/ui/src/components/chat/ModelSelector.tsx
+++ b/src/ui/src/components/chat/ModelSelector.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { CircleDollarSign, ChevronRight } from "lucide-react";
 import styles from "./ModelSelector.module.css";
-import { MODELS, type Model } from "./modelRegistry";
+import { MODELS, is1mContextModel, type Model } from "./modelRegistry";
 import { useAppStore } from "../../stores/useAppStore";
 
-export { MODELS } from "./modelRegistry";
+export { MODELS, is1mContextModel } from "./modelRegistry";
 
 interface ModelSelectorProps {
   selected: string;
@@ -19,7 +19,7 @@ export function ModelSelector({
 }: ModelSelectorProps) {
   const disable1mContext = useAppStore((s) => s.disable1mContext);
   const visibleModels = disable1mContext
-    ? MODELS.filter((m) => m.contextWindowTokens < 1_000_000)
+    ? MODELS.filter((m) => !is1mContextModel(m.id))
     : MODELS;
   const primary = visibleModels.filter((m) => !m.legacy);
   const legacy = visibleModels.filter((m) => m.legacy);

--- a/src/ui/src/components/chat/ModelSelector.tsx
+++ b/src/ui/src/components/chat/ModelSelector.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { CircleDollarSign, ChevronRight } from "lucide-react";
 import styles from "./ModelSelector.module.css";
 import { MODELS, type Model } from "./modelRegistry";
+import { useAppStore } from "../../stores/useAppStore";
 
 export { MODELS } from "./modelRegistry";
 
@@ -16,8 +17,12 @@ export function ModelSelector({
   onSelect,
   onClose,
 }: ModelSelectorProps) {
-  const primary = MODELS.filter((m) => !m.legacy);
-  const legacy = MODELS.filter((m) => m.legacy);
+  const disable1mContext = useAppStore((s) => s.disable1mContext);
+  const visibleModels = disable1mContext
+    ? MODELS.filter((m) => m.contextWindowTokens < 1_000_000)
+    : MODELS;
+  const primary = visibleModels.filter((m) => !m.legacy);
+  const legacy = visibleModels.filter((m) => m.legacy);
   const selectedIsLegacy = legacy.some((m) => m.id === selected);
 
   const [moreOpen, setMoreOpen] = useState(selectedIsLegacy);

--- a/src/ui/src/components/chat/applySelectedModel.ts
+++ b/src/ui/src/components/chat/applySelectedModel.ts
@@ -6,6 +6,7 @@ import {
   isMaxEffortAllowed,
   isXhighEffortAllowed,
 } from "./modelCapabilities";
+import { is1mContextModel } from "./modelRegistry";
 
 /**
  * Apply a model change for a workspace.
@@ -24,26 +25,29 @@ export async function applySelectedModel(
   nextModel: string,
 ): Promise<void> {
   const store = useAppStore.getState();
-  store.setSelectedModel(workspaceId, nextModel);
-  await setAppSetting(`model:${workspaceId}`, nextModel);
+  const model = store.disable1mContext && is1mContextModel(nextModel)
+    ? "sonnet"
+    : nextModel;
+  store.setSelectedModel(workspaceId, model);
+  await setAppSetting(`model:${workspaceId}`, model);
   await resetAgentSession(workspaceId);
   store.clearAgentQuestion(workspaceId);
   store.clearPlanApproval(workspaceId);
 
   const prevFastMode = store.fastMode[workspaceId] ?? false;
-  if (prevFastMode && !isFastSupported(nextModel)) {
+  if (prevFastMode && !isFastSupported(model)) {
     store.setFastMode(workspaceId, false);
     await setAppSetting(`fast_mode:${workspaceId}`, "false");
   }
 
   const prevEffort = store.effortLevel[workspaceId] ?? "auto";
-  if (!isEffortSupported(nextModel)) {
+  if (!isEffortSupported(model)) {
     store.setEffortLevel(workspaceId, "auto");
     await setAppSetting(`effort_level:${workspaceId}`, "auto");
-  } else if (prevEffort === "xhigh" && !isXhighEffortAllowed(nextModel)) {
+  } else if (prevEffort === "xhigh" && !isXhighEffortAllowed(model)) {
     store.setEffortLevel(workspaceId, "high");
     await setAppSetting(`effort_level:${workspaceId}`, "high");
-  } else if (prevEffort === "max" && !isMaxEffortAllowed(nextModel)) {
+  } else if (prevEffort === "max" && !isMaxEffortAllowed(model)) {
     store.setEffortLevel(workspaceId, "high");
     await setAppSetting(`effort_level:${workspaceId}`, "high");
   }

--- a/src/ui/src/components/chat/applySelectedModel.ts
+++ b/src/ui/src/components/chat/applySelectedModel.ts
@@ -6,7 +6,7 @@ import {
   isMaxEffortAllowed,
   isXhighEffortAllowed,
 } from "./modelCapabilities";
-import { is1mContextModel } from "./modelRegistry";
+import { is1mContextModel, get1mFallback } from "./modelRegistry";
 
 /**
  * Apply a model change for a workspace.
@@ -26,7 +26,7 @@ export async function applySelectedModel(
 ): Promise<void> {
   const store = useAppStore.getState();
   const model = store.disable1mContext && is1mContextModel(nextModel)
-    ? "sonnet"
+    ? get1mFallback(nextModel)
     : nextModel;
   store.setSelectedModel(workspaceId, model);
   await setAppSetting(`model:${workspaceId}`, model);

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { CircleDollarSign, Sparkles, BookOpen } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { getAppSetting, setAppSetting } from "../../../services/tauri";
-import { ModelSelector, MODELS } from "../ModelSelector";
+import { ModelSelector, MODELS, is1mContextModel } from "../ModelSelector";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "../modelCapabilities";
 import { applySelectedModel } from "../applySelectedModel";
 import { applyPlanModeMountDefault } from "../applyPlanModeMountDefault";
@@ -111,8 +111,7 @@ export function ComposerToolbar({ workspaceId, disabled }: ComposerToolbarProps)
 
   useEffect(() => {
     if (!loaded || !disable1mContext) return;
-    const entry = MODELS.find((m) => m.id === selectedModel);
-    if (entry && entry.contextWindowTokens >= 1_000_000) {
+    if (is1mContextModel(selectedModel)) {
       void applySelectedModel(workspaceId, "sonnet");
     }
   }, [loaded, disable1mContext, selectedModel, workspaceId]);

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -18,6 +18,7 @@ interface ComposerToolbarProps {
 
 export function ComposerToolbar({ workspaceId, disabled }: ComposerToolbarProps) {
   const selectedModel = useAppStore((s) => s.selectedModel[workspaceId] ?? "opus");
+  const disable1mContext = useAppStore((s) => s.disable1mContext);
   const thinkingEnabled = useAppStore((s) => s.thinkingEnabled[workspaceId] ?? false);
   const planMode = useAppStore((s) => s.planMode[workspaceId] ?? false);
   const modelSelectorOpen = useAppStore((s) => s.modelSelectorOpen);
@@ -107,6 +108,14 @@ export function ComposerToolbar({ workspaceId, disabled }: ComposerToolbarProps)
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [disabled, toggleThinking]);
+
+  useEffect(() => {
+    if (!loaded || !disable1mContext) return;
+    const entry = MODELS.find((m) => m.id === selectedModel);
+    if (entry && entry.contextWindowTokens >= 1_000_000) {
+      void applySelectedModel(workspaceId, "sonnet");
+    }
+  }, [loaded, disable1mContext, selectedModel, workspaceId]);
 
   const currentModel = MODELS.find((m) => m.id === selectedModel);
   const modelLabel = currentModel?.label ?? selectedModel;

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { CircleDollarSign, Sparkles, BookOpen } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { getAppSetting, setAppSetting } from "../../../services/tauri";
-import { ModelSelector, MODELS, is1mContextModel } from "../ModelSelector";
+import { ModelSelector, MODELS, is1mContextModel, get1mFallback } from "../ModelSelector";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "../modelCapabilities";
 import { applySelectedModel } from "../applySelectedModel";
 import { applyPlanModeMountDefault } from "../applyPlanModeMountDefault";
@@ -112,7 +112,7 @@ export function ComposerToolbar({ workspaceId, disabled }: ComposerToolbarProps)
   useEffect(() => {
     if (!loaded || !disable1mContext) return;
     if (is1mContextModel(selectedModel)) {
-      void applySelectedModel(workspaceId, "sonnet");
+      void applySelectedModel(workspaceId, get1mFallback(selectedModel));
     }
   }, [loaded, disable1mContext, selectedModel, workspaceId]);
 

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { MODELS } from "./modelRegistry";
+import { MODELS, is1mContextModel } from "./modelRegistry";
 
 describe("modelRegistry", () => {
   it("every model has a positive integer contextWindowTokens", () => {
@@ -27,5 +27,27 @@ describe("modelRegistry", () => {
     for (const m of standard) {
       expect(m.contextWindowTokens, m.id).toBe(200_000);
     }
+  });
+
+  describe("is1mContextModel", () => {
+    it("returns true for 1M-context models", () => {
+      const oneM = MODELS.filter((m) => m.contextWindowTokens >= 1_000_000);
+      expect(oneM.length).toBeGreaterThan(0);
+      for (const m of oneM) {
+        expect(is1mContextModel(m.id), m.id).toBe(true);
+      }
+    });
+
+    it("returns false for standard-context models", () => {
+      const standard = MODELS.filter((m) => m.contextWindowTokens < 1_000_000);
+      expect(standard.length).toBeGreaterThan(0);
+      for (const m of standard) {
+        expect(is1mContextModel(m.id), m.id).toBe(false);
+      }
+    });
+
+    it("returns false for unknown model IDs", () => {
+      expect(is1mContextModel("unknown-model")).toBe(false);
+    });
   });
 });

--- a/src/ui/src/components/chat/modelRegistry.test.ts
+++ b/src/ui/src/components/chat/modelRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { MODELS, is1mContextModel } from "./modelRegistry";
+import { MODELS, is1mContextModel, get1mFallback } from "./modelRegistry";
 
 describe("modelRegistry", () => {
   it("every model has a positive integer contextWindowTokens", () => {
@@ -48,6 +48,34 @@ describe("modelRegistry", () => {
 
     it("returns false for unknown model IDs", () => {
       expect(is1mContextModel("unknown-model")).toBe(false);
+    });
+  });
+
+  describe("get1mFallback", () => {
+    it("maps 1M models to their 200K equivalents", () => {
+      expect(get1mFallback("opus")).toBe("claude-opus-4-7");
+      expect(get1mFallback("claude-sonnet-4-6[1m]")).toBe("sonnet");
+      expect(get1mFallback("claude-opus-4-6[1m]")).toBe("claude-opus-4-6");
+    });
+
+    it("returns non-1M models unchanged", () => {
+      expect(get1mFallback("sonnet")).toBe("sonnet");
+      expect(get1mFallback("claude-opus-4-7")).toBe("claude-opus-4-7");
+      expect(get1mFallback("haiku")).toBe("haiku");
+    });
+
+    it("returns unknown model IDs unchanged", () => {
+      expect(get1mFallback("unknown-model")).toBe("unknown-model");
+    });
+
+    it("every 1M model has a fallback that exists in the registry", () => {
+      const oneM = MODELS.filter((m) => m.contextWindowTokens >= 1_000_000);
+      for (const m of oneM) {
+        const fallback = get1mFallback(m.id);
+        const target = MODELS.find((t) => t.id === fallback);
+        expect(target, `${m.id} → ${fallback} not in MODELS`).toBeDefined();
+        expect(target!.contextWindowTokens, `${m.id} → ${fallback} should be non-1M`).toBeLessThan(1_000_000);
+      }
     });
   });
 });

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -21,6 +21,16 @@ export function is1mContextModel(modelId: string): boolean {
   return entry ? entry.contextWindowTokens >= 1_000_000 : false;
 }
 
+const NON_1M_FALLBACKS: Record<string, string> = {
+  "opus": "claude-opus-4-7",
+  "claude-sonnet-4-6[1m]": "sonnet",
+  "claude-opus-4-6[1m]": "claude-opus-4-6",
+};
+
+export function get1mFallback(modelId: string): string {
+  return NON_1M_FALLBACKS[modelId] ?? modelId;
+}
+
 export const MODELS: readonly Model[] = [
   { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },

--- a/src/ui/src/components/chat/modelRegistry.ts
+++ b/src/ui/src/components/chat/modelRegistry.ts
@@ -16,6 +16,11 @@ export type Model = {
   readonly contextWindowTokens: number;
 };
 
+export function is1mContextModel(modelId: string): boolean {
+  const entry = MODELS.find((m) => m.id === modelId);
+  return entry ? entry.contextWindowTokens >= 1_000_000 : false;
+}
+
 export const MODELS: readonly Model[] = [
   { id: "opus", label: "Opus 4.7 1M", group: "Claude Code", extraUsage: true, contextWindowTokens: 1_000_000 },
   { id: "claude-opus-4-7", label: "Opus 4.7", group: "Claude Code", extraUsage: false, contextWindowTokens: 200_000 },

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -3,6 +3,7 @@ import type { NativeSlashKind, SlashCommand } from "../../services/tauri";
 import type { PermissionLevel } from "../../stores/useAppStore";
 import { parsePluginSlashCommand } from "./pluginSlashCommand";
 import { MODELS } from "./modelRegistry";
+import { useAppStore } from "../../stores/useAppStore";
 
 export type { NativeSlashKind };
 
@@ -476,10 +477,14 @@ const modelHandler: NativeHandler = {
       ctx.addLocalMessage("/model: no active workspace");
       return handled;
     }
+    const { disable1mContext } = useAppStore.getState();
+    const available = disable1mContext
+      ? MODELS.filter((m) => m.contextWindowTokens < 1_000_000)
+      : MODELS;
     const arg = args.trim();
-    const modelIds = MODELS.map((m) => m.id);
+    const modelIds = available.map((m) => m.id);
     if (arg === "") {
-      const lines = MODELS.map((m) => {
+      const lines = available.map((m) => {
         const marker = m.id === ctx.selectedModel ? "•" : " ";
         return ` ${marker} ${m.id} — ${m.label}`;
       }).join("\n");
@@ -487,7 +492,7 @@ const modelHandler: NativeHandler = {
       return handled;
     }
     const normalized = arg.toLowerCase();
-    const match = MODELS.find((m) => m.id.toLowerCase() === normalized);
+    const match = available.find((m) => m.id.toLowerCase() === normalized);
     if (!match) {
       ctx.addLocalMessage(
         `/model: unknown model "${arg}". Valid options: ${modelIds.join(", ")}`,

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -674,6 +674,10 @@ export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
 
+export function getHostEnvFlags(): Promise<{ disable1mContext: boolean }> {
+  return invoke("get_host_env_flags");
+}
+
 // -- Updater --
 
 export type UpdateChannel = "stable" | "nightly";

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -674,7 +674,7 @@ export function setAppSetting(key: string, value: string): Promise<void> {
   return invoke("set_app_setting", { key, value });
 }
 
-export function getHostEnvFlags(): Promise<{ disable1mContext: boolean }> {
+export function getHostEnvFlags(): Promise<{ disable_1m_context: boolean }> {
   return invoke("get_host_env_flags");
 }
 

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -487,6 +487,8 @@ interface AppState {
   setUsageInsightsEnabled: (enabled: boolean) => void;
   pluginManagementEnabled: boolean;
   setPluginManagementEnabled: (enabled: boolean) => void;
+  disable1mContext: boolean;
+  setDisable1mContext: (v: boolean) => void;
 
   // -- Claude Code Usage --
   claudeCodeUsage: ClaudeCodeUsage | null;
@@ -1629,6 +1631,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       pluginSettingsRepoId: enabled ? state.pluginSettingsRepoId : null,
       pluginSettingsTab: enabled ? state.pluginSettingsTab : "available",
     })),
+  disable1mContext: false,
+  setDisable1mContext: (v) => set({ disable1mContext: v }),
 
   // -- Claude Code Usage --
   claudeCodeUsage: null,


### PR DESCRIPTION
## Summary

When the host environment has `CLAUDE_CODE_DISABLE_1M_CONTEXT` set, 1M context models (Opus 4.7 1M, Sonnet 4.6 1M, and legacy 1M variants) are now hidden from the model selector and `/model` command. Previously, these models appeared but would run at 200K context anyway — this closes that UX gap.

**Changes across 9 files:**
- **Rust** (`commands/env.rs`, `main.rs`): New synchronous `get_host_env_flags` Tauri command
- **Frontend** (`tauri.ts`, `useAppStore.ts`, `App.tsx`): Bootstraps `disable1mContext` flag at startup
- **Model registry** (`modelRegistry.ts`): `is1mContextModel()` helper + `get1mFallback()` mapping (opus→claude-opus-4-7, sonnet-1m→sonnet, etc.)
- **UI** (`ModelSelector.tsx`): Filters 1M models from selector when flag is active
- **UI** (`ComposerToolbar.tsx`): Corrects saved 1M model to 200K equivalent on load
- **Enforcement** (`applySelectedModel.ts`): Guards all model-change paths (selector, `/model` command, settings)
- **Slash command** (`nativeSlashCommands.ts`): `/model` lists only available models when flag is active

## Complexity Notes

- The `ComposerToolbar` correction effect is still needed despite the `applySelectedModel` guard because initial model loading (`setSelectedModel`) bypasses `applySelectedModel` to avoid unnecessary session resets.
- `get1mFallback` uses an explicit mapping table rather than deriving the 200K variant from the ID string, since model ID naming isn't consistent (e.g. `opus` vs `claude-opus-4-7`).

## Test Steps

1. **With env var set:** Run `CLAUDE_CODE_DISABLE_1M_CONTEXT=1 cargo tauri dev`, open the model selector → confirm "Opus 4.7 1M", "Sonnet 4.6 1M", and "Opus 4.6 1M" (legacy) are absent
2. **Without env var:** Run `cargo tauri dev`, open the model selector → confirm all models appear as before
3. **Fallback test:** Set `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`, but first save `opus` (1M) as default model → on next launch, confirm the composer shows `Opus 4.7` (not `Sonnet 4.6`)
4. **Slash command:** With env var set, type `/model` → confirm 1M models are not listed; type `/model opus` → confirm "unknown model" response
5. **Type check:** `cd src/ui && bunx tsc -b` — no errors
6. **Tests:** `cd src/ui && bun run test` — all pass (843 tests including 7 new ones)

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (if applicable)