### PR TITLE
feat(community): verify minisign-signed registry + commit-pin install URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "flate2",
  "futures",
  "interprocess",
+ "minisign-verify",
  "mlua",
  "notify",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ dirs = "6"
 open = "5"
 mlua = { version = "0.10", features = ["luau", "serialize", "async", "send"] }
 flate2 = "1"
+# Pure-Rust minisign signature verification. Already in our dep tree
+# transitively via tauri-plugin-updater; pulling it in directly so the
+# community-registry signature check has a stable, named dep. We only
+# verify (never sign) on the client, so the verifier-only crate is the
+# right shape and keeps the binary slim.
+minisign-verify = "0.2"
 # Cross-platform filesystem watcher used by env-provider reactive
 # invalidation. RecommendedWatcher picks FSEvents (macOS), inotify
 # (Linux), and ReadDirectoryChangesW (Windows) — single API across all

--- a/flake.nix
+++ b/flake.nix
@@ -387,6 +387,14 @@
               # generation; awscli2 drives the EC2 API calls.
               pkgs.awscli2
               pkgs.openssl
+              # Community registry signing — minisign is the canonical C
+              # impl, rsign2 (binary name `rsign`) is the pure-Rust signer.
+              # Either signs/verifies the same on-wire format. Used by
+              # claudette-community CI to sign registry.json; mirrored
+              # into the devshell so maintainers can re-sign locally
+              # when bootstrapping a new key or auditing a published sig.
+              pkgs.minisign
+              pkgs.rsign2
             ]
             ++ darwinBuildInputs
             ++ linuxBuildInputs

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
             { slug: 'features/keyboard-shortcuts' },
             { slug: 'features/per-repo-settings' },
             { slug: 'features/settings' },
+            { slug: 'features/community-registry-trust' },
           ],
         },
         {

--- a/site/src/content/docs/features/community-registry-trust.mdx
+++ b/site/src/content/docs/features/community-registry-trust.mdx
@@ -1,0 +1,91 @@
+---
+title: Community Registry Trust Model
+description: How Claudette verifies the integrity of community themes, plugins, and grammars.
+---
+
+The community registry lets Claudette discover and install third-party themes, plugins, and language grammars from [`utensils/claudette-community`](https://github.com/utensils/claudette-community). Because installed extensions run inside Claudette — Lua plugins drive your SCM tab, grammars set how your code is highlighted — the bytes Claudette downloads have to be authenticated before they hit your disk.
+
+This page describes the trust chain that protects that path.
+
+## The trust anchor: an embedded minisign public key
+
+Claudette ships with a [minisign](https://jedisct1.github.io/minisign/) public key compiled directly into its binary. The matching secret key lives only in GitHub Actions Secrets on the `claudette-community` repository — it never leaves CI, and it's never on a contributor's machine.
+
+The current key fingerprint is:
+
+```
+982022ABB1139C7B
+```
+
+The same public key bytes are also published in plaintext at [`keys/community-registry.pub`](https://github.com/utensils/claudette-community/blob/main/keys/community-registry.pub) for transparency, so you can compare what's in `claudette-community` against what's embedded in a Claudette release. The authoritative copy is the embedded one — the file in `claudette-community` is informational.
+
+## What gets verified, and when
+
+Every time you open the Community section of Settings or click Install, Claudette:
+
+1. Fetches `registry.json` and `registry.json.sig` in parallel from `raw.githubusercontent.com/utensils/claudette-community/main/`.
+2. Verifies that `registry.json.sig` is a valid minisign signature over `registry.json` produced by the embedded public key.
+3. Only then parses `registry.json`.
+4. When you click Install, downloads the contribution tarball from `codeload.github.com/utensils/claudette-community/tar.gz/<commit-sha>` — pinned to the commit SHA the verified registry attests to, never to a mutable branch ref.
+5. Recomputes the per-contribution content `sha256` from the unpacked bytes and compares against the value in the verified registry.
+
+If any step fails — missing signature, signature signed by a key Claudette doesn't trust, content hash mismatch — the install is refused with a user-visible error and nothing is written to disk.
+
+## What this protects against
+
+| Attack | Mitigation |
+|---|---|
+| Maintainer's GitHub account compromised; attacker pushes a malicious `registry.json` | Attacker doesn't have the signing key — the new file fails sig verification, no install |
+| Network MITM (misconfigured CA, hostile WiFi, etc.) swaps registry bytes | Same — sig won't verify against the embedded key |
+| Attacker rewrites the codeload tarball at `<commit-sha>` after publication | GitHub commit SHAs are immutable; rewriting them requires breaking SHA-1, and the secondary `sha256` content hash gates the install regardless |
+| Replay of an older signed registry to suppress a security update | Mitigated partially — the older registry still pins each contribution to its `sha256`; revocation list (forthcoming, see [issue #581](https://github.com/utensils/Claudette/issues/581)) closes this fully |
+| Tampering with `registry.json.sig` on the network | Sig fails to decode or fails to verify; install refused |
+
+## What this does NOT protect against (yet)
+
+- **Compromise of the CI signing key itself.** If the GitHub Actions secret leaks, an attacker can sign whatever they want. Mitigation: rotate the key (see below) and revoke compromised contributions. A proper transparency log (sigstore, etc.) is on the roadmap.
+- **Malicious contributions submitted normally.** The signature only attests that *this is what the maintainers reviewed* — not that what they reviewed is safe. PR review of new contributions is the human-in-the-loop gate.
+- **`revocations.json` is not yet signed.** The same gap that motivated this work exists for the revocation list. A follow-up PR will sign it the same way.
+
+## Key rotation
+
+Rotation is coordinated across two repositories and one Claudette release:
+
+1. **Generate a new keypair** with `minisign -G -W -p next.pub -s next.key` (or `rsign generate -W`).
+2. **Open a Claudette PR** that adds `next.pub` alongside the current pubkey in [`src/community/trust/`](https://github.com/utensils/Claudette/tree/main/src/community/trust). The verifier accepts a signature from any embedded key.
+3. **Release Claudette N+1** with both keys embedded. Wait for it to roll out to most users.
+4. **Switch the CI signer** by updating `COMMUNITY_REGISTRY_MINISIGN_SECRET_KEY` in `claudette-community` repo settings. The next push to `main` re-signs `registry.json` with the new key. Existing installations of Claudette N+1 keep working because both keys are accepted.
+5. **Open a Claudette PR** that removes the old key.
+6. **Release Claudette N+2.** Old key is gone; rotation complete.
+
+Today there's a single key. The verifier API takes a slice of public keys, so adding a second one is a one-line code change once you have the new `.pub` file.
+
+## Verifying a published registry yourself
+
+If you want to confirm a published registry hasn't been tampered with, install [minisign](https://jedisct1.github.io/minisign/) and run:
+
+```sh
+curl -sLO https://raw.githubusercontent.com/utensils/claudette-community/main/registry.json
+curl -sLO https://raw.githubusercontent.com/utensils/claudette-community/main/registry.json.sig
+curl -sLO https://raw.githubusercontent.com/utensils/claudette-community/main/keys/community-registry.pub
+minisign -V -p community-registry.pub -m registry.json -x registry.json.sig
+```
+
+Expected output:
+
+```
+Signature and comment signature verified
+Trusted comment: claudette-community registry signed at <ISO-8601> for source.sha=<git-sha>
+```
+
+The trusted comment binds the signature to a specific commit SHA. You can confirm that SHA exists on `main`:
+
+```sh
+git ls-remote https://github.com/utensils/claudette-community.git main
+```
+
+## See also
+
+- [`utensils/claudette-community/keys/README.md`](https://github.com/utensils/claudette-community/blob/main/keys/README.md) — the published pubkey + maintainer-side rotation procedure
+- [Claudette issue #581](https://github.com/utensils/Claudette/issues/581) — the supply-chain audit that motivated this work
+- [Claudette issue #567](https://github.com/utensils/Claudette/issues/567) — the community registry TDD

--- a/src-tauri/src/commands/community.rs
+++ b/src-tauri/src/commands/community.rs
@@ -35,11 +35,27 @@ use crate::state::AppState;
 const REGISTRY_URL: &str =
     "https://raw.githubusercontent.com/utensils/claudette-community/main/registry.json";
 
+/// Detached minisign signature for [`REGISTRY_URL`]. Fetched in
+/// parallel with the registry; verified against an embedded public
+/// key (see `claudette::community::signature`) before the JSON is
+/// parsed. The .sig URL is also on mutable `main`, but its bytes
+/// only verify against an *immutable* embedded pubkey — an attacker
+/// who swaps it can DoS but not forge.
+const REGISTRY_SIG_URL: &str =
+    "https://raw.githubusercontent.com/utensils/claudette-community/main/registry.json.sig";
+
 /// `codeload.github.com/<repo>/tar.gz/<sha>` template. The `<repo>`
 /// is intentionally pinned — installing from arbitrary repos is the
 /// "direct install" path (PR #4), not this command.
 fn codeload_url(repo: &str, sha: &str) -> String {
     format!("https://codeload.github.com/{repo}/tar.gz/{sha}")
+}
+
+/// Pinned URL for an `External` mirror tarball. Uses the registry's
+/// `source.sha` rather than the mutable `main` ref so the bytes we
+/// fetch are bound to a specific commit reviewable in git history.
+fn mirror_url(repo: &str, sha: &str, mirror_path: &str) -> String {
+    format!("https://raw.githubusercontent.com/{repo}/{sha}/{mirror_path}")
 }
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
@@ -53,26 +69,47 @@ fn http_client() -> Result<reqwest::Client, String> {
 }
 
 /// Fetch and parse the community registry.
+///
+/// Trust path:
+///   1. Fetch `registry.json` and `registry.json.sig` in parallel.
+///   2. Verify the signature against the pubkey embedded in the
+///      Claudette binary (`claudette::community::verify_registry_signature`).
+///   3. Only after the sig verifies, parse the JSON.
+///
+/// Any of the three steps failing produces a distinct, user-visible
+/// error so the UI can distinguish "missing signature" (publication
+/// failure) from "invalid signature" (tamper / wrong key) from
+/// "parse error" (signed but malformed JSON).
 #[tauri::command]
 pub async fn community_registry_fetch(_force: bool) -> Result<Registry, String> {
     let client = http_client()?;
+    let (json_bytes, sig_bytes) = tokio::try_join!(
+        fetch_url_bytes(&client, REGISTRY_URL, "registry"),
+        fetch_url_bytes(&client, REGISTRY_SIG_URL, "registry signature"),
+    )?;
+    claudette::community::verify_registry_signature(&json_bytes, &sig_bytes)
+        .map_err(|e| format!("registry signature: {e}"))?;
+    serde_json::from_slice(&json_bytes).map_err(|e| format!("registry parse: {e}"))
+}
+
+async fn fetch_url_bytes(
+    client: &reqwest::Client,
+    url: &str,
+    label: &str,
+) -> Result<Vec<u8>, String> {
     let resp = client
-        .get(REGISTRY_URL)
+        .get(url)
         .send()
         .await
-        .map_err(|e| format!("registry fetch: {e}"))?;
+        .map_err(|e| format!("{label} fetch: {e}"))?;
     if !resp.status().is_success() {
-        return Err(format!(
-            "registry fetch returned {}: {}",
-            resp.status(),
-            REGISTRY_URL
-        ));
+        return Err(format!("{label} fetch returned {}: {url}", resp.status()));
     }
     let bytes = resp
         .bytes()
         .await
-        .map_err(|e| format!("registry body: {e}"))?;
-    serde_json::from_slice(&bytes).map_err(|e| format!("registry parse: {e}"))
+        .map_err(|e| format!("{label} body: {e}"))?;
+    Ok(bytes.to_vec())
 }
 
 /// Frontend-facing summary of an installed contribution. Sent to the
@@ -129,6 +166,11 @@ pub async fn community_install(
         granted_capabilities: entry.capabilities(),
         registry_sha: registry.source.sha.clone(),
     };
+    // Commit-pin the download URL to registry.source.sha — the SHA
+    // that the just-verified signature attests to. Per-entry sha is
+    // still recorded in .install_meta.json for diagnostics, but the
+    // bytes we fetch come from one reviewable commit, not N.
+    let registry_source_sha = registry.source.sha.clone();
     let display_name = match &entry {
         community::ContributionRef::Theme(t) => t.name.clone(),
         community::ContributionRef::Plugin(p) => p.display_name.clone(),
@@ -142,7 +184,7 @@ pub async fn community_install(
         community::ContributionRef::Plugin(p) => p.license.clone(),
     };
 
-    let tarball = fetch_tarball(&plan).await?;
+    let tarball = fetch_tarball(&plan, &registry_source_sha).await?;
     let roots = resolve_install_roots(&state).await?;
     tokio::fs::create_dir_all(&roots.plugins_dir)
         .await
@@ -480,17 +522,26 @@ pub async fn community_grant_capabilities(
 // Helpers
 // ---------------------------------------------------------------------------
 
-async fn fetch_tarball(plan: &InstallPlan) -> Result<Vec<u8>, String> {
+async fn fetch_tarball(plan: &InstallPlan, registry_source_sha: &str) -> Result<Vec<u8>, String> {
+    // Both URL forms commit-pin to `registry_source_sha` — the commit
+    // SHA that the just-verified signature attests to. The per-entry
+    // `source.sha` is the commit that last touched the contribution
+    // dir, which equals registry.source.sha for any freshly-regenerated
+    // registry (regen.yml runs on every push to main); using
+    // registry.source.sha consistently here makes the URL bind to one
+    // reviewable commit even in the rare drift case.
     let url = match &plan.source {
-        ContributionSource::InTree { sha, .. } => {
+        ContributionSource::InTree { .. } => {
             // PR #2 only handles in-tree contributions — the registry
             // schema rejects external themes outright, and we have no
             // external plugins yet. Direct-install (PR #4) handles
             // arbitrary repos.
-            codeload_url("utensils/claudette-community", sha)
+            codeload_url("utensils/claudette-community", registry_source_sha)
         }
-        ContributionSource::External { mirror_path, .. } => format!(
-            "https://raw.githubusercontent.com/utensils/claudette-community/main/{mirror_path}"
+        ContributionSource::External { mirror_path, .. } => mirror_url(
+            "utensils/claudette-community",
+            registry_source_sha,
+            mirror_path,
         ),
     };
 
@@ -600,4 +651,60 @@ fn read_theme_manifest(dir: &std::path::Path) -> Result<ThemeManifestLite, Strin
     let path = dir.join("theme.json");
     let bytes = std::fs::read(&path).map_err(|e| format!("read theme.json: {e}"))?;
     serde_json::from_slice(&bytes).map_err(|e| format!("parse theme.json: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// codeload URL is built from the repo + a single commit SHA;
+    /// constructing the URL is a pure function and the only place we
+    /// can test commit-pinning without spinning up an HTTP server.
+    /// The behavioral guarantee: nothing about the URL ever encodes
+    /// `main` or any other mutable ref.
+    #[test]
+    fn codeload_url_uses_immutable_commit_sha() {
+        let url = codeload_url(
+            "utensils/claudette-community",
+            "382298b4206010cea7865ae811c39e2a90d5c7fa",
+        );
+        assert_eq!(
+            url,
+            "https://codeload.github.com/utensils/claudette-community/tar.gz/382298b4206010cea7865ae811c39e2a90d5c7fa"
+        );
+        assert!(!url.contains("/main"));
+        assert!(!url.contains("HEAD"));
+    }
+
+    /// External (mirror) URL must also commit-pin to registry.source.sha.
+    /// Pre-PR, this URL was constructed against `main` — the bug being
+    /// fixed in this PR. Lock the commit-pinned shape in.
+    #[test]
+    fn mirror_url_pins_to_registry_source_sha_not_main() {
+        let url = mirror_url(
+            "utensils/claudette-community",
+            "382298b4206010cea7865ae811c39e2a90d5c7fa",
+            "mirrors/foo-bar-1234.tar.gz",
+        );
+        assert_eq!(
+            url,
+            "https://raw.githubusercontent.com/utensils/claudette-community/382298b4206010cea7865ae811c39e2a90d5c7fa/mirrors/foo-bar-1234.tar.gz"
+        );
+        assert!(!url.contains("/main/"));
+    }
+
+    /// Sanity: REGISTRY_SIG_URL must sit next to REGISTRY_URL on the
+    /// same path so swapping one without the other is server-visible.
+    /// (Anyone with write to the community repo can update both files
+    /// at once anyway — the signature check is what stops a forgery,
+    /// not URL co-location — but this catches accidental drift in the
+    /// constants.)
+    #[test]
+    fn registry_sig_url_is_sibling_of_registry_url() {
+        assert_eq!(
+            REGISTRY_SIG_URL,
+            format!("{REGISTRY_URL}.sig"),
+            "registry sig URL should be `{{registry url}}.sig`",
+        );
+    }
 }

--- a/src/community/mod.rs
+++ b/src/community/mod.rs
@@ -11,6 +11,7 @@
 //! for the complete design and roadmap.
 
 pub mod install;
+pub mod signature;
 pub mod types;
 pub mod verify;
 
@@ -18,6 +19,7 @@ pub use install::{
     InstallError, InstallPlan, InstallRoots, install, read_install_meta, uninstall,
     update_granted_capabilities,
 };
+pub use signature::{SignatureError, embedded_key_fingerprint, verify_registry_signature};
 pub use types::{
     ColorScheme, ContributionKind, ContributionRef, ContributionSource, InstallSource,
     InstalledMeta, PluginEntry, PluginKindWire, PluginsByKind, Registry, RegistrySource,

--- a/src/community/signature.rs
+++ b/src/community/signature.rs
@@ -1,0 +1,313 @@
+//! Minisign signature verification for the community registry.
+//!
+//! Trust model: the only trust anchor for `registry.json` is a
+//! [minisign](https://jedisct1.github.io/minisign/) signature produced
+//! by a key whose public half is **embedded in the Claudette binary**
+//! at compile time (see `trust/community-registry.pub`). The fetched
+//! `registry.json.sig` is verified against this embedded key before
+//! `registry.json` is parsed; nothing about the network response or
+//! the registry contents is trusted until that check passes.
+//!
+//! Rotation: [`accepted_public_keys`] returns a slice — today it has
+//! one entry, but adding a second keypair is a one-line change that
+//! lets a new release accept signatures from either key while the old
+//! one is retired. See `keys/README.md` in `claudette-community` for
+//! the procedure.
+//!
+//! Verifier-only: this module never signs. Signing happens in the
+//! `claudette-community` CI with a secret stored only in GitHub
+//! Actions Secrets.
+//!
+//! Note on attack surface: an attacker who can swap `registry.json`
+//! and `registry.json.sig` on the network can at most cause Claudette
+//! to refuse the install (if the sig doesn't verify) or replay an
+//! older signed registry (if they captured one previously). The first
+//! is a denial-of-service, not a code-execution path; the second is
+//! mitigated by per-entry content hashes — installing a stale registry
+//! still pins each contribution to its sha256.
+
+use std::sync::OnceLock;
+
+use minisign_verify::{PublicKey, Signature};
+
+/// Hex of the embedded production public key fingerprint, surfaced in
+/// error messages so users can compare against what's published in the
+/// `claudette-community/keys/README.md` and out-of-band channels.
+///
+/// Computed once from the embedded pubkey when first read.
+pub fn embedded_key_fingerprint() -> &'static str {
+    // Last 16 hex chars (8 bytes) of the key id — same form minisign
+    // itself prints in the `untrusted comment:` line of the pubkey.
+    // Parsed lazily so a malformed embedded key surfaces during the
+    // first verify, not at static-init time.
+    static FP: OnceLock<String> = OnceLock::new();
+    FP.get_or_init(|| {
+        let pub_text = include_str!("trust/community-registry.pub");
+        // The first line is `untrusted comment: minisign public key <FP>`;
+        // pull the fingerprint out for diagnostics. Fall back to
+        // "unknown" if the file isn't shaped as expected — the verify
+        // path will fail with a clearer error in that case.
+        pub_text
+            .lines()
+            .next()
+            .and_then(|l| l.rsplit(' ').next())
+            .map(str::to_string)
+            .unwrap_or_else(|| "unknown".to_string())
+    })
+}
+
+/// Embedded production public keys. Today: one. Adding a second slot
+/// is how key rotation works — ship a release with `[OLD, NEW]`,
+/// switch the CI signer to `NEW`, then ship a release with `[NEW]`.
+fn embedded_pubkeys() -> &'static [PublicKey] {
+    static KEYS: OnceLock<Vec<PublicKey>> = OnceLock::new();
+    KEYS.get_or_init(|| {
+        let pub_text = include_str!("trust/community-registry.pub");
+        // PublicKey::from_base64 takes only the base64-encoded key
+        // bytes (no comment lines), so split out the second line.
+        let key_b64 = pub_text
+            .lines()
+            .find(|l| !l.is_empty() && !l.starts_with("untrusted comment:"))
+            .expect("embedded community-registry.pub is malformed (no key line)");
+        let key = PublicKey::from_base64(key_b64.trim())
+            .expect("embedded community-registry.pub is not a valid minisign pubkey");
+        vec![key]
+    })
+}
+
+#[derive(Debug)]
+pub enum SignatureError {
+    /// The signature file couldn't be parsed — wrong format, truncated,
+    /// or empty bytes.
+    MalformedSignature(minisign_verify::Error),
+    /// Signature parsed cleanly but doesn't verify against any embedded
+    /// public key — either the message was tampered with, the signature
+    /// was forged, or it was signed with a key Claudette doesn't trust.
+    InvalidSignature {
+        embedded_fingerprint: String,
+        underlying: minisign_verify::Error,
+    },
+}
+
+impl std::fmt::Display for SignatureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MalformedSignature(e) => {
+                write!(f, "registry.json.sig is malformed: {e}")
+            }
+            Self::InvalidSignature {
+                embedded_fingerprint,
+                underlying,
+            } => {
+                write!(
+                    f,
+                    "registry.json.sig does not verify against the embedded \
+                     community-registry public key (fingerprint {embedded_fingerprint}): \
+                     {underlying}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SignatureError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::MalformedSignature(e) | Self::InvalidSignature { underlying: e, .. } => Some(e),
+        }
+    }
+}
+
+/// Verify `sig_bytes` (the raw contents of `registry.json.sig`) is a
+/// valid signature over `message` (the raw contents of `registry.json`)
+/// produced by any of the embedded public keys.
+///
+/// Returns `Ok(())` on success. Any failure — malformed sig file,
+/// signature that decodes but doesn't verify, signature for a different
+/// key — collapses into [`SignatureError`] with enough context for the
+/// UI to surface a useful error string.
+pub fn verify_registry_signature(message: &[u8], sig_bytes: &[u8]) -> Result<(), SignatureError> {
+    // Signature::decode wants a `&str`. The .sig file is ASCII (base64
+    // + comments), so a non-utf8 body is itself a sign of a malformed
+    // file — collapse to MalformedSignature rather than panic.
+    let sig_str = std::str::from_utf8(sig_bytes)
+        .map_err(|_| SignatureError::MalformedSignature(minisign_verify::Error::InvalidEncoding))?;
+    let sig = Signature::decode(sig_str).map_err(SignatureError::MalformedSignature)?;
+
+    let mut last_err: Option<minisign_verify::Error> = None;
+    for pubkey in embedded_pubkeys() {
+        match pubkey.verify(message, &sig, false) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(SignatureError::InvalidSignature {
+        embedded_fingerprint: embedded_key_fingerprint().to_string(),
+        underlying: last_err.unwrap_or(minisign_verify::Error::InvalidSignature),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test fixtures generated once with `minisign -G -W` + `minisign
+    // -S` (see commit message). Independent of the production keypair
+    // so unit tests don't depend on the in-the-wild key state.
+    const TEST_PUBKEY: &str = include_str!("trust/test_fixtures/test.pub");
+    const TEST_MESSAGE: &[u8] = include_bytes!("trust/test_fixtures/test_message.bin");
+    const TEST_SIG: &str = include_str!("trust/test_fixtures/test_message.bin.minisig");
+
+    // Round-trip fixture signed by the *production* key — proves the
+    // embedded pubkey actually verifies signatures from the matching
+    // secret. Without this, "verify against embedded key" would only
+    // be tested negatively (rejection of wrong-key sigs).
+    const PROD_MESSAGE: &[u8] = include_bytes!("trust/test_fixtures/prod_test_message.bin");
+    const PROD_SIG: &str = include_str!("trust/test_fixtures/prod_test_message.bin.minisig");
+
+    /// Helper: verify TEST_MESSAGE + TEST_SIG against TEST_PUBKEY
+    /// directly (bypassing the embedded-key path) so the cryptographic
+    /// portion of the test is independent of the embedded key. We also
+    /// test the embedded-key path separately below.
+    fn verify_with_test_key(
+        message: &[u8],
+        sig_bytes: &[u8],
+    ) -> Result<(), minisign_verify::Error> {
+        let key_b64 = TEST_PUBKEY
+            .lines()
+            .find(|l| !l.is_empty() && !l.starts_with("untrusted comment:"))
+            .expect("test pubkey malformed");
+        let pubkey = PublicKey::from_base64(key_b64.trim()).expect("test pubkey decode");
+        let sig_str = std::str::from_utf8(sig_bytes).expect("test sig is ascii");
+        let sig = Signature::decode(sig_str).expect("test sig decode");
+        pubkey.verify(message, &sig, false)
+    }
+
+    #[test]
+    fn fixture_sig_verifies_against_fixture_pubkey() {
+        // Sanity: the committed fixture is internally consistent. This
+        // is the test you'd add to catch a future "someone overwrote
+        // test.pub with the wrong file" mistake.
+        verify_with_test_key(TEST_MESSAGE, TEST_SIG.as_bytes())
+            .expect("fixture sig should verify against fixture pubkey");
+    }
+
+    #[test]
+    fn fixture_sig_rejects_tampered_message() {
+        let mut tampered = TEST_MESSAGE.to_vec();
+        tampered[0] ^= 0x01;
+        let err = verify_with_test_key(&tampered, TEST_SIG.as_bytes()).unwrap_err();
+        // minisign-verify reports this as InvalidSignature.
+        assert!(
+            matches!(err, minisign_verify::Error::InvalidSignature),
+            "expected InvalidSignature for tampered message, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn embedded_pubkey_parses_without_panic() {
+        // If the embedded community-registry.pub is malformed,
+        // embedded_pubkeys() panics on first call. Force the panic to
+        // surface here rather than at first install.
+        let keys = embedded_pubkeys();
+        assert!(!keys.is_empty(), "embedded pubkey slice must not be empty");
+    }
+
+    #[test]
+    fn embedded_fingerprint_is_extracted() {
+        let fp = embedded_key_fingerprint();
+        // Production key fingerprint, also documented in the trust
+        // model docs and in the community repo's keys/README.md.
+        assert_eq!(fp, "982022ABB1139C7B");
+    }
+
+    #[test]
+    fn verify_against_embedded_pubkey_accepts_production_sig() {
+        // Positive: a signature produced by the *real* production
+        // secret key verifies against the embedded production pubkey.
+        verify_registry_signature(PROD_MESSAGE, PROD_SIG.as_bytes())
+            .expect("production-signed fixture should verify against embedded pubkey");
+    }
+
+    #[test]
+    fn verify_against_embedded_pubkey_rejects_tampered_production_message() {
+        // Same production sig + message with one byte flipped → reject.
+        let mut tampered = PROD_MESSAGE.to_vec();
+        tampered[0] ^= 0x01;
+        let err = verify_registry_signature(&tampered, PROD_SIG.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, SignatureError::InvalidSignature { .. }),
+            "expected InvalidSignature for tampered production message, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_against_embedded_pubkey_rejects_test_fixture_sig() {
+        // The test fixture was signed by a different key; verifying
+        // against the embedded production key must fail. Any other
+        // result would mean either the embedded pubkey is wrong OR the
+        // verifier isn't actually checking the key id.
+        let err = verify_registry_signature(TEST_MESSAGE, TEST_SIG.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, SignatureError::InvalidSignature { .. }),
+            "expected InvalidSignature against embedded key, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_empty_sig_bytes() {
+        let err = verify_registry_signature(TEST_MESSAGE, b"").unwrap_err();
+        assert!(
+            matches!(err, SignatureError::MalformedSignature(_)),
+            "expected MalformedSignature for empty bytes, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_truncated_sig() {
+        // Lop off the trailing global signature line (last line) — the
+        // file still has plausible-looking data but is incomplete.
+        let truncated: String = TEST_SIG.lines().take(2).collect::<Vec<_>>().join("\n");
+        let err = verify_registry_signature(TEST_MESSAGE, truncated.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, SignatureError::MalformedSignature(_)),
+            "expected MalformedSignature for truncated sig, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_non_utf8_sig() {
+        let err = verify_registry_signature(TEST_MESSAGE, b"\xff\xfe\xfd not utf-8").unwrap_err();
+        assert!(
+            matches!(err, SignatureError::MalformedSignature(_)),
+            "expected MalformedSignature for non-utf8 bytes, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_garbage_that_resembles_sig_format() {
+        // Right shape (multiple lines, comment-line-then-base64), but
+        // the base64 decodes to bytes that aren't a valid minisign
+        // signature payload.
+        let garbage =
+            "untrusted comment: not really a sig\nAAAAAAAAAAAA\ntrusted comment: x\nAAAA\n";
+        let err = verify_registry_signature(TEST_MESSAGE, garbage.as_bytes()).unwrap_err();
+        assert!(
+            matches!(err, SignatureError::MalformedSignature(_)),
+            "expected MalformedSignature for garbage sig, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn signature_error_display_includes_fingerprint_for_invalid_sig() {
+        // The fingerprint is the bridge between an error message and
+        // the key the user can compare against the published pubkey;
+        // make sure it appears in the rendered string.
+        let err = verify_registry_signature(TEST_MESSAGE, TEST_SIG.as_bytes()).unwrap_err();
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("982022ABB1139C7B"),
+            "rendered error should include embedded fingerprint, got: {rendered}",
+        );
+    }
+}

--- a/src/community/signature.rs
+++ b/src/community/signature.rs
@@ -26,53 +26,99 @@
 //! mitigated by per-entry content hashes — installing a stale registry
 //! still pins each contribution to its sha256.
 
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
+use base64::Engine;
 use minisign_verify::{PublicKey, Signature};
 
-/// Hex of the embedded production public key fingerprint, surfaced in
-/// error messages so users can compare against what's published in the
-/// `claudette-community/keys/README.md` and out-of-band channels.
+/// Raw text of the embedded community-registry public key.
+const EMBEDDED_PUBKEY_TEXT: &str = include_str!("trust/community-registry.pub");
+
+/// Parsed pubkey + key-id fingerprint, lazily decoded from
+/// [`EMBEDDED_PUBKEY_TEXT`]. Stored as a `Result` so a malformed
+/// embedded file surfaces as a [`SignatureError::EmbeddedKey`] on the
+/// first verify call rather than panicking the process.
 ///
-/// Computed once from the embedded pubkey when first read.
-pub fn embedded_key_fingerprint() -> &'static str {
-    // Last 16 hex chars (8 bytes) of the key id — same form minisign
-    // itself prints in the `untrusted comment:` line of the pubkey.
-    // Parsed lazily so a malformed embedded key surfaces during the
-    // first verify, not at static-init time.
-    static FP: OnceLock<String> = OnceLock::new();
-    FP.get_or_init(|| {
-        let pub_text = include_str!("trust/community-registry.pub");
-        // The first line is `untrusted comment: minisign public key <FP>`;
-        // pull the fingerprint out for diagnostics. Fall back to
-        // "unknown" if the file isn't shaped as expected — the verify
-        // path will fail with a clearer error in that case.
-        pub_text
-            .lines()
-            .next()
-            .and_then(|l| l.rsplit(' ').next())
-            .map(str::to_string)
-            .unwrap_or_else(|| "unknown".to_string())
-    })
+/// Each entry corresponds to one trusted signing key. Today: one.
+/// Adding a second slot is how key rotation works — ship a release
+/// with `[OLD, NEW]`, switch the CI signer to `NEW`, then ship a
+/// release with `[NEW]` only. The verifier accepts a signature from
+/// any embedded key.
+#[derive(Debug)]
+struct EmbeddedKey {
+    pubkey: PublicKey,
+    /// Hex (uppercase) of the 8 key-id bytes from the parsed pubkey
+    /// payload. This is the same value `minisign` itself prints, but
+    /// derived from the cryptographic key bytes — not from the
+    /// `untrusted comment:` line, which is plaintext metadata that
+    /// could drift from the real key id if the file were hand-edited.
+    fingerprint: String,
 }
 
-/// Embedded production public keys. Today: one. Adding a second slot
-/// is how key rotation works — ship a release with `[OLD, NEW]`,
-/// switch the CI signer to `NEW`, then ship a release with `[NEW]`.
-fn embedded_pubkeys() -> &'static [PublicKey] {
-    static KEYS: OnceLock<Vec<PublicKey>> = OnceLock::new();
-    KEYS.get_or_init(|| {
-        let pub_text = include_str!("trust/community-registry.pub");
-        // PublicKey::from_base64 takes only the base64-encoded key
-        // bytes (no comment lines), so split out the second line.
-        let key_b64 = pub_text
-            .lines()
-            .find(|l| !l.is_empty() && !l.starts_with("untrusted comment:"))
-            .expect("embedded community-registry.pub is malformed (no key line)");
-        let key = PublicKey::from_base64(key_b64.trim())
-            .expect("embedded community-registry.pub is not a valid minisign pubkey");
-        vec![key]
-    })
+static EMBEDDED_KEYS: LazyLock<Result<Vec<EmbeddedKey>, String>> =
+    LazyLock::new(|| parse_embedded_keys(EMBEDDED_PUBKEY_TEXT));
+
+fn parse_embedded_keys(pub_text: &str) -> Result<Vec<EmbeddedKey>, String> {
+    let key_b64 = pub_text
+        .lines()
+        .find(|l| !l.is_empty() && !l.starts_with("untrusted comment:"))
+        .ok_or("embedded community-registry.pub is malformed (no key line)")?
+        .trim();
+    let pubkey = PublicKey::from_base64(key_b64).map_err(|e| {
+        format!("embedded community-registry.pub is not a valid minisign pubkey: {e}")
+    })?;
+    let fingerprint = derive_fingerprint(key_b64)?;
+    Ok(vec![EmbeddedKey {
+        pubkey,
+        fingerprint,
+    }])
+}
+
+/// Decode the minisign pubkey payload (`<algo:2><key_id:8><key:32>` =
+/// 42 bytes, base64-encoded) and return the hex-uppercase key id.
+/// Bound directly to the cryptographic key bytes — independent of the
+/// `untrusted comment:` line.
+fn derive_fingerprint(key_b64: &str) -> Result<String, String> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(key_b64.as_bytes())
+        .map_err(|e| format!("embedded pubkey base64 decode: {e}"))?;
+    if raw.len() < 10 {
+        return Err(format!(
+            "embedded pubkey payload too short ({} bytes; expected ≥ 10)",
+            raw.len()
+        ));
+    }
+    // Bytes layout: [algo:2][key_id:8][ed25519:32]. minisign displays
+    // the key_id in reversed (little-endian) byte order in its
+    // `untrusted comment: minisign public key <FP>` line and in
+    // `-V` / `-G` output, so we reverse here to match. The bytes
+    // themselves are still derived from the cryptographic payload —
+    // not from the plaintext comment line.
+    let mut key_id = [0u8; 8];
+    key_id.copy_from_slice(&raw[2..10]);
+    key_id.reverse();
+    let mut hex = String::with_capacity(16);
+    for b in &key_id {
+        use std::fmt::Write as _;
+        let _ = write!(&mut hex, "{b:02X}");
+    }
+    Ok(hex)
+}
+
+/// Hex (uppercase) of the embedded production public key's key id —
+/// derived from the parsed key bytes, **not** from the `untrusted
+/// comment:` line. Matches the value `minisign` itself displays.
+///
+/// Returns `"unknown"` if the embedded file failed to parse; the
+/// verify path returns the underlying error in that case.
+pub fn embedded_key_fingerprint() -> String {
+    match EMBEDDED_KEYS.as_ref() {
+        Ok(keys) => keys
+            .first()
+            .map(|k| k.fingerprint.clone())
+            .unwrap_or_else(|| "unknown".to_string()),
+        Err(_) => "unknown".to_string(),
+    }
 }
 
 #[derive(Debug)]
@@ -87,6 +133,11 @@ pub enum SignatureError {
         embedded_fingerprint: String,
         underlying: minisign_verify::Error,
     },
+    /// The pubkey baked into the binary at compile time couldn't be
+    /// parsed. Should never happen in a release build (the file is
+    /// in-tree and the test suite parses it); guards against a future
+    /// hand-edit that breaks the format without us noticing.
+    EmbeddedKey(String),
 }
 
 impl std::fmt::Display for SignatureError {
@@ -106,6 +157,13 @@ impl std::fmt::Display for SignatureError {
                      {underlying}"
                 )
             }
+            Self::EmbeddedKey(msg) => {
+                write!(
+                    f,
+                    "embedded community-registry public key could not be loaded: {msg} \
+                     (this is a build-time bug — please file an issue)"
+                )
+            }
         }
     }
 }
@@ -114,6 +172,7 @@ impl std::error::Error for SignatureError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::MalformedSignature(e) | Self::InvalidSignature { underlying: e, .. } => Some(e),
+            Self::EmbeddedKey(_) => None,
         }
     }
 }
@@ -124,9 +183,18 @@ impl std::error::Error for SignatureError {
 ///
 /// Returns `Ok(())` on success. Any failure — malformed sig file,
 /// signature that decodes but doesn't verify, signature for a different
-/// key — collapses into [`SignatureError`] with enough context for the
-/// UI to surface a useful error string.
+/// key, malformed embedded key — collapses into [`SignatureError`]
+/// with enough context for the UI to surface a useful error string.
 pub fn verify_registry_signature(message: &[u8], sig_bytes: &[u8]) -> Result<(), SignatureError> {
+    // Surface a malformed embedded key as a recoverable error rather
+    // than panicking the process. Should never trip in a release build
+    // (the embedded pubkey is in-tree and parsed by the test suite),
+    // but a hand-edit that breaks the format would otherwise crash on
+    // first install.
+    let keys = EMBEDDED_KEYS
+        .as_ref()
+        .map_err(|e| SignatureError::EmbeddedKey(e.clone()))?;
+
     // Signature::decode wants a `&str`. The .sig file is ASCII (base64
     // + comments), so a non-utf8 body is itself a sign of a malformed
     // file — collapse to MalformedSignature rather than panic.
@@ -135,14 +203,14 @@ pub fn verify_registry_signature(message: &[u8], sig_bytes: &[u8]) -> Result<(),
     let sig = Signature::decode(sig_str).map_err(SignatureError::MalformedSignature)?;
 
     let mut last_err: Option<minisign_verify::Error> = None;
-    for pubkey in embedded_pubkeys() {
-        match pubkey.verify(message, &sig, false) {
+    for entry in keys {
+        match entry.pubkey.verify(message, &sig, false) {
             Ok(()) => return Ok(()),
             Err(e) => last_err = Some(e),
         }
     }
     Err(SignatureError::InvalidSignature {
-        embedded_fingerprint: embedded_key_fingerprint().to_string(),
+        embedded_fingerprint: embedded_key_fingerprint(),
         underlying: last_err.unwrap_or(minisign_verify::Error::InvalidSignature),
     })
 }
@@ -205,20 +273,78 @@ mod tests {
     }
 
     #[test]
-    fn embedded_pubkey_parses_without_panic() {
-        // If the embedded community-registry.pub is malformed,
-        // embedded_pubkeys() panics on first call. Force the panic to
-        // surface here rather than at first install.
-        let keys = embedded_pubkeys();
+    fn embedded_pubkey_parses_successfully() {
+        // The embedded community-registry.pub must parse cleanly. A
+        // malformed file would surface as Err here rather than crash
+        // the app at first install.
+        let keys = EMBEDDED_KEYS
+            .as_ref()
+            .expect("embedded pubkey must parse successfully in the test build");
         assert!(!keys.is_empty(), "embedded pubkey slice must not be empty");
     }
 
     #[test]
-    fn embedded_fingerprint_is_extracted() {
+    fn embedded_fingerprint_is_derived_from_key_bytes_not_comment() {
+        // The fingerprint comes from base64-decoding the key payload
+        // and hex-encoding bytes 2..10 (the minisign key id) — not
+        // from the `untrusted comment:` line. This test would catch a
+        // future regression where someone reverts to comment-parsing.
         let fp = embedded_key_fingerprint();
         // Production key fingerprint, also documented in the trust
         // model docs and in the community repo's keys/README.md.
+        // Cross-checked: minisign-cli prints the same value in the
+        // pubkey's untrusted-comment line and in `-V` output.
         assert_eq!(fp, "982022ABB1139C7B");
+    }
+
+    #[test]
+    fn derive_fingerprint_works_for_arbitrary_pubkey() {
+        // Use the test fixture's key — confirms the derivation works
+        // for any valid minisign pubkey, not just the one we baked in.
+        // The fingerprint of test.pub (printed by `minisign -G`):
+        // `RWQGBBQ5L3rDN...` → key id `06041439 2F7AC337` → 0604143...
+        let test_key_b64 = TEST_PUBKEY
+            .lines()
+            .find(|l| !l.is_empty() && !l.starts_with("untrusted comment:"))
+            .unwrap()
+            .trim();
+        let fp = derive_fingerprint(test_key_b64).unwrap();
+        // Cross-check against `untrusted comment: minisign public key
+        // 37C37A2F39140406` from the test fixture — derive_fingerprint
+        // matches minisign's display convention exactly.
+        assert_eq!(fp, "37C37A2F39140406");
+    }
+
+    #[test]
+    fn derive_fingerprint_rejects_short_payload() {
+        // Base64-encode 8 bytes (less than the required 10).
+        let too_short = base64::engine::general_purpose::STANDARD.encode([0u8; 8]);
+        let err = derive_fingerprint(&too_short).unwrap_err();
+        assert!(
+            err.contains("too short"),
+            "expected length-error message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_embedded_keys_surfaces_malformed_input_as_err() {
+        // Feed a bogus pubkey body — should return Err, not panic.
+        let err = parse_embedded_keys("untrusted comment: junk\nnot-real-base64!!!\n").unwrap_err();
+        assert!(
+            !err.is_empty(),
+            "parse_embedded_keys should return a non-empty error message"
+        );
+    }
+
+    #[test]
+    fn parse_embedded_keys_rejects_missing_key_line() {
+        // Comment-only file → no key line found.
+        let err = parse_embedded_keys("untrusted comment: only\nuntrusted comment: comments\n")
+            .unwrap_err();
+        assert!(
+            err.contains("no key line"),
+            "expected 'no key line' error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/community/trust/community-registry.pub
+++ b/src/community/trust/community-registry.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 982022ABB1139C7B
+RWR7nBOxqyIgmCbRpPqjKicb+VX+AgvjeY1wB9QgLhhJY3hy64+l+MQe

--- a/src/community/trust/test_fixtures/prod_test_message.bin
+++ b/src/community/trust/test_fixtures/prod_test_message.bin
@@ -1,0 +1,1 @@
+{"version":1,"sample":"deterministic content for embedded-key production round-trip test"}

--- a/src/community/trust/test_fixtures/prod_test_message.bin.minisig
+++ b/src/community/trust/test_fixtures/prod_test_message.bin.minisig
@@ -1,0 +1,4 @@
+untrusted comment: signature from minisign secret key
+RUR7nBOxqyIgmDO7u1TZb+ICpFkgJx2HJYQspNW3cHn637B35nt/IZN7/C0A0UkrHd1mhWryCZPPs67jktkf6H6H7KZZCL8dJAs=
+trusted comment: production-key round-trip fixture
+CM3OExMt7uDArUxcv+EwswiJcwg1+H5KDRvv78Weh0W4cy2FOCgFCne45cUgwSFf3wlbG/raG26kvkF4JSzrDQ==

--- a/src/community/trust/test_fixtures/test.pub
+++ b/src/community/trust/test_fixtures/test.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 37C37A2F39140406
+RWQGBBQ5L3rDNwTIVjkNOjR8ZkEktEJwjOA2oLGPeU9Z9KyOKeSUhYEk

--- a/src/community/trust/test_fixtures/test_message.bin
+++ b/src/community/trust/test_fixtures/test_message.bin
@@ -1,0 +1,1 @@
+{"version":1,"sample":"this is a test message that the test verifier will sign over"}

--- a/src/community/trust/test_fixtures/test_message.bin.minisig
+++ b/src/community/trust/test_fixtures/test_message.bin.minisig
@@ -1,0 +1,4 @@
+untrusted comment: signature from minisign secret key
+RUQGBBQ5L3rDN9IL25aAtCzLDQAHDFbLtXnWfJjFOjTb3If0udedyPttVmudozzlkFwFLA99eEzXjU+Cc9bhQEFc39SlHtZxiwE=
+trusted comment: test fixture (deterministic content for unit test)
+8jmvvvECyTCbt0GjSF1GBZsiqgNlNJ6Z/VkstXyoIrZ1FVznsp7hmFvhuJVheQn/7biQwFlsPMIFmb6Q1Be1Cw==


### PR DESCRIPTION
## Summary

Closes the supply-chain gap surfaced in the registry MVP (#572): the only trust anchor was the `sha256` inside an unsigned `registry.json` fetched over HTTPS from mutable `main`, so anyone with write access (or a successful MITM) could ship arbitrary code as 'verified.'

After this change:
- `registry.json` is verified against a [minisign](https://jedisct1.github.io/minisign/) signature produced by a key whose public half is **embedded in Claudette's binary** at compile time.
- `registry.json.sig` is fetched in parallel with the registry and checked **before the JSON is parsed**.
- Install paths use `registry.source.sha` so codeload tarballs are bound to a specific reviewable commit, not mutable `main`.

The matching CI side already shipped: utensils/claudette-community#2 publishes the public key + signs the registry on every push to `main`. This PR is what makes Claudette the trust anchor.

## Trust model

- **Signer**: minisign — pure-Rust verifier (`minisign-verify` 0.2) that was already in our dep tree transitively via `tauri-plugin-updater`. Promoting it to a direct dep adds zero new vendored bytes.
- **Embedded pubkey**: `src/community/trust/community-registry.pub` (fingerprint `982022ABB1139C7B`) — `include_str!`'d at compile time. The matching pubkey is also published at [`claudette-community/keys/community-registry.pub`](https://github.com/utensils/claudette-community/blob/main/keys/community-registry.pub) for transparency.
- **Rotation**: the verifier API takes `&[PublicKey]`. Today: one key. Adding a second slot is a one-line change — ship a release with `[OLD, NEW]`, switch the CI signer, then ship a release with `[NEW]` only. Documented in the new trust-model docs page.
- **Failure modes**: distinct user-visible error strings for missing signature (404), invalid signature (tamper / wrong key), and JSON parse error (signed but malformed) so the UI can disambiguate.

## What changed

### `claudette` lib (`src/community/`)
- New `signature.rs` — verifier + embedded pubkey + 12 unit tests covering positive (production round-trip with the real production key), negative (wrong key, tampered message, malformed/truncated/empty/non-utf8/garbage sig), and the fingerprint-extraction path.
- New `trust/community-registry.pub` — embedded production pubkey.
- New `trust/test_fixtures/{test.pub, test_message.bin, test_message.bin.minisig, prod_test_message.bin, prod_test_message.bin.minisig}` — committed once with `minisign -G -W` + `minisign -S`.
- `mod.rs` re-exports `verify_registry_signature`, `embedded_key_fingerprint`, `SignatureError`.

### Tauri command (`src-tauri/src/commands/community.rs`)
- `community_registry_fetch` now `tokio::try_join!`s registry + sig, verifies before parsing, returns distinct error labels per failure mode.
- `fetch_tarball` takes the verified `registry.source.sha` and uses it to construct the codeload URL — both InTree (`codeload.github.com/<repo>/tar.gz/<sha>`) and External (`raw.githubusercontent.com/<repo>/<sha>/<mirror>`). The pre-PR External path used mutable `main` — fixed.
- 3 unit tests: codeload pins to commit, mirror pins to commit, sig URL is sibling of registry URL.

### Devshell (`flake.nix`)
- Adds `pkgs.minisign` + `pkgs.rsign2` (binary name `rsign`) so maintainers can re-sign locally when bootstrapping a new key or auditing a published sig.

### Docs (`site/`)
- New page `features/community-registry-trust.mdx` covers the trust model, what it does and doesn't protect against, key rotation, and how to verify a published registry locally with `minisign -V`.

## UAT (live signed registry, dev build)

| # | Acceptance criterion | Result |
|---|---|---|
| 1 | Signed registry installs cleanly | ✅ Uninstall + reinstall lang-nix end-to-end against live signed registry post-merge of utensils/claudette-community#2 |
| 2 | Unsigned/tampered registry rejected with user-visible error | ✅ Missing-sig: live test returned exact 'registry signature fetch returned 404 Not Found' string. Tamper/wrong-key/malformed: 12 unit tests. |
| 3 | Commit-pinned URL prevents post-publish content swaps | ✅ Codeload URL constructed from registry.source.sha (verified end-to-end + 3 unit tests). GitHub guarantees commit SHAs are immutable; the secondary sha256 content hash is defense in depth. |
| 4 | Existing installations remain valid after upgrade | ✅ Pre-PR lang-nix install (made yesterday by unsigned-registry code) still listed by community_list_installed after rebuild. |

## Test plan

- [x] cargo test --workspace --all-features — 1074 tests green (claudette 888 + claudette-tauri 182 + env_provider integration 4)
- [x] cargo clippy --workspace --all-targets -- -D warnings — clean
- [x] cargo fmt --all --check — clean
- [x] cd src/ui && bunx tsc -b — clean
- [x] cd src/ui && bun run test — 1118/1118 green
- [x] cd src/ui && bun run lint:css — clean
- [x] Live UAT against claudette-community post-merge (see table above)
- [x] gh pr merge utensils/claudette-community#2 exercised the full publish flow end-to-end

## Out of scope (intentionally — separate follow-ups)

- Signing revocations.json — same pattern, deserves its own PR
- Sigstore / transparency log — listed as future-work in #581
- Per-source pubkey allowlist for user-configurable additional registries — needed when PR #4 of #567 adds customRegistryUrls
- Update detection + capability re-consent — PR #4 of #567

## Action required from maintainer

Add the COMMUNITY_REGISTRY_MINISIGN_SECRET_KEY secret to utensils/claudette-community repository settings before any contribution PR lands. Without it, regen.yml fails on push to main with a clear secret-not-set error (already verified — see https://github.com/utensils/claudette-community/actions/runs/25255743707 ). The current published registry.json.sig was committed in the PR so live verification works today; the secret is needed to re-sign on every subsequent contribution merge.

## Related

- utensils/claudette-community#2 — CI publication side (merged)
- #581 — supply-chain audit (closes)
- #572 — registry MVP that introduced the gap
- #567 — community registry TDD