### PR TITLE
fix(terminal): restore workspace sidebar command indicator after split-pane refactor

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { applyTheme, applyUserFonts, loadAllThemes, findTheme } from "./utils/th
 import { adjustUiFontSize, resetUiFontSize } from "./utils/fontSettings";
 import { useMcpStatus } from "./hooks/useMcpStatus";
 import { AppLayout } from "./components/layout/AppLayout";
+import { findLeafByPtyId } from "./stores/terminalPaneTree";
 import type { CommandEvent } from "./types";
 import "./styles/theme.css";
 
@@ -146,42 +147,42 @@ function App() {
       .then(({ disable_1m_context }) => { if (disable_1m_context) setDisable1mContext(true); })
       .catch(() => {});
 
-    // Listen for terminal command events
+    // Listen for terminal command events. PTYs live on pane leaves inside
+    // each tab's pane tree (a tab can hold multiple split panes, each with
+    // its own PTY), so we walk the trees to find which tab owns the firing
+    // PTY, then resolve that tab's workspace.
+    const findWorkspaceForPty = (pty_id: number): string | null => {
+      const { terminalTabs, terminalPaneTrees } = useAppStore.getState();
+      for (const [wsId, tabs] of Object.entries(terminalTabs)) {
+        for (const tab of tabs) {
+          const tree = terminalPaneTrees[tab.id];
+          if (tree && findLeafByPtyId(tree, pty_id)) return wsId;
+        }
+      }
+      return null;
+    };
+
     const setupCommandListeners = async () => {
       const unlistenCommandDetected = await listen<CommandEvent>("pty-command-detected", (event) => {
         const { pty_id, command } = event.payload;
-
-        // Find the workspace that owns this PTY - use getState() to avoid stale closure
-        const { terminalTabs, setWorkspaceTerminalCommand } = useAppStore.getState();
-        for (const [wsId, tabs] of Object.entries(terminalTabs)) {
-          const tab = tabs.find((t) => t.pty_id === pty_id);
-          if (tab) {
-            setWorkspaceTerminalCommand(wsId, {
-              command: command || null,
-              isRunning: true,
-              exitCode: null,
-            });
-            break;
-          }
-        }
+        const wsId = findWorkspaceForPty(pty_id);
+        if (!wsId) return;
+        useAppStore.getState().setWorkspaceTerminalCommand(wsId, {
+          command: command || null,
+          isRunning: true,
+          exitCode: null,
+        });
       });
 
       const unlistenCommandStopped = await listen<CommandEvent>("pty-command-stopped", (event) => {
         const { pty_id, command, exit_code } = event.payload;
-
-        // Find the workspace that owns this PTY - use getState() to avoid stale closure
-        const { terminalTabs, setWorkspaceTerminalCommand } = useAppStore.getState();
-        for (const [wsId, tabs] of Object.entries(terminalTabs)) {
-          const tab = tabs.find((t) => t.pty_id === pty_id);
-          if (tab) {
-            setWorkspaceTerminalCommand(wsId, {
-              command: command || null,
-              isRunning: false,
-              exitCode: exit_code !== null && exit_code !== undefined ? exit_code : null,
-            });
-            break;
-          }
-        }
+        const wsId = findWorkspaceForPty(pty_id);
+        if (!wsId) return;
+        useAppStore.getState().setWorkspaceTerminalCommand(wsId, {
+          command: command || null,
+          isRunning: false,
+          exitCode: exit_code !== null && exit_code !== undefined ? exit_code : null,
+        });
       });
 
       return () => {

--- a/src/ui/src/stores/terminalPaneTree.test.ts
+++ b/src/ui/src/stores/terminalPaneTree.test.ts
@@ -9,6 +9,7 @@ import {
   closeLeaf,
   countLeaves,
   findLeaf,
+  findLeafByPtyId,
   findParentSplit,
   makeLeaf,
   neighborLeaf,
@@ -19,6 +20,10 @@ import {
 
 function leaf(id: string): TerminalLeafPane {
   return { kind: "leaf", id };
+}
+
+function leafWithPty(id: string, ptyId: number): TerminalLeafPane {
+  return { kind: "leaf", id, ptyId };
 }
 
 function split(
@@ -68,6 +73,49 @@ describe("findLeaf", () => {
       split("s2", "vertical", leaf("b"), split("s3", "horizontal", leaf("c"), leaf("d"))),
     );
     expect(findLeaf(tree, "d")?.id).toBe("d");
+  });
+});
+
+describe("findLeafByPtyId", () => {
+  it("returns the leaf when a lone leaf's ptyId matches", () => {
+    const tree = leafWithPty("a", 7);
+    expect(findLeafByPtyId(tree, 7)?.id).toBe("a");
+  });
+
+  it("returns null for a leaf without a ptyId", () => {
+    const tree = leaf("a");
+    expect(findLeafByPtyId(tree, 1)).toBeNull();
+  });
+
+  it("descends into both children of a split", () => {
+    const tree = split(
+      "s",
+      "horizontal",
+      leafWithPty("left", 11),
+      leafWithPty("right", 22),
+    );
+    expect(findLeafByPtyId(tree, 11)?.id).toBe("left");
+    expect(findLeafByPtyId(tree, 22)?.id).toBe("right");
+  });
+
+  it("finds a leaf nested several levels deep", () => {
+    const tree = split(
+      "s1",
+      "horizontal",
+      leafWithPty("a", 1),
+      split(
+        "s2",
+        "vertical",
+        leafWithPty("b", 2),
+        split("s3", "horizontal", leafWithPty("c", 3), leafWithPty("d", 4)),
+      ),
+    );
+    expect(findLeafByPtyId(tree, 4)?.id).toBe("d");
+  });
+
+  it("returns null when no leaf carries the ptyId", () => {
+    const tree = split("s", "horizontal", leafWithPty("a", 1), leaf("b"));
+    expect(findLeafByPtyId(tree, 99)).toBeNull();
   });
 });
 

--- a/src/ui/src/stores/terminalPaneTree.ts
+++ b/src/ui/src/stores/terminalPaneTree.ts
@@ -60,6 +60,17 @@ export function allLeafIds(tree: TerminalPaneNode): TerminalPaneNodeId[] {
   return [...allLeafIds(tree.children[0]), ...allLeafIds(tree.children[1])];
 }
 
+export function findLeafByPtyId(
+  tree: TerminalPaneNode,
+  ptyId: number,
+): TerminalLeafPane | null {
+  if (tree.kind === "leaf") return tree.ptyId === ptyId ? tree : null;
+  return (
+    findLeafByPtyId(tree.children[0], ptyId) ??
+    findLeafByPtyId(tree.children[1], ptyId)
+  );
+}
+
 export interface SplitLeafResult {
   tree: TerminalPaneNode;
   // The id of the new leaf created by the split. null when the operation

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -395,7 +395,6 @@ interface AppState {
     wsId: string,
     state: WorkspaceCommandState,
   ) => void;
-  updateTerminalTabPtyId: (tabId: number, ptyId: number) => void;
 
   // Per-tab split-pane layout (ephemeral — not persisted). Keyed by tab id.
   terminalPaneTrees: Record<number, TerminalPaneNode>;
@@ -1522,16 +1521,6 @@ export const useAppStore = create<AppState>((set, get) => ({
         [wsId]: state,
       },
     })),
-  updateTerminalTabPtyId: (tabId, ptyId) =>
-    set((s) => {
-      const newTabs: Record<string, TerminalTab[]> = {};
-      for (const [wsId, tabs] of Object.entries(s.terminalTabs)) {
-        newTabs[wsId] = tabs.map((tab) =>
-          tab.id === tabId ? { ...tab, pty_id: ptyId } : tab,
-        );
-      }
-      return { terminalTabs: newTabs };
-    }),
 
   // Pane-tree slice. State is ephemeral: if the app restarts, every tab
   // comes back as a single-leaf tree. See `terminalPaneTree.ts` for the

--- a/src/ui/src/types/terminal.ts
+++ b/src/ui/src/types/terminal.ts
@@ -5,7 +5,6 @@ export interface TerminalTab {
   is_script_output: boolean;
   sort_order: number;
   created_at: string;
-  pty_id?: number;
 }
 
 export interface WorkspaceCommandState {


### PR DESCRIPTION
## Summary

The workspace sidebar's last-run-command + running-process indicator stopped working after PR #414 (split-pane support). PR #414 moved PTYs from `TerminalTab.pty_id` onto pane leaves inside `terminalPaneTrees`, but the `pty-command-detected` / `pty-command-stopped` listeners in `App.tsx` were never updated — they still iterated `terminalTabs` looking for `tab.pty_id === pty_id`. Since the only setter for `tab.pty_id` (`updateTerminalTabPtyId`) was unused, the lookup always failed silently and `workspaceTerminalCommands` was never populated.

## Changes

- `terminalPaneTree.ts`: new `findLeafByPtyId(tree, ptyId)` helper.
- `App.tsx`: listeners now walk `terminalPaneTrees` to find the tab whose pane owns the firing PTY, then resolve the workspace via `terminalTabs`.
- `types/terminal.ts`: drop dead `pty_id?: number` field on `TerminalTab`.
- `useAppStore.ts`: drop unused `updateTerminalTabPtyId` setter.
- `terminalPaneTree.test.ts`: five new test cases for `findLeafByPtyId`.

Closes #459

## Test plan

- [x] `bunx tsc -b` — clean
- [x] `bun run test` — 930/930 pass
- [ ] Manual: open a workspace, run a long-running command in the terminal, confirm sidebar shows running indicator + command text
- [ ] Manual: command exits, confirm sidebar updates to success/failure indicator with the command still visible
- [ ] Manual: split a pane, run a command in the new pane, confirm the sidebar tracks it (it will overwrite — last command wins per workspace)