### PR TITLE
feat(ui): files-first right sidebar, terminal/chat polish, drop file viewer view/edit toggle

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -931,7 +931,7 @@
   border: 1px solid var(--sidebar-border);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-md);
-  margin: 0 6px;
+  margin: 0 6px 6px;
   outline: none;
 }
 

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -250,7 +250,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const showSourceEditor =
     !isImage && !bufferState?.isBinary && !showMarkdownPreview;
   const showSaveButton =
-    !editDisabled && !isImage && !bufferState?.isBinary && !showMarkdownPreview;
+    dirty && !editDisabled && !isImage && !bufferState?.isBinary && !showMarkdownPreview;
 
   return (
     <div className={styles.viewer}>
@@ -301,10 +301,8 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
             {showSaveButton && (
               <IconButton
                 onClick={handleSave}
-                tooltip={
-                  dirty ? t("file_tooltip_save") : t("file_tooltip_save_clean")
-                }
-                disabled={!dirty || saving}
+                tooltip={t("file_tooltip_save")}
+                disabled={saving}
               >
                 <Save size={14} aria-hidden="true" />
               </IconButton>

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -4,12 +4,11 @@ import {
   memo,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { BookOpen, Check, Code, Copy, Eye, Pencil, Save } from "lucide-react";
+import { BookOpen, Check, Code, Copy, Save } from "lucide-react";
 import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import {
   selectActiveFileTabPath,
@@ -69,7 +68,6 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const setFileBufferLoadError = useAppStore((s) => s.setFileBufferLoadError);
   const setFileBufferContent = useAppStore((s) => s.setFileBufferContent);
   const setFileBufferSaved = useAppStore((s) => s.setFileBufferSaved);
-  const setFileTabMode = useAppStore((s) => s.setFileTabMode);
   const setFileTabPreview = useAppStore((s) => s.setFileTabPreview);
   const addToast = useAppStore((s) => s.addToast);
 
@@ -154,27 +152,19 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
 
   const dirty = !!bufferState && bufferState.buffer !== bufferState.baseline;
 
-  const editDisabledReason = useMemo<string | null>(() => {
-    if (!bufferState || !bufferState.loaded) return null;
-    if (isImage) return t("file_edit_disabled_image");
-    if (bufferState.isBinary) return t("file_edit_disabled_binary");
-    if (bufferState.sizeBytes > EDIT_SIZE_LIMIT_BYTES) {
-      return t("file_edit_disabled_too_large", {
-        size: formatBytes(bufferState.sizeBytes),
-      });
-    }
-    if (bufferState.truncated) return t("file_edit_disabled_truncated");
-    return null;
-  }, [bufferState, isImage, t]);
-  const editDisabled = editDisabledReason !== null;
-
-  // If the user toggled Edit on and then opened (or switched to) a file
-  // that can't be edited, force the mode back to View.
-  useEffect(() => {
-    if (editDisabled && bufferState?.mode === "edit") {
-      setFileTabMode(workspaceId, path, "view");
-    }
-  }, [editDisabled, bufferState?.mode, workspaceId, path, setFileTabMode]);
+  // Files we render in the editor but won't let the user mutate. The
+  // truncated banner below the editor explains the truncated case; the
+  // others are obvious from the rendered output (image, "preview not
+  // available" for binary) or rare enough not to warrant chrome (oversize
+  // files between the edit cap and the viewer cap render read-only with
+  // no banner — Monaco's read-only cursor signals it).
+  const editDisabled =
+    !!bufferState &&
+    bufferState.loaded &&
+    (isImage ||
+      bufferState.isBinary ||
+      bufferState.sizeBytes > EDIT_SIZE_LIMIT_BYTES ||
+      bufferState.truncated);
 
   const handleBufferChange = useCallback(
     (next: string) => {
@@ -252,17 +242,15 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     }
   }, [bufferState, dirty, saving, workspaceId, path, setFileBufferSaved, addToast, t]);
 
-  const showMarkdownToggle = isMarkdown && bufferState?.mode === "view";
-  const showSourceEditor =
-    !isImage &&
-    !bufferState?.isBinary &&
-    (bufferState?.mode === "edit" ||
-      !showMarkdownToggle ||
-      bufferState?.preview === "source");
+  const showMarkdownToggle = isMarkdown && !editDisabled;
   const showMarkdownPreview =
     showMarkdownToggle &&
     bufferState?.preview === "preview" &&
     bufferState?.loaded;
+  const showSourceEditor =
+    !isImage && !bufferState?.isBinary && !showMarkdownPreview;
+  const showSaveButton =
+    !editDisabled && !isImage && !bufferState?.isBinary && !showMarkdownPreview;
 
   return (
     <div className={styles.viewer}>
@@ -310,26 +298,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
                 ]}
               />
             )}
-            <SegmentedControl
-              ariaLabel={t("file_view_mode_aria")}
-              value={bufferState?.mode ?? "view"}
-              onChange={(m) => setFileTabMode(workspaceId, path, m)}
-              options={[
-                {
-                  value: "view",
-                  icon: <Eye size={14} aria-hidden="true" />,
-                  tooltip: t("file_tooltip_view"),
-                },
-                {
-                  value: "edit",
-                  icon: <Pencil size={14} aria-hidden="true" />,
-                  tooltip: t("file_tooltip_edit"),
-                  disabled: editDisabled,
-                  disabledTooltip: editDisabledReason ?? undefined,
-                },
-              ]}
-            />
-            {bufferState?.mode === "edit" && (
+            {showSaveButton && (
               <IconButton
                 onClick={handleSave}
                 tooltip={
@@ -374,7 +343,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
               key={path}
               initialValue={bufferState.buffer}
               filename={path}
-              readOnly={bufferState.mode === "view"}
+              readOnly={editDisabled}
               onChange={handleBufferChange}
               onSave={handleSave}
             />

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
 import { ChevronRight, Undo2, Trash2 } from "lucide-react";
 import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
@@ -332,7 +332,11 @@ export const RightSidebar = memo(function RightSidebar() {
             ) : diffFiles.length === 0 ? (
               <div className={styles.empty}>No changes</div>
             ) : hasGrouped ? (
-              <>
+              // Key the group block on the active workspace so per-group
+              // collapse state (held in FileGroup's local useState) resets
+              // when the user switches workspaces — otherwise expanding
+              // "Committed" in workspace A would carry into workspace B.
+              <Fragment key={selectedWorkspaceId ?? ""}>
                 <FileGroup
                   label="Unstaged"
                   files={diffStagedFiles!.unstaged}
@@ -361,7 +365,7 @@ export const RightSidebar = memo(function RightSidebar() {
                   accentColor="var(--diff-added-text)"
                   renderFileRow={renderFileRow}
                 />
-              </>
+              </Fragment>
             ) : (
               // Fallback: flat list (remote server without staged_files)
               diffFiles.map((file) => renderFileRow(file))

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -334,20 +334,6 @@ export const RightSidebar = memo(function RightSidebar() {
             ) : hasGrouped ? (
               <>
                 <FileGroup
-                  label="Committed"
-                  files={diffStagedFiles!.committed}
-                  layer="committed"
-                  accentColor="var(--diff-added-text)"
-                  renderFileRow={renderFileRow}
-                />
-                <FileGroup
-                  label="Staged"
-                  files={diffStagedFiles!.staged}
-                  layer="staged"
-                  accentColor="var(--accent-dim)"
-                  renderFileRow={renderFileRow}
-                />
-                <FileGroup
                   label="Unstaged"
                   files={diffStagedFiles!.unstaged}
                   layer="unstaged"
@@ -359,6 +345,20 @@ export const RightSidebar = memo(function RightSidebar() {
                   files={diffStagedFiles!.untracked}
                   layer="untracked"
                   accentColor="var(--text-dim)"
+                  renderFileRow={renderFileRow}
+                />
+                <FileGroup
+                  label="Staged"
+                  files={diffStagedFiles!.staged}
+                  layer="staged"
+                  accentColor="var(--accent-dim)"
+                  renderFileRow={renderFileRow}
+                />
+                <FileGroup
+                  label="Committed"
+                  files={diffStagedFiles!.committed}
+                  layer="committed"
+                  accentColor="var(--diff-added-text)"
                   renderFileRow={renderFileRow}
                 />
               </>
@@ -426,12 +426,15 @@ function FileGroup({
   accentColor: string;
   renderFileRow: (file: DiffFile, layer?: DiffLayer) => React.ReactElement;
 }) {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(layer === "committed");
 
   if (files.length === 0) return null;
 
   return (
-    <div className={styles.fileGroup} style={{ borderLeftColor: accentColor }}>
+    <div
+      className={styles.fileGroup}
+      style={{ borderLeftColor: accentColor }}
+    >
       <button
         className={styles.groupHeader}
         onClick={() => setCollapsed(!collapsed)}

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -6,10 +6,10 @@
 
 .tabBar {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   height: 32px;
   padding: 0 4px;
-  background: var(--terminal-tab-bg);
+  background: transparent;
   border-bottom: 1px solid var(--sidebar-border);
   gap: 2px;
   flex-shrink: 0;
@@ -19,23 +19,15 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 8px;
+  padding: 0 8px;
   cursor: pointer;
   font-size: 12px;
   color: var(--text-dim);
   position: relative;
-  transition: color var(--transition-fast), background var(--transition-fast);
-}
-
-.tab::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 1px;
-  background: transparent;
-  transition: background var(--transition-fast);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color var(--transition-fast), background var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .tab:hover {
@@ -46,10 +38,7 @@
 .tabActive {
   color: var(--text-primary);
   background: transparent;
-}
-
-.tabActive::after {
-  background: var(--accent-primary);
+  border-bottom-color: var(--accent-primary);
 }
 
 .tabTitle {
@@ -167,20 +156,19 @@
  * layout — xterm itself keeps its own cursor-blink visual cue. */
 .paneRoot {
   position: absolute;
-  inset: 0;
+  inset: 8px;
 }
 
 .paneLeaf {
   position: relative;
   width: 100%;
   height: 100%;
-  outline: 1px solid transparent;
-  outline-offset: -1px;
-  transition: outline-color var(--transition-fast);
 }
 
 .paneLeafActive {
-  outline-color: var(--accent-primary);
+  /* Active-pane indicator removed — the cursor blink in xterm already
+   * signals focus, and a 1px outline produced a faint orange line at
+   * the panel's bottom edge in single-pane layouts. */
 }
 
 .paneHandleVertical,

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -1,7 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { AppState } from "../useAppStore";
 
-export type FileViewerMode = "view" | "edit";
 export type FileViewerPreviewMode = "source" | "preview";
 
 /** Per-tab buffer + UI state. Lives in the store keyed by `${wsId}:${path}`
@@ -24,7 +23,6 @@ export interface FileBufferState {
    *  False entries are still in flight or never started. */
   loaded: boolean;
   loadError: string | null;
-  mode: FileViewerMode;
   preview: FileViewerPreviewMode;
 }
 
@@ -47,7 +45,6 @@ export function makeUnloadedBuffer(): FileBufferState {
     imageBytesB64: null,
     loaded: false,
     loadError: null,
-    mode: "view",
     preview: "source",
   };
 }
@@ -127,11 +124,6 @@ export interface FileTreeSlice {
     workspaceId: string,
     path: string,
     baseline: string,
-  ) => void;
-  setFileTabMode: (
-    workspaceId: string,
-    path: string,
-    mode: FileViewerMode,
   ) => void;
   setFileTabPreview: (
     workspaceId: string,
@@ -322,19 +314,6 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
         fileBuffers: {
           ...s.fileBuffers,
           [key]: { ...prev, baseline },
-        },
-      };
-    }),
-
-  setFileTabMode: (workspaceId, path, mode) =>
-    set((s) => {
-      const key = fileBufferKey(workspaceId, path);
-      const prev = s.fileBuffers[key];
-      if (!prev) return s;
-      return {
-        fileBuffers: {
-          ...s.fileBuffers,
-          [key]: { ...prev, mode },
         },
       };
     }),

--- a/src/ui/src/stores/slices/uiSlice.ts
+++ b/src/ui/src/stores/slices/uiSlice.ts
@@ -85,7 +85,7 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (
   sidebarWidth: 260,
   rightSidebarWidth: 250,
   terminalHeight: 300,
-  rightSidebarTab: "changes",
+  rightSidebarTab: "files",
   sidebarGroupBy: "repo",
   sidebarRepoFilter: "all",
   sidebarShowArchived: false,

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -107,7 +107,7 @@ export const createWorkspacesSlice: StateCreator<
 
       const updates: Partial<AppState> = {
         selectedWorkspaceId: id,
-        rightSidebarTab: "changes",
+        rightSidebarTab: "files",
         diffSelectionByWorkspace: selectionMap,
         diffSelectedFile: tabExists ? restored!.path : null,
         diffSelectedLayer: tabExists ? restored!.layer : null,


### PR DESCRIPTION
## Summary

Several small UI quality-of-life changes bundled together while iterating on the right sidebar.

- **Right sidebar** — default tab is now **Files** (was Changes), both for the initial app load and on workspace switch. In the Changes tab, file groups now render in the order **Unstaged → Untracked → Staged → Committed**, and the Committed group starts collapsed so the user's own current changes are foregrounded over already-merged history.
- **Chat panel** — added a 6 px bottom margin to `.inputArea` so the input box has a symmetric gutter with its existing 6 px left/right margin. Previously it sat flush against the bottom of the chat panel.
- **Terminal panel**
  - Dropped the dedicated `--terminal-tab-bg` background on the tab bar so it inherits the surrounding panel theme and matches the rest of the UI chrome.
  - Replaced the active-tab `::after` underline with a real `border-bottom` (and a `-1 px` margin) so the indicator is flush over the tab bar's own bottom border instead of floating mid-tab.
  - Inset `.paneRoot` by 8 px so xterm renders inside an 8 px gutter filled by `.termContainer`'s `--terminal-bg`, giving the terminal some breathing room from the panel edges.
  - Removed the 1 px accent outline on the active pane leaf, which was showing as a faint orange line along the bottom of the terminal in single-pane layouts. The xterm cursor blink already conveys focus.
- **File viewer** — dropped the view/edit segmented control. Files now open immediately in an editable Monaco buffer; the Save button only appears when there's something to save. Files that can't safely be edited (image, binary, oversize > 5 MB, or truncated reads) render Monaco in `readOnly`. The existing truncated banner still explains the truncated case; the rest are obvious from the rendered output (image preview, "preview not available" for binary). The markdown source ↔ preview toggle is no longer gated on view mode — it shows for any editable `.md` file. Removes the `FileViewerMode` type, `FileBufferState.mode` field, and `setFileTabMode` slice action.

## Complexity notes

- The terminal pane gutter is implemented via `inset: 8px` on `.paneRoot`, not `padding` on `.termContainer`. `.paneRoot` is `position: absolute` so it would have ignored parent padding entirely — the gutter has to come from the inset.
- `editDisabledReason` was removed along with the toggle's disabled-tooltip path. The remaining boolean `editDisabled` is now computed inline. If we later want a "read-only because oversize" banner for the rare 5–10 MB unedited case, the reason string can be reintroduced from the same predicates.
- Existing i18n keys for the removed view/edit tooltips and `file_edit_disabled_*` reasons are left in place across all locales — they're cheap to keep and removing locale entries en masse is risky.

## Test steps

1. `cd src/ui && bun run build` — TypeScript and Vite build pass.
2. `cd src/ui && bun run test` — frontend unit tests pass.
3. **Right sidebar**: open the app cold; the right sidebar should land on the **Files** tab. Switch workspaces and confirm Files remains the default. In the Changes tab on a workspace with both committed and unstaged changes, verify groups render Unstaged → Untracked → Staged → Committed and the Committed group is collapsed by default.
4. **Chat panel**: confirm the input box has visible padding above it from messages and matching padding below it down to the panel edge.
5. **Terminal panel**: open the terminal; the tab bar background should match the surrounding panel (no darker fill). The active-tab underline should sit flush against the bottom of the tab bar. The terminal contents should have an ~8 px gutter on all sides. There should be no faint orange line at the bottom of the pane.
6. **File viewer**: open a `.ts` / `.rs` / `.md` file from the Files tab. The view/edit toggle should be gone; the cursor should be active and the buffer immediately editable. Make a change — the Save button appears and `Cmd/Ctrl+S` saves. Open an image, a binary file, and a > 5 MB text file — each should render appropriately and Monaco should be read-only when shown.

## Checklist
- [ ] Tests added/updated (UI-only changes; covered by existing component tests)
- [ ] Documentation updated (if applicable)