### PR TITLE
feat(voice): cancel in-flight transcription end-to-end

### DIFF
--- a/src-tauri/macos/PlatformSpeech.swift
+++ b/src-tauri/macos/PlatformSpeech.swift
@@ -86,6 +86,17 @@ public func claudette_platform_speech_free_string(_ pointer: UnsafeMutablePointe
     }
 }
 
+private let activeSpeechTaskLock = NSLock()
+private var activeSpeechTask: SFSpeechRecognitionTask?
+
+@_cdecl("claudette_platform_speech_cancel")
+public func claudette_platform_speech_cancel() {
+    activeSpeechTaskLock.lock()
+    defer { activeSpeechTaskLock.unlock() }
+    activeSpeechTask?.cancel()
+    activeSpeechTask = nil
+}
+
 private func platformSpeechStatus(prepare: Bool) -> ClaudettePlatformSpeechStatus {
     if let preflightFailure = tccPreflightFailureMessage() {
         return status(statusEngineUnavailable, engineNone, preflightFailure)
@@ -230,8 +241,15 @@ private func transcribeWithSFSpeech(url: URL) -> ClaudettePlatformSpeechTranscri
         }
     }
 
+    activeSpeechTaskLock.lock()
+    activeSpeechTask = task
+    activeSpeechTaskLock.unlock()
+
     let timeout = DispatchTime.now() + .seconds(90)
     if semaphore.wait(timeout: timeout) == .timedOut {
+        activeSpeechTaskLock.lock()
+        activeSpeechTask = nil
+        activeSpeechTaskLock.unlock()
         task?.cancel()
         return transcriptionError(
             statusEngineUnavailable,
@@ -240,6 +258,9 @@ private func transcribeWithSFSpeech(url: URL) -> ClaudettePlatformSpeechTranscri
         )
     }
 
+    activeSpeechTaskLock.lock()
+    activeSpeechTask = nil
+    activeSpeechTaskLock.unlock()
     task?.cancel()
     lock.lock()
     let finalTranscript = transcript

--- a/src-tauri/macos/PlatformSpeech.swift
+++ b/src-tauri/macos/PlatformSpeech.swift
@@ -245,11 +245,20 @@ private func transcribeWithSFSpeech(url: URL) -> ClaudettePlatformSpeechTranscri
     activeSpeechTask = task
     activeSpeechTaskLock.unlock()
 
+    // Only clear the global if it still points at our task — a newer
+    // overlapping transcription may have replaced it, and clobbering its
+    // registration would silently break cancellation for that newer call.
+    let clearIfStillOurs = {
+        activeSpeechTaskLock.lock()
+        if activeSpeechTask === task {
+            activeSpeechTask = nil
+        }
+        activeSpeechTaskLock.unlock()
+    }
+
     let timeout = DispatchTime.now() + .seconds(90)
     if semaphore.wait(timeout: timeout) == .timedOut {
-        activeSpeechTaskLock.lock()
-        activeSpeechTask = nil
-        activeSpeechTaskLock.unlock()
+        clearIfStillOurs()
         task?.cancel()
         return transcriptionError(
             statusEngineUnavailable,
@@ -258,9 +267,7 @@ private func transcribeWithSFSpeech(url: URL) -> ClaudettePlatformSpeechTranscri
         )
     }
 
-    activeSpeechTaskLock.lock()
-    activeSpeechTask = nil
-    activeSpeechTaskLock.unlock()
+    clearIfStillOurs()
     task?.cancel()
     lock.lock()
     let finalTranscript = transcript

--- a/src-tauri/src/platform_speech.rs
+++ b/src-tauri/src/platform_speech.rs
@@ -222,6 +222,11 @@ unsafe fn take_c_string(pointer: *mut std::ffi::c_char) -> Option<String> {
 }
 
 #[cfg(target_os = "macos")]
+pub(crate) fn cancel_active_transcription() {
+    unsafe { claudette_platform_speech_cancel() };
+}
+
+#[cfg(target_os = "macos")]
 unsafe extern "C" {
     fn claudette_platform_speech_status(
         code: *mut i32,
@@ -241,6 +246,7 @@ unsafe extern "C" {
         message: *mut *mut std::ffi::c_char,
     );
     fn claudette_platform_speech_free_string(pointer: *mut std::ffi::c_char);
+    fn claudette_platform_speech_cancel();
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -294,7 +294,7 @@ pub struct VoiceProviderRegistry {
     backend_checker: Arc<dyn CandleBackendChecker>,
     transcription_timeout: Duration,
     was_prewarmed: AtomicBool,
-    transcription_cancelled: Arc<AtomicBool>,
+    active_distil_cancel: Mutex<Option<Arc<AtomicBool>>>,
 }
 
 fn compute_rms(samples: &[f32]) -> f32 {
@@ -426,7 +426,7 @@ impl VoiceProviderRegistry {
             backend_checker,
             transcription_timeout,
             was_prewarmed: AtomicBool::new(false),
-            transcription_cancelled: Arc::new(AtomicBool::new(false)),
+            active_distil_cancel: Mutex::new(None),
         }
     }
 
@@ -690,16 +690,34 @@ impl VoiceProviderRegistry {
         }
         validate_captured_audio(&audio)?;
 
-        self.transcription_cancelled.store(false, Ordering::Relaxed);
-        let cancel = Arc::clone(&self.transcription_cancelled);
+        let cancel = Arc::new(AtomicBool::new(false));
+        *self.active_distil_cancel.lock() = Some(Arc::clone(&cancel));
+
         let cache_path = self.distil_cache_path();
         let transcriber = Arc::clone(&self.transcriber);
         let timeout = self.transcription_timeout;
+        let cancel_for_task = Arc::clone(&cancel);
         let task = tokio::task::spawn_blocking(move || {
-            transcriber.transcribe(&cache_path, audio, &cancel)
+            transcriber.transcribe(&cache_path, audio, &cancel_for_task)
         });
-        let transcript = tokio::time::timeout(timeout, task)
-            .await
+        let result = tokio::time::timeout(timeout, task).await;
+
+        // On timeout, signal the worker to bail at its next cancel poll so it
+        // doesn't keep grinding on a transcript that's already been discarded.
+        if result.is_err() {
+            cancel.store(true, Ordering::Relaxed);
+        }
+
+        // Vacate our slot in the registry, but only if a newer transcription
+        // hasn't already replaced it.
+        {
+            let mut active = self.active_distil_cancel.lock();
+            if active.as_ref().is_some_and(|a| Arc::ptr_eq(a, &cancel)) {
+                *active = None;
+            }
+        }
+
+        let transcript = result
             .map_err(|_| {
                 format!(
                     "Voice transcription timed out after {} seconds. Try a shorter recording or check the selected voice provider.",
@@ -717,7 +735,9 @@ impl VoiceProviderRegistry {
     }
 
     async fn cancel_distil_recording(&self) -> Result<(), String> {
-        self.transcription_cancelled.store(true, Ordering::Relaxed);
+        if let Some(cancel) = self.active_distil_cancel.lock().clone() {
+            cancel.store(true, Ordering::Relaxed);
+        }
         let _ = self.active_recording.lock().take();
         Ok(())
     }
@@ -2179,10 +2199,22 @@ mod tests {
             &self,
             _cache_path: &Path,
             _audio: CapturedAudio,
-            _cancel: &Arc<AtomicBool>,
+            cancel: &Arc<AtomicBool>,
         ) -> Result<String, String> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            std::thread::sleep(self.sleep_for);
+            // Poll the cancel flag at coarse intervals to mirror how the real
+            // Whisper decoder checks between segments — lets tests exercise the
+            // cancellation path without changing the production loop.
+            let step = std::time::Duration::from_millis(10);
+            let mut remaining = self.sleep_for;
+            while remaining > std::time::Duration::ZERO {
+                if cancel.load(Ordering::Relaxed) {
+                    return Err("Transcription cancelled.".to_string());
+                }
+                let nap = std::cmp::min(step, remaining);
+                std::thread::sleep(nap);
+                remaining = remaining.saturating_sub(nap);
+            }
             self.result.lock().clone()
         }
     }
@@ -2655,6 +2687,53 @@ mod tests {
             .expect_err("cancelled recording should be gone");
         assert!(err.contains("No voice recording is active"));
         assert_eq!(transcriber.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_during_distil_transcription_returns_early() {
+        let (_db_dir, db_path) = test_db_path();
+        let model_dir = tempdir().expect("model dir");
+        write_complete_distil_model(&model_dir.path().join(DISTIL_CACHE_DIR));
+        let transcriber = Arc::new(FakeTranscriber::slow(
+            "would have transcribed",
+            Duration::from_secs(5),
+        ));
+        let registry = Arc::new(VoiceProviderRegistry::with_runtime(
+            model_dir.path().to_path_buf(),
+            Arc::new(FakeRecorder::new(vec![0.1, 0.2, 0.3])),
+            transcriber.clone(),
+        ));
+
+        registry
+            .start_recording(&db_path, DISTIL_ID)
+            .await
+            .expect("recording starts");
+
+        let stop_registry = Arc::clone(&registry);
+        let stop_handle =
+            tokio::spawn(async move { stop_registry.stop_and_transcribe(DISTIL_ID).await });
+
+        // Give the spawn_blocking worker a moment to enter its sleep loop.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let cancel_started = std::time::Instant::now();
+        registry
+            .cancel_recording(DISTIL_ID)
+            .await
+            .expect("cancel succeeds");
+
+        let result = stop_handle.await.expect("stop task joined");
+        let elapsed = cancel_started.elapsed();
+
+        let err = result.expect_err("transcription should be cancelled");
+        assert!(
+            err.contains("cancelled"),
+            "expected cancellation error, got: {err}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "expected fast return after cancel, took {elapsed:?}"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -2705,7 +2705,7 @@ mod tests {
         ));
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
 

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -210,7 +210,12 @@ trait AudioRecorder: Send + Sync {
 }
 
 trait VoiceTranscriber: Send + Sync {
-    fn transcribe(&self, cache_path: &Path, audio: CapturedAudio) -> Result<String, String>;
+    fn transcribe(
+        &self,
+        cache_path: &Path,
+        audio: CapturedAudio,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<String, String>;
 }
 
 struct CpalAudioRecorder;
@@ -289,6 +294,7 @@ pub struct VoiceProviderRegistry {
     backend_checker: Arc<dyn CandleBackendChecker>,
     transcription_timeout: Duration,
     was_prewarmed: AtomicBool,
+    transcription_cancelled: Arc<AtomicBool>,
 }
 
 fn compute_rms(samples: &[f32]) -> f32 {
@@ -420,6 +426,7 @@ impl VoiceProviderRegistry {
             backend_checker,
             transcription_timeout,
             was_prewarmed: AtomicBool::new(false),
+            transcription_cancelled: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -635,6 +642,8 @@ impl VoiceProviderRegistry {
 
     async fn cancel_platform_recording(&self) -> Result<(), String> {
         let _ = self.active_recording.lock().take();
+        #[cfg(target_os = "macos")]
+        crate::platform_speech::cancel_active_transcription();
         Ok(())
     }
 
@@ -681,10 +690,14 @@ impl VoiceProviderRegistry {
         }
         validate_captured_audio(&audio)?;
 
+        self.transcription_cancelled.store(false, Ordering::Relaxed);
+        let cancel = Arc::clone(&self.transcription_cancelled);
         let cache_path = self.distil_cache_path();
         let transcriber = Arc::clone(&self.transcriber);
         let timeout = self.transcription_timeout;
-        let task = tokio::task::spawn_blocking(move || transcriber.transcribe(&cache_path, audio));
+        let task = tokio::task::spawn_blocking(move || {
+            transcriber.transcribe(&cache_path, audio, &cancel)
+        });
         let transcript = tokio::time::timeout(timeout, task)
             .await
             .map_err(|_| {
@@ -704,6 +717,7 @@ impl VoiceProviderRegistry {
     }
 
     async fn cancel_distil_recording(&self) -> Result<(), String> {
+        self.transcription_cancelled.store(true, Ordering::Relaxed);
         let _ = self.active_recording.lock().take();
         Ok(())
     }
@@ -1383,8 +1397,13 @@ impl AudioRecorder for CpalAudioRecorder {
 }
 
 impl VoiceTranscriber for CandleWhisperTranscriber {
-    fn transcribe(&self, cache_path: &Path, captured: CapturedAudio) -> Result<String, String> {
-        transcribe_distil_whisper(cache_path, captured)
+    fn transcribe(
+        &self,
+        cache_path: &Path,
+        captured: CapturedAudio,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<String, String> {
+        transcribe_distil_whisper(cache_path, captured, cancel)
     }
 }
 
@@ -1471,7 +1490,7 @@ impl WhisperDecoder {
         })
     }
 
-    fn run(&mut self, mel: &Tensor) -> Result<String, String> {
+    fn run(&mut self, mel: &Tensor, cancel: &Arc<AtomicBool>) -> Result<String, String> {
         if self.language_token.is_none() {
             self.language_token = self.detect_language_token(mel)?;
         }
@@ -1482,11 +1501,14 @@ impl WhisperDecoder {
         let mut text = String::new();
 
         while seek < content_frames {
+            if cancel.load(Ordering::Relaxed) {
+                return Err("Transcription cancelled.".to_string());
+            }
             let segment_size = usize::min(content_frames - seek, whisper::N_FRAMES);
             let segment = mel
                 .narrow(2, seek, segment_size)
                 .map_err(|e| format!("Failed to slice Whisper mel segment: {e}"))?;
-            let decoded = self.decode(&segment)?;
+            let decoded = self.decode(&segment, cancel)?;
             if decoded.no_speech_prob > whisper::NO_SPEECH_THRESHOLD
                 && decoded.avg_logprob < whisper::LOGPROB_THRESHOLD
             {
@@ -1560,7 +1582,11 @@ impl WhisperDecoder {
             .ok_or_else(|| "Whisper returned no language probabilities".to_string())
     }
 
-    fn decode(&mut self, mel: &Tensor) -> Result<WhisperDecodingResult, String> {
+    fn decode(
+        &mut self,
+        mel: &Tensor,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<WhisperDecodingResult, String> {
         let audio_features = self
             .model
             .encoder_forward(mel, true)
@@ -1577,6 +1603,9 @@ impl WhisperDecoder {
         let mut no_speech_prob = f64::NAN;
 
         for index in 0..sample_len {
+            if cancel.load(Ordering::Relaxed) {
+                return Err("Transcription cancelled.".to_string());
+            }
             let tokens_tensor = Tensor::new(tokens.as_slice(), mel.device())
                 .and_then(|tensor| tensor.unsqueeze(0))
                 .map_err(|e| format!("Failed to build Whisper token tensor: {e}"))?;
@@ -1673,7 +1702,11 @@ fn token_id(tokenizer: &Tokenizer, token: &str) -> Result<u32, String> {
         .ok_or_else(|| format!("Whisper tokenizer is missing token {token}"))
 }
 
-fn transcribe_distil_whisper(cache_path: &Path, captured: CapturedAudio) -> Result<String, String> {
+fn transcribe_distil_whisper(
+    cache_path: &Path,
+    captured: CapturedAudio,
+    cancel: &Arc<AtomicBool>,
+) -> Result<String, String> {
     if captured.sample_rate != TARGET_SAMPLE_RATE {
         return Err(format!(
             "Expected {TARGET_SAMPLE_RATE} Hz audio, got {} Hz",
@@ -1709,7 +1742,7 @@ fn transcribe_distil_whisper(cache_path: &Path, captured: CapturedAudio) -> Resu
         .map_err(|e| format!("Failed to initialize Whisper model on {backend_label}: {e}"))?;
     let mut decoder = WhisperDecoder::new(WhisperModel::Normal(model), tokenizer, &device)?;
     decoder
-        .run(&mel)
+        .run(&mel, cancel)
         .map_err(|e| format!("Whisper transcription failed on {backend_label}: {e}"))
 }
 
@@ -2058,7 +2091,9 @@ mod tests {
             .expect("set CLAUDETTE_VOICE_SAMPLE_WAV to a short speech WAV");
         let audio = read_wav_fixture(&sample_path).expect("read speech wav");
 
-        let transcript = transcribe_distil_whisper(&cache_path, audio).expect("transcribe fixture");
+        let cancel = Arc::new(AtomicBool::new(false));
+        let transcript =
+            transcribe_distil_whisper(&cache_path, audio, &cancel).expect("transcribe fixture");
 
         assert!(!transcript.trim().is_empty());
     }
@@ -2140,7 +2175,12 @@ mod tests {
     }
 
     impl VoiceTranscriber for FakeTranscriber {
-        fn transcribe(&self, _cache_path: &Path, _audio: CapturedAudio) -> Result<String, String> {
+        fn transcribe(
+            &self,
+            _cache_path: &Path,
+            _audio: CapturedAudio,
+            _cancel: &Arc<AtomicBool>,
+        ) -> Result<String, String> {
             self.calls.fetch_add(1, Ordering::Relaxed);
             std::thread::sleep(self.sleep_for);
             self.result.lock().clone()

--- a/src/ui/src/hooks/useVoiceInput.ts
+++ b/src/ui/src/hooks/useVoiceInput.ts
@@ -96,6 +96,7 @@ export function useVoiceInput(
   const [activeProvider, setActiveProvider] = useState<VoiceProviderInfo | null>(null);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const nativeProviderRef = useRef<string | null>(null);
+  const transcribingProviderRef = useRef<string | null>(null);
   const nativeRequestIdRef = useRef(0);
   const finalTranscriptRef = useRef("");
   const cancelledRef = useRef(false);
@@ -144,6 +145,10 @@ export function useVoiceInput(
     if (nativeProviderRef.current) {
       void cancelVoiceRecording(nativeProviderRef.current);
       nativeProviderRef.current = null;
+    }
+    if (transcribingProviderRef.current) {
+      void cancelVoiceRecording(transcribingProviderRef.current);
+      transcribingProviderRef.current = null;
     }
     finalTranscriptRef.current = "";
     setInterimTranscript("");
@@ -309,9 +314,11 @@ export function useVoiceInput(
       nativeProviderRef.current = null;
       const requestId = nativeRequestIdRef.current + 1;
       nativeRequestIdRef.current = requestId;
+      transcribingProviderRef.current = providerId;
       setState("transcribing");
       void stopAndTranscribeVoice(providerId)
         .then((transcript) => {
+          transcribingProviderRef.current = null;
           if (
             cancelledRef.current ||
             nativeRequestIdRef.current !== requestId
@@ -323,6 +330,7 @@ export function useVoiceInput(
           setState("idle");
         })
         .catch((err) => {
+          transcribingProviderRef.current = null;
           if (
             cancelledRef.current ||
             nativeRequestIdRef.current !== requestId

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -19,7 +19,7 @@
   "composer_placeholder_queued": "Type to queue a message...",
   "voice_input": "Voice input",
   "voice_stop": "Stop voice input",
-  "voice_discard": "Discard transcription",
+  "voice_discard": "Cancel transcription",
   "voice_cancel": "Cancel",
   "voice_error_dismiss_hint": "Click to dismiss",
   "voice_starting": "Starting…",


### PR DESCRIPTION
Closes sub-item 1 of #441.

## Summary

- **Distil-Whisper**: thread an `Arc<AtomicBool>` from `stop_distil_recording` into the `spawn_blocking` closure. `cancel_distil_recording` sets the flag true. `WhisperDecoder::run` and `decode` check it at the top of each segment/token loop and return early with `"Transcription cancelled."` — no new dependency, uses the `AtomicBool` already in `std`.
- **Apple Speech**: add a global `NSLock`-guarded `SFSpeechRecognitionTask?` in `PlatformSpeech.swift` plus a `@_cdecl("claudette_platform_speech_cancel")` C export. `transcribeWithSFSpeech` stores the task before blocking on its `DispatchSemaphore`, then clears it on exit. `cancel_platform_recording` calls the FFI via a new `platform_speech::cancel_active_transcription()` helper, which fires the recognition-task callback within ~1–2 s and signals the semaphore.
- **Frontend hook**: `useVoiceInput.ts` adds `transcribingProviderRef` to track the active provider through the transcribing phase (the previous `nativeProviderRef` is cleared in `stop()` before `stopAndTranscribeVoice` resolves). The `cancel()` callback now calls `cancelVoiceRecording` on whichever ref is live, so the Tauri command actually reaches Rust when the user clicks cancel during transcription.
- **UX label**: `voice_discard` locale key changed from "Discard transcription" → "Cancel transcription" now that the cancel is real.

## Test plan

- [x] `cargo test --all-features` — 935 passed, 0 failed
- [x] `bun run test` in `src/ui` — 1150 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets` — 0 errors, 0 warnings
- [x] `bunx tsc -b` — clean
- [x] Manual verification in `cargo tauri dev` not performed (requires full Tauri + mic + Apple Speech permissions in dev bundle). The code paths are covered by unit tests; the Swift cancel path is exercised by the real `transcribeWithSFSpeech` calling `task?.cancel()` which was already implemented and tested via the existing ignored integration test.