### PR TITLE
feat(site): add Themeable and Remote access feature cards

### DIFF
--- a/site/src/components/AndMore.astro
+++ b/site/src/components/AndMore.astro
@@ -1,6 +1,7 @@
 ---
+import { BUILTIN_THEME_META } from '../../../src/ui/src/styles/themes/index.ts';
 const items = [
-  '13 built-in themes, fully re-themeable',
+  `${BUILTIN_THEME_META.length} built-in themes, fully re-themeable`,
   'Pinned slash commands in the composer',
   'Native <code>/review</code>, <code>/plan</code>, <code>/compact</code>, <code>/usage</code>',
   'Stable + nightly update channels',

--- a/site/src/components/FeatureCards.astro
+++ b/site/src/components/FeatureCards.astro
@@ -1,4 +1,11 @@
 ---
+// Source the theme count from the desktop app's BUILTIN_THEME_META so the
+// Themeable card never drifts when themes are added or removed.
+import { BUILTIN_THEME_META } from '../../../src/ui/src/styles/themes/index.ts';
+const themeCount = BUILTIN_THEME_META.length;
+const lightThemeCount = BUILTIN_THEME_META.filter((t) => t.colorScheme === 'light').length;
+const darkThemeCount = themeCount - lightThemeCount;
+
 const features = [
   {
     title: 'Integrated terminal',
@@ -44,8 +51,8 @@ const features = [
   },
   {
     title: 'Themeable',
-    desc: '14 built-in themes spanning warm coral, deep navy, Solarized, Rosé Pine, and high-contrast — switch instantly from the command palette, or roll your own with CSS custom properties.',
-    meta: '14 themes · light + dark',
+    desc: `${themeCount} built-in themes spanning warm coral, deep navy, Solarized, Rosé Pine, and high-contrast — switch instantly from the command palette, or roll your own with CSS custom properties.`,
+    meta: `${darkThemeCount} dark · ${lightThemeCount} light`,
     icon: '<circle cx="13.5" cy="6.5" r=".5" fill="currentColor" stroke="none"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor" stroke="none"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor" stroke="none"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor" stroke="none"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>',
   },
   {

--- a/site/src/components/FeatureCards.astro
+++ b/site/src/components/FeatureCards.astro
@@ -42,6 +42,18 @@ const features = [
     meta: 'stays on your machine',
     icon: '<line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>',
   },
+  {
+    title: 'Themeable',
+    desc: '14 built-in themes spanning warm coral, deep navy, Solarized, Rosé Pine, and high-contrast — switch instantly from the command palette, or roll your own with CSS custom properties.',
+    meta: '14 themes · light + dark',
+    icon: '<circle cx="13.5" cy="6.5" r=".5" fill="currentColor" stroke="none"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor" stroke="none"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor" stroke="none"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor" stroke="none"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/>',
+  },
+  {
+    title: 'Remote access',
+    desc: 'Drive your local Claudette from another machine on the same network. WebSocket transport with mDNS discovery — no cloud round-trip, no third-party relay.',
+    meta: 'WebSocket · mDNS',
+    icon: '<path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/>',
+  },
 ];
 ---
 


### PR DESCRIPTION
## Summary

Fills the two empty cells in the homepage's "The rest of the toolkit" feature grid (`site/src/components/FeatureCards.astro`) with two flagship Claudette capabilities that previously only appeared in deeper docs:

- **Themeable** — surfaces that Claudette ships **14 built-in themes** (sourced from `BUILTIN_THEME_META` in `src/ui/src/styles/themes/index.ts` — 11 dark + 3 light), switchable from the command palette or extensible via CSS custom properties. Icon: Lucide palette.
- **Remote access** — describes the local-LAN remote-control capability backed by `claudette-server` (WebSocket transport in `src-tauri/src/transport/`) with mDNS discovery (`src-tauri/src/mdns.rs`). Icon: Lucide wifi.

Copy is intentionally scoped to what's shipped today — no claims about collaborative/multi-user sessions, since that's not released yet.

The grid is `repeat(3, 1fr)` and previously had 7 cards (one trailing row half-empty); with these two appended it's a clean 3×3.

## Complexity Notes

- **Soft coupling on the theme count.** The `desc` and `meta` for the Themeable card hardcode "14" — derived from `BUILTIN_THEME_META` but not auto-synced. If a future PR adds or removes a theme, this copy will silently drift. Worth a follow-up cross-reference comment in `themes/index.ts`, deferred from this PR.
- **Inline-SVG `set:html` pattern.** Existing convention in this file passes raw SVG path strings into Astro's `set:html` directive. Safe here because the source is hardcoded — would be an XSS surface if ever wired to user input.
- **Palette icon fill override.** The parent `<svg>` declares `fill="none"` for stroke-only icons. The Themeable swatch dots needed per-element `fill="currentColor" stroke="none"` overrides to render. The wifi icon's signal dot uses Lucide's zero-length-line trick (`<line x1="12" y1="20" x2="12.01" y2="20"/>` with `stroke-linecap="round"`) so no override is needed there.

## Test Steps

1. From `site/`, run `bun install && bun run dev` and visit http://localhost:4321/claudette.
2. Scroll to the "The rest of the toolkit" section. Confirm the grid shows a complete 3×3 layout with no empty cells.
3. Verify the two new cards (last row, columns 2 and 3):
   - **Themeable** — palette icon with four visible swatch dots; meta reads `14 themes · light + dark`.
   - **Remote access** — wifi icon with three concentric arcs and a signal dot; meta reads `WebSocket · mDNS`.
4. Hover each new card to confirm the `:hover` background transition (defined at `site/src/styles/homepage.css:525`) still fires.
5. Resize the viewport: at ≤1100px the grid collapses to 2 columns and at ≤700px to 1 column — confirm both new cards reflow correctly.
6. Re-verify the theme count by counting entries in `BUILTIN_THEME_META` (`src/ui/src/styles/themes/index.ts`) — should be 14. If it isn't, update the copy before merge.

## Checklist

- [ ] Tests added/updated (n/a — copy + SVG-only change in marketing component)
- [x] Documentation updated (this is the documentation change)