### PR TITLE
refactor(chat): extract create_turn_checkpoint into claudette::chat (#490)

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use claudette::agent::{self, AgentEvent, AgentSettings, InnerStreamEvent, StreamEvent};
 use claudette::chat::{
-    BuildAssistantArgs, build_assistant_chat_message, extract_assistant_text,
-    extract_event_thinking,
+    BuildAssistantArgs, CheckpointArgs, build_assistant_chat_message, create_turn_checkpoint,
+    extract_assistant_text, extract_event_thinking,
 };
 use claudette::db::Database;
 use claudette::model::{ChatMessage, ChatRole, Workspace, WorkspaceStatus};
@@ -614,6 +614,8 @@ async fn handle_send_chat_message(
     let ws_id = workspace_id.clone();
     let chat_session_id_for_stream = chat_session_id.clone();
     let db_path = state.db_path.clone();
+    let wt_path = worktree_path.clone();
+    let user_msg_id = user_msg.id.clone();
     let state = Arc::clone(state);
     let writer = Arc::clone(writer);
     tokio::spawn(async move {
@@ -625,6 +627,11 @@ async fn handle_send_chat_message(
         // reset to None after each persistence so per-message counts stay
         // distinct across multi-message turns. Mirrors the Tauri bridge.
         let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
+        // Tracks the most recently persisted assistant message id so the
+        // Result-event arm can update its cost/duration and use it as the
+        // checkpoint anchor without re-querying the DB. Mirrors the Tauri
+        // bridge.
+        let mut last_assistant_msg_id: Option<String> = None;
         while let Some(event) = rx.recv().await {
             if let AgentEvent::Stream(StreamEvent::System { ref subtype, .. }) = event
                 && subtype == "init"
@@ -677,22 +684,48 @@ async fn handle_send_chat_message(
                         usage: latest_usage.take(),
                         created_at: now_iso(),
                     });
-                    let _ = db.insert_chat_message(&msg);
+                    let msg_id = msg.id.clone();
+                    if db.insert_chat_message(&msg).is_ok() {
+                        last_assistant_msg_id = Some(msg_id);
+                    }
                 }
             }
 
-            // Update cost/duration.
+            // Update cost/duration on result events, then create a checkpoint.
             if let AgentEvent::Stream(StreamEvent::Result {
                 ref total_cost_usd,
                 ref duration_ms,
                 ..
             }) = event
-                && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
-                && let Ok(db) = Database::open(&db_path)
-                && let Ok(msgs) = db.list_chat_messages_for_session(&chat_session_id_for_stream)
-                && let Some(last) = msgs.iter().rfind(|m| m.role == ChatRole::Assistant)
             {
-                let _ = db.update_chat_message_cost(&last.id, *cost, *dur);
+                if let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
+                    && let Some(ref msg_id) = last_assistant_msg_id
+                    && let Ok(db) = Database::open(&db_path)
+                {
+                    let _ = db.update_chat_message_cost(msg_id, *cost, *dur);
+                }
+
+                let anchor_msg_id = last_assistant_msg_id.as_deref().unwrap_or(&user_msg_id);
+                if let Some(cp) = create_turn_checkpoint(CheckpointArgs {
+                    db_path: &db_path,
+                    workspace_id: &ws_id,
+                    chat_session_id: &chat_session_id_for_stream,
+                    anchor_msg_id,
+                    worktree_path: &wt_path,
+                    created_at: now_iso(),
+                })
+                .await
+                {
+                    let event_msg = json!({
+                        "event": "checkpoint-created",
+                        "payload": {
+                            "workspace_id": &ws_id,
+                            "chat_session_id": &chat_session_id_for_stream,
+                            "checkpoint": &cp,
+                        }
+                    });
+                    send_message(&writer, &event_msg).await;
+                }
             }
 
             // Emit event over WebSocket.

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -15,9 +15,8 @@ use claudette::chat::{
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
 use claudette::mcp_supervisor::McpSupervisor;
-use claudette::model::{ChatMessage, ChatRole, ConversationCheckpoint};
+use claudette::model::{ChatMessage, ChatRole};
 use claudette::permissions::tools_for_level;
-use claudette::snapshot;
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
 
@@ -1410,58 +1409,30 @@ pub async fn send_chat_message(
                 duration_ms,
                 ..
             }) = &event
-                && let Ok(db) = Database::open(&db_path)
             {
-                // Update cost on the assistant message from this turn (if any).
-                if let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
+                if let Ok(db) = Database::open(&db_path)
+                    && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
                     && let Some(ref msg_id) = last_assistant_msg_id
                 {
                     let _ = db.update_chat_message_cost(msg_id, *cost, *dur);
                 }
 
-                // Create a checkpoint anchored to the assistant message from
-                // this turn, or the user message for tool-only turns.
                 let anchor_msg_id = last_assistant_msg_id.as_deref().unwrap_or(&user_msg_id);
-
-                let turn_index = db
-                    .latest_checkpoint(&ws_id)
-                    .ok()
-                    .flatten()
-                    .map(|cp| cp.turn_index + 1)
-                    .unwrap_or(0);
-
-                let checkpoint = ConversationCheckpoint {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    workspace_id: ws_id.clone(),
-                    chat_session_id: chat_session_id_for_stream.clone(),
-                    message_id: anchor_msg_id.to_string(),
-                    commit_hash: None,
-                    has_file_state: false, // Updated after snapshot succeeds
-                    turn_index,
-                    message_count: 0, // Updated by frontend after finalizeTurn
-                    created_at: now_iso(),
-                };
-                if db.insert_checkpoint(&checkpoint).is_ok() {
-                    // Snapshot worktree files into SQLite.
-                    let has_files =
-                        match snapshot::save_snapshot(&db_path, &checkpoint.id, &wt_path).await {
-                            Ok(()) => true,
-                            Err(e) => {
-                                eprintln!(
-                                    "[chat] Snapshot failed for {ws_id}: {e} \
-                                 — checkpoint recorded without file restore capability"
-                                );
-                                false
-                            }
-                        };
-
-                    // Emit with up-to-date has_file_state so frontend knows.
-                    let mut cp_payload = checkpoint.clone();
-                    cp_payload.has_file_state = has_files;
+                if let Some(cp) =
+                    claudette::chat::create_turn_checkpoint(claudette::chat::CheckpointArgs {
+                        db_path: &db_path,
+                        workspace_id: &ws_id,
+                        chat_session_id: &chat_session_id_for_stream,
+                        anchor_msg_id,
+                        worktree_path: &wt_path,
+                        created_at: now_iso(),
+                    })
+                    .await
+                {
                     let payload = serde_json::json!({
                         "workspace_id": &ws_id,
                         "chat_session_id": &chat_session_id_for_stream,
-                        "checkpoint": &cp_payload,
+                        "checkpoint": &cp,
                     });
                     let _ = app.emit("checkpoint-created", &payload);
                 }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -8,9 +8,9 @@ use claudette::agent::{
 };
 use claudette::base64_decode;
 use claudette::chat::{
-    BuildAssistantArgs, RequestedFlags, SessionFlags, build_assistant_chat_message,
-    build_compaction_sentinel, build_permission_response, extract_assistant_text,
-    extract_event_thinking, persistent_session_flags_drifted,
+    BuildAssistantArgs, CheckpointArgs, RequestedFlags, SessionFlags, build_assistant_chat_message,
+    build_compaction_sentinel, build_permission_response, create_turn_checkpoint,
+    extract_assistant_text, extract_event_thinking, persistent_session_flags_drifted,
 };
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
@@ -1418,16 +1418,15 @@ pub async fn send_chat_message(
                 }
 
                 let anchor_msg_id = last_assistant_msg_id.as_deref().unwrap_or(&user_msg_id);
-                if let Some(cp) =
-                    claudette::chat::create_turn_checkpoint(claudette::chat::CheckpointArgs {
-                        db_path: &db_path,
-                        workspace_id: &ws_id,
-                        chat_session_id: &chat_session_id_for_stream,
-                        anchor_msg_id,
-                        worktree_path: &wt_path,
-                        created_at: now_iso(),
-                    })
-                    .await
+                if let Some(cp) = create_turn_checkpoint(CheckpointArgs {
+                    db_path: &db_path,
+                    workspace_id: &ws_id,
+                    chat_session_id: &chat_session_id_for_stream,
+                    anchor_msg_id,
+                    worktree_path: &wt_path,
+                    created_at: now_iso(),
+                })
+                .await
                 {
                     let payload = serde_json::json!({
                         "workspace_id": &ws_id,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -271,9 +271,9 @@ pub struct CheckpointArgs<'a> {
 /// Create the conversation checkpoint for a just-completed turn and snapshot
 /// the worktree files into SQLite.
 ///
-/// Returns the inserted checkpoint with `has_file_state` reflecting whether
-/// `save_snapshot` succeeded — callers should use it as the payload for any
-/// `checkpoint-created` event they emit.
+/// Returns the inserted checkpoint with `has_file_state` set to `true` only
+/// when the snapshot inserted at least one `checkpoint_files` row — callers
+/// should use it as the payload for any `checkpoint-created` event they emit.
 ///
 /// Returns `None` only when the DB connection or the checkpoint insert itself
 /// fails. Snapshot failures are logged to stderr (mirroring the prior Tauri
@@ -283,7 +283,8 @@ pub struct CheckpointArgs<'a> {
 /// Note: `has_file_state` is **derived** by SQL on read (EXISTS over
 /// `checkpoint_files`), so we don't persist the bool — we only set it on the
 /// returned struct to keep the emitted payload consistent with subsequent DB
-/// reads.
+/// reads. Zero-file snapshots (empty repo, all files gitignored) return
+/// `has_file_state = false` for the same reason.
 pub async fn create_turn_checkpoint(args: CheckpointArgs<'_>) -> Option<ConversationCheckpoint> {
     let CheckpointArgs {
         db_path,
@@ -318,8 +319,11 @@ pub async fn create_turn_checkpoint(args: CheckpointArgs<'_>) -> Option<Conversa
     db.insert_checkpoint(&checkpoint).ok()?;
     drop(db); // release the non-Send connection before awaiting save_snapshot
 
+    // Match the DB-derived `has_file_state` (EXISTS over `checkpoint_files`):
+    // a successful snapshot that inserted zero rows still means no restore
+    // capability — happens for empty / fully-ignored worktrees.
     let has_files = match snapshot::save_snapshot(db_path, &checkpoint.id, worktree_path).await {
-        Ok(()) => true,
+        Ok(count) => count > 0,
         Err(e) => {
             eprintln!(
                 "[chat] Snapshot failed for {workspace_id}: {e} \
@@ -366,13 +370,28 @@ mod tests {
         let wt = parent.join("wt");
         std::fs::create_dir_all(&wt).unwrap();
         std::fs::write(wt.join("hello.txt"), "hi").unwrap();
-        // Initialise a real git repo so git ls-files works during save_snapshot.
-        tokio::process::Command::new(crate::git::resolve_git_path_blocking())
+        init_git_repo(&wt).await;
+        wt
+    }
+
+    async fn make_empty_test_worktree(parent: &std::path::Path) -> PathBuf {
+        let wt = parent.join("empty_wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        init_git_repo(&wt).await;
+        wt
+    }
+
+    async fn init_git_repo(wt: &std::path::Path) {
+        let output = tokio::process::Command::new(crate::git::resolve_git_path_blocking())
             .args(["init", wt.to_str().unwrap()])
             .output()
             .await
-            .unwrap();
-        wt
+            .expect("spawn git init");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     // -- Session-flag drift -------------------------------------------------
@@ -849,5 +868,35 @@ mod tests {
             !row.has_file_state,
             "no checkpoint_files rows ⇒ derived false"
         );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_has_file_state_false_when_snapshot_inserts_zero_files() {
+        // Empty git-init'd worktree → save_snapshot succeeds with 0 files.
+        // The emitted payload's has_file_state must agree with the SQL EXISTS
+        // derivation (false), or the frontend will advertise a restorable
+        // checkpoint that has nothing to restore.
+        let (dir, db_path) = make_test_db().await;
+        let wt = make_empty_test_worktree(dir.path()).await;
+
+        let cp = create_turn_checkpoint(CheckpointArgs {
+            db_path: &db_path,
+            workspace_id: "ws-1",
+            chat_session_id: "cs-1",
+            anchor_msg_id: "msg-1",
+            worktree_path: wt.to_str().unwrap(),
+            created_at: "now".into(),
+        })
+        .await
+        .expect("checkpoint");
+
+        assert!(
+            !cp.has_file_state,
+            "zero-file snapshot must report has_file_state = false"
+        );
+
+        let db = crate::db::Database::open(&db_path).unwrap();
+        let row = db.latest_checkpoint("ws-1").unwrap().expect("row present");
+        assert!(!row.has_file_state, "DB-derived value agrees with payload");
     }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2,15 +2,16 @@
 //!
 //! The Tauri command (`src-tauri/src/commands/chat/send.rs`) and the remote
 //! WebSocket handler (`src-server/src/handler.rs`) both run a chat turn and
-//! persist the resulting messages. They duplicate a lot of logic that is
-//! pure: session-flag drift detection, the `can_use_tool` permission
-//! response, walking an `AssistantMessage`'s content blocks, and building
-//! `ChatMessage` rows for persistence.
+//! persist the resulting messages. They duplicate a lot of logic — pure
+//! helpers (session-flag drift, the `can_use_tool` permission response,
+//! walking an `AssistantMessage`'s content blocks, `ChatMessage` builders)
+//! plus an async helper that owns the per-turn checkpoint + worktree
+//! snapshot dance.
 //!
-//! This module collects those pure helpers so both call sites can share them
-//! and stay in lockstep. The transport-specific orchestration (event
-//! emission, `AppState` locking, notifications, checkpoint snapshotting)
-//! still lives in each call site — see issue #490 for the broader plan.
+//! This module collects those helpers so both call sites can share them and
+//! stay in lockstep. The remaining transport-specific orchestration (event
+//! emission, `AppState` locking, notifications) still lives in each call
+//! site — see issue #490 for the broader plan.
 //!
 //! See `docs/architecture` and the call sites for how these pieces are
 //! composed during a turn.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -15,11 +15,15 @@
 //! See `docs/architecture` and the call sites for how these pieces are
 //! composed during a turn.
 
+use std::path::Path;
+
 use serde_json::Value;
 
 use crate::agent::{AssistantMessage, CompactMetadata, ContentBlock, TokenUsage};
-use crate::model::{ChatMessage, ChatRole};
+use crate::db::Database;
+use crate::model::{ChatMessage, ChatRole, ConversationCheckpoint};
 use crate::permissions::is_bypass_tools;
+use crate::snapshot;
 
 // ---------------------------------------------------------------------------
 // Session-flag drift detection
@@ -247,13 +251,127 @@ pub fn build_compaction_sentinel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Turn checkpoint creation
+// ---------------------------------------------------------------------------
+
+/// Inputs for [`create_turn_checkpoint`]. `anchor_msg_id` is the assistant
+/// message id from this turn, or the user message id for tool-only turns
+/// where no assistant text was emitted.
+pub struct CheckpointArgs<'a> {
+    pub db_path: &'a Path,
+    pub workspace_id: &'a str,
+    pub chat_session_id: &'a str,
+    pub anchor_msg_id: &'a str,
+    pub worktree_path: &'a str,
+    pub created_at: String,
+}
+
+/// Create the conversation checkpoint for a just-completed turn and snapshot
+/// the worktree files into SQLite.
+///
+/// Returns the inserted checkpoint with `has_file_state` reflecting whether
+/// `save_snapshot` succeeded — callers should use it as the payload for any
+/// `checkpoint-created` event they emit.
+///
+/// Returns `None` only when the DB connection or the checkpoint insert itself
+/// fails. Snapshot failures are logged to stderr (mirroring the prior Tauri
+/// behavior) but do not prevent the checkpoint row from existing — restoring
+/// to that turn just won't be possible.
+///
+/// Note: `has_file_state` is **derived** by SQL on read (EXISTS over
+/// `checkpoint_files`), so we don't persist the bool — we only set it on the
+/// returned struct to keep the emitted payload consistent with subsequent DB
+/// reads.
+pub async fn create_turn_checkpoint(args: CheckpointArgs<'_>) -> Option<ConversationCheckpoint> {
+    let CheckpointArgs {
+        db_path,
+        workspace_id,
+        chat_session_id,
+        anchor_msg_id,
+        worktree_path,
+        created_at,
+    } = args;
+
+    let db = Database::open(db_path).ok()?;
+
+    let turn_index = db
+        .latest_checkpoint(workspace_id)
+        .ok()
+        .flatten()
+        .map(|cp| cp.turn_index + 1)
+        .unwrap_or(0);
+
+    let mut checkpoint = ConversationCheckpoint {
+        id: uuid::Uuid::new_v4().to_string(),
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
+        message_id: anchor_msg_id.to_string(),
+        commit_hash: None,
+        has_file_state: false,
+        turn_index,
+        message_count: 0,
+        created_at,
+    };
+
+    db.insert_checkpoint(&checkpoint).ok()?;
+    drop(db); // release the non-Send connection before awaiting save_snapshot
+
+    let has_files = match snapshot::save_snapshot(db_path, &checkpoint.id, worktree_path).await {
+        Ok(()) => true,
+        Err(e) => {
+            eprintln!(
+                "[chat] Snapshot failed for {workspace_id}: {e} \
+                 — checkpoint recorded without file restore capability"
+            );
+            false
+        }
+    };
+
+    checkpoint.has_file_state = has_files;
+    Some(checkpoint)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
     fn s(values: &[&str]) -> Vec<String> {
         values.iter().map(|v| (*v).to_string()).collect()
+    }
+
+    async fn make_test_db() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("test.db");
+        let db = crate::db::Database::open(&db_path).expect("open db");
+        // Seed the FK-required rows so insert_checkpoint doesn't reject ws-1 / cs-1.
+        db.execute_batch(
+            "INSERT INTO repositories (id, name, path) VALUES ('r-1', 'testrepo', '/tmp/r1'); \
+             INSERT INTO workspaces (id, repository_id, name, branch_name, status, status_line) \
+               VALUES ('ws-1', 'r-1', 'test', 'main', 'active', ''); \
+             INSERT INTO chat_sessions (id, workspace_id, name, sort_order, status) \
+               VALUES ('cs-1', 'ws-1', 'Main', 0, 'active');",
+        )
+        .expect("seed rows");
+        drop(db);
+        (dir, db_path)
+    }
+
+    async fn make_test_worktree(parent: &std::path::Path) -> PathBuf {
+        let wt = parent.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join("hello.txt"), "hi").unwrap();
+        // Initialise a real git repo so git ls-files works during save_snapshot.
+        tokio::process::Command::new(crate::git::resolve_git_path_blocking())
+            .args(["init", wt.to_str().unwrap()])
+            .output()
+            .await
+            .unwrap();
+        wt
     }
 
     // -- Session-flag drift -------------------------------------------------
@@ -635,5 +753,100 @@ mod tests {
         assert!(m.cache_creation_tokens.is_none());
         assert!(m.input_tokens.is_none());
         assert!(m.output_tokens.is_none());
+    }
+
+    // -- Turn checkpoint creation -----------------
+
+    #[tokio::test]
+    async fn checkpoint_turn_index_is_zero_on_empty_workspace() {
+        let (dir, db_path) = make_test_db().await;
+        let wt = make_test_worktree(dir.path()).await;
+
+        let cp = create_turn_checkpoint(CheckpointArgs {
+            db_path: &db_path,
+            workspace_id: "ws-1",
+            chat_session_id: "cs-1",
+            anchor_msg_id: "msg-1",
+            worktree_path: wt.to_str().unwrap(),
+            created_at: "now".into(),
+        })
+        .await
+        .expect("checkpoint");
+
+        assert_eq!(cp.turn_index, 0);
+        assert!(
+            cp.has_file_state,
+            "snapshot of fixture worktree should succeed"
+        );
+        assert_eq!(cp.message_id, "msg-1");
+        assert_eq!(cp.workspace_id, "ws-1");
+        assert_eq!(cp.chat_session_id, "cs-1");
+
+        let db = crate::db::Database::open(&db_path).unwrap();
+        let row = db.latest_checkpoint("ws-1").unwrap().expect("row inserted");
+        assert_eq!(row.id, cp.id);
+        assert!(row.has_file_state, "DB-derived has_file_state agrees");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_turn_index_increments_from_latest() {
+        let (dir, db_path) = make_test_db().await;
+        let wt = make_test_worktree(dir.path()).await;
+
+        {
+            let db = crate::db::Database::open(&db_path).unwrap();
+            let prior = crate::model::ConversationCheckpoint {
+                id: "prior".into(),
+                workspace_id: "ws-1".into(),
+                chat_session_id: "cs-1".into(),
+                message_id: "older".into(),
+                commit_hash: None,
+                has_file_state: false,
+                turn_index: 4,
+                message_count: 0,
+                created_at: "earlier".into(),
+            };
+            db.insert_checkpoint(&prior).unwrap();
+        }
+
+        let cp = create_turn_checkpoint(CheckpointArgs {
+            db_path: &db_path,
+            workspace_id: "ws-1",
+            chat_session_id: "cs-1",
+            anchor_msg_id: "msg-2",
+            worktree_path: wt.to_str().unwrap(),
+            created_at: "now".into(),
+        })
+        .await
+        .expect("checkpoint");
+
+        assert_eq!(cp.turn_index, 5);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_records_row_with_has_file_state_false_on_snapshot_failure() {
+        let (_dir, db_path) = make_test_db().await;
+        let bogus = "/definitely/does/not/exist/anywhere";
+
+        let cp = create_turn_checkpoint(CheckpointArgs {
+            db_path: &db_path,
+            workspace_id: "ws-1",
+            chat_session_id: "cs-1",
+            anchor_msg_id: "msg-1",
+            worktree_path: bogus,
+            created_at: "now".into(),
+        })
+        .await
+        .expect("checkpoint inserted even if snapshot fails");
+
+        assert!(!cp.has_file_state);
+
+        let db = crate::db::Database::open(&db_path).unwrap();
+        let row = db.latest_checkpoint("ws-1").unwrap().expect("row present");
+        assert_eq!(row.id, cp.id);
+        assert!(
+            !row.has_file_state,
+            "no checkpoint_files rows ⇒ derived false"
+        );
     }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -121,14 +121,17 @@ pub async fn collect_worktree_files(
     Ok(files)
 }
 
-/// Snapshot all worktree files into the `checkpoint_files` table.
-/// Opens its own DB connection so it can be called from async contexts
-/// without holding a non-Send `Database` across await points.
+/// Snapshot all worktree files into the `checkpoint_files` table. Returns
+/// the number of rows inserted — callers use a zero count as a signal that
+/// the checkpoint has no restorable file state, matching the SQL EXISTS
+/// derivation used when reading checkpoints back. Opens its own DB
+/// connection so it can be called from async contexts without holding a
+/// non-Send `Database` across await points.
 pub async fn save_snapshot(
     db_path: &Path,
     checkpoint_id: &str,
     worktree_path: &str,
-) -> Result<(), SnapshotError> {
+) -> Result<usize, SnapshotError> {
     let collected = collect_worktree_files(worktree_path).await?;
 
     let files: Vec<CheckpointFile> = collected
@@ -142,9 +145,10 @@ pub async fn save_snapshot(
         })
         .collect();
 
+    let count = files.len();
     let db = crate::db::Database::open(db_path).map_err(|e| SnapshotError::Db(e.to_string()))?;
     db.insert_checkpoint_files(&files)?;
-    Ok(())
+    Ok(count)
 }
 
 /// Restore a worktree to the exact state captured in a checkpoint snapshot.


### PR DESCRIPTION
## Summary

Phase 2 of #490. Extracts the per-turn checkpoint + worktree-snapshot logic into a shared `claudette::chat::create_turn_checkpoint` helper consumed by both transports — closing the remote-checkpoint parity gap that #561 left as a follow-up.

- **New helper** in `src/chat.rs`: `create_turn_checkpoint(CheckpointArgs<'_>) -> Option<ConversationCheckpoint>` opens the DB, derives `turn_index` from `latest_checkpoint`, inserts the checkpoint row, drops the non-`Send` `rusqlite::Connection` before awaiting `save_snapshot`, and returns the checkpoint with `has_file_state` reflecting snapshot success. Three `#[tokio::test]` tests cover happy-path, `turn_index` increment, and snapshot-failure branches.
- **Tauri** (`src-tauri/src/commands/chat/send.rs`): the inline ~62-line checkpoint block collapses to ~25 lines that call the helper. The cost/duration update is split into its own short-lived `Database::open` arm. `app.emit("checkpoint-created", ...)` stays in the transport.
- **Remote** (`src-server/src/handler.rs`): previously had **no checkpoint logic at all**. Now mirrors Tauri exactly — tracks `last_assistant_msg_id` in-memory, calls `create_turn_checkpoint`, and emits a `checkpoint-created` envelope via `send_message`.

### Bug fix (silent cost mis-attribution on remote tool-only turns)

The previous remote handler used `list_chat_messages_for_session().rfind(role == Assistant)` to locate the message to attribute cost to. On tool-only turns (AskUserQuestion / ExitPlanMode) where this turn produced no assistant message, `rfind` returned the *prior* turn's assistant row, so the new turn's cost/duration silently overwrote the prior turn's. The new in-memory `last_assistant_msg_id` is `None` on those turns, so the update correctly skips. Tauri already had this behavior; remote now matches.

### Scope

Foundation-only PR per #490. No `TurnTransport` trait yet — each remaining drift slice gets its own small PR. `now_iso()` divergence (Tauri = epoch seconds, remote = `YYYY-MM-DD HH:MM:SS`) is preserved as out-of-scope.

## Notable

- `has_file_state` is computed by SQL `EXISTS(SELECT 1 FROM checkpoint_files...)` on read (`src/db/checkpoint.rs:51-54`), not stored — so the in-memory bool is purely for matching the emitted event payload to a fresh DB read. The helper's doc comment explains this.
- Explicit `drop(db)` before `save_snapshot().await` is a small `Send`-safety improvement over the prior Tauri code, which held a non-`Send` `rusqlite::Connection` across the await scope.
- `claudette::chat` module doc comment updated to acknowledge the new async I/O helper alongside the existing pure helpers.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-server --all-targets` (zero warnings)
- [x] `cargo test --all-features` (879 backend tests pass, including 3 new helper tests)
- [x] `bunx tsc -b` (clean)
- [x] `bun run test` (1118 frontend tests pass)
- [x] `bun run lint:css` (clean)
- [ ] Manual: `cargo tauri dev`, send a chat turn, confirm `checkpoint-created` event still fires and a `conversation_checkpoints` row + `checkpoint_files` rows appear (skipped — not feasible in execution environment; please verify locally before merging)
- [ ] Manual: exercise remote (server-mode) chat turn, confirm new `checkpoint-created` envelope arrives and worktree snapshot is created

## Follow-ups (not blocking)

- Two cosmetic asymmetries between the Tauri and remote `Result`-event arms (cost-update gate ordering, `&event` vs `event` match style). Both compile to identical behavior; suggest a small follow-up commit if byte-identical arms are desired. Reviewer's preference: flip Tauri to match remote (avoids one `Database::open` per tool-only Result event).
- WebSocket-level integration test for the remote spawn task's checkpoint emission would pin both transports' parity into CI. Pre-existing test gap, but now the most leveraged single test for the rest of #490.