### PR TITLE
chore: add Anthropic trademark disclaimer footer

### DIFF
--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -59,6 +59,7 @@ const year = new Date().getFullYear();
 
   <div class="f-bottom">
     <span>© {year} Utensils · MIT licensed</span>
+    <span class="f-legal">Claude® and Claude Code® are trademarks of Anthropic, PBC. Claudette is not affiliated with Anthropic.</span>
     <span>Made with Tauri 2 · Rust · React</span>
   </div>
 </footer>

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -16,6 +16,7 @@ import { ModalRouter } from "../modals/ModalRouter";
 import { SettingsPage } from "../settings/SettingsPage";
 import { ResizeHandle } from "./ResizeHandle";
 import { ToastContainer } from "./Toast";
+import { Footer } from "./Footer";
 import { useAgentStream } from "../../hooks/useAgentStream";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useBranchRefresh } from "../../hooks/useBranchRefresh";
@@ -183,6 +184,7 @@ export function AppLayout() {
       {fuzzyFinderOpen && <FuzzyFinder />}
       {commandPaletteOpen && <CommandPalette />}
       <ToastContainer />
+      <Footer />
     </div>
   );
 }

--- a/src/ui/src/components/layout/Footer.module.css
+++ b/src/ui/src/components/layout/Footer.module.css
@@ -1,0 +1,9 @@
+.footer {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  font-size: 11px;
+  color: var(--text-dim);
+  border-top: 1px solid var(--divider);
+  text-align: center;
+  user-select: none;
+}

--- a/src/ui/src/components/layout/Footer.tsx
+++ b/src/ui/src/components/layout/Footer.tsx
@@ -1,0 +1,10 @@
+import styles from "./Footer.module.css";
+
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      Claudette is not affiliated with Anthropic. Claude® and Claude Code® are trademarks of
+      Anthropic, PBC.
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds the trademark notice to the **marketing website** footer (`site/src/components/SiteFooter.astro`) as a centered span in the bottom bar between the copyright and the tech-stack credits
- Also adds a slim `<Footer>` component to the **desktop app** (`AppLayout`) with the same text, visible at the bottom of every screen

Disclaimer text: *Claude® and Claude Code® are trademarks of Anthropic, PBC. Claudette is not affiliated with Anthropic.*

## Test Steps

**Website:**
1. Run the Astro site dev server (`cd site && npm run dev` or equivalent)
2. Scroll to the bottom of the homepage
3. Verify the trademark notice appears centered in the bottom bar between "© Utensils · MIT licensed" and "Made with Tauri 2 · Rust · React"

**Desktop app:**
1. Launch the app in dev mode (`cargo tauri dev`)
2. Verify the footer bar is visible at the bottom of the dashboard, workspace view, and settings page

## Checklist

- [ ] Tests added/updated — N/A (static text)
- [ ] Documentation updated — N/A