### PR TITLE
fix(theme): guard OS theme change handler against async race, add findTheme tests

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -41,6 +41,10 @@ function App() {
 
   // Cached theme list — populated on initial load, reused by the OS handler.
   const loadedThemesRef = useRef<ThemeDefinition[]>([]);
+  // Generation token: incremented on each OS theme change event so that a
+  // stale async loadAllThemes() result doesn't overwrite a later handler's
+  // applied theme when the OS toggles light↔dark in rapid succession.
+  const themeChangeTokenRef = useRef(0);
 
   // Listen for MCP supervisor status events from the Rust backend.
   useMcpStatus();
@@ -388,6 +392,7 @@ function App() {
     const handleChange = async (e: MediaQueryListEvent) => {
       const state = useAppStore.getState();
       if (state.themeMode !== "system") return;
+      const token = ++themeChangeTokenRef.current;
       const effectiveId = e.matches ? state.themeDark : state.themeLight;
       // The cached theme list is populated once on initial load. If the user
       // dropped a new JSON theme on disk and selected it via Settings, it
@@ -402,12 +407,16 @@ function App() {
           console.error("Failed to reload themes for system change:", err);
         }
       }
+      // A later handler already ran — discard this stale result.
+      if (themeChangeTokenRef.current !== token) return;
       if (themes.length === 0) return;
       try {
         const theme = findTheme(themes, effectiveId);
         applyTheme(theme);
-        applyUserFonts(state.fontFamilySans, state.fontFamilyMono, state.uiFontSize);
-        state.setCurrentThemeId(theme.id);
+        // Read fresh state: font settings may have changed during the await.
+        const fresh = useAppStore.getState();
+        applyUserFonts(fresh.fontFamilySans, fresh.fontFamilyMono, fresh.uiFontSize);
+        fresh.setCurrentThemeId(theme.id);
       } catch (err) {
         console.error("Failed to apply system theme change:", err);
       }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -390,16 +390,18 @@ function App() {
   useEffect(() => {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = async (e: MediaQueryListEvent) => {
-      const state = useAppStore.getState();
-      if (state.themeMode !== "system") return;
+      const initial = useAppStore.getState();
+      if (initial.themeMode !== "system") return;
       const token = ++themeChangeTokenRef.current;
-      const effectiveId = e.matches ? state.themeDark : state.themeLight;
+      // Tentative — only used to decide whether to refresh the theme cache.
+      // The authoritative effectiveId is recomputed from fresh state below.
+      const tentativeId = e.matches ? initial.themeDark : initial.themeLight;
       // The cached theme list is populated once on initial load. If the user
       // dropped a new JSON theme on disk and selected it via Settings, it
       // won't be in the ref — refresh on miss so we apply the right theme
       // instead of silently falling back via findTheme.
       let themes = loadedThemesRef.current;
-      if (!themes.some((t) => t.id === effectiveId)) {
+      if (!themes.some((t) => t.id === tentativeId)) {
         try {
           themes = await loadAllThemes();
           loadedThemesRef.current = themes;
@@ -407,14 +409,19 @@ function App() {
           console.error("Failed to reload themes for system change:", err);
         }
       }
-      // A later handler already ran — discard this stale result.
+      // A later OS event already ran — discard this stale result.
       if (themeChangeTokenRef.current !== token) return;
+      // Re-read store state: the user may have switched away from system mode
+      // (or changed themeDark/themeLight, fonts, etc.) during the await. If
+      // they did, their explicit action already applied a theme synchronously
+      // and we must not stomp it.
+      const fresh = useAppStore.getState();
+      if (fresh.themeMode !== "system") return;
       if (themes.length === 0) return;
+      const effectiveId = e.matches ? fresh.themeDark : fresh.themeLight;
       try {
         const theme = findTheme(themes, effectiveId);
         applyTheme(theme);
-        // Read fresh state: font settings may have changed during the await.
-        const fresh = useAppStore.getState();
         applyUserFonts(fresh.fontFamilySans, fresh.fontFamilyMono, fresh.uiFontSize);
         fresh.setCurrentThemeId(theme.id);
       } catch (err) {

--- a/src/ui/src/utils/theme.test.ts
+++ b/src/ui/src/utils/theme.test.ts
@@ -46,7 +46,9 @@ const {
   DEFAULT_MONO_STACK,
   getThemeDataAttr,
   cacheThemePreference,
+  findTheme,
 } = await import("./theme");
+const { DEFAULT_THEME_ID } = await import("../styles/themes");
 
 describe("applyUserFonts", () => {
   beforeEach(() => {
@@ -231,5 +233,27 @@ describe("cacheThemePreference", () => {
       removeItem: (k: string) => { lsMap.delete(k); },
       clear: () => { lsMap.clear(); },
     });
+  });
+});
+
+describe("findTheme", () => {
+  const dark = { id: DEFAULT_THEME_ID, name: "Default Dark", description: "", colors: {} };
+  const light = { id: "default-light", name: "Default Light", description: "", colors: {} };
+  const custom = { id: "my-custom", name: "Custom", description: "", colors: {} };
+
+  it("returns the matching theme when the requested id exists", () => {
+    expect(findTheme([dark, light, custom], "my-custom")).toBe(custom);
+  });
+
+  it("falls back to DEFAULT_THEME_ID when the requested id is not found", () => {
+    expect(findTheme([dark, light], "nonexistent")).toBe(dark);
+  });
+
+  it("falls back to themes[0] when even DEFAULT_THEME_ID is absent", () => {
+    expect(findTheme([light, custom], "nonexistent")).toBe(light);
+  });
+
+  it("throws when the themes array is empty", () => {
+    expect(() => findTheme([], "anything")).toThrow("No themes are available.");
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #369 incorporating two pieces of Copilot review feedback that weren't addressed before merge:

1. **Race condition in the OS `prefers-color-scheme` handler** (`src/ui/src/App.tsx`). The async `handleChange` calls `loadAllThemes()` on cache miss; if the OS toggles light↔dark twice in quick succession while the cache is stale, the earlier promise can resolve *after* the later one and overwrite the correct applied theme. Adds a `themeChangeTokenRef` generation counter — the handler captures the token at entry and short-circuits after the await if a newer event has already run. Also reads fresh store state after the await so font settings changed during the async window aren't ignored.

2. **Missing `findTheme` unit tests** (`src/ui/src/utils/theme.test.ts`). The function's three-level fallback chain (requested → `DEFAULT_THEME_ID` → `themes[0]` → throw) had no coverage despite being called throughout the app. Adds four tests covering each branch.

## Complexity Notes

The race-condition guard relies on a subtle invariant: `++themeChangeTokenRef.current` runs **before** any `await`, so synchronous (cache-hit) invocations always see a strictly increasing token, and async (cache-miss) invocations are correctly invalidated by any later event — sync or async. The post-await `if (themeChangeTokenRef.current !== token) return;` is the only abort point; nothing before the await can race.

## Test Steps

1. `cd src/ui && bunx tsc -b` — passes with no errors.
2. `cd src/ui && bun run test` — all 1014 tests pass (1010 prior + 4 new `findTheme` tests).
3. **Manual UAT** (race-condition path):
   - Set theme mode to "Follow system" in Appearance Settings.
   - Drop a custom JSON theme into `~/.claudette/themes/` and select it as the dark theme.
   - Toggle macOS Appearance light↔dark rapidly via System Settings (or `defaults write -g AppleInterfaceStyle Dark` / `defaults delete -g AppleInterfaceStyle` in quick succession).
   - The applied theme should match the *final* OS state — not flicker back to a stale earlier value.
4. **Manual UAT** (font-settings-mid-toggle):
   - In system mode, change the UI font size in Settings while immediately toggling OS theme — the new font size should apply with the post-toggle theme.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a — no public API changes)