### PR TITLE
feat(plugins): enforce granted_capabilities at every host.* call site

### DIFF
--- a/src-tauri/src/commands/community.rs
+++ b/src-tauri/src/commands/community.rs
@@ -372,6 +372,110 @@ pub async fn community_list_installed(
     Ok(out)
 }
 
+/// Capability re-consent request surfaced to the UI. Built from the
+/// diff of `manifest.required_clis` (live) vs `granted_capabilities`
+/// (recorded in `.install_meta.json` at install time).
+///
+/// Any plugin with non-empty `missing` cannot run — `call_operation`
+/// returns `PluginError::NeedsReconsent` until the user approves
+/// (which calls `community_grant_capabilities`).
+#[derive(Debug, Clone, Serialize)]
+pub struct PendingReconsent {
+    pub kind: String,
+    pub ident: String,
+    pub display_name: String,
+    /// Currently granted capability list (`granted_capabilities`).
+    pub granted: Vec<String>,
+    /// Capabilities the new manifest declares but the user hasn't
+    /// approved. `granted ∪ missing` is what would be granted on
+    /// approval.
+    pub missing: Vec<String>,
+}
+
+/// Walk every community-installed plugin and surface those whose live
+/// `required_clis` exceeds stored grants. Empty result = nothing to
+/// re-consent. Used by the Community settings UI to render a banner
+/// per affected plugin.
+#[tauri::command]
+pub async fn community_pending_reconsent(
+    state: State<'_, AppState>,
+) -> Result<Vec<PendingReconsent>, String> {
+    let registry = state.plugins.read().await;
+    let mut out = Vec::new();
+    for (name, plugin) in registry.plugins.iter() {
+        if let claudette::plugin_runtime::PluginTrust::Community { granted } = &plugin.trust {
+            let missing: Vec<String> = plugin
+                .manifest
+                .required_clis
+                .iter()
+                .filter(|c| !granted.iter().any(|g| g == *c))
+                .cloned()
+                .collect();
+            if missing.is_empty() {
+                continue;
+            }
+            // Derive kind from the manifest. The `.install_meta.json`
+            // also carries this — but the manifest is what discovery
+            // already parsed, so use it.
+            let kind_wire = ContributionKind::Plugin(plugin_kind_to_wire(plugin.manifest.kind));
+            out.push(PendingReconsent {
+                kind: kind_wire.wire(),
+                ident: name.clone(),
+                display_name: plugin.manifest.display_name.clone(),
+                granted: granted.clone(),
+                missing,
+            });
+        }
+    }
+    out.sort_by(|a, b| a.ident.cmp(&b.ident));
+    Ok(out)
+}
+
+/// Approve the live manifest's `required_clis` as the new grant set
+/// for a community-installed plugin. Rewrites `.install_meta.json`
+/// in place (preserving every other field) and rehydrates the
+/// runtime so the next `call_operation` sees the new trust.
+///
+/// Errors on:
+///   - unknown plugin name
+///   - non-community plugin (bundled / unknown — shouldn't reach this
+///     path; UI only offers re-consent when `pending_reconsent`
+///     surfaces the plugin)
+#[tauri::command]
+pub async fn community_grant_capabilities(
+    ident: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let install_dir = {
+        let registry = state.plugins.read().await;
+        let plugin = registry
+            .plugins
+            .get(&ident)
+            .ok_or_else(|| format!("unknown plugin: {ident}"))?;
+        if !matches!(
+            plugin.trust,
+            claudette::plugin_runtime::PluginTrust::Community { .. }
+        ) {
+            return Err(format!(
+                "plugin '{ident}' is not a community install — refusing to mutate grants"
+            ));
+        }
+        plugin.dir.clone()
+    };
+
+    // Read manifest off disk through the existing parser so we get the
+    // same `required_clis` view that discovery + call_operation see.
+    let manifest_path = install_dir.join("plugin.json");
+    let manifest = claudette::plugin_runtime::manifest::parse_manifest(&manifest_path)
+        .map_err(|e| format!("read plugin.json: {e}"))?;
+
+    community::update_granted_capabilities(&install_dir, &manifest.required_clis)
+        .map_err(|e| format!("write grants: {e}"))?;
+
+    rehydrate_plugin_registry(&state).await?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -618,6 +618,8 @@ fn main() {
             commands::community::community_install,
             commands::community::community_uninstall,
             commands::community::community_list_installed,
+            commands::community::community_pending_reconsent,
+            commands::community::community_grant_capabilities,
             // Voice providers
             commands::voice::voice_list_providers,
             commands::voice::voice_set_selected_provider,

--- a/src/community/install.rs
+++ b/src/community/install.rs
@@ -266,6 +266,35 @@ pub fn read_install_meta(install_dir: &Path) -> Result<Option<InstalledMeta>, In
     Ok(Some(meta))
 }
 
+/// Rewrite `.install_meta.json` in `install_dir` so its
+/// `granted_capabilities` field becomes `new_grants`. Every other
+/// field is preserved byte-for-byte. Used by the re-consent flow:
+/// when a plugin update declares new `required_clis` we deny at
+/// runtime until the user explicitly approves and we call this.
+///
+/// Returns `Err(InstallError::Io)` when the meta file is missing —
+/// callers must validate that the plugin was community-installed
+/// before invoking this. Bundled plugins have no meta file and
+/// shouldn't reach this path.
+pub fn update_granted_capabilities(
+    install_dir: &Path,
+    new_grants: &[String],
+) -> Result<(), InstallError> {
+    let meta_path = install_dir.join(".install_meta.json");
+    let bytes = std::fs::read(&meta_path).map_err(|e| InstallError::Io {
+        path: meta_path.display().to_string(),
+        source: e,
+    })?;
+    let mut meta: InstalledMeta = serde_json::from_slice(&bytes)?;
+    meta.granted_capabilities = new_grants.to_vec();
+    let new_bytes = serde_json::to_vec_pretty(&meta)?;
+    std::fs::write(&meta_path, new_bytes).map_err(|e| InstallError::Io {
+        path: meta_path.display().to_string(),
+        source: e,
+    })?;
+    Ok(())
+}
+
 fn write_install_meta(staging_dir: &Path, plan: &InstallPlan) -> Result<(), InstallError> {
     let meta = InstalledMeta {
         source: InstallSource::Community,
@@ -921,5 +950,51 @@ mod tests {
         assert_eq!(s.len(), 20);
         assert!(s.ends_with('Z'));
         assert_eq!(&s[10..11], "T");
+    }
+
+    #[test]
+    fn update_granted_capabilities_round_trips_and_preserves_other_fields() {
+        let payload: &[(&[u8], &[u8])] = &[];
+        let _ = payload;
+        let payload: &[(&str, &[u8])] = &[(
+            "plugins/language-grammars/lang-foo/plugin.json",
+            b"{\"name\":\"lang-foo\"}",
+        )];
+        let tarball = make_tarball("root/", payload);
+        let probe = tempdir().unwrap();
+        extract_subtree(&tarball, "plugins/language-grammars/lang-foo", probe.path()).unwrap();
+        let h = verify::content_hash(probe.path()).unwrap();
+
+        let mut plan = make_plan("lang-foo", &h);
+        plan.granted_capabilities = vec!["git".into()];
+        let (_tmp_root, roots) = make_roots();
+        let path = install(&plan, &tarball, &roots).unwrap();
+
+        let before = read_install_meta(&path).unwrap().unwrap();
+        assert_eq!(before.granted_capabilities, vec!["git".to_string()]);
+
+        let new_grants = vec!["git".to_string(), "curl".to_string(), "sh".to_string()];
+        update_granted_capabilities(&path, &new_grants).unwrap();
+
+        let after = read_install_meta(&path).unwrap().unwrap();
+        assert_eq!(after.granted_capabilities, new_grants);
+        // Every other field must be byte-identical.
+        assert_eq!(after.source, before.source);
+        assert_eq!(after.kind, before.kind);
+        assert_eq!(after.registry_sha, before.registry_sha);
+        assert_eq!(after.contribution_sha, before.contribution_sha);
+        assert_eq!(after.sha256, before.sha256);
+        assert_eq!(after.installed_at, before.installed_at);
+        assert_eq!(after.version, before.version);
+    }
+
+    #[test]
+    fn update_granted_capabilities_errors_when_meta_missing() {
+        let dir = tempdir().unwrap();
+        let result = update_granted_capabilities(dir.path(), &["git".to_string()]);
+        match result {
+            Err(InstallError::Io { .. }) => {}
+            other => panic!("expected Io error for missing meta, got {other:?}"),
+        }
     }
 }

--- a/src/community/install.rs
+++ b/src/community/install.rs
@@ -268,9 +268,16 @@ pub fn read_install_meta(install_dir: &Path) -> Result<Option<InstalledMeta>, In
 
 /// Rewrite `.install_meta.json` in `install_dir` so its
 /// `granted_capabilities` field becomes `new_grants`. Every other
-/// field is preserved byte-for-byte. Used by the re-consent flow:
-/// when a plugin update declares new `required_clis` we deny at
-/// runtime until the user explicitly approves and we call this.
+/// field's *value* is preserved (the function deserializes into
+/// `InstalledMeta`, mutates `granted_capabilities`, and serializes
+/// back via `to_vec_pretty`). The exact JSON byte layout — key
+/// ordering, whitespace — may change because the writer is the same
+/// one the installer uses; nothing downstream of this file depends
+/// on the original byte form.
+///
+/// Used by the re-consent flow: when a plugin update declares new
+/// `required_clis` we deny at runtime until the user explicitly
+/// approves and we call this.
 ///
 /// Returns `Err(InstallError::Io)` when the meta file is missing —
 /// callers must validate that the plugin was community-installed
@@ -954,8 +961,6 @@ mod tests {
 
     #[test]
     fn update_granted_capabilities_round_trips_and_preserves_other_fields() {
-        let payload: &[(&[u8], &[u8])] = &[];
-        let _ = payload;
         let payload: &[(&str, &[u8])] = &[(
             "plugins/language-grammars/lang-foo/plugin.json",
             b"{\"name\":\"lang-foo\"}",

--- a/src/community/mod.rs
+++ b/src/community/mod.rs
@@ -14,7 +14,10 @@ pub mod install;
 pub mod types;
 pub mod verify;
 
-pub use install::{InstallError, InstallPlan, InstallRoots, install, read_install_meta, uninstall};
+pub use install::{
+    InstallError, InstallPlan, InstallRoots, install, read_install_meta, uninstall,
+    update_granted_capabilities,
+};
 pub use types::{
     ColorScheme, ContributionKind, ContributionRef, ContributionSource, InstallSource,
     InstalledMeta, PluginEntry, PluginKindWire, PluginsByKind, Registry, RegistrySource,

--- a/src/grammar_provider/mod.rs
+++ b/src/grammar_provider/mod.rs
@@ -608,6 +608,7 @@ mod tests {
             dir: dir.path().to_path_buf(),
             config: HashMap::new(),
             cli_available: true,
+            trust: crate::plugin_runtime::PluginTrust::Unknown,
         };
         // Just confirm we can read its fields.
         assert_eq!(plugin.manifest.name, "smoke");

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -29,12 +29,74 @@ impl fmt::Display for LuaOperationTimeout {
 
 impl std::error::Error for LuaOperationTimeout {}
 
+/// Source-of-trust marker resolved once at discovery time. Drives
+/// whether a plugin's privileged `host.*` calls are gated by stored
+/// `granted_capabilities` (community installs) or pass through with
+/// the live manifest as the allowlist (bundled and hand-installed).
+#[derive(Debug, Clone)]
+pub enum PluginTrust {
+    /// Shipped inside the binary (seeded from `BUNDLED_PLUGINS` on
+    /// startup). The seeder writes a `.version` file alongside
+    /// `init.lua`; presence of that file in a directory whose name
+    /// matches a bundled plugin is the sentinel. Bundled plugins are
+    /// trusted: their `required_clis` is the install-time grant by
+    /// definition.
+    Bundled,
+    /// Installed via the community registry (`.install_meta.json`
+    /// with `source = "community"`). The `Vec<String>` is the
+    /// `granted_capabilities` recorded at install time and is the
+    /// authoritative allowlist for `host.exec`.
+    Community { granted: Vec<String> },
+    /// Plugin directory present in `~/.claudette/plugins/<name>/`
+    /// without an `.install_meta.json` and not matching a bundled
+    /// name. Pre-existing user-installed plugins fall here. We treat
+    /// these as trusted (allowlist = manifest) for backward
+    /// compatibility — flipping to deny is tracked as a follow-up to
+    /// avoid breaking hand-installed setups.
+    Unknown,
+}
+
+impl PluginTrust {
+    /// Effective CLI allowlist for `host.exec`. For community
+    /// plugins this is `manifest.required_clis ∩ granted_capabilities`
+    /// — never broader than what was declared at install. For
+    /// bundled and unknown trust, the manifest itself is the
+    /// allowlist.
+    pub fn effective_allowlist(&self, required: &[String]) -> Vec<String> {
+        match self {
+            Self::Community { granted } => required
+                .iter()
+                .filter(|c| granted.iter().any(|g| g == *c))
+                .cloned()
+                .collect(),
+            Self::Bundled | Self::Unknown => required.to_vec(),
+        }
+    }
+
+    /// Capabilities the live manifest requests that the user has not
+    /// yet approved. Empty for trusted (bundled / unknown) trust;
+    /// for community plugins it's `manifest.required_clis -
+    /// granted_capabilities`. Non-empty means the runtime must fail
+    /// closed and surface a re-consent prompt.
+    pub fn missing_capabilities(&self, required: &[String]) -> Vec<String> {
+        match self {
+            Self::Community { granted } => required
+                .iter()
+                .filter(|c| !granted.iter().any(|g| g == *c))
+                .cloned()
+                .collect(),
+            Self::Bundled | Self::Unknown => Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct LoadedPlugin {
     pub manifest: PluginManifest,
     pub dir: PathBuf,
     pub config: HashMap<String, serde_json::Value>,
     pub cli_available: bool,
+    pub trust: PluginTrust,
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +115,15 @@ pub enum PluginError {
     OperationNotSupported(String),
     PluginNotFound(String),
     PluginDisabled(String),
+    /// The plugin's live manifest declares CLI capabilities that the
+    /// user-approved `granted_capabilities` does not cover. Fail
+    /// closed: the runtime must NOT load the script or invoke
+    /// `host.exec` — the user has to review and approve the new
+    /// capabilities first via the Community settings UI.
+    NeedsReconsent {
+        plugin: String,
+        missing: Vec<String>,
+    },
 }
 
 impl fmt::Display for PluginError {
@@ -72,6 +143,11 @@ impl fmt::Display for PluginError {
             Self::OperationNotSupported(op) => write!(f, "Operation '{op}' is not supported"),
             Self::PluginNotFound(name) => write!(f, "Plugin '{name}' not found"),
             Self::PluginDisabled(name) => write!(f, "Plugin '{name}' is disabled"),
+            Self::NeedsReconsent { plugin, missing } => write!(
+                f,
+                "Plugin '{plugin}' needs re-consent: new capabilities {missing:?}. \
+                 Open Settings → Community to review and approve."
+            ),
         }
     }
 }
@@ -151,6 +227,7 @@ impl PluginRegistry {
                         continue;
                     }
                     let cli_available = check_clis_available(&manifest.required_clis);
+                    let trust = resolve_trust(&manifest.name, &path);
                     let name = manifest.name.clone();
                     plugins.insert(
                         name,
@@ -159,6 +236,7 @@ impl PluginRegistry {
                             dir: path,
                             config: HashMap::new(),
                             cli_available,
+                            trust,
                         },
                     );
                 }
@@ -300,6 +378,23 @@ impl PluginRegistry {
             return Err(PluginError::PluginDisabled(plugin_name.to_string()));
         }
 
+        // Capability gate (#580): for community-installed plugins,
+        // the live manifest's required_clis must be a subset of the
+        // user's approved grants. A plugin update that grew its
+        // required CLI set fails closed here — before init.lua is
+        // even read, and ahead of the cli_available probe so the
+        // user sees the consent prompt regardless of whether the
+        // tool is on PATH.
+        let missing = plugin
+            .trust
+            .missing_capabilities(&plugin.manifest.required_clis);
+        if !missing.is_empty() {
+            return Err(PluginError::NeedsReconsent {
+                plugin: plugin_name.to_string(),
+                missing,
+            });
+        }
+
         if !plugin.cli_available {
             let cli_list = plugin.manifest.required_clis.join(", ");
             return Err(PluginError::CliNotFound(cli_list));
@@ -316,10 +411,13 @@ impl PluginRegistry {
             .await
             .map_err(|e| PluginError::ScriptError(format!("Failed to read init.lua: {e}")))?;
 
+        let allowed_clis = plugin
+            .trust
+            .effective_allowlist(&plugin.manifest.required_clis);
         let ctx = HostContext {
             plugin_name: plugin_name.to_string(),
             kind: plugin.manifest.kind,
-            allowed_clis: plugin.manifest.required_clis.clone(),
+            allowed_clis,
             workspace_info,
             config: self.effective_config(plugin_name),
         };
@@ -429,6 +527,45 @@ fn is_lua_operation_timeout(error: &mlua::Error) -> bool {
 fn check_clis_available(clis: &[String]) -> bool {
     clis.iter()
         .all(|cli| crate::env::which_in_enriched_path(cli).is_ok())
+}
+
+/// Resolve a plugin directory's trust source at discovery time.
+///
+/// Decision order:
+///   1. `.install_meta.json` with `source = "community"` → community
+///      install. Use the recorded `granted_capabilities` as the
+///      authoritative allowlist.
+///   2. Plugin name matches a bundled name AND a `.version` sentinel
+///      is present (written by `seed_bundled_plugins`) → bundled
+///      and trusted.
+///   3. Anything else (no meta, no bundled match) → unknown
+///      hand-installed plugin; trusted for backward compat.
+///
+/// The check is one disk read per plugin at startup, never on hot
+/// paths — `call_operation` consults the cached `LoadedPlugin.trust`.
+fn resolve_trust(name: &str, dir: &Path) -> PluginTrust {
+    if let Ok(Some(meta)) = crate::community::read_install_meta(dir)
+        && meta.source == crate::community::InstallSource::Community
+    {
+        return PluginTrust::Community {
+            granted: meta.granted_capabilities,
+        };
+    }
+    if is_bundled_plugin(name) && dir.join(".version").exists() {
+        return PluginTrust::Bundled;
+    }
+    PluginTrust::Unknown
+}
+
+/// Names of plugins shipped inside the binary. Kept in sync with
+/// `seed::BUNDLED_PLUGINS`; we duplicate the list here to avoid
+/// exposing the seeder's `BundledPlugin` struct in the public API
+/// for what's effectively a name-membership check.
+fn is_bundled_plugin(name: &str) -> bool {
+    matches!(
+        name,
+        "github" | "gitlab" | "env-direnv" | "env-mise" | "env-dotenv" | "env-nix-devshell"
+    )
 }
 
 /// Whether discovery should require an `init.lua` for a plugin of this
@@ -971,5 +1108,346 @@ mod tests {
         // entries in the map.
         let overrides = registry.setting_overrides.read().unwrap();
         assert!(!overrides.contains_key("does-not-exist"));
+    }
+
+    // ---- Capability enforcement (#580) -------------------------------------
+
+    /// Build a plugin directory whose `.install_meta.json` records
+    /// `granted_capabilities` — i.e. the registry-installed shape.
+    /// Manifest `required_clis` is configurable so tests can simulate
+    /// post-install manifest drift (the threat model in #580).
+    fn write_community_plugin(
+        dir: &Path,
+        name: &str,
+        manifest_required_clis: &[&str],
+        granted: &[&str],
+        operations: &[&str],
+        init_lua: &str,
+    ) {
+        let plugin_dir = dir.join(name);
+        std::fs::create_dir(&plugin_dir).unwrap();
+        let manifest = serde_json::json!({
+            "name": name,
+            "display_name": name,
+            "version": "1.0.0",
+            "description": "test plugin",
+            "required_clis": manifest_required_clis,
+            "operations": operations,
+        });
+        std::fs::write(plugin_dir.join("plugin.json"), manifest.to_string()).unwrap();
+        std::fs::write(plugin_dir.join("init.lua"), init_lua).unwrap();
+        let meta = serde_json::json!({
+            "source": "community",
+            "kind": "plugin:scm",
+            "registry_sha": "0".repeat(40),
+            "contribution_sha": "1".repeat(40),
+            "sha256": "2".repeat(64),
+            "installed_at": "2026-05-02T00:00:00Z",
+            "granted_capabilities": granted,
+            "version": "1.0.0",
+        });
+        std::fs::write(
+            plugin_dir.join(".install_meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn community_plugin_with_grant_superset_is_allowed() {
+        // grant ⊇ manifest: pre-flight passes, op runs.
+        let dir = tempfile::tempdir().unwrap();
+        write_community_plugin(
+            dir.path(),
+            "ok-plugin",
+            &[], // empty required_clis so cli_available stays true
+            &["git", "gh"],
+            &["echo"],
+            r#"
+            local M = {}
+            function M.echo() return { ok = true } end
+            return M
+            "#,
+        );
+        let registry = PluginRegistry::discover(dir.path());
+        let trust = &registry.plugins["ok-plugin"].trust;
+        assert!(matches!(trust, PluginTrust::Community { .. }));
+
+        let result = registry
+            .call_operation("ok-plugin", "echo", serde_json::json!({}), test_workspace())
+            .await
+            .expect("op must succeed");
+        assert_eq!(result["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn community_plugin_with_manifest_exceeding_grants_fails_closed() {
+        // grant ⊊ manifest: pre-flight returns NeedsReconsent before
+        // the script even loads. Use a CLI-less manifest? No — we need
+        // required_clis to drift, and `check_clis_available` would deny
+        // first if those CLIs aren't on PATH. Solve by writing the
+        // plugin with empty required_clis at creation, then patching
+        // the manifest so cli_available was already true at discovery.
+        // A simpler approach: write plugin with empty required at
+        // discovery, then mutate the LoadedPlugin fields directly.
+        let dir = tempfile::tempdir().unwrap();
+        write_community_plugin(
+            dir.path(),
+            "drift-plugin",
+            &[], // discovery sees empty list → cli_available = true
+            &["git"],
+            &["op"],
+            r#"
+            local M = {}
+            function M.op() return { ok = true } end
+            return M
+            "#,
+        );
+        let mut registry = PluginRegistry::discover(dir.path());
+        // Simulate post-install manifest drift: registry update grew
+        // required_clis. We mutate in-place rather than re-reading the
+        // manifest because cli_available was determined at discovery
+        // and we don't want PATH-resolution to vary the test.
+        let plugin = registry.plugins.get_mut("drift-plugin").unwrap();
+        plugin.manifest.required_clis =
+            vec!["git".to_string(), "curl".to_string(), "sh".to_string()];
+
+        let result = registry
+            .call_operation(
+                "drift-plugin",
+                "op",
+                serde_json::json!({}),
+                test_workspace(),
+            )
+            .await;
+        match result {
+            Err(PluginError::NeedsReconsent { plugin, missing }) => {
+                assert_eq!(plugin, "drift-plugin");
+                assert_eq!(missing, vec!["curl".to_string(), "sh".to_string()]);
+            }
+            other => panic!("expected NeedsReconsent, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn community_plugin_host_exec_uses_intersection_allowlist() {
+        // Discovery: granted=[git, cargo], manifest=[cargo] → effective
+        // allowlist = [cargo]. host.exec("cargo") works; host.exec("git")
+        // — even though it's granted — is denied because the manifest
+        // doesn't declare it. (Intersection semantics: never broader
+        // than what's in the manifest.)
+        let dir = tempfile::tempdir().unwrap();
+        write_community_plugin(
+            dir.path(),
+            "intersect-plugin",
+            &[], // empty at discovery so cli_available = true
+            &["git", "cargo"],
+            &["run_cargo", "run_git"],
+            r#"
+            local M = {}
+            function M.run_cargo()
+                return host.exec("cargo", {"--version"})
+            end
+            function M.run_git()
+                return host.exec("git", {"--version"})
+            end
+            return M
+            "#,
+        );
+        let mut registry = PluginRegistry::discover(dir.path());
+        // After discovery, narrow the manifest to just `cargo`. The
+        // pre-flight gate sees missing=[] (cargo ∈ grants), so the
+        // call proceeds; host.exec then gates against the
+        // intersection grant ∩ required = {cargo}.
+        let plugin = registry.plugins.get_mut("intersect-plugin").unwrap();
+        plugin.manifest.required_clis = vec!["cargo".to_string()];
+
+        let cargo_result = registry
+            .call_operation(
+                "intersect-plugin",
+                "run_cargo",
+                serde_json::json!({}),
+                test_workspace(),
+            )
+            .await
+            .expect("cargo must execute");
+        assert_eq!(cargo_result["code"], 0);
+
+        let git_result = registry
+            .call_operation(
+                "intersect-plugin",
+                "run_git",
+                serde_json::json!({}),
+                test_workspace(),
+            )
+            .await;
+        assert!(
+            git_result.is_err(),
+            "git must be denied — not in manifest's required_clis"
+        );
+        let err = git_result.unwrap_err().to_string();
+        assert!(
+            err.contains("not in this plugin's allowed CLIs"),
+            "expected allowlist denial, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn community_plugin_missing_install_meta_treated_as_unknown() {
+        // No `.install_meta.json` at all → trust falls through to
+        // Unknown (hand-installed compat). Manifest-required CLIs all
+        // pass. This guards against accidentally promoting "missing
+        // meta" to "deny everything" for legacy installs that pre-date
+        // the grant-recording code.
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("legacy-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{
+                "name": "legacy-plugin",
+                "display_name": "Legacy",
+                "version": "1.0.0",
+                "description": "no meta",
+                "required_clis": [],
+                "operations": ["op"]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            plugin_dir.join("init.lua"),
+            r#"
+            local M = {}
+            function M.op() return { ok = true } end
+            return M
+            "#,
+        )
+        .unwrap();
+
+        let registry = PluginRegistry::discover(dir.path());
+        assert!(matches!(
+            registry.plugins["legacy-plugin"].trust,
+            PluginTrust::Unknown
+        ));
+        let result = registry
+            .call_operation(
+                "legacy-plugin",
+                "op",
+                serde_json::json!({}),
+                test_workspace(),
+            )
+            .await
+            .expect("legacy install with no meta must still run");
+        assert_eq!(result["ok"], true);
+    }
+
+    #[test]
+    fn bundled_plugin_dir_resolves_to_bundled_trust() {
+        // A plugin whose name matches BUNDLED_PLUGINS AND has a
+        // `.version` sentinel from the seeder is trusted. Capability
+        // enforcement is skipped — the bundle's manifest is the
+        // grant by construction.
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("github");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{
+                "name": "github",
+                "display_name": "GitHub",
+                "version": "1.0.0",
+                "description": "bundled",
+                "required_clis": ["git", "gh"],
+                "operations": []
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(plugin_dir.join("init.lua"), "return {}").unwrap();
+        // Sentinel that the seeder writes — proves bundled origin.
+        std::fs::write(plugin_dir.join(".version"), "0.0.0").unwrap();
+
+        let registry = PluginRegistry::discover(dir.path());
+        assert!(matches!(
+            registry.plugins["github"].trust,
+            PluginTrust::Bundled
+        ));
+        // `missing_capabilities` is empty for Bundled regardless of
+        // what the manifest declares — that's the trust bypass.
+        assert!(
+            registry.plugins["github"]
+                .trust
+                .missing_capabilities(&["git".into(), "gh".into(), "anything".into()])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn plugin_trust_effective_allowlist_intersects_for_community() {
+        let trust = PluginTrust::Community {
+            granted: vec!["git".into(), "gh".into()],
+        };
+        let allowed = trust.effective_allowlist(&["git".into(), "curl".into()]);
+        assert_eq!(allowed, vec!["git".to_string()]);
+    }
+
+    #[test]
+    fn plugin_trust_effective_allowlist_passes_through_for_bundled() {
+        let allowed = PluginTrust::Bundled.effective_allowlist(&["git".into(), "anything".into()]);
+        assert_eq!(allowed, vec!["git".to_string(), "anything".to_string()]);
+    }
+
+    #[test]
+    fn plugin_trust_missing_capabilities_diff_for_community() {
+        let trust = PluginTrust::Community {
+            granted: vec!["git".into()],
+        };
+        let missing = trust.missing_capabilities(&["git".into(), "curl".into(), "sh".into()]);
+        assert_eq!(missing, vec!["curl".to_string(), "sh".to_string()]);
+    }
+
+    #[test]
+    fn plugin_trust_missing_capabilities_empty_for_bundled() {
+        assert!(
+            PluginTrust::Bundled
+                .missing_capabilities(&["anything".into()])
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn is_bundled_plugin_recognizes_seeded_names() {
+        assert!(is_bundled_plugin("github"));
+        assert!(is_bundled_plugin("env-direnv"));
+        assert!(!is_bundled_plugin("user-installed"));
+    }
+
+    #[test]
+    fn bundled_name_without_version_sentinel_is_unknown() {
+        // Defense in depth: if a user creates a plugin dir named
+        // `github` but never had it seeded (no `.version`), we treat
+        // it as Unknown rather than auto-promoting to Bundled — a
+        // shadowed bundle could otherwise dodge enforcement.
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("github");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{
+                "name": "github",
+                "display_name": "User Github",
+                "version": "1.0.0",
+                "description": "shadow",
+                "operations": []
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(plugin_dir.join("init.lua"), "return {}").unwrap();
+        // No .version — discovery must NOT mark this as bundled.
+
+        let registry = PluginRegistry::discover(dir.path());
+        assert!(matches!(
+            registry.plugins["github"].trust,
+            PluginTrust::Unknown
+        ));
     }
 }

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -532,40 +532,65 @@ fn check_clis_available(clis: &[String]) -> bool {
 /// Resolve a plugin directory's trust source at discovery time.
 ///
 /// Decision order:
-///   1. `.install_meta.json` with `source = "community"` → community
-///      install. Use the recorded `granted_capabilities` as the
-///      authoritative allowlist.
-///   2. Plugin name matches a bundled name AND a `.version` sentinel
-///      is present (written by `seed_bundled_plugins`) → bundled
-///      and trusted.
-///   3. Anything else (no meta, no bundled match) → unknown
-///      hand-installed plugin; trusted for backward compat.
+/// 1. `.install_meta.json` is present on disk and parses with
+///    `source = "community"` → community install. Use recorded
+///    `granted_capabilities`. If it parses with a non-community
+///    source, fall through. If it fails to parse (corrupt /
+///    truncated / partial write), fail closed: treat as community
+///    with empty grants so the runtime returns `NeedsReconsent`,
+///    rather than silently falling through to Unknown
+///    (allow-everything).
+/// 2. Plugin name matches a bundled name AND a `.version` sentinel
+///    is present (written by `seed_bundled_plugins`) → bundled
+///    and trusted.
+/// 3. Anything else (no meta file, no bundled match) → unknown
+///    hand-installed plugin; trusted for backward compat.
 ///
 /// The check is one disk read per plugin at startup, never on hot
 /// paths — `call_operation` consults the cached `LoadedPlugin.trust`.
 fn resolve_trust(name: &str, dir: &Path) -> PluginTrust {
-    if let Ok(Some(meta)) = crate::community::read_install_meta(dir)
-        && meta.source == crate::community::InstallSource::Community
-    {
-        return PluginTrust::Community {
-            granted: meta.granted_capabilities,
-        };
+    let meta_path = dir.join(".install_meta.json");
+    if meta_path.exists() {
+        match crate::community::read_install_meta(dir) {
+            Ok(Some(meta)) if meta.source == crate::community::InstallSource::Community => {
+                return PluginTrust::Community {
+                    granted: meta.granted_capabilities,
+                };
+            }
+            Ok(Some(_)) => {
+                // Meta file present but not community-sourced
+                // (`direct` / `bundled`). No grant model applies —
+                // fall through to bundled / unknown resolution.
+            }
+            Ok(None) => {
+                // The exists() check passed but the read returned
+                // None — narrow race window where the file
+                // disappeared between checks. Fail closed: treat as
+                // community with empty grants.
+                eprintln!(
+                    "[plugin] {name}: .install_meta.json vanished during discovery — failing closed"
+                );
+                return PluginTrust::Community {
+                    granted: Vec::new(),
+                };
+            }
+            Err(e) => {
+                // Corrupt / truncated / partially-written meta file.
+                // Fail closed rather than silently allowing the
+                // manifest's full required_clis through.
+                eprintln!(
+                    "[plugin] {name}: failed to read .install_meta.json ({e}) — failing closed"
+                );
+                return PluginTrust::Community {
+                    granted: Vec::new(),
+                };
+            }
+        }
     }
-    if is_bundled_plugin(name) && dir.join(".version").exists() {
+    if seed::is_bundled_plugin_name(name) && dir.join(".version").exists() {
         return PluginTrust::Bundled;
     }
     PluginTrust::Unknown
-}
-
-/// Names of plugins shipped inside the binary. Kept in sync with
-/// `seed::BUNDLED_PLUGINS`; we duplicate the list here to avoid
-/// exposing the seeder's `BundledPlugin` struct in the public API
-/// for what's effectively a name-membership check.
-fn is_bundled_plugin(name: &str) -> bool {
-    matches!(
-        name,
-        "github" | "gitlab" | "env-direnv" | "env-mise" | "env-dotenv" | "env-nix-devshell"
-    )
 }
 
 /// Whether discovery should require an `init.lua` for a plugin of this
@@ -1416,9 +1441,50 @@ mod tests {
 
     #[test]
     fn is_bundled_plugin_recognizes_seeded_names() {
-        assert!(is_bundled_plugin("github"));
-        assert!(is_bundled_plugin("env-direnv"));
-        assert!(!is_bundled_plugin("user-installed"));
+        assert!(seed::is_bundled_plugin_name("github"));
+        assert!(seed::is_bundled_plugin_name("env-direnv"));
+        assert!(!seed::is_bundled_plugin_name("user-installed"));
+    }
+
+    #[test]
+    fn corrupt_install_meta_fails_closed_to_empty_grants() {
+        // Defense in depth: a malformed `.install_meta.json`
+        // (corrupt JSON, partial write, manual tampering) must NOT
+        // fall through to PluginTrust::Unknown — that would let the
+        // plugin run with full manifest-required_clis, defeating the
+        // grant model. Resolve to Community { granted: [] } so
+        // `call_operation` returns NeedsReconsent for any non-empty
+        // required_clis.
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("corrupt-meta");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{
+                "name": "corrupt-meta",
+                "display_name": "Corrupt",
+                "version": "1.0.0",
+                "description": "meta is broken",
+                "operations": []
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(plugin_dir.join("init.lua"), "return {}").unwrap();
+        // Garbage bytes — not valid JSON.
+        std::fs::write(
+            plugin_dir.join(".install_meta.json"),
+            "this is not json\x00",
+        )
+        .unwrap();
+
+        let registry = PluginRegistry::discover(dir.path());
+        match &registry.plugins["corrupt-meta"].trust {
+            PluginTrust::Community { granted } => assert!(
+                granted.is_empty(),
+                "corrupt meta must fail closed with empty grants"
+            ),
+            other => panic!("expected Community trust (fail-closed), got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/plugin_runtime/seed.rs
+++ b/src/plugin_runtime/seed.rs
@@ -60,6 +60,14 @@ const BUNDLED_PLUGINS: &[BundledPlugin] = &[
 /// The current app version, used for the .version sentinel file.
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// True iff `name` matches one of the bundled plugin names. Derived
+/// directly from `BUNDLED_PLUGINS` so adding or renaming a bundled
+/// plugin can never silently desync from trust resolution
+/// (`PluginTrust::Bundled` consults this).
+pub fn is_bundled_plugin_name(name: &str) -> bool {
+    BUNDLED_PLUGINS.iter().any(|p| p.name == name)
+}
+
 /// Seed bundled plugins into the plugin directory on app startup.
 ///
 /// Content-hash driven: the `.version` file used to gate this path,

--- a/src/scm/detect.rs
+++ b/src/scm/detect.rs
@@ -239,6 +239,7 @@ mod tests {
             dir: std::path::PathBuf::new(),
             config: std::collections::HashMap::new(),
             cli_available,
+            trust: crate::plugin_runtime::PluginTrust::Unknown,
         }
     }
 }

--- a/src/ui/src/components/settings/sections/CommunitySettings.tsx
+++ b/src/ui/src/components/settings/sections/CommunitySettings.tsx
@@ -2,12 +2,15 @@ import { useCallback, useEffect, useMemo, useState, type MouseEvent } from "reac
 import {
   fetchRegistry,
   flattenRegistry,
+  grantCommunityCapabilities,
   installContribution,
   listInstalled,
+  listPendingReconsent,
   uninstallContribution,
   type BrowseEntry,
   type ContributionKindWire,
   type InstalledContribution,
+  type PendingReconsent,
   type Registry,
 } from "../../../services/community";
 import { refreshGrammars } from "../../../utils/grammarRegistry";
@@ -42,6 +45,9 @@ export function CommunitySettings() {
   const [tab, setTab] = useState<Tab>("browse");
   const [registry, setRegistry] = useState<Registry | null>(null);
   const [installed, setInstalled] = useState<InstalledContribution[] | null>(null);
+  const [pendingReconsent, setPendingReconsent] = useState<PendingReconsent[]>(
+    [],
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busyIdent, setBusyIdent] = useState<string | null>(null);
@@ -51,18 +57,36 @@ export function CommunitySettings() {
     setLoading(true);
     setError(null);
     try {
-      const [reg, inst] = await Promise.all([
+      const [reg, inst, pending] = await Promise.all([
         fetchRegistry(false),
         listInstalled(),
+        listPendingReconsent(),
       ]);
       setRegistry(reg);
       setInstalled(inst);
+      setPendingReconsent(pending);
     } catch (e) {
       setError(String(e));
     } finally {
       setLoading(false);
     }
   }, []);
+
+  const handleApproveReconsent = useCallback(
+    async (ident: string) => {
+      setBusyIdent(`reconsent:${ident}`);
+      setError(null);
+      try {
+        await grantCommunityCapabilities(ident);
+        await refresh();
+      } catch (e) {
+        setError(String(e));
+      } finally {
+        setBusyIdent(null);
+      }
+    },
+    [refresh],
+  );
 
   useEffect(() => {
     void refresh();
@@ -141,6 +165,65 @@ export function CommunitySettings() {
         . Each install is verified against the published content hash before
         anything lands on disk.
       </div>
+
+      {pendingReconsent.length > 0 && (
+        <ul className={own.list}>
+          {pendingReconsent.map((p) => {
+            const isBusy = busyIdent === `reconsent:${p.ident}`;
+            return (
+              <li key={p.ident} className={own.row}>
+                <div className={own.rowHeader}>
+                  <strong>{p.display_name}</strong>
+                  <span className={own.meta}>needs re-consent</span>
+                </div>
+                <p className={own.description}>
+                  This plugin's update requested new CLI capabilities. The
+                  plugin is blocked from running until you review and
+                  approve.
+                </p>
+                <p className={own.meta}>
+                  Already approved:{" "}
+                  {p.granted.length === 0 ? (
+                    <em>none</em>
+                  ) : (
+                    p.granted.map((c) => (
+                      <code key={c} className={own.cli}>
+                        {c}
+                      </code>
+                    ))
+                  )}
+                </p>
+                <p className={own.meta}>
+                  New capabilities requested:{" "}
+                  {p.missing.map((c) => (
+                    <code key={c} className={own.cli}>
+                      {c}
+                    </code>
+                  ))}
+                </p>
+                <div className={own.actions}>
+                  <button
+                    type="button"
+                    className={own.primaryButton}
+                    disabled={isBusy}
+                    onClick={() => handleApproveReconsent(p.ident)}
+                  >
+                    {isBusy ? "Approving…" : "Approve new capabilities"}
+                  </button>
+                  <button
+                    type="button"
+                    className={own.dangerButton}
+                    disabled={isBusy}
+                    onClick={() => handleUninstall(p.kind, p.ident)}
+                  >
+                    Uninstall
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
 
       <div className={own.tabRow}>
         <button

--- a/src/ui/src/services/community.ts
+++ b/src/ui/src/services/community.ts
@@ -121,6 +121,29 @@ export function listInstalled(): Promise<InstalledContribution[]> {
   return invoke("community_list_installed");
 }
 
+export interface PendingReconsent {
+  kind: ContributionKindWire;
+  ident: string;
+  display_name: string;
+  granted: string[];
+  missing: string[];
+}
+
+/** List community plugins whose live manifest declares CLI
+ *  capabilities the user hasn't yet approved. While present, those
+ *  plugins fail closed at every `host.exec` and the operation
+ *  surfaces a "needs re-consent" error. */
+export function listPendingReconsent(): Promise<PendingReconsent[]> {
+  return invoke("community_pending_reconsent");
+}
+
+/** Approve the live manifest's required_clis as the new grant set
+ *  for a community plugin. Rewrites `.install_meta.json` and
+ *  rehydrates the runtime. The next operation succeeds. */
+export function grantCommunityCapabilities(ident: string): Promise<void> {
+  return invoke("community_grant_capabilities", { ident });
+}
+
 /** Helper: flatten a Registry into a single typed list useful for
  *  rendering a single browse grid filtered by kind. */
 export interface BrowseEntry {

--- a/tests/grants_enforcement.rs
+++ b/tests/grants_enforcement.rs
@@ -1,0 +1,239 @@
+//! End-to-end exercise of the granted_capabilities enforcement flow
+//! introduced for issue #580. Walks the full path a user takes:
+//!
+//!   1. Install a community plugin via the registry installer.
+//!   2. Discover it through `PluginRegistry::discover` and confirm
+//!      `PluginTrust::Community` is resolved with the install-time
+//!      grants.
+//!   3. Run an operation — succeeds because the manifest's
+//!      `required_clis` is a subset of grants.
+//!   4. Simulate a malicious / drift manifest update by rewriting
+//!      `plugin.json` to declare a new CLI. Re-discover.
+//!   5. Run the operation again — fails closed with
+//!      `PluginError::NeedsReconsent { missing }`.
+//!   6. Approve the new capabilities via
+//!      `community::update_granted_capabilities`. Re-discover.
+//!   7. Run the operation a third time — succeeds.
+//!
+//! This is the acceptance criteria #580 calls out, exercised
+//! through the same plumbing the live Tauri commands use.
+
+use std::path::Path;
+
+use claudette::community::{
+    self, ContributionKind, ContributionSource, InstallPlan, InstallRoots, PluginKindWire,
+};
+use claudette::plugin_runtime::host_api::WorkspaceInfo;
+use claudette::plugin_runtime::{PluginError, PluginRegistry, PluginTrust};
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+const PLUGIN_NAME: &str = "scm-fake";
+
+fn make_tarball(prefix: &str, entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let gz = GzEncoder::new(&mut tar_bytes, Compression::fast());
+        let mut builder = tar::Builder::new(gz);
+        for (path, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, format!("{prefix}{path}"), *data)
+                .unwrap();
+        }
+        builder.finish().unwrap();
+    }
+    tar_bytes
+}
+
+fn workspace(dir: &Path) -> WorkspaceInfo {
+    WorkspaceInfo {
+        id: "ws-1".into(),
+        name: "test".into(),
+        branch: "main".into(),
+        worktree_path: dir.to_string_lossy().into_owned(),
+        repo_path: dir.to_string_lossy().into_owned(),
+    }
+}
+
+#[tokio::test]
+async fn community_plugin_capability_lifecycle() {
+    let manifest_v1 = serde_json::json!({
+        "name": PLUGIN_NAME,
+        "display_name": "Fake SCM",
+        "version": "1.0.0",
+        "description": "Test plugin for grant enforcement",
+        // Empty required_clis at install time so the install-time
+        // grant is also empty — the grant ⊇ manifest invariant
+        // holds trivially. We test the manifest-grew threat model
+        // by rewriting plugin.json after install.
+        "required_clis": [],
+        "operations": ["run"]
+    });
+
+    let init_lua = "local M = {}\nfunction M.run(_)\n  return { ok = true }\nend\nreturn M\n";
+
+    let manifest_v1_bytes = manifest_v1.to_string();
+    let entries: Vec<(&str, &[u8])> = vec![
+        (
+            "plugins/scm/scm-fake/plugin.json",
+            manifest_v1_bytes.as_bytes(),
+        ),
+        ("plugins/scm/scm-fake/init.lua", init_lua.as_bytes()),
+    ];
+    let tarball = make_tarball("repo-root/", &entries);
+
+    // Compute the content hash the same way the installer + verify
+    // module does. Extract once into a probe dir.
+    let probe = tempfile::tempdir().unwrap();
+    {
+        // Reach into the lib for the same extraction the installer
+        // uses. We can't call `extract_subtree` (private), but
+        // installing into a probe dir gives us the verified hash by
+        // running the installer twice — so do it differently:
+        // hash the staged directory by hand. The verify module is
+        // re-exported.
+        let plugin_dir = probe.path().join("plugins/scm/scm-fake");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(plugin_dir.join("plugin.json"), manifest_v1_bytes.as_bytes()).unwrap();
+        std::fs::write(plugin_dir.join("init.lua"), init_lua).unwrap();
+    }
+
+    // The installer's verify is content-hash over the plugin
+    // directory only. Compute the same way:
+    let staged = probe.path().join("plugins/scm/scm-fake");
+    let sha = community::content_hash(&staged).unwrap();
+
+    // Install roots under a fresh tempdir.
+    let roots_tmp = tempfile::tempdir().unwrap();
+    let roots = InstallRoots {
+        plugins_dir: roots_tmp.path().join("plugins"),
+        themes_dir: roots_tmp.path().join("themes"),
+    };
+
+    // Install the plugin with empty granted_capabilities (mirrors a
+    // user clicking install on a plugin whose registry-snapshot
+    // required_clis was []).
+    let plan = InstallPlan {
+        kind: ContributionKind::Plugin(PluginKindWire::Scm),
+        ident: PLUGIN_NAME.into(),
+        source: ContributionSource::InTree {
+            path: "plugins/scm/scm-fake".into(),
+            sha: "1".repeat(40),
+            sha256: sha.clone(),
+        },
+        version: "1.0.0".into(),
+        granted_capabilities: vec![], // empty grant at install time
+        registry_sha: "2".repeat(40),
+    };
+    let install_path = community::install(&plan, &tarball, &roots).expect("install");
+    let installed_meta = community::read_install_meta(&install_path)
+        .unwrap()
+        .unwrap();
+    assert!(
+        installed_meta.granted_capabilities.is_empty(),
+        "fresh install records empty grants"
+    );
+
+    // ---- Step 2: discover --------------------------------------------------
+    let registry = PluginRegistry::discover(&roots.plugins_dir);
+    let trust = &registry
+        .plugins
+        .get(PLUGIN_NAME)
+        .expect("plugin discovered")
+        .trust;
+    match trust {
+        PluginTrust::Community { granted } => assert!(granted.is_empty()),
+        other => panic!("expected Community trust, got {other:?}"),
+    }
+
+    // ---- Step 3: op succeeds (manifest required_clis is empty) -------------
+    let result = registry
+        .call_operation(
+            PLUGIN_NAME,
+            "run",
+            serde_json::json!({}),
+            workspace(roots_tmp.path()),
+        )
+        .await
+        .expect("first run must succeed");
+    assert_eq!(result["ok"], true);
+
+    // ---- Step 4: simulate manifest drift -----------------------------------
+    // A registry update bumps required_clis to include `git`. Edit
+    // the on-disk manifest in place. Re-discover so the runtime
+    // sees the new manifest but the grant set in
+    // `.install_meta.json` is still empty.
+    let manifest_path = install_path.join("plugin.json");
+    let manifest_v2 = serde_json::json!({
+        "name": PLUGIN_NAME,
+        "display_name": "Fake SCM",
+        "version": "1.0.0",
+        "description": "Test plugin for grant enforcement",
+        "required_clis": ["git", "curl"],
+        "operations": ["run"]
+    });
+    std::fs::write(&manifest_path, manifest_v2.to_string()).unwrap();
+
+    let registry = PluginRegistry::discover(&roots.plugins_dir);
+    // Trust still says Community with empty grants — the
+    // .install_meta.json wasn't touched.
+    match &registry.plugins[PLUGIN_NAME].trust {
+        PluginTrust::Community { granted } => assert!(granted.is_empty()),
+        other => panic!("expected Community trust, got {other:?}"),
+    }
+
+    // ---- Step 5: op now fails closed with NeedsReconsent -------------------
+    let result = registry
+        .call_operation(
+            PLUGIN_NAME,
+            "run",
+            serde_json::json!({}),
+            workspace(roots_tmp.path()),
+        )
+        .await;
+    match result {
+        Err(PluginError::NeedsReconsent { plugin, missing }) => {
+            assert_eq!(plugin, PLUGIN_NAME);
+            assert_eq!(missing, vec!["git".to_string(), "curl".to_string()]);
+        }
+        other => panic!("expected NeedsReconsent, got {other:?}"),
+    }
+
+    // ---- Step 6: user approves the new grants ------------------------------
+    community::update_granted_capabilities(&install_path, &["git".to_string(), "curl".to_string()])
+        .expect("update grants");
+    let after_grant = community::read_install_meta(&install_path)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after_grant.granted_capabilities,
+        vec!["git".to_string(), "curl".to_string()]
+    );
+
+    // Re-discover to pick up the new grants. (The Tauri command
+    // `community_grant_capabilities` does this via
+    // `rehydrate_plugin_registry`.)
+    let registry = PluginRegistry::discover(&roots.plugins_dir);
+    match &registry.plugins[PLUGIN_NAME].trust {
+        PluginTrust::Community { granted } => {
+            assert_eq!(granted, &vec!["git".to_string(), "curl".to_string()]);
+        }
+        other => panic!("expected Community trust, got {other:?}"),
+    }
+
+    // ---- Step 7: op succeeds again -----------------------------------------
+    let result = registry
+        .call_operation(
+            PLUGIN_NAME,
+            "run",
+            serde_json::json!({}),
+            workspace(roots_tmp.path()),
+        )
+        .await
+        .expect("third run must succeed after re-consent");
+    assert_eq!(result["ok"], true);
+}

--- a/tests/grants_enforcement.rs
+++ b/tests/grants_enforcement.rs
@@ -163,17 +163,18 @@ async fn community_plugin_capability_lifecycle() {
     assert_eq!(result["ok"], true);
 
     // ---- Step 4: simulate manifest drift -----------------------------------
-    // A registry update bumps required_clis to include `git`. Edit
-    // the on-disk manifest in place. Re-discover so the runtime
-    // sees the new manifest but the grant set in
-    // `.install_meta.json` is still empty.
+    // A registry update bumps required_clis. We use `cargo` because
+    // it is guaranteed to be on PATH whenever this test runs (the
+    // test harness needs it to compile in the first place) — that
+    // keeps step 7 hermetic, since `cli_available` is probed against
+    // PATH at re-discovery.
     let manifest_path = install_path.join("plugin.json");
     let manifest_v2 = serde_json::json!({
         "name": PLUGIN_NAME,
         "display_name": "Fake SCM",
         "version": "1.0.0",
         "description": "Test plugin for grant enforcement",
-        "required_clis": ["git", "curl"],
+        "required_clis": ["cargo"],
         "operations": ["run"]
     });
     std::fs::write(&manifest_path, manifest_v2.to_string()).unwrap();
@@ -198,21 +199,18 @@ async fn community_plugin_capability_lifecycle() {
     match result {
         Err(PluginError::NeedsReconsent { plugin, missing }) => {
             assert_eq!(plugin, PLUGIN_NAME);
-            assert_eq!(missing, vec!["git".to_string(), "curl".to_string()]);
+            assert_eq!(missing, vec!["cargo".to_string()]);
         }
         other => panic!("expected NeedsReconsent, got {other:?}"),
     }
 
     // ---- Step 6: user approves the new grants ------------------------------
-    community::update_granted_capabilities(&install_path, &["git".to_string(), "curl".to_string()])
+    community::update_granted_capabilities(&install_path, &["cargo".to_string()])
         .expect("update grants");
     let after_grant = community::read_install_meta(&install_path)
         .unwrap()
         .unwrap();
-    assert_eq!(
-        after_grant.granted_capabilities,
-        vec!["git".to_string(), "curl".to_string()]
-    );
+    assert_eq!(after_grant.granted_capabilities, vec!["cargo".to_string()]);
 
     // Re-discover to pick up the new grants. (The Tauri command
     // `community_grant_capabilities` does this via
@@ -220,7 +218,7 @@ async fn community_plugin_capability_lifecycle() {
     let registry = PluginRegistry::discover(&roots.plugins_dir);
     match &registry.plugins[PLUGIN_NAME].trust {
         PluginTrust::Community { granted } => {
-            assert_eq!(granted, &vec!["git".to_string(), "curl".to_string()]);
+            assert_eq!(granted, &vec!["cargo".to_string()]);
         }
         other => panic!("expected Community trust, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

- Community plugins now fail closed when a manifest update grows `required_clis` beyond the user-approved grants recorded at install.
- Bundled plugins remain trusted (no enforcement); hand-installed plugins keep current allow-everything semantics for backward compatibility.
- Adds a re-consent UI banner in Settings → Community that diffs granted vs requested capabilities and offers Approve / Uninstall.

## Why

`granted_capabilities` was recorded at install (\`src/community/install.rs:269-287\`) but never consulted at runtime — \`host.exec\` was gated by the live manifest's \`required_clis\`. A registry update (or a compromise of the registry repo) could silently grow the allowlist without re-consent. See #580.

## What changed

- \`src/plugin_runtime/mod.rs\` — new \`PluginTrust\` resolved at \`discover\` time (\`Bundled | Community { granted } | Unknown\`); \`call_operation\` fails closed with \`PluginError::NeedsReconsent { plugin, missing }\` when the live manifest's \`required_clis\` is not a subset of stored grants. \`HostContext.allowed_clis\` is now the intersection \`grants ∩ manifest\` for community plugins.
- \`src/community/install.rs\` — adds \`update_granted_capabilities\` to rewrite \`.install_meta.json\` in place when the user approves new capabilities.
- \`src-tauri/src/commands/community.rs\` — adds \`community_pending_reconsent\` and \`community_grant_capabilities\` Tauri commands.
- \`src/ui/src/components/settings/sections/CommunitySettings.tsx\` + \`services/community.ts\` — polls pending re-consent on mount, renders a banner with the diff and Approve / Uninstall actions.
- Tests:
  - Unit tests for trust resolution, allowlist intersection, missing-capability diff, and the `bundled name without .version sentinel → Unknown` defense-in-depth case.
  - End-to-end \`tests/grants_enforcement.rs\` exercising install → discover → run → manifest drift → fail-closed → approve → run.

## Test plan

- [x] \`cargo test --all-features --workspace\` (889 + 179 + 4 + integration = all green)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] Frontend: \`bunx tsc -b\`, \`bun run test\` (1118 tests), \`bun run lint:css\` clean
- [x] UAT integration test (\`tests/grants_enforcement.rs\`) walks the full lifecycle: empty grants → manifest grows → \`NeedsReconsent\` → approve → succeeds.