### PR TITLE
fix(i18n): refactor modal warnings to use Trans (#529 follow-up)

### DIFF
--- a/src/ui/src/components/modals/ConfirmNightlyChannelModal.tsx
+++ b/src/ui/src/components/modals/ConfirmNightlyChannelModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { applyUpdateChannel } from "../../hooks/useAutoUpdater";
 import { Modal } from "./Modal";
@@ -31,9 +31,11 @@ export function ConfirmNightlyChannelModal() {
   return (
     <Modal title={t("nightly_title")} onClose={handleClose}>
       <div className={shared.warning}>
-        {t("nightly_warning_pre")}{" "}
-        <strong>main</strong>{" "}
-        {t("nightly_warning_post")}
+        <Trans
+          i18nKey="nightly_warning"
+          ns="modals"
+          components={{ strong: <strong /> }}
+        />
       </div>
       {error && <div className={shared.error}>{error}</div>}
       <div className={shared.actions}>

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { runWorkspaceSetup, setSetupScriptAutoRun } from "../../services/tauri";
 import { Modal } from "./Modal";
@@ -78,7 +78,12 @@ export function ConfirmSetupScriptModal() {
   return (
     <Modal title={t("setup_script_title")} onClose={closeModal}>
       <div className={shared.warning}>
-        {t("setup_script_warning_pre")} <strong>{label}</strong> {t("setup_script_warning_post")}
+        <Trans
+          i18nKey="setup_script_warning"
+          ns="modals"
+          values={{ source: label }}
+          components={{ strong: <strong /> }}
+        />
       </div>
       <div className={shared.field}>
         <label className={shared.label}>{t("setup_script_label")}</label>

--- a/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
+++ b/src/ui/src/components/modals/DeleteWorkspaceModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { deleteWorkspace } from "../../services/tauri";
 import { Modal } from "./Modal";
@@ -30,7 +30,12 @@ export function DeleteWorkspaceModal() {
   return (
     <Modal title={t("delete_workspace_title")} onClose={closeModal}>
       <div className={shared.warning}>
-        {t("delete_workspace_warning_pre")} <strong>{wsName}</strong>{t("delete_workspace_warning_post")}
+        <Trans
+          i18nKey="delete_workspace_warning"
+          ns="modals"
+          values={{ name: wsName }}
+          components={{ strong: <strong /> }}
+        />
       </div>
       <div className={shared.actions}>
         <button className={shared.btn} onClick={closeModal}>

--- a/src/ui/src/components/modals/RelinkRepoModal.tsx
+++ b/src/ui/src/components/modals/RelinkRepoModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { relinkRepository } from "../../services/tauri";
 import { Modal } from "./Modal";
@@ -37,7 +37,12 @@ export function RelinkRepoModal() {
   return (
     <Modal title={t("relink_title")} onClose={closeModal}>
       <div className={shared.warning}>
-        {t("relink_warning_pre")} <strong>{repoName}</strong> {t("relink_warning_post")}
+        <Trans
+          i18nKey="relink_warning"
+          ns="modals"
+          values={{ name: repoName }}
+          components={{ strong: <strong /> }}
+        />
       </div>
       <div className={shared.field}>
         <label className={shared.label}>{t("relink_new_path_label")}</label>

--- a/src/ui/src/components/modals/RemoveRepoModal.tsx
+++ b/src/ui/src/components/modals/RemoveRepoModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { removeRepository } from "../../services/tauri";
 import { Modal } from "./Modal";
@@ -37,7 +37,12 @@ export function RemoveRepoModal() {
   return (
     <Modal title={t("remove_repo_title")} onClose={closeModal}>
       <div className={shared.warning}>
-        {t("remove_repo_warning_pre")} <strong>{repoName}</strong>{t("remove_repo_warning_post")}
+        <Trans
+          i18nKey="remove_repo_warning"
+          ns="modals"
+          values={{ name: repoName }}
+          components={{ strong: <strong /> }}
+        />
       </div>
       {(active > 0 || archived > 0) && (
         <div className={shared.warning}>

--- a/src/ui/src/locales/en/modals.json
+++ b/src/ui/src/locales/en/modals.json
@@ -1,7 +1,6 @@
 {
   "delete_workspace_title": "Delete workspace",
-  "delete_workspace_warning_pre": "Are you sure you want to delete",
-  "delete_workspace_warning_post": "? The branch and any unmerged commits will be permanently deleted.",
+  "delete_workspace_warning": "Are you sure you want to delete <strong>{{name}}</strong>? The branch and any unmerged commits will be permanently deleted.",
   "delete_workspace_deleting": "Deleting...",
   "delete_workspace_confirm": "Delete",
 
@@ -26,22 +25,19 @@
   "rollback_confirm": "Roll Back",
 
   "nightly_title": "Switch to nightly channel?",
-  "nightly_warning_pre": "Nightly builds are untested pre-releases built from the latest",
-  "nightly_warning_post": "branch. They may contain bugs or break features. You can switch back to Stable at any time.",
+  "nightly_warning": "Nightly builds are untested pre-releases built from the latest <strong>main</strong> branch. They may contain bugs or break features. You can switch back to Stable at any time.",
   "nightly_switching": "Switching...",
   "nightly_confirm": "Switch to Nightly",
 
   "relink_title": "Re-link repository",
-  "relink_warning_pre": "Path for",
-  "relink_warning_post": "is no longer valid. Provide the new location.",
+  "relink_warning": "Path for <strong>{{name}}</strong> is no longer valid. Provide the new location.",
   "relink_new_path_label": "New path",
   "relink_new_path_placeholder": "/new/path/to/repository",
   "relink_relinking": "Re-linking...",
   "relink_confirm": "Re-link",
 
   "remove_repo_title": "Remove repository",
-  "remove_repo_warning_pre": "Are you sure you want to remove",
-  "remove_repo_warning_post": "? This will not delete the repository from disk, only unregister it.",
+  "remove_repo_warning": "Are you sure you want to remove <strong>{{name}}</strong>? This will not delete the repository from disk, only unregister it.",
   "remove_repo_will_destroy_pre": "Will permanently destroy:",
   "remove_repo_active": "{{count}} active",
   "remove_repo_archived": "{{count}} archived",
@@ -57,8 +53,7 @@
   "share_done": "Done",
 
   "setup_script_title": "Review setup script",
-  "setup_script_warning_pre": "This workspace has a setup script from",
-  "setup_script_warning_post": "that will be executed. Please review it before proceeding.",
+  "setup_script_warning": "This workspace has a setup script from <strong>{{source}}</strong> that will be executed. Please review it before proceeding.",
   "setup_script_source_repo_settings": "repo settings",
   "setup_script_label": "Script",
   "setup_script_always_run": "Always run setup scripts for this repo",

--- a/src/ui/src/locales/es/modals.json
+++ b/src/ui/src/locales/es/modals.json
@@ -1,7 +1,6 @@
 {
   "delete_workspace_title": "Eliminar espacio de trabajo",
-  "delete_workspace_warning_pre": "¿Seguro que quieres eliminar",
-  "delete_workspace_warning_post": "? La rama y los commits sin fusionar se eliminarán permanentemente.",
+  "delete_workspace_warning": "¿Seguro que quieres eliminar <strong>{{name}}</strong>? La rama y los commits sin fusionar se eliminarán permanentemente.",
   "delete_workspace_deleting": "Eliminando...",
   "delete_workspace_confirm": "Eliminar",
 
@@ -26,22 +25,19 @@
   "rollback_confirm": "Revertir",
 
   "nightly_title": "¿Cambiar al canal nocturno?",
-  "nightly_warning_pre": "Las versiones nocturnas son prelanzamientos sin probar construidos desde la rama",
-  "nightly_warning_post": "más reciente. Pueden contener errores o romper funciones. Puedes volver a Estable en cualquier momento.",
+  "nightly_warning": "Las versiones nocturnas son prelanzamientos sin probar construidos desde la rama <strong>main</strong> más reciente. Pueden contener errores o romper funciones. Puedes volver a Estable en cualquier momento.",
   "nightly_switching": "Cambiando...",
   "nightly_confirm": "Cambiar a Nocturna",
 
   "relink_title": "Volver a vincular repositorio",
-  "relink_warning_pre": "La ruta de",
-  "relink_warning_post": "ya no es válida. Indica la nueva ubicación.",
+  "relink_warning": "La ruta de <strong>{{name}}</strong> ya no es válida. Indica la nueva ubicación.",
   "relink_new_path_label": "Nueva ruta",
   "relink_new_path_placeholder": "/new/path/to/repository",
   "relink_relinking": "Volviendo a vincular...",
   "relink_confirm": "Volver a vincular",
 
   "remove_repo_title": "Quitar repositorio",
-  "remove_repo_warning_pre": "¿Seguro que quieres quitar",
-  "remove_repo_warning_post": "? Esto no eliminará el repositorio del disco, solo lo desregistrará.",
+  "remove_repo_warning": "¿Seguro que quieres quitar <strong>{{name}}</strong>? Esto no eliminará el repositorio del disco, solo lo desregistrará.",
   "remove_repo_will_destroy_pre": "Destruirá permanentemente:",
   "remove_repo_active": "{{count}} activo",
   "remove_repo_archived": "{{count}} archivado",
@@ -57,8 +53,7 @@
   "share_done": "Listo",
 
   "setup_script_title": "Revisar script de configuración",
-  "setup_script_warning_pre": "Este espacio de trabajo tiene un script de configuración de",
-  "setup_script_warning_post": "que se ejecutará. Por favor, revísalo antes de continuar.",
+  "setup_script_warning": "Este espacio de trabajo tiene un script de configuración de <strong>{{source}}</strong> que se ejecutará. Por favor, revísalo antes de continuar.",
   "setup_script_source_repo_settings": "configuración del repositorio",
   "setup_script_label": "Script",
   "setup_script_always_run": "Ejecutar siempre los scripts de configuración para este repositorio",

--- a/src/ui/src/locales/ja/modals.json
+++ b/src/ui/src/locales/ja/modals.json
@@ -1,7 +1,6 @@
 {
   "delete_workspace_title": "ワークスペースを削除",
-  "delete_workspace_warning_pre": "「",
-  "delete_workspace_warning_post": "」を削除してもよろしいですか？ブランチと未マージのコミットは完全に削除されます。",
+  "delete_workspace_warning": "ワークスペース「<strong>{{name}}</strong>」を削除してもよろしいですか？ブランチと未マージのコミットは完全に削除されます。",
   "delete_workspace_deleting": "削除中...",
   "delete_workspace_confirm": "削除",
 
@@ -26,22 +25,19 @@
   "rollback_confirm": "ロールバック",
 
   "nightly_title": "ナイトリーチャネルに切り替えますか？",
-  "nightly_warning_pre": "ナイトリービルドは最新の ",
-  "nightly_warning_post": " ブランチからビルドされた、テストされていないプレリリースです。バグや機能の不具合が含まれる可能性があります。「安定版」へはいつでも戻せます。",
+  "nightly_warning": "ナイトリービルドは最新の <strong>main</strong> ブランチからビルドされた、テストされていないプレリリースです。バグや機能の不具合が含まれる可能性があります。「安定版」へはいつでも戻せます。",
   "nightly_switching": "切り替え中...",
   "nightly_confirm": "ナイトリーに切り替え",
 
   "relink_title": "リポジトリを再リンク",
-  "relink_warning_pre": "「",
-  "relink_warning_post": "」のパスは無効になりました。新しい場所を指定してください。",
+  "relink_warning": "リポジトリ「<strong>{{name}}</strong>」のパスは無効になりました。新しい場所を指定してください。",
   "relink_new_path_label": "新しいパス",
   "relink_new_path_placeholder": "/new/path/to/repository",
   "relink_relinking": "再リンク中...",
   "relink_confirm": "再リンク",
 
   "remove_repo_title": "リポジトリを削除",
-  "remove_repo_warning_pre": "「",
-  "remove_repo_warning_post": "」を削除してもよろしいですか？ディスク上のリポジトリは削除されず、登録解除のみが行われます。",
+  "remove_repo_warning": "リポジトリ「<strong>{{name}}</strong>」を削除してもよろしいですか？ディスク上のリポジトリは削除されず、登録解除のみが行われます。",
   "remove_repo_will_destroy_pre": "次が完全に破棄されます:",
   "remove_repo_active": "{{count}} 件のアクティブ",
   "remove_repo_archived": "{{count}} 件のアーカイブ済み",
@@ -57,8 +53,7 @@
   "share_done": "完了",
 
   "setup_script_title": "セットアップスクリプトを確認",
-  "setup_script_warning_pre": "このワークスペースには、",
-  "setup_script_warning_post": " から実行されるセットアップスクリプトがあります。続行する前に内容を確認してください。",
+  "setup_script_warning": "このワークスペースには、<strong>{{source}}</strong> から実行されるセットアップスクリプトがあります。続行する前に内容を確認してください。",
   "setup_script_source_repo_settings": "リポジトリ設定",
   "setup_script_label": "スクリプト",
   "setup_script_always_run": "このリポジトリでは常にセットアップスクリプトを実行する",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -39,6 +39,7 @@
   "general_language_en": "English",
   "general_language_es": "Español",
   "general_language_ja": "日本語",
+  "general_language_pt_br": "ポルトガル語（ブラジル）",
   "general_update_check_failed": "更新の確認に失敗しました。しばらくしてから再度お試しください。",
 
   "appearance_title": "外観",

--- a/src/ui/src/locales/pt-BR/modals.json
+++ b/src/ui/src/locales/pt-BR/modals.json
@@ -1,7 +1,6 @@
 {
   "delete_workspace_title": "Excluir workspace",
-  "delete_workspace_warning_pre": "Tem certeza de que deseja excluir",
-  "delete_workspace_warning_post": "? A branch e quaisquer commits não mesclados serão excluídos permanentemente.",
+  "delete_workspace_warning": "Tem certeza de que deseja excluir <strong>{{name}}</strong>? A branch e quaisquer commits não mesclados serão excluídos permanentemente.",
   "delete_workspace_deleting": "Excluindo...",
   "delete_workspace_confirm": "Excluir",
 
@@ -26,22 +25,19 @@
   "rollback_confirm": "Reverter",
 
   "nightly_title": "Mudar para o canal nightly?",
-  "nightly_warning_pre": "Versões nightly são pré-lançamentos não testados, construídos a partir do último",
-  "nightly_warning_post": "branch. Podem conter bugs ou recursos com falhas. Você pode voltar para o Estável a qualquer momento.",
+  "nightly_warning": "Versões nightly são pré-lançamentos não testados, construídos a partir do último branch <strong>main</strong>. Podem conter bugs ou recursos com falhas. Você pode voltar para o Estável a qualquer momento.",
   "nightly_switching": "Alterando...",
   "nightly_confirm": "Mudar para Nightly",
 
   "relink_title": "Reconectar repositório",
-  "relink_warning_pre": "O caminho de",
-  "relink_warning_post": "não é mais válido. Forneça o novo local.",
+  "relink_warning": "O caminho de <strong>{{name}}</strong> não é mais válido. Forneça o novo local.",
   "relink_new_path_label": "Novo caminho",
   "relink_new_path_placeholder": "/novo/caminho/para/repositorio",
   "relink_relinking": "Reconectando...",
   "relink_confirm": "Reconectar",
 
   "remove_repo_title": "Remover repositório",
-  "remove_repo_warning_pre": "Tem certeza de que deseja remover",
-  "remove_repo_warning_post": "? Isso não excluirá o repositório do disco, apenas o desregistrará.",
+  "remove_repo_warning": "Tem certeza de que deseja remover <strong>{{name}}</strong>? Isso não excluirá o repositório do disco, apenas o desregistrará.",
   "remove_repo_will_destroy_pre": "Destruirá permanentemente:",
   "remove_repo_active": "{{count}} ativo(s)",
   "remove_repo_archived": "{{count}} arquivado(s)",
@@ -57,8 +53,7 @@
   "share_done": "Concluído",
 
   "setup_script_title": "Revisar script de configuração",
-  "setup_script_warning_pre": "Este workspace tem um script de configuração de",
-  "setup_script_warning_post": "que será executado. Por favor, revise antes de prosseguir.",
+  "setup_script_warning": "Este workspace tem um script de configuração de <strong>{{source}}</strong> que será executado. Por favor, revise antes de prosseguir.",
   "setup_script_source_repo_settings": "configurações do repositório",
   "setup_script_label": "Script",
   "setup_script_always_run": "Sempre executar scripts de configuração para este repositório",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -39,6 +39,7 @@
   "general_language_en": "Inglês",
   "general_language_es": "Espanhol",
   "general_language_pt_br": "Português (Brasil)",
+  "general_language_ja": "Japonês",
   "general_update_check_failed": "Falha na verificação de atualizações. Tente novamente mais tarde.",
 
   "appearance_title": "Aparência",


### PR DESCRIPTION
## Summary

Follow-up to #529 addressing all 7 Copilot review comments at the source rather than working around them in JA-only strings. Two distinct bugs are fixed:

1. **Locale key parity gaps** — `general_language_ja` was missing from `pt-BR/settings.json` and `general_language_pt_br` was missing from `ja/settings.json`, so the language picker silently fell back to English (or showed the raw key) for the missing option in those UIs.

2. **Whitespace contract violations across all locales** — five modals (`DeleteWorkspace`, `RelinkRepo`, `RemoveRepo`, `ConfirmSetupScript`, `ConfirmNightlyChannel`) split a single sentence across `*_warning_pre` + `<strong>{name}</strong>` + `*_warning_post` keys, with JSX whitespace (or explicit `{" "}`) injected around the `<strong>` token. English/Spanish/pt-BR translators happened to author strings that survived the contract; Japanese exposed it because `「」` quote brackets cannot float, producing visible artifacts like `「 NAME 」` with stray spaces.

The fix replaces the split-key pattern with `<Trans>` from `react-i18next` (already a project dependency; introduced for the first time here). Each warning is now one consolidated translation key per locale with inline `<strong>{{name}}</strong>` markup, eliminating the JSX-whitespace contract entirely. Translators no longer need to anticipate component spacing — the whole sentence is one string.

Net change: 5 key pairs → 5 single keys per locale (-20 keys across the four `modals.json` files), +2 keys in `settings.json` for parity.

## Complexity Notes

- **First use of `<Trans>` in the codebase** — all 30+ existing call sites use `useTranslation`'s `t()`. The component children-to-tag mapping in react-i18next can be subtle; here we use the named-tag form (`components={{ strong: <strong /> }}` matches `<strong>...</strong>` in the translation string), which is clearer than the indexed `<0>` form.
- **`ConfirmNightlyChannelModal` has no interpolated value** — the strong-wrapped text is the literal `main` (a hardcoded English branch name), now embedded directly in each locale's string with `<strong>main</strong>` markup. No `values` prop is needed.
- **Frontend lint (`bun run lint`) reports 73 pre-existing problems** in files this PR does not touch (`useTypewriter.ts`, `filePathLinks.ts`, `useAgentStream.ts`, `useVoiceInput.ts`). Confirmed they exist on `main` independently of this branch — out of scope here.
- **Frontend locale-parity test is intentionally NOT added in this PR.** The Rust-side `locales_have_identical_key_sets` covers `tray.json` only; nothing equivalent exists for the i18next bundles, which is why CI did not catch the missing `general_language_*` keys. A standalone PR adding that test would have caught comments #1 and #7 automatically — worth a follow-up, but bundling it here would widen the diff.

## Test Steps

1. **Type-check** (CI runs this via `bun run build`; vitest does not type-check):
   ```
   cd src/ui && bunx tsc -b
   ```
   Expect: clean exit, no output.

2. **Frontend tests:**
   ```
   cd src/ui && bun run test
   ```
   Expect: 1038 / 1038 passing across 67 files.

3. **Backend tests** (sanity, no Rust changes here):
   ```
   cargo test -p claudette --all-features
   ```
   Expect: 766 / 766 passing.

4. **Manual UAT** (`cargo tauri dev`):
   - For each locale (`en`, `es`, `pt-BR`, `ja`), open all five modals and confirm the bold-wrapped name renders cleanly with single spaces around `<strong>` — no double spaces, no `「 NAME 」` artifacts in JA:
     - **Delete workspace**: right-click any workspace in the sidebar → Delete.
     - **Relink repo**: archive a repo, manually rename its on-disk path, restart, then click the broken-link indicator.
     - **Remove repo**: Settings → Repositories → Remove.
     - **Setup script confirm**: trigger by adding a `setup` script in `.claudette.json` then opening any workspace from that repo.
     - **Nightly channel confirm**: Settings → General → Update channel → Nightly.
   - In **Português (Brasil)** UI: Settings → General → Language. Confirm the JA option label is `Japonês` (not `general_language_ja`).
   - In **日本語** UI: Settings → General → Language. Confirm the pt-BR option label is `ポルトガル語（ブラジル）`.
   - Switch the runtime language while a modal is open; confirm the `<Trans>` content re-renders in the new locale (live update).

## Checklist

- [x] Tests added/updated — N/A; no existing tests touch these modals (verified via Glob), and the refactor is locale-only behavioral parity. The 1038 existing frontend tests still pass.
- [x] Documentation updated — N/A; this is a fix for an already-shipped feature.