### PR TITLE
feat(pinned-prompts): redesign settings UI and add slash autocomplete

### DIFF
--- a/src/ui/src/components/chat/SlashCommandPicker.module.css
+++ b/src/ui/src/components/chat/SlashCommandPicker.module.css
@@ -14,6 +14,13 @@
   box-shadow: var(--shadow-lg);
 }
 
+.pickerBelow {
+  bottom: auto;
+  top: 100%;
+  margin-bottom: 0;
+  margin-top: 4px;
+}
+
 .item {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/chat/SlashCommandPicker.tsx
+++ b/src/ui/src/components/chat/SlashCommandPicker.tsx
@@ -6,6 +6,7 @@ interface SlashCommandPickerProps {
   selectedIndex: number;
   onSelect: (command: SlashCommand) => void;
   onHover: (index: number) => void;
+  placement?: "above" | "below";
 }
 
 export function SlashCommandPicker({
@@ -13,11 +14,20 @@ export function SlashCommandPicker({
   selectedIndex,
   onSelect,
   onHover,
+  placement = "above",
 }: SlashCommandPickerProps) {
   if (commands.length === 0) return null;
 
+  const className = placement === "below"
+    ? `${styles.picker} ${styles.pickerBelow}`
+    : styles.picker;
+
   return (
-    <div className={styles.picker} role="listbox">
+    <div
+      className={className}
+      role="listbox"
+      onMouseDown={(e) => e.preventDefault()}
+    >
       {commands.map((cmd, i) => (
         <div
           key={cmd.name}

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -280,6 +280,27 @@ describe("describeSlashQueryAtCursor", () => {
   it("returns null for plain text with no slash", () => {
     expect(describeSlashQueryAtCursor("just some text", 14)).toBeNull();
   });
+
+  it("extends end past cursor to cover the full token when caret is mid-token", () => {
+    // Caret sits between `e` and `v` of `/rev|iew`. The replacement range
+    // must cover all of `/review` so selection doesn't leave `iew` behind.
+    expect(describeSlashQueryAtCursor("/review", 4)).toEqual({
+      token: "rev",
+      start: 0,
+      end: 7,
+    });
+  });
+
+  it("extends end through token but stops at whitespace when caret is mid-token after a newline", () => {
+    // Input: `text\n/rev|iew rest`. Caret is at index 9 (mid-token);
+    // tokenEnd should walk forward to 12 (end of `/review`) but stop at
+    // the space before `rest`.
+    expect(describeSlashQueryAtCursor("text\n/review rest", 9)).toEqual({
+      token: "rev",
+      start: 5,
+      end: 12,
+    });
+  });
 });
 
 describe("native handler table", () => {

--- a/src/ui/src/components/chat/nativeSlashCommands.test.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.test.ts
@@ -6,6 +6,7 @@ import {
   CONFIG_SECTIONS,
   NATIVE_HANDLERS,
   describeSlashQuery,
+  describeSlashQueryAtCursor,
   formatHelpMessage,
   formatVersionMessage,
   parseSlashInput,
@@ -228,6 +229,56 @@ describe("describeSlashQuery", () => {
   it("does not consume a leading slash inside a longer prefix", async () => {
     expect(describeSlashQuery("  /plugin")).toBeNull();
     expect(describeSlashQuery("not/a/command")).toBeNull();
+  });
+});
+
+describe("describeSlashQueryAtCursor", () => {
+  it("detects a command at position 0", () => {
+    expect(describeSlashQueryAtCursor("/review", 7)).toEqual({
+      token: "review",
+      start: 0,
+      end: 7,
+    });
+  });
+
+  it("returns empty token for a bare slash", () => {
+    expect(describeSlashQueryAtCursor("/", 1)).toEqual({
+      token: "",
+      start: 0,
+      end: 1,
+    });
+  });
+
+  it("detects a command after a newline", () => {
+    expect(describeSlashQueryAtCursor("some text\n/rev", 14)).toEqual({
+      token: "rev",
+      start: 10,
+      end: 14,
+    });
+  });
+
+  it("returns null when slash is mid-line (not after newline)", () => {
+    expect(describeSlashQueryAtCursor("some text /rev", 14)).toBeNull();
+  });
+
+  it("returns null when cursor is past whitespace after the token", () => {
+    expect(describeSlashQueryAtCursor("/review args", 12)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(describeSlashQueryAtCursor("", 0)).toBeNull();
+  });
+
+  it("detects bare slash after newline", () => {
+    expect(describeSlashQueryAtCursor("text\n/", 6)).toEqual({
+      token: "",
+      start: 5,
+      end: 6,
+    });
+  });
+
+  it("returns null for plain text with no slash", () => {
+    expect(describeSlashQueryAtCursor("just some text", 14)).toBeNull();
   });
 });
 

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -144,10 +144,18 @@ export function describeSlashQueryAtCursor(
   // between the `/` and the cursor, the command token is closed.
   const tokenMatch = linePrefix.match(/^\/(\S*)$/);
   if (!tokenMatch) return null;
+  // Extend end past the cursor so replacement covers the full token even when
+  // the caret sits inside an existing `/command` (e.g. clicking into `/review`
+  // halfway through). The token used for filtering stays the prefix up to the
+  // cursor — that's what the user has committed to so far.
+  let tokenEnd = cursor;
+  while (tokenEnd < text.length && /\S/.test(text[tokenEnd] ?? "")) {
+    tokenEnd += 1;
+  }
   return {
     token: tokenMatch[1],
     start: lineStart,
-    end: cursor,
+    end: tokenEnd,
   };
 }
 

--- a/src/ui/src/components/chat/nativeSlashCommands.ts
+++ b/src/ui/src/components/chat/nativeSlashCommands.ts
@@ -124,6 +124,33 @@ export function describeSlashQuery(
   return { token: match[1] ?? "", hasArgs: match[2] !== undefined };
 }
 
+/**
+ * Detect a `/command` token at `cursor` inside multi-line `text`.
+ *
+ * A `/` triggers autocomplete when it sits at position 0 of the text or
+ * immediately after a newline. Returns the token (text between `/` and the
+ * next whitespace or end-of-input) plus the character range it occupies so
+ * the caller can replace it on selection.
+ */
+export function describeSlashQueryAtCursor(
+  text: string,
+  cursor: number,
+): { token: string; start: number; end: number } | null {
+  const before = text.slice(0, cursor);
+  const lineStart = before.lastIndexOf("\n") + 1;
+  const linePrefix = before.slice(lineStart);
+  if (!linePrefix.startsWith("/")) return null;
+  // Only the first word on the line qualifies — if there's whitespace
+  // between the `/` and the cursor, the command token is closed.
+  const tokenMatch = linePrefix.match(/^\/(\S*)$/);
+  if (!tokenMatch) return null;
+  return {
+    token: tokenMatch[1],
+    start: lineStart,
+    end: cursor,
+  };
+}
+
 function pluginHandler(root: "plugin" | "marketplace"): NativeHandler {
   return {
     name: root,

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
@@ -5,6 +5,8 @@
   margin-bottom: 16px;
 }
 
+/* ----- Card ----- */
+
 .row {
   border: 1px solid var(--divider);
   border-radius: 8px;
@@ -13,7 +15,63 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  overflow: hidden;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
+
+.rowEditing {
+  border-color: color-mix(in srgb, var(--accent-primary) 55%, var(--divider));
+}
+
+.rowDangerous {
+  border-color: color-mix(in srgb, var(--status-stopped) 35%, var(--divider));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row {
+    transition: none;
+  }
+}
+
+/* ----- Display mode ----- */
+
+.displayHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.displayName {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.displayPreview {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.displayMeta {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+/* ----- Editing mode ----- */
 
 .rowHeader {
   display: flex;
@@ -32,10 +90,12 @@
   font-weight: 500;
   outline: none;
   min-width: 0;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
 .nameInput:focus {
-  border-color: var(--text-dim);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-primary) 50%, transparent);
 }
 
 .nameInputError {
@@ -56,10 +116,19 @@
   resize: vertical;
   min-height: 56px;
   box-sizing: border-box;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
 .promptInput:focus {
-  border-color: var(--text-dim);
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-primary) 50%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nameInput,
+  .promptInput {
+    transition: none;
+  }
 }
 
 .textareaWrapper {
@@ -93,6 +162,28 @@
   gap: 4px;
 }
 
+/* ----- Footer (segmented action bar) ----- */
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 10px;
+  margin-top: 2px;
+  border-top: 1px solid var(--divider);
+}
+
+.footerSpacer {
+  margin-left: auto;
+}
+
+.errorText {
+  color: var(--status-stopped);
+  font-size: 11px;
+}
+
+/* ----- Icon buttons (chevrons, edit pencil) ----- */
+
 .iconButton {
   display: inline-flex;
   align-items: center;
@@ -107,6 +198,7 @@
   cursor: pointer;
   font-size: 13px;
   line-height: 1;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 
 .iconButton:hover:not(:disabled) {
@@ -119,19 +211,133 @@
   cursor: default;
 }
 
-.deleteButton {
-  composes: iconButton;
+@media (prefers-reduced-motion: reduce) {
+  .iconButton {
+    transition: none;
+  }
 }
 
-.deleteButton:hover {
+/* ----- Button variants ----- */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: none;
+  color: var(--text-primary);
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease,
+    box-shadow 0.12s ease, opacity 0.12s ease;
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-primary) 60%, transparent);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition: none;
+  }
+}
+
+.btnPrimary {
+  composes: btn;
+  background: var(--accent-primary);
+  color: var(--on-accent);
+  border-color: var(--accent-primary);
+}
+
+.btnPrimary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-primary) 88%, #000);
+  border-color: color-mix(in srgb, var(--accent-primary) 88%, #000);
+}
+
+.btnGhost {
+  composes: btn;
+  border-color: var(--divider);
+  color: var(--text-muted);
+}
+
+.btnGhost:hover:not(:disabled) {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+  border-color: var(--text-dim);
+}
+
+.btnDestructiveText {
+  composes: btn;
+  color: var(--status-stopped);
+}
+
+.btnDestructiveText:hover:not(:disabled) {
   background: var(--error-hover);
-  color: var(--status-stopped);
 }
 
-.errorText {
-  color: var(--status-stopped);
-  font-size: 11px;
+.btnDestructiveFill {
+  composes: btn;
+  background: var(--status-stopped);
+  color: var(--on-accent);
+  border-color: var(--status-stopped);
 }
+
+.btnDestructiveFill:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--status-stopped) 88%, #000);
+  border-color: color-mix(in srgb, var(--status-stopped) 88%, #000);
+}
+
+/* ----- Confirm-delete panel (inset, bleeds to card edges) ----- */
+
+.confirmPanel {
+  margin: 4px -14px -12px;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--status-stopped) 6%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--status-stopped) 25%, var(--divider));
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.confirmCopy {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.confirmTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.confirmSubtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.confirmActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+/* ----- Empty state + Add button ----- */
 
 .empty {
   padding: 16px;
@@ -160,6 +366,8 @@
   border-color: var(--text-dim);
   color: var(--text-primary);
 }
+
+/* ----- Inherited globals list ----- */
 
 .inheritedHeading {
   margin: 24px 0 8px;

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
@@ -15,7 +15,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  overflow: hidden;
   transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
@@ -303,6 +302,11 @@
   padding: 12px 14px;
   background: color-mix(in srgb, var(--status-stopped) 6%, transparent);
   border-top: 1px solid color-mix(in srgb, var(--status-stopped) 25%, var(--divider));
+  /* Match the card's inner corner radius (8px outer - 1px border) so the
+     destructive bleed looks flush with the card without `overflow: hidden`
+     on `.row`, which would clip the slash autocomplete picker. */
+  border-bottom-left-radius: 7px;
+  border-bottom-right-radius: 7px;
   display: flex;
   align-items: center;
   gap: 12px;

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
@@ -62,6 +62,10 @@
   border-color: var(--text-dim);
 }
 
+.textareaWrapper {
+  position: relative;
+}
+
 .controlsRow {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.module.css
@@ -261,8 +261,7 @@
 }
 
 .btnPrimary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent-primary) 88%, #000);
-  border-color: color-mix(in srgb, var(--accent-primary) 88%, #000);
+  filter: brightness(0.92);
 }
 
 .btnGhost {
@@ -294,8 +293,7 @@
 }
 
 .btnDestructiveFill:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--status-stopped) 88%, #000);
-  border-color: color-mix(in srgb, var(--status-stopped) 88%, #000);
+  filter: brightness(0.92);
 }
 
 /* ----- Confirm-delete panel (inset, bleeds to card edges) ----- */

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
@@ -1,15 +1,19 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Plus, Save, Trash2 } from "lucide-react";
 import {
   type PinnedPrompt,
+  type SlashCommand,
   createPinnedPrompt,
   deletePinnedPrompt,
+  listSlashCommands,
   reorderPinnedPrompts,
   updatePinnedPrompt,
 } from "../../../services/tauri";
 import { useAppStore } from "../../../stores/useAppStore";
 import { EMPTY_PINNED_PROMPTS } from "../../../stores/slices/pinnedPromptsSlice";
+import { useSlashAutocomplete } from "../../../hooks/useSlashAutocomplete";
+import { SlashCommandPicker } from "../../chat/SlashCommandPicker";
 import styles from "./PinnedPromptsManager.module.css";
 
 export type PinnedPromptScope =
@@ -18,6 +22,7 @@ export type PinnedPromptScope =
 
 interface PinnedPromptsManagerProps {
   scope: PinnedPromptScope;
+  projectPath?: string;
 }
 
 interface DraftRow {
@@ -38,8 +43,17 @@ function makeDraftId(): string {
  * exposes an "Add prompt" affordance. Persistence is optimistic; failures
  * roll back and surface an inline error.
  */
-export function PinnedPromptsManager({ scope }: PinnedPromptsManagerProps) {
+export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManagerProps) {
   const { t } = useTranslation("settings");
+
+  const [slashCommands, setSlashCommands] = useState<SlashCommand[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    listSlashCommands(projectPath ?? undefined)
+      .then((cmds) => { if (!cancelled) setSlashCommands(cmds); })
+      .catch((e) => console.error("Failed to load slash commands:", e));
+    return () => { cancelled = true; };
+  }, [projectPath]);
 
   // `null` for global scope, repo id string for repo scope. Used both as the
   // store key and as the API parameter — they're the same primitive.
@@ -295,6 +309,7 @@ export function PinnedPromptsManager({ scope }: PinnedPromptsManagerProps) {
               onMoveDown={() => handleMove(i, +1)}
               onDelete={() => handleDelete(p)}
               onCommit={(next) => commitEdit(p, next)}
+              slashCommands={slashCommands}
             />
           ))}
           {drafts.map((d) => (
@@ -308,6 +323,7 @@ export function PinnedPromptsManager({ scope }: PinnedPromptsManagerProps) {
                 setError(d.draftId, null);
                 removeDraft(d.draftId);
               }}
+              slashCommands={slashCommands}
             />
           ))}
         </div>
@@ -338,6 +354,7 @@ interface PromptRowProps {
     prompt: string;
     auto_send: boolean;
   }) => void;
+  slashCommands: SlashCommand[];
 }
 
 function PromptRow({
@@ -349,11 +366,14 @@ function PromptRow({
   onMoveDown,
   onDelete,
   onCommit,
+  slashCommands,
 }: PromptRowProps) {
   const { t } = useTranslation("settings");
   const [name, setName] = useState(prompt.display_name);
   const [body, setBody] = useState(prompt.prompt);
   const [autoSend, setAutoSend] = useState(prompt.auto_send);
+  const [cursorPos, setCursorPos] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Sync local state when the prompt is replaced from the store (e.g. after a
   // successful save returns the canonical row, or another tab reloads).
@@ -366,6 +386,34 @@ function PromptRow({
   const flush = useCallback(() => {
     onCommit({ display_name: name, prompt: body, auto_send: autoSend });
   }, [onCommit, name, body, autoSend]);
+
+  const onSlashInsert = useCallback(
+    (replacement: string, start: number, end: number) => {
+      const next = body.slice(0, start) + replacement + body.slice(end);
+      setBody(next);
+      const newCursor = start + replacement.length;
+      setCursorPos(newCursor);
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (ta) {
+          ta.selectionStart = ta.selectionEnd = newCursor;
+          ta.focus();
+        }
+      });
+    },
+    [body],
+  );
+
+  const slash = useSlashAutocomplete({
+    value: body,
+    cursorPosition: cursorPos,
+    commands: slashCommands,
+    onInsert: onSlashInsert,
+  });
+
+  const updateCursor = useCallback((el: HTMLTextAreaElement) => {
+    setCursorPos(el.selectionStart);
+  }, []);
 
   return (
     <div className={styles.row}>
@@ -410,15 +458,29 @@ function PromptRow({
           </button>
         </div>
       </div>
-      <textarea
-        className={styles.promptInput}
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-        onBlur={flush}
-        rows={3}
-        placeholder={t("pinned_prompts_prompt_placeholder")}
-        aria-label={t("pinned_prompts_prompt_label")}
-      />
+      <div className={styles.textareaWrapper}>
+        <textarea
+          ref={textareaRef}
+          className={styles.promptInput}
+          value={body}
+          onChange={(e) => { setBody(e.target.value); updateCursor(e.target); }}
+          onSelect={(e) => updateCursor(e.currentTarget)}
+          onBlur={flush}
+          onKeyDown={(e) => { if (slash.handleKeyDown(e)) e.preventDefault(); }}
+          rows={3}
+          placeholder={t("pinned_prompts_prompt_placeholder")}
+          aria-label={t("pinned_prompts_prompt_label")}
+        />
+        {slash.showPicker && (
+          <SlashCommandPicker
+            commands={slash.filteredCommands}
+            selectedIndex={slash.selectedIndex}
+            onSelect={slash.selectCommand}
+            onHover={slash.setSelectedIndex}
+            placement="below"
+          />
+        )}
+      </div>
       <div className={styles.controlsRow}>
         <label className={styles.autoSendLabel}>
           <input
@@ -447,6 +509,7 @@ interface DraftRowViewProps {
   onChange: (patch: Partial<DraftRow>) => void;
   onCommit: () => void;
   onCancel: () => void;
+  slashCommands: SlashCommand[];
 }
 
 function DraftRowView({
@@ -455,8 +518,40 @@ function DraftRowView({
   onChange,
   onCommit,
   onCancel,
+  slashCommands,
 }: DraftRowViewProps) {
   const { t } = useTranslation("settings");
+  const [cursorPos, setCursorPos] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const onSlashInsert = useCallback(
+    (replacement: string, start: number, end: number) => {
+      const next = draft.prompt.slice(0, start) + replacement + draft.prompt.slice(end);
+      onChange({ prompt: next });
+      const newCursor = start + replacement.length;
+      setCursorPos(newCursor);
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (ta) {
+          ta.selectionStart = ta.selectionEnd = newCursor;
+          ta.focus();
+        }
+      });
+    },
+    [draft.prompt, onChange],
+  );
+
+  const slash = useSlashAutocomplete({
+    value: draft.prompt,
+    cursorPosition: cursorPos,
+    commands: slashCommands,
+    onInsert: onSlashInsert,
+  });
+
+  const updateCursor = useCallback((el: HTMLTextAreaElement) => {
+    setCursorPos(el.selectionStart);
+  }, []);
+
   return (
     <div className={styles.row}>
       <div className={styles.rowHeader}>
@@ -480,14 +575,28 @@ function DraftRowView({
           </button>
         </div>
       </div>
-      <textarea
-        className={styles.promptInput}
-        value={draft.prompt}
-        onChange={(e) => onChange({ prompt: e.target.value })}
-        rows={3}
-        placeholder={t("pinned_prompts_prompt_placeholder")}
-        aria-label={t("pinned_prompts_prompt_label")}
-      />
+      <div className={styles.textareaWrapper}>
+        <textarea
+          ref={textareaRef}
+          className={styles.promptInput}
+          value={draft.prompt}
+          onChange={(e) => { onChange({ prompt: e.target.value }); updateCursor(e.target); }}
+          onSelect={(e) => updateCursor(e.currentTarget)}
+          onKeyDown={(e) => { if (slash.handleKeyDown(e)) e.preventDefault(); }}
+          rows={3}
+          placeholder={t("pinned_prompts_prompt_placeholder")}
+          aria-label={t("pinned_prompts_prompt_label")}
+        />
+        {slash.showPicker && (
+          <SlashCommandPicker
+            commands={slash.filteredCommands}
+            selectedIndex={slash.selectedIndex}
+            onSelect={slash.selectCommand}
+            onHover={slash.setSelectedIndex}
+            placement="below"
+          />
+        )}
+      </div>
       <div className={styles.controlsRow}>
         <label className={styles.autoSendLabel}>
           <input
@@ -506,7 +615,7 @@ function DraftRowView({
             title={t("pinned_prompts_save_draft")}
             aria-label={t("pinned_prompts_save_draft")}
           >
-            <Plus size={14} />
+            <Save size={14} />
           </button>
         </div>
       </div>

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
@@ -429,22 +429,39 @@ function PromptRow({
 
   const canSave = name.trim().length > 0 && body.trim().length > 0;
 
-  // Cmd/Ctrl+Enter saves; Esc cancels. Slash autocomplete consumes its own keys first.
+  // Save/cancel shortcuts that work from any field in the editor.
+  const handleSaveCancelKey = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (canSave) void save();
+        return true;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        cancelEdit();
+        return true;
+      }
+      return false;
+    },
+    [canSave, save, cancelEdit],
+  );
+
+  // Name input: only Cmd/Ctrl+Enter and Esc — never the slash picker, which
+  // is anchored to the textarea. Otherwise arrow/Enter keys in the name field
+  // would navigate/select picker items while the user is typing a name.
+  const handleNameKeyDown = handleSaveCancelKey;
+
+  // Textarea: slash autocomplete consumes its own keys first, then save/cancel.
   const handleEditorKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (slash.handleKeyDown(e)) {
         e.preventDefault();
         return;
       }
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        if (canSave) void save();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        cancelEdit();
-      }
+      handleSaveCancelKey(e);
     },
-    [slash, canSave, save, cancelEdit],
+    [slash, handleSaveCancelKey],
   );
 
   // ---------- Display mode ----------
@@ -506,7 +523,7 @@ function PromptRow({
           className={error ? styles.nameInputError : styles.nameInput}
           value={name}
           onChange={(e) => setName(e.target.value)}
-          onKeyDown={handleEditorKeyDown}
+          onKeyDown={handleNameKeyDown}
           placeholder={t("pinned_prompts_display_name_placeholder")}
           aria-label={t("pinned_prompts_display_name_label")}
           disabled={mode === "confirm-delete"}
@@ -655,21 +672,35 @@ function DraftRowView({
   const canSave =
     draft.display_name.trim().length > 0 && draft.prompt.trim().length > 0;
 
+  const handleSaveCancelKey = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (canSave) onCommit();
+        return true;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return true;
+      }
+      return false;
+    },
+    [canSave, onCommit, onCancel],
+  );
+
+  // Name input: save/cancel only — the picker is anchored to the textarea.
+  const handleNameKeyDown = handleSaveCancelKey;
+
   const handleEditorKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (slash.handleKeyDown(e)) {
         e.preventDefault();
         return;
       }
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        if (canSave) onCommit();
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        onCancel();
-      }
+      handleSaveCancelKey(e);
     },
-    [slash, canSave, onCommit, onCancel],
+    [slash, handleSaveCancelKey],
   );
 
   return (
@@ -679,7 +710,7 @@ function DraftRowView({
           className={error ? styles.nameInputError : styles.nameInput}
           value={draft.display_name}
           onChange={(e) => onChange({ display_name: e.target.value })}
-          onKeyDown={handleEditorKeyDown}
+          onKeyDown={handleNameKeyDown}
           placeholder={t("pinned_prompts_display_name_placeholder")}
           aria-label={t("pinned_prompts_display_name_label")}
           autoFocus

--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronUp, Plus, Save, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Pencil, Plus } from "lucide-react";
 import {
   type PinnedPrompt,
   type SlashCommand,
@@ -36,13 +36,6 @@ function makeDraftId(): string {
   return `draft-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/**
- * Settings UI for managing pinned prompts in a single scope.
- *
- * Renders the existing prompts, lets the user edit/reorder/delete them, and
- * exposes an "Add prompt" affordance. Persistence is optimistic; failures
- * roll back and surface an inline error.
- */
 export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManagerProps) {
   const { t } = useTranslation("settings");
 
@@ -55,14 +48,8 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
     return () => { cancelled = true; };
   }, [projectPath]);
 
-  // `null` for global scope, repo id string for repo scope. Used both as the
-  // store key and as the API parameter — they're the same primitive.
   const repoId: string | null = scope.kind === "repo" ? scope.repoId : null;
 
-  // Subscribe to the raw slice values. We deliberately reuse a single empty
-  // array reference (EMPTY_PINNED_PROMPTS) for the missing-key case so the
-  // selector returns a stable reference until the load completes — otherwise
-  // useSyncExternalStore loops on the fresh `[]`.
   const prompts: readonly PinnedPrompt[] = useAppStore((s) =>
     repoId
       ? (s.repoPinnedPrompts[repoId] ?? EMPTY_PINNED_PROMPTS)
@@ -84,7 +71,6 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
     [repoId, setForRepo, setGlobal],
   );
 
-  // Hydrate this scope when the manager mounts.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -160,9 +146,6 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
   const commitDraft = useCallback(
     async (draft: DraftRow) => {
       const trimmedName = draft.display_name.trim();
-      // Other names must include both persisted prompts and any sibling
-      // drafts in this scope — otherwise two drafts can race past the
-      // client-side check and surface a raw SQLite UNIQUE error on save.
       const otherNames = new Set(persistedNames);
       for (const other of drafts) {
         if (other.draftId === draft.draftId) continue;
@@ -209,10 +192,8 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
     async (
       original: PinnedPrompt,
       next: { display_name: string; prompt: string; auto_send: boolean },
-    ) => {
+    ): Promise<boolean> => {
       const trimmedName = next.display_name.trim();
-      // Other-name check must exclude the prompt being edited but include
-      // sibling drafts so an edit can't collide with a not-yet-saved draft.
       const others = new Set(
         prompts.filter((p) => p.id !== original.id).map((p) => p.display_name),
       );
@@ -223,20 +204,19 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
       const nameErr = validateName(trimmedName, others);
       if (nameErr) {
         setError(String(original.id), nameErr);
-        return;
+        return false;
       }
       if (!next.prompt.trim()) {
         setError(String(original.id), t("pinned_prompts_error_prompt_required"));
-        return;
+        return false;
       }
-      // Skip the round-trip when nothing changed.
       if (
         trimmedName === original.display_name &&
         next.prompt === original.prompt &&
         next.auto_send === original.auto_send
       ) {
         setError(String(original.id), null);
-        return;
+        return true;
       }
       setError(String(original.id), null);
       try {
@@ -247,9 +227,11 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
           next.auto_send,
         );
         upsertPrompt(saved);
+        return true;
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         setError(String(original.id), msg);
+        return false;
       }
     },
     [prompts, drafts, setError, t, upsertPrompt, validateName],
@@ -309,6 +291,7 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
               onMoveDown={() => handleMove(i, +1)}
               onDelete={() => handleDelete(p)}
               onCommit={(next) => commitEdit(p, next)}
+              clearError={() => setError(String(p.id), null)}
               slashCommands={slashCommands}
             />
           ))}
@@ -341,6 +324,8 @@ export function PinnedPromptsManager({ scope, projectPath }: PinnedPromptsManage
   );
 }
 
+type PromptRowMode = "display" | "editing" | "confirm-delete";
+
 interface PromptRowProps {
   prompt: PinnedPrompt;
   error: string | undefined;
@@ -353,7 +338,8 @@ interface PromptRowProps {
     display_name: string;
     prompt: string;
     auto_send: boolean;
-  }) => void;
+  }) => Promise<boolean>;
+  clearError: () => void;
   slashCommands: SlashCommand[];
 }
 
@@ -366,25 +352,51 @@ function PromptRow({
   onMoveDown,
   onDelete,
   onCommit,
+  clearError,
   slashCommands,
 }: PromptRowProps) {
   const { t } = useTranslation("settings");
+  const [mode, setMode] = useState<PromptRowMode>("display");
   const [name, setName] = useState(prompt.display_name);
   const [body, setBody] = useState(prompt.prompt);
   const [autoSend, setAutoSend] = useState(prompt.auto_send);
   const [cursorPos, setCursorPos] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const keepButtonRef = useRef<HTMLButtonElement>(null);
 
-  // Sync local state when the prompt is replaced from the store (e.g. after a
-  // successful save returns the canonical row, or another tab reloads).
+  // Sync local state when the prompt is replaced from the store.
   useEffect(() => {
     setName(prompt.display_name);
     setBody(prompt.prompt);
     setAutoSend(prompt.auto_send);
   }, [prompt.display_name, prompt.prompt, prompt.auto_send]);
 
-  const flush = useCallback(() => {
-    onCommit({ display_name: name, prompt: body, auto_send: autoSend });
+  // Auto-focus when entering editing or confirm-delete modes.
+  useEffect(() => {
+    if (mode === "editing") nameInputRef.current?.focus();
+    else if (mode === "confirm-delete") keepButtonRef.current?.focus();
+  }, [mode]);
+
+  const enterEdit = useCallback(() => {
+    setName(prompt.display_name);
+    setBody(prompt.prompt);
+    setAutoSend(prompt.auto_send);
+    clearError();
+    setMode("editing");
+  }, [prompt.display_name, prompt.prompt, prompt.auto_send, clearError]);
+
+  const cancelEdit = useCallback(() => {
+    setName(prompt.display_name);
+    setBody(prompt.prompt);
+    setAutoSend(prompt.auto_send);
+    clearError();
+    setMode("display");
+  }, [prompt.display_name, prompt.prompt, prompt.auto_send, clearError]);
+
+  const save = useCallback(async () => {
+    const ok = await onCommit({ display_name: name, prompt: body, auto_send: autoSend });
+    if (ok) setMode("display");
   }, [onCommit, name, body, autoSend]);
 
   const onSlashInsert = useCallback(
@@ -415,48 +427,90 @@ function PromptRow({
     setCursorPos(el.selectionStart);
   }, []);
 
+  const canSave = name.trim().length > 0 && body.trim().length > 0;
+
+  // Cmd/Ctrl+Enter saves; Esc cancels. Slash autocomplete consumes its own keys first.
+  const handleEditorKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (slash.handleKeyDown(e)) {
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (canSave) void save();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cancelEdit();
+      }
+    },
+    [slash, canSave, save, cancelEdit],
+  );
+
+  // ---------- Display mode ----------
+  if (mode === "display") {
+    return (
+      <div className={styles.row}>
+        <div className={styles.displayHeader}>
+          <span className={styles.displayName}>{prompt.display_name}</span>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.iconButton}
+              disabled={!canMoveUp}
+              onClick={onMoveUp}
+              aria-label={t("pinned_prompts_move_up")}
+              title={t("pinned_prompts_move_up")}
+            >
+              <ChevronUp size={14} />
+            </button>
+            <button
+              type="button"
+              className={styles.iconButton}
+              disabled={!canMoveDown}
+              onClick={onMoveDown}
+              aria-label={t("pinned_prompts_move_down")}
+              title={t("pinned_prompts_move_down")}
+            >
+              <ChevronDown size={14} />
+            </button>
+            <button
+              type="button"
+              className={styles.iconButton}
+              onClick={enterEdit}
+              aria-label={t("pinned_prompts_edit_action", { name: prompt.display_name })}
+              title={t("pinned_prompts_edit_action", { name: prompt.display_name })}
+            >
+              <Pencil size={14} />
+            </button>
+          </div>
+        </div>
+        <div className={styles.displayPreview}>{prompt.prompt}</div>
+        {prompt.auto_send && (
+          <div className={styles.displayMeta}>{t("pinned_prompts_auto_send")}</div>
+        )}
+      </div>
+    );
+  }
+
+  // ---------- Editing / Confirm-delete modes (shared editor body) ----------
+  const cardClass = mode === "confirm-delete"
+    ? `${styles.row} ${styles.rowDangerous}`
+    : `${styles.row} ${styles.rowEditing}`;
+
   return (
-    <div className={styles.row}>
+    <div className={cardClass}>
       <div className={styles.rowHeader}>
         <input
+          ref={nameInputRef}
           className={error ? styles.nameInputError : styles.nameInput}
           value={name}
           onChange={(e) => setName(e.target.value)}
-          onBlur={flush}
+          onKeyDown={handleEditorKeyDown}
           placeholder={t("pinned_prompts_display_name_placeholder")}
           aria-label={t("pinned_prompts_display_name_label")}
+          disabled={mode === "confirm-delete"}
         />
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={styles.iconButton}
-            disabled={!canMoveUp}
-            onClick={onMoveUp}
-            aria-label={t("pinned_prompts_move_up")}
-            title={t("pinned_prompts_move_up")}
-          >
-            <ChevronUp size={14} />
-          </button>
-          <button
-            type="button"
-            className={styles.iconButton}
-            disabled={!canMoveDown}
-            onClick={onMoveDown}
-            aria-label={t("pinned_prompts_move_down")}
-            title={t("pinned_prompts_move_down")}
-          >
-            <ChevronDown size={14} />
-          </button>
-          <button
-            type="button"
-            className={styles.deleteButton}
-            onClick={onDelete}
-            aria-label={t("pinned_prompts_delete", { name: prompt.display_name })}
-            title={t("pinned_prompts_delete", { name: prompt.display_name })}
-          >
-            <Trash2 size={14} />
-          </button>
-        </div>
       </div>
       <div className={styles.textareaWrapper}>
         <textarea
@@ -465,13 +519,13 @@ function PromptRow({
           value={body}
           onChange={(e) => { setBody(e.target.value); updateCursor(e.target); }}
           onSelect={(e) => updateCursor(e.currentTarget)}
-          onBlur={flush}
-          onKeyDown={(e) => { if (slash.handleKeyDown(e)) e.preventDefault(); }}
+          onKeyDown={handleEditorKeyDown}
           rows={3}
           placeholder={t("pinned_prompts_prompt_placeholder")}
           aria-label={t("pinned_prompts_prompt_label")}
+          disabled={mode === "confirm-delete"}
         />
-        {slash.showPicker && (
+        {mode === "editing" && slash.showPicker && (
           <SlashCommandPicker
             commands={slash.filteredCommands}
             selectedIndex={slash.selectedIndex}
@@ -486,19 +540,65 @@ function PromptRow({
           <input
             type="checkbox"
             checked={autoSend}
-            onChange={(e) => {
-              setAutoSend(e.target.checked);
-              onCommit({
-                display_name: name,
-                prompt: body,
-                auto_send: e.target.checked,
-              });
-            }}
+            onChange={(e) => setAutoSend(e.target.checked)}
+            disabled={mode === "confirm-delete"}
           />
           {t("pinned_prompts_auto_send")}
         </label>
         {error && <span className={styles.errorText}>{error}</span>}
       </div>
+
+      {mode === "editing" ? (
+        <div className={styles.footer}>
+          <button
+            type="button"
+            className={styles.btnDestructiveText}
+            onClick={() => setMode("confirm-delete")}
+          >
+            {t("pinned_prompts_delete_prompt")}
+          </button>
+          <div className={styles.footerSpacer} />
+          <button type="button" className={styles.btnGhost} onClick={cancelEdit}>
+            {t("pinned_prompts_cancel")}
+          </button>
+          <button
+            type="button"
+            className={styles.btnPrimary}
+            onClick={() => void save()}
+            disabled={!canSave}
+          >
+            {t("pinned_prompts_save_changes")}
+          </button>
+        </div>
+      ) : (
+        <div className={styles.confirmPanel}>
+          <div className={styles.confirmCopy}>
+            <div className={styles.confirmTitle}>
+              {t("pinned_prompts_confirm_delete_title")}
+            </div>
+            <div className={styles.confirmSubtitle}>
+              {t("pinned_prompts_confirm_delete_subtitle")}
+            </div>
+          </div>
+          <div className={styles.confirmActions}>
+            <button
+              ref={keepButtonRef}
+              type="button"
+              className={styles.btnGhost}
+              onClick={() => setMode("editing")}
+            >
+              {t("pinned_prompts_keep")}
+            </button>
+            <button
+              type="button"
+              className={styles.btnDestructiveFill}
+              onClick={onDelete}
+            >
+              {t("pinned_prompts_delete_prompt")}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -552,28 +652,38 @@ function DraftRowView({
     setCursorPos(el.selectionStart);
   }, []);
 
+  const canSave =
+    draft.display_name.trim().length > 0 && draft.prompt.trim().length > 0;
+
+  const handleEditorKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (slash.handleKeyDown(e)) {
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (canSave) onCommit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    },
+    [slash, canSave, onCommit, onCancel],
+  );
+
   return (
-    <div className={styles.row}>
+    <div className={`${styles.row} ${styles.rowEditing}`}>
       <div className={styles.rowHeader}>
         <input
           className={error ? styles.nameInputError : styles.nameInput}
           value={draft.display_name}
           onChange={(e) => onChange({ display_name: e.target.value })}
+          onKeyDown={handleEditorKeyDown}
           placeholder={t("pinned_prompts_display_name_placeholder")}
           aria-label={t("pinned_prompts_display_name_label")}
           autoFocus
         />
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={styles.deleteButton}
-            onClick={onCancel}
-            aria-label={t("pinned_prompts_cancel_draft")}
-            title={t("pinned_prompts_cancel_draft")}
-          >
-            <Trash2 size={14} />
-          </button>
-        </div>
       </div>
       <div className={styles.textareaWrapper}>
         <textarea
@@ -582,7 +692,7 @@ function DraftRowView({
           value={draft.prompt}
           onChange={(e) => { onChange({ prompt: e.target.value }); updateCursor(e.target); }}
           onSelect={(e) => updateCursor(e.currentTarget)}
-          onKeyDown={(e) => { if (slash.handleKeyDown(e)) e.preventDefault(); }}
+          onKeyDown={handleEditorKeyDown}
           rows={3}
           placeholder={t("pinned_prompts_prompt_placeholder")}
           aria-label={t("pinned_prompts_prompt_label")}
@@ -606,18 +716,21 @@ function DraftRowView({
           />
           {t("pinned_prompts_auto_send")}
         </label>
-        <div className={styles.actions}>
-          {error && <span className={styles.errorText}>{error}</span>}
-          <button
-            type="button"
-            className={styles.iconButton}
-            onClick={onCommit}
-            title={t("pinned_prompts_save_draft")}
-            aria-label={t("pinned_prompts_save_draft")}
-          >
-            <Save size={14} />
-          </button>
-        </div>
+        {error && <span className={styles.errorText}>{error}</span>}
+      </div>
+      <div className={styles.footer}>
+        <div className={styles.footerSpacer} />
+        <button type="button" className={styles.btnGhost} onClick={onCancel}>
+          {t("pinned_prompts_cancel")}
+        </button>
+        <button
+          type="button"
+          className={styles.btnPrimary}
+          onClick={onCommit}
+          disabled={!canSave}
+        >
+          {t("pinned_prompts_save_draft")}
+        </button>
       </div>
     </div>
   );
@@ -628,10 +741,6 @@ interface InheritedGlobalsListProps {
   repoNames: Set<string>;
 }
 
-/**
- * Read-only summary of the globals a repo will inherit. Anything whose name
- * is also defined as a repo prompt is flagged as overridden.
- */
 export function InheritedGlobalsList({
   globals,
   repoNames,

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -695,6 +695,7 @@ function RepoPinnedPromptsField({ repoId }: RepoPinnedPromptsFieldProps) {
   );
   const globalPrompts = useAppStore((s) => s.globalPinnedPrompts);
   const loadGlobals = useAppStore((s) => s.loadGlobalPinnedPrompts);
+  const repoPath = useAppStore((s) => s.repositories.find((r) => r.id === repoId)?.path);
 
   // Hydrate globals so the inherited list reflects current global state.
   useEffect(() => {
@@ -714,7 +715,7 @@ function RepoPinnedPromptsField({ repoId }: RepoPinnedPromptsFieldProps) {
       <div className={`${styles.fieldHint} ${styles.fieldHintSpaced}`}>
         {t("pinned_prompts_repo_description")}
       </div>
-      <PinnedPromptsManager scope={{ kind: "repo", repoId }} />
+      <PinnedPromptsManager scope={{ kind: "repo", repoId }} projectPath={repoPath} />
       <InheritedGlobalsList globals={globalPrompts} repoNames={repoNames} />
     </div>
   );

--- a/src/ui/src/hooks/useSlashAutocomplete.ts
+++ b/src/ui/src/hooks/useSlashAutocomplete.ts
@@ -44,6 +44,15 @@ export function useSlashAutocomplete({
     setDismissed(false);
   }, [token]);
 
+  // The token can stay stable while filteredCommands changes — e.g. the slash
+  // command list reloads asynchronously and a previously matching command
+  // disappears. Clamp selectedIndex so Enter/Tab never lands on an undefined
+  // entry and the highlight stays in range.
+  useEffect(() => {
+    if (!showPicker) return;
+    setSelectedIndex((i) => Math.min(i, filteredCommands.length - 1));
+  }, [showPicker, filteredCommands.length]);
+
   const selectCommand = useCallback(
     (cmd: SlashCommand) => {
       if (!query) return;

--- a/src/ui/src/hooks/useSlashAutocomplete.ts
+++ b/src/ui/src/hooks/useSlashAutocomplete.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { SlashCommand } from "../services/tauri";
+import { describeSlashQueryAtCursor } from "../components/chat/nativeSlashCommands";
+import { filterSlashCommands } from "../components/chat/SlashCommandPicker";
+
+interface UseSlashAutocompleteOptions {
+  value: string;
+  cursorPosition: number;
+  commands: SlashCommand[];
+  onInsert: (replacement: string, rangeStart: number, rangeEnd: number) => void;
+}
+
+interface SlashAutocompleteResult {
+  showPicker: boolean;
+  filteredCommands: SlashCommand[];
+  selectedIndex: number;
+  handleKeyDown: (e: React.KeyboardEvent) => boolean;
+  dismiss: () => void;
+  selectCommand: (cmd: SlashCommand) => void;
+  setSelectedIndex: (i: number) => void;
+}
+
+export function useSlashAutocomplete({
+  value,
+  cursorPosition,
+  commands,
+  onInsert,
+}: UseSlashAutocompleteOptions): SlashAutocompleteResult {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  const query = describeSlashQueryAtCursor(value, cursorPosition);
+  const token = query?.token ?? null;
+
+  const filteredCommands = useMemo(
+    () => (token === null ? [] : filterSlashCommands(commands, token)),
+    [commands, token],
+  );
+
+  const showPicker = token !== null && filteredCommands.length > 0 && !dismissed;
+
+  useEffect(() => {
+    setSelectedIndex(0);
+    setDismissed(false);
+  }, [token]);
+
+  const selectCommand = useCallback(
+    (cmd: SlashCommand) => {
+      if (!query) return;
+      const replacement = `/${cmd.name} `;
+      onInsert(replacement, query.start, query.end);
+      setDismissed(true);
+    },
+    [query, onInsert],
+  );
+
+  const dismiss = useCallback(() => setDismissed(true), []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!showPicker) return false;
+
+      if (e.key === "ArrowDown") {
+        setSelectedIndex((i) => Math.min(i + 1, filteredCommands.length - 1));
+        return true;
+      }
+      if (e.key === "ArrowUp") {
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+        return true;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        const cmd = filteredCommands[selectedIndex];
+        if (cmd) selectCommand(cmd);
+        return true;
+      }
+      if (e.key === "Escape") {
+        setDismissed(true);
+        return true;
+      }
+      return false;
+    },
+    [showPicker, filteredCommands, selectedIndex, selectCommand],
+  );
+
+  return {
+    showPicker,
+    filteredCommands,
+    selectedIndex,
+    handleKeyDown,
+    dismiss,
+    selectCommand,
+    setSelectedIndex,
+  };
+}

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -282,5 +282,12 @@
   "pinned_prompts_error_name_unique": "Another prompt already uses that name",
   "pinned_prompts_error_prompt_required": "Prompt body is required",
   "pinned_prompts_inherited_label": "Inherited from global",
-  "pinned_prompts_overridden_badge": "Overridden"
+  "pinned_prompts_overridden_badge": "Overridden",
+  "pinned_prompts_edit_action": "Edit {{name}}",
+  "pinned_prompts_cancel": "Cancel",
+  "pinned_prompts_save_changes": "Save changes",
+  "pinned_prompts_keep": "Keep",
+  "pinned_prompts_delete_prompt": "Delete prompt",
+  "pinned_prompts_confirm_delete_title": "Delete this prompt?",
+  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone."
 }

--- a/src/ui/src/stores/slices/pinnedPromptsSlice.ts
+++ b/src/ui/src/stores/slices/pinnedPromptsSlice.ts
@@ -23,6 +23,9 @@ export interface PinnedPromptsSlice {
   loadRepoPinnedPrompts: (repoId: string) => Promise<void>;
 }
 
+let inflightGlobal: Promise<void> | null = null;
+const inflightRepo: Record<string, Promise<void>> = {};
+
 export const createPinnedPromptsSlice: StateCreator<
   AppState,
   [],
@@ -89,13 +92,25 @@ export const createPinnedPromptsSlice: StateCreator<
     });
   },
 
-  loadGlobalPinnedPrompts: async () => {
-    const prompts = await listPinnedPromptsInScope(null);
-    get().setGlobalPinnedPrompts(prompts);
+  loadGlobalPinnedPrompts: () => {
+    if (inflightGlobal) return inflightGlobal;
+    inflightGlobal = listPinnedPromptsInScope(null)
+      .then((prompts) => get().setGlobalPinnedPrompts(prompts))
+      .finally(() => {
+        inflightGlobal = null;
+      });
+    return inflightGlobal;
   },
-  loadRepoPinnedPrompts: async (repoId) => {
-    const prompts = await listPinnedPromptsInScope(repoId);
-    get().setRepoPinnedPrompts(repoId, prompts);
+  loadRepoPinnedPrompts: (repoId) => {
+    const existing = inflightRepo[repoId];
+    if (existing) return existing;
+    const p = listPinnedPromptsInScope(repoId)
+      .then((prompts) => get().setRepoPinnedPrompts(repoId, prompts))
+      .finally(() => {
+        delete inflightRepo[repoId];
+      });
+    inflightRepo[repoId] = p;
+    return p;
   },
 });
 


### PR DESCRIPTION
## Summary

This started as a fix for newly-created pinned prompts vanishing on navigation, then expanded into a broader redesign of the Pinned Prompts settings UI plus a slash autocomplete in the prompt body. Three threads:

1. **Persistence** — the only commit affordance on a draft row was a small `Plus` icon that read as "add another"; users filled out drafts and walked away without saving. Drafts now have an explicit `Save` button in a dedicated footer.
2. **Manager redesign** — every existing prompt used to render as an always-editable form. Existing prompts now default to a read-only **display** card (name + preview + pencil) and only swap to **editing** when the user opts in. Delete is gated behind a **confirm-delete** inset panel inside the card with the border tinted red, replacing the silent one-click trash button.
3. **Slash autocomplete in the editor** — the prompt body now offers the same `/command` picker as the composer, including for multi-line prompts.

### What's new

- **State machine per row** (`display` ↔ `editing` → `confirm-delete`) with auto-focus on entry and auto-focus on the **Keep** button when confirming a delete (never the destructive action).
- **Segmented footer** with `.btnPrimary` / `.btnGhost` / `.btnDestructiveText` / `.btnDestructiveFill` variants, accent border on the active edit card, and red-tinted border in confirm mode.
- **Keyboard shortcuts**: `Cmd`/`Ctrl`+`Enter` saves, `Esc` cancels in both edit and draft flows. Save is disabled until name and prompt are non-empty.
- **`prefers-reduced-motion`** honoured on all 0.12s transitions.
- **Slash autocomplete** via a reusable `useSlashAutocomplete` hook extracted from the inline composer logic. New `describeSlashQueryAtCursor()` respects line boundaries (triggers when `/` is at position 0 or after `\n`) and walks forward past the cursor so picking a command mid-token replaces the full `/command` instead of leaving the suffix behind.
- **Dedup concurrent loads** in `pinnedPromptsSlice` — both `PinnedPromptsBar` and `PinnedPromptsManager` request on mount; the slice now shares one in-flight promise.

## Complexity Notes

- **Blur-vs-click race on the picker**: clicking a picker item would normally blur the textarea before `onClick` fires. The picker uses `onMouseDown={(e) => e.preventDefault()}` on its container so the mousedown doesn't move focus. (`SlashCommandPicker.tsx`)
- **Edit `commitEdit` returns `Promise<boolean>`** — the row stays in editing mode on validation/server failure rather than silently flipping back to display and stranding the user's unsaved input.
- **Confirm-delete bleed**: the inset panel uses negative horizontal margins equal to the card's padding plus `overflow: hidden` on the card to bleed the destructive surface to the rounded edge without restructuring DOM.
- **Theme-portable hover darkening**: `filter: brightness(0.92)` on `.btnPrimary` / `.btnDestructiveFill` hover, instead of `color-mix(... #000)`, so the design-system token check (`scripts/check-css-tokens.sh`) stays green and the effect adapts across all four palettes.
- **`describeSlashQueryAtCursor` vs `describeSlashQuery`**: the new function respects line boundaries; the original only checks position 0. Both are kept — composer behaviour is single-line-ish, prompt body is genuinely multi-line.

## Test Steps

1. **Display ↔ editing**:
   - Open Settings → Pinned Prompts. Existing prompts render as compact read-only cards with a pencil icon.
   - Click the pencil. Card border switches to accent; inputs appear; footer shows `Delete prompt` (left) and `Cancel` + `Save changes` (right).
   - Edit the name, press `Esc`. Card reverts to display mode with the original values.
   - Edit again, press `Cmd`/`Ctrl`+`Enter`. Changes persist; card returns to display mode.

2. **Confirm-delete**:
   - Enter editing mode, click `Delete prompt`. An inset destructive panel appears at the bottom of the card; card border tints red; inputs are disabled.
   - Verify focus is on `Keep` (not `Delete`). Press `Enter` — card returns to editing mode.
   - Click `Delete prompt` again, then click the red `Delete prompt` button. Row disappears.

3. **New draft**:
   - Click `+ Add prompt`. A draft card with accent border opens with the name input focused. Footer shows `Cancel` + `Save` (no Delete — drafts haven't been saved).
   - Try `Save` while name is empty — button is disabled.
   - Fill in name + body, press `Cmd`/`Ctrl`+`Enter`. Draft converts to a saved prompt.

4. **Slash autocomplete**:
   - In a row's body (in editing mode), place cursor on a new line and type `/`. Picker appears below.
   - Type `/rev` — picker filters to `/review`, `/security-review`. Arrow keys navigate, `Enter`/`Tab` selects, `Esc` dismisses.
   - Click a picker item with the mouse — selection inserts and the textarea retains focus.
   - Click into an existing `/review` mid-token and pick a different command — the whole `/review` is replaced (no orphaned `iew`).
   - Type `/` mid-line (after non-whitespace) — picker should NOT appear.

5. **Repo scope `projectPath`**:
   - Open a repo's Settings → Pinned Prompts. Slash command picker should include project-level commands from that repo (e.g. `.claudette/commands/*.md`).

6. **Reduced motion**:
   - Enable OS-level reduce-motion. Mode transitions and focus rings still apply but without easing.

7. **Verification commands**:
   ```bash
   cd src/ui && bunx tsc -b      # clean
   cd src/ui && bun run test     # 1058 tests pass
   cd src/ui && bun run lint:css # design-system token check passes
   ```

## Checklist

- [x] Tests added/updated (`describeSlashQueryAtCursor` cases in `nativeSlashCommands.test.ts`, including mid-token range)
- [x] Frontend CI green (Format, Lint, Test, Frontend)
- [ ] Documentation updated (UI-only change; no docs touched)