### PR TITLE
refactor(pinned-prompts): replace "pinned" label with Pin icon

### DIFF
--- a/src/ui/src/components/chat/PinnedPromptsBar.module.css
+++ b/src/ui/src/components/chat/PinnedPromptsBar.module.css
@@ -9,9 +9,7 @@
 
 .label {
   color: var(--text-faint);
-  font-size: var(--fs-xs);
-  text-transform: lowercase;
-  letter-spacing: 0.03em;
+  flex-shrink: 0;
   user-select: none;
   margin-right: 2px;
 }

--- a/src/ui/src/components/chat/PinnedPromptsBar.tsx
+++ b/src/ui/src/components/chat/PinnedPromptsBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { Pin } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import {
@@ -62,7 +63,7 @@ export function PinnedPromptsBar({
 
   return (
     <div className={styles.bar}>
-      <span className={styles.label}>{t("pinned_prompts_label")}</span>
+      <Pin className={styles.label} size={12} />
       {prompts.map((p) => {
         const tooltipKey = p.auto_send
           ? "pinned_prompt_tooltip_auto"


### PR DESCRIPTION
## Summary

Replaces the lowercase **"pinned"** text label above the composer with the lucide `Pin` icon, matching the icon-led visual language used by the rest of the composer toolbar (Sparkles, Brain, CircleDollarSign, etc.).

- `PinnedPromptsBar.tsx` — import `Pin` from `lucide-react` and render `<Pin size={12} />` in place of `<span>{t("pinned_prompts_label")}</span>`.
- `PinnedPromptsBar.module.css` — drop `font-size`, `text-transform`, and `letter-spacing` from `.label` (no longer applies to an SVG); add `flex-shrink: 0` so the icon doesn't squish in the flex row.
- The pill tooltip i18n logic (auto-send vs insert) is preserved.

## Test Steps

1. `cd src/ui && bunx tsc -b` — verify no type errors (CI uses this).
2. `cd src/ui && bun run test` — 1077 tests should pass.
3. `cargo tauri dev`, open a workspace that has at least one pinned prompt configured, and confirm:
   - The Pin icon appears immediately to the left of the pill row, in the same muted `--text-faint` color the text used.
   - Hovering a pinned-prompt pill still shows the auto-send / insert tooltip.
   - Clicking a pill behaves as before (auto-send pins fire, insert pins populate the composer).

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)