### PR TITLE
refactor(settings): replace theme mode dropdown with follow-system toggle

### DIFF
--- a/src/ui/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/ui/src/components/settings/sections/AppearanceSettings.tsx
@@ -32,6 +32,8 @@ export function AppearanceSettings() {
   const showSidebarRunningCommands = useAppStore((s) => s.showSidebarRunningCommands);
   const setShowSidebarRunningCommands = useAppStore((s) => s.setShowSidebarRunningCommands);
 
+  const isFollowSystem = themeMode === "system";
+
   const [availableThemes, setAvailableThemes] = useState<ThemeDefinition[]>([]);
   const [termFontSize, setTermFontSize] = useState(String(terminalFontSize));
   const [uiFontSizeStr, setUiFontSizeStr] = useState(String(uiFontSize));
@@ -142,6 +144,15 @@ export function AppearanceSettings() {
       await setAppSetting("theme_light", theme.id);
     } catch (e) {
       setError(String(e));
+    }
+  };
+
+  const handleFollowSystemToggle = async () => {
+    if (isFollowSystem) {
+      const systemIsDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      await handleModeChange(systemIsDark ? "dark" : "light");
+    } else {
+      await handleModeChange("system");
     }
   };
 
@@ -260,18 +271,22 @@ export function AppearanceSettings() {
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>
-          <div className={styles.settingLabel}>Theme mode</div>
+          <div className={styles.settingLabel}>Follow system</div>
+          <div className={styles.settingDescription}>
+            Automatically switch themes based on your OS setting
+          </div>
         </div>
         <div className={styles.settingControl}>
-          <select
-            className={styles.select}
-            value={themeMode}
-            onChange={(e) => handleModeChange(e.target.value as "light" | "dark" | "system")}
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={isFollowSystem}
+            aria-label="Follow system appearance"
+            data-checked={isFollowSystem}
+            onClick={handleFollowSystemToggle}
           >
-            <option value="dark">Dark</option>
-            <option value="light">Light</option>
-            <option value="system">Follow system</option>
-          </select>
+            <div className={styles.toggleKnob} />
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

The Appearance settings had a 3-option **Theme mode** dropdown (Dark / Light / Follow system) sitting alongside a **Color theme** picker. This conflated two different concerns — choosing a theme (cosmetic) and whether to follow the OS (behavioral) — and made the mode dropdown feel redundant for the common case.

This PR replaces the dropdown with a **Follow system** toggle:

- **Toggle off (default):** single **Color theme** picker showing all themes
- **Toggle on:** **Dark theme** + **Light theme** pickers for OS auto-switching

The underlying store model (`themeMode: "light" | "dark" | "system"`, `themeDark`, `themeLight`) and SQLite persistence keys (`theme_mode`, `theme_dark`, `theme_light`) are unchanged, so existing user preferences carry forward without migration.

When toggling **off**, the handler queries `prefers-color-scheme: dark` to set the internal mode to whichever side is currently visible — preventing a jarring theme flash at the moment of toggle.

## Complexity Notes

- The toggle handler reuses the existing \`handleModeChange\` (no duplicated apply / cache / persist logic).
- The conditional theme-picker block (\`themeMode !== \"system\"\` branch) is unchanged — it already does the right thing for both states.
- When the toggle is off and the user picks a theme from the single dropdown, the existing logic routes the write to either \`themeDark\` or \`themeLight\` based on the internal mode. A user could pick a \"light\" theme while internal mode is \`\"dark\"\`; this is intentional — the mode label is hidden from UI now and only matters for system-follow resolution.

## Test Steps

1. \`cd src/ui && bunx tsc -b\` — passes clean
2. \`cd src/ui && bun run test\` — 1010 tests pass
3. Run the app: \`cargo tauri dev\`
4. Open **Settings → Appearance**:
   - Verify the **Follow system** toggle is **off** by default
   - With toggle **off**: confirm a single **Color theme** picker shows all themes; pick different themes and confirm they apply
   - Toggle **on**: confirm **Dark theme** and **Light theme** pickers replace the single picker
   - Toggle from **on → off**: confirm the visible theme does not flash (it should match what you were just looking at)
   - With toggle **on**, change your OS appearance (System Settings → Appearance on macOS): confirm the app auto-switches between the configured dark and light themes

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)