### PR TITLE
build(voice): gate voice recording behind a default-on cargo feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,12 @@ cargo tauri dev
 > The `cpal` audio crate fails to build without it. The full apt
 > install line is in the [README prerequisites](README.md#prerequisites).
 > Nix users get this automatically via `flake.nix`.
+>
+> Headless or sandboxed Linux environments without ALSA can omit voice
+> support entirely:
+> ```sh
+> cargo tauri build --no-default-features --features tauri/custom-protocol,server
+> ```
 
 ## Commit Conventions
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Claudette is a cross-platform desktop application built with [Tauri 2](https://t
 - [Tauri CLI](https://tauri.app/start/): `cargo install tauri-cli --version "^2"`
 - Platform dependencies for Tauri:
   - **macOS**: Xcode Command Line Tools (`xcode-select --install`)
-  - **Linux**: System libraries for WebKitGTK and ALSA (the latter is needed by the voice-input recorder). On Debian/Ubuntu:
+  - **Linux**: System libraries for WebKitGTK and (when building with the default `voice` feature) ALSA. On Debian/Ubuntu:
 
     ```sh
     sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
@@ -30,6 +30,12 @@ Claudette is a cross-platform desktop application built with [Tauri 2](https://t
     ```
 
     Equivalents on other distros: `alsa-lib-devel` (Fedora/RHEL), `alsa-lib` (Arch). Nix users get this automatically via `flake.nix`.
+
+    Headless or sandboxed Linux environments that lack ALSA can build without voice support:
+
+    ```sh
+    cargo tauri build --no-default-features --features tauri/custom-protocol,server
+    ```
 
 ## Getting started
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,18 +42,18 @@ parking_lot = "0.12"
 chrono = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "stream"] }
 url = "2"
-cpal = "0.17"
-candle-core = "=0.9.2"
-candle-nn = "=0.9.2"
-candle-transformers = "=0.9.2"
-tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
-rubato = { version = "2", default-features = false }
-hound = "3"
+cpal = { version = "0.17", optional = true }
+candle-core = { version = "=0.9.2", optional = true }
+candle-nn = { version = "=0.9.2", optional = true }
+candle-transformers = { version = "=0.9.2", optional = true }
+tokenizers = { version = "0.22", default-features = false, features = ["onig"], optional = true }
+rubato = { version = "2", default-features = false, optional = true }
+hound = { version = "3", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-candle-core = { version = "=0.9.2", features = ["metal"] }
-candle-nn = { version = "=0.9.2", features = ["metal"] }
-candle-transformers = { version = "=0.9.2", features = ["metal"] }
+candle-core = { version = "=0.9.2", features = ["metal"], optional = true }
+candle-nn = { version = "=0.9.2", features = ["metal"], optional = true }
+candle-transformers = { version = "=0.9.2", features = ["metal"], optional = true }
 mac-notification-sys = "0.6"
 
 [target.'cfg(windows)'.dependencies]
@@ -67,9 +67,18 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [features]
-default = ["server"]
+default = ["server", "voice"]
 devtools = ["tauri/devtools"]
 server = ["dep:claudette-server"]
+voice = [
+    "dep:cpal",
+    "dep:candle-core",
+    "dep:candle-nn",
+    "dep:candle-transformers",
+    "dep:tokenizers",
+    "dep:rubato",
+    "dep:hound",
+]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -1,13 +1,20 @@
+// Real implementations (compiled when the `voice` feature is enabled).
+#[cfg(feature = "voice")]
 use claudette::db::Database;
+#[cfg(feature = "voice")]
 use tauri::{AppHandle, State};
 
+#[cfg(feature = "voice")]
 use crate::state::AppState;
+#[cfg(feature = "voice")]
 use crate::voice::VoiceProviderInfo;
 
+#[cfg(feature = "voice")]
 fn open_db(state: &State<'_, AppState>) -> Result<Database, String> {
     Database::open(&state.db_path).map_err(|e| e.to_string())
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_list_providers(
     state: State<'_, AppState>,
@@ -16,6 +23,7 @@ pub async fn voice_list_providers(
     Ok(state.voice.list_providers(&db))
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_set_selected_provider(
     provider_id: Option<String>,
@@ -27,6 +35,7 @@ pub async fn voice_set_selected_provider(
         .set_selected_provider(&db, provider_id.as_deref())
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_set_provider_enabled(
     provider_id: String,
@@ -37,6 +46,7 @@ pub async fn voice_set_provider_enabled(
     state.voice.set_enabled(&db, &provider_id, enabled)
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_prepare_provider(
     provider_id: String,
@@ -49,6 +59,7 @@ pub async fn voice_prepare_provider(
         .await
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_remove_provider_model(
     provider_id: String,
@@ -60,6 +71,7 @@ pub async fn voice_remove_provider_model(
         .await
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_start_recording(
     provider_id: Option<String>,
@@ -77,6 +89,7 @@ pub async fn voice_start_recording(
         .await
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_stop_and_transcribe(
     provider_id: Option<String>,
@@ -91,6 +104,7 @@ pub async fn voice_stop_and_transcribe(
     state.voice.stop_and_transcribe(&provider_id).await
 }
 
+#[cfg(feature = "voice")]
 #[tauri::command]
 pub async fn voice_cancel_recording(
     provider_id: Option<String>,
@@ -103,4 +117,58 @@ pub async fn voice_cancel_recording(
             .resolve_provider_id(&db, provider_id.as_deref())?
     };
     state.voice.cancel_recording(&provider_id).await
+}
+
+// Shim implementations (compiled when the `voice` feature is disabled).
+// These preserve the JS binding surface so callers get a clear error instead
+// of a missing-command panic.
+#[cfg(not(feature = "voice"))]
+const VOICE_NOT_BUILT: &str = "voice support not built into this binary";
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_list_providers() -> Result<Vec<serde_json::Value>, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_set_selected_provider() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_set_provider_enabled() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_prepare_provider() -> Result<serde_json::Value, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_remove_provider_model() -> Result<serde_json::Value, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_start_recording() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_stop_and_transcribe() -> Result<String, String> {
+    Err(VOICE_NOT_BUILT.into())
+}
+
+#[cfg(not(feature = "voice"))]
+#[tauri::command]
+pub async fn voice_cancel_recording() -> Result<(), String> {
+    Err(VOICE_NOT_BUILT.into())
 }

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -120,8 +120,9 @@ pub async fn voice_cancel_recording(
 }
 
 // Shim implementations (compiled when the `voice` feature is disabled).
-// These preserve the JS binding surface so callers get a clear error instead
-// of a missing-command panic.
+// These preserve the JS binding surface — including parameter names — so the
+// frontend's existing invoke args still deserialize cleanly and callers get
+// the intended VOICE_NOT_BUILT error instead of a Tauri arg-parse failure.
 #[cfg(not(feature = "voice"))]
 const VOICE_NOT_BUILT: &str = "voice support not built into this binary";
 
@@ -133,42 +134,57 @@ pub async fn voice_list_providers() -> Result<Vec<serde_json::Value>, String> {
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_set_selected_provider() -> Result<(), String> {
+pub async fn voice_set_selected_provider(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<(), String> {
     Err(VOICE_NOT_BUILT.into())
 }
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_set_provider_enabled() -> Result<(), String> {
+pub async fn voice_set_provider_enabled(
+    #[allow(unused_variables)] provider_id: String,
+    #[allow(unused_variables)] enabled: bool,
+) -> Result<(), String> {
     Err(VOICE_NOT_BUILT.into())
 }
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_prepare_provider() -> Result<serde_json::Value, String> {
+pub async fn voice_prepare_provider(
+    #[allow(unused_variables)] provider_id: String,
+) -> Result<serde_json::Value, String> {
     Err(VOICE_NOT_BUILT.into())
 }
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_remove_provider_model() -> Result<serde_json::Value, String> {
+pub async fn voice_remove_provider_model(
+    #[allow(unused_variables)] provider_id: String,
+) -> Result<serde_json::Value, String> {
     Err(VOICE_NOT_BUILT.into())
 }
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_start_recording() -> Result<(), String> {
+pub async fn voice_start_recording(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<(), String> {
     Err(VOICE_NOT_BUILT.into())
 }
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_stop_and_transcribe() -> Result<String, String> {
+pub async fn voice_stop_and_transcribe(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<String, String> {
     Err(VOICE_NOT_BUILT.into())
 }
 
 #[cfg(not(feature = "voice"))]
 #[tauri::command]
-pub async fn voice_cancel_recording() -> Result<(), String> {
+pub async fn voice_cancel_recording(
+    #[allow(unused_variables)] provider_id: Option<String>,
+) -> Result<(), String> {
     Err(VOICE_NOT_BUILT.into())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod agent_mcp_sink;
 mod commands;
 mod mdns;
 mod missing_cli;
+#[cfg(feature = "voice")]
 mod platform_speech;
 mod pty;
 mod pty_tracker;
@@ -14,6 +15,7 @@ mod subprocess_cleanup;
 mod transport;
 mod tray;
 mod usage;
+#[cfg(feature = "voice")]
 mod voice;
 mod webview2_check;
 
@@ -379,6 +381,7 @@ fn main() {
             // hits warm CoreAudio + Speech.framework state instead of
             // a multi-second cold-start delay. Touches enumeration /
             // status APIs only — no permission prompts triggered.
+            #[cfg(feature = "voice")]
             {
                 let voice = app.state::<state::AppState>().voice.clone();
                 std::thread::spawn(move || voice.prewarm());

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -14,6 +14,7 @@ use claudette::scm::types::{CiCheck, PullRequest};
 use crate::commands::apps::DetectedApp;
 use crate::remote::DiscoveredServer;
 use crate::usage::UsageCacheEntry;
+#[cfg(feature = "voice")]
 use crate::voice::VoiceProviderRegistry;
 
 /// Re-export for use in tray module without direct tauri::tray import.
@@ -338,6 +339,7 @@ pub struct AppState {
     /// SCM provider plugin registry.
     pub plugins: RwLock<PluginRegistry>,
     /// Native voice provider registry and model cache metadata.
+    #[cfg(feature = "voice")]
     pub voice: Arc<VoiceProviderRegistry>,
     /// mtime-keyed cache of env-provider exports. One entry per
     /// `(worktree, plugin_name)` pair, invalidated when any watched
@@ -383,6 +385,7 @@ impl AppState {
             next_tray_seq: AtomicU64::new(1),
             usage_cache: RwLock::new(None),
             plugins: RwLock::new(plugins),
+            #[cfg(feature = "voice")]
             voice: Arc::new(VoiceProviderRegistry::new(
                 VoiceProviderRegistry::default_model_root(),
             )),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -338,8 +338,8 @@ pub struct AppState {
     pub usage_cache: RwLock<Option<UsageCacheEntry>>,
     /// SCM provider plugin registry.
     pub plugins: RwLock<PluginRegistry>,
-    /// Native voice provider registry and model cache metadata.
     #[cfg(feature = "voice")]
+    /// Native voice provider registry and model cache metadata.
     pub voice: Arc<VoiceProviderRegistry>,
     /// mtime-keyed cache of env-provider exports. One entry per
     /// `(worktree, plugin_name)` pair, invalidated when any watched


### PR DESCRIPTION
Closes #441 (sub-item 3).

## What

Moves `cpal`, `candle-core/nn/transformers`, `tokenizers`, `rubato`, and `hound` behind a new `voice` Cargo feature that is **default-enabled**. Headless or sandboxed Linux environments (containers, CI without ALSA) can now build without `libasound2-dev` by opting out.

## Changes

| File | Change |
|---|---|
| `src-tauri/Cargo.toml` | Add `voice` feature; mark all audio/ML crates `optional = true` in both `[dependencies]` and `[target.'cfg(target_os = "macos")'.dependencies]` |
| `src-tauri/src/main.rs` | Gate `mod voice;`, `mod platform_speech;`, and the pre-warm spawn behind `#[cfg(feature = "voice")]` |
| `src-tauri/src/state.rs` | Gate `AppState::voice` field and its initializer |
| `src-tauri/src/commands/voice.rs` | Add `#[cfg(not(feature = "voice"))]` shims — commands still exist so JS bindings are unaffected; each returns `Err("voice support not built into this binary")` |
| `README.md`, `CONTRIBUTING.md` | Document the `--no-default-features` recipe |

## Surprising module

`platform_speech` (the macOS Swift bridge) imports `CapturedAudio` from `voice.rs`, so it had to move behind the same `#[cfg(feature = "voice")]` gate as `mod voice;`. It is not independently usable without the voice subsystem, so this is correct — but it's a non-obvious coupling worth noting.

## Verification

```
$ nix develop -c cargo check --workspace
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 20s

$ nix develop -c cargo check -p claudette-tauri --no-default-features
Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.31s
```

Both modes pass clippy with zero warnings (`RUSTFLAGS="-Dwarnings"` compatible).

## Recipe for ALSA-less builds

```sh
cargo tauri build --no-default-features --features tauri/custom-protocol,server
```