### PR TITLE
fix(updater): harden release promotion pipeline

### DIFF
--- a/.github/scripts/promote-release-assets.sh
+++ b/.github/scripts/promote-release-assets.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <repo> <staging-tag> <target-tag>" >&2
+  exit 2
+fi
+
+REPO="$1"
+STAGING_TAG="$2"
+TARGET_TAG="$3"
+WORK_DIR="${RUNNER_TEMP:-/tmp}/claudette-release-promote-${TARGET_TAG}"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+
+gh release download "$STAGING_TAG" \
+  --repo "$REPO" \
+  --dir "$WORK_DIR" \
+  --clobber
+
+if [ ! -f "$WORK_DIR/latest.json" ]; then
+  echo "::error::staging release ${STAGING_TAG} does not contain latest.json" >&2
+  exit 1
+fi
+
+python3 - "$WORK_DIR/latest.json" "$WORK_DIR/referenced-assets.txt" "$REPO" "$STAGING_TAG" "$TARGET_TAG" <<'PY'
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+manifest_path = Path(sys.argv[1])
+assets_path = Path(sys.argv[2])
+repo = sys.argv[3]
+staging_tag = sys.argv[4]
+target_tag = sys.argv[5]
+
+owner, name = repo.split("/", 1)
+marker = f"/{owner}/{name}/releases/download/"
+
+data = json.loads(manifest_path.read_text())
+asset_names = set()
+
+
+def rewrite(value):
+    if isinstance(value, dict):
+        return {k: rewrite(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [rewrite(v) for v in value]
+    if not isinstance(value, str):
+        return value
+
+    parsed = urlparse(value)
+    if parsed.netloc != "github.com" or marker not in parsed.path:
+        return value
+
+    prefix, rest = parsed.path.split(marker, 1)
+    tag, _, asset = rest.partition("/")
+    if not asset:
+        return value
+
+    asset_names.add(asset)
+    if tag == staging_tag or tag.startswith("untagged-") or "staging" in tag:
+        path = f"{prefix}{marker}{target_tag}/{asset}"
+        return parsed._replace(path=path).geturl()
+    return value
+
+
+rewritten = rewrite(data)
+
+bad_urls = []
+
+
+def collect_bad(value):
+    if isinstance(value, dict):
+        for v in value.values():
+            collect_bad(v)
+        return
+    if isinstance(value, list):
+        for v in value:
+            collect_bad(v)
+        return
+    if not isinstance(value, str):
+        return
+
+    parsed = urlparse(value)
+    if parsed.netloc != "github.com" or marker not in parsed.path:
+        return
+    _, rest = parsed.path.split(marker, 1)
+    tag, _, _ = rest.partition("/")
+    if tag != target_tag or "staging" in tag or tag.startswith("untagged-"):
+        bad_urls.append(value)
+
+
+collect_bad(rewritten)
+if bad_urls:
+    print("::error::latest.json contains non-target release URLs:", file=sys.stderr)
+    for url in bad_urls:
+        print(f"  {url}", file=sys.stderr)
+    sys.exit(1)
+
+manifest_path.write_text(json.dumps(rewritten, indent=2, sort_keys=False) + "\n")
+assets_path.write_text("\n".join(sorted(asset_names)) + "\n")
+PY
+
+while IFS= read -r asset; do
+  if [ -n "$asset" ] && [ ! -f "$WORK_DIR/$asset" ]; then
+    echo "::error::latest.json references asset missing from staging release: $asset" >&2
+    exit 1
+  fi
+done < "$WORK_DIR/referenced-assets.txt"
+
+mapfile -t ASSETS < <(find "$WORK_DIR" -maxdepth 1 -type f ! -name latest.json ! -name referenced-assets.txt | sort)
+if [ "${#ASSETS[@]}" -gt 0 ]; then
+  gh release upload "$TARGET_TAG" "${ASSETS[@]}" \
+    --repo "$REPO" \
+    --clobber
+fi
+
+# Upload the manifest last so clients never observe a new manifest before
+# its referenced assets exist on the public release.
+gh release upload "$TARGET_TAG" "$WORK_DIR/latest.json" \
+  --repo "$REPO" \
+  --clobber

--- a/.github/scripts/validate-public-latest.sh
+++ b/.github/scripts/validate-public-latest.sh
@@ -24,11 +24,9 @@ curl_with_retry() {
   local status=0
 
   while true; do
-    if curl -fsSL "$@"; then
-      return 0
-    fi
-
+    curl -fsSL "$@" && return 0
     status=$?
+
     if [ "$attempt" -ge "$max_attempts" ]; then
       echo "::error::failed to validate ${label} after ${attempt} attempts (curl ${status})" >&2
       return "$status"

--- a/.github/scripts/validate-public-latest.sh
+++ b/.github/scripts/validate-public-latest.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <repo> <tag>" >&2
+  exit 2
+fi
+
+REPO="$1"
+TAG="$2"
+WORK_DIR="${RUNNER_TEMP:-/tmp}/claudette-public-latest-${TAG}"
+LATEST_URL="https://github.com/${REPO}/releases/download/${TAG}/latest.json"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+
+curl -fsSL "$LATEST_URL" -o "$WORK_DIR/latest.json"
+
+python3 - "$WORK_DIR/latest.json" "$WORK_DIR/urls.txt" "$REPO" "$TAG" <<'PY'
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+manifest_path = Path(sys.argv[1])
+urls_path = Path(sys.argv[2])
+repo = sys.argv[3]
+target_tag = sys.argv[4]
+owner, name = repo.split("/", 1)
+marker = f"/{owner}/{name}/releases/download/"
+
+data = json.loads(manifest_path.read_text())
+urls = []
+bad_urls = []
+
+
+def walk(value):
+    if isinstance(value, dict):
+        for v in value.values():
+            walk(v)
+        return
+    if isinstance(value, list):
+        for v in value:
+            walk(v)
+        return
+    if not isinstance(value, str):
+        return
+
+    parsed = urlparse(value)
+    if parsed.netloc != "github.com" or marker not in parsed.path:
+        return
+    _, rest = parsed.path.split(marker, 1)
+    tag, _, asset = rest.partition("/")
+    if not asset:
+        return
+    urls.append(value)
+    if tag != target_tag or "staging" in tag or tag.startswith("untagged-"):
+        bad_urls.append(value)
+
+
+walk(data)
+if bad_urls:
+    print("::error::public latest.json contains invalid release URLs:", file=sys.stderr)
+    for url in bad_urls:
+        print(f"  {url}", file=sys.stderr)
+    sys.exit(1)
+if not urls:
+    print("::error::public latest.json contains no GitHub release asset URLs", file=sys.stderr)
+    sys.exit(1)
+
+urls_path.write_text("\n".join(sorted(set(urls))) + "\n")
+PY
+
+while IFS= read -r url; do
+  echo "validating $url"
+  curl -fsSL -r 0-0 -o /dev/null "$url"
+done < "$WORK_DIR/urls.txt"

--- a/.github/scripts/validate-public-latest.sh
+++ b/.github/scripts/validate-public-latest.sh
@@ -14,7 +14,40 @@ LATEST_URL="https://github.com/${REPO}/releases/download/${TAG}/latest.json"
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
 
-curl -fsSL "$LATEST_URL" -o "$WORK_DIR/latest.json"
+curl_with_retry() {
+  local label="$1"
+  shift
+
+  local attempt=1
+  local max_attempts=8
+  local delay=5
+  local status=0
+
+  while true; do
+    if curl -fsSL "$@"; then
+      return 0
+    fi
+
+    status=$?
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "::error::failed to validate ${label} after ${attempt} attempts (curl ${status})" >&2
+      return "$status"
+    fi
+
+    echo "::warning::failed to validate ${label} on attempt ${attempt} (curl ${status}); retrying in ${delay}s" >&2
+    sleep "$delay"
+
+    attempt=$((attempt + 1))
+    if [ "$delay" -lt 30 ]; then
+      delay=$((delay * 2))
+      if [ "$delay" -gt 30 ]; then
+        delay=30
+      fi
+    fi
+  done
+}
+
+curl_with_retry "$LATEST_URL" "$LATEST_URL" -o "$WORK_DIR/latest.json"
 
 python3 - "$WORK_DIR/latest.json" "$WORK_DIR/urls.txt" "$REPO" "$TAG" <<'PY'
 import json
@@ -73,5 +106,5 @@ PY
 
 while IFS= read -r url; do
   echo "validating $url"
-  curl -fsSL -r 0-0 -o /dev/null "$url"
+  curl_with_retry "$url" -r 0-0 -o /dev/null "$url"
 done < "$WORK_DIR/urls.txt"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -388,4 +388,5 @@ jobs:
 
           .github/scripts/validate-public-latest.sh "$GITHUB_REPOSITORY" nightly
 
-          gh release delete "$STAGING_TAG" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY"
+          gh release delete "$STAGING_TAG" --yes --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${STAGING_TAG}" 2>/dev/null || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,15 +101,14 @@ jobs:
 
           > **These builds are unstable pre-releases.**"
 
-          gh release create "$STAGING_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$GITHUB_SHA" \
-            --title "Nightly ${VERSION}" \
-            --notes "$NOTES" \
-            --prerelease \
-            --draft
-
-          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${STAGING_TAG}" --jq .id)
+          RELEASE_ID=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/releases" \
+            -f tag_name="$STAGING_TAG" \
+            -f target_commitish="$GITHUB_SHA" \
+            -f name="Nightly ${VERSION}" \
+            -f body="$NOTES" \
+            -F draft=true \
+            -F prerelease=true \
+            --jq .id)
           echo "tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
           echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -337,6 +337,12 @@ jobs:
         run: |
           set -euo pipefail
 
+          cleanup_staging() {
+            gh release delete "$STAGING_TAG" --yes --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${STAGING_TAG}" 2>/dev/null || true
+          }
+          trap cleanup_staging EXIT
+
           if ! gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "::error::${STAGING_TAG} release is not reachable; aborting promotion"
             exit 1
@@ -387,6 +393,3 @@ jobs:
             --draft=false
 
           .github/scripts/validate-public-latest.sh "$GITHUB_REPOSITORY" nightly
-
-          gh release delete "$STAGING_TAG" --yes --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
-          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${STAGING_TAG}" 2>/dev/null || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,22 +64,27 @@ jobs:
     name: Prepare Release
     needs: compute-version
     runs-on: ubuntu-latest
+    outputs:
+      staging_tag: ${{ steps.staging.outputs.tag }}
+      staging_release_id: ${{ steps.staging.outputs.release_id }}
     steps:
       - uses: actions/checkout@v6
 
-      # Build into a separate `nightly-staging` release so the live `nightly`
-      # release (with the previous build's assets) stays accessible to the
-      # in-app updater for the entire duration of the build. The `publish`
-      # job atomically promotes staging → nightly once all matrix jobs
-      # succeed, shrinking the unavailability window from "the entire build"
-      # to a couple of seconds.
+      # Build into a unique staging release so the live `nightly` release
+      # stays accessible to the in-app updater for the entire build. The
+      # publish job copies validated assets into `nightly` instead of
+      # retagging/deleting the live release.
       - name: Reset staging release
+        id: staging
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.compute-version.outputs.version }}
           LAST_TAG: ${{ needs.compute-version.outputs.last_tag }}
         run: |
-          gh release delete nightly-staging --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          set -euo pipefail
+
+          STAGING_TAG="nightly-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          gh release delete "$STAGING_TAG" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
           NOTES="Automated nightly build of \`${GITHUB_SHA}\`.
 
@@ -96,13 +101,17 @@ jobs:
 
           > **These builds are unstable pre-releases.**"
 
-          gh release create nightly-staging \
+          gh release create "$STAGING_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "Nightly ${VERSION}" \
             --notes "$NOTES" \
             --prerelease \
             --draft
+
+          RELEASE_ID=$(gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" --json id --jq .id)
+          echo "tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
+          echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
 
   build:
     needs: [compute-version, prepare-release]
@@ -212,7 +221,8 @@ jobs:
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
-          tagName: nightly-staging
+          tagName: ${{ needs.prepare-release.outputs.staging_tag }}
+          releaseId: ${{ needs.prepare-release.outputs.staging_release_id }}
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
           releaseDraft: true
           prerelease: true
@@ -251,7 +261,7 @@ jobs:
           ASSET="claudette-${{ matrix.label }}.zip"
           cp "$BIN" claudette.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette.exe' -DestinationPath '$ASSET' -Force"
-          gh release upload nightly-staging "$ASSET" --clobber
+          gh release upload "${{ needs.prepare-release.outputs.staging_tag }}" "$ASSET" --clobber
 
       - name: Build headless server
         shell: bash
@@ -265,7 +275,7 @@ jobs:
           BIN="target/${{ matrix.rust-target }}/release/claudette-server"
           ASSET="claudette-server-${{ matrix.label }}"
           cp "$BIN" "$ASSET"
-          gh release upload nightly-staging "$ASSET" --clobber
+          gh release upload "${{ needs.prepare-release.outputs.staging_tag }}" "$ASSET" --clobber
 
       - name: Upload headless server binary (Windows)
         if: startsWith(matrix.platform, 'windows')
@@ -277,119 +287,75 @@ jobs:
           ASSET="claudette-server-${{ matrix.label }}.zip"
           cp "$BIN" claudette-server.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette-server.exe' -DestinationPath '$ASSET' -Force"
-          gh release upload nightly-staging "$ASSET" --clobber
+          gh release upload "${{ needs.prepare-release.outputs.staging_tag }}" "$ASSET" --clobber
 
   # Nightly builds are not announced to Discord — too noisy. Stable releases only.
   publish:
     name: Publish Nightly
-    needs: build
+    needs: [compute-version, prepare-release, build]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      # Atomic-ish promote: verify the staging release is intact, delete the
-      # live `nightly` release+tag, then retag `nightly-staging` to
-      # `nightly` and un-draft. The blackout window between the delete and
-      # the retag is ~1–2s — orders of magnitude smaller than the prior
-      # delete-then-rebuild flow, and covered on the client side by treating
-      # "release manifest not found" as "no update".
+      - uses: actions/checkout@v6
+
       - name: Promote staging to nightly
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          LAST_TAG: ${{ needs.compute-version.outputs.last_tag }}
+          STAGING_TAG: ${{ needs.prepare-release.outputs.staging_tag }}
         run: |
           set -euo pipefail
 
-          # Pre-flight: ensure `nightly-staging` is reachable before we touch
-          # `nightly`. If staging is somehow missing or the API is down, we
-          # want to abort *with `nightly` still intact* rather than leave the
-          # repository with no nightly release at all.
-          if ! gh release view nightly-staging --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::error::nightly-staging release is not reachable; aborting promotion"
+          if ! gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::${STAGING_TAG} release is not reachable; aborting promotion"
             exit 1
           fi
 
-          # `tauri-action` generated `latest.json` while the release was
-          # tagged `nightly-staging`, so its embedded asset URLs are
-          # hardcoded to `releases/download/nightly-staging/...`. After the
-          # retag below those URLs would 404, breaking the in-app updater's
-          # download step. The Tauri signature covers binary contents — not
-          # the URL field — so rewriting URLs here does not invalidate
-          # verification.
-          #
-          # Fetch and rewrite *before* the retag, while staging still
-          # exists. We upload the rewritten file after the retag. This avoids
-          # depending on the freshly-retagged `nightly/...` URL being
-          # reachable via the public CDN, whose propagation delay previously
-          # exceeded our retry window and left a stale manifest live (#449
-          # follow-up). Aborting here is safe — `nightly` is still intact.
-          for attempt in 1 2 3; do
-            rm -f latest.json
-            if curl -fsSL -o latest.json \
-              "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly-staging/latest.json"; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to fetch nightly-staging/latest.json after 3 attempts"
-              exit 1
-            fi
-            backoff=$((attempt * 5))
-            echo "latest.json fetch attempt $attempt failed; retrying in ${backoff}s"
-            sleep "$backoff"
-          done
+          NOTES="Automated nightly build of \`${GITHUB_SHA}\`.
 
-          sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
-          # Hard-fail if the rewrite was a no-op AND staging URLs are still
-          # present — retrying with the same input won't help, and shipping
-          # a manifest with staging URLs would break the updater. (A no-op
-          # because the manifest was already rewritten on a prior crashed
-          # run is fine: grep will find nothing, and we proceed.)
-          if grep -q 'releases/download/nightly-staging/' latest.json; then
-            echo "::error::latest.json still contains nightly-staging URLs after rewrite; aborting"
-            exit 1
+          **Version:** \`${VERSION}\`
+          **Built:** $(date -u +%FT%TZ)"
+
+          if [ -n "$LAST_TAG" ]; then
+            DIFF_URL="https://github.com/${GITHUB_REPOSITORY}/compare/${LAST_TAG}...${GITHUB_SHA}"
+            NOTES="${NOTES}
+          [Changes since ${LAST_TAG}](${DIFF_URL})"
           fi
 
-          # Upload the rewritten manifest back to `nightly-staging` *before*
-          # we touch `nightly`. Assets follow the release when its tag
-          # changes, so when the retag below succeeds the corrected manifest
-          # appears at the `nightly/...` URL atomically — no separate
-          # post-retag upload that could fail and leave a broken manifest
-          # live on the promoted release.
-          for attempt in 1 2 3; do
-            if gh release upload nightly-staging latest.json --clobber --repo "$GITHUB_REPOSITORY"; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to upload rewritten latest.json to nightly-staging after 3 attempts"
-              exit 1
-            fi
-            backoff=$((attempt * 5))
-            echo "latest.json upload attempt $attempt failed; retrying in ${backoff}s"
-            sleep "$backoff"
-          done
+          NOTES="${NOTES}
 
-          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          > **These builds are unstable pre-releases.**"
 
-          # Retry the retag a few times to ride out transient API hiccups
-          # (rate limits, brief outages). If all retries fail, the workflow
-          # exits non-zero and a follow-up run can recover by re-promoting
-          # the still-intact `nightly-staging` release (which now carries
-          # the already-rewritten manifest).
-          for attempt in 1 2 3; do
-            if gh release edit nightly-staging \
+          if ! gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create nightly \
               --repo "$GITHUB_REPOSITORY" \
-              --tag nightly \
-              --draft=false \
-              --prerelease; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to promote nightly-staging to nightly after 3 attempts"
-              exit 1
-            fi
-            echo "Promotion attempt $attempt failed; retrying in 5s"
-            sleep 5
-          done
+              --target "$GITHUB_SHA" \
+              --title "Nightly ${VERSION}" \
+              --notes "$NOTES" \
+              --prerelease \
+              --draft
+          fi
 
-          # `gh release edit --tag` creates the new tag (`nightly`) at the
-          # release's target commit but leaves the old `nightly-staging`
-          # git tag orphaned. Clean it up so we don't accumulate dead tags.
-          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly-staging" 2>/dev/null || true
+          .github/scripts/promote-release-assets.sh "$GITHUB_REPOSITORY" "$STAGING_TAG" nightly
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/nightly" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" \
+              -f sha="$GITHUB_SHA" \
+              -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/nightly" \
+              -f sha="$GITHUB_SHA" >/dev/null
+          fi
+
+          gh release edit nightly \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Nightly ${VERSION}" \
+            --notes "$NOTES" \
+            --prerelease \
+            --draft=false
+
+          .github/scripts/validate-public-latest.sh "$GITHUB_REPOSITORY" nightly
+
+          gh release delete "$STAGING_TAG" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,7 +109,7 @@ jobs:
             --prerelease \
             --draft
 
-          RELEASE_ID=$(gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" --json id --jq .id)
+          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${STAGING_TAG}" --jq .id)
           echo "tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
           echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
 
@@ -121,11 +121,11 @@ jobs:
         include:
           - platform: macos-latest
             rust-target: aarch64-apple-darwin
-            bundles: app,dmg
+            bundles: app
             label: macos-aarch64
           - platform: macos-15-intel
             rust-target: x86_64-apple-darwin
-            bundles: app,dmg
+            bundles: app
             label: macos-x86_64
           - platform: ubuntu-22.04
             rust-target: x86_64-unknown-linux-gnu
@@ -227,6 +227,37 @@ jobs:
           releaseDraft: true
           prerelease: true
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      # DMGs are useful manual downloads, but they are not part of the
+      # updater contract. Build and upload them after the app tarball/manifest
+      # so a DMG packaging failure cannot strand the update feed again.
+      - name: Build and upload macOS DMG (best effort)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          STAGING_TAG: ${{ needs.prepare-release.outputs.staging_tag }}
+        run: |
+          set -euo pipefail
+          npx @tauri-apps/cli@v2 build --target ${{ matrix.rust-target }} --bundles dmg
+
+          shopt -s nullglob
+          dmgs=(target/${{ matrix.rust-target }}/release/bundle/dmg/*.dmg)
+          if [ "${#dmgs[@]}" -eq 0 ]; then
+            echo "::warning::No DMG was produced for ${{ matrix.label }}"
+            exit 0
+          fi
+
+          gh release upload "$STAGING_TAG" "${dmgs[@]}" --repo "$GITHUB_REPOSITORY" --clobber
 
       # ---- Windows: direct cargo build, ship the bare .exe -----------------
       # `custom-protocol` is the feature flag that tells tauri-build to

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -329,6 +329,7 @@ jobs:
         run: .github/scripts/validate-public-latest.sh "${{ github.repository }}" "${{ needs.resolve-tag.outputs.tag }}"
 
       - name: Delete staging release
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,9 +59,54 @@ jobs:
             echo "tag=${{ needs.release-please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-  build:
+  prepare-staging:
+    name: Prepare Staging Release
+    runs-on: ubuntu-latest
     needs: resolve-tag
     if: always() && needs.resolve-tag.result == 'success'
+    outputs:
+      staging_tag: ${{ steps.staging.outputs.tag }}
+      staging_release_id: ${{ steps.staging.outputs.release_id }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          TARGET_SHA=$(git rev-list -n 1 "$TAG")
+          STAGING_TAG="${TAG}-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          gh release delete "$STAGING_TAG" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "$TAG" \
+              --notes "" \
+              --draft
+          fi
+
+          gh release create "$STAGING_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$TARGET_SHA" \
+            --title "${TAG} staging" \
+            --notes "Temporary staging release for ${TAG}." \
+            --draft
+
+          RELEASE_ID=$(gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" --json id --jq .id)
+          echo "tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
+          echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: [resolve-tag, prepare-staging]
+    if: always() && needs.prepare-staging.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -160,7 +205,8 @@ jobs:
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
-          tagName: ${{ needs.resolve-tag.outputs.tag }}
+          tagName: ${{ needs.prepare-staging.outputs.staging_tag }}
+          releaseId: ${{ needs.prepare-staging.outputs.staging_release_id }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
@@ -198,7 +244,7 @@ jobs:
           ASSET="claudette-${{ matrix.label }}.zip"
           cp "$BIN" claudette.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette.exe' -DestinationPath '$ASSET' -Force"
-          gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
+          gh release upload "${{ needs.prepare-staging.outputs.staging_tag }}" "$ASSET" --clobber
 
       - name: Build headless server
         shell: bash
@@ -212,7 +258,7 @@ jobs:
           BIN="target/${{ matrix.rust-target }}/release/claudette-server"
           ASSET="claudette-server-${{ matrix.label }}"
           cp "$BIN" "$ASSET"
-          gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
+          gh release upload "${{ needs.prepare-staging.outputs.staging_tag }}" "$ASSET" --clobber
 
       - name: Upload headless server binary (Windows)
         if: startsWith(matrix.platform, 'windows')
@@ -224,18 +270,37 @@ jobs:
           ASSET="claudette-server-${{ matrix.label }}.zip"
           cp "$BIN" claudette-server.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette-server.exe' -DestinationPath '$ASSET' -Force"
-          gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
+          gh release upload "${{ needs.prepare-staging.outputs.staging_tag }}" "$ASSET" --clobber
 
   publish:
     name: Publish Release
-    needs: [resolve-tag, build]
+    needs: [resolve-tag, prepare-staging, build]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Promote staging assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-tag.outputs.tag }}
+          STAGING_TAG: ${{ needs.prepare-staging.outputs.staging_tag }}
+        run: |
+          set -euo pipefail
+          .github/scripts/promote-release-assets.sh "$GITHUB_REPOSITORY" "$STAGING_TAG" "$TAG"
+
       - name: Un-draft the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "${{ needs.resolve-tag.outputs.tag }}" --draft=false --repo "${{ github.repository }}"
+
+      - name: Validate public updater manifest
+        run: .github/scripts/validate-public-latest.sh "${{ github.repository }}" "${{ needs.resolve-tag.outputs.tag }}"
+
+      - name: Delete staging release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release delete "${{ needs.prepare-staging.outputs.staging_tag }}" --yes --cleanup-tag --repo "${{ github.repository }}"
 
   notify-discord:
     name: Discord Release Notification

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -331,7 +331,9 @@ jobs:
       - name: Delete staging release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete "${{ needs.prepare-staging.outputs.staging_tag }}" --yes --cleanup-tag --repo "${{ github.repository }}"
+        run: |
+          gh release delete "${{ needs.prepare-staging.outputs.staging_tag }}" --yes --repo "${{ github.repository }}" 2>/dev/null || true
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/${{ needs.prepare-staging.outputs.staging_tag }}" 2>/dev/null || true
 
   notify-discord:
     name: Discord Release Notification

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -93,14 +93,14 @@ jobs:
               --draft
           fi
 
-          gh release create "$STAGING_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$TARGET_SHA" \
-            --title "${TAG} staging" \
-            --notes "Temporary staging release for ${TAG}." \
-            --draft
-
-          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${STAGING_TAG}" --jq .id)
+          RELEASE_ID=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/releases" \
+            -f tag_name="$STAGING_TAG" \
+            -f target_commitish="$TARGET_SHA" \
+            -f name="${TAG} staging" \
+            -f body="Temporary staging release for ${TAG}." \
+            -F draft=true \
+            -F prerelease=false \
+            --jq .id)
           echo "tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
           echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -100,7 +100,7 @@ jobs:
             --notes "Temporary staging release for ${TAG}." \
             --draft
 
-          RELEASE_ID=$(gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" --json id --jq .id)
+          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${STAGING_TAG}" --jq .id)
           echo "tag=${STAGING_TAG}" >> "$GITHUB_OUTPUT"
           echo "release_id=${RELEASE_ID}" >> "$GITHUB_OUTPUT"
 
@@ -113,11 +113,11 @@ jobs:
         include:
           - platform: macos-latest
             rust-target: aarch64-apple-darwin
-            bundles: app,dmg
+            bundles: app
             label: macos-aarch64
           - platform: macos-15-intel
             rust-target: x86_64-apple-darwin
-            bundles: app,dmg
+            bundles: app
             label: macos-x86_64
           - platform: ubuntu-22.04
             rust-target: x86_64-unknown-linux-gnu
@@ -210,6 +210,37 @@ jobs:
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      # DMGs are useful manual downloads, but they are not part of the
+      # updater contract. Build and upload them after the app tarball/manifest
+      # so a DMG packaging failure cannot strand the update feed again.
+      - name: Build and upload macOS DMG (best effort)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          STAGING_TAG: ${{ needs.prepare-staging.outputs.staging_tag }}
+        run: |
+          set -euo pipefail
+          npx @tauri-apps/cli@v2 build --target ${{ matrix.rust-target }} --bundles dmg
+
+          shopt -s nullglob
+          dmgs=(target/${{ matrix.rust-target }}/release/bundle/dmg/*.dmg)
+          if [ "${#dmgs[@]}" -eq 0 ]; then
+            echo "::warning::No DMG was produced for ${{ matrix.label }}"
+            exit 0
+          fi
+
+          gh release upload "$STAGING_TAG" "${dmgs[@]}" --repo "$GITHUB_REPOSITORY" --clobber
 
       # ---- Windows: direct cargo build, ship the bare .exe -----------------
       # `custom-protocol` is the feature flag that tells tauri-build to

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -159,6 +159,47 @@ async fn endpoints_for(channel: &str) -> Result<Vec<Url>, String> {
     Ok(vec![url])
 }
 
+fn release_download_tag(url: &Url) -> Option<&str> {
+    if url.host_str() != Some("github.com") {
+        return None;
+    }
+
+    let mut segments = url.path_segments()?;
+    while let Some(segment) = segments.next() {
+        if segment == "releases" && segments.next() == Some("download") {
+            return segments.next();
+        }
+    }
+    None
+}
+
+fn is_transient_release_tag(tag: &str) -> bool {
+    tag.starts_with("untagged-") || tag.contains("staging")
+}
+
+fn string_contains_transient_release_url(value: &str) -> bool {
+    Url::parse(value)
+        .ok()
+        .and_then(|url| release_download_tag(&url).map(str::to_owned))
+        .is_some_and(|tag| is_transient_release_tag(&tag))
+}
+
+fn manifest_contains_transient_release_url(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(s) => string_contains_transient_release_url(s),
+        serde_json::Value::Array(items) => {
+            items.iter().any(manifest_contains_transient_release_url)
+        }
+        serde_json::Value::Object(map) => map.values().any(manifest_contains_transient_release_url),
+        _ => false,
+    }
+}
+
+fn update_contains_transient_release_url(update: &tauri_plugin_updater::Update) -> bool {
+    release_download_tag(&update.download_url).is_some_and(is_transient_release_tag)
+        || manifest_contains_transient_release_url(&update.raw_json)
+}
+
 /// Classifies an updater error: `Ok(())` means "downgrade to no update
 /// available", `Err(...)` is a real transport/parse failure that should
 /// bubble up to the UI.
@@ -195,29 +236,56 @@ pub async fn check_for_updates_with_channel(
     channel: String,
 ) -> Result<Option<UpdateInfo>, String> {
     let endpoints = endpoints_for(&channel).await?;
+    let mut update = None;
+    let mut last_error = None;
 
-    let result = app
-        .updater_builder()
-        .endpoints(endpoints)
-        .map_err(|e| e.to_string())?
-        .build()
-        .map_err(|e| e.to_string())?
-        .check()
-        .await;
+    for endpoint in endpoints {
+        let result = app
+            .updater_builder()
+            .endpoints(vec![endpoint.clone()])
+            .map_err(|e| e.to_string())?
+            .build()
+            .map_err(|e| e.to_string())?
+            .check()
+            .await;
 
-    let update = match result {
-        Ok(u) => u,
-        Err(e) => match classify_check_error(e) {
-            Ok(()) => {
-                eprintln!(
-                    "[updater] Release manifest unavailable for channel {channel:?}; \
-                     treating as no update available"
-                );
-                None
+        match result {
+            Ok(Some(candidate)) => {
+                if update_contains_transient_release_url(&candidate) {
+                    eprintln!(
+                        "[updater] Ignoring update manifest from {endpoint}: \
+                         asset URL points at staging/temporary release"
+                    );
+                    continue;
+                }
+                update = Some(candidate);
+                last_error = None;
+                break;
             }
-            Err(msg) => return Err(msg),
-        },
-    };
+            Ok(None) => {
+                last_error = None;
+                break;
+            }
+            Err(e) => match classify_check_error(e) {
+                Ok(()) => {
+                    eprintln!(
+                        "[updater] Release manifest unavailable at {endpoint} for channel \
+                         {channel:?}; trying next endpoint"
+                    );
+                }
+                Err(msg) => {
+                    eprintln!("[updater] Update check failed at {endpoint}: {msg}");
+                    last_error = Some(msg);
+                }
+            },
+        }
+    }
+
+    if update.is_none()
+        && let Some(msg) = last_error
+    {
+        return Err(msg);
+    }
 
     let mut slot = state.pending_update.lock().await;
     match update {
@@ -331,6 +399,52 @@ mod tests {
             "https://github.com/utensils/claudette/releases/download/{tag}/latest.json"
         ))
         .unwrap()
+    }
+
+    #[test]
+    fn extracts_release_download_tag_from_github_url() {
+        let url = Url::parse(
+            "https://github.com/utensils/claudette/releases/download/nightly/latest.json",
+        )
+        .unwrap();
+        assert_eq!(release_download_tag(&url), Some("nightly"));
+    }
+
+    #[test]
+    fn detects_transient_release_tags() {
+        assert!(is_transient_release_tag("nightly-staging"));
+        assert!(is_transient_release_tag("v0.20.0-staging-123"));
+        assert!(is_transient_release_tag("untagged-dc659d313a6f82718f77"));
+        assert!(!is_transient_release_tag("nightly"));
+        assert!(!is_transient_release_tag("v0.20.0"));
+    }
+
+    #[test]
+    fn detects_transient_release_urls_anywhere_in_manifest() {
+        let manifest = serde_json::json!({
+            "version": "0.20.0",
+            "platforms": {
+                "darwin-aarch64": {
+                    "signature": "sig",
+                    "url": "https://github.com/utensils/claudette/releases/download/nightly-staging/Claudette.app.tar.gz"
+                }
+            }
+        });
+        assert!(manifest_contains_transient_release_url(&manifest));
+    }
+
+    #[test]
+    fn accepts_public_release_urls_in_manifest() {
+        let manifest = serde_json::json!({
+            "version": "0.20.0",
+            "platforms": {
+                "darwin-aarch64": {
+                    "signature": "sig",
+                    "url": "https://github.com/utensils/claudette/releases/download/nightly/Claudette.app.tar.gz"
+                }
+            }
+        });
+        assert!(!manifest_contains_transient_release_url(&manifest));
     }
 
     #[test]

--- a/src/ui/src/components/layout/UpdateBanner.tsx
+++ b/src/ui/src/components/layout/UpdateBanner.tsx
@@ -84,7 +84,7 @@ export function UpdateBanner() {
             Will install when all agents finish
           </span>
           <div className={styles.actions}>
-            <button className={styles.btnPrimary} onClick={installNow}>
+            <button className={styles.btnPrimary} onClick={() => installNow()}>
               Install Now
             </button>
           </div>
@@ -97,7 +97,7 @@ export function UpdateBanner() {
             available
           </span>
           <div className={styles.actions}>
-            <button className={styles.btnPrimary} onClick={installNow}>
+            <button className={styles.btnPrimary} onClick={() => installNow()}>
               Install Now
             </button>
             <button className={styles.btn} onClick={installWhenIdle}>

--- a/src/ui/src/hooks/useAutoUpdater.test.ts
+++ b/src/ui/src/hooks/useAutoUpdater.test.ts
@@ -168,6 +168,31 @@ describe("installNow", () => {
     storeState.updateChannel = "stable";
     storeState.updateDownloading = false;
     storeState.updateAvailable = true;
+    mockCheckForUpdatesWithChannel.mockResolvedValue({ version: "2.0.0" });
+  });
+
+  it("refreshes the pending update before installing", async () => {
+    mockInstallPendingUpdate.mockResolvedValue(undefined);
+
+    await installNow();
+
+    expect(mockCheckForUpdatesWithChannel).toHaveBeenCalledWith("stable");
+    expect(mockInstallPendingUpdate).toHaveBeenCalled();
+    expect(
+      mockCheckForUpdatesWithChannel.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockInstallPendingUpdate.mock.invocationCallOrder[0]);
+  });
+
+  it("re-checks and retries once after an install failure", async () => {
+    mockInstallPendingUpdate
+      .mockRejectedValueOnce(new Error("stale URL"))
+      .mockResolvedValueOnce(undefined);
+
+    await installNow();
+
+    expect(mockCheckForUpdatesWithChannel).toHaveBeenCalledTimes(2);
+    expect(mockInstallPendingUpdate).toHaveBeenCalledTimes(2);
+    expect(mockSetUpdateError).not.toHaveBeenCalled();
   });
 
   it("surfaces install errors via setUpdateError so the banner can show them", async () => {
@@ -187,6 +212,16 @@ describe("installNow", () => {
     expect(mockSetUpdateError).toHaveBeenCalledWith(
       expect.stringContaining("404 Not Found")
     );
+  });
+
+  it("stops without installing when the refresh finds no update", async () => {
+    mockCheckForUpdatesWithChannel.mockResolvedValue(null);
+
+    await installNow();
+
+    expect(mockInstallPendingUpdate).not.toHaveBeenCalled();
+    expect(mockSetUpdateDownloading).toHaveBeenLastCalledWith(false);
+    expect(mockSetUpdateProgress).toHaveBeenLastCalledWith(0);
   });
 
   it("is a no-op when no update is available", async () => {

--- a/src/ui/src/hooks/useAutoUpdater.ts
+++ b/src/ui/src/hooks/useAutoUpdater.ts
@@ -14,6 +14,15 @@ const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
 export type UpdateCheckResult = "available" | "up-to-date" | "error";
 
+interface InstallNowOptions {
+  refreshFirst?: boolean;
+  retryOnFailure?: boolean;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /** Check the updater endpoint for the active channel and update Zustand state. */
 export async function checkForUpdate(): Promise<UpdateCheckResult> {
   const channel = useAppStore.getState().updateChannel;
@@ -32,7 +41,10 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
   }
 }
 
-export async function installNow(): Promise<void> {
+export async function installNow({
+  refreshFirst = true,
+  retryOnFailure = true,
+}: InstallNowOptions = {}): Promise<void> {
   const store = useAppStore.getState();
   if (store.updateDownloading) return;
   if (!store.updateAvailable) return;
@@ -41,16 +53,43 @@ export async function installNow(): Promise<void> {
   store.setUpdateProgress(0);
 
   try {
+    if (refreshFirst) {
+      const result = await checkForUpdate();
+      if (result === "error") {
+        throw new Error("Failed to check for updates. Please try again.");
+      }
+      if (result !== "available") {
+        const s = useAppStore.getState();
+        s.setUpdateDownloading(false);
+        s.setUpdateProgress(0);
+        return;
+      }
+    }
+
     await installPendingUpdate();
     // The Rust side calls app.restart() after install completes, so this
     // line typically isn't reached. If it is (e.g. install failed silently),
     // fall through to the catch on the next tick.
   } catch (e) {
     console.error("[updater] Install failed:", e);
+    let finalError = e;
+    if (retryOnFailure) {
+      const result = await checkForUpdate();
+      if (result === "available") {
+        try {
+          await installPendingUpdate();
+          return;
+        } catch (retryError) {
+          console.error("[updater] Retry after recheck failed:", retryError);
+          finalError = retryError;
+        }
+      }
+    }
+
     const s = useAppStore.getState();
     s.setUpdateDownloading(false);
     s.setUpdateProgress(0);
-    s.setUpdateError(String(e));
+    s.setUpdateError(errorMessage(finalError));
   }
 }
 
@@ -75,7 +114,9 @@ export async function retryInstall(): Promise<void> {
       .setUpdateError("Failed to check for updates. Please try again.");
     return;
   }
-  if (result === "available") await installNow();
+  if (result === "available") {
+    await installNow({ refreshFirst: false, retryOnFailure: true });
+  }
 }
 
 export function installWhenIdle(): void {


### PR DESCRIPTION
## Summary

Fixes the updater release pipeline root cause from #442 and hardens the client so bad staging manifests are rejected instead of cached/installed.

## Root Cause

- Nightly and stable workflows uploaded updater manifests while their referenced assets were still attached to draft/staging releases.
- Public GitHub release URLs for draft assets return 404, so `latest.json` could exist while every platform URL was unusable.
- Duplicate draft releases with the same tag made tag-based `gh release` operations ambiguous.
- The app accepted parsed manifests even when their asset URLs pointed at `nightly-staging`, `*-staging-*`, or `untagged-*` release URLs.

## Changes

- Publish into unique draft staging releases, then copy validated assets into the live tag without deleting the live release.
- Rewrite `latest.json` during promotion so all GitHub release URLs point at the final public tag.
- Upload `latest.json` last and validate the public manifest after publish.
- Use REST-created draft releases and numeric release IDs to avoid duplicate staging releases from `tauri-action`.
- Build macOS updater `.app.tar.gz` artifacts independently from best-effort DMG packaging.
- Retry public updater asset validation to absorb short-lived GitHub/CDN 5xx responses after upload.
- Harden the Tauri updater command to skip release manifests that contain transient staging or untagged asset URLs.
- Refresh/retry frontend install flow so stale update handles get rechecked before install.

## Live Repair Performed

- Repaired the live `nightly` feed so asset URLs point at `/releases/download/nightly/...`.
- Rebuilt and promoted `v0.20.0` assets so the stable updater endpoint now serves `latest.json` and public assets.
- Removed stale duplicate draft releases.
- Opened follow-up issue #469 for a separate older-build manual-check UI hang.

## Verification

- `cargo fmt --all`
- `cargo test -p claudette-tauri updater`
- `cd src/ui && bun run test useAutoUpdater.test.ts`
- `cd src/ui && bunx tsc -b`
- `git diff --check`
- `.github/scripts/validate-public-latest.sh utensils/claudette v0.20.0`
- `.github/scripts/validate-public-latest.sh utensils/claudette nightly`

A final workflow-dispatch validation run is still in progress on this branch: https://github.com/utensils/claudette/actions/runs/25023462292
