### PR TITLE
feat(release): add native linux-aarch64 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,67 @@ jobs:
       - run: bun run build
       - run: bun run test
 
+  # Native Linux aarch64 build smoke test. The other Linux jobs (clippy,
+  # test) run on `ubuntu-latest` (x86_64), so this catches arch-specific
+  # regressions in the release build path before they reach a tag. Runs
+  # on the GA `ubuntu-22.04-arm` first-party runner — native, no QEMU /
+  # cross toolchain.
+  linux-aarch64-check:
+    name: Linux aarch64 Check
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94"
+          targets: aarch64-unknown-linux-gnu
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: linux-aarch64
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libasound2-dev
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "latest"
+
+      - name: Install frontend dependencies
+        run: cd src/ui && bun install --frozen-lockfile
+
+      # `tauri::generate_context!()` checks that `frontendDist` exists at
+      # compile time, and the release build actually embeds the files,
+      # so we need a built frontend before any `cargo` command that
+      # touches claudette-tauri.
+      - name: Build frontend
+        run: cd src/ui && bun run build
+
+      - name: Generate icons
+        run: npx @tauri-apps/cli icon assets/logo.png
+
+      - name: cargo check (full workspace)
+        run: cargo check --workspace --target aarch64-unknown-linux-gnu
+
+      # Release-mode build of just the Tauri bin, so the asset-embedding
+      # path (tauri_build + custom-protocol) is exercised on aarch64.
+      - name: cargo build --release (claudette-tauri)
+        run: cargo build --release -p claudette-tauri --features tauri/custom-protocol --target aarch64-unknown-linux-gnu
+
+      - name: cargo test (library crates)
+        run: cargo test -p claudette -p claudette-server --target aarch64-unknown-linux-gnu
+
   # Native Windows build check on both supported targets. We compile the
   # full workspace (including the Tauri bin, which pulls in WebView2 +
   # Win32 APIs) and run the library tests so Windows-specific code paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,11 @@ jobs:
       - name: cargo build --release (claudette-tauri)
         run: cargo build --release -p claudette-tauri --features tauri/custom-protocol --target aarch64-unknown-linux-gnu
 
+      # Match the main `test` job's feature set (`cargo llvm-cov ... --all-features`)
+      # so this smoke test exercises the same code paths on aarch64 that CI
+      # exercises on x86_64.
       - name: cargo test (library crates)
-        run: cargo test -p claudette -p claudette-server --target aarch64-unknown-linux-gnu
+        run: cargo test -p claudette -p claudette-server --all-features --target aarch64-unknown-linux-gnu
 
   # Native Windows build check on both supported targets. We compile the
   # full workspace (including the Tauri bin, which pulls in WebView2 +

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,6 +122,12 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             bundles: appimage,deb
             label: linux-x86_64
+          # GitHub-hosted aarch64 Linux runner (`ubuntu-22.04-arm`) is GA and
+          # native, so this is a real ARM64 build — no QEMU / cross toolchain.
+          - platform: ubuntu-22.04-arm
+            rust-target: aarch64-unknown-linux-gnu
+            bundles: appimage,deb
+            label: linux-aarch64
           # Windows ships bare `.exe` assets only (no MSI/NSIS bundle).
           # The tauri-action step is skipped on Windows and we drive
           # cargo directly against the native MSVC toolchain baked into

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,6 +78,12 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             bundles: appimage,deb
             label: linux-x86_64
+          # GitHub-hosted aarch64 Linux runner (`ubuntu-22.04-arm`) is GA and
+          # native, so this is a real ARM64 build — no QEMU / cross toolchain.
+          - platform: ubuntu-22.04-arm
+            rust-target: aarch64-unknown-linux-gnu
+            bundles: appimage,deb
+            label: linux-aarch64
           # Windows ships bare `.exe` assets only (no MSI/NSIS bundle).
           # The tauri-action step is skipped on Windows and we drive
           # cargo directly against the native MSVC toolchain baked into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ A single sandboxed Lua runtime (`src/plugin_runtime/`) serves multiple plugin ki
 - See GitHub Issue #5 for the full MVP PRD
 - See GitHub Issue #11 for the Workspace Management TDD
 - P0 features: workspace management, agent chat, diff viewer, integrated terminal, checkpoints, git/GitHub integration, scripts, repo settings
-- Target platforms: macOS (Apple Silicon + Intel), Linux (x86_64, Wayland + X11), and Windows (x86_64 + ARM64)
+- Target platforms: macOS (Apple Silicon + Intel), Linux (x86_64 + aarch64, Wayland + X11), and Windows (x86_64 + ARM64)
 
 ## Debugging (dev builds only)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.reddit.com/r/ClaudetteApp"><img src="https://img.shields.io/reddit/subreddit-subscribers/ClaudetteApp?style=social" alt="Reddit"/></a>
 </p>
 
-Claudette is a cross-platform desktop application built with [Tauri 2](https://tauri.app) (Rust backend) and React/TypeScript (frontend). It provides a lightweight interface for managing and orchestrating Claude Code sessions, similar in spirit to [Conductor.build](https://conductor.build) but with a focused feature set. Unlike most similar tools, Claudette runs natively on **macOS** (Apple Silicon + Intel), **Linux** (x86_64, Wayland + X11), and **Windows** (x86_64 + ARM64).
+Claudette is a cross-platform desktop application built with [Tauri 2](https://tauri.app) (Rust backend) and React/TypeScript (frontend). It provides a lightweight interface for managing and orchestrating Claude Code sessions, similar in spirit to [Conductor.build](https://conductor.build) but with a focused feature set. Unlike most similar tools, Claudette runs natively on **macOS** (Apple Silicon + Intel), **Linux** (x86_64 + aarch64, Wayland + X11), and **Windows** (x86_64 + ARM64).
 
 ## Prerequisites
 

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -12,6 +12,7 @@ Claudette is available as a pre-built binary from [GitHub Releases](https://gith
 | macOS | Apple Silicon (aarch64) | `.dmg` |
 | macOS | Intel (x86_64) | `.dmg` |
 | Linux | x86_64 | `.AppImage`, `.deb` |
+| Linux | aarch64 | `.AppImage`, `.deb` |
 | Windows | x86_64 | `.zip` |
 | Windows | ARM64 | `.zip` |
 


### PR DESCRIPTION
Closes #421.

## Summary

- Add `ubuntu-22.04-arm` (GitHub-hosted, GA, native ARM64 — no QEMU / cross toolchain) matrix entry to:
  - `.github/workflows/release-please.yml` (produces `.AppImage`, `.deb`, `claudette-server-linux-aarch64`)
  - `.github/workflows/nightly.yml`
- Add a `linux-aarch64-check` job to `.github/workflows/ci.yml` modelled after the existing `windows-check` matrix — runs `cargo check --workspace`, a release build of `claudette-tauri`, and the library tests on the ARM64 runner so arch-specific regressions surface on PRs.
- Update `README.md`, `CLAUDE.md`, and `site/src/content/docs/getting-started/installation.mdx` to list the new platform.

The existing release-please workflow already gates `apt-get install`, the `tauri-action` step, and the `claudette-server` upload on platform prefix (`startsWith(matrix.platform, 'ubuntu')` / `!startsWith(matrix.platform, 'windows')`), so the new matrix entry slots in without further changes to those steps.

## Verification

**This PR's CI**: the new `linux-aarch64-check` job exercises the full Rust build path (frontend build, `cargo check --workspace`, release build of `claudette-tauri` with `custom-protocol`, library tests) on `ubuntu-22.04-arm`. That is the strongest pre-merge signal that the aarch64 build chain is healthy.

**Bundle production (`.AppImage` / `.deb`)** on `ubuntu-22.04-arm` will be exercised by the next nightly run after merge (the nightly matrix mirrors the release-please matrix and uploads to a `nightly-staging` release). I deliberately did **not** dispatch the release-please workflow against `v0.19.0` for verification — it would upload new aarch64 assets to the already-published live release, which is an out-of-band change to a stable release rather than a clean verification.

**Out of scope for this PR (deferred to a follow-up)**: on-hardware AppImage / `.deb` / `claudette-server-linux-aarch64` smoke testing on real ARM64 Linux (Pi 5 / Asahi / Ampere). Reviewers should not expect this here.

## Local checks

Run inside the Nix devshell:

- `nix develop -c cargo fmt --all --check` — ✅
- `nix develop -c cargo clippy --workspace --all-targets` — ✅
- `nix develop -c cargo test --all-features` — ✅ (727 + 16 passed)
- `cd src/ui && nix develop ../.. -c bun run test` — ✅ (864 passed)
- `cd src/ui && nix develop ../.. -c bunx tsc -b` — ✅

## Test plan

- [ ] CI's `linux-aarch64-check` job passes on this PR.
- [ ] After merge, the next nightly build successfully uploads `claudette-linux-aarch64.AppImage`, `claudette-linux-aarch64.deb`, and `claudette-server-linux-aarch64` to the `nightly` release.
- [ ] After merge, the next stable release-please tag produces the same three aarch64 assets.
- [ ] Follow-up: on-hardware smoke test of AppImage / .deb / `claudette-server` on Pi 5 / Asahi / Ampere.