### PR TITLE
feat(voice): real VU meter driven by RMS from cpal (#441 item 4)

### DIFF
--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -63,6 +63,7 @@ pub async fn voice_remove_provider_model(
 #[tauri::command]
 pub async fn voice_start_recording(
     provider_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let provider_id = {
@@ -73,7 +74,7 @@ pub async fn voice_start_recording(
     };
     state
         .voice
-        .start_recording(&state.db_path, &provider_id)
+        .start_recording(&state.db_path, &provider_id, Some(app))
         .await
 }
 

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use tokenizers::Tokenizer;
 use tokio::io::AsyncWriteExt;
+use tokio::task::AbortHandle;
 
 #[cfg(target_os = "macos")]
 use crate::platform_speech::PlatformSpeechAvailability;
@@ -74,6 +75,15 @@ pub enum VoiceRecordingMode {
     Webview,
 }
 
+/// Payload emitted on the `voice://level` Tauri event at ~30 Hz during recording.
+/// `level` is linear RMS of the mic buffer window, clamped to [0.0, 1.0].
+/// Full-scale sine wave ≈ 0.707; typical speech 0.05–0.3; silence < 0.01.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceLevelPayload {
+    pub level: f32,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VoiceProviderMetadata {
@@ -129,11 +139,22 @@ pub(crate) struct CapturedAudio {
     pub(crate) sample_rate: u32,
 }
 
+/// Cancels the level-emitter Tokio task when dropped.
+struct LevelTask(AbortHandle);
+
+impl Drop for LevelTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 struct RecordingSession {
     samples: Arc<Mutex<Vec<f32>>>,
     stream_error: Arc<Mutex<Option<String>>>,
     sample_rate: u32,
     _stream: Option<cpal::Stream>,
+    /// Kept alive to abort the level-emitter task when recording stops.
+    _level_task: Option<LevelTask>,
 }
 
 impl RecordingSession {
@@ -144,6 +165,7 @@ impl RecordingSession {
             stream_error: Arc::new(Mutex::new(None)),
             sample_rate,
             _stream: None,
+            _level_task: None,
         }
     }
 
@@ -158,6 +180,7 @@ impl RecordingSession {
             stream_error: Arc::new(Mutex::new(Some(stream_error.into()))),
             sample_rate,
             _stream: None,
+            _level_task: None,
         }
     }
 
@@ -254,6 +277,46 @@ pub struct VoiceProviderRegistry {
     platform_speech: Arc<dyn PlatformSpeechEngine>,
     backend_checker: Arc<dyn CandleBackendChecker>,
     transcription_timeout: Duration,
+}
+
+fn compute_rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+    (sum_sq / samples.len() as f32).sqrt().min(1.0)
+}
+
+/// Spawn a Tokio task that emits `voice://level` events at ~30 Hz.
+///
+/// The task reads samples accumulated since its last tick, computes RMS
+/// over that window, and emits a normalized [0.0, 1.0] level. The first
+/// three ticks are suppressed so the buffer has time to fill before the
+/// frontend sees any signal (avoids a flash of empty bars at recording start).
+///
+/// Returns an `AbortHandle`; store it in a `LevelTask` so the task is
+/// cancelled automatically when recording stops.
+fn spawn_level_emitter(app: AppHandle, samples: Arc<Mutex<Vec<f32>>>) -> AbortHandle {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(33));
+        let mut offset = 0usize;
+        let mut tick = 0u8;
+        loop {
+            interval.tick().await;
+            let (level, new_offset) = {
+                let s = samples.lock();
+                let window = &s[offset.min(s.len())..];
+                let rms = compute_rms(window);
+                (rms, s.len())
+            };
+            offset = new_offset;
+            tick = tick.saturating_add(1);
+            if tick > 3 {
+                let _ = app.emit("voice://level", VoiceLevelPayload { level });
+            }
+        }
+    })
+    .abort_handle()
 }
 
 impl VoiceProviderRegistry {
@@ -452,11 +515,16 @@ impl VoiceProviderRegistry {
         Ok(DistilWhisperCandleProvider.status(self, &db))
     }
 
-    pub async fn start_recording(&self, db_path: &Path, provider_id: &str) -> Result<(), String> {
+    pub async fn start_recording(
+        &self,
+        db_path: &Path,
+        provider_id: &str,
+        app: Option<AppHandle>,
+    ) -> Result<(), String> {
         self.ensure_known(provider_id)?;
         match provider_id {
-            PLATFORM_ID => self.start_platform_recording(db_path).await,
-            DISTIL_ID => self.start_distil_recording(db_path).await,
+            PLATFORM_ID => self.start_platform_recording(db_path, app).await,
+            DISTIL_ID => self.start_distil_recording(db_path, app).await,
             _ => Err(format!("Unknown voice provider: {provider_id}")),
         }
     }
@@ -479,7 +547,11 @@ impl VoiceProviderRegistry {
         }
     }
 
-    async fn start_platform_recording(&self, db_path: &Path) -> Result<(), String> {
+    async fn start_platform_recording(
+        &self,
+        db_path: &Path,
+        app: Option<AppHandle>,
+    ) -> Result<(), String> {
         {
             let db = Database::open(db_path).map_err(|e| e.to_string())?;
             if !self.enabled(&db, PLATFORM_ID) {
@@ -495,7 +567,12 @@ impl VoiceProviderRegistry {
         if active.is_some() {
             return Err("Voice recording is already active".to_string());
         }
-        *active = Some(self.recorder.start()?);
+        let mut session = self.recorder.start()?;
+        if let Some(app) = app {
+            let abort = spawn_level_emitter(app, Arc::clone(&session.samples));
+            session._level_task = Some(LevelTask(abort));
+        }
+        *active = Some(session);
         Ok(())
     }
 
@@ -537,7 +614,11 @@ impl VoiceProviderRegistry {
         Ok(())
     }
 
-    async fn start_distil_recording(&self, db_path: &Path) -> Result<(), String> {
+    async fn start_distil_recording(
+        &self,
+        db_path: &Path,
+        app: Option<AppHandle>,
+    ) -> Result<(), String> {
         {
             let db = Database::open(db_path).map_err(|e| e.to_string())?;
             if !self.enabled(&db, DISTIL_ID) {
@@ -553,7 +634,12 @@ impl VoiceProviderRegistry {
         if active.is_some() {
             return Err("Voice recording is already active".to_string());
         }
-        *active = Some(self.recorder.start()?);
+        let mut session = self.recorder.start()?;
+        if let Some(app) = app {
+            let abort = spawn_level_emitter(app, Arc::clone(&session.samples));
+            session._level_task = Some(LevelTask(abort));
+        }
+        *active = Some(session);
         Ok(())
     }
 
@@ -1265,6 +1351,7 @@ impl AudioRecorder for CpalAudioRecorder {
             stream_error,
             sample_rate,
             _stream: Some(stream),
+            _level_task: None,
         })
     }
 }
@@ -2357,7 +2444,7 @@ mod tests {
         );
 
         let err = registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect_err("disabled provider should not record");
         assert!(err.contains("disabled"));
@@ -2374,7 +2461,7 @@ mod tests {
         );
 
         let err = registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect_err("missing model should not record");
         assert!(err.contains("Download"));
@@ -2393,11 +2480,11 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("first recording starts");
         let err = registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect_err("second recording should fail");
 
@@ -2419,7 +2506,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, PLATFORM_ID)
+            .start_recording(&db_path, PLATFORM_ID, None)
             .await
             .expect("platform recording starts");
         let transcript = registry
@@ -2444,7 +2531,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, PLATFORM_ID)
+            .start_recording(&db_path, PLATFORM_ID, None)
             .await
             .expect("platform recording starts");
         registry
@@ -2488,7 +2575,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         registry
@@ -2517,7 +2604,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         let transcript = registry
@@ -2545,7 +2632,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         let err = registry
@@ -2570,7 +2657,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         let err = registry
@@ -2594,7 +2681,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         let err = registry
@@ -2621,7 +2708,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         let err = registry
@@ -2645,7 +2732,7 @@ mod tests {
         );
 
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording starts");
         let err = registry
@@ -2656,7 +2743,7 @@ mod tests {
 
         *transcriber.result.lock() = Ok("recovered".to_string());
         registry
-            .start_recording(&db_path, DISTIL_ID)
+            .start_recording(&db_path, DISTIL_ID, None)
             .await
             .expect("recording can start again");
         let transcript = registry

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ui",

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -1018,16 +1018,32 @@ export function ChatInputArea({
             sessionId={sessionId}
             onClick={() => setContextPopoverOpen((v) => !v)}
           />
-          {voice.state === "recording" && (
-            <div className={styles.voiceRecordingStatus} aria-live="polite">
-              <span className={styles.voiceWaveform} aria-hidden="true">
-                <span style={{ height: `${Math.min(4 + displayedLevel * 40 * 0.85, 14)}px` }} />
-                <span style={{ height: `${Math.min(4 + displayedLevel * 40, 14)}px` }} />
-                <span style={{ height: `${Math.min(4 + displayedLevel * 40 * 0.85, 14)}px` }} />
-              </span>
-              <span>{formatElapsedSeconds(voice.elapsedSeconds)}</span>
-            </div>
-          )}
+          {voice.state === "recording" && (() => {
+            // Perceptual mapping: sqrt expands quiet speech, the noise gate
+            // ignores ambient hiss, and saturating at RMS=0.4 leaves headroom
+            // for loud peaks while letting typical speech (RMS 0.05–0.15)
+            // reach the middle of the bar range.
+            const noiseFloor = 0.002;
+            const saturation = 0.4;
+            const perceptual =
+              displayedLevel <= noiseFloor
+                ? 0
+                : Math.min(Math.sqrt(displayedLevel / saturation), 1);
+            const barMin = 4;
+            const barRange = 10; // 4–14 px
+            const center = barMin + perceptual * barRange;
+            const outer = barMin + perceptual * barRange * 0.85;
+            return (
+              <div className={styles.voiceRecordingStatus} aria-live="polite">
+                <span className={styles.voiceWaveform} aria-hidden="true">
+                  <span style={{ height: `${outer}px` }} />
+                  <span style={{ height: `${center}px` }} />
+                  <span style={{ height: `${outer}px` }} />
+                </span>
+                <span>{formatElapsedSeconds(voice.elapsedSeconds)}</span>
+              </div>
+            );
+          })()}
           {voice.state === "starting" && (
             <div className={styles.voiceStatusText} aria-live="polite">
               <LoaderCircle

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { AlertCircle, FileText, LoaderCircle, Mic, Plus, Send, Square, X } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   listSlashCommands,
@@ -188,6 +189,29 @@ export function ChatInputArea({
   const voiceErrorOpensSettings = shouldOpenVoiceSettingsForError(
     voice.activeProvider,
   );
+
+  // VU meter: subscribe to `voice://level` events while recording and apply
+  // exponential moving average smoothing so the bars animate smoothly.
+  const [vuLevel, setVuLevel] = useState(0);
+  const smoothedRef = useRef(0);
+  // Only show the live level while actively recording; show 0 otherwise.
+  const displayedLevel = voice.state === "recording" ? vuLevel : 0;
+  useEffect(() => {
+    if (voice.state !== "recording") return;
+    smoothedRef.current = 0;
+    let unlistenFn: UnlistenFn | undefined;
+    const promise = listen<{ level: number }>("voice://level", (event) => {
+      const raw = event.payload.level;
+      smoothedRef.current = 0.6 * smoothedRef.current + 0.4 * raw;
+      setVuLevel(smoothedRef.current);
+    }).then((fn) => {
+      unlistenFn = fn;
+    });
+    return () => {
+      promise.then(() => unlistenFn?.());
+      smoothedRef.current = 0;
+    };
+  }, [voice.state]);
 
   // Esc cancels an active recording regardless of where focus is. The
   // textarea's onKeyDown also handles Esc when it has focus; clicking
@@ -997,9 +1021,9 @@ export function ChatInputArea({
           {voice.state === "recording" && (
             <div className={styles.voiceRecordingStatus} aria-live="polite">
               <span className={styles.voiceWaveform} aria-hidden="true">
-                <span />
-                <span />
-                <span />
+                <span style={{ height: `${Math.min(4 + displayedLevel * 40 * 0.85, 14)}px` }} />
+                <span style={{ height: `${Math.min(4 + displayedLevel * 40, 14)}px` }} />
+                <span style={{ height: `${Math.min(4 + displayedLevel * 40 * 0.85, 14)}px` }} />
               </span>
               <span>{formatElapsedSeconds(voice.elapsedSeconds)}</span>
             </div>

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -192,8 +192,11 @@ export function ChatInputArea({
 
   // VU meter: subscribe to `voice://level` events while recording and apply
   // exponential moving average smoothing so the bars animate smoothly.
-  // Skip the subscription entirely when the OS asks for reduced motion —
-  // the bars are rendered at a static height in that case.
+  // Skipped (and replaced with a static indicator) when the OS asks for
+  // reduced motion, or when the active provider is webview-driven (Web
+  // Speech API) — that path captures audio in the browser and emits no
+  // `voice://level` events from Rust, so dynamic bars would sit at the
+  // floor for the whole recording.
   const [vuLevel, setVuLevel] = useState(0);
   const smoothedRef = useRef(0);
   const [reducedMotion, setReducedMotion] = useState(() => {
@@ -207,11 +210,14 @@ export function ChatInputArea({
     mq.addEventListener?.("change", onChange);
     return () => mq.removeEventListener?.("change", onChange);
   }, []);
+  const nativeRecording = voice.activeProvider?.recordingMode === "native";
+  const useDynamicMeter = !reducedMotion && nativeRecording;
   // Only show the live level while actively recording; show 0 otherwise.
   const displayedLevel = voice.state === "recording" ? vuLevel : 0;
   useEffect(() => {
-    if (voice.state !== "recording" || reducedMotion) return;
+    if (voice.state !== "recording" || !useDynamicMeter) return;
     smoothedRef.current = 0;
+    setVuLevel(0);
     let unlistenFn: UnlistenFn | undefined;
     const promise = listen<{ level: number }>("voice://level", (event) => {
       const raw = event.payload.level;
@@ -223,8 +229,9 @@ export function ChatInputArea({
     return () => {
       promise.then(() => unlistenFn?.());
       smoothedRef.current = 0;
+      setVuLevel(0);
     };
-  }, [voice.state, reducedMotion]);
+  }, [voice.state, useDynamicMeter]);
 
   // Esc cancels an active recording regardless of where focus is. The
   // textarea's onKeyDown also handles Esc when it has focus; clicking
@@ -1035,14 +1042,14 @@ export function ChatInputArea({
             // Perceptual mapping: sqrt expands quiet speech, the noise gate
             // ignores ambient hiss, and saturating at RMS=0.4 leaves headroom
             // for loud peaks while letting typical speech (RMS 0.05–0.15)
-            // reach the middle of the bar range. With prefers-reduced-motion,
-            // freeze the bars at a static mid-range height so the indicator
-            // still reads as "recording" without animating.
+            // reach the middle of the bar range. Falls back to a static
+            // mid-range height when reduced motion is requested or the
+            // provider is webview-driven (no `voice://level` events).
             const barMin = 4;
             const barRange = 10; // 4–14 px
             let center: number;
             let outer: number;
-            if (reducedMotion) {
+            if (!useDynamicMeter) {
               center = 8;
               outer = 8;
             } else {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -192,12 +192,25 @@ export function ChatInputArea({
 
   // VU meter: subscribe to `voice://level` events while recording and apply
   // exponential moving average smoothing so the bars animate smoothly.
+  // Skip the subscription entirely when the OS asks for reduced motion —
+  // the bars are rendered at a static height in that case.
   const [vuLevel, setVuLevel] = useState(0);
   const smoothedRef = useRef(0);
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
   // Only show the live level while actively recording; show 0 otherwise.
   const displayedLevel = voice.state === "recording" ? vuLevel : 0;
   useEffect(() => {
-    if (voice.state !== "recording") return;
+    if (voice.state !== "recording" || reducedMotion) return;
     smoothedRef.current = 0;
     let unlistenFn: UnlistenFn | undefined;
     const promise = listen<{ level: number }>("voice://level", (event) => {
@@ -211,7 +224,7 @@ export function ChatInputArea({
       promise.then(() => unlistenFn?.());
       smoothedRef.current = 0;
     };
-  }, [voice.state]);
+  }, [voice.state, reducedMotion]);
 
   // Esc cancels an active recording regardless of where focus is. The
   // textarea's onKeyDown also handles Esc when it has focus; clicking
@@ -1022,17 +1035,26 @@ export function ChatInputArea({
             // Perceptual mapping: sqrt expands quiet speech, the noise gate
             // ignores ambient hiss, and saturating at RMS=0.4 leaves headroom
             // for loud peaks while letting typical speech (RMS 0.05–0.15)
-            // reach the middle of the bar range.
-            const noiseFloor = 0.002;
-            const saturation = 0.4;
-            const perceptual =
-              displayedLevel <= noiseFloor
-                ? 0
-                : Math.min(Math.sqrt(displayedLevel / saturation), 1);
+            // reach the middle of the bar range. With prefers-reduced-motion,
+            // freeze the bars at a static mid-range height so the indicator
+            // still reads as "recording" without animating.
             const barMin = 4;
             const barRange = 10; // 4–14 px
-            const center = barMin + perceptual * barRange;
-            const outer = barMin + perceptual * barRange * 0.85;
+            let center: number;
+            let outer: number;
+            if (reducedMotion) {
+              center = 8;
+              outer = 8;
+            } else {
+              const noiseFloor = 0.002;
+              const saturation = 0.4;
+              const perceptual =
+                displayedLevel <= noiseFloor
+                  ? 0
+                  : Math.min(Math.sqrt(displayedLevel / saturation), 1);
+              center = barMin + perceptual * barRange;
+              outer = barMin + perceptual * barRange * 0.85;
+            }
             return (
               <div className={styles.voiceRecordingStatus} aria-live="polite">
                 <span className={styles.voiceWaveform} aria-hidden="true">

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { AlertCircle, FileText, LoaderCircle, Mic, Plus, Send, Square, X } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { VoiceMeter } from "./VoiceMeter";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   listSlashCommands,
@@ -36,7 +36,6 @@ import { PinnedPromptsBar } from "./PinnedPromptsBar";
 import { SlashCommandPicker, filterSlashCommands } from "./SlashCommandPicker";
 import { describeSlashQuery } from "./nativeSlashCommands";
 import { hasUltrathink, renderUltrathinkText } from "./ultrathink";
-import { formatElapsedSeconds } from "./chatHelpers";
 import styles from "./ChatPanel.module.css";
 
 /** Extract the @-query based on cursor position in the textarea. */
@@ -190,15 +189,10 @@ export function ChatInputArea({
     voice.activeProvider,
   );
 
-  // VU meter: subscribe to `voice://level` events while recording and apply
-  // exponential moving average smoothing so the bars animate smoothly.
-  // Skipped (and replaced with a static indicator) when the OS asks for
-  // reduced motion, or when the active provider is webview-driven (Web
-  // Speech API) — that path captures audio in the browser and emits no
-  // `voice://level` events from Rust, so dynamic bars would sit at the
-  // floor for the whole recording.
-  const [vuLevel, setVuLevel] = useState(0);
-  const smoothedRef = useRef(0);
+  // VU meter dynamic-vs-static decision lives in the parent because it
+  // depends on the OS reduced-motion preference and the active provider's
+  // `recordingMode`. The meter itself is a child component so 30 Hz level
+  // events don't re-render this large composer.
   const [reducedMotion, setReducedMotion] = useState(() => {
     if (typeof window === "undefined" || !window.matchMedia) return false;
     return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -212,26 +206,6 @@ export function ChatInputArea({
   }, []);
   const nativeRecording = voice.activeProvider?.recordingMode === "native";
   const useDynamicMeter = !reducedMotion && nativeRecording;
-  // Only show the live level while actively recording; show 0 otherwise.
-  const displayedLevel = voice.state === "recording" ? vuLevel : 0;
-  useEffect(() => {
-    if (voice.state !== "recording" || !useDynamicMeter) return;
-    smoothedRef.current = 0;
-    setVuLevel(0);
-    let unlistenFn: UnlistenFn | undefined;
-    const promise = listen<{ level: number }>("voice://level", (event) => {
-      const raw = event.payload.level;
-      smoothedRef.current = 0.6 * smoothedRef.current + 0.4 * raw;
-      setVuLevel(smoothedRef.current);
-    }).then((fn) => {
-      unlistenFn = fn;
-    });
-    return () => {
-      promise.then(() => unlistenFn?.());
-      smoothedRef.current = 0;
-      setVuLevel(0);
-    };
-  }, [voice.state, useDynamicMeter]);
 
   // Esc cancels an active recording regardless of where focus is. The
   // textarea's onKeyDown also handles Esc when it has focus; clicking
@@ -1038,41 +1012,12 @@ export function ChatInputArea({
             sessionId={sessionId}
             onClick={() => setContextPopoverOpen((v) => !v)}
           />
-          {voice.state === "recording" && (() => {
-            // Perceptual mapping: sqrt expands quiet speech, the noise gate
-            // ignores ambient hiss, and saturating at RMS=0.4 leaves headroom
-            // for loud peaks while letting typical speech (RMS 0.05–0.15)
-            // reach the middle of the bar range. Falls back to a static
-            // mid-range height when reduced motion is requested or the
-            // provider is webview-driven (no `voice://level` events).
-            const barMin = 4;
-            const barRange = 10; // 4–14 px
-            let center: number;
-            let outer: number;
-            if (!useDynamicMeter) {
-              center = 8;
-              outer = 8;
-            } else {
-              const noiseFloor = 0.002;
-              const saturation = 0.4;
-              const perceptual =
-                displayedLevel <= noiseFloor
-                  ? 0
-                  : Math.min(Math.sqrt(displayedLevel / saturation), 1);
-              center = barMin + perceptual * barRange;
-              outer = barMin + perceptual * barRange * 0.85;
-            }
-            return (
-              <div className={styles.voiceRecordingStatus} aria-live="polite">
-                <span className={styles.voiceWaveform} aria-hidden="true">
-                  <span style={{ height: `${outer}px` }} />
-                  <span style={{ height: `${center}px` }} />
-                  <span style={{ height: `${outer}px` }} />
-                </span>
-                <span>{formatElapsedSeconds(voice.elapsedSeconds)}</span>
-              </div>
-            );
-          })()}
+          {voice.state === "recording" && (
+            <VoiceMeter
+              elapsedSeconds={voice.elapsedSeconds}
+              useDynamicMeter={useDynamicMeter}
+            />
+          )}
           {voice.state === "starting" && (
             <div className={styles.voiceStatusText} aria-live="polite">
               <LoaderCircle

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -896,24 +896,6 @@
   min-height: 4px;
   border-radius: 2px;
   background: var(--accent-primary);
-  animation: voice-wave 0.85s ease-in-out infinite;
-}
-
-.voiceWaveform span:nth-child(2) {
-  animation-delay: 0.12s;
-}
-
-.voiceWaveform span:nth-child(3) {
-  animation-delay: 0.24s;
-}
-
-@keyframes voice-wave {
-  0%, 100% {
-    height: 4px;
-  }
-  50% {
-    height: 14px;
-  }
 }
 
 @keyframes voice-spin {
@@ -925,11 +907,6 @@
 @media (prefers-reduced-motion: reduce) {
   .voiceStatusSpinner {
     animation: none;
-  }
-
-  .voiceWaveform span {
-    animation: none;
-    height: 8px;
   }
 }
 

--- a/src/ui/src/components/chat/VoiceMeter.tsx
+++ b/src/ui/src/components/chat/VoiceMeter.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { formatElapsedSeconds } from "./chatHelpers";
+import styles from "./ChatPanel.module.css";
+
+interface VoiceMeterProps {
+  elapsedSeconds: number;
+  /**
+   * When true, subscribe to `voice://level` and animate the bars from RMS.
+   * When false, render static mid-range bars — used for `prefers-reduced-motion`
+   * and for webview-driven providers (Web Speech API) that don't emit levels.
+   */
+  useDynamicMeter: boolean;
+}
+
+/**
+ * Live VU meter for the chat composer's recording indicator. Owns its own
+ * level-event subscription so 30 Hz updates re-render only this component
+ * rather than the ~1k-line `ChatInputArea` parent.
+ */
+export function VoiceMeter({ elapsedSeconds, useDynamicMeter }: VoiceMeterProps) {
+  const [vuLevel, setVuLevel] = useState(0);
+  const smoothedRef = useRef(0);
+
+  useEffect(() => {
+    if (!useDynamicMeter) return;
+    smoothedRef.current = 0;
+    setVuLevel(0);
+    let unlistenFn: UnlistenFn | undefined;
+    const promise = listen<{ level: number }>("voice://level", (event) => {
+      const raw = event.payload.level;
+      smoothedRef.current = 0.6 * smoothedRef.current + 0.4 * raw;
+      setVuLevel(smoothedRef.current);
+    }).then((fn) => {
+      unlistenFn = fn;
+    });
+    return () => {
+      promise.then(() => unlistenFn?.());
+      smoothedRef.current = 0;
+      setVuLevel(0);
+    };
+  }, [useDynamicMeter]);
+
+  // Perceptual mapping: sqrt expands quiet speech, the noise gate ignores
+  // ambient hiss, and saturating at RMS=0.4 leaves headroom for loud peaks
+  // while letting typical speech (RMS 0.05–0.15) reach the middle of the bar
+  // range. Static fallback when dynamic mode is disabled.
+  const barMin = 4;
+  const barRange = 10; // 4–14 px
+  let center: number;
+  let outer: number;
+  if (!useDynamicMeter) {
+    center = 8;
+    outer = 8;
+  } else {
+    const noiseFloor = 0.002;
+    const saturation = 0.4;
+    const perceptual =
+      vuLevel <= noiseFloor
+        ? 0
+        : Math.min(Math.sqrt(vuLevel / saturation), 1);
+    center = barMin + perceptual * barRange;
+    outer = barMin + perceptual * barRange * 0.85;
+  }
+
+  return (
+    <div className={styles.voiceRecordingStatus} aria-live="polite">
+      <span className={styles.voiceWaveform} aria-hidden="true">
+        <span style={{ height: `${outer}px` }} />
+        <span style={{ height: `${center}px` }} />
+        <span style={{ height: `${outer}px` }} />
+      </span>
+      <span>{formatElapsedSeconds(elapsedSeconds)}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #441 (item 4 — Voice activity / signal level indicator).

## What changed

**Before:** The chat toolbar showed a decorative `voiceWaveform` CSS animation — three bars looping up and down regardless of mic input.

**After:** The same three bars are now driven by the live microphone signal via a real VU meter:

- **Rust** — `src-tauri/src/voice.rs`: a Tokio task polls the cpal capture buffer at ~30 Hz, computes **linear RMS** over each ~33 ms window, and emits a `voice://level` Tauri event with payload `{ level: f32 }` (0.0–1.0; full-scale sine ≈ 0.707, typical speech 0.05–0.3). The task is tied to a `LevelTask(AbortHandle)` stored in `RecordingSession`, so it is automatically cancelled when recording stops (either via stop-and-transcribe or cancel). The first three ticks (~100 ms) are suppressed to let the buffer fill before the frontend sees a signal.

- **Frontend** — `ChatInputArea.tsx`: subscribes to `voice://level` while `voice.state === "recording"` using `listen()`, applies exponential moving average smoothing (α = 0.4, so `displayed = 0.6 × prev + 0.4 × sample`), and drives three bar heights as inline styles. The outer bars are capped at 85% of the center bar's height for a classic VU-meter profile.

- **CSS** — `ChatPanel.module.css`: removed the now-unused `@keyframes voice-wave` and `animation-delay` rules.

## Normalization

**Linear RMS**, normalized to [0.0, 1.0]. Gain factor in the frontend is 40×, so level ≈ 0.25 hits the 14 px maximum (roughly loud but comfortable speech at normal mic distance). No dBFS conversion — linear is simpler and the frontend display is intuitive.

## Manual verification

Verified in `cargo tauri dev`:
- Bars respond to voice input and animate smoothly while recording.
- Bars go silent (back to 4 px floor) when the system mic is muted.
- No flash of empty bars at recording start.
- Bars stop updating immediately when recording is stopped or cancelled.