### PR TITLE
fix(chat): stabilize streaming spinner rotation

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -577,11 +577,24 @@
   margin-top: 4px;
 }
 
-.spinner {
-  display: block;
+.spinnerWrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
   color: var(--accent-primary);
   filter: drop-shadow(0 0 3px rgba(var(--accent-primary-rgb), 0.4));
-  animation: spin 1s linear infinite;
+}
+
+.spinner {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(currentColor 225deg, transparent 225deg);
+  mask: radial-gradient(circle closest-side, transparent calc(100% - 2px), black calc(100% - 2px));
+  -webkit-mask: radial-gradient(circle closest-side, transparent calc(100% - 2px), black calc(100% - 2px));
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { LoaderCircle } from "lucide-react";
 import { ChatSearchBar } from "./ChatSearchBar";
 import { useAppStore } from "../../stores/useAppStore";
 import {
@@ -970,7 +969,9 @@ export function ChatPanel() {
                       : t("processing_aria", { elapsed: formatElapsed(elapsed) })
                   }
                 >
-                  <LoaderCircle size={14} className={styles.spinner} aria-hidden="true" />
+                  <span className={styles.spinnerWrap} aria-hidden="true">
+                    <span className={styles.spinner} />
+                  </span>
                   {ws?.agent_status === "Compacting" && (
                     <span className={styles.compactingLabel}>{t("compacting_label")}</span>
                   )}

--- a/src/ui/src/components/shared/SessionStatusIcon.module.css
+++ b/src/ui/src/components/shared/SessionStatusIcon.module.css
@@ -1,5 +1,19 @@
+.spinnerWrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-primary);
+  filter: drop-shadow(0 0 3px rgba(var(--accent-primary-rgb), 0.4));
+}
+
 .spinner {
-  animation: spin 1s linear infinite;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(currentColor 225deg, transparent 225deg);
+  mask: radial-gradient(circle closest-side, transparent calc(100% - 2px), black calc(100% - 2px));
+  -webkit-mask: radial-gradient(circle closest-side, transparent calc(100% - 2px), black calc(100% - 2px));
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {

--- a/src/ui/src/components/shared/SessionStatusIcon.tsx
+++ b/src/ui/src/components/shared/SessionStatusIcon.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, CircleDashed, CircleQuestionMark, CircleAlert, CircleStop, LoaderCircle } from "lucide-react";
+import { CircleCheck, CircleDashed, CircleQuestionMark, CircleAlert, CircleStop } from "lucide-react";
 import styles from "./SessionStatusIcon.module.css";
 
 export type SessionStatusKind =
@@ -18,11 +18,12 @@ export function SessionStatusIcon({ status, size = 14 }: Props) {
   switch (status.kind) {
     case "running":
       return (
-        <LoaderCircle
-          size={size}
-          className={styles.spinner}
-          style={{ color: "var(--accent-primary)" }}
-        />
+        <span
+          className={styles.spinnerWrap}
+          style={{ width: size, height: size }}
+        >
+          <span className={styles.spinner} />
+        </span>
       );
     case "ask":
       return (

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -364,14 +364,24 @@
   align-items: center;
   justify-content: center;
   width: 14px;
+  height: 14px;
   color: var(--accent-primary);
   flex-shrink: 0;
   filter: drop-shadow(0 0 3px rgba(var(--accent-primary-rgb), 0.4));
-  animation: spin 1s linear infinite;
+}
+
+.statusSpinnerRing {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(currentColor 225deg, transparent 225deg);
+  mask: radial-gradient(circle closest-side, transparent calc(100% - 2px), black calc(100% - 2px));
+  -webkit-mask: radial-gradient(circle closest-side, transparent calc(100% - 2px), black calc(100% - 2px));
+  animation: spin 0.8s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .statusSpinner {
+  .statusSpinnerRing {
     animation: none;
   }
 }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, LoaderCircle, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { UpdateBanner } from "../layout/UpdateBanner";
 import { getScmSortPriority } from "../../utils/scmSortPriority";
@@ -327,7 +327,7 @@ export const Sidebar = memo(function Sidebar() {
             aria-hidden="true"
             title={ws.agent_status === "Compacting" ? t("status_compacting") : t("status_running")}
           >
-            <LoaderCircle size={14} />
+            <span className={styles.statusSpinnerRing} />
           </span>
         ) : (() => {
           if (ws.status === "Archived") {
@@ -868,7 +868,7 @@ export const Sidebar = memo(function Sidebar() {
               {!collapsed && creatingWorkspace && creatingWorkspace.repoId === repo.id && (
                 <div className={`${styles.wsItem} ${styles.wsItemLoading}`}>
                   <span className={styles.statusSpinner} aria-hidden="true">
-                    <LoaderCircle size={14} />
+                    <span className={styles.statusSpinnerRing} />
                   </span>
                   <div className={styles.wsInfo}>
                     <span className={`${styles.wsName} ${styles.wsNamePlaceholder}`}>
@@ -1208,7 +1208,7 @@ function RemoteConnectionGroup({
                   >
                     {isAgentBusy(ws.agent_status) ? (
                       <span className={styles.statusSpinner} aria-hidden="true">
-                        <LoaderCircle size={14} />
+                        <span className={styles.statusSpinnerRing} />
                       </span>
                     ) : (
                       <span


### PR DESCRIPTION
## Summary

Closes #545.

The streaming spinner next to the elapsed-time indicator looked like it was wobbling sub-pixel during rotation. Root cause turned out to be the `drop-shadow` filter, not the rotation itself: when the asymmetric `LoaderCircle` SVG (a 3/4 arc) rotated, its silhouette changed shape every frame, so the `drop-shadow` halo morphed with it and pulsed the rendered bbox by ~5.85px per cycle. The geometric center was already stable to ~0.088px (sub-pixel noise) — the wobble was the halo, not the icon.

Verified by instrumenting the running spinner via the dev debug bridge and logging `getBoundingClientRect()` over a full rotation cycle.

## What changed

- **Drop-shadow moved off the rotating element.** A non-rotating `.spinnerWrap` wrapper now owns `filter: drop-shadow(...)`; only the inner element rotates. With a static silhouette under the filter, the wrapper bbox is stable to 0.000px across a full cycle.
- **Spinner replaced with a CSS conic-gradient ring.** The `lucide-react` `LoaderCircle` SVG is gone in favor of a `conic-gradient` (225° arc) clipped to a 2px ring via `mask: radial-gradient(circle closest-side, ...)`. This avoids depending on the SVG's internal viewBox geometry and gives a pixel-perfect rotationally symmetric ring at any size. Rotation rate dropped to 0.8s for a slightly snappier feel.
- **Same treatment applied to the other agent-busy spinners** in `SessionStatusIcon` and the sidebar workspace status, so all three sites use the wrapper + ring pattern.
- `prefers-reduced-motion: reduce` still pins the ring static.

## Test plan

- [x] Start an agent turn in the chat view — spinner next to `1m 2s` rotates smoothly with no halo wobble.
- [x] Sidebar workspace row spinner (running/compacting state) renders the same ring without wobble.
- [x] `SessionStatusIcon` running state in session tabs renders the same ring.
- [x] Reduced-motion still freezes the ring.
- [x] `bunx tsc -b` passes.