### PR TITLE
fix(chat): show paths relative to workspace root in tool usage rows

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -49,7 +49,7 @@ import {
   isTextFile,
 } from "../../utils/attachmentValidation";
 import { useTypewriter } from "../../hooks/useTypewriter";
-import { extractToolSummary } from "../../hooks/toolSummary";
+import { extractToolSummary, relativizePath } from "../../hooks/toolSummary";
 import { AgentQuestionCard } from "./AgentQuestionCard";
 import { PlanApprovalCard } from "./PlanApprovalCard";
 import { ComposerToolbar } from "./composer/ComposerToolbar";
@@ -1114,6 +1114,7 @@ export function ChatPanel() {
                   sessionId={activeSessionId}
                   isRunning={isRunning ?? false}
                   searchQuery={searchQuery}
+                  worktreePath={ws?.worktree_path}
                 />
               )}
 
@@ -1400,6 +1401,7 @@ function TurnSummary({
   onFork,
   onRollback,
   searchQuery,
+  worktreePath,
 }: {
   turn: CompletedTurn;
   collapsed: boolean;
@@ -1417,6 +1419,7 @@ function TurnSummary({
   /** Active chat-search query. Force-expands this card when non-empty and
    *  the query matches inside any of the contained activity summaries. */
   searchQuery: string;
+  worktreePath?: string | null;
 }) {
   const hasElapsed = typeof turn.durationMs === "number" && turn.durationMs > 0;
   const hasTokens =
@@ -1474,7 +1477,7 @@ function TurnSummary({
                   {(act.summary || act.inputJson) && (
                     <span className={styles.toolSummary}>
                       <HighlightedPlainText
-                        text={act.summary || extractToolSummary(act.toolName, act.inputJson)}
+                        text={relativizePath(act.summary || extractToolSummary(act.toolName, act.inputJson), worktreePath)}
                         query={searchQuery}
                       />
                     </span>
@@ -1754,6 +1757,9 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
   const chatAttachments = useAppStore(
     (s) => s.chatAttachments[sessionId] ?? EMPTY_ATTACHMENTS
   );
+  const worktreePath = useAppStore(
+    (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path
+  );
 
   // Pre-build a Map keyed by message_id for O(1) lookup in the render loop.
   //
@@ -1981,6 +1987,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
         onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
         onRollback={buildOnRollback(turn.id)}
         searchQuery={searchQuery}
+        worktreePath={worktreePath}
       />
     ));
   };
@@ -2170,6 +2177,7 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
             onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
             onRollback={buildOnRollback(turn.id)}
             searchQuery={searchQuery}
+            worktreePath={worktreePath}
           />
         ))}
     </>
@@ -2184,10 +2192,12 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
   sessionId,
   isRunning,
   searchQuery,
+  worktreePath,
 }: {
   sessionId: string;
   isRunning: boolean;
   searchQuery: string;
+  worktreePath?: string | null;
 }) {
   const activities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES
@@ -2248,7 +2258,7 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
                   <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>{act.toolName}</span>
                   {act.summary && (
                     <span className={styles.toolSummary}>
-                      <HighlightedPlainText text={act.summary} query={searchQuery} />
+                      <HighlightedPlainText text={relativizePath(act.summary, worktreePath)} query={searchQuery} />
                     </span>
                   )}
                 </div>

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1433,10 +1433,16 @@ function TurnSummary({
   // resolved tool-summary fallback. Without this, marks would land in
   // detached DOM (the collapsed branch never renders), so the bar's
   // counter would tick up but nothing visible would change.
+  // Match against the same relativized text we render — otherwise a query
+  // hitting only the stripped workspace prefix would force-expand with no
+  // visible highlight inside.
   const queryHasMatch =
     !!searchQuery &&
     turn.activities.some((a) => {
-      const text = a.summary || extractToolSummary(a.toolName, a.inputJson);
+      const text = relativizePath(
+        a.summary || extractToolSummary(a.toolName, a.inputJson),
+        worktreePath,
+      );
       return text.toLowerCase().includes(searchQuery.toLowerCase());
     });
   const isExpanded = !collapsed || queryHasMatch;
@@ -2218,13 +2224,15 @@ const ToolActivitiesSection = memo(function ToolActivitiesSection({
   // Force-expand when the active search query matches inside any of this
   // section's activity summaries — otherwise marks would be silently
   // hidden behind the collapsed header and the user would see a non-zero
-  // counter with no visible highlight.
+  // counter with no visible highlight. Match against the same relativized
+  // text we render, not the raw summary.
   const queryHasMatch =
     !!searchQuery &&
-    activities.some(
-      (a) =>
-        a.summary && a.summary.toLowerCase().includes(searchQuery.toLowerCase()),
-    );
+    activities.some((a) => {
+      if (!a.summary) return false;
+      const text = relativizePath(a.summary, worktreePath);
+      return text.toLowerCase().includes(searchQuery.toLowerCase());
+    });
   const isExpanded = !collapsed || queryHasMatch;
 
   return (

--- a/src/ui/src/hooks/toolSummary.test.ts
+++ b/src/ui/src/hooks/toolSummary.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { relativizePath } from "./toolSummary";
+
+describe("relativizePath", () => {
+  it("returns the original text when root is null/undefined/empty", () => {
+    expect(relativizePath("/abs/path/file.ts", null)).toBe("/abs/path/file.ts");
+    expect(relativizePath("/abs/path/file.ts", undefined)).toBe("/abs/path/file.ts");
+    expect(relativizePath("/abs/path/file.ts", "")).toBe("/abs/path/file.ts");
+  });
+
+  it("returns the original text when text is empty", () => {
+    expect(relativizePath("", "/abs/path")).toBe("");
+  });
+
+  it("strips a POSIX root prefix", () => {
+    expect(
+      relativizePath("/Users/me/project/src/app.tsx", "/Users/me/project")
+    ).toBe("src/app.tsx");
+  });
+
+  it("strips a POSIX root prefix even when root has a trailing slash", () => {
+    expect(
+      relativizePath("/Users/me/project/src/app.tsx", "/Users/me/project/")
+    ).toBe("src/app.tsx");
+  });
+
+  it("strips a Windows root prefix with backslashes", () => {
+    expect(
+      relativizePath("C:\\Users\\me\\project\\src\\app.tsx", "C:\\Users\\me\\project")
+    ).toBe("src\\app.tsx");
+  });
+
+  it("strips a Windows root prefix with trailing backslash", () => {
+    expect(
+      relativizePath("C:\\Users\\me\\project\\src\\app.tsx", "C:\\Users\\me\\project\\")
+    ).toBe("src\\app.tsx");
+  });
+
+  it("relativizes paths embedded mid-string (Grep `pattern in <path>` form)", () => {
+    expect(
+      relativizePath(
+        "sortBy|orderBy in /Users/me/project/src",
+        "/Users/me/project"
+      )
+    ).toBe("sortBy|orderBy in src");
+  });
+
+  it("leaves text unchanged when the root does not appear", () => {
+    expect(
+      relativizePath("/some/other/path/file.ts", "/Users/me/project")
+    ).toBe("/some/other/path/file.ts");
+  });
+
+  it("strips multiple occurrences of the root prefix", () => {
+    expect(
+      relativizePath(
+        "moved /Users/me/project/a.ts to /Users/me/project/b.ts",
+        "/Users/me/project"
+      )
+    ).toBe("moved a.ts to b.ts");
+  });
+
+  it("does not strip everything when root is just a separator", () => {
+    expect(relativizePath("/a/b/c", "/")).toBe("/a/b/c");
+    expect(relativizePath("\\a\\b\\c", "\\")).toBe("\\a\\b\\c");
+  });
+});

--- a/src/ui/src/hooks/toolSummary.ts
+++ b/src/ui/src/hooks/toolSummary.ts
@@ -97,3 +97,13 @@ function truncate(s: string, max: number): string {
   if (max <= 3) return s.slice(0, max);
   return s.slice(0, max - 3) + "...";
 }
+
+/** Strip the workspace root prefix from a summary string, leaving a relative path. */
+export function relativizePath(
+  text: string,
+  root: string | null | undefined
+): string {
+  if (!root || !text) return text;
+  const prefix = root.endsWith("/") ? root : root + "/";
+  return text.replaceAll(prefix, "");
+}

--- a/src/ui/src/hooks/toolSummary.ts
+++ b/src/ui/src/hooks/toolSummary.ts
@@ -98,12 +98,17 @@ function truncate(s: string, max: number): string {
   return s.slice(0, max - 3) + "...";
 }
 
-/** Strip the workspace root prefix from a summary string, leaving a relative path. */
+/** Strip the workspace root prefix from a summary string, leaving a relative path.
+ *  Handles both POSIX (`/`) and Windows (`\`) separators since `worktree_path`
+ *  is canonicalized to a backslash drive-letter path on Windows. */
 export function relativizePath(
   text: string,
   root: string | null | undefined
 ): string {
   if (!root || !text) return text;
-  const prefix = root.endsWith("/") ? root : root + "/";
-  return text.replaceAll(prefix, "");
+  const normalizedRoot = root.replace(/[\\/]+$/, "");
+  if (!normalizedRoot) return text;
+  return text
+    .replaceAll(normalizedRoot + "/", "")
+    .replaceAll(normalizedRoot + "\\", "");
 }


### PR DESCRIPTION
## Summary

Tool activity rows in the chat (Read, Grep, Edit, etc.) currently display the full absolute file path, which dominates the row width and visually buries the part of the path that actually matters to the user (the part inside the workspace).

This change strips the workspace's `worktree_path` prefix from tool-activity summaries before rendering, so a row that previously read:

```
Read /Users/spork/.claudette/workspaces/ssk-web/roaring-periwinkle/app/dashboard/[organizationSlug]/warehouses/...
```

now reads:

```
Read app/dashboard/[organizationSlug]/warehouses/...
```

The transformation is applied in three places, all routed through a single new `relativizePath` helper in `src/ui/src/hooks/toolSummary.ts`:
- Completed-turn tool rows in `TurnSummary` (uses `act.summary` or the client-computed `extractToolSummary` fallback)
- In-progress streaming tool rows in `ToolActivitiesSection` (uses `act.summary` from the agent stream)
- The Grep case (`pattern in <abs path>`) is handled by using `replaceAll` rather than `startsWith`, so the prefix is stripped wherever it appears in the string

The workspace root is sourced from the existing `Workspace.worktree_path` field already present in the Zustand store; `MessagesWithTurns` looks it up from `workspaceId` and threads it down through `TurnSummary`, while `ChatPanel` passes it directly into `ToolActivitiesSection`.

## Complexity Notes

- `relativizePath` uses `replaceAll` because the workspace root can appear mid-string (e.g., Grep's `pattern in /abs/path`), not just as a prefix. This is intentional — `startsWith`-based stripping would miss the Grep case.
- For workspaces where `worktree_path` is `null` (e.g., a workspace that hasn't been fully initialized), the function short-circuits and returns the original text unchanged, preserving today's behavior.

## Test Steps

1. `cd src/ui && bunx tsc -b` — should pass with zero errors
2. `cd src/ui && bun run test` — all 942 tests should pass
3. Run `cargo tauri dev` and open a workspace
4. Send a prompt that triggers tool use, e.g., "Read the package.json and grep for the word 'name'"
5. Verify the tool rows show paths relative to the workspace root (e.g., `package.json` instead of the full absolute path)
6. Verify both the in-progress streaming rows and the collapsed completed-turn rows are relativized
7. Verify the Grep row's `pattern in <path>` form has the path relativized

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)