### PR TITLE
fix(chat): scope blockToolMapRef by session id (#484)

### DIFF
--- a/src/ui/src/hooks/blockToolMap.test.ts
+++ b/src/ui/src/hooks/blockToolMap.test.ts
@@ -6,7 +6,7 @@ import {
   type BlockToolMap,
 } from "./blockToolMap";
 
-// Regression tests for issue #484. The map drives content_block_delta →
+// Regression tests for issue 484. The map drives content_block_delta →
 // tool input routing in useAgentStream. Before the fix it was a flat
 // Record<number, …> keyed only by content-block index, so two concurrent
 // sessions whose Anthropic API streams reused the same block index

--- a/src/ui/src/hooks/blockToolMap.test.ts
+++ b/src/ui/src/hooks/blockToolMap.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  setBlockTool,
+  getBlockTool,
+  clearBlockToolsForSession,
+  type BlockToolMap,
+} from "./blockToolMap";
+
+// Regression tests for issue #484. The map drives content_block_delta →
+// tool input routing in useAgentStream. Before the fix it was a flat
+// Record<number, …> keyed only by content-block index, so two concurrent
+// sessions whose Anthropic API streams reused the same block index
+// (which they routinely do — index 0 is the first block of every turn)
+// would overwrite each other's tool ids, and a ProcessExited for either
+// session blew away the whole map.
+
+describe("blockToolMap", () => {
+  describe("session isolation", () => {
+    it("keeps two sessions' entries at the same content-block index separate", () => {
+      const map: BlockToolMap = {};
+      setBlockTool(map, "sessA", 0, { toolUseId: "tool-a", toolName: "Bash" });
+      setBlockTool(map, "sessB", 0, { toolUseId: "tool-b", toolName: "Read" });
+
+      expect(getBlockTool(map, "sessA", 0)).toEqual({
+        toolUseId: "tool-a",
+        toolName: "Bash",
+      });
+      expect(getBlockTool(map, "sessB", 0)).toEqual({
+        toolUseId: "tool-b",
+        toolName: "Read",
+      });
+    });
+
+    it("scopes overwrites of the same index to a single session", () => {
+      const map: BlockToolMap = {};
+      setBlockTool(map, "sessA", 0, { toolUseId: "tool-a1", toolName: "Bash" });
+      setBlockTool(map, "sessA", 0, { toolUseId: "tool-a2", toolName: "Edit" });
+      setBlockTool(map, "sessB", 0, { toolUseId: "tool-b", toolName: "Read" });
+
+      expect(getBlockTool(map, "sessA", 0)).toEqual({
+        toolUseId: "tool-a2",
+        toolName: "Edit",
+      });
+      expect(getBlockTool(map, "sessB", 0)).toEqual({
+        toolUseId: "tool-b",
+        toolName: "Read",
+      });
+    });
+
+    it("returns undefined for a missing session even if another session has that index", () => {
+      const map: BlockToolMap = {};
+      setBlockTool(map, "sessA", 0, { toolUseId: "tool-a", toolName: "Bash" });
+      expect(getBlockTool(map, "sessB", 0)).toBeUndefined();
+    });
+  });
+
+  describe("clearBlockToolsForSession", () => {
+    it("only clears entries for the exiting session", () => {
+      const map: BlockToolMap = {};
+      setBlockTool(map, "sessA", 0, { toolUseId: "tool-a", toolName: "Bash" });
+      setBlockTool(map, "sessB", 0, { toolUseId: "tool-b", toolName: "Read" });
+      setBlockTool(map, "sessB", 1, { toolUseId: "tool-b2", toolName: "Edit" });
+
+      clearBlockToolsForSession(map, "sessA");
+
+      expect(getBlockTool(map, "sessA", 0)).toBeUndefined();
+      expect(getBlockTool(map, "sessB", 0)).toEqual({
+        toolUseId: "tool-b",
+        toolName: "Read",
+      });
+      expect(getBlockTool(map, "sessB", 1)).toEqual({
+        toolUseId: "tool-b2",
+        toolName: "Edit",
+      });
+    });
+
+    it("is a no-op for a session with no entries", () => {
+      const map: BlockToolMap = {};
+      setBlockTool(map, "sessA", 0, { toolUseId: "tool-a", toolName: "Bash" });
+
+      clearBlockToolsForSession(map, "sessB");
+
+      expect(getBlockTool(map, "sessA", 0)).toEqual({
+        toolUseId: "tool-a",
+        toolName: "Bash",
+      });
+    });
+  });
+});

--- a/src/ui/src/hooks/blockToolMap.ts
+++ b/src/ui/src/hooks/blockToolMap.ts
@@ -1,0 +1,37 @@
+/** What we track per content-block-start of type tool_use. */
+export type BlockToolEntry = { toolUseId: string; toolName: string };
+
+/**
+ * Per-session map: sessionId → (content-block index → tool entry).
+ *
+ * The Anthropic streaming protocol numbers content blocks within a single
+ * stream — so two concurrent sessions routinely reuse the same indices
+ * (e.g. block 0). Keying by sessionId prevents one session's tool ids from
+ * clobbering another's, and lets ProcessExited clean up only the exiting
+ * session without touching the rest.
+ */
+export type BlockToolMap = Record<string, Record<number, BlockToolEntry>>;
+
+export function setBlockTool(
+  map: BlockToolMap,
+  sessionId: string,
+  blockIndex: number,
+  entry: BlockToolEntry,
+): void {
+  (map[sessionId] ??= {})[blockIndex] = entry;
+}
+
+export function getBlockTool(
+  map: BlockToolMap,
+  sessionId: string,
+  blockIndex: number,
+): BlockToolEntry | undefined {
+  return map[sessionId]?.[blockIndex];
+}
+
+export function clearBlockToolsForSession(
+  map: BlockToolMap,
+  sessionId: string,
+): void {
+  delete map[sessionId];
+}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -7,6 +7,12 @@ import type { ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
 import { extractToolSummary } from "./toolSummary";
 import { parseAskUserQuestion } from "./parseAgentQuestion";
+import {
+  type BlockToolMap,
+  setBlockTool,
+  getBlockTool,
+  clearBlockToolsForSession,
+} from "./blockToolMap";
 import { debugChat } from "../utils/chatDebug";
 import { extractLatestCallUsage } from "../utils/extractLatestCallUsage";
 import { buildCompactionSentinel } from "../utils/compactionSentinel";
@@ -34,11 +40,12 @@ export function useAgentStream() {
   const setPlanMode = useAppStore((s) => s.setPlanMode);
   const addCompactionEvent = useAppStore((s) => s.addCompactionEvent);
 
-  // Map content block index → { toolUseId, toolName } for the current turn.
-  // Reset on process exit.
-  const blockToolMapRef = useRef<
-    Record<number, { toolUseId: string; toolName: string }>
-  >({});
+  // Per-session map: sessionId → (content-block index → tool entry). Two
+  // concurrent sessions routinely reuse the same Anthropic content-block
+  // indices, so a flat per-index map would let one session's tool ids
+  // clobber the other's. Cleared on each session's ProcessExited (only
+  // that session's slot — the rest stays intact).
+  const blockToolMapRef = useRef<BlockToolMap>({});
   // Per-session turn-state bookkeeping (keyed by session_id).
   const turnMessageCountRef = useRef<Record<string, number>>({});
   const turnFinalizedRef = useRef<Record<string, boolean>>({});
@@ -101,7 +108,7 @@ export function useAgentStream() {
         useAppStore.getState().clearPromptStartTime(wsId);
         setStreamingContent(sessionId, "");
         clearStreamingThinking(sessionId);
-        blockToolMapRef.current = {};
+        clearBlockToolsForSession(blockToolMapRef.current, sessionId);
         delete thinkingBlocksRef.current[sessionId];
         // NOTE: Do NOT clear agentQuestion here. In --print mode the CLI
         // exits immediately after emitting AskUserQuestion, so ProcessExited
@@ -232,7 +239,11 @@ export function useAgentStream() {
                     delta.type === "input_json_delta" &&
                     delta.partial_json
                   ) {
-                    const entry = blockToolMapRef.current[inner.index];
+                    const entry = getBlockTool(
+                      blockToolMapRef.current,
+                      sessionId,
+                      inner.index,
+                    );
                     if (entry) {
                       appendToolActivityInput(
                         sessionId,
@@ -246,7 +257,11 @@ export function useAgentStream() {
                     delta.type === "tool_use_delta" &&
                     delta.partial_json
                   ) {
-                    const entry = blockToolMapRef.current[inner.index];
+                    const entry = getBlockTool(
+                      blockToolMapRef.current,
+                      sessionId,
+                      inner.index,
+                    );
                     if (entry) {
                       appendToolActivityInput(
                         sessionId,
@@ -280,10 +295,15 @@ export function useAgentStream() {
                     "type" in inner.content_block &&
                     inner.content_block.type === "tool_use"
                   ) {
-                    blockToolMapRef.current[inner.index] = {
-                      toolUseId: inner.content_block.id,
-                      toolName: inner.content_block.name,
-                    };
+                    setBlockTool(
+                      blockToolMapRef.current,
+                      sessionId,
+                      inner.index,
+                      {
+                        toolUseId: inner.content_block.id,
+                        toolName: inner.content_block.name,
+                      },
+                    );
                     addToolActivity(sessionId, {
                       toolUseId: inner.content_block.id,
                       toolName: inner.content_block.name,
@@ -307,7 +327,11 @@ export function useAgentStream() {
                     thinkingBlocksRef.current[sessionId].delete(inner.index);
                     break;
                   }
-                  const entry = blockToolMapRef.current[inner.index];
+                  const entry = getBlockTool(
+                    blockToolMapRef.current,
+                    sessionId,
+                    inner.index,
+                  );
                   if (!entry) break;
 
                   // Read accumulated input JSON from the tool activity.


### PR DESCRIPTION
## Summary
- Closes #484. `blockToolMapRef` in `useAgentStream` was a flat `Record<number, …>` keyed only by Anthropic content-block index. Two concurrent chat sessions routinely reuse the same indices (every turn starts at 0), so each session would clobber the other's tool ids; subsequent `input_json_delta` events would route to the wrong tool or get dropped. Worse, ProcessExited cleared the *entire* map regardless of which session exited, so a single session finishing wiped every other session's in-flight tool state.
- Lift the data structure into a small per-session helper module (`blockToolMap.ts`) keyed by `sessionId`, and clear only the exiting session's entry on ProcessExited.

## Test plan
- [x] `blockToolMap.test.ts` regression tests for cross-session isolation and selective cleanup (2 sessions, overlapping indices)
- [x] `nix develop ../.. -c bun run test` — 65 files, 1019 tests passing
- [x] `nix develop ../.. -c bunx tsc -b` — clean
- [x] `nix develop -c cargo test --all-features` — 751 passing
- [x] `nix develop -c cargo clippy --workspace --all-targets` — clean
- [x] `nix develop -c cargo fmt --all --check` — clean
- [x] UAT in dev build: two concurrent sessions in different workspaces with prompts that trigger Bash. Traced `appendToolActivityInput` for both sessions → 22 calls, 11 per session, **0 cross-session leaks** and **0 orphaned tool ids**. One session completed while the other was still streaming; the still-running session retained its tool entry and finished with correct `inputJson` + summary, confirming ProcessExited no longer wipes other sessions.