### PR TITLE
fix(settings): show all fonts in both pickers and add search

### DIFF
--- a/src/ui/src/components/settings/FontSelect.tsx
+++ b/src/ui/src/components/settings/FontSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, type CSSProperties } from "react";
+import { useState, useRef, useEffect, useMemo, type CSSProperties, type ReactNode } from "react";
 import type { FontOption } from "../../utils/fontSettings";
 import styles from "./Settings.module.css";
 
@@ -22,6 +22,7 @@ const MONO_FALLBACK = '"JetBrains Mono", ui-monospace, "SF Mono", monospace';
  */
 export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }: FontSelectProps) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const ref = useRef<HTMLDivElement>(null);
   const listId = useRef(`font-list-${Math.random().toString(36).slice(2, 8)}`).current;
   const fallback = kind === "mono" ? MONO_FALLBACK : SANS_FALLBACK;
@@ -51,6 +52,15 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
     return () => document.removeEventListener("keydown", handler);
   }, [open]);
 
+  const filteredOptions = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((opt) => {
+      if (opt.value === "" || opt.value === "__custom__") return false;
+      return opt.label.toLowerCase().includes(q);
+    });
+  }, [options, search]);
+
   const selectedLabel = isCustom
     ? value || "Custom..."
     : (options.find((o) => o.value === value)?.label ?? "Default");
@@ -62,13 +72,62 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
     return { fontFamily: fallback };
   };
 
+  const renderOptions = (): ReactNode[] => {
+    const elements: ReactNode[] = [];
+    let lastGroup: string | undefined;
+
+    for (const opt of filteredOptions) {
+      if (opt.group && opt.group !== lastGroup) {
+        elements.push(
+          <div
+            key={`group-${opt.group}`}
+            className={styles.fontPickerGroupLabel}
+            role="presentation"
+          >
+            {opt.group === "sans" ? "Sans-serif" : "Monospace"}
+          </div>,
+        );
+        lastGroup = opt.group;
+      }
+
+      const isSelected = !isCustom && opt.value === value;
+      const cls = isSelected
+        ? styles.fontPickerOptionSelected
+        : styles.fontPickerOption;
+
+      elements.push(
+        <button
+          key={opt.value || "__default__"}
+          type="button"
+          role="option"
+          aria-selected={isSelected}
+          className={cls}
+          style={fontStyle(opt.value)}
+          onClick={() => {
+            onChange(opt.value);
+            if (opt.value !== "__custom__") setOpen(false);
+          }}
+        >
+          {opt.label}
+        </button>,
+      );
+    }
+
+    return elements;
+  };
+
   return (
     <div className={styles.fontPicker} ref={ref}>
       <button
         type="button"
         className={styles.fontPickerButton}
         style={fontStyle(isCustom ? "" : value)}
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          setOpen((prev) => {
+            if (!prev) setSearch("");
+            return !prev;
+          });
+        }}
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listId : undefined}
@@ -82,28 +141,18 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
           id={listId}
           aria-label="Font selection"
         >
-          {options.map((opt) => {
-            const isSelected = !isCustom && opt.value === value;
-            const cls = isSelected
-              ? styles.fontPickerOptionSelected
-              : styles.fontPickerOption;
-            return (
-              <button
-                key={opt.value || "__default__"}
-                type="button"
-                role="option"
-                aria-selected={isSelected}
-                className={cls}
-                style={fontStyle(opt.value)}
-                onClick={() => {
-                  onChange(opt.value);
-                  if (opt.value !== "__custom__") setOpen(false);
-                }}
-              >
-                {opt.label}
-              </button>
-            );
-          })}
+          <input
+            className={styles.fontPickerSearch}
+            type="text"
+            placeholder="Search fonts…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+          {renderOptions()}
+          {filteredOptions.length === 0 && search.trim() && (
+            <div className={styles.fontPickerNoResults}>No matching fonts</div>
+          )}
         </div>
       )}
     </div>

--- a/src/ui/src/components/settings/FontSelect.tsx
+++ b/src/ui/src/components/settings/FontSelect.tsx
@@ -76,7 +76,7 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
     const elements: ReactNode[] = [];
     let lastGroup: string | undefined;
 
-    for (const opt of filteredOptions) {
+    filteredOptions.forEach((opt, i) => {
       if (opt.group && opt.group !== lastGroup) {
         elements.push(
           <div
@@ -97,7 +97,7 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
 
       elements.push(
         <button
-          key={opt.value || "__default__"}
+          key={`opt-${i}-${opt.value}`}
           type="button"
           role="option"
           aria-selected={isSelected}
@@ -111,7 +111,7 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
           {opt.label}
         </button>,
       );
-    }
+    });
 
     return elements;
   };
@@ -135,12 +135,7 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
         {selectedLabel}
       </button>
       {open && (
-        <div
-          className={styles.fontPickerDropdown}
-          role="listbox"
-          id={listId}
-          aria-label="Font selection"
-        >
+        <div className={styles.fontPickerDropdown}>
           <input
             className={styles.fontPickerSearch}
             type="text"
@@ -149,9 +144,12 @@ export function FontSelect({ options, value, onChange, isCustom, kind = "sans" }
             onChange={(e) => setSearch(e.target.value)}
             autoFocus
           />
-          {renderOptions()}
-          {filteredOptions.length === 0 && search.trim() && (
+          {filteredOptions.length === 0 && search.trim() ? (
             <div className={styles.fontPickerNoResults}>No matching fonts</div>
+          ) : (
+            <div role="listbox" id={listId} aria-label="Font selection">
+              {renderOptions()}
+            </div>
           )}
         </div>
       )}

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -197,7 +197,7 @@
   top: calc(100% + 4px);
   right: 0;
   min-width: 100%;
-  max-height: 280px;
+  max-height: 320px;
   overflow-y: auto;
   background: var(--sidebar-bg);
   border: 1px solid var(--divider);
@@ -233,6 +233,50 @@
 
 .fontPickerOptionSelected:hover {
   background: var(--accent-bg-strong);
+}
+
+.fontPickerSearch {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  border-bottom: 1px solid var(--divider);
+  border-radius: 0;
+  background: var(--sidebar-bg);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.fontPickerSearch::placeholder {
+  color: var(--text-dim);
+}
+
+.fontPickerGroupLabel {
+  padding: 8px 10px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.fontPickerGroupLabel:not(:first-child) {
+  margin-top: 4px;
+  border-top: 1px solid var(--divider);
+  padding-top: 8px;
+}
+
+.fontPickerNoResults {
+  padding: 12px 10px;
+  color: var(--text-dim);
+  font-size: 13px;
+  text-align: center;
 }
 
 .numberInput {

--- a/src/ui/src/utils/fontSettings.test.ts
+++ b/src/ui/src/utils/fontSettings.test.ts
@@ -46,18 +46,51 @@ describe("buildFontOptions", () => {
     "SF Mono",
   ];
 
-  it("splits fonts into sans and mono lists", () => {
+  it("both lists contain all non-hidden fonts", () => {
     const { sans, mono } = buildFontOptions(systemFonts);
     const sansValues = sans.map((o) => o.value);
     const monoValues = mono.map((o) => o.value);
-    expect(sansValues).toContain("Arial");
-    expect(sansValues).toContain("SF Pro");
-    expect(sansValues).toContain("Roboto");
-    expect(monoValues).toContain("Fira Code");
-    expect(monoValues).toContain("JetBrains Mono");
-    expect(monoValues).toContain("Source Code Pro");
-    expect(monoValues).toContain("SF Mono");
-    expect(monoValues).toContain("Menlo");
+    const visibleFonts = systemFonts.filter((n) => !n.startsWith(".") && !n.startsWith("#"));
+    for (const name of visibleFonts) {
+      expect(sansValues).toContain(name);
+      expect(monoValues).toContain(name);
+    }
+  });
+
+  it("sans list orders sans-group fonts before mono-group fonts", () => {
+    const { sans } = buildFontOptions(systemFonts);
+    const fontEntries = sans.filter((o) => o.group);
+    const firstMonoIdx = fontEntries.findIndex((o) => o.group === "mono");
+    const lastSansIdx = fontEntries.map((o) => o.group).lastIndexOf("sans");
+    if (firstMonoIdx !== -1 && lastSansIdx !== -1) {
+      expect(lastSansIdx).toBeLessThan(firstMonoIdx);
+    }
+  });
+
+  it("mono list orders mono-group fonts before sans-group fonts", () => {
+    const { mono } = buildFontOptions(systemFonts);
+    const fontEntries = mono.filter((o) => o.group);
+    const firstSansIdx = fontEntries.findIndex((o) => o.group === "sans");
+    const lastMonoIdx = fontEntries.map((o) => o.group).lastIndexOf("mono");
+    if (firstSansIdx !== -1 && lastMonoIdx !== -1) {
+      expect(lastMonoIdx).toBeLessThan(firstSansIdx);
+    }
+  });
+
+  it("tags fonts with correct group field", () => {
+    const { sans } = buildFontOptions(systemFonts);
+    const arial = sans.find((o) => o.value === "Arial");
+    const firaCode = sans.find((o) => o.value === "Fira Code");
+    expect(arial?.group).toBe("sans");
+    expect(firaCode?.group).toBe("mono");
+  });
+
+  it("Default and Custom entries have no group field", () => {
+    const { sans, mono } = buildFontOptions(systemFonts);
+    expect(sans[0].group).toBeUndefined();
+    expect(sans[sans.length - 1].group).toBeUndefined();
+    expect(mono[0].group).toBeUndefined();
+    expect(mono[mono.length - 1].group).toBeUndefined();
   });
 
   it("has default entries with empty value", () => {
@@ -85,21 +118,15 @@ describe("buildFontOptions", () => {
   });
 
   it("classifies Courier New as mono", () => {
-    const { mono } = buildFontOptions(systemFonts);
-    expect(mono.map((o) => o.value)).toContain("Courier New");
+    const { sans } = buildFontOptions(systemFonts);
+    const courierNew = sans.find((o) => o.value === "Courier New");
+    expect(courierNew?.group).toBe("mono");
   });
 
   it("classifies Inconsolata as mono", () => {
-    const { mono } = buildFontOptions(systemFonts);
-    expect(mono.map((o) => o.value)).toContain("Inconsolata");
-  });
-
-  it("does not put sans fonts in mono list", () => {
-    const { mono } = buildFontOptions(systemFonts);
-    const monoValues = mono.map((o) => o.value);
-    expect(monoValues).not.toContain("Arial");
-    expect(monoValues).not.toContain("SF Pro");
-    expect(monoValues).not.toContain("Noto Sans");
+    const { sans } = buildFontOptions(systemFonts);
+    const inconsolata = sans.find((o) => o.value === "Inconsolata");
+    expect(inconsolata?.group).toBe("mono");
   });
 
   it("filters out fonts starting with #", () => {
@@ -115,54 +142,54 @@ describe("buildFontOptions", () => {
       "Anonymous Pro", "Ubuntu Mono", "Roboto Mono",
       "Liberation Mono", "Droid Sans Mono", "Geist Mono",
     ];
-    const { mono } = buildFontOptions(monoNames);
-    const monoValues = mono.map((o) => o.value);
+    const { sans } = buildFontOptions(monoNames);
     for (const name of monoNames) {
-      expect(monoValues).toContain(name);
+      const opt = sans.find((o) => o.value === name);
+      expect(opt?.group).toBe("mono");
     }
   });
 
   it("uses font name as both value and label", () => {
     const { sans } = buildFontOptions(["Helvetica Neue"]);
     const opt = sans.find((o) => o.value === "Helvetica Neue");
-    expect(opt).toEqual({ value: "Helvetica Neue", label: "Helvetica Neue" });
+    expect(opt).toEqual({ value: "Helvetica Neue", label: "Helvetica Neue", group: "sans" });
   });
 
-  it("preserves input order within each list", () => {
+  it("preserves input order within each group", () => {
     const { sans } = buildFontOptions(["Zapfino", "Arial", "Baskerville"]);
-    const values = sans.map((o) => o.value).filter((v) => v && v !== "__custom__");
-    expect(values).toEqual(["Zapfino", "Arial", "Baskerville"]);
+    const sansGroupValues = sans.filter((o) => o.group === "sans").map((o) => o.value);
+    expect(sansGroupValues).toEqual(["Zapfino", "Arial", "Baskerville"]);
   });
 
   it("classifies macOS-specific mono fonts", () => {
-    const { mono } = buildFontOptions(["Monaco", "Andale Mono", "PT Mono"]);
-    const values = mono.map((o) => o.value);
-    expect(values).toContain("Monaco");
-    expect(values).toContain("Andale Mono");
-    expect(values).toContain("PT Mono");
+    const { sans } = buildFontOptions(["Monaco", "Andale Mono", "PT Mono"]);
+    for (const name of ["Monaco", "Andale Mono", "PT Mono"]) {
+      expect(sans.find((o) => o.value === name)?.group).toBe("mono");
+    }
   });
 
   it("classifies modern mono fonts", () => {
-    const { mono } = buildFontOptions([
+    const { sans } = buildFontOptions([
       "Monaspace Neon", "Maple Mono", "Intel One Mono", "0xProto", "Commit Mono",
     ]);
-    const values = mono.map((o) => o.value);
     for (const name of ["Monaspace Neon", "Maple Mono", "Intel One Mono", "0xProto", "Commit Mono"]) {
-      expect(values).toContain(name);
+      expect(sans.find((o) => o.value === name)?.group).toBe("mono");
     }
   });
 
   it("does not misclassify 'Monotype Corsiva' as mono", () => {
-    // "Monotype" contains "mono" but \bmono\b won't match because
-    // the trailing "t" is a word character (no boundary after "mono").
     const { sans } = buildFontOptions(["Monotype Corsiva"]);
-    expect(sans.map((o) => o.value)).toContain("Monotype Corsiva");
+    expect(sans.find((o) => o.value === "Monotype Corsiva")?.group).toBe("sans");
+  });
+
+  it("both lists have same length", () => {
+    const { sans, mono } = buildFontOptions(systemFonts);
+    expect(sans.length).toBe(mono.length);
   });
 
   it("handles duplicate font names in input", () => {
     const { sans } = buildFontOptions(["Arial", "Arial", "Helvetica"]);
     const arialCount = sans.filter((o) => o.value === "Arial").length;
-    // buildFontOptions does not deduplicate — that's the backend's job
     expect(arialCount).toBe(2);
   });
 });

--- a/src/ui/src/utils/fontSettings.test.ts
+++ b/src/ui/src/utils/fontSettings.test.ts
@@ -62,9 +62,9 @@ describe("buildFontOptions", () => {
     const fontEntries = sans.filter((o) => o.group);
     const firstMonoIdx = fontEntries.findIndex((o) => o.group === "mono");
     const lastSansIdx = fontEntries.map((o) => o.group).lastIndexOf("sans");
-    if (firstMonoIdx !== -1 && lastSansIdx !== -1) {
-      expect(lastSansIdx).toBeLessThan(firstMonoIdx);
-    }
+    expect(firstMonoIdx).not.toBe(-1);
+    expect(lastSansIdx).not.toBe(-1);
+    expect(lastSansIdx).toBeLessThan(firstMonoIdx);
   });
 
   it("mono list orders mono-group fonts before sans-group fonts", () => {
@@ -72,9 +72,9 @@ describe("buildFontOptions", () => {
     const fontEntries = mono.filter((o) => o.group);
     const firstSansIdx = fontEntries.findIndex((o) => o.group === "sans");
     const lastMonoIdx = fontEntries.map((o) => o.group).lastIndexOf("mono");
-    if (firstSansIdx !== -1 && lastMonoIdx !== -1) {
-      expect(lastMonoIdx).toBeLessThan(firstSansIdx);
-    }
+    expect(firstSansIdx).not.toBe(-1);
+    expect(lastMonoIdx).not.toBe(-1);
+    expect(lastMonoIdx).toBeLessThan(firstSansIdx);
   });
 
   it("tags fonts with correct group field", () => {

--- a/src/ui/src/utils/fontSettings.ts
+++ b/src/ui/src/utils/fontSettings.ts
@@ -35,6 +35,7 @@ export function resetUiFontSize(): void {
 export interface FontOption {
   value: string;
   label: string;
+  group?: "sans" | "mono";
 }
 
 /** Heuristic: does a font family name look monospaced? */
@@ -42,28 +43,38 @@ const MONO_KEYWORDS = /\b(mono|code|consol|courier|menlo|monaco|terminal|fixed|h
 
 /**
  * Build font option lists from system-installed fonts.
- * Splits into sans-serif and monospace based on name heuristics.
+ * Both lists contain ALL fonts, with the relevant category sorted first.
+ * Each font carries a `group` tag ("sans" | "mono") for rendering group headers.
  */
 export function buildFontOptions(systemFonts: string[]): {
   sans: FontOption[];
   mono: FontOption[];
 } {
-  const sans: FontOption[] = [{ value: "", label: "Default (Inter)" }];
-  const mono: FontOption[] = [{ value: "", label: "Default (JetBrains Mono)" }];
+  const sansGroup: FontOption[] = [];
+  const monoGroup: FontOption[] = [];
 
   for (const name of systemFonts) {
-    // Skip hidden/internal fonts
     if (name.startsWith(".") || name.startsWith("#")) continue;
-    const opt: FontOption = { value: name, label: name };
     if (MONO_KEYWORDS.test(name)) {
-      mono.push(opt);
+      monoGroup.push({ value: name, label: name, group: "mono" });
     } else {
-      sans.push(opt);
+      sansGroup.push({ value: name, label: name, group: "sans" });
     }
   }
 
-  sans.push({ value: "__custom__", label: "Custom..." });
-  mono.push({ value: "__custom__", label: "Custom..." });
+  const sans: FontOption[] = [
+    { value: "", label: "Default (Inter)" },
+    ...sansGroup,
+    ...monoGroup,
+    { value: "__custom__", label: "Custom..." },
+  ];
+
+  const mono: FontOption[] = [
+    { value: "", label: "Default (JetBrains Mono)" },
+    ...monoGroup,
+    ...sansGroup,
+    { value: "__custom__", label: "Custom..." },
+  ];
 
   return { sans, mono };
 }


### PR DESCRIPTION
## Summary

The Interface Font picker hid any font matching a "looks like mono" heuristic (e.g. FiraCode Nerd Font, JetBrains Mono), so users couldn't pick a monospace font for UI text even when they wanted to. The classification was being used as an exclusion gate when it was originally intended as a convenience grouping.

This PR changes the classification from a **partition** into a **sort key**:
- Both pickers now contain every system font
- The relevant category is sorted first under a group header (Sans-serif first in Interface Font, Monospace first in Monospace Font)
- A sticky search input at the top of the dropdown filters by name as you type

```mermaid
flowchart LR
    A[System fonts] --> B{MONO_KEYWORDS regex}
    B -->|matches| C[mono group]
    B -->|no match| D[sans group]
    C --> E[Interface Font:<br/>sans first, then mono]
    D --> E
    C --> F[Monospace Font:<br/>mono first, then sans]
    D --> F
```

## Complexity Notes

- **`isCustomSans`/`isCustomMono` detection in `AppearanceSettings.tsx`** uses `.some()` against the options list to decide whether to show the custom font input. Since both lists now contain *all* fonts, selecting a mono font as the interface font now correctly resolves to `isCustomSans = false` without any consumer changes — but it's worth verifying this still behaves correctly with already-stored custom fonts.
- **Group headers are derived from `FontOption.group` at render time**, not stored as separate items in the array. This keeps `.some()` and `.find()` lookups straightforward but means the rendering logic in `FontSelect` carries the responsibility for detecting group transitions.
- **Search hides the Default and Custom… sentinels** when the query is non-empty (they don't match font names), but they're always visible when search is empty.

## Test Steps

1. Run the app: `cargo tauri dev`
2. Open **Settings → Appearance**
3. Click the **Interface font** picker:
   - Verify Sans-serif fonts appear first under a "Sans-serif" group header
   - Scroll down — verify a "Monospace" group header followed by mono fonts (including FiraCode Nerd Font, JetBrains Mono, etc.)
   - Type "fira" in the search box — verify only fonts containing "fira" remain
   - Clear the search — verify all fonts and group headers reappear
   - Type "zzznotafont" — verify "No matching fonts" is shown
   - Select **FiraCode Nerd Font** — verify it applies as the interface font (UI text changes immediately)
4. Click the **Monospace font** picker:
   - Verify Monospace fonts appear first under "Monospace", then Sans-serif fonts under "Sans-serif"
   - Same search behaviors as above
5. Restart the app — verify the selected fonts are persisted
6. Verify the **Custom…** entry still works (renders the custom font input field)
7. Press Escape with the dropdown open — verify it closes

## Checklist

- [x] Tests added/updated (`fontSettings.test.ts` rewritten for non-exclusive lists + group field assertions)
- [ ] Documentation updated (no user-facing docs for this UI exist)