### PR TITLE
docs(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug Report
+about: Report a reproducible bug in Claudette
+labels: bug
+title: "bug: "
+assignees: ""
+---
+
+## Platform
+
+| Field | Value |
+|---|---|
+| **OS** | <!-- macOS / Linux / Windows --> |
+| **OS version** | <!-- e.g. macOS 15.4, Ubuntu 24.04 --> |
+| **Architecture** | <!-- Apple Silicon / Intel / x86_64 / aarch64 / ARM64 --> |
+| **Claudette version** | <!-- release tag or commit SHA, e.g. v0.4.2 --> |
+
+## Description
+
+<!-- A clear, concise summary of the bug. -->
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+<!-- What should have happened? -->
+
+## Actual Behavior
+
+<!-- What actually happened? -->
+
+## Logs / Screenshots
+
+<!-- Paste relevant terminal output, error messages, or attach screenshots.
+     Remove or redact any sensitive information before posting. -->
+
+<details>
+<summary>Logs</summary>
+
+```
+paste logs here
+```
+
+</details>
+
+## Additional Context
+
+<!-- Anything else that might help: related issues, workarounds you tried, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for Claudette
+labels: enhancement
+title: "feat: "
+assignees: ""
+---
+
+> **Before opening a PR:** a maintainer must acknowledge and approve this feature request first.
+> Not every feature aligns with Claudette's goals. Opening a PR without prior maintainer sign-off
+> risks it being closed without review, regardless of the quality of the implementation.
+> Please wait for a maintainer to comment with approval before writing any code.
+
+## Use Case
+
+<!-- What problem does this solve? Who is affected and how often?
+     Focus on the *why* — describe the situation that motivates this request. -->
+
+## Proposed Behavior
+
+<!-- What should Claudette do? Describe the expected outcome as concretely as possible.
+     Mockups, sketches, or example workflows are very welcome here. -->
+
+## Alternatives Considered
+
+<!-- What other approaches did you think about? Why did you prefer this one? -->
+
+## Additional Context
+
+<!-- Related issues, prior art in other tools, links to relevant discussions, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+> **There must be a maintainer-approved issue before opening this PR.**
+> Submitting a PR without prior issue approval may result in it being closed without review.
+> Maintainer time is limited — PRs that arrive without an agreed-on issue create review burden
+> that is unfair to everyone. Link the approved issue below before requesting a review.
+
+## Linked Issue
+
+Closes #<!-- issue number -->
+
+## Summary
+
+<!-- What changed and why? A few bullet points is enough. -->
+
+- 
+
+## Screenshots
+
+<!-- Required for any UI changes. Attach before/after screenshots or a short screen recording.
+     If this PR has no UI changes, write "N/A". -->
+
+## UAT Plan
+
+<!-- A short checklist a reviewer can follow to verify this works end-to-end.
+     Be specific — "it works" is not a UAT plan. -->
+
+- [ ] 
+- [ ] 
+
+## Checklist
+
+- [ ] CI passes (tests, clippy, fmt, tsc -b)
+- [ ] New or updated tests cover the changed behaviour
+- [ ] Documentation updated if public behaviour changed
+- [ ] PR title follows [conventional commit](../CONTRIBUTING.md#commit-conventions) format


### PR DESCRIPTION
## Summary

Adds three GitHub templates ahead of broader Claudette outreach so incoming contributors arrive with clear expectations:

- **`.github/ISSUE_TEMPLATE/bug_report.md`** — requires OS / version / arch / Claudette version, reproduction steps, expected vs actual behavior, and a collapsible logs block.
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — leads with use-case (the *why*) before proposed behavior, and prominently states that maintainers must approve a feature request **before** any PR is opened. Not every feature aligns with Claudette's goals.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — opens with a blockquote warning that PRs without a maintainer-approved issue may be closed without review. Requires linked issue, screenshots for UI changes, a concrete UAT plan, and the standard CI checklist.

The existing `tdd.md` issue template is untouched and continues to appear in the issue chooser alongside the two new templates.

## Complexity Notes

None — these are pure Markdown additions to `.github/`. No code, no CI surface, no risk to runtime behavior. The PR template won't apply retroactively to this PR (templates only take effect after merge to `main`), which is why this PR's description is hand-written to match the new format.

## Test Steps

1. After merge, visit https://github.com/utensils/claudette/issues/new/choose — verify three templates show up: **Bug Report**, **Feature Request**, **Technical Design Document**.
2. Click **Bug Report** — confirm the platform table, repro steps, expected/actual sections, and collapsible logs block render correctly.
3. Click **Feature Request** — confirm the maintainer-approval blockquote renders prominently above the form fields.
4. Open a new PR against `main` from any branch — confirm the PR description is pre-populated with the approval warning, linked issue, summary, screenshots, UAT plan, and checklist sections.

## Checklist

- [x] Tests added/updated (N/A — Markdown templates only)
- [x] Documentation updated (these *are* the docs; `CONTRIBUTING.md` already references the bug-report and feature-request flow)