### PR TITLE
fix(ci): prefix nightly short SHA with 'g' to keep version SemVer-valid

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
           SHORT=$(git rev-parse --short=7 HEAD)
-          VERSION="${NEXT_MINOR}-dev.${COMMITS}.${SHORT}"
+          VERSION="${NEXT_MINOR}-dev.${COMMITS}.g${SHORT}"
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The nightly build pipeline broke on commit `0104498` because Cargo rejected the constructed version `0.20.0-dev.18.0104498` with:

```
error: invalid leading zero in pre-release identifier
```

[SemVer 2.0.0 §9](https://semver.org/#spec-item-9) requires that purely-numeric pre-release identifiers have no leading zeros. When the 7-char git short hash happens to be all hex digits *and* starts with `0`, the segment is parsed as a numeric identifier and rejected. Roughly 1 in ~2,680 commits hits this — rare enough to feel random, common enough to keep biting an active repo.

This change prefixes the short SHA with `g` (the convention `git describe` uses for "git"), which forces the segment to be alphanumeric. Alphanumeric SemVer identifiers permit leading zeros.

**Before:** `0.20.0-dev.18.0104498` ❌
**After:**  `0.20.0-dev.18.g0104498` ✅

## Complexity Notes

- No code in the repo parses this version format — the Tauri updater plugin handles semver comparison internally, the frontend only displays version strings, and the `Cargo.toml` stamping in the same workflow uses a generic regex that accepts any version. So the blast radius is bounded to this one workflow.
- Existing nightly artifacts on the `nightly` GitHub release continue to work; the in-app updater compares versions via the Tauri plugin which handles both formats correctly.

## Test Steps

1. Confirm the diff is a single-line change in `.github/workflows/nightly.yml` line 56.
2. After merging, the next push to `main` will trigger the Nightly Build workflow. Verify in the Actions tab that the `compute-version` job logs a version of the form `X.Y.Z-dev.N.gXXXXXXX` (note the `g` prefix).
3. Verify the `build` matrix job for at least one platform (e.g. `macos-aarch64`) now gets past the `Stamp nightly version` step without Cargo rejecting the version.
4. Confirm the resulting `nightly-staging` → `nightly` release publishes successfully and `latest.json` is uploaded.

## Checklist

- [x] Tests added/updated — N/A; pure CI workflow fix, no test surface
- [x] Documentation updated — N/A; no user-visible behavior change