### PR TITLE
docs(i18n): mark Spanish complete and add Brazilian Portuguese

### DIFF
--- a/site/src/content/docs/contributing-translations.md
+++ b/site/src/content/docs/contributing-translations.md
@@ -7,10 +7,11 @@ Claudette is built by a small team and a growing community. One of the most impa
 
 ## What's localized today
 
-The app ships with English and Spanish:
+The app ships with English, Spanish, and Brazilian Portuguese:
 
 - **English** is the complete baseline: the full UI (buttons, tooltips, settings, modals, chat, sidebar) plus the system tray menu, native notifications, and the quit-confirm dialog.
-- **Spanish** is a partial translation. The tray menu, notifications, quit dialog, and parts of the frontend UI (general settings, sidebar, common controls) are translated; the chat and modal namespaces are still empty and currently fall back to English.
+- **Spanish** is a complete translation: the full UI (buttons, tooltips, settings, modals, chat, sidebar) plus the system tray menu, native notifications, and the quit-confirm dialog.
+- **Brazilian Portuguese (pt-BR)** is a complete translation: the full UI plus the system tray menu, native notifications, and the quit-confirm dialog.
 
 Missing translation keys fall back to English at runtime, so a partially translated language is safe to ship — anything not yet translated simply shows in English until someone fills it in.
 


### PR DESCRIPTION
## Summary

The translation contribution guide (`site/src/content/docs/contributing-translations.md`) was out of date. It still described Spanish as a partial translation and didn't mention Brazilian Portuguese (pt-BR), which has shipped since the doc was written.

- Spanish was completed in `badbba6` — all 6 locale files (`chat`, `common`, `modals`, `settings`, `sidebar`, `tray`) are fully populated.
- Brazilian Portuguese was added in `5bcc998` — also fully complete across all 6 files.

This PR updates the "What's localized today" section to:
1. List all three shipped languages in the intro sentence.
2. Mark Spanish as a complete translation.
3. Add a Brazilian Portuguese (pt-BR) bullet describing its coverage.

## Test Steps

1. Open `site/src/content/docs/contributing-translations.md` and confirm the "What's localized today" section now lists English, Spanish, and Brazilian Portuguese as complete.
2. (Optional) From `site/`, run `bun install && bun run build` to confirm the Astro Starlight site builds with the updated content.
3. Sanity-check that the locale state described matches reality:
   - `ls src/ui/src/locales/es/ src/ui/src/locales/pt-BR/` — each should contain `chat.json`, `common.json`, `modals.json`, `settings.json`, `sidebar.json`.
   - `ls src/locales/es/tray.json src/locales/pt-BR/tray.json` — both should exist and be non-empty.

## Checklist

- [x] Documentation updated
- [ ] Tests added/updated (N/A — docs-only change)