### PR TITLE
feat(chat): add hover copy button to user messages

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -194,6 +194,9 @@
   padding: 4px;
   border-radius: 6px;
   opacity: 0;
+  /* Don't intercept clicks/text-selection while hidden — only bubble hover or
+     keyboard focus re-enables hit testing below. */
+  pointer-events: none;
   transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
   display: flex;
   align-items: center;
@@ -203,6 +206,7 @@
 
 .role_User:hover .userMessageCopyButton {
   opacity: 0.7;
+  pointer-events: auto;
 }
 
 .role_User:hover .userMessageCopyButton:hover {
@@ -214,6 +218,7 @@
 
 .userMessageCopyButton:focus-visible {
   opacity: 1;
+  pointer-events: auto;
   outline: 2px solid var(--accent-primary);
   outline-offset: 1px;
 }

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -183,6 +183,41 @@
   color: var(--text-muted);
 }
 
+.userMessageCopyButton {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.role_User:hover .userMessageCopyButton {
+  opacity: 0.7;
+}
+
+.role_User:hover .userMessageCopyButton:hover {
+  opacity: 1;
+  background: var(--hover-bg);
+  border-color: var(--divider);
+  color: var(--text-primary);
+}
+
+.userMessageCopyButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
 /* Assistant messages — clean prose, no chrome */
 .role_Assistant {
   background: transparent;

--- a/src/ui/src/components/chat/MessageCopyButton.tsx
+++ b/src/ui/src/components/chat/MessageCopyButton.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export function MessageCopyButton({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const { t } = useTranslation("chat");
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          setCopied(true);
+          if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+          timeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
+        })
+        .catch((err) => console.error("Copy message failed:", err));
+    },
+    [text],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const label = copied ? t("message_copied") : t("message_copy");
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={handleCopy}
+      title={label}
+      aria-label={label}
+    >
+      {copied ? (
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/ui/src/components/chat/MessageCopyButton.tsx
+++ b/src/ui/src/components/chat/MessageCopyButton.tsx
@@ -33,15 +33,13 @@ export function MessageCopyButton({
     };
   }, []);
 
-  const label = copied ? t("message_copied") : t("message_copy");
-
   return (
     <button
       type="button"
       className={className}
       onClick={handleCopy}
-      title={label}
-      aria-label={label}
+      title={copied ? t("message_copied") : t("message_copy")}
+      aria-label={t("message_copy")}
     >
       {copied ? (
         <svg

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -40,6 +40,7 @@ import styles from "./ChatPanel.module.css";
 import { TurnSummary } from "./TurnSummary";
 import { TurnFooter } from "./TurnFooter";
 import { PdfThumbnail } from "./PdfThumbnail";
+import { MessageCopyButton } from "./MessageCopyButton";
 import {
   EMPTY_ATTACHMENTS,
   EMPTY_CHECKPOINTS,
@@ -388,6 +389,12 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
               <div className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}`}>
                 {msg.role === "User" && (
                   <div className={styles.roleLabel}>{t("you_label")}</div>
+                )}
+                {msg.role === "User" && msg.content.length > 0 && (
+                  <MessageCopyButton
+                    text={msg.content}
+                    className={styles.userMessageCopyButton}
+                  />
                 )}
                 {msg.role === "Assistant" && msg.thinking && showThinkingBlocks && (
                   <ThinkingBlock content={msg.thinking} isStreaming={false} searchQuery={searchQuery} />

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -101,6 +101,8 @@
 
   "code_block_copy": "Copy code",
   "code_block_copied": "Copied",
+  "message_copy": "Copy message",
+  "message_copied": "Copied",
   "attachment_close_lightbox": "Close image preview",
 
   "mcp_unknown_error": "unknown",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -101,6 +101,8 @@
 
   "code_block_copy": "Copiar código",
   "code_block_copied": "Copiado",
+  "message_copy": "Copiar mensaje",
+  "message_copied": "Copiado",
   "attachment_close_lightbox": "Cerrar vista previa de imagen",
 
   "mcp_unknown_error": "desconocido",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -101,6 +101,8 @@
 
   "code_block_copy": "Copiar código",
   "code_block_copied": "Copiado",
+  "message_copy": "Copiar mensagem",
+  "message_copied": "Copiado",
   "attachment_close_lightbox": "Fechar visualização da imagem",
 
   "mcp_unknown_error": "desconhecido",


### PR DESCRIPTION
## Summary

Adds a small copy-to-clipboard affordance to user-message bubbles in chat. On hover, a copy icon fades in at the top-right of the bubble (~70% opacity). Clicking it copies the raw message text via `navigator.clipboard.writeText` and briefly swaps to a checkmark for ~1.2s, matching the existing affordance on code blocks (`CodeBlock.tsx`) and turn footers (`TurnFooter.tsx`).

The button is conditionally rendered — only when `msg.content.length > 0` — so attachment-only messages, which have nothing meaningful to copy, do not show the button.

Implementation notes:
- New self-contained component `src/ui/src/components/chat/MessageCopyButton.tsx`. Mirrors the established pattern from `CodeBlock.tsx`: `useState` `copied` flag, `useRef` timeout cleared on unmount, custom inline copy/check SVGs (kept consistent with the rest of chat — `lucide-react` is intentionally avoided here so all chat copy buttons share visuals).
- Hover reveal is **CSS-only** (`.role_User:hover .userMessageCopyButton { opacity: 0.7 }`) — no React hover state, so we don't burn re-renders on cursor moves over a long message list.
- The `.role_User` container already had `position: relative`, so the button absolutely positions cleanly without restructuring the existing JSX.
- Translations added for `en`, `es`, and `pt-BR` (`message_copy` / `message_copied`) — same set of locales the recently-merged #526 / #527 keep complete.

## Complexity Notes

- `useCallback` for the copy handler depends on `text` — every re-render with a different message string recreates the handler. This is intentional: without it, the closure would capture a stale message and copy the wrong text after the user edits/regens a message.
- The button renders as a sibling of `roleLabel` and `content` (not nested inside `content`). This is deliberate — `.role_User .content` has `white-space: pre-wrap`, which would otherwise apply to the button's accessible name and SVG layout.
- Frontend i18n parity is **not** CI-enforced (the `locales_have_identical_key_sets` test only checks backend `tray.json`), but I added all three locales anyway to avoid English fallbacks bleeding into the now-complete Spanish/pt-BR chat translations.

## Test Steps

1. `cargo tauri dev` and open any session.
2. Send a multi-line user message.
3. Hover the user bubble — a copy icon fades in at the top-right at ~70% opacity.
4. Mouse off the bubble — icon fades out.
5. Click the icon — it swaps to a checkmark for ~1.2s. Paste somewhere external (e.g., a text editor) and confirm the **exact** text was copied, including any newlines.
6. Send a message with **only an image attachment** (no typed text) — no copy icon should appear on that bubble.
7. Tab-focus through the bubble — the button shows the `focus-visible` outline; Enter/Space activates it.
8. Verify on both light and dark themes that the icon contrast against `--chat-user-bg` is acceptable.
9. Switch UI language to Spanish (Settings → General → Language) — the button tooltip should read "Copiar mensaje" / "Copiado".
10. Switch to Brazilian Portuguese — should read "Copiar mensagem" / "Copiado".

## Checklist

- [ ] Tests added/updated  *(no new tests — pure JSX/CSS hover affordance with the same copy logic already covered indirectly via `CodeBlock`/`TurnFooter` patterns; manual UAT covers the click + clipboard path)*
- [x] Documentation updated (if applicable)  *(N/A — no user-facing docs changed; translations added per the i18n contributing guide)*