### PR TITLE
refactor(chat): extract shared turn helpers into claudette::chat

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use claudette::agent::{self, AgentEvent, AgentSettings, StreamEvent};
+use claudette::agent::{self, AgentEvent, AgentSettings, InnerStreamEvent, StreamEvent};
+use claudette::chat::{
+    BuildAssistantArgs, build_assistant_chat_message, extract_assistant_text,
+    extract_event_thinking,
+};
 use claudette::db::Database;
 use claudette::model::{ChatMessage, ChatRole, Workspace, WorkspaceStatus};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
@@ -616,6 +620,11 @@ async fn handle_send_chat_message(
         let mut rx = turn_handle.event_rx;
         let mut got_init = false;
         let mut pending_thinking: Option<String> = None;
+        // Tracks the most recent per-message usage observed on a MessageDelta
+        // event. Written into the next persisted assistant ChatMessage and
+        // reset to None after each persistence so per-message counts stay
+        // distinct across multi-message turns. Mirrors the Tauri bridge.
+        let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
         while let Some(event) = rx.recv().await {
             if let AgentEvent::Stream(StreamEvent::System { ref subtype, .. }) = event
                 && subtype == "init"
@@ -630,43 +639,24 @@ async fn handle_send_chat_message(
                 agents.remove(&chat_session_id_for_stream);
             }
 
+            // Track per-assistant-message cumulative usage as the CLI streams
+            // it. The final MessageDelta before message_stop carries the
+            // authoritative per-message total; we overwrite on every delta and
+            // consume it when the assistant message is persisted below.
+            if let AgentEvent::Stream(StreamEvent::Stream {
+                event: InnerStreamEvent::MessageDelta { usage: Some(u) },
+            }) = &event
+            {
+                latest_usage = Some(u.clone());
+            }
+
             // Persist assistant messages. The CLI may fire multiple assistant
             // events per turn (thinking-only, then text). Accumulate thinking
             // and save only when text content arrives.
             if let AgentEvent::Stream(StreamEvent::Assistant { ref message }) = event {
-                let full_text: String = message
-                    .content
-                    .iter()
-                    .filter_map(|block| {
-                        if let claudette::agent::ContentBlock::Text { text } = block {
-                            Some(text.as_str())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("");
+                let full_text = extract_assistant_text(message);
 
-                let event_thinking: Option<String> = {
-                    let parts: Vec<&str> = message
-                        .content
-                        .iter()
-                        .filter_map(|block| {
-                            if let claudette::agent::ContentBlock::Thinking { thinking } = block {
-                                Some(thinking.as_str())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    if parts.is_empty() {
-                        None
-                    } else {
-                        Some(parts.join(""))
-                    }
-                };
-
-                if let Some(t) = event_thinking {
+                if let Some(t) = extract_event_thinking(message) {
                     pending_thinking = Some(match pending_thinking.take() {
                         Some(mut existing) => {
                             existing.push_str(&t);
@@ -679,25 +669,14 @@ async fn handle_send_chat_message(
                 if !full_text.trim().is_empty()
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    // TODO(#300 phase 1+): the Tauri bridge (commands/chat.rs) tracks
-                    // `latest_usage` from MessageDelta events and stamps per-message
-                    // token counts here. The remote server path hasn't been updated
-                    // yet, so remote sessions currently persist NULL token fields.
-                    let msg = ChatMessage {
-                        id: uuid::Uuid::new_v4().to_string(),
-                        workspace_id: ws_id.clone(),
-                        chat_session_id: chat_session_id_for_stream.clone(),
-                        role: ChatRole::Assistant,
+                    let msg = build_assistant_chat_message(BuildAssistantArgs {
+                        workspace_id: &ws_id,
+                        chat_session_id: &chat_session_id_for_stream,
                         content: full_text,
-                        cost_usd: None,
-                        duration_ms: None,
-                        created_at: now_iso(),
                         thinking: pending_thinking.take(),
-                        input_tokens: None,
-                        output_tokens: None,
-                        cache_read_tokens: None,
-                        cache_creation_tokens: None,
-                    };
+                        usage: latest_usage.take(),
+                        created_at: now_iso(),
+                    });
                     let _ = db.insert_chat_message(&msg);
                 }
             }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -7,11 +7,16 @@ use claudette::agent::{
     PersistentSession, StartContentBlock, StreamEvent,
 };
 use claudette::base64_decode;
+use claudette::chat::{
+    BuildAssistantArgs, RequestedFlags, SessionFlags, build_assistant_chat_message,
+    build_compaction_sentinel, build_permission_response, extract_assistant_text,
+    extract_event_thinking, persistent_session_flags_drifted,
+};
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
 use claudette::mcp_supervisor::McpSupervisor;
 use claudette::model::{ChatMessage, ChatRole, ConversationCheckpoint};
-use claudette::permissions::{is_bypass_tools, tools_for_level};
+use claudette::permissions::tools_for_level;
 use claudette::snapshot;
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
@@ -22,94 +27,6 @@ use super::{
     ATTENTION_NOTIFY_DELAY_MS, AgentStreamPayload, AttachmentInput, fire_completion_notification,
     now_iso, start_bridge_and_inject_mcp,
 };
-
-/// Spawn-time flags of the currently running persistent session, plus the
-/// backend-observed `exited_plan` latch (set when the agent emits
-/// `ExitPlanMode` during this session).
-pub(crate) struct SessionFlags<'a> {
-    pub plan_mode: bool,
-    pub allowed_tools: &'a [String],
-    pub exited_plan: bool,
-    pub disable_1m_context: bool,
-}
-
-/// Flags the next turn is asking for. Compared against [`SessionFlags`] to
-/// decide whether the process must be torn down and respawned.
-pub(crate) struct RequestedFlags<'a> {
-    pub plan_mode: bool,
-    pub allowed_tools: &'a [String],
-    pub disable_1m_context: bool,
-}
-
-/// Detect whether the persistent session's spawn-time flags have drifted
-/// from what the current turn is asking for. Both `--permission-mode` and
-/// `--allowedTools` are only applied when the `claude` process starts, so
-/// a drift means the running process cannot serve this turn correctly and
-/// must be torn down.
-///
-/// `exited_plan` is a backend-observed signal that the agent called
-/// `ExitPlanMode` during the current session. When set alongside
-/// `plan_mode`, the plan phase is over regardless of whether the frontend
-/// remembered to send `plan_mode=false` — force a teardown so the CLI
-/// respawns without `--permission-mode plan`.
-pub(crate) fn persistent_session_flags_drifted(
-    session: SessionFlags<'_>,
-    requested: RequestedFlags<'_>,
-) -> bool {
-    session.plan_mode != requested.plan_mode
-        || session.allowed_tools != requested.allowed_tools
-        || session.disable_1m_context != requested.disable_1m_context
-        || (session.plan_mode && session.exited_plan)
-}
-
-/// Decide how to respond to a `can_use_tool` control_request that reached the
-/// handler for a tool other than AskUserQuestion / ExitPlanMode.
-///
-/// Bypass mode + plan not active → allow (echo `updatedInput` — required by
-/// the CLI's `PermissionPromptToolResultSchema`). This is the fix for "full"
-/// sessions seeing spurious denials: the CLI still routes certain tools
-/// (MCP servers, Skills, some built-in edge paths) through
-/// `--permission-prompt-tool stdio` even under `--permission-mode
-/// bypassPermissions`, so we must answer allow rather than fall through.
-///
-/// Plan mode is considered **inactive** once the agent has emitted
-/// `ExitPlanMode` (`session_exited_plan = true`) — even though the
-/// subprocess still runs with `--permission-mode plan` until the drift
-/// detector respawns it on the next turn. Without this, a bypass session
-/// that just had its plan approved would still deny every mutating tool
-/// for the remainder of the current turn.
-///
-/// Otherwise (standard/readonly, or plan-mode genuinely active) → deny with
-/// a message that names the escalation path; the model paraphrases this
-/// string to the user.
-///
-/// Auto-allow in bypass mode does not bypass an MCP server's own
-/// authorization — servers refuse at their layer via a normal tool_result,
-/// not a control_request.
-pub(crate) fn build_permission_response(
-    session_allowed_tools: &[String],
-    session_plan_mode: bool,
-    session_exited_plan: bool,
-    tool_name: &str,
-    original_input: &serde_json::Value,
-) -> serde_json::Value {
-    let bypass = is_bypass_tools(session_allowed_tools);
-    let plan_active = session_plan_mode && !session_exited_plan;
-    if bypass && !plan_active {
-        serde_json::json!({
-            "behavior": "allow",
-            "updatedInput": original_input,
-        })
-    } else {
-        let msg = format!(
-            "{tool_name} isn't enabled at the current permission level. Switch to 'full' in the chat toolbar (or run /permissions full) to allow it."
-        );
-        serde_json::json!({
-            "behavior": "deny",
-            "message": msg,
-        })
-    }
-}
 
 #[tauri::command]
 pub async fn load_chat_history(
@@ -1044,25 +961,8 @@ pub async fn send_chat_message(
                 && subtype == "compact_boundary"
                 && let Ok(db) = Database::open(&db_path)
             {
-                let sentinel = format!(
-                    "COMPACTION:{}:{}:{}:{}",
-                    meta.trigger, meta.pre_tokens, meta.post_tokens, meta.duration_ms
-                );
-                let msg = ChatMessage {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    workspace_id: ws_id.clone(),
-                    chat_session_id: chat_session_id_for_stream.clone(),
-                    role: ChatRole::System,
-                    content: sentinel,
-                    cost_usd: None,
-                    duration_ms: None,
-                    created_at: now_iso(),
-                    thinking: None,
-                    input_tokens: None,
-                    output_tokens: None,
-                    cache_read_tokens: Some(meta.post_tokens as i64),
-                    cache_creation_tokens: None,
-                };
+                let msg =
+                    build_compaction_sentinel(&ws_id, &chat_session_id_for_stream, meta, now_iso());
                 let _ = db.insert_chat_message(&msg);
             }
 
@@ -1472,41 +1372,10 @@ pub async fn send_chat_message(
             // thinking blocks only, then one with text. We accumulate thinking
             // and only save when we have text content to attach it to.
             if let AgentEvent::Stream(StreamEvent::Assistant { ref message }) = event {
-                let full_text: String = message
-                    .content
-                    .iter()
-                    .filter_map(|block| {
-                        if let claudette::agent::ContentBlock::Text { text } = block {
-                            Some(text.as_str())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("");
-
-                // Extract thinking from this event.
-                let event_thinking: Option<String> = {
-                    let parts: Vec<&str> = message
-                        .content
-                        .iter()
-                        .filter_map(|block| {
-                            if let claudette::agent::ContentBlock::Thinking { thinking } = block {
-                                Some(thinking.as_str())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    if parts.is_empty() {
-                        None
-                    } else {
-                        Some(parts.join(""))
-                    }
-                };
+                let full_text = extract_assistant_text(message);
 
                 // Accumulate thinking from this event.
-                if let Some(t) = event_thinking {
+                if let Some(t) = extract_event_thinking(message) {
                     pending_thinking = Some(match pending_thinking.take() {
                         Some(mut existing) => {
                             existing.push_str(&t);
@@ -1520,27 +1389,15 @@ pub async fn send_chat_message(
                 if !full_text.trim().is_empty()
                     && let Ok(db) = Database::open(&db_path)
                 {
-                    let msg_id = uuid::Uuid::new_v4().to_string();
-                    let taken_usage = latest_usage.take();
-                    let msg = ChatMessage {
-                        id: msg_id.clone(),
-                        workspace_id: ws_id.clone(),
-                        chat_session_id: chat_session_id_for_stream.clone(),
-                        role: ChatRole::Assistant,
+                    let msg = build_assistant_chat_message(BuildAssistantArgs {
+                        workspace_id: &ws_id,
+                        chat_session_id: &chat_session_id_for_stream,
                         content: full_text,
-                        cost_usd: None,
-                        duration_ms: None,
-                        created_at: now_iso(),
                         thinking: pending_thinking.take(),
-                        input_tokens: taken_usage.as_ref().map(|u| u.input_tokens as i64),
-                        output_tokens: taken_usage.as_ref().map(|u| u.output_tokens as i64),
-                        cache_read_tokens: taken_usage
-                            .as_ref()
-                            .and_then(|u| u.cache_read_input_tokens.map(|n| n as i64)),
-                        cache_creation_tokens: taken_usage
-                            .as_ref()
-                            .and_then(|u| u.cache_creation_input_tokens.map(|n| n as i64)),
-                    };
+                        usage: latest_usage.take(),
+                        created_at: now_iso(),
+                    });
+                    let msg_id = msg.id.clone();
                     if db.insert_chat_message(&msg).is_ok() {
                         last_assistant_msg_id = Some(msg_id);
                     }
@@ -1620,272 +1477,4 @@ pub async fn send_chat_message(
     });
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        RequestedFlags, SessionFlags, build_permission_response, persistent_session_flags_drifted,
-    };
-
-    fn s(values: &[&str]) -> Vec<String> {
-        values.iter().map(|v| (*v).to_string()).collect()
-    }
-
-    fn session<'a>(
-        plan_mode: bool,
-        allowed_tools: &'a [String],
-        exited_plan: bool,
-    ) -> SessionFlags<'a> {
-        SessionFlags {
-            plan_mode,
-            allowed_tools,
-            exited_plan,
-            disable_1m_context: false,
-        }
-    }
-
-    fn requested<'a>(plan_mode: bool, allowed_tools: &'a [String]) -> RequestedFlags<'a> {
-        RequestedFlags {
-            plan_mode,
-            allowed_tools,
-            disable_1m_context: false,
-        }
-    }
-
-    #[test]
-    fn no_drift_when_plan_mode_and_tools_match() {
-        let tools = s(&["Read", "Write"]);
-        assert!(!persistent_session_flags_drifted(
-            session(false, &tools, false),
-            requested(false, &tools),
-        ));
-    }
-
-    #[test]
-    fn drift_when_plan_mode_flips_off_after_approval() {
-        // Session was spawned with --permission-mode plan; next turn is not.
-        let tools = s(&["Read", "Write"]);
-        assert!(persistent_session_flags_drifted(
-            session(true, &tools, false),
-            requested(false, &tools),
-        ));
-    }
-
-    #[test]
-    fn drift_when_plan_mode_flips_on() {
-        let tools = s(&["Read"]);
-        assert!(persistent_session_flags_drifted(
-            session(false, &tools, false),
-            requested(true, &tools),
-        ));
-    }
-
-    #[test]
-    fn drift_when_permission_level_changes() {
-        let before = s(&["Read", "Glob"]);
-        let after = s(&["Read", "Write", "Edit"]);
-        assert!(persistent_session_flags_drifted(
-            session(false, &before, false),
-            requested(false, &after),
-        ));
-    }
-
-    #[test]
-    fn drift_when_allowed_tools_reordered() {
-        // Strict equality: a different order counts as drift. Callers build
-        // the list deterministically from the permission level, so any
-        // observed diff signals a real configuration change.
-        let before = s(&["Read", "Write"]);
-        let after = s(&["Write", "Read"]);
-        assert!(persistent_session_flags_drifted(
-            session(false, &before, false),
-            requested(false, &after),
-        ));
-    }
-
-    #[test]
-    fn no_drift_when_wildcard_unchanged() {
-        // Permission level "full" resolves to the wildcard sentinel; reusing
-        // the same bypass-permissions session should not trigger a respawn.
-        let full = s(&["*"]);
-        assert!(!persistent_session_flags_drifted(
-            session(false, &full, false),
-            requested(false, &full),
-        ));
-    }
-
-    #[test]
-    fn drift_when_escalating_to_wildcard() {
-        // Switching from a concrete list ("standard"/"readonly") up to "full"
-        // needs a respawn so `build_claude_args` can apply
-        // `--permission-mode bypassPermissions`.
-        let standard = s(&["Read", "Write", "Edit"]);
-        let full = s(&["*"]);
-        assert!(persistent_session_flags_drifted(
-            session(false, &standard, false),
-            requested(false, &full),
-        ));
-    }
-
-    #[test]
-    fn drift_when_demoting_from_wildcard() {
-        // Dropping from "full" back to a concrete list needs a respawn so
-        // the bypass-permissions mode is cleared and `--allowedTools` is
-        // constrained.
-        let full = s(&["*"]);
-        let readonly = s(&["Read", "Glob", "Grep"]);
-        assert!(persistent_session_flags_drifted(
-            session(false, &full, false),
-            requested(false, &readonly),
-        ));
-    }
-
-    #[test]
-    fn drift_when_session_exited_plan_even_if_request_still_says_plan() {
-        // Safety net: agent emitted ExitPlanMode so the plan phase is over.
-        // Even if the frontend forgets to flip plan_mode=false on the next
-        // turn (known bug class), the backend must still respawn so the CLI
-        // no longer auto-denies mutating tools.
-        let tools = s(&["Read", "Write"]);
-        assert!(persistent_session_flags_drifted(
-            session(true, &tools, true),
-            requested(true, &tools),
-        ));
-    }
-
-    #[test]
-    fn no_drift_when_exited_plan_but_session_never_had_plan() {
-        // Nonsense state defensively handled: if session_plan_mode is false
-        // the exited-plan flag is irrelevant and should not trigger drift.
-        let tools = s(&["Read"]);
-        assert!(!persistent_session_flags_drifted(
-            session(false, &tools, true),
-            requested(false, &tools),
-        ));
-    }
-
-    #[test]
-    fn drift_when_disable_1m_context_flips() {
-        // Switching between a 200k model SKU (disable_1m_context=true) and a
-        // 1M SKU (false) must respawn: CLAUDE_CODE_DISABLE_1M_CONTEXT is baked
-        // into the subprocess env at spawn and cannot be changed per-turn.
-        let tools = s(&["Read", "Write"]);
-        assert!(persistent_session_flags_drifted(
-            SessionFlags {
-                plan_mode: false,
-                allowed_tools: &tools,
-                exited_plan: false,
-                disable_1m_context: false,
-            },
-            RequestedFlags {
-                plan_mode: false,
-                allowed_tools: &tools,
-                disable_1m_context: true,
-            },
-        ));
-        assert!(persistent_session_flags_drifted(
-            SessionFlags {
-                plan_mode: false,
-                allowed_tools: &tools,
-                exited_plan: false,
-                disable_1m_context: true,
-            },
-            RequestedFlags {
-                plan_mode: false,
-                allowed_tools: &tools,
-                disable_1m_context: false,
-            },
-        ));
-    }
-
-    #[test]
-    fn no_drift_when_disable_1m_context_matches() {
-        let tools = s(&["Read"]);
-        assert!(!persistent_session_flags_drifted(
-            SessionFlags {
-                plan_mode: false,
-                allowed_tools: &tools,
-                exited_plan: false,
-                disable_1m_context: true,
-            },
-            RequestedFlags {
-                plan_mode: false,
-                allowed_tools: &tools,
-                disable_1m_context: true,
-            },
-        ));
-    }
-
-    use serde_json::json;
-
-    #[test]
-    fn permission_response_allows_bypass_session_non_plan() {
-        let input = json!({ "path": "/tmp/foo" });
-        let response = build_permission_response(&s(&["*"]), false, false, "Skill", &input);
-        assert_eq!(response["behavior"], "allow");
-        assert_eq!(response["updatedInput"], input);
-    }
-
-    #[test]
-    fn permission_response_denies_bypass_session_during_active_plan() {
-        let input = json!({});
-        let response = build_permission_response(&s(&["*"]), true, false, "Edit", &input);
-        assert_eq!(response["behavior"], "deny");
-    }
-
-    #[test]
-    fn permission_response_allows_bypass_session_after_plan_exit() {
-        // The agent emitted ExitPlanMode and the user approved, so the plan
-        // phase is over. The subprocess still has --permission-mode plan
-        // until the next turn's drift detection respawns it, but within
-        // this turn we should auto-allow because the user chose bypass.
-        let input = json!({ "file_path": "/tmp/fib.py", "content": "..." });
-        let response = build_permission_response(&s(&["*"]), true, true, "Write", &input);
-        assert_eq!(response["behavior"], "allow");
-        assert_eq!(response["updatedInput"], input);
-    }
-
-    #[test]
-    fn permission_response_denies_standard_session() {
-        let input = json!({});
-        let response =
-            build_permission_response(&s(&["Read", "Write"]), false, false, "Edit", &input);
-        assert_eq!(response["behavior"], "deny");
-        let msg = response["message"].as_str().expect("message");
-        assert!(
-            msg.contains("full"),
-            "message should name the escalation: {msg}"
-        );
-        assert!(
-            msg.contains("/permissions"),
-            "message should point at the slash command: {msg}"
-        );
-    }
-
-    #[test]
-    fn permission_response_denies_standard_session_after_plan_exit() {
-        // Non-bypass sessions should still deny after ExitPlanMode — they
-        // need the drift-triggered respawn to pick up the concrete
-        // --allowedTools list, and auto-allowing any tool would exceed the
-        // user's chosen permission scope.
-        let input = json!({});
-        let response =
-            build_permission_response(&s(&["Read", "Write"]), true, true, "Bash", &input);
-        assert_eq!(response["behavior"], "deny");
-    }
-
-    #[test]
-    fn permission_response_denies_empty_session() {
-        let input = json!({});
-        let response = build_permission_response(&[], false, false, "Edit", &input);
-        assert_eq!(response["behavior"], "deny");
-    }
-
-    #[test]
-    fn permission_response_rejects_multi_element_wildcard() {
-        let input = json!({});
-        let response = build_permission_response(&s(&["*", "Read"]), false, false, "Edit", &input);
-        assert_eq!(response["behavior"], "deny");
-    }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,0 +1,639 @@
+//! Shared chat turn helpers consumed by both transports.
+//!
+//! The Tauri command (`src-tauri/src/commands/chat/send.rs`) and the remote
+//! WebSocket handler (`src-server/src/handler.rs`) both run a chat turn and
+//! persist the resulting messages. They duplicate a lot of logic that is
+//! pure: session-flag drift detection, the `can_use_tool` permission
+//! response, walking an `AssistantMessage`'s content blocks, and building
+//! `ChatMessage` rows for persistence.
+//!
+//! This module collects those pure helpers so both call sites can share them
+//! and stay in lockstep. The transport-specific orchestration (event
+//! emission, `AppState` locking, notifications, checkpoint snapshotting)
+//! still lives in each call site — see issue #490 for the broader plan.
+//!
+//! See `docs/architecture` and the call sites for how these pieces are
+//! composed during a turn.
+
+use serde_json::Value;
+
+use crate::agent::{AssistantMessage, CompactMetadata, ContentBlock, TokenUsage};
+use crate::model::{ChatMessage, ChatRole};
+use crate::permissions::is_bypass_tools;
+
+// ---------------------------------------------------------------------------
+// Session-flag drift detection
+// ---------------------------------------------------------------------------
+
+/// Spawn-time flags of the currently running persistent session, plus the
+/// backend-observed `exited_plan` latch (set when the agent emits
+/// `ExitPlanMode` during this session).
+pub struct SessionFlags<'a> {
+    pub plan_mode: bool,
+    pub allowed_tools: &'a [String],
+    pub exited_plan: bool,
+    pub disable_1m_context: bool,
+}
+
+/// Flags the next turn is asking for. Compared against [`SessionFlags`] to
+/// decide whether the process must be torn down and respawned.
+pub struct RequestedFlags<'a> {
+    pub plan_mode: bool,
+    pub allowed_tools: &'a [String],
+    pub disable_1m_context: bool,
+}
+
+/// Detect whether the persistent session's spawn-time flags have drifted
+/// from what the current turn is asking for. Both `--permission-mode` and
+/// `--allowedTools` are only applied when the `claude` process starts, so
+/// a drift means the running process cannot serve this turn correctly and
+/// must be torn down.
+///
+/// `exited_plan` is a backend-observed signal that the agent called
+/// `ExitPlanMode` during the current session. When set alongside
+/// `plan_mode`, the plan phase is over regardless of whether the frontend
+/// remembered to send `plan_mode=false` — force a teardown so the CLI
+/// respawns without `--permission-mode plan`.
+pub fn persistent_session_flags_drifted(
+    session: SessionFlags<'_>,
+    requested: RequestedFlags<'_>,
+) -> bool {
+    session.plan_mode != requested.plan_mode
+        || session.allowed_tools != requested.allowed_tools
+        || session.disable_1m_context != requested.disable_1m_context
+        || (session.plan_mode && session.exited_plan)
+}
+
+// ---------------------------------------------------------------------------
+// Permission response builder
+// ---------------------------------------------------------------------------
+
+/// Decide how to respond to a `can_use_tool` control_request that reached the
+/// handler for a tool other than AskUserQuestion / ExitPlanMode.
+///
+/// Bypass mode + plan not active → allow (echo `updatedInput` — required by
+/// the CLI's `PermissionPromptToolResultSchema`). This is the fix for "full"
+/// sessions seeing spurious denials: the CLI still routes certain tools
+/// (MCP servers, Skills, some built-in edge paths) through
+/// `--permission-prompt-tool stdio` even under `--permission-mode
+/// bypassPermissions`, so we must answer allow rather than fall through.
+///
+/// Plan mode is considered **inactive** once the agent has emitted
+/// `ExitPlanMode` (`session_exited_plan = true`) — even though the
+/// subprocess still runs with `--permission-mode plan` until the drift
+/// detector respawns it on the next turn. Without this, a bypass session
+/// that just had its plan approved would still deny every mutating tool
+/// for the remainder of the current turn.
+///
+/// Otherwise (standard/readonly, or plan-mode genuinely active) → deny with
+/// a message that names the escalation path; the model paraphrases this
+/// string to the user.
+///
+/// Auto-allow in bypass mode does not bypass an MCP server's own
+/// authorization — servers refuse at their layer via a normal tool_result,
+/// not a control_request.
+pub fn build_permission_response(
+    session_allowed_tools: &[String],
+    session_plan_mode: bool,
+    session_exited_plan: bool,
+    tool_name: &str,
+    original_input: &Value,
+) -> Value {
+    let bypass = is_bypass_tools(session_allowed_tools);
+    let plan_active = session_plan_mode && !session_exited_plan;
+    if bypass && !plan_active {
+        serde_json::json!({
+            "behavior": "allow",
+            "updatedInput": original_input,
+        })
+    } else {
+        let msg = format!(
+            "{tool_name} isn't enabled at the current permission level. Switch to 'full' in the chat toolbar (or run /permissions full) to allow it."
+        );
+        serde_json::json!({
+            "behavior": "deny",
+            "message": msg,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Assistant message extraction
+// ---------------------------------------------------------------------------
+
+/// Concatenate every `text` content block in an assistant message.
+///
+/// The CLI may fire multiple assistant events per turn — one with thinking
+/// blocks only, then one with text — and a single event may carry multiple
+/// text blocks. Callers use the joined string as the `content` field of the
+/// persisted [`ChatMessage`] and only persist when it's non-empty.
+pub fn extract_assistant_text(message: &AssistantMessage) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// Concatenate every `thinking` content block in an assistant message.
+/// Returns `None` when the message carries no thinking blocks at all.
+///
+/// Callers accumulate this across thinking-only events and attach it to the
+/// next text-bearing assistant message that arrives in the same turn.
+pub fn extract_event_thinking(message: &AssistantMessage) -> Option<String> {
+    let parts: Vec<&str> = message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Thinking { thinking } => Some(thinking.as_str()),
+            _ => None,
+        })
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(""))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ChatMessage constructors
+// ---------------------------------------------------------------------------
+
+/// Inputs for [`build_assistant_chat_message`]. Bundled into a struct to keep
+/// the call-site readable and to leave room for future fields without a
+/// signature break.
+pub struct BuildAssistantArgs<'a> {
+    pub workspace_id: &'a str,
+    pub chat_session_id: &'a str,
+    /// Joined text from [`extract_assistant_text`].
+    pub content: String,
+    /// Accumulated thinking from prior events in this turn (taken from the
+    /// caller's running buffer).
+    pub thinking: Option<String>,
+    /// Per-message usage as last seen on a `MessageDelta` event. `None`
+    /// produces NULL token fields — used for historical rows and for any
+    /// transport that hasn't wired token tracking yet.
+    pub usage: Option<TokenUsage>,
+    pub created_at: String,
+}
+
+/// Build the `ChatMessage` row to persist for an assistant turn message.
+/// Maps `TokenUsage` into the four per-message token fields when present.
+pub fn build_assistant_chat_message(args: BuildAssistantArgs<'_>) -> ChatMessage {
+    let BuildAssistantArgs {
+        workspace_id,
+        chat_session_id,
+        content,
+        thinking,
+        usage,
+        created_at,
+    } = args;
+    ChatMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
+        role: ChatRole::Assistant,
+        content,
+        cost_usd: None,
+        duration_ms: None,
+        created_at,
+        thinking,
+        input_tokens: usage.as_ref().map(|u| u.input_tokens as i64),
+        output_tokens: usage.as_ref().map(|u| u.output_tokens as i64),
+        cache_read_tokens: usage
+            .as_ref()
+            .and_then(|u| u.cache_read_input_tokens.map(|n| n as i64)),
+        cache_creation_tokens: usage
+            .as_ref()
+            .and_then(|u| u.cache_creation_input_tokens.map(|n| n as i64)),
+    }
+}
+
+/// Build the `COMPACTION:trigger:pre:post:duration` system sentinel row.
+///
+/// Persisted on `subtype: "compact_boundary"` events so the timeline renders
+/// a divider on live + reload. `cache_read_tokens` is set to `post_tokens`
+/// so the frontend's `extractLatestCallUsage` picks up the new meter
+/// baseline on workspace reload.
+pub fn build_compaction_sentinel(
+    workspace_id: &str,
+    chat_session_id: &str,
+    meta: &CompactMetadata,
+    created_at: String,
+) -> ChatMessage {
+    let sentinel = format!(
+        "COMPACTION:{}:{}:{}:{}",
+        meta.trigger, meta.pre_tokens, meta.post_tokens, meta.duration_ms
+    );
+    ChatMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
+        role: ChatRole::System,
+        content: sentinel,
+        cost_usd: None,
+        duration_ms: None,
+        created_at,
+        thinking: None,
+        input_tokens: None,
+        output_tokens: None,
+        cache_read_tokens: Some(meta.post_tokens as i64),
+        cache_creation_tokens: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn s(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| (*v).to_string()).collect()
+    }
+
+    // -- Session-flag drift -------------------------------------------------
+
+    fn session<'a>(
+        plan_mode: bool,
+        allowed_tools: &'a [String],
+        exited_plan: bool,
+    ) -> SessionFlags<'a> {
+        SessionFlags {
+            plan_mode,
+            allowed_tools,
+            exited_plan,
+            disable_1m_context: false,
+        }
+    }
+
+    fn requested<'a>(plan_mode: bool, allowed_tools: &'a [String]) -> RequestedFlags<'a> {
+        RequestedFlags {
+            plan_mode,
+            allowed_tools,
+            disable_1m_context: false,
+        }
+    }
+
+    #[test]
+    fn no_drift_when_plan_mode_and_tools_match() {
+        let tools = s(&["Read", "Write"]);
+        assert!(!persistent_session_flags_drifted(
+            session(false, &tools, false),
+            requested(false, &tools),
+        ));
+    }
+
+    #[test]
+    fn drift_when_plan_mode_flips_off_after_approval() {
+        let tools = s(&["Read", "Write"]);
+        assert!(persistent_session_flags_drifted(
+            session(true, &tools, false),
+            requested(false, &tools),
+        ));
+    }
+
+    #[test]
+    fn drift_when_plan_mode_flips_on() {
+        let tools = s(&["Read"]);
+        assert!(persistent_session_flags_drifted(
+            session(false, &tools, false),
+            requested(true, &tools),
+        ));
+    }
+
+    #[test]
+    fn drift_when_permission_level_changes() {
+        let before = s(&["Read", "Glob"]);
+        let after = s(&["Read", "Write", "Edit"]);
+        assert!(persistent_session_flags_drifted(
+            session(false, &before, false),
+            requested(false, &after),
+        ));
+    }
+
+    #[test]
+    fn drift_when_allowed_tools_reordered() {
+        // Strict equality: a different order counts as drift. Callers build
+        // the list deterministically from the permission level, so any
+        // observed diff signals a real configuration change.
+        let before = s(&["Read", "Write"]);
+        let after = s(&["Write", "Read"]);
+        assert!(persistent_session_flags_drifted(
+            session(false, &before, false),
+            requested(false, &after),
+        ));
+    }
+
+    #[test]
+    fn no_drift_when_wildcard_unchanged() {
+        let full = s(&["*"]);
+        assert!(!persistent_session_flags_drifted(
+            session(false, &full, false),
+            requested(false, &full),
+        ));
+    }
+
+    #[test]
+    fn drift_when_escalating_to_wildcard() {
+        let standard = s(&["Read", "Write", "Edit"]);
+        let full = s(&["*"]);
+        assert!(persistent_session_flags_drifted(
+            session(false, &standard, false),
+            requested(false, &full),
+        ));
+    }
+
+    #[test]
+    fn drift_when_demoting_from_wildcard() {
+        let full = s(&["*"]);
+        let readonly = s(&["Read", "Glob", "Grep"]);
+        assert!(persistent_session_flags_drifted(
+            session(false, &full, false),
+            requested(false, &readonly),
+        ));
+    }
+
+    #[test]
+    fn drift_when_session_exited_plan_even_if_request_still_says_plan() {
+        let tools = s(&["Read", "Write"]);
+        assert!(persistent_session_flags_drifted(
+            session(true, &tools, true),
+            requested(true, &tools),
+        ));
+    }
+
+    #[test]
+    fn no_drift_when_exited_plan_but_session_never_had_plan() {
+        let tools = s(&["Read"]);
+        assert!(!persistent_session_flags_drifted(
+            session(false, &tools, true),
+            requested(false, &tools),
+        ));
+    }
+
+    #[test]
+    fn drift_when_disable_1m_context_flips() {
+        let tools = s(&["Read", "Write"]);
+        assert!(persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                exited_plan: false,
+                disable_1m_context: false,
+            },
+            RequestedFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                disable_1m_context: true,
+            },
+        ));
+        assert!(persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                exited_plan: false,
+                disable_1m_context: true,
+            },
+            RequestedFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                disable_1m_context: false,
+            },
+        ));
+    }
+
+    #[test]
+    fn no_drift_when_disable_1m_context_matches() {
+        let tools = s(&["Read"]);
+        assert!(!persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                exited_plan: false,
+                disable_1m_context: true,
+            },
+            RequestedFlags {
+                plan_mode: false,
+                allowed_tools: &tools,
+                disable_1m_context: true,
+            },
+        ));
+    }
+
+    // -- Permission response ------------------------------------------------
+
+    #[test]
+    fn permission_response_allows_bypass_session_non_plan() {
+        let input = json!({ "path": "/tmp/foo" });
+        let response = build_permission_response(&s(&["*"]), false, false, "Skill", &input);
+        assert_eq!(response["behavior"], "allow");
+        assert_eq!(response["updatedInput"], input);
+    }
+
+    #[test]
+    fn permission_response_denies_bypass_session_during_active_plan() {
+        let input = json!({});
+        let response = build_permission_response(&s(&["*"]), true, false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_allows_bypass_session_after_plan_exit() {
+        let input = json!({ "file_path": "/tmp/fib.py", "content": "..." });
+        let response = build_permission_response(&s(&["*"]), true, true, "Write", &input);
+        assert_eq!(response["behavior"], "allow");
+        assert_eq!(response["updatedInput"], input);
+    }
+
+    #[test]
+    fn permission_response_denies_standard_session() {
+        let input = json!({});
+        let response =
+            build_permission_response(&s(&["Read", "Write"]), false, false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+        let msg = response["message"].as_str().expect("message");
+        assert!(
+            msg.contains("full"),
+            "message should name the escalation: {msg}"
+        );
+        assert!(
+            msg.contains("/permissions"),
+            "message should point at the slash command: {msg}"
+        );
+    }
+
+    #[test]
+    fn permission_response_denies_standard_session_after_plan_exit() {
+        let input = json!({});
+        let response =
+            build_permission_response(&s(&["Read", "Write"]), true, true, "Bash", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_denies_empty_session() {
+        let input = json!({});
+        let response = build_permission_response(&[], false, false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    #[test]
+    fn permission_response_rejects_multi_element_wildcard() {
+        let input = json!({});
+        let response = build_permission_response(&s(&["*", "Read"]), false, false, "Edit", &input);
+        assert_eq!(response["behavior"], "deny");
+    }
+
+    // -- Assistant content extraction --------------------------------------
+
+    fn msg(blocks: Vec<ContentBlock>) -> AssistantMessage {
+        AssistantMessage { content: blocks }
+    }
+
+    #[test]
+    fn extract_text_joins_multiple_text_blocks() {
+        let m = msg(vec![
+            ContentBlock::Text {
+                text: "Hello, ".into(),
+            },
+            ContentBlock::Text {
+                text: "world!".into(),
+            },
+        ]);
+        assert_eq!(extract_assistant_text(&m), "Hello, world!");
+    }
+
+    #[test]
+    fn extract_text_skips_thinking_and_tool_use() {
+        let m = msg(vec![
+            ContentBlock::Thinking {
+                thinking: "ignored".into(),
+            },
+            ContentBlock::Text {
+                text: "kept".into(),
+            },
+            ContentBlock::ToolUse {
+                id: "1".into(),
+                name: "Read".into(),
+            },
+        ]);
+        assert_eq!(extract_assistant_text(&m), "kept");
+    }
+
+    #[test]
+    fn extract_text_returns_empty_for_thinking_only_message() {
+        let m = msg(vec![ContentBlock::Thinking {
+            thinking: "thinking".into(),
+        }]);
+        assert_eq!(extract_assistant_text(&m), "");
+    }
+
+    #[test]
+    fn extract_thinking_returns_none_when_no_thinking_blocks() {
+        let m = msg(vec![ContentBlock::Text {
+            text: "answer".into(),
+        }]);
+        assert!(extract_event_thinking(&m).is_none());
+    }
+
+    #[test]
+    fn extract_thinking_joins_multiple_thinking_blocks() {
+        let m = msg(vec![
+            ContentBlock::Thinking {
+                thinking: "step1 ".into(),
+            },
+            ContentBlock::Thinking {
+                thinking: "step2".into(),
+            },
+        ]);
+        assert_eq!(extract_event_thinking(&m).as_deref(), Some("step1 step2"));
+    }
+
+    // -- ChatMessage builders ----------------------------------------------
+
+    fn args(content: &str, usage: Option<TokenUsage>) -> BuildAssistantArgs<'static> {
+        BuildAssistantArgs {
+            workspace_id: "ws-1",
+            chat_session_id: "cs-1",
+            content: content.into(),
+            thinking: None,
+            usage,
+            created_at: "1234".into(),
+        }
+    }
+
+    #[test]
+    fn build_assistant_message_populates_token_fields_when_usage_present() {
+        let usage = TokenUsage {
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_creation_input_tokens: Some(30),
+            cache_read_input_tokens: Some(40),
+            iterations: None,
+        };
+        let m = build_assistant_chat_message(args("hello", Some(usage)));
+        assert_eq!(m.input_tokens, Some(10));
+        assert_eq!(m.output_tokens, Some(20));
+        assert_eq!(m.cache_creation_tokens, Some(30));
+        assert_eq!(m.cache_read_tokens, Some(40));
+        assert_eq!(m.role, ChatRole::Assistant);
+        assert_eq!(m.content, "hello");
+        assert_eq!(m.created_at, "1234");
+    }
+
+    #[test]
+    fn build_assistant_message_leaves_token_fields_null_when_usage_absent() {
+        let m = build_assistant_chat_message(args("hello", None));
+        assert!(m.input_tokens.is_none());
+        assert!(m.output_tokens.is_none());
+        assert!(m.cache_read_tokens.is_none());
+        assert!(m.cache_creation_tokens.is_none());
+    }
+
+    #[test]
+    fn build_assistant_message_passes_through_thinking() {
+        let mut a = args("hello", None);
+        a.thinking = Some("planning…".into());
+        let m = build_assistant_chat_message(a);
+        assert_eq!(m.thinking.as_deref(), Some("planning…"));
+    }
+
+    #[test]
+    fn build_assistant_message_handles_partial_cache_fields() {
+        // Older CLI / fallback responses may omit one of the cache_* fields.
+        let usage = TokenUsage {
+            input_tokens: 5,
+            output_tokens: 7,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: Some(99),
+            iterations: None,
+        };
+        let m = build_assistant_chat_message(args("x", Some(usage)));
+        assert_eq!(m.input_tokens, Some(5));
+        assert_eq!(m.output_tokens, Some(7));
+        assert_eq!(m.cache_creation_tokens, None);
+        assert_eq!(m.cache_read_tokens, Some(99));
+    }
+
+    #[test]
+    fn compaction_sentinel_encodes_metadata_and_baseline_meter() {
+        let meta = CompactMetadata {
+            trigger: "auto".into(),
+            pre_tokens: 100_000,
+            post_tokens: 25_000,
+            duration_ms: 1234,
+        };
+        let m = build_compaction_sentinel("ws", "cs", &meta, "now".into());
+        assert_eq!(m.role, ChatRole::System);
+        assert_eq!(m.content, "COMPACTION:auto:100000:25000:1234");
+        assert_eq!(m.cache_read_tokens, Some(25_000));
+        assert!(m.cache_creation_tokens.is_none());
+        assert!(m.input_tokens.is_none());
+        assert!(m.output_tokens.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod agent_mcp;
 pub mod cesp;
+pub mod chat;
 pub mod community;
 pub mod config;
 pub mod db;


### PR DESCRIPTION
## Summary

Foundation-only step toward #490. The Tauri chat send path (`src-tauri/src/commands/chat/send.rs`) and the remote WebSocket handler (`src-server/src/handler.rs`) reimplement the same chat turn pipeline and have drifted; most painful, the remote path persisted NULL token fields on every assistant message (the existing `TODO(#300 phase 1+)` at `handler.rs:682`).

This PR extracts the pure helpers into a new `claudette::chat` module so both call sites share them — and quietly closes the NULL-tokens drift on the remote side.

### What moves into `src/chat.rs`

- `SessionFlags` / `RequestedFlags` / `persistent_session_flags_drifted` — persistent-session flag drift detection
- `build_permission_response` — `can_use_tool` allow/deny response
- `extract_assistant_text` / `extract_event_thinking` — duplicated content-block walks
- `build_assistant_chat_message` — `ChatMessage` constructor that maps `TokenUsage` into the four per-message token fields
- `build_compaction_sentinel` — `COMPACTION:…` system message

All five are pure functions with no Tauri / `AppHandle` dependency. The 17 existing tests for drift + permission move with them, plus 9 new tests for the extraction helpers and `ChatMessage` builders.

### What changes at the call sites

- **Tauri (`commands/chat/send.rs`)**: removes the in-file definitions and ~210 lines of inline assistant-message / compaction-sentinel construction; behavior unchanged.
- **Remote (`handler.rs`)**: same swap, *plus* adds the `latest_usage` tracking pattern (3-line addition: a local, set on `MessageDelta`, taken when persisting). Token fields now populated; the `TODO(#300 phase 1+)` comment is gone.

### What's intentionally **not** in this PR

Per the scope discussion, this is foundation-only. No transport trait yet, no `TurnRunner`. The remote side still lacks: persistent sessions, checkpoints, env-drift teardown, notifications, MCP monitoring, attention prompts, attachments — all flagged in #490 for follow-up PRs.

The `now_iso()` mismatch between the two transports (Tauri returns epoch-seconds; remote returns ISO 8601) is preserved — helpers take `created_at: String` from the caller, so neither side's stored format changes.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --all-targets`
- [x] `cargo test --all-features` (all 812 backend tests pass; 29 chat module tests including 9 new)
- [x] `cd src/ui && bunx tsc -b`
- [ ] Manual smoke (Tauri): send a chat turn, confirm assistant message persists with token fields and conversation streams as before
- [ ] Manual smoke (remote): connect via WebSocket transport, send a chat turn, verify the persisted assistant `ChatMessage` row now has non-NULL `input_tokens`/`output_tokens`/`cache_read_tokens`/`cache_creation_tokens` (was NULL before this change)

Refs #490