### PR TITLE
perf(branch-refresh): focus-aware polling and bounded startup git probes

### DIFF
--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -1,13 +1,21 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use serde::Serialize;
 use tauri::State;
+use tokio::sync::Semaphore;
 
 use claudette::db::Database;
 use claudette::git;
 use claudette::model::{ChatMessage, Repository, Workspace};
 
 use crate::state::AppState;
+
+/// Caps concurrent `git` invocations during initial data load so a user
+/// with many repos/workspaces doesn't fork-bomb their machine on startup.
+/// Tuned at 6 — each git probe is short, but on a cold filesystem the
+/// system call cost dominates and unbounded fan-out can wedge slow disks.
+const STARTUP_GIT_PROBE_CONCURRENCY: usize = 6;
 
 #[derive(Serialize)]
 pub struct InitialData {
@@ -56,29 +64,35 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         })
         .collect();
 
+    let probe_sem = Arc::new(Semaphore::new(STARTUP_GIT_PROBE_CONCURRENCY));
+
     if !needs_backfill.is_empty() {
         use super::repository::{resolve_default_branch, resolve_default_remote};
 
         let backfill_futures: Vec<_> = needs_backfill
             .into_iter()
-            .map(|(id, path, existing_remote, existing_branch)| async move {
-                let remote = match existing_remote {
-                    Some(r) => Some(r),
-                    None => {
-                        let remotes = git::list_remotes(&path).await.unwrap_or_default();
-                        resolve_default_remote(&remotes)
-                    }
-                };
-                let branch = match existing_branch {
-                    Some(b) => Some(b),
-                    None => {
-                        let branches = git::list_remote_tracking_branches(&path)
-                            .await
-                            .unwrap_or_default();
-                        resolve_default_branch(&branches, remote.as_deref())
-                    }
-                };
-                (id, remote, branch)
+            .map(|(id, path, existing_remote, existing_branch)| {
+                let sem = Arc::clone(&probe_sem);
+                async move {
+                    let _permit = sem.acquire_owned().await.ok();
+                    let remote = match existing_remote {
+                        Some(r) => Some(r),
+                        None => {
+                            let remotes = git::list_remotes(&path).await.unwrap_or_default();
+                            resolve_default_remote(&remotes)
+                        }
+                    };
+                    let branch = match existing_branch {
+                        Some(b) => Some(b),
+                        None => {
+                            let branches = git::list_remote_tracking_branches(&path)
+                                .await
+                                .unwrap_or_default();
+                            resolve_default_branch(&branches, remote.as_deref())
+                        }
+                    };
+                    (id, remote, branch)
+                }
             })
             .collect();
 
@@ -102,7 +116,8 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         }
     }
 
-    // Resolve default branch for each valid repo concurrently (best-effort).
+    // Resolve default branch for each valid repo concurrently (best-effort,
+    // bounded by `probe_sem`).
     let branch_futures: Vec<_> = repositories
         .iter()
         .filter(|r| r.path_valid)
@@ -111,7 +126,9 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
             let path = r.path.clone();
             let base = r.base_branch.clone();
             let remote = r.default_remote.clone();
+            let sem = Arc::clone(&probe_sem);
             async move {
+                let _permit = sem.acquire_owned().await.ok();
                 let branch = match base {
                     Some(b) => Some(b),
                     None => git::default_branch(&path, remote.as_deref()).await.ok(),
@@ -123,7 +140,9 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
     let branch_results = futures::future::join_all(branch_futures).await;
     let default_branches: HashMap<String, String> = branch_results.into_iter().flatten().collect();
 
-    // Resolve current branch for each active workspace with a valid worktree path.
+    // Resolve current branch for each active workspace with a valid worktree path,
+    // bounded by `probe_sem` so a user with many workspaces doesn't fan-out
+    // unbounded git probes at startup.
     let workspace_branch_futures: Vec<_> = workspaces
         .iter()
         .filter(|ws| ws.status == claudette::model::WorkspaceStatus::Active)
@@ -134,7 +153,9 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
                 .map(|path| {
                     let id = ws.id.clone();
                     let path = path.clone();
+                    let sem = Arc::clone(&probe_sem);
                     async move {
+                        let _permit = sem.acquire_owned().await.ok();
                         match git::current_branch(&path).await {
                             Ok(branch) => (id, branch),
                             Err(_) => (id, "(detached)".to_string()),

--- a/src/ui/src/hooks/useBranchRefresh.test.ts
+++ b/src/ui/src/hooks/useBranchRefresh.test.ts
@@ -11,6 +11,9 @@ vi.mock("../services/tauri", () => ({
 }));
 
 import {
+  BRANCH_POLL_BASE_MS,
+  BRANCH_POLL_MAX_MS,
+  nextBranchPollDelay,
   pollAndApplyBranchUpdates,
   refreshSelectedWorkspaceBranch,
 } from "./useBranchRefresh";
@@ -20,15 +23,16 @@ describe("pollAndApplyBranchUpdates", () => {
     vi.clearAllMocks();
   });
 
-  it("applies every drift returned by the backend", async () => {
+  it("applies every drift returned by the backend and reports the count", async () => {
     mockRefreshBranches.mockResolvedValue([
       ["w1", "user/renamed"],
       ["w2", "feature/new"],
     ]);
     const updateWorkspace = vi.fn();
 
-    await pollAndApplyBranchUpdates(updateWorkspace);
+    const applied = await pollAndApplyBranchUpdates(updateWorkspace);
 
+    expect(applied).toBe(2);
     expect(updateWorkspace).toHaveBeenCalledTimes(2);
     expect(updateWorkspace).toHaveBeenNthCalledWith(1, "w1", {
       branch_name: "user/renamed",
@@ -38,23 +42,40 @@ describe("pollAndApplyBranchUpdates", () => {
     });
   });
 
-  it("makes no store writes when the backend returns no drift", async () => {
+  it("returns zero and writes nothing when the backend returns no drift", async () => {
     mockRefreshBranches.mockResolvedValue([]);
     const updateWorkspace = vi.fn();
 
-    await pollAndApplyBranchUpdates(updateWorkspace);
+    const applied = await pollAndApplyBranchUpdates(updateWorkspace);
 
+    expect(applied).toBe(0);
     expect(updateWorkspace).not.toHaveBeenCalled();
   });
 
-  it("swallows errors so the polling loop keeps running", async () => {
+  it("returns zero on backend error so the polling loop keeps running", async () => {
     mockRefreshBranches.mockRejectedValue(new Error("IPC down"));
     const updateWorkspace = vi.fn();
 
-    await expect(
-      pollAndApplyBranchUpdates(updateWorkspace),
-    ).resolves.toBeUndefined();
+    const applied = await pollAndApplyBranchUpdates(updateWorkspace);
+
+    expect(applied).toBe(0);
     expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+describe("nextBranchPollDelay", () => {
+  it("returns the base interval after a poll that observed drift", () => {
+    expect(nextBranchPollDelay(0)).toBe(BRANCH_POLL_BASE_MS);
+  });
+
+  it("doubles the interval on each consecutive empty poll", () => {
+    expect(nextBranchPollDelay(1)).toBe(BRANCH_POLL_BASE_MS * 2);
+    expect(nextBranchPollDelay(2)).toBe(BRANCH_POLL_BASE_MS * 4);
+  });
+
+  it("never grows beyond the cap", () => {
+    expect(nextBranchPollDelay(10)).toBe(BRANCH_POLL_MAX_MS);
+    expect(nextBranchPollDelay(100)).toBe(BRANCH_POLL_MAX_MS);
   });
 });
 

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -5,27 +5,46 @@ import type { Workspace } from "../types/workspace";
 
 type UpdateWorkspace = (id: string, updates: Partial<Workspace>) => void;
 
+/** Base poll interval when the window is focused and we have just observed drift. */
+export const BRANCH_POLL_BASE_MS = 5_000;
+/** Upper bound for back-off when consecutive polls report no drift. */
+export const BRANCH_POLL_MAX_MS = 30_000;
+
+/**
+ * Compute the next poll delay given how many consecutive polls have come back
+ * empty. Doubles from the base on each empty tick (5s → 10s → 20s → 30s cap).
+ * Reset to base any time drift is observed or the window regains focus.
+ */
+export function nextBranchPollDelay(consecutiveEmpty: number): number {
+  if (consecutiveEmpty <= 0) return BRANCH_POLL_BASE_MS;
+  const grown = BRANCH_POLL_BASE_MS * 2 ** consecutiveEmpty;
+  return Math.min(grown, BRANCH_POLL_MAX_MS);
+}
+
 /**
  * Poll all active workspaces for external branch-name drift and mirror any
  * detected changes into the Zustand store. Errors are swallowed so a
- * transient git/IPC failure doesn't break the polling loop.
+ * transient git/IPC failure doesn't break the polling loop. Returns the
+ * number of drift entries applied so the caller can adapt its cadence.
  */
 export async function pollAndApplyBranchUpdates(
   updateWorkspace: UpdateWorkspace,
-): Promise<void> {
+): Promise<number> {
   try {
     const updates = await refreshBranches();
     for (const [wsId, branchName] of updates) {
       updateWorkspace(wsId, { branch_name: branchName });
     }
+    return updates.length;
   } catch {
     // Silently ignore refresh errors
+    return 0;
   }
 }
 
 /**
  * Immediate refresh for a single workspace — called when the user selects
- * one so external renames appear without waiting on the 5s poll. Returns
+ * one so external renames appear without waiting on the poll. Returns
  * the new branch name if one was applied (useful for tests).
  */
 export async function refreshSelectedWorkspaceBranch(
@@ -43,17 +62,87 @@ export async function refreshSelectedWorkspaceBranch(
   }
 }
 
+function isWindowVisible(): boolean {
+  if (typeof document === "undefined") return true;
+  return !document.hidden;
+}
+
 export function useBranchRefresh() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
 
   useEffect(() => {
-    const refresh = () => pollAndApplyBranchUpdates(updateWorkspace);
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let consecutiveEmpty = 0;
+    let inFlight = false;
 
-    // Run immediately on mount, then poll.
-    refresh();
-    const interval = setInterval(refresh, 5000);
-    return () => clearInterval(interval);
+    const clearTimer = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const schedule = (delay: number) => {
+      clearTimer();
+      if (cancelled) return;
+      timer = setTimeout(tick, delay);
+    };
+
+    const tick = async () => {
+      timer = null;
+      if (cancelled) return;
+      // Skip the network round-trip when the window is hidden — no UI is
+      // visible to update, and waking up again on visibilitychange will
+      // refresh immediately. Reschedule a check at the back-off cap so we
+      // catch up shortly after the window comes back without spamming.
+      if (!isWindowVisible()) {
+        schedule(BRANCH_POLL_MAX_MS);
+        return;
+      }
+      if (inFlight) {
+        schedule(BRANCH_POLL_BASE_MS);
+        return;
+      }
+      inFlight = true;
+      const applied = await pollAndApplyBranchUpdates(updateWorkspace);
+      inFlight = false;
+      if (cancelled) return;
+      consecutiveEmpty = applied > 0 ? 0 : consecutiveEmpty + 1;
+      schedule(nextBranchPollDelay(consecutiveEmpty));
+    };
+
+    // Run immediately on mount, then enter the back-off loop.
+    void tick();
+
+    const onVisible = () => {
+      // Returning to visible: reset back-off and refresh now so the user
+      // sees current state without waiting on the (possibly long) timer.
+      if (!isWindowVisible()) return;
+      consecutiveEmpty = 0;
+      void tick();
+    };
+    const onFocus = () => onVisible();
+    const onBlur = () => {
+      // No need to immediately cancel — the next tick will see the hidden
+      // state and bail. But cancel anyway so a near-due timer doesn't
+      // perform a pointless probe right after blur.
+      clearTimer();
+      schedule(BRANCH_POLL_MAX_MS);
+    };
+
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("blur", onBlur);
+
+    return () => {
+      cancelled = true;
+      clearTimer();
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("blur", onBlur);
+    };
   }, [updateWorkspace]);
 
   // Immediate refresh when the user selects a workspace — picks up branch

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -62,9 +62,13 @@ export async function refreshSelectedWorkspaceBranch(
   }
 }
 
-function isWindowVisible(): boolean {
+function isAppActive(): boolean {
   if (typeof document === "undefined") return true;
-  return !document.hidden;
+  // Treat both hidden tabs (`document.hidden`) and unfocused-but-visible
+  // windows (`!document.hasFocus()`) as inactive. On macOS the user
+  // commonly Cmd-Tabs to another app — that blurs the window without
+  // hiding the document, so a hidden-only check would still poll there.
+  return !document.hidden && document.hasFocus();
 }
 
 export function useBranchRefresh() {
@@ -93,14 +97,12 @@ export function useBranchRefresh() {
     const tick = async () => {
       timer = null;
       if (cancelled) return;
-      // Skip the network round-trip when the window is hidden — no UI is
-      // visible to update, and waking up again on visibilitychange will
-      // refresh immediately. Reschedule a check at the back-off cap so we
-      // catch up shortly after the window comes back without spamming.
-      if (!isWindowVisible()) {
-        schedule(BRANCH_POLL_MAX_MS);
-        return;
-      }
+      // Skip the network round-trip when the app is inactive — no UI is
+      // visible to update, and waking up on focus/visibility will refresh
+      // immediately. Holding the timer empty (instead of rescheduling)
+      // means a backgrounded window won't keep firing pointless probes;
+      // the focus/visibility handler is the single source of resumption.
+      if (!isAppActive()) return;
       if (inFlight) {
         schedule(BRANCH_POLL_BASE_MS);
         return;
@@ -116,32 +118,35 @@ export function useBranchRefresh() {
     // Run immediately on mount, then enter the back-off loop.
     void tick();
 
-    const onVisible = () => {
-      // Returning to visible: reset back-off and refresh now so the user
-      // sees current state without waiting on the (possibly long) timer.
-      if (!isWindowVisible()) return;
+    const onResume = () => {
+      // App became active again: cancel any pending timer (otherwise we'd
+      // double-poll once the focus-driven `tick` schedules its own next
+      // delay), reset the back-off, and refresh now.
+      if (!isAppActive()) return;
+      clearTimer();
       consecutiveEmpty = 0;
       void tick();
     };
-    const onFocus = () => onVisible();
-    const onBlur = () => {
-      // No need to immediately cancel — the next tick will see the hidden
-      // state and bail. But cancel anyway so a near-due timer doesn't
-      // perform a pointless probe right after blur.
+    const onPause = () => {
+      // App went inactive — stop the timer outright. Resumption goes
+      // through `onResume`, which re-arms the loop.
       clearTimer();
-      schedule(BRANCH_POLL_MAX_MS);
     };
 
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", onFocus);
-    window.addEventListener("blur", onBlur);
+    const onVisibilityChange = () => {
+      if (isAppActive()) onResume();
+      else onPause();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", onResume);
+    window.addEventListener("blur", onPause);
 
     return () => {
       cancelled = true;
       clearTimer();
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", onFocus);
-      window.removeEventListener("blur", onBlur);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", onResume);
+      window.removeEventListener("blur", onPause);
     };
   }, [updateWorkspace]);
 

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -11,10 +11,18 @@
 //! selection.
 
 use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
 
 use crate::db::Database;
 use crate::git;
 use crate::model::WorkspaceStatus;
+
+/// Caps concurrent `git rev-parse` invocations driven by the periodic
+/// branch reconcile. Bounded so a user with dozens of active workspaces
+/// doesn't fan-out a fresh `git` process per workspace every poll tick.
+const RECONCILE_GIT_PROBE_CONCURRENCY: usize = 6;
 
 /// Re-read the current branch for every active workspace. For each workspace
 /// whose stored `branch_name` no longer matches the worktree's HEAD, persist
@@ -31,18 +39,35 @@ pub async fn reconcile_all_workspace_branches(
         db.list_workspaces().map_err(|e| e.to_string())?
     };
 
-    let mut updates = Vec::new();
-    for ws in &workspaces {
-        if ws.status != WorkspaceStatus::Active {
-            continue;
-        }
-        if let Some(ref wt_path) = ws.worktree_path
-            && let Ok(branch) = git::current_branch(wt_path).await
-            && branch != ws.branch_name
-        {
-            updates.push((ws.id.clone(), branch));
-        }
-    }
+    // Bounded-concurrent fan-out — capped by `RECONCILE_GIT_PROBE_CONCURRENCY`
+    // so a user with many active workspaces doesn't trigger an unbounded
+    // wave of `git rev-parse` processes on every poll tick.
+    let sem = Arc::new(Semaphore::new(RECONCILE_GIT_PROBE_CONCURRENCY));
+    let probe_futures: Vec<_> = workspaces
+        .iter()
+        .filter(|ws| ws.status == WorkspaceStatus::Active)
+        .filter_map(|ws| {
+            ws.worktree_path.as_ref().map(|wt_path| {
+                let id = ws.id.clone();
+                let wt_path = wt_path.clone();
+                let stored_branch = ws.branch_name.clone();
+                let sem = Arc::clone(&sem);
+                async move {
+                    let _permit = sem.acquire_owned().await.ok();
+                    match git::current_branch(&wt_path).await {
+                        Ok(branch) if branch != stored_branch => Some((id, branch)),
+                        _ => None,
+                    }
+                }
+            })
+        })
+        .collect();
+
+    let updates: Vec<(String, String)> = futures::future::join_all(probe_futures)
+        .await
+        .into_iter()
+        .flatten()
+        .collect();
 
     if !updates.is_empty() {
         let db = Database::open(db_path).map_err(|e| e.to_string())?;
@@ -353,6 +378,50 @@ mod tests {
         let w2 = all.iter().find(|w| w.id == "w2").unwrap();
         assert_eq!(w1.branch_name, "claudette/stable");
         assert_eq!(w2.branch_name, "user/renamed");
+    }
+
+    #[tokio::test]
+    async fn reconcile_all_handles_more_workspaces_than_concurrency_cap() {
+        // Spin up more workspaces than RECONCILE_GIT_PROBE_CONCURRENCY so the
+        // semaphore is genuinely exercised. Every odd-indexed workspace is
+        // renamed externally; the result must contain exactly those, in any
+        // order, with the DB updated to match.
+        let total = RECONCILE_GIT_PROBE_CONCURRENCY * 2 + 1;
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+
+        let mut repo_dirs = Vec::with_capacity(total);
+        let mut expected = Vec::new();
+        for i in 0..total {
+            let dir = tempfile::tempdir().unwrap();
+            init_git_repo(dir.path(), "claudette/orig");
+            let repo_id = format!("r{i}");
+            let ws_id = format!("w{i}");
+            db.insert_repository(&make_repo(&repo_id, dir.path()))
+                .unwrap();
+            db.insert_workspace(&make_ws(&ws_id, &repo_id, "claudette/orig", dir.path()))
+                .unwrap();
+            if i % 2 == 1 {
+                let new_branch = format!("user/r{i}");
+                rename_branch(dir.path(), &new_branch);
+                expected.push((ws_id, new_branch));
+            }
+            repo_dirs.push(dir);
+        }
+        drop(db);
+
+        let mut updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        updates.sort();
+        expected.sort();
+        assert_eq!(updates, expected);
+
+        let db = Database::open(&db_path).unwrap();
+        let all = db.list_workspaces().unwrap();
+        for (id, branch) in &expected {
+            let ws = all.iter().find(|w| &w.id == id).unwrap();
+            assert_eq!(&ws.branch_name, branch);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #488. Reduces branch refresh polling overhead when many workspaces/repos are active.

- **Frontend** (`useBranchRefresh.ts`): polling now pauses on `blur` / `visibilitychange→hidden` and resumes immediately on `focus` / `visibilitychange→visible`. Empty polls back off exponentially (5s → 10s → 20s → 30s cap), resetting to 5s on the first detected drift or on focus return.
- **Backend** (`commands/data.rs` and `workspace_sync.rs`): both the startup `load_initial_data` fan-out and the periodic `reconcile_all_workspace_branches` loop now route their `git` probes through a `tokio::sync::Semaphore` (cap of 6). The previous code fired unbounded concurrent processes at startup and reconciled sequentially per-tick — both are now bounded-parallel.

## Test plan

Unit tests:
- [x] `nextBranchPollDelay` covers base / doubling / capped cases.
- [x] `pollAndApplyBranchUpdates` reports the new applied count and surfaces error → 0.
- [x] `reconcile_all_handles_more_workspaces_than_concurrency_cap` exercises 13 workspaces (>2× the cap) through the new bounded-parallel path and verifies every drifted workspace updates correctly.
- [x] `cargo test --all-features` (752 passed) and `bun run test` (1017 passed).
- [x] `cargo clippy --workspace --all-targets` clean. `cargo fmt --all` and `tsc -b` clean.

UAT (live dev build):
- [x] Installed a debug probe inside the hook and observed against the running app:
  - Baseline focused: poll fires, then back-off lengthens (`consecutive_empty` advances, only one poll over 40s once cap reached).
  - `dispatchEvent("blur")`: zero polls for 18s — the timer was cleared and rescheduled at MAX.
  - `dispatchEvent("focus")`: poll count incremented within ~1s of dispatch.
- Note: the running dev DB had only 4 active workspaces (less than the cap of 6), so the bounded-concurrency behavior of `load_initial_data` is verified by the >cap unit test rather than live observation.

## Tuning

`STARTUP_GIT_PROBE_CONCURRENCY` and `RECONCILE_GIT_PROBE_CONCURRENCY` are both 6, matching the existing `scm_semaphore` precedent in `state.rs`. Either can be lifted later without a schema change.