### PR TITLE
feat(chat): Cmd/Ctrl+F to search the current workspace chat session

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -486,6 +486,23 @@
   margin: 8px 0 16px;
 }
 
+/* Cmd/Ctrl+F search highlights. Lives inside ChatPanel.module.css with
+   :global() so the wrapper components in this folder (and the post-render
+   DOM walker in HighlightedMessageMarkdown) can style raw <mark> tags
+   without needing to import CSS modules. */
+.messages :global(mark.cc-search-match) {
+  background: var(--accent-bg-strong);
+  color: inherit;
+  border-radius: var(--radius-xs);
+  padding: 0 1px;
+}
+
+.messages :global(mark.cc-search-match.cc-search-match-active) {
+  background: var(--accent-primary);
+  color: var(--on-accent);
+  font-weight: 600;
+}
+
 /* Blockquotes — subtle card with left accent */
 .content blockquote {
   border-left: 2px solid var(--text-faint);

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -96,6 +96,18 @@
 
 
 /* Messages area */
+/* Wraps the search bar + scrolling messages list. The bar is absolutely
+   positioned over the top of this wrapper so opening Cmd+F doesn't push
+   the messages list down. The wrapper itself participates in the chat
+   panel's flex column with `flex: 1` like .messages used to. */
+.messagesWrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  position: relative;
+}
+
 .messages {
   flex: 1;
   overflow-y: auto;
@@ -489,18 +501,31 @@
 /* Cmd/Ctrl+F search highlights. Lives inside ChatPanel.module.css with
    :global() so the wrapper components in this folder (and the post-render
    DOM walker in HighlightedMessageMarkdown) can style raw <mark> tags
-   without needing to import CSS modules. */
+   without needing to import CSS modules.
+
+   Critical: every property here must be width-neutral. Padding, margins,
+   border, and bolder font-weight all change inline metrics — when the
+   user types, marks appear/disappear per keystroke and any width-changing
+   style reflows the surrounding text. The user perceives this as text
+   "jumping around" with every keystroke. Background color, text color,
+   and box-shadow do not affect layout, so they're safe. */
 .messages :global(mark.cc-search-match) {
   background: var(--accent-bg-strong);
   color: inherit;
-  border-radius: var(--radius-xs);
-  padding: 0 1px;
+  /* No padding, border-radius (with padding), border, margin, or font-
+     weight change here — see comment above. The flat background reads
+     fine because matched text sits flush against accent-tinted bg. */
 }
 
 .messages :global(mark.cc-search-match.cc-search-match-active) {
   background: var(--accent-primary);
   color: var(--on-accent);
-  font-weight: 600;
+  /* box-shadow is render-only (no layout impact) so we use it to add a
+     subtle ring around the active match without shifting any character.
+     Bold weight would be more visually prominent but bold metrics are
+     wider than regular, which would reflow text every time the user
+     cycles to a new match. */
+  box-shadow: 0 0 0 1px var(--accent-primary);
 }
 
 /* Blockquotes — subtle card with left accent */

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1032,14 +1032,15 @@ export function ChatPanel() {
         </div>
       </div>
 
-      <ScrollContext.Provider value={scrollContextValue}>
+      <div className={styles.messagesWrapper}>
+        {selectedWorkspaceId && (
+          <ChatSearchBar
+            workspaceId={selectedWorkspaceId}
+            scopeRef={messagesContainerRef}
+          />
+        )}
+        <ScrollContext.Provider value={scrollContextValue}>
         <div className={styles.messages} ref={messagesContainerRef}>
-          {selectedWorkspaceId && (
-            <ChatSearchBar
-              workspaceId={selectedWorkspaceId}
-              scopeRef={messagesContainerRef}
-            />
-          )}
           {messages.length === 0 && !hasStreaming ? (
             <div className={styles.empty}>
               Send a message to start a conversation
@@ -1163,6 +1164,7 @@ export function ChatPanel() {
           )}
         </div>
       </ScrollContext.Provider>
+      </div>
 
       <ScrollToBottomPill
         visible={!isAtBottom && messages.length > 0}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, memo, useContext, useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
-import { MessageMarkdown } from "./MessageMarkdown";
+import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
+import { HighlightedPlainText } from "./HighlightedPlainText";
+import { ChatSearchBar } from "./ChatSearchBar";
 import { AlertCircle, FileText, GitBranch, LoaderCircle, Mic, Plus, RotateCcw, Send, Split, Square, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
@@ -265,6 +267,17 @@ export function ChatPanel() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Cmd/Ctrl+F search bar state. `searchQuery` flows down to message
+  // renderers as the highlight trigger; an empty string short-circuits the
+  // wrappers' DOM-walk pass entirely, so search-off has zero render cost.
+  const chatSearchOpen = useAppStore(
+    (s) => (selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.open ?? false : false),
+  );
+  const chatSearchQuery = useAppStore(
+    (s) => (selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.query ?? "" : ""),
+  );
+  const searchQuery = chatSearchOpen ? chatSearchQuery : "";
 
   const [attachmentMenu, setAttachmentMenu] = useState<{
     x: number;
@@ -1021,6 +1034,12 @@ export function ChatPanel() {
 
       <ScrollContext.Provider value={scrollContextValue}>
         <div className={styles.messages} ref={messagesContainerRef}>
+          {selectedWorkspaceId && (
+            <ChatSearchBar
+              workspaceId={selectedWorkspaceId}
+              scopeRef={messagesContainerRef}
+            />
+          )}
           {messages.length === 0 && !hasStreaming ? (
             <div className={styles.empty}>
               Send a message to start a conversation
@@ -1035,6 +1054,7 @@ export function ChatPanel() {
                   onForkTurn={isRemote ? undefined : handleFork}
                   onAttachmentContextMenu={openAttachmentMenu}
                   onAttachmentClick={openLightbox}
+                  searchQuery={searchQuery}
                 />
               )}
 
@@ -1043,13 +1063,14 @@ export function ChatPanel() {
               )}
 
               {selectedWorkspaceId && (hasStreaming || hasPendingTypewriter) && (
-                <StreamingMessage workspaceId={selectedWorkspaceId} />
+                <StreamingMessage workspaceId={selectedWorkspaceId} searchQuery={searchQuery} />
               )}
 
               {selectedWorkspaceId && activitiesCount > 0 && (
                 <ToolActivitiesSection
                   workspaceId={selectedWorkspaceId}
                   isRunning={isRunning ?? false}
+                  searchQuery={searchQuery}
                 />
               )}
 
@@ -1266,8 +1287,10 @@ const StreamingThinkingBlock = memo(function StreamingThinkingBlock({
  */
 const StreamingMessage = memo(function StreamingMessage({
   workspaceId,
+  searchQuery,
 }: {
   workspaceId: string;
+  searchQuery: string;
 }) {
   const streaming = useAppStore(
     (s) => s.streamingContent[workspaceId] || ""
@@ -1308,7 +1331,7 @@ const StreamingMessage = memo(function StreamingMessage({
     >
       <div className={styles.content}>
         <StreamingContext.Provider value={isStreaming || pendingText.length > 0}>
-          <MessageMarkdown content={displayed} />
+          <HighlightedMessageMarkdown content={displayed} query={searchQuery} />
         </StreamingContext.Provider>
         {showCaret && <span className={caretStyles.caret} aria-hidden="true" />}
       </div>
@@ -1609,6 +1632,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   onForkTurn,
   onAttachmentContextMenu,
   onAttachmentClick,
+  searchQuery,
 }: {
   messages: ChatMessage[];
   workspaceId: string;
@@ -1630,6 +1654,9 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
     e: React.MouseEvent,
     attachment: DownloadableAttachment,
   ) => void;
+  /** Active chat-search query (Cmd/Ctrl+F). Empty string when the bar is
+   *  closed; non-empty values trigger highlight wrappers on each message. */
+  searchQuery: string;
 }) {
   const completedTurns = useAppStore(
     (s) => s.completedTurns[workspaceId] ?? EMPTY_COMPLETED_TURNS
@@ -2026,7 +2053,13 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                 // setup-script output, and other multi-line system notes
                 // preserve headings, lists, and code blocks instead of
                 // collapsing newlines into a single paragraph.
-                <MessageMarkdown content={msg.content} />
+                <HighlightedMessageMarkdown content={msg.content} query={searchQuery} />
+              ) : searchQuery ? (
+                // While the search bar is open, render user messages as plain
+                // highlighted text so matches inside them get marked. The
+                // ultrathink rainbow animation is suppressed in this mode —
+                // searchability wins over the easter egg.
+                <HighlightedPlainText text={msg.content} query={searchQuery} />
               ) : (
                 renderUltrathinkText(msg.content, {
                   animated: false,
@@ -2070,9 +2103,11 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
 const ToolActivitiesSection = memo(function ToolActivitiesSection({
   workspaceId,
   isRunning,
+  searchQuery,
 }: {
   workspaceId: string;
   isRunning: boolean;
+  searchQuery: string;
 }) {
   const activities = useAppStore(
     (s) => s.toolActivities[workspaceId] ?? EMPTY_ACTIVITIES
@@ -2121,7 +2156,7 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
                   <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>{act.toolName}</span>
                   {act.summary && (
                     <span className={styles.toolSummary}>
-                      {act.summary}
+                      <HighlightedPlainText text={act.summary} query={searchQuery} />
                     </span>
                   )}
                 </div>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1060,7 +1060,11 @@ export function ChatPanel() {
               )}
 
               {selectedWorkspaceId && hasThinking && showThinkingBlocks && (
-                <StreamingThinkingBlock workspaceId={selectedWorkspaceId} isStreaming={isRunning ?? false} />
+                <StreamingThinkingBlock
+                  workspaceId={selectedWorkspaceId}
+                  isStreaming={isRunning ?? false}
+                  searchQuery={searchQuery}
+                />
               )}
 
               {selectedWorkspaceId && (hasStreaming || hasPendingTypewriter) && (
@@ -1269,15 +1273,24 @@ export function ChatPanel() {
 const StreamingThinkingBlock = memo(function StreamingThinkingBlock({
   workspaceId,
   isStreaming,
+  searchQuery,
 }: {
   workspaceId: string;
   isStreaming: boolean;
+  searchQuery: string;
 }) {
   const thinking = useAppStore(
     (s) => s.streamingThinking[workspaceId] || ""
   );
   if (!thinking) return null;
-  return <ThinkingBlock content={thinking} isStreaming={isStreaming} enableTypewriter />;
+  return (
+    <ThinkingBlock
+      content={thinking}
+      isStreaming={isStreaming}
+      enableTypewriter
+      searchQuery={searchQuery}
+    />
+  );
 });
 
 /**
@@ -1352,6 +1365,7 @@ function TurnSummary({
   assistantText,
   onFork,
   onRollback,
+  searchQuery,
 }: {
   turn: CompletedTurn;
   collapsed: boolean;
@@ -1366,6 +1380,9 @@ function TurnSummary({
   /** Called when the user clicks rollback. Undefined hides the button
    *  (e.g. turn is running, or no checkpoint exists for this turn). */
   onRollback?: () => void;
+  /** Active chat-search query. Force-expands this card when non-empty and
+   *  the query matches inside any of the contained activity summaries. */
+  searchQuery: string;
 }) {
   const hasElapsed = typeof turn.durationMs === "number" && turn.durationMs > 0;
   const hasTokens =
@@ -1374,6 +1391,18 @@ function TurnSummary({
   const hasFork = !!onFork;
   const hasRollback = !!onRollback;
   const showFooter = hasElapsed || hasTokens || hasCopy || hasFork || hasRollback;
+
+  // Force-expand if the query matches in any activity summary or the
+  // resolved tool-summary fallback. Without this, marks would land in
+  // detached DOM (the collapsed branch never renders), so the bar's
+  // counter would tick up but nothing visible would change.
+  const queryHasMatch =
+    !!searchQuery &&
+    turn.activities.some((a) => {
+      const text = a.summary || extractToolSummary(a.toolName, a.inputJson);
+      return text.toLowerCase().includes(searchQuery.toLowerCase());
+    });
+  const isExpanded = !collapsed || queryHasMatch;
 
   return (
     <div className={styles.turnSummaryWrapper}>
@@ -1391,7 +1420,7 @@ function TurnSummary({
       >
         <div className={styles.turnHeader}>
           <span className={styles.toolChevron}>
-            {collapsed ? "›" : "⌄"}
+            {isExpanded ? "⌄" : "›"}
           </span>
           <span className={styles.turnLabel}>
             {turn.activities.length} tool call
@@ -1400,7 +1429,7 @@ function TurnSummary({
               `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
           </span>
         </div>
-        {!collapsed && (
+        {isExpanded && (
           <div className={styles.turnActivities}>
             {turn.activities.map((act: ToolActivity) => (
               <div key={act.toolUseId} className={styles.toolActivity}>
@@ -1410,7 +1439,10 @@ function TurnSummary({
                   </span>
                   {(act.summary || act.inputJson) && (
                     <span className={styles.toolSummary}>
-                      {act.summary || extractToolSummary(act.toolName, act.inputJson)}
+                      <HighlightedPlainText
+                        text={act.summary || extractToolSummary(act.toolName, act.inputJson)}
+                        query={searchQuery}
+                      />
                     </span>
                   )}
                 </div>
@@ -1904,6 +1936,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
         assistantText={assistantTextByTurnId.get(turn.id) ?? ""}
         onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
         onRollback={buildOnRollback(turn.id)}
+        searchQuery={searchQuery}
       />
     ));
   };
@@ -1952,7 +1985,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
               <div className={styles.roleLabel}>You</div>
             )}
             {msg.role === "Assistant" && msg.thinking && showThinkingBlocks && (
-              <ThinkingBlock content={msg.thinking} isStreaming={false} />
+              <ThinkingBlock content={msg.thinking} isStreaming={false} searchQuery={searchQuery} />
             )}
             <div className={styles.content}>
               {attachmentsByMessage.has(msg.id) && (
@@ -2092,6 +2125,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
             assistantText={assistantTextByTurnId.get(turn.id) ?? ""}
             onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
             onRollback={buildOnRollback(turn.id)}
+            searchQuery={searchQuery}
           />
         ))}
     </>
@@ -2127,6 +2161,18 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
 
   if (activities.length === 0) return null;
 
+  // Force-expand when the active search query matches inside any of this
+  // section's activity summaries — otherwise marks would be silently
+  // hidden behind the collapsed header and the user would see a non-zero
+  // counter with no visible highlight.
+  const queryHasMatch =
+    !!searchQuery &&
+    activities.some(
+      (a) =>
+        a.summary && a.summary.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+  const isExpanded = !collapsed || queryHasMatch;
+
   return (
     <div className={styles.toolActivities} aria-live="polite" aria-atomic="true">
       <div className={styles.turnSummary}>
@@ -2143,14 +2189,14 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
           }}
         >
           <span className={styles.toolChevron}>
-            {collapsed ? "›" : "⌄"}
+            {isExpanded ? "⌄" : "›"}
           </span>
           <span className={styles.turnLabel}>
             {activities.length} tool call{activities.length !== 1 ? "s" : ""}
             {isRunning && <span className={styles.inProgressNote}> in progress</span>}
           </span>
         </div>
-        {!collapsed && (
+        {isExpanded && (
           <div className={styles.turnActivities}>
             {activities.map((act: ToolActivity) => (
               <div key={act.toolUseId} className={styles.toolActivity}>

--- a/src/ui/src/components/chat/ChatSearchBar.module.css
+++ b/src/ui/src/components/chat/ChatSearchBar.module.css
@@ -1,0 +1,63 @@
+.bar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--chat-header-bg);
+  border-bottom: 1px solid var(--divider);
+  backdrop-filter: blur(8px);
+}
+
+.input {
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  padding: 0 8px;
+  background: var(--chat-input-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 1px var(--accent-bg-strong);
+}
+
+.counter {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 56px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.iconButton:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/src/ui/src/components/chat/ChatSearchBar.module.css
+++ b/src/ui/src/components/chat/ChatSearchBar.module.css
@@ -1,6 +1,14 @@
 .bar {
-  position: sticky;
+  /* Absolute (overlay) rather than sticky so the bar appearing/disappearing
+     doesn't push the messages list down by its height — opening Cmd+F would
+     otherwise shift every visible message by ~40px, which the issue calls
+     out as "portal-positioned to avoid layout shift". The .messages parent
+     uses `contain: layout style`, which already establishes a containing
+     block for absolute descendants — no need for `position: relative`. */
+  position: absolute;
   top: 0;
+  left: 0;
+  right: 0;
   z-index: 5;
   display: flex;
   align-items: center;
@@ -8,6 +16,8 @@
   padding: 6px 10px;
   background: var(--chat-header-bg);
   border-bottom: 1px solid var(--divider);
+  /* Subtle translucency so the bar reads as floating over content rather
+     than as a hard separator. backdrop-filter blurs whatever's behind it. */
   backdrop-filter: blur(8px);
 }
 

--- a/src/ui/src/components/chat/ChatSearchBar.tsx
+++ b/src/ui/src/components/chat/ChatSearchBar.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import { focusChatPrompt } from "../../utils/focusTargets";
+import styles from "./ChatSearchBar.module.css";
+
+const SEARCH_MARK_SELECTOR = "mark.cc-search-match";
+const ACTIVE_CLASS = "cc-search-match-active";
+
+interface Props {
+  workspaceId: string;
+  /** The chat panel's `.messages` container — used to scope DOM lookups so
+   *  matches outside the active workspace's message list never bleed in. */
+  scopeRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
+  const open = useAppStore(
+    (s) => s.chatSearch[workspaceId]?.open ?? false,
+  );
+  const query = useAppStore((s) => s.chatSearch[workspaceId]?.query ?? "");
+  const matchIndex = useAppStore(
+    (s) => s.chatSearch[workspaceId]?.matchIndex ?? -1,
+  );
+  const setQuery = useAppStore((s) => s.setChatSearchQuery);
+  const setMatchIndex = useAppStore((s) => s.setChatSearchMatchIndex);
+  const closeChatSearch = useAppStore((s) => s.closeChatSearch);
+
+  // Trigger DOM-derived count + active-mark refresh after every commit that
+  // could change which marks are in the DOM. We listen to a few store-derived
+  // signals (messageCount, streamingLength, activitiesLength) to know when
+  // a re-tally is needed.
+  const messageCount = useAppStore(
+    (s) => s.chatMessages[workspaceId]?.length ?? 0,
+  );
+  const streamingLength = useAppStore(
+    (s) => s.streamingContent[workspaceId]?.length ?? 0,
+  );
+  const activitiesLength = useAppStore(
+    (s) => s.toolActivities[workspaceId]?.length ?? 0,
+  );
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [matchCount, setMatchCount] = useState(0);
+
+  // Auto-focus input when the bar opens (and when re-opening to a still-
+  // mounted bar, focus may have moved away — re-grabbing it here keeps the
+  // hotkey idempotent).
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [open]);
+
+  // Tally matches and re-clamp the active index after every relevant render.
+  // Uses `useEffect` rather than `useLayoutEffect` so the DOM-mutation pass
+  // in HighlightedMessageMarkdown / HighlightedPlainText (which run as their
+  // own layout effects further down the tree, but as siblings of this bar)
+  // has finished by the time the count runs. A layout-effect here would
+  // race the wrappers and read a pre-highlight DOM.
+  useEffect(() => {
+    if (!open) return;
+    const scope = scopeRef.current;
+    if (!scope) {
+      setMatchCount(0);
+      return;
+    }
+    const count = scope.querySelectorAll(SEARCH_MARK_SELECTOR).length;
+    setMatchCount(count);
+    if (count === 0) {
+      if (matchIndex !== -1) setMatchIndex(workspaceId, -1);
+      return;
+    }
+    if (matchIndex === -1 || matchIndex >= count) {
+      setMatchIndex(workspaceId, 0);
+    }
+  }, [
+    open,
+    query,
+    messageCount,
+    streamingLength,
+    activitiesLength,
+    matchIndex,
+    setMatchIndex,
+    workspaceId,
+    scopeRef,
+  ]);
+
+  // Apply the .active class to the Nth mark and scroll it into view.
+  useEffect(() => {
+    if (!open) return;
+    const scope = scopeRef.current;
+    if (!scope) return;
+    const marks = scope.querySelectorAll<HTMLElement>(SEARCH_MARK_SELECTOR);
+    for (const m of Array.from(marks)) m.classList.remove(ACTIVE_CLASS);
+    if (matchIndex < 0 || matchIndex >= marks.length) return;
+    const active = marks[matchIndex];
+    active.classList.add(ACTIVE_CLASS);
+    active.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, [open, query, matchIndex, matchCount, scopeRef]);
+
+  const handleClose = () => {
+    closeChatSearch(workspaceId);
+    focusChatPrompt();
+  };
+
+  const handleNext = () => {
+    if (matchCount === 0) return;
+    const next = matchIndex < 0 ? 0 : (matchIndex + 1) % matchCount;
+    setMatchIndex(workspaceId, next);
+  };
+
+  const handlePrev = () => {
+    if (matchCount === 0) return;
+    const prev =
+      matchIndex < 0
+        ? matchCount - 1
+        : (matchIndex - 1 + matchCount) % matchCount;
+    setMatchIndex(workspaceId, prev);
+  };
+
+  if (!open) return null;
+
+  // Counter rules: show "n / N" when there are matches, "No matches" when
+  // the query is non-empty but unmatched, blank when the query is empty.
+  const counter = !query
+    ? ""
+    : matchCount === 0
+      ? "No matches"
+      : `${matchIndex + 1} / ${matchCount}`;
+
+  return (
+    <div
+      className={styles.bar}
+      role="search"
+      aria-label="Search chat"
+      data-search-total={matchCount}
+      data-search-active={matchIndex}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        className={styles.input}
+        placeholder="Search chat…"
+        value={query}
+        onChange={(e) => setQuery(workspaceId, e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) handlePrev();
+            else handleNext();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            handleClose();
+          }
+        }}
+        // Prevent global Cmd+F handler from re-opening / re-focusing the bar
+        // while typing — let the input own all keystrokes.
+        onKeyDownCapture={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.code === "KeyF") {
+            e.preventDefault();
+            inputRef.current?.select();
+          }
+        }}
+        aria-label="Search query"
+      />
+      <span className={styles.counter} aria-live="polite">
+        {counter}
+      </span>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handlePrev}
+        disabled={matchCount === 0}
+        aria-label="Previous match"
+        title="Previous (Shift+Enter)"
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handleNext}
+        disabled={matchCount === 0}
+        aria-label="Next match"
+        title="Next (Enter)"
+      >
+        <ChevronDown size={14} />
+      </button>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handleClose}
+        aria-label="Close search"
+        title="Close (Esc)"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/ChatSearchBar.tsx
+++ b/src/ui/src/components/chat/ChatSearchBar.tsx
@@ -97,7 +97,16 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
     if (matchIndex < 0 || matchIndex >= marks.length) return;
     const active = marks[matchIndex];
     active.classList.add(ACTIVE_CLASS);
-    active.scrollIntoView({ block: "center", behavior: "smooth" });
+    // Skip the smooth scroll for users who've opted into reduced motion —
+    // the cycle would otherwise force a noticeable animation despite their
+    // OS-level preference.
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    active.scrollIntoView({
+      block: "center",
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+    });
   }, [open, query, matchIndex, matchCount, scopeRef]);
 
   const handleClose = () => {
@@ -124,11 +133,14 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
 
   // Counter rules: show "n / N" when there are matches, "No matches" when
   // the query is non-empty but unmatched, blank when the query is empty.
+  // `matchIndex` can briefly be -1 between a query change and the clamping
+  // effect that lands on 0 — clamp here so the user never sees "0 / N".
+  const displayMatchIndex = matchIndex < 0 ? 0 : matchIndex;
   const counter = !query
     ? ""
     : matchCount === 0
       ? "No matches"
-      : `${matchIndex + 1} / ${matchCount}`;
+      : `${displayMatchIndex + 1} / ${matchCount}`;
 
   return (
     <div
@@ -160,6 +172,7 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
         onKeyDownCapture={(e) => {
           if ((e.metaKey || e.ctrlKey) && e.code === "KeyF") {
             e.preventDefault();
+            e.stopPropagation();
             inputRef.current?.select();
           }
         }}

--- a/src/ui/src/components/chat/ChatSearchBar.tsx
+++ b/src/ui/src/components/chat/ChatSearchBar.tsx
@@ -1,11 +1,46 @@
 import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp, X } from "lucide-react";
-import { useAppStore } from "../../stores/useAppStore";
+import { useAppStore, type ToolActivity } from "../../stores/useAppStore";
 import { focusChatPrompt } from "../../utils/focusTargets";
 import styles from "./ChatSearchBar.module.css";
 
 const SEARCH_MARK_SELECTOR = "mark.cc-search-match";
 const ACTIVE_CLASS = "cc-search-match-active";
+
+// Stable empty-array sentinel so the Zustand selector below returns the
+// same reference on every read when the workspace has no activities yet —
+// otherwise `?? []` would create a fresh array each render and trip the
+// selector's identity check, causing unnecessary effect re-runs.
+const EMPTY_ACTIVITIES: ToolActivity[] = [];
+
+/**
+ * Walk every search mark within `scope` in document order and return the
+ * unique `data-match-id` values, preserving first-seen order. Logical
+ * matches that the highlight wrappers split across multiple <mark>s share
+ * one id, so this function tells the bar both how many distinct matches
+ * exist and the order to cycle through them.
+ */
+function collectOrderedMatchIds(scope: HTMLElement): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  const marks = scope.querySelectorAll<HTMLElement>(SEARCH_MARK_SELECTOR);
+  for (const m of Array.from(marks)) {
+    const id = m.dataset.matchId;
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ordered.push(id);
+  }
+  return ordered;
+}
+
+/**
+ * Minimal CSS attribute-value escape — the match ids we generate are
+ * stringified integers today, but escaping the `\` and `"` characters
+ * keeps `[data-match-id="…"]` selectors safe if the format ever changes.
+ */
+function cssEscape(value: string): string {
+  return value.replace(/[\\"]/g, "\\$&");
+}
 
 interface Props {
   workspaceId: string;
@@ -27,17 +62,21 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
   const closeChatSearch = useAppStore((s) => s.closeChatSearch);
 
   // Trigger DOM-derived count + active-mark refresh after every commit that
-  // could change which marks are in the DOM. We listen to a few store-derived
-  // signals (messageCount, streamingLength, activitiesLength) to know when
-  // a re-tally is needed.
+  // could change which marks are in the DOM. `messageCount` /
+  // `streamingLength` are sufficient for chat messages and streaming text
+  // because new content always grows their length. Tool activities are
+  // different: `updateToolActivity` mutates an existing activity's summary
+  // in place, replacing the array but keeping the same length, so we
+  // subscribe to the array reference instead of `.length` to catch
+  // in-place summary edits.
   const messageCount = useAppStore(
     (s) => s.chatMessages[workspaceId]?.length ?? 0,
   );
   const streamingLength = useAppStore(
     (s) => s.streamingContent[workspaceId]?.length ?? 0,
   );
-  const activitiesLength = useAppStore(
-    (s) => s.toolActivities[workspaceId]?.length ?? 0,
+  const activities = useAppStore(
+    (s) => s.toolActivities[workspaceId] ?? EMPTY_ACTIVITIES,
   );
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -54,6 +93,11 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
   }, [open]);
 
   // Tally matches and re-clamp the active index after every relevant render.
+  // Counts unique `data-match-id` values rather than raw <mark> elements so
+  // a single logical match split across multiple marks (e.g., "def " across
+  // two Shiki spans) is reported as one entry in the counter and traversed
+  // as a single step when cycling.
+  //
   // Uses `useEffect` rather than `useLayoutEffect` so the DOM-mutation pass
   // in HighlightedMessageMarkdown / HighlightedPlainText (which run as their
   // own layout effects further down the tree, but as siblings of this bar)
@@ -66,7 +110,8 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
       setMatchCount(0);
       return;
     }
-    const count = scope.querySelectorAll(SEARCH_MARK_SELECTOR).length;
+    const ids = collectOrderedMatchIds(scope);
+    const count = ids.length;
     setMatchCount(count);
     if (count === 0) {
       if (matchIndex !== -1) setMatchIndex(workspaceId, -1);
@@ -80,30 +125,37 @@ export function ChatSearchBar({ workspaceId, scopeRef }: Props) {
     query,
     messageCount,
     streamingLength,
-    activitiesLength,
+    activities,
     matchIndex,
     setMatchIndex,
     workspaceId,
     scopeRef,
   ]);
 
-  // Apply the .active class to the Nth mark and scroll it into view.
+  // Apply the .active class to every mark belonging to the active logical
+  // match (multiple <mark>s may share the same data-match-id) and scroll
+  // the first one into view.
   useEffect(() => {
     if (!open) return;
     const scope = scopeRef.current;
     if (!scope) return;
-    const marks = scope.querySelectorAll<HTMLElement>(SEARCH_MARK_SELECTOR);
-    for (const m of Array.from(marks)) m.classList.remove(ACTIVE_CLASS);
-    if (matchIndex < 0 || matchIndex >= marks.length) return;
-    const active = marks[matchIndex];
-    active.classList.add(ACTIVE_CLASS);
+    const allMarks = scope.querySelectorAll<HTMLElement>(SEARCH_MARK_SELECTOR);
+    for (const m of Array.from(allMarks)) m.classList.remove(ACTIVE_CLASS);
+    const ids = collectOrderedMatchIds(scope);
+    if (matchIndex < 0 || matchIndex >= ids.length) return;
+    const activeId = ids[matchIndex];
+    const activeMarks = scope.querySelectorAll<HTMLElement>(
+      `${SEARCH_MARK_SELECTOR}[data-match-id="${cssEscape(activeId)}"]`,
+    );
+    if (activeMarks.length === 0) return;
+    for (const m of Array.from(activeMarks)) m.classList.add(ACTIVE_CLASS);
     // Skip the smooth scroll for users who've opted into reduced motion —
     // the cycle would otherwise force a noticeable animation despite their
     // OS-level preference.
     const prefersReducedMotion =
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    active.scrollIntoView({
+    activeMarks[0].scrollIntoView({
       block: "center",
       behavior: prefersReducedMotion ? "auto" : "smooth",
     });

--- a/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
+++ b/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
@@ -111,17 +111,22 @@ function applyHighlights(root: HTMLElement, query: string): void {
 
 function removeHighlights(root: HTMLElement): void {
   const marks = root.querySelectorAll<HTMLElement>(`mark.${SEARCH_MARK_CLASS}`);
+  if (marks.length === 0) return;
+  // Collect every parent we touched so we can normalize each one only once
+  // at the end. Calling Node.normalize() per-mark inside the loop is O(N²)
+  // when many matches share the same parent — each call walks all of that
+  // parent's children to merge adjacent text nodes.
+  const parentsToNormalize = new Set<Node>();
   for (const mark of Array.from(marks)) {
     const parent = mark.parentNode;
     if (!parent) continue;
-    // Replace <mark>text</mark> with a single TextNode and merge with
-    // adjacent siblings so the parent ends up indistinguishable from
-    // before the highlight pass — react-markdown's reconciliation can
-    // then reuse the same DOM on the next render.
     parent.replaceChild(
       document.createTextNode(mark.textContent ?? ""),
       mark,
     );
+    parentsToNormalize.add(parent);
+  }
+  for (const parent of parentsToNormalize) {
     parent.normalize();
   }
 }

--- a/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
+++ b/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
@@ -1,0 +1,127 @@
+import { memo, useLayoutEffect, useRef } from "react";
+import { MessageMarkdown } from "./MessageMarkdown";
+
+/**
+ * Wraps `<MessageMarkdown>` and overlays `<mark class="cc-search-match">`
+ * around every case-insensitive substring match of `query`, applied via a
+ * post-render DOM walker on the wrapper element.
+ *
+ * The DOM-mutation path (rather than a render-time text split) is
+ * deliberate: the markdown pipeline is heavily memoized — `MessageMarkdown`
+ * caches its parse result keyed on `content`, the Shiki worker caches
+ * highlighted code keyed on `(lang, code)`. Re-running react-markdown for
+ * every keystroke would invalidate both. By layering highlights after the
+ * markdown DOM is committed, the cached subtree stays mounted and the
+ * highlight effect runs in O(visible-text) per keystroke.
+ *
+ * Code blocks are skipped so search highlights don't fragment Shiki's
+ * tokenized DOM.
+ */
+const SEARCH_MARK_CLASS = "cc-search-match";
+
+interface Props {
+  content: string;
+  query: string;
+}
+
+export const HighlightedMessageMarkdown = memo(function HighlightedMessageMarkdown({
+  content,
+  query,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Re-run on every (content, query) change. Body is idempotent: it first
+  // strips any marks we previously added, then re-applies. We don't use a
+  // cleanup function because cleanup runs *after* React reconciles the next
+  // render, which is too late — by then the inner markdown subtree may have
+  // already been rebuilt by react-markdown (when `content` changes) or
+  // preserved verbatim (when only `query` changes). Running both passes
+  // here keeps the wrapper in sync with the latest commit either way.
+  useLayoutEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    removeHighlights(root);
+    if (query) applyHighlights(root, query);
+  }, [content, query]);
+
+  return (
+    <div ref={containerRef} className="cc-highlight-wrap">
+      <MessageMarkdown content={content} />
+    </div>
+  );
+});
+
+function applyHighlights(root: HTMLElement, query: string): void {
+  const lowerQuery = query.toLowerCase();
+  if (!lowerQuery) return;
+  const queryLength = lowerQuery.length;
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      // Skip text inside <code> / <pre> — those are syntax-highlighted by
+      // Shiki and fragmenting the token spans would break colors.
+      let p: Node | null = node.parentNode;
+      while (p && p !== root) {
+        const tag = (p as HTMLElement).tagName;
+        if (tag === "CODE" || tag === "PRE") return NodeFilter.FILTER_REJECT;
+        if ((p as HTMLElement).classList?.contains(SEARCH_MARK_CLASS)) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        p = p.parentNode;
+      }
+      return node.nodeValue && node.nodeValue.length > 0
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT;
+    },
+  });
+
+  // Collect first to avoid mutating the tree mid-walk.
+  const targets: Text[] = [];
+  let current = walker.nextNode();
+  while (current) {
+    targets.push(current as Text);
+    current = walker.nextNode();
+  }
+
+  for (const textNode of targets) {
+    const text = textNode.nodeValue ?? "";
+    const lower = text.toLowerCase();
+    let from = 0;
+    let idx = lower.indexOf(lowerQuery, from);
+    if (idx === -1) continue;
+
+    const fragment = document.createDocumentFragment();
+    while (idx !== -1) {
+      if (idx > from) {
+        fragment.appendChild(document.createTextNode(text.slice(from, idx)));
+      }
+      const mark = document.createElement("mark");
+      mark.className = SEARCH_MARK_CLASS;
+      mark.textContent = text.slice(idx, idx + queryLength);
+      fragment.appendChild(mark);
+      from = idx + queryLength;
+      idx = lower.indexOf(lowerQuery, from);
+    }
+    if (from < text.length) {
+      fragment.appendChild(document.createTextNode(text.slice(from)));
+    }
+    textNode.parentNode?.replaceChild(fragment, textNode);
+  }
+}
+
+function removeHighlights(root: HTMLElement): void {
+  const marks = root.querySelectorAll<HTMLElement>(`mark.${SEARCH_MARK_CLASS}`);
+  for (const mark of Array.from(marks)) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    // Replace <mark>text</mark> with a single TextNode and merge with
+    // adjacent siblings so the parent ends up indistinguishable from
+    // before the highlight pass — react-markdown's reconciliation can
+    // then reuse the same DOM on the next render.
+    parent.replaceChild(
+      document.createTextNode(mark.textContent ?? ""),
+      mark,
+    );
+    parent.normalize();
+  }
+}

--- a/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
+++ b/src/ui/src/components/chat/HighlightedMessageMarkdown.tsx
@@ -1,5 +1,6 @@
 import { memo, useLayoutEffect, useRef } from "react";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { findAllRanges, nextSearchMatchId } from "../../utils/textSearch";
 
 /**
  * Wraps `<MessageMarkdown>` and overlays `<mark class="cc-search-match">`
@@ -51,19 +52,41 @@ export const HighlightedMessageMarkdown = memo(function HighlightedMessageMarkdo
   );
 });
 
-function applyHighlights(root: HTMLElement, query: string): void {
-  const lowerQuery = query.toLowerCase();
-  if (!lowerQuery) return;
-  const queryLength = lowerQuery.length;
+// Block-level tags that bound a "match container". Text nodes inside the
+// same block-tag ancestor get joined when searching, so a query can span
+// inline elements (e.g., across Shiki token spans inside <pre>, or across
+// <em>/<strong> inside a <p>) — but never across paragraph or list-item
+// boundaries, which would produce confusing matches with no visible
+// separator. Tag-name lookup is cheaper than getComputedStyle().
+const BLOCK_TAGS = new Set([
+  "P", "H1", "H2", "H3", "H4", "H5", "H6", "LI", "PRE", "BLOCKQUOTE",
+  "TD", "TH", "DIV", "SECTION", "ARTICLE", "HEADER", "FOOTER", "DD", "DT",
+]);
 
+function nearestBlockAncestor(el: Element | null, root: HTMLElement): Element {
+  let cur: Element | null = el;
+  while (cur && cur !== root) {
+    if (BLOCK_TAGS.has(cur.tagName)) return cur;
+    cur = cur.parentElement;
+  }
+  return root;
+}
+
+function applyHighlights(root: HTMLElement, query: string): void {
+  if (!query) return;
+
+  // Group all text nodes by their nearest block ancestor. Cross-token /
+  // cross-inline-element matches inside the same block then "just work"
+  // because we match against the block's joined text rather than each
+  // text node in isolation. This is what makes a search like "def " land
+  // when Shiki has tokenized "def" and " " into adjacent <span>s.
+  const groups = new Map<Element, Text[]>();
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
-      // Skip text inside <code> / <pre> — those are syntax-highlighted by
-      // Shiki and fragmenting the token spans would break colors.
+      // Skip text already wrapped in a previous mark (defensive — cleanup
+      // should have removed them, but the check makes re-runs idempotent).
       let p: Node | null = node.parentNode;
       while (p && p !== root) {
-        const tag = (p as HTMLElement).tagName;
-        if (tag === "CODE" || tag === "PRE") return NodeFilter.FILTER_REJECT;
         if ((p as HTMLElement).classList?.contains(SEARCH_MARK_CLASS)) {
           return NodeFilter.FILTER_REJECT;
         }
@@ -75,37 +98,78 @@ function applyHighlights(root: HTMLElement, query: string): void {
     },
   });
 
-  // Collect first to avoid mutating the tree mid-walk.
-  const targets: Text[] = [];
-  let current = walker.nextNode();
-  while (current) {
-    targets.push(current as Text);
-    current = walker.nextNode();
+  let n: Node | null;
+  while ((n = walker.nextNode())) {
+    const container = nearestBlockAncestor(n.parentNode as Element, root);
+    let arr = groups.get(container);
+    if (!arr) {
+      arr = [];
+      groups.set(container, arr);
+    }
+    arr.push(n as Text);
   }
 
-  for (const textNode of targets) {
-    const text = textNode.nodeValue ?? "";
-    const lower = text.toLowerCase();
-    let from = 0;
-    let idx = lower.indexOf(lowerQuery, from);
-    if (idx === -1) continue;
+  for (const nodes of groups.values()) {
+    highlightTextNodeGroup(nodes, query);
+  }
+}
 
-    const fragment = document.createDocumentFragment();
-    while (idx !== -1) {
-      if (idx > from) {
-        fragment.appendChild(document.createTextNode(text.slice(from, idx)));
+function highlightTextNodeGroup(nodes: Text[], query: string): void {
+  if (nodes.length === 0) return;
+  // Build a single joined string spanning every text node in this block,
+  // then run the shared regex finder against it. Matches are returned in
+  // joined-string coordinates; we then walk back through the nodes and
+  // apply each match's portion to whichever node(s) it lands on.
+  const joined = nodes.map((t) => t.nodeValue ?? "").join("");
+  const ranges = findAllRanges(joined, query);
+  if (ranges.length === 0) return;
+
+  // Assign a stable id per logical range up-front so every <mark> we
+  // produce for that range can be tagged with the same `data-match-id`.
+  // ChatSearchBar uses these ids to collapse split matches into a single
+  // counter entry and to apply the active class to all of a match's
+  // pieces simultaneously.
+  const rangeIds = ranges.map(() => nextSearchMatchId());
+
+  let nodeStart = 0;
+  for (const node of nodes) {
+    const text = node.nodeValue ?? "";
+    const nodeEnd = nodeStart + text.length;
+
+    // Collect all match sub-ranges that fall inside this node, expressed
+    // as local (text-relative) offsets, paired with their range id.
+    const subRanges: Array<{ start: number; end: number; id: string }> = [];
+    for (let i = 0; i < ranges.length; i++) {
+      const r = ranges[i];
+      if (r.end <= nodeStart || r.start >= nodeEnd) continue;
+      subRanges.push({
+        start: Math.max(0, r.start - nodeStart),
+        end: Math.min(text.length, r.end - nodeStart),
+        id: rangeIds[i],
+      });
+    }
+
+    if (subRanges.length > 0) {
+      const fragment = document.createDocumentFragment();
+      let cursor = 0;
+      for (const sr of subRanges) {
+        if (sr.start > cursor) {
+          fragment.appendChild(document.createTextNode(text.slice(cursor, sr.start)));
+        }
+        const mark = document.createElement("mark");
+        mark.className = SEARCH_MARK_CLASS;
+        mark.dataset.matchId = sr.id;
+        mark.textContent = text.slice(sr.start, sr.end);
+        fragment.appendChild(mark);
+        cursor = sr.end;
       }
-      const mark = document.createElement("mark");
-      mark.className = SEARCH_MARK_CLASS;
-      mark.textContent = text.slice(idx, idx + queryLength);
-      fragment.appendChild(mark);
-      from = idx + queryLength;
-      idx = lower.indexOf(lowerQuery, from);
+      if (cursor < text.length) {
+        fragment.appendChild(document.createTextNode(text.slice(cursor)));
+      }
+      node.parentNode?.replaceChild(fragment, node);
     }
-    if (from < text.length) {
-      fragment.appendChild(document.createTextNode(text.slice(from)));
-    }
-    textNode.parentNode?.replaceChild(fragment, textNode);
+
+    nodeStart = nodeEnd;
   }
 }
 

--- a/src/ui/src/components/chat/HighlightedPlainText.tsx
+++ b/src/ui/src/components/chat/HighlightedPlainText.tsx
@@ -1,0 +1,43 @@
+import { Fragment, memo, useMemo } from "react";
+import { findAllRanges, splitByRanges } from "../../utils/textSearch";
+
+/**
+ * Renders plain text with `<mark class="cc-search-match">` segments around
+ * every case-insensitive substring match of `query`. When `query` is empty,
+ * the text renders as-is — no DOM nodes are inserted, so the search-off
+ * path has zero overhead.
+ *
+ * The shared `cc-search-match` class is what `ChatSearchBar` queries to
+ * count and target the active match. Don't rename without updating the bar.
+ */
+export const HighlightedPlainText = memo(function HighlightedPlainText({
+  text,
+  query,
+}: {
+  text: string;
+  query: string;
+}) {
+  const segments = useMemo(() => {
+    if (!query) return null;
+    const ranges = findAllRanges(text, query);
+    if (ranges.length === 0) return null;
+    return splitByRanges(text, ranges);
+  }, [text, query]);
+
+  if (!segments) {
+    return <>{text}</>;
+  }
+  return (
+    <>
+      {segments.map((seg, i) => (
+        <Fragment key={i}>
+          {seg.kind === "match" ? (
+            <mark className="cc-search-match">{seg.text}</mark>
+          ) : (
+            seg.text
+          )}
+        </Fragment>
+      ))}
+    </>
+  );
+});

--- a/src/ui/src/components/chat/HighlightedPlainText.tsx
+++ b/src/ui/src/components/chat/HighlightedPlainText.tsx
@@ -1,5 +1,9 @@
 import { Fragment, memo, useMemo } from "react";
-import { findAllRanges, splitByRanges } from "../../utils/textSearch";
+import {
+  findAllRanges,
+  nextSearchMatchId,
+  splitByRanges,
+} from "../../utils/textSearch";
 
 /**
  * Renders plain text with `<mark class="cc-search-match">` segments around
@@ -17,22 +21,33 @@ export const HighlightedPlainText = memo(function HighlightedPlainText({
   text: string;
   query: string;
 }) {
-  const segments = useMemo(() => {
+  const result = useMemo(() => {
     if (!query) return null;
     const ranges = findAllRanges(text, query);
     if (ranges.length === 0) return null;
-    return splitByRanges(text, ranges);
+    // Pre-allocate one id per match so every <mark> we render shares the
+    // same data-match-id with the markdown wrapper's tagging scheme. The
+    // ChatSearchBar groups marks by id, so an id per match here keeps the
+    // counter aligned with what the user perceives as "one match" — even
+    // when a match would later split (it can't here, but symmetry helps).
+    const ids = ranges.map(() => nextSearchMatchId());
+    return { segments: splitByRanges(text, ranges), ids };
   }, [text, query]);
 
-  if (!segments) {
+  if (!result) {
     return <>{text}</>;
   }
   return (
     <>
-      {segments.map((seg, i) => (
+      {result.segments.map((seg, i) => (
         <Fragment key={i}>
           {seg.kind === "match" ? (
-            <mark className="cc-search-match">{seg.text}</mark>
+            <mark
+              className="cc-search-match"
+              data-match-id={result.ids[seg.rangeIndex]}
+            >
+              {seg.text}
+            </mark>
           ) : (
             seg.text
           )}

--- a/src/ui/src/components/chat/ThinkingBlock.tsx
+++ b/src/ui/src/components/chat/ThinkingBlock.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Brain } from "lucide-react";
 import { useTypewriter } from "../../hooks/useTypewriter";
+import { HighlightedPlainText } from "./HighlightedPlainText";
 import styles from "./ThinkingBlock.module.css";
 import caretStyles from "./caret.module.css";
 
@@ -8,9 +9,13 @@ interface ThinkingBlockProps {
   content: string;
   isStreaming: boolean;
   enableTypewriter?: boolean;
+  /** Active chat-search query. When non-empty and the query matches inside
+   *  this block's content, the block force-expands so matches aren't
+   *  hidden behind the collapsed header. */
+  searchQuery?: string;
 }
 
-export function ThinkingBlock({ content, isStreaming, enableTypewriter }: ThinkingBlockProps) {
+export function ThinkingBlock({ content, isStreaming, enableTypewriter, searchQuery }: ThinkingBlockProps) {
   const [expanded, setExpanded] = useState(false);
   const { displayed, showCaret } = useTypewriter(content, isStreaming, {
     enabled: enableTypewriter && expanded,
@@ -18,7 +23,10 @@ export function ThinkingBlock({ content, isStreaming, enableTypewriter }: Thinki
 
   if (!content) return null;
 
-  const label = isStreaming ? "Thinking\u2026" : "Thinking";
+  const label = isStreaming ? "Thinking…" : "Thinking";
+  const queryMatches =
+    !!searchQuery && content.toLowerCase().includes(searchQuery.toLowerCase());
+  const isExpanded = expanded || queryMatches;
   const visibleContent = enableTypewriter ? displayed : content;
 
   return (
@@ -26,17 +34,21 @@ export function ThinkingBlock({ content, isStreaming, enableTypewriter }: Thinki
       <button
         className={styles.header}
         onClick={() => setExpanded(!expanded)}
-        aria-expanded={expanded}
+        aria-expanded={isExpanded}
       >
-        <span className={`${styles.chevron} ${expanded ? styles.chevronExpanded : ""}`}>
+        <span className={`${styles.chevron} ${isExpanded ? styles.chevronExpanded : ""}`}>
           ›
         </span>
         <Brain size={14} />
         <span className={styles.label}>{label}</span>
       </button>
-      {expanded && (
+      {isExpanded && (
         <div className={styles.content}>
-          {visibleContent}
+          {searchQuery ? (
+            <HighlightedPlainText text={visibleContent} query={searchQuery} />
+          ) : (
+            visibleContent
+          )}
           {showCaret && <span className={caretStyles.caret} aria-hidden="true" />}
         </div>
       )}

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -26,6 +26,11 @@ export function useKeyboardShortcuts() {
   const planMode = useAppStore(
     (s) => (selectedWorkspaceId ? s.planMode[selectedWorkspaceId] ?? false : false),
   );
+  const chatSearchOpen = useAppStore(
+    (s) => (selectedWorkspaceId ? s.chatSearch[selectedWorkspaceId]?.open ?? false : false),
+  );
+  const openChatSearch = useAppStore((s) => s.openChatSearch);
+  const closeChatSearch = useAppStore((s) => s.closeChatSearch);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -56,6 +61,11 @@ export function useKeyboardShortcuts() {
           toggleFuzzyFinder();
         } else if (useAppStore.getState().settingsOpen) {
           return;
+        } else if (chatSearchOpen && selectedWorkspaceId) {
+          // Close the search bar and put focus back in the composer so
+          // Esc lands the user where they were before Cmd+F.
+          closeChatSearch(selectedWorkspaceId);
+          focusChatPrompt();
         } else if (diffSelectedFile) {
           setDiffSelectedFile(null);
         } else if (selectedWorkspaceId) {
@@ -153,6 +163,25 @@ export function useKeyboardShortcuts() {
       if (e.code === "Minus") {
         e.preventDefault();
         adjustUiFontSize(-1);
+        return;
+      }
+
+      // Cmd/Ctrl + F — open the in-chat search bar for the current workspace.
+      // Suppressed while any overlay owns focus so the hotkey doesn't steal
+      // from settings / fuzzy finder / modal inputs.
+      if (e.code === "KeyF" && !e.shiftKey && !e.altKey) {
+        if (!selectedWorkspaceId) return;
+        const state = useAppStore.getState();
+        if (
+          state.settingsOpen ||
+          state.activeModal ||
+          state.commandPaletteOpen ||
+          state.fuzzyFinderOpen
+        ) {
+          return;
+        }
+        e.preventDefault();
+        openChatSearch(selectedWorkspaceId);
         return;
       }
 
@@ -265,5 +294,8 @@ export function useKeyboardShortcuts() {
     selectedWorkspaceId,
     setPlanMode,
     planMode,
+    chatSearchOpen,
+    openChatSearch,
+    closeChatSearch,
   ]);
 }

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -322,6 +322,86 @@ describe("agentQuestion lifecycle (per-workspace)", () => {
   });
 });
 
+describe("chatSearch (per-workspace)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ chatSearch: {} });
+  });
+
+  it("defaults to undefined (no entry until first open)", () => {
+    expect(useAppStore.getState().chatSearch[WS_ID]).toBeUndefined();
+  });
+
+  it("openChatSearch initializes with empty query and -1 matchIndex", () => {
+    useAppStore.getState().openChatSearch(WS_ID);
+    expect(useAppStore.getState().chatSearch[WS_ID]).toEqual({
+      open: true,
+      query: "",
+      matchIndex: -1,
+    });
+  });
+
+  it("openChatSearch preserves prior query on re-open", () => {
+    useAppStore.getState().openChatSearch(WS_ID);
+    useAppStore.getState().setChatSearchQuery(WS_ID, "todo");
+    useAppStore.getState().closeChatSearch(WS_ID);
+    useAppStore.getState().openChatSearch(WS_ID);
+    expect(useAppStore.getState().chatSearch[WS_ID]?.query).toBe("todo");
+    expect(useAppStore.getState().chatSearch[WS_ID]?.open).toBe(true);
+  });
+
+  it("closeChatSearch keeps the entry but flips open=false", () => {
+    useAppStore.getState().openChatSearch(WS_ID);
+    useAppStore.getState().setChatSearchQuery(WS_ID, "todo");
+    useAppStore.getState().closeChatSearch(WS_ID);
+    expect(useAppStore.getState().chatSearch[WS_ID]).toEqual({
+      open: false,
+      query: "todo",
+      matchIndex: -1,
+    });
+  });
+
+  it("setChatSearchQuery resets matchIndex to -1", () => {
+    useAppStore.getState().openChatSearch(WS_ID);
+    useAppStore.getState().setChatSearchQuery(WS_ID, "todo");
+    useAppStore.getState().setChatSearchMatchIndex(WS_ID, 4);
+    expect(useAppStore.getState().chatSearch[WS_ID]?.matchIndex).toBe(4);
+    useAppStore.getState().setChatSearchQuery(WS_ID, "todos");
+    expect(useAppStore.getState().chatSearch[WS_ID]?.matchIndex).toBe(-1);
+  });
+
+  it("setChatSearchMatchIndex updates without touching query", () => {
+    useAppStore.getState().openChatSearch(WS_ID);
+    useAppStore.getState().setChatSearchQuery(WS_ID, "hello");
+    useAppStore.getState().setChatSearchMatchIndex(WS_ID, 2);
+    expect(useAppStore.getState().chatSearch[WS_ID]).toEqual({
+      open: true,
+      query: "hello",
+      matchIndex: 2,
+    });
+  });
+
+  it("search state is isolated per workspace", () => {
+    useAppStore.getState().openChatSearch("ws-a");
+    useAppStore.getState().openChatSearch("ws-b");
+    useAppStore.getState().setChatSearchQuery("ws-a", "alpha");
+    useAppStore.getState().setChatSearchQuery("ws-b", "beta");
+    expect(useAppStore.getState().chatSearch["ws-a"]?.query).toBe("alpha");
+    expect(useAppStore.getState().chatSearch["ws-b"]?.query).toBe("beta");
+  });
+
+  it("rollbackConversation drops chatSearch entry for the workspace", () => {
+    useAppStore.getState().openChatSearch(WS_ID);
+    useAppStore.getState().setChatSearchQuery(WS_ID, "stale");
+    useAppStore.setState({
+      checkpoints: { [WS_ID]: [makeCheckpoint("cp1", WS_ID, "m1", 0)] },
+    });
+
+    useAppStore.getState().rollbackConversation(WS_ID, "cp1", []);
+
+    expect(useAppStore.getState().chatSearch[WS_ID]).toBeUndefined();
+  });
+});
+
 describe("applyPlanModeMountDefault", () => {
   // ChatToolbar delegates its mount-time "apply global default" step to this
   // helper. The contract: only touch the store if the runtime value is

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -997,8 +997,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => {
       const prev = s.chatSearch[wsId];
       // Preserve query/matchIndex so re-opening restores the previous search.
-      if (!prev) return {};
-      if (!prev.open) return {};
+      // Return the existing state reference for no-op paths so Zustand's
+      // identity check skips the listener notification entirely.
+      if (!prev) return s;
+      if (!prev.open) return s;
       return {
         chatSearch: {
           ...s.chatSearch,
@@ -1025,8 +1027,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   setChatSearchMatchIndex: (wsId, idx) =>
     set((s) => {
       const prev = s.chatSearch[wsId];
-      if (!prev) return {};
-      if (prev.matchIndex === idx) return {};
+      if (!prev) return s;
+      if (prev.matchIndex === idx) return s;
       return {
         chatSearch: {
           ...s.chatSearch,

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -119,6 +119,19 @@ export interface PlanApproval {
 }
 
 /**
+ * Per-workspace state for the in-chat Cmd/Ctrl+F search bar.
+ * `query` is preserved when the bar is closed so re-opening with the same
+ * workspace selected restores the previous search.
+ * `matchIndex` is the active match's 0-based index across all hits in the
+ * current workspace; -1 when there are no matches yet.
+ */
+export interface ChatSearchState {
+  open: boolean;
+  query: string;
+  matchIndex: number;
+}
+
+/**
  * Token usage from the most recent completed turn for a workspace.
  * Lives as its own slice (`latestTurnUsage`) rather than being derived from
  * `completedTurns` because `finalizeTurn` early-returns for tool-free turns
@@ -232,6 +245,13 @@ interface AppState {
   planApprovals: Record<string, PlanApproval>;
   setPlanApproval: (p: PlanApproval) => void;
   clearPlanApproval: (wsId: string) => void;
+
+  // -- Chat Search (per-workspace) --
+  chatSearch: Record<string, ChatSearchState>;
+  openChatSearch: (wsId: string) => void;
+  closeChatSearch: (wsId: string) => void;
+  setChatSearchQuery: (wsId: string, query: string) => void;
+  setChatSearchMatchIndex: (wsId: string, idx: number) => void;
 
   // -- Queued Messages (sent while agent is running, dispatched when idle) --
   queuedMessages: Record<
@@ -957,6 +977,64 @@ export const useAppStore = create<AppState>((set, get) => ({
       return { planApprovals: rest };
     }),
 
+  // -- Chat Search (per-workspace) --
+  chatSearch: {},
+  openChatSearch: (wsId) =>
+    set((s) => {
+      const prev = s.chatSearch[wsId];
+      return {
+        chatSearch: {
+          ...s.chatSearch,
+          [wsId]: {
+            open: true,
+            query: prev?.query ?? "",
+            matchIndex: prev?.matchIndex ?? -1,
+          },
+        },
+      };
+    }),
+  closeChatSearch: (wsId) =>
+    set((s) => {
+      const prev = s.chatSearch[wsId];
+      // Preserve query/matchIndex so re-opening restores the previous search.
+      if (!prev) return {};
+      if (!prev.open) return {};
+      return {
+        chatSearch: {
+          ...s.chatSearch,
+          [wsId]: { ...prev, open: false },
+        },
+      };
+    }),
+  setChatSearchQuery: (wsId, query) =>
+    set((s) => {
+      const prev = s.chatSearch[wsId] ?? {
+        open: true,
+        query: "",
+        matchIndex: -1,
+      };
+      // Reset matchIndex on every query change — the new query produces a
+      // fresh match set, so any prior index is meaningless.
+      return {
+        chatSearch: {
+          ...s.chatSearch,
+          [wsId]: { ...prev, query, matchIndex: -1 },
+        },
+      };
+    }),
+  setChatSearchMatchIndex: (wsId, idx) =>
+    set((s) => {
+      const prev = s.chatSearch[wsId];
+      if (!prev) return {};
+      if (prev.matchIndex === idx) return {};
+      return {
+        chatSearch: {
+          ...s.chatSearch,
+          [wsId]: { ...prev, matchIndex: idx },
+        },
+      };
+    }),
+
   // -- Queued Messages --
   queuedMessages: {},
   setQueuedMessage: (wsId, content, mentionedFiles, attachments) =>
@@ -989,6 +1067,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => {
       const { [wsId]: _q, ...restQuestions } = s.agentQuestions;
       const { [wsId]: _p, ...restApprovals } = s.planApprovals;
+      const { [wsId]: _cs, ...restChatSearch } = s.chatSearch;
       // Update lastMessages so workspace preview cards stay in sync.
       const lastMsg =
         messages.length > 0 ? messages[messages.length - 1] : undefined;
@@ -1024,6 +1103,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         streamingThinking: { ...s.streamingThinking, [wsId]: "" },
         agentQuestions: restQuestions,
         planApprovals: restApprovals,
+        chatSearch: restChatSearch,
         checkpoints: {
           ...s.checkpoints,
           [wsId]: (() => {

--- a/src/ui/src/utils/textSearch.test.ts
+++ b/src/ui/src/utils/textSearch.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { findAllRanges, splitByRanges } from "./textSearch";
+
+describe("findAllRanges", () => {
+  it("returns no matches for an empty needle", () => {
+    expect(findAllRanges("hello world", "")).toEqual([]);
+  });
+
+  it("returns no matches for an empty haystack", () => {
+    expect(findAllRanges("", "x")).toEqual([]);
+  });
+
+  it("finds a single occurrence", () => {
+    expect(findAllRanges("hello world", "world")).toEqual([
+      { start: 6, end: 11 },
+    ]);
+  });
+
+  it("finds multiple occurrences", () => {
+    expect(findAllRanges("foo bar foo bar foo", "foo")).toEqual([
+      { start: 0, end: 3 },
+      { start: 8, end: 11 },
+      { start: 16, end: 19 },
+    ]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(findAllRanges("Hello HELLO hello", "HeLLo")).toEqual([
+      { start: 0, end: 5 },
+      { start: 6, end: 11 },
+      { start: 12, end: 17 },
+    ]);
+  });
+
+  it("does not double-count overlapping matches", () => {
+    // 'aa' inside 'aaaa' produces hits at 0 and 2, not 0/1/2.
+    expect(findAllRanges("aaaa", "aa")).toEqual([
+      { start: 0, end: 2 },
+      { start: 2, end: 4 },
+    ]);
+  });
+
+  it("handles needle longer than haystack", () => {
+    expect(findAllRanges("hi", "hello")).toEqual([]);
+  });
+
+  it("handles unicode characters", () => {
+    expect(findAllRanges("café CAFÉ café", "café")).toEqual([
+      { start: 0, end: 4 },
+      // 'CAFÉ' lowercases to 'café' so the middle hit lands too.
+      { start: 5, end: 9 },
+      { start: 10, end: 14 },
+    ]);
+  });
+});
+
+describe("splitByRanges", () => {
+  it("returns empty array for empty input", () => {
+    expect(splitByRanges("", [])).toEqual([]);
+  });
+
+  it("returns a single text segment when there are no ranges", () => {
+    expect(splitByRanges("hello world", [])).toEqual([
+      { kind: "text", text: "hello world" },
+    ]);
+  });
+
+  it("splits into text + match + text", () => {
+    expect(
+      splitByRanges("hello world", [{ start: 6, end: 11 }]),
+    ).toEqual([
+      { kind: "text", text: "hello " },
+      { kind: "match", text: "world", rangeIndex: 0 },
+    ]);
+  });
+
+  it("emits a leading match without an empty text segment", () => {
+    expect(splitByRanges("hello", [{ start: 0, end: 5 }])).toEqual([
+      { kind: "match", text: "hello", rangeIndex: 0 },
+    ]);
+  });
+
+  it("interleaves multiple matches", () => {
+    expect(
+      splitByRanges("foo bar foo bar foo", [
+        { start: 0, end: 3 },
+        { start: 8, end: 11 },
+        { start: 16, end: 19 },
+      ]),
+    ).toEqual([
+      { kind: "match", text: "foo", rangeIndex: 0 },
+      { kind: "text", text: " bar " },
+      { kind: "match", text: "foo", rangeIndex: 1 },
+      { kind: "text", text: " bar " },
+      { kind: "match", text: "foo", rangeIndex: 2 },
+    ]);
+  });
+
+  it("preserves rangeIndex even when ranges are passed in order", () => {
+    const segments = splitByRanges("ab cd ef", [
+      { start: 0, end: 2 },
+      { start: 6, end: 8 },
+    ]);
+    const matches = segments.filter((s) => s.kind === "match");
+    expect(matches).toEqual([
+      { kind: "match", text: "ab", rangeIndex: 0 },
+      { kind: "match", text: "ef", rangeIndex: 1 },
+    ]);
+  });
+});

--- a/src/ui/src/utils/textSearch.test.ts
+++ b/src/ui/src/utils/textSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findAllRanges, splitByRanges } from "./textSearch";
+import { findAllRanges, nextSearchMatchId, splitByRanges } from "./textSearch";
 
 describe("findAllRanges", () => {
   it("returns no matches for an empty needle", () => {
@@ -51,6 +51,29 @@ describe("findAllRanges", () => {
       { start: 5, end: 9 },
       { start: 10, end: 14 },
     ]);
+  });
+
+  it("treats regex metacharacters in the needle literally", () => {
+    // Regex metacharacters in the user's query must not change matching —
+    // searching "a.c" should not match "abc" (the dot is literal, not "any
+    // character"). These would all break a non-escaped RegExp constructor.
+    expect(findAllRanges("abc a.c", "a.c")).toEqual([{ start: 4, end: 7 }]);
+    expect(findAllRanges("(open)", "(")).toEqual([{ start: 0, end: 1 }]);
+    expect(findAllRanges("a+b a*b", "a*b")).toEqual([{ start: 4, end: 7 }]);
+  });
+
+  it("returns ranges in original-string coordinates after a length-changing case fold", () => {
+    // The old `toLowerCase()` + `indexOf` approach silently misaligned
+    // when a character in the haystack changed length on lowercase — e.g.
+    // "İ" (1 code unit) lowercases to "i" + COMBINING DOT ABOVE (2 units).
+    // Matches *after* the length-changing character then sliced the wrong
+    // span out of the original string. The regex-on-original approach
+    // returns indices that always line up with the source.
+    const haystack = "İab";
+    expect(haystack.toLowerCase()).toHaveLength(haystack.length + 1);
+    const ranges = findAllRanges(haystack, "ab");
+    expect(ranges).toHaveLength(1);
+    expect(haystack.slice(ranges[0].start, ranges[0].end)).toBe("ab");
   });
 });
 
@@ -105,6 +128,54 @@ describe("splitByRanges", () => {
     expect(matches).toEqual([
       { kind: "match", text: "ab", rangeIndex: 0 },
       { kind: "match", text: "ef", rangeIndex: 1 },
+    ]);
+  });
+});
+
+describe("nextSearchMatchId", () => {
+  it("returns a fresh string id on every call", () => {
+    const a = nextSearchMatchId();
+    const b = nextSearchMatchId();
+    const c = nextSearchMatchId();
+    expect(typeof a).toBe("string");
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    expect(a).not.toBe(c);
+  });
+});
+
+describe("end-to-end: splitByRanges over findAllRanges output", () => {
+  // The two helpers compose in the production highlight pipeline, so
+  // verify a couple of common chat-search shapes end-to-end.
+  it("splits prose containing multiple highlighted matches", () => {
+    const text = "the quick brown fox jumps over the lazy dog";
+    const ranges = findAllRanges(text, "the");
+    const segments = splitByRanges(text, ranges);
+    const stitched = segments.map((s) => s.text).join("");
+    expect(stitched).toBe(text);
+    expect(segments.filter((s) => s.kind === "match").map((s) => s.text)).toEqual([
+      "the",
+      "the",
+    ]);
+  });
+
+  it("splits a query that touches the start of the string", () => {
+    const text = "Hello world";
+    const ranges = findAllRanges(text, "hello");
+    const segments = splitByRanges(text, ranges);
+    expect(segments).toEqual([
+      { kind: "match", text: "Hello", rangeIndex: 0 },
+      { kind: "text", text: " world" },
+    ]);
+  });
+
+  it("splits a query that touches the end of the string", () => {
+    const text = "Hello world";
+    const ranges = findAllRanges(text, "world");
+    const segments = splitByRanges(text, ranges);
+    expect(segments).toEqual([
+      { kind: "text", text: "Hello " },
+      { kind: "match", text: "world", rangeIndex: 0 },
     ]);
   });
 });

--- a/src/ui/src/utils/textSearch.ts
+++ b/src/ui/src/utils/textSearch.ts
@@ -1,0 +1,75 @@
+/**
+ * Text-search primitives for the in-chat Cmd/Ctrl+F search bar.
+ *
+ * Kept dependency-free so they can run anywhere in the React tree (and in
+ * tests) without pulling in store / DOM context. Both helpers are O(n) over
+ * the input text.
+ */
+
+export interface MatchRange {
+  /** Inclusive start index into the original text. */
+  start: number;
+  /** Exclusive end index into the original text. */
+  end: number;
+}
+
+/**
+ * Find every case-insensitive substring occurrence of `needle` in `haystack`.
+ * Empty needles return no matches (avoids an infinite loop and matches the
+ * "no query → no highlight" UX).
+ *
+ * Matches advance by `needle.length` so overlapping hits aren't double-counted
+ * (e.g. searching "aa" in "aaaa" returns 2 matches at indices 0 and 2).
+ */
+export function findAllRanges(haystack: string, needle: string): MatchRange[] {
+  if (!needle) return [];
+  if (!haystack) return [];
+  const lowerHaystack = haystack.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  const out: MatchRange[] = [];
+  let from = 0;
+  while (from <= lowerHaystack.length - lowerNeedle.length) {
+    const idx = lowerHaystack.indexOf(lowerNeedle, from);
+    if (idx === -1) break;
+    out.push({ start: idx, end: idx + lowerNeedle.length });
+    from = idx + lowerNeedle.length;
+  }
+  return out;
+}
+
+export type Segment =
+  | { kind: "text"; text: string }
+  | { kind: "match"; text: string; rangeIndex: number };
+
+/**
+ * Split `text` into alternating non-match / match segments using the supplied
+ * ranges. `rangeIndex` on each match segment carries the position of the
+ * range in the input array so callers can map a segment back to a global
+ * match index for active-match highlighting.
+ *
+ * Ranges must be non-overlapping and sorted by `start`. (`findAllRanges`
+ * already produces them in that shape.)
+ */
+export function splitByRanges(text: string, ranges: MatchRange[]): Segment[] {
+  if (ranges.length === 0) {
+    return text ? [{ kind: "text", text }] : [];
+  }
+  const out: Segment[] = [];
+  let cursor = 0;
+  for (let i = 0; i < ranges.length; i++) {
+    const r = ranges[i];
+    if (r.start > cursor) {
+      out.push({ kind: "text", text: text.slice(cursor, r.start) });
+    }
+    out.push({
+      kind: "match",
+      text: text.slice(r.start, r.end),
+      rangeIndex: i,
+    });
+    cursor = r.end;
+  }
+  if (cursor < text.length) {
+    out.push({ kind: "text", text: text.slice(cursor) });
+  }
+  return out;
+}

--- a/src/ui/src/utils/textSearch.ts
+++ b/src/ui/src/utils/textSearch.ts
@@ -13,26 +13,54 @@ export interface MatchRange {
   end: number;
 }
 
+// Module-level monotonic counter handed out by `nextSearchMatchId()`. Both
+// the React-render-time `HighlightedPlainText` and the post-render DOM
+// walker in `HighlightedMessageMarkdown` stamp their `<mark>` elements
+// with these ids so the ChatSearchBar can group adjacent / split marks
+// that belong to the same logical match. Globally-unique avoids id
+// collisions between multiple highlight wrappers rendering at the same
+// time. Wrap-around is fine — Number.MAX_SAFE_INTEGER would take an
+// unrealistic number of renders to reach.
+let nextMatchIdCounter = 0;
+export function nextSearchMatchId(): string {
+  return String(nextMatchIdCounter++);
+}
+
+// Escape every regex metacharacter so the user's query is treated as a
+// literal substring even when it contains characters like "." or "(".
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Find every case-insensitive substring occurrence of `needle` in `haystack`.
  * Empty needles return no matches (avoids an infinite loop and matches the
  * "no query → no highlight" UX).
  *
- * Matches advance by `needle.length` so overlapping hits aren't double-counted
- * (e.g. searching "aa" in "aaaa" returns 2 matches at indices 0 and 2).
+ * Uses a `gi` regex on the original string (rather than lower-casing both
+ * sides and walking with indexOf) so the returned `{start, end}` indices
+ * line up with the original `haystack`. Some Unicode case folds change
+ * string length — e.g. "İ" lowercases to "i" + a combining dot — and the
+ * old index-by-lowercased-string approach silently misaligned `<mark>`
+ * insertion for those characters. The regex match's `index` and `[0]`
+ * length are always in source-string coordinates.
+ *
+ * Matches advance by the matched length so overlapping hits aren't
+ * double-counted (e.g. searching "aa" in "aaaa" returns 2 matches at 0 and 2).
  */
 export function findAllRanges(haystack: string, needle: string): MatchRange[] {
   if (!needle) return [];
   if (!haystack) return [];
-  const lowerHaystack = haystack.toLowerCase();
-  const lowerNeedle = needle.toLowerCase();
+  const re = new RegExp(escapeRegExp(needle), "gi");
   const out: MatchRange[] = [];
-  let from = 0;
-  while (from <= lowerHaystack.length - lowerNeedle.length) {
-    const idx = lowerHaystack.indexOf(lowerNeedle, from);
-    if (idx === -1) break;
-    out.push({ start: idx, end: idx + lowerNeedle.length });
-    from = idx + lowerNeedle.length;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(haystack)) !== null) {
+    const start = m.index;
+    const end = start + m[0].length;
+    out.push({ start, end });
+    // If the match was zero-width (shouldn't happen with our escapes, but
+    // be defensive), advance manually so we don't loop forever.
+    if (end === start) re.lastIndex = start + 1;
   }
   return out;
 }


### PR DESCRIPTION
## Summary

- Adds an in-chat **Cmd/Ctrl+F** search affordance that enumerates matches across user/assistant/system messages, streaming content, and tool activity summaries; **Enter** / **Shift+Enter** cycle next / previous; **Esc** closes and returns focus to the composer.
- Search state is per-workspace (Zustand `chatSearch` slice keyed by `wsId`) — re-opening with the same workspace selected restores the previous query; switching workspaces leaves each one's bar isolated.
- Highlights are layered onto the markdown DOM via a post-render `TreeWalker` (skipping `<code>`/`<pre>` to preserve Shiki tokens), so the existing `react-markdown` + Shiki worker memoization stays warm and search-off has zero render cost.

Closes #429.

## Test plan

- [x] `nix develop -c cargo test --all-features` (727 tests pass)
- [x] `nix develop -c cargo clippy --workspace --all-targets` with `-Dwarnings` (clean)
- [x] `nix develop -c cargo fmt --all --check`
- [x] `cd src/ui && nix develop ../.. -c bun run test` (886 tests, includes 8 new chatSearch slice tests + 14 new textSearch utility tests)
- [x] `cd src/ui && nix develop ../.. -c bunx tsc -b` (clean)
- [x] UAT against running dev build: Cmd+F opens, typing highlights live, Enter cycles forward, Shift+Enter cycles backward, counter updates (n / N and "No matches"), Esc returns focus to composer, per-workspace state isolated and restores on switch-back.
- [x] No regression on Cmd+B (sidebar), Cmd+\` (terminal), Cmd+1 (project jump), Cmd+0 / Cmd+=/- (font size).
- [x] Light + dark theme screenshots verified.