### PR TITLE
perf(workspace): apply optimistic UI when archiving

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -244,20 +244,28 @@ export const Sidebar = memo(function Sidebar() {
   const handleArchive = useCallback(async (wsId: string) => {
     if (archivingRef.current.has(wsId)) return;
     archivingRef.current.add(wsId);
+
+    const snapshot = useAppStore.getState().workspaces.find((w) => w.id === wsId);
+    const wasSelected = useAppStore.getState().selectedWorkspaceId === wsId;
+
+    updateWorkspace(wsId, {
+      status: "Archived",
+      worktree_path: null,
+      agent_status: "Stopped",
+    });
+    if (wasSelected) selectWorkspace(null);
+
     try {
       const deleted = await archiveWorkspace(wsId);
       if (deleted) {
         removeWorkspace(wsId);
-      } else {
-        updateWorkspace(wsId, {
-          status: "Archived",
-          worktree_path: null,
-          agent_status: "Stopped",
-        });
       }
-      if (useAppStore.getState().selectedWorkspaceId === wsId) selectWorkspace(null);
     } catch (e) {
       console.error("Failed to archive workspace:", e);
+      if (snapshot) {
+        updateWorkspace(wsId, snapshot);
+        if (wasSelected) selectWorkspace(wsId);
+      }
     } finally {
       archivingRef.current.delete(wsId);
     }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -245,8 +245,9 @@ export const Sidebar = memo(function Sidebar() {
     if (archivingRef.current.has(wsId)) return;
     archivingRef.current.add(wsId);
 
-    const snapshot = useAppStore.getState().workspaces.find((w) => w.id === wsId);
-    const wasSelected = useAppStore.getState().selectedWorkspaceId === wsId;
+    const initialState = useAppStore.getState();
+    const snapshot = initialState.workspaces.find((w) => w.id === wsId);
+    const wasSelected = initialState.selectedWorkspaceId === wsId;
 
     updateWorkspace(wsId, {
       status: "Archived",
@@ -264,7 +265,11 @@ export const Sidebar = memo(function Sidebar() {
       console.error("Failed to archive workspace:", e);
       if (snapshot) {
         updateWorkspace(wsId, snapshot);
-        if (wasSelected) selectWorkspace(wsId);
+        // Only restore selection if the user hasn't navigated elsewhere
+        // while the archive command was in flight.
+        if (wasSelected && useAppStore.getState().selectedWorkspaceId === null) {
+          selectWorkspace(wsId);
+        }
       }
     } finally {
       archivingRef.current.delete(wsId);


### PR DESCRIPTION
## Summary

Archiving a workspace had a visible delay because the UI awaited the Tauri command (`git worktree remove` + optional `git branch -D` + DB updates) before updating store state. The workspace would sit visibly stuck in the active list for several hundred milliseconds.

This change applies the archived state to the store immediately on click, then runs the backend command in the background:

- Capture a snapshot of the workspace and selection state up front.
- Mark the workspace as `Archived` with `worktree_path: null` and `agent_status: "Stopped"` synchronously, deselecting it if it was active.
- Await `archive_workspace`. If it returns `true` (backend hard-deleted the branch), upgrade the optimistic update to a full `removeWorkspace` (which cascades terminal/diff/chat-draft cleanup). If it returns `false`, the store is already in the correct final state.
- On error, restore from the snapshot — fields and selection.

The optimistic state works for both backend outcomes because they share the same intermediate state (`Archived`, null worktree). The existing `filteredWorkspaces` memo handles the visual disappearance for free when `sidebarShowArchived` is off, and re-buckets the workspace into the archived group when it's on.

## Complexity Notes

- The two backend return values (`true` = hard delete vs `false` = soft archive) collapse to the same optimistic state. We only need a follow-up call (`removeWorkspace`) on the `true` path.
- Rollback passes the full `Workspace` snapshot to `updateWorkspace`, which works because the second arg is `Partial<Workspace>` and a full object satisfies that.
- The existing `archivingRef` gate still blocks double-clicks; nothing new there.

## Test Steps

1. `cd src/ui && bun install && bun run test` — all 1132 tests pass
2. `cd src/ui && bunx tsc -b` — clean
3. Run the app: `cargo tauri dev`
4. Create or pick an active workspace and click the archive icon. Confirm it disappears from the active list immediately (no perceptible delay).
5. Repeat with the workspace currently selected — it should disappear instantly and the chat/diff panel should clear (selection drops to `null`).
6. Toggle the sidebar's "show archived" filter on, then archive an active workspace — it should re-bucket into the archived group instantly rather than waiting.
7. With `git_delete_branch_on_archive` enabled in settings, archive a workspace and verify it is fully removed (not in archived bucket either) once the backend completes.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)