### PR TITLE
docs: add voice input feature documentation

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -76,6 +76,7 @@ export default defineConfig({
             { slug: 'features/pinned-prompts' },
             { slug: 'features/theming' },
             { slug: 'features/notifications' },
+            { slug: 'features/voice-input' },
             { slug: 'features/keyboard-shortcuts' },
             { slug: 'features/per-repo-settings' },
             { slug: 'features/settings' },

--- a/site/src/components/AndMore.astro
+++ b/site/src/components/AndMore.astro
@@ -5,6 +5,7 @@ const items = [
   'Pinned slash commands in the composer',
   'Native <code>/review</code>, <code>/plan</code>, <code>/compact</code>, <code>/usage</code>',
   'Stable + nightly update channels',
+  'Voice input — Apple Speech, on-device Distil-Whisper, or Web Speech API',
   'Drag-and-drop file attachments',
   'SCM status persistence + PR integration',
   'Typewriter-style streaming reveal',

--- a/site/src/content/docs/features/keyboard-shortcuts.mdx
+++ b/site/src/content/docs/features/keyboard-shortcuts.mdx
@@ -39,6 +39,15 @@ Claudette supports keyboard shortcuts for fast navigation and common actions. Ho
 | `Shift + Tab` | Toggle plan mode |
 | `Escape` | Dismiss current overlay, or stop running agent |
 
+### Voice Input
+
+| Shortcut | Action |
+|----------|--------|
+| `⌘⇧M` (macOS) / `Ctrl+Shift+M` (Linux/Windows) | Toggle voice recording |
+| `Right ⌥` (macOS only) | Hold to record, release to transcribe |
+
+Both shortcuts are customisable in **Settings → Keyboard → Voice**. The hold-to-talk key is macOS-only by default but can be bound to any key on any platform. See [Voice Input](/claudette/features/voice-input/) for provider setup.
+
 ### Terminal Panes
 
 These fire only when a terminal pane has keyboard focus — they shadow the

--- a/site/src/content/docs/features/voice-input.mdx
+++ b/site/src/content/docs/features/voice-input.mdx
@@ -1,0 +1,72 @@
+---
+title: Voice Input
+description: Speak prompts directly into the chat composer using Apple Speech, on-device Distil-Whisper, or the Web Speech API.
+---
+
+Claudette lets you dictate prompts to the composer using your microphone. Three providers are available — the app picks the best one automatically, or you can pin a specific provider in Settings.
+
+## Providers
+
+| Provider | Platforms | Runs where | Notes |
+|----------|-----------|-----------|-------|
+| **Apple Speech** | macOS | On-device, OS-managed | Uses the native Speech framework. Fast and lightweight — no model download required. Needs microphone permission in System Settings → Privacy & Security → Microphone. |
+| **Distil-Whisper** | macOS, Linux, Windows | Fully on-device | Bundled local model (distil-whisper-large-v3). Downloads ~1.5 GB once from Hugging Face on first use; all subsequent transcription is offline. Metal GPU acceleration on macOS; CPU on Linux and Windows. |
+| **Web Speech API** | Linux, Windows (fallback) | Browser-managed | Used when native capture is unavailable. Quality and language support depend on the OS browser engine. |
+
+Claudette's automatic selection order: a **pinned** provider (if set and enabled) → any **ready local model** → **Apple Speech** → a provider that still needs setup. The mic button in the composer reflects whichever provider is active.
+
+## How to use
+
+Click the **microphone icon** in the chat composer, or use a keyboard shortcut:
+
+| Shortcut | Action |
+|----------|--------|
+| `⌘⇧M` (macOS) / `Ctrl+Shift+M` (Linux/Windows) | Toggle recording on/off |
+| `Right ⌥` (macOS) | Hold to record, release to transcribe |
+
+Hold-to-talk (`Right ⌥`) is macOS-only by default. Linux and Windows users can bind any key in **Settings → Keyboard → Voice: Hold to talk**.
+
+While recording, a live VU meter appears next to the mic button — bar height tracks your microphone level in real time. A noise gate filters out silence, so you don't need to click precisely around pauses.
+
+When you stop recording, the transcription is inserted at the cursor position in the composer. You can edit it before sending.
+
+## Language support
+
+Distil-Whisper supports **99 languages** via Whisper language codes. The model auto-detects the spoken language; no per-session configuration is needed.
+
+Apple Speech uses the system's active language and locale settings.
+
+## Setting up
+
+### Apple Speech
+
+macOS requires an explicit microphone permission grant. The first time you start recording, macOS will prompt you. You can also grant it in advance:
+
+**System Settings → Privacy & Security → Microphone → Claudette**
+
+### Distil-Whisper
+
+Open **Settings → Plugins** and find the **Voice Input** section. Click **Download model** next to Distil-Whisper. The download is roughly 1.5 GB and happens once — subsequent launches load the cached model from disk. The cache path is shown in the provider row.
+
+Once the download completes, click **Use** to pin Distil-Whisper as the active provider.
+
+To free up disk space, click **Remove model** at any time. The model will be re-downloaded if you enable the provider again.
+
+### Keyboard shortcuts
+
+Voice hotkeys can be customised or disabled in **Settings → Keyboard**, under the **Voice** group. Both the toggle shortcut and the hold-to-talk key are independently configurable.
+
+## Configuring providers
+
+All voice provider management lives in **Settings → Plugins → Voice Input**:
+
+- **Enable/disable** each provider independently
+- **Select** (pin) a specific provider as the preferred one
+- **Download** or **remove** the Distil-Whisper model
+- See the model size, cache path, and accelerator in use (Metal / CPU)
+
+## Privacy
+
+All transcription runs on your machine. Distil-Whisper performs inference entirely locally via [Candle](https://github.com/huggingface/candle) — no audio leaves the app. Apple Speech sends audio to Apple's servers per their privacy policy; if that matters for your workflow, use Distil-Whisper instead.
+
+The Distil-Whisper model is fetched from `huggingface.co/distil-whisper/distil-large-v3/` on first use. After that, no network access is needed for voice.

--- a/site/src/content/docs/features/voice-input.mdx
+++ b/site/src/content/docs/features/voice-input.mdx
@@ -9,8 +9,8 @@ Claudette lets you dictate prompts to the composer using your microphone. Three 
 
 | Provider | Platforms | Runs where | Notes |
 |----------|-----------|-----------|-------|
-| **Apple Speech** | macOS | On-device, OS-managed | Uses the native Speech framework. Fast and lightweight — no model download required. Needs microphone permission in System Settings → Privacy & Security → Microphone. |
-| **Distil-Whisper** | macOS, Linux, Windows | Fully on-device | Bundled local model (distil-whisper-large-v3). Downloads ~1.5 GB once from Hugging Face on first use; all subsequent transcription is offline. Metal GPU acceleration on macOS; CPU on Linux and Windows. |
+| **Apple Speech** | macOS | On-device, OS-managed | Uses the native Speech framework. Fast and lightweight — no model download required. Requires Microphone and Speech Recognition permission in System Settings. |
+| **Distil-Whisper** | macOS, Linux, Windows | Fully on-device | Uses the [`distil-whisper/distil-large-v3`](https://huggingface.co/distil-whisper/distil-large-v3) model (~1.5 GB), downloaded once from Hugging Face on first use and cached locally. All subsequent transcription is offline. Metal GPU acceleration on macOS; CPU on Linux and Windows. |
 | **Web Speech API** | Linux, Windows (fallback) | Browser-managed | Used when native capture is unavailable. Quality and language support depend on the OS browser engine. |
 
 Claudette's automatic selection order: a **pinned** provider (if set and enabled) → any **ready local model** → **Apple Speech** → a provider that still needs setup. The mic button in the composer reflects whichever provider is active.
@@ -40,9 +40,10 @@ Apple Speech uses the system's active language and locale settings.
 
 ### Apple Speech
 
-macOS requires an explicit microphone permission grant. The first time you start recording, macOS will prompt you. You can also grant it in advance:
+macOS requires two permissions — **Microphone** and **Speech Recognition**. The first time you start recording, macOS will prompt for both. You can also grant them in advance:
 
-**System Settings → Privacy & Security → Microphone → Claudette**
+- **System Settings → Privacy & Security → Microphone → Claudette**
+- **System Settings → Privacy & Security → Speech Recognition → Claudette**
 
 ### Distil-Whisper
 
@@ -67,6 +68,6 @@ All voice provider management lives in **Settings → Plugins → Voice Input**:
 
 ## Privacy
 
-All transcription runs on your machine. Distil-Whisper performs inference entirely locally via [Candle](https://github.com/huggingface/candle) — no audio leaves the app. Apple Speech sends audio to Apple's servers per their privacy policy; if that matters for your workflow, use Distil-Whisper instead.
+**Distil-Whisper** performs inference entirely locally via [Candle](https://github.com/huggingface/candle) — audio never leaves the app. The model is fetched from `huggingface.co/distil-whisper/distil-large-v3/` on first use; after that, no network access is needed for voice.
 
-The Distil-Whisper model is fetched from `huggingface.co/distil-whisper/distil-large-v3/` on first use. After that, no network access is needed for voice.
+**Apple Speech** and **Web Speech API** may process audio off-device depending on OS and browser settings. Apple's offline behavior varies by language support; the Web Speech API's behavior depends on the browser engine. If strict on-device processing is required, use Distil-Whisper.


### PR DESCRIPTION
## Summary

- Adds `site/src/content/docs/features/voice-input.mdx` — a full feature doc covering all three providers (Apple Speech, Distil-Whisper, Web Speech API), keyboard shortcuts, per-provider setup steps, language support (99 languages via Whisper), and privacy guarantees
- Registers the new page in the Starlight sidebar under **Core Features** (between Notifications and Keyboard Shortcuts)
- Updates `keyboard-shortcuts.mdx` with a **Voice Input** shortcut table and a cross-link to the new doc
- Adds a voice input bullet to the `AndMore.astro` homepage strip

Voice input has been shipping for several releases but was never called out in the docs or on the website — this closes that gap.

## Test Steps

1. Run `cd site && bun install && bun run build` — should complete with no errors and emit `features/voice-input/index.html`
2. Run `cd site && bun run dev` and open http://localhost:4321/claudette/features/voice-input/ — verify the page renders with correct sidebar position
3. Open http://localhost:4321/claudette/features/keyboard-shortcuts/ — confirm the Voice Input section appears with both shortcuts and the cross-link works
4. Open the homepage — confirm "Voice input" appears in the "And more" strip

## Checklist

- [x] Documentation updated
- [x] Site build passes (`astro build` — 32 pages, no errors)