### PR TITLE
style(chat): tighten session tabs spacing and flush left edge

### DIFF
--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -55,11 +55,6 @@
   color: var(--text-primary);
 }
 
-.tab:focus-visible {
-  outline: none;
-  box-shadow: none;
-}
-
 .active {
   color: var(--text-primary);
 }

--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -4,8 +4,6 @@
   flex-wrap: nowrap;
   overflow-x: auto;
   overflow-y: hidden;
-  gap: 4px;
-  padding: 0 8px;
   background: transparent;
   scrollbar-width: thin;
   scrollbar-color: var(--border-subtle) transparent;
@@ -24,7 +22,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 14px;
+  padding: 8px 10px;
   min-width: 0;
   max-width: 220px;
   font-size: 12px;
@@ -38,11 +36,15 @@
   transition: color 80ms ease;
 }
 
+.tab:first-child {
+  padding-left: 8px;
+}
+
 .tab::after {
   content: "";
   position: absolute;
-  left: 8px;
-  right: 8px;
+  left: 0;
+  right: 0;
   bottom: 0;
   height: 1px;
   background: transparent;
@@ -51,6 +53,11 @@
 
 .tab:hover:not(.active) {
   color: var(--text-primary);
+}
+
+.tab:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .active {


### PR DESCRIPTION
## Summary
- Drop the `.tabBar` outer gutter (`padding: 0 8px`) and inter-tab `gap: 4px` so the first session tab sits flush against the sidebar with no inter-tab whitespace.
- Tighten each tab's horizontal padding from `8px 14px` to `8px 10px`, with a `padding-left: 8px` override on the first tab to match the new flush edge.
- Extend the active-tab underline (`.tab::after`) to span the full tab width now that there's no gap.
- Suppress the global `:focus-visible` ring on `.tab` (theme.css gives a 2px accent box-shadow) since the active underline already indicates selection.

## Test plan
- [ ] Open a workspace with the multi-session tab bar visible; confirm the first tab is flush with the left sidebar edge and tabs sit immediately adjacent to each other.
- [ ] Click and arrow-key between tabs and verify only the active tab shows the blue underline with no stray focus ring.
- [ ] Confirm hover, rename (double-click / F2), and close interactions still work as before.