### PR TITLE
feat(file-viewer): show git gutter markers in Monaco editor

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -212,6 +212,41 @@ pub async fn read_workspace_file_bytes(
     })
 }
 
+#[derive(Clone, Serialize)]
+pub struct HeadBlobContent {
+    pub path: String,
+    /// Some(text) for tracked text blobs; None for binary blobs at HEAD or
+    /// when the file doesn't exist at HEAD.
+    pub content: Option<String>,
+    /// false when the path is not tracked at HEAD (untracked / staged-only /
+    /// not on the branch).
+    pub exists_at_head: bool,
+}
+
+/// Read a file's HEAD-blob contents. Used by the file viewer's git gutter
+/// to compute per-line decorations against the last committed version.
+///
+/// On any error (workspace missing, no worktree, not a git repo, etc.) we
+/// return an `Err` string. The frontend treats errors as "gutter unavailable
+/// for this file" and silently disables markers — they are not surfaced as
+/// toasts.
+#[tauri::command]
+pub async fn read_workspace_file_at_head(
+    workspace_id: String,
+    relative_path: String,
+    state: State<'_, AppState>,
+) -> Result<HeadBlobContent, String> {
+    let worktree_path = resolve_worktree_path(&workspace_id, &state)?;
+    let result = claudette::git::read_blob_at_head(&worktree_path, &relative_path)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(HeadBlobContent {
+        path: relative_path,
+        content: result.content,
+        exists_at_head: result.exists_at_head,
+    })
+}
+
 /// Write UTF-8 text to a file in a workspace's worktree. Path-traversal
 /// protected. Creates the file if missing; truncates if it exists.
 ///

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -473,6 +473,7 @@ fn main() {
             commands::files::read_workspace_file,
             commands::files::read_workspace_file_for_viewer,
             commands::files::read_workspace_file_bytes,
+            commands::files::read_workspace_file_at_head,
             commands::files::write_workspace_file,
             commands::files::save_attachment_bytes,
             commands::files::open_attachment_in_browser,

--- a/src/git.rs
+++ b/src/git.rs
@@ -253,6 +253,82 @@ pub async fn validate_repo(path: &str) -> Result<(), GitError> {
     Ok(())
 }
 
+/// Result of reading a file's blob at HEAD via [`read_blob_at_head`].
+#[derive(Debug, Clone, Serialize)]
+pub struct HeadBlobResult {
+    /// UTF-8 text of the blob, or `None` when the blob is binary or absent.
+    pub content: Option<String>,
+    /// Whether the file path resolves to a blob in the current `HEAD` tree.
+    pub exists_at_head: bool,
+}
+
+/// Read a file's contents as they exist at the current `HEAD` commit.
+///
+/// Three return shapes:
+/// 1. **Tracked text:** `exists_at_head = true`, `content = Some(text)`. The
+///    blob exists at `HEAD` and decodes as UTF-8 (lossy — invalid bytes are
+///    replaced with `U+FFFD`).
+/// 2. **Tracked binary:** `exists_at_head = true`, `content = None`. The blob
+///    exists at `HEAD` but contains a NUL byte in its first 8 KiB, so we treat
+///    it as binary and decline to materialize it as a `String`.
+/// 3. **Not at HEAD:** `exists_at_head = false`, `content = None`. The path is
+///    untracked, staged-only, or otherwise absent from the `HEAD` tree.
+///
+/// Returns [`GitError::NotAGitRepo`] / [`GitError::CommandFailed`] when the
+/// directory is not a git worktree, and propagates other git failures verbatim.
+pub async fn read_blob_at_head(
+    worktree_path: &str,
+    file_path: &str,
+) -> Result<HeadBlobResult, GitError> {
+    validate_repo(worktree_path).await?;
+
+    let spec = format!("HEAD:{file_path}");
+    let exists = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
+        .args(["-C", worktree_path])
+        .args(["cat-file", "-e", &spec])
+        .output()
+        .await
+        .map_err(GitError::from_spawn_io)?;
+
+    if !exists.status.success() {
+        return Ok(HeadBlobResult {
+            content: None,
+            exists_at_head: false,
+        });
+    }
+
+    let bytes_out = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
+        .args(["-C", worktree_path])
+        .args(["cat-file", "blob", &spec])
+        .output()
+        .await
+        .map_err(GitError::from_spawn_io)?;
+
+    if !bytes_out.status.success() {
+        let stderr = String::from_utf8_lossy(&bytes_out.stderr).into_owned();
+        return Err(GitError::CommandFailed(stderr));
+    }
+
+    let raw = bytes_out.stdout;
+    let check_len = raw.len().min(8192);
+    let is_binary = raw[..check_len].contains(&0);
+
+    if is_binary {
+        return Ok(HeadBlobResult {
+            content: None,
+            exists_at_head: true,
+        });
+    }
+
+    let text = String::from_utf8_lossy(&raw).into_owned();
+    Ok(HeadBlobResult {
+        content: Some(text),
+        exists_at_head: true,
+    })
+}
+
 /// Resolve the default branch for a repository.
 ///
 /// Tries, in order: remote HEAD symbolic-ref, remote-tracking `main`/`master`,
@@ -1562,5 +1638,108 @@ mod tests {
             real.into_os_string(),
             "resolver must skip the non-exec placeholder and pick the real binary",
         );
+    }
+}
+
+#[cfg(test)]
+mod head_blob_tests {
+    use super::*;
+    use std::process::Command as StdCommand;
+    use tempfile::tempdir;
+
+    fn git_cmd(dir: &Path, args: &[&str]) -> String {
+        let out = StdCommand::new("git")
+            .current_dir(dir)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap()
+    }
+
+    fn init_repo(dir: &Path) {
+        git_cmd(dir, &["init", "-q", "-b", "main"]);
+        git_cmd(dir, &["config", "user.email", "t@t"]);
+        git_cmd(dir, &["config", "user.name", "t"]);
+    }
+
+    #[tokio::test]
+    async fn returns_committed_text_for_tracked_file() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "hello\nworld\n").unwrap();
+        git_cmd(tmp.path(), &["add", "a.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "a.txt")
+            .await
+            .expect("read");
+        assert!(result.exists_at_head);
+        assert_eq!(result.content.as_deref(), Some("hello\nworld\n"));
+    }
+
+    #[tokio::test]
+    async fn returns_not_at_head_for_untracked_file() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("seed.txt"), "x").unwrap();
+        git_cmd(tmp.path(), &["add", "seed.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        std::fs::write(tmp.path().join("new.txt"), "fresh\n").unwrap();
+        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "new.txt")
+            .await
+            .expect("read");
+        assert!(!result.exists_at_head);
+        assert!(result.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn returns_not_at_head_for_staged_only_file() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("seed.txt"), "x").unwrap();
+        git_cmd(tmp.path(), &["add", "seed.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        std::fs::write(tmp.path().join("staged.txt"), "staged\n").unwrap();
+        git_cmd(tmp.path(), &["add", "staged.txt"]);
+
+        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "staged.txt")
+            .await
+            .expect("read");
+        assert!(!result.exists_at_head);
+        assert!(result.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn returns_none_content_for_binary_blob() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        let bytes: Vec<u8> = vec![
+            0xFF, 0x00, 0x01, 0x02, b'h', b'i', 0x00, 0xEE, 0, 1, 2, 3, 4, 5, 6, 7,
+        ];
+        std::fs::write(tmp.path().join("blob.bin"), &bytes).unwrap();
+        git_cmd(tmp.path(), &["add", "blob.bin"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "blob.bin")
+            .await
+            .expect("read");
+        assert!(result.exists_at_head);
+        assert!(result.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn errors_in_non_git_directory() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "hi").unwrap();
+        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "a.txt").await;
+        assert!(result.is_err());
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -256,21 +256,29 @@ pub async fn validate_repo(path: &str) -> Result<(), GitError> {
 /// Result of reading a file's blob at HEAD via [`read_blob_at_head`].
 #[derive(Debug, Clone, Serialize)]
 pub struct HeadBlobResult {
-    /// UTF-8 text of the blob, or `None` when the blob is binary or absent.
+    /// UTF-8 text of the blob, or `None` when the blob is binary, oversized,
+    /// or absent.
     pub content: Option<String>,
     /// Whether the file path resolves to a blob in the current `HEAD` tree.
     pub exists_at_head: bool,
 }
 
+/// Maximum blob size we materialize via `read_blob_at_head`. Mirrors the
+/// frontend's `GUTTER_MAX_BYTES` cap — beyond this the file viewer's git
+/// gutter is disabled anyway, so reading the bytes only wastes IPC.
+pub const MAX_BLOB_AT_HEAD_BYTES: u64 = 1024 * 1024;
+
 /// Read a file's contents as they exist at the current `HEAD` commit.
 ///
-/// Three return shapes:
+/// Four return shapes:
 /// 1. **Tracked text:** `exists_at_head = true`, `content = Some(text)`. The
 ///    blob exists at `HEAD` and decodes as UTF-8 (lossy — invalid bytes are
 ///    replaced with `U+FFFD`).
-/// 2. **Tracked binary:** `exists_at_head = true`, `content = None`. The blob
-///    exists at `HEAD` but contains a NUL byte in its first 8 KiB, so we treat
-///    it as binary and decline to materialize it as a `String`.
+/// 2. **Tracked binary or oversized:** `exists_at_head = true`,
+///    `content = None`. Either the blob contains a NUL byte in its first
+///    8 KiB (treated as binary) or its size exceeds [`MAX_BLOB_AT_HEAD_BYTES`]
+///    (the frontend gutter is disabled at that scale anyway, so we skip the
+///    IPC cost of materializing it).
 /// 3. **Not at HEAD:** `exists_at_head = false`, `content = None`. The path is
 ///    untracked, staged-only, or otherwise absent from the `HEAD` tree.
 ///
@@ -295,6 +303,35 @@ pub async fn read_blob_at_head(
         return Ok(HeadBlobResult {
             content: None,
             exists_at_head: false,
+        });
+    }
+
+    // Size probe before materializing: `git cat-file -s` prints a single
+    // decimal byte count followed by a newline. For oversized blobs the
+    // frontend disables the gutter regardless, so we short-circuit here to
+    // skip a wasteful IPC roundtrip.
+    let size_out = Command::new(crate::git::resolve_git_path_blocking())
+        .no_console_window()
+        .args(["-C", worktree_path])
+        .args(["cat-file", "-s", &spec])
+        .output()
+        .await
+        .map_err(GitError::from_spawn_io)?;
+
+    if !size_out.status.success() {
+        let stderr = String::from_utf8_lossy(&size_out.stderr).into_owned();
+        return Err(GitError::CommandFailed(stderr));
+    }
+
+    let size: u64 = String::from_utf8_lossy(&size_out.stdout)
+        .trim()
+        .parse()
+        .map_err(|e| GitError::CommandFailed(format!("could not parse cat-file -s output: {e}")))?;
+
+    if size > MAX_BLOB_AT_HEAD_BYTES {
+        return Ok(HeadBlobResult {
+            content: None,
+            exists_at_head: true,
         });
     }
 
@@ -1741,5 +1778,23 @@ mod head_blob_tests {
         std::fs::write(tmp.path().join("a.txt"), "hi").unwrap();
         let result = read_blob_at_head(tmp.path().to_str().unwrap(), "a.txt").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn skips_materializing_oversized_blob() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        // One byte over the cap — size check fires before binary detection,
+        // so any bytes work.
+        let bytes = vec![b'a'; (MAX_BLOB_AT_HEAD_BYTES + 1) as usize];
+        std::fs::write(tmp.path().join("big.txt"), &bytes).unwrap();
+        git_cmd(tmp.path(), &["add", "big.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "big.txt")
+            .await
+            .expect("read");
+        assert!(result.exists_at_head);
+        assert!(result.content.is_none());
     }
 }

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ui",
@@ -16,6 +15,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "ansi_up": "^6.0.6",
+        "diff": "^9.0.0",
         "hast-util-to-html": "^9.0.5",
         "i18next": "^26.0.8",
         "lucide-react": "^1.7.0",
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@types/diff": "^8.0.0",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -313,6 +314,8 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/diff": ["@types/diff@8.0.0", "", { "dependencies": { "diff": "*" } }, "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -536,6 +539,8 @@
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -25,6 +25,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "ansi_up": "^6.0.6",
+    "diff": "^9.0.0",
     "hast-util-to-html": "^9.0.5",
     "i18next": "^26.0.8",
     "lucide-react": "^1.7.0",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@types/diff": "^8.0.0",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -408,6 +408,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
           <Suspense fallback={<div className={styles.center}>{t("file_loading")}</div>}>
             <MonacoEditor
               key={path}
+              workspaceId={workspaceId}
               initialValue={bufferState.buffer}
               filename={path}
               readOnly={editDisabled}

--- a/src/ui/src/components/file-viewer/MonacoEditor.module.css
+++ b/src/ui/src/components/file-viewer/MonacoEditor.module.css
@@ -16,3 +16,33 @@
 .host :global(.monaco-editor) {
   width: 100%;
 }
+
+/* Git gutter — colored bars in Monaco's line-numbers gutter. Decorations
+   are applied via `linesDecorationsClassName`; Monaco renders the class
+   on a thin strip immediately right of the line numbers. */
+.gitGutterAdd {
+  background: var(--diff-added-text);
+  width: 3px !important;
+  margin-left: 3px;
+}
+
+.gitGutterModify {
+  background: var(--git-gutter-modified);
+  width: 3px !important;
+  margin-left: 3px;
+}
+
+/* delete-above: a small downward-pointing red triangle in the gutter on
+   the line where the deletion landed. We render it via ::before so the
+   line itself stays clean. */
+.gitGutterDeleteAbove::before {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 0;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--diff-removed-text);
+}

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -1,11 +1,17 @@
-import { memo, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import Editor, { type BeforeMount, type OnMount } from "@monaco-editor/react";
 import "./monacoSetup";
 import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
+import {
+  useGitGutter,
+  type DecorationsCollection,
+} from "./useGitGutter";
 import styles from "./MonacoEditor.module.css";
 
 interface MonacoEditorProps {
+  /** Workspace id used to scope HEAD-blob lookups for the git gutter. */
+  workspaceId: string;
   /** Initial document text. The parent uses `key={path}` so that switching
    *  files remounts the editor with a fresh undo history; mode toggles
    *  (view↔edit) reuse the same instance via `updateOptions`. */
@@ -26,6 +32,7 @@ interface MonacoEditorProps {
 }
 
 export const MonacoEditor = memo(function MonacoEditor({
+  workspaceId,
   initialValue,
   filename,
   readOnly,
@@ -46,7 +53,19 @@ export const MonacoEditor = memo(function MonacoEditor({
   }, [onSave]);
 
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const monacoRef = useRef<Parameters<OnMount>[1] | null>(null);
   const cleanupThemeSyncRef = useRef<(() => void) | null>(null);
+  // Owned by this component so the git-gutter hook can read it on mount.
+  // Created in `handleMount` once Monaco has resolved — that's the only
+  // point where `editor.createDecorationsCollection()` is callable. A
+  // `[]`-deps effect inside the hook would run *before* the lazy-loaded
+  // editor mounts, so the collection has to be initialized here.
+  const gutterCollectionRef = useRef<DecorationsCollection | null>(null);
+
+  // Mirror the editor's text into React state so the git-gutter hook can
+  // recompute on every change. Seeded from `initialValue`; the parent
+  // remounts via `key={path}` on file switches so the seed stays correct.
+  const [currentBuffer, setCurrentBuffer] = useState(initialValue);
 
   // Reflect readOnly changes into the editor without remounting. Monaco's
   // `updateOptions` is the explicit runtime API for this; with CodeMirror
@@ -55,8 +74,18 @@ export const MonacoEditor = memo(function MonacoEditor({
     editorRef.current?.updateOptions({ readOnly });
   }, [readOnly]);
 
-  // Disconnect the theme observer when the editor unmounts.
-  useEffect(() => () => { cleanupThemeSyncRef.current?.(); }, []);
+  // Disconnect the theme observer and clear the gutter collection when
+  // the editor unmounts. The collection is owned by Monaco's editor
+  // instance, which is itself disposed by the `<Editor>` component, but
+  // null-ing the ref is cheap insurance against stale reads.
+  useEffect(
+    () => () => {
+      cleanupThemeSyncRef.current?.();
+      gutterCollectionRef.current?.clear();
+      gutterCollectionRef.current = null;
+    },
+    [],
+  );
 
   // Define the 'claudette' theme before the editor instance is created so
   // the theme prop resolves immediately and there's no flash of vs-dark.
@@ -66,6 +95,13 @@ export const MonacoEditor = memo(function MonacoEditor({
 
   const handleMount: OnMount = (editor, monacoInstance) => {
     editorRef.current = editor;
+    monacoRef.current = monacoInstance;
+    // Initialize the gutter decoration collection now that Monaco has
+    // handed us a live editor. The collection survives buffer/file
+    // changes within the same mount; the parent remounts on file
+    // switches via `key={path}`, so a fresh collection is created per
+    // file.
+    gutterCollectionRef.current = editor.createDecorationsCollection();
     // Start live theme sync: re-derives the Monaco theme whenever the
     // Claudette theme changes (data-theme attribute or inline CSS vars).
     cleanupThemeSyncRef.current = initMonacoThemeSync(monacoInstance);
@@ -78,6 +114,14 @@ export const MonacoEditor = memo(function MonacoEditor({
     );
   };
 
+  const handleEditorChange = useCallback((value: string | undefined) => {
+    const next = value ?? "";
+    setCurrentBuffer(next);
+    onChangeRef.current(next);
+  }, []);
+
+  useGitGutter(monacoRef, gutterCollectionRef, workspaceId, filename, currentBuffer);
+
   return (
     <div className={styles.host}>
       <Editor
@@ -87,7 +131,7 @@ export const MonacoEditor = memo(function MonacoEditor({
         theme="claudette"
         beforeMount={handleBeforeMount}
         onMount={handleMount}
-        onChange={(value) => onChangeRef.current(value ?? "")}
+        onChange={handleEditorChange}
         options={{
           readOnly,
           minimap: { enabled: false },

--- a/src/ui/src/components/file-viewer/gitGutter.test.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.test.ts
@@ -65,8 +65,8 @@ describe("computeLineChanges", () => {
   });
 });
 
-// Minimal Monaco stub for the Range constructor — `lineChangesToDecorations`
-// only needs `monacoInstance.Range`, nothing else.
+// Minimal Monaco stub for the Range constructor and the
+// TrackedRangeStickiness enum that `lineChangesToDecorations` reads.
 const monacoStub = {
   Range: class {
     startLineNumber: number;
@@ -84,6 +84,11 @@ const monacoStub = {
       this.endLineNumber = endLineNumber;
       this.endColumn = endColumn;
     }
+  },
+  editor: {
+    TrackedRangeStickiness: {
+      NeverGrowsWhenTypingAtEdges: 1,
+    },
   },
 } as unknown as typeof monacoNs;
 

--- a/src/ui/src/components/file-viewer/gitGutter.test.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { computeLineChanges } from "./gitGutter";
+
+describe("computeLineChanges", () => {
+  it("returns [] for identical strings", () => {
+    expect(computeLineChanges("a\nb\nc\n", "a\nb\nc\n")).toEqual([]);
+  });
+
+  it("classifies appended lines as add", () => {
+    const changes = computeLineChanges("a\n", "a\nb\nc\n");
+    expect(changes).toEqual([
+      { line: 2, kind: "add" },
+      { line: 3, kind: "add" },
+    ]);
+  });
+
+  it("classifies a pure removal as delete-above on the line that follows", () => {
+    const changes = computeLineChanges("a\nb\nc\n", "a\nc\n");
+    // 'b' was removed; the marker sits on the line that now occupies its
+    // position (line 2 in the new buffer, which holds 'c').
+    expect(changes).toEqual([{ line: 2, kind: "delete-above" }]);
+  });
+
+  it("classifies a 1->1 replacement as a single modify line", () => {
+    const changes = computeLineChanges("a\nb\nc\n", "a\nB\nc\n");
+    expect(changes).toEqual([{ line: 2, kind: "modify" }]);
+  });
+
+  it("classifies a 3->5 replacement as 5 modify lines spanning the addition", () => {
+    const head = "a\nx1\nx2\nx3\nb\n";
+    const buf = "a\ny1\ny2\ny3\ny4\ny5\nb\n";
+    const changes = computeLineChanges(head, buf);
+    expect(changes).toEqual([
+      { line: 2, kind: "modify" },
+      { line: 3, kind: "modify" },
+      { line: 4, kind: "modify" },
+      { line: 5, kind: "modify" },
+      { line: 6, kind: "modify" },
+    ]);
+  });
+
+  it("clamps end-of-file deletions to the last existing buffer line", () => {
+    // Removing trailing lines: marker on the last surviving buffer line.
+    const changes = computeLineChanges("a\nb\nc\n", "a\n");
+    expect(changes).toEqual([{ line: 1, kind: "delete-above" }]);
+  });
+
+  it("places start-of-file deletions at line 1", () => {
+    const changes = computeLineChanges("a\nb\nc\n", "b\nc\n");
+    expect(changes).toEqual([{ line: 1, kind: "delete-above" }]);
+  });
+
+  it("treats every line as add when head is empty", () => {
+    const changes = computeLineChanges("", "a\nb\n");
+    expect(changes).toEqual([
+      { line: 1, kind: "add" },
+      { line: 2, kind: "add" },
+    ]);
+  });
+
+  it("emits a single delete-above at line 1 when the buffer is empty", () => {
+    const changes = computeLineChanges("a\nb\n", "");
+    expect(changes).toEqual([{ line: 1, kind: "delete-above" }]);
+  });
+});

--- a/src/ui/src/components/file-viewer/gitGutter.test.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.test.ts
@@ -1,5 +1,6 @@
+import type * as monacoNs from "monaco-editor";
 import { describe, expect, it } from "vitest";
-import { computeLineChanges } from "./gitGutter";
+import { computeLineChanges, lineChangesToDecorations } from "./gitGutter";
 
 describe("computeLineChanges", () => {
   it("returns [] for identical strings", () => {
@@ -61,5 +62,72 @@ describe("computeLineChanges", () => {
   it("emits a single delete-above at line 1 when the buffer is empty", () => {
     const changes = computeLineChanges("a\nb\n", "");
     expect(changes).toEqual([{ line: 1, kind: "delete-above" }]);
+  });
+});
+
+// Minimal Monaco stub for the Range constructor — `lineChangesToDecorations`
+// only needs `monacoInstance.Range`, nothing else.
+const monacoStub = {
+  Range: class {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+    constructor(
+      startLineNumber: number,
+      startColumn: number,
+      endLineNumber: number,
+      endColumn: number,
+    ) {
+      this.startLineNumber = startLineNumber;
+      this.startColumn = startColumn;
+      this.endLineNumber = endLineNumber;
+      this.endColumn = endColumn;
+    }
+  },
+} as unknown as typeof monacoNs;
+
+describe("lineChangesToDecorations", () => {
+  it("maps add to gitGutterAdd class on the line's full range", () => {
+    const decos = lineChangesToDecorations(
+      [{ line: 3, kind: "add" }],
+      monacoStub,
+    );
+    expect(decos).toHaveLength(1);
+    expect(decos[0].options.linesDecorationsClassName).toMatch(/gitGutterAdd/);
+    expect(decos[0].range.startLineNumber).toBe(3);
+    expect(decos[0].range.endLineNumber).toBe(3);
+  });
+
+  it("maps modify to gitGutterModify class", () => {
+    const decos = lineChangesToDecorations(
+      [{ line: 5, kind: "modify" }],
+      monacoStub,
+    );
+    expect(decos[0].options.linesDecorationsClassName).toMatch(/gitGutterModify/);
+    expect(decos[0].range.startLineNumber).toBe(5);
+  });
+
+  it("maps delete-above to gitGutterDeleteAbove class on the line", () => {
+    const decos = lineChangesToDecorations(
+      [{ line: 7, kind: "delete-above" }],
+      monacoStub,
+    );
+    expect(decos[0].options.linesDecorationsClassName).toMatch(/gitGutterDeleteAbove/);
+    expect(decos[0].range.startLineNumber).toBe(7);
+    expect(decos[0].range.endLineNumber).toBe(7);
+  });
+
+  it("returns one decoration per change, preserving order", () => {
+    const decos = lineChangesToDecorations(
+      [
+        { line: 1, kind: "add" },
+        { line: 2, kind: "modify" },
+        { line: 3, kind: "delete-above" },
+      ],
+      monacoStub,
+    );
+    expect(decos).toHaveLength(3);
+    expect(decos.map((d) => d.range.startLineNumber)).toEqual([1, 2, 3]);
   });
 });

--- a/src/ui/src/components/file-viewer/gitGutter.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.ts
@@ -90,9 +90,9 @@ function countLines(s: string): number {
  * change becomes a 0-column, 1-line range with a `linesDecorationsClassName`
  * pointing at our CSS-module class for the appropriate kind.
  *
- * `stickiness: 1` (NeverGrowsWhenTypingAtEdges) keeps a marker pinned to
- * its line — without it, an insertion at the start of the line would pull
- * the marker onto the next line.
+ * `NeverGrowsWhenTypingAtEdges` stickiness keeps a marker pinned to its
+ * line — without it, an insertion at the start of the line would pull the
+ * marker onto the next line.
  */
 export function lineChangesToDecorations(
   changes: LineChange[],
@@ -102,7 +102,7 @@ export function lineChangesToDecorations(
     range: new monacoInstance.Range(change.line, 1, change.line, 1),
     options: {
       linesDecorationsClassName: classFor(change.kind),
-      stickiness: 1,
+      stickiness: monacoInstance.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
     },
   }));
 }

--- a/src/ui/src/components/file-viewer/gitGutter.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.ts
@@ -1,0 +1,84 @@
+import { diffLines } from "diff";
+
+export type LineChangeKind = "add" | "modify" | "delete-above";
+
+export interface LineChange {
+  /** 1-based line number in the current buffer. */
+  line: number;
+  kind: LineChangeKind;
+}
+
+/**
+ * Classify each line of `buffer` as added/modified/(delete-above) relative
+ * to `head`. Pure: same inputs always yield the same output.
+ *
+ * Algorithm: walk the `diffLines` chunk list once. A `removed` chunk
+ * immediately followed by an `added` chunk is a modification — every line
+ * of the addition gets marked `modify`. A `removed` chunk with no following
+ * addition is a pure deletion — emit a single `delete-above` marker on the
+ * line that now sits where the deletion landed (clamped to [1, lastLine]).
+ * An `added` chunk not preceded by a `removed` chunk is a pure addition.
+ */
+export function computeLineChanges(head: string, buffer: string): LineChange[] {
+  const chunks = diffLines(head, buffer);
+  const changes: LineChange[] = [];
+
+  // Track the 1-based line number in the *buffer* as we walk chunks. Lines
+  // covered by `removed` chunks don't advance the buffer cursor; `added`
+  // and unchanged chunks do.
+  let bufferLine = 1;
+  // Total line count of the buffer — used to clamp end-of-file deletes.
+  const bufferLineCount = countLines(buffer);
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const lines = chunk.count ?? countLines(chunk.value);
+
+    if (chunk.removed) {
+      const next = chunks[i + 1];
+      if (next && next.added) {
+        // Modification: emit one `modify` per line of the addition.
+        const addLines = next.count ?? countLines(next.value);
+        for (let k = 0; k < addLines; k++) {
+          changes.push({ line: bufferLine + k, kind: "modify" });
+        }
+        bufferLine += addLines;
+        // Skip the addition we just consumed.
+        i++;
+      } else {
+        // Pure deletion: marker on the line that now occupies the deleted
+        // chunk's position. Clamp to [1, bufferLineCount]; clamp to 1 when
+        // the buffer is empty (no surviving line).
+        const target =
+          bufferLineCount === 0 ? 1 : Math.min(Math.max(bufferLine, 1), bufferLineCount);
+        // Avoid duplicate markers if multiple removed chunks fall on the
+        // same line.
+        const last = changes[changes.length - 1];
+        if (!last || last.line !== target || last.kind !== "delete-above") {
+          changes.push({ line: target, kind: "delete-above" });
+        }
+      }
+      // `removed` chunks don't advance the buffer cursor.
+      continue;
+    }
+
+    if (chunk.added) {
+      for (let k = 0; k < lines; k++) {
+        changes.push({ line: bufferLine + k, kind: "add" });
+      }
+      bufferLine += lines;
+      continue;
+    }
+
+    // Unchanged.
+    bufferLine += lines;
+  }
+
+  return changes;
+}
+
+function countLines(s: string): number {
+  if (s === "") return 0;
+  const parts = s.split("\n");
+  return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}

--- a/src/ui/src/components/file-viewer/gitGutter.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.ts
@@ -1,4 +1,6 @@
 import { diffLines } from "diff";
+import type * as monacoNs from "monaco-editor";
+import styles from "./MonacoEditor.module.css";
 
 export type LineChangeKind = "add" | "modify" | "delete-above";
 
@@ -81,4 +83,37 @@ function countLines(s: string): number {
   if (s === "") return 0;
   const parts = s.split("\n");
   return parts[parts.length - 1] === "" ? parts.length - 1 : parts.length;
+}
+
+/**
+ * Convert structured line-change data into Monaco decoration deltas. Each
+ * change becomes a 0-column, 1-line range with a `linesDecorationsClassName`
+ * pointing at our CSS-module class for the appropriate kind.
+ *
+ * `stickiness: 1` (NeverGrowsWhenTypingAtEdges) keeps a marker pinned to
+ * its line — without it, an insertion at the start of the line would pull
+ * the marker onto the next line.
+ */
+export function lineChangesToDecorations(
+  changes: LineChange[],
+  monacoInstance: typeof monacoNs,
+): monacoNs.editor.IModelDeltaDecoration[] {
+  return changes.map((change) => ({
+    range: new monacoInstance.Range(change.line, 1, change.line, 1),
+    options: {
+      linesDecorationsClassName: classFor(change.kind),
+      stickiness: 1,
+    },
+  }));
+}
+
+function classFor(kind: LineChangeKind): string {
+  switch (kind) {
+    case "add":
+      return styles.gitGutterAdd;
+    case "modify":
+      return styles.gitGutterModify;
+    case "delete-above":
+      return styles.gitGutterDeleteAbove;
+  }
 }

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+import type { OnMount } from "@monaco-editor/react";
+import { readWorkspaceFileAtHead } from "../../services/tauri";
+import { useAppStore } from "../../stores/useAppStore";
+import { computeLineChanges, lineChangesToDecorations } from "./gitGutter";
+
+export const GUTTER_DEBOUNCE_MS = 250;
+export const GUTTER_MAX_BYTES = 1024 * 1024;
+export const GUTTER_MAX_LINES = 20_000;
+
+type Editor = Parameters<OnMount>[0];
+type Monaco = Parameters<OnMount>[1];
+export type DecorationsCollection = ReturnType<Editor["createDecorationsCollection"]>;
+export type DecorationsCollectionRef = React.MutableRefObject<DecorationsCollection | null>;
+
+/**
+ * Wires the git gutter into a mounted Monaco editor. Fetches the file's
+ * HEAD blob once per `(workspaceId, filename, diffMergeBase)`, then
+ * recomputes line decorations on each buffer change (debounced 250 ms).
+ *
+ * The decoration collection is owned by the parent (created in
+ * `handleMount` once Monaco has resolved both `editor` and `monaco`) and
+ * passed in via `collectionRef`. The hook can't create it itself: a
+ * `[]`-deps init effect would run before the lazy-loaded editor is
+ * mounted, and a deps-tracked effect can't reliably detect mount.
+ *
+ * Bails out for files larger than 1 MiB or 20 000 lines — the diff cost
+ * isn't worth the gutter on files that big.
+ */
+export function useGitGutter(
+  monacoRef: React.MutableRefObject<Monaco | null>,
+  collectionRef: DecorationsCollectionRef,
+  workspaceId: string,
+  filename: string,
+  buffer: string,
+) {
+  // `null` = gutter unavailable (no head, fetch error, binary). Empty
+  // string `""` = file untracked at HEAD; treat every line as added.
+  // Lifted into state so HEAD fetch resolution triggers a re-render and
+  // the buffer-effect re-runs even when the buffer hasn't changed yet
+  // (the common case on file open: `currentBuffer === initialValue`).
+  const [head, setHead] = useState<string | null>(null);
+  // Race-safety counter for the async HEAD fetch — mirrors the
+  // `loadVersionRef` pattern in FileViewer.tsx.
+  const fetchVersionRef = useRef(0);
+
+  const diffMergeBase = useAppStore((s) => s.diffMergeBase);
+
+  // Fetch the HEAD blob whenever the file or merge-base changes. The
+  // version counter discards stale responses if a newer fetch has
+  // already started.
+  useEffect(() => {
+    const version = ++fetchVersionRef.current;
+    // Reset to "loading" synchronously so the buffer-effect bails out
+    // until the new fetch resolves — the cascade is intentional and
+    // bounded (one extra render per file/merge-base change).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setHead(null);
+    collectionRef.current?.clear();
+
+    readWorkspaceFileAtHead(workspaceId, filename)
+      .then((res) => {
+        if (version !== fetchVersionRef.current) return;
+        if (!res.exists_at_head) {
+          setHead("");
+          return;
+        }
+        setHead(res.content);
+      })
+      .catch(() => {
+        if (version !== fetchVersionRef.current) return;
+        setHead(null);
+      });
+  }, [workspaceId, filename, diffMergeBase, collectionRef]);
+
+  // Debounced recompute on every buffer or head change. Skips work when
+  // the head hasn't loaded yet or the file is too big — Monaco's
+  // decoration model is fast but the diff isn't free at scale.
+  useEffect(() => {
+    const collection = collectionRef.current;
+    const monacoInstance = monacoRef.current;
+    if (head === null || !collection || !monacoInstance) return;
+
+    if (buffer.length > GUTTER_MAX_BYTES) {
+      collection.clear();
+      return;
+    }
+    if (buffer.split("\n").length > GUTTER_MAX_LINES) {
+      collection.clear();
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const changes = computeLineChanges(head, buffer);
+      const decos = lineChangesToDecorations(changes, monacoInstance);
+      collection.set(decos);
+    }, GUTTER_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [head, buffer, monacoRef, collectionRef]);
+}

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -51,10 +51,20 @@ export function useGitGutter(
   // already started.
   useEffect(() => {
     const version = ++fetchVersionRef.current;
+    // Skip the fetch entirely when the buffer is already past the cap —
+    // the gutter would be disabled regardless. Read `buffer.length` once
+    // at effect-run time; we don't depend on `buffer` (would fire per
+    // keystroke), so we just snapshot the value as it stands when this
+    // fires (file open, merge-base change).
+    if (buffer.length > GUTTER_MAX_BYTES) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setHead(null);
+      collectionRef.current?.clear();
+      return;
+    }
     // Reset to "loading" synchronously so the buffer-effect bails out
     // until the new fetch resolves — the cascade is intentional and
     // bounded (one extra render per file/merge-base change).
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHead(null);
     collectionRef.current?.clear();
 
@@ -71,6 +81,9 @@ export function useGitGutter(
         if (version !== fetchVersionRef.current) return;
         setHead(null);
       });
+    // We intentionally do NOT depend on `buffer` — that would refire the
+    // fetch on every keystroke. We snapshot `buffer.length` at run time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceId, filename, diffMergeBase, collectionRef]);
 
   // Debounced recompute on every buffer or head change. Skips work when
@@ -81,16 +94,11 @@ export function useGitGutter(
     const monacoInstance = monacoRef.current;
     if (head === null || !collection || !monacoInstance) return;
 
-    if (buffer.length > GUTTER_MAX_BYTES) {
-      collection.clear();
-      return;
-    }
-    if (buffer.split("\n").length > GUTTER_MAX_LINES) {
-      collection.clear();
-      return;
-    }
-
     const timer = window.setTimeout(() => {
+      if (buffer.length > GUTTER_MAX_BYTES || exceedsLineCap(buffer)) {
+        collection.clear();
+        return;
+      }
       const changes = computeLineChanges(head, buffer);
       const decos = lineChangesToDecorations(changes, monacoInstance);
       collection.set(decos);
@@ -98,4 +106,23 @@ export function useGitGutter(
 
     return () => window.clearTimeout(timer);
   }, [head, buffer, monacoRef, collectionRef]);
+}
+
+/**
+ * Cheap line-count check that bails out as soon as the cap is exceeded.
+ * Counts '\n' (charCode 10) without allocating; saves per-keystroke array
+ * allocation that `buffer.split("\n").length` would do.
+ */
+function exceedsLineCap(buffer: string): boolean {
+  let nlCount = 0;
+  for (let i = 0; i < buffer.length; i++) {
+    if (buffer.charCodeAt(i) === 10) {
+      nlCount++;
+      // The cap counts lines, not newlines. A buffer with N newlines has
+      // either N or N+1 lines (depending on trailing newline). Bail when
+      // we've definitely exceeded the cap.
+      if (nlCount >= GUTTER_MAX_LINES) return true;
+    }
+  }
+  return false;
 }

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -772,6 +772,22 @@ export function readWorkspaceFileBytes(
   return invoke("read_workspace_file_bytes", { workspaceId, relativePath });
 }
 
+export interface HeadBlobContent {
+  path: string;
+  content: string | null;
+  exists_at_head: boolean;
+}
+
+export function readWorkspaceFileAtHead(
+  workspaceId: string,
+  relativePath: string,
+): Promise<HeadBlobContent> {
+  return invoke("read_workspace_file_at_head", {
+    workspaceId,
+    relativePath,
+  });
+}
+
 export function writeWorkspaceFile(
   workspaceId: string,
   relativePath: string,

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -117,6 +117,7 @@
   --diff-added-bg:       rgba(60, 180, 90, 0.12);
   --diff-removed-bg:     rgba(220, 60, 60, 0.12);
   --diff-added-text:     #6ccc80;
+  --git-gutter-modified: #5ba3d0;
   --diff-removed-text:   #f07070;
   --diff-hunk-header:    #8cb8e0;
   --diff-line-number:    #686058;
@@ -268,6 +269,7 @@
   --diff-added-bg:   rgba(26, 127, 55, 0.10);
   --diff-removed-bg: rgba(196, 32, 32, 0.10);
   --diff-added-text: #1a7f37;
+  --git-gutter-modified: #1d6fa5;
   --diff-removed-text: #c42020;
   --diff-hunk-header: #3d6da0;
   --diff-line-number: #b8afa5;
@@ -331,6 +333,7 @@
   --diff-added-bg: rgba(67, 112, 25, 0.25);
   --diff-removed-bg: rgba(112, 0, 9, 0.25);
   --diff-added-text: #d2ebbe;
+  --git-gutter-modified: #a3c8e0;
   --diff-removed-text: #cf6a4c;
   --diff-hunk-header: #8fbfdc;
 }
@@ -407,6 +410,7 @@
   --diff-added-bg:   rgba(49, 116, 143, 0.22);
   --diff-removed-bg: rgba(235, 111, 146, 0.18);
   --diff-added-text:   #9ccfd8;
+  --git-gutter-modified: #3e8fb0;
   --diff-removed-text: #eb6f92;
   --diff-hunk-header:  #c4a7e7;
 }
@@ -455,6 +459,7 @@
   --diff-added-bg:   rgba(62, 143, 176, 0.22);
   --diff-removed-bg: rgba(235, 111, 146, 0.18);
   --diff-added-text:   #9ccfd8;
+  --git-gutter-modified: #3e8fb0;
   --diff-removed-text: #eb6f92;
   --diff-hunk-header:  #c4a7e7;
 }
@@ -506,6 +511,7 @@
   --diff-added-bg:   rgba(40, 105, 131, 0.12);
   --diff-removed-bg: rgba(180, 99, 122, 0.12);
   --diff-added-text:   #286983;
+  --git-gutter-modified: #56949f;
   --diff-removed-text: #b4637a;
   --diff-hunk-header:  #907aa9;
 }
@@ -556,6 +562,7 @@
   --diff-added-bg:   rgba(133, 153, 0, 0.18);
   --diff-removed-bg: rgba(220, 50, 47, 0.18);
   --diff-added-text:   #859900;
+  --git-gutter-modified: #268bd2;
   --diff-removed-text: #dc322f;
   --diff-hunk-header:  #2aa198;
 }
@@ -607,6 +614,7 @@
   --diff-added-bg:   rgba(133, 153, 0, 0.14);
   --diff-removed-bg: rgba(220, 50, 47, 0.14);
   --diff-added-text:   #657b83;
+  --git-gutter-modified: #268bd2;
   --diff-removed-text: #dc322f;
   --diff-hunk-header:  #2aa198;
 }
@@ -655,6 +663,7 @@
   --diff-added-bg:   rgba(173, 218, 120, 0.14);
   --diff-removed-bg: rgba(253, 104, 131, 0.14);
   --diff-added-text:   #adda78;
+  --git-gutter-modified: #82aaff;
   --diff-removed-text: #fd6883;
   --diff-hunk-header:  #85dacc;
 }
@@ -703,6 +712,7 @@
   --diff-added-bg:   rgba(60, 95, 25, 0.20);
   --diff-removed-bg: rgba(95, 10, 15, 0.20);
   --diff-added-text:   #b8cca0;
+  --git-gutter-modified: #9bb8d8;
   --diff-removed-text: #b56a53;
   --diff-hunk-header:  #7aa8c0;
 }
@@ -751,6 +761,7 @@
   --diff-added-bg:   rgba(0, 180, 80, 0.12);
   --diff-removed-bg: rgba(220, 40, 40, 0.12);
   --diff-added-text:   rgb(80, 220, 120);
+  --git-gutter-modified: rgb(120, 170, 230);
   --diff-removed-text: rgb(240, 100, 100);
   --diff-hunk-header:  rgb(100, 160, 240);
 }
@@ -799,6 +810,7 @@
   --diff-added-bg:   rgba(0, 180, 80, 0.12);
   --diff-removed-bg: rgba(220, 40, 40, 0.12);
   --diff-added-text:   rgb(80, 210, 110);
+  --git-gutter-modified: rgb(120, 170, 220);
   --diff-removed-text: rgb(235, 100, 100);
   --diff-hunk-header:  rgb(120, 170, 230);
 }
@@ -848,6 +860,7 @@
   --diff-added-bg:   rgba(8, 163, 99, 0.18);
   --diff-removed-bg: rgba(217, 40, 40, 0.18);
   --diff-added-text:   #90ed87;
+  --git-gutter-modified: #87b8ed;
   --diff-removed-text: #ff8a8a;
   --diff-hunk-header:  #8adcff;
 }


### PR DESCRIPTION
## Summary

Adds VSCode/neovim-gitgutter-style colored bars in the line-numbers gutter of Claudette's Monaco file editor, classifying every line of the buffer as **added**, **modified**, or **delete-above** relative to `HEAD`.

- **Baseline:** `HEAD` (matches gitgutter / VSCode default — "what have I changed since I last committed").
- **Markers:** thin 3px bars in the line-numbers gutter — green (`--diff-added-text`), blue (new `--git-gutter-modified` token), red triangle for deletions (`--diff-removed-text`).
- **Update model:** live, debounced 250ms. HEAD blob fetched once on file open and re-fetched when the diff store's merge-base changes (proxy for "HEAD might have moved").
- **Architecture:** a new Tauri command (`read_workspace_file_at_head`) wraps a Rust `read_blob_at_head` helper that runs `git show HEAD:<path>`. Frontend caches the HEAD blob in component state, runs `diffLines` (`diff` package, ~30 KB gzipped) on every debounced edit, and feeds a `IEditorDecorationsCollection`.
- **Caps:** silently disabled for files > 1 MB or > 20,000 lines, for binary blobs at HEAD, for untracked files outside any git repo, and on any fetch error. Untracked files inside a repo show every line as added.

```mermaid
flowchart LR
    A[MonacoEditor mount] --> B[read_workspace_file_at_head]
    B --> C{exists at HEAD?}
    C -->|yes, text| D[setHead content]
    C -->|no| E[setHead empty string -> all-add]
    C -->|binary / error| F[setHead null -> gutter off]
    G[buffer change] -->|debounce 250ms| H[computeLineChanges]
    D --> H
    E --> H
    H --> I[lineChangesToDecorations]
    I --> J[collection.set]
    K[diffMergeBase changes] --> B
```

Spec and plan committed locally in `docs/superpowers/specs/` and `docs/superpowers/plans/` (gitignored, so not pushed).

## Complexity Notes

- **Hook lifecycle.** `useGitGutter` had to navigate the lazy-mount of `@monaco-editor/react`: the editor instance only becomes available inside `OnMount`, so the decoration collection is created there (not in a React effect) and the hook receives it via a stable ref. The fetch effect uses a version-counter pattern (`fetchVersionRef`) to discard stale responses, since promises can't be aborted.
- **Why `head` lives in state, not a ref.** First-paint requires a re-render after the HEAD fetch resolves; a ref mutation alone would only paint on the first keystroke. The buffer-effect depends on `[head, buffer, ...]` so resolution triggers a recompute.
- **Diff library lives client-side.** Each debounced edit runs `diffLines(head, buffer)` in JS rather than shelling out to `git diff` per tick. Sub-millisecond at typical sizes; trades one new ~30 KB dep for zero IPC during typing.
- **Per-workspace fan-out.** The hook subscribes to the global `diffMergeBase` from `diffSlice`, which means every open editor refetches when any workspace's diff reloads. Acceptable for a single open file; if multi-tab usage shows up as a perf issue we can split this into a per-workspace signal.
- **Trailing-newline edits** classify as `modify` rather than the visually-cleaner "no marker on unchanged text" — a known artifact of jsdiff's chunk semantics. Documented in the design but not worked around (would meaningfully complicate the helper).
- **`width: 3px !important`** on `.gitGutterAdd` / `.gitGutterModify` overrides Monaco's inline gutter-decoration width. Standard pattern for Monaco gutter customization.

## Test Steps

1. **Backend tests:** `cargo test -p claudette head_blob_tests` — should show 5 passing (tracked text round-trip, untracked, staged-only, binary blob, non-git directory).
2. **Frontend unit tests:** `cd src/ui && bun run test gitGutter` — should show 13 passing (9 for `computeLineChanges`, 4 for `lineChangesToDecorations`).
3. **Type-check + CSS lint:** `cd src/ui && bunx tsc -b && bun run lint:css` — both clean.
4. **Manual UI verification** in `cargo tauri dev`:
   1. Open a tracked text file → no markers initially.
   2. Edit one line → blue bar appears in the gutter ~250ms after typing stops.
   3. Insert a new line → green bar.
   4. Delete a line → red triangle on the line that now occupies the deletion's position.
   5. Save (Cmd/Ctrl+S) → bars persist (file is now ahead of HEAD).
   6. In Claudette's terminal: \`git add . && git commit -m "test"\` → bars clear once the diff store refreshes.
   7. Create a new file in the worktree (e.g., \`echo hi > new.txt\`), open it → entire file shows green bars.
   8. Open a binary file (image/PDF) → editor falls back to image viewer / "preview not available"; no console errors.
5. **Theme switching:** flip themes via settings; gutter colors track the theme (live-updated CSS variables).

## Checklist

- [x] Tests added/updated (5 Rust + 13 frontend, all passing)
- [x] Type checks pass (`bunx tsc -b` clean)
- [x] CSS token enforcement passes (`bun run lint:css`)
- [x] Clippy clean on CI-blocking crates (`claudette` + `claudette-server`)
- [ ] Manual verification per Test Steps #4 above (please walk through before merge)