### PR TITLE
feat(chat): paginate history and bundle attachments per page (#489)

### DIFF
--- a/src-tauri/src/commands/chat/mod.rs
+++ b/src-tauri/src/commands/chat/mod.rs
@@ -49,6 +49,17 @@ pub struct AttachmentResponse {
     pub tool_use_id: Option<String>,
 }
 
+/// Paginated response returned by [`super::send::load_chat_history_page`].
+/// Bundles the message page with its attachments so the frontend needs only
+/// one IPC round-trip per page instead of two.
+#[derive(Serialize)]
+pub struct ChatHistoryPage {
+    pub messages: Vec<claudette::model::ChatMessage>,
+    pub attachments: Vec<AttachmentResponse>,
+    pub has_more: bool,
+    pub total_count: i64,
+}
+
 #[derive(Clone, Serialize)]
 pub(crate) struct AgentStreamPayload {
     pub workspace_id: String,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -83,22 +83,37 @@ pub async fn load_chat_history_page(
     // attachments are FK-anchored to the triggering User message, so a turn
     // that straddles a page boundary would otherwise drop its attachments
     // until older history is loaded.
+    //
+    // We track the carry-over user id separately so we can filter its
+    // attachments to `origin = "agent"` only — fetching its user-origin
+    // rows would re-inline large image/text bytes that the page never needs
+    // to render (the user message itself is on the previous page).
     let mut message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+    let mut carry_over_user_id: Option<String> = None;
     if let Some(first) = messages.first()
         && first.role != ChatRole::User
         && let Some(prev_user) = db
             .previous_user_message_id(&session_id, &first.id)
             .map_err(|e| e.to_string())?
     {
-        message_ids.push(prev_user);
+        message_ids.push(prev_user.clone());
+        carry_over_user_id = Some(prev_user);
     }
     let att_map = db
         .list_attachments_for_messages(&message_ids)
         .map_err(|e| e.to_string())?;
 
     let mut attachments = Vec::new();
-    for (_, atts) in att_map {
+    for (msg_id, atts) in att_map {
+        let is_carry_over = carry_over_user_id.as_deref() == Some(msg_id.as_str());
         for a in atts {
+            // For the carry-over user, skip non-agent attachments — the user
+            // message itself is on the previous page, so its own attachments
+            // (potentially large images / text files) shouldn't be inlined
+            // into this response.
+            if is_carry_over && !matches!(a.origin, claudette::model::AttachmentOrigin::Agent) {
+                continue;
+            }
             let is_text = matches!(
                 a.media_type.as_str(),
                 "text/plain" | "text/csv" | "text/markdown" | "application/json"

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -24,8 +24,8 @@ use crate::state::{AgentSessionState, AppState, PendingPermission};
 use super::interaction::{deny_drained_permissions, drain_pending_permissions};
 use super::naming::{try_auto_rename, try_generate_session_name};
 use super::{
-    ATTENTION_NOTIFY_DELAY_MS, AgentStreamPayload, AttachmentInput, fire_completion_notification,
-    now_iso, start_bridge_and_inject_mcp,
+    ATTENTION_NOTIFY_DELAY_MS, AgentStreamPayload, AttachmentInput, AttachmentResponse,
+    ChatHistoryPage, fire_completion_notification, now_iso, start_bridge_and_inject_mcp,
 };
 
 #[tauri::command]
@@ -36,6 +36,80 @@ pub async fn load_chat_history(
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.list_chat_messages_for_session(&session_id)
         .map_err(|e| e.to_string())
+}
+
+/// Load a page of chat history starting from the newest messages.
+///
+/// Pass `before_message_id` to page backwards: set it to the `id` of the
+/// oldest message already held by the client and the next `limit` older
+/// messages are returned, together with their attachments.
+///
+/// The response also carries `total_count` so the frontend can compute the
+/// global index offset of the returned page without a separate round-trip
+/// (`global_offset = total_count - already_loaded_count`).
+#[tauri::command]
+pub async fn load_chat_history_page(
+    session_id: String,
+    limit: i64,
+    before_message_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<ChatHistoryPage, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    let total_count = db
+        .count_chat_messages_for_session(&session_id)
+        .map_err(|e| e.to_string())?;
+
+    let messages = db
+        .list_chat_messages_page(&session_id, limit, before_message_id.as_deref())
+        .map_err(|e| e.to_string())?;
+
+    let has_more = messages.len() as i64 == limit;
+
+    let message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+    let att_map = db
+        .list_attachments_for_messages(&message_ids)
+        .map_err(|e| e.to_string())?;
+
+    let mut attachments = Vec::new();
+    for (_, atts) in att_map {
+        for a in atts {
+            let is_text = matches!(
+                a.media_type.as_str(),
+                "text/plain" | "text/csv" | "text/markdown" | "application/json"
+            );
+            let data_base64 = if a.media_type.starts_with("image/") || is_text {
+                claudette::base64_encode(&a.data)
+            } else {
+                String::new()
+            };
+            let text_content = if is_text {
+                std::str::from_utf8(&a.data).ok().map(str::to_owned)
+            } else {
+                None
+            };
+            attachments.push(AttachmentResponse {
+                id: a.id,
+                message_id: a.message_id,
+                filename: a.filename,
+                media_type: a.media_type,
+                data_base64,
+                text_content,
+                width: a.width,
+                height: a.height,
+                size_bytes: a.size_bytes,
+                origin: a.origin,
+                tool_use_id: a.tool_use_id,
+            });
+        }
+    }
+
+    Ok(ChatHistoryPage {
+        messages,
+        attachments,
+        has_more,
+        total_count,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -64,9 +64,34 @@ pub async fn load_chat_history_page(
         .list_chat_messages_page(&session_id, limit, before_message_id.as_deref())
         .map_err(|e| e.to_string())?;
 
-    let has_more = messages.len() as i64 == limit;
+    // `has_more` reflects whether older rows exist beyond the cursor — never
+    // just `messages.len() == limit`, which over-reports on sessions whose
+    // total is an exact multiple of the page size and triggers a wasted fetch.
+    let has_more = match before_message_id.as_deref() {
+        // First page: the page covers the newest `messages.len()` rows; older
+        // rows exist iff the total exceeds what we returned.
+        None => total_count > messages.len() as i64,
+        // Subsequent page: assume more if we filled the page. Hitting an exact
+        // boundary still wastes one fetch, but avoiding it would require a
+        // second count keyed to the cursor — not worth the round-trip.
+        Some(_) => messages.len() as i64 == limit,
+    };
 
-    let message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+    // Build the attachment lookup set. Start with the page's own message ids,
+    // then — when the page begins mid-turn (first row isn't a User) — also
+    // include the most recent User message before the cursor. Agent-origin
+    // attachments are FK-anchored to the triggering User message, so a turn
+    // that straddles a page boundary would otherwise drop its attachments
+    // until older history is loaded.
+    let mut message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+    if let Some(first) = messages.first()
+        && first.role != ChatRole::User
+        && let Some(prev_user) = db
+            .previous_user_message_id(&session_id, &first.id)
+            .map_err(|e| e.to_string())?
+    {
+        message_ids.push(prev_user);
+    }
     let att_map = db
         .list_attachments_for_messages(&message_ids)
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -479,6 +479,7 @@ fn main() {
             commands::files::open_attachment_with_default_app,
             // Chat
             commands::chat::send::load_chat_history,
+            commands::chat::send::load_chat_history_page,
             commands::chat::send::send_chat_message,
             commands::chat::attachments::load_attachments_for_session,
             commands::chat::attachments::load_attachment_data,

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -114,6 +114,70 @@ impl Database {
         rows.collect()
     }
 
+    /// Count all messages for a session. Used to compute pagination metadata
+    /// (`total_count`) so callers can derive the global index offset of any
+    /// loaded page without a separate round-trip.
+    pub fn count_chat_messages_for_session(
+        &self,
+        chat_session_id: &str,
+    ) -> Result<i64, rusqlite::Error> {
+        self.conn.query_row(
+            "SELECT COUNT(*) FROM chat_messages WHERE chat_session_id = ?1",
+            params![chat_session_id],
+            |row| row.get(0),
+        )
+    }
+
+    /// Return up to `limit` messages for a session in ascending chronological
+    /// order. When `before_message_id` is `None` the newest `limit` messages
+    /// are returned; when it is `Some(id)` only messages whose `rowid` is
+    /// strictly less than the row identified by that id are considered, so the
+    /// caller can page backwards through history by passing the id of the
+    /// oldest already-loaded message as the cursor.
+    pub fn list_chat_messages_page(
+        &self,
+        chat_session_id: &str,
+        limit: i64,
+        before_message_id: Option<&str>,
+    ) -> Result<Vec<ChatMessage>, rusqlite::Error> {
+        let mut rows: Vec<ChatMessage> = match before_message_id {
+            None => {
+                let sql = format!(
+                    "SELECT {cols} FROM chat_messages
+                     WHERE chat_session_id = ?1
+                     ORDER BY created_at DESC, rowid DESC
+                     LIMIT ?2",
+                    cols = Self::CHAT_MESSAGE_COLS
+                );
+                let mut stmt = self.conn.prepare(&sql)?;
+                stmt.query_map(
+                    params![chat_session_id, limit],
+                    Self::parse_chat_message_row,
+                )?
+                .collect::<Result<Vec<_>, _>>()?
+            }
+            Some(cursor_id) => {
+                let sql = format!(
+                    "SELECT {cols} FROM chat_messages
+                     WHERE chat_session_id = ?1
+                       AND rowid < (SELECT rowid FROM chat_messages WHERE id = ?3)
+                     ORDER BY created_at DESC, rowid DESC
+                     LIMIT ?2",
+                    cols = Self::CHAT_MESSAGE_COLS
+                );
+                let mut stmt = self.conn.prepare(&sql)?;
+                stmt.query_map(
+                    params![chat_session_id, limit, cursor_id],
+                    Self::parse_chat_message_row,
+                )?
+                .collect::<Result<Vec<_>, _>>()?
+            }
+        };
+        // Reverse so callers receive messages in ascending chronological order.
+        rows.reverse();
+        Ok(rows)
+    }
+
     #[allow(dead_code)]
     pub fn update_chat_message_content(
         &self,

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -86,6 +86,14 @@ impl Database {
          duration_ms, created_at, thinking, input_tokens, output_tokens, cache_read_tokens, \
          cache_creation_tokens";
 
+    /// Predicate that filters out legacy empty assistant rows (assistant role,
+    /// empty content, no thinking text). The frontend used to drop these in
+    /// the renderer; we apply it here so `count_chat_messages_for_session`
+    /// and `list_chat_messages_page` agree on what "exists" — which keeps the
+    /// `globalOffset = totalCount - messages.length` invariant honest.
+    const NON_LEGACY_MESSAGE_PREDICATE: &str =
+        "NOT (role = 'assistant' AND TRIM(content) = '' AND COALESCE(TRIM(thinking), '') = '')";
+
     #[allow(dead_code)]
     pub fn list_chat_messages(
         &self,
@@ -114,18 +122,22 @@ impl Database {
         rows.collect()
     }
 
-    /// Count all messages for a session. Used to compute pagination metadata
-    /// (`total_count`) so callers can derive the global index offset of any
-    /// loaded page without a separate round-trip.
+    /// Count all non-legacy messages for a session (legacy = empty assistant
+    /// rows; see `NON_LEGACY_MESSAGE_PREDICATE`). Used to compute pagination
+    /// metadata (`total_count`) so callers can derive the global index offset
+    /// of any loaded page without a separate round-trip.
     pub fn count_chat_messages_for_session(
         &self,
         chat_session_id: &str,
     ) -> Result<i64, rusqlite::Error> {
-        self.conn.query_row(
-            "SELECT COUNT(*) FROM chat_messages WHERE chat_session_id = ?1",
-            params![chat_session_id],
-            |row| row.get(0),
-        )
+        let sql = format!(
+            "SELECT COUNT(*) FROM chat_messages
+             WHERE chat_session_id = ?1
+               AND {predicate}",
+            predicate = Self::NON_LEGACY_MESSAGE_PREDICATE,
+        );
+        self.conn
+            .query_row(&sql, params![chat_session_id], |row| row.get(0))
     }
 
     /// Return up to `limit` messages for a session in ascending chronological
@@ -134,6 +146,9 @@ impl Database {
     /// strictly less than the row identified by that id are considered, so the
     /// caller can page backwards through history by passing the id of the
     /// oldest already-loaded message as the cursor.
+    ///
+    /// Legacy empty assistant rows are excluded — see
+    /// `NON_LEGACY_MESSAGE_PREDICATE`.
     pub fn list_chat_messages_page(
         &self,
         chat_session_id: &str,
@@ -145,9 +160,11 @@ impl Database {
                 let sql = format!(
                     "SELECT {cols} FROM chat_messages
                      WHERE chat_session_id = ?1
+                       AND {predicate}
                      ORDER BY created_at DESC, rowid DESC
                      LIMIT ?2",
-                    cols = Self::CHAT_MESSAGE_COLS
+                    cols = Self::CHAT_MESSAGE_COLS,
+                    predicate = Self::NON_LEGACY_MESSAGE_PREDICATE,
                 );
                 let mut stmt = self.conn.prepare(&sql)?;
                 stmt.query_map(
@@ -161,9 +178,11 @@ impl Database {
                     "SELECT {cols} FROM chat_messages
                      WHERE chat_session_id = ?1
                        AND rowid < (SELECT rowid FROM chat_messages WHERE id = ?3)
+                       AND {predicate}
                      ORDER BY created_at DESC, rowid DESC
                      LIMIT ?2",
-                    cols = Self::CHAT_MESSAGE_COLS
+                    cols = Self::CHAT_MESSAGE_COLS,
+                    predicate = Self::NON_LEGACY_MESSAGE_PREDICATE,
                 );
                 let mut stmt = self.conn.prepare(&sql)?;
                 stmt.query_map(
@@ -176,6 +195,29 @@ impl Database {
         // Reverse so callers receive messages in ascending chronological order.
         rows.reverse();
         Ok(rows)
+    }
+
+    /// For pagination: find the most recent user message strictly older than
+    /// the given message id, in the same session. Used to recover agent
+    /// attachments anchored to a user message that lives on the previous page
+    /// when the new page begins mid-turn.
+    pub fn previous_user_message_id(
+        &self,
+        chat_session_id: &str,
+        before_message_id: &str,
+    ) -> Result<Option<String>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT id FROM chat_messages
+                 WHERE chat_session_id = ?1
+                   AND role = 'user'
+                   AND rowid < (SELECT rowid FROM chat_messages WHERE id = ?2)
+                 ORDER BY rowid DESC
+                 LIMIT 1",
+                params![chat_session_id, before_message_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
     }
 
     #[allow(dead_code)]
@@ -786,6 +828,201 @@ mod tests {
         assert_eq!(msgs[0].output_tokens, None);
         assert_eq!(msgs[0].cache_read_tokens, None);
         assert_eq!(msgs[0].cache_creation_tokens, None);
+    }
+
+    // --- Pagination tests ---
+
+    fn session_id_for(db: &Database, workspace_id: &str) -> String {
+        db.default_session_id_for_workspace(workspace_id)
+            .unwrap()
+            .expect("workspace must have a default session for tests")
+    }
+
+    #[test]
+    fn test_count_messages_empty_session() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        assert_eq!(db.count_chat_messages_for_session(&sid).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_count_messages_excludes_legacy_empty_assistant() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        // Real user + assistant turn.
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "hi"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            &db,
+            "m2",
+            "w1",
+            ChatRole::Assistant,
+            "hello",
+        ))
+        .unwrap();
+        // Legacy empty-assistant row (no content, no thinking) — should be filtered.
+        db.insert_chat_message(&make_chat_msg(&db, "m3", "w1", ChatRole::Assistant, ""))
+            .unwrap();
+        // Empty-content assistant *with* thinking is real — should count.
+        let mut thinking = make_chat_msg(&db, "m4", "w1", ChatRole::Assistant, "");
+        thinking.thinking = Some("internal monologue".into());
+        db.insert_chat_message(&thinking).unwrap();
+
+        assert_eq!(db.count_chat_messages_for_session(&sid).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_list_page_first_returns_newest_in_asc_order() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        for i in 1..=5 {
+            db.insert_chat_message(&make_chat_msg(
+                &db,
+                &format!("m{i}"),
+                "w1",
+                if i % 2 == 1 {
+                    ChatRole::User
+                } else {
+                    ChatRole::Assistant
+                },
+                &format!("msg {i}"),
+            ))
+            .unwrap();
+        }
+
+        let page = db.list_chat_messages_page(&sid, 3, None).unwrap();
+        assert_eq!(page.len(), 3);
+        // Newest 3 messages, returned ASC — m3, m4, m5.
+        assert_eq!(page[0].id, "m3");
+        assert_eq!(page[1].id, "m4");
+        assert_eq!(page[2].id, "m5");
+    }
+
+    #[test]
+    fn test_list_page_cursor_returns_older_batch() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        for i in 1..=5 {
+            db.insert_chat_message(&make_chat_msg(
+                &db,
+                &format!("m{i}"),
+                "w1",
+                ChatRole::User,
+                &format!("msg {i}"),
+            ))
+            .unwrap();
+        }
+        // Use m3 as the cursor — should return m1 and m2 in ASC order.
+        let older = db.list_chat_messages_page(&sid, 10, Some("m3")).unwrap();
+        assert_eq!(older.len(), 2);
+        assert_eq!(older[0].id, "m1");
+        assert_eq!(older[1].id, "m2");
+    }
+
+    #[test]
+    fn test_list_page_excludes_legacy_empty_assistant() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "hi"))
+            .unwrap();
+        // Legacy empty-assistant row in the middle.
+        db.insert_chat_message(&make_chat_msg(&db, "m2", "w1", ChatRole::Assistant, ""))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "m3", "w1", ChatRole::Assistant, "real"))
+            .unwrap();
+
+        let page = db.list_chat_messages_page(&sid, 10, None).unwrap();
+        let ids: Vec<&str> = page.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["m1", "m3"]);
+    }
+
+    #[test]
+    fn test_list_page_exact_limit_signals_more_via_cursor() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        for i in 1..=4 {
+            db.insert_chat_message(&make_chat_msg(
+                &db,
+                &format!("m{i}"),
+                "w1",
+                ChatRole::User,
+                &format!("msg {i}"),
+            ))
+            .unwrap();
+        }
+        // First page returns 2 newest (m3, m4); count is 4 so caller knows more exist.
+        let first = db.list_chat_messages_page(&sid, 2, None).unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[0].id, "m3");
+        assert_eq!(first[1].id, "m4");
+        let total = db.count_chat_messages_for_session(&sid).unwrap();
+        assert!(total > first.len() as i64);
+
+        // Second page (cursor = m3) returns m1, m2.
+        let second = db.list_chat_messages_page(&sid, 2, Some("m3")).unwrap();
+        assert_eq!(second.len(), 2);
+        assert_eq!(second[0].id, "m1");
+        assert_eq!(second[1].id, "m2");
+
+        // Third page (cursor = m1) returns nothing — exhausted.
+        let third = db.list_chat_messages_page(&sid, 2, Some("m1")).unwrap();
+        assert!(third.is_empty());
+    }
+
+    #[test]
+    fn test_list_page_tied_timestamps_disambiguate_via_rowid() {
+        // make_chat_msg sets `created_at = ""` so all rows tie on timestamp; the
+        // ORDER BY rowid tiebreaker must still produce a stable insertion order.
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        for i in 1..=4 {
+            db.insert_chat_message(&make_chat_msg(
+                &db,
+                &format!("m{i}"),
+                "w1",
+                ChatRole::User,
+                &format!("msg {i}"),
+            ))
+            .unwrap();
+        }
+        let page = db.list_chat_messages_page(&sid, 2, None).unwrap();
+        assert_eq!(page[0].id, "m3");
+        assert_eq!(page[1].id, "m4");
+    }
+
+    #[test]
+    fn test_previous_user_message_id_finds_prior_user() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        db.insert_chat_message(&make_chat_msg(&db, "u1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "a1", "w1", ChatRole::Assistant, "ok"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "u2", "w1", ChatRole::User, "second"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "a2", "w1", ChatRole::Assistant, "done"))
+            .unwrap();
+
+        // Prior user before a2 is u2.
+        assert_eq!(
+            db.previous_user_message_id(&sid, "a2").unwrap(),
+            Some("u2".into()),
+        );
+        // Prior user before u2 is u1 (skips a1).
+        assert_eq!(
+            db.previous_user_message_id(&sid, "u2").unwrap(),
+            Some("u1".into()),
+        );
+    }
+
+    #[test]
+    fn test_previous_user_message_id_none_when_no_prior_user() {
+        let db = setup_db_with_workspace();
+        let sid = session_id_for(&db, "w1");
+        db.insert_chat_message(&make_chat_msg(&db, "u1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        // No user message exists strictly before u1.
+        assert_eq!(db.previous_user_message_id(&sid, "u1").unwrap(), None);
     }
 
     // --- Attachment tests ---

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -1081,3 +1081,22 @@
   font-size: 9px;
   color: var(--text-faint);
 }
+
+.loadingOlder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.loadingOlderSpinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -1096,6 +1096,12 @@
   animation: spin 1s linear infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .loadingOlderSpinner {
+    animation: none;
+  }
+}
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -493,12 +493,41 @@ export function ChatPanel() {
 
         loadChatHistoryPage(sessionId, 50, cursorId)
           .then((page) => {
-            store.prependChatMessages(sessionId, page.messages);
-            store.prependChatAttachments(sessionId, page.attachments);
-            store.setChatPagination(sessionId, {
+            // Staleness guard: if the user switched sessions, cleared the
+            // conversation, or scrolled further while this fetch was in
+            // flight, the response is no longer applicable. Bail before
+            // mutating any state — applying it would prepend old rows back
+            // into a session that has moved on. We still reset the source
+            // session's `isLoadingMore` flag if it's safe (pagination state
+            // unchanged for that session), so the user can retry on return.
+            const liveStore = useAppStore.getState();
+            const livePagination = liveStore.chatPagination[sessionId];
+            const stillCurrent =
+              activeSessionIdRef.current === sessionId &&
+              livePagination &&
+              livePagination.oldestMessageId === cursorId;
+            if (!stillCurrent) {
+              if (livePagination && livePagination.isLoadingMore) {
+                liveStore.setChatPagination(sessionId, {
+                  ...livePagination,
+                  isLoadingMore: false,
+                });
+              }
+              return;
+            }
+            liveStore.prependChatMessages(sessionId, page.messages);
+            liveStore.prependChatAttachments(sessionId, page.attachments);
+            // Merge live `totalCount` (which may have grown via streaming
+            // `addChatMessage` while the request was in flight) with the
+            // server snapshot. `totalCount` must stay monotonic per session
+            // — moving it backwards would shift `globalOffset` and corrupt
+            // CompletedTurn placement until the next full reload.
+            const liveTotal =
+              useAppStore.getState().chatPagination[sessionId]?.totalCount ?? 0;
+            liveStore.setChatPagination(sessionId, {
               hasMore: page.has_more,
               isLoadingMore: false,
-              totalCount: page.total_count,
+              totalCount: Math.max(page.total_count, liveTotal),
               oldestMessageId: page.messages[0]?.id ?? cursorId,
             });
             // Backfill prompt history: Shift+Up walks `historyRef`, which was
@@ -526,9 +555,13 @@ export function ChatPanel() {
             // against the now-larger message window resolves them.
             const merged =
               useAppStore.getState().chatMessages[sessionId] ?? [];
-            const mergedOffset = page.total_count - merged.length;
+            const mergedTotal =
+              useAppStore.getState().chatPagination[sessionId]?.totalCount ??
+              page.total_count;
+            const mergedOffset = mergedTotal - merged.length;
             loadCompletedTurns(sessionId)
               .then((turnData) => {
+                if (activeSessionIdRef.current !== sessionId) return;
                 const turns = reconstructCompletedTurns(
                   merged,
                   turnData,
@@ -547,7 +580,19 @@ export function ChatPanel() {
           })
           .catch((e) => {
             console.error("Failed to load older messages:", e);
-            store.setChatPagination(sessionId, { ...pagination, isLoadingMore: false });
+            // Read fresh pagination state — `addChatMessage` may have
+            // incremented `totalCount` while the fetch was in flight, and
+            // writing back the captured snapshot here would clobber it.
+            const live = useAppStore.getState().chatPagination[sessionId];
+            if (!live) return; // session was cleared
+            useAppStore
+              .getState()
+              .setChatPagination(sessionId, { ...live, isLoadingMore: false });
+          })
+          .finally(() => {
+            // Clear the synchronous gate regardless of outcome so the next
+            // top-of-scroll event can fetch again.
+            isLoadingMoreRef.current = false;
           });
       }
     };

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { LoaderCircle } from "lucide-react";
 import { ChatSearchBar } from "./ChatSearchBar";
 import { useAppStore } from "../../stores/useAppStore";
 import {
@@ -396,17 +397,32 @@ export function ChatPanel() {
     };
 
     if (isLocal) {
-      // Load newest page of messages and their attachments in one round-trip.
-      loadChatHistoryPage(sessionId, 50)
-        .then((page) => {
-          onMessages(page.messages, page.attachments, {
-            hasMore: page.has_more,
-            isLoadingMore: false,
-            totalCount: page.total_count,
-            oldestMessageId: page.messages[0]?.id ?? null,
-          });
-        })
-        .catch((e) => console.error("Failed to load chat history:", e));
+      // Skip the reload when we've already loaded this session — otherwise
+      // bouncing between long conversations would drop any older pages the
+      // user already scrolled through and snap them back to the newest 50.
+      // CompletedTurns and attachments are kept live in the store via the
+      // streaming path, so re-fetching from the DB here would also clobber
+      // in-flight state.
+      const existingPagination =
+        useAppStore.getState().chatPagination[sessionId];
+      if (existingPagination) {
+        debugChat("ChatPanel", "load-history:skip-already-loaded", {
+          sessionId,
+          totalCount: existingPagination.totalCount,
+        });
+      } else {
+        // Load newest page of messages and their attachments in one round-trip.
+        loadChatHistoryPage(sessionId, 50)
+          .then((page) => {
+            onMessages(page.messages, page.attachments, {
+              hasMore: page.has_more,
+              isLoadingMore: false,
+              totalCount: page.total_count,
+              oldestMessageId: page.messages[0]?.id ?? null,
+            });
+          })
+          .catch((e) => console.error("Failed to load chat history:", e));
+      }
     } else {
       sendRemoteCommand(currentWs!.remote_connection_id!, "load_chat_history", {
         chat_session_id: sessionId,
@@ -467,6 +483,11 @@ export function ChatPanel() {
         const pagination = store.chatPagination[sessionId];
         if (!pagination) return;
 
+        // Flip the ref synchronously: subsequent scroll events fire before
+        // React commits the store update, so without this guard fast scrolls
+        // at the top can dispatch multiple page fetches with the same cursor
+        // and prepend the same rows repeatedly.
+        isLoadingMoreRef.current = true;
         store.setChatPagination(sessionId, { ...pagination, isLoadingMore: true });
         const prevScrollHeight = container.scrollHeight;
 
@@ -480,6 +501,20 @@ export function ChatPanel() {
               totalCount: page.total_count,
               oldestMessageId: page.messages[0]?.id ?? cursorId,
             });
+            // Backfill prompt history: Shift+Up walks `historyRef`, which was
+            // seeded from the initial page only. Without this, older user
+            // messages stay invisible to history navigation even after the
+            // user scrolls them into view.
+            const olderUserPrompts = page.messages
+              .filter((m) => m.role === "User")
+              .map((m) => m.content);
+            if (olderUserPrompts.length > 0) {
+              const existing = historyRef.current[sessionId] ?? [];
+              historyRef.current[sessionId] = [
+                ...olderUserPrompts,
+                ...existing,
+              ];
+            }
             // Restore scroll position so prepended messages don't push the
             // view upward.
             requestAnimationFrame(() => {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -4,7 +4,7 @@ import { ChatSearchBar } from "./ChatSearchBar";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   loadAttachmentData,
-  loadChatHistory,
+  loadChatHistoryPage,
   loadAttachmentsForSession,
   listCheckpoints,
   listSlashCommands,
@@ -81,6 +81,10 @@ export function ChatPanel() {
   const setChatMessages = useAppStore((s) => s.setChatMessages);
   const hydrateCompletedTurns = useAppStore((s) => s.hydrateCompletedTurns);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
+  const setChatPagination = useAppStore((s) => s.setChatPagination);
+  const chatPaginationState = useAppStore((s) =>
+    activeSessionId ? s.chatPagination[activeSessionId] : undefined,
+  );
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const openPluginSettings = useAppStore((s) => s.openPluginSettings);
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
@@ -175,6 +179,15 @@ export function ChatPanel() {
   const messages = activeSessionId
     ? chatMessages[activeSessionId] || []
     : [];
+  const hasMore = chatPaginationState?.hasMore ?? false;
+  const isLoadingMore = chatPaginationState?.isLoadingMore ?? false;
+  const paginationTotalCount = chatPaginationState?.totalCount ?? messages.length;
+  const oldestMessageId = chatPaginationState?.oldestMessageId ?? null;
+  // Global 0-based index of the first loaded message in the full message sequence.
+  // Zero for new/fully-loaded sessions; positive for paginated sessions where
+  // older messages have not been fetched yet.
+  const globalOffset = paginationTotalCount - messages.length;
+
   // Subscribe only to boolean — avoids re-render on every streaming character
   const hasStreaming = useAppStore(
     (s) => !!(activeSessionId && s.streamingContent[activeSessionId])
@@ -301,12 +314,6 @@ export function ChatPanel() {
       .getState()
       .workspaces.find((w) => w.id === selectedWorkspaceId);
     const sessionId = activeSessionId;
-    const loadHistory = currentWs?.remote_connection_id
-      ? sendRemoteCommand(currentWs.remote_connection_id, "load_chat_history", {
-          chat_session_id: sessionId,
-        }).then((data) => (data as { messages?: ChatMessage[] })?.messages ?? data as ChatMessage[])
-      : loadChatHistory(sessionId);
-
     const isLocal = !currentWs?.remote_connection_id;
 
     debugChat("ChatPanel", "load-history:start", {
@@ -315,75 +322,92 @@ export function ChatPanel() {
       agentStatus: currentWs?.agent_status ?? null,
     });
 
-    loadHistory
-      .then((msgs: ChatMessage[]) => {
-        if (cancelled) return;
-        // Filter out empty assistant messages (legacy data), but keep
-        // those that carry thinking content.
-        const filtered = msgs.filter(
-          (m) => m.role !== "Assistant" || m.content.trim() !== "" || !!m.thinking
-        );
-        debugChat("ChatPanel", "load-history:success", {
+    const onMessages = (msgs: ChatMessage[], attachments?: import("../../types").ChatAttachment[], pageState?: import("../../types").ChatPaginationState) => {
+      if (cancelled) return;
+      // Filter out empty assistant messages (legacy data), but keep
+      // those that carry thinking content.
+      const filtered = msgs.filter(
+        (m) => m.role !== "Assistant" || m.content.trim() !== "" || !!m.thinking
+      );
+      debugChat("ChatPanel", "load-history:success", {
+        sessionId,
+        rawMessageCount: msgs.length,
+        filteredMessageCount: filtered.length,
+        messageIds: filtered.map((msg) => msg.id),
+      });
+      setChatMessages(sessionId, filtered);
+      if (attachments) {
+        useAppStore.getState().setChatAttachments(sessionId, attachments);
+      }
+      if (pageState) {
+        setChatPagination(sessionId, pageState);
+      }
+      historyRef.current[sessionId] = filtered
+        .filter((m) => m.role === "User")
+        .map((m) => m.content);
+      // Seed the ContextMeter from the last assistant message's per-call
+      // token data. If none is available (fresh / pre-migration workspace),
+      // clear any stale value so the meter hides.
+      const callUsage = extractLatestCallUsage(filtered);
+      const store = useAppStore.getState();
+      if (callUsage) store.setLatestTurnUsage(sessionId, callUsage);
+      else store.clearLatestTurnUsage(sessionId);
+      // Phase 3: seed compactionEvents by scanning for COMPACTION: sentinels.
+      store.setCompactionEvents(sessionId, extractCompactionEvents(filtered));
+
+      // Load persisted completed turns and reconstruct with correct positions.
+      // Skip if the agent is currently running — the in-memory state from
+      // finalizeTurn() is more current than the DB and must not be overwritten.
+      if (isLocal) {
+        const sessions = useAppStore.getState().sessionsByWorkspace[selectedWorkspaceId] ?? [];
+        const thisSession = sessions.find((s) => s.id === sessionId);
+        const isRunning = thisSession?.agent_status === "Running";
+        debugChat("ChatPanel", "load-completed-turns:gate", {
           sessionId,
-          rawMessageCount: msgs.length,
-          filteredMessageCount: filtered.length,
-          messageIds: filtered.map((msg) => msg.id),
+          isRunning,
+          currentCompletedTurnIds: (useAppStore.getState().completedTurns[sessionId] || []).map(
+            (turn) => turn.id
+          ),
         });
-        setChatMessages(sessionId, filtered);
-        historyRef.current[sessionId] = filtered
-          .filter((m) => m.role === "User")
-          .map((m) => m.content);
-        // Seed the ContextMeter from the last assistant message's per-call
-        // token data. If none is available (fresh / pre-migration workspace),
-        // clear any stale value so the meter hides.
-        const callUsage = extractLatestCallUsage(filtered);
-        const store = useAppStore.getState();
-        if (callUsage) store.setLatestTurnUsage(sessionId, callUsage);
-        else store.clearLatestTurnUsage(sessionId);
-        // Phase 3: seed compactionEvents by scanning for COMPACTION: sentinels.
-        store.setCompactionEvents(sessionId, extractCompactionEvents(filtered));
-
-        // Load attachments for this session's messages.
-        if (isLocal) {
-          loadAttachmentsForSession(sessionId)
-            .then((atts) => {
+        if (!isRunning) {
+          loadCompletedTurns(sessionId)
+            .then((turnData) => {
               if (cancelled) return;
-              useAppStore.getState().setChatAttachments(sessionId, atts);
+              const turns = reconstructCompletedTurns(filtered, turnData);
+              debugChat("ChatPanel", "load-completed-turns:success", {
+                sessionId,
+                dbTurnIds: turnData.map((turn) => turn.checkpoint_id),
+                reconstructedTurnIds: turns.map((turn) => turn.id),
+              });
+              hydrateCompletedTurns(sessionId, turns);
             })
-            .catch((e) => console.error("Failed to load attachments:", e));
+            .catch((e) => console.error("Failed to load completed turns:", e));
         }
+      }
+    };
 
-        // Load persisted completed turns and reconstruct with correct positions.
-        // Skip if the agent is currently running — the in-memory state from
-        // finalizeTurn() is more current than the DB and must not be overwritten.
-        if (isLocal) {
-          const sessions = useAppStore.getState().sessionsByWorkspace[selectedWorkspaceId] ?? [];
-          const thisSession = sessions.find((s) => s.id === sessionId);
-          const isRunning = thisSession?.agent_status === "Running";
-          debugChat("ChatPanel", "load-completed-turns:gate", {
-            sessionId,
-            isRunning,
-            currentCompletedTurnIds: (useAppStore.getState().completedTurns[sessionId] || []).map(
-              (turn) => turn.id
-            ),
+    if (isLocal) {
+      // Load newest page of messages and their attachments in one round-trip.
+      loadChatHistoryPage(sessionId, 50)
+        .then((page) => {
+          onMessages(page.messages, page.attachments, {
+            hasMore: page.has_more,
+            isLoadingMore: false,
+            totalCount: page.total_count,
+            oldestMessageId: page.messages[0]?.id ?? null,
           });
-          if (!isRunning) {
-            loadCompletedTurns(sessionId)
-              .then((turnData) => {
-                if (cancelled) return;
-                const turns = reconstructCompletedTurns(filtered, turnData);
-                debugChat("ChatPanel", "load-completed-turns:success", {
-                  sessionId,
-                  dbTurnIds: turnData.map((turn) => turn.checkpoint_id),
-                  reconstructedTurnIds: turns.map((turn) => turn.id),
-                });
-                hydrateCompletedTurns(sessionId, turns);
-              })
-              .catch((e) => console.error("Failed to load completed turns:", e));
-          }
-        }
+        })
+        .catch((e) => console.error("Failed to load chat history:", e));
+    } else {
+      sendRemoteCommand(currentWs!.remote_connection_id!, "load_chat_history", {
+        chat_session_id: sessionId,
       })
-      .catch((e) => console.error("Failed to load chat history:", e));
+        .then((data) => {
+          const msgs = (data as { messages?: ChatMessage[] })?.messages ?? (data as ChatMessage[]);
+          onMessages(msgs);
+        })
+        .catch((e) => console.error("Failed to load chat history:", e));
+    }
 
     // Load checkpoints for rollback support.
     if (isLocal) {
@@ -399,12 +423,71 @@ export function ChatPanel() {
     return () => {
       cancelled = true;
     };
-  }, [activeSessionId, selectedWorkspaceId, setChatMessages, hydrateCompletedTurns]);
+  }, [activeSessionId, selectedWorkspaceId, setChatMessages, setChatPagination, hydrateCompletedTurns]);
 
   // Scroll to bottom unconditionally on session switch.
   useEffect(() => {
     if (activeSessionId) scrollToBottom();
   }, [activeSessionId, scrollToBottom]);
+
+  // Load older messages when the user scrolls to the top of the message list.
+  const hasMoreRef = useRef(false);
+  hasMoreRef.current = hasMore;
+  const isLoadingMoreRef = useRef(false);
+  isLoadingMoreRef.current = isLoadingMore;
+  const oldestMessageIdRef = useRef<string | null>(null);
+  oldestMessageIdRef.current = oldestMessageId;
+  const activeSessionIdRef = useRef<string | null>(null);
+  activeSessionIdRef.current = activeSessionId;
+
+  useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const onScroll = () => {
+      if (
+        container.scrollTop < 200 &&
+        hasMoreRef.current &&
+        !isLoadingMoreRef.current &&
+        activeSessionIdRef.current &&
+        oldestMessageIdRef.current
+      ) {
+        const sessionId = activeSessionIdRef.current;
+        const cursorId = oldestMessageIdRef.current;
+        const store = useAppStore.getState();
+        const pagination = store.chatPagination[sessionId];
+        if (!pagination) return;
+
+        store.setChatPagination(sessionId, { ...pagination, isLoadingMore: true });
+        const prevScrollHeight = container.scrollHeight;
+
+        loadChatHistoryPage(sessionId, 50, cursorId)
+          .then((page) => {
+            store.prependChatMessages(sessionId, page.messages);
+            store.prependChatAttachments(sessionId, page.attachments);
+            store.setChatPagination(sessionId, {
+              hasMore: page.has_more,
+              isLoadingMore: false,
+              totalCount: page.total_count,
+              oldestMessageId: page.messages[0]?.id ?? cursorId,
+            });
+            // Restore scroll position so prepended messages don't push the
+            // view upward.
+            requestAnimationFrame(() => {
+              container.scrollTop += container.scrollHeight - prevScrollHeight;
+            });
+          })
+          .catch((e) => {
+            console.error("Failed to load older messages:", e);
+            store.setChatPagination(sessionId, { ...pagination, isLoadingMore: false });
+          });
+      }
+    };
+
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => container.removeEventListener("scroll", onScroll);
+    // Re-attach on session switch so the sessionId ref stays in sync.
+  }, [activeSessionId]);
 
   // Auto-scroll when new content arrives — respects user intent via useStickyScroll.
   // Only scrolls if the user is already at/near the bottom.
@@ -873,6 +956,12 @@ export function ChatPanel() {
             </div>
           ) : (
             <>
+              {isLoadingMore && (
+                <div className={styles.loadingOlder}>
+                  <LoaderCircle size={14} className={styles.loadingOlderSpinner} />
+                  Loading older messages…
+                </div>
+              )}
               {activeSessionId && selectedWorkspaceId && (
                 <MessagesWithTurns
                   messages={messages}
@@ -883,6 +972,7 @@ export function ChatPanel() {
                   onAttachmentContextMenu={openAttachmentMenu}
                   onAttachmentClick={openLightbox}
                   searchQuery={searchQuery}
+                  globalOffset={globalOffset}
                 />
               )}
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -324,11 +324,14 @@ export function ChatPanel() {
 
     const onMessages = (msgs: ChatMessage[], attachments?: import("../../types").ChatAttachment[], pageState?: import("../../types").ChatPaginationState) => {
       if (cancelled) return;
-      // Filter out empty assistant messages (legacy data), but keep
-      // those that carry thinking content.
-      const filtered = msgs.filter(
-        (m) => m.role !== "Assistant" || m.content.trim() !== "" || !!m.thinking
-      );
+      // The paginated backend already drops legacy empty-assistant rows so
+      // `total_count` matches the page contents. The remote (non-paginated)
+      // path still needs the filter — apply it only when no pageState exists.
+      const filtered = pageState
+        ? msgs
+        : msgs.filter(
+            (m) => m.role !== "Assistant" || m.content.trim() !== "" || !!m.thinking
+          );
       debugChat("ChatPanel", "load-history:success", {
         sessionId,
         rawMessageCount: msgs.length,
@@ -342,6 +345,12 @@ export function ChatPanel() {
       if (pageState) {
         setChatPagination(sessionId, pageState);
       }
+      // Global index of the first loaded message — needed below so persisted
+      // CompletedTurn rows whose checkpoint sits inside the loaded window
+      // resolve to the correct GLOBAL afterMessageIndex.
+      const loadGlobalOffset = pageState
+        ? pageState.totalCount - filtered.length
+        : 0;
       historyRef.current[sessionId] = filtered
         .filter((m) => m.role === "User")
         .map((m) => m.content);
@@ -373,7 +382,7 @@ export function ChatPanel() {
           loadCompletedTurns(sessionId)
             .then((turnData) => {
               if (cancelled) return;
-              const turns = reconstructCompletedTurns(filtered, turnData);
+              const turns = reconstructCompletedTurns(filtered, turnData, loadGlobalOffset);
               debugChat("ChatPanel", "load-completed-turns:success", {
                 sessionId,
                 dbTurnIds: turnData.map((turn) => turn.checkpoint_id),
@@ -476,6 +485,30 @@ export function ChatPanel() {
             requestAnimationFrame(() => {
               container.scrollTop += container.scrollHeight - prevScrollHeight;
             });
+            // Re-hydrate persisted completed turns: any whose checkpoint
+            // message_id was in the just-loaded older range was filtered out
+            // of `reconstructCompletedTurns` on the initial load. Re-running
+            // against the now-larger message window resolves them.
+            const merged =
+              useAppStore.getState().chatMessages[sessionId] ?? [];
+            const mergedOffset = page.total_count - merged.length;
+            loadCompletedTurns(sessionId)
+              .then((turnData) => {
+                const turns = reconstructCompletedTurns(
+                  merged,
+                  turnData,
+                  mergedOffset,
+                );
+                useAppStore
+                  .getState()
+                  .hydrateCompletedTurns(sessionId, turns);
+              })
+              .catch((err) =>
+                console.error(
+                  "Failed to re-hydrate completed turns after prepend:",
+                  err,
+                ),
+              );
           })
           .catch((e) => {
             console.error("Failed to load older messages:", e);
@@ -637,21 +670,25 @@ export function ChatPanel() {
         const isRemoteWorkspace = !!ws.remote_connection_id;
 
         const addLocalMessage = (text: string) => {
-          addChatMessage(sessionId, {
-            id: crypto.randomUUID(),
-            workspace_id: workspaceId,
-            chat_session_id: sessionId,
-            role: "System",
-            content: text,
-            cost_usd: null,
-            duration_ms: null,
-            created_at: new Date().toISOString(),
-            thinking: null,
-            input_tokens: null,
-            output_tokens: null,
-            cache_read_tokens: null,
-            cache_creation_tokens: null,
-          });
+          addChatMessage(
+            sessionId,
+            {
+              id: crypto.randomUUID(),
+              workspace_id: workspaceId,
+              chat_session_id: sessionId,
+              role: "System",
+              content: text,
+              cost_usd: null,
+              duration_ms: null,
+              created_at: new Date().toISOString(),
+              thinking: null,
+              input_tokens: null,
+              output_tokens: null,
+              cache_read_tokens: null,
+              cache_creation_tokens: null,
+            },
+            { persisted: false },
+          );
         };
 
         const setSelectedModelBound = (nextModel: string) =>

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -135,21 +135,44 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     // Single reverse pass: each User message maps to the most recent
     // Assistant message that follows it. O(n) instead of O(n²).
     const userToNextAssistant = new Map<string, string>();
+    const loadedMessageIds = new Set<string>();
     let nextAssistantId: string | null = null;
+    let firstAssistantInWindow: string | null = null;
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i];
+      loadedMessageIds.add(m.id);
       if (m.role === "Assistant") {
         nextAssistantId = m.id;
+        firstAssistantInWindow = m.id;
       } else if (m.role === "User" && nextAssistantId) {
         userToNextAssistant.set(m.id, nextAssistantId);
       }
     }
     const map = new Map<string, ChatAttachment[]>();
     for (const att of chatAttachments) {
-      const targetId =
-        att.origin === "agent"
-          ? (userToNextAssistant.get(att.message_id) ?? att.message_id)
-          : att.message_id;
+      let targetId: string;
+      if (att.origin === "agent") {
+        // Anchor user is in the loaded window: route to the assistant of
+        // that turn. Anchor user is NOT loaded but the page begins mid-turn:
+        // the orphan agent rows belong to the carry-over assistant — i.e.
+        // the first Assistant message at the top of the loaded window.
+        // Otherwise fall back to the raw anchor (which won't render — that's
+        // intentional for stale attachments whose turn is fully out-of-view).
+        const routed = userToNextAssistant.get(att.message_id);
+        if (routed) {
+          targetId = routed;
+        } else if (
+          !loadedMessageIds.has(att.message_id) &&
+          firstAssistantInWindow !== null &&
+          messages[0]?.role === "Assistant"
+        ) {
+          targetId = firstAssistantInWindow;
+        } else {
+          targetId = att.message_id;
+        }
+      } else {
+        targetId = att.message_id;
+      }
       const list = map.get(targetId);
       if (list) list.push(att);
       else map.set(targetId, [att]);
@@ -187,19 +210,28 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     [completedTurnPositions, globalOffset, messages.length],
   );
 
+  // CompletedTurn.afterMessageIndex is GLOBAL (counts from message 0 of the
+  // session, not from the loaded window). Shift to local before indexing into
+  // the `messages` array; otherwise older summaries' "Copy output", rollback,
+  // and fork actions would target the wrong message once the loaded window
+  // contains more than one user message.
   const findTriggeringUserIdx = useCallback(
     (afterMessageIndex: number) => {
-      return findTriggeringUserIndex(messages, afterMessageIndex);
+      const localAfter = afterMessageIndex - globalOffset;
+      if (localAfter <= 0) return -1;
+      return findTriggeringUserIndex(messages, localAfter);
     },
-    [messages],
+    [messages, globalOffset],
   );
 
   // Map user message index → checkpoint for rollback buttons.
-  // Each user message maps to the latest preceding checkpoint, with the first
-  // user message mapping to null so it can clear the whole conversation.
+  // Each user message maps to the latest preceding checkpoint. The first user
+  // message in the FULL conversation gets `null` (clear-all) — but on a
+  // paginated window the first row might not be the conversation root, so
+  // pass `globalOffset` through to suppress the clear-all sentinel.
   const rollbackCheckpointByIdx = useMemo(
-    () => buildRollbackMap(messages, checkpoints),
-    [messages, checkpoints],
+    () => buildRollbackMap(messages, checkpoints, globalOffset),
+    [messages, checkpoints, globalOffset],
   );
 
   const buildRollbackData = useCallback(
@@ -235,13 +267,19 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
         map.set(turn.id, "");
         continue;
       }
+      // assistantTextForTurn slices the messages array — pass the LOCAL turn
+      // boundary (afterMessageIndex - globalOffset), not the global value.
       map.set(
         turn.id,
-        assistantTextForTurn(messages, userIdx, turn.afterMessageIndex),
+        assistantTextForTurn(
+          messages,
+          userIdx,
+          turn.afterMessageIndex - globalOffset,
+        ),
       );
     }
     return map;
-  }, [completedTurns, findTriggeringUserIdx, messages]);
+  }, [completedTurns, findTriggeringUserIdx, messages, globalOffset]);
 
   // Per-turn rollback data, keyed by turn.id. Completed turns are only
   // persisted for tool-using turns, so the triggering user is the nearest

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -62,6 +62,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   onAttachmentContextMenu,
   onAttachmentClick,
   searchQuery,
+  globalOffset = 0,
 }: {
   messages: ChatMessage[];
   /** The enclosing workspace id — forwarded into rollback data so the modal
@@ -92,6 +93,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   /** Active chat-search query (Cmd/Ctrl+F). Empty string when the bar is
    *  closed; non-empty values trigger highlight wrappers on each message. */
   searchQuery: string;
+  /** 0-based index of the first loaded message in the full session message
+   *  sequence. Zero for fully-loaded sessions; positive when older messages
+   *  have not been fetched yet (pagination). Used to match CompletedTurn
+   *  positions (which are global) against the local message array. */
+  globalOffset?: number;
 }) {
   const { t } = useTranslation("chat");
   const completedTurns = useAppStore(
@@ -165,6 +171,20 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const completedTurnPositions = useMemo(
     () => new Set(completedTurns.map((turn) => turn.afterMessageIndex)),
     [completedTurns],
+  );
+
+  // Local version of completedTurnPositions with global indices shifted to
+  // local array indices. Used by buildPlainTurnFooters, which works in local
+  // index space, so it correctly suppresses plain footers at positions that
+  // already have a TurnSummary even when older messages are paginated out.
+  const localCompletedTurnPositions = useMemo(
+    () =>
+      new Set(
+        [...completedTurnPositions]
+          .map((p) => p - globalOffset)
+          .filter((p) => p >= 0 && p <= messages.length),
+      ),
+    [completedTurnPositions, globalOffset, messages.length],
   );
 
   const findTriggeringUserIdx = useCallback(
@@ -248,10 +268,10 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     return buildPlainTurnFooters(
       messages,
       rollbackCheckpointByIdx,
-      completedTurnPositions,
+      localCompletedTurnPositions,
       checkpoints,
     );
-  }, [checkpoints, completedTurnPositions, messages, rollbackCheckpointByIdx]);
+  }, [checkpoints, localCompletedTurnPositions, messages, rollbackCheckpointByIdx]);
 
   const renderPlainTurnFooter = (position: number) => {
     const data = plainTurnFootersByPosition.get(position);
@@ -324,7 +344,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       turnLayout: completedTurns.map((turn) => ({
         id: turn.id,
         afterMessageIndex: turn.afterMessageIndex,
-        postLastMessage: turn.afterMessageIndex >= messages.length,
+        postLastMessage: turn.afterMessageIndex >= globalOffset + messages.length,
         toolCount: turn.activities.length,
       })),
     });
@@ -360,12 +380,12 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           if (compaction) {
             return (
               <React.Fragment key={msg.id}>
-                {renderTurns(idx)}
+                {renderTurns(globalOffset + idx)}
                 <CompactionDivider
                   event={{
                     ...compaction,
                     timestamp: msg.created_at,
-                    afterMessageIndex: idx,
+                    afterMessageIndex: globalOffset + idx,
                   }}
                 />
               </React.Fragment>
@@ -375,7 +395,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           if (syntheticBody !== null) {
             return (
               <React.Fragment key={msg.id}>
-                {renderTurns(idx)}
+                {renderTurns(globalOffset + idx)}
                 <SyntheticContinuationMessage body={syntheticBody} />
               </React.Fragment>
             );
@@ -384,7 +404,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
         // Default rendering for User, Assistant, and non-sentinel System messages.
         return (
           <React.Fragment key={msg.id}>
-            {renderTurns(idx)}
+            {renderTurns(globalOffset + idx)}
             {msg.id === pendingMessageId ? null : (
               <div className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}`}>
                 {msg.role === "User" && (
@@ -508,10 +528,10 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           </React.Fragment>
         );
       })}
-      {/* Turns that finalized after or at the last message index */}
+      {/* Turns that finalized at or after the end of the loaded message window */}
       {completedTurns
         .map((turn, globalIdx) => ({ turn, globalIdx }))
-        .filter(({ turn }) => turn.afterMessageIndex >= messages.length)
+        .filter(({ turn }) => turn.afterMessageIndex >= globalOffset + messages.length)
         .map(({ turn, globalIdx }) => (
           <TurnSummary
             key={turn.id}

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -148,6 +148,12 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
         userToNextAssistant.set(m.id, nextAssistantId);
       }
     }
+    // Detect a mid-turn page start: the first non-System row at the top of
+    // the window is an Assistant. Pages can begin with a System sentinel
+    // (e.g. compaction marker) before the carry-over assistant, so we can't
+    // just check messages[0].role.
+    const firstNonSystem = messages.find((m) => m.role !== "System");
+    const startsMidTurn = firstNonSystem?.role === "Assistant";
     const map = new Map<string, ChatAttachment[]>();
     for (const att of chatAttachments) {
       let targetId: string;
@@ -164,7 +170,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
         } else if (
           !loadedMessageIds.has(att.message_id) &&
           firstAssistantInWindow !== null &&
-          messages[0]?.role === "Assistant"
+          startsMidTurn
         ) {
           targetId = firstAssistantInWindow;
         } else {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -4,6 +4,7 @@ import type {
   Workspace,
   ChatMessage,
   ChatAttachment,
+  ChatHistoryPage,
   AttachmentInput,
   ChatSession,
   DiffFile,
@@ -483,6 +484,18 @@ export function listWorkspaceFiles(
 
 export function loadChatHistory(sessionId: string): Promise<ChatMessage[]> {
   return invoke("load_chat_history", { sessionId });
+}
+
+export function loadChatHistoryPage(
+  sessionId: string,
+  limit: number,
+  beforeMessageId?: string,
+): Promise<ChatHistoryPage> {
+  return invoke("load_chat_history_page", {
+    sessionId,
+    limit,
+    beforeMessageId: beforeMessageId ?? null,
+  });
 }
 
 export function sendChatMessage(

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import type { ChatMessage, ChatAttachment } from "../../types";
+import type { ChatMessage, ChatAttachment, ChatPaginationState } from "../../types";
 import { debugChat } from "../../utils/chatDebug";
 import type { CompactionEvent } from "../../utils/compactionSentinel";
 import type { AppState } from "../useAppStore";
@@ -99,6 +99,10 @@ export interface ChatSlice {
   compactionEvents: Record<string, CompactionEvent[]>;
   setCompactionEvents: (sessionId: string, events: CompactionEvent[]) => void;
   addCompactionEvent: (sessionId: string, event: CompactionEvent) => void;
+  chatPagination: Record<string, ChatPaginationState>;
+  setChatPagination: (sessionId: string, state: ChatPaginationState) => void;
+  prependChatMessages: (sessionId: string, messages: ChatMessage[]) => void;
+  prependChatAttachments: (sessionId: string, attachments: ChatAttachment[]) => void;
   setChatMessages: (sessionId: string, messages: ChatMessage[]) => void;
   addChatMessage: (sessionId: string, message: ChatMessage) => void;
   setStreamingContent: (sessionId: string, content: string) => void;
@@ -161,6 +165,25 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         [sessionId]: [...(s.chatAttachments[sessionId] ?? []), ...attachments],
       },
     })),
+  chatPagination: {},
+  setChatPagination: (sessionId, state) =>
+    set((s) => ({
+      chatPagination: { ...s.chatPagination, [sessionId]: state },
+    })),
+  prependChatMessages: (sessionId, messages) =>
+    set((s) => ({
+      chatMessages: {
+        ...s.chatMessages,
+        [sessionId]: [...messages, ...(s.chatMessages[sessionId] ?? [])],
+      },
+    })),
+  prependChatAttachments: (sessionId, attachments) =>
+    set((s) => ({
+      chatAttachments: {
+        ...s.chatAttachments,
+        [sessionId]: [...attachments, ...(s.chatAttachments[sessionId] ?? [])],
+      },
+    })),
   streamingContent: {},
   streamingThinking: {},
   pendingTypewriter: {},
@@ -208,13 +231,28 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
       chatMessages: { ...s.chatMessages, [sessionId]: messages },
     })),
   addChatMessage: (sessionId, message) =>
-    set((s) => ({
-      chatMessages: {
-        ...s.chatMessages,
-        [sessionId]: [...(s.chatMessages[sessionId] || []), message],
-      },
-      lastMessages: { ...s.lastMessages, [sessionId]: message },
-    })),
+    set((s) => {
+      const pagination = s.chatPagination[sessionId];
+      return {
+        chatMessages: {
+          ...s.chatMessages,
+          [sessionId]: [...(s.chatMessages[sessionId] || []), message],
+        },
+        lastMessages: { ...s.lastMessages, [sessionId]: message },
+        // Keep totalCount in sync so globalOffset stays correct during streaming.
+        ...(pagination
+          ? {
+              chatPagination: {
+                ...s.chatPagination,
+                [sessionId]: {
+                  ...pagination,
+                  totalCount: pagination.totalCount + 1,
+                },
+              },
+            }
+          : {}),
+      };
+    }),
   setStreamingContent: (sessionId, content) =>
     set((s) => ({
       streamingContent: { ...s.streamingContent, [sessionId]: content },
@@ -322,6 +360,14 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         });
         return {};
       }
+      const loadedCount = (s.chatMessages[sessionId] || []).length;
+      const pagination = s.chatPagination[sessionId];
+      // For paginated sessions, afterMessageIndex must be the GLOBAL position
+      // (i.e. totalCount) so the turn summary renders at the right spot even
+      // when only a window of the message history is loaded.
+      const afterMessageIndex = pagination
+        ? pagination.totalCount
+        : loadedCount;
       const turn: CompletedTurn = {
         id: turnId ?? crypto.randomUUID(),
         activities: activities.map((a) => ({
@@ -334,7 +380,7 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         })),
         messageCount,
         collapsed: true,
-        afterMessageIndex: (s.chatMessages[sessionId] || []).length,
+        afterMessageIndex,
         durationMs,
         inputTokens,
         outputTokens,

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -193,12 +193,22 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
       },
     })),
   prependChatAttachments: (sessionId, attachments) =>
-    set((s) => ({
-      chatAttachments: {
-        ...s.chatAttachments,
-        [sessionId]: [...attachments, ...(s.chatAttachments[sessionId] ?? [])],
-      },
-    })),
+    set((s) => {
+      // Dedupe by id: when a page begins mid-turn, the page loader includes
+      // the previous user message's anchor id so its attachments come back
+      // again. Without this guard the same row would render twice once the
+      // older page is loaded.
+      const existing = s.chatAttachments[sessionId] ?? [];
+      const seen = new Set(existing.map((a) => a.id));
+      const fresh = attachments.filter((a) => !seen.has(a.id));
+      if (fresh.length === 0) return {};
+      return {
+        chatAttachments: {
+          ...s.chatAttachments,
+          [sessionId]: [...fresh, ...existing],
+        },
+      };
+    }),
   streamingContent: {},
   streamingThinking: {},
   pendingTypewriter: {},

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -104,7 +104,22 @@ export interface ChatSlice {
   prependChatMessages: (sessionId: string, messages: ChatMessage[]) => void;
   prependChatAttachments: (sessionId: string, attachments: ChatAttachment[]) => void;
   setChatMessages: (sessionId: string, messages: ChatMessage[]) => void;
-  addChatMessage: (sessionId: string, message: ChatMessage) => void;
+  /**
+   * Append a chat message to the session's list.
+   *
+   * Pass `{ persisted: false }` for client-only messages that have no
+   * matching DB row (e.g. the System messages produced by local slash
+   * commands like `/help`, `/plan`, `/status`). Persisted messages bump
+   * `chatPagination[sessionId].totalCount` so `globalOffset` stays correct
+   * during streaming; client-only ones must NOT, or the next paginated
+   * load returns a smaller total than the in-memory list and turn
+   * placement drifts.
+   */
+  addChatMessage: (
+    sessionId: string,
+    message: ChatMessage,
+    options?: { persisted?: boolean },
+  ) => void;
   setStreamingContent: (sessionId: string, content: string) => void;
   appendStreamingContent: (sessionId: string, text: string) => void;
   setPendingTypewriter: (sessionId: string, messageId: string, text: string) => void;
@@ -230,9 +245,10 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
     set((s) => ({
       chatMessages: { ...s.chatMessages, [sessionId]: messages },
     })),
-  addChatMessage: (sessionId, message) =>
+  addChatMessage: (sessionId, message, options) =>
     set((s) => {
       const pagination = s.chatPagination[sessionId];
+      const persisted = options?.persisted ?? true;
       return {
         chatMessages: {
           ...s.chatMessages,
@@ -240,7 +256,9 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         },
         lastMessages: { ...s.lastMessages, [sessionId]: message },
         // Keep totalCount in sync so globalOffset stays correct during streaming.
-        ...(pagination
+        // Client-only messages (no DB row) opt out so the count doesn't drift
+        // ahead of the persisted set.
+        ...(pagination && persisted
           ? {
               chatPagination: {
                 ...s.chatPagination,

--- a/src/ui/src/stores/slices/checkpointsSlice.ts
+++ b/src/ui/src/stores/slices/checkpointsSlice.ts
@@ -63,6 +63,24 @@ export const createCheckpointsSlice: StateCreator<
         ...s.compactionEvents,
         [sessionId]: extractCompactionEvents(messages),
       };
+      // Pagination state must follow the rolled-back message list. The new
+      // total IS what we now hold (rollback returns the full surviving set,
+      // not a window), so totalCount = messages.length, hasMore = false,
+      // and the cursor points to the new oldest message — leaving the prior
+      // entry would let `globalOffset` and the scroll-to-top loader race
+      // against a conversation that has already been truncated or cleared.
+      const nextChatPagination =
+        sessionId in s.chatPagination
+          ? {
+              ...s.chatPagination,
+              [sessionId]: {
+                hasMore: false,
+                isLoadingMore: false,
+                totalCount: messages.length,
+                oldestMessageId: messages[0]?.id ?? null,
+              },
+            }
+          : s.chatPagination;
       return {
         chatMessages: { ...s.chatMessages, [sessionId]: messages },
         lastMessages: updatedLastMessages,
@@ -85,6 +103,7 @@ export const createCheckpointsSlice: StateCreator<
         },
         latestTurnUsage,
         compactionEvents: nextCompactionEvents,
+        chatPagination: nextChatPagination,
       };
     }),
 });

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -527,6 +527,65 @@ describe("finalizeTurn afterMessageIndex", () => {
   });
 });
 
+// When a session is paginated, `afterMessageIndex` must be the GLOBAL turn
+// position so MessagesWithTurns renders the summary at the right slot even
+// when only a window of history is loaded. The slice computes this from
+// `chatPagination[sessionId].totalCount`, falling back to the local
+// `chatMessages` length when no pagination state exists.
+describe("finalizeTurn afterMessageIndex (paginated branch)", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      toolActivities: {},
+      completedTurns: {},
+      chatMessages: {},
+      chatPagination: {},
+    });
+  });
+
+  it("uses pagination.totalCount when the session is paginated", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS_ID]: [
+          { id: "m99", workspace_id: WS_ID, chat_session_id: WS_ID, role: "User", content: "hi", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null },
+          { id: "m100", workspace_id: WS_ID, chat_session_id: WS_ID, role: "Assistant", content: "ok", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null },
+        ],
+      },
+      chatPagination: {
+        [WS_ID]: {
+          hasMore: true,
+          isLoadingMore: false,
+          totalCount: 100,
+          oldestMessageId: "m99",
+        },
+      },
+    });
+    addToolActivities();
+
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns).toHaveLength(1);
+    expect(turns[0].afterMessageIndex).toBe(100);
+  });
+
+  it("falls back to chatMessages length when no pagination entry exists", () => {
+    useAppStore.setState({
+      chatMessages: {
+        [WS_ID]: [
+          { id: "m1", workspace_id: WS_ID, chat_session_id: WS_ID, role: "User", content: "hi", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null },
+          { id: "m2", workspace_id: WS_ID, chat_session_id: WS_ID, role: "Assistant", content: "ok", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null },
+        ],
+      },
+    });
+    addToolActivities();
+
+    useAppStore.getState().finalizeTurn(WS_ID, 1);
+
+    const turns = useAppStore.getState().completedTurns[WS_ID];
+    expect(turns[0].afterMessageIndex).toBe(2);
+  });
+});
+
 // Regression coverage for issue 463: clicking a completed turn's chevron
 // must flip `collapsed`, and the toggle's key must match the key the
 // readers use (sessionId, not workspaceId — these diverged after the
@@ -880,6 +939,99 @@ describe("rollbackConversation", () => {
 
     expect(useAppStore.getState().chatMessages[OTHER_WS]).toHaveLength(1);
     expect(useAppStore.getState().checkpoints[OTHER_WS]).toHaveLength(1);
+  });
+});
+
+// rollbackConversation must reset chatPagination so the cursor and total
+// count match the truncated message list — leaving the prior entry would
+// race the scroll-to-top loader against a conversation that has already
+// shrunk.
+describe("rollbackConversation resets chatPagination", () => {
+  beforeEach(() => {
+    useAppStore.setState({ chatPagination: {}, checkpoints: {} });
+  });
+
+  it("rewrites pagination to match the truncated message list", () => {
+    const truncated: ChatMessage[] = [
+      { id: "m1", workspace_id: WS_ID, chat_session_id: WS_ID, role: "User", content: "q1", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null },
+      { id: "m2", workspace_id: WS_ID, chat_session_id: WS_ID, role: "Assistant", content: "a1", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null },
+    ];
+    useAppStore.setState({
+      chatPagination: {
+        [WS_ID]: {
+          hasMore: true,
+          isLoadingMore: false,
+          totalCount: 100,
+          oldestMessageId: "m50",
+        },
+      },
+      checkpoints: { [WS_ID]: [makeCheckpoint("cp1", WS_ID, "m2", 0)] },
+    });
+
+    useAppStore.getState().rollbackConversation(WS_ID, WS_ID, "cp1", truncated);
+
+    const pag = useAppStore.getState().chatPagination[WS_ID];
+    expect(pag).toEqual({
+      hasMore: false,
+      isLoadingMore: false,
+      totalCount: 2,
+      oldestMessageId: "m1",
+    });
+  });
+
+  it("leaves chatPagination untouched for sessions that never had pagination", () => {
+    useAppStore.setState({
+      checkpoints: { [WS_ID]: [makeCheckpoint("cp1", WS_ID, "m1", 0)] },
+    });
+
+    useAppStore.getState().rollbackConversation(WS_ID, WS_ID, "cp1", []);
+
+    expect(useAppStore.getState().chatPagination[WS_ID]).toBeUndefined();
+  });
+});
+
+// addChatMessage must NOT bump pagination.totalCount for client-only
+// system messages (e.g. slash command echo). Only persisted messages —
+// the default — should advance the global count.
+describe("addChatMessage pagination totalCount", () => {
+  beforeEach(() => {
+    useAppStore.setState({ chatMessages: {}, chatPagination: {} });
+  });
+
+  function seedPagination() {
+    useAppStore.setState({
+      chatPagination: {
+        [WS_ID]: {
+          hasMore: false,
+          isLoadingMore: false,
+          totalCount: 10,
+          oldestMessageId: "m1",
+        },
+      },
+    });
+  }
+
+  function makeMsg(id: string, role: "User" | "System" = "User"): ChatMessage {
+    return { id, workspace_id: WS_ID, chat_session_id: WS_ID, role, content: "x", cost_usd: null, duration_ms: null, created_at: "", thinking: null, input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null };
+  }
+
+  it("bumps totalCount by default (persisted message)", () => {
+    seedPagination();
+    useAppStore.getState().addChatMessage(WS_ID, makeMsg("m11"));
+    expect(useAppStore.getState().chatPagination[WS_ID].totalCount).toBe(11);
+  });
+
+  it("does NOT bump totalCount when persisted: false", () => {
+    seedPagination();
+    useAppStore
+      .getState()
+      .addChatMessage(WS_ID, makeMsg("m-local", "System"), { persisted: false });
+    expect(useAppStore.getState().chatPagination[WS_ID].totalCount).toBe(10);
+  });
+
+  it("no-ops on pagination state when no pagination entry exists", () => {
+    useAppStore.getState().addChatMessage(WS_ID, makeMsg("m1"));
+    expect(useAppStore.getState().chatPagination[WS_ID]).toBeUndefined();
   });
 });
 

--- a/src/ui/src/types/chat.ts
+++ b/src/ui/src/types/chat.ts
@@ -79,6 +79,26 @@ export interface AttachmentInput {
   text_content?: string;
 }
 
+/** Paginated history response from `load_chat_history_page`. */
+export interface ChatHistoryPage {
+  messages: ChatMessage[];
+  attachments: ChatAttachment[];
+  has_more: boolean;
+  total_count: number;
+}
+
+/** Pagination state tracked per chat session in the store. */
+export interface ChatPaginationState {
+  /** Whether there are older messages not yet loaded. */
+  hasMore: boolean;
+  /** True while a "load older" request is in flight. */
+  isLoadingMore: boolean;
+  /** Total message count in the DB (used to compute `globalOffset`). */
+  totalCount: number;
+  /** The `id` of the oldest loaded message — cursor for the next page request. */
+  oldestMessageId: string | null;
+}
+
 /** A staged attachment in the frontend before the message is sent. */
 export interface PendingAttachment {
   id: string;

--- a/src/ui/src/types/index.ts
+++ b/src/ui/src/types/index.ts
@@ -8,6 +8,8 @@ export type {
   ChatMessage,
   ChatRole,
   ChatAttachment,
+  ChatHistoryPage,
+  ChatPaginationState,
   AttachmentInput,
   PendingAttachment,
   ChatSession,

--- a/src/ui/src/utils/checkpointUtils.test.ts
+++ b/src/ui/src/utils/checkpointUtils.test.ts
@@ -261,4 +261,35 @@ describe("buildRollbackMap", () => {
     expect(result.has(0)).toBe(false);
     expect(result.has(1)).toBe(false);
   });
+
+  // When the loaded `messages` array is a paginated window into a longer
+  // session, the top user is NOT the conversation root and must NOT get the
+  // clear-all sentinel — that would let users wipe the whole session by
+  // clicking rollback on a top-of-window user.
+  it("suppresses clear-all on top user when globalOffset > 0", () => {
+    const messages = [msg("m50", "User"), msg("m51", "Assistant")];
+    const cps = [{ ...cp("cp1", "aaa", 0), message_id: "m51" }];
+    const result = buildRollbackMap(messages, cps, /* globalOffset */ 50);
+    // Top user (index 0) is NOT the root, so no clear-all entry.
+    expect(result.has(0)).toBe(false);
+  });
+
+  it("falls back to latest preceding checkpoint for top user on paginated window", () => {
+    // The top user has a preceding checkpoint inside the window — it should
+    // resolve to that checkpoint, not clear-all.
+    const messages = [
+      msg("m50", "Assistant"), // carry-over assistant from previous page
+      msg("m51", "User"),
+      msg("m52", "Assistant"),
+    ];
+    const cps = [{ ...cp("cp1", "aaa", 0), message_id: "m50" }];
+    const result = buildRollbackMap(messages, cps, /* globalOffset */ 50);
+    expect(result.get(1)?.id).toBe("cp1");
+  });
+
+  it("globalOffset = 0 still maps top user to clear-all (default behavior)", () => {
+    const messages = [msg("m1", "User"), msg("m2", "Assistant")];
+    const result = buildRollbackMap(messages, [], 0);
+    expect(result.get(0)).toBeNull();
+  });
 });

--- a/src/ui/src/utils/checkpointUtils.ts
+++ b/src/ui/src/utils/checkpointUtils.ts
@@ -39,18 +39,28 @@ export function clearAllHasFileChanges(
  * before it, so users can always roll back — even past interrupted
  * turns that didn't produce a checkpoint.
  *
- * The first User message always maps to `null` (clear-all) — clearing the
- * conversation doesn't require a checkpoint. Subsequent User messages map
- * to the most recent checkpoint seen so far. Uses a single forward pass
- * (O(n)) by tracking the latest checkpoint while iterating.
+ * The first User message of the FULL conversation maps to `null`
+ * (clear-all) — clearing the conversation doesn't require a checkpoint.
+ * Subsequent User messages map to the most recent checkpoint seen so far.
+ * Uses a single forward pass (O(n)) by tracking the latest checkpoint
+ * while iterating.
+ *
+ * `globalOffset` is the number of older messages that exist in the session
+ * but aren't in `messages` (pagination). When > 0 the top user message in
+ * the loaded window is NOT the conversation root, so the clear-all sentinel
+ * is suppressed for it: that user gets the latest preceding checkpoint
+ * (or no entry if none has been seen yet — checkpoints belonging to older
+ * pages will surface once the user scrolls them into view and the merged
+ * window is re-evaluated). Defaults to 0 for fully-loaded sessions.
  */
 export function buildRollbackMap(
   messages: ChatMessage[],
   checkpoints: ConversationCheckpoint[],
+  globalOffset = 0,
 ): Map<number, ConversationCheckpoint | null> {
   const msgIdToCp = new Map(checkpoints.map((cp) => [cp.message_id, cp]));
   const result = new Map<number, ConversationCheckpoint | null>();
-  let firstUser = true;
+  let firstUser = globalOffset === 0;
   let latestCp: ConversationCheckpoint | undefined;
 
   for (let i = 0; i < messages.length; i++) {
@@ -60,7 +70,7 @@ export function buildRollbackMap(
 
     if (messages[i].role === "User") {
       if (firstUser) {
-        // First user message always gets clear-all (no checkpoint needed).
+        // First user message of the full conversation: clear-all.
         result.set(i, null);
         firstUser = false;
       } else if (latestCp) {

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -243,6 +243,68 @@ describe("reconstructCompletedTurns", () => {
     expect(result[0].commitHash).toBe("abc123");
   });
 
+  it("offsets afterMessageIndex by globalOffset so values are global session positions", () => {
+    // Paginated session: only the newest 2 of 52 total messages are loaded.
+    // The persisted turn anchored on m51 should resolve to a global
+    // afterMessageIndex of 52 (local index 1 + 1 + globalOffset 50), not 2.
+    const messages = [makeMsg("m50", "User"), makeMsg("m51", "Assistant")];
+    const turnData = [makeTurnData("cp1", "m51")];
+
+    const result = reconstructCompletedTurns(messages, turnData, /* globalOffset */ 50);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].afterMessageIndex).toBe(52);
+  });
+
+  it("defaults globalOffset to 0 when omitted (fully-loaded session)", () => {
+    const messages = [makeMsg("m1", "User"), makeMsg("m2", "Assistant")];
+    const turnData = [makeTurnData("cp1", "m2")];
+
+    const result = reconstructCompletedTurns(messages, turnData);
+
+    expect(result[0].afterMessageIndex).toBe(2);
+  });
+
+  it("computes durationMs using local indices regardless of globalOffset", () => {
+    // The durationMs slice reaches back to the prior turn's local boundary
+    // (or 0). globalOffset must NOT shift that slice — assistant messages in
+    // the loaded window are the only source of truth for per-turn metrics.
+    const m1: ChatMessage = { ...makeMsg("m1", "User"), duration_ms: 99_999 };
+    const m2: ChatMessage = { ...makeMsg("m2", "Assistant"), duration_ms: 1_500 };
+    const messages = [m1, m2];
+    const turnData = [makeTurnData("cp1", "m2")];
+
+    const result = reconstructCompletedTurns(messages, turnData, 100);
+
+    // Only m2 (Assistant) contributes — 1_500ms.
+    expect(result[0].durationMs).toBe(1_500);
+    // afterMessageIndex is global: local 1 + 1 + offset 100 = 102.
+    expect(result[0].afterMessageIndex).toBe(102);
+  });
+
+  it("does not bleed assistant metrics across turns when globalOffset > 0", () => {
+    // Multi-turn paginated session: each turn's metrics must be bounded by
+    // the LOCAL slice [priorBoundary, localAfter), not the global one — a
+    // global-end slice would clamp to messages.length and pull in later
+    // turns' assistant messages.
+    const m1: ChatMessage = { ...makeMsg("m1", "User"), duration_ms: 99_999 };
+    const m2: ChatMessage = { ...makeMsg("m2", "Assistant"), duration_ms: 1_000 };
+    const m3: ChatMessage = { ...makeMsg("m3", "User"), duration_ms: 99_999 };
+    const m4: ChatMessage = { ...makeMsg("m4", "Assistant"), duration_ms: 4_000 };
+    const messages = [m1, m2, m3, m4];
+    const turnData = [makeTurnData("cp1", "m2"), makeTurnData("cp2", "m4")];
+
+    const result = reconstructCompletedTurns(messages, turnData, 50);
+
+    expect(result).toHaveLength(2);
+    // Turn 1 (anchored m2): slice(0, 2) → only m2 → 1_000ms.
+    expect(result[0].durationMs).toBe(1_000);
+    expect(result[0].afterMessageIndex).toBe(52);
+    // Turn 2 (anchored m4): slice(2, 4) → only m4 → 4_000ms.
+    expect(result[1].durationMs).toBe(4_000);
+    expect(result[1].afterMessageIndex).toBe(54);
+  });
+
   it("maps activity fields correctly", () => {
     const messages = [makeMsg("m1")];
     const turnData: CompletedTurnData[] = [

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -6,11 +6,17 @@ import { debugChat } from "./chatDebug";
 /**
  * Reconstruct CompletedTurn[] from persisted turn data and loaded messages.
  * Resolves afterMessageIndex by finding the checkpoint's message_id in the
- * messages array and setting it to index + 1 (the turn renders after that message).
+ * messages array and setting it to (local index + 1) + globalOffset.
+ *
+ * `globalOffset` is the number of older messages that exist in the session
+ * but aren't in `messages` because of pagination — pass it so the returned
+ * `afterMessageIndex` values are global session positions, matching the rest
+ * of the rendering pipeline. Defaults to 0 for fully-loaded sessions.
  */
 export function reconstructCompletedTurns(
   messages: ChatMessage[],
   turnData: CompletedTurnData[],
+  globalOffset = 0,
 ): CompletedTurn[] {
   const msgIdToIndex = new Map(messages.map((m, i) => [m.id, i]));
   const droppedTurnIds = turnData
@@ -30,7 +36,8 @@ export function reconstructCompletedTurns(
   const valid = turnData.filter((td) => msgIdToIndex.has(td.message_id));
 
   return valid.map((td, i) => {
-    const afterMessageIndex = msgIdToIndex.get(td.message_id)! + 1;
+    const localAfter = msgIdToIndex.get(td.message_id)! + 1;
+    const afterMessageIndex = localAfter + globalOffset;
     const priorBoundary =
       i > 0 ? msgIdToIndex.get(valid[i - 1].message_id)! + 1 : 0;
     const turnAssistantMessages = messages

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -40,8 +40,10 @@ export function reconstructCompletedTurns(
     const afterMessageIndex = localAfter + globalOffset;
     const priorBoundary =
       i > 0 ? msgIdToIndex.get(valid[i - 1].message_id)! + 1 : 0;
+    // Slice bounds are LOCAL — `afterMessageIndex` is global and would over-
+    // run into the next turn's range when the slice clamps.
     const turnAssistantMessages = messages
-      .slice(priorBoundary, afterMessageIndex)
+      .slice(priorBoundary, localAfter)
       .filter((m) => m.role === "Assistant");
     const durationMs =
       turnAssistantMessages.reduce(


### PR DESCRIPTION
Closes #489.

### Summary
`ChatPanel` previously loaded the entire message list on session switch via `load_chat_history`, then ran a second IPC (`load_attachments_for_session`) that re-queried every message and base64-inlined every image/text attachment up front. Long sessions paid the full IPC + memory + render cost on every switch.

This PR replaces that with cursor-paginated loads:

- **Backend**: new `load_chat_history_page(session_id, limit, before_message_id?)` Tauri command returning `{ messages, attachments, has_more, total_count }` in one round-trip. Attachments are filtered to the page's `message_ids`, so only the visible window is inlined. Cursor uses SQLite `rowid` for stable ordering even when `created_at` ties.
- **Frontend store**: new `chatPagination` slice keyed by session id (`hasMore`, `isLoadingMore`, `totalCount`, `oldestMessageId`) plus `prependChatMessages` / `prependChatAttachments` actions. `addChatMessage` increments `totalCount` so the `globalOffset` invariant holds during streaming.
- **`ChatPanel`**: session-switch loads the newest 50 messages; a scroll-to-top handler pages older messages in 50-message chunks. Scroll position is preserved via a captured `scrollHeight` delta. Refs back the scroll handler to avoid stale closures during fast-fire scroll events. Remote workspace path is unchanged.
- **`MessagesWithTurns`**: accepts `globalOffset` so `CompletedTurn.afterMessageIndex` (which is a global index) keeps lining up with locally-rendered messages. Plain turn-footer positions are localized before rendering so paginated views don't double-render footers alongside summaries.

```mermaid
sequenceDiagram
  participant UI as ChatPanel
  participant Store as Zustand
  participant Cmd as load_chat_history_page
  participant DB as SQLite

  UI->>Cmd: (session, limit=50, before=null)
  Cmd->>DB: count + page query (DESC, LIMIT)
  DB-->>Cmd: newest 50 + total_count
  Cmd->>DB: list_attachments_for_messages(page ids)
  DB-->>Cmd: attachments for page only
  Cmd-->>UI: { messages, attachments, has_more, total_count }
  UI->>Store: setChatMessages / setChatAttachments / setChatPagination

  Note over UI: User scrolls near top
  UI->>Cmd: (session, 50, oldestMessageId)
  Cmd-->>UI: older page
  UI->>Store: prependChatMessages / prependChatAttachments
  UI->>UI: restore scroll via scrollHeight delta
```

### Complexity Notes

- **`globalOffset` invariant** (`globalOffset = totalCount - messages.length`): `CompletedTurn.afterMessageIndex` is a *global* index. `MessagesWithTurns` translates between global turn positions and local array indices using the offset. `addChatMessage` must keep `totalCount` in sync during streaming, and `finalizeTurn` records `afterMessageIndex` as `pagination.totalCount` (not the local length) when pagination is active.
- **Stale closures in the scroll handler**: pagination state is read through refs (`hasMoreRef`, `isLoadingMoreRef`, `oldestMessageIdRef`, `activeSessionIdRef`) because the scroll listener fires far more often than the component re-renders.
- **Scroll preservation**: capture `prevScrollHeight` *before* the prepend, then in a `requestAnimationFrame` set `scrollTop += scrollHeight - prevScrollHeight`. RAF is needed because React hasn't laid out the new nodes yet at the moment the page resolves.
- **Cursor stability**: paging uses `WHERE rowid < (SELECT rowid FROM chat_messages WHERE id = ?)` — `rowid` is monotonic for inserts, so duplicate `created_at` values can't cause the cursor to skip or repeat rows.
- Existing `load_chat_history` and `load_attachments_for_session` are intentionally kept for the remote-workspace path.

### Test Steps

1. **Build & test**:
   - `cargo test --all-features` (771 tests pass)
   - `cargo clippy --workspace --all-targets -- -D warnings` (clean)
   - `cd src/ui && bunx tsc -b` (clean)
   - `cd src/ui && bun run test` (1077 tests pass)
2. **Long-session smoke test**: open a workspace with a chat session containing 100+ messages and several image attachments. On session switch, only ~50 messages should render; verify via `claudette-debug state chatMessages` that the loaded count is bounded.
3. **Scroll-to-top paging**: scroll the messages container to the top — verify "Loading older messages…" briefly appears, older messages prepend, and the scroll position holds (no jump).
4. **CompletedTurn placement**: confirm turn summaries render at the right boundary both before and after paging older messages in. Useful: `/claudette-debug state completedTurns`.
5. **Empty/new session**: open a fresh session and send a message — `globalOffset` is `0`, no regressions in turn placement.
6. **Session switching**: bounce between two long sessions — verify each session keeps its own pagination cursor (no cross-session bleed).
7. **Streaming**: while a turn is streaming, `addChatMessage` should increment `totalCount`; subsequent `finalizeTurn` calls should record the correct global `afterMessageIndex`.

### Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)