### PR TITLE
feat(changes): per-file and bulk stage/unstage/discard controls

### DIFF
--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -102,6 +102,51 @@ pub async fn revert_file(
 }
 
 #[tauri::command]
+pub async fn stage_file(worktree_path: String, file_path: String) -> Result<(), String> {
+    diff::stage_file(&worktree_path, &file_path)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn unstage_file(worktree_path: String, file_path: String) -> Result<(), String> {
+    diff::unstage_file(&worktree_path, &file_path)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn stage_files(
+    worktree_path: String,
+    file_paths: Vec<String>,
+) -> Result<(), String> {
+    diff::stage_files(&worktree_path, &file_paths)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn unstage_files(
+    worktree_path: String,
+    file_paths: Vec<String>,
+) -> Result<(), String> {
+    diff::unstage_files(&worktree_path, &file_paths)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn discard_files(
+    worktree_path: String,
+    tracked: Vec<String>,
+    untracked: Vec<String>,
+) -> Result<(), String> {
+    diff::discard_files(&worktree_path, &tracked, &untracked)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn discard_file(
     worktree_path: String,
     file_path: String,

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -116,20 +116,14 @@ pub async fn unstage_file(worktree_path: String, file_path: String) -> Result<()
 }
 
 #[tauri::command]
-pub async fn stage_files(
-    worktree_path: String,
-    file_paths: Vec<String>,
-) -> Result<(), String> {
+pub async fn stage_files(worktree_path: String, file_paths: Vec<String>) -> Result<(), String> {
     diff::stage_files(&worktree_path, &file_paths)
         .await
         .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub async fn unstage_files(
-    worktree_path: String,
-    file_paths: Vec<String>,
-) -> Result<(), String> {
+pub async fn unstage_files(worktree_path: String, file_paths: Vec<String>) -> Result<(), String> {
     diff::unstage_files(&worktree_path, &file_paths)
         .await
         .map_err(|e| e.to_string())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -510,6 +510,11 @@ fn main() {
             commands::diff::load_file_diff,
             commands::diff::revert_file,
             commands::diff::discard_file,
+            commands::diff::stage_file,
+            commands::diff::unstage_file,
+            commands::diff::stage_files,
+            commands::diff::unstage_files,
+            commands::diff::discard_files,
             // Terminal
             commands::terminal::create_terminal_tab,
             commands::terminal::delete_terminal_tab,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -385,6 +385,86 @@ pub async fn revert_file(
     Ok(())
 }
 
+/// Stage a single file (`git add -- <file>`). Works for tracked and untracked
+/// paths; pathspec literal mode (`--`) prevents glob expansion.
+pub async fn stage_file(worktree_path: &str, file_path: &str) -> Result<(), DiffError> {
+    validate_file_path(file_path)?;
+    run_git(worktree_path, &["add", "--", file_path]).await?;
+    Ok(())
+}
+
+/// Unstage a single file (`git restore --staged -- <file>`). Leaves the
+/// worktree copy untouched.
+pub async fn unstage_file(worktree_path: &str, file_path: &str) -> Result<(), DiffError> {
+    validate_file_path(file_path)?;
+    run_git(worktree_path, &["restore", "--staged", "--", file_path]).await?;
+    Ok(())
+}
+
+/// Stage many files in a single `git add` invocation. Issuing one command
+/// with N pathspecs avoids `.git/index.lock` contention that parallel
+/// per-file `git add`s race on, and is also faster than serializing them.
+pub async fn stage_files(
+    worktree_path: &str,
+    file_paths: &[String],
+) -> Result<(), DiffError> {
+    if file_paths.is_empty() {
+        return Ok(());
+    }
+    for p in file_paths {
+        validate_file_path(p)?;
+    }
+    let mut args: Vec<&str> = vec!["add", "--"];
+    args.extend(file_paths.iter().map(String::as_str));
+    run_git(worktree_path, &args).await?;
+    Ok(())
+}
+
+/// Unstage many files in a single `git restore --staged` invocation.
+/// See [`stage_files`] for why this batches.
+pub async fn unstage_files(
+    worktree_path: &str,
+    file_paths: &[String],
+) -> Result<(), DiffError> {
+    if file_paths.is_empty() {
+        return Ok(());
+    }
+    for p in file_paths {
+        validate_file_path(p)?;
+    }
+    let mut args: Vec<&str> = vec!["restore", "--staged", "--"];
+    args.extend(file_paths.iter().map(String::as_str));
+    run_git(worktree_path, &args).await?;
+    Ok(())
+}
+
+/// Discard worktree changes for many files in one go. Tracked paths are
+/// passed to a single `git restore --` invocation; untracked paths are
+/// removed from disk via `fs::remove_file` in series. Splitting by
+/// `is_untracked` mirrors [`discard_file`]'s per-file branching, but
+/// folds the tracked branch into one git call to avoid index-lock races.
+pub async fn discard_files(
+    worktree_path: &str,
+    tracked: &[String],
+    untracked: &[String],
+) -> Result<(), DiffError> {
+    for p in tracked.iter().chain(untracked.iter()) {
+        validate_file_path(p)?;
+    }
+    if !tracked.is_empty() {
+        let mut args: Vec<&str> = vec!["restore", "--"];
+        args.extend(tracked.iter().map(String::as_str));
+        run_git(worktree_path, &args).await?;
+    }
+    for p in untracked {
+        let full_path = Path::new(worktree_path).join(p);
+        tokio::fs::remove_file(&full_path)
+            .await
+            .map_err(|e| DiffError::CommandFailed(e.to_string()))?;
+    }
+    Ok(())
+}
+
 /// Discard worktree changes for a single file from the Changes sidebar.
 ///
 /// - `is_untracked = false`: runs `git restore -- <file>`, which restores the

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -385,11 +385,14 @@ pub async fn revert_file(
     Ok(())
 }
 
-/// Stage a single file (`git add -- <file>`). Works for tracked and untracked
-/// paths; pathspec literal mode (`--`) prevents glob expansion.
+/// Stage a single file (`git add -A -- <file>`). `-A` ensures additions,
+/// modifications, and removals are all reflected — without it, staging an
+/// unstaged deletion (the file is gone from the worktree) errors with
+/// "pathspec did not match any files". Pathspec literal mode (`--`) prevents
+/// glob expansion.
 pub async fn stage_file(worktree_path: &str, file_path: &str) -> Result<(), DiffError> {
     validate_file_path(file_path)?;
-    run_git(worktree_path, &["add", "--", file_path]).await?;
+    run_git(worktree_path, &["add", "-A", "--", file_path]).await?;
     Ok(())
 }
 
@@ -401,9 +404,11 @@ pub async fn unstage_file(worktree_path: &str, file_path: &str) -> Result<(), Di
     Ok(())
 }
 
-/// Stage many files in a single `git add` invocation. Issuing one command
+/// Stage many files in a single `git add -A` invocation. Issuing one command
 /// with N pathspecs avoids `.git/index.lock` contention that parallel
 /// per-file `git add`s race on, and is also faster than serializing them.
+/// `-A` is required so deleted paths in the batch stage as removals rather
+/// than failing with "pathspec did not match any files".
 pub async fn stage_files(worktree_path: &str, file_paths: &[String]) -> Result<(), DiffError> {
     if file_paths.is_empty() {
         return Ok(());
@@ -411,7 +416,7 @@ pub async fn stage_files(worktree_path: &str, file_paths: &[String]) -> Result<(
     for p in file_paths {
         validate_file_path(p)?;
     }
-    let mut args: Vec<&str> = vec!["add", "--"];
+    let mut args: Vec<&str> = vec!["add", "-A", "--"];
     args.extend(file_paths.iter().map(String::as_str));
     run_git(worktree_path, &args).await?;
     Ok(())

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -404,10 +404,7 @@ pub async fn unstage_file(worktree_path: &str, file_path: &str) -> Result<(), Di
 /// Stage many files in a single `git add` invocation. Issuing one command
 /// with N pathspecs avoids `.git/index.lock` contention that parallel
 /// per-file `git add`s race on, and is also faster than serializing them.
-pub async fn stage_files(
-    worktree_path: &str,
-    file_paths: &[String],
-) -> Result<(), DiffError> {
+pub async fn stage_files(worktree_path: &str, file_paths: &[String]) -> Result<(), DiffError> {
     if file_paths.is_empty() {
         return Ok(());
     }
@@ -422,10 +419,7 @@ pub async fn stage_files(
 
 /// Unstage many files in a single `git restore --staged` invocation.
 /// See [`stage_files`] for why this batches.
-pub async fn unstage_files(
-    worktree_path: &str,
-    file_paths: &[String],
-) -> Result<(), DiffError> {
+pub async fn unstage_files(worktree_path: &str, file_paths: &[String]) -> Result<(), DiffError> {
     if file_paths.is_empty() {
         return Ok(());
     }

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -484,6 +484,7 @@ export function SessionTabs({ workspaceId }: Props) {
             onSelect={() => selectFileTab(workspaceId, path)}
             onClose={() => requestCloseFileTab(path)}
             onNavigate={(direction) => navigateTabs(navKey, direction)}
+            onContextMenu={(x, y) => openContextMenu(navKey, x, y)}
             tabRef={(el) => {
               if (el) tabRefs.current.set(navKey, el);
               else tabRefs.current.delete(navKey);
@@ -675,6 +676,7 @@ interface FileTabProps {
   onSelect: () => void;
   onClose: () => void;
   onNavigate: (direction: NavDirection) => void;
+  onContextMenu: (x: number, y: number) => void;
   tabRef: (el: HTMLDivElement | null) => void;
 }
 
@@ -685,6 +687,7 @@ function FileTab({
   onSelect,
   onClose,
   onNavigate,
+  onContextMenu,
   tabRef,
 }: FileTabProps) {
   const { t } = useTranslation("chat");
@@ -707,6 +710,10 @@ function FileTab({
       tabIndex={isActive ? 0 : -1}
       className={`${styles.tab} ${isActive ? styles.active : ""}`}
       onClick={onSelect}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onContextMenu(e.clientX, e.clientY);
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();

--- a/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
+++ b/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
@@ -5,16 +5,14 @@ import type { DiffLayer } from "../../types/diff";
 
 export type DiscardableLayer = Extract<DiffLayer, "unstaged" | "untracked">;
 
-interface DiscardChangesConfirmProps {
-  /** Single-file confirm — shows the path inline. */
-  filePath?: string;
-  /** Bulk-discard confirm — shows "N files" instead of the path. Mutually
-   *  exclusive with `filePath`; takes precedence when both are set. */
-  bulkCount?: number;
+type DiscardChangesConfirmProps = {
   layer: DiscardableLayer;
   onConfirm: () => Promise<void>;
   onClose: () => void;
-}
+} & (
+  | { filePath: string; bulkCount?: never }
+  | { bulkCount: number; filePath?: never }
+);
 
 export function DiscardChangesConfirm({
   filePath,

--- a/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
+++ b/src/ui/src/components/right-sidebar/DiscardChangesConfirm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { Modal } from "../modals/Modal";
 import shared from "../modals/shared.module.css";
 import type { DiffLayer } from "../../types/diff";
@@ -6,7 +6,11 @@ import type { DiffLayer } from "../../types/diff";
 export type DiscardableLayer = Extract<DiffLayer, "unstaged" | "untracked">;
 
 interface DiscardChangesConfirmProps {
-  filePath: string;
+  /** Single-file confirm — shows the path inline. */
+  filePath?: string;
+  /** Bulk-discard confirm — shows "N files" instead of the path. Mutually
+   *  exclusive with `filePath`; takes precedence when both are set. */
+  bulkCount?: number;
   layer: DiscardableLayer;
   onConfirm: () => Promise<void>;
   onClose: () => void;
@@ -14,6 +18,7 @@ interface DiscardChangesConfirmProps {
 
 export function DiscardChangesConfirm({
   filePath,
+  bulkCount,
   layer,
   onConfirm,
   onClose,
@@ -41,17 +46,45 @@ export function DiscardChangesConfirm({
   };
 
   const isUntracked = layer === "untracked";
-  const title = isUntracked ? "Delete untracked file?" : "Discard changes?";
+  const isBulk = bulkCount != null && bulkCount > 0;
+  const title = isBulk
+    ? isUntracked
+      ? "Delete all untracked files?"
+      : "Discard all unstaged changes?"
+    : isUntracked
+      ? "Delete untracked file?"
+      : "Discard changes?";
   const action = isUntracked ? "Delete" : "Discard";
+  const target: ReactNode = isBulk ? (
+    <strong>
+      {bulkCount} file{bulkCount === 1 ? "" : "s"}
+    </strong>
+  ) : (
+    <strong>{filePath}</strong>
+  );
   const description = isUntracked ? (
+    isBulk ? (
+      <>
+        Delete {target} that {bulkCount === 1 ? "is" : "are"} not tracked by
+        git. They will be removed from disk.{" "}
+        <strong>This cannot be undone.</strong>
+      </>
+    ) : (
+      <>
+        The file {target} is not tracked by git. Deleting it will remove it
+        from disk. <strong>This cannot be undone.</strong>
+      </>
+    )
+  ) : isBulk ? (
     <>
-      The file <strong>{filePath}</strong> is not tracked by git. Deleting it
-      will remove it from disk. <strong>This cannot be undone.</strong>
+      Discard unstaged changes across {target}. Files will be restored from
+      the index. Any staged changes are kept.{" "}
+      <strong>This cannot be undone.</strong>
     </>
   ) : (
     <>
-      Discard unstaged changes to <strong>{filePath}</strong>. The file will be
-      restored from the index. Any staged changes are kept.{" "}
+      Discard unstaged changes to {target}. The file will be restored from the
+      index. Any staged changes are kept.{" "}
       <strong>This cannot be undone.</strong>
     </>
   );

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -93,7 +93,7 @@
   width: 18px;
   height: 18px;
   padding: 0;
-  margin-left: 4px;
+  margin-left: 0;
   border: none;
   background: transparent;
   color: var(--text-dim);
@@ -116,7 +116,21 @@
 
 .rowAction:hover {
   background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.rowActionDanger:hover {
+  background: var(--hover-bg);
   color: var(--diff-removed-text);
+}
+
+/* Cluster of per-row action buttons. Tighter than the row's 8px gap so
+ * the icons read as one control group rather than scattered siblings. */
+.rowActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  flex-shrink: 0;
 }
 
 .status {
@@ -163,19 +177,74 @@
   gap: 4px;
   width: 100%;
   padding: 4px 8px;
-  background: none;
-  border: none;
   color: var(--text-dim);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  cursor: pointer;
   transition: color var(--transition-fast);
 }
 
 .groupHeader:hover {
   color: var(--text-muted);
+}
+
+/* The expand/collapse toggle owns most of the header (chevron + label +
+ * count). Splitting this from the bulk-action buttons keeps the header
+ * out of the "button inside button" trap and lets toggle-clicks miss the
+ * bulk actions. */
+.groupToggle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.groupActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+
+.groupAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.fileGroup:hover .groupAction {
+  color: var(--text-dim);
+}
+
+.groupAction:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.groupActionDanger:hover {
+  background: var(--hover-bg);
+  color: var(--diff-removed-text);
 }
 
 .groupChevron {

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -213,10 +213,9 @@ export const RightSidebar = memo(function RightSidebar() {
     const canDiscard = discardEnabled && isDiscardableLayer(layer);
     const canStage = discardEnabled && (layer === "unstaged" || layer === "untracked");
     const canUnstage = discardEnabled && layer === "staged";
-    // Source file no longer exists on disk for an unstaged deletion, so the
-    // "open file" button would just produce a load error.
-    const canOpenSource = selectedWorkspaceId != null
-      && !(layer === "unstaged" && file.status === "Deleted");
+    // Deleted files don't exist on disk regardless of layer (staged deletions
+    // are already removed by `git rm`; committed deletions are gone from HEAD).
+    const canOpenSource = selectedWorkspaceId != null && file.status !== "Deleted";
 
     const handleContextMenu = (e: React.MouseEvent) => {
       if (!canDiscard) return;
@@ -336,7 +335,9 @@ export const RightSidebar = memo(function RightSidebar() {
       if (!worktreePath || !selectedWorkspaceId) return;
       await stageFile(worktreePath, filePath);
       const result = await loadDiff(selectedWorkspaceId);
-      applyDiffResult(result);
+      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+        applyDiffResult(result);
+      }
     },
     [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
   );
@@ -346,7 +347,9 @@ export const RightSidebar = memo(function RightSidebar() {
       if (!worktreePath || !selectedWorkspaceId) return;
       await unstageFile(worktreePath, filePath);
       const result = await loadDiff(selectedWorkspaceId);
-      applyDiffResult(result);
+      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+        applyDiffResult(result);
+      }
     },
     [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
   );
@@ -358,7 +361,9 @@ export const RightSidebar = memo(function RightSidebar() {
       // `.git/index.lock` and would fail.
       await stageFiles(worktreePath, files.map((f) => f.path));
       const result = await loadDiff(selectedWorkspaceId);
-      applyDiffResult(result);
+      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+        applyDiffResult(result);
+      }
     },
     [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
   );
@@ -368,7 +373,9 @@ export const RightSidebar = memo(function RightSidebar() {
       if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
       await unstageFiles(worktreePath, files.map((f) => f.path));
       const result = await loadDiff(selectedWorkspaceId);
-      applyDiffResult(result);
+      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+        applyDiffResult(result);
+      }
     },
     [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
   );
@@ -389,7 +396,9 @@ export const RightSidebar = memo(function RightSidebar() {
         state.setDiffSelectedFile(null);
       }
       const result = await loadDiff(selectedWorkspaceId);
-      applyDiffResult(result);
+      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+        applyDiffResult(result);
+      }
     },
     [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
   );
@@ -407,7 +416,9 @@ export const RightSidebar = memo(function RightSidebar() {
       }
 
       const result = await loadDiff(selectedWorkspaceId);
-      applyDiffResult(result);
+      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+        applyDiffResult(result);
+      }
     },
     [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult]
   );

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -65,9 +65,9 @@ export const RightSidebar = memo(function RightSidebar() {
   const activeSessionId = useAppStore(selectActiveSessionId);
   const { totalCount: taskCount } = useTaskTracker(activeSessionId);
 
-  // Discard-changes UI state. Local-only — discard isn't bridged through the
-  // remote server (matches revert_file), so the action is hidden when the
-  // workspace is connected to a remote.
+  // Local-only stage/unstage/discard UI state. None of these git index
+  // operations are bridged through the remote server (matches revert_file),
+  // so the actions are hidden when the workspace is connected to a remote.
   const [discardTarget, setDiscardTarget] = useState<
     { file: DiffFile; layer: DiscardableLayer } | null
   >(null);
@@ -77,7 +77,14 @@ export const RightSidebar = memo(function RightSidebar() {
   const [contextMenu, setContextMenu] = useState<
     { x: number; y: number; file: DiffFile; layer: DiscardableLayer } | null
   >(null);
-  const discardEnabled = !remoteConnectionId && worktreePath != null;
+  // Gates stage/unstage/discard (single + bulk). Hidden when connected to a
+  // remote (the server doesn't bridge index ops) or when there's no local
+  // worktree to operate against.
+  const localGitOpsEnabled = !remoteConnectionId && worktreePath != null;
+  // True while a stage/unstage/discard git invocation is awaiting. Disables
+  // every action button so rapid clicks can't fire overlapping `git add` /
+  // `git restore` calls that would race on `.git/index.lock`.
+  const [gitOpInFlight, setGitOpInFlight] = useState(false);
 
   // Load diff files for either local or remote workspace
   const loadDiff = useCallback(
@@ -210,9 +217,9 @@ export const RightSidebar = memo(function RightSidebar() {
   const renderFileRow = (file: DiffFile, layer?: DiffLayer) => {
     const isSelected = diffSelectedFile === file.path
       && (diffSelectedLayer ?? "flat") === (layer ?? "flat");
-    const canDiscard = discardEnabled && isDiscardableLayer(layer);
-    const canStage = discardEnabled && (layer === "unstaged" || layer === "untracked");
-    const canUnstage = discardEnabled && layer === "staged";
+    const canDiscard = localGitOpsEnabled && isDiscardableLayer(layer);
+    const canStage = localGitOpsEnabled && (layer === "unstaged" || layer === "untracked");
+    const canUnstage = localGitOpsEnabled && layer === "staged";
     // Deleted files don't exist on disk regardless of layer (staged deletions
     // are already removed by `git rm`; committed deletions are gone from HEAD).
     const canOpenSource = selectedWorkspaceId != null && file.status !== "Deleted";
@@ -232,14 +239,18 @@ export const RightSidebar = memo(function RightSidebar() {
 
     const handleStageClick = (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!canStage) return;
-      void performStage(file.path);
+      if (!canStage || gitOpInFlight) return;
+      performStage(file.path).catch((err) => {
+        console.error("Failed to stage file:", err);
+      });
     };
 
     const handleUnstageClick = (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!canUnstage) return;
-      void performUnstage(file.path);
+      if (!canUnstage || gitOpInFlight) return;
+      performUnstage(file.path).catch((err) => {
+        console.error("Failed to unstage file:", err);
+      });
     };
 
     const handleOpenClick = (e: React.MouseEvent) => {
@@ -293,6 +304,7 @@ export const RightSidebar = memo(function RightSidebar() {
             type="button"
             className={styles.rowAction}
             onClick={handleStageClick}
+            disabled={gitOpInFlight}
             title="Stage"
             aria-label="Stage"
           >
@@ -304,6 +316,7 @@ export const RightSidebar = memo(function RightSidebar() {
             type="button"
             className={styles.rowAction}
             onClick={handleUnstageClick}
+            disabled={gitOpInFlight}
             title="Unstage"
             aria-label="Unstage"
           >
@@ -315,6 +328,7 @@ export const RightSidebar = memo(function RightSidebar() {
             type="button"
             className={`${styles.rowAction} ${styles.rowActionDanger}`}
             onClick={handleDiscardClick}
+            disabled={gitOpInFlight}
             title={layer === "untracked" ? "Delete" : "Discard changes"}
             aria-label={layer === "untracked" ? "Delete" : "Discard changes"}
           >
@@ -330,97 +344,108 @@ export const RightSidebar = memo(function RightSidebar() {
     );
   };
 
-  const performStage = useCallback(
-    async (filePath: string) => {
+  // Wraps a stage/unstage/discard body so concurrent invocations are blocked
+  // (the in-flight flag also dims every action button) and the resulting
+  // diff reload is dropped if the user switched workspaces while git was
+  // running. Errors propagate so callers can surface them — discard hands
+  // them to the confirm modal; fire-and-forget click handlers log them.
+  const runIndexOp = useCallback(
+    async (op: () => Promise<void>) => {
       if (!worktreePath || !selectedWorkspaceId) return;
-      await stageFile(worktreePath, filePath);
-      const result = await loadDiff(selectedWorkspaceId);
-      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
-        applyDiffResult(result);
+      if (gitOpInFlight) return;
+      setGitOpInFlight(true);
+      try {
+        await op();
+        const result = await loadDiff(selectedWorkspaceId);
+        if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
+          applyDiffResult(result);
+        }
+      } finally {
+        setGitOpInFlight(false);
       }
     },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult, gitOpInFlight],
+  );
+
+  // Clear the diff selection when the currently-selected row is about to
+  // move between layers (stage/unstage) or disappear (discard). Without
+  // this, `diffSelectedLayer` keeps pointing at the now-empty old layer,
+  // which leaves the sidebar with no highlighted row and the diff viewer
+  // showing stale content.
+  const clearSelectionIfAffected = useCallback((paths: string[]) => {
+    if (paths.length === 0) return;
+    const state = useAppStore.getState();
+    const selected = state.diffSelectedFile;
+    if (selected && paths.includes(selected)) {
+      state.setDiffSelectedFile(null);
+    }
+  }, []);
+
+  const performStage = useCallback(
+    (filePath: string) =>
+      runIndexOp(async () => {
+        clearSelectionIfAffected([filePath]);
+        await stageFile(worktreePath!, filePath);
+      }),
+    [runIndexOp, clearSelectionIfAffected, worktreePath],
   );
 
   const performUnstage = useCallback(
-    async (filePath: string) => {
-      if (!worktreePath || !selectedWorkspaceId) return;
-      await unstageFile(worktreePath, filePath);
-      const result = await loadDiff(selectedWorkspaceId);
-      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
-        applyDiffResult(result);
-      }
-    },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+    (filePath: string) =>
+      runIndexOp(async () => {
+        clearSelectionIfAffected([filePath]);
+        await unstageFile(worktreePath!, filePath);
+      }),
+    [runIndexOp, clearSelectionIfAffected, worktreePath],
   );
 
   const performStageAll = useCallback(
-    async (files: DiffFile[]) => {
-      if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
-      // One git invocation with all paths — parallel `git add`s race on
-      // `.git/index.lock` and would fail.
-      await stageFiles(worktreePath, files.map((f) => f.path));
-      const result = await loadDiff(selectedWorkspaceId);
-      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
-        applyDiffResult(result);
-      }
-    },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+    (files: DiffFile[]) =>
+      runIndexOp(async () => {
+        if (files.length === 0) return;
+        const paths = files.map((f) => f.path);
+        clearSelectionIfAffected(paths);
+        // One git invocation with all paths — parallel `git add`s race on
+        // `.git/index.lock` and would fail.
+        await stageFiles(worktreePath!, paths);
+      }),
+    [runIndexOp, clearSelectionIfAffected, worktreePath],
   );
 
   const performUnstageAll = useCallback(
-    async (files: DiffFile[]) => {
-      if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
-      await unstageFiles(worktreePath, files.map((f) => f.path));
-      const result = await loadDiff(selectedWorkspaceId);
-      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
-        applyDiffResult(result);
-      }
-    },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+    (files: DiffFile[]) =>
+      runIndexOp(async () => {
+        if (files.length === 0) return;
+        const paths = files.map((f) => f.path);
+        clearSelectionIfAffected(paths);
+        await unstageFiles(worktreePath!, paths);
+      }),
+    [runIndexOp, clearSelectionIfAffected, worktreePath],
   );
 
   const performBulkDiscard = useCallback(
-    async (files: DiffFile[], layer: DiscardableLayer) => {
-      if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
-      const isUntracked = layer === "untracked";
-      const paths = files.map((f) => f.path);
-      await discardFiles(
-        worktreePath,
-        isUntracked ? [] : paths,
-        isUntracked ? paths : [],
-      );
-      const state = useAppStore.getState();
-      const selectedPath = state.diffSelectedFile;
-      if (selectedPath && files.some((f) => f.path === selectedPath)) {
-        state.setDiffSelectedFile(null);
-      }
-      const result = await loadDiff(selectedWorkspaceId);
-      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
-        applyDiffResult(result);
-      }
-    },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+    (files: DiffFile[], layer: DiscardableLayer) =>
+      runIndexOp(async () => {
+        if (files.length === 0) return;
+        const isUntracked = layer === "untracked";
+        const paths = files.map((f) => f.path);
+        clearSelectionIfAffected(paths);
+        await discardFiles(
+          worktreePath!,
+          isUntracked ? [] : paths,
+          isUntracked ? paths : [],
+        );
+      }),
+    [runIndexOp, clearSelectionIfAffected, worktreePath],
   );
 
   const performDiscard = useCallback(
-    async (filePath: string, layer: DiscardableLayer) => {
-      if (!worktreePath || !selectedWorkspaceId) return;
-      await discardFile(worktreePath, filePath, layer === "untracked");
-
-      // Clear selection if the discarded file was selected so the diff
-      // viewer doesn't keep displaying a stale entry.
-      const state = useAppStore.getState();
-      if (state.diffSelectedFile === filePath) {
-        state.setDiffSelectedFile(null);
-      }
-
-      const result = await loadDiff(selectedWorkspaceId);
-      if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
-        applyDiffResult(result);
-      }
-    },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult]
+    (filePath: string, layer: DiscardableLayer) =>
+      runIndexOp(async () => {
+        clearSelectionIfAffected([filePath]);
+        await discardFile(worktreePath!, filePath, layer === "untracked");
+      }),
+    [runIndexOp, clearSelectionIfAffected, worktreePath],
   );
 
   // Determine if we have grouped data to show
@@ -482,12 +507,15 @@ export const RightSidebar = memo(function RightSidebar() {
                   accentColor="var(--accent-dim)"
                   renderFileRow={renderFileRow}
                   onUnstageAll={
-                    discardEnabled
+                    localGitOpsEnabled
                       ? () => {
-                          void performUnstageAll(diffStagedFiles!.staged);
+                          performUnstageAll(diffStagedFiles!.staged).catch((err) => {
+                            console.error("Failed to unstage all files:", err);
+                          });
                         }
                       : undefined
                   }
+                  disabled={gitOpInFlight}
                 />
                 <FileGroup
                   label="Unstaged"
@@ -496,14 +524,16 @@ export const RightSidebar = memo(function RightSidebar() {
                   accentColor="var(--tool-task)"
                   renderFileRow={renderFileRow}
                   onStageAll={
-                    discardEnabled
+                    localGitOpsEnabled
                       ? () => {
-                          void performStageAll(diffStagedFiles!.unstaged);
+                          performStageAll(diffStagedFiles!.unstaged).catch((err) => {
+                            console.error("Failed to stage all files:", err);
+                          });
                         }
                       : undefined
                   }
                   onDiscardAll={
-                    discardEnabled
+                    localGitOpsEnabled
                       ? () =>
                           setBulkDiscardTarget({
                             files: diffStagedFiles!.unstaged,
@@ -511,6 +541,7 @@ export const RightSidebar = memo(function RightSidebar() {
                           })
                       : undefined
                   }
+                  disabled={gitOpInFlight}
                 />
                 <FileGroup
                   label="Untracked"
@@ -598,6 +629,7 @@ function FileGroup({
   onStageAll,
   onUnstageAll,
   onDiscardAll,
+  disabled,
 }: {
   label: string;
   files: DiffFile[];
@@ -607,6 +639,7 @@ function FileGroup({
   onStageAll?: () => void;
   onUnstageAll?: () => void;
   onDiscardAll?: () => void;
+  disabled?: boolean;
 }) {
   const [collapsed, setCollapsed] = useState(layer === "committed");
 
@@ -639,6 +672,7 @@ function FileGroup({
                 type="button"
                 className={styles.groupAction}
                 onClick={onStageAll}
+                disabled={disabled}
                 title="Stage all"
                 aria-label="Stage all"
               >
@@ -650,6 +684,7 @@ function FileGroup({
                 type="button"
                 className={styles.groupAction}
                 onClick={onUnstageAll}
+                disabled={disabled}
                 title="Unstage all"
                 aria-label="Unstage all"
               >
@@ -661,6 +696,7 @@ function FileGroup({
                 type="button"
                 className={`${styles.groupAction} ${styles.groupActionDanger}`}
                 onClick={onDiscardAll}
+                disabled={disabled}
                 title="Discard all"
                 aria-label="Discard all"
               >

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,9 +1,18 @@
 import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
-import { ChevronRight, Undo2, Trash2 } from "lucide-react";
+import { ChevronRight, Undo2, Trash2, Plus, Minus, FileText } from "lucide-react";
 import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
 import { useTaskTracker } from "../../hooks/useTaskTracker";
-import { discardFile, loadDiffFiles, sendRemoteCommand } from "../../services/tauri";
+import {
+  discardFile,
+  discardFiles,
+  loadDiffFiles,
+  sendRemoteCommand,
+  stageFile,
+  stageFiles,
+  unstageFile,
+  unstageFiles,
+} from "../../services/tauri";
 import type { DiffFilesResult } from "../../services/tauri";
 import type { DiffFile, DiffLayer } from "../../types/diff";
 import {
@@ -34,6 +43,7 @@ export const RightSidebar = memo(function RightSidebar() {
   const setDiffFiles = useAppStore((s) => s.setDiffFiles);
   const clearDiff = useAppStore((s) => s.clearDiff);
   const openDiffTab = useAppStore((s) => s.openDiffTab);
+  const openFileTab = useAppStore((s) => s.openFileTab);
   const setDiffLoading = useAppStore((s) => s.setDiffLoading);
   const activeTab = useAppStore((s) => s.rightSidebarTab);
   const setActiveTab = useAppStore((s) => s.setRightSidebarTab);
@@ -60,6 +70,9 @@ export const RightSidebar = memo(function RightSidebar() {
   // workspace is connected to a remote.
   const [discardTarget, setDiscardTarget] = useState<
     { file: DiffFile; layer: DiscardableLayer } | null
+  >(null);
+  const [bulkDiscardTarget, setBulkDiscardTarget] = useState<
+    { files: DiffFile[]; layer: DiscardableLayer } | null
   >(null);
   const [contextMenu, setContextMenu] = useState<
     { x: number; y: number; file: DiffFile; layer: DiscardableLayer } | null
@@ -198,6 +211,12 @@ export const RightSidebar = memo(function RightSidebar() {
     const isSelected = diffSelectedFile === file.path
       && (diffSelectedLayer ?? "flat") === (layer ?? "flat");
     const canDiscard = discardEnabled && isDiscardableLayer(layer);
+    const canStage = discardEnabled && (layer === "unstaged" || layer === "untracked");
+    const canUnstage = discardEnabled && layer === "staged";
+    // Source file no longer exists on disk for an unstaged deletion, so the
+    // "open file" button would just produce a load error.
+    const canOpenSource = selectedWorkspaceId != null
+      && !(layer === "unstaged" && file.status === "Deleted");
 
     const handleContextMenu = (e: React.MouseEvent) => {
       if (!canDiscard) return;
@@ -210,6 +229,24 @@ export const RightSidebar = memo(function RightSidebar() {
       e.stopPropagation();
       if (!canDiscard) return;
       setDiscardTarget({ file, layer });
+    };
+
+    const handleStageClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!canStage) return;
+      void performStage(file.path);
+    };
+
+    const handleUnstageClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!canUnstage) return;
+      void performUnstage(file.path);
+    };
+
+    const handleOpenClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!canOpenSource || !selectedWorkspaceId) return;
+      openFileTab(selectedWorkspaceId, file.path);
     };
 
     return (
@@ -240,32 +277,122 @@ export const RightSidebar = memo(function RightSidebar() {
           )}
         </span>
       )}
-      {canDiscard && (
-        <button
-          type="button"
-          className={styles.rowAction}
-          onClick={handleDiscardClick}
-          title={
-            layer === "untracked"
-              ? `Delete ${file.path}`
-              : `Discard changes to ${file.path}`
-          }
-          aria-label={
-            layer === "untracked"
-              ? `Delete ${file.path}`
-              : `Discard changes to ${file.path}`
-          }
-        >
-          {layer === "untracked" ? (
-            <Trash2 size={12} />
-          ) : (
-            <Undo2 size={12} />
-          )}
-        </button>
-      )}
+      <span className={styles.rowActions}>
+        {canOpenSource && (
+          <button
+            type="button"
+            className={styles.rowAction}
+            onClick={handleOpenClick}
+            title="Open in editor"
+            aria-label="Open in editor"
+          >
+            <FileText size={12} />
+          </button>
+        )}
+        {canStage && (
+          <button
+            type="button"
+            className={styles.rowAction}
+            onClick={handleStageClick}
+            title="Stage"
+            aria-label="Stage"
+          >
+            <Plus size={12} />
+          </button>
+        )}
+        {canUnstage && (
+          <button
+            type="button"
+            className={styles.rowAction}
+            onClick={handleUnstageClick}
+            title="Unstage"
+            aria-label="Unstage"
+          >
+            <Minus size={12} />
+          </button>
+        )}
+        {canDiscard && (
+          <button
+            type="button"
+            className={`${styles.rowAction} ${styles.rowActionDanger}`}
+            onClick={handleDiscardClick}
+            title={layer === "untracked" ? "Delete" : "Discard changes"}
+            aria-label={layer === "untracked" ? "Delete" : "Discard changes"}
+          >
+            {layer === "untracked" ? (
+              <Trash2 size={12} />
+            ) : (
+              <Undo2 size={12} />
+            )}
+          </button>
+        )}
+      </span>
     </div>
     );
   };
+
+  const performStage = useCallback(
+    async (filePath: string) => {
+      if (!worktreePath || !selectedWorkspaceId) return;
+      await stageFile(worktreePath, filePath);
+      const result = await loadDiff(selectedWorkspaceId);
+      applyDiffResult(result);
+    },
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+  );
+
+  const performUnstage = useCallback(
+    async (filePath: string) => {
+      if (!worktreePath || !selectedWorkspaceId) return;
+      await unstageFile(worktreePath, filePath);
+      const result = await loadDiff(selectedWorkspaceId);
+      applyDiffResult(result);
+    },
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+  );
+
+  const performStageAll = useCallback(
+    async (files: DiffFile[]) => {
+      if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
+      // One git invocation with all paths — parallel `git add`s race on
+      // `.git/index.lock` and would fail.
+      await stageFiles(worktreePath, files.map((f) => f.path));
+      const result = await loadDiff(selectedWorkspaceId);
+      applyDiffResult(result);
+    },
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+  );
+
+  const performUnstageAll = useCallback(
+    async (files: DiffFile[]) => {
+      if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
+      await unstageFiles(worktreePath, files.map((f) => f.path));
+      const result = await loadDiff(selectedWorkspaceId);
+      applyDiffResult(result);
+    },
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+  );
+
+  const performBulkDiscard = useCallback(
+    async (files: DiffFile[], layer: DiscardableLayer) => {
+      if (!worktreePath || !selectedWorkspaceId || files.length === 0) return;
+      const isUntracked = layer === "untracked";
+      const paths = files.map((f) => f.path);
+      await discardFiles(
+        worktreePath,
+        isUntracked ? [] : paths,
+        isUntracked ? paths : [],
+      );
+      const state = useAppStore.getState();
+      const selectedPath = state.diffSelectedFile;
+      if (selectedPath && files.some((f) => f.path === selectedPath)) {
+        state.setDiffSelectedFile(null);
+      }
+      const result = await loadDiff(selectedWorkspaceId);
+      applyDiffResult(result);
+    },
+    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult],
+  );
 
   const performDiscard = useCallback(
     async (filePath: string, layer: DiscardableLayer) => {
@@ -338,24 +465,47 @@ export const RightSidebar = memo(function RightSidebar() {
               // "Committed" in workspace A would carry into workspace B.
               <Fragment key={selectedWorkspaceId ?? ""}>
                 <FileGroup
+                  label="Staged"
+                  files={diffStagedFiles!.staged}
+                  layer="staged"
+                  accentColor="var(--accent-dim)"
+                  renderFileRow={renderFileRow}
+                  onUnstageAll={
+                    discardEnabled
+                      ? () => {
+                          void performUnstageAll(diffStagedFiles!.staged);
+                        }
+                      : undefined
+                  }
+                />
+                <FileGroup
                   label="Unstaged"
                   files={diffStagedFiles!.unstaged}
                   layer="unstaged"
                   accentColor="var(--tool-task)"
                   renderFileRow={renderFileRow}
+                  onStageAll={
+                    discardEnabled
+                      ? () => {
+                          void performStageAll(diffStagedFiles!.unstaged);
+                        }
+                      : undefined
+                  }
+                  onDiscardAll={
+                    discardEnabled
+                      ? () =>
+                          setBulkDiscardTarget({
+                            files: diffStagedFiles!.unstaged,
+                            layer: "unstaged",
+                          })
+                      : undefined
+                  }
                 />
                 <FileGroup
                   label="Untracked"
                   files={diffStagedFiles!.untracked}
                   layer="untracked"
                   accentColor="var(--text-dim)"
-                  renderFileRow={renderFileRow}
-                />
-                <FileGroup
-                  label="Staged"
-                  files={diffStagedFiles!.staged}
-                  layer="staged"
-                  accentColor="var(--accent-dim)"
                   renderFileRow={renderFileRow}
                 />
                 <FileGroup
@@ -399,6 +549,17 @@ export const RightSidebar = memo(function RightSidebar() {
           onClose={() => setDiscardTarget(null)}
         />
       )}
+
+      {bulkDiscardTarget && (
+        <DiscardChangesConfirm
+          bulkCount={bulkDiscardTarget.files.length}
+          layer={bulkDiscardTarget.layer}
+          onConfirm={() =>
+            performBulkDiscard(bulkDiscardTarget.files, bulkDiscardTarget.layer)
+          }
+          onClose={() => setBulkDiscardTarget(null)}
+        />
+      )}
     </div>
   );
 });
@@ -423,33 +584,81 @@ function FileGroup({
   layer,
   accentColor,
   renderFileRow,
+  onStageAll,
+  onUnstageAll,
+  onDiscardAll,
 }: {
   label: string;
   files: DiffFile[];
   layer: DiffLayer;
   accentColor: string;
   renderFileRow: (file: DiffFile, layer?: DiffLayer) => React.ReactElement;
+  onStageAll?: () => void;
+  onUnstageAll?: () => void;
+  onDiscardAll?: () => void;
 }) {
   const [collapsed, setCollapsed] = useState(layer === "committed");
 
   if (files.length === 0) return null;
+
+  const hasActions = onStageAll != null || onUnstageAll != null || onDiscardAll != null;
 
   return (
     <div
       className={styles.fileGroup}
       style={{ borderLeftColor: accentColor }}
     >
-      <button
-        className={styles.groupHeader}
-        onClick={() => setCollapsed(!collapsed)}
-      >
-        <ChevronRight
-          size={12}
-          className={`${styles.groupChevron} ${!collapsed ? styles.groupChevronOpen : ""}`}
-        />
-        <span className={styles.groupLabel}>{label}</span>
-        <span className={styles.groupCount}>{files.length}</span>
-      </button>
+      <div className={styles.groupHeader}>
+        <button
+          type="button"
+          className={styles.groupToggle}
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          <ChevronRight
+            size={12}
+            className={`${styles.groupChevron} ${!collapsed ? styles.groupChevronOpen : ""}`}
+          />
+          <span className={styles.groupLabel}>{label}</span>
+          <span className={styles.groupCount}>{files.length}</span>
+        </button>
+        {hasActions && (
+          <span className={styles.groupActions}>
+            {onStageAll && (
+              <button
+                type="button"
+                className={styles.groupAction}
+                onClick={onStageAll}
+                title="Stage all"
+                aria-label="Stage all"
+              >
+                <Plus size={12} />
+              </button>
+            )}
+            {onUnstageAll && (
+              <button
+                type="button"
+                className={styles.groupAction}
+                onClick={onUnstageAll}
+                title="Unstage all"
+                aria-label="Unstage all"
+              >
+                <Minus size={12} />
+              </button>
+            )}
+            {onDiscardAll && (
+              <button
+                type="button"
+                className={`${styles.groupAction} ${styles.groupActionDanger}`}
+                onClick={onDiscardAll}
+                title="Discard all"
+                aria-label="Discard all"
+              >
+                <Undo2 size={12} />
+              </button>
+            )}
+          </span>
+        )}
+      </div>
       {!collapsed && files.map((file) => renderFileRow(file, layer))}
     </div>
   );

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -783,6 +783,42 @@ export function discardFile(
   return invoke("discard_file", { worktreePath, filePath, isUntracked });
 }
 
+export function stageFile(
+  worktreePath: string,
+  filePath: string,
+): Promise<void> {
+  return invoke("stage_file", { worktreePath, filePath });
+}
+
+export function unstageFile(
+  worktreePath: string,
+  filePath: string,
+): Promise<void> {
+  return invoke("unstage_file", { worktreePath, filePath });
+}
+
+export function stageFiles(
+  worktreePath: string,
+  filePaths: string[],
+): Promise<void> {
+  return invoke("stage_files", { worktreePath, filePaths });
+}
+
+export function unstageFiles(
+  worktreePath: string,
+  filePaths: string[],
+): Promise<void> {
+  return invoke("unstage_files", { worktreePath, filePaths });
+}
+
+export function discardFiles(
+  worktreePath: string,
+  tracked: string[],
+  untracked: string[],
+): Promise<void> {
+  return invoke("discard_files", { worktreePath, tracked, untracked });
+}
+
 // -- Terminal --
 
 export function createTerminalTab(

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -1059,17 +1059,21 @@ select:disabled {
  * inline `color-scheme: light|dark` on `<html>` (set in theme.ts:applyTheme).
  *
  * Selector targets only the Shiki-emitted token spans (those carrying the
- * `--shiki-light` custom property inline). The line-wrapper spans Shiki
- * also emits don't carry that property, so they harmlessly miss this rule
- * and inherit `currentColor`. Using the inline-style attribute selector
- * keeps the rule independent of CSS-module class hashing.
+ * `--shiki-light` custom property inline) regardless of ancestor. The
+ * diff viewer mounts Shiki HTML directly inside a `<span>` (no
+ * `<pre><code>` wrapper), so an ancestor-constrained selector misses
+ * those tokens and they render with no token color. The line-wrapper
+ * spans Shiki also emits don't carry the inline property and so
+ * harmlessly miss this rule and inherit `currentColor`. Using the
+ * inline-style attribute selector keeps the rule independent of
+ * CSS-module class hashing.
  */
-pre code [style*="--shiki-light"] {
+[style*="--shiki-light"] {
   color: var(--shiki-dark);
 }
-[data-theme="default-light"] pre code [style*="--shiki-light"],
-[data-theme="rose-pine-dawn"] pre code [style*="--shiki-light"],
-[data-theme="solarized-light"] pre code [style*="--shiki-light"],
-html[style*="color-scheme: light"] pre code [style*="--shiki-light"] {
+[data-theme="default-light"] [style*="--shiki-light"],
+[data-theme="rose-pine-dawn"] [style*="--shiki-light"],
+[data-theme="solarized-light"] [style*="--shiki-light"],
+html[style*="color-scheme: light"] [style*="--shiki-light"] {
   color: var(--shiki-light);
 }


### PR DESCRIPTION
## Summary

- **Per-file row controls** — each file entry in the changes panel now shows hover-revealed action buttons: Stage (unstaged/untracked files), Unstage (staged files), and Open in editor (all files with a disk copy). Non-destructive buttons use a neutral hover color; discard keeps red.
- **Bulk section-header actions** — the Staged section header gains an Unstage all button; the Unstaged section header gains Stage all and Discard all. All bulk ops issue a single `git` invocation to avoid `.git/index.lock` contention that parallel per-file calls race on.
- **Section reorder** — groups now appear as Staged → Unstaged → Untracked → Committed, with Committed collapsed by default.
- **Shiki syntax highlighting fix** — the diff viewer renders Shiki tokens inside a plain `<span>` (no `<pre><code>` wrapper), so the old `pre code [style*=--shiki-light]` selectors never matched. Dropping the `pre code` ancestor restores colors; introduced in #568.

## Changes

### Backend (`claudette` crate — `src/diff.rs`)
- `stage_file` / `unstage_file` — single-file `git add` / `git restore --staged`
- `stage_files` / `unstage_files` — batch variants; all paths in one git call
- `discard_files(tracked, untracked)` — one `git restore` for tracked, sequential `fs::remove_file` for untracked (no index involved)

### Tauri (`src-tauri/`)
- Five new `#[tauri::command]` wrappers registered in `invoke_handler`

### Frontend (`src/ui/`)
- `services/tauri.ts` — invoke wrappers for all five commands
- `RightSidebar.tsx` — per-file buttons, bulk header buttons, section reorder
- `RightSidebar.module.css` — `.rowActions` wrapper (gap: 1px), neutral vs danger hover colors, `.groupActions` / `.groupAction` / `.groupActionDanger`
- `DiscardChangesConfirm.tsx` — `bulkCount` prop for plural confirmation text ("Discard unstaged changes across N files…")
- `styles/theme.css` — Shiki selector fix

## Test plan

- [ ] Stage an individual unstaged file via the row `+` button — file moves to Staged group
- [ ] Unstage an individual staged file via the row `-` button — file moves back to Unstaged
- [ ] Open in editor button opens the file in a new editor tab
- [ ] Stage all (Unstaged header `+`) — all unstaged files move to Staged in one operation; no `index.lock` error in console
- [ ] Unstage all (Staged header `-`) — all staged files move to Unstaged
- [ ] Discard all (Unstaged header undo) — confirmation modal shows plural text; confirming discards all unstaged changes
- [ ] Discard single file still works and shows singular confirmation text
- [ ] Syntax highlighting renders correctly in the diff viewer (light and dark themes)
- [ ] Section order is Staged → Unstaged → Untracked → Committed; Committed starts collapsed

<img width="254" height="230" alt="image" src="https://github.com/user-attachments/assets/e7034b85-ada1-4e02-80ff-853ca4598d38" />
