### PR TITLE
fix(chat): require Shift modifier for input history navigation

### DIFF
--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -812,7 +812,7 @@ export function ChatInputArea({
     const history = historyRef.current[sessionId] ?? [];
     if (history.length === 0) return;
 
-    if (e.key === "ArrowUp" && e.ctrlKey) {
+    if (e.key === "ArrowUp" && e.shiftKey) {
       e.preventDefault();
       if (historyIndexRef.current === -1) {
         draftRef.current = chatInput;
@@ -821,7 +821,7 @@ export function ChatInputArea({
         historyIndexRef.current -= 1;
       }
       setChatInput(history[historyIndexRef.current]);
-    } else if (e.key === "ArrowDown" && e.ctrlKey) {
+    } else if (e.key === "ArrowDown" && e.shiftKey) {
       e.preventDefault();
       if (historyIndexRef.current === -1) return;
       if (historyIndexRef.current < history.length - 1) {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -812,7 +812,7 @@ export function ChatInputArea({
     const history = historyRef.current[sessionId] ?? [];
     if (history.length === 0) return;
 
-    if (e.key === "ArrowUp") {
+    if (e.key === "ArrowUp" && e.ctrlKey) {
       e.preventDefault();
       if (historyIndexRef.current === -1) {
         draftRef.current = chatInput;
@@ -821,7 +821,7 @@ export function ChatInputArea({
         historyIndexRef.current -= 1;
       }
       setChatInput(history[historyIndexRef.current]);
-    } else if (e.key === "ArrowDown") {
+    } else if (e.key === "ArrowDown" && e.ctrlKey) {
       e.preventDefault();
       if (historyIndexRef.current === -1) return;
       if (historyIndexRef.current < history.length - 1) {


### PR DESCRIPTION
## Summary

The chat composer was intercepting `ArrowUp` / `ArrowDown` to navigate user input history, which had two side effects users hit constantly:

1. Anything they were currently typing got clobbered when they pressed Up.
2. They couldn't use the arrow keys to move the cursor within multi-line input — even just to fix a typo on a previous line.

This PR keeps the history-navigation feature but moves it behind the `Shift` modifier. Plain `ArrowUp` / `ArrowDown` now pass through to the textarea as normal cursor movement; `Shift+ArrowUp` / `Shift+ArrowDown` step backward / forward through the session's user-message history (with draft preservation, same as before).

`Shift` was chosen over `Ctrl` because macOS binds `Ctrl+ArrowUp` / `Ctrl+ArrowDown` to Mission Control / Application Windows at the OS level, so those keystrokes never reach the webview reliably. `Shift` works on every platform.

The change is two characters per branch in `handleKeyDown` — adding `&& e.shiftKey` to the two arrow-key conditions in `src/ui/src/components/chat/ChatInputArea.tsx`. All other history mechanics (the `historyRef` / `historyIndexRef` / `draftRef` state in `ChatPanel.tsx`) are untouched.

## Test Steps

1. `cd src/ui && bunx tsc -b` — type check passes.
2. `cd src/ui && bun run test` — vitest suite passes (1077 tests).
3. In a dev build, open a workspace with prior user messages in the session.
4. Type a multi-line message in the composer. Press `ArrowUp` — the cursor moves up a line within your draft; the draft is preserved.
5. Press `Shift+ArrowUp` — the previous user message replaces the input. Press `Shift+ArrowUp` again to step further back.
6. Press `Shift+ArrowDown` to step forward; once past the most recent history entry, the original draft is restored.
7. Confirm slash-command and file-mention pickers still respond to plain `ArrowUp` / `ArrowDown` (they short-circuit earlier in `handleKeyDown` via `showFilePicker` / `showSlashPicker`).

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)