### PR TITLE
docs: update Discord invite link to non-expiring URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://codecov.io/gh/utensils/claudette"><img src="https://codecov.io/gh/utensils/claudette/graph/badge.svg" alt="codecov"/></a>
-  <a href="https://discord.gg/Ks9Ghnem"><img src="https://img.shields.io/discord/1491165880820699398?logo=discord&label=Discord" alt="Discord"/></a>
+  <a href="https://discord.gg/JQdfT3Z67F"><img src="https://img.shields.io/discord/1491165880820699398?logo=discord&label=Discord" alt="Discord"/></a>
   <a href="https://www.reddit.com/r/ClaudetteApp"><img src="https://img.shields.io/reddit/subreddit-subscribers/ClaudetteApp?style=social" alt="Reddit"/></a>
 </p>
 
@@ -263,7 +263,7 @@ All traffic is encrypted with TLS. The local app pins the server's certificate f
 
 ## Community
 
-Join us on [Discord](https://discord.gg/aumGBKccmD) to ask questions, share feedback, and connect with other Claudette users.
+Join us on [Discord](https://discord.gg/JQdfT3Z67F) to ask questions, share feedback, and connect with other Claudette users.
 
 ## Contributing
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
         {
           icon: 'discord',
           label: 'Discord',
-          href: 'https://discord.gg/aumGBKccmD',
+          href: 'https://discord.gg/JQdfT3Z67F',
         },
         {
           icon: 'reddit',

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -7,7 +7,7 @@ const project = [
 ];
 
 const community = [
-  { label: 'Discord', href: 'https://discord.gg/aumGBKccmD' },
+  { label: 'Discord', href: 'https://discord.gg/JQdfT3Z67F' },
   { label: 'r/ClaudetteApp', href: 'https://www.reddit.com/r/ClaudetteApp/' },
   { label: 'Issues', href: 'https://github.com/utensils/Claudette/issues' },
   { label: 'Contributing', href: 'https://github.com/utensils/Claudette/blob/main/CONTRIBUTING.md' },

--- a/site/src/content/docs/contributing-translations.md
+++ b/site/src/content/docs/contributing-translations.md
@@ -50,4 +50,4 @@ If you only want to fix a typo or polish wording in an existing language, the pr
 
 ## Questions?
 
-Hop into our [Discord](https://discord.gg/aumGBKccmD) and ask in the contributors channel, or open a discussion on GitHub. Translations are a fantastic way to make Claudette accessible to people who would otherwise have to work in a second language — thank you for helping out.
+Hop into our [Discord](https://discord.gg/JQdfT3Z67F) and ask in the contributors channel, or open a discussion on GitHub. Translations are a fantastic way to make Claudette accessible to people who would otherwise have to work in a second language — thank you for helping out.


### PR DESCRIPTION
## Summary

- Replaces two expired/expiring Discord invite codes (`Ks9Ghnem`, `aumGBKccmD`) with the permanent invite link `JQdfT3Z67F` across all 4 reference points in the repo.

## Test Steps

1. Click the Discord badge in `README.md` — should land on the Claudette Discord server.
2. Visit the docs site and click the Discord icon in the nav/footer — same destination.
3. Check `site/src/content/docs/contributing-translations.md` questions section link.

## Checklist

- [x] No code changes — docs/config only
- [ ] Documentation updated (if applicable)