### PR TITLE
feat(sidebar): discard changes from unstaged + untracked files

### DIFF
--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -100,3 +100,14 @@ pub async fn revert_file(
         .await
         .map_err(|e| e.to_string())
 }
+
+#[tauri::command]
+pub async fn discard_file(
+    worktree_path: String,
+    file_path: String,
+    is_untracked: bool,
+) -> Result<(), String> {
+    diff::discard_file(&worktree_path, &file_path, is_untracked)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -492,6 +492,7 @@ fn main() {
             commands::diff::load_diff_files,
             commands::diff::load_file_diff,
             commands::diff::revert_file,
+            commands::diff::discard_file,
             // Terminal
             commands::terminal::create_terminal_tab,
             commands::terminal::delete_terminal_tab,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -385,6 +385,32 @@ pub async fn revert_file(
     Ok(())
 }
 
+/// Discard worktree changes for a single file from the Changes sidebar.
+///
+/// - `is_untracked = false`: runs `git restore -- <file>`, which restores the
+///   worktree copy from the index. Any staged changes are preserved.
+/// - `is_untracked = true`: deletes the file from disk via `fs::remove_file`.
+///
+/// This is distinct from [`revert_file`], which restores all the way back to
+/// the merge base and so also discards staged changes.
+pub async fn discard_file(
+    worktree_path: &str,
+    file_path: &str,
+    is_untracked: bool,
+) -> Result<(), DiffError> {
+    validate_file_path(file_path)?;
+
+    if is_untracked {
+        let full_path = Path::new(worktree_path).join(file_path);
+        tokio::fs::remove_file(&full_path)
+            .await
+            .map_err(|e| DiffError::CommandFailed(e.to_string()))?;
+    } else {
+        run_git(worktree_path, &["restore", "--", file_path]).await?;
+    }
+    Ok(())
+}
+
 /// Parse unified diff output into structured data.
 pub fn parse_unified_diff(raw: &str, path: &str) -> FileDiff {
     if raw.contains("Binary files") && raw.contains("differ") {
@@ -1069,6 +1095,118 @@ mod integration_tests {
         .unwrap();
 
         assert!(!tmp.path().join("new_file.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_discard_unstaged_modified_restores_from_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        git_cmd(dir, &["init", "-b", "main"]);
+        git_cmd(dir, &["config", "user.email", "test@test.com"]);
+        git_cmd(dir, &["config", "user.name", "Test"]);
+        git_cmd(dir, &["config", "core.autocrlf", "false"]);
+        std::fs::write(dir.join("file.txt"), "original\n").unwrap();
+        git_cmd(dir, &["add", "."]);
+        git_cmd(dir, &["commit", "-m", "initial"]);
+
+        // Unstaged modification
+        std::fs::write(dir.join("file.txt"), "modified\n").unwrap();
+
+        discard_file(dir.to_str().unwrap(), "file.txt", false)
+            .await
+            .unwrap();
+
+        let content = std::fs::read_to_string(dir.join("file.txt")).unwrap();
+        assert_eq!(content, "original\n");
+    }
+
+    #[tokio::test]
+    async fn test_discard_unstaged_modified_preserves_staged_changes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        git_cmd(dir, &["init", "-b", "main"]);
+        git_cmd(dir, &["config", "user.email", "test@test.com"]);
+        git_cmd(dir, &["config", "user.name", "Test"]);
+        git_cmd(dir, &["config", "core.autocrlf", "false"]);
+        std::fs::write(dir.join("file.txt"), "v1\n").unwrap();
+        git_cmd(dir, &["add", "."]);
+        git_cmd(dir, &["commit", "-m", "initial"]);
+
+        // Stage v2, then add an unstaged v3 layer on top
+        std::fs::write(dir.join("file.txt"), "v2\n").unwrap();
+        git_cmd(dir, &["add", "file.txt"]);
+        std::fs::write(dir.join("file.txt"), "v3\n").unwrap();
+
+        discard_file(dir.to_str().unwrap(), "file.txt", false)
+            .await
+            .unwrap();
+
+        // Worktree restored to staged copy (v2), staged changes still present
+        let content = std::fs::read_to_string(dir.join("file.txt")).unwrap();
+        assert_eq!(content, "v2\n");
+
+        // Confirm v2 is still staged
+        let staged_diff = git_cmd(dir, &["diff", "--cached", "--", "file.txt"]);
+        assert!(staged_diff.contains("+v2"));
+    }
+
+    #[tokio::test]
+    async fn test_discard_unstaged_deleted_restores_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        git_cmd(dir, &["init", "-b", "main"]);
+        git_cmd(dir, &["config", "user.email", "test@test.com"]);
+        git_cmd(dir, &["config", "user.name", "Test"]);
+        git_cmd(dir, &["config", "core.autocrlf", "false"]);
+        std::fs::write(dir.join("keep.txt"), "keep\n").unwrap();
+        git_cmd(dir, &["add", "."]);
+        git_cmd(dir, &["commit", "-m", "initial"]);
+
+        std::fs::remove_file(dir.join("keep.txt")).unwrap();
+
+        discard_file(dir.to_str().unwrap(), "keep.txt", false)
+            .await
+            .unwrap();
+
+        let content = std::fs::read_to_string(dir.join("keep.txt")).unwrap();
+        assert_eq!(content, "keep\n");
+    }
+
+    #[tokio::test]
+    async fn test_discard_untracked_file_removes_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        git_cmd(dir, &["init", "-b", "main"]);
+        git_cmd(dir, &["config", "user.email", "test@test.com"]);
+        git_cmd(dir, &["config", "user.name", "Test"]);
+        std::fs::write(dir.join("base.txt"), "base\n").unwrap();
+        git_cmd(dir, &["add", "."]);
+        git_cmd(dir, &["commit", "-m", "initial"]);
+
+        std::fs::write(dir.join("new.txt"), "untracked\n").unwrap();
+        assert!(dir.join("new.txt").exists());
+
+        discard_file(dir.to_str().unwrap(), "new.txt", true)
+            .await
+            .unwrap();
+
+        assert!(!dir.join("new.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_discard_rejects_path_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        git_cmd(dir, &["init", "-b", "main"]);
+
+        let err = discard_file(dir.to_str().unwrap(), "../etc/passwd", true)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DiffError::CommandFailed(_)));
     }
 
     #[tokio::test]

--- a/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
+++ b/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Modal } from "../modals/Modal";
 import shared from "../modals/shared.module.css";
 import type { DiffLayer } from "../../types/diff";
 
+export type DiscardableLayer = Extract<DiffLayer, "unstaged" | "untracked">;
+
 interface DiscardChangesConfirmProps {
   filePath: string;
-  layer: DiffLayer;
+  layer: DiscardableLayer;
   onConfirm: () => Promise<void>;
   onClose: () => void;
 }
@@ -37,17 +39,6 @@ export function DiscardChangesConfirm({
     if (loading) return;
     onClose();
   };
-
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Enter" && !loading) {
-        e.preventDefault();
-        void handleConfirm();
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [loading, handleConfirm]);
 
   const isUntracked = layer === "untracked";
   const title = isUntracked ? "Delete untracked file?" : "Discard changes?";
@@ -83,6 +74,12 @@ export function DiscardChangesConfirm({
           onClick={handleConfirm}
           disabled={loading}
           type="button"
+          // Auto-focus the primary action so Enter activates it via the
+          // browser's native button keyboard handling. A window-level
+          // keydown listener was tried earlier but raced with other
+          // global Enter handlers in the app and could double-fire the
+          // confirm if the button was already focused.
+          autoFocus
         >
           {loading ? `${action}ing…` : action}
         </button>

--- a/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
+++ b/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+import { Modal } from "../modals/Modal";
+import shared from "../modals/shared.module.css";
+import type { DiffLayer } from "../../types/diff";
+
+interface DiscardChangesConfirmProps {
+  filePath: string;
+  layer: DiffLayer;
+  onConfirm: () => Promise<void>;
+  onClose: () => void;
+}
+
+export function DiscardChangesConfirm({
+  filePath,
+  layer,
+  onConfirm,
+  onClose,
+}: DiscardChangesConfirmProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await onConfirm();
+      onClose();
+    } catch (e) {
+      setError(String(e));
+      setLoading(false);
+    }
+  }, [onConfirm, onClose]);
+
+  // Block backdrop dismiss while the discard is in flight, matching the
+  // disabled Cancel button below.
+  const handleClose = () => {
+    if (loading) return;
+    onClose();
+  };
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Enter" && !loading) {
+        e.preventDefault();
+        void handleConfirm();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [loading, handleConfirm]);
+
+  const isUntracked = layer === "untracked";
+  const title = isUntracked ? "Delete untracked file?" : "Discard changes?";
+  const action = isUntracked ? "Delete" : "Discard";
+  const description = isUntracked ? (
+    <>
+      The file <strong>{filePath}</strong> is not tracked by git. Deleting it
+      will remove it from disk. <strong>This cannot be undone.</strong>
+    </>
+  ) : (
+    <>
+      Discard unstaged changes to <strong>{filePath}</strong>. The file will be
+      restored from the index. Any staged changes are kept.{" "}
+      <strong>This cannot be undone.</strong>
+    </>
+  );
+
+  return (
+    <Modal title={title} onClose={handleClose}>
+      <div className={shared.warning}>{description}</div>
+      {error && <div className={shared.error}>{error}</div>}
+      <div className={shared.actions}>
+        <button
+          className={shared.btn}
+          onClick={handleClose}
+          disabled={loading}
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          className={shared.btnDanger}
+          onClick={handleConfirm}
+          disabled={loading}
+          type="button"
+        >
+          {loading ? `${action}ing…` : action}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -120,7 +120,9 @@
 
 /* Hover-revealed action (e.g. discard) for unstaged/untracked rows. Hidden
  * by default to keep the row uncluttered; appears on hover/focus or when
- * the row is selected so keyboard users can reach it. */
+ * the row is selected. `pointer-events: none` while hidden prevents the
+ * invisible button area on the right edge of the row from being clicked
+ * accidentally and triggering a destructive discard. */
 .rowAction {
   display: inline-flex;
   align-items: center;
@@ -135,6 +137,7 @@
   border-radius: 4px;
   cursor: pointer;
   opacity: 0;
+  pointer-events: none;
   transition: opacity var(--transition-fast),
     color var(--transition-fast),
     background var(--transition-fast);
@@ -145,6 +148,7 @@
 .fileSelected .rowAction,
 .rowAction:focus-visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .rowAction:hover {

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -118,6 +118,40 @@
   background: var(--selected-bg);
 }
 
+/* Hover-revealed action (e.g. discard) for unstaged/untracked rows. Hidden
+ * by default to keep the row uncluttered; appears on hover/focus or when
+ * the row is selected so keyboard users can reach it. */
+.rowAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  margin-left: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.file:hover .rowAction,
+.fileSelected .rowAction,
+.rowAction:focus-visible {
+  opacity: 1;
+}
+
+.rowAction:hover {
+  background: var(--hover-bg);
+  color: var(--diff-removed-text);
+}
+
 .status {
   font-weight: 700;
   width: 14px;

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -13,10 +13,11 @@ import {
 import { TaskList } from "./TaskList";
 import { ScmPanel } from "./ScmPanel";
 import { PrStatusBanner } from "./PrStatusBanner";
-import { DiscardChangesConfirm } from "./DiscardChangesConfirm";
+import {
+  DiscardChangesConfirm,
+  type DiscardableLayer,
+} from "./DiscardChangesConfirm";
 import styles from "./RightSidebar.module.css";
-
-type DiscardableLayer = "unstaged" | "untracked";
 
 function isDiscardableLayer(layer: DiffLayer | undefined): layer is DiscardableLayer {
   return layer === "unstaged" || layer === "untracked";

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,15 +1,26 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Undo2, Trash2 } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { useTaskTracker } from "../../hooks/useTaskTracker";
-import { loadDiffFiles, sendRemoteCommand } from "../../services/tauri";
+import { discardFile, loadDiffFiles, sendRemoteCommand } from "../../services/tauri";
 import type { DiffFilesResult } from "../../services/tauri";
 import type { DiffFile, DiffLayer } from "../../types/diff";
+import {
+  AttachmentContextMenu,
+  type AttachmentContextMenuItem,
+} from "../chat/AttachmentContextMenu";
 import { TaskList } from "./TaskList";
 import { ScmPanel } from "./ScmPanel";
 import { PrStatusBanner } from "./PrStatusBanner";
+import { DiscardChangesConfirm } from "./DiscardChangesConfirm";
 import styles from "./RightSidebar.module.css";
+
+type DiscardableLayer = "unstaged" | "untracked";
+
+function isDiscardableLayer(layer: DiffLayer | undefined): layer is DiscardableLayer {
+  return layer === "unstaged" || layer === "untracked";
+}
 
 export const RightSidebar = memo(function RightSidebar() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -30,9 +41,21 @@ export const RightSidebar = memo(function RightSidebar() {
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = isAgentBusy(ws?.agent_status);
   const remoteConnectionId = ws?.remote_connection_id ?? null;
+  const worktreePath = ws?.worktree_path ?? null;
   const prevIsRunning = useRef<boolean | undefined>(undefined);
 
   const { totalCount: taskCount } = useTaskTracker(selectedWorkspaceId);
+
+  // Discard-changes UI state. Local-only — discard isn't bridged through the
+  // remote server (matches revert_file), so the action is hidden when the
+  // workspace is connected to a remote.
+  const [discardTarget, setDiscardTarget] = useState<
+    { file: DiffFile; layer: DiscardableLayer } | null
+  >(null);
+  const [contextMenu, setContextMenu] = useState<
+    { x: number; y: number; file: DiffFile; layer: DiscardableLayer } | null
+  >(null);
+  const discardEnabled = !remoteConnectionId && worktreePath != null;
 
   // Load diff files for either local or remote workspace
   const loadDiff = useCallback(
@@ -148,11 +171,27 @@ export const RightSidebar = memo(function RightSidebar() {
   const renderFileRow = (file: DiffFile, layer?: DiffLayer) => {
     const isSelected = diffSelectedFile === file.path
       && (diffSelectedLayer ?? "flat") === (layer ?? "flat");
+    const canDiscard = discardEnabled && isDiscardableLayer(layer);
+
+    const handleContextMenu = (e: React.MouseEvent) => {
+      if (!canDiscard) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setContextMenu({ x: e.clientX, y: e.clientY, file, layer });
+    };
+
+    const handleDiscardClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!canDiscard) return;
+      setDiscardTarget({ file, layer });
+    };
+
     return (
     <div
       key={`${layer ?? "flat"}-${file.path}`}
       className={`${styles.file} ${isSelected ? styles.fileSelected : ""}`}
       onClick={() => setDiffSelectedFile(file.path, layer)}
+      onContextMenu={handleContextMenu}
     >
       <span
         className={styles.status}
@@ -171,9 +210,50 @@ export const RightSidebar = memo(function RightSidebar() {
           )}
         </span>
       )}
+      {canDiscard && (
+        <button
+          type="button"
+          className={styles.rowAction}
+          onClick={handleDiscardClick}
+          title={
+            layer === "untracked"
+              ? `Delete ${file.path}`
+              : `Discard changes to ${file.path}`
+          }
+          aria-label={
+            layer === "untracked"
+              ? `Delete ${file.path}`
+              : `Discard changes to ${file.path}`
+          }
+        >
+          {layer === "untracked" ? (
+            <Trash2 size={12} />
+          ) : (
+            <Undo2 size={12} />
+          )}
+        </button>
+      )}
     </div>
     );
   };
+
+  const performDiscard = useCallback(
+    async (filePath: string, layer: DiscardableLayer) => {
+      if (!worktreePath || !selectedWorkspaceId) return;
+      await discardFile(worktreePath, filePath, layer === "untracked");
+
+      // Clear selection if the discarded file was selected so the diff
+      // viewer doesn't keep displaying a stale entry.
+      const state = useAppStore.getState();
+      if (state.diffSelectedFile === filePath) {
+        state.setDiffSelectedFile(null);
+      }
+
+      const result = await loadDiff(selectedWorkspaceId);
+      applyDiffResult(result);
+    },
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult]
+  );
 
   // Determine if we have grouped data to show
   const hasGrouped = diffStagedFiles &&
@@ -283,9 +363,43 @@ export const RightSidebar = memo(function RightSidebar() {
       )}
 
       {activeTab === "scm" && <ScmPanel />}
+
+      {contextMenu && (
+        <AttachmentContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={buildDiscardMenuItems(contextMenu.layer, () => {
+            setDiscardTarget({ file: contextMenu.file, layer: contextMenu.layer });
+          })}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+
+      {discardTarget && (
+        <DiscardChangesConfirm
+          filePath={discardTarget.file.path}
+          layer={discardTarget.layer}
+          onConfirm={() => performDiscard(discardTarget.file.path, discardTarget.layer)}
+          onClose={() => setDiscardTarget(null)}
+        />
+      )}
     </div>
   );
 });
+
+function buildDiscardMenuItems(
+  layer: DiscardableLayer,
+  onDiscard: () => void,
+): AttachmentContextMenuItem[] {
+  const isUntracked = layer === "untracked";
+  return [
+    {
+      label: isUntracked ? "Delete file…" : "Discard changes…",
+      icon: isUntracked ? <Trash2 size={14} /> : <Undo2 size={14} />,
+      onSelect: onDiscard,
+    },
+  ];
+}
 
 function FileGroup({
   label,

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -610,6 +610,14 @@ export function revertFile(
   return invoke("revert_file", { worktreePath, mergeBase, filePath, status });
 }
 
+export function discardFile(
+  worktreePath: string,
+  filePath: string,
+  isUntracked: boolean
+): Promise<void> {
+  return invoke("discard_file", { worktreePath, filePath, isUntracked });
+}
+
 // -- Terminal --
 
 export function createTerminalTab(


### PR DESCRIPTION
## Summary

- Adds a per-file discard action to the Changes sidebar (Unstaged + Untracked groups). Users no longer have to drop to a terminal for `git restore` / `rm` on individual files.
- Hover-revealed icon button on each row (Undo2 for unstaged, Trash2 for untracked) plus a right-click context menu with the same action.
- Confirmation modal names the file and warns the action is irreversible. Refreshes the diff list on success and clears diff selection if the discarded file was the active one.

## Backend

- New `discard_file` in `src/diff.rs` runs `git restore -- <file>` for unstaged tracked changes (preserves any staged copy) and removes untracked files via `tokio::fs::remove_file`. Distinct from the existing `revert_file`, which restores all the way back to merge-base and so also discards staged changes.
- Tauri command `commands::diff::discard_file` registered in `src-tauri/src/main.rs`.
- Local-only (matches `revert_file` — not bridged through the remote server).

## Test plan

- [x] `cargo test --all-features` (727 passed, 5 new)
- [x] `cargo clippy --workspace --all-targets` (zero warnings)
- [x] `cargo fmt --all --check`
- [x] `cd src/ui && bunx tsc -b`
- [x] `cd src/ui && bun run test` (863 passed)
- [x] UAT in dev build:
  - [x] Discard unstaged-modified file (`git restore` semantics) — content reverts, row leaves Unstaged group
  - [x] Discard unstaged-deleted file — file restored on disk
  - [x] Delete untracked file — file removed from disk
  - [x] Discard with both staged + unstaged on same file — staged copy preserved
  - [x] Discard button hidden on Committed/Staged groups
  - [x] Right-click context menu shows "Delete file…" / "Discard changes…" with correct icon
  - [x] Cancel button closes modal without acting

Closes #378