### PR TITLE
fix: handle workspace name collisions

### DIFF
--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -788,39 +788,56 @@ async fn handle_create_workspace(
     repository_id: &str,
     name: &str,
 ) -> Result<serde_json::Value, String> {
+    if !claudette::workspace_alloc::is_valid_workspace_name(name) {
+        return Err(format!("Invalid workspace name: '{name}'"));
+    }
+
     let db = open_db(state)?;
     let repo = db
         .get_repository(repository_id)
         .map_err(|e| e.to_string())?
         .ok_or("Repository not found")?;
 
-    let worktree_base_dir = state.worktree_base_dir.read().await;
-    let branch_name = format!("{}/{}", repo.path_slug, name);
-    let worktree_path = worktree_base_dir.join(&repo.path_slug).join(name);
+    let worktree_base_dir = state.worktree_base_dir.read().await.clone();
+    let branch_prefix = format!("{}/", repo.path_slug);
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let allocation = claudette::workspace_alloc::allocate_workspace_name(
+        &repo,
+        &workspaces,
+        name,
+        &branch_prefix,
+        worktree_base_dir.as_path(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
 
     // Create git worktree.
-    claudette::git::create_worktree(
+    let actual_path = claudette::git::create_worktree(
         &repo.path,
-        &branch_name,
-        &worktree_path.to_string_lossy(),
+        &allocation.branch_name,
+        &allocation.worktree_path.to_string_lossy(),
         repo.base_branch.as_deref(),
         repo.default_remote.as_deref(),
     )
     .await
-    .map_err(|e| format!("{e:?}"))?;
+    .map_err(|e| e.to_string())?;
 
     let workspace = Workspace {
         id: uuid::Uuid::new_v4().to_string(),
         repository_id: repository_id.to_string(),
-        name: name.to_string(),
-        branch_name,
-        worktree_path: Some(worktree_path.to_string_lossy().to_string()),
+        name: allocation.name,
+        branch_name: allocation.branch_name,
+        worktree_path: Some(actual_path.clone()),
         status: WorkspaceStatus::Active,
         agent_status: claudette::model::AgentStatus::Idle,
         status_line: String::new(),
         created_at: now_iso(),
     };
-    db.insert_workspace(&workspace).map_err(|e| e.to_string())?;
+    if let Err(e) = db.insert_workspace(&workspace) {
+        let _ = claudette::git::remove_worktree(&repo.path, &actual_path, true).await;
+        let _ = claudette::git::branch_delete(&repo.path, &workspace.branch_name).await;
+        return Err(e.to_string());
+    }
 
     Ok(serde_json::to_value(&workspace).unwrap_or_default())
 }

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -817,11 +817,12 @@ async fn handle_create_workspace(
             )
             .await
             .map_err(|e| e.to_string())?;
+            let worktree_path_str = allocation.worktree_path.to_string_lossy().to_string();
 
             match claudette::git::create_worktree(
                 &repo.path,
                 &allocation.branch_name,
-                &allocation.worktree_path.to_string_lossy(),
+                &worktree_path_str,
                 repo.base_branch.as_deref(),
                 repo.default_remote.as_deref(),
             )

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -14,6 +14,8 @@ use crate::ws::{AgentSessionState, PtyHandle, ServerState, Writer, send_message}
 
 use claudette::permissions::tools_for_level;
 
+const CREATE_WORKTREE_ALLOCATION_ATTEMPTS: usize = 5;
+
 /// Dispatch a JSON-RPC request and return a JSON-RPC response.
 pub async fn handle_request(
     state: &Arc<ServerState>,
@@ -800,27 +802,48 @@ async fn handle_create_workspace(
 
     let worktree_base_dir = state.worktree_base_dir.read().await.clone();
     let branch_prefix = format!("{}/", repo.path_slug);
-    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
-    let allocation = claudette::workspace_alloc::allocate_workspace_name(
-        &repo,
-        &workspaces,
-        name,
-        &branch_prefix,
-        worktree_base_dir.as_path(),
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+    let (allocation, actual_path) = {
+        let mut last_collision: Option<claudette::git::GitError> = None;
+        let mut created = None;
 
-    // Create git worktree.
-    let actual_path = claudette::git::create_worktree(
-        &repo.path,
-        &allocation.branch_name,
-        &allocation.worktree_path.to_string_lossy(),
-        repo.base_branch.as_deref(),
-        repo.default_remote.as_deref(),
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+        for _ in 0..CREATE_WORKTREE_ALLOCATION_ATTEMPTS {
+            let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+            let allocation = claudette::workspace_alloc::allocate_workspace_name(
+                &repo,
+                &workspaces,
+                name,
+                &branch_prefix,
+                worktree_base_dir.as_path(),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+
+            match claudette::git::create_worktree(
+                &repo.path,
+                &allocation.branch_name,
+                &allocation.worktree_path.to_string_lossy(),
+                repo.base_branch.as_deref(),
+                repo.default_remote.as_deref(),
+            )
+            .await
+            {
+                Ok(actual_path) => {
+                    created = Some((allocation, actual_path));
+                    break;
+                }
+                Err(err) if claudette::git::is_worktree_create_collision_error(&err) => {
+                    last_collision = Some(err);
+                }
+                Err(err) => return Err(err.to_string()),
+            }
+        }
+
+        created.ok_or_else(|| {
+            last_collision
+                .map(|err| err.to_string())
+                .unwrap_or_else(|| "Could not allocate a unique workspace name".to_string())
+        })?
+    };
 
     let workspace = Workspace {
         id: uuid::Uuid::new_v4().to_string(),

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -19,6 +19,8 @@ use claudette::names::NameGenerator;
 use crate::state::AppState;
 use claudette::process::CommandWindowExt as _;
 
+const CREATE_WORKTREE_ALLOCATION_ATTEMPTS: usize = 5;
+
 #[derive(Serialize, Clone)]
 pub struct SetupResult {
     pub source: String,
@@ -121,27 +123,49 @@ pub async fn create_workspace(
     let (prefix_mode, prefix_custom) = read_branch_prefix_settings(&db);
     let prefix = resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
     let worktree_base = state.worktree_base_dir.read().await.clone();
-    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
-    let allocation = claudette::workspace_alloc::allocate_workspace_name(
-        repo,
-        &workspaces,
-        &name,
-        &prefix,
-        worktree_base.as_path(),
-    )
-    .await
-    .map_err(|e| e.to_string())?;
-    let worktree_path_str = allocation.worktree_path.to_string_lossy().to_string();
+    let (allocation, actual_path) = {
+        let mut last_collision: Option<git::GitError> = None;
+        let mut created = None;
 
-    let actual_path = git::create_worktree(
-        &repo_path,
-        &allocation.branch_name,
-        &worktree_path_str,
-        repo.base_branch.as_deref(),
-        repo.default_remote.as_deref(),
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+        for _ in 0..CREATE_WORKTREE_ALLOCATION_ATTEMPTS {
+            let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+            let allocation = claudette::workspace_alloc::allocate_workspace_name(
+                repo,
+                &workspaces,
+                &name,
+                &prefix,
+                worktree_base.as_path(),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+            let worktree_path_str = allocation.worktree_path.to_string_lossy().to_string();
+
+            match git::create_worktree(
+                &repo_path,
+                &allocation.branch_name,
+                &worktree_path_str,
+                repo.base_branch.as_deref(),
+                repo.default_remote.as_deref(),
+            )
+            .await
+            {
+                Ok(actual_path) => {
+                    created = Some((allocation, actual_path));
+                    break;
+                }
+                Err(err) if git::is_worktree_create_collision_error(&err) => {
+                    last_collision = Some(err);
+                }
+                Err(err) => return Err(err.to_string()),
+            }
+        }
+
+        created.ok_or_else(|| {
+            last_collision
+                .map(|err| err.to_string())
+                .unwrap_or_else(|| "Could not allocate a unique workspace name".to_string())
+        })?
+    };
 
     let ws = Workspace {
         id: uuid::Uuid::new_v4().to_string(),

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -120,14 +120,22 @@ pub async fn create_workspace(
 
     let (prefix_mode, prefix_custom) = read_branch_prefix_settings(&db);
     let prefix = resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
-    let branch_name = format!("{prefix}{name}");
-    let worktree_base = state.worktree_base_dir.read().await;
-    let worktree_path: PathBuf = worktree_base.join(&repo.path_slug).join(&name);
-    let worktree_path_str = worktree_path.to_string_lossy().to_string();
+    let worktree_base = state.worktree_base_dir.read().await.clone();
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let allocation = claudette::workspace_alloc::allocate_workspace_name(
+        repo,
+        &workspaces,
+        &name,
+        &prefix,
+        worktree_base.as_path(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+    let worktree_path_str = allocation.worktree_path.to_string_lossy().to_string();
 
     let actual_path = git::create_worktree(
         &repo_path,
-        &branch_name,
+        &allocation.branch_name,
         &worktree_path_str,
         repo.base_branch.as_deref(),
         repo.default_remote.as_deref(),
@@ -138,8 +146,8 @@ pub async fn create_workspace(
     let ws = Workspace {
         id: uuid::Uuid::new_v4().to_string(),
         repository_id: repo_id,
-        name,
-        branch_name: branch_name.clone(),
+        name: allocation.name,
+        branch_name: allocation.branch_name.clone(),
         worktree_path: Some(actual_path.clone()),
         status: WorkspaceStatus::Active,
         agent_status: AgentStatus::Idle,
@@ -151,7 +159,7 @@ pub async fn create_workspace(
     // so we don't leave orphan git state pointing to nothing.
     if let Err(e) = db.insert_workspace(&ws) {
         let _ = git::remove_worktree(&repo_path, &actual_path, true).await;
-        let _ = git::branch_delete(&repo_path, &branch_name).await;
+        let _ = git::branch_delete(&repo_path, &ws.branch_name).await;
         return Err(e.to_string());
     }
 
@@ -808,10 +816,7 @@ pub struct DiscoveredWorktree {
 
 /// Validate a workspace name: ASCII alphanumeric + hyphens, no leading/trailing hyphens.
 fn is_valid_workspace_name(name: &str) -> bool {
-    !name.is_empty()
-        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
-        && !name.starts_with('-')
-        && !name.ends_with('-')
+    claudette::workspace_alloc::is_valid_workspace_name(name)
 }
 
 /// Discover existing git worktrees for a repository that are not yet tracked in Claudette.

--- a/src/git.rs
+++ b/src/git.rs
@@ -446,6 +446,15 @@ pub async fn create_worktree(
     canonicalize_worktree_path(worktree_path)
 }
 
+pub fn is_worktree_create_collision_error(err: &GitError) -> bool {
+    match err {
+        GitError::CommandFailed(msg) => {
+            msg.contains("already exists") || msg.contains("is already checked out")
+        }
+        GitError::NotAGitRepo | GitError::CliNotFound => false,
+    }
+}
+
 /// Create a worktree + new branch rooted at an explicit git ref (commit hash,
 /// tag, or branch name). Unlike [`create_worktree`], this does NOT fetch or
 /// resolve the default branch — the caller supplies the exact base ref.
@@ -1029,6 +1038,22 @@ mod tests {
             err.to_string().contains("no commits"),
             "expected 'no commits' error, got: {err}"
         );
+    }
+
+    #[test]
+    fn test_worktree_create_collision_classifier() {
+        assert!(is_worktree_create_collision_error(
+            &GitError::CommandFailed(
+                "fatal: a branch named 'user/dusty-dandelion' already exists".into(),
+            ),
+        ));
+        assert!(is_worktree_create_collision_error(
+            &GitError::CommandFailed("fatal: 'main' is already checked out at '/tmp/repo'".into(),),
+        ));
+        assert!(!is_worktree_create_collision_error(
+            &GitError::CommandFailed("fatal: not a valid object name: origin/main".into()),
+        ));
+        assert!(!is_worktree_create_collision_error(&GitError::NotAGitRepo));
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod process;
 pub mod scm;
 pub mod slash_commands;
 pub mod snapshot;
+pub mod workspace_alloc;
 pub mod workspace_sync;
 
 use base64::Engine;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -1083,10 +1083,10 @@ function RemoteConnectionGroup({
     if (creatingRef.current.has(repoId)) return;
     creatingRef.current.add(repoId);
     try {
-      const name = await generateWorkspaceName();
+      const generated = await generateWorkspaceName();
       const result = await sendRemoteCommand(conn.id, "create_workspace", {
         repository_id: repoId,
-        name,
+        name: generated.slug,
       });
       if (result === null || typeof result !== "object" || !("id" in result)) {
         throw new Error("Remote server returned an invalid workspace");

--- a/src/workspace_alloc.rs
+++ b/src/workspace_alloc.rs
@@ -1,0 +1,321 @@
+use std::path::{Path, PathBuf};
+
+use crate::model::{Repository, Workspace};
+
+const MAX_ALLOCATION_ATTEMPTS: usize = 10_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceAllocation {
+    pub name: String,
+    pub branch_name: String,
+    pub worktree_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub enum WorkspaceAllocationError {
+    Git(crate::git::GitError),
+    Exhausted,
+}
+
+impl std::fmt::Display for WorkspaceAllocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Git(err) => write!(f, "{err}"),
+            Self::Exhausted => write!(f, "Could not allocate a unique workspace name"),
+        }
+    }
+}
+
+impl std::error::Error for WorkspaceAllocationError {}
+
+impl From<crate::git::GitError> for WorkspaceAllocationError {
+    fn from(err: crate::git::GitError) -> Self {
+        Self::Git(err)
+    }
+}
+
+/// Validate a workspace name: ASCII alphanumeric + hyphens, no leading/trailing hyphens.
+pub fn is_valid_workspace_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        && !name.starts_with('-')
+        && !name.ends_with('-')
+}
+
+pub async fn allocate_workspace_name(
+    repo: &Repository,
+    workspaces: &[Workspace],
+    requested_name: &str,
+    branch_prefix: &str,
+    worktree_base: &Path,
+) -> Result<WorkspaceAllocation, WorkspaceAllocationError> {
+    let existing_workspace_names: std::collections::HashSet<String> = workspaces
+        .iter()
+        .filter(|w| w.repository_id == repo.id)
+        .map(|w| w.name.clone())
+        .collect();
+    let existing_workspace_branches: std::collections::HashSet<String> = workspaces
+        .iter()
+        .filter(|w| w.repository_id == repo.id)
+        .map(|w| w.branch_name.clone())
+        .collect();
+    let existing_workspace_paths: std::collections::HashSet<String> = workspaces
+        .iter()
+        .filter(|w| w.repository_id == repo.id)
+        .filter_map(|w| w.worktree_path.as_deref())
+        .map(path_key)
+        .collect();
+
+    let existing_git_branches: std::collections::HashSet<String> =
+        crate::git::list_branches(&repo.path)
+            .await?
+            .into_iter()
+            .collect();
+    let existing_git_worktree_paths: std::collections::HashSet<String> =
+        crate::git::list_worktrees(&repo.path)
+            .await?
+            .into_iter()
+            .map(|wt| path_key(&wt.path))
+            .collect();
+
+    for attempt in 0..MAX_ALLOCATION_ATTEMPTS {
+        let name = if attempt == 0 {
+            requested_name.to_string()
+        } else {
+            format!("{requested_name}-{}", attempt + 1)
+        };
+        let branch_name = format!("{branch_prefix}{name}");
+        let worktree_path = worktree_base.join(&repo.path_slug).join(&name);
+        let worktree_key = path_key(&worktree_path);
+
+        if existing_workspace_names.contains(&name)
+            || existing_workspace_branches.contains(&branch_name)
+            || existing_workspace_paths.contains(&worktree_key)
+            || existing_git_branches.contains(&branch_name)
+            || existing_git_worktree_paths.contains(&worktree_key)
+            || worktree_path.exists()
+        {
+            continue;
+        }
+
+        return Ok(WorkspaceAllocation {
+            name,
+            branch_name,
+            worktree_path,
+        });
+    }
+
+    Err(WorkspaceAllocationError::Exhausted)
+}
+
+fn path_key(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use crate::model::{AgentStatus, Repository, Workspace, WorkspaceStatus};
+    use std::process::Command;
+
+    fn make_repo(id: &str, path: &str) -> Repository {
+        Repository {
+            id: id.into(),
+            path: path.into(),
+            name: id.into(),
+            path_slug: id.into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+        }
+    }
+
+    fn make_workspace(id: &str, repo: &str, name: &str, branch: &str, path: &Path) -> Workspace {
+        Workspace {
+            id: id.into(),
+            repository_id: repo.into(),
+            name: name.into(),
+            branch_name: branch.into(),
+            worktree_path: Some(path.to_string_lossy().to_string()),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+        }
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let status = Command::new(crate::git::resolve_git_path_blocking())
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git command failed: {args:?}");
+    }
+
+    fn setup_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let status = Command::new(crate::git::resolve_git_path_blocking())
+            .arg("-C")
+            .arg(repo)
+            .args(["init", "-b", "main"])
+            .status()
+            .unwrap();
+        assert!(status.success());
+        git(repo, &["config", "user.email", "test@test.com"]);
+        git(repo, &["config", "user.name", "Test"]);
+        std::fs::write(repo.join("README.md"), "# test").unwrap();
+        git(repo, &["add", "-A"]);
+        git(repo, &["commit", "-m", "initial"]);
+        dir
+    }
+
+    #[tokio::test]
+    async fn allocation_uses_base_name_when_available() {
+        let repo_dir = setup_repo();
+        let db = Database::open_in_memory().unwrap();
+        let repo = make_repo("repo1", repo_dir.path().to_str().unwrap());
+        db.insert_repository(&repo).unwrap();
+        let base = tempfile::tempdir().unwrap();
+
+        let allocation = allocate_workspace_name(
+            &repo,
+            &db.list_workspaces().unwrap(),
+            "dusty-dandelion",
+            "user/",
+            base.path(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(allocation.name, "dusty-dandelion");
+        assert_eq!(allocation.branch_name, "user/dusty-dandelion");
+        assert_eq!(
+            allocation.worktree_path,
+            base.path().join("repo1").join("dusty-dandelion")
+        );
+    }
+
+    #[tokio::test]
+    async fn allocation_suffixes_existing_workspace_name() {
+        let repo_dir = setup_repo();
+        let db = Database::open_in_memory().unwrap();
+        let repo = make_repo("repo1", repo_dir.path().to_str().unwrap());
+        db.insert_repository(&repo).unwrap();
+        let base = tempfile::tempdir().unwrap();
+        db.insert_workspace(&make_workspace(
+            "w1",
+            "repo1",
+            "dusty-dandelion",
+            "user/dusty-dandelion",
+            &base.path().join("repo1").join("dusty-dandelion"),
+        ))
+        .unwrap();
+
+        let allocation = allocate_workspace_name(
+            &repo,
+            &db.list_workspaces().unwrap(),
+            "dusty-dandelion",
+            "user/",
+            base.path(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(allocation.name, "dusty-dandelion-2");
+        assert_eq!(allocation.branch_name, "user/dusty-dandelion-2");
+    }
+
+    #[tokio::test]
+    async fn allocation_suffixes_existing_git_branch() {
+        let repo_dir = setup_repo();
+        git(repo_dir.path(), &["branch", "user/dusty-dandelion"]);
+        let db = Database::open_in_memory().unwrap();
+        let repo = make_repo("repo1", repo_dir.path().to_str().unwrap());
+        db.insert_repository(&repo).unwrap();
+        let base = tempfile::tempdir().unwrap();
+
+        let allocation = allocate_workspace_name(
+            &repo,
+            &db.list_workspaces().unwrap(),
+            "dusty-dandelion",
+            "user/",
+            base.path(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(allocation.name, "dusty-dandelion-2");
+        assert_eq!(allocation.branch_name, "user/dusty-dandelion-2");
+    }
+
+    #[tokio::test]
+    async fn allocation_suffixes_existing_worktree_path_on_disk() {
+        let repo_dir = setup_repo();
+        let db = Database::open_in_memory().unwrap();
+        let repo = make_repo("repo1", repo_dir.path().to_str().unwrap());
+        db.insert_repository(&repo).unwrap();
+        let base = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(base.path().join("repo1").join("dusty-dandelion")).unwrap();
+
+        let allocation = allocate_workspace_name(
+            &repo,
+            &db.list_workspaces().unwrap(),
+            "dusty-dandelion",
+            "user/",
+            base.path(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(allocation.name, "dusty-dandelion-2");
+        assert_eq!(allocation.branch_name, "user/dusty-dandelion-2");
+    }
+
+    #[tokio::test]
+    async fn allocation_ignores_same_name_in_other_repo() {
+        let repo_dir = setup_repo();
+        let other_repo_dir = setup_repo();
+        let db = Database::open_in_memory().unwrap();
+        let repo = make_repo("repo1", repo_dir.path().to_str().unwrap());
+        let other = make_repo("repo2", other_repo_dir.path().to_str().unwrap());
+        db.insert_repository(&repo).unwrap();
+        db.insert_repository(&other).unwrap();
+        let base = tempfile::tempdir().unwrap();
+        db.insert_workspace(&make_workspace(
+            "w1",
+            "repo2",
+            "dusty-dandelion",
+            "user/dusty-dandelion",
+            &base.path().join("repo2").join("dusty-dandelion"),
+        ))
+        .unwrap();
+
+        let allocation = allocate_workspace_name(
+            &repo,
+            &db.list_workspaces().unwrap(),
+            "dusty-dandelion",
+            "user/",
+            base.path(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(allocation.name, "dusty-dandelion");
+        assert_eq!(allocation.branch_name, "user/dusty-dandelion");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #590.

- Add shared backend workspace-name allocation with deterministic suffix fallback for occupied slugs.
- Check existing workspace names, branches, paths, git branches, registered worktrees, and on-disk paths before creating a worktree.
- Wire both local Tauri and remote server workspace creation through the shared allocator.
- Retry allocation when concurrent creation loses the race at `git worktree add`.
- Send `generated.slug` for remote workspace creation.

## Verification

- `cargo test --all-features`
- `cargo test -p claudette workspace_alloc::tests`
- `cargo test -p claudette git::tests::test_worktree_create_collision_classifier`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test`
- `cd src/ui && bun run lint:css`

Note: `cd src/ui && bun run lint` still fails on existing unrelated repo-wide React lint violations.