### PR TITLE
fix(workspace): preserve branch names for imported workspaces

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -977,9 +977,16 @@ pub async fn import_worktrees(
         .map_err(|e| e.to_string())?;
 
     // Imported workspaces already have user-defined branch names — pre-claim
-    // the auto-rename slot so the first-message rename never fires.
+    // the auto-rename slot so the first-message rename never fires. Match the
+    // logging in chat/send.rs so a SQLite failure here is visible rather than
+    // silently leaving the workspace eligible for rename.
     for ws in &created {
-        let _ = db.claim_branch_auto_rename(&ws.id);
+        if let Err(e) = db.claim_branch_auto_rename(&ws.id) {
+            eprintln!(
+                "[import] claim_branch_auto_rename failed for {} ({}): {e}",
+                ws.name, ws.id
+            );
+        }
     }
 
     crate::tray::rebuild_tray(&app);

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -976,6 +976,12 @@ pub async fn import_worktrees(
     db.insert_workspaces_batch(&created)
         .map_err(|e| e.to_string())?;
 
+    // Imported workspaces already have user-defined branch names — pre-claim
+    // the auto-rename slot so the first-message rename never fires.
+    for ws in &created {
+        let _ = db.claim_branch_auto_rename(&ws.id);
+    }
+
     crate::tray::rebuild_tray(&app);
 
     Ok(created)


### PR DESCRIPTION
## Summary

When importing a workspace from an external tool (e.g., Conductor) that already has a meaningful branch name like `sean/cleanup-variant-synced-...`, the first message sent to that workspace would rename the branch via the Haiku-driven auto-rename flow (e.g., `summarize changes` → `summarize-changes`, `rebase on main` → `rebase-main`). That rename is intended for *Claudette-created* workspaces that start with random adjective-plant names — not for imported ones.

This change pre-claims the one-shot `branch_auto_rename_claimed` slot for every imported workspace immediately after `insert_workspaces_batch`, so when the first message lands, the rename logic finds the slot already taken and skips entirely.

## Complexity Notes

- The `branch_auto_rename_claimed` flag is the same one-shot mutex used by `claim_branch_auto_rename` on first turn, and by the `20260421192849_workspace_branch_auto_rename_claimed.sql` migration that backfilled `claimed = 1` for existing workspaces with chat history. We're applying the same pattern at a different lifecycle point — workspace import — rather than introducing new state.
- `let _ = db.claim_branch_auto_rename(...)` intentionally discards the boolean return and any DB error: the claim is best-effort and a failure (or already-claimed row) shouldn't block the import. This matches how the first-turn caller in `chat/send.rs` treats the claim as fire-and-forget.
- No schema changes, no migrations, no new DB functions.

## Test Steps

1. Have an external tool (e.g., Conductor) check out a worktree with a non-random branch name like `sean/some-feature`.
2. In Claudette, import that worktree via the import worktrees flow in repository settings.
3. Open the imported workspace and send a first message (e.g., "summarize the changes" or "rebase on main").
4. Confirm the branch name in the sidebar **does not change** — it should still read `sean/some-feature`.
5. Regression check: create a fresh Claudette workspace (which gets a random adjective-plant name like `lazy-woad`), send a first message, and confirm the branch **still gets auto-renamed** based on the prompt content.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)