### PR TITLE
perf(plugins): eliminate cold-start delay on plugin settings page

### DIFF
--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -377,6 +377,7 @@ impl VoiceProviderRegistry {
     pub fn prewarm(&self) {
         self.recorder.warmup();
         let _ = self.platform_speech.availability();
+        let _ = self.backend_checker.ready_backend();
     }
 
     pub fn set_selected_provider(
@@ -828,12 +829,25 @@ impl VoiceProvider for DistilWhisperCandleProvider {
             download_required: true,
             model_size_label: Some("About 1.5 GB plus tokenizer/config files".to_string()),
             cache_path: Some(cache_path.display().to_string()),
-            accelerator_label: Some(registry.candle_accelerator_label()),
+            accelerator_label: None,
         }
     }
 
     fn status(&self, registry: &VoiceProviderRegistry, db: &Database) -> VoiceProviderInfo {
         let enabled = registry.enabled(db, self.id());
+        if !enabled {
+            return VoiceProviderInfo {
+                metadata: self.metadata(registry),
+                status: VoiceProviderStatus::Unavailable,
+                status_label: "Disabled".to_string(),
+                enabled: false,
+                selected: false,
+                setup_required: false,
+                can_remove_model: false,
+                error: None,
+            };
+        }
+
         let cache_path = registry.distil_cache_path();
         let model_status = db
             .get_app_setting(&model_status_key(self.id()))
@@ -841,56 +855,54 @@ impl VoiceProvider for DistilWhisperCandleProvider {
             .flatten();
         let installed = distil_model_ready(&cache_path);
         let backend_status = registry.ensure_candle_backend_ready();
-        let (status, status_label, setup_required, error) = if !enabled {
-            (
-                VoiceProviderStatus::Unavailable,
-                "Disabled".to_string(),
-                false,
-                None,
-            )
-        } else if model_status.as_deref() == Some("downloading") {
-            (
-                VoiceProviderStatus::Downloading,
-                "Downloading model".to_string(),
-                true,
-                None,
-            )
-        } else if let Err(err) = &backend_status {
-            (
-                VoiceProviderStatus::EngineUnavailable,
-                "Voice engine unavailable".to_string(),
-                false,
-                Some(err.clone()),
-            )
-        } else if installed {
-            let backend = backend_status.expect("backend availability checked");
-            (
-                VoiceProviderStatus::Ready,
-                format!("{DISTIL_READY_MESSAGE} ({})", backend.label()),
-                false,
-                None,
-            )
-        } else if model_status
-            .as_deref()
-            .is_some_and(|status| status.starts_with("error:"))
-        {
-            (
-                VoiceProviderStatus::Error,
-                "Download failed".to_string(),
-                true,
-                model_status.map(|s| s.trim_start_matches("error:").to_string()),
-            )
-        } else {
-            (
-                VoiceProviderStatus::NeedsSetup,
-                "Download required".to_string(),
-                true,
-                None,
-            )
-        };
+
+        let mut metadata = self.metadata(registry);
+        metadata.accelerator_label = Some(registry.candle_accelerator_label());
+
+        let (status, status_label, setup_required, error) =
+            if model_status.as_deref() == Some("downloading") {
+                (
+                    VoiceProviderStatus::Downloading,
+                    "Downloading model".to_string(),
+                    true,
+                    None,
+                )
+            } else if let Err(err) = &backend_status {
+                (
+                    VoiceProviderStatus::EngineUnavailable,
+                    "Voice engine unavailable".to_string(),
+                    false,
+                    Some(err.clone()),
+                )
+            } else if installed {
+                let backend = backend_status.expect("backend availability checked");
+                (
+                    VoiceProviderStatus::Ready,
+                    format!("{DISTIL_READY_MESSAGE} ({})", backend.label()),
+                    false,
+                    None,
+                )
+            } else if model_status
+                .as_deref()
+                .is_some_and(|status| status.starts_with("error:"))
+            {
+                (
+                    VoiceProviderStatus::Error,
+                    "Download failed".to_string(),
+                    true,
+                    model_status.map(|s| s.trim_start_matches("error:").to_string()),
+                )
+            } else {
+                (
+                    VoiceProviderStatus::NeedsSetup,
+                    "Download required".to_string(),
+                    true,
+                    None,
+                )
+            };
 
         VoiceProviderInfo {
-            metadata: self.metadata(registry),
+            metadata,
             status,
             status_label,
             enabled,
@@ -1894,6 +1906,36 @@ mod tests {
     }
 
     #[test]
+    fn distil_provider_skips_backend_probe_when_disabled() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        let db = open_test_db(&db_path);
+        db.set_app_setting(&enabled_key(DISTIL_ID), "false")
+            .expect("disable");
+        let checker = Arc::new(CountingBackendChecker::new());
+        let registry = VoiceProviderRegistry::with_runtime_and_backend(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1])),
+            Arc::new(FakeTranscriber::ok("ignored")),
+            checker.clone(),
+        );
+
+        let provider = registry
+            .list_providers(&db)
+            .into_iter()
+            .find(|p| p.metadata.id == DISTIL_ID)
+            .expect("distil provider");
+
+        assert_eq!(provider.status, VoiceProviderStatus::Unavailable);
+        assert_eq!(
+            checker.call_count(),
+            0,
+            "backend probe should not be called for disabled provider"
+        );
+        assert!(provider.metadata.accelerator_label.is_none());
+    }
+
+    #[test]
     #[ignore = "requires local Distil-Whisper cache and CLAUDETTE_VOICE_SAMPLE_WAV"]
     fn ignored_real_model_probe_transcribes_fixture_wav() {
         let cache_path = std::env::var_os("CLAUDETTE_VOICE_MODEL_CACHE")
@@ -2010,6 +2052,32 @@ mod tests {
     impl CandleBackendChecker for FakeBackendChecker {
         fn ready_backend(&self) -> Result<CandleBackend, String> {
             self.result.clone()
+        }
+    }
+
+    struct CountingBackendChecker {
+        calls: AtomicUsize,
+    }
+
+    impl CountingBackendChecker {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl CandleBackendChecker for CountingBackendChecker {
+        fn ready_backend(&self) -> Result<CandleBackend, String> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            #[cfg(target_os = "macos")]
+            return Ok(CandleBackend::Metal);
+            #[cfg(not(target_os = "macos"))]
+            return Ok(CandleBackend::Cpu);
         }
     }
 

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -627,12 +627,6 @@ impl VoiceProviderRegistry {
         self.backend_checker.ready_backend()
     }
 
-    fn candle_accelerator_label(&self) -> String {
-        self.ensure_candle_backend_ready()
-            .map(|backend| backend.accelerator_label().to_string())
-            .unwrap_or_else(|err| format!("Unavailable: {err}"))
-    }
-
     pub(crate) fn resolve_provider_id(
         &self,
         db: &Database,
@@ -857,7 +851,10 @@ impl VoiceProvider for DistilWhisperCandleProvider {
         let backend_status = registry.ensure_candle_backend_ready();
 
         let mut metadata = self.metadata(registry);
-        metadata.accelerator_label = Some(registry.candle_accelerator_label());
+        metadata.accelerator_label = Some(match &backend_status {
+            Ok(backend) => backend.accelerator_label().to_string(),
+            Err(err) => format!("Unavailable: {err}"),
+        });
 
         let (status, status_label, setup_required, error) =
             if model_status.as_deref() == Some("downloading") {

--- a/src/ui/src/components/settings/sections/PluginsSettings.tsx
+++ b/src/ui/src/components/settings/sections/PluginsSettings.tsx
@@ -66,6 +66,7 @@ export function PluginsSettings() {
   }, []);
 
   const refreshPlugins = useCallback(async () => {
+    setError(null);
     try {
       setPlugins(await listClaudettePlugins());
     } catch (e) {
@@ -74,6 +75,7 @@ export function PluginsSettings() {
   }, []);
 
   const refreshBuiltins = useCallback(async () => {
+    setError(null);
     try {
       setBuiltins(await listBuiltinClaudettePlugins());
     } catch (e) {
@@ -82,6 +84,7 @@ export function PluginsSettings() {
   }, []);
 
   const refreshVoice = useCallback(async () => {
+    setError(null);
     try {
       setVoiceProviders(await listVoiceProviders());
     } catch (e) {

--- a/src/ui/src/components/settings/sections/PluginsSettings.tsx
+++ b/src/ui/src/components/settings/sections/PluginsSettings.tsx
@@ -46,7 +46,7 @@ export function PluginsSettings() {
   const [reseedMessage, setReseedMessage] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const refresh = useCallback(async () => {
+  const refreshAll = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -65,40 +65,64 @@ export function PluginsSettings() {
     }
   }, []);
 
+  const refreshPlugins = useCallback(async () => {
+    try {
+      setPlugins(await listClaudettePlugins());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  const refreshBuiltins = useCallback(async () => {
+    try {
+      setBuiltins(await listBuiltinClaudettePlugins());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  const refreshVoice = useCallback(async () => {
+    try {
+      setVoiceProviders(await listVoiceProviders());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
   const handleToggleBuiltin = useCallback(
     async (pluginName: string, nextEnabled: boolean) => {
       try {
         await setBuiltinClaudettePluginEnabled(pluginName, nextEnabled);
-        await refresh();
+        await refreshBuiltins();
       } catch (e) {
         setError(String(e));
       }
     },
-    [refresh],
+    [refreshBuiltins],
   );
 
   const handleSelectVoiceProvider = useCallback(
     async (providerId: string) => {
       try {
         await setSelectedVoiceProvider(providerId);
-        await refresh();
+        await refreshVoice();
       } catch (e) {
         setError(String(e));
       }
     },
-    [refresh],
+    [refreshVoice],
   );
 
   const handleToggleVoiceProvider = useCallback(
     async (providerId: string, nextEnabled: boolean) => {
       try {
         await setVoiceProviderEnabled(providerId, nextEnabled);
-        await refresh();
+        await refreshVoice();
       } catch (e) {
         setError(String(e));
       }
     },
-    [refresh],
+    [refreshVoice],
   );
 
   const handlePrepareVoiceProvider = useCallback(
@@ -106,32 +130,32 @@ export function PluginsSettings() {
       setPreparingVoiceProvider(providerId);
       try {
         await prepareVoiceProvider(providerId);
-        await refresh();
+        await refreshVoice();
       } catch (e) {
         setError(String(e));
-        await refresh();
+        await refreshVoice();
       } finally {
         setPreparingVoiceProvider(null);
       }
     },
-    [refresh],
+    [refreshVoice],
   );
 
   const handleRemoveVoiceProviderModel = useCallback(
     async (providerId: string) => {
       try {
         await removeVoiceProviderModel(providerId);
-        await refresh();
+        await refreshVoice();
       } catch (e) {
         setError(String(e));
       }
     },
-    [refresh],
+    [refreshVoice],
   );
 
   useEffect(() => {
-    void refresh();
-  }, [refresh]);
+    void refreshAll();
+  }, [refreshAll]);
 
   const voiceProviderFocus = useAppStore((s) => s.voiceProviderFocus);
   const focusVoiceProvider = useAppStore((s) => s.focusVoiceProvider);
@@ -177,24 +201,24 @@ export function PluginsSettings() {
     async (pluginName: string, nextEnabled: boolean) => {
       try {
         await setClaudettePluginEnabled(pluginName, nextEnabled);
-        await refresh();
+        await refreshPlugins();
       } catch (e) {
         setError(String(e));
       }
     },
-    [refresh],
+    [refreshPlugins],
   );
 
   const handleSettingChange = useCallback(
     async (pluginName: string, key: string, value: unknown) => {
       try {
         await setClaudettePluginSetting(pluginName, key, value);
-        await refresh();
+        await refreshPlugins();
       } catch (e) {
         setError(String(e));
       }
     },
-    [refresh],
+    [refreshPlugins],
   );
 
   const handleReseed = useCallback(async () => {
@@ -206,11 +230,11 @@ export function PluginsSettings() {
           ? t("plugins_reseeded")
           : t("plugins_reseeded_warnings", { count: warnings.length, warnings: warnings.join("; ") }),
       );
-      await refresh();
+      await refreshPlugins();
     } catch (e) {
       setError(String(e));
     }
-  }, [refresh, t]);
+  }, [refreshPlugins, t]);
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

The Plugins settings page was blocking for 500-2000ms on first open per app session. Root cause: `DistilWhisperCandleProvider::status()` called `ensure_candle_backend_ready()` unconditionally on the IPC thread, triggering Metal GPU initialization and 6 tensor verification probes (conv1d, gelu, layer_norm, softmax, matmul, broadcast_add) — even when the provider was disabled. The `OnceLock` cached the result, but the first call always paid the full cost.

Three coordinated fixes:

```mermaid
flowchart TD
    A[App startup] --> B[prewarm thread]
    B --> B1[recorder.warmup]
    B --> B2[platform_speech.availability]
    B --> B3["NEW: backend_checker.ready_backend()"]
    B3 --> C[Metal init + tensor probes<br/>500-2000ms in background]
    C --> D[OnceLock populated]

    U[User opens Plugins settings] --> R[refreshAll]
    R --> R1[listClaudettePlugins]
    R --> R2[listBuiltinClaudettePlugins]
    R --> R3[listVoiceProviders]
    R3 --> S[DistilProvider::status]
    S --> SE{enabled?}
    SE -->|No| SX[early return: Unavailable]
    SE -->|Yes| SY[ensure_candle_backend_ready<br/>fast: OnceLock hit]
    SY --> D

    M[User toggles a Lua plugin] --> M1["refreshPlugins() only<br/>(was: all 3 endpoints)"]
```

**Backend** (`src-tauri/src/voice.rs`):
1. `prewarm()` now also warms the Candle backend, so the existing background thread spawned at startup populates the `OnceLock` before settings is opened.
2. `DistilWhisperCandleProvider::status()` early-returns when disabled — skips backend probe, file stat checks, and DB queries entirely.
3. `metadata()` no longer unconditionally calls `candle_accelerator_label()`; `status()` enriches the label only when enabled.

**Frontend** (`PluginsSettings.tsx`):
4. Split monolithic `refresh()` into `refreshAll()` (initial load) plus `refreshPlugins()` / `refreshBuiltins()` / `refreshVoice()`. Each mutation handler only re-fetches its affected data source — eliminates two unnecessary IPC round-trips per toggle.

## Complexity Notes

- **`metadata()` semantics changed**: It used to unconditionally include `accelerator_label`. It now returns `accelerator_label: None`, with `status()` patching it in when enabled. The frontend already handles `null` correctly (the accelerator label section is conditional). Any future caller of `metadata()` standalone would need to be aware.
- **Pre-warm timing**: `prewarm()` runs on a `std::thread`, not Tokio. If the user opens settings within ~500ms of app launch on a cold machine, the `OnceLock` may not yet be populated — but Fix 2 (the early return when disabled) ensures only enabled providers pay the wait.
- **Refresh split impacts UX subtly**: `refreshAll()` keeps the loading state for initial load; targeted refreshes deliberately don't, so toggling a switch doesn't trigger a full-page loading flash.

## Test Steps

1. **Automated**:
   - `cargo test -p claudette-tauri -- voice` — 31 tests pass including new `distil_provider_skips_backend_probe_when_disabled`
   - `cd src/ui && bunx tsc -b` — clean
   - `cd src/ui && bun run test` — 1038 tests pass
   - `cargo clippy -p claudette-tauri --all-targets` — clean

2. **Manual**:
   - `cargo tauri dev`
   - Open Settings → Plugins (the always-visible Claudette plugins section, not Claude Code Plugins)
   - Section should render instantly with no perceptible delay (was 1-2s on first open)
   - Toggle a Lua plugin (e.g. an SCM provider) — voice provider rows should NOT flash/re-render
   - Toggle the Distil-Whisper voice provider — Lua plugin rows should NOT flash/re-render
   - Disable Distil-Whisper, then open settings in a fresh app session — should be instant even if Candle prewarm hasn't completed (Fix 2 short-circuits)

## Checklist

- [x] Tests added/updated (`distil_provider_skips_backend_probe_when_disabled`, `CountingBackendChecker` helper)
- [ ] Documentation updated (n/a — internal performance change, no user-visible API)