### PR TITLE
fix(ui): prevent repo name overlap with macOS traffic lights when sidebar closed

### DIFF
--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -64,6 +64,6 @@
   white-space: nowrap;
 }
 
-.macNoSidebar {
+[data-platform="mac"] .noSidebar {
   padding-left: 80px;
 }

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -63,3 +63,7 @@
   color: var(--text-dim);
   white-space: nowrap;
 }
+
+.macNoSidebar {
+  padding-left: 80px;
+}

--- a/src/ui/src/components/shared/WorkspacePanelHeader.tsx
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.tsx
@@ -4,9 +4,6 @@ import { WorkspaceActions } from "../chat/WorkspaceActions";
 import { PanelToggles } from "./PanelToggles";
 import styles from "./WorkspacePanelHeader.module.css";
 
-const isMac =
-  typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
-
 export function WorkspacePanelHeader() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
@@ -19,7 +16,7 @@ export function WorkspacePanelHeader() {
   const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
 
   return (
-    <div className={`${styles.header} ${isMac && !sidebarVisible ? styles.macNoSidebar : ""}`} data-tauri-drag-region>
+    <div className={`${styles.header} ${!sidebarVisible ? styles.noSidebar : ""}`} data-tauri-drag-region>
       <div className={styles.headerLeft}>
         {ws && (repo ? (
           <span className={styles.branchInfo}>

--- a/src/ui/src/components/shared/WorkspacePanelHeader.tsx
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.tsx
@@ -4,18 +4,22 @@ import { WorkspaceActions } from "../chat/WorkspaceActions";
 import { PanelToggles } from "./PanelToggles";
 import styles from "./WorkspacePanelHeader.module.css";
 
+const isMac =
+  typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
+
 export function WorkspacePanelHeader() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaces = useAppStore((s) => s.workspaces);
   const repositories = useAppStore((s) => s.repositories);
   const defaultBranchesMap = useAppStore((s) => s.defaultBranches);
+  const sidebarVisible = useAppStore((s) => s.sidebarVisible);
 
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const repo = repositories.find((r) => r.id === ws?.repository_id);
   const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
 
   return (
-    <div className={styles.header} data-tauri-drag-region>
+    <div className={`${styles.header} ${isMac && !sidebarVisible ? styles.macNoSidebar : ""}`} data-tauri-drag-region>
       <div className={styles.headerLeft}>
         {ws && (repo ? (
           <span className={styles.branchInfo}>


### PR DESCRIPTION
## Summary

When the left workspace sidebar is closed on macOS, the `WorkspacePanelHeader` (which displays `repo / branch` at the top of the center panel) renders directly behind the native traffic light buttons (close/minimize/maximize). Tauri's `titleBarStyle: "Overlay"` leaves it to the webview to manage its own insets — and the existing `[data-platform=\"mac\"]` paddings only covered the sidebar and Settings sidebar headers, not the workspace header.

This change adds a conditional `padding-left: 80px` to `WorkspacePanelHeader` when on macOS **and** the sidebar is hidden. When the sidebar is visible, no padding is added — the sidebar already provides natural left clearance, so unconditional padding would just create dead whitespace.

The 80px value clears the standard macOS traffic light cluster (3 × 14px buttons + 8px gaps + 12px inset ≈ 72px), and follows the same hardcoded-pixel approach as the existing `padding-top: 38px` used by `Sidebar.module.css` and `Settings.module.css`.

## Complexity Notes

- The `isMac` check is module-level (matches `PanelToggles.tsx` pattern) — safe because `navigator.platform` doesn't change at runtime.
- Non-macOS platforms are unaffected (the conditional class never applies).

## Test Steps

1. Build & run on macOS: `cargo tauri dev`
2. Open a workspace with the sidebar visible — header layout should be unchanged.
3. Close the sidebar with `⌘B` — the repo/branch text should shift right and clear the traffic lights.
4. Reopen the sidebar with `⌘B` — header returns to its normal position with no extra left padding.
5. Verify on Linux/Windows that nothing visually changes (the `isMac` guard prevents the class from applying).

## Checklist

- [ ] Tests added/updated (visual-only CSS change; not unit-testable in vitest)
- [ ] Documentation updated (N/A)