### PR TITLE
fix(workspace): level-triggered branch reconcile so a stale sidebar self-heals

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -770,21 +770,24 @@ pub fn generate_workspace_name() -> GeneratedWorkspaceName {
     }
 }
 
-/// Re-read the current branch for every active workspace and return the set
-/// of workspaces whose stored `branch_name` is now stale. Any drift is also
-/// persisted back to the DB so external branch renames (`git branch -m`,
-/// `git checkout -b`, etc.) made from the integrated terminal or elsewhere
-/// stop the DB from diverging from git reality.
+/// Re-read the current branch for every active workspace. Returns one
+/// `(workspace_id, current_branch)` entry per workspace we could probe
+/// (level-triggered: every active workspace, not just ones that drifted),
+/// so the frontend store can self-heal if it has somehow diverged from the
+/// DB. See issue #538. Drift is still persisted to the DB on diff, so
+/// external renames (`git branch -m`, `git checkout -b`, …) made from the
+/// integrated terminal flow back into SQLite as well.
 #[tauri::command]
 pub async fn refresh_branches(state: State<'_, AppState>) -> Result<Vec<(String, String)>, String> {
     claudette::workspace_sync::reconcile_all_workspace_branches(&state.db_path).await
 }
 
-/// Re-read the current branch for a single workspace, persist any change, and
-/// return the new branch name (or `None` if nothing changed or the workspace
-/// isn't active). Used for event-driven refreshes — e.g. when the user selects
-/// a workspace or focuses its terminal panel — so sidebar state tracks
-/// external `git` operations without waiting on the 5s poll.
+/// Re-read the current branch for a single workspace, persist any change,
+/// and return the current branch (`Some`) — always the live git value, not
+/// just on drift, so the caller can overwrite its store unconditionally
+/// (#538). `None` means we have nothing authoritative to publish: the
+/// workspace is archived, has no worktree path, or git couldn't name a
+/// branch (e.g. detached HEAD).
 #[tauri::command]
 pub async fn refresh_workspace_branch(
     workspace_id: String,

--- a/src/ui/src/hooks/useBranchRefresh.test.ts
+++ b/src/ui/src/hooks/useBranchRefresh.test.ts
@@ -23,30 +23,61 @@ describe("pollAndApplyBranchUpdates", () => {
     vi.clearAllMocks();
   });
 
-  it("applies every drift returned by the backend and reports the count", async () => {
+  it("writes only the workspaces whose backend branch differs from the store", async () => {
+    // Backend reports two workspaces (level-triggered). Only one differs
+    // from the store value — that's the only one we should write.
     mockRefreshBranches.mockResolvedValue([
       ["w1", "user/renamed"],
       ["w2", "feature/new"],
     ]);
     const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn((id: string) =>
+      id === "w1" ? "user/renamed" : "feature/old",
+    );
 
-    const applied = await pollAndApplyBranchUpdates(updateWorkspace);
+    const applied = await pollAndApplyBranchUpdates(
+      updateWorkspace,
+      getCurrentBranch,
+    );
 
-    expect(applied).toBe(2);
-    expect(updateWorkspace).toHaveBeenCalledTimes(2);
-    expect(updateWorkspace).toHaveBeenNthCalledWith(1, "w1", {
-      branch_name: "user/renamed",
-    });
-    expect(updateWorkspace).toHaveBeenNthCalledWith(2, "w2", {
+    expect(applied).toBe(1);
+    expect(updateWorkspace).toHaveBeenCalledTimes(1);
+    expect(updateWorkspace).toHaveBeenCalledWith("w2", {
       branch_name: "feature/new",
     });
   });
 
-  it("returns zero and writes nothing when the backend returns no drift", async () => {
+  it("returns zero and writes nothing when every backend value matches the store", async () => {
+    // Steady state under level-triggered semantics: backend reports every
+    // active workspace, but nothing has actually drifted. The hook must
+    // not call updateWorkspace at all so the back-off can grow.
+    mockRefreshBranches.mockResolvedValue([
+      ["w1", "main"],
+      ["w2", "feature"],
+    ]);
+    const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn((id: string) =>
+      id === "w1" ? "main" : "feature",
+    );
+
+    const applied = await pollAndApplyBranchUpdates(
+      updateWorkspace,
+      getCurrentBranch,
+    );
+
+    expect(applied).toBe(0);
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns zero and writes nothing when the backend returns an empty list", async () => {
     mockRefreshBranches.mockResolvedValue([]);
     const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn(() => "main");
 
-    const applied = await pollAndApplyBranchUpdates(updateWorkspace);
+    const applied = await pollAndApplyBranchUpdates(
+      updateWorkspace,
+      getCurrentBranch,
+    );
 
     expect(applied).toBe(0);
     expect(updateWorkspace).not.toHaveBeenCalled();
@@ -55,8 +86,12 @@ describe("pollAndApplyBranchUpdates", () => {
   it("returns zero on backend error so the polling loop keeps running", async () => {
     mockRefreshBranches.mockRejectedValue(new Error("IPC down"));
     const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn(() => "main");
 
-    const applied = await pollAndApplyBranchUpdates(updateWorkspace);
+    const applied = await pollAndApplyBranchUpdates(
+      updateWorkspace,
+      getCurrentBranch,
+    );
 
     expect(applied).toBe(0);
     expect(updateWorkspace).not.toHaveBeenCalled();
@@ -84,11 +119,16 @@ describe("refreshSelectedWorkspaceBranch", () => {
     vi.clearAllMocks();
   });
 
-  it("writes the fresh branch to the store when the backend reports drift", async () => {
+  it("writes the fresh branch to the store when the backend value differs from the store", async () => {
     mockRefreshWorkspaceBranch.mockResolvedValue("user/renamed");
     const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn(() => "main");
 
-    const result = await refreshSelectedWorkspaceBranch("w1", updateWorkspace);
+    const result = await refreshSelectedWorkspaceBranch(
+      "w1",
+      updateWorkspace,
+      getCurrentBranch,
+    );
 
     expect(result).toBe("user/renamed");
     expect(mockRefreshWorkspaceBranch).toHaveBeenCalledWith("w1");
@@ -97,11 +137,33 @@ describe("refreshSelectedWorkspaceBranch", () => {
     });
   });
 
-  it("leaves the store untouched when there is no drift", async () => {
+  it("returns the resolved branch but skips the store write when it matches", async () => {
+    // Level-triggered: backend always returns the current branch. When the
+    // store already agrees, we should not trigger a re-render.
+    mockRefreshWorkspaceBranch.mockResolvedValue("main");
+    const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn(() => "main");
+
+    const result = await refreshSelectedWorkspaceBranch(
+      "w1",
+      updateWorkspace,
+      getCurrentBranch,
+    );
+
+    expect(result).toBe("main");
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("leaves the store untouched when the backend returns null", async () => {
     mockRefreshWorkspaceBranch.mockResolvedValue(null);
     const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn(() => "main");
 
-    const result = await refreshSelectedWorkspaceBranch("w1", updateWorkspace);
+    const result = await refreshSelectedWorkspaceBranch(
+      "w1",
+      updateWorkspace,
+      getCurrentBranch,
+    );
 
     expect(result).toBeNull();
     expect(updateWorkspace).not.toHaveBeenCalled();
@@ -112,8 +174,13 @@ describe("refreshSelectedWorkspaceBranch", () => {
       new Error("workspace gone"),
     );
     const updateWorkspace = vi.fn();
+    const getCurrentBranch = vi.fn(() => "main");
 
-    const result = await refreshSelectedWorkspaceBranch("w1", updateWorkspace);
+    const result = await refreshSelectedWorkspaceBranch(
+      "w1",
+      updateWorkspace,
+      getCurrentBranch,
+    );
 
     expect(result).toBeNull();
     expect(updateWorkspace).not.toHaveBeenCalled();

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -4,6 +4,7 @@ import { refreshBranches, refreshWorkspaceBranch } from "../services/tauri";
 import type { Workspace } from "../types/workspace";
 
 type UpdateWorkspace = (id: string, updates: Partial<Workspace>) => void;
+type GetCurrentBranch = (workspaceId: string) => string | undefined;
 
 /** Base poll interval when the window is focused and we have just observed drift. */
 export const BRANCH_POLL_BASE_MS = 5_000;
@@ -25,20 +26,27 @@ export function nextBranchPollDelay(consecutiveEmpty: number): number {
  * Poll all active workspaces and mirror the backend-reported branch into the
  * Zustand store. The backend returns one entry per active workspace
  * (level-triggered, see issue 538), so this also self-heals a store that
- * has somehow drifted from the DB. Errors are caught so a transient git/IPC
- * failure doesn't break the polling loop, but they're surfaced to the
- * console so the failure mode isn't invisible. Returns the number of
- * entries applied so the caller can adapt its cadence.
+ * has somehow drifted from the DB. To avoid pointless re-renders and to
+ * keep the back-off loop meaningful, `updateWorkspace` is only called when
+ * the backend value differs from the current store value, and the returned
+ * count reflects only those actual writes. Errors are caught so a
+ * transient git/IPC failure doesn't break the polling loop, but they're
+ * surfaced to the console so the failure mode isn't invisible.
  */
 export async function pollAndApplyBranchUpdates(
   updateWorkspace: UpdateWorkspace,
+  getCurrentBranch: GetCurrentBranch,
 ): Promise<number> {
   try {
     const updates = await refreshBranches();
+    let applied = 0;
     for (const [wsId, branchName] of updates) {
-      updateWorkspace(wsId, { branch_name: branchName });
+      if (getCurrentBranch(wsId) !== branchName) {
+        updateWorkspace(wsId, { branch_name: branchName });
+        applied++;
+      }
     }
-    return updates.length;
+    return applied;
   } catch (err) {
     console.warn("[branch-refresh] poll failed:", err);
     return 0;
@@ -48,17 +56,19 @@ export async function pollAndApplyBranchUpdates(
 /**
  * Immediate refresh for a single workspace — called when the user selects
  * one so external renames appear without waiting on the poll. The backend
- * returns the current branch (not just on drift) per issue 538, so any
- * non-null value is written through to the store unconditionally. Returns
- * the resolved branch (or `null` if the backend couldn't determine one).
+ * returns the current branch (not just on drift) per issue 538; the store
+ * is only written when that value actually differs, so a no-op refresh
+ * does not trigger re-renders. Returns the resolved branch (or `null` if
+ * the backend couldn't determine one).
  */
 export async function refreshSelectedWorkspaceBranch(
   workspaceId: string,
   updateWorkspace: UpdateWorkspace,
+  getCurrentBranch: GetCurrentBranch,
 ): Promise<string | null> {
   try {
     const branch = await refreshWorkspaceBranch(workspaceId);
-    if (branch !== null) {
+    if (branch !== null && getCurrentBranch(workspaceId) !== branch) {
       updateWorkspace(workspaceId, { branch_name: branch });
     }
     return branch;
@@ -79,6 +89,12 @@ function isAppActive(): boolean {
   // hiding the document, so a hidden-only check would still poll there.
   return !document.hidden && document.hasFocus();
 }
+
+// Reads the live workspace branch name straight from the store at call
+// time so the polling/selection helpers don't depend on a snapshot
+// captured when an effect was set up.
+const getCurrentBranchFromStore: GetCurrentBranch = (id) =>
+  useAppStore.getState().workspaces.find((w) => w.id === id)?.branch_name;
 
 export function useBranchRefresh() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
@@ -117,7 +133,10 @@ export function useBranchRefresh() {
         return;
       }
       inFlight = true;
-      const applied = await pollAndApplyBranchUpdates(updateWorkspace);
+      const applied = await pollAndApplyBranchUpdates(
+        updateWorkspace,
+        getCurrentBranchFromStore,
+      );
       inFlight = false;
       if (cancelled) return;
       consecutiveEmpty = applied > 0 ? 0 : consecutiveEmpty + 1;
@@ -164,6 +183,10 @@ export function useBranchRefresh() {
   // poll tick.
   useEffect(() => {
     if (!selectedWorkspaceId) return;
-    refreshSelectedWorkspaceBranch(selectedWorkspaceId, updateWorkspace);
+    refreshSelectedWorkspaceBranch(
+      selectedWorkspaceId,
+      updateWorkspace,
+      getCurrentBranchFromStore,
+    );
   }, [selectedWorkspaceId, updateWorkspace]);
 }

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -91,10 +91,22 @@ function isAppActive(): boolean {
 }
 
 // Reads the live workspace branch name straight from the store at call
-// time so the polling/selection helpers don't depend on a snapshot
-// captured when an effect was set up.
+// time. Cheap (single .find on a small array) and used for one-shot
+// lookups like the selection-change refresh; the polling tick takes a
+// snapshot Map up-front instead so its lookups stay O(1).
 const getCurrentBranchFromStore: GetCurrentBranch = (id) =>
   useAppStore.getState().workspaces.find((w) => w.id === id)?.branch_name;
+
+// Snapshot the {id → branch} mapping from the store as a Map so the
+// polling helper can look up each backend entry in O(1). Without this,
+// `getCurrentBranchFromStore` would do a linear scan per backend entry
+// and the whole tick would become O(n²) in the workspace count.
+function snapshotBranchMap(): GetCurrentBranch {
+  const snapshot = new Map<string, string>(
+    useAppStore.getState().workspaces.map((w) => [w.id, w.branch_name]),
+  );
+  return (id) => snapshot.get(id);
+}
 
 export function useBranchRefresh() {
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
@@ -135,7 +147,7 @@ export function useBranchRefresh() {
       inFlight = true;
       const applied = await pollAndApplyBranchUpdates(
         updateWorkspace,
-        getCurrentBranchFromStore,
+        snapshotBranchMap(),
       );
       inFlight = false;
       if (cancelled) return;

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -22,10 +22,13 @@ export function nextBranchPollDelay(consecutiveEmpty: number): number {
 }
 
 /**
- * Poll all active workspaces for external branch-name drift and mirror any
- * detected changes into the Zustand store. Errors are swallowed so a
- * transient git/IPC failure doesn't break the polling loop. Returns the
- * number of drift entries applied so the caller can adapt its cadence.
+ * Poll all active workspaces and mirror the backend-reported branch into the
+ * Zustand store. The backend returns one entry per active workspace
+ * (level-triggered, see issue #538), so this also self-heals a store that
+ * has somehow drifted from the DB. Errors are caught so a transient git/IPC
+ * failure doesn't break the polling loop, but they're surfaced to the
+ * console so the failure mode isn't invisible. Returns the number of
+ * entries applied so the caller can adapt its cadence.
  */
 export async function pollAndApplyBranchUpdates(
   updateWorkspace: UpdateWorkspace,
@@ -36,16 +39,18 @@ export async function pollAndApplyBranchUpdates(
       updateWorkspace(wsId, { branch_name: branchName });
     }
     return updates.length;
-  } catch {
-    // Silently ignore refresh errors
+  } catch (err) {
+    console.warn("[branch-refresh] poll failed:", err);
     return 0;
   }
 }
 
 /**
  * Immediate refresh for a single workspace — called when the user selects
- * one so external renames appear without waiting on the poll. Returns
- * the new branch name if one was applied (useful for tests).
+ * one so external renames appear without waiting on the poll. The backend
+ * returns the current branch (not just on drift) per issue #538, so any
+ * non-null value is written through to the store unconditionally. Returns
+ * the resolved branch (or `null` if the backend couldn't determine one).
  */
 export async function refreshSelectedWorkspaceBranch(
   workspaceId: string,
@@ -57,7 +62,11 @@ export async function refreshSelectedWorkspaceBranch(
       updateWorkspace(workspaceId, { branch_name: branch });
     }
     return branch;
-  } catch {
+  } catch (err) {
+    console.warn(
+      `[branch-refresh] single refresh failed for ${workspaceId}:`,
+      err,
+    );
     return null;
   }
 }

--- a/src/ui/src/hooks/useBranchRefresh.ts
+++ b/src/ui/src/hooks/useBranchRefresh.ts
@@ -24,7 +24,7 @@ export function nextBranchPollDelay(consecutiveEmpty: number): number {
 /**
  * Poll all active workspaces and mirror the backend-reported branch into the
  * Zustand store. The backend returns one entry per active workspace
- * (level-triggered, see issue #538), so this also self-heals a store that
+ * (level-triggered, see issue 538), so this also self-heals a store that
  * has somehow drifted from the DB. Errors are caught so a transient git/IPC
  * failure doesn't break the polling loop, but they're surfaced to the
  * console so the failure mode isn't invisible. Returns the number of
@@ -48,7 +48,7 @@ export async function pollAndApplyBranchUpdates(
 /**
  * Immediate refresh for a single workspace — called when the user selects
  * one so external renames appear without waiting on the poll. The backend
- * returns the current branch (not just on drift) per issue #538, so any
+ * returns the current branch (not just on drift) per issue 538, so any
  * non-null value is written through to the store unconditionally. Returns
  * the resolved branch (or `null` if the backend couldn't determine one).
  */

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -24,10 +24,20 @@ use crate::model::WorkspaceStatus;
 /// doesn't fan-out a fresh `git` process per workspace every poll tick.
 const RECONCILE_GIT_PROBE_CONCURRENCY: usize = 6;
 
-/// Re-read the current branch for every active workspace. For each workspace
-/// whose stored `branch_name` no longer matches the worktree's HEAD, persist
-/// the fresh value to the DB and return the `(workspace_id, new_branch)` pair
-/// so the caller can mirror the change into in-memory UI state.
+/// Re-read the current branch for every active workspace and return the
+/// `(workspace_id, current_branch)` pair for each one we could probe. The
+/// caller (the frontend store) is expected to overwrite its in-memory branch
+/// label with whatever we return, regardless of whether the DB row needed
+/// updating — this is **level-triggered** by design so a store that has
+/// somehow drifted from the DB can self-heal on the next poll. See issue
+/// #538 for the divergence trap this avoids.
+///
+/// Workspaces whose worktree is missing, that aren't active, or that are in
+/// detached HEAD (where `git::current_branch` errors) are silently omitted —
+/// we have nothing authoritative to publish for them.
+///
+/// DB writes are still gated on actual diff so the polling path doesn't
+/// rewrite identical values every tick.
 ///
 /// DB access is split into short synchronous blocks around the async git
 /// calls, because `rusqlite::Connection` is not `Send`.
@@ -55,34 +65,50 @@ pub async fn reconcile_all_workspace_branches(
                 async move {
                     let _permit = sem.acquire_owned().await.ok();
                     match git::current_branch(&wt_path).await {
-                        Ok(branch) if branch != stored_branch => Some((id, branch)),
-                        _ => None,
+                        Ok(branch) => {
+                            let drifted = branch != stored_branch;
+                            Some((id, branch, drifted))
+                        }
+                        Err(_) => None,
                     }
                 }
             })
         })
         .collect();
 
-    let updates: Vec<(String, String)> = futures::future::join_all(probe_futures)
+    let probes: Vec<(String, String, bool)> = futures::future::join_all(probe_futures)
         .await
         .into_iter()
         .flatten()
         .collect();
 
-    if !updates.is_empty() {
+    let drifted: Vec<(&String, &String)> = probes
+        .iter()
+        .filter_map(|(id, branch, drifted)| if *drifted { Some((id, branch)) } else { None })
+        .collect();
+    if !drifted.is_empty() {
         let db = Database::open(db_path).map_err(|e| e.to_string())?;
-        for (id, branch) in &updates {
+        for (id, branch) in &drifted {
             db.update_workspace_branch_name(id, branch)
                 .map_err(|e| e.to_string())?;
         }
     }
 
-    Ok(updates)
+    Ok(probes
+        .into_iter()
+        .map(|(id, branch, _)| (id, branch))
+        .collect())
 }
 
-/// Re-read the current branch for a single workspace. Returns the new branch
-/// name if the DB was stale (and was just updated), or `None` when nothing
-/// needed to change, the workspace isn't active, or the worktree is missing.
+/// Re-read the current branch for a single workspace and return whatever git
+/// reports — `Some(branch)` is **always the current branch**, not just on
+/// drift, so the frontend can overwrite its store value unconditionally.
+/// `None` means we have nothing authoritative to publish: the workspace is
+/// archived, has no worktree path, doesn't exist, or git refused to name a
+/// branch (e.g. detached HEAD). See issue #538.
+///
+/// The DB write is still gated on diff so a no-op refresh costs only a
+/// `git rev-parse`.
 pub async fn reconcile_single_workspace_branch(
     db_path: &Path,
     workspace_id: &str,
@@ -105,13 +131,12 @@ pub async fn reconcile_single_workspace_branch(
     let Ok(branch) = git::current_branch(wt_path).await else {
         return Ok(None);
     };
-    if branch == ws.branch_name {
-        return Ok(None);
-    }
 
-    let db = Database::open(db_path).map_err(|e| e.to_string())?;
-    db.update_workspace_branch_name(&ws.id, &branch)
-        .map_err(|e| e.to_string())?;
+    if branch != ws.branch_name {
+        let db = Database::open(db_path).map_err(|e| e.to_string())?;
+        db.update_workspace_branch_name(&ws.id, &branch)
+            .map_err(|e| e.to_string())?;
+    }
     Ok(Some(branch))
 }
 
@@ -204,9 +229,13 @@ mod tests {
             .unwrap();
         drop(db);
 
-        // First pass: DB already matches git, no updates expected.
+        // First pass: DB already matches git. Level-triggered reconcile still
+        // reports the current branch so a stale store can self-heal.
         let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
-        assert!(updates.is_empty());
+        assert_eq!(
+            updates,
+            vec![("w1".to_string(), "claudette/original".to_string())]
+        );
 
         // Simulate the user renaming the branch externally.
         rename_branch(repo_dir.path(), "user/renamed-branch");
@@ -229,7 +258,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconcile_single_returns_none_when_unchanged() {
+    async fn reconcile_single_reports_branch_when_unchanged() {
+        // Level-triggered semantics (#538): when DB and git agree, still
+        // return the current branch so a stale store can be overwritten.
         let repo_dir = tempfile::tempdir().unwrap();
         init_git_repo(repo_dir.path(), "main");
 
@@ -245,7 +276,7 @@ mod tests {
         let result = reconcile_single_workspace_branch(&db_path, "w1")
             .await
             .unwrap();
-        assert!(result.is_none());
+        assert_eq!(result, Some("main".to_string()));
     }
 
     #[tokio::test]
@@ -307,7 +338,8 @@ mod tests {
             .unwrap();
         drop(db);
 
-        // Rename the branch on disk; an archived workspace must not drive an update.
+        // Rename the branch on disk; an archived workspace must not drive an
+        // update or appear in the level-triggered result set.
         rename_branch(repo_dir.path(), "something/else");
 
         let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
@@ -342,10 +374,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reconcile_all_updates_only_drifted_workspaces() {
-        // Two workspaces pointed at two separate repos; only one has been
-        // renamed externally. The return value and the DB should only
-        // reflect the drifted one.
+    async fn reconcile_all_reports_every_active_workspace_writes_only_drifted() {
+        // Level-triggered semantics (#538): both workspaces appear in the
+        // result, but only the drifted one is written back to the DB.
         let stable = tempfile::tempdir().unwrap();
         init_git_repo(stable.path(), "claudette/stable");
         let drifted = tempfile::tempdir().unwrap();
@@ -366,10 +397,14 @@ mod tests {
 
         rename_branch(drifted.path(), "user/renamed");
 
-        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        let mut updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        updates.sort();
         assert_eq!(
             updates,
-            vec![("w2".to_string(), "user/renamed".to_string())]
+            vec![
+                ("w1".to_string(), "claudette/stable".to_string()),
+                ("w2".to_string(), "user/renamed".to_string()),
+            ]
         );
 
         let db = Database::open(&db_path).unwrap();
@@ -384,15 +419,17 @@ mod tests {
     async fn reconcile_all_handles_more_workspaces_than_concurrency_cap() {
         // Spin up more workspaces than RECONCILE_GIT_PROBE_CONCURRENCY so the
         // semaphore is genuinely exercised. Every odd-indexed workspace is
-        // renamed externally; the result must contain exactly those, in any
-        // order, with the DB updated to match.
+        // renamed externally; under level-triggered semantics every active
+        // workspace appears in the result (even ones that haven't drifted),
+        // while DB writes still happen only for those that actually changed.
         let total = RECONCILE_GIT_PROBE_CONCURRENCY * 2 + 1;
         let db_dir = tempfile::tempdir().unwrap();
         let db_path = db_dir.path().join("test.db");
         let db = Database::open(&db_path).unwrap();
 
         let mut repo_dirs = Vec::with_capacity(total);
-        let mut expected = Vec::new();
+        let mut expected_results: Vec<(String, String)> = Vec::new();
+        let mut expected_db: Vec<(String, String)> = Vec::new();
         for i in 0..total {
             let dir = tempfile::tempdir().unwrap();
             init_git_repo(dir.path(), "claudette/orig");
@@ -402,26 +439,54 @@ mod tests {
                 .unwrap();
             db.insert_workspace(&make_ws(&ws_id, &repo_id, "claudette/orig", dir.path()))
                 .unwrap();
-            if i % 2 == 1 {
+            let final_branch = if i % 2 == 1 {
                 let new_branch = format!("user/r{i}");
                 rename_branch(dir.path(), &new_branch);
-                expected.push((ws_id, new_branch));
-            }
+                new_branch
+            } else {
+                "claudette/orig".to_string()
+            };
+            expected_results.push((ws_id.clone(), final_branch.clone()));
+            expected_db.push((ws_id, final_branch));
             repo_dirs.push(dir);
         }
         drop(db);
 
         let mut updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
         updates.sort();
-        expected.sort();
-        assert_eq!(updates, expected);
+        expected_results.sort();
+        assert_eq!(updates, expected_results);
 
         let db = Database::open(&db_path).unwrap();
         let all = db.list_workspaces().unwrap();
-        for (id, branch) in &expected {
+        for (id, branch) in &expected_db {
             let ws = all.iter().find(|w| &w.id == id).unwrap();
             assert_eq!(&ws.branch_name, branch);
         }
+    }
+
+    #[tokio::test]
+    async fn reconcile_all_self_heals_stale_caller_when_db_matches_git() {
+        // Regression for #538: even when DB and git agree, the result must
+        // contain a non-empty entry per active workspace so a frontend store
+        // that has somehow drifted can be overwritten on the next poll.
+        let repo_dir = tempfile::tempdir().unwrap();
+        init_git_repo(repo_dir.path(), "claudette/agreed");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&make_repo("r1", repo_dir.path()))
+            .unwrap();
+        db.insert_workspace(&make_ws("w1", "r1", "claudette/agreed", repo_dir.path()))
+            .unwrap();
+        drop(db);
+
+        let updates = reconcile_all_workspace_branches(&db_path).await.unwrap();
+        assert_eq!(
+            updates,
+            vec![("w1".to_string(), "claudette/agreed".to_string())]
+        );
     }
 
     #[tokio::test]

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -104,8 +104,9 @@ pub async fn reconcile_all_workspace_branches(
 /// reports — `Some(branch)` is **always the current branch**, not just on
 /// drift, so the frontend can overwrite its store value unconditionally.
 /// `None` means we have nothing authoritative to publish: the workspace is
-/// archived, has no worktree path, doesn't exist, or git refused to name a
-/// branch (e.g. detached HEAD). See issue #538.
+/// archived, has no worktree path, or git refused to name a branch (e.g.
+/// detached HEAD). A missing workspace id surfaces as `Err("Workspace not
+/// found")` rather than `None`. See issue #538.
 ///
 /// The DB write is still gated on diff so a no-op refresh costs only a
 /// `git rev-parse`.


### PR DESCRIPTION
## Summary

Fixes #538.

The sidebar branch label could get permanently stuck on an old branch name even when the SQLite DB and the underlying git worktree both held the correct, updated value. Once the Zustand store and the DB diverged — focus blur during a rename, an in-flight race, etc. — there was no recovery path short of restarting the app, because `reconcile_*_workspace_branch` was **edge-triggered**: it only emitted a result when the DB row had to change.

This change makes both reconcile paths **level-triggered**: they always report the current git branch for every active workspace (single + all), so the frontend can overwrite its store value unconditionally on every tick. DB writes are still gated on actual diff, so a steady-state poll costs only a `git rev-parse` per workspace.

## Changes

- `src/workspace_sync.rs` — both reconcile fns return the current branch on success regardless of whether the DB needed updating. `Some(branch)` from the single-workspace path now means "current branch", not "drift detected"; `None` is reserved for "nothing authoritative" (archived, no worktree, detached HEAD).
- `src-tauri/src/commands/workspace.rs` — doc-comments updated; signatures unchanged.
- `src/ui/src/hooks/useBranchRefresh.ts` — empty `catch {}` blocks replaced with `console.warn` so failures surface in DevTools instead of being silently lost.
- Tests updated for new semantics; added `reconcile_all_self_heals_stale_caller_when_db_matches_git` as the explicit #538 regression.

## Out of scope (deferred)

- Manual "refresh" affordance on the workspace row.
- Distinguishing detached HEAD from "healthy" in the UI.
- Auditing other git → DB → store fields (`agent_status`, `worktree_path`, ...) for the same trap.

## Test plan

- [x] `cargo test -p claudette workspace_sync` — 10/10 pass (incl. new regression test)
- [x] `cargo clippy -p claudette --all-targets` with `RUSTFLAGS=-Dwarnings` — clean
- [x] `cargo clippy -p claudette-server --all-targets` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bunx tsc -b` — clean
- [x] `bun run test --run` — 1038/1038 pass
- [ ] Manual: reproduce the original divergence (force the store to a stale branch name via the dev debug eval) and confirm the next poll tick restores the live value.