### PR TITLE
style(dashboard): replace left-border accent with full border on active cards

### DIFF
--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -85,7 +85,6 @@
 .card {
   background: var(--hover-bg-subtle);
   border: 1px solid var(--divider);
-  border-left: 3px solid var(--status-idle);
   border-radius: 8px;
   padding: 14px 16px;
   cursor: pointer;
@@ -113,15 +112,11 @@
 }
 
 .cardRunning {
-  border-left-color: var(--status-running);
+  border-color: var(--status-running);
 }
 
 .cardStopped {
-  border-left-color: var(--status-stopped);
-}
-
-.cardIdle {
-  border-left-color: var(--status-idle);
+  border-color: var(--status-stopped);
 }
 
 .cardHeader {

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -85,8 +85,10 @@ const WorkspaceCard = memo(function WorkspaceCard({
       ? styles.cardRunning
       : ws.agent_status === "Stopped" || typeof ws.agent_status !== "string"
         ? styles.cardStopped
-        : styles.cardIdle,
-  ].join(" ");
+        : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   const statusTitle = isRunning
     ? "Running"


### PR DESCRIPTION
### Summary
Workspace cards on the Dashboard previously used a 3px colored left-border accent to indicate status (running = orange, stopped = red, idle = gray). This pattern has become a UI cliché and visually competes with the card's actual edge. This PR replaces it with a cleaner indicator: active (running/stopped) cards get a full-perimeter border in the status color, and idle cards just keep the plain `--divider` border.

The status color tokens (`--status-running`, `--status-stopped`) are unchanged, so the new indicator continues to theme correctly across all themes.

### Changes
- `Dashboard.module.css`: drop the `border-left: 3px solid var(--status-idle)` override on `.card`; switch `.cardRunning` / `.cardStopped` from `border-left-color` to `border-color` (full perimeter); remove the now-redundant `.cardIdle` rule.
- `Dashboard.tsx`: drop the `styles.cardIdle` branch (the base `.card` style covers idle now) and `.filter(Boolean)` the className list so the dropped branch doesn't pollute the className with `"undefined"`.

### Test Steps
1. `cargo tauri dev`
2. Open the Dashboard
3. Idle workspace cards should show a plain thin border with no colored accent
4. Trigger an agent run on a workspace; the card's full border should turn orange (or the active theme color)
5. Stop a session so it enters the Stopped state; the full border should turn red
6. Hover both active and idle cards — the hover border-color (`--text-faint`) should still apply uniformly

### Checklist
- [ ] Tests added/updated  *(CSS-only visual change; no behavior covered by existing tests changed)*
- [ ] Documentation updated (if applicable)  *(N/A)*