### PR TITLE
fix(apps): drop redundant path arg from nvim/vim launch (resolves dual file-tree)

### DIFF
--- a/src-tauri/default-apps.json
+++ b/src-tauri/default-apps.json
@@ -37,7 +37,7 @@
       "name": "Neovim",
       "category": "editor",
       "bin_names": ["nvim"],
-      "open_args": ["{}"],
+      "open_args": [],
       "needs_terminal": true
     },
     {
@@ -45,7 +45,7 @@
       "name": "Vim",
       "category": "editor",
       "bin_names": ["vim"],
-      "open_args": ["{}"],
+      "open_args": [],
       "needs_terminal": true
     },
     {


### PR DESCRIPTION
## Summary

\"Open in Neovim\" was opening with two active file trees for users running a sidebar tree plugin (nvim-tree, neo-tree, NERDTree). Same trap exists for vim users running NERDTree.

## Root cause

The TUI editor launch path in \`src-tauri/src/commands/apps.rs\` (\`open_in_terminal\`) builds an argv like:

\`\`\`
<terminal> --working-directory <wt> [-e] /usr/bin/nvim .
\`\`\`

The terminal's working-directory flag already sets the new shell's cwd to the worktree, so the trailing \`.\` passed to nvim is redundant. Worse: when nvim is given a directory as a positional, it auto-opens **netrw** (the built-in file browser) into the first buffer. If the user also has a sidebar tree plugin configured to auto-open on startup, they see both — netrw in the main buffer plus the plugin's sidebar. Two file trees.

## Fix

Drop \`{}\` from \`open_args\` for the \`neovim\` and \`vim\` entries in \`default-apps.json\`. The editor still launches in the worktree's cwd (inherited from the terminal), and plugins fire as the user has them configured.

\`helix\` is left alone — it has a native picker, no dual-tree collision.

## Notes for users with an existing install

\`default-apps.json\` is the **embedded** default. The first time Claudette launched, it seeded \`~/.claudette/apps.json\` from the embedded copy, and the runtime loader prefers the on-disk file. Existing installs will still see the old behavior until they either delete \`~/.claudette/apps.json\` (it'll be re-seeded from the new defaults) or hand-edit the \`neovim\`/\`vim\` entries to set \`\"open_args\": []\`.

Worth flagging in release notes; could also be addressed by a one-shot config migration if the project wants to push the fix automatically, but that felt out of scope for this PR.

## Test plan

- [x] \`cargo test -p claudette-tauri --bin claudette commands::apps\` — 11/11 pass
- [ ] Manual: \"Open in Neovim\" against a workspace launches a single nvim with no netrw buffer; user's tree plugin opens normally.