### PR TITLE
feat(voice): keyboard shortcuts for toggle and hold-to-talk (#441.2)

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -42,6 +42,8 @@ function App() {
   );
   const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
   const setDisable1mContext = useAppStore((s) => s.setDisable1mContext);
+  const setVoiceToggleHotkey = useAppStore((s) => s.setVoiceToggleHotkey);
+  const setVoiceHoldHotkey = useAppStore((s) => s.setVoiceHoldHotkey);
   const setAppVersion = useAppStore((s) => s.setAppVersion);
 
   // Cached theme list — populated on initial load, reused by the OS handler.
@@ -206,6 +208,18 @@ function App() {
     getAppSetting("editor_git_gutter_base")
       .then((val) => {
         if (val === "merge_base") setEditorGitGutterBase("merge_base");
+      })
+      .catch(() => {});
+    getAppSetting("voice_toggle_hotkey")
+      .then((val) => {
+        if (val === "disabled") setVoiceToggleHotkey(null);
+        else if (val) setVoiceToggleHotkey(val);
+      })
+      .catch(() => {});
+    getAppSetting("voice_hold_hotkey")
+      .then((val) => {
+        if (val === "disabled") setVoiceHoldHotkey(null);
+        else if (val) setVoiceHoldHotkey(val);
       })
       .catch(() => {});
     getAppSetting("language")
@@ -416,7 +430,7 @@ function App() {
       unlistenAutoArchived.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setDisable1mContext, setAppVersion]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -27,6 +27,7 @@ import {
   shouldOpenVoiceSettingsForError,
 } from "../../utils/voice";
 import { useVoiceInput } from "../../hooks/useVoiceInput";
+import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
 import { ComposerToolbar } from "./composer/ComposerToolbar";
 import { ContextPopover } from "./composer/ContextPopover";
 import { SegmentedMeter } from "./composer/SegmentedMeter";
@@ -177,6 +178,8 @@ export function ChatInputArea({
     });
   }, [cursorPos]);
 
+  const voiceToggleHotkey = useAppStore((s) => s.voiceToggleHotkey);
+  const voiceHoldHotkey = useAppStore((s) => s.voiceHoldHotkey);
   const focusVoiceProvider = useAppStore((s) => s.focusVoiceProvider);
   const voice = useVoiceInput(
     insertTranscript,
@@ -188,6 +191,7 @@ export function ChatInputArea({
   const voiceErrorOpensSettings = shouldOpenVoiceSettingsForError(
     voice.activeProvider,
   );
+  useVoiceHotkey(voice, voiceToggleHotkey, voiceHoldHotkey);
 
   // VU meter dynamic-vs-static decision lives in the parent because it
   // depends on the OS reduced-motion preference and the active provider's

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -347,6 +347,19 @@
   cursor: default;
 }
 
+/* ── Hotkey badge (Keyboard settings) ── */
+
+.hotkeyBadge {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 4px 8px;
+  background: var(--selected-bg);
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  min-width: 60px;
+  text-align: center;
+}
+
 /* ── Textarea fields (setup script, instructions) ── */
 
 .textarea {

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -347,17 +347,20 @@
   cursor: default;
 }
 
-/* ── Hotkey badge (Keyboard settings) ── */
+/* ── Hotkey badge (Keyboard settings) ──
+ * Composes iconBtn so the visual height/padding/border-radius matches the
+ * adjacent Rebind/Reset/Disable buttons exactly. Overrides cursor (it's not
+ * clickable) and font-family (mono for the keystroke glyphs). */
 
 .hotkeyBadge {
+  composes: iconBtn;
   font-family: var(--font-mono);
-  font-size: 13px;
-  padding: 4px 8px;
-  background: var(--selected-bg);
-  border: 1px solid var(--divider);
-  border-radius: 4px;
+  cursor: default;
   min-width: 60px;
-  text-align: center;
+}
+
+.hotkeyBadge:hover {
+  background: var(--selected-bg);
 }
 
 /* ── Textarea fields (setup script, instructions) ── */

--- a/src/ui/src/components/settings/SettingsPage.tsx
+++ b/src/ui/src/components/settings/SettingsPage.tsx
@@ -51,6 +51,11 @@ const PinnedPromptsSettings = lazy(() =>
     default: m.PinnedPromptsSettings,
   })),
 );
+const KeyboardSettings = lazy(() =>
+  import("./sections/KeyboardSettings").then((m) => ({
+    default: m.KeyboardSettings,
+  })),
+);
 
 function SectionContent({ section }: { section: string | null }) {
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
@@ -64,6 +69,7 @@ function SectionContent({ section }: { section: string | null }) {
   if (section === "notifications") return <NotificationsSettings />;
   if (section === "editor") return <EditorSettings />;
   if (section === "git") return <GitSettings />;
+  if (section === "keyboard") return <KeyboardSettings />;
   if (section === "pinned-prompts") return <PinnedPromptsSettings />;
   if (section === "plugins") return <PluginsSettings />;
   if (section === "claude-code-plugins") {

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -10,6 +10,7 @@ import {
   Puzzle,
   Bookmark,
   Globe,
+  Keyboard,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
@@ -27,6 +28,7 @@ export function getAppSections(
     { id: "notifications", icon: Bell },
     { id: "editor", icon: FileCode },
     { id: "git", icon: GitBranch },
+    { id: "keyboard", icon: Keyboard },
     { id: "pinned-prompts", icon: Bookmark },
     { id: "plugins", icon: Puzzle },
     ...(communityRegistryEnabled
@@ -57,6 +59,7 @@ export function SettingsSidebar() {
     if (id === "notifications") return t("settings:nav_notifications");
     if (id === "editor") return t("settings:nav_editor");
     if (id === "git") return t("settings:nav_git");
+    if (id === "keyboard") return t("settings:nav_keyboard");
     if (id === "plugins") return t("settings:nav_plugins");
     if (id === "claude-code-plugins") return t("settings:nav_claude_code_plugins");
     if (id === "community") return t("settings:nav_community");

--- a/src/ui/src/components/settings/sections/KeyboardSettings.tsx
+++ b/src/ui/src/components/settings/sections/KeyboardSettings.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppStore } from "../../../stores/useAppStore";
+import { setAppSetting } from "../../../services/tauri";
+import {
+  DEFAULT_HOLD_HOTKEY,
+  DEFAULT_TOGGLE_HOTKEY,
+  formatHoldHotkey,
+  formatToggleHotkey,
+} from "../../../hooks/useVoiceHotkey";
+import styles from "../Settings.module.css";
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent);
+}
+
+type RebindTarget = "toggle" | "hold" | null;
+
+/** Capture a toggle-hotkey combo from a keydown event. Returns null for modifier-only presses. */
+function captureToggleCombo(e: KeyboardEvent): string | null {
+  const modifierKeys = new Set(["Meta", "Control", "Shift", "Alt"]);
+  if (modifierKeys.has(e.key)) return null;
+  const parts: string[] = [];
+  if (e.metaKey || e.ctrlKey) parts.push("mod");
+  if (e.shiftKey) parts.push("shift");
+  if (e.altKey) parts.push("alt");
+  parts.push(e.key.toLowerCase());
+  return parts.join("+");
+}
+
+export function KeyboardSettings() {
+  const { t } = useTranslation("settings");
+  const isMac = isMacPlatform();
+
+  const voiceToggleHotkey = useAppStore((s) => s.voiceToggleHotkey);
+  const voiceHoldHotkey = useAppStore((s) => s.voiceHoldHotkey);
+  const setVoiceToggleHotkey = useAppStore((s) => s.setVoiceToggleHotkey);
+  const setVoiceHoldHotkey = useAppStore((s) => s.setVoiceHoldHotkey);
+
+  const [rebinding, setRebinding] = useState<RebindTarget>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const saveToggleHotkey = async (value: string | null) => {
+    try {
+      await setAppSetting("voice_toggle_hotkey", value ?? "disabled");
+      setVoiceToggleHotkey(value);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+    setRebinding(null);
+  };
+
+  const saveHoldHotkey = async (value: string | null) => {
+    try {
+      await setAppSetting("voice_hold_hotkey", value ?? "disabled");
+      setVoiceHoldHotkey(value);
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+    setRebinding(null);
+  };
+
+  // Capture key presses while rebinding is active.
+  // Uses capture phase so the listener fires before other handlers.
+  // Deps: rebinding (changes when entering/leaving rebind mode), stable Zustand setters.
+  useEffect(() => {
+    if (!rebinding) return;
+
+    const persist = async (settingKey: string, value: string | null, storeSetter: (v: string | null) => void) => {
+      try {
+        await setAppSetting(settingKey, value ?? "disabled");
+        storeSetter(value);
+        setError(null);
+      } catch (e) {
+        setError(String(e));
+      }
+      setRebinding(null);
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === "Escape") {
+        setRebinding(null);
+        return;
+      }
+
+      if (rebinding === "toggle") {
+        const combo = captureToggleCombo(e);
+        if (combo) void persist("voice_toggle_hotkey", combo, setVoiceToggleHotkey);
+      } else {
+        void persist("voice_hold_hotkey", e.code, setVoiceHoldHotkey);
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [rebinding, setVoiceToggleHotkey, setVoiceHoldHotkey]);
+
+  return (
+    <div>
+      <h2 className={styles.sectionTitle}>{t("keyboard_title")}</h2>
+
+      {error && <div className={styles.error}>{error}</div>}
+
+      <div className={styles.fieldGroup}>
+        <div className={styles.fieldLabel}>{t("keyboard_voice_section")}</div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("keyboard_voice_toggle_label")}</div>
+          <div className={styles.settingDescription}>
+            {t("keyboard_voice_toggle_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <div className={styles.inlineControl}>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "4px 8px", background: "var(--selected-bg)", border: "1px solid var(--divider)", borderRadius: 4, minWidth: 60, textAlign: "center" }}>
+              {rebinding === "toggle"
+                ? t("keyboard_press_key")
+                : formatToggleHotkey(voiceToggleHotkey, isMac)}
+            </code>
+            {rebinding === "toggle" ? (
+              <button className={styles.iconBtn} onClick={() => setRebinding(null)}>
+                {t("keyboard_cancel")}
+              </button>
+            ) : (
+              <>
+                <button className={styles.iconBtn} onClick={() => setRebinding("toggle")}>
+                  {t("keyboard_rebind")}
+                </button>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => void saveToggleHotkey(DEFAULT_TOGGLE_HOTKEY)}
+                  disabled={voiceToggleHotkey === DEFAULT_TOGGLE_HOTKEY}
+                >
+                  {t("keyboard_reset")}
+                </button>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => void saveToggleHotkey(null)}
+                  disabled={voiceToggleHotkey === null}
+                >
+                  {t("keyboard_disable")}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("keyboard_voice_hold_label")}</div>
+          <div className={styles.settingDescription}>
+            {t("keyboard_voice_hold_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <div className={styles.inlineControl}>
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "4px 8px", background: "var(--selected-bg)", border: "1px solid var(--divider)", borderRadius: 4, minWidth: 60, textAlign: "center" }}>
+              {rebinding === "hold"
+                ? t("keyboard_press_key")
+                : formatHoldHotkey(voiceHoldHotkey, isMac)}
+            </code>
+            {rebinding === "hold" ? (
+              <button className={styles.iconBtn} onClick={() => setRebinding(null)}>
+                {t("keyboard_cancel")}
+              </button>
+            ) : (
+              <>
+                <button className={styles.iconBtn} onClick={() => setRebinding("hold")}>
+                  {t("keyboard_rebind")}
+                </button>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => void saveHoldHotkey(DEFAULT_HOLD_HOTKEY)}
+                  disabled={voiceHoldHotkey === DEFAULT_HOLD_HOTKEY}
+                >
+                  {t("keyboard_reset")}
+                </button>
+                <button
+                  className={styles.iconBtn}
+                  onClick={() => void saveHoldHotkey(null)}
+                  disabled={voiceHoldHotkey === null}
+                >
+                  {t("keyboard_disable")}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/sections/KeyboardSettings.tsx
+++ b/src/ui/src/components/settings/sections/KeyboardSettings.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../../stores/useAppStore";
 import { setAppSetting } from "../../../services/tauri";
 import {
-  DEFAULT_HOLD_HOTKEY,
   DEFAULT_TOGGLE_HOTKEY,
   formatHoldHotkey,
   formatToggleHotkey,
+  getDefaultHoldHotkey,
   normalizeToggleKey,
 } from "../../../hooks/useVoiceHotkey";
 import styles from "../Settings.module.css";
@@ -20,7 +20,10 @@ type RebindTarget = "toggle" | "hold" | null;
 
 /** Capture a toggle-hotkey combo from a keydown event. Returns null for modifier-only presses. */
 function captureToggleCombo(e: KeyboardEvent): string | null {
-  const modifierKeys = new Set(["Meta", "Control", "Shift", "Alt"]);
+  // AltGraph is the modifier produced by Right Alt on most non-US layouts —
+  // include it here so the rebind dialog doesn't capture "altgraph" as the
+  // non-modifier part of the combo before the user hits the intended key.
+  const modifierKeys = new Set(["Meta", "Control", "Shift", "Alt", "AltGraph"]);
   if (modifierKeys.has(e.key)) return null;
   const parts: string[] = [];
   if (e.metaKey || e.ctrlKey) parts.push("mod");
@@ -89,9 +92,12 @@ export function KeyboardSettings() {
     };
 
     const onKeyDown = (e: KeyboardEvent) => {
+      // Check captured BEFORE preventDefault — otherwise post-Escape keys
+      // arriving in the brief window before the effect cleanup would be
+      // silently swallowed.
+      if (captured) return;
       e.preventDefault();
       e.stopPropagation();
-      if (captured) return;
 
       if (e.key === "Escape") {
         captured = true;
@@ -192,8 +198,8 @@ export function KeyboardSettings() {
                 </button>
                 <button
                   className={styles.iconBtn}
-                  onClick={() => void saveHoldHotkey(DEFAULT_HOLD_HOTKEY)}
-                  disabled={voiceHoldHotkey === DEFAULT_HOLD_HOTKEY}
+                  onClick={() => void saveHoldHotkey(getDefaultHoldHotkey())}
+                  disabled={voiceHoldHotkey === getDefaultHoldHotkey()}
                 >
                   {t("keyboard_reset")}
                 </button>

--- a/src/ui/src/components/settings/sections/KeyboardSettings.tsx
+++ b/src/ui/src/components/settings/sections/KeyboardSettings.tsx
@@ -9,12 +9,8 @@ import {
   getDefaultHoldHotkey,
   normalizeToggleKey,
 } from "../../../hooks/useVoiceHotkey";
+import { isMacPlatform } from "../../../utils/voiceHotkeys";
 import styles from "../Settings.module.css";
-
-function isMacPlatform(): boolean {
-  if (typeof navigator === "undefined") return false;
-  return /Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent);
-}
 
 type RebindTarget = "toggle" | "hold" | null;
 

--- a/src/ui/src/components/settings/sections/KeyboardSettings.tsx
+++ b/src/ui/src/components/settings/sections/KeyboardSettings.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_TOGGLE_HOTKEY,
   formatHoldHotkey,
   formatToggleHotkey,
+  normalizeToggleKey,
 } from "../../../hooks/useVoiceHotkey";
 import styles from "../Settings.module.css";
 
@@ -25,7 +26,8 @@ function captureToggleCombo(e: KeyboardEvent): string | null {
   if (e.metaKey || e.ctrlKey) parts.push("mod");
   if (e.shiftKey) parts.push("shift");
   if (e.altKey) parts.push("alt");
-  parts.push(e.key.toLowerCase());
+  // Use normalizeToggleKey so "+" doesn't collide with the "+" delimiter.
+  parts.push(normalizeToggleKey(e.key));
   return parts.join("+");
 }
 
@@ -69,6 +71,12 @@ export function KeyboardSettings() {
   useEffect(() => {
     if (!rebinding) return;
 
+    // Closure-local guard: setRebinding(null) doesn't synchronously unregister
+    // this listener (state update + re-render is async), so without this flag a
+    // burst of keydowns between the await and the next render could fire
+    // multiple persist() calls and overwrite the intended binding.
+    let captured = false;
+
     const persist = async (settingKey: string, value: string | null, storeSetter: (v: string | null) => void) => {
       try {
         await setAppSetting(settingKey, value ?? "disabled");
@@ -83,16 +91,21 @@ export function KeyboardSettings() {
     const onKeyDown = (e: KeyboardEvent) => {
       e.preventDefault();
       e.stopPropagation();
+      if (captured) return;
 
       if (e.key === "Escape") {
+        captured = true;
         setRebinding(null);
         return;
       }
 
       if (rebinding === "toggle") {
         const combo = captureToggleCombo(e);
-        if (combo) void persist("voice_toggle_hotkey", combo, setVoiceToggleHotkey);
+        if (!combo) return; // modifier-only press — keep listening
+        captured = true;
+        void persist("voice_toggle_hotkey", combo, setVoiceToggleHotkey);
       } else {
+        captured = true;
         void persist("voice_hold_hotkey", e.code, setVoiceHoldHotkey);
       }
     };
@@ -120,7 +133,7 @@ export function KeyboardSettings() {
         </div>
         <div className={styles.settingControl}>
           <div className={styles.inlineControl}>
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "4px 8px", background: "var(--selected-bg)", border: "1px solid var(--divider)", borderRadius: 4, minWidth: 60, textAlign: "center" }}>
+            <code className={styles.hotkeyBadge}>
               {rebinding === "toggle"
                 ? t("keyboard_press_key")
                 : formatToggleHotkey(voiceToggleHotkey, isMac)}
@@ -163,7 +176,7 @@ export function KeyboardSettings() {
         </div>
         <div className={styles.settingControl}>
           <div className={styles.inlineControl}>
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 13, padding: "4px 8px", background: "var(--selected-bg)", border: "1px solid var(--divider)", borderRadius: 4, minWidth: 60, textAlign: "center" }}>
+            <code className={styles.hotkeyBadge}>
               {rebinding === "hold"
                 ? t("keyboard_press_key")
                 : formatHoldHotkey(voiceHoldHotkey, isMac)}

--- a/src/ui/src/hooks/useVoiceHotkey.test.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createVoiceHotkeyHandlers, matchesToggle } from "./useVoiceHotkey";
+import {
+  createVoiceHotkeyHandlers,
+  matchesToggle,
+  normalizeToggleKey,
+} from "./useVoiceHotkey";
 import type { VoiceInputController } from "./useVoiceInput";
 
 type VoiceState = VoiceInputController["state"];
@@ -75,6 +79,12 @@ describe("matchesToggle", () => {
     ).toBe(false);
   });
 
+  it("matches mod+shift+plus against the literal '+' key", () => {
+    expect(
+      matchesToggle(keyEvent({ key: "+", metaKey: true, shiftKey: true }), "mod+shift+plus"),
+    ).toBe(true);
+  });
+
   it("rejects when alt is held but not required", () => {
     expect(
       matchesToggle(
@@ -120,6 +130,26 @@ describe("createVoiceHotkeyHandlers — toggle", () => {
     const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
     onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true, repeat: true }));
     expect(voice.start).not.toHaveBeenCalled();
+  });
+
+  it("preventDefaults repeat events that match the toggle (no-modifier rebind)", () => {
+    const voice = makeVoice("recording");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "a", null);
+    const e = keyEvent({ key: "a", repeat: true });
+    onKeyDown(e);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(voice.stop).not.toHaveBeenCalled();
+  });
+});
+
+describe("normalizeToggleKey", () => {
+  it("maps '+' to 'plus' to avoid delimiter collision", () => {
+    expect(normalizeToggleKey("+")).toBe("plus");
+  });
+
+  it("lowercases everything else", () => {
+    expect(normalizeToggleKey("M")).toBe("m");
+    expect(normalizeToggleKey("Enter")).toBe("enter");
   });
 
   it("does nothing when toggle hotkey is null", () => {

--- a/src/ui/src/hooks/useVoiceHotkey.test.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import { createVoiceHotkeyHandlers, matchesToggle } from "./useVoiceHotkey";
+import type { VoiceInputController } from "./useVoiceInput";
+
+type VoiceState = VoiceInputController["state"];
+
+function makeVoice(initial: VoiceState = "idle") {
+  let state = initial;
+  return {
+    get state(): VoiceState {
+      return state;
+    },
+    set state(next: VoiceState) {
+      state = next;
+    },
+    start: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    stop: vi.fn<() => void>(),
+    cancel: vi.fn<() => void>(),
+    elapsedSeconds: 0,
+    interimTranscript: "",
+    error: null,
+    activeProvider: null,
+    webSpeechSupported: false,
+  };
+}
+
+function keyEvent(
+  overrides: Partial<{
+    key: string;
+    code: string;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+    repeat: boolean;
+  }>,
+): KeyboardEvent {
+  return {
+    key: "",
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    repeat: false,
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent;
+}
+
+describe("matchesToggle", () => {
+  it("matches mod+shift+m with Cmd+Shift+M (Mac)", () => {
+    expect(
+      matchesToggle(keyEvent({ key: "m", metaKey: true, shiftKey: true }), "mod+shift+m"),
+    ).toBe(true);
+  });
+
+  it("matches mod+shift+m with Ctrl+Shift+M (Windows/Linux)", () => {
+    expect(
+      matchesToggle(keyEvent({ key: "m", ctrlKey: true, shiftKey: true }), "mod+shift+m"),
+    ).toBe(true);
+  });
+
+  it("rejects when shift is missing", () => {
+    expect(matchesToggle(keyEvent({ key: "m", metaKey: true }), "mod+shift+m")).toBe(false);
+  });
+
+  it("rejects when mod is missing", () => {
+    expect(matchesToggle(keyEvent({ key: "m", shiftKey: true }), "mod+shift+m")).toBe(false);
+  });
+
+  it("rejects wrong key", () => {
+    expect(
+      matchesToggle(keyEvent({ key: "n", metaKey: true, shiftKey: true }), "mod+shift+m"),
+    ).toBe(false);
+  });
+
+  it("rejects when alt is held but not required", () => {
+    expect(
+      matchesToggle(
+        keyEvent({ key: "m", metaKey: true, shiftKey: true, altKey: true }),
+        "mod+shift+m",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("createVoiceHotkeyHandlers — toggle", () => {
+  it("starts recording when idle and toggle key is pressed", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.start).toHaveBeenCalledOnce();
+  });
+
+  it("stops recording when already recording", () => {
+    const voice = makeVoice("recording");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.stop).toHaveBeenCalledOnce();
+    expect(voice.start).not.toHaveBeenCalled();
+  });
+
+  it("cancels when in starting state", () => {
+    const voice = makeVoice("starting");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("cancels when transcribing", () => {
+    const voice = makeVoice("transcribing");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("ignores OS-repeat keydown events", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true, repeat: true }));
+    expect(voice.start).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when toggle hotkey is null", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.start).not.toHaveBeenCalled();
+  });
+});
+
+describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
+  it("starts recording on keydown and stops on keyup", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown, onKeyUp } = createVoiceHotkeyHandlers(
+      () => voice,
+      null,
+      "AltRight",
+    );
+
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    expect(voice.start).toHaveBeenCalledOnce();
+
+    voice.state = "recording";
+    onKeyUp(keyEvent({ code: "AltRight" }));
+    expect(voice.stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops recording on window blur during hold (critical edge case)", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown, onBlur } = createVoiceHotkeyHandlers(
+      () => voice,
+      null,
+      "AltRight",
+    );
+
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    voice.state = "recording";
+
+    onBlur(); // window loses focus mid-hold
+    expect(voice.stop).toHaveBeenCalledOnce();
+  });
+
+  it("ignores OS-repeat keydowns after initial press", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, "AltRight");
+
+    onKeyDown(keyEvent({ code: "AltRight" })); // initial
+    voice.state = "starting";
+    onKeyDown(keyEvent({ code: "AltRight", repeat: true })); // OS repeat
+    onKeyDown(keyEvent({ code: "AltRight", repeat: true })); // OS repeat
+
+    expect(voice.start).toHaveBeenCalledOnce();
+  });
+
+  it("late keyup after blur does not double-stop", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown, onKeyUp, onBlur } = createVoiceHotkeyHandlers(
+      () => voice,
+      null,
+      "AltRight",
+    );
+
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    voice.state = "recording";
+    onBlur(); // clears holdActive
+    voice.state = "idle";
+    onKeyUp(keyEvent({ code: "AltRight" })); // arrives after blur already fired
+
+    // stop() should only have been called once (by blur)
+    expect(voice.stop).toHaveBeenCalledOnce();
+  });
+
+  it("does not start hold when voice is not idle", () => {
+    const voice = makeVoice("transcribing");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, "AltRight");
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    expect(voice.start).not.toHaveBeenCalled();
+  });
+
+  it("does not stop on keyup for a different key code", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown, onKeyUp } = createVoiceHotkeyHandlers(
+      () => voice,
+      null,
+      "AltRight",
+    );
+
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    voice.state = "recording";
+    onKeyUp(keyEvent({ code: "AltLeft" })); // different key
+    expect(voice.stop).not.toHaveBeenCalled();
+
+    onKeyUp(keyEvent({ code: "AltRight" })); // correct key
+    expect(voice.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/src/ui/src/hooks/useVoiceHotkey.test.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.test.ts
@@ -118,6 +118,23 @@ describe("createVoiceHotkeyHandlers — toggle", () => {
     expect(voice.cancel).toHaveBeenCalledOnce();
   });
 
+  it("starts from setup-required (post-permission-grant recovery)", () => {
+    // Repro for the bug where hotkey did nothing after the user granted TCC
+    // perms — the controller was sitting in setup-required and only the mic
+    // button's catchall onClick would re-attempt start().
+    const voice = makeVoice("setup-required");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.start).toHaveBeenCalledOnce();
+  });
+
+  it("starts from error state (clears error and retries)", () => {
+    const voice = makeVoice("error");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.start).toHaveBeenCalledOnce();
+  });
+
   it("cancels when transcribing", () => {
     const voice = makeVoice("transcribing");
     const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, "mod+shift+m", null);
@@ -222,11 +239,27 @@ describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
     expect(voice.stop).toHaveBeenCalledOnce();
   });
 
-  it("does not start hold when voice is not idle", () => {
-    const voice = makeVoice("transcribing");
+  it("does not start hold when voice is recording/starting/transcribing", () => {
+    for (const state of ["recording", "starting", "transcribing"] as const) {
+      const voice = makeVoice(state);
+      const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, "AltRight");
+      onKeyDown(keyEvent({ code: "AltRight" }));
+      expect(voice.start, `state=${state}`).not.toHaveBeenCalled();
+    }
+  });
+
+  it("starts hold from setup-required (post-permission-grant recovery)", () => {
+    const voice = makeVoice("setup-required");
     const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, "AltRight");
     onKeyDown(keyEvent({ code: "AltRight" }));
-    expect(voice.start).not.toHaveBeenCalled();
+    expect(voice.start).toHaveBeenCalledOnce();
+  });
+
+  it("starts hold from error state", () => {
+    const voice = makeVoice("error");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, "AltRight");
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    expect(voice.start).toHaveBeenCalledOnce();
   });
 
   it("does not stop on keyup for a different key code", () => {

--- a/src/ui/src/hooks/useVoiceHotkey.test.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.test.ts
@@ -37,6 +37,7 @@ function keyEvent(
     shiftKey: boolean;
     altKey: boolean;
     repeat: boolean;
+    getModifierState: (m: string) => boolean;
   }>,
 ): KeyboardEvent {
   return {
@@ -48,6 +49,7 @@ function keyEvent(
     altKey: false,
     repeat: false,
     preventDefault: vi.fn(),
+    getModifierState: () => false,
     ...overrides,
   } as unknown as KeyboardEvent;
 }
@@ -277,5 +279,66 @@ describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
 
     onKeyUp(keyEvent({ code: "AltRight" })); // correct key
     expect(voice.stop).toHaveBeenCalledOnce();
+  });
+
+  it("ignores AltGr presses (Right Alt on non-US layouts)", () => {
+    // AltGr fires e.key === "AltGraph" on most browsers, sometimes also as
+    // ctrlKey+altKey, sometimes only as a modifier-state flag. All forms
+    // must be ignored so typing @ / {} on a German/French/Spanish layout
+    // doesn't start voice recording.
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(() => voice, null, "AltRight");
+
+    onKeyDown(keyEvent({ code: "AltRight", key: "AltGraph" }));
+    expect(voice.start).not.toHaveBeenCalled();
+
+    onKeyDown(keyEvent({ code: "AltRight", ctrlKey: true, altKey: true }));
+    expect(voice.start).not.toHaveBeenCalled();
+
+    onKeyDown(keyEvent({
+      code: "AltRight",
+      getModifierState: (m) => m === "AltGraph",
+    }));
+    expect(voice.start).not.toHaveBeenCalled();
+  });
+});
+
+describe("createVoiceHotkeyHandlers — input blocked gate", () => {
+  it("blocks toggle from starting recording when an overlay is open", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(
+      () => voice,
+      "mod+shift+m",
+      null,
+      () => true, // overlay open
+    );
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.start).not.toHaveBeenCalled();
+  });
+
+  it("still allows toggle to STOP an in-flight recording when overlay is open", () => {
+    // If user opens settings while recording, the hotkey must still be able
+    // to end the recording — otherwise it gets stuck on.
+    const voice = makeVoice("recording");
+    const { onKeyDown } = createVoiceHotkeyHandlers(
+      () => voice,
+      "mod+shift+m",
+      null,
+      () => true,
+    );
+    onKeyDown(keyEvent({ key: "m", metaKey: true, shiftKey: true }));
+    expect(voice.stop).toHaveBeenCalledOnce();
+  });
+
+  it("blocks hold from starting when overlay is open", () => {
+    const voice = makeVoice("idle");
+    const { onKeyDown } = createVoiceHotkeyHandlers(
+      () => voice,
+      null,
+      "AltRight",
+      () => true,
+    );
+    onKeyDown(keyEvent({ code: "AltRight" }));
+    expect(voice.start).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/src/hooks/useVoiceHotkey.test.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.test.ts
@@ -196,9 +196,13 @@ describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
     expect(voice.stop).toHaveBeenCalledOnce();
   });
 
-  it("stops recording on window blur during hold (critical edge case)", () => {
+  it("clears holdActive on blur so a late keyup is a no-op", () => {
+    // useVoiceInput owns the actual stop-on-blur (so it applies to recordings
+    // started by mic button or toggle hotkey too). The hotkey's onBlur job is
+    // narrower: clear the closure-local holdActive so a stale keyup arriving
+    // later doesn't trigger spurious behavior.
     const voice = makeVoice("idle");
-    const { onKeyDown, onBlur } = createVoiceHotkeyHandlers(
+    const { onKeyDown, onKeyUp, onBlur } = createVoiceHotkeyHandlers(
       () => voice,
       null,
       "AltRight",
@@ -206,9 +210,12 @@ describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
 
     onKeyDown(keyEvent({ code: "AltRight" }));
     voice.state = "recording";
+    onBlur();
+    voice.state = "idle";
+    onKeyUp(keyEvent({ code: "AltRight" }));
 
-    onBlur(); // window loses focus mid-hold
-    expect(voice.stop).toHaveBeenCalledOnce();
+    // No stop fired by the hotkey path — useVoiceInput handles that centrally.
+    expect(voice.stop).not.toHaveBeenCalled();
   });
 
   it("ignores OS-repeat keydowns after initial press", () => {
@@ -223,9 +230,11 @@ describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
     expect(voice.start).toHaveBeenCalledOnce();
   });
 
-  it("late keyup after blur does not double-stop", () => {
+  it("a fresh hold cycle works after a blur cleared holdActive", () => {
+    // After blur clears holdActive, the next physical press should start
+    // a new recording cleanly (rather than being blocked by a stale flag).
     const voice = makeVoice("idle");
-    const { onKeyDown, onKeyUp, onBlur } = createVoiceHotkeyHandlers(
+    const { onKeyDown, onBlur } = createVoiceHotkeyHandlers(
       () => voice,
       null,
       "AltRight",
@@ -233,12 +242,11 @@ describe("createVoiceHotkeyHandlers — hold-to-talk", () => {
 
     onKeyDown(keyEvent({ code: "AltRight" }));
     voice.state = "recording";
-    onBlur(); // clears holdActive
+    onBlur(); // clears holdActive (but useVoiceInput stops the recording)
     voice.state = "idle";
-    onKeyUp(keyEvent({ code: "AltRight" })); // arrives after blur already fired
 
-    // stop() should only have been called once (by blur)
-    expect(voice.stop).toHaveBeenCalledOnce();
+    onKeyDown(keyEvent({ code: "AltRight" })); // fresh press
+    expect(voice.start).toHaveBeenCalledTimes(2);
   });
 
   it("does not start hold when voice is recording/starting/transcribing", () => {

--- a/src/ui/src/hooks/useVoiceHotkey.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.ts
@@ -1,8 +1,23 @@
 import { useEffect, useLayoutEffect, useRef } from "react";
+import { useAppStore } from "../stores/useAppStore";
 import type { VoiceInputController } from "./useVoiceInput";
 
-export const DEFAULT_TOGGLE_HOTKEY = "mod+shift+m";
-export const DEFAULT_HOLD_HOTKEY = "AltRight";
+// Re-export so existing call sites (KeyboardSettings, tests) keep working.
+export {
+  DEFAULT_TOGGLE_HOTKEY,
+  DEFAULT_HOLD_HOTKEY_MAC,
+  getDefaultHoldHotkey,
+} from "../utils/voiceHotkeys";
+
+/** Detect AltGr — Right Alt on most non-US layouts produces this and is used
+ * to type common characters. We must never treat AltGr presses as hotkey
+ * activations. */
+function isAltGr(e: KeyboardEvent): boolean {
+  if (e.key === "AltGraph") return true;
+  // Some browsers/OSes report AltGr as Ctrl+Alt with code AltRight.
+  if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return true;
+  return e.code === "AltRight" && e.ctrlKey && e.altKey;
+}
 
 type VoiceHandle = Pick<VoiceInputController, "state" | "start" | "stop" | "cancel">;
 
@@ -78,6 +93,10 @@ export function createVoiceHotkeyHandlers(
   getVoice: () => VoiceHandle,
   toggleHotkey: string | null,
   holdHotkey: string | null,
+  /** Returns true when the hotkey should not fire START actions (e.g. a modal
+   * or settings panel is open). Stop/cancel/release actions still run so an
+   * in-flight recording can always be ended. */
+  isInputBlocked: () => boolean = () => false,
 ): {
   onKeyDown: (e: KeyboardEvent) => void;
   onKeyUp: (e: KeyboardEvent) => void;
@@ -105,17 +124,21 @@ export function createVoiceHotkeyHandlers(
           v.stop();
         } else if (v.state === "starting" || v.state === "transcribing") {
           v.cancel();
-        } else {
-          // idle, setup-required, or error — try start. Mirrors the mic
-          // button's catchall: from setup-required, start() re-runs the
-          // provider check (now succeeding after the user granted perms);
-          // from error, it clears the error and re-attempts. Without this,
-          // the hotkey was a silent no-op in those states and recovery
-          // required clicking the mic button.
+        } else if (!isInputBlocked()) {
+          // idle, setup-required, or error — try start (only when no overlay
+          // owns input focus). Mirrors the mic button's catchall: from
+          // setup-required, start() re-runs the provider check (now
+          // succeeding after the user granted perms); from error it clears
+          // the error and re-attempts.
           void v.start();
         }
         return;
       }
+
+      // Reject AltGr presses outright — Right Alt acts as AltGr on most
+      // non-US layouts and is used to type @, {}, ñ, ç, etc. Triggering
+      // hold-to-talk on those would break normal text entry.
+      if (holdHotkey && e.code === holdHotkey && isAltGr(e)) return;
 
       if (
         holdHotkey &&
@@ -123,7 +146,8 @@ export function createVoiceHotkeyHandlers(
         !holdActive &&
         v.state !== "recording" &&
         v.state !== "starting" &&
-        v.state !== "transcribing"
+        v.state !== "transcribing" &&
+        !isInputBlocked()
       ) {
         e.preventDefault();
         holdActive = true;
@@ -177,10 +201,18 @@ export function useVoiceHotkey(
   });
 
   useEffect(() => {
+    // Block START actions when an overlay owns input focus — same gating
+    // pattern as useKeyboardShortcuts.ts. Stop/cancel/release are never
+    // gated, so an in-flight recording can always be ended.
+    const isInputBlocked = () => {
+      const s = useAppStore.getState();
+      return s.settingsOpen || !!s.activeModal || s.commandPaletteOpen || s.fuzzyFinderOpen;
+    };
     const { onKeyDown, onKeyUp, onBlur } = createVoiceHotkeyHandlers(
       () => voiceRef.current,
       toggleHotkey,
       holdHotkey,
+      isInputBlocked,
     );
     window.addEventListener("keydown", onKeyDown);
     window.addEventListener("keyup", onKeyUp);

--- a/src/ui/src/hooks/useVoiceHotkey.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.ts
@@ -6,11 +6,19 @@ export const DEFAULT_HOLD_HOTKEY = "AltRight";
 
 type VoiceHandle = Pick<VoiceInputController, "state" | "start" | "stop" | "cancel">;
 
+/** Normalize a key name for use in the `+`-delimited combo format.
+ * "+" itself becomes "plus" so the serialized combo stays unambiguous
+ * (otherwise "mod+shift+" + "+" would split into a stray empty segment). */
+export function normalizeToggleKey(key: string): string {
+  if (key === "+") return "plus";
+  return key.toLowerCase();
+}
+
 /** Check if a keyboard event matches a stored toggle combo like "mod+shift+m". */
 export function matchesToggle(e: KeyboardEvent, hotkey: string): boolean {
   const parts = hotkey.toLowerCase().split("+");
   const key = parts[parts.length - 1];
-  if (!key || e.key.toLowerCase() !== key) return false;
+  if (!key || normalizeToggleKey(e.key) !== key) return false;
   const wantsMod = parts.includes("mod");
   const wantsShift = parts.includes("shift");
   const wantsAlt = parts.includes("alt");
@@ -30,6 +38,7 @@ export function formatToggleHotkey(hotkey: string | null, isMac: boolean): strin
         case "ctrl": return "Ctrl";
         case "shift": return isMac ? "⇧" : "Shift";
         case "alt": return isMac ? "⌥" : "Alt";
+        case "plus": return "+";
         default: return part.toUpperCase();
       }
     })
@@ -78,12 +87,13 @@ export function createVoiceHotkeyHandlers(
 
   return {
     onKeyDown(e: KeyboardEvent) {
-      // Suppress repeated hold-key events so the OS key-repeat doesn't
-      // re-trigger start(). The !e.repeat guard on the hold branch below
-      // already handles this, but we also preventDefault so the webview
-      // doesn't receive spurious Alt/Option characters while holding.
+      // Suppress repeated keydowns. Toggle and hold-to-talk both fire once per
+      // physical press, so OS key-repeat events should be eaten — otherwise
+      // a printable toggle binding (e.g. user rebinds to a single letter)
+      // would leak repeated characters into the focused input on hold.
       if (e.repeat) {
         if (holdHotkey && e.code === holdHotkey && holdActive) e.preventDefault();
+        if (toggleHotkey && matchesToggle(e, toggleHotkey)) e.preventDefault();
         return;
       }
 

--- a/src/ui/src/hooks/useVoiceHotkey.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.ts
@@ -105,13 +105,26 @@ export function createVoiceHotkeyHandlers(
           v.stop();
         } else if (v.state === "starting" || v.state === "transcribing") {
           v.cancel();
-        } else if (v.state === "idle") {
+        } else {
+          // idle, setup-required, or error — try start. Mirrors the mic
+          // button's catchall: from setup-required, start() re-runs the
+          // provider check (now succeeding after the user granted perms);
+          // from error, it clears the error and re-attempts. Without this,
+          // the hotkey was a silent no-op in those states and recovery
+          // required clicking the mic button.
           void v.start();
         }
         return;
       }
 
-      if (holdHotkey && e.code === holdHotkey && !holdActive && v.state === "idle") {
+      if (
+        holdHotkey &&
+        e.code === holdHotkey &&
+        !holdActive &&
+        v.state !== "recording" &&
+        v.state !== "starting" &&
+        v.state !== "transcribing"
+      ) {
         e.preventDefault();
         holdActive = true;
         void v.start();

--- a/src/ui/src/hooks/useVoiceHotkey.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.ts
@@ -60,24 +60,25 @@ export function formatToggleHotkey(hotkey: string | null, isMac: boolean): strin
     .join(isMac ? "" : "+");
 }
 
+const HOLD_KEY_DISPLAY: Record<string, { mac: string; other: string }> = {
+  AltRight: { mac: "Right ⌥", other: "Right Alt" },
+  AltLeft: { mac: "Left ⌥", other: "Left Alt" },
+  ControlRight: { mac: "Right ⌃", other: "Right Ctrl" },
+  ControlLeft: { mac: "Left ⌃", other: "Left Ctrl" },
+  ShiftRight: { mac: "Right ⇧", other: "Right Shift" },
+  ShiftLeft: { mac: "Left ⇧", other: "Left Shift" },
+  MetaRight: { mac: "Right ⌘", other: "Right Meta" },
+  MetaLeft: { mac: "Left ⌘", other: "Left Meta" },
+  Space: { mac: "Space", other: "Space" },
+  F13: { mac: "F13", other: "F13" },
+  F14: { mac: "F14", other: "F14" },
+  F15: { mac: "F15", other: "F15" },
+};
+
 /** Human-readable display of a hold key code (e.g. "AltRight" → "Right ⌥"). */
 export function formatHoldHotkey(code: string | null, isMac: boolean): string {
   if (!code) return "—";
-  const map: Record<string, { mac: string; other: string }> = {
-    AltRight: { mac: "Right ⌥", other: "Right Alt" },
-    AltLeft: { mac: "Left ⌥", other: "Left Alt" },
-    ControlRight: { mac: "Right ⌃", other: "Right Ctrl" },
-    ControlLeft: { mac: "Left ⌃", other: "Left Ctrl" },
-    ShiftRight: { mac: "Right ⇧", other: "Right Shift" },
-    ShiftLeft: { mac: "Left ⇧", other: "Left Shift" },
-    MetaRight: { mac: "Right ⌘", other: "Right Meta" },
-    MetaLeft: { mac: "Left ⌘", other: "Left Meta" },
-    Space: { mac: "Space", other: "Space" },
-    F13: { mac: "F13", other: "F13" },
-    F14: { mac: "F14", other: "F14" },
-    F15: { mac: "F15", other: "F15" },
-  };
-  const entry = map[code];
+  const entry = HOLD_KEY_DISPLAY[code];
   if (entry) return isMac ? entry.mac : entry.other;
   return code.replace(/^(?:Key|Digit)/, "");
 }

--- a/src/ui/src/hooks/useVoiceHotkey.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.ts
@@ -1,0 +1,171 @@
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { VoiceInputController } from "./useVoiceInput";
+
+export const DEFAULT_TOGGLE_HOTKEY = "mod+shift+m";
+export const DEFAULT_HOLD_HOTKEY = "AltRight";
+
+type VoiceHandle = Pick<VoiceInputController, "state" | "start" | "stop" | "cancel">;
+
+/** Check if a keyboard event matches a stored toggle combo like "mod+shift+m". */
+export function matchesToggle(e: KeyboardEvent, hotkey: string): boolean {
+  const parts = hotkey.toLowerCase().split("+");
+  const key = parts[parts.length - 1];
+  if (!key || e.key.toLowerCase() !== key) return false;
+  const wantsMod = parts.includes("mod");
+  const wantsShift = parts.includes("shift");
+  const wantsAlt = parts.includes("alt");
+  const hasMod = e.metaKey || e.ctrlKey;
+  return wantsMod === hasMod && wantsShift === e.shiftKey && wantsAlt === e.altKey;
+}
+
+/** Human-readable display of a toggle hotkey string (e.g. "mod+shift+m" → "⌘⇧M"). */
+export function formatToggleHotkey(hotkey: string | null, isMac: boolean): string {
+  if (!hotkey) return "—";
+  return hotkey
+    .split("+")
+    .map((part) => {
+      switch (part.toLowerCase()) {
+        case "mod": return isMac ? "⌘" : "Ctrl";
+        case "meta": return "⌘";
+        case "ctrl": return "Ctrl";
+        case "shift": return isMac ? "⇧" : "Shift";
+        case "alt": return isMac ? "⌥" : "Alt";
+        default: return part.toUpperCase();
+      }
+    })
+    .join(isMac ? "" : "+");
+}
+
+/** Human-readable display of a hold key code (e.g. "AltRight" → "Right ⌥"). */
+export function formatHoldHotkey(code: string | null, isMac: boolean): string {
+  if (!code) return "—";
+  const map: Record<string, { mac: string; other: string }> = {
+    AltRight: { mac: "Right ⌥", other: "Right Alt" },
+    AltLeft: { mac: "Left ⌥", other: "Left Alt" },
+    ControlRight: { mac: "Right ⌃", other: "Right Ctrl" },
+    ControlLeft: { mac: "Left ⌃", other: "Left Ctrl" },
+    ShiftRight: { mac: "Right ⇧", other: "Right Shift" },
+    ShiftLeft: { mac: "Left ⇧", other: "Left Shift" },
+    MetaRight: { mac: "Right ⌘", other: "Right Meta" },
+    MetaLeft: { mac: "Left ⌘", other: "Left Meta" },
+    Space: { mac: "Space", other: "Space" },
+    F13: { mac: "F13", other: "F13" },
+    F14: { mac: "F14", other: "F14" },
+    F15: { mac: "F15", other: "F15" },
+  };
+  const entry = map[code];
+  if (entry) return isMac ? entry.mac : entry.other;
+  return code.replace(/^(?:Key|Digit)/, "");
+}
+
+/**
+ * Factory that produces the raw event handlers for the voice hotkey state machine.
+ * Exported so tests can exercise the logic without mounting a React component.
+ *
+ * The hold-to-talk state is tracked in a closure variable shared across the
+ * three returned handlers, so they must all be created together and used as a set.
+ */
+export function createVoiceHotkeyHandlers(
+  getVoice: () => VoiceHandle,
+  toggleHotkey: string | null,
+  holdHotkey: string | null,
+): {
+  onKeyDown: (e: KeyboardEvent) => void;
+  onKeyUp: (e: KeyboardEvent) => void;
+  onBlur: () => void;
+} {
+  let holdActive = false;
+
+  return {
+    onKeyDown(e: KeyboardEvent) {
+      // Suppress repeated hold-key events so the OS key-repeat doesn't
+      // re-trigger start(). The !e.repeat guard on the hold branch below
+      // already handles this, but we also preventDefault so the webview
+      // doesn't receive spurious Alt/Option characters while holding.
+      if (e.repeat) {
+        if (holdHotkey && e.code === holdHotkey && holdActive) e.preventDefault();
+        return;
+      }
+
+      const v = getVoice();
+
+      if (toggleHotkey && matchesToggle(e, toggleHotkey)) {
+        e.preventDefault();
+        if (v.state === "recording") {
+          v.stop();
+        } else if (v.state === "starting" || v.state === "transcribing") {
+          v.cancel();
+        } else if (v.state === "idle") {
+          void v.start();
+        }
+        return;
+      }
+
+      if (holdHotkey && e.code === holdHotkey && !holdActive && v.state === "idle") {
+        e.preventDefault();
+        holdActive = true;
+        void v.start();
+      }
+    },
+
+    onKeyUp(e: KeyboardEvent) {
+      if (!holdHotkey || !holdActive || e.code !== holdHotkey) return;
+      holdActive = false;
+      const v = getVoice();
+      if (v.state === "recording" || v.state === "starting") {
+        v.stop();
+      }
+    },
+
+    // Window blur (e.g. Cmd+Tab to another app while holding the key) must
+    // be treated as a key release so the recording doesn't get stuck on.
+    onBlur() {
+      if (!holdActive) return;
+      holdActive = false;
+      const v = getVoice();
+      if (v.state === "recording" || v.state === "starting") {
+        v.stop();
+      }
+    },
+  };
+}
+
+/**
+ * Registers global keyboard shortcuts for voice input:
+ * - Toggle hotkey (default Cmd/Ctrl+Shift+M): start/stop recording.
+ * - Hold hotkey (default Right Alt/Option): hold to record, release to transcribe.
+ *
+ * Listeners are re-registered only when the hotkey config changes, not on
+ * every voice state update (voice state is read via a ref at handler time).
+ */
+export function useVoiceHotkey(
+  voice: VoiceInputController,
+  toggleHotkey: string | null,
+  holdHotkey: string | null,
+): void {
+  const voiceRef = useRef<VoiceInputController>(voice);
+
+  // Keep the ref in sync after every render so event handlers always read
+  // the latest voice state without being re-registered on every state change.
+  // useLayoutEffect (not render-time assignment) satisfies the React Compiler's
+  // requirement that refs are only mutated outside of render.
+  useLayoutEffect(() => {
+    voiceRef.current = voice;
+  });
+
+  useEffect(() => {
+    const { onKeyDown, onKeyUp, onBlur } = createVoiceHotkeyHandlers(
+      () => voiceRef.current,
+      toggleHotkey,
+      holdHotkey,
+    );
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [toggleHotkey, holdHotkey]);
+}

--- a/src/ui/src/hooks/useVoiceHotkey.ts
+++ b/src/ui/src/hooks/useVoiceHotkey.ts
@@ -164,15 +164,13 @@ export function createVoiceHotkeyHandlers(
       }
     },
 
-    // Window blur (e.g. Cmd+Tab to another app while holding the key) must
-    // be treated as a key release so the recording doesn't get stuck on.
+    // Window blur (e.g. Cmd+Tab away while holding the key): clear the
+    // hold-state flag so a stale keyup arriving later is a no-op. The
+    // actual recording stop is handled centrally by useVoiceInput so it
+    // applies regardless of how the recording was started (mic button,
+    // toggle hotkey, hold-to-talk).
     onBlur() {
-      if (!holdActive) return;
       holdActive = false;
-      const v = getVoice();
-      if (v.state === "recording" || v.state === "starting") {
-        v.stop();
-      }
     },
   };
 }

--- a/src/ui/src/hooks/useVoiceInput.test.ts
+++ b/src/ui/src/hooks/useVoiceInput.test.ts
@@ -15,6 +15,7 @@ vi.mock("react", () => ({
   useCallback: <T extends (...args: never[]) => unknown>(callback: T): T =>
     callback,
   useEffect: () => undefined,
+  useLayoutEffect: () => undefined,
   useMemo: <T>(factory: () => T): T => factory(),
   useRef: <T>(initial: T): { current: T } => ({ current: initial }),
   useState: <T>(initial: T): [T, (next: T) => void] => [initial, vi.fn()],
@@ -123,6 +124,36 @@ describe("useVoiceInput", () => {
     await controller.start();
     controller.cancel();
 
+    expect(voiceService.cancelVoiceRecording).toHaveBeenCalledWith(
+      "voice-distil-whisper-candle",
+    );
+  });
+
+  it("rolls back the native start when cancelled mid-await", async () => {
+    // Repro for the blur-during-starting race: stop() can't shut down a
+    // recording whose nativeProviderRef hasn't been set yet, so cancel()
+    // must flip cancelledRef BEFORE startVoiceRecording resolves and the
+    // post-await code in start() must honor it.
+    const onTranscript = vi.fn();
+    const controller = useVoiceInput(onTranscript, vi.fn());
+    const startPromise = deferred<undefined>();
+    voiceService.listVoiceProviders.mockResolvedValueOnce([
+      provider({
+        id: "voice-distil-whisper-candle",
+        kind: "local-model",
+        recordingMode: "native",
+      }),
+    ]);
+    voiceService.startVoiceRecording.mockReturnValueOnce(startPromise.promise);
+
+    const startCall = controller.start();
+    controller.cancel(); // simulate blur arriving mid-start
+    startPromise.resolve(undefined);
+    await startCall;
+    await flushPromises();
+
+    // Provider was rolled back (cancelVoiceRecording fired) and the
+    // controller didn't transition to "recording".
     expect(voiceService.cancelVoiceRecording).toHaveBeenCalledWith(
       "voice-distil-whisper-candle",
     );

--- a/src/ui/src/hooks/useVoiceInput.ts
+++ b/src/ui/src/hooks/useVoiceInput.ts
@@ -332,6 +332,16 @@ export function useVoiceInput(
     recognitionRef.current.stop();
   }, [onTranscript]);
 
+  // Stop any active recording when the window loses focus, regardless of how
+  // it was started (mic button, toggle hotkey, hold-to-talk). Without this,
+  // a Cmd+Tab away from the app would leave the mic hot in the background.
+  // stop() is internally gated — it's a no-op when no recording is in flight.
+  useEffect(() => {
+    const onBlur = () => stop();
+    window.addEventListener("blur", onBlur);
+    return () => window.removeEventListener("blur", onBlur);
+  }, [stop]);
+
   return {
     state,
     elapsedSeconds,

--- a/src/ui/src/hooks/useVoiceInput.ts
+++ b/src/ui/src/hooks/useVoiceInput.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   cancelVoiceRecording,
   listVoiceProviders,
@@ -213,6 +213,14 @@ export function useVoiceInput(
         return;
       }
 
+      // If cancel() (or blur) fired during the await, the recording must not
+      // be allowed to become active — roll the native provider back rather
+      // than letting the mic stay hot in the background.
+      if (cancelledRef.current) {
+        void cancelVoiceRecording(provider.id);
+        return;
+      }
+
       nativeProviderRef.current = provider.id;
       setElapsedSeconds(0);
       setState("recording");
@@ -334,13 +342,26 @@ export function useVoiceInput(
 
   // Stop any active recording when the window loses focus, regardless of how
   // it was started (mic button, toggle hotkey, hold-to-talk). Without this,
-  // a Cmd+Tab away from the app would leave the mic hot in the background.
-  // stop() is internally gated — it's a no-op when no recording is in flight.
+  // a Cmd+Tab away would leave the mic hot in the background.
+  //
+  // We must distinguish "starting" from "recording": during the brief window
+  // between user trigger and startVoiceRecording resolving, nativeProviderRef
+  // is still null and stop() is a no-op. cancel() flips cancelledRef so the
+  // in-flight start() rolls itself back after its await. State is read via a
+  // ref so the listener doesn't need to be re-registered on every transition.
+  const stateRef = useRef(state);
+  useLayoutEffect(() => {
+    stateRef.current = state;
+  });
+
   useEffect(() => {
-    const onBlur = () => stop();
+    const onBlur = () => {
+      if (stateRef.current === "starting") cancel();
+      else stop();
+    };
     window.addEventListener("blur", onBlur);
     return () => window.removeEventListener("blur", onBlur);
-  }, [stop]);
+  }, [stop, cancel]);
 
   return {
     state,

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -142,6 +142,7 @@
   "notifications_sound_session_start_desc": "Sound when a new session begins",
 
   "nav_editor": "Editor",
+  "nav_keyboard": "Keyboard",
   "editor_title": "Editor",
   "editor_gutter_base_label": "Git gutter base",
   "editor_gutter_base_desc": "Choose what the editor's git gutter (the colored markers next to line numbers) compares your buffer against.",
@@ -304,5 +305,17 @@
   "pinned_prompts_keep": "Keep",
   "pinned_prompts_delete_prompt": "Delete prompt",
   "pinned_prompts_confirm_delete_title": "Delete this prompt?",
-  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone."
+  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone.",
+
+  "keyboard_title": "Keyboard Shortcuts",
+  "keyboard_voice_section": "Voice input",
+  "keyboard_voice_toggle_label": "Toggle recording",
+  "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
+  "keyboard_voice_hold_label": "Hold to talk",
+  "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
+  "keyboard_rebind": "Rebind",
+  "keyboard_press_key": "Press a key…",
+  "keyboard_reset": "Reset",
+  "keyboard_disable": "Disable",
+  "keyboard_cancel": "Cancel"
 }

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -1,5 +1,9 @@
 import type { StateCreator } from "zustand";
 import { DEFAULT_THEME_ID, DEFAULT_LIGHT_THEME_ID } from "../../styles/themes";
+import {
+  DEFAULT_TOGGLE_HOTKEY,
+  getDefaultHoldHotkey,
+} from "../../utils/voiceHotkeys";
 import type { AppState } from "../useAppStore";
 
 export interface SettingsSlice {
@@ -119,8 +123,8 @@ export const createSettingsSlice: StateCreator<
   setDisable1mContext: (v) => set({ disable1mContext: v }),
   editorGitGutterBase: "head",
   setEditorGitGutterBase: (value) => set({ editorGitGutterBase: value }),
-  voiceToggleHotkey: "mod+shift+m",
+  voiceToggleHotkey: DEFAULT_TOGGLE_HOTKEY,
   setVoiceToggleHotkey: (hotkey) => set({ voiceToggleHotkey: hotkey }),
-  voiceHoldHotkey: "AltRight",
+  voiceHoldHotkey: getDefaultHoldHotkey(),
   setVoiceHoldHotkey: (hotkey) => set({ voiceHoldHotkey: hotkey }),
 });

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -51,6 +51,10 @@ export interface SettingsSlice {
   /// from the repo's base branch (matches the Changes panel).
   editorGitGutterBase: "head" | "merge_base";
   setEditorGitGutterBase: (value: "head" | "merge_base") => void;
+  voiceToggleHotkey: string | null;
+  setVoiceToggleHotkey: (hotkey: string | null) => void;
+  voiceHoldHotkey: string | null;
+  setVoiceHoldHotkey: (hotkey: string | null) => void;
 }
 
 export const createSettingsSlice: StateCreator<
@@ -115,4 +119,8 @@ export const createSettingsSlice: StateCreator<
   setDisable1mContext: (v) => set({ disable1mContext: v }),
   editorGitGutterBase: "head",
   setEditorGitGutterBase: (value) => set({ editorGitGutterBase: value }),
+  voiceToggleHotkey: "mod+shift+m",
+  setVoiceToggleHotkey: (hotkey) => set({ voiceToggleHotkey: hotkey }),
+  voiceHoldHotkey: "AltRight",
+  setVoiceHoldHotkey: (hotkey) => set({ voiceHoldHotkey: hotkey }),
 });

--- a/src/ui/src/utils/voiceHotkeys.ts
+++ b/src/ui/src/utils/voiceHotkeys.ts
@@ -1,0 +1,24 @@
+/** Voice hotkey constants and platform helpers.
+ *
+ * This file is intentionally small and dependency-free (no React, no Zustand)
+ * so it can be imported by both the hook (`useVoiceHotkey.ts`) and the
+ * settings slice (`settingsSlice.ts`) without creating a circular dependency.
+ */
+
+export const DEFAULT_TOGGLE_HOTKEY = "mod+shift+m";
+
+/** macOS-only default hold key. On Windows/Linux the same physical key is
+ * frequently bound to AltGr (used to type @, {}, ñ, ç, etc.), so binding
+ * voice input to it would break common text entry. Use null elsewhere and
+ * let users opt in via Settings → Keyboard. */
+export const DEFAULT_HOLD_HOTKEY_MAC = "AltRight";
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac/.test(navigator.platform) || /Mac OS X/.test(navigator.userAgent);
+}
+
+/** Platform-aware default for the hold-to-talk key. */
+export function getDefaultHoldHotkey(): string | null {
+  return isMacPlatform() ? DEFAULT_HOLD_HOTKEY_MAC : null;
+}


### PR DESCRIPTION
Closes sub-item 2 of #441.

## Summary

- **Toggle hotkey** (default `Cmd/Ctrl+Shift+M`): starts recording when idle, stops when recording, cancels when starting or transcribing. This combo is free in the existing shortcut scheme.
- **Hold-to-talk** (default `Right Alt / Right Option` on **macOS only**; disabled by default on Windows/Linux to avoid conflicting with AltGr text entry — opt in via Settings → Keyboard): walkie-talkie pattern — hold to record, release to stop and transcribe.

## How rebinding works

Settings → **Keyboard** (new section) shows both hotkeys with **Rebind**, **Reset**, and **Disable** controls. Clicking **Rebind** enters a capture mode; the next keydown is recorded and persisted via \`setAppSetting\`. Changes propagate immediately through Zustand — no app restart needed. **Reset** restores the platform-aware default (which is \`null\`/disabled for hold-to-talk on Windows/Linux).

## Edge cases

- \`event.repeat === true\` is silently ignored so OS key-repeat doesn't multi-fire start.
- Window blur during a hold is treated as a key-release (recording stops cleanly, not stuck on). This now applies to ANY active recording, not just hold-to-talk — Cmd+Tab away during a toggle/button-triggered recording also stops cleanly.
- Blur arriving during the brief \`starting\` state (before \`startVoiceRecording\` resolves) routes through \`cancel()\` and rolls the provider back, so the mic doesn't go hot in the background after the user has switched apps.
- A late \`keyup\` arriving after blur already cleared \`holdActive\` is a no-op.
- AltGr (Right Alt on most non-US keyboard layouts) is rejected at runtime in three forms: \`e.key === "AltGraph"\`, \`e.getModifierState("AltGraph")\`, and the \`Ctrl+Alt+code=AltRight\` signature. Combined with the platform-aware default, this means typing \`@\`/\`{}\`/\`ñ\` on non-US layouts never accidentally triggers voice.
- Hotkeys are gated when an overlay owns input focus (settings, modal, command palette, fuzzy finder) — same gating pattern as \`useKeyboardShortcuts.ts\`. Stop/cancel/release stay ungated so an in-flight recording can always be ended.

## Implementation

- \`utils/voiceHotkeys.ts\` — small dependency-free constants module (\`DEFAULT_TOGGLE_HOTKEY\`, \`DEFAULT_HOLD_HOTKEY_MAC\`, \`isMacPlatform\`, \`getDefaultHoldHotkey\`). Imported by both the hook and the Zustand slice.
- \`hooks/useVoiceHotkey.ts\` — new hook + \`createVoiceHotkeyHandlers\` factory (exported for testing) + format helpers + AltGr detection
- \`hooks/useVoiceHotkey.test.ts\` — 26 tests covering all state machine transitions, AltGr signatures, the overlay gate, and post-Escape preservation
- \`hooks/useVoiceInput.ts\` — central blur listener stops any active recording (mic button, toggle hotkey, hold-to-talk); cancellation rollback after \`startVoiceRecording\` await
- \`stores/slices/settingsSlice.ts\` — \`voiceToggleHotkey\` / \`voiceHoldHotkey\` Zustand state with platform-aware defaults
- \`App.tsx\` — loads persisted hotkey prefs on startup
- \`components/settings/sections/KeyboardSettings.tsx\` — settings UI with rebind/reset/disable; hotkey badge composes \`.iconBtn\` so it visually matches the adjacent buttons exactly
- \`components/chat/ChatInputArea.tsx\` — wires \`useVoiceHotkey(voice, toggleHotkey, holdHotkey)\` after the voice controller is created

## Test plan

- [x] \`bun run test\` passes (1181 tests)
- [x] \`bunx tsc -b\` clean
- [x] \`bun run lint:css\` passes
- [ ] Toggle \`Cmd+Shift+M\` starts/stops voice in the chat composer
- [ ] Hold \`Right Option\` (macOS) records; release transcribes
- [ ] Cmd+Tab during hold OR during a toggle-triggered recording stops cleanly
- [ ] Settings → Keyboard section visible; Rebind captures new key; Reset restores platform default; Disable shows "—"