### PR TITLE
ci(nightly): fetch latest.json via gh CLI to support draft releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -323,8 +323,11 @@ jobs:
           # follow-up). Aborting here is safe — `nightly` is still intact.
           for attempt in 1 2 3; do
             rm -f latest.json
-            if curl -fsSL -o latest.json \
-              "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly-staging/latest.json"; then
+            if gh release download nightly-staging \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "latest.json" \
+              --dir . \
+              --clobber; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then


### PR DESCRIPTION
### Summary

The nightly workflow's `publish` job has been failing with:

```
curl: (22) The requested URL returned error: 404
Error: Failed to fetch nightly-staging/latest.json after 3 attempts
```

**Root cause:** `nightly-staging` is created as a **draft** release (`gh release create ... --draft`). GitHub does not serve draft release assets at the public `releases/download/<tag>/<asset>` CDN path — only published releases are reachable that way. Draft assets require API authentication.

`tauri-action` uploads `latest.json` to the draft successfully (it uses the API), but the subsequent unauthenticated `curl` in the `publish` job hits the public path and 404s every time.

**Fix:** Replace `curl` with `gh release download`, which uses the already-exported `GH_TOKEN` to authenticate against the GitHub API. This works against draft releases. The retry/backoff loop is preserved verbatim.

```mermaid
flowchart LR
    A[tauri-action uploads<br/>latest.json to nightly-staging<br/>via authenticated API] --> B[publish job fetches<br/>latest.json]
    B -->|Before: curl public CDN| C[404 — draft assets<br/>not on public CDN]
    B -->|After: gh release download| D[200 — gh uses<br/>GH_TOKEN API auth]
    D --> E[Rewrite URLs,<br/>retag staging→nightly]
```

### Complexity Notes

- The Tauri update signature covers binary contents only, not URL fields, so the existing in-place `sed` rewrite of `nightly-staging/` → `nightly/` continues to be safe — this PR doesn't alter that behavior.
- `GH_TOKEN` was already in the `publish` job's `env:` block for the `gh release` calls that follow, so no new secrets or scopes are required.

### Test Steps

1. Wait for this PR to merge to `main` (or trigger via `workflow_dispatch` from the branch UI on `Actions → Nightly Build → Run workflow`).
2. Watch the `Publish Nightly` job in the resulting run. The `Promote staging to nightly` step should:
   - Download `latest.json` on the first attempt (no retry/backoff messages).
   - Rewrite `nightly-staging/` → `nightly/` URLs without hitting the "still contains nightly-staging URLs" abort.
   - Successfully promote the release.
3. After promotion, verify `https://github.com/utensils/claudette/releases/download/nightly/latest.json` is reachable and contains `releases/download/nightly/...` URLs (not `nightly-staging`).
4. Confirm the in-app updater can fetch the manifest end-to-end.

### Checklist

- [ ] Tests added/updated (N/A — workflow YAML change; verified by live nightly run)
- [ ] Documentation updated (N/A)