### PR TITLE
fix(site): pin header brand title to Silkscreen weight 400

### DIFF
--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -41,6 +41,7 @@
 /* Header brand title — Silkscreen pixel font to match the footer brand mark */
 .site-title span {
   font-family: var(--font-display);
+  font-weight: 400;
   letter-spacing: 0.02em;
   text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary

The "CLAUDETTE" header brand title was rendering visibly bolder on the homepage than on docs pages. Root cause: `@fontsource/silkscreen/700.css` is imported only by `src/content/docs/index.mdx` (homepage), while Silkscreen 400 is loaded globally via `astro.config.mjs`. Because `.site-title span` had no explicit `font-weight`, the browser was free to render the header using whichever weight happened to be available — picking the heavier face on the homepage.

Fix: add `font-weight: 400` to `.site-title span` in `site/src/styles/custom.css` so the header is pinned to the globally-loaded weight on every page. The 700 import on the homepage is left in place since it's used by other display elements (e.g. footer brand mark).

## Test Steps

1. `cd site && bun install && bun run build` — confirm Astro builds cleanly.
2. `bun run dev` and visit `http://localhost:4321/` (homepage).
3. Compare the header "CLAUDETTE" lockup against any docs route (e.g. `/getting-started/`).
4. Verify the brand title renders at the same stroke weight on both — no thicker rendering on the homepage.

## Checklist

- [ ] Tests added/updated (n/a — pure styling fix, no test surface)
- [ ] Documentation updated (n/a)