### PR TITLE
chore(file-viewer): single-source font stack for Monaco and theme.css

### DIFF
--- a/src/ui/scripts/check-css-tokens.sh
+++ b/src/ui/scripts/check-css-tokens.sh
@@ -75,8 +75,6 @@ if [ "$violations" -gt 0 ]; then
   exit 1
 fi
 
-echo "Design-system token check passed."
-
 # --- Rule 3: Monaco font stack must mirror --font-mono ---
 # Monaco computes glyph widths via canvas.measureText, which does not resolve
 # CSS variables, so the editor is configured with a literal stack imported
@@ -84,3 +82,5 @@ echo "Design-system token check passed."
 # styles/theme.css, cursor/selection positioning silently breaks. Run a
 # Node-based parser to assert equality after whitespace normalization.
 node scripts/check-font-mono.mjs
+
+echo "Design-system token check passed."

--- a/src/ui/scripts/check-css-tokens.sh
+++ b/src/ui/scripts/check-css-tokens.sh
@@ -76,3 +76,11 @@ if [ "$violations" -gt 0 ]; then
 fi
 
 echo "Design-system token check passed."
+
+# --- Rule 3: Monaco font stack must mirror --font-mono ---
+# Monaco computes glyph widths via canvas.measureText, which does not resolve
+# CSS variables, so the editor is configured with a literal stack imported
+# from src/styles/fonts.ts. If that literal drifts away from --font-mono in
+# styles/theme.css, cursor/selection positioning silently breaks. Run a
+# Node-based parser to assert equality after whitespace normalization.
+node scripts/check-font-mono.mjs

--- a/src/ui/scripts/check-font-mono.mjs
+++ b/src/ui/scripts/check-font-mono.mjs
@@ -37,15 +37,21 @@ function readFile(path) {
 }
 
 function extractTsConstant(source, name) {
-  // Match `export const NAME = '...'` or `export const NAME = "..."`,
-  // possibly broken across lines. Captures the inner string contents.
+  // Match `export const NAME = '...'`, `"..."`, or backtick form, possibly
+  // broken across lines. The inner pattern `(?:\\.|(?!\1).)*` consumes
+  // either an escaped character (so `\"` inside `"..."` doesn't terminate
+  // the match) or any character that isn't the chosen delimiter. Avoids
+  // pulling in a full TS parser for one constant while staying robust to
+  // someone switching the literal's quote style.
   const re = new RegExp(
-    `export\\s+const\\s+${name}\\s*=\\s*(['"\`])([\\s\\S]*?)\\1`,
+    `export\\s+const\\s+${name}\\s*=\\s*(['"\`])((?:\\\\.|(?!\\1)[\\s\\S])*)\\1`,
     "m",
   );
   const m = source.match(re);
   if (!m) return null;
-  return m[2];
+  // Unescape the captured value so the comparison sees the actual string
+  // contents (e.g. `\"` → `"`).
+  return m[2].replace(/\\(.)/g, "$1");
 }
 
 function extractCssVar(source, name) {

--- a/src/ui/scripts/check-font-mono.mjs
+++ b/src/ui/scripts/check-font-mono.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Enforce that the Monaco editor's monospace font stack matches the CSS
+// `--font-mono` token. Monaco measures glyph widths via `canvas.measureText`,
+// which does not resolve CSS custom properties — so the editor is configured
+// with a literal stack imported from `src/styles/fonts.ts`. If that literal
+// drifts away from `--font-mono` in `styles/theme.css`, cursor and selection
+// positioning silently break on machines where the new front-of-stack font
+// is installed but the old stack falls back.
+//
+// This script parses both files, normalizes whitespace, and asserts equality.
+// It runs from src/ui as part of `bun run lint:css`.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const uiRoot = resolve(here, "..");
+const fontsTsPath = resolve(uiRoot, "src/styles/fonts.ts");
+const themeCssPath = resolve(uiRoot, "src/styles/theme.css");
+
+function normalize(value) {
+  // Collapse all runs of whitespace (incl. newlines inside the CSS value)
+  // to a single space, then trim. Quotes are preserved so `"JetBrains Mono"`
+  // and `'JetBrains Mono'` would still differ — that's intentional, the two
+  // sources should agree on punctuation.
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function readFile(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch (err) {
+    console.error(`ERROR: cannot read ${path}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+function extractTsConstant(source, name) {
+  // Match `export const NAME = '...'` or `export const NAME = "..."`,
+  // possibly broken across lines. Captures the inner string contents.
+  const re = new RegExp(
+    `export\\s+const\\s+${name}\\s*=\\s*(['"\`])([\\s\\S]*?)\\1`,
+    "m",
+  );
+  const m = source.match(re);
+  if (!m) return null;
+  return m[2];
+}
+
+function extractCssVar(source, name) {
+  // Match `--name: <value>;`. The value can span multiple lines if
+  // the author wraps it, so we use [^;]+.
+  const re = new RegExp(`--${name}\\s*:\\s*([^;]+);`);
+  const m = source.match(re);
+  if (!m) return null;
+  return m[1];
+}
+
+const fontsTs = readFile(fontsTsPath);
+const themeCss = readFile(themeCssPath);
+
+const tsValue = extractTsConstant(fontsTs, "DEFAULT_MONO_STACK");
+if (tsValue === null) {
+  console.error(
+    `ERROR: could not find \`export const DEFAULT_MONO_STACK\` in ${fontsTsPath}`,
+  );
+  process.exit(2);
+}
+
+const cssValue = extractCssVar(themeCss, "font-mono");
+if (cssValue === null) {
+  console.error(
+    `ERROR: could not find \`--font-mono\` declaration in ${themeCssPath}`,
+  );
+  process.exit(2);
+}
+
+const tsNorm = normalize(tsValue);
+const cssNorm = normalize(cssValue);
+
+if (tsNorm !== cssNorm) {
+  console.error("ERROR: Monaco font stack drift detected.");
+  console.error("");
+  console.error(`  src/styles/fonts.ts  DEFAULT_MONO_STACK:`);
+  console.error(`    ${tsNorm}`);
+  console.error(`  src/styles/theme.css --font-mono:`);
+  console.error(`    ${cssNorm}`);
+  console.error("");
+  console.error(
+    "These must match exactly (after whitespace normalization) so that",
+  );
+  console.error(
+    "Monaco's canvas-measured glyph widths agree with the rendered DOM font.",
+  );
+  console.error(
+    "Update both `src/styles/fonts.ts` and `src/styles/theme.css` together.",
+  );
+  process.exit(1);
+}
+
+console.log("Monaco font-stack drift check passed.");

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useRef } from "react";
 import Editor, { type BeforeMount, type OnMount } from "@monaco-editor/react";
 import "./monacoSetup";
 import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
+import { DEFAULT_MONO_STACK } from "../../styles/fonts";
 import styles from "./MonacoEditor.module.css";
 
 interface MonacoEditorProps {
@@ -101,9 +102,12 @@ export const MonacoEditor = memo(function MonacoEditor({
           // Literal stack rather than `var(--font-mono)`: Monaco computes
           // character widths via `canvas.measureText`, which does not
           // resolve CSS variables. Mismatched widths cause cursor and
-          // selection positioning to drift on every keystroke. Mirrors
-          // the value of `--font-mono` in styles/theme.css.
-          fontFamily: '"JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", monospace',
+          // selection positioning to drift on every keystroke. The
+          // canonical value lives in `src/styles/fonts.ts` and is mirrored
+          // into `--font-mono` in `styles/theme.css`; the drift check at
+          // `scripts/check-font-mono.mjs` (run by `lint:css`) asserts the
+          // two stay equal.
+          fontFamily: DEFAULT_MONO_STACK,
           fontSize: 13,
         }}
       />

--- a/src/ui/src/styles/fonts.ts
+++ b/src/ui/src/styles/fonts.ts
@@ -1,0 +1,18 @@
+// Single source of truth for the default font stacks referenced from both
+// CSS (`--font-sans` / `--font-mono` in styles/theme.css) and TypeScript
+// (Monaco's `fontFamily` and the user-font fallback in utils/theme.ts).
+//
+// Monaco computes glyph widths via `canvas.measureText`, which does NOT
+// resolve CSS custom properties — so the editor must be configured with a
+// literal font stack. To prevent the literal from drifting away from
+// `--font-mono`, scripts/check-font-mono.mjs (run as part of `lint:css`)
+// parses both files and asserts they match after whitespace normalization.
+//
+// Edit one place: change the value here, then mirror it into theme.css.
+// The drift check is what catches a missed update.
+
+export const DEFAULT_SANS_STACK =
+  '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+export const DEFAULT_MONO_STACK =
+  '"JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", monospace';

--- a/src/ui/src/utils/theme.ts
+++ b/src/ui/src/utils/theme.ts
@@ -6,7 +6,12 @@ import {
   DEFAULT_THEME_ID,
   DEFAULT_LIGHT_THEME_ID,
 } from "../styles/themes";
+import { DEFAULT_SANS_STACK, DEFAULT_MONO_STACK } from "../styles/fonts";
 import { listUserThemes } from "../services/tauri";
+
+// Re-export so existing call sites (tests, components) keep working while
+// the canonical definitions live in src/styles/fonts.ts.
+export { DEFAULT_SANS_STACK, DEFAULT_MONO_STACK };
 
 // localStorage key used by index.html's pre-hydration script to set
 // data-theme before React mounts. Keep in sync with that script.
@@ -72,11 +77,6 @@ const THEMEABLE_VARS = [
   "font-mono",
   "font-display",
 ];
-
-export const DEFAULT_SANS_STACK =
-  '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
-export const DEFAULT_MONO_STACK =
-  '"JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", monospace';
 
 /**
  * Apply user font overrides on top of the current theme.


### PR DESCRIPTION
## Summary

Monaco computes glyph widths via `canvas.measureText`, which does not resolve CSS custom properties. As a result, `MonacoEditor.tsx` had to hardcode the same literal font stack that lives in `--font-mono` in `styles/theme.css`. Two unrelated places, easy to drift, and a drift silently breaks cursor / selection positioning on machines where the new front-of-stack font is installed but the old stack falls back to `ui-monospace`.

This PR makes that pairing safe by construction:

- New `src/ui/src/styles/fonts.ts` exports `DEFAULT_MONO_STACK` (and `DEFAULT_SANS_STACK`, refactored out of `utils/theme.ts`).
- `MonacoEditor.tsx` imports `DEFAULT_MONO_STACK` and uses it as `fontFamily`. Updated the existing comment to point at the new architecture.
- `utils/theme.ts` re-exports both stacks so existing call sites (tests, `applyUserFonts`) keep working without churn.
- New `src/ui/scripts/check-font-mono.mjs` parses `--font-mono` out of `theme.css` and the `DEFAULT_MONO_STACK` literal out of `fonts.ts`, normalizes whitespace, and asserts equality. Wired into `lint:css` so CI catches drift.

The two values still need to be edited together — the check is what makes that contract enforced rather than aspirational.

## Test plan

- [x] `cd src/ui && bun run build` (full tsc + vite)
- [x] `cd src/ui && bunx tsc -b`
- [x] `cd src/ui && bun run test` (1105 tests)
- [x] `cd src/ui && bun run lint` (no new warnings/errors vs baseline)
- [x] `cd src/ui && bun run lint:css` — passes
- [x] Negative test: temporarily change `--font-mono` to a different stack, run `bun run lint:css`, confirm it fails with a clear error showing both values + remediation guidance, revert.
- [x] Inspected built bundle (`dist/assets/fonts-*.js`) to confirm the literal stack is preserved in the Monaco chunk after Vite minification.