### PR TITLE
style(terminal): match session tab underline styling

### DIFF
--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -20,12 +20,22 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
   cursor: pointer;
   font-size: 12px;
   color: var(--text-dim);
-  border-bottom: 2px solid transparent;
+  position: relative;
   transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.tab::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: transparent;
+  transition: background var(--transition-fast);
 }
 
 .tab:hover {
@@ -35,8 +45,11 @@
 
 .tabActive {
   color: var(--text-primary);
-  border-bottom-color: var(--accent-primary);
   background: transparent;
+}
+
+.tabActive::after {
+  background: var(--accent-primary);
 }
 
 .tabTitle {


### PR DESCRIPTION
## Summary

Terminal tabs used a 2px `border-bottom` plus a 4px `border-radius`, giving them a pill/badge appearance that didn't match session tabs (flat, 1px `::after` underline). This PR brings terminal tabs in line with the session tab pattern: no rounded corners, thin underline indicator on the active tab.

**Before:** rounded terminal tabs with thicker border-bottom underline.
**After:** flat terminal tabs with the same 1px accent underline used by session tabs.

The pattern mirrors `SessionTabs.module.css` exactly — `position: relative` on the tab, a `::after` pseudo-element pinned to the bottom edge, transitioning its `background` to `var(--accent-primary)` on the active state.

## Test Steps

1. `cargo tauri dev`
2. Open a workspace and reveal the integrated terminal panel.
3. Open at least two terminal tabs.
4. Verify:
   - The active terminal tab shows a 1px accent-colored underline along its bottom edge.
   - No tab has rounded corners.
   - Hovering an inactive tab still shifts its color/background.
   - Visual consistency with session tabs at the top of the chat panel.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)