### PR TITLE
feat(diff): open file diffs as tabs alongside chat sessions

### DIFF
--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-// `FileDiff` is also a TS type re-exported from "../../types" — alias the
-// lucide icon to avoid the name collision in this file.
 import { FileDiff as FileDiffIcon, Plus, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
@@ -82,7 +80,13 @@ export function SessionTabs({ workspaceId }: Props) {
       });
   }, [workspaceId, setSessionsForWorkspace]);
 
-  const activeSessions = sessions.filter((s) => s.status === "Active");
+  // Memoized so navEntries / navigateTabs stay referentially stable when the
+  // session list hasn't changed — without this, `sessions.filter` returns a
+  // fresh array each render and defeats the downstream useMemo/useCallback.
+  const activeSessions = useMemo(
+    () => sessions.filter((s) => s.status === "Active"),
+    [sessions],
+  );
 
   const handleCreate = async () => {
     try {

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Plus, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+// `FileDiff` is also a TS type re-exported from "../../types" — alias the
+// lucide icon to avoid the name collision in this file.
+import { FileDiff as FileDiffIcon, Plus, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   listChatSessions,
@@ -8,8 +10,18 @@ import {
   archiveChatSession,
 } from "../../services/tauri";
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
-import type { ChatSession } from "../../types";
+import type { ChatSession, DiffFileTab, DiffLayer } from "../../types";
 import styles from "./SessionTabs.module.css";
+
+type NavDirection = "prev" | "next" | "first" | "last";
+
+// Unified key namespace for the tab strip's keyboard nav and ref map.
+// Sessions and diff tabs occupy a single ordered list; encoding the kind in
+// the key keeps the navigation logic flat without touching the underlying
+// data shapes.
+const sessionNavKey = (id: string) => `s:${id}`;
+const diffNavKey = (path: string, layer: DiffLayer | null) =>
+  `d:${path}:${layer ?? "null"}`;
 
 interface Props {
   workspaceId: string;
@@ -28,6 +40,7 @@ function statusFor(session: ChatSession): SessionStatusKind {
 // consecutive snapshots with `Object.is` and forces a re-render on mismatch;
 // a fresh `[]` every call turns that into an infinite render loop.
 const EMPTY_SESSIONS: ChatSession[] = [];
+const EMPTY_DIFF_TABS: DiffFileTab[] = [];
 
 export function SessionTabs({ workspaceId }: Props) {
   const sessions = useAppStore(
@@ -36,11 +49,18 @@ export function SessionTabs({ workspaceId }: Props) {
   const selectedSessionId = useAppStore(
     (s) => s.selectedSessionIdByWorkspaceId[workspaceId] ?? null,
   );
+  const diffTabs = useAppStore(
+    (s) => s.diffTabsByWorkspace[workspaceId] ?? EMPTY_DIFF_TABS,
+  );
+  const diffSelectedFile = useAppStore((s) => s.diffSelectedFile);
+  const diffSelectedLayer = useAppStore((s) => s.diffSelectedLayer);
   const setSessionsForWorkspace = useAppStore((s) => s.setSessionsForWorkspace);
   const addChatSession = useAppStore((s) => s.addChatSession);
   const updateChatSession = useAppStore((s) => s.updateChatSession);
   const removeChatSession = useAppStore((s) => s.removeChatSession);
   const selectSession = useAppStore((s) => s.selectSession);
+  const selectDiffTab = useAppStore((s) => s.selectDiffTab);
+  const closeDiffTab = useAppStore((s) => s.closeDiffTab);
 
   // Monotonic version token: each local mutation (create/archive) bumps this so
   // an in-flight `listChatSessions` response can detect it's stale and skip the
@@ -96,58 +116,103 @@ export function SessionTabs({ workspaceId }: Props) {
     }
   };
 
-  // Refs keyed by session id so arrow-key navigation can move DOM focus
-  // to the newly-selected tab (the previously-focused element loses
-  // tabIndex=0 once selection moves, so we need to programmatically focus
-  // the new active tab).
+  // Refs keyed by a unified nav key (sessionNavKey / diffNavKey) so arrow-key
+  // navigation can focus any tab in the strip, regardless of kind.
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
+  // Unified ordered list of focusable tab entries. Sessions first, diffs
+  // second — the layout users see in the strip. Wrapped in useMemo so the
+  // navigateTabs callback identity stays stable across unrelated re-renders.
+  type NavEntry =
+    | { key: string; kind: "session"; sessionId: string }
+    | { key: string; kind: "diff"; path: string; layer: DiffLayer | null };
+  const navEntries = useMemo<NavEntry[]>(() => {
+    const sessionEntries: NavEntry[] = activeSessions.map((s) => ({
+      key: sessionNavKey(s.id),
+      kind: "session",
+      sessionId: s.id,
+    }));
+    const diffEntries: NavEntry[] = diffTabs.map((t) => ({
+      key: diffNavKey(t.path, t.layer),
+      kind: "diff",
+      path: t.path,
+      layer: t.layer,
+    }));
+    return [...sessionEntries, ...diffEntries];
+  }, [activeSessions, diffTabs]);
+
   const navigateTabs = useCallback(
-    (from: string, direction: "prev" | "next" | "first" | "last") => {
-      if (activeSessions.length === 0) return;
-      const idx = activeSessions.findIndex((s) => s.id === from);
+    (fromKey: string, direction: NavDirection) => {
+      if (navEntries.length === 0) return;
+      const idx = navEntries.findIndex((e) => e.key === fromKey);
       if (idx < 0) return;
       let targetIdx: number;
       switch (direction) {
         case "prev":
-          targetIdx = (idx - 1 + activeSessions.length) % activeSessions.length;
+          targetIdx = (idx - 1 + navEntries.length) % navEntries.length;
           break;
         case "next":
-          targetIdx = (idx + 1) % activeSessions.length;
+          targetIdx = (idx + 1) % navEntries.length;
           break;
         case "first":
           targetIdx = 0;
           break;
         case "last":
-          targetIdx = activeSessions.length - 1;
+          targetIdx = navEntries.length - 1;
           break;
       }
-      const target = activeSessions[targetIdx];
-      selectSession(workspaceId, target.id);
-      tabRefs.current.get(target.id)?.focus();
+      const target = navEntries[targetIdx];
+      if (target.kind === "session") {
+        selectSession(workspaceId, target.sessionId);
+      } else {
+        selectDiffTab(target.path, target.layer);
+      }
+      tabRefs.current.get(target.key)?.focus();
     },
-    [activeSessions, selectSession, workspaceId],
+    [navEntries, selectSession, selectDiffTab, workspaceId],
   );
 
   return (
     <div className={styles.tabBar} role="tablist">
-      {activeSessions.map((session) => (
-        <SessionTab
-          key={session.id}
-          session={session}
-          isActive={session.id === selectedSessionId}
-          onSelect={() => selectSession(workspaceId, session.id)}
-          onClose={() => handleArchive(session)}
-          onRename={(name) => {
-            updateChatSession(session.id, { name, name_edited: true });
-          }}
-          onNavigate={(direction) => navigateTabs(session.id, direction)}
-          tabRef={(el) => {
-            if (el) tabRefs.current.set(session.id, el);
-            else tabRefs.current.delete(session.id);
-          }}
-        />
-      ))}
+      {activeSessions.map((session) => {
+        const navKey = sessionNavKey(session.id);
+        return (
+          <SessionTab
+            key={session.id}
+            session={session}
+            isActive={session.id === selectedSessionId && diffSelectedFile === null}
+            onSelect={() => selectSession(workspaceId, session.id)}
+            onClose={() => handleArchive(session)}
+            onRename={(name) => {
+              updateChatSession(session.id, { name, name_edited: true });
+            }}
+            onNavigate={(direction) => navigateTabs(navKey, direction)}
+            tabRef={(el) => {
+              if (el) tabRefs.current.set(navKey, el);
+              else tabRefs.current.delete(navKey);
+            }}
+          />
+        );
+      })}
+      {diffTabs.map((tab) => {
+        const navKey = diffNavKey(tab.path, tab.layer);
+        const isActive =
+          diffSelectedFile === tab.path && diffSelectedLayer === tab.layer;
+        return (
+          <DiffTab
+            key={navKey}
+            tab={tab}
+            isActive={isActive}
+            onSelect={() => selectDiffTab(tab.path, tab.layer)}
+            onClose={() => closeDiffTab(workspaceId, tab.path, tab.layer)}
+            onNavigate={(direction) => navigateTabs(navKey, direction)}
+            tabRef={(el) => {
+              if (el) tabRefs.current.set(navKey, el);
+              else tabRefs.current.delete(navKey);
+            }}
+          />
+        );
+      })}
       <button
         type="button"
         className={styles.addBtn}
@@ -286,6 +351,70 @@ function SessionTab({
         }}
         title="Close session"
         aria-label="Close session"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}
+
+interface DiffTabProps {
+  tab: DiffFileTab;
+  isActive: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+  onNavigate: (direction: NavDirection) => void;
+  tabRef: (el: HTMLDivElement | null) => void;
+}
+
+function DiffTab({ tab, isActive, onSelect, onClose, onNavigate, tabRef }: DiffTabProps) {
+  // Show just the basename in the tab; the full path goes in the tooltip
+  // (mirrors how editors label file tabs). `path.split("/").pop()` is fine
+  // because diff paths come from git and use forward slashes on every
+  // platform.
+  const basename = tab.path.split("/").pop() || tab.path;
+  return (
+    <div
+      ref={tabRef}
+      role="tab"
+      aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      className={`${styles.tab} ${isActive ? styles.active : ""}`}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        } else if (e.key === "ArrowLeft") {
+          e.preventDefault();
+          onNavigate("prev");
+        } else if (e.key === "ArrowRight") {
+          e.preventDefault();
+          onNavigate("next");
+        } else if (e.key === "Home") {
+          e.preventDefault();
+          onNavigate("first");
+        } else if (e.key === "End") {
+          e.preventDefault();
+          onNavigate("last");
+        }
+      }}
+    >
+      <span className={styles.icon}>
+        <FileDiffIcon size={12} />
+      </span>
+      <span className={styles.name} title={tab.path}>
+        {basename}
+      </span>
+      <button
+        type="button"
+        className={styles.closeBtn}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+        title="Close diff"
+        aria-label="Close diff"
       >
         <X size={12} />
       </button>

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -22,22 +22,6 @@
   min-width: 0;
 }
 
-.backBtn {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-size: 13px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: color var(--transition-fast), background var(--transition-fast);
-}
-
-.backBtn:hover {
-  color: var(--accent-primary);
-  background: var(--accent-bg);
-}
-
 .fileName {
   font-family: var(--font-mono);
   font-size: 13px;

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { loadFileDiff } from "../../services/tauri";
 import { PanelToggles } from "../shared/PanelToggles";
@@ -60,15 +60,23 @@ export function DiffViewer() {
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
 
+  // Monotonic version token: each new fetch bumps it so a stale in-flight
+  // response (e.g. user already switched diff tabs) gets dropped instead of
+  // overwriting the now-active file's content.
+  const loadVersionRef = useRef(0);
+
   useEffect(() => {
     if (!diffSelectedFile || !ws?.worktree_path || !diffMergeBase) return;
+    const version = ++loadVersionRef.current;
     setDiffLoading(true);
     loadFileDiff(ws.worktree_path, diffMergeBase, diffSelectedFile, diffSelectedLayer ?? undefined)
       .then((content) => {
+        if (version !== loadVersionRef.current) return;
         setDiffContent(content);
         setDiffLoading(false);
       })
       .catch((e) => {
+        if (version !== loadVersionRef.current) return;
         setDiffError(String(e));
         setDiffLoading(false);
       });

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { loadFileDiff } from "../../services/tauri";
 import { PanelToggles } from "../shared/PanelToggles";
+import { SessionTabs } from "../chat/SessionTabs";
 import type { DiffLine } from "../../types/diff";
 import styles from "./DiffViewer.module.css";
 
@@ -53,7 +54,6 @@ export function DiffViewer() {
   const diffLoading = useAppStore((s) => s.diffLoading);
   const setDiffContent = useAppStore((s) => s.setDiffContent);
   const setDiffLoading = useAppStore((s) => s.setDiffLoading);
-  const setDiffSelectedFile = useAppStore((s) => s.setDiffSelectedFile);
   const setDiffError = useAppStore((s) => s.setDiffError);
   const workspaces = useAppStore((s) => s.workspaces);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -94,16 +94,11 @@ export function DiffViewer() {
     <div className={styles.viewer}>
       <div className={styles.header} data-tauri-drag-region>
         <div className={styles.headerLeft}>
-          <button
-            className={styles.backBtn}
-            onClick={() => setDiffSelectedFile(null)}
-          >
-            ← Back
-          </button>
           <span className={styles.fileName}>{diffSelectedFile}</span>
         </div>
         <PanelToggles />
       </div>
+      {selectedWorkspaceId && <SessionTabs workspaceId={selectedWorkspaceId} />}
       <div className={styles.content}>
         {diffLoading ? (
           <div className={styles.center}>Loading diff...</div>

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -32,7 +32,7 @@ export const RightSidebar = memo(function RightSidebar() {
   const diffSelectedLayer = useAppStore((s) => s.diffSelectedLayer);
   const diffLoading = useAppStore((s) => s.diffLoading);
   const setDiffFiles = useAppStore((s) => s.setDiffFiles);
-  const setDiffSelectedFile = useAppStore((s) => s.setDiffSelectedFile);
+  const openDiffTab = useAppStore((s) => s.openDiffTab);
   const setDiffLoading = useAppStore((s) => s.setDiffLoading);
   const setDiffViewMode = useAppStore((s) => s.setDiffViewMode);
   const diffViewMode = useAppStore((s) => s.diffViewMode);
@@ -191,7 +191,11 @@ export const RightSidebar = memo(function RightSidebar() {
     <div
       key={`${layer ?? "flat"}-${file.path}`}
       className={`${styles.file} ${isSelected ? styles.fileSelected : ""}`}
-      onClick={() => setDiffSelectedFile(file.path, layer)}
+      onClick={() => {
+        if (selectedWorkspaceId) {
+          openDiffTab(selectedWorkspaceId, file.path, layer);
+        }
+      }}
       onContextMenu={handleContextMenu}
     >
       <span

--- a/src/ui/src/stores/useAppStore.diffTabs.test.ts
+++ b/src/ui/src/stores/useAppStore.diffTabs.test.ts
@@ -129,6 +129,60 @@ describe("selectDiffTab", () => {
     expect(state.diffSelectedLayer).toBe("unstaged");
     expect(state.diffTabsByWorkspace[WS_A]).toBe(tabsBefore);
   });
+
+  it("clears stale content/error when switching to a different tab", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_A, "b.ts", "unstaged");
+    // Simulate a load completing for b.ts.
+    useAppStore.setState({
+      diffContent: { path: "b.ts", hunks: [], is_binary: false },
+      diffError: "boom",
+    });
+
+    useAppStore.getState().selectDiffTab("a.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.diffContent).toBeNull();
+    expect(state.diffError).toBeNull();
+  });
+
+  it("preserves content when re-selecting the already-active tab", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    const content = { path: "a.ts", hunks: [], is_binary: false };
+    useAppStore.setState({ diffContent: content });
+
+    useAppStore.getState().selectDiffTab("a.ts", "unstaged");
+
+    expect(useAppStore.getState().diffContent).toBe(content);
+  });
+});
+
+describe("openDiffTab clears stale content", () => {
+  beforeEach(reset);
+
+  it("nulls diffContent/diffError when opening a different file", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.setState({
+      diffContent: { path: "a.ts", hunks: [], is_binary: false },
+      diffError: "boom",
+    });
+
+    useAppStore.getState().openDiffTab(WS_A, "b.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.diffContent).toBeNull();
+    expect(state.diffError).toBeNull();
+  });
+
+  it("preserves diffContent when re-opening the already-active tab", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    const content = { path: "a.ts", hunks: [], is_binary: false };
+    useAppStore.setState({ diffContent: content });
+
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+
+    expect(useAppStore.getState().diffContent).toBe(content);
+  });
 });
 
 describe("selectSession clears active diff", () => {

--- a/src/ui/src/stores/useAppStore.diffTabs.test.ts
+++ b/src/ui/src/stores/useAppStore.diffTabs.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "./useAppStore";
+
+const WS_A = "workspace-a";
+const WS_B = "workspace-b";
+
+// Minimal reset so each case starts from a known empty state.
+function reset() {
+  useAppStore.setState({
+    diffTabsByWorkspace: {},
+    diffSelectedFile: null,
+    diffSelectedLayer: null,
+    diffContent: null,
+    diffError: null,
+    sessionsByWorkspace: {},
+    selectedSessionIdByWorkspaceId: {},
+  });
+}
+
+describe("openDiffTab", () => {
+  beforeEach(reset);
+
+  it("appends the tab and sets it active", () => {
+    useAppStore.getState().openDiffTab(WS_A, "src/foo.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.diffTabsByWorkspace[WS_A]).toEqual([
+      { path: "src/foo.ts", layer: "unstaged" },
+    ]);
+    expect(state.diffSelectedFile).toBe("src/foo.ts");
+    expect(state.diffSelectedLayer).toBe("unstaged");
+  });
+
+  it("dedupes when re-opening the same (path, layer)", () => {
+    useAppStore.getState().openDiffTab(WS_A, "src/foo.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_A, "src/foo.ts", "unstaged");
+
+    expect(useAppStore.getState().diffTabsByWorkspace[WS_A]).toHaveLength(1);
+  });
+
+  it("treats different layers of the same path as distinct tabs", () => {
+    useAppStore.getState().openDiffTab(WS_A, "src/foo.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_A, "src/foo.ts", "committed");
+
+    const tabs = useAppStore.getState().diffTabsByWorkspace[WS_A];
+    expect(tabs).toEqual([
+      { path: "src/foo.ts", layer: "unstaged" },
+      { path: "src/foo.ts", layer: "committed" },
+    ]);
+  });
+
+  it("isolates tabs by workspace", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", null);
+    useAppStore.getState().openDiffTab(WS_B, "b.ts", null);
+
+    const state = useAppStore.getState();
+    expect(state.diffTabsByWorkspace[WS_A]).toEqual([{ path: "a.ts", layer: null }]);
+    expect(state.diffTabsByWorkspace[WS_B]).toEqual([{ path: "b.ts", layer: null }]);
+  });
+
+  it("treats omitted layer as null", () => {
+    useAppStore.getState().openDiffTab(WS_A, "x.ts");
+    useAppStore.getState().openDiffTab(WS_A, "x.ts", null);
+
+    expect(useAppStore.getState().diffTabsByWorkspace[WS_A]).toHaveLength(1);
+  });
+});
+
+describe("closeDiffTab", () => {
+  beforeEach(reset);
+
+  it("removes the tab from the strip", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_A, "b.ts", "unstaged");
+
+    useAppStore.getState().closeDiffTab(WS_A, "a.ts", "unstaged");
+
+    expect(useAppStore.getState().diffTabsByWorkspace[WS_A]).toEqual([
+      { path: "b.ts", layer: "unstaged" },
+    ]);
+  });
+
+  it("clears active-diff state when closing the active tab", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.setState({ diffContent: { path: "a.ts", hunks: [], is_binary: false } });
+
+    useAppStore.getState().closeDiffTab(WS_A, "a.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBeNull();
+    expect(state.diffSelectedLayer).toBeNull();
+    expect(state.diffContent).toBeNull();
+  });
+
+  it("preserves active-diff state when closing a non-active tab", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_A, "b.ts", "unstaged");
+    // a.ts is now non-active (b.ts opened last and became active).
+
+    useAppStore.getState().closeDiffTab(WS_A, "a.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBe("b.ts");
+    expect(state.diffSelectedLayer).toBe("unstaged");
+  });
+
+  it("is a no-op for an unknown (path, layer)", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    const before = useAppStore.getState().diffTabsByWorkspace[WS_A];
+
+    useAppStore.getState().closeDiffTab(WS_A, "missing.ts", "unstaged");
+
+    expect(useAppStore.getState().diffTabsByWorkspace[WS_A]).toBe(before);
+  });
+});
+
+describe("selectDiffTab", () => {
+  beforeEach(reset);
+
+  it("focuses the diff without mutating the tab list", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_A, "b.ts", "unstaged");
+    const tabsBefore = useAppStore.getState().diffTabsByWorkspace[WS_A];
+
+    useAppStore.getState().selectDiffTab("a.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBe("a.ts");
+    expect(state.diffSelectedLayer).toBe("unstaged");
+    expect(state.diffTabsByWorkspace[WS_A]).toBe(tabsBefore);
+  });
+});
+
+describe("selectSession clears active diff", () => {
+  beforeEach(reset);
+
+  it("nulls diffSelectedFile so AppLayout swaps back to chat", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    expect(useAppStore.getState().diffSelectedFile).toBe("a.ts");
+
+    useAppStore.getState().selectSession(WS_A, "session-1");
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBeNull();
+    expect(state.diffSelectedLayer).toBeNull();
+    // Diff tabs themselves remain in the strip.
+    expect(state.diffTabsByWorkspace[WS_A]).toHaveLength(1);
+    expect(state.selectedSessionIdByWorkspaceId[WS_A]).toBe("session-1");
+  });
+});
+
+describe("workspace removal cleans up diff tabs", () => {
+  beforeEach(reset);
+
+  it("removeWorkspace drops the workspace's diff tabs", () => {
+    useAppStore.setState({
+      workspaces: [
+        // Minimal stub — only fields touched by removeWorkspace matter here.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: WS_A } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: WS_B } as any,
+      ],
+    });
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    useAppStore.getState().openDiffTab(WS_B, "b.ts", "unstaged");
+
+    useAppStore.getState().removeWorkspace(WS_A);
+
+    const state = useAppStore.getState();
+    expect(state.diffTabsByWorkspace[WS_A]).toBeUndefined();
+    expect(state.diffTabsByWorkspace[WS_B]).toEqual([
+      { path: "b.ts", layer: "unstaged" },
+    ]);
+  });
+});
+
+describe("selectWorkspace clears active diff pointer", () => {
+  beforeEach(reset);
+
+  it("nulls diffSelectedFile when switching workspaces but preserves per-workspace tabs", () => {
+    useAppStore.getState().openDiffTab(WS_A, "a.ts", "unstaged");
+    expect(useAppStore.getState().diffSelectedFile).toBe("a.ts");
+
+    useAppStore.getState().selectWorkspace(WS_B);
+
+    const state = useAppStore.getState();
+    expect(state.diffSelectedFile).toBeNull();
+    expect(state.diffSelectedLayer).toBeNull();
+    // The original workspace's diff tab list is untouched.
+    expect(state.diffTabsByWorkspace[WS_A]).toEqual([
+      { path: "a.ts", layer: "unstaged" },
+    ]);
+  });
+});

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -1397,14 +1397,31 @@ export const useAppStore = create<AppState>((set, get) => ({
             ...s.diffTabsByWorkspace,
             [workspaceId]: [...existing, { path, layer: normalizedLayer }],
           };
+      // Only clear content when the selection actually changes — clicking the
+      // already-active tab must not blank the viewer (the loader effect
+      // wouldn't refire on identical deps, leaving the user staring at empty).
+      const isSameSelection =
+        s.diffSelectedFile === path && s.diffSelectedLayer === normalizedLayer;
       return {
         diffTabsByWorkspace: nextTabs,
         diffSelectedFile: path,
         diffSelectedLayer: normalizedLayer,
+        ...(isSameSelection ? {} : { diffContent: null, diffError: null }),
       };
     }),
   selectDiffTab: (path, layer) =>
-    set({ diffSelectedFile: path, diffSelectedLayer: layer ?? null }),
+    set((s) => {
+      const normalizedLayer = layer ?? null;
+      const isSameSelection =
+        s.diffSelectedFile === path && s.diffSelectedLayer === normalizedLayer;
+      if (isSameSelection) return s;
+      return {
+        diffSelectedFile: path,
+        diffSelectedLayer: normalizedLayer,
+        diffContent: null,
+        diffError: null,
+      };
+    }),
   closeDiffTab: (workspaceId, path, layer) =>
     set((s) => {
       const normalizedLayer = layer ?? null;

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -14,6 +14,7 @@ import type {
   AttachmentInput,
   ChatSession,
   DiffFile,
+  DiffFileTab,
   FileDiff,
   DiffViewMode,
   TerminalTab,
@@ -356,6 +357,11 @@ interface AppState {
   diffViewMode: DiffViewMode;
   diffLoading: boolean;
   diffError: string | null;
+  // Per-workspace open diff-file tabs. Ephemeral — not persisted across
+  // restarts. Identity is (path, layer); the same path opened from two
+  // different layers produces two distinct tabs because their diff content
+  // differs.
+  diffTabsByWorkspace: Record<string, DiffFileTab[]>;
   setDiffFiles: (files: DiffFile[], mergeBase: string, stagedFiles?: import("../types/diff").StagedDiffFiles | null) => void;
   setDiffSelectedFile: (path: string | null, layer?: import("../types/diff").DiffLayer | null) => void;
   setDiffContent: (content: FileDiff | null) => void;
@@ -363,6 +369,15 @@ interface AppState {
   setDiffLoading: (loading: boolean) => void;
   setDiffError: (error: string | null) => void;
   clearDiff: () => void;
+  // Open a diff tab for the given file (deduped by path+layer) and make it
+  // the active view. The previously-selected chat session stays selected so
+  // closing all diff tabs restores it.
+  openDiffTab: (workspaceId: string, path: string, layer?: import("../types/diff").DiffLayer | null) => void;
+  // Focus an already-open diff tab without mutating the tab list.
+  selectDiffTab: (path: string, layer?: import("../types/diff").DiffLayer | null) => void;
+  // Close a diff tab. If it was the active diff, the chat session selected
+  // for this workspace becomes active again.
+  closeDiffTab: (workspaceId: string, path: string, layer?: import("../types/diff").DiffLayer | null) => void;
 
   // -- Terminal --
   terminalTabs: Record<string, TerminalTab[]>;
@@ -633,6 +648,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         delete newPaneTrees[tabId];
         delete newActivePane[tabId];
       }
+      const newDiffTabs = { ...s.diffTabsByWorkspace };
+      for (const wsId of removedWsIds) {
+        delete newDiffTabs[wsId];
+      }
       return {
         repositories: s.repositories.filter((r) => r.id !== id),
         workspaces: s.workspaces.filter((w) => w.repository_id !== id),
@@ -648,6 +667,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         unreadCompletions: newUnreadCompletions,
         terminalPaneTrees: newPaneTrees,
         activeTerminalPaneId: newActivePane,
+        diffTabsByWorkspace: newDiffTabs,
       };
     }),
 
@@ -683,6 +703,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         delete newPaneTrees[tabId];
         delete newActivePane[tabId];
       }
+      const newDiffTabs = { ...s.diffTabsByWorkspace };
+      delete newDiffTabs[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -693,11 +715,23 @@ export const useAppStore = create<AppState>((set, get) => ({
         workspaceTerminalCommands: newWorkspaceTerminalCommands,
         terminalPaneTrees: newPaneTrees,
         activeTerminalPaneId: newActivePane,
+        diffTabsByWorkspace: newDiffTabs,
       };
     }),
   selectWorkspace: (id) =>
     set((s) => {
-      const updates: Partial<AppState> = { selectedWorkspaceId: id, rightSidebarTab: "changes" };
+      const updates: Partial<AppState> = {
+        selectedWorkspaceId: id,
+        rightSidebarTab: "changes",
+        // diffSelectedFile/Layer are workspace-global pointers; switching
+        // workspaces must drop them so the new workspace's tab strip and
+        // content render cleanly. Per-workspace diff *tabs* live in
+        // diffTabsByWorkspace and are preserved.
+        diffSelectedFile: null,
+        diffSelectedLayer: null,
+        diffContent: null,
+        diffError: null,
+      };
       if (id && s.unreadCompletions.has(id)) {
         const next = new Set(s.unreadCompletions);
         next.delete(id);
@@ -786,6 +820,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         ...s.selectedSessionIdByWorkspaceId,
         [workspaceId]: sessionId,
       },
+      // Clicking a chat tab is an explicit "show me chat" intent, so any
+      // active diff view yields. Diff tabs themselves remain in the strip.
+      diffSelectedFile: null,
+      diffSelectedLayer: null,
     })),
 
   // -- Chat --
@@ -1327,6 +1365,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   diffViewMode: "Unified",
   diffLoading: false,
   diffError: null,
+  diffTabsByWorkspace: {},
   setDiffFiles: (files, mergeBase, stagedFiles) =>
     set({ diffFiles: files, diffMergeBase: mergeBase, diffStagedFiles: stagedFiles ?? null }),
   setDiffSelectedFile: (path, layer) => set({ diffSelectedFile: path, diffSelectedLayer: layer ?? null }),
@@ -1343,6 +1382,55 @@ export const useAppStore = create<AppState>((set, get) => ({
       diffStagedFiles: null,
       diffContent: null,
       diffError: null,
+      diffTabsByWorkspace: {},
+    }),
+  openDiffTab: (workspaceId, path, layer) =>
+    set((s) => {
+      const normalizedLayer = layer ?? null;
+      const existing = s.diffTabsByWorkspace[workspaceId] ?? [];
+      const alreadyOpen = existing.some(
+        (t) => t.path === path && t.layer === normalizedLayer,
+      );
+      const nextTabs = alreadyOpen
+        ? s.diffTabsByWorkspace
+        : {
+            ...s.diffTabsByWorkspace,
+            [workspaceId]: [...existing, { path, layer: normalizedLayer }],
+          };
+      return {
+        diffTabsByWorkspace: nextTabs,
+        diffSelectedFile: path,
+        diffSelectedLayer: normalizedLayer,
+      };
+    }),
+  selectDiffTab: (path, layer) =>
+    set({ diffSelectedFile: path, diffSelectedLayer: layer ?? null }),
+  closeDiffTab: (workspaceId, path, layer) =>
+    set((s) => {
+      const normalizedLayer = layer ?? null;
+      const existing = s.diffTabsByWorkspace[workspaceId] ?? [];
+      const idx = existing.findIndex(
+        (t) => t.path === path && t.layer === normalizedLayer,
+      );
+      if (idx < 0) return s;
+      const nextWsTabs = existing.slice(0, idx).concat(existing.slice(idx + 1));
+      const wasActive =
+        s.diffSelectedFile === path && s.diffSelectedLayer === normalizedLayer;
+      const updates: Partial<AppState> = {
+        diffTabsByWorkspace: {
+          ...s.diffTabsByWorkspace,
+          [workspaceId]: nextWsTabs,
+        },
+      };
+      if (wasActive) {
+        // Drop active-diff state. AppLayout will fall back to ChatPanel,
+        // which renders whichever session is in selectedSessionIdByWorkspaceId.
+        updates.diffSelectedFile = null;
+        updates.diffSelectedLayer = null;
+        updates.diffContent = null;
+        updates.diffError = null;
+      }
+      return updates;
     }),
 
   // -- SCM --

--- a/src/ui/src/types/diff.ts
+++ b/src/ui/src/types/diff.ts
@@ -13,6 +13,11 @@ export interface DiffFile {
 
 export type DiffLayer = "committed" | "staged" | "unstaged" | "untracked";
 
+export interface DiffFileTab {
+  path: string;
+  layer: DiffLayer | null;
+}
+
 export interface StagedDiffFiles {
   committed: DiffFile[];
   staged: DiffFile[];

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -17,6 +17,7 @@ export type {
 } from "./chat";
 export type {
   DiffFile,
+  DiffFileTab,
   DiffLayer,
   FileStatus,
   DiffViewMode,


### PR DESCRIPTION
## Summary

Clicking a changed file in the right sidebar now opens it as a tab in the session tab strip, instead of replacing the chat view with no obvious way back. Diff tabs live next to chat tabs, share keyboard navigation (←/→/Home/End), and are kept per workspace so switching workspaces preserves the open set.

The `DiffViewer`'s old "← Back" button is retired — closing the tab or clicking a chat tab is now the way back to chat.

### Store shape

- New `diffTabsByWorkspace: Record<workspaceId, DiffFileTab[]>` — ephemeral, not persisted.
- New actions: `openDiffTab`, `selectDiffTab`, `closeDiffTab`.
- `selectWorkspace` clears `diffSelectedFile/Layer/Content/Error` so the new workspace renders cleanly; per-workspace tabs are preserved.
- `selectSession` clears `diffSelectedFile/Layer` so chat-tab clicks always show chat.

### Layout

`SessionTabs` is rendered inside both `ChatPanel` and `DiffViewer`, sitting below each view's header. (An earlier draft hoisted it into `AppLayout` above the body, but that placed it above the header — which read wrong. The chat ↔ diff swap is infrequent enough that the duplicate mount is cheap; data lives in the store.)

## Complexity Notes

- **Tab identity is `(path, layer)`**: opening the same path from two layers (e.g. `unstaged` vs `staged`) intentionally produces two tabs because their diff content differs.
- **`SessionTabs` mounts twice**: once in `ChatPanel`, once in `DiffViewer`. Each mount triggers a `listChatSessions` refetch — fine because the result merges into the same store and the swap is user-initiated.
- **Keyboard nav across kinds**: `navEntries` flattens sessions + diff tabs into one ordered list keyed by `s:<id>` / `d:<path>:<layer>`. Arrow keys walk both; `selectSession` / `selectDiffTab` are dispatched based on entry kind.
- **Close-active-diff fallback**: closing the active diff tab returns focus to the workspace's selected chat session (via `diffSelectedFile = null`); the chat session pointer was preserved the whole time.

## Test Steps

1. `cd src/ui && bunx tsc -b && bun run test` — should pass (914 tests).
2. `cargo tauri dev` and open a workspace with uncommitted changes.
3. Click a file in the right sidebar → it opens as a tab next to the chat tab; chat tab is no longer active but stays in the strip.
4. Click another changed file → second diff tab appears.
5. Click the chat tab → chat reappears; both diff tabs remain in the strip.
6. Click a diff tab → diff for that file shows again.
7. Use ←/→ keys with focus on a tab → focus walks across chat and diff tabs in order.
8. Close a diff tab via its × → if it was the active diff, the chat session becomes active again.
9. Switch workspaces → diff tabs for the new workspace render independently; old workspace's tabs survive when you switch back.

## Checklist

- [x] Tests added (`useAppStore.diffTabs.test.ts`, 195 lines covering open/select/close/workspace cleanup)
- [ ] Documentation updated (no user-facing docs changed)