### PR TITLE
fix: persist diff selection and chat drafts across workspace switches

### DIFF
--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -105,7 +105,11 @@ export function ChatInputArea({
     attachment: DownloadableAttachment,
   ) => void;
 }) {
-  const [chatInput, setChatInput] = useState("");
+  // Lazy-init from the store so a saved draft is restored on mount (e.g. when
+  // returning to a session after the component unmounted via workspace switch).
+  const [chatInput, setChatInput] = useState(
+    () => useAppStore.getState().chatDrafts[sessionId] ?? "",
+  );
   const [cursorPos, setCursorPos] = useState(0);
   const [inputScrollTop, setInputScrollTop] = useState(0);
   const [slashPickerIndex, setSlashPickerIndex] = useState(0);

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -195,23 +195,21 @@ export function ChatInputArea({
     textareaRef.current?.focus();
   }, []);
 
-  // Per-session draft storage: save input when switching away,
-  // restore when switching back.
-  const draftsRef = useRef<Record<string, string>>({});
+  const chatDrafts = useAppStore((s) => s.chatDrafts);
+  const setChatDraft = useAppStore((s) => s.setChatDraft);
+  const chatInputRef = useRef(chatInput);
+  chatInputRef.current = chatInput;
+
   const prevSessionRef = useRef(sessionId);
   useEffect(() => {
     const prev = prevSessionRef.current;
     if (prev !== sessionId) {
-      // Save draft for the session we're leaving.
-      draftsRef.current[prev] = chatInput;
-      // Restore draft for the session we're entering.
-      setChatInput(draftsRef.current[sessionId] ?? "");
+      setChatDraft(prev, chatInput);
+      setChatInput(chatDrafts[sessionId] ?? "");
       prevSessionRef.current = sessionId;
-      // Reset file picker and attachment state for new session.
       setFilesLoaded(false);
       setWorkspaceFiles([]);
       mentionedFilesRef.current = new Set();
-      // Clear staged attachments so they don't leak across sessions.
       setPendingAttachments((prev) => {
         for (const a of prev) {
           if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
@@ -221,6 +219,12 @@ export function ChatInputArea({
       voice.cancel();
     }
   }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    return () => {
+      setChatDraft(sessionId, chatInputRef.current);
+    };
+  }, [sessionId, setChatDraft]);
 
   // Auto-focus the textarea when switching or creating sessions.
   useEffect(() => {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -199,7 +199,10 @@ export function ChatInputArea({
     textareaRef.current?.focus();
   }, []);
 
-  const chatDrafts = useAppStore((s) => s.chatDrafts);
+  // Don't subscribe to chatDrafts — drafts are read inside the session-switch
+  // effect (one-shot) and via getState() in the lazy initializer above. A
+  // selector subscription would re-render this component on every keystroke
+  // in *any* session.
   const setChatDraft = useAppStore((s) => s.setChatDraft);
   const chatInputRef = useRef(chatInput);
   chatInputRef.current = chatInput;
@@ -209,7 +212,7 @@ export function ChatInputArea({
     const prev = prevSessionRef.current;
     if (prev !== sessionId) {
       setChatDraft(prev, chatInput);
-      setChatInput(chatDrafts[sessionId] ?? "");
+      setChatInput(useAppStore.getState().chatDrafts[sessionId] ?? "");
       prevSessionRef.current = sessionId;
       setFilesLoaded(false);
       setWorkspaceFiles([]);

--- a/src/ui/src/stores/slices/chatSessionsSlice.ts
+++ b/src/ui/src/stores/slices/chatSessionsSlice.ts
@@ -89,9 +89,12 @@ export const createChatSessionsSlice: StateCreator<
           break;
         }
       }
+      const nextDrafts = { ...s.chatDrafts };
+      delete nextDrafts[sessionId];
       return {
         sessionsByWorkspace: next,
         selectedSessionIdByWorkspaceId: nextSelected,
+        chatDrafts: nextDrafts,
       };
     }),
   selectSession: (workspaceId, sessionId) =>

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -138,6 +138,9 @@ export interface ChatSlice {
     toolUseId: string,
     partialJson: string,
   ) => void;
+  chatDrafts: Record<string, string>;
+  setChatDraft: (sessionId: string, draft: string) => void;
+  clearChatDraft: (sessionId: string) => void;
   lastMessages: Record<string, ChatMessage>;
   setLastMessages: (msgs: Record<string, ChatMessage>) => void;
 }
@@ -426,6 +429,18 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         ),
       },
     })),
+  chatDrafts: {},
+  setChatDraft: (sessionId, draft) =>
+    set((s) => ({
+      chatDrafts: { ...s.chatDrafts, [sessionId]: draft },
+    })),
+  clearChatDraft: (sessionId) =>
+    set((s) => {
+      if (!(sessionId in s.chatDrafts)) return {};
+      const next = { ...s.chatDrafts };
+      delete next[sessionId];
+      return { chatDrafts: next };
+    }),
   lastMessages: {},
   setLastMessages: (msgs) => set({ lastMessages: msgs }),
 });

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -436,7 +436,7 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
     })),
   clearChatDraft: (sessionId) =>
     set((s) => {
-      if (!(sessionId in s.chatDrafts)) return {};
+      if (!(sessionId in s.chatDrafts)) return s;
       const next = { ...s.chatDrafts };
       delete next[sessionId];
       return { chatDrafts: next };

--- a/src/ui/src/stores/slices/diffSlice.ts
+++ b/src/ui/src/stores/slices/diffSlice.ts
@@ -5,7 +5,11 @@ import type {
   FileDiff,
   DiffViewMode,
 } from "../../types";
-import type { DiffLayer, StagedDiffFiles } from "../../types/diff";
+import type {
+  DiffLayer,
+  DiffSelection,
+  StagedDiffFiles,
+} from "../../types/diff";
 import type { FileContent } from "../../services/tauri";
 import type { AppState } from "../useAppStore";
 
@@ -33,6 +37,9 @@ export interface DiffSlice {
   // different layers produces two distinct tabs because their diff content
   // differs.
   diffTabsByWorkspace: Record<string, DiffFileTab[]>;
+  // Which diff tab was active per workspace. Saved on workspace switch,
+  // restored (with tab-existence validation) when switching back.
+  diffSelectionByWorkspace: Record<string, DiffSelection>;
   setDiffFiles: (
     files: DiffFile[],
     mergeBase: string,
@@ -84,6 +91,7 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
   diffPreviewLoading: false,
   diffPreviewError: null,
   diffTabsByWorkspace: {},
+  diffSelectionByWorkspace: {},
   setDiffFiles: (files, mergeBase, stagedFiles) =>
     set({
       diffFiles: files,
@@ -114,6 +122,7 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
       diffPreviewLoading: false,
       diffPreviewError: null,
       diffTabsByWorkspace: {},
+      diffSelectionByWorkspace: {},
     }),
   openDiffTab: (workspaceId, path, layer) =>
     set((s) => {

--- a/src/ui/src/stores/slices/repositoriesSlice.ts
+++ b/src/ui/src/stores/slices/repositoriesSlice.ts
@@ -53,8 +53,14 @@ export const createRepositoriesSlice: StateCreator<
         delete newActivePane[tabId];
       }
       const newDiffTabs = { ...s.diffTabsByWorkspace };
+      const newDiffSelection = { ...s.diffSelectionByWorkspace };
+      const newChatDrafts = { ...s.chatDrafts };
       for (const wsId of removedWsIds) {
         delete newDiffTabs[wsId];
+        delete newDiffSelection[wsId];
+        for (const session of s.sessionsByWorkspace[wsId] ?? []) {
+          delete newChatDrafts[session.id];
+        }
       }
       return {
         repositories: s.repositories.filter((r) => r.id !== id),
@@ -72,6 +78,8 @@ export const createRepositoriesSlice: StateCreator<
         terminalPaneTrees: newPaneTrees,
         activeTerminalPaneId: newActivePane,
         diffTabsByWorkspace: newDiffTabs,
+        diffSelectionByWorkspace: newDiffSelection,
+        chatDrafts: newChatDrafts,
       };
     }),
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -76,14 +76,24 @@ export const createWorkspacesSlice: StateCreator<
     set((s) => {
       if (id === s.selectedWorkspaceId) return s;
 
-      // Save outgoing workspace's active diff selection.
+      // Save the outgoing workspace's active diff selection, or clear it if
+      // the user left that workspace in chat view (e.g. they clicked a chat
+      // tab, which nulls diffSelectedFile while leaving diff tabs open).
+      // Without the explicit clear, a stale selection from an earlier diff
+      // visit would resurrect the diff view on workspace return.
       const prev = s.selectedWorkspaceId;
       let selectionMap = s.diffSelectionByWorkspace;
-      if (prev && s.diffSelectedFile) {
-        selectionMap = {
-          ...selectionMap,
-          [prev]: { path: s.diffSelectedFile, layer: s.diffSelectedLayer },
-        };
+      if (prev) {
+        if (s.diffSelectedFile) {
+          selectionMap = {
+            ...selectionMap,
+            [prev]: { path: s.diffSelectedFile, layer: s.diffSelectedLayer },
+          };
+        } else if (prev in selectionMap) {
+          const next = { ...selectionMap };
+          delete next[prev];
+          selectionMap = next;
+        }
       }
 
       // Restore incoming workspace's selection, validated against open tabs.

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -51,6 +51,12 @@ export const createWorkspacesSlice: StateCreator<
       }
       const newDiffTabs = { ...s.diffTabsByWorkspace };
       delete newDiffTabs[id];
+      const newDiffSelection = { ...s.diffSelectionByWorkspace };
+      delete newDiffSelection[id];
+      const newChatDrafts = { ...s.chatDrafts };
+      for (const session of s.sessionsByWorkspace[id] ?? []) {
+        delete newChatDrafts[session.id];
+      }
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -62,19 +68,39 @@ export const createWorkspacesSlice: StateCreator<
         terminalPaneTrees: newPaneTrees,
         activeTerminalPaneId: newActivePane,
         diffTabsByWorkspace: newDiffTabs,
+        diffSelectionByWorkspace: newDiffSelection,
+        chatDrafts: newChatDrafts,
       };
     }),
   selectWorkspace: (id) =>
     set((s) => {
+      if (id === s.selectedWorkspaceId) return s;
+
+      // Save outgoing workspace's active diff selection.
+      const prev = s.selectedWorkspaceId;
+      let selectionMap = s.diffSelectionByWorkspace;
+      if (prev && s.diffSelectedFile) {
+        selectionMap = {
+          ...selectionMap,
+          [prev]: { path: s.diffSelectedFile, layer: s.diffSelectedLayer },
+        };
+      }
+
+      // Restore incoming workspace's selection, validated against open tabs.
+      const restored = id ? selectionMap[id] : undefined;
+      const incomingTabs = id ? (s.diffTabsByWorkspace[id] ?? []) : [];
+      const tabExists =
+        restored?.path != null &&
+        incomingTabs.some(
+          (t) => t.path === restored.path && t.layer === restored.layer,
+        );
+
       const updates: Partial<AppState> = {
         selectedWorkspaceId: id,
         rightSidebarTab: "changes",
-        // diffSelectedFile/Layer are workspace-global pointers; switching
-        // workspaces must drop them so the new workspace's tab strip and
-        // content render cleanly. Per-workspace diff *tabs* live in
-        // diffTabsByWorkspace and are preserved.
-        diffSelectedFile: null,
-        diffSelectedLayer: null,
+        diffSelectionByWorkspace: selectionMap,
+        diffSelectedFile: tabExists ? restored!.path : null,
+        diffSelectedLayer: tabExists ? restored!.layer : null,
         diffContent: null,
         diffError: null,
         diffPreviewMode: "diff",

--- a/src/ui/src/stores/useAppStore.persistence.test.ts
+++ b/src/ui/src/stores/useAppStore.persistence.test.ts
@@ -138,6 +138,25 @@ describe("selectWorkspace diff selection persistence", () => {
     expect(useAppStore.getState().diffSelectionByWorkspace["ws-a"]).toBeUndefined();
   });
 
+  it("clears stale selection when leaving a workspace in chat view", () => {
+    // User opens a diff, then clicks a chat tab (which nulls diffSelectedFile
+    // via selectSession), then switches workspaces. The previously-saved
+    // selection must be cleared so it doesn't resurrect on return.
+    useAppStore.getState().openDiffTab("ws-a", "file.ts", "unstaged");
+    useAppStore.getState().selectWorkspace("ws-b");
+    useAppStore.getState().selectWorkspace("ws-a");
+    expect(useAppStore.getState().diffSelectedFile).toBe("file.ts");
+
+    useAppStore.getState().selectSession("ws-a", "s-a1");
+    expect(useAppStore.getState().diffSelectedFile).toBeNull();
+
+    useAppStore.getState().selectWorkspace("ws-b");
+    expect(useAppStore.getState().diffSelectionByWorkspace["ws-a"]).toBeUndefined();
+
+    useAppStore.getState().selectWorkspace("ws-a");
+    expect(useAppStore.getState().diffSelectedFile).toBeNull();
+  });
+
   it("clears diff content on workspace switch even when restoring selection", () => {
     useAppStore.getState().openDiffTab("ws-a", "file.ts", "unstaged");
     useAppStore.setState({ diffContent: { path: "file.ts", hunks: [], is_binary: false } });
@@ -202,6 +221,14 @@ describe("chatDrafts store operations", () => {
     const before = useAppStore.getState().chatDrafts;
     useAppStore.getState().clearChatDraft("nonexistent");
     expect(useAppStore.getState().chatDrafts).toBe(before);
+  });
+
+  it("clearChatDraft no-op preserves overall state identity", () => {
+    // Returning {} from a Zustand setter still merges into a new state object.
+    // Returning s preserves identity so subscribers aren't woken up.
+    const before = useAppStore.getState();
+    useAppStore.getState().clearChatDraft("nonexistent");
+    expect(useAppStore.getState()).toBe(before);
   });
 
   it("drafts are independent per session", () => {

--- a/src/ui/src/stores/useAppStore.persistence.test.ts
+++ b/src/ui/src/stores/useAppStore.persistence.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "./useAppStore";
+import type { Workspace } from "../types/workspace";
+import type { ChatSession } from "../types/chat";
+import type { Repository } from "../types/repository";
+
+function makeWorkspace(id: string, repoId: string = "r1"): Workspace {
+  return {
+    id,
+    repository_id: repoId,
+    name: `ws-${id}`,
+    branch_name: `branch-${id}`,
+    worktree_path: null,
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "2026-01-01T00:00:00Z",
+    remote_connection_id: null,
+  };
+}
+
+function makeSession(id: string, wsId: string): ChatSession {
+  return {
+    id,
+    workspace_id: wsId,
+    session_id: null,
+    name: `session-${id}`,
+    name_edited: false,
+    turn_count: 0,
+    sort_order: 0,
+    status: "Active",
+    created_at: "2026-01-01T00:00:00Z",
+    archived_at: null,
+    agent_status: "Idle",
+    needs_attention: false,
+    attention_kind: null,
+  };
+}
+
+function makeRepository(id: string): Repository {
+  return {
+    id,
+    path: `/repo-${id}`,
+    name: `repo-${id}`,
+    path_slug: `repo-${id}`,
+    icon: null,
+    created_at: "2026-01-01T00:00:00Z",
+    setup_script: null,
+    custom_instructions: null,
+    sort_order: 0,
+    branch_rename_preferences: null,
+    setup_script_auto_run: false,
+    base_branch: null,
+    default_remote: null,
+    path_valid: true,
+    remote_connection_id: null,
+  };
+}
+
+function reset() {
+  useAppStore.setState({
+    workspaces: [makeWorkspace("ws-a"), makeWorkspace("ws-b")],
+    selectedWorkspaceId: "ws-a",
+    diffTabsByWorkspace: {},
+    diffSelectionByWorkspace: {},
+    diffSelectedFile: null,
+    diffSelectedLayer: null,
+    diffContent: null,
+    diffError: null,
+    diffPreviewMode: "diff",
+    diffPreviewContent: null,
+    diffPreviewLoading: false,
+    diffPreviewError: null,
+    sessionsByWorkspace: {
+      "ws-a": [makeSession("s-a1", "ws-a"), makeSession("s-a2", "ws-a")],
+      "ws-b": [makeSession("s-b1", "ws-b")],
+    },
+    selectedSessionIdByWorkspaceId: { "ws-a": "s-a1", "ws-b": "s-b1" },
+    chatDrafts: {},
+    unreadCompletions: new Set(),
+    terminalTabs: {},
+    activeTerminalTabId: {},
+    workspaceTerminalCommands: {},
+    terminalPaneTrees: {},
+    activeTerminalPaneId: {},
+    repositories: [],
+  });
+}
+
+// ---------- Diff selection persistence ----------
+
+describe("selectWorkspace diff selection persistence", () => {
+  beforeEach(reset);
+
+  it("is a no-op when re-selecting the current workspace", () => {
+    useAppStore.getState().openDiffTab("ws-a", "file.ts", "unstaged");
+    const before = useAppStore.getState();
+    useAppStore.getState().selectWorkspace("ws-a");
+    const after = useAppStore.getState();
+    expect(after).toBe(before);
+  });
+
+  it("saves and restores diff selection on workspace switch", () => {
+    useAppStore.getState().openDiffTab("ws-a", "file.ts", "unstaged");
+    expect(useAppStore.getState().diffSelectedFile).toBe("file.ts");
+
+    useAppStore.getState().selectWorkspace("ws-b");
+    expect(useAppStore.getState().diffSelectedFile).toBeNull();
+
+    useAppStore.getState().selectWorkspace("ws-a");
+    expect(useAppStore.getState().diffSelectedFile).toBe("file.ts");
+    expect(useAppStore.getState().diffSelectedLayer).toBe("unstaged");
+  });
+
+  it("does not restore a dead selection when the tab was closed", () => {
+    useAppStore.getState().openDiffTab("ws-a", "file.ts", "unstaged");
+    useAppStore.getState().selectWorkspace("ws-b");
+
+    useAppStore.setState({ diffTabsByWorkspace: { "ws-a": [], "ws-b": [] } });
+
+    useAppStore.getState().selectWorkspace("ws-a");
+    expect(useAppStore.getState().diffSelectedFile).toBeNull();
+  });
+
+  it("preserves diff tabs across workspace switches", () => {
+    useAppStore.getState().openDiffTab("ws-a", "a.ts", "staged");
+    useAppStore.getState().openDiffTab("ws-a", "b.ts", "unstaged");
+
+    useAppStore.getState().selectWorkspace("ws-b");
+    useAppStore.getState().openDiffTab("ws-b", "c.ts", "committed");
+
+    expect(useAppStore.getState().diffTabsByWorkspace["ws-a"]).toHaveLength(2);
+    expect(useAppStore.getState().diffTabsByWorkspace["ws-b"]).toHaveLength(1);
+  });
+
+  it("does not save selection when outgoing workspace has no active diff", () => {
+    useAppStore.getState().selectWorkspace("ws-b");
+    expect(useAppStore.getState().diffSelectionByWorkspace["ws-a"]).toBeUndefined();
+  });
+
+  it("clears diff content on workspace switch even when restoring selection", () => {
+    useAppStore.getState().openDiffTab("ws-a", "file.ts", "unstaged");
+    useAppStore.setState({ diffContent: { path: "file.ts", hunks: [], is_binary: false } });
+
+    useAppStore.getState().selectWorkspace("ws-b");
+    useAppStore.getState().selectWorkspace("ws-a");
+
+    expect(useAppStore.getState().diffSelectedFile).toBe("file.ts");
+    expect(useAppStore.getState().diffContent).toBeNull();
+  });
+});
+
+// ---------- Diff selection cleanup ----------
+
+describe("diff selection cleanup on removal", () => {
+  beforeEach(() => {
+    reset();
+    useAppStore.setState({
+      repositories: [makeRepository("r1")],
+      diffSelectionByWorkspace: {
+        "ws-a": { path: "a.ts", layer: "unstaged" },
+        "ws-b": { path: "b.ts", layer: "staged" },
+      },
+    });
+  });
+
+  it("removeWorkspace cleans up diffSelectionByWorkspace", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    expect(useAppStore.getState().diffSelectionByWorkspace["ws-a"]).toBeUndefined();
+    expect(useAppStore.getState().diffSelectionByWorkspace["ws-b"]).toBeDefined();
+  });
+
+  it("removeRepository cleans up diffSelectionByWorkspace for all workspaces", () => {
+    useAppStore.getState().removeRepository("r1");
+    expect(useAppStore.getState().diffSelectionByWorkspace).toEqual({});
+  });
+});
+
+// ---------- Chat draft persistence ----------
+
+describe("chatDrafts store operations", () => {
+  beforeEach(reset);
+
+  it("setChatDraft writes and reads correctly", () => {
+    useAppStore.getState().setChatDraft("s-a1", "hello world");
+    expect(useAppStore.getState().chatDrafts["s-a1"]).toBe("hello world");
+  });
+
+  it("setChatDraft overwrites existing draft", () => {
+    useAppStore.getState().setChatDraft("s-a1", "first");
+    useAppStore.getState().setChatDraft("s-a1", "second");
+    expect(useAppStore.getState().chatDrafts["s-a1"]).toBe("second");
+  });
+
+  it("clearChatDraft removes the draft entry", () => {
+    useAppStore.getState().setChatDraft("s-a1", "hello");
+    useAppStore.getState().clearChatDraft("s-a1");
+    expect(useAppStore.getState().chatDrafts["s-a1"]).toBeUndefined();
+  });
+
+  it("clearChatDraft is a no-op for missing key", () => {
+    const before = useAppStore.getState().chatDrafts;
+    useAppStore.getState().clearChatDraft("nonexistent");
+    expect(useAppStore.getState().chatDrafts).toBe(before);
+  });
+
+  it("drafts are independent per session", () => {
+    useAppStore.getState().setChatDraft("s-a1", "draft-a1");
+    useAppStore.getState().setChatDraft("s-a2", "draft-a2");
+    expect(useAppStore.getState().chatDrafts["s-a1"]).toBe("draft-a1");
+    expect(useAppStore.getState().chatDrafts["s-a2"]).toBe("draft-a2");
+  });
+});
+
+// ---------- Chat draft cleanup ----------
+
+describe("chat draft cleanup on removal", () => {
+  beforeEach(() => {
+    reset();
+    useAppStore.setState({
+      repositories: [makeRepository("r1")],
+      chatDrafts: {
+        "s-a1": "draft a1",
+        "s-a2": "draft a2",
+        "s-b1": "draft b1",
+      },
+    });
+  });
+
+  it("removeChatSession cleans up draft for that session", () => {
+    useAppStore.getState().removeChatSession("s-a1");
+    expect(useAppStore.getState().chatDrafts["s-a1"]).toBeUndefined();
+    expect(useAppStore.getState().chatDrafts["s-a2"]).toBe("draft a2");
+  });
+
+  it("removeWorkspace cleans up drafts for all sessions in that workspace", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    expect(useAppStore.getState().chatDrafts["s-a1"]).toBeUndefined();
+    expect(useAppStore.getState().chatDrafts["s-a2"]).toBeUndefined();
+    expect(useAppStore.getState().chatDrafts["s-b1"]).toBe("draft b1");
+  });
+
+  it("removeRepository cleans up drafts for all sessions across all workspaces", () => {
+    useAppStore.getState().removeRepository("r1");
+    expect(useAppStore.getState().chatDrafts).toEqual({});
+  });
+});
+
+// ---------- clearDiff ----------
+
+describe("clearDiff resets selection map", () => {
+  beforeEach(reset);
+
+  it("clears diffSelectionByWorkspace along with other diff state", () => {
+    useAppStore.setState({
+      diffSelectionByWorkspace: {
+        "ws-a": { path: "a.ts", layer: "unstaged" },
+      },
+    });
+    useAppStore.getState().clearDiff();
+    expect(useAppStore.getState().diffSelectionByWorkspace).toEqual({});
+  });
+});

--- a/src/ui/src/types/diff.ts
+++ b/src/ui/src/types/diff.ts
@@ -18,6 +18,11 @@ export interface DiffFileTab {
   layer: DiffLayer | null;
 }
 
+export interface DiffSelection {
+  path: string;
+  layer: DiffLayer | null;
+}
+
 export interface StagedDiffFiles {
   committed: DiffFile[];
   staged: DiffFile[];


### PR DESCRIPTION
## Summary

Re-roll of #353 by @chxmbley, adapted to the current architecture (session tabs and `diffTabsByWorkspace`, both of which landed after the original PR was authored).

- **Diff selection persistence** — adds `diffSelectionByWorkspace` to track which diff tab was active per workspace. Saves on switch-away, restores on switch-back, and validates against open tabs so a closed tab cannot be resurrected as a phantom selection.
- **Chat draft persistence** — moves drafts from component-local `useRef` to the store as `chatDrafts`, keyed by **session ID** (not workspace ID as in the original PR). This naturally handles both session-tab and workspace switches with a single mechanism, and preserves per-session drafts when a workspace has multiple sessions open. Resolves the scope conflict Copilot flagged on the original PR.
- Cleanup hooked into `removeWorkspace`, `removeRepository`, and `removeChatSession`.

The ToolActivitiesSection flicker change from #353 was not carried forward — the current `useEffect` + `useRef` pattern is standard and `collapsed` already defaults to `true`, so there's nothing to fix.

Closes #353. Credit to @chxmbley for identifying both bugs and the original implementation; this PR adapts the approach for the post-session-tabs architecture.

## Test plan

- [x] `bunx tsc -b` — clean
- [x] `bun run test` — 1055 tests pass (68 files), including 17 new tests in `useAppStore.persistence.test.ts` covering save/restore, no-op re-select, dead-tab validation, and cleanup on workspace/repo/session removal
- [ ] Manual: open a diff tab in workspace A, switch to B, switch back — tab is re-selected
- [ ] Manual: type a draft in session 1 of workspace A, switch to session 2, switch to workspace B, switch back to A — session 1's draft is preserved
- [ ] Manual: remove a workspace/repo — verify no stale entries via `/claudette-debug state`