### PR TITLE
feat(agent): inject bundled global system prompt into every session

### DIFF
--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -470,37 +470,15 @@ pub async fn send_chat_message(
     // agent has neither the tool nor any hint it exists.
     let send_to_user_enabled = claudette::agent_mcp::is_builtin_plugin_enabled(&db, "send_to_user");
 
-    // Prepend the agent-MCP nudge to the user's repo-level instructions so
-    // the model knows to reach for `mcp__claudette__send_to_user` when the
-    // user asks for an inline file delivery. The nudge is session-level
-    // (only applied on fresh spawns via `--append-system-prompt`); on resume
-    // turns the original spawn's prompt is already in the CLI process.
-    let custom_instructions = if send_to_user_enabled {
-        let nudge = claudette::agent_mcp::SYSTEM_PROMPT_NUDGE;
-        match session.custom_instructions.as_deref() {
-            Some(existing) if !existing.trim().is_empty() => Some(format!("{nudge}\n\n{existing}")),
-            _ => Some(nudge.to_string()),
-        }
-    } else {
-        session.custom_instructions.clone()
-    };
-
-    // Prepend the developer-bundled global system prompt to every fresh
-    // session. The global prompt is compiled into the binary via include_str!
-    // and sits outermost so it frames all per-repo and MCP instructions.
-    let custom_instructions = {
-        let global = claudette::global_prompt::GLOBAL_SYSTEM_PROMPT;
-        if global.trim().is_empty() {
-            custom_instructions
-        } else {
-            match custom_instructions.as_deref() {
-                Some(existing) if !existing.trim().is_empty() => {
-                    Some(format!("{global}\n\n{existing}"))
-                }
-                _ => Some(global.to_string()),
-            }
-        }
-    };
+    // Compose the system prompt for fresh spawns: bundled global prompt →
+    // MCP nudge (so the model reaches for `mcp__claudette__send_to_user`
+    // when asked to deliver a file) → per-repo instructions. Resume turns
+    // reuse the persistent CLI process and never re-pass the prompt.
+    let nudge = send_to_user_enabled.then_some(claudette::agent_mcp::SYSTEM_PROMPT_NUDGE);
+    let custom_instructions = claudette::global_prompt::compose_system_prompt(
+        session.custom_instructions.as_deref(),
+        nudge,
+    );
     session.turn_count += 1;
     session.needs_attention = false;
     session.attention_kind = None;

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -484,6 +484,23 @@ pub async fn send_chat_message(
     } else {
         session.custom_instructions.clone()
     };
+
+    // Prepend the developer-bundled global system prompt to every fresh
+    // session. The global prompt is compiled into the binary via include_str!
+    // and sits outermost so it frames all per-repo and MCP instructions.
+    let custom_instructions = {
+        let global = claudette::global_prompt::GLOBAL_SYSTEM_PROMPT;
+        if global.trim().is_empty() {
+            custom_instructions
+        } else {
+            match custom_instructions.as_deref() {
+                Some(existing) if !existing.trim().is_empty() => {
+                    Some(format!("{global}\n\n{existing}"))
+                }
+                _ => Some(global.to_string()),
+            }
+        }
+    };
     session.turn_count += 1;
     session.needs_attention = false;
     session.attention_kind = None;

--- a/src/global-system-prompt.md
+++ b/src/global-system-prompt.md
@@ -1,0 +1,6 @@
+You are operating within Claudette, a desktop application for orchestrating parallel Claude Code agents across multiple git worktree workspaces. Each workspace is an isolated git worktree — changes in one workspace do not affect another.
+
+## Rules
+
+- Whenever you have a question for the user — no matter how minor — you MUST use the `AskUserQuestion` tool. No exceptions: do not ask questions in plain text output.
+- Before complaining about a permissions error or denied tool call, check whether you are in plan mode. If you are in plan mode, you must exit plan mode (via `ExitPlanMode`) before retrying — many tools are intentionally blocked while planning.

--- a/src/global_prompt.rs
+++ b/src/global_prompt.rs
@@ -2,3 +2,121 @@
 /// Edit `src/global-system-prompt.md` to update the content — changes take
 /// effect after a rebuild (the string is compiled in via `include_str!`).
 pub const GLOBAL_SYSTEM_PROMPT: &str = include_str!("global-system-prompt.md");
+
+/// Compose the final `--append-system-prompt` value for a fresh agent
+/// session. Layers from outermost to innermost: bundled global prompt → MCP
+/// nudge (when `send_to_user` is enabled) → per-repo instructions. Each
+/// layer is dropped when empty or whitespace-only. Returns `None` when no
+/// layer contributes content, so the caller can skip the CLI flag entirely
+/// rather than pass an empty string.
+///
+/// Resume turns reuse the persistent CLI process and never re-pass
+/// `--append-system-prompt`, so this composition only matters on fresh
+/// spawns.
+pub fn compose_system_prompt(
+    repo_instructions: Option<&str>,
+    nudge: Option<&str>,
+) -> Option<String> {
+    compose_with_global(GLOBAL_SYSTEM_PROMPT, repo_instructions, nudge)
+}
+
+fn compose_with_global(
+    global: &str,
+    repo_instructions: Option<&str>,
+    nudge: Option<&str>,
+) -> Option<String> {
+    let mut parts: Vec<&str> = Vec::with_capacity(3);
+    if !global.trim().is_empty() {
+        parts.push(global);
+    }
+    if let Some(n) = nudge
+        && !n.trim().is_empty()
+    {
+        parts.push(n);
+    }
+    if let Some(repo) = repo_instructions
+        && !repo.trim().is_empty()
+    {
+        parts.push(repo);
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_everything_returns_none() {
+        assert_eq!(compose_with_global("", None, None), None);
+    }
+
+    #[test]
+    fn whitespace_only_layers_treated_as_empty() {
+        assert_eq!(
+            compose_with_global("  \n\t  ", Some("\n\n"), Some("   ")),
+            None
+        );
+    }
+
+    #[test]
+    fn global_only() {
+        assert_eq!(
+            compose_with_global("GLOBAL", None, None),
+            Some("GLOBAL".to_string())
+        );
+    }
+
+    #[test]
+    fn nudge_only() {
+        assert_eq!(
+            compose_with_global("", None, Some("NUDGE")),
+            Some("NUDGE".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_only() {
+        assert_eq!(
+            compose_with_global("", Some("REPO"), None),
+            Some("REPO".to_string())
+        );
+    }
+
+    #[test]
+    fn all_three_in_priority_order() {
+        assert_eq!(
+            compose_with_global("GLOBAL", Some("REPO"), Some("NUDGE")),
+            Some("GLOBAL\n\nNUDGE\n\nREPO".to_string())
+        );
+    }
+
+    #[test]
+    fn global_and_repo_no_nudge() {
+        assert_eq!(
+            compose_with_global("GLOBAL", Some("REPO"), None),
+            Some("GLOBAL\n\nREPO".to_string())
+        );
+    }
+
+    #[test]
+    fn nudge_and_repo_no_global() {
+        assert_eq!(
+            compose_with_global("", Some("REPO"), Some("NUDGE")),
+            Some("NUDGE\n\nREPO".to_string())
+        );
+    }
+
+    #[test]
+    fn public_api_uses_bundled_constant() {
+        // Concrete content is intentionally not asserted to keep this test
+        // stable across edits to `global-system-prompt.md`.
+        let composed = compose_system_prompt(Some("REPO"), None).unwrap();
+        assert!(composed.contains("REPO"));
+        assert!(composed.starts_with(GLOBAL_SYSTEM_PROMPT.trim_end()));
+    }
+}

--- a/src/global_prompt.rs
+++ b/src/global_prompt.rs
@@ -1,0 +1,4 @@
+/// Developer-bundled system prompt injected into every agent session.
+/// Edit `src/global-system-prompt.md` to update the content — changes take
+/// effect after a rebuild (the string is compiled in via `include_str!`).
+pub const GLOBAL_SYSTEM_PROMPT: &str = include_str!("global-system-prompt.md");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod env_provider;
 pub mod file_expand;
 pub mod fork;
 pub mod git;
+pub mod global_prompt;
 pub mod i18n;
 pub mod mcp;
 pub mod mcp_supervisor;


### PR DESCRIPTION
## Summary

Adds a developer-maintained system prompt that ships with the binary and is prepended to every fresh agent session, on top of any per-repo custom directions. The content lives in `src/global-system-prompt.md` and is compiled in via `include_str!` — edited like any source file, reviewed in PRs, zero runtime I/O.

The injection sits at the same point as the existing MCP nudge in `chat::send` and follows the same empty-string guard, so a blank prompt file is a no-op. Final ordering passed to the Claude CLI's `--append-system-prompt`:

```
global prompt  (always, if non-empty)
  +
MCP nudge      (if send_to_user plugin enabled)
  +
per-repo       (.claudette.json > DB custom_instructions)
```

The prompt currently contains a workspace-context line plus two rules: agents must use `AskUserQuestion` for any user question, and must check for plan mode before complaining about denied tool calls.

## Complexity Notes

- The prompt is only re-applied on **fresh** spawns (`!is_resume`). Resumed sessions retain whatever the original spawn was given — this is unchanged behavior, but worth noting since edits to the markdown won't reach mid-session agents until they're restarted.
- `include_str!` paths resolve relative to the source file at compile time. If `global_prompt.rs` is ever moved, the path string must be updated too.
- The empty-string guard (`global.trim().is_empty()`) is intentional: a blank file should not emit a bare `--append-system-prompt ""` flag.

## Test Steps

1. Pull the branch and run `cargo build -p claudette` — should compile cleanly
2. Start a new agent session in any workspace (not a resumed one)
3. Ask the agent: *"What is the very first thing in your system prompt? Quote it verbatim."* — confirm the response begins with the workspace-context line from `src/global-system-prompt.md`
4. Edit `src/global-system-prompt.md`, rebuild, start another fresh session — confirm the change appears
5. Set `src/global-system-prompt.md` to an empty file, rebuild — confirm no `--append-system-prompt` flag is emitted on spawn (check via process inspection or by confirming behavior matches a session with no instructions at all)
6. In a workspace that has per-repo `custom_instructions` set, start a fresh session — confirm both global and repo content appear, with global first
7. Run `cargo test --all-features`, `cargo clippy --workspace --all-targets`, `cd src/ui && bunx tsc -b` — all should pass

## Checklist

- [ ] Tests added/updated (relies on existing instruction-pipeline coverage; no new tests for the constant itself)
- [ ] Documentation updated (if applicable)