### PR TITLE
docs: add Anthropic ToS compliance disclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,28 @@ Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md)
 - The backend (`src/`) is a library crate consumed by the Tauri binary (`src-tauri/`).
 - See `CLAUDE.md` for detailed architecture and contribution guidelines.
 
+## Relationship to Anthropic
+
+Claudette is an independent, community-built tool. **It is not affiliated with, endorsed by, or sponsored by Anthropic, PBC.** "Claude" and "Claude Code" are trademarks of Anthropic, PBC; their use here is descriptive — Claudette orchestrates the official Claude Code CLI — and does not imply any partnership.
+
+### How Claudette uses your Claude account
+
+Claudette does **not** authenticate to Anthropic on your behalf. It spawns the official `claude` CLI you have installed locally as a subprocess; the CLI authenticates itself using the credentials you have configured for it. Claudette never reads, copies, or forwards your Claude OAuth tokens, and explicitly strips any inherited subscription tokens from spawned subprocesses so they are never passed through.
+
+### Pro/Max plan usage and parallel agents
+
+Per the [Claude Code legal and compliance page](https://code.claude.com/docs/en/legal-and-compliance):
+
+> Advertised usage limits for Pro and Max plans assume ordinary, individual usage of Claude Code and the Agent SDK.
+
+Claudette can run multiple agents in parallel git worktrees. **We recommend keeping default parallelism low (1–3 simultaneous agents)** and treating heavier use as something you explicitly opt into. Whether running N parallel agents counts as "ordinary, individual usage" under your plan is a judgment Anthropic reserves for itself; Claudette is the affordance, but the responsibility for staying within your plan's terms is yours.
+
+If you need higher throughput, the supported path is API-key authentication via [Claude Console](https://platform.claude.com/), which is governed by Anthropic's [Commercial Terms](https://www.anthropic.com/legal/commercial-terms).
+
+### Plugin secrets storage
+
+Claude Code plugins may require their own secrets (API keys, tokens). Claudette stores these in the same secure-storage object Claude Code itself uses — the macOS Keychain entry `Claude Code-credentials`, or `~/.claude/.credentials.json` on Linux — but only under its own `pluginSecrets` namespace. Your Claude OAuth tokens (`claudeAiOauth.*`) are never read or written by Claudette's plugin code.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
             #   nix build .#frontend 2>&1 | grep 'got:' | awk '{print $2}'
             outputHash =
               if pkgs.stdenv.isDarwin then
-                "sha256-4DTkNSdBEuOH4cwx9arUglGaDUp87gnbOflAjDBYVEM="
+                "sha256-jAvDzhkVASfcc36K4ngTKAWTAus2H7oqaqp1pUXZRFo="
               else
                 "sha256-TP3Ck8BOXAZRMo7YPVGvxe9ULewNhdVsUU9x/bpjJL4=";
 
@@ -142,7 +142,11 @@
               (craneLib.filterCargoSources path type)
               || (builtins.match ".*src-tauri/.*" path != null)
               || (builtins.match ".*assets/.*" path != null)
-              || (builtins.match ".*plugins/.*" path != null);
+              || (builtins.match ".*plugins/.*" path != null)
+              # Migration .sql files are loaded via include_str! in
+              # src/migrations/mod.rs, so they must survive the source
+              # filter even though they aren't *.rs.
+              || (builtins.match ".*/migrations/.*\\.sql" path != null);
           };
 
           # Platform-specific build dependencies
@@ -311,9 +315,20 @@
           };
 
           # -- Checks ------------------------------------------------------------
+          # `claudette` (the Tauri binary) is only included on Linux:
+          # the macOS build requires Apple's Swift toolchain (`swiftc`)
+          # for the Apple Speech FFI bridge in src-tauri/build.rs, which
+          # is not available in the pure Nix sandbox. Use `cargo tauri
+          # build` outside the sandbox to produce the macOS bundle.
+          # `claudette-server` has no Swift dependency and builds clean
+          # on all platforms.
           checks = {
-            inherit claudette claudette-server;
-
+            inherit claudette-server;
+          }
+          // lib.optionalAttrs pkgs.stdenv.isLinux {
+            inherit claudette;
+          }
+          // {
             clippy = craneLib.cargoClippy (
               commonCraneArgs
               // {
@@ -539,6 +554,16 @@
                 command = "exec ./scripts/dev.sh";
                 help = "Start Tauri dev mode with hot-reload (auto-selects free Vite + debug ports)";
                 category = "development";
+              }
+              {
+                name = "docs-dev";
+                command = ''
+                  cd "$PRJ_ROOT/site"
+                  [ -d node_modules ] || bun install --frozen-lockfile
+                  exec bun run dev "$@"
+                '';
+                help = "Start the docs site (Astro/Starlight) in dev mode with hot-reload (default http://localhost:4321)";
+                category = "documentation";
               }
               {
                 name = "build-app";

--- a/site/src/content/docs/features/remote-workspaces.mdx
+++ b/site/src/content/docs/features/remote-workspaces.mdx
@@ -5,6 +5,12 @@ description: Connect to workspaces on remote machines via encrypted WebSocket.
 
 Claudette can connect to workspaces on another machine over an encrypted WebSocket connection. The local app discovers or connects to a remote server and displays remote repos, agents, and terminals alongside local ones.
 
+:::caution[Use with your own account only]
+Agents started on a remote Claudette server run under whatever Claude credentials are configured on the *server* machine. If you pair multiple devices to a server signed into your Claude Pro/Max account, all of those devices share that single subscription identity.
+
+[Anthropic's Consumer Terms](https://www.anthropic.com/legal/consumer-terms) prohibit making your account "available to anyone else." Pair only your own devices to a server tied to a Pro/Max subscription. If you need to share access with a teammate, use API-key authentication on the server and have your teammate sign in with their own credentials.
+:::
+
 ## Sharing from the Desktop App
 
 Click **Share this machine** in the sidebar. The server starts automatically as a subprocess — no separate installation required. The server is embedded in the Claudette binary (gated behind the default-enabled `server` feature).

--- a/site/src/content/docs/privacy.mdx
+++ b/site/src/content/docs/privacy.mdx
@@ -9,6 +9,14 @@ Claudette is designed with a simple privacy principle: **your data stays on your
 
 Claudette has no user registration, no login, and no accounts. You download the app and start using it — there's nothing to sign up for.
 
+## Relationship to Anthropic
+
+Claudette is an independent, community-built tool. It is **not affiliated with, endorsed by, or sponsored by Anthropic, PBC.** "Claude" and "Claude Code" are trademarks of Anthropic, PBC; their use here is descriptive — Claudette orchestrates the official Claude Code CLI — and does not imply any partnership.
+
+Claudette does not authenticate to Anthropic on your behalf. It spawns the official `claude` CLI you have installed locally as a subprocess; the CLI authenticates itself with whatever credentials you have configured. Claudette never reads, copies, or forwards your Claude OAuth tokens.
+
+Per the [Claude Code legal and compliance page](https://code.claude.com/docs/en/legal-and-compliance), "advertised usage limits for Pro and Max plans assume ordinary, individual usage of Claude Code and the Agent SDK." We recommend keeping default parallelism low (1–3 simultaneous agents) and treating heavier use as something you explicitly opt into. Responsibility for staying within your plan's terms is yours.
+
 ## No Remote Servers
 
 Claudette does not operate any remote servers. Nothing you do in Claudette is transmitted to any servers managed by Claudette or [utensils](https://utensils.io). There is:
@@ -31,6 +39,21 @@ Your Machine ←→ Anthropic API
 
 Claudette never proxies, intercepts, or stores your API traffic on any third-party server.
 
+## Network Activity
+
+Beyond the Claude API traffic that flows through your locally-installed `claude` CLI, Claudette itself reaches a small number of external endpoints. None of these handle your prompts, code, or Claude credentials.
+
+| Destination | What it's for | When |
+|---|---|---|
+| `github.com/utensils/Claudette/releases` | App update checks (Tauri updater) | On app start |
+| `api.github.com/repos/utensils/claudette/releases` | Nightly build discovery | If nightly channel selected |
+| `peonping.github.io/registry/` | Soundpack registry index | If you open the soundpack picker |
+| `github.com/<repo>/archive/refs/tags/<tag>.tar.gz` | Soundpack downloads | Only when you install a pack |
+| `huggingface.co/distil-whisper/distil-large-v3/...` | Local speech-to-text model | Only the first time you use voice input |
+| `fonts.googleapis.com` | UI font (rendered in webview) | While the app window is open |
+
+There is no telemetry endpoint, no analytics endpoint, and no crash-reporting endpoint. The destinations above exist to make features work, not to track you.
+
 ## Local Storage
 
 Claudette stores workspace metadata and chat history in a local **SQLite database** on your machine:
@@ -39,6 +62,10 @@ Claudette stores workspace metadata and chat history in a local **SQLite databas
 - **Linux**: `~/.local/share/com.claudette.app/`
 
 This database contains workspace names, chat messages, and settings — all stored locally. You can back it up, delete it, or move it at any time.
+
+## Plugin Secrets
+
+Claude Code plugins may require their own secrets — API keys, tokens, etc. Claudette stores these in the same secure-storage object Claude Code itself uses (the macOS Keychain entry `Claude Code-credentials`, or `~/.claude/.credentials.json` on Linux), but only under its own `pluginSecrets` namespace. Your Claude OAuth tokens (`claudeAiOauth.*`) are never read or written by Claudette's plugin code.
 
 ## Remote Workspaces
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -16,6 +16,24 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 fn compile_platform_speech_swift() {
+    // Detect missing swiftc gracefully — a pure Nix sandbox build has
+    // xcrun (from apple-sdk) but no Swift toolchain. Skipping here lets
+    // `cargo check` and `cargo clippy` run inside the sandbox; the
+    // resulting object files won't satisfy the Speech-framework linker
+    // step, so full binary builds must still run outside the sandbox
+    // with a working Xcode toolchain.
+    let swiftc_available = Command::new("xcrun")
+        .args(["--find", "swiftc"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !swiftc_available {
+        println!(
+            "cargo:warning=swiftc not found; skipping Apple Speech Swift bridge. Full Tauri builds require Xcode."
+        );
+        return;
+    }
+
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("manifest dir"));
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("out dir"));
     let source = manifest_dir.join("macos").join("PlatformSpeech.swift");


### PR DESCRIPTION
## Summary

Adds user-facing disclosures derived from a ToS compliance audit of Claudette's relationship to Anthropic's Claude Code product, plus the build-infrastructure fixes required to keep `nix flake check` green on Darwin.

### Docs

- **README** — new "Relationship to Anthropic" section: affiliation disclaimer, how Claudette spawns the user's local `claude` CLI under their account, the "ordinary, individual usage" recommendation (1–3 simultaneous agents) with a quote from the [Claude Code legal page](https://code.claude.com/docs/en/legal-and-compliance), and plugin-secrets scope.
- **`site/.../privacy.mdx`** — same disclosures plus a "Network Activity" table enumerating every outbound endpoint Claudette reaches (updater, GitHub Releases API, CESP soundpack registry/downloads, Hugging Face Whisper model, Google Fonts) and what each is for.
- **`site/.../features/remote-workspaces.mdx`** — `:::caution` admonition: pairing multiple devices to a Pro/Max-credentialed server is account-sharing under Anthropic's Consumer Terms; recommend API-key auth for multi-user.

### Devshell

- **`docs-dev`** — new command launches the Astro/Starlight site in dev mode with hot-reload (auto-`bun install` on first run, default `http://localhost:4321/claudette/`).

### Build infrastructure (prerequisite)

`nix flake check --all-systems` was failing on Darwin before this branch — three latent issues surfaced once the FOD hash mismatch was fixed:

- **Frontend FOD hash bump (Darwin)** — sourcemap path drift since the last update.
- **Migration `.sql` source filter** — `src/migrations/*.sql` files are loaded via `include_str!` in `src/migrations/mod.rs`, but the crane source filter only allowed `*.rs`. Added a matcher.
- **Apple Speech Swift bridge** — `src-tauri/build.rs` panicked when `swiftc` wasn't on PATH, breaking `cargo clippy` in the pure sandbox. Now skips gracefully with a `cargo:warning=` so check/clippy run; full Tauri binary builds still require Xcode (use `cargo tauri build`).
- **Darwin `checks` set** — `claudette` (full Tauri binary) cannot link in the pure sandbox without the Swift static lib, so it's excluded from Darwin `checks`. It remains in `packages` for impure builds. `claudette-server` builds clean on all platforms and stays in checks.

### Verification

- `nix flake check --all-systems` → exit 0 (4 checks pass: clippy, fmt, claudette-server, treefmt).
- `nix develop -c docs-dev` → Astro server up on `:4321`, edited pages render HTTP 200.

## Test plan

- [ ] Render the privacy page locally (`docs-dev`) and confirm:
  - [ ] [Relationship to Anthropic](http://localhost:4321/claudette/privacy/#relationship-to-anthropic)
  - [ ] [Network Activity](http://localhost:4321/claudette/privacy/#network-activity)
  - [ ] [Plugin Secrets](http://localhost:4321/claudette/privacy/#plugin-secrets)
- [ ] Render [remote workspaces](http://localhost:4321/claudette/features/remote-workspaces/) and confirm the caution admonition is visible at the top.
- [ ] Re-run `nix flake check --all-systems` on Linux to confirm the Linux check set still includes the full `claudette` binary build.
- [ ] Confirm `cargo tauri dev` (or `dev` in the devshell) still works on macOS — the build.rs swiftc-skip path should not engage when Xcode is on PATH.