### PR TITLE
feat(chat): inline plan refinement via feedback textarea

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -2299,9 +2299,13 @@ pub async fn submit_plan_approval(
             "updatedInput": pending.original_input,
         })
     } else {
+        let feedback = reason.unwrap_or_else(|| "Plan denied. Please revise the approach.".into());
+        let message = format!(
+            "{feedback}\n\nRevise the plan to address this feedback, then call ExitPlanMode again to present the updated plan for approval. Do not begin implementation until the user approves the revised plan."
+        );
         serde_json::json!({
             "behavior": "deny",
-            "message": reason.unwrap_or_else(|| "Plan denied. Please revise the approach.".into()),
+            "message": message,
         })
     };
     ps.send_control_response(&pending.request_id, response)

--- a/src/ui/src/components/chat/PlanApprovalCard.module.css
+++ b/src/ui/src/components/chat/PlanApprovalCard.module.css
@@ -235,13 +235,9 @@
   font-family: var(--font-mono, monospace);
 }
 
-.actions {
-  display: flex;
-  gap: 8px;
-}
-
 .approveBtn {
-  flex: 1;
+  display: block;
+  width: 100%;
   padding: 10px 14px;
   background: rgba(var(--accent-primary-rgb), 0.1);
   border: 1px solid rgba(var(--accent-primary-rgb), 0.25);
@@ -257,19 +253,74 @@
   background: rgba(var(--accent-primary-rgb), 0.18);
 }
 
-.denyBtn {
-  padding: 10px 14px;
-  background: transparent;
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 14px 0 12px;
+  font-size: 11px;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--hover-bg);
+}
+
+.freeformRow {
+  display: flex;
+  gap: 8px;
+}
+
+.freeformInput {
+  flex: 1;
+  background: var(--hover-bg-subtle);
   border: 1px solid var(--divider);
   border-radius: 8px;
-  color: var(--text-dim);
+  padding: 10px 14px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+  resize: none;
+  min-height: 38px;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.freeformInput:focus {
+  border-color: rgba(var(--accent-primary-rgb), 0.3);
+  box-shadow: 0 0 0 3px rgba(var(--accent-primary-rgb), 0.06);
+}
+
+.freeformInput::placeholder {
+  color: var(--text-faint);
+}
+
+.feedbackBtn {
+  background: transparent;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.25);
+  color: var(--accent-dim);
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
   font-size: 13px;
   font-weight: 500;
-  cursor: pointer;
+  align-self: flex-end;
   transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.denyBtn:hover {
-  background: var(--error-bg);
-  color: var(--text-primary);
+.feedbackBtn:hover:not(:disabled) {
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  color: var(--accent-primary);
+}
+
+.feedbackBtn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -23,6 +23,7 @@ export function PlanApprovalCard({
   const [planContent, setPlanContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [feedback, setFeedback] = useState("");
 
   const handleViewPlan = async () => {
     if (planContent !== null) {
@@ -92,18 +93,39 @@ export function PlanApprovalCard({
         </div>
       )}
 
-      <div className={styles.actions}>
+      <button
+        className={styles.approveBtn}
+        onClick={() => onRespond(true)}
+      >
+        Approve plan
+      </button>
+
+      <div className={styles.divider}>Or provide feedback below</div>
+
+      <div className={styles.freeformRow}>
+        <textarea
+          className={styles.freeformInput}
+          value={feedback}
+          onChange={(e) => setFeedback(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              const text = feedback.trim();
+              if (text) onRespond(false, text);
+            }
+          }}
+          placeholder="Request changes or ask for a revision…"
+          rows={1}
+        />
         <button
-          className={styles.approveBtn}
-          onClick={() => onRespond(true)}
+          className={styles.feedbackBtn}
+          onClick={() => {
+            const text = feedback.trim();
+            if (text) onRespond(false, text);
+          }}
+          disabled={!feedback.trim()}
         >
-          Approve plan
-        </button>
-        <button
-          className={styles.denyBtn}
-          onClick={() => onRespond(false, "Plan denied. Please revise the approach.")}
-        >
-          Deny
+          Send
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Refines the plan approval flow to make plan refinement a one-step action and ensures revised plans cycle back through the same approval card UI.

- **`PlanApprovalCard`** — replaces the standalone *Deny* button with a freeform feedback textarea + Send button, matching the visual language of `AgentQuestionCard`. Users can approve directly or type refinement guidance and submit; Enter submits, Shift+Enter inserts a newline, Send is disabled when empty.
- **`submit_plan_approval` (backend)** — wraps the deny `message` sent to the CLI with an explicit instruction telling the agent to call `ExitPlanMode` again after revising. Without this nudge, the agent often replied with prose like "Revised plan is at `<path>`" instead of re-presenting the plan in the approval card.

```mermaid
sequenceDiagram
    participant User
    participant Card as PlanApprovalCard
    participant Backend as submit_plan_approval
    participant CLI as Claude CLI
    participant Agent

    User->>Card: types feedback + Send
    Card->>Backend: onRespond(false, feedback)
    Backend->>CLI: deny + (feedback + nudge to re-call ExitPlanMode)
    CLI->>Agent: tool error w/ message
    Agent->>Agent: revises plan file
    Agent->>CLI: ExitPlanMode (revised)
    CLI->>Card: agent-permission-prompt
    Card->>User: re-renders approval card
```

## Complexity Notes

- The "re-present revised plan" behavior depends on the model honoring the instruction in the deny message. It's a strong nudge (explicit + paragraph-separated from the user's feedback so the model treats them distinctly), but it is not a hard guarantee — if the model ever ignores it, the worst case is the previous behavior (prose reply with file path), which is what users get on `main` today.
- The feedback textarea fully replaces the *Deny* button — there is no longer a way to deny without providing a reason. This is intentional: an empty denial gives the agent nothing to act on. Users who just want to abort can close/cancel the session.

## Test Steps

1. `cd src/ui && bunx tsc -b` — passes clean
2. `cd src/ui && bun run test` — 942 tests pass
3. `cargo clippy --workspace --all-targets` — no warnings
4. `cargo test --all-features` — 737 tests pass
5. In `cargo tauri dev`, ask an agent to enter plan mode and produce a plan
6. Confirm the approval card shows: full-width *Approve plan* button, a divider reading *"Or provide feedback below"*, and a textarea + *Send* button
7. Click *Approve plan* → plan is approved as before
8. In another session, type refinement feedback and press Enter (or click Send)
9. Confirm the agent revises the plan and re-presents it via the approval card (not as prose with a file path)
10. Confirm Shift+Enter inserts a newline rather than submitting; confirm *Send* is disabled when textarea is empty

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)