### PR TITLE
fix(chat): surface env-provider trust errors as system message before agent spawn

### DIFF
--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -509,6 +509,7 @@ pub async fn send_chat_message(
                 session_resolved_env: Default::default(),
                 mcp_bridge: None,
                 last_user_msg_id: None,
+                posted_env_trust_warning: false,
             };
         }
 
@@ -531,6 +532,7 @@ pub async fn send_chat_message(
             session_resolved_env: Default::default(),
             mcp_bridge: None,
             last_user_msg_id: None,
+            posted_env_trust_warning: false,
         }
     });
 
@@ -773,6 +775,10 @@ pub async fn send_chat_message(
         session.mcp_bridge = None;
         session.active_pid = None;
         session.session_exited_plan = false;
+        // Env vars changed → re-arm the trust-warning dedupe so a fresh
+        // failure (e.g. user ran `mise trust` but `.envrc` is still
+        // blocked) reposts exactly once for the new error set.
+        session.posted_env_trust_warning = false;
         if stale_pid.is_some() || to_deny_env.is_some() {
             drop(agents);
             if let Some((ref ps, drained)) = to_deny_env {
@@ -790,6 +796,42 @@ pub async fn send_chat_message(
         }
     }
     let session = agents.get_mut(&chat_session_id).ok_or("Session lost")?;
+
+    // If any env-provider reported a trust/priming error (`mise trust`,
+    // `direnv allow`, …) surface it inline as a System message. Without
+    // this the agent spawns with a degraded env and the user sees no
+    // explanation for the resulting silent failure (#478). Dedupe via
+    // `posted_env_trust_warning` so we don't spam every turn while the
+    // user fixes it; the flag clears when the resolved env changes.
+    if !session.posted_env_trust_warning
+        && let Some(body) = resolved_env.format_trust_message()
+    {
+        let warning = ChatMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            workspace_id: workspace_id.clone(),
+            chat_session_id: chat_session_id.clone(),
+            role: ChatRole::System,
+            content: body,
+            cost_usd: None,
+            duration_ms: None,
+            created_at: now_iso(),
+            thinking: None,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        };
+        if let Err(err) = db.insert_chat_message(&warning) {
+            // Logging-only: a missing warning shouldn't block the turn.
+            eprintln!("[chat] failed to post env-trust warning: {err}");
+        } else {
+            session.posted_env_trust_warning = true;
+            // Emit so the open chat panel can render the warning
+            // immediately without waiting for the failing turn to
+            // finalize and trigger a history reload.
+            let _ = app.emit("chat-system-message", &warning);
+        }
+    }
 
     // Use persistent session to keep MCP servers alive across turns.
     // First turn or after restart: start a PersistentSession.
@@ -3140,6 +3182,7 @@ mod tests {
             session_resolved_env: Default::default(),
             mcp_bridge: None,
             last_user_msg_id: None,
+            posted_env_trust_warning: false,
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -116,10 +116,12 @@ pub struct AgentSessionState {
     /// session teardown. See `agent_mcp_sink::ChatBridgeSink`.
     pub last_user_msg_id: Option<String>,
     /// Set after we've posted a trust-error system message into the
-    /// chat for the current resolved env. Cleared whenever the resolved
-    /// env vars change (the user ran `direnv allow` / `mise trust`,
-    /// edited the config, toggled a provider) so a fresh failure
-    /// re-emits exactly once.
+    /// chat for the current resolved env. Cleared when an existing
+    /// persistent session is torn down because the resolved env drifted
+    /// (e.g. after `direnv allow` / `mise trust`, config edits, or
+    /// provider toggles), so a fresh failure re-emits once after that
+    /// restart. Stays sticky until then so we don't spam every turn
+    /// while the user is fixing the underlying issue.
     pub posted_env_trust_warning: bool,
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -115,6 +115,12 @@ pub struct AgentSessionState {
     /// turn. Updated each time a new user message is inserted; cleared on
     /// session teardown. See `agent_mcp_sink::ChatBridgeSink`.
     pub last_user_msg_id: Option<String>,
+    /// Set after we've posted a trust-error system message into the
+    /// chat for the current resolved env. Cleared whenever the resolved
+    /// env vars change (the user ran `direnv allow` / `mise trust`,
+    /// edited the config, toggled a provider) so a fresh failure
+    /// re-emits exactly once.
+    pub posted_env_trust_warning: bool,
 }
 
 /// Handle to an active PTY process.

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -758,6 +758,7 @@ mod tests {
             session_resolved_env: Default::default(),
             mcp_bridge: None,
             last_user_msg_id: None,
+            posted_env_trust_warning: false,
         }
     }
 

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -139,9 +139,10 @@ impl ResolvedEnv {
     }
 
     /// Render a markdown system message describing every trust error,
-    /// or `None` when there are none. Each block names the provider, the
-    /// stderr the plugin captured, and a one-line remediation hint
-    /// pointing at the action the user can take.
+    /// or `None` when there are none. Each block names the provider, a
+    /// fenced-code-block excerpt of the stderr the plugin captured, and
+    /// a one-line remediation hint pointing at the action the user can
+    /// take.
     pub fn format_trust_message(&self) -> Option<String> {
         let errors = self.trust_errors();
         if errors.is_empty() {
@@ -153,8 +154,14 @@ impl ResolvedEnv {
         for src in errors {
             let display = display_name_for(&src.plugin_name);
             let hint = remediation_hint(&src.plugin_name);
-            let err = src.error.as_deref().unwrap_or("");
-            body.push_str(&format!("\n- **{display}**: {err}\n  - {hint}\n"));
+            let excerpt = excerpt_error(src.error.as_deref().unwrap_or(""));
+            // Fenced block keeps multi-line stderr (and any leading
+            // whitespace direnv/mise emit) from collapsing the list
+            // layout; the indent under the bullet keeps the code block
+            // visually associated with the parent list item.
+            body.push_str(&format!(
+                "\n- **{display}**\n\n    ```\n{excerpt}\n    ```\n\n    {hint}\n"
+            ));
         }
         body.push_str(
             "\nYou can also configure a setup script in **Repo Settings → Setup Script** so future workspaces auto-prime this environment.",
@@ -163,12 +170,39 @@ impl ResolvedEnv {
     }
 }
 
+/// Truncate and re-indent an error string for embedding inside a
+/// markdown fenced code block under a list item. Caps the excerpt at
+/// `MAX_EXCERPT_BYTES` so a runaway stderr (mise/direnv occasionally
+/// dump multi-screen diagnostics) doesn't blow out the chat surface,
+/// and prefixes every line with four spaces so the block stays inside
+/// the parent bullet's indent context.
+fn excerpt_error(error: &str) -> String {
+    const MAX_EXCERPT_BYTES: usize = 800;
+    let trimmed = error.trim_end();
+    let truncated = if trimmed.len() > MAX_EXCERPT_BYTES {
+        // Cut at a UTF-8 char boundary to avoid panicking on non-ASCII.
+        let mut cut = MAX_EXCERPT_BYTES;
+        while cut > 0 && !trimmed.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        format!("{}…", &trimmed[..cut])
+    } else {
+        trimmed.to_string()
+    };
+    truncated
+        .lines()
+        .map(|l| format!("    {l}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Trust-error heuristic. Matches the stderr substrings that mise and
-/// direnv emit when their config hasn't been allowed yet, plus the
-/// "permission denied" wording nix-devshell can return for an
-/// untrusted flake. Generic `export:` / `detect:` errors that don't
-/// contain any of these markers fall through and are not surfaced as
-/// trust warnings.
+/// direnv emit when their config hasn't been allowed yet. Generic
+/// `export:` / `detect:` errors that don't contain any of these
+/// markers fall through and are not surfaced as trust warnings —
+/// notably "permission denied" is intentionally NOT matched, since it
+/// is too broad and would catch unrelated filesystem failures (e.g.
+/// the plugin couldn't read its own config because of POSIX perms).
 fn is_trust_error(error: &str) -> bool {
     let lower = error.to_ascii_lowercase();
     ["not trusted", "is blocked", "is not allowed", "untrusted"]
@@ -943,8 +977,47 @@ mod tests {
         assert!(body.contains("**direnv**"));
         assert!(body.contains("`mise trust`"));
         assert!(body.contains("`direnv allow`"));
+        // Stderr renders inside a fenced code block so multi-line
+        // output can't break the surrounding markdown list.
+        assert!(body.contains("```"));
+        assert!(body.contains("    export: mise env failed: not trusted"));
         // The closing pointer to repo settings is the durable fix.
         assert!(body.contains("Repo Settings"));
+    }
+
+    #[test]
+    fn excerpt_error_preserves_short_single_line() {
+        let s = excerpt_error("mise.toml is not trusted");
+        assert_eq!(s, "    mise.toml is not trusted");
+    }
+
+    #[test]
+    fn excerpt_error_indents_each_line_for_list_block() {
+        let s = excerpt_error("first\nsecond\nthird");
+        assert_eq!(s, "    first\n    second\n    third");
+    }
+
+    #[test]
+    fn excerpt_error_truncates_runaway_stderr_at_char_boundary() {
+        // 1500 ASCII bytes of stderr — past the 800-byte cap.
+        let huge = "x".repeat(1500);
+        let s = excerpt_error(&huge);
+        // Truncated and ellipsis-suffixed so the chat surface doesn't
+        // explode if a plugin dumps multi-screen diagnostics.
+        assert!(s.ends_with('…'));
+        assert!(s.len() < 1500);
+    }
+
+    #[test]
+    fn excerpt_error_handles_multibyte_chars_at_truncation_boundary() {
+        // 4-byte UTF-8 characters padded past the 800-byte cap. The
+        // boundary scan must back up rather than panicking. Each "🚀"
+        // is 4 bytes, so 250 of them = 1000 bytes.
+        let s = excerpt_error(&"🚀".repeat(250));
+        assert!(s.ends_with('…'));
+        // Sanity: still valid UTF-8 (push to String would have panicked
+        // if the cut landed mid-char).
+        assert!(s.is_char_boundary(s.len()));
     }
 
     #[tokio::test]

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -123,6 +123,79 @@ impl ResolvedEnv {
             }
         }
     }
+
+    /// Sources whose error string indicates the user needs to take a
+    /// one-time priming action (run `direnv allow`, `mise trust`, etc.)
+    /// before this provider can contribute env. Heuristic match on the
+    /// stderr text the plugin propagated up — keeps generic export
+    /// failures (malformed TOML, missing CLI) out of the trust-warning
+    /// surface so we don't tell the user to "run `mise trust`" when
+    /// `mise` isn't even installed.
+    pub fn trust_errors(&self) -> Vec<&ResolvedSource> {
+        self.sources
+            .iter()
+            .filter(|s| s.error.as_deref().is_some_and(is_trust_error))
+            .collect()
+    }
+
+    /// Render a markdown system message describing every trust error,
+    /// or `None` when there are none. Each block names the provider, the
+    /// stderr the plugin captured, and a one-line remediation hint
+    /// pointing at the action the user can take.
+    pub fn format_trust_message(&self) -> Option<String> {
+        let errors = self.trust_errors();
+        if errors.is_empty() {
+            return None;
+        }
+        let mut body = String::from(
+            "**Environment setup needed.** One or more env-provider plugins reported a trust/priming error. Until this is resolved, the agent will spawn without the tools and variables this provider would normally contribute, which can cause prompts to fail.\n",
+        );
+        for src in errors {
+            let display = display_name_for(&src.plugin_name);
+            let hint = remediation_hint(&src.plugin_name);
+            let err = src.error.as_deref().unwrap_or("");
+            body.push_str(&format!("\n- **{display}**: {err}\n  - {hint}\n"));
+        }
+        body.push_str(
+            "\nYou can also configure a setup script in **Repo Settings → Setup Script** so future workspaces auto-prime this environment.",
+        );
+        Some(body)
+    }
+}
+
+/// Trust-error heuristic. Matches the stderr substrings that mise and
+/// direnv emit when their config hasn't been allowed yet, plus the
+/// "permission denied" wording nix-devshell can return for an
+/// untrusted flake. Generic `export:` / `detect:` errors that don't
+/// contain any of these markers fall through and are not surfaced as
+/// trust warnings.
+fn is_trust_error(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    ["not trusted", "is blocked", "is not allowed", "untrusted"]
+        .iter()
+        .any(|needle| lower.contains(needle))
+}
+
+fn display_name_for(plugin_name: &str) -> &str {
+    match plugin_name {
+        "env-mise" => "mise",
+        "env-direnv" => "direnv",
+        "env-nix-devshell" => "nix",
+        "env-dotenv" => "dotenv",
+        _ => plugin_name,
+    }
+}
+
+fn remediation_hint(plugin_name: &str) -> &'static str {
+    match plugin_name {
+        "env-mise" => {
+            "Run `mise trust` in the worktree, or open the Environment panel and click **Trust**."
+        }
+        "env-direnv" => {
+            "Run `direnv allow` in the worktree, or open the Environment panel and click **Allow**."
+        }
+        _ => "Open the Environment panel for this workspace to inspect and prime this provider.",
+    }
 }
 
 /// Hardcoded precedence for v1. Higher value = wins on key collision.
@@ -785,6 +858,93 @@ mod tests {
             cache.get_fresh(tmp.path(), "env-direnv").is_none(),
             "disable must invalidate the cache entry"
         );
+    }
+
+    fn make_source(name: &str, error: Option<&str>) -> ResolvedSource {
+        ResolvedSource {
+            plugin_name: name.into(),
+            detected: error.is_none(),
+            vars_contributed: 0,
+            cached: false,
+            evaluated_at: SystemTime::now(),
+            error: error.map(|s| s.into()),
+        }
+    }
+
+    #[test]
+    fn trust_errors_match_mise_not_trusted() {
+        let env = ResolvedEnv {
+            vars: Default::default(),
+            sources: vec![make_source(
+                "env-mise",
+                Some("export: mise env failed: mise.toml is not trusted"),
+            )],
+        };
+        let errors = env.trust_errors();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].plugin_name, "env-mise");
+    }
+
+    #[test]
+    fn trust_errors_match_direnv_blocked() {
+        let env = ResolvedEnv {
+            vars: Default::default(),
+            sources: vec![make_source(
+                "env-direnv",
+                Some("export: direnv export failed: .envrc is blocked"),
+            )],
+        };
+        assert_eq!(env.trust_errors().len(), 1);
+    }
+
+    #[test]
+    fn trust_errors_skip_generic_export_failures() {
+        // A malformed mise.toml or missing CLI is a different problem
+        // class — `mise trust` won't fix it, so it must NOT surface as a
+        // trust warning.
+        let env = ResolvedEnv {
+            vars: Default::default(),
+            sources: vec![make_source(
+                "env-mise",
+                Some("export: mise env failed: failed to parse mise.toml"),
+            )],
+        };
+        assert!(env.trust_errors().is_empty());
+    }
+
+    #[test]
+    fn trust_errors_empty_when_no_errors() {
+        let env = ResolvedEnv {
+            vars: Default::default(),
+            sources: vec![make_source("env-mise", None)],
+        };
+        assert!(env.trust_errors().is_empty());
+        assert!(env.format_trust_message().is_none());
+    }
+
+    #[test]
+    fn format_trust_message_lists_each_failing_provider() {
+        let env = ResolvedEnv {
+            vars: Default::default(),
+            sources: vec![
+                make_source("env-mise", Some("export: mise env failed: not trusted")),
+                make_source(
+                    "env-direnv",
+                    Some("export: direnv export failed: is blocked"),
+                ),
+            ],
+        };
+        let body = env
+            .format_trust_message()
+            .expect("trust errors should produce a message");
+        // Names + remediation hints both surface so the user knows what
+        // to run for each failing provider.
+        assert!(body.contains("**mise**"));
+        assert!(body.contains("**direnv**"));
+        assert!(body.contains("`mise trust`"));
+        assert!(body.contains("`direnv allow`"));
+        // The closing pointer to repo settings is the durable fix.
+        assert!(body.contains("Repo Settings"));
     }
 
     #[tokio::test]

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -677,6 +677,24 @@ export function useAgentStream() {
     };
   }, [updateWorkspace]);
 
+  // Listen for backend-authored system messages that the chat command
+  // inserts into the DB out-of-band (currently: env-provider trust
+  // warnings emitted before agent spawn). The DB insert keeps the
+  // message in history; this event mirrors it into the live store so
+  // the user sees it immediately, not only after the failing turn
+  // finalizes and triggers a history reload.
+  useEffect(() => {
+    let active = true;
+    const unlisten = listen<ChatMessage>("chat-system-message", (event) => {
+      if (!active) return;
+      addChatMessage(event.payload.chat_session_id, event.payload);
+    });
+    return () => {
+      active = false;
+      unlisten.then((fn) => fn());
+    };
+  }, [addChatMessage]);
+
   // Listen for agent-authored attachments delivered via the
   // `mcp__claudette__send_to_user` tool. The Rust bridge has already
   // persisted them; we just need to mirror into the in-memory store so the


### PR DESCRIPTION
## Summary
- Adds `ResolvedEnv::trust_errors()` and `format_trust_message()` helpers that filter trust-related env-provider failures (`mise.toml not trusted`, `.envrc is blocked`, …) and render a markdown system message with a per-provider remediation hint.
- On chat send, posts that message into the chat session and emits a `chat-system-message` Tauri event so the open ChatPanel renders it immediately instead of waiting for the failing turn to finalize and trigger a history reload.
- Dedupe via a `posted_env_trust_warning` flag on `AgentSessionState`; the flag clears on the existing env-drift teardown so a new failure (e.g. user fixed mise but `.envrc` is now blocked) reposts exactly once.

Closes #478. Without this, a workspace whose mise/direnv config hasn't been allowed silently spawned the agent with a degraded env and the user saw no explanation for the resulting hang. The error string was already captured into `ResolvedSource.error` but never surfaced.

Generic export failures (malformed TOML, missing CLI binary) are deliberately excluded — telling the user to "run `mise trust`" when `mise` isn't installed would be misleading.

## Test plan
- [x] `cargo test --all-features` (744 passed)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets` with `-Dwarnings`
- [x] `cargo fmt --all --check`
- [x] `cd src/ui && bunx tsc -b` — frontend typechecks
- [x] `cd src/ui && bun run test` — 1003 passed
- [x] New unit tests in `src/env_provider/mod.rs` cover: mise "not trusted", direnv "blocked", generic export failure (must NOT match), no-error case, and the formatted message body.
- [ ] **Manual UAT**: in a worktree with an untrusted `mise.toml` and no setup script, send a chat prompt and confirm the system warning appears immediately (before any agent output) with the `mise trust` remediation hint. Then run `mise trust` in the worktree, send another prompt, and confirm the warning does not repost.