### PR TITLE
refactor(ui): flatten ineffective dynamic imports flagged by Vite

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity, CompletedTurn } from "../../stores/useAppStore";
 import {
   loadChatHistory,
+  loadAttachmentData,
   loadAttachmentsForSession,
   readFileAsBase64,
   listCheckpoints,
@@ -165,7 +166,6 @@ function PdfThumbnail({ dataBase64, attachmentId, filename, className, onClick, 
       let b64 = dataBase64;
       // If no inline data, fetch on demand from the backend.
       if (!b64 && attachmentId) {
-        const { loadAttachmentData } = await import("../../services/tauri");
         b64 = await loadAttachmentData(attachmentId);
       }
       if (!b64 || cancelled) return;
@@ -321,7 +321,6 @@ export function ChatPanel() {
       attachmentId?: string,
     ): Promise<DownloadableAttachment> => {
       if (attachment.data_base64 || !attachmentId) return attachment;
-      const { loadAttachmentData } = await import("../../services/tauri");
       const data_base64 = await loadAttachmentData(attachmentId);
       return { ...attachment, data_base64 };
     },
@@ -2083,9 +2082,6 @@ const MessagesWithTurns = memo(function MessagesWithTurns({
                               // load to avoid IPC bloat — fetch on demand.
                               let b64 = att.data_base64;
                               if (!b64) {
-                                const { loadAttachmentData } = await import(
-                                  "../../services/tauri"
-                                );
                                 b64 = await loadAttachmentData(att.id);
                               }
                               await openAttachmentWithDefaultApp({

--- a/src/ui/src/components/chat/useAttachmentText.ts
+++ b/src/ui/src/components/chat/useAttachmentText.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { loadAttachmentData } from "../../services/tauri";
 import { base64ToBytes } from "../../utils/base64";
 
 /**
@@ -29,7 +30,6 @@ export function useAttachmentText(opts: {
       try {
         let b64 = data_base64 ?? null;
         if (!b64 && attachmentId) {
-          const { loadAttachmentData } = await import("../../services/tauri");
           b64 = await loadAttachmentData(attachmentId);
         }
         if (cancelled) return;

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -1,4 +1,5 @@
 import { save } from "@tauri-apps/plugin-dialog";
+import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import { invoke } from "@tauri-apps/api/core";
 
 import { base64ToBytes } from "./base64";
@@ -152,8 +153,7 @@ export async function copyAttachmentToClipboard(
       return;
     }
     if (typeof window !== "undefined") {
-      const mod = await import("@tauri-apps/plugin-clipboard-manager");
-      await mod.writeText(text);
+      await clipboardWriteText(text);
       return;
     }
     if (!clipboard) {


### PR DESCRIPTION
### Summary

Vite's Rollup pass was emitting two `INEFFECTIVE_DYNAMIC_IMPORT` warnings:

- `src/services/tauri.ts` — dynamically imported by `ChatPanel.tsx` (×3) and `useAttachmentText.ts`, but **already statically imported** by `App.tsx`, `ChatPanel.tsx` itself, `PinnedCommandsBar.tsx`, `PlanApprovalCard.tsx`, `SessionTabs.tsx`, etc.
- `@tauri-apps/plugin-clipboard-manager` — dynamically imported by `attachmentDownload.ts`, but **already statically imported** by `WorkspaceActions.tsx` and `EnvPanel.tsx`.

When Rollup sees a static import path into a module, it can't peel that module into a separate chunk, so the matching `await import()` adds a Promise round-trip while delivering zero code-splitting benefit. Convert those redundant dynamic imports to top-level static imports.

The genuinely lazy `pdfjs-dist` dynamic import (~410 kB chunk) in `ChatPanel.tsx` is **left untouched** — nothing pulls it into the main static graph, so it remains a real lazy-load win.

### Test Steps

1. Pull the branch and run a clean install:
   ```
   cd src/ui && bun install --frozen-lockfile
   ```
2. Confirm the Vite warnings are gone:
   ```
   bun run build
   ```
   The build output should no longer contain either `INEFFECTIVE_DYNAMIC_IMPORT` warning. (The unrelated chunk-size advisory remains.)
3. Type-check and run the frontend tests:
   ```
   bunx tsc -b
   bun run test --run
   ```
   Expect 0 type errors and 1038 passing tests across 67 files.
4. Spot-check the runtime behavior in `cargo tauri dev`:
   - Send a message with a PDF attachment, then re-open the workspace and verify the PDF thumbnail still loads (exercises `loadAttachmentData` static path in `ChatPanel.tsx`).
   - From an attachment menu, copy an SVG image to the clipboard and paste it into another app (exercises the `@tauri-apps/plugin-clipboard-manager` SVG fallback in `attachmentDownload.ts`).
   - Open `useAttachmentText`-backed text attachments (e.g. small `.txt`/`.md` files) and confirm they render.

### Checklist

- [x] Tests added/updated — existing 21 `attachmentDownload` tests still pass; behavior is unchanged so no new tests required.
- [ ] Documentation updated (if applicable) — n/a.