### PR TITLE
fix(sidebar): key Tasks panel by active sessionId, not workspaceId

### DIFF
--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
 import { ChevronRight, Undo2, Trash2 } from "lucide-react";
-import { useAppStore } from "../../stores/useAppStore";
+import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
 import { useTaskTracker } from "../../hooks/useTaskTracker";
 import { discardFile, loadDiffFiles, sendRemoteCommand } from "../../services/tauri";
 import type { DiffFilesResult } from "../../services/tauri";
@@ -45,7 +45,8 @@ export const RightSidebar = memo(function RightSidebar() {
   const worktreePath = ws?.worktree_path ?? null;
   const prevIsRunning = useRef<boolean | undefined>(undefined);
 
-  const { totalCount: taskCount } = useTaskTracker(selectedWorkspaceId);
+  const activeSessionId = useAppStore(selectActiveSessionId);
+  const { totalCount: taskCount } = useTaskTracker(activeSessionId);
 
   // Discard-changes UI state. Local-only — discard isn't bridged through the
   // remote server (matches revert_file), so the action is hidden when the
@@ -363,7 +364,7 @@ export const RightSidebar = memo(function RightSidebar() {
 
       {activeTab === "tasks" && (
         selectedWorkspaceId
-          ? <TaskList workspaceId={selectedWorkspaceId} />
+          ? <TaskList sessionId={activeSessionId} />
           : <div className={styles.list}><div className={styles.empty}>No workspace selected</div></div>
       )}
 

--- a/src/ui/src/components/right-sidebar/TaskList.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.tsx
@@ -67,11 +67,11 @@ function TaskItem({ task }: { task: TrackedTask }) {
 }
 
 export const TaskList = memo(function TaskList({
-  workspaceId,
+  sessionId,
 }: {
-  workspaceId: string;
+  sessionId: string | null;
 }) {
-  const { tasks } = useTaskTracker(workspaceId);
+  const { tasks } = useTaskTracker(sessionId);
 
   if (tasks.length === 0) {
     return (

--- a/src/ui/src/hooks/useTaskTracker.ts
+++ b/src/ui/src/hooks/useTaskTracker.ts
@@ -202,16 +202,16 @@ export function hasTaskActivity(activities: ToolActivity[]): boolean {
  * Scans both completed turns and current-turn activities for
  * TaskCreate, TaskUpdate, TaskStop, and TodoWrite tool calls.
  */
-export function useTaskTracker(wsId: string | null): TaskTrackerResult {
+export function useTaskTracker(sessionId: string | null): TaskTrackerResult {
   const completedTurns = useAppStore(
-    (s) => (wsId ? s.completedTurns[wsId] : null) ?? EMPTY_TURNS
+    (s) => (sessionId ? s.completedTurns[sessionId] : null) ?? EMPTY_TURNS
   );
   const toolActivities = useAppStore(
-    (s) => (wsId ? s.toolActivities[wsId] : null) ?? EMPTY_ACTIVITIES
+    (s) => (sessionId ? s.toolActivities[sessionId] : null) ?? EMPTY_ACTIVITIES
   );
 
   return useMemo(
-    () => (wsId ? deriveTasks(completedTurns, toolActivities) : EMPTY_RESULT),
-    [wsId, completedTurns, toolActivities]
+    () => (sessionId ? deriveTasks(completedTurns, toolActivities) : EMPTY_RESULT),
+    [sessionId, completedTurns, toolActivities]
   );
 }


### PR DESCRIPTION
## Summary

The Tasks sidebar showed "No tasks" even when the agent had written several TodoWrite items — the in-conversation status bar (e.g. "0/9 tasks") rendered correctly at the same time.

Root cause: the multi-session refactor (`abd79d7`) moved `completedTurns` and `toolActivities` in the Zustand store to be keyed by **sessionId**. `CurrentTurnTaskProgress` was updated to match, but `useTaskTracker` and the Tasks sidebar were missed — they kept looking up by **workspaceId**, which never matches a key in those records, so the hook always returned an empty list.

The fix resolves the active session via the existing `selectActiveSessionId` selector in `RightSidebar`, then threads `sessionId` through `TaskList` and into `useTaskTracker`. Because `selectActiveSessionId` reads `selectedSessionIdByWorkspaceId[wsId]`, switching session tabs automatically re-renders the sidebar with the new session's tasks.

```mermaid
flowchart LR
  subgraph Before
    WS1[selectedWorkspaceId] --> TT1[useTaskTracker]
    TT1 -->|completedTurns wsId| MISS[empty - keyed by sessionId]
  end
  subgraph After
    WS2[selectedWorkspaceId] --> SEL[selectActiveSessionId]
    SEL --> SID[activeSessionId]
    SID --> TT2[useTaskTracker]
    TT2 -->|completedTurns sessionId| HIT[matches store key]
  end
```

## Complexity Notes

- The store methods (`addToolActivity`, `finalizeTurn`, etc.) still have their parameter named `wsId` even though every caller passes a `sessionId`. This naming inconsistency is the trap that caused the bug. Renaming it is intentionally **out of scope** for this fix — it's a wider store-side refactor with no behavioral change.
- `TaskList`'s prop changed from `workspaceId: string` to `sessionId: string | null`. The only call site is `RightSidebar`, so the type widening is safe.

## Test Steps

1. `cd src/ui && bunx tsc -b` — type-check passes.
2. `cd src/ui && bun run test` — vitest suite passes (942 tests).
3. `cargo tauri dev` — start the app, open a workspace, and run a Claude prompt that uses TodoWrite (e.g. ask for a multi-step plan).
4. Confirm the Tasks tab in the right sidebar shows the same count and items as the in-conversation status bar (e.g. "0/9 tasks").
5. Open a second session tab in the same workspace, run a different prompt that also writes todos, and switch between the tabs — confirm the sidebar updates to show each session's own tasks.
6. Select a workspace with no agent activity — confirm "No tasks" still renders cleanly.

## Checklist

- [x] Tests added/updated (existing `useTaskTracker.test.ts` covers the pure derivation; the bug was purely in the wiring)
- [ ] Documentation updated (n/a)