### PR TITLE
chore: add CODEOWNERS for utensils/partners team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @utensils/partners


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` file that assigns the `@utensils/partners` GitHub team as the code owner for every path in the repository (`* @utensils/partners`). This causes GitHub to automatically request a review from the team on every pull request and — if branch protection requires code owner review — gates merges on their approval.

## Test Steps

1. Confirm the file exists at `.github/CODEOWNERS` on the PR branch with the single line `* @utensils/partners`.
2. Observe that this PR itself has `@utensils/partners` listed under "Reviewers" (GitHub picks up CODEOWNERS from the PR's head ref).
3. Optionally, after merge, open any new PR against `main` and verify the team is auto-requested.

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)