### PR TITLE
fix(updater): rewrite latest.json URLs after staging promote

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -332,15 +332,38 @@ jobs:
           # `tauri-action` generated `latest.json` while the release was
           # tagged `nightly-staging`, so the asset URLs inside the manifest
           # are hardcoded to `releases/download/nightly-staging/...`. Once
-          # we delete the staging tag below those URLs 404, breaking the
-          # in-app updater's download step (the manifest is reachable but
-          # `download_and_install` fails on the asset fetch). The Tauri
-          # signature covers the binary file contents — not the URL field —
-          # so rewriting the URLs here does not invalidate verification.
-          curl -fsSL -o latest.json \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
-          sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
-          gh release upload nightly latest.json --clobber --repo "$GITHUB_REPOSITORY"
+          # the release is retagged to `nightly` above, those old URLs 404,
+          # breaking the in-app updater's download step (the manifest is
+          # reachable but `download_and_install` fails on the asset fetch).
+          # The Tauri signature covers the binary file contents — not the
+          # URL field — so rewriting the URLs here does not invalidate
+          # verification.
+          #
+          # Retry the fetch+rewrite+upload sequence a few times so a
+          # transient network or GitHub API failure does not leave the
+          # promoted release published with a stale manifest. Also verify
+          # the substitution actually took before uploading.
+          for attempt in 1 2 3; do
+            rm -f latest.json
+            if ! curl -fsSL -o latest.json \
+              "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"; then
+              echo "latest.json fetch attempt $attempt failed"
+            else
+              sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
+              if grep -q 'releases/download/nightly-staging/' latest.json; then
+                echo "::warning::latest.json still contains nightly-staging URLs after rewrite"
+              elif gh release upload nightly latest.json --clobber --repo "$GITHUB_REPOSITORY"; then
+                break
+              fi
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to refresh latest.json for nightly after 3 attempts"
+              exit 1
+            fi
+            backoff=$((attempt * 5))
+            echo "latest.json refresh attempt $attempt failed; retrying in ${backoff}s"
+            sleep "$backoff"
+          done
 
           # `gh release edit --tag` creates the new tag (`nightly`) at the
           # release's target commit but leaves the old `nightly-staging`

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -329,6 +329,19 @@ jobs:
             sleep 5
           done
 
+          # `tauri-action` generated `latest.json` while the release was
+          # tagged `nightly-staging`, so the asset URLs inside the manifest
+          # are hardcoded to `releases/download/nightly-staging/...`. Once
+          # we delete the staging tag below those URLs 404, breaking the
+          # in-app updater's download step (the manifest is reachable but
+          # `download_and_install` fails on the asset fetch). The Tauri
+          # signature covers the binary file contents — not the URL field —
+          # so rewriting the URLs here does not invalidate verification.
+          curl -fsSL -o latest.json \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
+          sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
+          gh release upload nightly latest.json --clobber --repo "$GITHUB_REPOSITORY"
+
           # `gh release edit --tag` creates the new tag (`nightly`) at the
           # release's target commit but leaves the old `nightly-staging`
           # git tag orphaned. Clean it up so we don't accumulate dead tags.


### PR DESCRIPTION
## Summary

- Fixes the regression where the in-app updater silently fails on `Install Now` for nightly builds
- Root cause: `tauri-action` embeds `releases/download/nightly-staging/...` URLs into `latest.json` at build time. After the promote step retags the release to `nightly` and cleans up the staging git tag, those embedded URLs return 404. The manifest itself is reachable (so the banner appears) but `download_and_install` 404s on the asset, surfacing as a click that "does nothing".
- The fix is a small post-promote step that downloads `latest.json`, sed-replaces the staging path segment with `nightly`, and re-uploads it with `--clobber`. Tauri's update signature is over the binary contents, not the URL field, so verification is unaffected.

Closes the regression introduced in #443 / #442.

## Test plan

- [ ] CI passes
- [ ] Trigger the nightly workflow (or wait for the next push to `main`) and confirm the published `latest.json` has `download/nightly/...` URLs
- [ ] On a built app, confirm `Install Now` actually downloads and installs the new build