### PR TITLE
fix(db): surface unknown enum values instead of silent fallback

### DIFF
--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -62,11 +62,14 @@ impl Database {
     pub(super) fn parse_chat_message_row(row: &rusqlite::Row) -> rusqlite::Result<ChatMessage> {
         let role_str: String = row.get(3)?;
         let chat_session_id: String = row.get::<_, Option<String>>(2)?.unwrap_or_default();
+        let role = role_str.parse().map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(e))
+        })?;
         Ok(ChatMessage {
             id: row.get(0)?,
             workspace_id: row.get(1)?,
             chat_session_id,
-            role: role_str.parse().unwrap(),
+            role,
             content: row.get(4)?,
             cost_usd: row.get(5)?,
             duration_ms: row.get(6)?,
@@ -193,6 +196,9 @@ impl Database {
 
     fn parse_chat_session_row(row: &rusqlite::Row) -> rusqlite::Result<ChatSession> {
         let status_str: String = row.get(7)?;
+        let status = status_str.parse().map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(e))
+        })?;
         Ok(ChatSession {
             id: row.get(0)?,
             workspace_id: row.get(1)?,
@@ -201,7 +207,7 @@ impl Database {
             name_edited: row.get::<_, i32>(4)? != 0,
             turn_count: row.get(5)?,
             sort_order: row.get(6)?,
-            status: status_str.parse().unwrap(),
+            status,
             created_at: row.get(8)?,
             archived_at: row.get(9)?,
             agent_status: AgentStatus::Idle,
@@ -1060,5 +1066,61 @@ mod tests {
         let db = setup_db_with_workspace();
         let last = db.last_message_per_workspace().unwrap();
         assert!(last.is_empty());
+    }
+
+    /// Regression: an unknown `role` string in the `chat_messages` table must
+    /// surface as a `FromSqlConversionFailure`, not silently become
+    /// `ChatRole::User`. See issue #485.
+    ///
+    /// We bypass the table's `CHECK(role IN (...))` constraint via
+    /// `PRAGMA ignore_check_constraints` so this test can simulate corrupted
+    /// data or a future-version row whose role string post-dates the CHECK.
+    #[test]
+    fn test_list_chat_messages_unknown_role_returns_error() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "hi"))
+            .unwrap();
+        db.conn
+            .execute_batch("PRAGMA ignore_check_constraints = ON;")
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE chat_messages SET role = 'unknown_role' WHERE id = 'm1'",
+                [],
+            )
+            .unwrap();
+        let result = db.list_chat_messages("w1");
+        assert!(
+            matches!(
+                result,
+                Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))
+            ),
+            "expected FromSqlConversionFailure for unknown role, got: {result:?}",
+        );
+    }
+
+    /// Regression: an unknown `status` string in the `chat_sessions` table
+    /// must surface as a `FromSqlConversionFailure`, not silently coerce to
+    /// `SessionStatus::Active`. See issue #485.
+    #[test]
+    fn test_list_chat_sessions_unknown_status_returns_error() {
+        let db = setup_db_with_workspace();
+        // The workspace was seeded with a default chat session — corrupt its status.
+        db.conn
+            .execute(
+                "UPDATE chat_sessions SET status = 'pending' WHERE workspace_id = 'w1'",
+                [],
+            )
+            .unwrap();
+        // include_archived = true so the WHERE filter doesn't pre-exclude the
+        // corrupt row before parse_chat_session_row gets a chance to see it.
+        let result = db.list_chat_sessions_for_workspace("w1", true);
+        assert!(
+            matches!(
+                result,
+                Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))
+            ),
+            "expected FromSqlConversionFailure for unknown session status, got: {result:?}",
+        );
     }
 }

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -1090,13 +1090,17 @@ mod tests {
             )
             .unwrap();
         let result = db.list_chat_messages("w1");
-        assert!(
-            matches!(
-                result,
-                Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))
-            ),
-            "expected FromSqlConversionFailure for unknown role, got: {result:?}",
-        );
+        match result {
+            Err(rusqlite::Error::FromSqlConversionFailure(idx, ty, _)) => {
+                assert_eq!(idx, 3, "expected chat_messages.role column index 3");
+                assert_eq!(
+                    ty,
+                    rusqlite::types::Type::Text,
+                    "expected chat_messages.role to be reported as TEXT"
+                );
+            }
+            other => panic!("expected FromSqlConversionFailure for unknown role, got: {other:?}",),
+        }
     }
 
     /// Regression: an unknown `status` string in the `chat_sessions` table
@@ -1115,12 +1119,18 @@ mod tests {
         // include_archived = true so the WHERE filter doesn't pre-exclude the
         // corrupt row before parse_chat_session_row gets a chance to see it.
         let result = db.list_chat_sessions_for_workspace("w1", true);
-        assert!(
-            matches!(
-                result,
-                Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))
+        match result {
+            Err(rusqlite::Error::FromSqlConversionFailure(idx, ty, _)) => {
+                assert_eq!(idx, 7, "expected chat_sessions.status column index 7");
+                assert_eq!(
+                    ty,
+                    rusqlite::types::Type::Text,
+                    "expected chat_sessions.status to be reported as TEXT"
+                );
+            }
+            other => panic!(
+                "expected FromSqlConversionFailure for unknown session status, got: {other:?}",
             ),
-            "expected FromSqlConversionFailure for unknown session status, got: {result:?}",
-        );
+        }
     }
 }

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -84,7 +84,13 @@ impl Database {
         )?;
         let rows = stmt.query_map([], |row| {
             let status_str: String = row.get(5)?;
-            let status: WorkspaceStatus = status_str.parse().unwrap();
+            let status: WorkspaceStatus = status_str.parse().map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    5,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
             let agent_status = if status == WorkspaceStatus::Archived {
                 crate::model::AgentStatus::Stopped
             } else {
@@ -1187,5 +1193,27 @@ mod tests {
             .unwrap();
         assert_eq!((turns_w1, adds_w1), (4, 12));
         assert_eq!((turns_w2, adds_w2), (9, 30));
+    }
+
+    /// Regression: an unknown `status` string in the `workspaces` table must
+    /// surface as a `FromSqlConversionFailure`, not silently coerce to a
+    /// default. See issue #485.
+    #[test]
+    fn test_list_workspaces_unknown_status_returns_error() {
+        let db = setup_db_with_workspace();
+        db.conn
+            .execute(
+                "UPDATE workspaces SET status = 'frozen' WHERE id = 'w1'",
+                [],
+            )
+            .unwrap();
+        let result = db.list_workspaces();
+        assert!(
+            matches!(
+                result,
+                Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))
+            ),
+            "expected FromSqlConversionFailure for unknown status, got: {result:?}",
+        );
     }
 }

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -1208,12 +1208,18 @@ mod tests {
             )
             .unwrap();
         let result = db.list_workspaces();
-        assert!(
-            matches!(
-                result,
-                Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))
-            ),
-            "expected FromSqlConversionFailure for unknown status, got: {result:?}",
-        );
+        match result {
+            Err(rusqlite::Error::FromSqlConversionFailure(idx, ty, _)) => {
+                assert_eq!(idx, 5, "expected workspaces.status column index 5");
+                assert_eq!(
+                    ty,
+                    rusqlite::types::Type::Text,
+                    "expected workspaces.status to be reported as TEXT"
+                );
+            }
+            other => {
+                panic!("expected FromSqlConversionFailure for unknown status, got: {other:?}",)
+            }
+        }
     }
 }

--- a/src/model/chat_message.rs
+++ b/src/model/chat_message.rs
@@ -18,15 +18,30 @@ impl ChatRole {
     }
 }
 
+/// Returned when a string doesn't correspond to any known [`ChatRole`].
+/// Surfacing the unknown value (instead of silently coercing) lets callers
+/// detect corrupted DB rows or values written by a forward-version of the app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseChatRoleError(pub String);
+
+impl std::fmt::Display for ParseChatRoleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown ChatRole value: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for ParseChatRoleError {}
+
 impl std::str::FromStr for ChatRole {
-    type Err = std::convert::Infallible;
+    type Err = ParseChatRoleError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "assistant" => Self::Assistant,
-            "system" => Self::System,
-            _ => Self::User,
-        })
+        match s {
+            "user" => Ok(Self::User),
+            "assistant" => Ok(Self::Assistant),
+            "system" => Ok(Self::System),
+            other => Err(ParseChatRoleError(other.to_string())),
+        }
     }
 }
 

--- a/src/model/chat_session.rs
+++ b/src/model/chat_session.rs
@@ -17,14 +17,29 @@ impl SessionStatus {
     }
 }
 
+/// Returned when a string doesn't correspond to any known [`SessionStatus`].
+/// Surfacing the unknown value (instead of silently coercing) lets callers
+/// detect corrupted DB rows or values written by a forward-version of the app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseSessionStatusError(pub String);
+
+impl std::fmt::Display for ParseSessionStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown SessionStatus value: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for ParseSessionStatusError {}
+
 impl std::str::FromStr for SessionStatus {
-    type Err = std::convert::Infallible;
+    type Err = ParseSessionStatusError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "archived" => Self::Archived,
-            _ => Self::Active,
-        })
+        match s {
+            "active" => Ok(Self::Active),
+            "archived" => Ok(Self::Archived),
+            other => Err(ParseSessionStatusError(other.to_string())),
+        }
     }
 }
 

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -39,14 +39,29 @@ impl WorkspaceStatus {
     }
 }
 
+/// Returned when a string doesn't correspond to any known [`WorkspaceStatus`].
+/// Surfacing the unknown value (instead of silently coercing) lets callers
+/// detect corrupted DB rows or values written by a forward-version of the app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseWorkspaceStatusError(pub String);
+
+impl std::fmt::Display for ParseWorkspaceStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown WorkspaceStatus value: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for ParseWorkspaceStatusError {}
+
 impl std::str::FromStr for WorkspaceStatus {
-    type Err = std::convert::Infallible;
+    type Err = ParseWorkspaceStatusError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "archived" => Self::Archived,
-            _ => Self::Active,
-        })
+        match s {
+            "active" => Ok(Self::Active),
+            "archived" => Ok(Self::Archived),
+            other => Err(ParseWorkspaceStatusError(other.to_string())),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #485.

The issue's premise was slightly off — `.parse().unwrap()` in `parse_chat_message_row`, `parse_chat_session_row`, and `list_workspaces` couldn't actually panic, because all three `FromStr` impls had `type Err = Infallible` with a wildcard fallback. But the underlying concern — that a corrupted row, manual DB edit, or value written by a forward-version of the app would behave incorrectly — was very real. The actual failure mode is **silent coercion to a default**, which is arguably worse than a panic:

- A `chat_messages.role = 'tool'` row from a hypothetical future version silently becomes `ChatRole::User`, misattributing who said what.
- A `workspaces.status = 'frozen'` row silently becomes `WorkspaceStatus::Active`, putting an in-an-unknown-state workspace in the active list.
- A `chat_sessions.status = 'pending'` row silently becomes `SessionStatus::Active`.

## What changed

**Models (`src/model/chat_message.rs`, `workspace.rs`, `chat_session.rs`):**
- Each enum gets a small newtype error: `ParseChatRoleError(pub String)`, `ParseWorkspaceStatusError(pub String)`, `ParseSessionStatusError(pub String)`.
- `FromStr::Err` changes from `std::convert::Infallible` to the new error type.
- The wildcard branch (`_ => Self::Default`) becomes `other => Err(...)` carrying the offending string.
- All three error types implement `Display` and `Error` so they compose into `rusqlite::Error`.

**DB call sites (`src/db/workspace.rs`, `src/db/chat.rs` — three sites):**
- `.parse().unwrap()` becomes `.parse().map_err(|e| rusqlite::Error::FromSqlConversionFailure(idx, Type::Text, Box::new(e)))?`.
- The column index in each `FromSqlConversionFailure` matches the row position the SELECT lists.

**Tests (one per enum, TDD):**
- Inserts a row with valid data via the normal API.
- Corrupts the enum value via raw SQL on `db.conn`.
- Calls the corresponding list method and asserts the result is `Err(rusqlite::Error::FromSqlConversionFailure(_, _, _))`.
- For `chat_messages.role`, the test bypasses the table's `CHECK(role IN ...)` constraint via `PRAGMA ignore_check_constraints = ON` so the corruption simulation works against a constrained table — exactly the scenario where a future version's CHECK might allow values today's code doesn't recognize.

I confirmed the tests fail under the previous (silent-fallback) behavior before applying the fix, then pass after — proper red→green TDD per the issue's recommendation.

## Scope of impact

`grep` confirmed the three db parse sites are the only callers of these `FromStr` impls — no UI code, no commands, no other crate. Changing the `Err` type from `Infallible` to a real error is safe.

The new error path means a single corrupt row will now break the entire `list_workspaces` / `list_chat_messages` / `list_chat_sessions_for_workspace` call (instead of silently misrendering one row). This trade-off is intentional: surfacing corruption is better than silent misattribution. If a real-world case needs lenient behavior (e.g. forward-compat with a known new variant), a future PR can add a `*_lenient` variant or a sanitize pass — better to start strict.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --all-features` — 758 passed; 0 failed (was 755 before this PR; +3 new regression tests)
- [x] `cargo clippy -p claudette -p claudette-server --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] All three regression tests fail under prior behavior, pass after the fix