### PR TITLE
feat(changes): committed group, diff stats, and open-in-editor for commit files + diff toolbar

### DIFF
--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AlignJustify, Check, Columns2, Copy, Eye, GitCompare } from "lucide-react";
+import { AlignJustify, Check, Columns2, Copy, Eye, FilePenLine, GitCompare } from "lucide-react";
 import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import { useAppStore } from "../../stores/useAppStore";
 import { loadCommitFileDiff, loadFileDiff, readWorkspaceFile } from "../../services/tauri";
@@ -111,6 +111,7 @@ export function DiffViewer() {
   const setDiffPreviewError = useAppStore((s) => s.setDiffPreviewError);
   const workspaces = useAppStore((s) => s.workspaces);
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const openFileTab = useAppStore((s) => s.openFileTab);
   const diffSelectedCommitHash = useAppStore((s) => s.diffSelectedCommitHash);
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
@@ -330,6 +331,14 @@ export function DiffViewer() {
                   <Copy size={14} aria-hidden="true" />
                 )}
               </IconButton>
+              {selectedWorkspaceId && diffSelectedFile && (
+                <IconButton
+                  onClick={() => openFileTab(selectedWorkspaceId, diffSelectedFile)}
+                  tooltip="Open in editor"
+                >
+                  <FilePenLine size={14} aria-hidden="true" />
+                </IconButton>
+              )}
               {isMarkdown && (
                 <SegmentedControl
                   ariaLabel={t("diff_markdown_view_mode_aria")}

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -1,6 +1,6 @@
 import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react";
 import { isAgentBusy } from "../../utils/agentStatus";
-import { ChevronRight, Undo2, Trash2, Plus, Minus, FileText } from "lucide-react";
+import { ChevronRight, Undo2, Trash2, Plus, Minus, FilePenLine } from "lucide-react";
 import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
 import { useTaskTracker } from "../../hooks/useTaskTracker";
 import {
@@ -281,12 +281,12 @@ export const RightSidebar = memo(function RightSidebar() {
         {statusLabel(file.status)}
       </span>
       <span className={styles.path}>{file.path}</span>
-      {(file.additions !== undefined || file.deletions !== undefined) && (
+      {(file.additions != null || file.deletions != null) && (
         <span className={styles.stats}>
-          {file.additions !== undefined && (
+          {file.additions != null && (
             <span className={styles.additions}>+{file.additions}</span>
           )}
-          {file.deletions !== undefined && (
+          {file.deletions != null && (
             <span className={styles.deletions}>-{file.deletions}</span>
           )}
         </span>
@@ -300,7 +300,7 @@ export const RightSidebar = memo(function RightSidebar() {
             title="Open in editor"
             aria-label="Open in editor"
           >
-            <FileText size={12} />
+            <FilePenLine size={12} />
           </button>
         )}
         {canStage && (
@@ -555,10 +555,10 @@ export const RightSidebar = memo(function RightSidebar() {
                   renderFileRow={renderFileRow}
                 />
                 <FileGroup
-                  label="Staged"
-                  files={diffStagedFiles!.staged}
-                  layer="staged"
-                  accentColor="var(--accent-dim)"
+                  label="Committed"
+                  files={diffStagedFiles!.committed}
+                  layer="committed"
+                  accentColor="var(--diff-added-text)"
                   renderFileRow={renderFileRow}
                 />
                 {commitHistory && commitHistory.length > 0 && (
@@ -566,6 +566,8 @@ export const RightSidebar = memo(function RightSidebar() {
                     commits={commitHistory}
                     selectedFile={diffSelectedFile}
                     selectedCommitHash={diffSelectedCommitHash}
+                    selectedWorkspaceId={selectedWorkspaceId}
+                    openFileTab={openFileTab}
                     onFileClick={(file, commitHash) => {
                       if (selectedWorkspaceId) {
                         openDiffTab(selectedWorkspaceId, file.path, "committed");
@@ -745,11 +747,15 @@ function CommitGroup({
   commits,
   selectedFile,
   selectedCommitHash,
+  selectedWorkspaceId,
+  openFileTab,
   onFileClick,
 }: {
   commits: CommitEntry[];
   selectedFile: string | null;
   selectedCommitHash: string | null;
+  selectedWorkspaceId: string | null;
+  openFileTab: (workspaceId: string, path: string) => void;
   onFileClick: (file: DiffFile, commitHash: string) => void;
 }) {
   const [collapsed, setCollapsed] = useState(true);
@@ -799,6 +805,7 @@ function CommitGroup({
                     const isSelected =
                       selectedFile === file.path &&
                       selectedCommitHash === commit.hash;
+                    const canOpen = selectedWorkspaceId != null && file.status !== "Deleted";
                     return (
                       <div
                         key={file.path}
@@ -827,6 +834,32 @@ function CommitGroup({
                             : "R"}
                         </span>
                         <span className={styles.path}>{file.path}</span>
+                        {(file.additions != null || file.deletions != null) && (
+                          <span className={styles.stats}>
+                            {file.additions != null && (
+                              <span className={styles.additions}>+{file.additions}</span>
+                            )}
+                            {file.deletions != null && (
+                              <span className={styles.deletions}>-{file.deletions}</span>
+                            )}
+                          </span>
+                        )}
+                        <span className={styles.rowActions}>
+                          {canOpen && (
+                            <button
+                              type="button"
+                              className={styles.rowAction}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                openFileTab(selectedWorkspaceId, file.path);
+                              }}
+                              title="Open in editor"
+                              aria-label="Open in editor"
+                            >
+                              <FilePenLine size={12} />
+                            </button>
+                          )}
+                        </span>
                       </div>
                     );
                   })


### PR DESCRIPTION
## Summary

- **Restores the Committed `FileGroup`** (merge-base..HEAD flat list) above the Commits expandable group — the prior commit (#593) accidentally replaced it with a duplicate Staged group
- **Diff stats on committed file rows** — shows `+additions` / `-deletions` counts on each file row inside the Commits expandable group; also fixes a null-guard bug in `renderFileRow` where Rust's `Option<u32>::None` serialises as JSON `null` (not `undefined`), causing empty `+ -` spans
- **Open-in-editor button on committed file rows** — hover-revealed `FilePenLine` button on each file row in the Commits group; hidden for Deleted files (which no longer exist on disk)
- **Open-in-editor button in the diff viewer toolbar** — `FilePenLine` `IconButton` added to the `PaneToolbar` actions bar, grouped next to the copy-contents button; visible whenever a file diff is open
- **Unified icon** — all open-in-editor buttons across the Changes panel and diff toolbar now use `FilePenLine` (was `FileText`)

## UAT Plan

- [ ] Open a workspace with commits ahead of the merge base; open the Changes tab
- [ ] Confirm a flat **Committed** group appears above the **Commits** expandable group, listing all files changed since the merge base
- [ ] Expand the Commits group; expand a commit row — verify each file row shows `+X` / `-Y` diff counts
- [ ] Hover a commit file row — verify a `FilePenLine` open-in-editor button appears; click it and confirm the file opens in the editor tab
- [ ] Verify the open-in-editor button is absent for Deleted files in commit rows
- [ ] Open any file diff — verify a `FilePenLine` button appears in the toolbar to the right of the copy button; click it and confirm the file opens in the editor tab
- [ ] Click a file in the Staged or Unstaged group; verify open-in-editor still works there (icon is now `FilePenLine`)

## Checklist

- [x] `bunx tsc -b` — clean
- [ ] Manual verification per UAT Plan above