### PR TITLE
feat(settings): configurable git gutter base in new Editor section

### DIFF
--- a/.claude/skills/claudette-debug/reference/store-actions.md
+++ b/.claude/skills/claudette-debug/reference/store-actions.md
@@ -82,6 +82,7 @@ All actions are on `window.__CLAUDETTE_STORE__.getState()`.
 ## Diff
 
 - `setDiffFiles(files, mergeBase)` -- load diff file list (note: two params)
+- `setDiffMergeBase(sha)` -- update only the merge-base SHA, leaving the diff file list intact
 - `setDiffSelectedFile(path)` -- select file (path or null)
 - `setDiffContent(content)` -- load diff content (FileDiff or null)
 - `setDiffViewMode(mode)` -- "Unified" or "Split"
@@ -130,6 +131,8 @@ All actions are on `window.__CLAUDETTE_STORE__.getState()`.
 - `setAudioNotifications(enabled)` -- boolean
 - `setCurrentThemeId(id)` -- theme identifier
 - `setLastMessages(msgs)` -- Record<wsId, ChatMessage>
+- `editorGitGutterBase: "head" | "merge_base"` -- which revision the Monaco git gutter compares against
+- `setEditorGitGutterBase(value)` -- update store state (persistence to app_settings is the caller's responsibility)
 
 ## Remote Connections
 

--- a/.claude/skills/claudette-debug/reference/tauri-commands.md
+++ b/.claude/skills/claudette-debug/reference/tauri-commands.md
@@ -57,6 +57,7 @@ For example, `workspace_id: String` in Rust becomes `workspaceId` in the JS invo
 
 - `loadDiffFiles(workspaceId)` -> `DiffFilesResult { files, merge_base }`
 - `loadFileDiff(worktreePath, mergeBase, filePath)` -> `FileDiff`
+- `computeWorkspaceMergeBase(workspaceId)` -> string  (lightweight: returns just the merge-base SHA, no file list)
 - `revertFile(worktreePath, mergeBase, filePath, status)` -> void
 
 ## Terminal

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -64,6 +64,20 @@ curl -X POST "$SLACK_WEBHOOK_URL" \
   -d "{\"text\": \"Claudette: $CLAUDETTE_WORKSPACE_NAME needs attention\"}"
 ```
 
+## Editor
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Git gutter base | Which revision the editor's git gutter compares your buffer against. `Last commit (HEAD)` shows uncommitted changes only; `Workspace branch base` shows every change made on this workspace's branch since it diverged from the repository's base branch (matches the [Changes panel](/claudette/features/diff-viewer/)). | Last commit (HEAD) |
+
+### Git Gutter Base
+
+The git gutter is the colored marker column to the left of line numbers in the file editor. By default it compares your editor buffer against `HEAD`, so the markers reflect uncommitted changes only.
+
+If you'd rather see every change you've made in this workspace since branching from the repository's base branch, switch to **Workspace branch base**. This matches the view in the **Changes** panel.
+
+When the workspace is checked out on the base branch itself, "Workspace branch base" collapses to `HEAD`, so the gutter behaves identically. The setting is global — it applies to every workspace.
+
 ## Git
 
 | Setting | Description | Default |

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -2,7 +2,6 @@ use tauri::State;
 
 use claudette::db::Database;
 use claudette::diff;
-use claudette::git;
 use claudette::model::diff::{CommitEntry, DiffFile, FileDiff, StagedDiffFiles};
 
 use crate::state::AppState;
@@ -22,6 +21,12 @@ pub async fn load_diff_files(
 ) -> Result<DiffFilesResult, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
+    let merge_base = diff::resolve_workspace_merge_base(&db, &workspace_id).await?;
+
+    // Re-open the workspace list to get the worktree_path for the file queries.
+    // Two list_workspaces() calls on the same connection is acceptable — both
+    // are cheap reads and keeping resolve_workspace_merge_base's contract simple
+    // (returns only the SHA) is worth the duplication.
     let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
     let ws = workspaces
         .iter()
@@ -31,23 +36,6 @@ pub async fn load_diff_files(
         .worktree_path
         .as_ref()
         .ok_or("Workspace has no worktree")?;
-
-    let repos = db.list_repositories().map_err(|e| e.to_string())?;
-    let repo = repos
-        .iter()
-        .find(|r| r.id == ws.repository_id)
-        .ok_or("Repository not found")?;
-
-    let base_branch = match repo.base_branch.as_deref() {
-        Some(b) => b.to_string(),
-        None => git::default_branch(&repo.path, repo.default_remote.as_deref())
-            .await
-            .map_err(|e| e.to_string())?,
-    };
-
-    let merge_base = diff::merge_base(worktree_path, "HEAD", &base_branch)
-        .await
-        .map_err(|e| e.to_string())?;
 
     // Get both the flat file list (backward compat) and staged groups
     let (files, staged_files, commits) = tokio::join!(
@@ -66,6 +54,20 @@ pub async fn load_diff_files(
         staged_files,
         commits,
     })
+}
+
+/// Lightweight sibling of `load_diff_files` that returns only the workspace's
+/// merge-base SHA. Used by the file viewer's git gutter when the user has
+/// selected the "Workspace branch base" comparison and the SHA isn't already
+/// cached in the diff slice (e.g. they opened a file before the Changes
+/// panel ever ran).
+#[tauri::command]
+pub async fn compute_workspace_merge_base(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    diff::resolve_workspace_merge_base(&db, &workspace_id).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -21,21 +21,9 @@ pub async fn load_diff_files(
 ) -> Result<DiffFilesResult, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
-    let merge_base = diff::resolve_workspace_merge_base(&db, &workspace_id).await?;
-
-    // Re-open the workspace list to get the worktree_path for the file queries.
-    // Two list_workspaces() calls on the same connection is acceptable — both
-    // are cheap reads and keeping resolve_workspace_merge_base's contract simple
-    // (returns only the SHA) is worth the duplication.
-    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
-    let ws = workspaces
-        .iter()
-        .find(|w| w.id == workspace_id)
-        .ok_or("Workspace not found")?;
-    let worktree_path = ws
-        .worktree_path
-        .as_ref()
-        .ok_or("Workspace has no worktree")?;
+    let (merge_base, worktree_path) =
+        diff::resolve_workspace_merge_base(&db, &workspace_id).await?;
+    let worktree_path = &worktree_path;
 
     // Get both the flat file list (backward compat) and staged groups
     let (files, staged_files, commits) = tokio::join!(
@@ -67,7 +55,9 @@ pub async fn compute_workspace_merge_base(
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    diff::resolve_workspace_merge_base(&db, &workspace_id).await
+    diff::resolve_workspace_merge_base(&db, &workspace_id)
+        .await
+        .map(|(sha, _)| sha)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -213,37 +213,45 @@ pub async fn read_workspace_file_bytes(
 }
 
 #[derive(Clone, Serialize)]
-pub struct HeadBlobContent {
+pub struct BlobAtRevisionContent {
     pub path: String,
-    /// Some(text) for tracked text blobs; None for binary blobs at HEAD or
-    /// when the file doesn't exist at HEAD.
+    /// The revision the blob was read at. Echoed back so the caller can
+    /// distinguish responses across in-flight requests.
+    pub revision: String,
+    /// Some(text) for tracked text blobs; None for binary blobs at the
+    /// revision, oversized blobs, or when the file doesn't exist at the
+    /// revision.
     pub content: Option<String>,
-    /// false when the path is not tracked at HEAD (untracked / staged-only /
-    /// not on the branch).
-    pub exists_at_head: bool,
+    /// false when the path is not tracked at the revision (untracked /
+    /// staged-only / not on the branch / not in the SHA's tree).
+    pub exists_at_revision: bool,
 }
 
-/// Read a file's HEAD-blob contents. Used by the file viewer's git gutter
-/// to compute per-line decorations against the last committed version.
+/// Read a file's blob contents at the given `revision`. Used by the file
+/// viewer's git gutter to compute per-line decorations against either HEAD
+/// (default) or the workspace's merge-base with the repo's base branch.
 ///
-/// On any error (workspace missing, no worktree, not a git repo, etc.) we
-/// return an `Err` string. The frontend treats errors as "gutter unavailable
-/// for this file" and silently disables markers — they are not surfaced as
-/// toasts.
+/// `revision` must be either the literal string `"HEAD"` or a 40-char hex
+/// SHA — anything else is rejected by `git::read_blob_at_revision` and
+/// surfaces here as an `Err(String)`. The frontend treats errors as "gutter
+/// unavailable for this revision" and silently disables markers — they are
+/// not surfaced as toasts.
 #[tauri::command]
-pub async fn read_workspace_file_at_head(
+pub async fn read_workspace_file_at_revision(
     workspace_id: String,
     relative_path: String,
+    revision: String,
     state: State<'_, AppState>,
-) -> Result<HeadBlobContent, String> {
+) -> Result<BlobAtRevisionContent, String> {
     let worktree_path = resolve_worktree_path(&workspace_id, &state)?;
-    let result = claudette::git::read_blob_at_head(&worktree_path, &relative_path)
+    let result = claudette::git::read_blob_at_revision(&worktree_path, &relative_path, &revision)
         .await
         .map_err(|e| e.to_string())?;
-    Ok(HeadBlobContent {
+    Ok(BlobAtRevisionContent {
         path: relative_path,
+        revision,
         content: result.content,
-        exists_at_head: result.exists_at_head,
+        exists_at_revision: result.exists_at_revision,
     })
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -473,7 +473,7 @@ fn main() {
             commands::files::read_workspace_file,
             commands::files::read_workspace_file_for_viewer,
             commands::files::read_workspace_file_bytes,
-            commands::files::read_workspace_file_at_head,
+            commands::files::read_workspace_file_at_revision,
             commands::files::write_workspace_file,
             commands::files::save_attachment_bytes,
             commands::files::open_attachment_in_browser,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -508,6 +508,7 @@ fn main() {
             commands::metrics::get_analytics_metrics,
             // Diff
             commands::diff::load_diff_files,
+            commands::diff::compute_workspace_merge_base,
             commands::diff::load_file_diff,
             commands::diff::revert_file,
             commands::diff::discard_file,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -27,7 +27,7 @@ mod workspace;
 mod commands;
 
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 
 pub struct Database {
     conn: Connection,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -73,6 +73,46 @@ pub async fn merge_base(repo_path: &str, branch: &str, base: &str) -> Result<Str
     run_git(repo_path, &["merge-base", "--", base, branch]).await
 }
 
+/// Resolve the workspace's merge-base SHA against its repository's base branch.
+///
+/// Encapsulates the workspace + repository lookups and the base-branch
+/// resolution (preferring `repo.base_branch`, falling back to
+/// `git::default_branch`). Used by both the Changes panel's `load_diff_files`
+/// command and the file viewer's lightweight `compute_workspace_merge_base`
+/// command — keeping a single source of truth means the gutter and diff
+/// viewer can never disagree about which SHA "the merge base" is.
+pub async fn resolve_workspace_merge_base(
+    db: &crate::db::Database,
+    workspace_id: &str,
+) -> Result<String, String> {
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or_else(|| "Workspace not found".to_string())?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or_else(|| "Workspace has no worktree".to_string())?;
+
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let repo = repos
+        .iter()
+        .find(|r| r.id == ws.repository_id)
+        .ok_or_else(|| "Repository not found".to_string())?;
+
+    let base_branch = match repo.base_branch.as_deref() {
+        Some(b) => b.to_string(),
+        None => crate::git::default_branch(&repo.path, repo.default_remote.as_deref())
+            .await
+            .map_err(|e| e.to_string())?,
+    };
+
+    merge_base(worktree_path, "HEAD", &base_branch)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// List all changed files between merge base and current working tree.
 pub async fn changed_files(
     worktree_path: &str,
@@ -1586,5 +1626,38 @@ mod integration_tests {
             .unwrap();
         let parsed = parse_unified_diff(&raw, "file.txt");
         assert!(!parsed.hunks.is_empty(), "default layer should have diff");
+    }
+
+    #[tokio::test]
+    async fn resolve_workspace_merge_base_matches_git_merge_base() {
+        // Build a repo with a feature branch that has diverged from main.
+        // setup_test_repo creates: main (initial commit) → feature (feature commit).
+        // After setup the working tree is on `feature`, so HEAD is the feature commit
+        // and the merge-base of HEAD vs main is the initial commit.
+        let tmp = tempfile::tempdir().unwrap();
+        setup_test_repo(tmp.path());
+
+        // The expected SHA — git's ground truth.
+        let expected = merge_base(tmp.path().to_str().unwrap(), "feature", "main")
+            .await
+            .expect("merge_base helper should succeed");
+        assert!(!expected.is_empty(), "expected SHA must not be empty");
+
+        // Build an in-memory database with one repo + one workspace.
+        let db = crate::db::Database::open_in_memory().unwrap();
+        let mut repo =
+            crate::db::test_support::make_repo("r1", tmp.path().to_str().unwrap(), "test-repo");
+        repo.base_branch = Some("main".into());
+        db.insert_repository(&repo).unwrap();
+
+        let mut ws = crate::db::test_support::make_workspace("w1", "r1", "feature-ws");
+        ws.worktree_path = Some(tmp.path().to_str().unwrap().into());
+        db.insert_workspace(&ws).unwrap();
+
+        let got = resolve_workspace_merge_base(&db, "w1")
+            .await
+            .expect("resolve_workspace_merge_base should succeed");
+
+        assert_eq!(got, expected);
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1628,20 +1628,58 @@ mod integration_tests {
         assert!(!parsed.hunks.is_empty(), "default layer should have diff");
     }
 
+    /// Like `setup_test_repo` but adds a post-divergence commit on `main` so that
+    /// the true merge-base (the initial commit) is strictly *less than* both
+    /// `main` HEAD and `feature` HEAD.  Without this, a buggy implementation that
+    /// simply returned `main`'s HEAD would pass undetected.
+    ///
+    /// Final state
+    /// -----------
+    ///   main:    initial ── main-post-divergence
+    ///   feature: initial ── feature-changes          ← worktree HEAD
+    ///
+    /// Expected merge-base: SHA of `initial`.
+    fn setup_diverged_test_repo(dir: &Path) {
+        // Reuse the shared helper: creates `initial` on main, then branches to
+        // `feature` and commits `feature changes`.  Worktree is left on `feature`.
+        setup_test_repo(dir);
+
+        // Switch back to main and add a commit that diverges it past the branch point.
+        git_cmd(dir, &["checkout", "main"]);
+        std::fs::write(dir.join("main_extra.txt"), "main post-divergence\n").unwrap();
+        git_cmd(dir, &["add", "main_extra.txt"]);
+        git_cmd(dir, &["commit", "-m", "main post-divergence"]);
+
+        // Return to feature so the worktree HEAD is the feature tip.
+        git_cmd(dir, &["checkout", "feature"]);
+    }
+
     #[tokio::test]
     async fn resolve_workspace_merge_base_matches_git_merge_base() {
-        // Build a repo with a feature branch that has diverged from main.
-        // setup_test_repo creates: main (initial commit) → feature (feature commit).
-        // After setup the working tree is on `feature`, so HEAD is the feature commit
-        // and the merge-base of HEAD vs main is the initial commit.
+        // Build a repo where both branches have diverged from the branch point so
+        // that merge-base != main HEAD and merge-base != feature HEAD.
         let tmp = tempfile::tempdir().unwrap();
-        setup_test_repo(tmp.path());
+        setup_diverged_test_repo(tmp.path());
 
         // The expected SHA — git's ground truth.
         let expected = merge_base(tmp.path().to_str().unwrap(), "feature", "main")
             .await
             .expect("merge_base helper should succeed");
         assert!(!expected.is_empty(), "expected SHA must not be empty");
+
+        // Sanity-check the divergence: the merge-base (initial commit) must be
+        // strictly different from both branch tips so a buggy implementation that
+        // returns either tip would fail this test.
+        let main_head = git_cmd(tmp.path(), &["rev-parse", "main"]);
+        let feature_head = git_cmd(tmp.path(), &["rev-parse", "feature"]);
+        assert_ne!(
+            expected, main_head,
+            "merge-base must not equal main HEAD — divergence requires post-branch main commit"
+        );
+        assert_ne!(
+            expected, feature_head,
+            "merge-base must not equal feature HEAD — divergence requires post-branch feature commit"
+        );
 
         // Build an in-memory database with one repo + one workspace.
         let db = crate::db::Database::open_in_memory().unwrap();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -73,7 +73,23 @@ pub async fn merge_base(repo_path: &str, branch: &str, base: &str) -> Result<Str
     run_git(repo_path, &["merge-base", "--", base, branch]).await
 }
 
+/// Owned inputs extracted from the DB for [`resolve_workspace_merge_base`].
+///
+/// Returned by the synchronous extraction step so the `&Database` reference is
+/// fully dropped before any `.await` — necessary because
+/// `rusqlite::Connection` is not `Sync`, so `&Database` is not `Send`, and
+/// Tauri requires command futures to be `Send`.
+struct WorkspaceMergeBaseInputs {
+    worktree_path: String,
+    repo_path: String,
+    base_branch: Option<String>,
+    default_remote: Option<String>,
+}
+
 /// Resolve the workspace's merge-base SHA against its repository's base branch.
+///
+/// Returns `(merge_base_sha, worktree_path)` so callers that need the worktree
+/// path (e.g. `load_diff_files`) don't need a second `list_workspaces` call.
 ///
 /// Encapsulates the workspace + repository lookups and the base-branch
 /// resolution (preferring `repo.base_branch`, falling back to
@@ -81,36 +97,64 @@ pub async fn merge_base(repo_path: &str, branch: &str, base: &str) -> Result<Str
 /// command and the file viewer's lightweight `compute_workspace_merge_base`
 /// command — keeping a single source of truth means the gutter and diff
 /// viewer can never disagree about which SHA "the merge base" is.
-pub async fn resolve_workspace_merge_base(
+///
+/// # Send-safety
+///
+/// This function is intentionally **not** `async`. It performs the
+/// synchronous DB extraction first, then returns a `Future` that owns only the
+/// extracted data — so `&Database` is never held across an `.await` point.
+/// This is required because `rusqlite::Connection` is not `Sync` (it contains
+/// `RefCell`), which means `&Database` is not `Send`, and Tauri command futures
+/// must be `Send`.
+pub fn resolve_workspace_merge_base(
     db: &crate::db::Database,
     workspace_id: &str,
-) -> Result<String, String> {
-    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
-    let ws = workspaces
-        .iter()
-        .find(|w| w.id == workspace_id)
-        .ok_or_else(|| "Workspace not found".to_string())?;
-    let worktree_path = ws
-        .worktree_path
-        .as_ref()
-        .ok_or_else(|| "Workspace has no worktree".to_string())?;
+) -> impl std::future::Future<Output = Result<(String, String), String>> + Send {
+    // Perform all synchronous DB work here, before the async block.
+    // After this point the &Database reference is no longer needed.
+    let inputs_result: Result<WorkspaceMergeBaseInputs, String> = (|| {
+        let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+        let ws = workspaces
+            .iter()
+            .find(|w| w.id == workspace_id)
+            .ok_or_else(|| "Workspace not found".to_string())?;
+        let worktree_path = ws
+            .worktree_path
+            .as_ref()
+            .ok_or_else(|| "Workspace has no worktree".to_string())?
+            .clone();
 
-    let repos = db.list_repositories().map_err(|e| e.to_string())?;
-    let repo = repos
-        .iter()
-        .find(|r| r.id == ws.repository_id)
-        .ok_or_else(|| "Repository not found".to_string())?;
+        let repos = db.list_repositories().map_err(|e| e.to_string())?;
+        let repo = repos
+            .iter()
+            .find(|r| r.id == ws.repository_id)
+            .ok_or_else(|| "Repository not found".to_string())?;
 
-    let base_branch = match repo.base_branch.as_deref() {
-        Some(b) => b.to_string(),
-        None => crate::git::default_branch(&repo.path, repo.default_remote.as_deref())
+        Ok(WorkspaceMergeBaseInputs {
+            worktree_path,
+            repo_path: repo.path.clone(),
+            base_branch: repo.base_branch.clone(),
+            default_remote: repo.default_remote.clone(),
+        })
+    })();
+
+    // The returned async block owns only `inputs_result` (no &Database).
+    async move {
+        let inputs = inputs_result?;
+
+        let base_branch = match inputs.base_branch {
+            Some(b) => b,
+            None => crate::git::default_branch(&inputs.repo_path, inputs.default_remote.as_deref())
+                .await
+                .map_err(|e| e.to_string())?,
+        };
+
+        let sha = merge_base(&inputs.worktree_path, "HEAD", &base_branch)
             .await
-            .map_err(|e| e.to_string())?,
-    };
+            .map_err(|e| e.to_string())?;
 
-    merge_base(worktree_path, "HEAD", &base_branch)
-        .await
-        .map_err(|e| e.to_string())
+        Ok((sha, inputs.worktree_path))
+    }
 }
 
 /// List all changed files between merge base and current working tree.
@@ -1692,10 +1736,10 @@ mod integration_tests {
         ws.worktree_path = Some(tmp.path().to_str().unwrap().into());
         db.insert_workspace(&ws).unwrap();
 
-        let got = resolve_workspace_merge_base(&db, "w1")
+        let (got_sha, _worktree_path) = resolve_workspace_merge_base(&db, "w1")
             .await
             .expect("resolve_workspace_merge_base should succeed");
 
-        assert_eq!(got, expected);
+        assert_eq!(got_sha, expected);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -253,44 +253,67 @@ pub async fn validate_repo(path: &str) -> Result<(), GitError> {
     Ok(())
 }
 
-/// Result of reading a file's blob at HEAD via [`read_blob_at_head`].
+/// Result of reading a file's blob at an arbitrary revision via
+/// [`read_blob_at_revision`]. The "revision" can be `HEAD` or a full 40-char
+/// commit SHA (validated by `validate_revision`).
 #[derive(Debug, Clone, Serialize)]
-pub struct HeadBlobResult {
+pub struct BlobAtRevisionResult {
     /// UTF-8 text of the blob, or `None` when the blob is binary, oversized,
     /// or absent.
     pub content: Option<String>,
-    /// Whether the file path resolves to a blob in the current `HEAD` tree.
-    pub exists_at_head: bool,
+    /// Whether the file path resolves to a blob in the requested revision's tree.
+    pub exists_at_revision: bool,
 }
 
-/// Maximum blob size we materialize via `read_blob_at_head`. Mirrors the
+/// Maximum blob size we materialize via `read_blob_at_revision`. Mirrors the
 /// frontend's `GUTTER_MAX_BYTES` cap — beyond this the file viewer's git
 /// gutter is disabled anyway, so reading the bytes only wastes IPC.
-pub const MAX_BLOB_AT_HEAD_BYTES: u64 = 1024 * 1024;
+pub const MAX_BLOB_AT_REVISION_BYTES: u64 = 1024 * 1024;
 
-/// Read a file's contents as they exist at the current `HEAD` commit.
+/// Allow-list for revisions accepted by [`read_blob_at_revision`]. Two
+/// shapes only: literal `"HEAD"` or a full 40-char hex SHA. The merge-base
+/// values the gutter passes in are pre-resolved SHAs (via `diff::merge_base`,
+/// which returns the SHA from `git merge-base`), so this covers every
+/// in-product caller while keeping arbitrary user input out of the
+/// `git cat-file` argv.
+fn validate_revision(revision: &str) -> Result<(), GitError> {
+    if revision == "HEAD" {
+        return Ok(());
+    }
+    if revision.len() == 40 && revision.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Ok(());
+    }
+    Err(GitError::CommandFailed(format!(
+        "invalid revision (expected 'HEAD' or 40-char hex SHA): {revision}"
+    )))
+}
+
+/// Read a file's contents as they exist at the given `revision` (`HEAD` or a
+/// 40-char hex SHA — see [`validate_revision`]).
 ///
 /// Four return shapes:
-/// 1. **Tracked text:** `exists_at_head = true`, `content = Some(text)`. The
-///    blob exists at `HEAD` and decodes as UTF-8 (lossy — invalid bytes are
-///    replaced with `U+FFFD`).
-/// 2. **Tracked binary or oversized:** `exists_at_head = true`,
+/// 1. **Tracked text:** `exists_at_revision = true`, `content = Some(text)`.
+///    The blob exists in the revision's tree and decodes as UTF-8 (lossy —
+///    invalid bytes are replaced with `U+FFFD`).
+/// 2. **Tracked binary or oversized:** `exists_at_revision = true`,
 ///    `content = None`. Either the blob contains a NUL byte in its first
-///    8 KiB (treated as binary) or its size exceeds [`MAX_BLOB_AT_HEAD_BYTES`]
-///    (the frontend gutter is disabled at that scale anyway, so we skip the
-///    IPC cost of materializing it).
-/// 3. **Not at HEAD:** `exists_at_head = false`, `content = None`. The path is
-///    untracked, staged-only, or otherwise absent from the `HEAD` tree.
+///    8 KiB (treated as binary) or its size exceeds [`MAX_BLOB_AT_REVISION_BYTES`].
+/// 3. **Not at revision:** `exists_at_revision = false`, `content = None`.
+///    The path is untracked, staged-only, or otherwise absent from the
+///    revision's tree.
 ///
 /// Returns [`GitError::NotAGitRepo`] / [`GitError::CommandFailed`] when the
-/// directory is not a git worktree, and propagates other git failures verbatim.
-pub async fn read_blob_at_head(
+/// directory is not a git worktree, when the revision fails the allow-list,
+/// or when an underlying git command fails.
+pub async fn read_blob_at_revision(
     worktree_path: &str,
     file_path: &str,
-) -> Result<HeadBlobResult, GitError> {
+    revision: &str,
+) -> Result<BlobAtRevisionResult, GitError> {
+    validate_revision(revision)?;
     validate_repo(worktree_path).await?;
 
-    let spec = format!("HEAD:{file_path}");
+    let spec = format!("{revision}:{file_path}");
     let exists = Command::new(crate::git::resolve_git_path_blocking())
         .no_console_window()
         .args(["-C", worktree_path])
@@ -300,9 +323,9 @@ pub async fn read_blob_at_head(
         .map_err(GitError::from_spawn_io)?;
 
     if !exists.status.success() {
-        return Ok(HeadBlobResult {
+        return Ok(BlobAtRevisionResult {
             content: None,
-            exists_at_head: false,
+            exists_at_revision: false,
         });
     }
 
@@ -328,10 +351,10 @@ pub async fn read_blob_at_head(
         .parse()
         .map_err(|e| GitError::CommandFailed(format!("could not parse cat-file -s output: {e}")))?;
 
-    if size > MAX_BLOB_AT_HEAD_BYTES {
-        return Ok(HeadBlobResult {
+    if size > MAX_BLOB_AT_REVISION_BYTES {
+        return Ok(BlobAtRevisionResult {
             content: None,
-            exists_at_head: true,
+            exists_at_revision: true,
         });
     }
 
@@ -353,16 +376,16 @@ pub async fn read_blob_at_head(
     let is_binary = raw[..check_len].contains(&0);
 
     if is_binary {
-        return Ok(HeadBlobResult {
+        return Ok(BlobAtRevisionResult {
             content: None,
-            exists_at_head: true,
+            exists_at_revision: true,
         });
     }
 
     let text = String::from_utf8_lossy(&raw).into_owned();
-    Ok(HeadBlobResult {
+    Ok(BlobAtRevisionResult {
         content: Some(text),
-        exists_at_head: true,
+        exists_at_revision: true,
     })
 }
 
@@ -1713,10 +1736,10 @@ mod head_blob_tests {
         git_cmd(tmp.path(), &["add", "a.txt"]);
         git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
 
-        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "a.txt")
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "a.txt", "HEAD")
             .await
             .expect("read");
-        assert!(result.exists_at_head);
+        assert!(result.exists_at_revision);
         assert_eq!(result.content.as_deref(), Some("hello\nworld\n"));
     }
 
@@ -1729,10 +1752,10 @@ mod head_blob_tests {
         git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
 
         std::fs::write(tmp.path().join("new.txt"), "fresh\n").unwrap();
-        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "new.txt")
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "new.txt", "HEAD")
             .await
             .expect("read");
-        assert!(!result.exists_at_head);
+        assert!(!result.exists_at_revision);
         assert!(result.content.is_none());
     }
 
@@ -1747,10 +1770,10 @@ mod head_blob_tests {
         std::fs::write(tmp.path().join("staged.txt"), "staged\n").unwrap();
         git_cmd(tmp.path(), &["add", "staged.txt"]);
 
-        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "staged.txt")
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "staged.txt", "HEAD")
             .await
             .expect("read");
-        assert!(!result.exists_at_head);
+        assert!(!result.exists_at_revision);
         assert!(result.content.is_none());
     }
 
@@ -1765,10 +1788,10 @@ mod head_blob_tests {
         git_cmd(tmp.path(), &["add", "blob.bin"]);
         git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
 
-        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "blob.bin")
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "blob.bin", "HEAD")
             .await
             .expect("read");
-        assert!(result.exists_at_head);
+        assert!(result.exists_at_revision);
         assert!(result.content.is_none());
     }
 
@@ -1776,7 +1799,7 @@ mod head_blob_tests {
     async fn errors_in_non_git_directory() {
         let tmp = tempdir().unwrap();
         std::fs::write(tmp.path().join("a.txt"), "hi").unwrap();
-        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "a.txt").await;
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "a.txt", "HEAD").await;
         assert!(result.is_err());
     }
 
@@ -1786,15 +1809,68 @@ mod head_blob_tests {
         init_repo(tmp.path());
         // One byte over the cap — size check fires before binary detection,
         // so any bytes work.
-        let bytes = vec![b'a'; (MAX_BLOB_AT_HEAD_BYTES + 1) as usize];
+        let bytes = vec![b'a'; (MAX_BLOB_AT_REVISION_BYTES + 1) as usize];
         std::fs::write(tmp.path().join("big.txt"), &bytes).unwrap();
         git_cmd(tmp.path(), &["add", "big.txt"]);
         git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
 
-        let result = read_blob_at_head(tmp.path().to_str().unwrap(), "big.txt")
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "big.txt", "HEAD")
             .await
             .expect("read");
-        assert!(result.exists_at_head);
+        assert!(result.exists_at_revision);
         assert!(result.content.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_blob_at_revision_with_sha_returns_blob() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "hello\n").unwrap();
+        git_cmd(tmp.path(), &["add", "a.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        let sha = git_cmd(tmp.path(), &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+
+        let result = read_blob_at_revision(tmp.path().to_str().unwrap(), "a.txt", &sha)
+            .await
+            .expect("read");
+        assert!(result.exists_at_revision);
+        assert_eq!(result.content.as_deref(), Some("hello\n"));
+    }
+
+    #[tokio::test]
+    async fn read_blob_at_revision_rejects_non_head_non_sha_inputs() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "x\n").unwrap();
+        git_cmd(tmp.path(), &["add", "a.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        for bad in ["main", "HEAD~1", "; rm -rf /", "refs/heads/main", ""] {
+            let err = read_blob_at_revision(tmp.path().to_str().unwrap(), "a.txt", bad)
+                .await
+                .expect_err(&format!("expected error for revision {bad:?}"));
+            assert!(
+                matches!(err, GitError::CommandFailed(_)),
+                "expected CommandFailed for {bad:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn read_blob_at_revision_rejects_short_sha() {
+        let tmp = tempdir().unwrap();
+        init_repo(tmp.path());
+        std::fs::write(tmp.path().join("a.txt"), "x\n").unwrap();
+        git_cmd(tmp.path(), &["add", "a.txt"]);
+        git_cmd(tmp.path(), &["commit", "-q", "-m", "init"]);
+
+        let short = "abc1234"; // 7 hex chars — valid in git, but our allow-list rejects.
+        let err = read_blob_at_revision(tmp.path().to_str().unwrap(), "a.txt", short)
+            .await
+            .expect_err("short sha must be rejected");
+        assert!(matches!(err, GitError::CommandFailed(_)));
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1702,7 +1702,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod head_blob_tests {
+mod blob_at_revision_tests {
     use super::*;
     use std::process::Command as StdCommand;
     use tempfile::tempdir;

--- a/src/git.rs
+++ b/src/git.rs
@@ -291,7 +291,7 @@ fn validate_revision(revision: &str) -> Result<(), GitError> {
 /// Read a file's contents as they exist at the given `revision` (`HEAD` or a
 /// 40-char hex SHA — see [`validate_revision`]).
 ///
-/// Four return shapes:
+/// Three return shapes:
 /// 1. **Tracked text:** `exists_at_revision = true`, `content = Some(text)`.
 ///    The blob exists in the revision's tree and decodes as UTF-8 (lossy —
 ///    invalid bytes are replaced with `U+FFFD`).

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
   const setCommunityRegistryEnabled = useAppStore(
     (s) => s.setCommunityRegistryEnabled,
   );
+  const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
   const setDisable1mContext = useAppStore((s) => s.setDisable1mContext);
   const setAppVersion = useAppStore((s) => s.setAppVersion);
 
@@ -201,6 +202,11 @@ function App() {
       .catch(() => {});
     getAppSetting("community_registry_enabled")
       .then((val) => { if (val === "true") setCommunityRegistryEnabled(true); })
+      .catch(() => {});
+    getAppSetting("editor_git_gutter_base")
+      .then((val) => {
+        if (val === "merge_base") setEditorGitGutterBase("merge_base");
+      })
       .catch(() => {});
     getAppSetting("language")
       .then((lang) => {
@@ -410,7 +416,7 @@ function App() {
       unlistenAutoArchived.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setDisable1mContext, setAppVersion]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setDisable1mContext, setAppVersion]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/components/file-viewer/useGitGutter.test.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { selectGutterRevision, shouldFetchMergeBase } from "./useGitGutter";
+import { selectGutterRevision } from "./useGitGutter";
 
 const SHA = "a".repeat(40);
 
@@ -15,17 +15,5 @@ describe("selectGutterRevision", () => {
 
   it("returns null when the setting is 'merge_base' and no SHA is cached (caller waits)", () => {
     expect(selectGutterRevision("merge_base", null)).toBeNull();
-  });
-});
-
-describe("shouldFetchMergeBase", () => {
-  it("does not fire when the setting is 'head'", () => {
-    expect(shouldFetchMergeBase("head", null)).toBe(false);
-    expect(shouldFetchMergeBase("head", SHA)).toBe(false);
-  });
-
-  it("fires only when 'merge_base' is selected and no SHA is cached", () => {
-    expect(shouldFetchMergeBase("merge_base", null)).toBe(true);
-    expect(shouldFetchMergeBase("merge_base", SHA)).toBe(false);
   });
 });

--- a/src/ui/src/components/file-viewer/useGitGutter.test.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { selectGutterRevision, shouldFetchMergeBase } from "./useGitGutter";
+
+const SHA = "a".repeat(40);
+
+describe("selectGutterRevision", () => {
+  it("returns 'HEAD' when the setting is 'head'", () => {
+    expect(selectGutterRevision("head", null)).toBe("HEAD");
+    expect(selectGutterRevision("head", SHA)).toBe("HEAD");
+  });
+
+  it("returns the cached merge-base SHA when the setting is 'merge_base' and one is cached", () => {
+    expect(selectGutterRevision("merge_base", SHA)).toBe(SHA);
+  });
+
+  it("returns null when the setting is 'merge_base' and no SHA is cached (caller waits)", () => {
+    expect(selectGutterRevision("merge_base", null)).toBeNull();
+  });
+});
+
+describe("shouldFetchMergeBase", () => {
+  it("does not fire when the setting is 'head'", () => {
+    expect(shouldFetchMergeBase("head", null)).toBe(false);
+    expect(shouldFetchMergeBase("head", SHA)).toBe(false);
+  });
+
+  it("fires only when 'merge_base' is selected and no SHA is cached", () => {
+    expect(shouldFetchMergeBase("merge_base", null)).toBe(true);
+    expect(shouldFetchMergeBase("merge_base", SHA)).toBe(false);
+  });
+});

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -128,8 +128,16 @@ export function useGitGutter(
       });
     // We intentionally do NOT depend on `buffer` — that would refire the
     // fetch on every keystroke. We snapshot `buffer.length` at run time.
+    //
+    // `diffMergeBase` is included even though `revision` already encodes
+    // it for `merge_base` mode: in `head` mode `revision` is the constant
+    // string `"HEAD"`, so without this dep the fetch effect would no
+    // longer pick up the invalidation signal RightSidebar's
+    // `setDiffFiles(...)` produces after a refresh (e.g. once a commit
+    // has moved HEAD). Re-fetching on `diffMergeBase` change is the
+    // cheapest way to inherit that signal in both modes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, filename, revision, collectionRef]);
+  }, [workspaceId, filename, revision, diffMergeBase, collectionRef]);
 
   // Debounced recompute on every buffer or head change. (Unchanged from
   // before Task 6 except that it now responds to `head` updates produced

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { OnMount } from "@monaco-editor/react";
-import { readWorkspaceFileAtHead } from "../../services/tauri";
+import { readWorkspaceFileAtRevision } from "../../services/tauri";
 import { useAppStore } from "../../stores/useAppStore";
 import { computeLineChanges, lineChangesToDecorations } from "./gitGutter";
 
@@ -68,10 +68,10 @@ export function useGitGutter(
     setHead(null);
     collectionRef.current?.clear();
 
-    readWorkspaceFileAtHead(workspaceId, filename)
+    readWorkspaceFileAtRevision(workspaceId, filename, "HEAD")
       .then((res) => {
         if (version !== fetchVersionRef.current) return;
-        if (!res.exists_at_head) {
+        if (!res.exists_at_revision) {
           setHead("");
           return;
         }

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -33,18 +33,6 @@ export function selectGutterRevision(
 }
 
 /**
- * True when the hook should fire `compute_workspace_merge_base`. Only fires
- * once per `(workspaceId, setting)` change — gates on the cached SHA being
- * absent, so a previously-resolved SHA short-circuits.
- */
-export function shouldFetchMergeBase(
-  setting: "head" | "merge_base",
-  cachedMergeBase: string | null,
-): boolean {
-  return setting === "merge_base" && cachedMergeBase === null;
-}
-
-/**
  * Wires the git gutter into a mounted Monaco editor. Fetches the file's
  * blob at the configured revision once per `(workspaceId, filename, revision)`,
  * then recomputes line decorations on each buffer change (debounced 250 ms).
@@ -83,7 +71,9 @@ export function useGitGutter(
   // selected and the SHA isn't cached. Errors silently disable the
   // gutter — same UX as today's binary/oversized/no-head paths.
   useEffect(() => {
-    if (!shouldFetchMergeBase(editorGitGutterBase, diffMergeBase)) return;
+    // Resolve the merge-base on demand: fires only when "merge_base" is
+    // selected and no SHA is cached (revision === null in that case).
+    if (revision !== null || editorGitGutterBase !== "merge_base") return;
     let cancelled = false;
     computeWorkspaceMergeBase(workspaceId)
       .then((sha) => {
@@ -95,7 +85,7 @@ export function useGitGutter(
     return () => {
       cancelled = true;
     };
-  }, [editorGitGutterBase, diffMergeBase, workspaceId, setDiffMergeBase]);
+  }, [editorGitGutterBase, revision, workspaceId, setDiffMergeBase]);
 
   // Fetch the blob at `revision` whenever the file or revision changes. The
   // version counter discards stale responses if a newer fetch has already

--- a/src/ui/src/components/file-viewer/useGitGutter.ts
+++ b/src/ui/src/components/file-viewer/useGitGutter.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import type { OnMount } from "@monaco-editor/react";
-import { readWorkspaceFileAtRevision } from "../../services/tauri";
+import {
+  readWorkspaceFileAtRevision,
+  computeWorkspaceMergeBase,
+} from "../../services/tauri";
 import { useAppStore } from "../../stores/useAppStore";
 import { computeLineChanges, lineChangesToDecorations } from "./gitGutter";
 
@@ -14,15 +17,45 @@ export type DecorationsCollection = ReturnType<Editor["createDecorationsCollecti
 export type DecorationsCollectionRef = React.MutableRefObject<DecorationsCollection | null>;
 
 /**
- * Wires the git gutter into a mounted Monaco editor. Fetches the file's
- * HEAD blob once per `(workspaceId, filename, diffMergeBase)`, then
- * recomputes line decorations on each buffer change (debounced 250 ms).
+ * Given the current setting and the cached merge-base SHA, return the
+ * revision string to use for the gutter's blob fetch — or `null` when the
+ * merge-base SHA hasn't been resolved yet (the caller should wait).
  *
- * The decoration collection is owned by the parent (created in
- * `handleMount` once Monaco has resolved both `editor` and `monaco`) and
- * passed in via `collectionRef`. The hook can't create it itself: a
- * `[]`-deps init effect would run before the lazy-loaded editor is
- * mounted, and a deps-tracked effect can't reliably detect mount.
+ * - `"head"`        → `"HEAD"` (always available).
+ * - `"merge_base"`  → the cached SHA, or `null` if not yet resolved.
+ */
+export function selectGutterRevision(
+  setting: "head" | "merge_base",
+  cachedMergeBase: string | null,
+): string | null {
+  if (setting === "head") return "HEAD";
+  return cachedMergeBase;
+}
+
+/**
+ * True when the hook should fire `compute_workspace_merge_base`. Only fires
+ * once per `(workspaceId, setting)` change — gates on the cached SHA being
+ * absent, so a previously-resolved SHA short-circuits.
+ */
+export function shouldFetchMergeBase(
+  setting: "head" | "merge_base",
+  cachedMergeBase: string | null,
+): boolean {
+  return setting === "merge_base" && cachedMergeBase === null;
+}
+
+/**
+ * Wires the git gutter into a mounted Monaco editor. Fetches the file's
+ * blob at the configured revision once per `(workspaceId, filename, revision)`,
+ * then recomputes line decorations on each buffer change (debounced 250 ms).
+ *
+ * The revision is selected by `editorGitGutterBase`:
+ *   - "head"        → "HEAD"
+ *   - "merge_base"  → diffMergeBase (lazily fetched via
+ *                     compute_workspace_merge_base when not yet cached).
+ *
+ * Failure modes are silent (no toasts): missing merge-base, binary blob,
+ * oversized file, IPC error — all leave the gutter cleared.
  *
  * Bails out for files larger than 1 MiB or 20 000 lines — the diff cost
  * isn't worth the gutter on files that big.
@@ -34,41 +67,63 @@ export function useGitGutter(
   filename: string,
   buffer: string,
 ) {
-  // `null` = gutter unavailable (no head, fetch error, binary). Empty
-  // string `""` = file untracked at HEAD; treat every line as added.
-  // Lifted into state so HEAD fetch resolution triggers a re-render and
-  // the buffer-effect re-runs even when the buffer hasn't changed yet
-  // (the common case on file open: `currentBuffer === initialValue`).
+  // `null` = gutter unavailable (no head, fetch error, binary, or revision
+  // not yet resolved). Empty string `""` = file untracked at the revision;
+  // treat every line as added.
   const [head, setHead] = useState<string | null>(null);
-  // Race-safety counter for the async HEAD fetch — mirrors the
-  // `loadVersionRef` pattern in FileViewer.tsx.
   const fetchVersionRef = useRef(0);
 
+  const editorGitGutterBase = useAppStore((s) => s.editorGitGutterBase);
   const diffMergeBase = useAppStore((s) => s.diffMergeBase);
+  const setDiffMergeBase = useAppStore((s) => s.setDiffMergeBase);
 
-  // Fetch the HEAD blob whenever the file or merge-base changes. The
-  // version counter discards stale responses if a newer fetch has
-  // already started.
+  const revision = selectGutterRevision(editorGitGutterBase, diffMergeBase);
+
+  // One-shot merge-base resolution. Only fires when "merge_base" is
+  // selected and the SHA isn't cached. Errors silently disable the
+  // gutter — same UX as today's binary/oversized/no-head paths.
+  useEffect(() => {
+    if (!shouldFetchMergeBase(editorGitGutterBase, diffMergeBase)) return;
+    let cancelled = false;
+    computeWorkspaceMergeBase(workspaceId)
+      .then((sha) => {
+        if (!cancelled) setDiffMergeBase(sha);
+      })
+      .catch(() => {
+        // Stay silent — gutter remains cleared.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [editorGitGutterBase, diffMergeBase, workspaceId, setDiffMergeBase]);
+
+  // Fetch the blob at `revision` whenever the file or revision changes. The
+  // version counter discards stale responses if a newer fetch has already
+  // started.
   useEffect(() => {
     const version = ++fetchVersionRef.current;
-    // Skip the fetch entirely when the buffer is already past the cap —
-    // the gutter would be disabled regardless. Read `buffer.length` once
-    // at effect-run time; we don't depend on `buffer` (would fire per
-    // keystroke), so we just snapshot the value as it stands when this
-    // fires (file open, merge-base change).
+
+    // Bail when the file is past the cap — gutter is disabled regardless.
+    // We snapshot `buffer.length` at run time so we don't fire per
+    // keystroke (`buffer` is intentionally not in the deps array).
     if (buffer.length > GUTTER_MAX_BYTES) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setHead(null);
       collectionRef.current?.clear();
       return;
     }
-    // Reset to "loading" synchronously so the buffer-effect bails out
-    // until the new fetch resolves — the cascade is intentional and
-    // bounded (one extra render per file/merge-base change).
+
+    // Bail when the revision isn't resolved yet (merge-base in flight).
+    if (revision === null) {
+      setHead(null);
+      collectionRef.current?.clear();
+      return;
+    }
+
     setHead(null);
     collectionRef.current?.clear();
 
-    readWorkspaceFileAtRevision(workspaceId, filename, "HEAD")
+    readWorkspaceFileAtRevision(workspaceId, filename, revision)
       .then((res) => {
         if (version !== fetchVersionRef.current) return;
         if (!res.exists_at_revision) {
@@ -84,11 +139,11 @@ export function useGitGutter(
     // We intentionally do NOT depend on `buffer` — that would refire the
     // fetch on every keystroke. We snapshot `buffer.length` at run time.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, filename, diffMergeBase, collectionRef]);
+  }, [workspaceId, filename, revision, collectionRef]);
 
-  // Debounced recompute on every buffer or head change. Skips work when
-  // the head hasn't loaded yet or the file is too big — Monaco's
-  // decoration model is fast but the diff isn't free at scale.
+  // Debounced recompute on every buffer or head change. (Unchanged from
+  // before Task 6 except that it now responds to `head` updates produced
+  // by the dynamic-revision fetch above.)
   useEffect(() => {
     const collection = collectionRef.current;
     const monacoInstance = monacoRef.current;

--- a/src/ui/src/components/settings/SettingsPage.tsx
+++ b/src/ui/src/components/settings/SettingsPage.tsx
@@ -18,6 +18,9 @@ const AppearanceSettings = lazy(() =>
 const NotificationsSettings = lazy(() =>
   import("./sections/NotificationsSettings").then((m) => ({ default: m.NotificationsSettings })),
 );
+const EditorSettings = lazy(() =>
+  import("./sections/EditorSettings").then((m) => ({ default: m.EditorSettings })),
+);
 const GitSettings = lazy(() =>
   import("./sections/GitSettings").then((m) => ({ default: m.GitSettings })),
 );
@@ -59,6 +62,7 @@ function SectionContent({ section }: { section: string | null }) {
   if (section === "usage") return <UsageSettings />;
   if (section === "appearance") return <AppearanceSettings />;
   if (section === "notifications") return <NotificationsSettings />;
+  if (section === "editor") return <EditorSettings />;
   if (section === "git") return <GitSettings />;
   if (section === "pinned-prompts") return <PinnedPromptsSettings />;
   if (section === "plugins") return <PluginsSettings />;

--- a/src/ui/src/components/settings/SettingsSidebar.test.ts
+++ b/src/ui/src/components/settings/SettingsSidebar.test.ts
@@ -37,4 +37,17 @@ describe("getAppSections", () => {
       "community",
     );
   });
+
+  it("places the Editor section between Notifications and Git", () => {
+    // The Editor section is where the git-gutter base preference lives
+    // — it must sit alongside the other "how the app behaves" settings,
+    // not be hidden under Plugins / Experimental.
+    const ids = getAppSections(false, false).map((section) => section.id);
+    const editorIdx = ids.indexOf("editor");
+    const notificationsIdx = ids.indexOf("notifications");
+    const gitIdx = ids.indexOf("git");
+    expect(editorIdx).toBeGreaterThan(-1);
+    expect(notificationsIdx).toBeLessThan(editorIdx);
+    expect(editorIdx).toBeLessThan(gitIdx);
+  });
 });

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -3,6 +3,7 @@ import {
   Cpu,
   Palette,
   Bell,
+  FileCode,
   GitBranch,
   FlaskConical,
   BarChart3,
@@ -24,6 +25,7 @@ export function getAppSections(
     { id: "models", icon: Cpu },
     { id: "appearance", icon: Palette },
     { id: "notifications", icon: Bell },
+    { id: "editor", icon: FileCode },
     { id: "git", icon: GitBranch },
     { id: "pinned-prompts", icon: Bookmark },
     { id: "plugins", icon: Puzzle },
@@ -53,6 +55,7 @@ export function SettingsSidebar() {
     if (id === "models") return t("settings:nav_models");
     if (id === "appearance") return t("settings:nav_appearance");
     if (id === "notifications") return t("settings:nav_notifications");
+    if (id === "editor") return t("settings:nav_editor");
     if (id === "git") return t("settings:nav_git");
     if (id === "plugins") return t("settings:nav_plugins");
     if (id === "claude-code-plugins") return t("settings:nav_claude_code_plugins");

--- a/src/ui/src/components/settings/sections/EditorSettings.tsx
+++ b/src/ui/src/components/settings/sections/EditorSettings.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppStore } from "../../../stores/useAppStore";
+import { setAppSetting } from "../../../services/tauri";
+import styles from "../Settings.module.css";
+
+type GutterBase = "head" | "merge_base";
+
+export function EditorSettings() {
+  const { t } = useTranslation("settings");
+  const editorGitGutterBase = useAppStore((s) => s.editorGitGutterBase);
+  const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = async (value: GutterBase) => {
+    const previous = editorGitGutterBase;
+    setEditorGitGutterBase(value);
+    try {
+      setError(null);
+      await setAppSetting("editor_git_gutter_base", value);
+    } catch (e) {
+      setEditorGitGutterBase(previous);
+      setError(String(e));
+    }
+  };
+
+  return (
+    <div>
+      <h2 className={styles.sectionTitle}>{t("editor_title")}</h2>
+
+      {error && <div className={styles.error}>{error}</div>}
+
+      <div className={styles.fieldGroup}>
+        <div className={styles.fieldLabel}>{t("editor_gutter_base_label")}</div>
+        <div className={`${styles.fieldHint} ${styles.fieldHintSpacedWide}`}>
+          {t("editor_gutter_base_desc")}
+        </div>
+
+        <label className={styles.radioLabel}>
+          <input
+            type="radio"
+            name="editor-gutter-base"
+            checked={editorGitGutterBase === "head"}
+            onChange={() => handleChange("head")}
+          />
+          <span>{t("editor_gutter_base_head")}</span>
+        </label>
+        <div className={styles.fieldHint}>
+          {t("editor_gutter_base_head_desc")}
+        </div>
+
+        <label className={styles.radioLabel}>
+          <input
+            type="radio"
+            name="editor-gutter-base"
+            checked={editorGitGutterBase === "merge_base"}
+            onChange={() => handleChange("merge_base")}
+          />
+          <span>{t("editor_gutter_base_merge_base")}</span>
+        </label>
+        <div className={styles.fieldHint}>
+          {t("editor_gutter_base_merge_base_desc")}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/sections/EditorSettings.tsx
+++ b/src/ui/src/components/settings/sections/EditorSettings.tsx
@@ -43,11 +43,13 @@ export function EditorSettings() {
             checked={editorGitGutterBase === "head"}
             onChange={() => handleChange("head")}
           />
-          <span>{t("editor_gutter_base_head")}</span>
+          <div>
+            <div>{t("editor_gutter_base_head")}</div>
+            <div className={styles.fieldHint}>
+              {t("editor_gutter_base_head_desc")}
+            </div>
+          </div>
         </label>
-        <div className={styles.fieldHint}>
-          {t("editor_gutter_base_head_desc")}
-        </div>
 
         <label className={styles.radioLabel}>
           <input
@@ -56,11 +58,13 @@ export function EditorSettings() {
             checked={editorGitGutterBase === "merge_base"}
             onChange={() => handleChange("merge_base")}
           />
-          <span>{t("editor_gutter_base_merge_base")}</span>
+          <div>
+            <div>{t("editor_gutter_base_merge_base")}</div>
+            <div className={styles.fieldHint}>
+              {t("editor_gutter_base_merge_base_desc")}
+            </div>
+          </div>
         </label>
-        <div className={styles.fieldHint}>
-          {t("editor_gutter_base_merge_base_desc")}
-        </div>
       </div>
     </div>
   );

--- a/src/ui/src/components/settings/sections/EditorSettings.tsx
+++ b/src/ui/src/components/settings/sections/EditorSettings.tsx
@@ -11,16 +11,26 @@ export function EditorSettings() {
   const editorGitGutterBase = useAppStore((s) => s.editorGitGutterBase);
   const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
   const [error, setError] = useState<string | null>(null);
+  // Lock the radios while a persistence write is in flight. Without this,
+  // a rapid head→merge_base→head sequence whose first two writes both
+  // reject would have the second catch roll the store back to merge_base,
+  // even though the persisted value never left head — the UI would then
+  // disagree with disk until the app is restarted.
+  const [pending, setPending] = useState(false);
 
   const handleChange = async (value: GutterBase) => {
+    if (pending) return;
     const previous = editorGitGutterBase;
     setEditorGitGutterBase(value);
+    setPending(true);
     try {
       setError(null);
       await setAppSetting("editor_git_gutter_base", value);
     } catch (e) {
       setEditorGitGutterBase(previous);
       setError(String(e));
+    } finally {
+      setPending(false);
     }
   };
 
@@ -41,6 +51,7 @@ export function EditorSettings() {
             type="radio"
             name="editor-gutter-base"
             checked={editorGitGutterBase === "head"}
+            disabled={pending}
             onChange={() => handleChange("head")}
           />
           <div>
@@ -56,6 +67,7 @@ export function EditorSettings() {
             type="radio"
             name="editor-gutter-base"
             checked={editorGitGutterBase === "merge_base"}
+            disabled={pending}
             onChange={() => handleChange("merge_base")}
           />
           <div>

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -141,6 +141,15 @@
   "notifications_sound_session_start_label": "Session start",
   "notifications_sound_session_start_desc": "Sound when a new session begins",
 
+  "nav_editor": "Editor",
+  "editor_title": "Editor",
+  "editor_gutter_base_label": "Git gutter base",
+  "editor_gutter_base_desc": "Choose what the editor's git gutter (the colored markers next to line numbers) compares your buffer against.",
+  "editor_gutter_base_head": "Last commit (HEAD)",
+  "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
+  "editor_gutter_base_merge_base": "Workspace branch base",
+  "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+
   "git_title": "Git",
   "git_branch_prefix": "Branch name prefix",
   "git_branch_prefix_desc": "Prefix for new workspace branch names.",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -141,6 +141,15 @@
   "notifications_sound_session_start_label": "Inicio de sesión",
   "notifications_sound_session_start_desc": "Sonido cuando comienza una nueva sesión",
 
+  "nav_editor": "Editor",
+  "editor_title": "Editor",
+  "editor_gutter_base_label": "Git gutter base",
+  "editor_gutter_base_desc": "Choose what the editor's git gutter (the colored markers next to line numbers) compares your buffer against.",
+  "editor_gutter_base_head": "Last commit (HEAD)",
+  "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
+  "editor_gutter_base_merge_base": "Workspace branch base",
+  "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+
   "git_title": "Git",
   "git_branch_prefix": "Prefijo del nombre de la rama",
   "git_branch_prefix_desc": "Prefijo para los nombres de las ramas de los nuevos espacios de trabajo.",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -141,6 +141,15 @@
   "notifications_sound_session_start_label": "セッション開始",
   "notifications_sound_session_start_desc": "新しいセッションが開始されたときのサウンド",
 
+  "nav_editor": "Editor",
+  "editor_title": "Editor",
+  "editor_gutter_base_label": "Git gutter base",
+  "editor_gutter_base_desc": "Choose what the editor's git gutter (the colored markers next to line numbers) compares your buffer against.",
+  "editor_gutter_base_head": "Last commit (HEAD)",
+  "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
+  "editor_gutter_base_merge_base": "Workspace branch base",
+  "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+
   "git_title": "Git",
   "git_branch_prefix": "ブランチ名のプレフィックス",
   "git_branch_prefix_desc": "新しいワークスペースのブランチ名に付けるプレフィックスです。",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -141,6 +141,15 @@
   "notifications_sound_session_start_label": "Início de sessão",
   "notifications_sound_session_start_desc": "Som quando uma nova sessão começa",
 
+  "nav_editor": "Editor",
+  "editor_title": "Editor",
+  "editor_gutter_base_label": "Git gutter base",
+  "editor_gutter_base_desc": "Choose what the editor's git gutter (the colored markers next to line numbers) compares your buffer against.",
+  "editor_gutter_base_head": "Last commit (HEAD)",
+  "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
+  "editor_gutter_base_merge_base": "Workspace branch base",
+  "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+
   "git_title": "Git",
   "git_branch_prefix": "Prefixo do nome da branch",
   "git_branch_prefix_desc": "Prefixo para nomes de branch de novos workspaces.",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -141,6 +141,15 @@
   "notifications_sound_session_start_label": "会话开始",
   "notifications_sound_session_start_desc": "当新会话开始时播放的声音",
 
+  "nav_editor": "Editor",
+  "editor_title": "Editor",
+  "editor_gutter_base_label": "Git gutter base",
+  "editor_gutter_base_desc": "Choose what the editor's git gutter (the colored markers next to line numbers) compares your buffer against.",
+  "editor_gutter_base_head": "Last commit (HEAD)",
+  "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
+  "editor_gutter_base_merge_base": "Workspace branch base",
+  "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+
   "git_title": "Git",
   "git_branch_prefix": "分支名称前缀",
   "git_branch_prefix_desc": "新工作区分支名称的前缀。",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -791,6 +791,12 @@ export function readWorkspaceFileAtRevision(
   });
 }
 
+export function computeWorkspaceMergeBase(
+  workspaceId: string,
+): Promise<string> {
+  return invoke("compute_workspace_merge_base", { workspaceId });
+}
+
 export function writeWorkspaceFile(
   workspaceId: string,
   relativePath: string,

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -772,19 +772,22 @@ export function readWorkspaceFileBytes(
   return invoke("read_workspace_file_bytes", { workspaceId, relativePath });
 }
 
-export interface HeadBlobContent {
+export interface BlobAtRevisionContent {
   path: string;
+  revision: string;
   content: string | null;
-  exists_at_head: boolean;
+  exists_at_revision: boolean;
 }
 
-export function readWorkspaceFileAtHead(
+export function readWorkspaceFileAtRevision(
   workspaceId: string,
   relativePath: string,
-): Promise<HeadBlobContent> {
-  return invoke("read_workspace_file_at_head", {
+  revision: string,
+): Promise<BlobAtRevisionContent> {
+  return invoke("read_workspace_file_at_revision", {
     workspaceId,
     relativePath,
+    revision,
   });
 }
 

--- a/src/ui/src/stores/slices/diffSlice.ts
+++ b/src/ui/src/stores/slices/diffSlice.ts
@@ -49,6 +49,7 @@ export interface DiffSlice {
     stagedFiles?: StagedDiffFiles | null,
     commits?: CommitEntry[] | null,
   ) => void;
+  setDiffMergeBase: (sha: string) => void;
   setDiffSelectedFile: (path: string | null, layer?: DiffLayer | null) => void;
   setDiffContent: (content: FileDiff | null) => void;
   setDiffViewMode: (mode: DiffViewMode) => void;
@@ -107,6 +108,7 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
       diffStagedFiles: stagedFiles ?? null,
       commitHistory: commits ?? null,
     }),
+  setDiffMergeBase: (sha) => set({ diffMergeBase: sha }),
   setDiffSelectedFile: (path, layer) =>
     set({ diffSelectedFile: path, diffSelectedLayer: layer ?? null }),
   setDiffContent: (content) => set({ diffContent: content }),

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -45,6 +45,12 @@ export interface SettingsSlice {
   setCommunityRegistryEnabled: (enabled: boolean) => void;
   disable1mContext: boolean;
   setDisable1mContext: (v: boolean) => void;
+  /// Which revision the Monaco git gutter compares the editor buffer
+  /// against. "head" (default) shows uncommitted changes only; "merge_base"
+  /// shows every change made on the workspace's branch since it diverged
+  /// from the repo's base branch (matches the Changes panel).
+  editorGitGutterBase: "head" | "merge_base";
+  setEditorGitGutterBase: (value: "head" | "merge_base") => void;
 }
 
 export const createSettingsSlice: StateCreator<
@@ -107,4 +113,6 @@ export const createSettingsSlice: StateCreator<
     })),
   disable1mContext: false,
   setDisable1mContext: (v) => set({ disable1mContext: v }),
+  editorGitGutterBase: "head",
+  setEditorGitGutterBase: (value) => set({ editorGitGutterBase: value }),
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -117,6 +117,14 @@ export const createWorkspacesSlice: StateCreator<
         diffPreviewContent: null,
         diffPreviewLoading: false,
         diffPreviewError: null,
+        // diffMergeBase is a single global string keyed off whichever
+        // workspace last set it. Clearing on switch prevents the file
+        // viewer's git gutter (which reads diffMergeBase) from comparing
+        // against the prior workspace's merge-base SHA when the right
+        // sidebar is hidden — without this, RightSidebar's clearDiff()
+        // never runs because the component isn't mounted, and the stale
+        // SHA leaks across the boundary.
+        diffMergeBase: null,
       };
       if (id && s.unreadCompletions.has(id)) {
         const next = new Set(s.unreadCompletions);

--- a/src/ui/src/stores/useAppStore.diffTabs.test.ts
+++ b/src/ui/src/stores/useAppStore.diffTabs.test.ts
@@ -324,4 +324,22 @@ describe("selectWorkspace clears active diff pointer", () => {
       { path: "a.ts", layer: "unstaged" },
     ]);
   });
+
+  it("clears diffMergeBase so the file viewer's git gutter cannot read the prior workspace's SHA", () => {
+    // Regression for PR 602 review: the right sidebar's clearDiff() runs
+    // on workspace switch only when the sidebar is mounted; when it's
+    // hidden, the cached merge-base SHA leaked across the switch and the
+    // file viewer's gutter would diff against the wrong workspace's base.
+    //
+    // Anchor the starting workspace so selectWorkspace's no-op guard
+    // (`if (id === s.selectedWorkspaceId) return s;`) doesn't short-circuit
+    // — earlier tests in this file may have left selectedWorkspaceId at WS_B.
+    useAppStore.getState().selectWorkspace(WS_A);
+    useAppStore.getState().setDiffMergeBase("a".repeat(40));
+    expect(useAppStore.getState().diffMergeBase).not.toBeNull();
+
+    useAppStore.getState().selectWorkspace(WS_B);
+
+    expect(useAppStore.getState().diffMergeBase).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a global **Editor** settings section with a single radio control that chooses what the Monaco git gutter compares your buffer against:

- **Last commit (HEAD)** *(default — preserves today's behavior)*: shows uncommitted changes only.
- **Workspace branch base**: shows every change made on this workspace's branch since it diverged from the repository's base branch (matches the **Changes** panel).

Inspired by vim-gitgutter's `g:gitgutter_diff_base`, but expressed the Claudette way (typed enum + native settings UI rather than free-form ref).

```mermaid
flowchart TD
    Setting["editor_git_gutter_base<br/>(app_settings)"] --> Hook[useGitGutter]
    Cache["diffMergeBase (store)"] --> Hook
    Hook -->|"head"| RevHEAD[revision = HEAD]
    Hook -->|"merge_base + cached"| RevSHA[revision = cached SHA]
    Hook -->|"merge_base + null"| Resolve[compute_workspace_merge_base]
    Resolve --> SetCache[setDiffMergeBase] --> Cache
    RevHEAD --> Fetch[read_workspace_file_at_revision]
    RevSHA --> Fetch
    Fetch --> Decorations[Monaco gutter decorations]
```

### What changed

**Backend (Rust)**
- `read_blob_at_head` → `read_blob_at_revision` with a strict allow-list (literal `HEAD` or 40-char hex SHA only). Validation lives in the library crate so any future caller inherits it.
- New `compute_workspace_merge_base` Tauri command — lightweight sibling of `load_diff_files` that returns just the SHA.
- New shared `claudette::diff::resolve_workspace_merge_base` helper. Both the Changes panel and the gutter route through it, guaranteeing they can never disagree about which SHA "the merge base" is. Returns `(sha, worktree_path)` so `load_diff_files` skips a duplicate workspace lookup.
- Helper is structured as `fn -> impl Future + Send` (not `async fn`) so `&Database` (non-`Send` because of `RefCell` in `rusqlite::Connection`) is dropped before any `.await`. Without this, the Tauri command future fails the `Send` bound.

**Frontend (React/TypeScript)**
- New `editorGitGutterBase: \"head\" | \"merge_base\"` field in the settings slice (default `\"head\"`); hydrated from `app_settings` on app boot mirroring `usage_insights_enabled`.
- New `setDiffMergeBase(sha)` single-field setter on the diff slice so the gutter can stash a resolved SHA without clobbering the diff file list.
- New **Editor** settings section between Notifications and Git. Two-radio picker, optimistic update + rollback on persistence error.
- 8 new i18n keys in all 5 locales (English copy in non-English locales — translation pass is a follow-up).
- `useGitGutter` derives the revision via a pure `selectGutterRevision(setting, cachedMergeBase)` helper, fires `compute_workspace_merge_base` lazily when the SHA isn't yet cached, and bails (clears the gutter) when the revision can't be resolved. All failure paths stay silent — same UX as today's binary/oversized handling.

**Docs**
- New \"Editor\" section in `site/src/content/docs/features/settings.mdx`.
- `tauri-commands.md` and `store-actions.md` references in `.claude/skills/claudette-debug/` updated for the new commands and store actions.

## Complexity Notes

- **`Send` bound on the merge-base helper** is the kind of subtle bug that only shows up when `cargo build -p claudette-tauri` runs — `cargo test` skips compiling crates without tests, so the broken state can pass local checks. Worth keeping the `fn -> impl Future + Send` shape if anyone refactors this.
- **The `\"head\"` / `\"merge_base\"` strings** are the persisted contract. Renaming them would silently break existing users' settings (the hydration would fall back to `\"head\"`). The literal-union type in TS keeps callers honest, but the persisted value is the long-term contract.
- **Validation lives in `claudette::git::validate_revision`**, not at the Tauri command boundary. The library crate is the trust boundary that shells out to git, so any future caller (server transport, plugin host, debug eval) inherits the protection without re-implementing it.
- **Default branch on default branch:** when the workspace is checked out on the base branch itself, merge-base collapses to HEAD, so the gutter goes silent. This is the correct behavior (matches the Changes panel) and is documented in the new settings.mdx section.
- **9 obsolete commits dropped during rebase:** the original branch carried PR #596's pre-merge dev history; those commits were already squashed onto main. The branch was rebased with `--onto origin/main e67ac9e3` to drop them. The 13 commits in this PR are the new gutter-base feature only.

## Test Steps

1. **Pull + build:**
   \`\`\`bash
   git fetch origin && git checkout eben/monaco-git-gutter-fork
   cargo tauri dev
   \`\`\`

2. **Default behavior (regression check):**
   - Open a workspace with uncommitted changes.
   - Open a file in the editor.
   - Confirm the gutter shows uncommitted-line markers (today's HEAD-based behavior).

3. **Toggle to merge-base:**
   - Open **Settings → Editor**. Confirm the section exists between Notifications and Git, with two radios. Default selection: **Last commit (HEAD)**.
   - Switch to **Workspace branch base**. Close settings.
   - Re-open the same file. Confirm the gutter now shows since-branch changes (typically more markers than the HEAD view, if the workspace has committed work on top of main).

4. **Toggle back:**
   - Switch the radio back to **Last commit (HEAD)**. Confirm the gutter immediately reverts.

5. **Fresh-workspace path:**
   - Restart the app or open a workspace whose Changes panel hasn't been opened yet.
   - With the setting on **Workspace branch base**, open a file viewer. Confirm the gutter populates (the lazy `compute_workspace_merge_base` IPC fires once and caches in `diffMergeBase`).

6. **Failure modes are silent:**
   - In a repo with detached HEAD or no base branch configured, switch to **Workspace branch base** and open a file. Confirm the gutter stays empty, no toasts, no console errors.

7. **Persistence:**
   - Set the radio to **Workspace branch base**. Quit the app. Relaunch. Confirm the radio is still on **Workspace branch base** and the gutter renders accordingly.

## Checklist

- [x] Tests added/updated (3 new pure-helper tests in \`useGitGutter.test.ts\`; 1 new Rust integration test for \`resolve_workspace_merge_base\`; existing \`read_blob_at_head\` tests migrated to \`read_blob_at_revision\` with the new revision parameter).
- [x] Documentation updated (\`site/src/content/docs/features/settings.mdx\` + debug-skill references).
- [ ] Manual UAT (steps above) — please run before merging.