### PR TITLE
fix(chat): unblock + new session button while a session is streaming (#574)

### DIFF
--- a/src-tauri/src/commands/chat/session.rs
+++ b/src-tauri/src/commands/chat/session.rs
@@ -60,17 +60,29 @@ pub async fn get_chat_session(
     Ok(hydrate_session(session, &agents))
 }
 
+/// Body of [`create_chat_session`], extracted so unit tests can drive it
+/// without going through Tauri's `State<'_, _>` plumbing. A brand-new chat
+/// session has no entry in `state.agents`, so the live-agent overlay would
+/// always be a no-op — we deliberately skip [`hydrate_session`] (and the
+/// `state.agents` read it would require) so the "+ new session" click
+/// can't get queued behind a streaming task that holds the agents lock
+/// for writes per-event. The DB defaults (`Idle`, no attention) are
+/// already the right values for a freshly-created session. See issue #574.
+pub async fn create_chat_session_inner(
+    state: &AppState,
+    workspace_id: &str,
+) -> Result<ChatSession, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.create_chat_session(workspace_id)
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub async fn create_chat_session(
     workspace_id: String,
     state: State<'_, AppState>,
 ) -> Result<ChatSession, String> {
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let session = db
-        .create_chat_session(&workspace_id)
-        .map_err(|e| e.to_string())?;
-    let agents = state.agents.read().await;
-    Ok(hydrate_session(session, &agents))
+    create_chat_session_inner(&state, &workspace_id).await
 }
 
 #[tauri::command]
@@ -131,4 +143,94 @@ pub async fn archive_chat_session(
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claudette::model::{AgentStatus, Repository, Workspace, WorkspaceStatus};
+    use claudette::plugin_runtime::PluginRegistry;
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn make_repo(id: &str) -> Repository {
+        Repository {
+            id: id.into(),
+            path: format!("/tmp/{id}"),
+            name: id.into(),
+            path_slug: id.into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+        }
+    }
+
+    fn make_workspace(id: &str, repo_id: &str) -> Workspace {
+        Workspace {
+            id: id.into(),
+            repository_id: repo_id.into(),
+            name: id.into(),
+            branch_name: format!("claudette/{id}"),
+            worktree_path: None,
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+        }
+    }
+
+    fn fresh_state(db_path: PathBuf) -> AppState {
+        let plugins = PluginRegistry::discover(std::path::Path::new("/nonexistent"));
+        AppState::new(db_path, std::path::PathBuf::from("/tmp"), plugins)
+    }
+
+    /// Regression test for issue #574: while a streaming task holds
+    /// `state.agents.write()`, clicking "+" must still create a session
+    /// promptly. Tokio's RwLock is writer-preferring, so a `read().await`
+    /// queued behind a writer (and behind further writers that re-queue)
+    /// can starve indefinitely. The fix is for `create_chat_session` to
+    /// not touch `state.agents` at all — a brand-new session has no entry
+    /// to hydrate.
+    #[tokio::test]
+    async fn create_chat_session_does_not_block_on_agents_writer() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        {
+            let db = Database::open(&db_path).unwrap();
+            db.insert_repository(&make_repo("r1")).unwrap();
+            db.insert_workspace(&make_workspace("w1", "r1")).unwrap();
+        }
+
+        let state = fresh_state(db_path);
+
+        // Hold the agents write lock for the duration of the call —
+        // simulates the streaming task in `send.rs` mid-turn.
+        let writer = state.agents.write().await;
+
+        // 500ms is generous: the create itself is microseconds. If we hit
+        // the timeout, the call is blocked on `state.agents.read().await`.
+        let outcome = tokio::time::timeout(
+            Duration::from_millis(500),
+            create_chat_session_inner(&state, "w1"),
+        )
+        .await;
+
+        drop(writer);
+
+        let session = outcome
+            .expect(
+                "create_chat_session blocked while another task held the agents write lock — \
+                 issue #574 regression",
+            )
+            .expect("create_chat_session_inner returned an error");
+        assert_eq!(session.workspace_id, "w1");
+    }
 }

--- a/src-tauri/src/commands/chat/session.rs
+++ b/src-tauri/src/commands/chat/session.rs
@@ -68,7 +68,7 @@ pub async fn get_chat_session(
 /// can't get queued behind a streaming task that holds the agents lock
 /// for writes per-event. The DB defaults (`Idle`, no attention) are
 /// already the right values for a freshly-created session. See issue #574.
-pub async fn create_chat_session_inner(
+async fn create_chat_session_inner(
     state: &AppState,
     workspace_id: &str,
 ) -> Result<ChatSession, String> {

--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -171,7 +171,12 @@
   flex-shrink: 0;
 }
 
-.addBtn:hover {
+.addBtn:hover:not(:disabled) {
   color: var(--text-primary);
+}
+
+.addBtn:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -157,12 +157,21 @@ export function SessionTabs({ workspaceId }: Props) {
   );
 
   const handleCreate = async () => {
-    if (gateRef.current.isPending()) return;
-    setCreating(true);
+    // Drive `setCreating` from inside the gated callback so it only fires
+    // for the call that actually acquires the gate. If a second click
+    // somehow slipped past the synchronous `isPending()` check, gate.run
+    // would return `null` immediately for it and that caller wouldn't
+    // touch the visual state — leaving the in-flight call's `creating=true`
+    // intact for the duration of the real request.
     try {
-      const session = await gateRef.current.run(() =>
-        createChatSession(workspaceId),
-      );
+      const session = await gateRef.current.run(async () => {
+        setCreating(true);
+        try {
+          return await createChatSession(workspaceId);
+        } finally {
+          setCreating(false);
+        }
+      });
       if (session !== null) {
         // Invalidate any in-flight load — our local addChatSession is authoritative.
         loadVersionRef.current += 1;
@@ -171,8 +180,6 @@ export function SessionTabs({ workspaceId }: Props) {
       }
     } catch (err) {
       console.error("[SessionTabs] Failed to create session:", err);
-    } finally {
-      setCreating(false);
     }
   };
 

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -19,6 +19,7 @@ import {
 } from "./AttachmentContextMenu";
 import { DiscardUnsavedChangesConfirm } from "../files/DiscardUnsavedChangesConfirm";
 import { getFileIcon } from "../../utils/fileIcons";
+import { createSerialGate } from "../../utils/serialGate";
 import type { ChatSession, DiffFileTab, DiffLayer } from "../../types";
 import styles from "./SessionTabs.module.css";
 
@@ -119,6 +120,20 @@ export function SessionTabs({ workspaceId }: Props) {
   // can get stomped by the older snapshot.
   const loadVersionRef = useRef(0);
 
+  // Defang rapid clicks on the "+ new session" button. Without the gate, a
+  // user mashing the button while `createChatSession` is in flight would
+  // queue every click as a separate tab once the backend caught up.
+  // Issue 574 made this trivial to repro because the streaming task
+  // could starve the create command for the duration of an entire turn.
+  // We keep both pieces of state because each is load-bearing:
+  //  - `gateRef` is the synchronous source of truth (a `useState` setter
+  //    only takes effect after the next render, so two clicks in the same
+  //    tick would both observe `false`).
+  //  - `creating` drives the disabled prop / aria-busy on the button so
+  //    the user gets immediate visual feedback.
+  const gateRef = useRef(createSerialGate());
+  const [creating, setCreating] = useState(false);
+
   // Load sessions for this workspace on mount / workspace change.
   useEffect(() => {
     const version = ++loadVersionRef.current;
@@ -142,14 +157,22 @@ export function SessionTabs({ workspaceId }: Props) {
   );
 
   const handleCreate = async () => {
+    if (gateRef.current.isPending()) return;
+    setCreating(true);
     try {
-      const session = await createChatSession(workspaceId);
-      // Invalidate any in-flight load — our local addChatSession is authoritative.
-      loadVersionRef.current += 1;
-      addChatSession(session);
-      switchToSession(session.id);
+      const session = await gateRef.current.run(() =>
+        createChatSession(workspaceId),
+      );
+      if (session !== null) {
+        // Invalidate any in-flight load — our local addChatSession is authoritative.
+        loadVersionRef.current += 1;
+        addChatSession(session);
+        switchToSession(session.id);
+      }
     } catch (err) {
       console.error("[SessionTabs] Failed to create session:", err);
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -467,6 +490,8 @@ export function SessionTabs({ workspaceId }: Props) {
         onClick={handleCreate}
         title={t("session_new")}
         aria-label={t("session_new")}
+        aria-busy={creating}
+        disabled={creating}
       >
         <Plus size={14} />
       </button>

--- a/src/ui/src/utils/serialGate.test.ts
+++ b/src/ui/src/utils/serialGate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createSerialGate } from "./serialGate";
+
+describe("createSerialGate", () => {
+  it("returns the underlying result for the first call", async () => {
+    const gate = createSerialGate();
+    const result = await gate.run(async () => "ok");
+    expect(result).toBe("ok");
+  });
+
+  it("returns null and does not invoke the fn for concurrent calls", async () => {
+    const gate = createSerialGate();
+    let resolveFirst!: (value: string) => void;
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((r) => {
+            resolveFirst = r;
+          }),
+      )
+      .mockResolvedValue("second");
+
+    const first = gate.run(fn);
+    const second = gate.run(fn);
+    const third = gate.run(fn);
+
+    expect(await second).toBeNull();
+    expect(await third).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    resolveFirst("first");
+    expect(await first).toBe("first");
+  });
+
+  it("releases the gate after a successful call", async () => {
+    const gate = createSerialGate();
+    const fn = vi.fn(async () => "x");
+    expect(await gate.run(fn)).toBe("x");
+    expect(await gate.run(fn)).toBe("x");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the gate after a rejected call so the next click can retry", async () => {
+    const gate = createSerialGate();
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(gate.run(fn)).rejects.toThrow("boom");
+    expect(await gate.run(fn)).toBe("ok");
+  });
+
+  it("isPending tracks the gate state across the call lifecycle", async () => {
+    const gate = createSerialGate();
+    expect(gate.isPending()).toBe(false);
+
+    let release!: () => void;
+    const promise = gate.run(
+      () =>
+        new Promise<void>((r) => {
+          release = r;
+        }),
+    );
+    expect(gate.isPending()).toBe(true);
+
+    release();
+    await promise;
+    expect(gate.isPending()).toBe(false);
+  });
+});

--- a/src/ui/src/utils/serialGate.ts
+++ b/src/ui/src/utils/serialGate.ts
@@ -1,0 +1,34 @@
+/**
+ * Tiny guard against concurrent invocations of a single async operation.
+ *
+ * `gate.run(fn)` invokes `fn` if no call is in flight and forwards its
+ * result. If a call is already pending, `run` returns `null` immediately
+ * without invoking `fn`. The gate releases as soon as the underlying call
+ * resolves OR rejects, so a transient error doesn't permanently disable
+ * the caller.
+ *
+ * Used by SessionTabs to defang rapid double-clicks on the "+ new session"
+ * button while the backend create is in flight — see issue 574, where a
+ * stalled `create_chat_session` queued every click into a separate tab once
+ * the streaming session finally released the agents lock.
+ */
+export interface SerialGate {
+  run<R>(fn: () => Promise<R>): Promise<R | null>;
+  isPending(): boolean;
+}
+
+export function createSerialGate(): SerialGate {
+  let inflight = false;
+  return {
+    async run<R>(fn: () => Promise<R>): Promise<R | null> {
+      if (inflight) return null;
+      inflight = true;
+      try {
+        return await fn();
+      } finally {
+        inflight = false;
+      }
+    },
+    isPending: () => inflight,
+  };
+}


### PR DESCRIPTION
Fixes #574.

## Root cause

`create_chat_session` ended with `state.agents.read().await` to hydrate the
returned session with live-agent fields. Tokio's `RwLock` is writer-preferring,
and the streaming task in `send.rs` re-acquires the write lock on every event
the Claude CLI emits (lines 1095/1152/1230/1324/1385). With hundreds of events
per turn, the queued read for `create_chat_session` got starved until the turn
ended — every queued click then materialized as a separate "New chat" tab.

Why "new sessions" don't repro: a session that has never been sent a message
has no streaming task, so there's no writer churn to starve the read.

## Fix

**Backend** — `src-tauri/src/commands/chat/session.rs`: extract
`create_chat_session_inner` and drop the `state.agents.read().await` from it.
A brand-new chat session has no entry in `state.agents`, so the hydration
overlay was always a no-op. The DB row's defaults (`Idle`, no attention) are
already the correct values for a fresh session.

**Frontend** — `src/ui/src/components/chat/SessionTabs.tsx`: guard
`handleCreate` with a small `createSerialGate` helper, and disable / mark
`aria-busy` the + button while a create is in flight. Defense in depth so
rapid double-clicks during the brief pre-render window can't enqueue
duplicate creates even if the backend takes longer for some other reason.

## Tests (TDD)

- Rust regression: `commands::chat::session::tests::create_chat_session_does_not_block_on_agents_writer`
  holds `state.agents.write()` and calls the inner function under a 500ms
  `tokio::time::timeout`. **Failed** at `Elapsed(())` before the fix; **passes**
  after.
- Frontend: 5 vitest cases for `createSerialGate` covering concurrent dedup,
  release after success, release after error, and `isPending` lifecycle.

Suite snapshot on this branch:
- `cargo test --workspace --all-features`: 1049 passing
- `cargo clippy --workspace --all-targets`: clean
- `cargo fmt --all --check`: clean
- `bun run test`: 1110 passing across 72 files
- `bunx tsc -b`, `bun run lint:css`, `bun run build`: clean

## UAT

Live UAT confirmed by James: sending a message and clicking + during streaming
no longer hangs; the new tab appears immediately and rapid clicks produce a
single new session.

## Out of scope (tracked separately if needed)

- Other `state.agents.read()` callers (list/get session, checkpoint, send)
  share the same hazard but only stall the specific command the user is
  invoking on the session — worth a follow-up audit.
- Narrowing the streaming task's per-event write-lock window in `send.rs`
  is the structural fix for the whole class of issues.

## Test plan

- [x] Rust regression test fails on main, passes on this branch
- [x] Frontend serialGate tests cover dedup + release + isPending
- [x] Live click during streaming returns immediately
- [x] Rapid clicks while streaming produce exactly one new session