### PR TITLE
fix(git): create workspace branches with no upstream

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1142,6 +1142,23 @@ mod tests {
             "worktree should be based on the latest remote commit, not the stale one"
         );
 
+        // The new branch must NOT track the remote base — branching off
+        // `origin/main` should not silently set it as upstream.
+        let upstream = run_git(
+            wt_path,
+            &[
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+            ],
+        )
+        .await;
+        assert!(
+            upstream.is_err(),
+            "expected no upstream to be configured, but got: {upstream:?}"
+        );
+
         // Clean up.
         remove_worktree(clone_path, wt_path, true).await.unwrap();
     }
@@ -1232,6 +1249,23 @@ mod tests {
 
         let forked_head = run_git(fork_path, &["rev-parse", "HEAD"]).await.unwrap();
         assert_eq!(forked_head, hash1);
+
+        // Forked branch must NOT track any upstream — checkpoint forks are
+        // local-only by design.
+        let upstream = run_git(
+            fork_path,
+            &[
+                "rev-parse",
+                "--abbrev-ref",
+                "--symbolic-full-name",
+                "@{upstream}",
+            ],
+        )
+        .await;
+        assert!(
+            upstream.is_err(),
+            "expected no upstream to be configured, but got: {upstream:?}"
+        );
 
         remove_worktree(repo_path, fork_path, true).await.unwrap();
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -431,7 +431,15 @@ pub async fn create_worktree(
 
     run_git(
         repo_path,
-        &["worktree", "add", "-b", branch_name, worktree_path, &base],
+        &[
+            "worktree",
+            "add",
+            "--no-track",
+            "-b",
+            branch_name,
+            worktree_path,
+            &base,
+        ],
     )
     .await?;
 
@@ -454,6 +462,7 @@ pub async fn create_worktree_from_ref(
         &[
             "worktree",
             "add",
+            "--no-track",
             "-b",
             branch_name,
             worktree_path,


### PR DESCRIPTION
## Summary
- `git worktree add -b <branch> <path> <base>` was implicitly setting the workspace branch's upstream to the base when `<base>` was a remote-tracking ref like `origin/main`. A casual `git push` from inside a workspace would then push to whatever the base remote was — surprising and unwanted.
- Pass `--no-track` to both `create_worktree` and `create_worktree_from_ref` in `src/git.rs` so newly minted workspace branches start with no upstream. `git push` now requires an explicit `-u <remote> <branch>`, which is the desired default for short-lived agent branches.

## Test plan
- [ ] Create a new workspace; `cd` into it and run `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` — should fail with "no upstream configured" instead of returning `origin/main`.
- [ ] `git branch -vv` inside the workspace shows the branch with no `[origin/...]` tracking annotation.
- [ ] Forking a workspace from a checkpoint commit produces a branch with no upstream as well.
- [ ] `cargo test -p claudette --lib git::` passes (26 tests).
- [ ] `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` pass.