### PR TITLE
chore(codeowners): update code owner to utensils/claudette team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @utensils/partners
+* @utensils/claudette


### PR DESCRIPTION
### Summary

Updates the CODEOWNERS file to point to the new `@utensils/claudette` GitHub team, replacing the previous `@utensils/partners` team. This ensures pull request review assignments and code ownership notifications go to the correct team going forward.

### Test Steps

1. Verify the PR is assigned to `@utensils/claudette` for review (check the Reviewers panel on this PR).
2. Confirm `@utensils/claudette` exists at https://github.com/orgs/utensils/teams/claudette.

### Checklist

- [x] No tests needed — config-only change
- [ ] Documentation updated (if applicable)