### PR TITLE
refactor(db): relocate stranded mod.rs tests to their domain modules

### DIFF
--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -1004,4 +1004,61 @@ mod tests {
         assert_eq!(origin, "agent");
         assert_eq!(tool_use_id.as_deref(), Some("toolu_123"));
     }
+
+    #[test]
+    fn test_last_message_per_workspace() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "feature"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            &db,
+            "m2",
+            "w1",
+            ChatRole::Assistant,
+            "second",
+        ))
+        .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            &db,
+            "m3",
+            "w2",
+            ChatRole::User,
+            "other workspace",
+        ))
+        .unwrap();
+
+        let last = db.last_message_per_workspace().unwrap();
+        assert_eq!(last.len(), 2);
+
+        let w1_msg = last.iter().find(|m| m.workspace_id == "w1").unwrap();
+        assert_eq!(w1_msg.content, "second");
+
+        let w2_msg = last.iter().find(|m| m.workspace_id == "w2").unwrap();
+        assert_eq!(w2_msg.content, "other workspace");
+    }
+
+    #[test]
+    fn test_last_message_per_workspace_same_timestamp() {
+        let db = setup_db_with_workspace();
+        // Insert two messages with identical timestamps — the later rowid should win.
+        let mut m1 = make_chat_msg(&db, "m1", "w1", ChatRole::User, "first");
+        m1.created_at = "2026-01-01 00:00:00".into();
+        let mut m2 = make_chat_msg(&db, "m2", "w1", ChatRole::Assistant, "second");
+        m2.created_at = "2026-01-01 00:00:00".into();
+        db.insert_chat_message(&m1).unwrap();
+        db.insert_chat_message(&m2).unwrap();
+
+        let last = db.last_message_per_workspace().unwrap();
+        assert_eq!(last.len(), 1);
+        assert_eq!(last[0].content, "second");
+    }
+
+    #[test]
+    fn test_last_message_empty_when_no_messages() {
+        let db = setup_db_with_workspace();
+        let last = db.last_message_per_workspace().unwrap();
+        assert!(last.is_empty());
+    }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -298,64 +298,6 @@ fn is_already_exists_error(err: &rusqlite::Error) -> bool {
 mod tests {
     use super::*;
     use crate::db::test_support::*;
-    use crate::model::ChatRole;
-
-    #[test]
-    fn test_last_message_per_workspace() {
-        let db = setup_db_with_workspace();
-        db.insert_workspace(&make_workspace("w2", "r1", "feature"))
-            .unwrap();
-        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "first"))
-            .unwrap();
-        db.insert_chat_message(&make_chat_msg(
-            &db,
-            "m2",
-            "w1",
-            ChatRole::Assistant,
-            "second",
-        ))
-        .unwrap();
-        db.insert_chat_message(&make_chat_msg(
-            &db,
-            "m3",
-            "w2",
-            ChatRole::User,
-            "other workspace",
-        ))
-        .unwrap();
-
-        let last = db.last_message_per_workspace().unwrap();
-        assert_eq!(last.len(), 2);
-
-        let w1_msg = last.iter().find(|m| m.workspace_id == "w1").unwrap();
-        assert_eq!(w1_msg.content, "second");
-
-        let w2_msg = last.iter().find(|m| m.workspace_id == "w2").unwrap();
-        assert_eq!(w2_msg.content, "other workspace");
-    }
-
-    #[test]
-    fn test_last_message_per_workspace_same_timestamp() {
-        let db = setup_db_with_workspace();
-        // Insert two messages with identical timestamps — the later rowid should win.
-        let mut m1 = make_chat_msg(&db, "m1", "w1", ChatRole::User, "first");
-        m1.created_at = "2026-01-01 00:00:00".into();
-        let mut m2 = make_chat_msg(&db, "m2", "w1", ChatRole::Assistant, "second");
-        m2.created_at = "2026-01-01 00:00:00".into();
-        db.insert_chat_message(&m1).unwrap();
-        db.insert_chat_message(&m2).unwrap();
-
-        let last = db.last_message_per_workspace().unwrap();
-        assert_eq!(last.len(), 1);
-        assert_eq!(last[0].content, "second");
-    }
-
-    #[test]
-    fn test_last_message_empty_when_no_messages() {
-        let db = setup_db_with_workspace();
-        let last = db.last_message_per_workspace().unwrap();
-        assert!(last.is_empty());
-    }
 
     // --- Migration runner tests ---
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -298,63 +298,7 @@ fn is_already_exists_error(err: &rusqlite::Error) -> bool {
 mod tests {
     use super::*;
     use crate::db::test_support::*;
-    use crate::model::{ChatRole, Repository};
-
-    // --- Repository settings tests ---
-
-    #[test]
-    fn test_update_repository_name() {
-        let db = Database::open_in_memory().unwrap();
-        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
-            .unwrap();
-        db.update_repository_name("r1", "My Custom Name").unwrap();
-        let repos = db.list_repositories().unwrap();
-        assert_eq!(repos[0].name, "My Custom Name");
-        // path_slug should remain unchanged
-        assert_eq!(repos[0].path_slug, "repo1");
-    }
-
-    #[test]
-    fn test_update_repository_icon() {
-        let db = Database::open_in_memory().unwrap();
-        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
-            .unwrap();
-
-        // Set icon
-        db.update_repository_icon("r1", Some("rocket")).unwrap();
-        let repos = db.list_repositories().unwrap();
-        assert_eq!(repos[0].icon.as_deref(), Some("rocket"));
-
-        // Clear icon
-        db.update_repository_icon("r1", None).unwrap();
-        let repos = db.list_repositories().unwrap();
-        assert!(repos[0].icon.is_none());
-    }
-
-    #[test]
-    fn test_repository_path_slug_persisted() {
-        let db = Database::open_in_memory().unwrap();
-        let repo = Repository {
-            id: "r1".into(),
-            path: "/tmp/my-project".into(),
-            name: "My Project".into(),
-            path_slug: "my-project".into(),
-            icon: None,
-            created_at: String::new(),
-            setup_script: None,
-            custom_instructions: None,
-            sort_order: 0,
-            branch_rename_preferences: None,
-            setup_script_auto_run: false,
-            base_branch: None,
-            default_remote: None,
-            path_valid: true,
-        };
-        db.insert_repository(&repo).unwrap();
-        let repos = db.list_repositories().unwrap();
-        assert_eq!(repos[0].name, "My Project");
-        assert_eq!(repos[0].path_slug, "my-project");
-    }
+    use crate::model::ChatRole;
 
     #[test]
     fn test_last_message_per_workspace() {

--- a/src/db/repository.rs
+++ b/src/db/repository.rs
@@ -248,4 +248,58 @@ mod tests {
             "id collision should not be mapped to the duplicate-path branch: {err:?}",
         );
     }
+
+    #[test]
+    fn test_update_repository_name() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.update_repository_name("r1", "My Custom Name").unwrap();
+        let repos = db.list_repositories().unwrap();
+        assert_eq!(repos[0].name, "My Custom Name");
+        // path_slug should remain unchanged
+        assert_eq!(repos[0].path_slug, "repo1");
+    }
+
+    #[test]
+    fn test_update_repository_icon() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+
+        // Set icon
+        db.update_repository_icon("r1", Some("rocket")).unwrap();
+        let repos = db.list_repositories().unwrap();
+        assert_eq!(repos[0].icon.as_deref(), Some("rocket"));
+
+        // Clear icon
+        db.update_repository_icon("r1", None).unwrap();
+        let repos = db.list_repositories().unwrap();
+        assert!(repos[0].icon.is_none());
+    }
+
+    #[test]
+    fn test_repository_path_slug_persisted() {
+        let db = Database::open_in_memory().unwrap();
+        let repo = Repository {
+            id: "r1".into(),
+            path: "/tmp/my-project".into(),
+            name: "My Project".into(),
+            path_slug: "my-project".into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+        };
+        db.insert_repository(&repo).unwrap();
+        let repos = db.list_repositories().unwrap();
+        assert_eq!(repos[0].name, "My Project");
+        assert_eq!(repos[0].path_slug, "my-project");
+    }
 }

--- a/src/db/repository.rs
+++ b/src/db/repository.rs
@@ -281,22 +281,8 @@ mod tests {
     #[test]
     fn test_repository_path_slug_persisted() {
         let db = Database::open_in_memory().unwrap();
-        let repo = Repository {
-            id: "r1".into(),
-            path: "/tmp/my-project".into(),
-            name: "My Project".into(),
-            path_slug: "my-project".into(),
-            icon: None,
-            created_at: String::new(),
-            setup_script: None,
-            custom_instructions: None,
-            sort_order: 0,
-            branch_rename_preferences: None,
-            setup_script_auto_run: false,
-            base_branch: None,
-            default_remote: None,
-            path_valid: true,
-        };
+        let mut repo = make_repo("r1", "/tmp/my-project", "My Project");
+        repo.path_slug = "my-project".into();
         db.insert_repository(&repo).unwrap();
         let repos = db.list_repositories().unwrap();
         assert_eq!(repos[0].name, "My Project");


### PR DESCRIPTION
## Summary

Cleanup follow-up to the `src/db.rs` god-file split (parent: #491, tracking: #495). Moves 6 tests that were stranded in `src/db/mod.rs::tests` to their proper domain modules. Pure test relocation — no production code changes, test count unchanged at 755.

- **3 repository tests → `src/db/repository.rs::tests`** (commit 1):
  - `test_update_repository_name`
  - `test_update_repository_icon`
  - `test_repository_path_slug_persisted`
- **3 chat tests → `src/db/chat.rs::tests`** (commit 2):
  - `test_last_message_per_workspace`
  - `test_last_message_per_workspace_same_timestamp`
  - `test_last_message_empty_when_no_messages`

The `// --- Repository settings tests ---` section header in `mod.rs::tests` is removed (the section is now empty). Unused `Repository` and `ChatRole` imports in `mod.rs::tests` are pruned.

All 6 tests use shared fixtures already in `src/db/test_support.rs` (`make_repo`, `make_workspace`, `setup_db_with_workspace`, `make_chat_msg`) — no fixture changes needed.

## What stays in `mod.rs::tests`

After this PR, `mod.rs::tests` contains only:
- Migration runner tests (~500 lines testing the migration system itself — they belong with the migration code which lives in `mod.rs`)
- A handful of chat-session-related tests that exercise behavior near migration boundaries (e.g. `test_chat_sessions_migration_backfills_sessions`, `test_save_chat_session_state_persists_session_id`) — these have stronger coupling to migration internals than to chat domain methods, and are deferred for a future judgment call.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --all-features` — 755 passed; 0 failed (count unchanged)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

## Refs

- Parent issue: #491 (god-file split)
- Tracking issue: #495 (db.rs domain split)
- Series: #492, #503, #504, #505, #507 (final PR landed the workspace + commands extraction)