### PR TITLE
fix(updater): keep nightly available during in-progress builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -280,22 +280,48 @@ jobs:
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      # Atomic-ish promote: delete the live `nightly` release+tag, then retag
-      # `nightly-staging` to `nightly` and un-draft. The blackout window
-      # between these two API calls is ~1–2s — orders of magnitude smaller
-      # than the prior delete-then-rebuild flow, and covered on the client
-      # side by treating "release manifest not found" as "no update".
+      # Atomic-ish promote: verify the staging release is intact, delete the
+      # live `nightly` release+tag, then retag `nightly-staging` to
+      # `nightly` and un-draft. The blackout window between the delete and
+      # the retag is ~1–2s — orders of magnitude smaller than the prior
+      # delete-then-rebuild flow, and covered on the client side by treating
+      # "release manifest not found" as "no update".
       - name: Promote staging to nightly
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+
+          # Pre-flight: ensure `nightly-staging` is reachable before we touch
+          # `nightly`. If staging is somehow missing or the API is down, we
+          # want to abort *with `nightly` still intact* rather than leave the
+          # repository with no nightly release at all.
+          if ! gh release view nightly-staging --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::nightly-staging release is not reachable; aborting promotion"
+            exit 1
+          fi
+
           gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-          gh release edit nightly-staging \
-            --repo "$GITHUB_REPOSITORY" \
-            --tag nightly \
-            --draft=false \
-            --prerelease
+
+          # Retry the retag a few times to ride out transient API hiccups
+          # (rate limits, brief outages). If all retries fail, the workflow
+          # exits non-zero and a follow-up run can recover by re-promoting
+          # the still-intact `nightly-staging` release.
+          for attempt in 1 2 3; do
+            if gh release edit nightly-staging \
+              --repo "$GITHUB_REPOSITORY" \
+              --tag nightly \
+              --draft=false \
+              --prerelease; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to promote nightly-staging to nightly after 3 attempts"
+              exit 1
+            fi
+            echo "Promotion attempt $attempt failed; retrying in 5s"
+            sleep 5
+          done
 
           # `gh release edit --tag` creates the new tag (`nightly`) at the
           # release's target commit but leaves the old `nightly-staging`

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,13 +67,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Reset nightly release
+      # Build into a separate `nightly-staging` release so the live `nightly`
+      # release (with the previous build's assets) stays accessible to the
+      # in-app updater for the entire duration of the build. The `publish`
+      # job atomically promotes staging → nightly once all matrix jobs
+      # succeed, shrinking the unavailability window from "the entire build"
+      # to a couple of seconds.
+      - name: Reset staging release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.compute-version.outputs.version }}
           LAST_TAG: ${{ needs.compute-version.outputs.last_tag }}
         run: |
-          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          gh release delete nightly-staging --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
           NOTES="Automated nightly build of \`${GITHUB_SHA}\`.
 
@@ -90,7 +96,7 @@ jobs:
 
           > **These builds are unstable pre-releases.**"
 
-          gh release create nightly \
+          gh release create nightly-staging \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "Nightly ${VERSION}" \
@@ -200,7 +206,7 @@ jobs:
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
-          tagName: nightly
+          tagName: nightly-staging
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
           releaseDraft: true
           prerelease: true
@@ -239,7 +245,7 @@ jobs:
           ASSET="claudette-${{ matrix.label }}.zip"
           cp "$BIN" claudette.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette.exe' -DestinationPath '$ASSET' -Force"
-          gh release upload nightly "$ASSET" --clobber
+          gh release upload nightly-staging "$ASSET" --clobber
 
       - name: Build headless server
         shell: bash
@@ -253,7 +259,7 @@ jobs:
           BIN="target/${{ matrix.rust-target }}/release/claudette-server"
           ASSET="claudette-server-${{ matrix.label }}"
           cp "$BIN" "$ASSET"
-          gh release upload nightly "$ASSET" --clobber
+          gh release upload nightly-staging "$ASSET" --clobber
 
       - name: Upload headless server binary (Windows)
         if: startsWith(matrix.platform, 'windows')
@@ -265,7 +271,7 @@ jobs:
           ASSET="claudette-server-${{ matrix.label }}.zip"
           cp "$BIN" claudette-server.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette-server.exe' -DestinationPath '$ASSET' -Force"
-          gh release upload nightly "$ASSET" --clobber
+          gh release upload nightly-staging "$ASSET" --clobber
 
   # Nightly builds are not announced to Discord — too noisy. Stable releases only.
   publish:
@@ -274,7 +280,24 @@ jobs:
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Un-draft the nightly release
+      # Atomic-ish promote: delete the live `nightly` release+tag, then retag
+      # `nightly-staging` to `nightly` and un-draft. The blackout window
+      # between these two API calls is ~1–2s — orders of magnitude smaller
+      # than the prior delete-then-rebuild flow, and covered on the client
+      # side by treating "release manifest not found" as "no update".
+      - name: Promote staging to nightly
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit nightly --draft=false --prerelease --repo "$GITHUB_REPOSITORY"
+        run: |
+          set -euo pipefail
+          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          gh release edit nightly-staging \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag nightly \
+            --draft=false \
+            --prerelease
+
+          # `gh release edit --tag` creates the new tag (`nightly`) at the
+          # release's target commit but leaves the old `nightly-staging`
+          # git tag orphaned. Clean it up so we don't accumulate dead tags.
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly-staging" 2>/dev/null || true

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -29,9 +29,9 @@ fn endpoint_for(channel: &str) -> &'static str {
     }
 }
 
-/// Classifies an updater error: `Ok(None)` means "treat as no update available
-/// rather than a hard failure", `Err(...)` is a real transport/parse failure
-/// that should bubble up to the UI.
+/// Classifies an updater error: `Ok(())` means "downgrade to no update
+/// available", `Err(...)` is a real transport/parse failure that should
+/// bubble up to the UI.
 ///
 /// `Error::ReleaseNotFound` covers two situations:
 ///   1. HTTP 404 on `latest.json` — the manifest does not exist (or is hidden
@@ -45,9 +45,9 @@ fn endpoint_for(channel: &str) -> &'static str {
 /// red error banner for either is more alarming than the situation warrants.
 /// True transport failures (DNS, TLS, connect) reach us as `Reqwest`/`Network`
 /// variants and continue to error.
-fn classify_check_error(err: tauri_plugin_updater::Error) -> Result<Option<()>, String> {
+fn classify_check_error(err: tauri_plugin_updater::Error) -> Result<(), String> {
     match err {
-        tauri_plugin_updater::Error::ReleaseNotFound => Ok(None),
+        tauri_plugin_updater::Error::ReleaseNotFound => Ok(()),
         other => Err(other.to_string()),
     }
 }
@@ -80,16 +80,14 @@ pub async fn check_for_updates_with_channel(
     let update = match result {
         Ok(u) => u,
         Err(e) => match classify_check_error(e) {
-            Ok(None) => {
+            Ok(()) => {
                 eprintln!(
                     "[updater] Release manifest unavailable for channel {channel:?}; \
-                     treating as no update (likely an in-progress nightly build)"
+                     treating as no update available"
                 );
                 None
             }
             Err(msg) => return Err(msg),
-            // `Ok(Some(_))` is unreachable: the helper never returns it.
-            Ok(Some(())) => unreachable!(),
         },
     };
 
@@ -163,7 +161,7 @@ mod tests {
     #[test]
     fn release_not_found_is_treated_as_no_update() {
         let result = classify_check_error(tauri_plugin_updater::Error::ReleaseNotFound);
-        assert!(matches!(result, Ok(None)));
+        assert!(matches!(result, Ok(())));
     }
 
     #[test]

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -29,6 +29,29 @@ fn endpoint_for(channel: &str) -> &'static str {
     }
 }
 
+/// Classifies an updater error: `Ok(None)` means "treat as no update available
+/// rather than a hard failure", `Err(...)` is a real transport/parse failure
+/// that should bubble up to the UI.
+///
+/// `Error::ReleaseNotFound` covers two situations:
+///   1. HTTP 404 on `latest.json` — the manifest does not exist (or is hidden
+///      behind a draft release, as happens during an in-progress nightly build).
+///   2. Any other non-success HTTP status (e.g. 5xx) where the response was
+///      received but parsed nothing — the upstream plugin maps these to the
+///      same variant.
+///
+/// Both are benign from the user's standpoint: their currently-installed build
+/// is still working; the catalog is just temporarily uninformative. Surfacing a
+/// red error banner for either is more alarming than the situation warrants.
+/// True transport failures (DNS, TLS, connect) reach us as `Reqwest`/`Network`
+/// variants and continue to error.
+fn classify_check_error(err: tauri_plugin_updater::Error) -> Result<Option<()>, String> {
+    match err {
+        tauri_plugin_updater::Error::ReleaseNotFound => Ok(None),
+        other => Err(other.to_string()),
+    }
+}
+
 /// Check the configured channel's release feed for an update.
 ///
 /// On success, the resulting [`tauri_plugin_updater::Update`] is stashed in
@@ -45,15 +68,30 @@ pub async fn check_for_updates_with_channel(
         .parse()
         .map_err(|e: url::ParseError| e.to_string())?;
 
-    let update = app
+    let result = app
         .updater_builder()
         .endpoints(vec![endpoint])
         .map_err(|e| e.to_string())?
         .build()
         .map_err(|e| e.to_string())?
         .check()
-        .await
-        .map_err(|e| e.to_string())?;
+        .await;
+
+    let update = match result {
+        Ok(u) => u,
+        Err(e) => match classify_check_error(e) {
+            Ok(None) => {
+                eprintln!(
+                    "[updater] Release manifest unavailable for channel {channel:?}; \
+                     treating as no update (likely an in-progress nightly build)"
+                );
+                None
+            }
+            Err(msg) => return Err(msg),
+            // `Ok(Some(_))` is unreachable: the helper never returns it.
+            Ok(Some(())) => unreachable!(),
+        },
+    };
 
     let mut slot = state.pending_update.lock().await;
     match update {
@@ -116,4 +154,34 @@ pub async fn install_pending_update(
     // `AppHandle::restart` returns `!` (it ends the process), so it satisfies
     // the `Result<(), String>` signature without an explicit `Ok(())`.
     app.restart();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_not_found_is_treated_as_no_update() {
+        let result = classify_check_error(tauri_plugin_updater::Error::ReleaseNotFound);
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn other_errors_bubble_up_as_strings() {
+        // Pick any non-ReleaseNotFound variant the upstream enum exposes.
+        let err = tauri_plugin_updater::Error::EmptyEndpoints;
+        let expected = err.to_string();
+        match classify_check_error(err) {
+            Err(msg) => assert_eq!(msg, expected),
+            Ok(_) => panic!("EmptyEndpoints should not be downgraded"),
+        }
+    }
+
+    #[test]
+    fn endpoint_for_known_channels() {
+        assert_eq!(endpoint_for("stable"), STABLE_URL);
+        assert_eq!(endpoint_for("nightly"), NIGHTLY_URL);
+        // Unknown channels fall back to stable (and log a warning).
+        assert_eq!(endpoint_for("garbage"), STABLE_URL);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #442.

The nightly workflow used a **delete-then-rebuild** pattern that took the `nightly` release out of service for the **entire 10–25 minute build window**. During that window, the in-app updater hit `https://github.com/utensils/claudette/releases/download/nightly/latest.json`, got a 404, and surfaced a red **"Update check failed"** banner — even though the user was running an older nightly that should have been a no-op check.

This PR ships both fix layers from the issue.

### A. Workflow — keep the previously-published nightly accessible

`.github/workflows/nightly.yml` now uses a staging-then-promote pattern:

1. `prepare-release` resets a separate **`nightly-staging`** release (draft, prerelease) at the new SHA. The live `nightly` release is **untouched** — it stays serving the previous build's assets.
2. `build` matrix uploads all assets (tauri-action + manual `gh release upload`) to **`nightly-staging`** instead of `nightly`.
3. `publish` atomically promotes:
   - Delete the live `nightly` release+tag.
   - `gh release edit nightly-staging --tag nightly --draft=false --prerelease`.
   - Clean up the now-orphaned `nightly-staging` git tag via the GitHub API.

The blackout window shrinks from **"the entire build"** to **~2 seconds** between the delete and the retag.

### B. Client — treat "release manifest not found" as "no update available"

In `src-tauri/src/commands/updater.rs`, `check_for_updates_with_channel` now classifies `tauri_plugin_updater::Error::ReleaseNotFound` (the variant the plugin returns for any non-2xx response on `latest.json`) as `Ok(None)` — i.e. "You're up to date" — rather than a hard error.

Real transport failures (DNS, TLS, connect, parse) reach us as `Reqwest`/`Network`/`Serialization` variants and continue to surface in the UI as the existing **"Update check failed"** banner. Three unit tests cover the classifier.

This second layer also covers the small ~2s gap during the promote step in (A) and any future scenario where the manifest is briefly unavailable.

## Test plan

- [x] `nix develop -c cargo test --all-features` — 722 tests pass; 3 new in `commands::updater::tests`.
- [x] `nix develop -c cargo clippy --workspace --all-targets` — clean.
- [x] `nix develop -c cargo fmt --all --check` — clean.
- [x] `cd src/ui && nix develop ../.. -c bunx tsc -b` — clean.
- [x] `cd src/ui && nix develop ../.. -c bun run test` — 863 tests pass.
- [ ] Trigger the nightly workflow on this branch (`gh workflow run nightly.yml --ref <branch>`) and observe: live `nightly` release stays intact during the build; staging promotes atomically.
- [ ] On a dev build with channel=Nightly, exercise Settings → General → Check for Updates during a build and confirm "You're up to date" / available-update — never the red error banner.
- [ ] Confirm bogus host (e.g. point `NIGHTLY_URL` at `https://nonexistent.invalid/latest.json` temporarily) still shows the error banner.
- [ ] Confirm the happy-path nightly install still works end-to-end after a successful build promotes.

## Acceptance (per #442)

- [x] During an in-progress nightly build, **Check for Updates** never shows "Update check failed":
  - Returns the previous nightly when promoted (preferred), or
  - Returns "You're up to date" during the brief promote gap (acceptable).
- [x] Real transport failures still surface as "Update check failed".