### PR TITLE
fix(ui): clear active file tab when selecting Changes diff entry (#573)

### DIFF
--- a/src/ui/src/stores/slices/diffSlice.ts
+++ b/src/ui/src/stores/slices/diffSlice.ts
@@ -142,10 +142,25 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
       // wouldn't refire on identical deps, leaving the user staring at empty).
       const isSameSelection =
         s.diffSelectedFile === path && s.diffSelectedLayer === normalizedLayer;
+      // issue 573: AppLayout gives the file viewer strict precedence over the
+      // diff viewer, so opening a diff while a file tab is active would
+      // leave the user staring at Monaco. Release the active file pointer
+      // for this workspace so the diff actually becomes visible. Only the
+      // active pointer is cleared — the file tab itself stays in the strip
+      // so the user can switch back. Other workspaces are untouched.
+      const wsActiveFile = s.activeFileTabByWorkspace[workspaceId] ?? null;
+      const nextActiveFileTabByWorkspace =
+        wsActiveFile === null
+          ? s.activeFileTabByWorkspace
+          : {
+              ...s.activeFileTabByWorkspace,
+              [workspaceId]: null,
+            };
       return {
         diffTabsByWorkspace: nextTabs,
         diffSelectedFile: path,
         diffSelectedLayer: normalizedLayer,
+        activeFileTabByWorkspace: nextActiveFileTabByWorkspace,
         ...(isSameSelection
           ? {}
           : {

--- a/src/ui/src/stores/useAppStore.diffTabs.test.ts
+++ b/src/ui/src/stores/useAppStore.diffTabs.test.ts
@@ -14,6 +14,9 @@ function reset() {
     diffError: null,
     sessionsByWorkspace: {},
     selectedSessionIdByWorkspaceId: {},
+    fileTabsByWorkspace: {},
+    activeFileTabByWorkspace: {},
+    fileBuffers: {},
   });
 }
 
@@ -226,6 +229,81 @@ describe("workspace removal cleans up diff tabs", () => {
     expect(state.diffTabsByWorkspace[WS_B]).toEqual([
       { path: "b.ts", layer: "unstaged" },
     ]);
+  });
+});
+
+// Regression for issue 573: opening a Changes-panel diff entry while a file tab
+// is active in the FileViewer must release the file tab so AppLayout's
+// "file viewer beats diff viewer" precedence stops blocking the diff. The
+// fix lives in the slice so every caller of openDiffTab gets the right
+// behavior automatically (previously only SessionTabs.switchToDiff
+// remembered to call clearActiveFileTab — RightSidebar's row click forgot).
+describe("openDiffTab releases the active file tab (issue 573)", () => {
+  beforeEach(reset);
+
+  it("clears activeFileTabByWorkspace[workspaceId] so the diff is visible", () => {
+    useAppStore.getState().openFileTab(WS_A, "src/foo.ts");
+    expect(useAppStore.getState().activeFileTabByWorkspace[WS_A]).toBe(
+      "src/foo.ts",
+    );
+
+    useAppStore.getState().openDiffTab(WS_A, "src/bar.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.activeFileTabByWorkspace[WS_A]).toBeNull();
+    expect(state.diffSelectedFile).toBe("src/bar.ts");
+    expect(state.diffSelectedLayer).toBe("unstaged");
+    // The file tab itself stays open in the strip so the user can switch
+    // back; only the active pointer is released.
+    expect(state.fileTabsByWorkspace[WS_A]).toEqual(["src/foo.ts"]);
+  });
+
+  it("does not touch other workspaces' active file tabs", () => {
+    useAppStore.getState().openFileTab(WS_A, "src/a.ts");
+    useAppStore.getState().openFileTab(WS_B, "src/b.ts");
+
+    useAppStore.getState().openDiffTab(WS_A, "src/diff.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.activeFileTabByWorkspace[WS_A]).toBeNull();
+    expect(state.activeFileTabByWorkspace[WS_B]).toBe("src/b.ts");
+  });
+
+  it("is a no-op when no file tab was active", () => {
+    // Sanity: workspace has no open file tabs at all.
+    useAppStore.getState().openDiffTab(WS_A, "src/bar.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.activeFileTabByWorkspace[WS_A] ?? null).toBeNull();
+    expect(state.diffSelectedFile).toBe("src/bar.ts");
+  });
+});
+
+// Baseline: the SessionTabs.switchToDiff path (clearActiveFileTab +
+// selectDiffTab, in that order) was the only diff-navigation entry point
+// that already honored the file-viewer release contract before issue 573. Keep
+// a regression on it so a future refactor of switchToDiff can't silently
+// break the working baseline.
+describe("SessionTabs.switchToDiff baseline still releases the file tab", () => {
+  beforeEach(reset);
+
+  it("clearActiveFileTab + selectDiffTab leaves the diff visible", () => {
+    useAppStore.getState().openFileTab(WS_A, "src/foo.ts");
+    useAppStore.getState().openDiffTab(WS_A, "src/bar.ts", "unstaged");
+    // Re-open the file tab to mimic the user clicking back to the file
+    // viewer; that re-asserts activeFileTabByWorkspace[WS_A].
+    useAppStore.getState().openFileTab(WS_A, "src/foo.ts");
+    expect(useAppStore.getState().activeFileTabByWorkspace[WS_A]).toBe(
+      "src/foo.ts",
+    );
+
+    // Mirror SessionTabs.switchToDiff exactly.
+    useAppStore.getState().clearActiveFileTab(WS_A);
+    useAppStore.getState().selectDiffTab("src/bar.ts", "unstaged");
+
+    const state = useAppStore.getState();
+    expect(state.activeFileTabByWorkspace[WS_A]).toBeNull();
+    expect(state.diffSelectedFile).toBe("src/bar.ts");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #573.

When a file is open in Monaco (the file viewer), clicking an entry in the Changes panel of the right sidebar registered (row highlighted, `openDiffTab` ran) but the main pane stayed on Monaco — the selected diff was invisible until the file tab was explicitly closed.

**Root cause** (per the issue): `AppLayout.tsx:53-54` gives the file viewer strict precedence over the diff viewer. Any caller that switches to a diff must first release the active file tab. `SessionTabs.switchToDiff` did this; `RightSidebar`'s row-click handler did not.

**Fix** — at the slice layer, defensive against future regressions: `openDiffTab` now also nulls `activeFileTabByWorkspace[workspaceId]` in the same `set()` call. Every caller — current and future — gets the right behavior automatically without having to remember the explicit `clearActiveFileTab` step. `SessionTabs.switchToDiff`'s existing call becomes redundant but idempotent (left in place to document intent). Other workspaces' active file tabs are untouched, and the file tab itself stays in the strip so the user can switch back.

**Audit** of every diff-selection entry point:
- `RightSidebar.tsx:219-223` — `openDiffTab(...)`: was broken; now fixed via slice
- `SessionTabs.tsx:99-104` — `clearActiveFileTab + selectDiffTab`: already correct; baseline preserved
- All other `openDiffTab` / `selectDiffTab` references are inside store tests

## Test plan

- [x] `cd src/ui && nix develop ../.. -c bun run test` (1118 tests pass; 3 new + 1 baseline regression added in `useAppStore.diffTabs.test.ts`)
- [x] `cd src/ui && nix develop ../.. -c bunx tsc -b`
- [x] `cd src/ui && nix develop ../.. -c bun run lint:css` (Monaco font-stack + design-system token checks pass)
- [x] `nix develop -c cargo test --all-features` (847 pass)
- [x] `nix develop -c cargo clippy --workspace --all-targets`
- [x] `nix develop -c cargo fmt --all --check`
- [x] Manual UAT — open `flake.nix` in Files (Monaco mounts), edit + save, switch right sidebar to Changes, click unstaged entry → main pane shows the diff (was Monaco). SessionTabs.switchToDiff baseline still works.

## New tests

In `src/ui/src/stores/useAppStore.diffTabs.test.ts`:

- `openDiffTab releases the active file tab (issue 573) > clears activeFileTabByWorkspace[workspaceId] so the diff is visible` — direct repro of the bug; confirmed RED before the fix, GREEN after
- `... > does not touch other workspaces' active file tabs` — regression for cross-workspace isolation
- `... > is a no-op when no file tab was active` — sanity for the common path
- `SessionTabs.switchToDiff baseline still releases the file tab` — locks in the working pattern so a future refactor of `switchToDiff` can't silently break it