### PR TITLE
docs(i18n): document translation contribution process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Key principles:
 
 ## Translating Claudette
 
-Claudette is internationalized using [i18next](https://www.i18next.com/) on the frontend and a small bespoke loader on the Rust side. Today the app ships with English (`en`) and Spanish (`es`); UI strings, the system tray menu, native notifications, and the quit-confirm dialog are all localized. Missing keys fall back to English at runtime, so partial translations are safe to ship — they just leave a few English strings showing through.
+Claudette is internationalized using [i18next](https://www.i18next.com/) on the frontend and a small bespoke loader on the Rust side. Today the app ships with English (`en`) and Spanish (`es`). English is the complete baseline; Spanish is a partial translation that covers the tray menu, notifications, quit dialog, and the `common` / `settings` / `sidebar` frontend namespaces — the `chat` and `modals` namespaces are still empty and fall back to English. Missing keys fall back to English at runtime, so partial translations are safe to ship — they just leave a few English strings showing through.
 
 Adding a language is mostly a JSON-translation task. You don't need Rust or TypeScript experience to translate the strings; the small registration step at the end is just a handful of lines.
 
@@ -128,7 +128,7 @@ Both sides use the same `{{var}}` placeholder syntax for interpolation, so a tra
 2. **Copy the English files.** Duplicate `src/ui/src/locales/en/` and `src/locales/en/` to your new locale directory. Translate the **values**; leave the **keys** byte-for-byte identical to English.
 3. **Register the language on the frontend.** In `src/ui/src/i18n.ts`, add imports for each of the five namespace files, append your locale code to `SUPPORTED_LANGUAGES`, and add a matching entry to the `resources` map.
 4. **Update the TypeScript declaration** in `src/ui/src/types/i18next.d.ts` only if you've introduced a new namespace (most translation contributions don't need this).
-5. **Register the language on the backend.** In `src/i18n/mod.rs`, add a variant to the `Locale` enum, add an `include_str!` line for your `tray.json`, add a matching `*_store()` constant, and update `Locale::from_db_value` and `Locale::store` to recognize the new code.
+5. **Register the language on the backend.** In `src/i18n/mod.rs`, add a variant to the `Locale` enum, add an `include_str!` line for your `tray.json`, add a matching `*_store()` function alongside the existing `en_store()` / `es_store()` (each wraps a `OnceLock` over the parsed JSON), and update `Locale::from_db_value` and `Locale::store` to recognize the new code. Also extend the `locales_have_identical_key_sets` test in the same file to include your new store, so the parity check covers your locale.
 6. **Add the language to the selector** in Settings → General, following the existing pattern for English and Spanish.
 
 ### Updating an existing translation
@@ -143,7 +143,7 @@ If you'd like to fix a mistranslation or polish wording in an existing language,
 
 ### What CI checks
 
-- `cargo test --all-features` runs `locales_have_identical_key_sets` in `src/i18n/mod.rs`, which fails if any backend locale has missing or extra keys relative to English. Run it locally before opening a PR.
+- `cargo test --all-features` runs `locales_have_identical_key_sets` in `src/i18n/mod.rs`, which fails if the backend locales it includes (currently `en` and `es`) disagree on which keys exist. The check only covers the locales explicitly compared in the test, so when adding a new backend locale make sure to extend the test to include it (see the registration step above). Run the suite locally before opening a PR.
 - `cd src/ui && bunx tsc -b` enforces frontend type safety, which transitively catches mistyped translation keys consumed via `useTranslation()`.
 - `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` round out the standard checks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,46 @@ Key principles:
 - **React components** are organized by feature area in `src/ui/src/components/`
 - **State management** uses Zustand with domain slices
 
+## Translating Claudette
+
+Claudette is internationalized using [i18next](https://www.i18next.com/) on the frontend and a small bespoke loader on the Rust side. Today the app ships with English (`en`) and Spanish (`es`); UI strings, the system tray menu, native notifications, and the quit-confirm dialog are all localized. Missing keys fall back to English at runtime, so partial translations are safe to ship — they just leave a few English strings showing through.
+
+Adding a language is mostly a JSON-translation task. You don't need Rust or TypeScript experience to translate the strings; the small registration step at the end is just a handful of lines.
+
+### Where translation files live
+
+- **Frontend** — `src/ui/src/locales/<lang>/` contains five namespace files: `common.json`, `chat.json`, `modals.json`, `settings.json`, and `sidebar.json`.
+- **Backend** — `src/locales/<lang>/tray.json` contains the tray, notification, and quit-dialog strings.
+
+Both sides use the same `{{var}}` placeholder syntax for interpolation, so a translator only learns one convention.
+
+### Adding a new language
+
+1. **Pick a locale code.** Use the 2-letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) code (e.g. `fr`, `de`, `pt`). If you need a regional variant, use BCP-47 style (e.g. `pt-BR`, `zh-TW`).
+2. **Copy the English files.** Duplicate `src/ui/src/locales/en/` and `src/locales/en/` to your new locale directory. Translate the **values**; leave the **keys** byte-for-byte identical to English.
+3. **Register the language on the frontend.** In `src/ui/src/i18n.ts`, add imports for each of the five namespace files, append your locale code to `SUPPORTED_LANGUAGES`, and add a matching entry to the `resources` map.
+4. **Update the TypeScript declaration** in `src/ui/src/types/i18next.d.ts` only if you've introduced a new namespace (most translation contributions don't need this).
+5. **Register the language on the backend.** In `src/i18n/mod.rs`, add a variant to the `Locale` enum, add an `include_str!` line for your `tray.json`, add a matching `*_store()` constant, and update `Locale::from_db_value` and `Locale::store` to recognize the new code.
+6. **Add the language to the selector** in Settings → General, following the existing pattern for English and Spanish.
+
+### Updating an existing translation
+
+If you'd like to fix a mistranslation or polish wording in an existing language, just edit the relevant file under `src/ui/src/locales/<lang>/` or `src/locales/<lang>/tray.json` and open a PR — no registration steps required.
+
+### Conventions
+
+- **Keep `{{placeholder}}` interpolation tokens verbatim.** They're substituted at runtime; translating them will break the rendered string.
+- **Honor `_one` / `_other` plural keys.** If a key has both forms in English (i18next's plural convention), provide both forms in your language even if your language uses fewer plural categories — i18next will pick the right one.
+- **Match casing and punctuation choices** to the language's UI conventions, but be aware that some strings (e.g. button labels) have tight space budgets in the UI.
+
+### What CI checks
+
+- `cargo test --all-features` runs `locales_have_identical_key_sets` in `src/i18n/mod.rs`, which fails if any backend locale has missing or extra keys relative to English. Run it locally before opening a PR.
+- `cd src/ui && bunx tsc -b` enforces frontend type safety, which transitively catches mistyped translation keys consumed via `useTranslation()`.
+- `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` round out the standard checks.
+
+If you're not sure where to start, [open an issue](https://github.com/utensils/Claudette/issues/new) to claim a language so two contributors don't unknowingly translate in parallel.
+
 ## Pull Request Guidelines
 
 - Keep PRs focused — one feature or fix per PR

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ Join us on [Discord](https://discord.gg/aumGBKccmD) to ask questions, share feed
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) to get started. All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
+### Translations
+
+Claudette currently ships in English and Spanish, and we'd love help adding more languages. Translations live as JSON files under `src/ui/src/locales/<lang>/` (frontend) and `src/locales/<lang>/` (tray menu, notifications, and quit dialog) — most of the work is editing key/value pairs and requires no Rust or TypeScript experience. See [Translating Claudette](CONTRIBUTING.md#translating-claudette) in the Contributing Guide for the step-by-step recipe.
+
 ## Development notes
 
 - The project uses Rust edition 2024 and Bun as the frontend package manager.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
           autogenerate: { directory: 'quickstart' },
         },
         { slug: 'built-with' },
+        { slug: 'contributing-translations' },
         { slug: 'privacy' },
       ],
       lastUpdated: true,

--- a/site/src/content/docs/contributing-translations.md
+++ b/site/src/content/docs/contributing-translations.md
@@ -7,12 +7,10 @@ Claudette is built by a small team and a growing community. One of the most impa
 
 ## What's localized today
 
-The app ships with English and Spanish. Both cover:
+The app ships with English and Spanish:
 
-- The full UI (buttons, tooltips, settings, modals, chat, sidebar)
-- The system tray menu
-- Native notifications
-- The quit-confirm dialog when agents are still running
+- **English** is the complete baseline: the full UI (buttons, tooltips, settings, modals, chat, sidebar) plus the system tray menu, native notifications, and the quit-confirm dialog.
+- **Spanish** is a partial translation. The tray menu, notifications, quit dialog, and parts of the frontend UI (general settings, sidebar, common controls) are translated; the chat and modal namespaces are still empty and currently fall back to English.
 
 Missing translation keys fall back to English at runtime, so a partially translated language is safe to ship — anything not yet translated simply shows in English until someone fills it in.
 
@@ -31,7 +29,7 @@ Both sides use the same `{{name}}` placeholder syntax for inserting dynamic valu
 2. **Fork the repository** and create a feature branch.
 3. **Copy the English locale folders** to a new folder named with your language code (`fr`, `de`, `pt`, `pt-BR`, etc.) and translate the values. Keep the keys exactly as they are.
 4. **Register your language** so the app knows it exists — this is a small change to two files (one TypeScript, one Rust). The exact steps are in the [Contributing Guide on GitHub](https://github.com/utensils/Claudette/blob/main/CONTRIBUTING.md#translating-claudette).
-5. **Open a pull request.** CI runs a key-parity check that flags any keys you've missed or accidentally renamed, so you'll get fast feedback.
+5. **Open a pull request.** CI runs a key-parity check on the backend (`src/locales/<lang>/tray.json`) that fails if any of the locales it knows about disagree on which keys exist — note that adding a brand-new backend locale also means extending that test to include your locale. The frontend doesn't enforce parity; partial translations are fine and rely on English fallback for any keys you haven't filled in yet.
 
 If you only want to fix a typo or polish wording in an existing language, the process is even simpler — edit the relevant JSON file and open a PR. No registration step is required.
 

--- a/site/src/content/docs/contributing-translations.md
+++ b/site/src/content/docs/contributing-translations.md
@@ -1,0 +1,46 @@
+---
+title: Contributing Translations
+description: Help bring Claudette to your language. No Rust or TypeScript required.
+---
+
+Claudette is built by a small team and a growing community. One of the most impactful contributions you can make — especially if you're not a developer — is **translating the app into your language**.
+
+## What's localized today
+
+The app ships with English and Spanish. Both cover:
+
+- The full UI (buttons, tooltips, settings, modals, chat, sidebar)
+- The system tray menu
+- Native notifications
+- The quit-confirm dialog when agents are still running
+
+Missing translation keys fall back to English at runtime, so a partially translated language is safe to ship — anything not yet translated simply shows in English until someone fills it in.
+
+## How it works
+
+Translations live in the [Claudette repository](https://github.com/utensils/Claudette) as plain JSON files. Each language gets its own folder, and translating is mostly a matter of editing key/value pairs:
+
+- **Frontend strings** live in `src/ui/src/locales/<lang>/` and are split across five files by area (`common`, `chat`, `modals`, `settings`, `sidebar`).
+- **Tray, notification, and quit-dialog strings** live in `src/locales/<lang>/tray.json`.
+
+Both sides use the same `{{name}}` placeholder syntax for inserting dynamic values, so you only need to learn one convention.
+
+## How to contribute a translation
+
+1. **Open an issue** on GitHub to claim the language you want to translate. This stops two contributors from duplicating effort.
+2. **Fork the repository** and create a feature branch.
+3. **Copy the English locale folders** to a new folder named with your language code (`fr`, `de`, `pt`, `pt-BR`, etc.) and translate the values. Keep the keys exactly as they are.
+4. **Register your language** so the app knows it exists — this is a small change to two files (one TypeScript, one Rust). The exact steps are in the [Contributing Guide on GitHub](https://github.com/utensils/Claudette/blob/main/CONTRIBUTING.md#translating-claudette).
+5. **Open a pull request.** CI runs a key-parity check that flags any keys you've missed or accidentally renamed, so you'll get fast feedback.
+
+If you only want to fix a typo or polish wording in an existing language, the process is even simpler — edit the relevant JSON file and open a PR. No registration step is required.
+
+## A few translator tips
+
+- **Don't translate `{{placeholder}}` tokens.** They're swapped in at runtime; translating them will break the rendered string.
+- **Watch for tight UI space.** Some labels (especially in the sidebar and tray menu) have limited room. Prefer concise wording where the language allows.
+- **Plural forms** use i18next's `_one` / `_other` key convention. If English provides both, please provide both in your language too — i18next will pick the right one based on the count.
+
+## Questions?
+
+Hop into our [Discord](https://discord.gg/aumGBKccmD) and ask in the contributors channel, or open a discussion on GitHub. Translations are a fantastic way to make Claudette accessible to people who would otherwise have to work in a second language — thank you for helping out.


### PR DESCRIPTION
## Summary

Closes phase 3 of #362. The i18n infrastructure already shipped in #457 (frontend i18next + locales) and #523 (Rust-side tray / notifications / quit dialog), but the project had no contributor-facing documentation telling people **where translation files live, how to add a new language, or what CI will check.** This PR adds that documentation in three places:

- **`README.md`** — short Translations subsection under Contributing, pointing into CONTRIBUTING.md.
- **`CONTRIBUTING.md`** — full "Translating Claudette" section: file locations on both sides, six-step add-a-language recipe, conventions (`{{var}}` placeholders, `_one`/`_other` plurals), and the CI key-parity check.
- **`site/src/content/docs/contributing-translations.md`** — new Starlight page aimed at non-developers; warmer tone, explains the why and how, links out to CONTRIBUTING.md for the technical recipe. Sidebar entry added in `site/astro.config.mjs` alongside `built-with` and `privacy`.

No code, no new locale, no tooling commitment (Crowdin/Weblate is in #362 as a "consider" item — deferred to a follow-up if community demand materializes).

```mermaid
flowchart LR
    A[README.md<br/><i>3-sentence pointer</i>] --> B[CONTRIBUTING.md<br/><i>technical recipe</i>]
    C[Starlight site<br/><i>contributing-translations</i>] --> B
    B --> D[src/ui/src/locales/<lang>/<br/>5 namespace JSON files]
    B --> E[src/locales/<lang>/tray.json]
    B --> F[src/ui/src/i18n.ts<br/>+ src/i18n/mod.rs<br/><i>registration</i>]
```

## Complexity Notes

- The audience split is intentional: the Starlight page does **not** duplicate the technical recipe — it links into CONTRIBUTING.md so the step list lives in one place. If the recipe drifts (e.g. the `Locale` enum changes shape), reviewers should remember there's only one source of truth to update.
- The site sidebar entry is a top-level page, not a new "Contributing" group. If more contributor docs land later, that's the moment to refactor into a group.
- Symbols cited in the docs (`SUPPORTED_LANGUAGES`, `Locale::*`, `locales_have_identical_key_sets`) were verified against `src/ui/src/i18n.ts` and `src/i18n/mod.rs` before commit.

## Test Steps

1. **Read the README change** — confirm the Translations subsection sits between the existing Contributing paragraph and Development notes, and that the link `CONTRIBUTING.md#translating-claudette` resolves on GitHub.
2. **Read the CONTRIBUTING change** — verify the file paths (`src/ui/src/locales/<lang>/`, `src/locales/<lang>/tray.json`) and symbols (`SUPPORTED_LANGUAGES`, `Locale::from_db_value`, `locales_have_identical_key_sets`) match the current code.
3. **Build the site locally:**
   ```sh
   cd site && bun install && bun run build
   ```
   Open `site/dist/contributing-translations/index.html` in a browser. Confirm the page renders, headings are styled, and the sidebar contains the new entry between **Built With** and **Privacy**.
4. **Click through links on the new docs page** — Discord invite, GitHub repo, the link to `CONTRIBUTING.md#translating-claudette` on GitHub.
5. **Confirm no functional code changed** — `git diff origin/main...HEAD -- 'src/**' 'src-tauri/**' 'src-server/**'` should be empty.

## Checklist

- [ ] Tests added/updated *(N/A — docs-only; no executable code paths added)*
- [x] Documentation updated