### PR TITLE
feat(site): use Silkscreen pixel font for header brand title

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -36,10 +36,14 @@ export default defineConfig({
         '@fontsource/inter/400.css',
         '@fontsource/inter/500.css',
         '@fontsource/inter/600.css',
+        // Silkscreen 400 is the display font for the header brand title —
+        // must be global since the header appears on every page.
+        // Weight 700 stays in `src/content/docs/index.mdx` (homepage-only).
+        '@fontsource/silkscreen/400.css',
         // Header chrome (nav links, social icons, search-centering grid)
         // applies site-wide — also global.
         './src/styles/custom.css',
-        // Note: `homepage.css` and `@fontsource/silkscreen/{400,700}.css`
+        // Note: `homepage.css` and `@fontsource/silkscreen/700.css`
         // are intentionally NOT here. They're imported in
         // `src/content/docs/index.mdx` so they only load on the splash
         // homepage, not on every docs page.

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -20,7 +20,6 @@ import Anatomy from '../../components/Anatomy.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import CTASection from '../../components/CTASection.astro';
 import SiteFooter from '../../components/SiteFooter.astro';
-import '@fontsource/silkscreen/400.css';
 import '@fontsource/silkscreen/700.css';
 import '../../styles/homepage.css';
 

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -16,6 +16,7 @@
 
   --sl-font: 'Inter', system-ui, -apple-system, sans-serif;
   --sl-font-system: var(--sl-font);
+  --font-display: "Silkscreen", "Inter", sans-serif;
 }
 
 :root[data-theme='light'] {
@@ -35,6 +36,13 @@
 /* Starlight logo image — pixelated rendering for pixel art */
 .site-title img {
   image-rendering: pixelated;
+}
+
+/* Header brand title — Silkscreen pixel font to match the footer brand mark */
+.site-title span {
+  font-family: var(--font-display);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 /* Warmer link colors */

--- a/site/src/styles/homepage.css
+++ b/site/src/styles/homepage.css
@@ -74,7 +74,6 @@
   --transition-normal: 0.2s ease;
 
   --font-mono: ui-monospace, "JetBrains Mono", "SF Mono", "Cascadia Code", monospace;
-  --font-display: "Silkscreen", "Inter", sans-serif;
   --fw-semibold: 600;
   --fw-bold: 700;
 }


### PR DESCRIPTION
## Summary

Brings the Starlight site header's "Claudette" title in line with the footer brand mark — both now render in the Silkscreen pixel font with uppercase + `letter-spacing: 0.02em`. Previously the header used Inter (Starlight's default body font) while the footer used Silkscreen, which read as an inconsistency between the two brand lockups on the same page.

The non-trivial bit: Silkscreen was intentionally page-scoped to the homepage (imported in `index.mdx`) to avoid loading on every docs page. Since the header appears on every route, weight 400 is promoted to a global stylesheet via `astro.config.mjs`'s `customCss`. Weight 700 stays homepage-only — it's only referenced by display headings on the splash page, so docs pages don't need it.

Files changed:
- `site/astro.config.mjs` — Silkscreen 400 added to global `customCss`; comment updated
- `site/src/content/docs/index.mdx` — drops the now-redundant 400 import (keeps 700)
- `site/src/styles/custom.css` — defines `--font-display` and styles `.site-title span`
- `site/src/styles/homepage.css` — removes the duplicate `--font-display` definition (now inherited from `custom.css`)

## Complexity Notes

- **Font payload:** Silkscreen 400 now ships on every docs page. The `@fontsource/silkscreen/400.css` payload is small (one self-hosted woff2 + a `@font-face` declaration), but reviewers may want to confirm this tradeoff is acceptable vs. limiting the brand font to the homepage.
- **Selector specificity:** `.site-title span` targets Starlight's internal markup. If Starlight ever changes how `SiteTitle` renders the title text (e.g., wrapping it in a different element), this rule will silently no-op. Visually verifying after Starlight upgrades is a good idea.
- **Uppercase via CSS, not HTML:** The DOM text remains `Claudette` — `text-transform: uppercase` handles the visual transform. This preserves screen reader output, copy-paste behavior, and SEO keywords.

## Test Steps

1. `cd site && bun install && bun run build` — verify the build passes (it does locally; produces 31 pages cleanly).
2. `cd site && bun run dev` and open the dev server.
3. Confirm the header "Claudette" title renders in the Silkscreen pixel font on the homepage (`/claudette/`).
4. Navigate to a docs page (e.g., `/claudette/getting-started/installation/`) and confirm the header title still renders in Silkscreen there too — this is the key check, since previously Silkscreen was homepage-only.
5. Scroll to the footer on the homepage and confirm the footer brand mark renders identically to before (Silkscreen, 18px, uppercase).
6. Toggle between dark and light theme — the font should remain Silkscreen in both modes.

## Checklist

- [ ] Tests added/updated _(N/A — visual change, no test layer for the marketing site)_
- [x] Documentation updated _(inline comment in `astro.config.mjs` updated to reflect the new global/homepage-scoped split)_