### PR TITLE
fix(updater): unstick nightly install via CI URL fix and visible error UI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -337,20 +337,42 @@ jobs:
           done
 
           sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
-          # Hard-fail if the rewrite was a no-op — retrying with the same
-          # input won't help, and shipping a manifest with staging URLs
-          # would break the updater for every nightly user.
+          # Hard-fail if the rewrite was a no-op AND staging URLs are still
+          # present — retrying with the same input won't help, and shipping
+          # a manifest with staging URLs would break the updater. (A no-op
+          # because the manifest was already rewritten on a prior crashed
+          # run is fine: grep will find nothing, and we proceed.)
           if grep -q 'releases/download/nightly-staging/' latest.json; then
             echo "::error::latest.json still contains nightly-staging URLs after rewrite; aborting"
             exit 1
           fi
+
+          # Upload the rewritten manifest back to `nightly-staging` *before*
+          # we touch `nightly`. Assets follow the release when its tag
+          # changes, so when the retag below succeeds the corrected manifest
+          # appears at the `nightly/...` URL atomically — no separate
+          # post-retag upload that could fail and leave a broken manifest
+          # live on the promoted release.
+          for attempt in 1 2 3; do
+            if gh release upload nightly-staging latest.json --clobber --repo "$GITHUB_REPOSITORY"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to upload rewritten latest.json to nightly-staging after 3 attempts"
+              exit 1
+            fi
+            backoff=$((attempt * 5))
+            echo "latest.json upload attempt $attempt failed; retrying in ${backoff}s"
+            sleep "$backoff"
+          done
 
           gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
           # Retry the retag a few times to ride out transient API hiccups
           # (rate limits, brief outages). If all retries fail, the workflow
           # exits non-zero and a follow-up run can recover by re-promoting
-          # the still-intact `nightly-staging` release.
+          # the still-intact `nightly-staging` release (which now carries
+          # the already-rewritten manifest).
           for attempt in 1 2 3; do
             if gh release edit nightly-staging \
               --repo "$GITHUB_REPOSITORY" \
@@ -365,23 +387,6 @@ jobs:
             fi
             echo "Promotion attempt $attempt failed; retrying in 5s"
             sleep 5
-          done
-
-          # Upload the URL-rewritten latest.json over the one tauri-action
-          # produced. `gh release upload` talks to the GitHub API by tag,
-          # which is consistent immediately after the retag (no public-CDN
-          # propagation in the path).
-          for attempt in 1 2 3; do
-            if gh release upload nightly latest.json --clobber --repo "$GITHUB_REPOSITORY"; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to upload rewritten latest.json after 3 attempts"
-              exit 1
-            fi
-            backoff=$((attempt * 5))
-            echo "latest.json upload attempt $attempt failed; retrying in ${backoff}s"
-            sleep "$backoff"
           done
 
           # `gh release edit --tag` creates the new tag (`nightly`) at the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -307,6 +307,44 @@ jobs:
             exit 1
           fi
 
+          # `tauri-action` generated `latest.json` while the release was
+          # tagged `nightly-staging`, so its embedded asset URLs are
+          # hardcoded to `releases/download/nightly-staging/...`. After the
+          # retag below those URLs would 404, breaking the in-app updater's
+          # download step. The Tauri signature covers binary contents — not
+          # the URL field — so rewriting URLs here does not invalidate
+          # verification.
+          #
+          # Fetch and rewrite *before* the retag, while staging still
+          # exists. We upload the rewritten file after the retag. This avoids
+          # depending on the freshly-retagged `nightly/...` URL being
+          # reachable via the public CDN, whose propagation delay previously
+          # exceeded our retry window and left a stale manifest live (#449
+          # follow-up). Aborting here is safe — `nightly` is still intact.
+          for attempt in 1 2 3; do
+            rm -f latest.json
+            if curl -fsSL -o latest.json \
+              "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly-staging/latest.json"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to fetch nightly-staging/latest.json after 3 attempts"
+              exit 1
+            fi
+            backoff=$((attempt * 5))
+            echo "latest.json fetch attempt $attempt failed; retrying in ${backoff}s"
+            sleep "$backoff"
+          done
+
+          sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
+          # Hard-fail if the rewrite was a no-op — retrying with the same
+          # input won't help, and shipping a manifest with staging URLs
+          # would break the updater for every nightly user.
+          if grep -q 'releases/download/nightly-staging/' latest.json; then
+            echo "::error::latest.json still contains nightly-staging URLs after rewrite; aborting"
+            exit 1
+          fi
+
           gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
           # Retry the retag a few times to ride out transient API hiccups
@@ -329,39 +367,20 @@ jobs:
             sleep 5
           done
 
-          # `tauri-action` generated `latest.json` while the release was
-          # tagged `nightly-staging`, so the asset URLs inside the manifest
-          # are hardcoded to `releases/download/nightly-staging/...`. Once
-          # the release is retagged to `nightly` above, those old URLs 404,
-          # breaking the in-app updater's download step (the manifest is
-          # reachable but `download_and_install` fails on the asset fetch).
-          # The Tauri signature covers the binary file contents — not the
-          # URL field — so rewriting the URLs here does not invalidate
-          # verification.
-          #
-          # Retry the fetch+rewrite+upload sequence a few times so a
-          # transient network or GitHub API failure does not leave the
-          # promoted release published with a stale manifest. Also verify
-          # the substitution actually took before uploading.
+          # Upload the URL-rewritten latest.json over the one tauri-action
+          # produced. `gh release upload` talks to the GitHub API by tag,
+          # which is consistent immediately after the retag (no public-CDN
+          # propagation in the path).
           for attempt in 1 2 3; do
-            rm -f latest.json
-            if ! curl -fsSL -o latest.json \
-              "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"; then
-              echo "latest.json fetch attempt $attempt failed"
-            else
-              sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
-              if grep -q 'releases/download/nightly-staging/' latest.json; then
-                echo "::warning::latest.json still contains nightly-staging URLs after rewrite"
-              elif gh release upload nightly latest.json --clobber --repo "$GITHUB_REPOSITORY"; then
-                break
-              fi
+            if gh release upload nightly latest.json --clobber --repo "$GITHUB_REPOSITORY"; then
+              break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to refresh latest.json for nightly after 3 attempts"
+              echo "::error::Failed to upload rewritten latest.json after 3 attempts"
               exit 1
             fi
             backoff=$((attempt * 5))
-            echo "latest.json refresh attempt $attempt failed; retrying in ${backoff}s"
+            echo "latest.json upload attempt $attempt failed; retrying in ${backoff}s"
             sleep "$backoff"
           done
 

--- a/src/ui/src/components/layout/UpdateBanner.module.css
+++ b/src/ui/src/components/layout/UpdateBanner.module.css
@@ -13,6 +13,11 @@
   color: var(--text-primary);
 }
 
+.errorMessage {
+  color: var(--error, var(--text-primary));
+  word-break: break-word;
+}
+
 .version {
   color: var(--accent-primary);
   font-weight: 600;

--- a/src/ui/src/components/layout/UpdateBanner.module.css
+++ b/src/ui/src/components/layout/UpdateBanner.module.css
@@ -14,7 +14,7 @@
 }
 
 .errorMessage {
-  color: var(--error, var(--text-primary));
+  color: var(--status-stopped);
   word-break: break-word;
 }
 

--- a/src/ui/src/components/layout/UpdateBanner.tsx
+++ b/src/ui/src/components/layout/UpdateBanner.tsx
@@ -1,6 +1,17 @@
 import { useAppStore } from "../../stores/useAppStore";
-import { installNow, installWhenIdle, dismiss } from "../../hooks/useAutoUpdater";
+import {
+  installNow,
+  installWhenIdle,
+  dismiss,
+  retryInstall,
+} from "../../hooks/useAutoUpdater";
+import { openUrl } from "../../services/tauri";
 import styles from "./UpdateBanner.module.css";
+
+const RELEASE_URL_BY_CHANNEL = {
+  stable: "https://github.com/utensils/claudette/releases/latest",
+  nightly: "https://github.com/utensils/claudette/releases/tag/nightly",
+} as const;
 
 export function UpdateBanner() {
   const updateAvailable = useAppStore((s) => s.updateAvailable);
@@ -10,6 +21,39 @@ export function UpdateBanner() {
   const updateDownloading = useAppStore((s) => s.updateDownloading);
   const updateProgress = useAppStore((s) => s.updateProgress);
   const updateChannel = useAppStore((s) => s.updateChannel);
+  const updateError = useAppStore((s) => s.updateError);
+  const setUpdateError = useAppStore((s) => s.setUpdateError);
+
+  if (updateError) {
+    const releaseUrl = RELEASE_URL_BY_CHANNEL[updateChannel];
+    const dismissError = () => {
+      setUpdateError(null);
+      dismiss();
+    };
+    return (
+      <div className={styles.banner}>
+        <span className={`${styles.message} ${styles.errorMessage}`}>
+          Update failed: {updateError}
+        </span>
+        <div className={styles.actions}>
+          <button className={styles.btnPrimary} onClick={retryInstall}>
+            Try again
+          </button>
+          <button
+            className={styles.btn}
+            onClick={() => {
+              void openUrl(releaseUrl).catch(() => {});
+            }}
+          >
+            View release page
+          </button>
+          <button className={styles.btn} onClick={dismissError}>
+            Dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   if (!updateAvailable || updateDismissed) return null;
 

--- a/src/ui/src/components/layout/UpdateBanner.tsx
+++ b/src/ui/src/components/layout/UpdateBanner.tsx
@@ -31,7 +31,7 @@ export function UpdateBanner() {
       dismiss();
     };
     return (
-      <div className={styles.banner}>
+      <div className={styles.banner} role="alert">
         <span className={`${styles.message} ${styles.errorMessage}`}>
           Update failed: {updateError}
         </span>

--- a/src/ui/src/hooks/useAutoUpdater.test.ts
+++ b/src/ui/src/hooks/useAutoUpdater.test.ts
@@ -11,6 +11,8 @@ const {
   mockSetUpdateDownloading,
   mockSetUpdateProgress,
   mockSetUpdateError,
+  mockSetUpdateDismissed,
+  mockSetUpdateInstallWhenIdle,
   storeState,
 } = vi.hoisted(() => ({
   mockCheckForUpdatesWithChannel: vi.fn(),
@@ -22,12 +24,16 @@ const {
   mockSetUpdateDownloading: vi.fn(),
   mockSetUpdateProgress: vi.fn(),
   mockSetUpdateError: vi.fn(),
+  mockSetUpdateDismissed: vi.fn(),
+  mockSetUpdateInstallWhenIdle: vi.fn(),
   storeState: {
     setUpdateAvailable: vi.fn(),
     setUpdateChannel: vi.fn(),
     setUpdateDownloading: vi.fn(),
     setUpdateProgress: vi.fn(),
     setUpdateError: vi.fn(),
+    setUpdateDismissed: vi.fn(),
+    setUpdateInstallWhenIdle: vi.fn(),
     updateDownloading: false,
     updateAvailable: false,
     workspaces: [] as { agent_status: string }[],
@@ -41,6 +47,8 @@ storeState.setUpdateChannel = mockSetUpdateChannel;
 storeState.setUpdateDownloading = mockSetUpdateDownloading;
 storeState.setUpdateProgress = mockSetUpdateProgress;
 storeState.setUpdateError = mockSetUpdateError;
+storeState.setUpdateDismissed = mockSetUpdateDismissed;
+storeState.setUpdateInstallWhenIdle = mockSetUpdateInstallWhenIdle;
 
 vi.mock("../services/tauri", () => ({
   checkForUpdatesWithChannel: mockCheckForUpdatesWithChannel,
@@ -227,6 +235,36 @@ describe("retryInstall", () => {
     await retryInstall();
 
     expect(mockSetUpdateError).toHaveBeenCalledWith(null);
+    expect(mockInstallPendingUpdate).not.toHaveBeenCalled();
+  });
+
+  it("un-dismisses the banner and clears install-when-idle so the retry is visible", async () => {
+    // If the user previously chose "When Idle" (which sets dismissed=true)
+    // and then an install fails, retrying must un-dismiss the banner —
+    // otherwise clearing the error makes UpdateBanner render null and the
+    // retry runs invisibly with no progress indicator.
+    mockCheckForUpdatesWithChannel.mockResolvedValue({ version: "2.0.0" });
+    mockInstallPendingUpdate.mockResolvedValue(undefined);
+
+    await retryInstall();
+
+    expect(mockSetUpdateDismissed).toHaveBeenCalledWith(false);
+    expect(mockSetUpdateInstallWhenIdle).toHaveBeenCalledWith(false);
+  });
+
+  it("re-surfaces a check failure as an error so the user is not left with a blank banner", async () => {
+    // The retry clears the previous install error, then re-runs the check.
+    // If the check itself fails (e.g. network down), we must repopulate
+    // updateError or the banner disappears and the user has no signal that
+    // anything happened.
+    mockCheckForUpdatesWithChannel.mockRejectedValue(new Error("network down"));
+
+    await retryInstall();
+
+    expect(mockSetUpdateError).toHaveBeenNthCalledWith(1, null);
+    expect(mockSetUpdateError).toHaveBeenLastCalledWith(
+      expect.stringContaining("Failed to check for updates")
+    );
     expect(mockInstallPendingUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/src/hooks/useAutoUpdater.test.ts
+++ b/src/ui/src/hooks/useAutoUpdater.test.ts
@@ -8,6 +8,9 @@ const {
   mockSetAppSetting,
   mockSetUpdateAvailable,
   mockSetUpdateChannel,
+  mockSetUpdateDownloading,
+  mockSetUpdateProgress,
+  mockSetUpdateError,
   storeState,
 } = vi.hoisted(() => ({
   mockCheckForUpdatesWithChannel: vi.fn(),
@@ -16,10 +19,17 @@ const {
   mockSetAppSetting: vi.fn(),
   mockSetUpdateAvailable: vi.fn(),
   mockSetUpdateChannel: vi.fn(),
+  mockSetUpdateDownloading: vi.fn(),
+  mockSetUpdateProgress: vi.fn(),
+  mockSetUpdateError: vi.fn(),
   storeState: {
     setUpdateAvailable: vi.fn(),
     setUpdateChannel: vi.fn(),
+    setUpdateDownloading: vi.fn(),
+    setUpdateProgress: vi.fn(),
+    setUpdateError: vi.fn(),
     updateDownloading: false,
+    updateAvailable: false,
     workspaces: [] as { agent_status: string }[],
     updateChannel: "stable" as "stable" | "nightly",
   },
@@ -28,6 +38,9 @@ const {
 // Wire the hoisted helpers into the store mock.
 storeState.setUpdateAvailable = mockSetUpdateAvailable;
 storeState.setUpdateChannel = mockSetUpdateChannel;
+storeState.setUpdateDownloading = mockSetUpdateDownloading;
+storeState.setUpdateProgress = mockSetUpdateProgress;
+storeState.setUpdateError = mockSetUpdateError;
 
 vi.mock("../services/tauri", () => ({
   checkForUpdatesWithChannel: mockCheckForUpdatesWithChannel,
@@ -51,6 +64,8 @@ import {
   checkForUpdate,
   applyUpdateChannel,
   loadUpdateChannel,
+  installNow,
+  retryInstall,
 } from "./useAutoUpdater";
 
 describe("checkForUpdate", () => {
@@ -136,6 +151,83 @@ describe("applyUpdateChannel", () => {
     await expect(applyUpdateChannel("nightly")).rejects.toThrow("disk full");
     expect(mockSetUpdateChannel).not.toHaveBeenCalled();
     expect(mockCheckForUpdatesWithChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe("installNow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState.updateChannel = "stable";
+    storeState.updateDownloading = false;
+    storeState.updateAvailable = true;
+  });
+
+  it("surfaces install errors via setUpdateError so the banner can show them", async () => {
+    // Regression: a previous version swallowed the failure and re-ran the
+    // check, leaving the banner stuck on "Downloading..." forever. The fix
+    // is to push the error string into the store so the banner can render
+    // the failure and offer a retry.
+    mockInstallPendingUpdate.mockRejectedValue(
+      new Error("Download request failed with status: 404 Not Found")
+    );
+
+    await installNow();
+
+    expect(mockSetUpdateDownloading).toHaveBeenCalledWith(true);
+    expect(mockSetUpdateDownloading).toHaveBeenLastCalledWith(false);
+    expect(mockSetUpdateProgress).toHaveBeenLastCalledWith(0);
+    expect(mockSetUpdateError).toHaveBeenCalledWith(
+      expect.stringContaining("404 Not Found")
+    );
+  });
+
+  it("is a no-op when no update is available", async () => {
+    storeState.updateAvailable = false;
+
+    await installNow();
+
+    expect(mockInstallPendingUpdate).not.toHaveBeenCalled();
+    expect(mockSetUpdateDownloading).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when a download is already in flight", async () => {
+    storeState.updateDownloading = true;
+
+    await installNow();
+
+    expect(mockInstallPendingUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("retryInstall", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState.updateChannel = "stable";
+    storeState.updateDownloading = false;
+    storeState.updateAvailable = true;
+  });
+
+  it("clears the error, re-checks, and re-installs when an update is still available", async () => {
+    // The Rust side `take()`s the pending update on the first attempt, so a
+    // bare retry would no-op. The retry must re-run the check to repopulate
+    // the pending update before installNow can succeed.
+    mockCheckForUpdatesWithChannel.mockResolvedValue({ version: "2.0.0" });
+    mockInstallPendingUpdate.mockResolvedValue(undefined);
+
+    await retryInstall();
+
+    expect(mockSetUpdateError).toHaveBeenCalledWith(null);
+    expect(mockCheckForUpdatesWithChannel).toHaveBeenCalled();
+    expect(mockInstallPendingUpdate).toHaveBeenCalled();
+  });
+
+  it("does not re-install when the re-check finds no update", async () => {
+    mockCheckForUpdatesWithChannel.mockResolvedValue(null);
+
+    await retryInstall();
+
+    expect(mockSetUpdateError).toHaveBeenCalledWith(null);
+    expect(mockInstallPendingUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -47,10 +47,22 @@ export async function installNow(): Promise<void> {
     // fall through to the catch on the next tick.
   } catch (e) {
     console.error("[updater] Install failed:", e);
-    useAppStore.getState().setUpdateDownloading(false);
-    useAppStore.getState().setUpdateProgress(0);
-    checkForUpdate();
+    const s = useAppStore.getState();
+    s.setUpdateDownloading(false);
+    s.setUpdateProgress(0);
+    s.setUpdateError(String(e));
   }
+}
+
+/**
+ * User-initiated retry after a failed install. The Rust side `take()`s the
+ * pending update on the previous attempt, so we must re-run the check to
+ * repopulate it before another install can succeed.
+ */
+export async function retryInstall(): Promise<void> {
+  useAppStore.getState().setUpdateError(null);
+  const result = await checkForUpdate();
+  if (result === "available") await installNow();
 }
 
 export function installWhenIdle(): void {

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -57,11 +57,24 @@ export async function installNow(): Promise<void> {
 /**
  * User-initiated retry after a failed install. The Rust side `take()`s the
  * pending update on the previous attempt, so we must re-run the check to
- * repopulate it before another install can succeed.
+ * repopulate it before another install can succeed. Also un-dismiss the
+ * banner and clear install-when-idle — otherwise a retry triggered from the
+ * error banner would run invisibly, since clearing the error in a dismissed
+ * state causes UpdateBanner to render nothing.
  */
 export async function retryInstall(): Promise<void> {
-  useAppStore.getState().setUpdateError(null);
+  const store = useAppStore.getState();
+  store.setUpdateError(null);
+  store.setUpdateDismissed(false);
+  store.setUpdateInstallWhenIdle(false);
+
   const result = await checkForUpdate();
+  if (result === "error") {
+    useAppStore
+      .getState()
+      .setUpdateError("Failed to check for updates. Please try again.");
+    return;
+  }
   if (result === "available") await installNow();
 }
 

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -577,12 +577,14 @@ interface AppState {
   updateDownloading: boolean;
   updateProgress: number;
   updateChannel: "stable" | "nightly";
+  updateError: string | null;
   setUpdateAvailable: (available: boolean, version: string | null) => void;
   setUpdateDismissed: (dismissed: boolean) => void;
   setUpdateInstallWhenIdle: (enabled: boolean) => void;
   setUpdateDownloading: (downloading: boolean) => void;
   setUpdateProgress: (progress: number) => void;
   setUpdateChannel: (channel: "stable" | "nightly") => void;
+  setUpdateError: (error: string | null) => void;
 
   // -- App info --
   appVersion: string | null;
@@ -1896,18 +1898,23 @@ export const useAppStore = create<AppState>((set, get) => ({
   updateDownloading: false,
   updateProgress: 0,
   updateChannel: "stable",
+  updateError: null,
   setUpdateAvailable: (available, version) =>
     set((state) => ({
       updateAvailable: available,
       updateVersion: version,
       updateDismissed:
         version === state.updateVersion ? state.updateDismissed : false,
+      updateError: null,
     })),
   setUpdateDismissed: (dismissed) => set({ updateDismissed: dismissed }),
   setUpdateInstallWhenIdle: (enabled) =>
     set({ updateInstallWhenIdle: enabled }),
   setUpdateDownloading: (downloading) =>
-    set({ updateDownloading: downloading }),
+    set((state) => ({
+      updateDownloading: downloading,
+      updateError: downloading ? null : state.updateError,
+    })),
   setUpdateProgress: (progress) => set({ updateProgress: progress }),
   setUpdateChannel: (channel) =>
     set({
@@ -1916,7 +1923,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       updateVersion: null,
       updateDismissed: false,
       updateInstallWhenIdle: false,
+      updateError: null,
     }),
+  setUpdateError: (error) => set({ updateError: error }),
 
   // -- App info --
   appVersion: null,


### PR DESCRIPTION
## Summary

Two paired fixes for the nightly auto-updater's stuck-install symptom — one
treats the cause, the other surfaces the failure mode if it ever returns.

**`fix(ci)` — workflow:** PR #449 rewrote `releases/download/nightly-staging/`
→ `releases/download/nightly/` in `latest.json` *after* the retag, but the
fetch raced GitHub's release-asset CDN propagation and failed all three
retries. The rewritten manifest never uploaded; the broken one
(staging-tagged URLs) went live anyway. Verified live `latest.json` for
`v0.20.0-dev.20.g47af807` still has every asset URL pointing at
`releases/download/nightly-staging/...`, all of which now 404.

The fix reorders the promote step:

```mermaid
flowchart TD
  A[Pre-flight: nightly-staging reachable?] --> B[Fetch latest.json from staging URL]
  B --> C[sed-rewrite URLs locally]
  C --> D{Any staging URLs left?}
  D -->|yes| E[exit 1 — abort, nightly intact]
  D -->|no| F[Delete nightly]
  F --> G[Retag staging → nightly]
  G --> H[Upload rewritten latest.json via API]
  H --> I[Cleanup orphan nightly-staging tag]
```

Key properties: the fetch happens while staging is fully alive (no CDN
race); aborting before the retag leaves `nightly` intact; the post-retag
upload uses `gh release upload` which talks to the GitHub API by tag
(consistent immediately, no CDN dependency).

**`fix(updater)` — UI:** A failed `installPendingUpdate` previously cleared
the downloading flag and silently re-ran a check, leaving the banner
stuck on "Downloading..." indefinitely. Now the error string lands in
the store (`updateError`) and the banner renders a dedicated error mode
with **Try Again**, **View release page**, and **Dismiss** actions.
Retry re-runs the check first because the Rust side `take()`s the
pending update on each attempt — a bare install would no-op.

## Complexity Notes

- **Tauri signature scope:** the `latest.json` URL rewrite is safe because
  Tauri's signature covers binary file *contents*, not the URL field. If
  this assumption ever changes (e.g. Tauri starts signing the manifest
  itself), the workflow rewrite breaks signature verification silently.
  Worth flagging in any future Tauri major-version bumps.
- **Currently broken release:** the `nightly` release that triggered this
  bug (v0.20.0-dev.20.g47af807) won't self-heal — its `latest.json` will
  remain broken until the next nightly run produces a fresh one. Existing
  nightly users will keep seeing the 404 (now visible thanks to the UI
  fix) until the next workflow run, or until someone manually re-uploads
  a rewritten manifest with `gh release upload nightly latest.json
  --clobber --repo utensils/claudette`.
- **Retry escalation:** the previous code treated "sed didn't replace
  anything" as a retryable warning. Now it's a hard `exit 1` — retrying
  with identical input cannot help, and shipping a manifest with staging
  URLs is exactly the bug we're fixing.

## Test Steps

1. Verify the workflow YAML is well-formed: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml'))"`
2. Verify the new `latest.json` flow by reading `nightly.yml:295-395` — fetch happens before the `gh release delete nightly` line; upload happens after the retag loop; both have independent 3-attempt retry with backoff.
3. Run frontend tests: `cd src/ui && bun run test useAutoUpdater` — should report 15 passed (10 existing + 5 new covering the error-surface and retry paths).
4. Run typecheck: `cd src/ui && bunx tsc -b` — must be clean (CI runs the same command).
5. UAT the UI flow in dev:
   - Start `cargo tauri dev`.
   - In the dev console: `window.__CLAUDETTE_STORE__.setState({ updateError: 'Download request failed with status: 404 Not Found', updateChannel: 'nightly' })`
   - Banner should switch to error mode with **Try Again** / **View release page** / **Dismiss**. Clicking Dismiss should clear it; clicking View release page should open the GitHub releases page in the browser.
6. After merge, watch the next nightly run's "Promote staging to nightly" step — the new fetch-before-retag log lines should appear, and the live `latest.json` should embed `releases/download/nightly/...` URLs (curl + jq to confirm).

## Checklist

- [x] Tests added/updated (`useAutoUpdater.test.ts` + 5 new cases for `installNow`/`retryInstall`)
- [ ] Documentation updated (n/a — no user-facing docs reference these internals)