### PR TITLE
feat(terminal): agent background terminal tabs + drag/context-menu polish

### DIFF
--- a/src-tauri/src/commands/chat/lifecycle.rs
+++ b/src-tauri/src/commands/chat/lifecycle.rs
@@ -169,6 +169,7 @@ mod tests {
             session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
             running_background_tasks: Default::default(),
+            background_wake_active: false,
             session_exited_plan: false,
             session_resolved_env: Default::default(),
             mcp_bridge: None,

--- a/src-tauri/src/commands/chat/lifecycle.rs
+++ b/src-tauri/src/commands/chat/lifecycle.rs
@@ -168,6 +168,7 @@ mod tests {
             session_allowed_tools: Vec::new(),
             session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
+            running_background_tasks: Default::default(),
             session_exited_plan: false,
             session_resolved_env: Default::default(),
             mcp_bridge: None,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -60,6 +60,13 @@ fn emit_agent_background_task_event(
     let _ = app.emit("agent-background-task", &payload);
 }
 
+fn is_terminal_task_status(status: &str) -> bool {
+    matches!(
+        status.to_ascii_lowercase().as_str(),
+        "completed" | "failed" | "stopped" | "killed" | "cancelled" | "canceled"
+    )
+}
+
 fn create_agent_task_terminal_tab(
     db_path: &std::path::Path,
     workspace_id: &str,
@@ -1149,6 +1156,50 @@ pub async fn send_chat_message(
                 got_init = true;
             }
 
+            // Claude Code emits a structured SDK event for terminal
+            // task-notifications before feeding the XML notification back to
+            // the model. Use it to keep read-only agent task tabs accurate
+            // even when the corresponding user-role XML is collapsed or delayed.
+            if let AgentEvent::Stream(StreamEvent::System {
+                subtype,
+                task_id: Some(task_id),
+                status: Some(status),
+                output_file,
+                summary,
+                ..
+            }) = &event
+                && subtype == "task_notification"
+                && let Ok(db) = Database::open(&db_path)
+            {
+                if is_terminal_task_status(status) {
+                    let app_state = app.state::<AppState>();
+                    let mut agents = app_state.agents.write().await;
+                    if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
+                        session.running_background_tasks.remove(task_id);
+                    }
+                }
+                let output_file = output_file.as_deref().filter(|s| !s.trim().is_empty());
+                let summary = summary.as_deref().filter(|s| !s.trim().is_empty());
+                let _ = db.update_agent_task_terminal_tab_status(
+                    &chat_session_id_for_stream,
+                    task_id,
+                    status,
+                    summary,
+                    output_file,
+                );
+                if let Ok(Some(tab)) =
+                    db.get_terminal_tab_by_agent_task(&chat_session_id_for_stream, task_id)
+                {
+                    emit_agent_background_task_event(
+                        &app,
+                        AgentBackgroundTaskEventKind::Status,
+                        &ws_id,
+                        &chat_session_id_for_stream,
+                        tab,
+                    );
+                }
+            }
+
             if let AgentEvent::Stream(StreamEvent::Stream {
                 event:
                     InnerStreamEvent::ContentBlockStart {
@@ -1493,10 +1544,12 @@ pub async fn send_chat_message(
                         if let Some(notification) = parse_task_notification(body)
                             && let Ok(db) = Database::open(&db_path)
                         {
-                            if matches!(
-                                notification.status.to_ascii_lowercase().as_str(),
-                                "completed" | "failed" | "stopped" | "cancelled" | "canceled"
-                            ) {
+                            let status = notification.status.as_deref().unwrap_or("running");
+                            if notification
+                                .status
+                                .as_deref()
+                                .is_some_and(is_terminal_task_status)
+                            {
                                 let app_state = app.state::<AppState>();
                                 let mut agents = app_state.agents.write().await;
                                 if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
@@ -1508,7 +1561,7 @@ pub async fn send_chat_message(
                             let _ = db.update_agent_task_terminal_tab_status(
                                 &chat_session_id_for_stream,
                                 &notification.task_id,
-                                &notification.status,
+                                status,
                                 notification.summary.as_deref(),
                                 notification.output_file.as_deref(),
                             );

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -17,7 +17,7 @@ use claudette::chat::{
     build_compaction_sentinel, build_permission_response, create_turn_checkpoint,
     extract_assistant_text, extract_event_thinking, persistent_session_flags_drifted,
 };
-use claudette::db::Database;
+use claudette::db::{CLAUDETTE_TERMINAL_TITLE, Database};
 use claudette::env::WorkspaceEnv;
 use claudette::mcp_supervisor::McpSupervisor;
 use claudette::model::{ChatMessage, ChatRole, TerminalTab, TerminalTabKind};
@@ -125,19 +125,22 @@ fn get_or_create_agent_shell_terminal_tab(
     chat_session_id: &str,
 ) -> Option<TerminalTab> {
     let db = Database::open(db_path).ok()?;
-    if let Ok(Some(tab)) = db.get_agent_shell_terminal_tab(chat_session_id) {
+    if let Ok(Some(mut tab)) = db.get_agent_shell_terminal_tab(chat_session_id) {
+        if tab.title != CLAUDETTE_TERMINAL_TITLE {
+            let _ = db.update_terminal_tab_title(tab.id, CLAUDETTE_TERMINAL_TITLE);
+            tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
+        }
         return Some(tab);
     }
     let max_id = db.max_terminal_tab_id().ok()?;
-    let existing = db.list_terminal_tabs_by_workspace(workspace_id).ok()?;
     let output_path = agent_bash_output_path(chat_session_id);
     let tab = TerminalTab {
         id: max_id + 1,
         workspace_id: workspace_id.to_string(),
-        title: "Agent shell".to_string(),
+        title: CLAUDETTE_TERMINAL_TITLE.to_string(),
         kind: TerminalTabKind::AgentTask,
         is_script_output: false,
-        sort_order: existing.len() as i32,
+        sort_order: 0,
         created_at: now_iso(),
         agent_chat_session_id: Some(chat_session_id.to_string()),
         agent_tool_use_id: None,
@@ -163,6 +166,7 @@ async fn apply_task_notification_status(
     workspace_id: &str,
     chat_session_id: &str,
     task_id: &str,
+    tool_use_id: Option<&str>,
     status: &str,
     summary: Option<&str>,
     output_file: Option<&str>,
@@ -175,6 +179,9 @@ async fn apply_task_notification_status(
         let mut agents = app_state.agents.write().await;
         if let Some(session) = agents.get_mut(chat_session_id) {
             session.running_background_tasks.remove(task_id);
+            if let Some(tool_use_id) = tool_use_id {
+                session.running_background_tasks.remove(tool_use_id);
+            }
         }
     }
     let _ = db.update_agent_task_terminal_tab_status(
@@ -276,6 +283,9 @@ fn schedule_background_task_wake(
             if let AgentEvent::Stream(StreamEvent::System {
                 subtype,
                 task_id: Some(task_id),
+                tool_use_id,
+                output_file,
+                summary,
                 status: Some(status),
                 ..
             }) = &event
@@ -289,9 +299,10 @@ fn schedule_background_task_wake(
                     &workspace_id,
                     &chat_session_id,
                     task_id,
+                    tool_use_id.as_deref(),
                     status,
-                    None,
-                    None,
+                    summary.as_deref(),
+                    output_file.as_deref(),
                 )
                 .await;
             }
@@ -309,6 +320,7 @@ fn schedule_background_task_wake(
                     &workspace_id,
                     &chat_session_id,
                     &notification.task_id,
+                    notification.tool_use_id.as_deref(),
                     status,
                     notification.summary.as_deref(),
                     notification.output_file.as_deref(),
@@ -332,6 +344,7 @@ fn schedule_background_task_wake(
                             &workspace_id,
                             &chat_session_id,
                             &notification.task_id,
+                            notification.tool_use_id.as_deref(),
                             status,
                             notification.summary.as_deref(),
                             notification.output_file.as_deref(),
@@ -1516,6 +1529,9 @@ pub async fn send_chat_message(
             if let AgentEvent::Stream(StreamEvent::System {
                 subtype,
                 task_id: Some(task_id),
+                tool_use_id,
+                output_file,
+                summary,
                 status: Some(status),
                 ..
             }) = &event
@@ -1527,9 +1543,10 @@ pub async fn send_chat_message(
                     &ws_id,
                     &chat_session_id_for_stream,
                     task_id,
+                    tool_use_id.as_deref(),
                     status,
-                    None,
-                    None,
+                    summary.as_deref(),
+                    output_file.as_deref(),
                 )
                 .await;
             }
@@ -1949,6 +1966,7 @@ pub async fn send_chat_message(
                                             &ws_id,
                                             &chat_session_id_for_stream,
                                             &notification.task_id,
+                                            notification.tool_use_id.as_deref(),
                                             status,
                                             notification.summary.as_deref(),
                                             notification.output_file.as_deref(),
@@ -1969,6 +1987,7 @@ pub async fn send_chat_message(
                                 &ws_id,
                                 &chat_session_id_for_stream,
                                 &notification.task_id,
+                                notification.tool_use_id.as_deref(),
                                 status,
                                 notification.summary.as_deref(),
                                 notification.output_file.as_deref(),

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -2443,4 +2443,17 @@ mod tests {
             "Building [======]\r\x1b[KBuilding [>]\r\ndone"
         );
     }
+
+    #[test]
+    fn terminal_text_preserves_ansi_sequences() {
+        assert_eq!(
+            terminal_text("\x1b[32mok\x1b[0m\n"),
+            "\x1b[32mok\x1b[0m\r\n"
+        );
+    }
+
+    #[test]
+    fn terminal_text_normalizes_crlf_without_extra_clear() {
+        assert_eq!(terminal_text("one\r\ntwo\r\n"), "one\r\ntwo\r\n");
+    }
 }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -217,12 +217,75 @@ async fn apply_task_notification_status(
     }
 }
 
-const BACKGROUND_TASK_WAKE_PROMPT: &str = "\
-<system-reminder>
-Claudette is waking this stream-json session so Claude Code can deliver queued background task notifications.
-First call the Sleep tool for 1 second so Claude Code can flush queued background task notifications.
-After Sleep returns, do not answer unless a <task-notification> is present in the runtime context. If no task notification is present yet, produce no user-facing text.
-</system-reminder>";
+#[derive(Debug, Clone)]
+struct BackgroundTaskCompletion {
+    task_id: String,
+    tool_use_id: Option<String>,
+    output_file: Option<String>,
+    status: String,
+    summary: Option<String>,
+}
+
+fn task_completion_from_notification(
+    notification: claudette::agent::background::TaskNotification,
+) -> Option<BackgroundTaskCompletion> {
+    let status = notification.status.unwrap_or_else(|| "running".to_string());
+    if !is_terminal_task_status(&status) {
+        return None;
+    }
+    Some(BackgroundTaskCompletion {
+        task_id: notification.task_id,
+        tool_use_id: notification.tool_use_id,
+        output_file: notification.output_file,
+        status,
+        summary: notification.summary,
+    })
+}
+
+fn read_background_output_for_prompt(output_file: Option<&str>) -> Option<String> {
+    let output_file = output_file?.trim();
+    if output_file.is_empty() {
+        return None;
+    }
+    let bytes = std::fs::read(output_file).ok()?;
+    const MAX_OUTPUT_BYTES: usize = 24_000;
+    let start = bytes.len().saturating_sub(MAX_OUTPUT_BYTES);
+    let mut text = String::from_utf8_lossy(&bytes[start..]).to_string();
+    if start > 0 {
+        text.insert_str(0, "[output truncated to last 24000 bytes]\n");
+    }
+    if text.trim().is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn build_background_task_completion_prompt(completion: &BackgroundTaskCompletion) -> String {
+    let mut prompt = format!(
+        "A background Bash task completed. Respond to the user now with the result.\n\n<task-notification>\n<task-id>{}</task-id>\n<status>{}</status>",
+        completion.task_id, completion.status
+    );
+    if let Some(tool_use_id) = completion.tool_use_id.as_deref() {
+        prompt.push_str(&format!("\n<tool-use-id>{tool_use_id}</tool-use-id>"));
+    }
+    if let Some(output_file) = completion.output_file.as_deref() {
+        prompt.push_str(&format!("\n<output-file>{output_file}</output-file>"));
+    }
+    if let Some(summary) = completion.summary.as_deref() {
+        prompt.push_str(&format!("\n<summary>{summary}</summary>"));
+    }
+    prompt.push_str("\n</task-notification>");
+    if let Some(output) = read_background_output_for_prompt(completion.output_file.as_deref()) {
+        prompt.push_str("\n\nOutput:\n```text\n");
+        prompt.push_str(&output);
+        if !output.ends_with('\n') {
+            prompt.push('\n');
+        }
+        prompt.push_str("```");
+    }
+    prompt
+}
 
 fn schedule_background_task_wake(
     app: AppHandle,
@@ -251,10 +314,95 @@ fn schedule_background_task_wake(
             return;
         };
 
-        let handle = match ps.send_turn(BACKGROUND_TASK_WAKE_PROMPT, &[]).await {
+        let mut rx = ps.subscribe();
+        let completion = loop {
+            let event = match tokio::time::timeout(Duration::from_secs(600), rx.recv()).await {
+                Ok(Ok(event)) => event,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) | Err(_) => {
+                    break None;
+                }
+            };
+
+            if let AgentEvent::ProcessExited(_) = &event {
+                break None;
+            }
+            if let AgentEvent::Stream(StreamEvent::System {
+                subtype,
+                task_id: Some(task_id),
+                tool_use_id,
+                output_file,
+                summary,
+                status: Some(status),
+                ..
+            }) = &event
+                && subtype == "task_notification"
+                && is_terminal_task_status(status)
+            {
+                break Some(BackgroundTaskCompletion {
+                    task_id: task_id.clone(),
+                    tool_use_id: tool_use_id.clone(),
+                    output_file: output_file.clone(),
+                    status: status.clone(),
+                    summary: summary.clone(),
+                });
+            }
+            if let AgentEvent::Stream(StreamEvent::User { message, .. }) = &event {
+                match &message.content {
+                    claudette::agent::UserMessageContent::Text(body) => {
+                        if let Some(notification) = parse_task_notification(body)
+                            && let Some(completion) =
+                                task_completion_from_notification(notification)
+                        {
+                            break Some(completion);
+                        }
+                    }
+                    claudette::agent::UserMessageContent::Blocks(blocks) => {
+                        let mut found = None;
+                        for block in blocks {
+                            if let claudette::agent::UserContentBlock::Text { text } = block
+                                && let Some(notification) = parse_task_notification(text)
+                                && let Some(completion) =
+                                    task_completion_from_notification(notification)
+                            {
+                                found = Some(completion);
+                                break;
+                            }
+                        }
+                        if found.is_some() {
+                            break found;
+                        }
+                    }
+                }
+            }
+        };
+
+        let Some(completion) = completion else {
+            let mut agents = app_state.agents.write().await;
+            if let Some(session) = agents.get_mut(&chat_session_id) {
+                session.background_wake_active = false;
+            }
+            return;
+        };
+
+        apply_task_notification_status(
+            &app,
+            &db_path,
+            &workspace_id,
+            &chat_session_id,
+            &completion.task_id,
+            completion.tool_use_id.as_deref(),
+            &completion.status,
+            completion.summary.as_deref(),
+            completion.output_file.as_deref(),
+        )
+        .await;
+
+        let prompt = build_background_task_completion_prompt(&completion);
+        let handle = match ps.send_turn(&prompt, &[]).await {
             Ok(handle) => handle,
             Err(err) => {
-                eprintln!("[chat] failed to wake background task notifications: {err}");
+                eprintln!("[chat] failed to deliver background task notification: {err}");
                 let mut agents = app_state.agents.write().await;
                 if let Some(session) = agents.get_mut(&chat_session_id) {
                     session.background_wake_active = false;
@@ -272,14 +420,11 @@ fn schedule_background_task_wake(
         crate::tray::rebuild_tray(&app);
 
         let mut rx = handle.event_rx;
-        let mut saw_task_notification = false;
         let mut last_assistant_msg_id: Option<String> = None;
         let mut pending_thinking: Option<String> = None;
         let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
 
         while let Some(event) = rx.recv().await {
-            let mut should_emit_stream = saw_task_notification;
-
             if let AgentEvent::Stream(StreamEvent::System {
                 subtype,
                 task_id: Some(task_id),
@@ -291,8 +436,6 @@ fn schedule_background_task_wake(
             }) = &event
                 && subtype == "task_notification"
             {
-                saw_task_notification = true;
-                should_emit_stream = true;
                 apply_task_notification_status(
                     &app,
                     &db_path,
@@ -311,8 +454,6 @@ fn schedule_background_task_wake(
                 && let claudette::agent::UserMessageContent::Text(body) = &message.content
                 && let Some(notification) = parse_task_notification(body)
             {
-                saw_task_notification = true;
-                should_emit_stream = true;
                 let status = notification.status.as_deref().unwrap_or("running");
                 apply_task_notification_status(
                     &app,
@@ -335,8 +476,6 @@ fn schedule_background_task_wake(
                     if let claudette::agent::UserContentBlock::Text { text } = block
                         && let Some(notification) = parse_task_notification(text)
                     {
-                        saw_task_notification = true;
-                        should_emit_stream = true;
                         let status = notification.status.as_deref().unwrap_or("running");
                         apply_task_notification_status(
                             &app,
@@ -351,24 +490,6 @@ fn schedule_background_task_wake(
                         )
                         .await;
                     }
-                }
-            }
-
-            if let AgentEvent::Stream(StreamEvent::ControlRequest {
-                request_id,
-                request:
-                    ControlRequestInner::CanUseTool {
-                        tool_name, input, ..
-                    },
-            }) = &event
-                && tool_name == "Sleep"
-            {
-                let response = serde_json::json!({
-                    "behavior": "allow",
-                    "updatedInput": input,
-                });
-                if let Err(err) = ps.send_control_response(request_id, response).await {
-                    eprintln!("[chat] failed to allow background wake Sleep: {err}");
                 }
             }
 
@@ -390,8 +511,7 @@ fn schedule_background_task_wake(
                         None => t,
                     });
                 }
-                if saw_task_notification
-                    && !full_text.trim().is_empty()
+                if !full_text.trim().is_empty()
                     && let Ok(db) = Database::open(&db_path)
                 {
                     let msg = build_assistant_chat_message(BuildAssistantArgs {
@@ -428,14 +548,12 @@ fn schedule_background_task_wake(
                 AgentEvent::Stream(StreamEvent::Result { .. }) | AgentEvent::ProcessExited(_)
             );
 
-            if should_emit_stream || (is_done && saw_task_notification) {
-                let payload = AgentStreamPayload {
-                    workspace_id: workspace_id.clone(),
-                    chat_session_id: chat_session_id.clone(),
-                    event,
-                };
-                let _ = app.emit("agent-stream", &payload);
-            }
+            let payload = AgentStreamPayload {
+                workspace_id: workspace_id.clone(),
+                chat_session_id: chat_session_id.clone(),
+                event,
+            };
+            let _ = app.emit("agent-stream", &payload);
 
             if is_done {
                 break;

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::background::{
-    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, parse_background_task_binding,
-    parse_bash_start, parse_task_notification,
+    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, agent_bash_output_path,
+    parse_background_task_binding, parse_bash_start, parse_task_notification,
 };
 use claudette::agent::{
     self, AgentEvent, AgentSettings, ControlRequestInner, FileAttachment, InnerStreamEvent,
@@ -46,13 +46,6 @@ fn emit_agent_background_task_event(
         tab,
     };
     let _ = app.emit("agent-background-task", &payload);
-}
-
-fn agent_bash_output_path(chat_session_id: &str) -> std::path::PathBuf {
-    std::env::temp_dir()
-        .join("claudette-agent-bash")
-        .join(chat_session_id)
-        .join("agent-shell.output")
 }
 
 fn terminal_text(text: &str) -> String {
@@ -125,11 +118,19 @@ fn get_or_create_agent_shell_terminal_tab(
     chat_session_id: &str,
 ) -> Option<TerminalTab> {
     let db = Database::open(db_path).ok()?;
-    if let Ok(Some(mut tab)) = db.get_agent_shell_terminal_tab(chat_session_id) {
-        if tab.title != CLAUDETTE_TERMINAL_TITLE {
-            let _ = db.update_terminal_tab_title(tab.id, CLAUDETTE_TERMINAL_TITLE);
-            tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
-        }
+    if let Ok(Some(mut tab)) = db.get_agent_shell_terminal_tab_by_workspace(workspace_id) {
+        let output_path = agent_bash_output_path(chat_session_id)
+            .to_string_lossy()
+            .into_owned();
+        let _ = db.update_agent_shell_terminal_tab_session(tab.id, chat_session_id, &output_path);
+        tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
+        tab.sort_order = 0;
+        tab.agent_chat_session_id = Some(chat_session_id.to_string());
+        tab.agent_tool_use_id = None;
+        tab.agent_task_id = None;
+        tab.output_path = Some(output_path);
+        tab.task_status = None;
+        tab.task_summary = None;
         return Some(tab);
     }
     let max_id = db.max_terminal_tab_id().ok()?;

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::background::{
-    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, is_tail_bash_command,
-    parse_background_task_binding, parse_bash_start, parse_task_notification,
+    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, parse_background_task_binding,
+    parse_bash_start, parse_task_notification,
 };
 use claudette::agent::{
     self, AgentEvent, AgentSettings, ControlRequestInner, FileAttachment, InnerStreamEvent,
@@ -32,19 +32,6 @@ use super::{
     ChatHistoryPage, fire_completion_notification, now_iso, start_bridge_and_inject_mcp,
 };
 
-fn truncate_task_title(command: Option<&str>) -> String {
-    let raw = command.unwrap_or("Bash").trim();
-    let mut title = if raw.is_empty() {
-        "Bash".to_string()
-    } else {
-        raw.to_string()
-    };
-    if title.chars().count() > 42 {
-        title = title.chars().take(39).collect::<String>() + "...";
-    }
-    format!("Agent: {title}")
-}
-
 fn emit_agent_background_task_event(
     app: &AppHandle,
     kind: AgentBackgroundTaskEventKind,
@@ -61,11 +48,11 @@ fn emit_agent_background_task_event(
     let _ = app.emit("agent-background-task", &payload);
 }
 
-fn agent_bash_output_path(chat_session_id: &str, tool_use_id: &str) -> std::path::PathBuf {
+fn agent_bash_output_path(chat_session_id: &str) -> std::path::PathBuf {
     std::env::temp_dir()
         .join("claudette-agent-bash")
         .join(chat_session_id)
-        .join(format!("{tool_use_id}.output"))
+        .join("agent-shell.output")
 }
 
 fn terminal_text(text: &str) -> String {
@@ -84,34 +71,80 @@ fn append_agent_bash_output(path: &std::path::Path, text: &str) -> std::io::Resu
     file.write_all(text.as_bytes())
 }
 
-fn create_agent_bash_terminal_tab(
+fn mirror_background_task_output(source: std::path::PathBuf, destination: std::path::PathBuf) {
+    tokio::spawn(async move {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let mut offset = 0_u64;
+        let mut idle_ticks_after_output = 0_u8;
+        let mut buf = vec![0_u8; 8192];
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let Ok(mut file) = tokio::fs::File::open(&source).await else {
+                continue;
+            };
+            let len = file.metadata().await.ok().map(|m| m.len()).unwrap_or(0);
+            if len < offset {
+                offset = 0;
+            }
+            if file.seek(std::io::SeekFrom::Start(offset)).await.is_err() {
+                continue;
+            }
+            let mut wrote = false;
+            loop {
+                match file.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        offset += n as u64;
+                        wrote = true;
+                        if let Err(err) = append_agent_bash_output(
+                            &destination,
+                            &String::from_utf8_lossy(&buf[..n]),
+                        ) {
+                            eprintln!("[chat] failed to mirror background output: {err}");
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            if wrote {
+                idle_ticks_after_output = 0;
+            } else if offset > 0 {
+                idle_ticks_after_output = idle_ticks_after_output.saturating_add(1);
+                if idle_ticks_after_output >= 20 {
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn get_or_create_agent_shell_terminal_tab(
     db_path: &std::path::Path,
     workspace_id: &str,
     chat_session_id: &str,
-    tool_use_id: &str,
-    command: Option<&str>,
-    output_path: Option<&std::path::Path>,
 ) -> Option<TerminalTab> {
     let db = Database::open(db_path).ok()?;
-    if let Ok(Some(tab)) = db.get_terminal_tab_by_tool_use_id(tool_use_id) {
+    if let Ok(Some(tab)) = db.get_agent_shell_terminal_tab(chat_session_id) {
         return Some(tab);
     }
     let max_id = db.max_terminal_tab_id().ok()?;
     let existing = db.list_terminal_tabs_by_workspace(workspace_id).ok()?;
+    let output_path = agent_bash_output_path(chat_session_id);
     let tab = TerminalTab {
         id: max_id + 1,
         workspace_id: workspace_id.to_string(),
-        title: truncate_task_title(command),
+        title: "Agent shell".to_string(),
         kind: TerminalTabKind::AgentTask,
         is_script_output: false,
         sort_order: existing.len() as i32,
         created_at: now_iso(),
         agent_chat_session_id: Some(chat_session_id.to_string()),
-        agent_tool_use_id: Some(tool_use_id.to_string()),
+        agent_tool_use_id: None,
         agent_task_id: None,
-        output_path: output_path.map(|path| path.to_string_lossy().into_owned()),
-        task_status: Some("starting".to_string()),
-        task_summary: command.map(ToOwned::to_owned),
+        output_path: Some(output_path.to_string_lossy().into_owned()),
+        task_status: None,
+        task_summary: None,
     };
     db.insert_terminal_tab(&tab).ok()?;
     Some(tab)
@@ -151,7 +184,22 @@ async fn apply_task_notification_status(
         summary.filter(|s| !s.trim().is_empty()),
         output_file.filter(|s| !s.trim().is_empty()),
     );
-    if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(chat_session_id, task_id) {
+    let _ = db.update_agent_shell_terminal_tab_status(
+        chat_session_id,
+        Some(task_id),
+        status,
+        summary.filter(|s| !s.trim().is_empty()),
+    );
+    let tab = db
+        .get_terminal_tab_by_agent_task(chat_session_id, task_id)
+        .ok()
+        .flatten()
+        .or_else(|| {
+            db.get_agent_shell_terminal_tab(chat_session_id)
+                .ok()
+                .flatten()
+        });
+    if let Some(tab) = tab {
         emit_agent_background_task_event(
             app,
             AgentBackgroundTaskEventKind::Status,
@@ -266,6 +314,31 @@ fn schedule_background_task_wake(
                     notification.output_file.as_deref(),
                 )
                 .await;
+            }
+
+            if let AgentEvent::Stream(StreamEvent::User { message, .. }) = &event
+                && let claudette::agent::UserMessageContent::Blocks(blocks) = &message.content
+            {
+                for block in blocks {
+                    if let claudette::agent::UserContentBlock::Text { text } = block
+                        && let Some(notification) = parse_task_notification(text)
+                    {
+                        saw_task_notification = true;
+                        should_emit_stream = true;
+                        let status = notification.status.as_deref().unwrap_or("running");
+                        apply_task_notification_status(
+                            &app,
+                            &db_path,
+                            &workspace_id,
+                            &chat_session_id,
+                            &notification.task_id,
+                            status,
+                            notification.summary.as_deref(),
+                            notification.output_file.as_deref(),
+                        )
+                        .await;
+                    }
+                }
             }
 
             if let AgentEvent::Stream(StreamEvent::ControlRequest {
@@ -1503,35 +1576,42 @@ pub async fn send_chat_message(
                         session.running_background_tasks.insert(tool_use_id.clone());
                     }
                 }
-                if !command.is_some_and(is_tail_bash_command) {
-                    let output_path = if start.run_in_background {
-                        None
-                    } else {
-                        let path =
-                            agent_bash_output_path(&chat_session_id_for_stream, &tool_use_id);
-                        let echo = command
-                            .map(|cmd| format!("\r\n$ {}\r\n", terminal_text(cmd)))
-                            .unwrap_or_else(|| "\r\n$ Bash\r\n".to_string());
-                        if let Err(err) = append_agent_bash_output(&path, &echo) {
-                            eprintln!("[chat] failed to write agent bash output: {err}");
-                        }
-                        Some(path)
-                    };
-                    if let Some(tab) = create_agent_bash_terminal_tab(
-                        &db_path,
-                        &ws_id,
-                        &chat_session_id_for_stream,
-                        &tool_use_id,
-                        command,
-                        output_path.as_deref(),
-                    ) {
-                        emit_agent_background_task_event(
-                            &app,
-                            AgentBackgroundTaskEventKind::Starting,
-                            &ws_id,
+                let path = agent_bash_output_path(&chat_session_id_for_stream);
+                let echo = command
+                    .map(|cmd| format!("\r\n$ {}\r\n", terminal_text(cmd)))
+                    .unwrap_or_else(|| "\r\n$ Bash\r\n".to_string());
+                if let Err(err) = append_agent_bash_output(&path, &echo) {
+                    eprintln!("[chat] failed to write agent bash output: {err}");
+                }
+                if get_or_create_agent_shell_terminal_tab(
+                    &db_path,
+                    &ws_id,
+                    &chat_session_id_for_stream,
+                )
+                .is_some()
+                {
+                    if let Ok(db) = Database::open(&db_path) {
+                        let _ = db.update_agent_shell_terminal_tab_status(
                             &chat_session_id_for_stream,
-                            tab,
+                            None,
+                            if start.run_in_background {
+                                "running"
+                            } else {
+                                "starting"
+                            },
+                            command,
                         );
+                        if let Ok(Some(tab)) =
+                            db.get_agent_shell_terminal_tab(&chat_session_id_for_stream)
+                        {
+                            emit_agent_background_task_event(
+                                &app,
+                                AgentBackgroundTaskEventKind::Starting,
+                                &ws_id,
+                                &chat_session_id_for_stream,
+                                tab,
+                            );
+                        }
                     }
                 }
             }
@@ -1778,78 +1858,105 @@ pub async fn send_chat_message(
                 match &message.content {
                     claudette::agent::UserMessageContent::Blocks(blocks) => {
                         for block in blocks {
-                            if let claudette::agent::UserContentBlock::ToolResult {
-                                tool_use_id,
-                                content,
-                            } = block
-                            {
-                                let text = tool_result_content_text(content);
-                                if let Some(binding) = parse_background_task_binding(&text) {
-                                    {
-                                        let app_state = app.state::<AppState>();
-                                        let mut agents = app_state.agents.write().await;
-                                        if let Some(session) =
-                                            agents.get_mut(&chat_session_id_for_stream)
+                            match block {
+                                claudette::agent::UserContentBlock::ToolResult {
+                                    tool_use_id,
+                                    content,
+                                } => {
+                                    let text = tool_result_content_text(content);
+                                    if let Some(binding) = parse_background_task_binding(&text) {
                                         {
-                                            session.running_background_tasks.remove(tool_use_id);
-                                            session
-                                                .running_background_tasks
-                                                .insert(binding.task_id.clone());
+                                            let app_state = app.state::<AppState>();
+                                            let mut agents = app_state.agents.write().await;
+                                            if let Some(session) =
+                                                agents.get_mut(&chat_session_id_for_stream)
+                                            {
+                                                session
+                                                    .running_background_tasks
+                                                    .remove(tool_use_id);
+                                                session
+                                                    .running_background_tasks
+                                                    .insert(binding.task_id.clone());
+                                            }
                                         }
-                                    }
-                                    if let Ok(db) = Database::open(&db_path) {
-                                        let _ = db.update_agent_task_terminal_tab_binding(
-                                            tool_use_id,
-                                            &binding.task_id,
-                                            &binding.output_path,
+                                        let aggregate_path =
+                                            agent_bash_output_path(&chat_session_id_for_stream);
+                                        mirror_background_task_output(
+                                            std::path::PathBuf::from(&binding.output_path),
+                                            aggregate_path,
                                         );
-                                        if let Ok(Some(tab)) =
-                                            db.get_terminal_tab_by_tool_use_id(tool_use_id)
-                                        {
-                                            emit_agent_background_task_event(
-                                                &app,
-                                                AgentBackgroundTaskEventKind::Bound,
-                                                &ws_id,
+                                        if let Ok(db) = Database::open(&db_path) {
+                                            let _ = db.update_agent_shell_terminal_tab_status(
                                                 &chat_session_id_for_stream,
-                                                tab,
+                                                Some(&binding.task_id),
+                                                "running",
+                                                None,
                                             );
+                                            if let Ok(Some(tab)) = db.get_agent_shell_terminal_tab(
+                                                &chat_session_id_for_stream,
+                                            ) {
+                                                emit_agent_background_task_event(
+                                                    &app,
+                                                    AgentBackgroundTaskEventKind::Bound,
+                                                    &ws_id,
+                                                    &chat_session_id_for_stream,
+                                                    tab,
+                                                );
+                                            }
                                         }
-                                    }
-                                } else if let Ok(db) = Database::open(&db_path)
-                                    && let Ok(Some(tab)) =
-                                        db.get_terminal_tab_by_tool_use_id(tool_use_id)
-                                {
-                                    if let Some(path) = tab.output_path.as_deref() {
+                                    } else {
+                                        let path =
+                                            agent_bash_output_path(&chat_session_id_for_stream);
                                         let text = terminal_text(&text);
                                         let suffix =
                                             if text.ends_with("\r\n") { "" } else { "\r\n" };
                                         if let Err(err) = append_agent_bash_output(
-                                            std::path::Path::new(path),
+                                            &path,
                                             &format!("{text}{suffix}"),
                                         ) {
                                             eprintln!(
                                                 "[chat] failed to append agent bash output: {err}"
                                             );
                                         }
-                                    }
-                                    let _ = db.update_agent_task_terminal_tab_by_tool_use_id(
-                                        tool_use_id,
-                                        "completed",
-                                        Some("Command completed"),
-                                        None,
-                                    );
-                                    if let Ok(Some(tab)) =
-                                        db.get_terminal_tab_by_tool_use_id(tool_use_id)
-                                    {
-                                        emit_agent_background_task_event(
-                                            &app,
-                                            AgentBackgroundTaskEventKind::Status,
-                                            &ws_id,
-                                            &chat_session_id_for_stream,
-                                            tab,
-                                        );
+                                        if let Ok(db) = Database::open(&db_path) {
+                                            let _ = db.update_agent_shell_terminal_tab_status(
+                                                &chat_session_id_for_stream,
+                                                None,
+                                                "completed",
+                                                Some("Command completed"),
+                                            );
+                                            if let Ok(Some(tab)) = db.get_agent_shell_terminal_tab(
+                                                &chat_session_id_for_stream,
+                                            ) {
+                                                emit_agent_background_task_event(
+                                                    &app,
+                                                    AgentBackgroundTaskEventKind::Status,
+                                                    &ws_id,
+                                                    &chat_session_id_for_stream,
+                                                    tab,
+                                                );
+                                            }
+                                        }
                                     }
                                 }
+                                claudette::agent::UserContentBlock::Text { text } => {
+                                    if let Some(notification) = parse_task_notification(text) {
+                                        let status =
+                                            notification.status.as_deref().unwrap_or("running");
+                                        apply_task_notification_status(
+                                            &app,
+                                            &db_path,
+                                            &ws_id,
+                                            &chat_session_id_for_stream,
+                                            &notification.task_id,
+                                            status,
+                                            notification.summary.as_deref(),
+                                            notification.output_file.as_deref(),
+                                        )
+                                        .await;
+                                    }
+                                }
+                                claudette::agent::UserContentBlock::Unknown => {}
                             }
                         }
                     }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::background::{
-    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, parse_background_bash_start,
-    parse_background_task_binding, parse_task_notification,
+    parse_background_bash_start, parse_background_task_binding, parse_task_notification,
 };
 use claudette::agent::{
     self, AgentEvent, AgentSettings, ControlRequestInner, FileAttachment, InnerStreamEvent,
@@ -20,7 +19,7 @@ use claudette::chat::{
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
 use claudette::mcp_supervisor::McpSupervisor;
-use claudette::model::{ChatMessage, ChatRole, TerminalTab, TerminalTabKind};
+use claudette::model::{ChatMessage, ChatRole};
 use claudette::permissions::tools_for_level;
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
@@ -32,35 +31,6 @@ use super::{
     ChatHistoryPage, fire_completion_notification, now_iso, start_bridge_and_inject_mcp,
 };
 
-fn truncate_task_title(command: Option<&str>) -> String {
-    let raw = command.unwrap_or("Background task").trim();
-    let mut title = if raw.is_empty() {
-        "Background task".to_string()
-    } else {
-        raw.to_string()
-    };
-    if title.chars().count() > 42 {
-        title = title.chars().take(39).collect::<String>() + "...";
-    }
-    format!("Agent: {title}")
-}
-
-fn emit_agent_background_task_event(
-    app: &AppHandle,
-    kind: AgentBackgroundTaskEventKind,
-    workspace_id: &str,
-    chat_session_id: &str,
-    tab: TerminalTab,
-) {
-    let payload = AgentBackgroundTaskEvent {
-        kind,
-        workspace_id: workspace_id.to_string(),
-        chat_session_id: chat_session_id.to_string(),
-        tab,
-    };
-    let _ = app.emit("agent-background-task", &payload);
-}
-
 fn is_terminal_task_status(status: &str) -> bool {
     matches!(
         status.to_ascii_lowercase().as_str(),
@@ -70,17 +40,10 @@ fn is_terminal_task_status(status: &str) -> bool {
 
 async fn apply_task_notification_status(
     app: &AppHandle,
-    db_path: &std::path::Path,
-    workspace_id: &str,
     chat_session_id: &str,
     task_id: &str,
     status: &str,
-    summary: Option<&str>,
-    output_file: Option<&str>,
 ) {
-    let Ok(db) = Database::open(db_path) else {
-        return;
-    };
     if is_terminal_task_status(status) {
         let app_state = app.state::<AppState>();
         let mut agents = app_state.agents.write().await;
@@ -88,54 +51,6 @@ async fn apply_task_notification_status(
             session.running_background_tasks.remove(task_id);
         }
     }
-    let _ = db.update_agent_task_terminal_tab_status(
-        chat_session_id,
-        task_id,
-        status,
-        summary.filter(|s| !s.trim().is_empty()),
-        output_file.filter(|s| !s.trim().is_empty()),
-    );
-    if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(chat_session_id, task_id) {
-        emit_agent_background_task_event(
-            app,
-            AgentBackgroundTaskEventKind::Status,
-            workspace_id,
-            chat_session_id,
-            tab,
-        );
-    }
-}
-
-fn create_agent_task_terminal_tab(
-    db_path: &std::path::Path,
-    workspace_id: &str,
-    chat_session_id: &str,
-    tool_use_id: &str,
-    command: Option<&str>,
-) -> Option<TerminalTab> {
-    let db = Database::open(db_path).ok()?;
-    if let Ok(Some(tab)) = db.get_terminal_tab_by_tool_use_id(tool_use_id) {
-        return Some(tab);
-    }
-    let max_id = db.max_terminal_tab_id().ok()?;
-    let existing = db.list_terminal_tabs_by_workspace(workspace_id).ok()?;
-    let tab = TerminalTab {
-        id: max_id + 1,
-        workspace_id: workspace_id.to_string(),
-        title: truncate_task_title(command),
-        kind: TerminalTabKind::AgentTask,
-        is_script_output: false,
-        sort_order: existing.len() as i32,
-        created_at: now_iso(),
-        agent_chat_session_id: Some(chat_session_id.to_string()),
-        agent_tool_use_id: Some(tool_use_id.to_string()),
-        agent_task_id: None,
-        output_path: None,
-        task_status: Some("starting".to_string()),
-        task_summary: None,
-    };
-    db.insert_terminal_tab(&tab).ok()?;
-    Some(tab)
 }
 
 const BACKGROUND_TASK_WAKE_PROMPT: &str = "\
@@ -204,25 +119,13 @@ fn schedule_background_task_wake(
                 subtype,
                 task_id: Some(task_id),
                 status: Some(status),
-                output_file,
-                summary,
                 ..
             }) = &event
                 && subtype == "task_notification"
             {
                 saw_task_notification = true;
                 should_emit_stream = true;
-                apply_task_notification_status(
-                    &app,
-                    &db_path,
-                    &workspace_id,
-                    &chat_session_id,
-                    task_id,
-                    status,
-                    summary.as_deref(),
-                    output_file.as_deref(),
-                )
-                .await;
+                apply_task_notification_status(&app, &chat_session_id, task_id, status).await;
             }
 
             if let AgentEvent::Stream(StreamEvent::User { message, .. }) = &event
@@ -234,13 +137,9 @@ fn schedule_background_task_wake(
                 let status = notification.status.as_deref().unwrap_or("running");
                 apply_task_notification_status(
                     &app,
-                    &db_path,
-                    &workspace_id,
                     &chat_session_id,
                     &notification.task_id,
                     status,
-                    notification.summary.as_deref(),
-                    notification.output_file.as_deref(),
                 )
                 .await;
             }
@@ -1403,23 +1302,12 @@ pub async fn send_chat_message(
                 subtype,
                 task_id: Some(task_id),
                 status: Some(status),
-                output_file,
-                summary,
                 ..
             }) = &event
                 && subtype == "task_notification"
             {
-                apply_task_notification_status(
-                    &app,
-                    &db_path,
-                    &ws_id,
-                    &chat_session_id_for_stream,
-                    task_id,
-                    status,
-                    summary.as_deref(),
-                    output_file.as_deref(),
-                )
-                .await;
+                apply_task_notification_status(&app, &chat_session_id_for_stream, task_id, status)
+                    .await;
             }
 
             if let AgentEvent::Stream(StreamEvent::Stream {
@@ -1454,29 +1342,13 @@ pub async fn send_chat_message(
                 event: InnerStreamEvent::ContentBlockStop { index },
             }) = &event
                 && let Some((tool_use_id, input_json)) = background_bash_inputs.remove(index)
-                && let Some(start) = parse_background_bash_start(&input_json)
-                && let Some(tab) = create_agent_task_terminal_tab(
-                    &db_path,
-                    &ws_id,
-                    &chat_session_id_for_stream,
-                    &tool_use_id,
-                    start.command.as_deref(),
-                )
+                && parse_background_bash_start(&input_json).is_some()
             {
-                {
-                    let app_state = app.state::<AppState>();
-                    let mut agents = app_state.agents.write().await;
-                    if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
-                        session.running_background_tasks.insert(tool_use_id.clone());
-                    }
+                let app_state = app.state::<AppState>();
+                let mut agents = app_state.agents.write().await;
+                if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
+                    session.running_background_tasks.insert(tool_use_id);
                 }
-                emit_agent_background_task_event(
-                    &app,
-                    AgentBackgroundTaskEventKind::Starting,
-                    &ws_id,
-                    &chat_session_id_for_stream,
-                    tab,
-                );
             }
 
             // Compaction boundary event: the CLI emits this after context
@@ -1727,9 +1599,7 @@ pub async fn send_chat_message(
                             } = block
                             {
                                 let text = tool_result_content_text(content);
-                                if let Some(binding) = parse_background_task_binding(&text)
-                                    && let Ok(db) = Database::open(&db_path)
-                                {
+                                if let Some(binding) = parse_background_task_binding(&text) {
                                     {
                                         let app_state = app.state::<AppState>();
                                         let mut agents = app_state.agents.write().await;
@@ -1742,22 +1612,6 @@ pub async fn send_chat_message(
                                                 .insert(binding.task_id.clone());
                                         }
                                     }
-                                    let _ = db.update_agent_task_terminal_tab_binding(
-                                        tool_use_id,
-                                        &binding.task_id,
-                                        &binding.output_path,
-                                    );
-                                    if let Ok(Some(tab)) =
-                                        db.get_terminal_tab_by_tool_use_id(tool_use_id)
-                                    {
-                                        emit_agent_background_task_event(
-                                            &app,
-                                            AgentBackgroundTaskEventKind::Bound,
-                                            &ws_id,
-                                            &chat_session_id_for_stream,
-                                            tab,
-                                        );
-                                    }
                                 }
                             }
                         }
@@ -1767,13 +1621,9 @@ pub async fn send_chat_message(
                             let status = notification.status.as_deref().unwrap_or("running");
                             apply_task_notification_status(
                                 &app,
-                                &db_path,
-                                &ws_id,
                                 &chat_session_id_for_stream,
                                 &notification.task_id,
                                 status,
-                                notification.summary.as_deref(),
-                                notification.output_file.as_deref(),
                             )
                             .await;
                         }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -49,7 +49,19 @@ fn emit_agent_background_task_event(
 }
 
 fn terminal_text(text: &str) -> String {
-    text.replace("\r\n", "\n").replace('\n', "\r\n")
+    let normalized = text.replace("\r\n", "\n");
+    let mut rendered = String::with_capacity(normalized.len());
+    for ch in normalized.chars() {
+        match ch {
+            // Progress renderers such as cargo frequently redraw one terminal
+            // row with carriage returns. Clear the rest of the row so shorter
+            // redraws do not leave stale text behind in the read-only terminal.
+            '\r' => rendered.push_str("\r\x1b[K"),
+            '\n' => rendered.push_str("\r\n"),
+            _ => rendered.push(ch),
+        }
+    }
+    rendered
 }
 
 fn append_agent_bash_output(path: &std::path::Path, text: &str) -> std::io::Result<()> {
@@ -99,7 +111,7 @@ fn mirror_background_task_output(source: std::path::PathBuf, destination: std::p
                         wrote = true;
                         if let Err(err) = append_agent_bash_output(
                             &destination,
-                            &String::from_utf8_lossy(&buf[..n]),
+                            &terminal_text(&String::from_utf8_lossy(&buf[..n])),
                         ) {
                             eprintln!("[chat] failed to mirror background output: {err}");
                         }
@@ -2413,4 +2425,22 @@ pub async fn send_chat_message(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::terminal_text;
+
+    #[test]
+    fn terminal_text_converts_newlines_to_terminal_newlines() {
+        assert_eq!(terminal_text("one\ntwo\r\nthree"), "one\r\ntwo\r\nthree");
+    }
+
+    #[test]
+    fn terminal_text_clears_carriage_return_redraws() {
+        assert_eq!(
+            terminal_text("Building [======]\rBuilding [>]\ndone"),
+            "Building [======]\r\x1b[KBuilding [>]\r\ndone"
+        );
+    }
 }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -180,6 +180,20 @@ fn is_terminal_task_status(status: &str) -> bool {
     )
 }
 
+fn should_defer_persistent_restart(session: &AgentSessionState) -> bool {
+    should_defer_persistent_restart_for_state(
+        session.persistent_session.is_some(),
+        !session.running_background_tasks.is_empty(),
+    )
+}
+
+fn should_defer_persistent_restart_for_state(
+    has_persistent_session: bool,
+    has_running_background_tasks: bool,
+) -> bool {
+    has_persistent_session && has_running_background_tasks
+}
+
 async fn apply_task_notification_status(
     app: &AppHandle,
     db_path: &std::path::Path,
@@ -1062,7 +1076,11 @@ pub async fn send_chat_message(
     // MCP config changed while a previous turn was in flight — tear down the
     // persistent session so the next spawn picks up updated --mcp-config.
     // The session is idle between turns so a graceful SIGTERM is sufficient.
-    if session.mcp_config_dirty {
+    if session.mcp_config_dirty && should_defer_persistent_restart(session) {
+        eprintln!(
+            "[chat] MCP config dirty, but background tasks are running — deferring persistent session restart for {workspace_id}"
+        );
+    } else if session.mcp_config_dirty {
         eprintln!("[chat] MCP config dirty — tearing down persistent session for {workspace_id}");
         let to_deny_mcp = drain_pending_permissions(session);
         let stale_pid = session.persistent_session.as_ref().map(|ps| ps.pid());
@@ -1128,7 +1146,25 @@ pub async fn send_chat_message(
     // "Approve plan", and the next turn arrives with `plan_mode=false`.
     // Without a teardown the process stays in plan mode and every mutating
     // tool is silently auto-denied.
-    if session.persistent_session.is_some()
+    if should_defer_persistent_restart(session)
+        && persistent_session_flags_drifted(
+            SessionFlags {
+                plan_mode: session.session_plan_mode,
+                allowed_tools: &session.session_allowed_tools,
+                exited_plan: session.session_exited_plan,
+                disable_1m_context: session.session_disable_1m_context,
+            },
+            RequestedFlags {
+                plan_mode: agent_settings.plan_mode,
+                allowed_tools: &allowed_tools,
+                disable_1m_context: agent_settings.disable_1m_context,
+            },
+        )
+    {
+        eprintln!(
+            "[chat] session flags drifted, but background tasks are running — deferring persistent session restart for {workspace_id}"
+        );
+    } else if session.persistent_session.is_some()
         && persistent_session_flags_drifted(
             SessionFlags {
                 plan_mode: session.session_plan_mode,
@@ -1242,7 +1278,14 @@ pub async fn send_chat_message(
     // snapshot stored at spawn and teardown on any divergence. The
     // mtime-keyed cache makes this re-resolve nearly free on quiet
     // turns, so the check costs nothing in the common case.
-    if session.persistent_session.is_some() && session.session_resolved_env != resolved_env.vars {
+    if should_defer_persistent_restart(session) && session.session_resolved_env != resolved_env.vars
+    {
+        eprintln!(
+            "[chat] env-provider output changed, but background tasks are running — deferring persistent session restart for {workspace_id}"
+        );
+    } else if session.persistent_session.is_some()
+        && session.session_resolved_env != resolved_env.vars
+    {
         eprintln!(
             "[chat] env-provider output changed ({} vars before, {} after) — tearing down persistent session for {workspace_id}",
             session.session_resolved_env.len(),
@@ -2429,7 +2472,7 @@ pub async fn send_chat_message(
 
 #[cfg(test)]
 mod tests {
-    use super::terminal_text;
+    use super::{should_defer_persistent_restart_for_state, terminal_text};
 
     #[test]
     fn terminal_text_converts_newlines_to_terminal_newlines() {
@@ -2455,5 +2498,13 @@ mod tests {
     #[test]
     fn terminal_text_normalizes_crlf_without_extra_clear() {
         assert_eq!(terminal_text("one\r\ntwo\r\n"), "one\r\ntwo\r\n");
+    }
+
+    #[test]
+    fn persistent_restart_is_deferred_only_while_background_tasks_are_owned() {
+        assert!(should_defer_persistent_restart_for_state(true, true));
+        assert!(!should_defer_persistent_restart_for_state(true, false));
+        assert!(!should_defer_persistent_restart_for_state(false, true));
+        assert!(!should_defer_persistent_restart_for_state(false, false));
     }
 }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -67,6 +68,44 @@ fn is_terminal_task_status(status: &str) -> bool {
     )
 }
 
+async fn apply_task_notification_status(
+    app: &AppHandle,
+    db_path: &std::path::Path,
+    workspace_id: &str,
+    chat_session_id: &str,
+    task_id: &str,
+    status: &str,
+    summary: Option<&str>,
+    output_file: Option<&str>,
+) {
+    let Ok(db) = Database::open(db_path) else {
+        return;
+    };
+    if is_terminal_task_status(status) {
+        let app_state = app.state::<AppState>();
+        let mut agents = app_state.agents.write().await;
+        if let Some(session) = agents.get_mut(chat_session_id) {
+            session.running_background_tasks.remove(task_id);
+        }
+    }
+    let _ = db.update_agent_task_terminal_tab_status(
+        chat_session_id,
+        task_id,
+        status,
+        summary.filter(|s| !s.trim().is_empty()),
+        output_file.filter(|s| !s.trim().is_empty()),
+    );
+    if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(chat_session_id, task_id) {
+        emit_agent_background_task_event(
+            app,
+            AgentBackgroundTaskEventKind::Status,
+            workspace_id,
+            chat_session_id,
+            tab,
+        );
+    }
+}
+
 fn create_agent_task_terminal_tab(
     db_path: &std::path::Path,
     workspace_id: &str,
@@ -97,6 +136,204 @@ fn create_agent_task_terminal_tab(
     };
     db.insert_terminal_tab(&tab).ok()?;
     Some(tab)
+}
+
+const BACKGROUND_TASK_WAKE_PROMPT: &str = "\
+<system-reminder>
+Claudette is waking this stream-json session so Claude Code can deliver queued background task notifications.
+Do not answer unless a <task-notification> is present in the runtime context. If no task notification is present yet, produce no user-facing text.
+</system-reminder>";
+
+fn schedule_background_task_wake(
+    app: AppHandle,
+    db_path: std::path::PathBuf,
+    workspace_id: String,
+    chat_session_id: String,
+) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        let app_state = app.state::<AppState>();
+        let Some(ps) = ({
+            let mut agents = app_state.agents.write().await;
+            let Some(session) = agents.get_mut(&chat_session_id) else {
+                return;
+            };
+            if session.running_background_tasks.is_empty()
+                || session.background_wake_active
+                || session.persistent_session.is_none()
+            {
+                return;
+            }
+            session.background_wake_active = true;
+            session.persistent_session.clone()
+        }) else {
+            return;
+        };
+
+        let handle = match ps.send_turn(BACKGROUND_TASK_WAKE_PROMPT, &[]).await {
+            Ok(handle) => handle,
+            Err(err) => {
+                eprintln!("[chat] failed to wake background task notifications: {err}");
+                let mut agents = app_state.agents.write().await;
+                if let Some(session) = agents.get_mut(&chat_session_id) {
+                    session.background_wake_active = false;
+                }
+                return;
+            }
+        };
+
+        {
+            let mut agents = app_state.agents.write().await;
+            if let Some(session) = agents.get_mut(&chat_session_id) {
+                session.active_pid = Some(handle.pid);
+            }
+        }
+        crate::tray::rebuild_tray(&app);
+
+        let mut rx = handle.event_rx;
+        let mut saw_task_notification = false;
+        let mut last_assistant_msg_id: Option<String> = None;
+        let mut pending_thinking: Option<String> = None;
+        let mut latest_usage: Option<claudette::agent::TokenUsage> = None;
+
+        while let Some(event) = rx.recv().await {
+            let mut should_emit_stream = saw_task_notification;
+
+            if let AgentEvent::Stream(StreamEvent::System {
+                subtype,
+                task_id: Some(task_id),
+                status: Some(status),
+                output_file,
+                summary,
+                ..
+            }) = &event
+                && subtype == "task_notification"
+            {
+                saw_task_notification = true;
+                should_emit_stream = true;
+                apply_task_notification_status(
+                    &app,
+                    &db_path,
+                    &workspace_id,
+                    &chat_session_id,
+                    task_id,
+                    status,
+                    summary.as_deref(),
+                    output_file.as_deref(),
+                )
+                .await;
+            }
+
+            if let AgentEvent::Stream(StreamEvent::User { message, .. }) = &event
+                && let claudette::agent::UserMessageContent::Text(body) = &message.content
+                && let Some(notification) = parse_task_notification(body)
+            {
+                saw_task_notification = true;
+                should_emit_stream = true;
+                let status = notification.status.as_deref().unwrap_or("running");
+                apply_task_notification_status(
+                    &app,
+                    &db_path,
+                    &workspace_id,
+                    &chat_session_id,
+                    &notification.task_id,
+                    status,
+                    notification.summary.as_deref(),
+                    notification.output_file.as_deref(),
+                )
+                .await;
+            }
+
+            if let AgentEvent::Stream(StreamEvent::Stream {
+                event: InnerStreamEvent::MessageDelta { usage: Some(u) },
+            }) = &event
+            {
+                latest_usage = Some(u.clone());
+            }
+
+            if let AgentEvent::Stream(StreamEvent::Assistant { message }) = &event {
+                let full_text = extract_assistant_text(message);
+                if let Some(t) = extract_event_thinking(message) {
+                    pending_thinking = Some(match pending_thinking.take() {
+                        Some(mut existing) => {
+                            existing.push_str(&t);
+                            existing
+                        }
+                        None => t,
+                    });
+                }
+                if saw_task_notification
+                    && !full_text.trim().is_empty()
+                    && let Ok(db) = Database::open(&db_path)
+                {
+                    let msg = build_assistant_chat_message(BuildAssistantArgs {
+                        workspace_id: &workspace_id,
+                        chat_session_id: &chat_session_id,
+                        content: full_text,
+                        thinking: pending_thinking.take(),
+                        usage: latest_usage.take(),
+                        created_at: now_iso(),
+                    });
+                    let msg_id = msg.id.clone();
+                    if db.insert_chat_message(&msg).is_ok() {
+                        last_assistant_msg_id = Some(msg_id);
+                    }
+                }
+            }
+
+            if let AgentEvent::Stream(StreamEvent::Result {
+                total_cost_usd,
+                duration_ms,
+                ..
+            }) = &event
+            {
+                if let Ok(db) = Database::open(&db_path)
+                    && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
+                    && let Some(ref msg_id) = last_assistant_msg_id
+                {
+                    let _ = db.update_chat_message_cost(msg_id, *cost, *dur);
+                }
+            }
+
+            let is_done = matches!(
+                &event,
+                AgentEvent::Stream(StreamEvent::Result { .. }) | AgentEvent::ProcessExited(_)
+            );
+
+            if should_emit_stream || (is_done && saw_task_notification) {
+                let payload = AgentStreamPayload {
+                    workspace_id: workspace_id.clone(),
+                    chat_session_id: chat_session_id.clone(),
+                    event,
+                };
+                let _ = app.emit("agent-stream", &payload);
+            }
+
+            if is_done {
+                break;
+            }
+        }
+
+        let should_retry = {
+            let mut agents = app_state.agents.write().await;
+            if let Some(session) = agents.get_mut(&chat_session_id) {
+                session.background_wake_active = false;
+                if session.active_pid == Some(ps.pid()) {
+                    session.active_pid = None;
+                }
+                !session.running_background_tasks.is_empty() && session.persistent_session.is_some()
+            } else {
+                false
+            }
+        };
+        crate::tray::rebuild_tray(&app);
+
+        if should_retry {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            schedule_background_task_wake(app, db_path, workspace_id, chat_session_id);
+        }
+    });
 }
 
 fn tool_result_content_text(content: &serde_json::Value) -> String {
@@ -484,6 +721,7 @@ pub async fn send_chat_message(
                 session_disable_1m_context: false,
                 pending_permissions: std::collections::HashMap::new(),
                 running_background_tasks: std::collections::HashSet::new(),
+                background_wake_active: false,
                 session_exited_plan: false,
                 session_resolved_env: Default::default(),
                 mcp_bridge: None,
@@ -508,6 +746,7 @@ pub async fn send_chat_message(
             session_disable_1m_context: false,
             pending_permissions: std::collections::HashMap::new(),
             running_background_tasks: std::collections::HashSet::new(),
+            background_wake_active: false,
             session_exited_plan: false,
             session_resolved_env: Default::default(),
             mcp_bridge: None,
@@ -1169,35 +1408,18 @@ pub async fn send_chat_message(
                 ..
             }) = &event
                 && subtype == "task_notification"
-                && let Ok(db) = Database::open(&db_path)
             {
-                if is_terminal_task_status(status) {
-                    let app_state = app.state::<AppState>();
-                    let mut agents = app_state.agents.write().await;
-                    if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
-                        session.running_background_tasks.remove(task_id);
-                    }
-                }
-                let output_file = output_file.as_deref().filter(|s| !s.trim().is_empty());
-                let summary = summary.as_deref().filter(|s| !s.trim().is_empty());
-                let _ = db.update_agent_task_terminal_tab_status(
+                apply_task_notification_status(
+                    &app,
+                    &db_path,
+                    &ws_id,
                     &chat_session_id_for_stream,
                     task_id,
                     status,
-                    summary,
-                    output_file,
-                );
-                if let Ok(Some(tab)) =
-                    db.get_terminal_tab_by_agent_task(&chat_session_id_for_stream, task_id)
-                {
-                    emit_agent_background_task_event(
-                        &app,
-                        AgentBackgroundTaskEventKind::Status,
-                        &ws_id,
-                        &chat_session_id_for_stream,
-                        tab,
-                    );
-                }
+                    summary.as_deref(),
+                    output_file.as_deref(),
+                )
+                .await;
             }
 
             if let AgentEvent::Stream(StreamEvent::Stream {
@@ -1541,42 +1763,19 @@ pub async fn send_chat_message(
                         }
                     }
                     claudette::agent::UserMessageContent::Text(body) => {
-                        if let Some(notification) = parse_task_notification(body)
-                            && let Ok(db) = Database::open(&db_path)
-                        {
+                        if let Some(notification) = parse_task_notification(body) {
                             let status = notification.status.as_deref().unwrap_or("running");
-                            if notification
-                                .status
-                                .as_deref()
-                                .is_some_and(is_terminal_task_status)
-                            {
-                                let app_state = app.state::<AppState>();
-                                let mut agents = app_state.agents.write().await;
-                                if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
-                                    session
-                                        .running_background_tasks
-                                        .remove(&notification.task_id);
-                                }
-                            }
-                            let _ = db.update_agent_task_terminal_tab_status(
+                            apply_task_notification_status(
+                                &app,
+                                &db_path,
+                                &ws_id,
                                 &chat_session_id_for_stream,
                                 &notification.task_id,
                                 status,
                                 notification.summary.as_deref(),
                                 notification.output_file.as_deref(),
-                            );
-                            if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(
-                                &chat_session_id_for_stream,
-                                &notification.task_id,
-                            ) {
-                                emit_agent_background_task_event(
-                                    &app,
-                                    AgentBackgroundTaskEventKind::Status,
-                                    &ws_id,
-                                    &chat_session_id_for_stream,
-                                    tab,
-                                );
-                            }
+                            )
+                            .await;
                         }
                     }
                 }
@@ -1662,6 +1861,21 @@ pub async fn send_chat_message(
                     fire_completion_notification(&db_path, &app_state.cesp_playback, event, &ws_id)
                         .await;
                     notified_via_result = true;
+                }
+
+                let should_wake_background_tasks = {
+                    let agents = app_state.agents.read().await;
+                    agents
+                        .get(&chat_session_id_for_stream)
+                        .is_some_and(|s| !s.running_background_tasks.is_empty())
+                };
+                if should_wake_background_tasks {
+                    schedule_background_task_wake(
+                        app.clone(),
+                        db_path.clone(),
+                        ws_id.clone(),
+                        chat_session_id_for_stream.clone(),
+                    );
                 }
             }
 

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -111,7 +111,7 @@ fn create_agent_bash_terminal_tab(
         agent_task_id: None,
         output_path: output_path.map(|path| path.to_string_lossy().into_owned()),
         task_status: Some("starting".to_string()),
-        task_summary: None,
+        task_summary: command.map(ToOwned::to_owned),
     };
     db.insert_terminal_tab(&tab).ok()?;
     Some(tab)
@@ -165,7 +165,8 @@ async fn apply_task_notification_status(
 const BACKGROUND_TASK_WAKE_PROMPT: &str = "\
 <system-reminder>
 Claudette is waking this stream-json session so Claude Code can deliver queued background task notifications.
-Do not answer unless a <task-notification> is present in the runtime context. If no task notification is present yet, produce no user-facing text.
+First call the Sleep tool for 1 second so Claude Code can flush queued background task notifications.
+After Sleep returns, do not answer unless a <task-notification> is present in the runtime context. If no task notification is present yet, produce no user-facing text.
 </system-reminder>";
 
 fn schedule_background_task_wake(
@@ -265,6 +266,24 @@ fn schedule_background_task_wake(
                     notification.output_file.as_deref(),
                 )
                 .await;
+            }
+
+            if let AgentEvent::Stream(StreamEvent::ControlRequest {
+                request_id,
+                request:
+                    ControlRequestInner::CanUseTool {
+                        tool_name, input, ..
+                    },
+            }) = &event
+                && tool_name == "Sleep"
+            {
+                let response = serde_json::json!({
+                    "behavior": "allow",
+                    "updatedInput": input,
+                });
+                if let Err(err) = ps.send_control_response(request_id, response).await {
+                    eprintln!("[chat] failed to allow background wake Sleep: {err}");
+                }
             }
 
             if let AgentEvent::Stream(StreamEvent::Stream {

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use claudette::agent::background::{
-    parse_background_bash_start, parse_background_task_binding, parse_task_notification,
+    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, is_tail_bash_command,
+    parse_background_task_binding, parse_bash_start, parse_task_notification,
 };
 use claudette::agent::{
     self, AgentEvent, AgentSettings, ControlRequestInner, FileAttachment, InnerStreamEvent,
@@ -19,7 +20,7 @@ use claudette::chat::{
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
 use claudette::mcp_supervisor::McpSupervisor;
-use claudette::model::{ChatMessage, ChatRole};
+use claudette::model::{ChatMessage, ChatRole, TerminalTab, TerminalTabKind};
 use claudette::permissions::tools_for_level;
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
@@ -31,6 +32,91 @@ use super::{
     ChatHistoryPage, fire_completion_notification, now_iso, start_bridge_and_inject_mcp,
 };
 
+fn truncate_task_title(command: Option<&str>) -> String {
+    let raw = command.unwrap_or("Bash").trim();
+    let mut title = if raw.is_empty() {
+        "Bash".to_string()
+    } else {
+        raw.to_string()
+    };
+    if title.chars().count() > 42 {
+        title = title.chars().take(39).collect::<String>() + "...";
+    }
+    format!("Agent: {title}")
+}
+
+fn emit_agent_background_task_event(
+    app: &AppHandle,
+    kind: AgentBackgroundTaskEventKind,
+    workspace_id: &str,
+    chat_session_id: &str,
+    tab: TerminalTab,
+) {
+    let payload = AgentBackgroundTaskEvent {
+        kind,
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
+        tab,
+    };
+    let _ = app.emit("agent-background-task", &payload);
+}
+
+fn agent_bash_output_path(chat_session_id: &str, tool_use_id: &str) -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("claudette-agent-bash")
+        .join(chat_session_id)
+        .join(format!("{tool_use_id}.output"))
+}
+
+fn terminal_text(text: &str) -> String {
+    text.replace("\r\n", "\n").replace('\n', "\r\n")
+}
+
+fn append_agent_bash_output(path: &std::path::Path, text: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    file.write_all(text.as_bytes())
+}
+
+fn create_agent_bash_terminal_tab(
+    db_path: &std::path::Path,
+    workspace_id: &str,
+    chat_session_id: &str,
+    tool_use_id: &str,
+    command: Option<&str>,
+    output_path: Option<&std::path::Path>,
+) -> Option<TerminalTab> {
+    let db = Database::open(db_path).ok()?;
+    if let Ok(Some(tab)) = db.get_terminal_tab_by_tool_use_id(tool_use_id) {
+        return Some(tab);
+    }
+    let max_id = db.max_terminal_tab_id().ok()?;
+    let existing = db.list_terminal_tabs_by_workspace(workspace_id).ok()?;
+    let tab = TerminalTab {
+        id: max_id + 1,
+        workspace_id: workspace_id.to_string(),
+        title: truncate_task_title(command),
+        kind: TerminalTabKind::AgentTask,
+        is_script_output: false,
+        sort_order: existing.len() as i32,
+        created_at: now_iso(),
+        agent_chat_session_id: Some(chat_session_id.to_string()),
+        agent_tool_use_id: Some(tool_use_id.to_string()),
+        agent_task_id: None,
+        output_path: output_path.map(|path| path.to_string_lossy().into_owned()),
+        task_status: Some("starting".to_string()),
+        task_summary: None,
+    };
+    db.insert_terminal_tab(&tab).ok()?;
+    Some(tab)
+}
+
 fn is_terminal_task_status(status: &str) -> bool {
     matches!(
         status.to_ascii_lowercase().as_str(),
@@ -40,16 +126,39 @@ fn is_terminal_task_status(status: &str) -> bool {
 
 async fn apply_task_notification_status(
     app: &AppHandle,
+    db_path: &std::path::Path,
+    workspace_id: &str,
     chat_session_id: &str,
     task_id: &str,
     status: &str,
+    summary: Option<&str>,
+    output_file: Option<&str>,
 ) {
+    let Ok(db) = Database::open(db_path) else {
+        return;
+    };
     if is_terminal_task_status(status) {
         let app_state = app.state::<AppState>();
         let mut agents = app_state.agents.write().await;
         if let Some(session) = agents.get_mut(chat_session_id) {
             session.running_background_tasks.remove(task_id);
         }
+    }
+    let _ = db.update_agent_task_terminal_tab_status(
+        chat_session_id,
+        task_id,
+        status,
+        summary.filter(|s| !s.trim().is_empty()),
+        output_file.filter(|s| !s.trim().is_empty()),
+    );
+    if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(chat_session_id, task_id) {
+        emit_agent_background_task_event(
+            app,
+            AgentBackgroundTaskEventKind::Status,
+            workspace_id,
+            chat_session_id,
+            tab,
+        );
     }
 }
 
@@ -125,7 +234,17 @@ fn schedule_background_task_wake(
             {
                 saw_task_notification = true;
                 should_emit_stream = true;
-                apply_task_notification_status(&app, &chat_session_id, task_id, status).await;
+                apply_task_notification_status(
+                    &app,
+                    &db_path,
+                    &workspace_id,
+                    &chat_session_id,
+                    task_id,
+                    status,
+                    None,
+                    None,
+                )
+                .await;
             }
 
             if let AgentEvent::Stream(StreamEvent::User { message, .. }) = &event
@@ -137,9 +256,13 @@ fn schedule_background_task_wake(
                 let status = notification.status.as_deref().unwrap_or("running");
                 apply_task_notification_status(
                     &app,
+                    &db_path,
+                    &workspace_id,
                     &chat_session_id,
                     &notification.task_id,
                     status,
+                    notification.summary.as_deref(),
+                    notification.output_file.as_deref(),
                 )
                 .await;
             }
@@ -1267,10 +1390,10 @@ pub async fn send_chat_message(
         // MCP monitoring: map tool_use_id → tool_name for MCP error detection.
         let mut mcp_tool_names: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
-        // Background-Bash detection: map content-block index → (tool_use_id,
+        // Bash detection: map content-block index → (tool_use_id,
         // accumulated input JSON). The CLI streams tool input in deltas, so we
-        // only know `run_in_background` once the block stops.
-        let mut background_bash_inputs: std::collections::HashMap<usize, (String, String)> =
+        // only know command details once the block stops.
+        let mut bash_inputs: std::collections::HashMap<usize, (String, String)> =
             std::collections::HashMap::new();
         // Track the last assistant message inserted in THIS turn. Falls back
         // to the user message ID for tool-only turns (AskUserQuestion, plan
@@ -1306,8 +1429,17 @@ pub async fn send_chat_message(
             }) = &event
                 && subtype == "task_notification"
             {
-                apply_task_notification_status(&app, &chat_session_id_for_stream, task_id, status)
-                    .await;
+                apply_task_notification_status(
+                    &app,
+                    &db_path,
+                    &ws_id,
+                    &chat_session_id_for_stream,
+                    task_id,
+                    status,
+                    None,
+                    None,
+                )
+                .await;
             }
 
             if let AgentEvent::Stream(StreamEvent::Stream {
@@ -1319,13 +1451,13 @@ pub async fn send_chat_message(
             }) = &event
                 && name == "Bash"
             {
-                background_bash_inputs.insert(*index, (id.clone(), String::new()));
+                bash_inputs.insert(*index, (id.clone(), String::new()));
             }
 
             if let AgentEvent::Stream(StreamEvent::Stream {
                 event: InnerStreamEvent::ContentBlockDelta { index, delta },
             }) = &event
-                && let Some((_tool_use_id, input)) = background_bash_inputs.get_mut(index)
+                && let Some((_tool_use_id, input)) = bash_inputs.get_mut(index)
             {
                 match delta {
                     claudette::agent::Delta::ToolUse {
@@ -1341,13 +1473,47 @@ pub async fn send_chat_message(
             if let AgentEvent::Stream(StreamEvent::Stream {
                 event: InnerStreamEvent::ContentBlockStop { index },
             }) = &event
-                && let Some((tool_use_id, input_json)) = background_bash_inputs.remove(index)
-                && parse_background_bash_start(&input_json).is_some()
+                && let Some((tool_use_id, input_json)) = bash_inputs.remove(index)
+                && let Some(start) = parse_bash_start(&input_json)
             {
-                let app_state = app.state::<AppState>();
-                let mut agents = app_state.agents.write().await;
-                if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
-                    session.running_background_tasks.insert(tool_use_id);
+                let command = start.command.as_deref();
+                if start.run_in_background {
+                    let app_state = app.state::<AppState>();
+                    let mut agents = app_state.agents.write().await;
+                    if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
+                        session.running_background_tasks.insert(tool_use_id.clone());
+                    }
+                }
+                if !command.is_some_and(is_tail_bash_command) {
+                    let output_path = if start.run_in_background {
+                        None
+                    } else {
+                        let path =
+                            agent_bash_output_path(&chat_session_id_for_stream, &tool_use_id);
+                        let echo = command
+                            .map(|cmd| format!("\r\n$ {}\r\n", terminal_text(cmd)))
+                            .unwrap_or_else(|| "\r\n$ Bash\r\n".to_string());
+                        if let Err(err) = append_agent_bash_output(&path, &echo) {
+                            eprintln!("[chat] failed to write agent bash output: {err}");
+                        }
+                        Some(path)
+                    };
+                    if let Some(tab) = create_agent_bash_terminal_tab(
+                        &db_path,
+                        &ws_id,
+                        &chat_session_id_for_stream,
+                        &tool_use_id,
+                        command,
+                        output_path.as_deref(),
+                    ) {
+                        emit_agent_background_task_event(
+                            &app,
+                            AgentBackgroundTaskEventKind::Starting,
+                            &ws_id,
+                            &chat_session_id_for_stream,
+                            tab,
+                        );
+                    }
                 }
             }
 
@@ -1612,6 +1778,58 @@ pub async fn send_chat_message(
                                                 .insert(binding.task_id.clone());
                                         }
                                     }
+                                    if let Ok(db) = Database::open(&db_path) {
+                                        let _ = db.update_agent_task_terminal_tab_binding(
+                                            tool_use_id,
+                                            &binding.task_id,
+                                            &binding.output_path,
+                                        );
+                                        if let Ok(Some(tab)) =
+                                            db.get_terminal_tab_by_tool_use_id(tool_use_id)
+                                        {
+                                            emit_agent_background_task_event(
+                                                &app,
+                                                AgentBackgroundTaskEventKind::Bound,
+                                                &ws_id,
+                                                &chat_session_id_for_stream,
+                                                tab,
+                                            );
+                                        }
+                                    }
+                                } else if let Ok(db) = Database::open(&db_path)
+                                    && let Ok(Some(tab)) =
+                                        db.get_terminal_tab_by_tool_use_id(tool_use_id)
+                                {
+                                    if let Some(path) = tab.output_path.as_deref() {
+                                        let text = terminal_text(&text);
+                                        let suffix =
+                                            if text.ends_with("\r\n") { "" } else { "\r\n" };
+                                        if let Err(err) = append_agent_bash_output(
+                                            std::path::Path::new(path),
+                                            &format!("{text}{suffix}"),
+                                        ) {
+                                            eprintln!(
+                                                "[chat] failed to append agent bash output: {err}"
+                                            );
+                                        }
+                                    }
+                                    let _ = db.update_agent_task_terminal_tab_by_tool_use_id(
+                                        tool_use_id,
+                                        "completed",
+                                        Some("Command completed"),
+                                        None,
+                                    );
+                                    if let Ok(Some(tab)) =
+                                        db.get_terminal_tab_by_tool_use_id(tool_use_id)
+                                    {
+                                        emit_agent_background_task_event(
+                                            &app,
+                                            AgentBackgroundTaskEventKind::Status,
+                                            &ws_id,
+                                            &chat_session_id_for_stream,
+                                            tab,
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -1621,9 +1839,13 @@ pub async fn send_chat_message(
                             let status = notification.status.as_deref().unwrap_or("running");
                             apply_task_notification_status(
                                 &app,
+                                &db_path,
+                                &ws_id,
                                 &chat_session_id_for_stream,
                                 &notification.task_id,
                                 status,
+                                notification.summary.as_deref(),
+                                notification.output_file.as_deref(),
                             )
                             .await;
                         }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -143,7 +143,6 @@ fn get_or_create_agent_shell_terminal_tab(
             .into_owned();
         let _ = db.update_agent_shell_terminal_tab_session(tab.id, chat_session_id, &output_path);
         tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
-        tab.sort_order = 0;
         tab.agent_chat_session_id = Some(chat_session_id.to_string());
         tab.agent_tool_use_id = None;
         tab.agent_task_id = None;
@@ -160,7 +159,7 @@ fn get_or_create_agent_shell_terminal_tab(
         title: CLAUDETTE_TERMINAL_TITLE.to_string(),
         kind: TerminalTabKind::AgentTask,
         is_script_output: false,
-        sort_order: 0,
+        sort_order: -1,
         created_at: now_iso(),
         agent_chat_session_id: Some(chat_session_id.to_string()),
         agent_tool_use_id: None,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter, Manager, State};
 
+use claudette::agent::background::{
+    AgentBackgroundTaskEvent, AgentBackgroundTaskEventKind, parse_background_bash_start,
+    parse_background_task_binding, parse_task_notification,
+};
 use claudette::agent::{
     self, AgentEvent, AgentSettings, ControlRequestInner, FileAttachment, InnerStreamEvent,
     PersistentSession, StartContentBlock, StreamEvent,
@@ -15,7 +19,7 @@ use claudette::chat::{
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
 use claudette::mcp_supervisor::McpSupervisor;
-use claudette::model::{ChatMessage, ChatRole};
+use claudette::model::{ChatMessage, ChatRole, TerminalTab, TerminalTabKind};
 use claudette::permissions::tools_for_level;
 
 use crate::state::{AgentSessionState, AppState, PendingPermission};
@@ -26,6 +30,84 @@ use super::{
     ATTENTION_NOTIFY_DELAY_MS, AgentStreamPayload, AttachmentInput, AttachmentResponse,
     ChatHistoryPage, fire_completion_notification, now_iso, start_bridge_and_inject_mcp,
 };
+
+fn truncate_task_title(command: Option<&str>) -> String {
+    let raw = command.unwrap_or("Background task").trim();
+    let mut title = if raw.is_empty() {
+        "Background task".to_string()
+    } else {
+        raw.to_string()
+    };
+    if title.chars().count() > 42 {
+        title = title.chars().take(39).collect::<String>() + "...";
+    }
+    format!("Agent: {title}")
+}
+
+fn emit_agent_background_task_event(
+    app: &AppHandle,
+    kind: AgentBackgroundTaskEventKind,
+    workspace_id: &str,
+    chat_session_id: &str,
+    tab: TerminalTab,
+) {
+    let payload = AgentBackgroundTaskEvent {
+        kind,
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
+        tab,
+    };
+    let _ = app.emit("agent-background-task", &payload);
+}
+
+fn create_agent_task_terminal_tab(
+    db_path: &std::path::Path,
+    workspace_id: &str,
+    chat_session_id: &str,
+    tool_use_id: &str,
+    command: Option<&str>,
+) -> Option<TerminalTab> {
+    let db = Database::open(db_path).ok()?;
+    if let Ok(Some(tab)) = db.get_terminal_tab_by_tool_use_id(tool_use_id) {
+        return Some(tab);
+    }
+    let max_id = db.max_terminal_tab_id().ok()?;
+    let existing = db.list_terminal_tabs_by_workspace(workspace_id).ok()?;
+    let tab = TerminalTab {
+        id: max_id + 1,
+        workspace_id: workspace_id.to_string(),
+        title: truncate_task_title(command),
+        kind: TerminalTabKind::AgentTask,
+        is_script_output: false,
+        sort_order: existing.len() as i32,
+        created_at: now_iso(),
+        agent_chat_session_id: Some(chat_session_id.to_string()),
+        agent_tool_use_id: Some(tool_use_id.to_string()),
+        agent_task_id: None,
+        output_path: None,
+        task_status: Some("starting".to_string()),
+        task_summary: None,
+    };
+    db.insert_terminal_tab(&tab).ok()?;
+    Some(tab)
+}
+
+fn tool_result_content_text(content: &serde_json::Value) -> String {
+    if let Some(s) = content.as_str() {
+        return s.to_string();
+    }
+    if let Some(items) = content.as_array() {
+        return items
+            .iter()
+            .filter_map(|item| {
+                item.as_str()
+                    .or_else(|| item.get("text").and_then(serde_json::Value::as_str))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+    content.to_string()
+}
 
 #[tauri::command]
 pub async fn load_chat_history(
@@ -394,6 +476,7 @@ pub async fn send_chat_message(
                 session_allowed_tools: Vec::new(),
                 session_disable_1m_context: false,
                 pending_permissions: std::collections::HashMap::new(),
+                running_background_tasks: std::collections::HashSet::new(),
                 session_exited_plan: false,
                 session_resolved_env: Default::default(),
                 mcp_bridge: None,
@@ -417,6 +500,7 @@ pub async fn send_chat_message(
             session_allowed_tools: Vec::new(),
             session_disable_1m_context: false,
             pending_permissions: std::collections::HashMap::new(),
+            running_background_tasks: std::collections::HashSet::new(),
             session_exited_plan: false,
             session_resolved_env: Default::default(),
             mcp_bridge: None,
@@ -1038,6 +1122,11 @@ pub async fn send_chat_message(
         // MCP monitoring: map tool_use_id → tool_name for MCP error detection.
         let mut mcp_tool_names: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
+        // Background-Bash detection: map content-block index → (tool_use_id,
+        // accumulated input JSON). The CLI streams tool input in deltas, so we
+        // only know `run_in_background` once the block stops.
+        let mut background_bash_inputs: std::collections::HashMap<usize, (String, String)> =
+            std::collections::HashMap::new();
         // Track the last assistant message inserted in THIS turn. Falls back
         // to the user message ID for tool-only turns (AskUserQuestion, plan
         // approval) so that checkpoint creation isn't skipped entirely.
@@ -1058,6 +1147,63 @@ pub async fn send_chat_message(
                 && subtype == "init"
             {
                 got_init = true;
+            }
+
+            if let AgentEvent::Stream(StreamEvent::Stream {
+                event:
+                    InnerStreamEvent::ContentBlockStart {
+                        index,
+                        content_block: Some(StartContentBlock::ToolUse { id, name }),
+                    },
+            }) = &event
+                && name == "Bash"
+            {
+                background_bash_inputs.insert(*index, (id.clone(), String::new()));
+            }
+
+            if let AgentEvent::Stream(StreamEvent::Stream {
+                event: InnerStreamEvent::ContentBlockDelta { index, delta },
+            }) = &event
+                && let Some((_tool_use_id, input)) = background_bash_inputs.get_mut(index)
+            {
+                match delta {
+                    claudette::agent::Delta::ToolUse {
+                        partial_json: Some(part),
+                    }
+                    | claudette::agent::Delta::InputJson {
+                        partial_json: Some(part),
+                    } => input.push_str(part),
+                    _ => {}
+                }
+            }
+
+            if let AgentEvent::Stream(StreamEvent::Stream {
+                event: InnerStreamEvent::ContentBlockStop { index },
+            }) = &event
+                && let Some((tool_use_id, input_json)) = background_bash_inputs.remove(index)
+                && let Some(start) = parse_background_bash_start(&input_json)
+                && let Some(tab) = create_agent_task_terminal_tab(
+                    &db_path,
+                    &ws_id,
+                    &chat_session_id_for_stream,
+                    &tool_use_id,
+                    start.command.as_deref(),
+                )
+            {
+                {
+                    let app_state = app.state::<AppState>();
+                    let mut agents = app_state.agents.write().await;
+                    if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
+                        session.running_background_tasks.insert(tool_use_id.clone());
+                    }
+                }
+                emit_agent_background_task_event(
+                    &app,
+                    AgentBackgroundTaskEventKind::Starting,
+                    &ws_id,
+                    &chat_session_id_for_stream,
+                    tab,
+                );
             }
 
             // Compaction boundary event: the CLI emits this after context
@@ -1296,6 +1442,91 @@ pub async fn send_chat_message(
                     cache_creation_tokens: None,
                 };
                 let _ = db.insert_chat_message(&msg);
+            }
+
+            if let AgentEvent::Stream(StreamEvent::User { message, .. }) = &event {
+                match &message.content {
+                    claudette::agent::UserMessageContent::Blocks(blocks) => {
+                        for block in blocks {
+                            if let claudette::agent::UserContentBlock::ToolResult {
+                                tool_use_id,
+                                content,
+                            } = block
+                            {
+                                let text = tool_result_content_text(content);
+                                if let Some(binding) = parse_background_task_binding(&text)
+                                    && let Ok(db) = Database::open(&db_path)
+                                {
+                                    {
+                                        let app_state = app.state::<AppState>();
+                                        let mut agents = app_state.agents.write().await;
+                                        if let Some(session) =
+                                            agents.get_mut(&chat_session_id_for_stream)
+                                        {
+                                            session.running_background_tasks.remove(tool_use_id);
+                                            session
+                                                .running_background_tasks
+                                                .insert(binding.task_id.clone());
+                                        }
+                                    }
+                                    let _ = db.update_agent_task_terminal_tab_binding(
+                                        tool_use_id,
+                                        &binding.task_id,
+                                        &binding.output_path,
+                                    );
+                                    if let Ok(Some(tab)) =
+                                        db.get_terminal_tab_by_tool_use_id(tool_use_id)
+                                    {
+                                        emit_agent_background_task_event(
+                                            &app,
+                                            AgentBackgroundTaskEventKind::Bound,
+                                            &ws_id,
+                                            &chat_session_id_for_stream,
+                                            tab,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    claudette::agent::UserMessageContent::Text(body) => {
+                        if let Some(notification) = parse_task_notification(body)
+                            && let Ok(db) = Database::open(&db_path)
+                        {
+                            if matches!(
+                                notification.status.to_ascii_lowercase().as_str(),
+                                "completed" | "failed" | "stopped" | "cancelled" | "canceled"
+                            ) {
+                                let app_state = app.state::<AppState>();
+                                let mut agents = app_state.agents.write().await;
+                                if let Some(session) = agents.get_mut(&chat_session_id_for_stream) {
+                                    session
+                                        .running_background_tasks
+                                        .remove(&notification.task_id);
+                                }
+                            }
+                            let _ = db.update_agent_task_terminal_tab_status(
+                                &chat_session_id_for_stream,
+                                &notification.task_id,
+                                &notification.status,
+                                notification.summary.as_deref(),
+                                notification.output_file.as_deref(),
+                            );
+                            if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(
+                                &chat_session_id_for_stream,
+                                &notification.task_id,
+                            ) {
+                                emit_agent_background_task_event(
+                                    &app,
+                                    AgentBackgroundTaskEventKind::Status,
+                                    &ws_id,
+                                    &chat_session_id_for_stream,
+                                    tab,
+                                );
+                            }
+                        }
+                    }
+                }
             }
 
             // MCP monitoring: check tool results for connection failure patterns.

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -64,6 +64,13 @@ fn append_agent_bash_output(path: &std::path::Path, text: &str) -> std::io::Resu
     file.write_all(text.as_bytes())
 }
 
+fn truncate_agent_bash_output(path: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::File::create(path).map(|_| ())
+}
+
 fn mirror_background_task_output(source: std::path::PathBuf, destination: std::path::PathBuf) {
     tokio::spawn(async move {
         use tokio::io::{AsyncReadExt, AsyncSeekExt};
@@ -1705,6 +1712,13 @@ pub async fn send_chat_message(
                 && let Some(start) = parse_bash_start(&input_json)
             {
                 let command = start.command.as_deref();
+                let had_running_background_tasks = {
+                    let app_state = app.state::<AppState>();
+                    let agents = app_state.agents.read().await;
+                    agents
+                        .get(&chat_session_id_for_stream)
+                        .is_some_and(|s| !s.running_background_tasks.is_empty())
+                };
                 if start.run_in_background {
                     let app_state = app.state::<AppState>();
                     let mut agents = app_state.agents.write().await;
@@ -1713,6 +1727,10 @@ pub async fn send_chat_message(
                     }
                 }
                 let path = agent_bash_output_path(&chat_session_id_for_stream);
+                if !had_running_background_tasks && let Err(err) = truncate_agent_bash_output(&path)
+                {
+                    eprintln!("[chat] failed to reset agent bash output: {err}");
+                }
                 let echo = command
                     .map(|cmd| format!("\r\n$ {}\r\n", terminal_text(cmd)))
                     .unwrap_or_else(|| "\r\n$ Bash\r\n".to_string());

--- a/src-tauri/src/commands/chat/session.rs
+++ b/src-tauri/src/commands/chat/session.rs
@@ -17,6 +17,8 @@ fn hydrate_session(
     if let Some(agent) = agents.get(&session.id) {
         session.agent_status = if agent.active_pid.is_some() {
             claudette::model::AgentStatus::Running
+        } else if !agent.running_background_tasks.is_empty() {
+            claudette::model::AgentStatus::IdleWithBackground
         } else {
             claudette::model::AgentStatus::Idle
         };
@@ -190,6 +192,73 @@ mod tests {
     fn fresh_state(db_path: PathBuf) -> AppState {
         let plugins = PluginRegistry::discover(std::path::Path::new("/nonexistent"));
         AppState::new(db_path, std::path::PathBuf::from("/tmp"), plugins)
+    }
+
+    fn make_chat_session(id: &str) -> ChatSession {
+        ChatSession {
+            id: id.to_string(),
+            workspace_id: "w1".to_string(),
+            session_id: None,
+            name: "New chat".to_string(),
+            name_edited: false,
+            turn_count: 0,
+            sort_order: 0,
+            status: claudette::model::SessionStatus::Active,
+            created_at: String::new(),
+            archived_at: None,
+            agent_status: AgentStatus::Idle,
+            needs_attention: false,
+            attention_kind: None,
+        }
+    }
+
+    fn make_agent_state(background_tasks: &[&str], active_pid: Option<u32>) -> AgentSessionState {
+        AgentSessionState {
+            workspace_id: "w1".to_string(),
+            session_id: "claude-session".to_string(),
+            turn_count: 1,
+            active_pid,
+            custom_instructions: None,
+            needs_attention: false,
+            attention_kind: None,
+            attention_notification_sent: false,
+            persistent_session: None,
+            mcp_config_dirty: false,
+            session_plan_mode: false,
+            session_allowed_tools: Vec::new(),
+            session_disable_1m_context: false,
+            pending_permissions: Default::default(),
+            running_background_tasks: background_tasks
+                .iter()
+                .map(|task| (*task).to_string())
+                .collect(),
+            background_wake_active: false,
+            session_exited_plan: false,
+            session_resolved_env: Default::default(),
+            mcp_bridge: None,
+            last_user_msg_id: None,
+            posted_env_trust_warning: false,
+        }
+    }
+
+    #[test]
+    fn hydrate_session_reports_idle_with_background_when_tasks_are_running() {
+        let mut agents = std::collections::HashMap::new();
+        agents.insert("s1".to_string(), make_agent_state(&["task-1"], None));
+
+        let session = hydrate_session(make_chat_session("s1"), &agents);
+
+        assert_eq!(session.agent_status, AgentStatus::IdleWithBackground);
+    }
+
+    #[test]
+    fn hydrate_session_reports_running_before_background_status() {
+        let mut agents = std::collections::HashMap::new();
+        agents.insert("s1".to_string(), make_agent_state(&["task-1"], Some(42)));
+
+        let session = hydrate_session(make_chat_session("s1"), &agents);
+
+        assert_eq!(session.agent_status, AgentStatus::Running);
     }
 
     /// Regression test for issue #574: while a streaming task holds

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -123,6 +123,17 @@ pub async fn list_terminal_tabs(
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub async fn update_terminal_tab_order(
+    workspace_id: String,
+    tab_ids: Vec<i64>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.update_terminal_tab_sort_order(&workspace_id, &tab_ids)
+        .map_err(|e| e.to_string())
+}
+
 #[derive(Clone, Serialize)]
 struct AgentTaskOutputPayload {
     tab_id: i64,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -222,13 +222,38 @@ pub async fn stop_agent_background_task(
     Ok(())
 }
 
+/// Cap the initial dump to the last ~64 KiB of an existing output file.
+/// A long-lived agent shell can accumulate megabytes of history; emitting
+/// it all on first attach would lock the renderer and force xterm to
+/// reflow a huge buffer. New writes (the common case once the tail is
+/// caught up) ignore this cap.
+const INITIAL_TAIL_BYTES: u64 = 64 * 1024;
+
 async fn tail_agent_task_file(
     tab_id: i64,
     path: PathBuf,
     app: AppHandle,
     cancel: Arc<tokio::sync::Notify>,
 ) {
-    let mut offset = 0_u64;
+    // Seed `offset` so the first read returns at most the last
+    // INITIAL_TAIL_BYTES of an already-grown file. We still emit a `reset`
+    // marker before the chunk so the frontend doesn't render half-baked
+    // output ahead of a partial line — the agent shell is line-oriented
+    // so an interior offset is fine for visual continuity.
+    let mut offset = match tokio::fs::metadata(&path).await {
+        Ok(meta) => meta.len().saturating_sub(INITIAL_TAIL_BYTES),
+        Err(_) => 0,
+    };
+    if offset > 0 {
+        let _ = app.emit(
+            "agent-task-output",
+            &AgentTaskOutputPayload {
+                tab_id,
+                data: Vec::new(),
+                reset: true,
+            },
+        );
+    }
     let mut buf = vec![0_u8; 8192];
     loop {
         tokio::select! {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,9 +1,16 @@
-use tauri::State;
+use std::io::SeekFrom;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
 use claudette::db::Database;
 use claudette::model::TerminalTab;
 
-use crate::state::AppState;
+use crate::state::{AgentTaskTailHandle, AppState};
 
 #[tauri::command]
 pub async fn create_terminal_tab(
@@ -31,9 +38,16 @@ pub async fn create_terminal_tab(
         id: new_id,
         workspace_id,
         title: format!("Terminal {n}"),
+        kind: Default::default(),
         is_script_output: false,
         sort_order,
         created_at: now_iso(),
+        agent_chat_session_id: None,
+        agent_tool_use_id: None,
+        agent_task_id: None,
+        output_path: None,
+        task_status: None,
+        task_summary: None,
     };
 
     db.insert_terminal_tab(&tab).map_err(|e| e.to_string())?;
@@ -55,6 +69,137 @@ pub async fn list_terminal_tabs(
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.list_terminal_tabs_by_workspace(&workspace_id)
         .map_err(|e| e.to_string())
+}
+
+#[derive(Clone, Serialize)]
+struct AgentTaskOutputPayload {
+    tab_id: i64,
+    data: Vec<u8>,
+}
+
+#[tauri::command]
+pub async fn start_agent_task_tail(
+    tab_id: i64,
+    output_path: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if output_path.trim().is_empty() {
+        return Err("Output path is empty".to_string());
+    }
+
+    stop_agent_task_tail(tab_id, state.clone()).await?;
+
+    let cancel = Arc::new(tokio::sync::Notify::new());
+    state.agent_task_tailers.write().await.insert(
+        tab_id,
+        AgentTaskTailHandle {
+            cancel: cancel.clone(),
+        },
+    );
+
+    tokio::spawn(async move {
+        tail_agent_task_file(tab_id, PathBuf::from(output_path), app, cancel).await;
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_agent_task_tail(tab_id: i64, state: State<'_, AppState>) -> Result<(), String> {
+    if let Some(handle) = state.agent_task_tailers.write().await.remove(&tab_id) {
+        handle.cancel.notify_waiters();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn stop_agent_background_task(
+    chat_session_id: String,
+    task_id: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let ps = {
+        let agents = state.agents.read().await;
+        agents
+            .get(&chat_session_id)
+            .and_then(|session| session.persistent_session.clone())
+    };
+    let Some(ps) = ps else {
+        return Err("Agent session is not running".to_string());
+    };
+    ps.send_task_stop(&task_id).await?;
+    {
+        let mut agents = state.agents.write().await;
+        if let Some(session) = agents.get_mut(&chat_session_id) {
+            session.running_background_tasks.remove(&task_id);
+        }
+    }
+
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let _ = db.update_agent_task_terminal_tab_status(
+        &chat_session_id,
+        &task_id,
+        "stopped",
+        Some("Stopped by user"),
+        None,
+    );
+    if let Ok(Some(tab)) = db.get_terminal_tab_by_agent_task(&chat_session_id, &task_id) {
+        let _ = app.emit(
+            "agent-background-task",
+            &claudette::agent::background::AgentBackgroundTaskEvent {
+                kind: claudette::agent::background::AgentBackgroundTaskEventKind::Status,
+                workspace_id: tab.workspace_id.clone(),
+                chat_session_id,
+                tab,
+            },
+        );
+    }
+    Ok(())
+}
+
+async fn tail_agent_task_file(
+    tab_id: i64,
+    path: PathBuf,
+    app: AppHandle,
+    cancel: Arc<tokio::sync::Notify>,
+) {
+    let mut offset = 0_u64;
+    let mut buf = vec![0_u8; 8192];
+    loop {
+        tokio::select! {
+            _ = cancel.notified() => break,
+            _ = tokio::time::sleep(Duration::from_millis(33)) => {}
+        }
+
+        let Ok(mut file) = tokio::fs::File::open(&path).await else {
+            continue;
+        };
+        let len = file.metadata().await.ok().map(|m| m.len()).unwrap_or(0);
+        if len < offset {
+            offset = 0;
+        }
+        if file.seek(SeekFrom::Start(offset)).await.is_err() {
+            continue;
+        }
+        loop {
+            match file.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    offset += n as u64;
+                    let _ = app.emit(
+                        "agent-task-output",
+                        &AgentTaskOutputPayload {
+                            tab_id,
+                            data: buf[..n].to_vec(),
+                        },
+                    );
+                }
+                Err(_) => break,
+            }
+        }
+    }
 }
 
 fn now_iso() -> String {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -7,8 +7,9 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
-use claudette::db::Database;
-use claudette::model::TerminalTab;
+use claudette::agent::background::agent_bash_output_path;
+use claudette::db::{CLAUDETTE_TERMINAL_TITLE, Database};
+use claudette::model::{TerminalTab, TerminalTabKind};
 
 use crate::state::{AgentTaskTailHandle, AppState};
 
@@ -52,6 +53,57 @@ pub async fn create_terminal_tab(
 
     db.insert_terminal_tab(&tab).map_err(|e| e.to_string())?;
 
+    Ok(tab)
+}
+
+#[tauri::command]
+pub async fn ensure_claudette_terminal_tab(
+    workspace_id: String,
+    chat_session_id: String,
+    state: State<'_, AppState>,
+) -> Result<TerminalTab, String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    if let Some(mut tab) = db
+        .get_agent_shell_terminal_tab_by_workspace(&workspace_id)
+        .map_err(|e| e.to_string())?
+    {
+        let output_path = agent_bash_output_path(&chat_session_id)
+            .to_string_lossy()
+            .into_owned();
+        db.update_agent_shell_terminal_tab_session(tab.id, &chat_session_id, &output_path)
+            .map_err(|e| e.to_string())?;
+        tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
+        tab.sort_order = 0;
+        tab.agent_chat_session_id = Some(chat_session_id);
+        tab.agent_tool_use_id = None;
+        tab.agent_task_id = None;
+        tab.output_path = Some(output_path);
+        tab.task_status = None;
+        tab.task_summary = None;
+        return Ok(tab);
+    }
+
+    let tab = TerminalTab {
+        id: db.max_terminal_tab_id().map_err(|e| e.to_string())? + 1,
+        workspace_id,
+        title: CLAUDETTE_TERMINAL_TITLE.to_string(),
+        kind: TerminalTabKind::AgentTask,
+        is_script_output: false,
+        sort_order: 0,
+        created_at: now_iso(),
+        agent_chat_session_id: Some(chat_session_id.clone()),
+        agent_tool_use_id: None,
+        agent_task_id: None,
+        output_path: Some(
+            agent_bash_output_path(&chat_session_id)
+                .to_string_lossy()
+                .into_owned(),
+        ),
+        task_status: None,
+        task_summary: None,
+    };
+    db.insert_terminal_tab(&tab).map_err(|e| e.to_string())?;
     Ok(tab)
 }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -74,7 +74,6 @@ pub async fn ensure_claudette_terminal_tab(
         db.update_agent_shell_terminal_tab_session(tab.id, &chat_session_id, &output_path)
             .map_err(|e| e.to_string())?;
         tab.title = CLAUDETTE_TERMINAL_TITLE.to_string();
-        tab.sort_order = 0;
         tab.agent_chat_session_id = Some(chat_session_id);
         tab.agent_tool_use_id = None;
         tab.agent_task_id = None;
@@ -90,7 +89,7 @@ pub async fn ensure_claudette_terminal_tab(
         title: CLAUDETTE_TERMINAL_TITLE.to_string(),
         kind: TerminalTabKind::AgentTask,
         is_script_output: false,
-        sort_order: 0,
+        sort_order: -1,
         created_at: now_iso(),
         agent_chat_session_id: Some(chat_session_id.clone()),
         agent_tool_use_id: None,
@@ -138,6 +137,7 @@ pub async fn update_terminal_tab_order(
 struct AgentTaskOutputPayload {
     tab_id: i64,
     data: Vec<u8>,
+    reset: bool,
 }
 
 #[tauri::command]
@@ -242,6 +242,14 @@ async fn tail_agent_task_file(
         let len = file.metadata().await.ok().map(|m| m.len()).unwrap_or(0);
         if len < offset {
             offset = 0;
+            let _ = app.emit(
+                "agent-task-output",
+                &AgentTaskOutputPayload {
+                    tab_id,
+                    data: Vec::new(),
+                    reset: true,
+                },
+            );
         }
         if file.seek(SeekFrom::Start(offset)).await.is_err() {
             continue;
@@ -256,6 +264,7 @@ async fn tail_agent_task_file(
                         &AgentTaskOutputPayload {
                             tab_id,
                             data: buf[..n].to_vec(),
+                            reset: false,
                         },
                     );
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -525,6 +525,9 @@ fn main() {
             commands::terminal::create_terminal_tab,
             commands::terminal::delete_terminal_tab,
             commands::terminal::list_terminal_tabs,
+            commands::terminal::start_agent_task_tail,
+            commands::terminal::stop_agent_task_tail,
+            commands::terminal::stop_agent_background_task,
             // PTY
             pty::spawn_pty,
             pty::write_pty,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -526,6 +526,7 @@ fn main() {
             commands::terminal::delete_terminal_tab,
             commands::terminal::ensure_claudette_terminal_tab,
             commands::terminal::list_terminal_tabs,
+            commands::terminal::update_terminal_tab_order,
             commands::terminal::start_agent_task_tail,
             commands::terminal::stop_agent_task_tail,
             commands::terminal::stop_agent_background_task,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -524,6 +524,7 @@ fn main() {
             // Terminal
             commands::terminal::create_terminal_tab,
             commands::terminal::delete_terminal_tab,
+            commands::terminal::ensure_claudette_terminal_tab,
             commands::terminal::list_terminal_tabs,
             commands::terminal::start_agent_task_tail,
             commands::terminal::stop_agent_task_tail,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -97,6 +97,9 @@ pub struct AgentSessionState {
     /// Keys begin as tool_use_id while the task is starting, then switch to the
     /// CLI task_id once the tool result binds it.
     pub running_background_tasks: std::collections::HashSet<String>,
+    /// True while Claudette has an internal wake turn queued/running to let
+    /// Claude Code drain task-notification messages for background jobs.
+    pub background_wake_active: bool,
     /// Set when the agent emits `ExitPlanMode` during the current persistent
     /// session. The plan phase is over even if the frontend fails to flip
     /// `plan_mode=false` on the next turn, so we force a teardown regardless

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -93,6 +93,10 @@ pub struct AgentSessionState {
     /// Outstanding `can_use_tool` control requests awaiting a `control_response`,
     /// keyed by tool_use_id. See [`PendingPermission`].
     pub pending_permissions: HashMap<String, PendingPermission>,
+    /// Agent-owned background Bash tasks that are still believed to be running.
+    /// Keys begin as tool_use_id while the task is starting, then switch to the
+    /// CLI task_id once the tool result binds it.
+    pub running_background_tasks: std::collections::HashSet<String>,
     /// Set when the agent emits `ExitPlanMode` during the current persistent
     /// session. The plan phase is over even if the frontend fails to flip
     /// `plan_mode=false` on the next turn, so we force a teardown regardless
@@ -159,6 +163,10 @@ pub struct PtyHandle {
     /// drops its duplicated master FD and exits before this handle is freed.
     /// `None` on platforms where the tracker is not spawned (Windows).
     pub tracker_cancel: Option<Arc<tokio::sync::Notify>>,
+}
+
+pub struct AgentTaskTailHandle {
+    pub cancel: Arc<tokio::sync::Notify>,
 }
 
 /// State of the embedded claudette-server subprocess.
@@ -318,6 +326,8 @@ pub struct AppState {
     pub agents: RwLock<HashMap<String, AgentSessionState>>,
     /// Active PTY processes keyed by pty_id.
     pub ptys: RwLock<HashMap<u64, PtyHandle>>,
+    /// Active file-tail streams for agent-owned background task terminal tabs.
+    pub agent_task_tailers: RwLock<HashMap<i64, AgentTaskTailHandle>>,
     /// Counter for generating unique PTY IDs.
     pub next_pty_id: AtomicU64,
     /// mDNS-discovered servers on the local network.
@@ -377,6 +387,7 @@ impl AppState {
             worktree_base_dir: RwLock::new(worktree_base_dir),
             agents: RwLock::new(HashMap::new()),
             ptys: RwLock::new(HashMap::new()),
+            agent_task_tailers: RwLock::new(HashMap::new()),
             next_pty_id: AtomicU64::new(1),
             discovered_servers: RwLock::new(Vec::new()),
             local_server: RwLock::new(None),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -809,6 +809,7 @@ mod tests {
             session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
             running_background_tasks: Default::default(),
+            background_wake_active: false,
             session_exited_plan: false,
             session_resolved_env: Default::default(),
             mcp_bridge: None,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -536,7 +536,9 @@ fn compute_tray_state(state: &AppState) -> TrayState {
 pub fn has_running_agents(
     agents: &std::collections::HashMap<String, crate::state::AgentSessionState>,
 ) -> bool {
-    agents.values().any(|s| s.active_pid.is_some())
+    agents
+        .values()
+        .any(|s| s.active_pid.is_some() || !s.running_background_tasks.is_empty())
 }
 
 /// Authoritatively clear `needs_attention` / `attention_kind` for every
@@ -806,6 +808,7 @@ mod tests {
             session_allowed_tools: Vec::new(),
             session_disable_1m_context: false,
             pending_permissions: HashMap::new(),
+            running_background_tasks: Default::default(),
             session_exited_plan: false,
             session_resolved_env: Default::default(),
             mcp_bridge: None,
@@ -973,6 +976,15 @@ mod tests {
         let mut agents = HashMap::new();
         agents.insert("ws1".to_string(), session(Some(1234), false));
         agents.insert("ws2".to_string(), session(None, false));
+        assert!(has_running_agents(&agents));
+    }
+
+    #[test]
+    fn test_has_running_agents_one_background_task() {
+        let mut agents = HashMap::new();
+        let mut s = session(None, false);
+        s.running_background_tasks.insert("task_1".to_string());
+        agents.insert("ws1".to_string(), s);
         assert!(has_running_agents(&agents));
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -536,9 +536,7 @@ fn compute_tray_state(state: &AppState) -> TrayState {
 pub fn has_running_agents(
     agents: &std::collections::HashMap<String, crate::state::AgentSessionState>,
 ) -> bool {
-    agents
-        .values()
-        .any(|s| s.active_pid.is_some() || !s.running_background_tasks.is_empty())
+    agents.values().any(|s| s.active_pid.is_some())
 }
 
 /// Authoritatively clear `needs_attention` / `attention_kind` for every
@@ -981,12 +979,12 @@ mod tests {
     }
 
     #[test]
-    fn test_has_running_agents_one_background_task() {
+    fn test_has_running_agents_ignores_background_task_without_active_pid() {
         let mut agents = HashMap::new();
         let mut s = session(None, false);
         s.running_background_tasks.insert("task_1".to_string());
         agents.insert("ws1".to_string(), s);
-        assert!(has_running_agents(&agents));
+        assert!(!has_running_agents(&agents));
     }
 
     #[test]

--- a/src/agent/args.rs
+++ b/src/agent/args.rs
@@ -165,6 +165,7 @@ pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> Stri
 
     serde_json::json!({
         "type": "user",
+        "uuid": uuid::Uuid::new_v4().to_string(),
         "message": {
             "role": "user",
             "content": content_blocks,
@@ -601,6 +602,11 @@ mod tests {
         let msg = build_stdin_message("hello", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         assert_eq!(parsed["type"], "user");
+        assert!(
+            parsed["uuid"]
+                .as_str()
+                .is_some_and(|id| uuid::Uuid::parse_str(id).is_ok())
+        );
         assert_eq!(parsed["parent_tool_use_id"], serde_json::Value::Null);
         let content = parsed["message"]["content"].as_array().unwrap();
         assert_eq!(content.len(), 1);

--- a/src/agent/background.rs
+++ b/src/agent/background.rs
@@ -1,6 +1,12 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BashStart {
+    pub command: Option<String>,
+    pub run_in_background: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackgroundBashStart {
     pub command: Option<String>,
 }
@@ -36,22 +42,76 @@ pub struct AgentBackgroundTaskEvent {
     pub tab: crate::model::TerminalTab,
 }
 
-pub fn parse_background_bash_start(input_json: &str) -> Option<BackgroundBashStart> {
+pub fn parse_bash_start(input_json: &str) -> Option<BashStart> {
     let value: serde_json::Value = serde_json::from_str(input_json).ok()?;
-    if value
+    let run_in_background = value
         .get("run_in_background")
         .and_then(serde_json::Value::as_bool)
-        != Some(true)
-    {
-        return None;
-    }
+        == Some(true);
     let command = value
         .get("command")
         .and_then(serde_json::Value::as_str)
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(ToOwned::to_owned);
-    Some(BackgroundBashStart { command })
+    Some(BashStart {
+        command,
+        run_in_background,
+    })
+}
+
+pub fn parse_background_bash_start(input_json: &str) -> Option<BackgroundBashStart> {
+    let start = parse_bash_start(input_json)?;
+    if !start.run_in_background {
+        return None;
+    }
+    Some(BackgroundBashStart {
+        command: start.command,
+    })
+}
+
+pub fn is_tail_bash_command(command: &str) -> bool {
+    let Some(first) = first_shell_word(command.trim_start()) else {
+        return false;
+    };
+    let command_name = first.rsplit('/').next().unwrap_or(first);
+    command_name == "tail" || command_name == "gtail"
+}
+
+fn first_shell_word(command: &str) -> Option<&str> {
+    let mut end = 0;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for (idx, ch) in command.char_indices() {
+        if escaped {
+            escaped = false;
+            end = idx + ch.len_utf8();
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            end = idx + ch.len_utf8();
+            continue;
+        }
+        if let Some(q) = quote {
+            if ch == q {
+                quote = None;
+            }
+            end = idx + ch.len_utf8();
+            continue;
+        }
+        if ch == '"' || ch == '\'' {
+            quote = Some(ch);
+            end = idx + ch.len_utf8();
+            continue;
+        }
+        if ch.is_whitespace() || matches!(ch, '|' | '&' | ';' | '(' | ')') {
+            break;
+        }
+        end = idx + ch.len_utf8();
+    }
+    let word = command.get(..end)?.trim();
+    if word.is_empty() { None } else { Some(word) }
 }
 
 pub fn parse_background_task_binding(text: &str) -> Option<BackgroundTaskBinding> {
@@ -123,6 +183,22 @@ mod tests {
     #[test]
     fn ignores_foreground_bash() {
         assert!(parse_background_bash_start(r#"{"command":"pwd"}"#).is_none());
+    }
+
+    #[test]
+    fn parses_foreground_bash_start() {
+        let start = parse_bash_start(r#"{"command":"pwd"}"#).unwrap();
+        assert_eq!(start.command.as_deref(), Some("pwd"));
+        assert!(!start.run_in_background);
+    }
+
+    #[test]
+    fn detects_tail_commands() {
+        assert!(is_tail_bash_command("tail -f /tmp/out"));
+        assert!(is_tail_bash_command(" /usr/bin/tail -n 20 file"));
+        assert!(is_tail_bash_command("gtail -F file"));
+        assert!(!is_tail_bash_command("tailwindcss --help"));
+        assert!(!is_tail_bash_command("cat file | tail -n 1"));
     }
 
     #[test]

--- a/src/agent/background.rs
+++ b/src/agent/background.rs
@@ -1,0 +1,148 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundBashStart {
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundTaskBinding {
+    pub task_id: String,
+    pub output_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskNotification {
+    pub task_id: String,
+    pub output_file: Option<String>,
+    pub status: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentBackgroundTaskEventKind {
+    Starting,
+    Bound,
+    Status,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentBackgroundTaskEvent {
+    pub kind: AgentBackgroundTaskEventKind,
+    pub workspace_id: String,
+    pub chat_session_id: String,
+    pub tab: crate::model::TerminalTab,
+}
+
+pub fn parse_background_bash_start(input_json: &str) -> Option<BackgroundBashStart> {
+    let value: serde_json::Value = serde_json::from_str(input_json).ok()?;
+    if value
+        .get("run_in_background")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return None;
+    }
+    let command = value
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned);
+    Some(BackgroundBashStart { command })
+}
+
+pub fn parse_background_task_binding(text: &str) -> Option<BackgroundTaskBinding> {
+    const PREFIX: &str = "Command running in background with ID:";
+    const MIDDLE: &str = "Output is being written to:";
+    let start = text.find(PREFIX)? + PREFIX.len();
+    let rest = text[start..].trim_start();
+    let middle = rest.find(MIDDLE)?;
+    let task_id = rest[..middle].trim().trim_end_matches('.');
+    let output_path = rest[middle + MIDDLE.len()..].trim();
+    let output_path = output_path.trim_end_matches(|c: char| c == '.' || c.is_whitespace());
+    if task_id.is_empty() || output_path.is_empty() {
+        return None;
+    }
+    Some(BackgroundTaskBinding {
+        task_id: task_id.to_string(),
+        output_path: output_path.to_string(),
+    })
+}
+
+pub fn parse_task_notification(text: &str) -> Option<TaskNotification> {
+    if !text.contains("<task-notification") {
+        return None;
+    }
+    let task_id = extract_xml_tag(text, "task-id")?;
+    let status = extract_xml_tag(text, "status")?;
+    Some(TaskNotification {
+        task_id,
+        output_file: extract_xml_tag(text, "output-file"),
+        status,
+        summary: extract_xml_tag(text, "summary"),
+    })
+}
+
+fn extract_xml_tag(text: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = text.find(&open)? + open.len();
+    let end = text[start..].find(&close)? + start;
+    let value = text[start..end].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(unescape_xml(value))
+    }
+}
+
+fn unescape_xml(value: &str) -> String {
+    value
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_background_bash_start() {
+        let start =
+            parse_background_bash_start(r#"{"command":"bun run dev","run_in_background":true}"#)
+                .unwrap();
+        assert_eq!(start.command.as_deref(), Some("bun run dev"));
+    }
+
+    #[test]
+    fn ignores_foreground_bash() {
+        assert!(parse_background_bash_start(r#"{"command":"pwd"}"#).is_none());
+    }
+
+    #[test]
+    fn parses_background_task_binding() {
+        let binding = parse_background_task_binding(
+            "Command running in background with ID: task_123. Output is being written to: /tmp/out.log",
+        )
+        .unwrap();
+        assert_eq!(binding.task_id, "task_123");
+        assert_eq!(binding.output_path, "/tmp/out.log");
+    }
+
+    #[test]
+    fn parses_task_notification_xml() {
+        let notification = parse_task_notification(
+            "<task-notification><task-id>task_123</task-id><output-file>/tmp/out.log</output-file><status>completed</status><summary>exit 0</summary></task-notification>",
+        )
+        .unwrap();
+        assert_eq!(notification.task_id, "task_123");
+        assert_eq!(notification.output_file.as_deref(), Some("/tmp/out.log"));
+        assert_eq!(notification.status, "completed");
+        assert_eq!(notification.summary.as_deref(), Some("exit 0"));
+    }
+}

--- a/src/agent/background.rs
+++ b/src/agent/background.rs
@@ -1,5 +1,12 @@
 use serde::{Deserialize, Serialize};
 
+pub fn agent_bash_output_path(chat_session_id: &str) -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("claudette-agent-bash")
+        .join(chat_session_id)
+        .join("agent-shell.output")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BashStart {
     pub command: Option<String>,

--- a/src/agent/background.rs
+++ b/src/agent/background.rs
@@ -193,10 +193,33 @@ mod tests {
     }
 
     #[test]
+    fn parses_explicit_foreground_bash_start() {
+        let start = parse_bash_start(r#"{"command":"pwd","run_in_background":false}"#).unwrap();
+        assert_eq!(start.command.as_deref(), Some("pwd"));
+        assert!(!start.run_in_background);
+        assert!(
+            parse_background_bash_start(r#"{"command":"pwd","run_in_background":false}"#).is_none()
+        );
+    }
+
+    #[test]
     fn parses_foreground_bash_start() {
         let start = parse_bash_start(r#"{"command":"pwd"}"#).unwrap();
         assert_eq!(start.command.as_deref(), Some("pwd"));
         assert!(!start.run_in_background);
+    }
+
+    #[test]
+    fn parses_empty_bash_command_as_none() {
+        let start = parse_bash_start(r#"{"command":"   ","run_in_background":true}"#).unwrap();
+        assert_eq!(start.command, None);
+        assert!(start.run_in_background);
+    }
+
+    #[test]
+    fn rejects_invalid_bash_start_json() {
+        assert!(parse_bash_start("not json").is_none());
+        assert!(parse_background_bash_start("not json").is_none());
     }
 
     #[test]
@@ -209,6 +232,13 @@ mod tests {
     }
 
     #[test]
+    fn detects_tail_commands_with_shell_prefix_boundaries() {
+        assert!(is_tail_bash_command("tail\t-f /tmp/out"));
+        assert!(is_tail_bash_command("/opt/homebrew/bin/gtail && true"));
+        assert!(!is_tail_bash_command("env tail -f /tmp/out"));
+    }
+
+    #[test]
     fn parses_background_task_binding() {
         let binding = parse_background_task_binding(
             "Command running in background with ID: task_123. Output is being written to: /tmp/out.log",
@@ -216,6 +246,30 @@ mod tests {
         .unwrap();
         assert_eq!(binding.task_id, "task_123");
         assert_eq!(binding.output_path, "/tmp/out.log");
+    }
+
+    #[test]
+    fn parses_background_task_binding_inside_tool_text() {
+        let binding = parse_background_task_binding(
+            "Started.\nCommand running in background with ID: task_123.\nOutput is being written to: /tmp/out.log.\n",
+        )
+        .unwrap();
+        assert_eq!(binding.task_id, "task_123");
+        assert_eq!(binding.output_path, "/tmp/out.log");
+    }
+
+    #[test]
+    fn rejects_incomplete_background_task_binding() {
+        assert!(
+            parse_background_task_binding("Command running in background with ID: task_123.")
+                .is_none()
+        );
+        assert!(
+            parse_background_task_binding(
+                "Command running in background with ID: . Output is being written to: /tmp/out.log",
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -240,5 +294,25 @@ mod tests {
         assert_eq!(notification.task_id, "task_123");
         assert_eq!(notification.status, None);
         assert_eq!(notification.summary.as_deref(), Some("waiting for input"));
+    }
+
+    #[test]
+    fn parses_task_notification_with_escaped_fields() {
+        let notification = parse_task_notification(
+            "<task-notification><task-id>task_123</task-id><summary>done &amp; wrote &lt;file&gt;</summary></task-notification>",
+        )
+        .unwrap();
+        assert_eq!(notification.summary.as_deref(), Some("done & wrote <file>"));
+    }
+
+    #[test]
+    fn rejects_task_notification_without_task_id() {
+        assert!(
+            parse_task_notification(
+                "<task-notification><status>completed</status></task-notification>",
+            )
+            .is_none()
+        );
+        assert!(parse_task_notification("plain text").is_none());
     }
 }

--- a/src/agent/background.rs
+++ b/src/agent/background.rs
@@ -14,8 +14,9 @@ pub struct BackgroundTaskBinding {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskNotification {
     pub task_id: String,
+    pub tool_use_id: Option<String>,
     pub output_file: Option<String>,
-    pub status: String,
+    pub status: Option<String>,
     pub summary: Option<String>,
 }
 
@@ -76,11 +77,11 @@ pub fn parse_task_notification(text: &str) -> Option<TaskNotification> {
         return None;
     }
     let task_id = extract_xml_tag(text, "task-id")?;
-    let status = extract_xml_tag(text, "status")?;
     Some(TaskNotification {
         task_id,
+        tool_use_id: extract_xml_tag(text, "tool-use-id"),
         output_file: extract_xml_tag(text, "output-file"),
-        status,
+        status: extract_xml_tag(text, "status"),
         summary: extract_xml_tag(text, "summary"),
     })
 }
@@ -137,12 +138,24 @@ mod tests {
     #[test]
     fn parses_task_notification_xml() {
         let notification = parse_task_notification(
-            "<task-notification><task-id>task_123</task-id><output-file>/tmp/out.log</output-file><status>completed</status><summary>exit 0</summary></task-notification>",
+            "<task-notification><task-id>task_123</task-id><tool-use-id>toolu_1</tool-use-id><output-file>/tmp/out.log</output-file><status>completed</status><summary>exit 0</summary></task-notification>",
         )
         .unwrap();
         assert_eq!(notification.task_id, "task_123");
+        assert_eq!(notification.tool_use_id.as_deref(), Some("toolu_1"));
         assert_eq!(notification.output_file.as_deref(), Some("/tmp/out.log"));
-        assert_eq!(notification.status, "completed");
+        assert_eq!(notification.status.as_deref(), Some("completed"));
         assert_eq!(notification.summary.as_deref(), Some("exit 0"));
+    }
+
+    #[test]
+    fn parses_statusless_task_notification_xml() {
+        let notification = parse_task_notification(
+            "<task-notification><task-id>task_123</task-id><output-file>/tmp/out.log</output-file><summary>waiting for input</summary></task-notification>",
+        )
+        .unwrap();
+        assert_eq!(notification.task_id, "task_123");
+        assert_eq!(notification.status, None);
+        assert_eq!(notification.summary.as_deref(), Some("waiting for input"));
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,4 +1,5 @@
 mod args;
+pub mod background;
 mod binary;
 mod naming;
 mod process;

--- a/src/agent/process.rs
+++ b/src/agent/process.rs
@@ -15,6 +15,12 @@ use super::binary::resolve_claude_path;
 use super::types::{FileAttachment, StreamEvent, parse_stream_line};
 
 /// Events emitted by an agent turn (stream events + process lifecycle).
+//
+// `Stream` is large (~240 B) and `ProcessExited` is tiny (~8 B), so clippy
+// flags the size gap. Boxing `Stream` would force a heap allocation per
+// streamed event in the hot path while saving stack only on the rare
+// end-of-turn sentinel — a net pessimization. Keep the inline payload.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize)]
 pub enum AgentEvent {
     /// A parsed stream event from stdout.

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -226,6 +226,13 @@ impl PersistentSession {
         })
     }
 
+    /// Subscribe to the persistent process's raw stream-json events without
+    /// sending a new turn. Used by session-level infrastructure that must
+    /// observe SDK events emitted while no user turn receiver is active.
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<AgentEvent> {
+        self.event_tx.subscribe()
+    }
+
     /// Write a `control_response` line to the CLI's stdin, answering a
     /// prior `control_request: can_use_tool`. The inner `response` value is
     /// either a permission-allow (`{ behavior: "allow", updatedInput }`) or

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -262,10 +262,40 @@ impl PersistentSession {
         Ok(())
     }
 
+    /// Ask the persistent Claude CLI process to stop an agent-owned
+    /// background task. The CLI accepts out-of-band JSON lines on the same
+    /// stream-json stdin used for user turns and permission responses.
+    pub async fn send_task_stop(&self, task_id: &str) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt;
+        let message = build_task_stop_message(task_id);
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(message.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write task_stop: {e}"))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("Failed to write task_stop newline: {e}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| format!("Failed to flush task_stop: {e}"))?;
+        Ok(())
+    }
+
     /// Get the process ID.
     pub fn pid(&self) -> u32 {
         self.pid
     }
+}
+
+fn build_task_stop_message(task_id: &str) -> String {
+    serde_json::json!({
+        "type": "task_stop",
+        "task_id": task_id,
+    })
+    .to_string()
 }
 
 /// Build CLI arguments for a persistent session (no prompt, with `--input-format stream-json`).
@@ -612,5 +642,13 @@ mod tests {
             .position(|a| a == "--permission-prompt-tool")
             .expect("--permission-prompt-tool missing in persistent args");
         assert_eq!(args.get(idx + 1).map(String::as_str), Some("stdio"));
+    }
+
+    #[test]
+    fn build_task_stop_message_writes_out_of_band_control_shape() {
+        let raw = build_task_stop_message("task_123");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["type"], "task_stop");
+        assert_eq!(parsed["task_id"], "task_123");
     }
 }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -263,24 +263,25 @@ impl PersistentSession {
     }
 
     /// Ask the persistent Claude CLI process to stop an agent-owned
-    /// background task. The CLI accepts out-of-band JSON lines on the same
-    /// stream-json stdin used for user turns and permission responses.
+    /// background task. The CLI accepts this as an SDK `control_request` on
+    /// the same stream-json stdin used for user turns and permission responses.
     pub async fn send_task_stop(&self, task_id: &str) -> Result<(), String> {
         use tokio::io::AsyncWriteExt;
-        let message = build_task_stop_message(task_id);
+        let request_id = format!("claudette-stop-task-{}", uuid::Uuid::new_v4());
+        let message = build_task_stop_message(&request_id, task_id);
         let mut stdin = self.stdin.lock().await;
         stdin
             .write_all(message.as_bytes())
             .await
-            .map_err(|e| format!("Failed to write task_stop: {e}"))?;
+            .map_err(|e| format!("Failed to write stop_task control_request: {e}"))?;
         stdin
             .write_all(b"\n")
             .await
-            .map_err(|e| format!("Failed to write task_stop newline: {e}"))?;
+            .map_err(|e| format!("Failed to write stop_task control_request newline: {e}"))?;
         stdin
             .flush()
             .await
-            .map_err(|e| format!("Failed to flush task_stop: {e}"))?;
+            .map_err(|e| format!("Failed to flush stop_task control_request: {e}"))?;
         Ok(())
     }
 
@@ -290,10 +291,14 @@ impl PersistentSession {
     }
 }
 
-fn build_task_stop_message(task_id: &str) -> String {
+fn build_task_stop_message(request_id: &str, task_id: &str) -> String {
     serde_json::json!({
-        "type": "task_stop",
-        "task_id": task_id,
+        "type": "control_request",
+        "request_id": request_id,
+        "request": {
+            "subtype": "stop_task",
+            "task_id": task_id,
+        },
     })
     .to_string()
 }
@@ -646,9 +651,11 @@ mod tests {
 
     #[test]
     fn build_task_stop_message_writes_out_of_band_control_shape() {
-        let raw = build_task_stop_message("task_123");
+        let raw = build_task_stop_message("req_123", "task_123");
         let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert_eq!(parsed["type"], "task_stop");
-        assert_eq!(parsed["task_id"], "task_123");
+        assert_eq!(parsed["type"], "control_request");
+        assert_eq!(parsed["request_id"], "req_123");
+        assert_eq!(parsed["request"]["subtype"], "stop_task");
+        assert_eq!(parsed["request"]["task_id"], "task_123");
     }
 }

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -251,6 +251,12 @@ impl Default for UserMessageContent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum UserContentBlock {
+    #[serde(rename = "text")]
+    Text {
+        #[serde(default)]
+        text: String,
+    },
+
     #[serde(rename = "tool_result")]
     ToolResult {
         tool_use_id: String,

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -60,6 +60,20 @@ pub enum StreamEvent {
         subtype: String,
         #[serde(default)]
         session_id: Option<String>,
+        /// Present on `subtype: "task_notification"` events emitted when a
+        /// background task completes or fails.
+        #[serde(default)]
+        task_id: Option<String>,
+        /// Present on `subtype: "task_notification"` events when the
+        /// notification can be tied back to the originating tool use.
+        #[serde(default)]
+        tool_use_id: Option<String>,
+        /// Present on `subtype: "task_notification"` events.
+        #[serde(default)]
+        output_file: Option<String>,
+        /// Present on `subtype: "task_notification"` events.
+        #[serde(default)]
+        summary: Option<String>,
         /// Only present on `subtype: "status"` events. Values observed:
         /// `"requesting"` (normal API call), `"compacting"` (compaction in
         /// flight), or `null` (compaction complete).
@@ -925,6 +939,40 @@ mod compaction_tests {
                 assert_eq!(s, "compacting");
             }
             other => panic!("expected System(status:compacting), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserializes_task_notification_system_event() {
+        let line = r#"{
+            "type": "system",
+            "subtype": "task_notification",
+            "task_id": "task_123",
+            "tool_use_id": "toolu_1",
+            "status": "completed",
+            "output_file": "/tmp/task_123.output",
+            "summary": "Background command completed",
+            "session_id": "sess-abc"
+        }"#;
+        let ev: StreamEvent = serde_json::from_str(line).unwrap();
+        match ev {
+            StreamEvent::System {
+                subtype,
+                task_id,
+                tool_use_id,
+                status,
+                output_file,
+                summary,
+                ..
+            } => {
+                assert_eq!(subtype, "task_notification");
+                assert_eq!(task_id.as_deref(), Some("task_123"));
+                assert_eq!(tool_use_id.as_deref(), Some("toolu_1"));
+                assert_eq!(status.as_deref(), Some("completed"));
+                assert_eq!(output_file.as_deref(), Some("/tmp/task_123.output"));
+                assert_eq!(summary.as_deref(), Some("Background command completed"));
+            }
+            other => panic!("expected System(task_notification), got {other:?}"),
         }
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,6 +15,7 @@ mod scm;
 pub use scm::ScmStatusCacheRow;
 
 mod terminal;
+pub use terminal::CLAUDETTE_TERMINAL_TITLE;
 
 mod remote;
 

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -7,7 +7,7 @@
 
 use rusqlite::params;
 
-use crate::model::TerminalTab;
+use crate::model::{TerminalTab, TerminalTabKind};
 
 use super::Database;
 
@@ -16,14 +16,25 @@ impl Database {
 
     pub fn insert_terminal_tab(&self, tab: &TerminalTab) -> Result<(), rusqlite::Error> {
         self.conn.execute(
-            "INSERT INTO terminal_tabs (id, workspace_id, title, is_script_output, sort_order)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO terminal_tabs (
+                id, workspace_id, title, kind, is_script_output, sort_order,
+                agent_chat_session_id, agent_tool_use_id, agent_task_id,
+                output_path, task_status, task_summary
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 tab.id,
                 tab.workspace_id,
                 tab.title,
+                terminal_tab_kind_to_str(tab.kind),
                 tab.is_script_output as i32,
                 tab.sort_order,
+                tab.agent_chat_session_id,
+                tab.agent_tool_use_id,
+                tab.agent_task_id,
+                tab.output_path,
+                tab.task_status,
+                tab.task_summary,
             ],
         )?;
         Ok(())
@@ -42,21 +53,134 @@ impl Database {
         workspace_id: &str,
     ) -> Result<Vec<TerminalTab>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, workspace_id, title, is_script_output, sort_order, created_at
+            "SELECT id, workspace_id, title, kind, is_script_output, sort_order, created_at,
+                    agent_chat_session_id, agent_tool_use_id, agent_task_id,
+                    output_path, task_status, task_summary
              FROM terminal_tabs WHERE workspace_id = ?1 ORDER BY sort_order, id",
         )?;
         let rows = stmt.query_map(params![workspace_id], |row| {
-            let is_script: i32 = row.get(3)?;
+            let kind: String = row.get(3)?;
+            let is_script: i32 = row.get(4)?;
             Ok(TerminalTab {
                 id: row.get(0)?,
                 workspace_id: row.get(1)?,
                 title: row.get(2)?,
+                kind: parse_terminal_tab_kind(&kind),
                 is_script_output: is_script != 0,
-                sort_order: row.get(4)?,
-                created_at: row.get(5)?,
+                sort_order: row.get(5)?,
+                created_at: row.get(6)?,
+                agent_chat_session_id: row.get(7)?,
+                agent_tool_use_id: row.get(8)?,
+                agent_task_id: row.get(9)?,
+                output_path: row.get(10)?,
+                task_status: row.get(11)?,
+                task_summary: row.get(12)?,
             })
         })?;
         rows.collect()
+    }
+
+    pub fn get_terminal_tab_by_tool_use_id(
+        &self,
+        tool_use_id: &str,
+    ) -> Result<Option<TerminalTab>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, title, kind, is_script_output, sort_order, created_at,
+                    agent_chat_session_id, agent_tool_use_id, agent_task_id,
+                    output_path, task_status, task_summary
+             FROM terminal_tabs WHERE agent_tool_use_id = ?1 LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![tool_use_id])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let kind: String = row.get(3)?;
+        let is_script: i32 = row.get(4)?;
+        Ok(Some(TerminalTab {
+            id: row.get(0)?,
+            workspace_id: row.get(1)?,
+            title: row.get(2)?,
+            kind: parse_terminal_tab_kind(&kind),
+            is_script_output: is_script != 0,
+            sort_order: row.get(5)?,
+            created_at: row.get(6)?,
+            agent_chat_session_id: row.get(7)?,
+            agent_tool_use_id: row.get(8)?,
+            agent_task_id: row.get(9)?,
+            output_path: row.get(10)?,
+            task_status: row.get(11)?,
+            task_summary: row.get(12)?,
+        }))
+    }
+
+    pub fn get_terminal_tab_by_agent_task(
+        &self,
+        chat_session_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TerminalTab>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, title, kind, is_script_output, sort_order, created_at,
+                    agent_chat_session_id, agent_tool_use_id, agent_task_id,
+                    output_path, task_status, task_summary
+             FROM terminal_tabs
+             WHERE agent_chat_session_id = ?1 AND agent_task_id = ?2
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![chat_session_id, task_id])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let kind: String = row.get(3)?;
+        let is_script: i32 = row.get(4)?;
+        Ok(Some(TerminalTab {
+            id: row.get(0)?,
+            workspace_id: row.get(1)?,
+            title: row.get(2)?,
+            kind: parse_terminal_tab_kind(&kind),
+            is_script_output: is_script != 0,
+            sort_order: row.get(5)?,
+            created_at: row.get(6)?,
+            agent_chat_session_id: row.get(7)?,
+            agent_tool_use_id: row.get(8)?,
+            agent_task_id: row.get(9)?,
+            output_path: row.get(10)?,
+            task_status: row.get(11)?,
+            task_summary: row.get(12)?,
+        }))
+    }
+
+    pub fn update_agent_task_terminal_tab_binding(
+        &self,
+        tool_use_id: &str,
+        task_id: &str,
+        output_path: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE terminal_tabs
+             SET agent_task_id = ?1, output_path = ?2, task_status = 'running'
+             WHERE agent_tool_use_id = ?3",
+            params![task_id, output_path, tool_use_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_agent_task_terminal_tab_status(
+        &self,
+        chat_session_id: &str,
+        task_id: &str,
+        status: &str,
+        summary: Option<&str>,
+        output_path: Option<&str>,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE terminal_tabs
+             SET task_status = ?1,
+                 task_summary = COALESCE(?2, task_summary),
+                 output_path = COALESCE(?3, output_path)
+             WHERE agent_chat_session_id = ?4 AND agent_task_id = ?5",
+            params![status, summary, output_path, chat_session_id, task_id],
+        )?;
+        Ok(())
     }
 
     pub fn delete_terminal_tab(&self, id: i64) -> Result<(), rusqlite::Error> {
@@ -87,6 +211,20 @@ impl Database {
     }
 }
 
+fn terminal_tab_kind_to_str(kind: TerminalTabKind) -> &'static str {
+    match kind {
+        TerminalTabKind::Pty => "pty",
+        TerminalTabKind::AgentTask => "agent_task",
+    }
+}
+
+fn parse_terminal_tab_kind(raw: &str) -> TerminalTabKind {
+    match raw {
+        "agent_task" => TerminalTabKind::AgentTask,
+        _ => TerminalTabKind::Pty,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,9 +235,16 @@ mod tests {
             id,
             workspace_id: ws_id.into(),
             title: title.into(),
+            kind: TerminalTabKind::Pty,
             is_script_output: false,
             sort_order: 0,
             created_at: String::new(),
+            agent_chat_session_id: None,
+            agent_tool_use_id: None,
+            agent_task_id: None,
+            output_path: None,
+            task_status: None,
+            task_summary: None,
         }
     }
 

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -113,6 +113,41 @@ impl Database {
         }))
     }
 
+    pub fn get_agent_shell_terminal_tab(
+        &self,
+        chat_session_id: &str,
+    ) -> Result<Option<TerminalTab>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, title, kind, is_script_output, sort_order, created_at,
+                    agent_chat_session_id, agent_tool_use_id, agent_task_id,
+                    output_path, task_status, task_summary
+             FROM terminal_tabs
+             WHERE agent_chat_session_id = ?1 AND kind = 'agent_task' AND title = 'Agent shell'
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![chat_session_id])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let kind: String = row.get(3)?;
+        let is_script: i32 = row.get(4)?;
+        Ok(Some(TerminalTab {
+            id: row.get(0)?,
+            workspace_id: row.get(1)?,
+            title: row.get(2)?,
+            kind: parse_terminal_tab_kind(&kind),
+            is_script_output: is_script != 0,
+            sort_order: row.get(5)?,
+            created_at: row.get(6)?,
+            agent_chat_session_id: row.get(7)?,
+            agent_tool_use_id: row.get(8)?,
+            agent_task_id: row.get(9)?,
+            output_path: row.get(10)?,
+            task_status: row.get(11)?,
+            task_summary: row.get(12)?,
+        }))
+    }
+
     pub fn get_terminal_tab_by_agent_task(
         &self,
         chat_session_id: &str,
@@ -160,6 +195,24 @@ impl Database {
              SET agent_task_id = ?1, output_path = ?2, task_status = 'running'
              WHERE agent_tool_use_id = ?3",
             params![task_id, output_path, tool_use_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_agent_shell_terminal_tab_status(
+        &self,
+        chat_session_id: &str,
+        task_id: Option<&str>,
+        status: &str,
+        summary: Option<&str>,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE terminal_tabs
+             SET agent_task_id = ?1,
+                 task_status = ?2,
+                 task_summary = COALESCE(?3, task_summary)
+             WHERE agent_chat_session_id = ?4 AND kind = 'agent_task' AND title = 'Agent shell'",
+            params![task_id, status, summary, chat_session_id],
         )?;
         Ok(())
     }

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -62,7 +62,16 @@ impl Database {
              WHERE workspace_id = ?1
                AND (
                    kind != 'agent_task'
-                   OR title IN ('Claudette terminal', 'Agent shell')
+                   OR id = (
+                       SELECT id FROM terminal_tabs AS agent_terminal
+                       WHERE agent_terminal.workspace_id = ?1
+                         AND agent_terminal.kind = 'agent_task'
+                         AND agent_terminal.title IN ('Claudette terminal', 'Agent shell')
+                       ORDER BY
+                         CASE WHEN agent_terminal.title = 'Claudette terminal' THEN 0 ELSE 1 END,
+                         agent_terminal.id
+                       LIMIT 1
+                   )
                )
              ORDER BY
                CASE WHEN kind = 'agent_task' THEN 0 ELSE 1 END,
@@ -160,6 +169,66 @@ impl Database {
             task_status: row.get(11)?,
             task_summary: row.get(12)?,
         }))
+    }
+
+    pub fn get_agent_shell_terminal_tab_by_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<TerminalTab>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, workspace_id, title, kind, is_script_output, sort_order, created_at,
+                    agent_chat_session_id, agent_tool_use_id, agent_task_id,
+                    output_path, task_status, task_summary
+             FROM terminal_tabs
+             WHERE workspace_id = ?1
+               AND kind = 'agent_task'
+               AND title IN ('Claudette terminal', 'Agent shell')
+             ORDER BY CASE WHEN title = 'Claudette terminal' THEN 0 ELSE 1 END, id
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![workspace_id])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let kind: String = row.get(3)?;
+        let is_script: i32 = row.get(4)?;
+        Ok(Some(TerminalTab {
+            id: row.get(0)?,
+            workspace_id: row.get(1)?,
+            title: row.get(2)?,
+            kind: parse_terminal_tab_kind(&kind),
+            is_script_output: is_script != 0,
+            sort_order: row.get(5)?,
+            created_at: row.get(6)?,
+            agent_chat_session_id: row.get(7)?,
+            agent_tool_use_id: row.get(8)?,
+            agent_task_id: row.get(9)?,
+            output_path: row.get(10)?,
+            task_status: row.get(11)?,
+            task_summary: row.get(12)?,
+        }))
+    }
+
+    pub fn update_agent_shell_terminal_tab_session(
+        &self,
+        id: i64,
+        chat_session_id: &str,
+        output_path: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE terminal_tabs
+             SET title = 'Claudette terminal',
+                 sort_order = 0,
+                 agent_chat_session_id = ?1,
+                 agent_tool_use_id = NULL,
+                 agent_task_id = NULL,
+                 output_path = ?2,
+                 task_status = NULL,
+                 task_summary = NULL
+             WHERE id = ?3",
+            params![chat_session_id, output_path, id],
+        )?;
+        Ok(())
     }
 
     pub fn get_terminal_tab_by_agent_task(

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -11,6 +11,8 @@ use crate::model::{TerminalTab, TerminalTabKind};
 
 use super::Database;
 
+pub const CLAUDETTE_TERMINAL_TITLE: &str = "Claudette terminal";
+
 impl Database {
     // --- Terminal Tabs ---
 
@@ -56,7 +58,16 @@ impl Database {
             "SELECT id, workspace_id, title, kind, is_script_output, sort_order, created_at,
                     agent_chat_session_id, agent_tool_use_id, agent_task_id,
                     output_path, task_status, task_summary
-             FROM terminal_tabs WHERE workspace_id = ?1 ORDER BY sort_order, id",
+             FROM terminal_tabs
+             WHERE workspace_id = ?1
+               AND (
+                   kind != 'agent_task'
+                   OR title IN ('Claudette terminal', 'Agent shell')
+               )
+             ORDER BY
+               CASE WHEN kind = 'agent_task' THEN 0 ELSE 1 END,
+               sort_order,
+               id",
         )?;
         let rows = stmt.query_map(params![workspace_id], |row| {
             let kind: String = row.get(3)?;
@@ -122,7 +133,10 @@ impl Database {
                     agent_chat_session_id, agent_tool_use_id, agent_task_id,
                     output_path, task_status, task_summary
              FROM terminal_tabs
-             WHERE agent_chat_session_id = ?1 AND kind = 'agent_task' AND title = 'Agent shell'
+             WHERE agent_chat_session_id = ?1
+               AND kind = 'agent_task'
+               AND title IN ('Claudette terminal', 'Agent shell')
+             ORDER BY CASE WHEN title = 'Claudette terminal' THEN 0 ELSE 1 END, id
              LIMIT 1",
         )?;
         let mut rows = stmt.query(params![chat_session_id])?;
@@ -211,7 +225,9 @@ impl Database {
              SET agent_task_id = ?1,
                  task_status = ?2,
                  task_summary = COALESCE(?3, task_summary)
-             WHERE agent_chat_session_id = ?4 AND kind = 'agent_task' AND title = 'Agent shell'",
+             WHERE agent_chat_session_id = ?4
+               AND kind = 'agent_task'
+               AND title IN ('Claudette terminal', 'Agent shell')",
             params![task_id, status, summary, chat_session_id],
         )?;
         Ok(())
@@ -319,6 +335,19 @@ mod tests {
         }
     }
 
+    fn make_agent_terminal_tab(
+        id: i64,
+        ws_id: &str,
+        title: &str,
+        chat_session_id: &str,
+    ) -> TerminalTab {
+        TerminalTab {
+            kind: TerminalTabKind::AgentTask,
+            agent_chat_session_id: Some(chat_session_id.into()),
+            ..make_terminal_tab(id, ws_id, title)
+        }
+    }
+
     #[test]
     fn test_insert_and_list_terminal_tabs() {
         let db = setup_db_with_workspace();
@@ -344,6 +373,32 @@ mod tests {
         let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
         assert_eq!(tabs.len(), 1);
         assert_eq!(tabs[0].title, "T1");
+    }
+
+    #[test]
+    fn test_agent_terminal_tabs_are_single_fixed_tab_first() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
+            .unwrap();
+        db.insert_terminal_tab(&make_agent_terminal_tab(
+            2,
+            "w1",
+            "Agent: sleep 30 && date",
+            "chat-1",
+        ))
+        .unwrap();
+        db.insert_terminal_tab(&make_agent_terminal_tab(
+            3,
+            "w1",
+            CLAUDETTE_TERMINAL_TITLE,
+            "chat-1",
+        ))
+        .unwrap();
+
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        assert_eq!(tabs.len(), 2);
+        assert_eq!(tabs[0].title, CLAUDETTE_TERMINAL_TITLE);
+        assert_eq!(tabs[1].title, "Terminal 1");
     }
 
     #[test]

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -74,7 +74,6 @@ impl Database {
                    )
                )
              ORDER BY
-               CASE WHEN kind = 'agent_task' THEN 0 ELSE 1 END,
                sort_order,
                id",
         )?;
@@ -218,7 +217,6 @@ impl Database {
         self.conn.execute(
             "UPDATE terminal_tabs
              SET title = 'Claudette terminal',
-                 sort_order = 0,
                  agent_chat_session_id = ?1,
                  agent_tool_use_id = NULL,
                  agent_task_id = NULL,
@@ -465,10 +463,11 @@ mod tests {
     }
 
     #[test]
-    fn test_agent_terminal_tabs_are_single_fixed_tab_first() {
+    fn test_agent_terminal_tabs_are_single_visible_tab_ordered_by_sort_order() {
         let db = setup_db_with_workspace();
-        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
-            .unwrap();
+        let mut user_tab = make_terminal_tab(1, "w1", "Terminal 1");
+        user_tab.sort_order = 0;
+        db.insert_terminal_tab(&user_tab).unwrap();
         db.insert_terminal_tab(&make_agent_terminal_tab(
             2,
             "w1",
@@ -476,18 +475,15 @@ mod tests {
             "chat-1",
         ))
         .unwrap();
-        db.insert_terminal_tab(&make_agent_terminal_tab(
-            3,
-            "w1",
-            CLAUDETTE_TERMINAL_TITLE,
-            "chat-1",
-        ))
-        .unwrap();
+        let mut claudette_tab =
+            make_agent_terminal_tab(3, "w1", CLAUDETTE_TERMINAL_TITLE, "chat-1");
+        claudette_tab.sort_order = 1;
+        db.insert_terminal_tab(&claudette_tab).unwrap();
 
         let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
         assert_eq!(tabs.len(), 2);
-        assert_eq!(tabs[0].title, CLAUDETTE_TERMINAL_TITLE);
-        assert_eq!(tabs[1].title, "Terminal 1");
+        assert_eq!(tabs[0].title, "Terminal 1");
+        assert_eq!(tabs[1].title, CLAUDETTE_TERMINAL_TITLE);
     }
 
     #[test]
@@ -509,7 +505,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(tab.title, CLAUDETTE_TERMINAL_TITLE);
-        assert_eq!(tab.sort_order, 0);
+        assert_eq!(tab.sort_order, legacy.sort_order);
         assert_eq!(tab.agent_chat_session_id.as_deref(), Some("new-chat"));
         assert_eq!(tab.agent_tool_use_id, None);
         assert_eq!(tab.agent_task_id, None);
@@ -603,6 +599,22 @@ mod tests {
         let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
         let ids: Vec<_> = tabs.iter().map(|tab| tab.id).collect();
         assert_eq!(ids, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn test_update_terminal_tab_sort_order_can_move_agent_terminal() {
+        let db = setup_db_with_workspace();
+        let mut agent_tab = make_agent_terminal_tab(1, "w1", CLAUDETTE_TERMINAL_TITLE, "chat-1");
+        agent_tab.sort_order = -1;
+        db.insert_terminal_tab(&agent_tab).unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(2, "w1", "Terminal 1"))
+            .unwrap();
+
+        db.update_terminal_tab_sort_order("w1", &[2, 1]).unwrap();
+
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        let ids: Vec<_> = tabs.iter().map(|tab| tab.id).collect();
+        assert_eq!(ids, vec![2, 1]);
     }
 
     #[test]

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -345,6 +345,26 @@ impl Database {
         Ok(())
     }
 
+    pub fn update_terminal_tab_sort_order(
+        &self,
+        workspace_id: &str,
+        tab_ids: &[i64],
+    ) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "UPDATE terminal_tabs
+                 SET sort_order = ?1
+                 WHERE workspace_id = ?2 AND id = ?3",
+            )?;
+            for (sort_order, id) in tab_ids.iter().enumerate() {
+                stmt.execute(params![sort_order as i32, workspace_id, id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     #[allow(dead_code)]
     pub fn delete_terminal_tabs_for_workspace(
         &self,
@@ -566,6 +586,45 @@ mod tests {
         db.delete_terminal_tab(1).unwrap();
         let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
         assert!(tabs.is_empty());
+    }
+
+    #[test]
+    fn test_update_terminal_tab_sort_order() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))
+            .unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(2, "w1", "Terminal 2"))
+            .unwrap();
+        db.insert_terminal_tab(&make_terminal_tab(3, "w1", "Terminal 3"))
+            .unwrap();
+
+        db.update_terminal_tab_sort_order("w1", &[3, 1, 2]).unwrap();
+
+        let tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        let ids: Vec<_> = tabs.iter().map(|tab| tab.id).collect();
+        assert_eq!(ids, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn test_update_terminal_tab_sort_order_is_workspace_scoped() {
+        let db = setup_db_with_workspace();
+        db.insert_workspace(&make_workspace("w2", "r1", "workspace-2"))
+            .unwrap();
+        let mut w1_tab = make_terminal_tab(1, "w1", "Terminal 1");
+        w1_tab.sort_order = 0;
+        let mut w2_tab = make_terminal_tab(2, "w2", "Terminal 2");
+        w2_tab.sort_order = 0;
+        db.insert_terminal_tab(&w1_tab).unwrap();
+        db.insert_terminal_tab(&w2_tab).unwrap();
+
+        db.update_terminal_tab_sort_order("w1", &[2, 1]).unwrap();
+
+        let w1_tabs = db.list_terminal_tabs_by_workspace("w1").unwrap();
+        let w2_tabs = db.list_terminal_tabs_by_workspace("w2").unwrap();
+        assert_eq!(w1_tabs[0].id, 1);
+        assert_eq!(w1_tabs[0].sort_order, 1);
+        assert_eq!(w2_tabs[0].id, 2);
+        assert_eq!(w2_tabs[0].sort_order, 0);
     }
 
     #[test]

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -164,6 +164,24 @@ impl Database {
         Ok(())
     }
 
+    pub fn update_agent_task_terminal_tab_by_tool_use_id(
+        &self,
+        tool_use_id: &str,
+        status: &str,
+        summary: Option<&str>,
+        output_path: Option<&str>,
+    ) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "UPDATE terminal_tabs
+             SET task_status = ?1,
+                 task_summary = COALESCE(?2, task_summary),
+                 output_path = COALESCE(?3, output_path)
+             WHERE agent_tool_use_id = ?4",
+            params![status, summary, output_path, tool_use_id],
+        )?;
+        Ok(())
+    }
+
     pub fn update_agent_task_terminal_tab_status(
         &self,
         chat_session_id: &str,

--- a/src/db/terminal.rs
+++ b/src/db/terminal.rs
@@ -471,6 +471,94 @@ mod tests {
     }
 
     #[test]
+    fn test_agent_terminal_session_update_resets_legacy_task_metadata() {
+        let db = setup_db_with_workspace();
+        let mut legacy = make_agent_terminal_tab(2, "w1", "Agent shell", "old-chat");
+        legacy.agent_tool_use_id = Some("toolu-old".into());
+        legacy.agent_task_id = Some("task-old".into());
+        legacy.output_path = Some("/tmp/old.output".into());
+        legacy.task_status = Some("running".into());
+        legacy.task_summary = Some("old command".into());
+        db.insert_terminal_tab(&legacy).unwrap();
+
+        db.update_agent_shell_terminal_tab_session(2, "new-chat", "/tmp/new.output")
+            .unwrap();
+
+        let tab = db
+            .get_agent_shell_terminal_tab("new-chat")
+            .unwrap()
+            .unwrap();
+        assert_eq!(tab.title, CLAUDETTE_TERMINAL_TITLE);
+        assert_eq!(tab.sort_order, 0);
+        assert_eq!(tab.agent_chat_session_id.as_deref(), Some("new-chat"));
+        assert_eq!(tab.agent_tool_use_id, None);
+        assert_eq!(tab.agent_task_id, None);
+        assert_eq!(tab.output_path.as_deref(), Some("/tmp/new.output"));
+        assert_eq!(tab.task_status, None);
+        assert_eq!(tab.task_summary, None);
+    }
+
+    #[test]
+    fn test_agent_terminal_status_updates_task_binding_and_keeps_summary() {
+        let db = setup_db_with_workspace();
+        let mut tab = make_agent_terminal_tab(2, "w1", CLAUDETTE_TERMINAL_TITLE, "chat-1");
+        tab.task_summary = Some("sleep 30 && date".into());
+        db.insert_terminal_tab(&tab).unwrap();
+
+        db.update_agent_shell_terminal_tab_status("chat-1", Some("task-1"), "running", None)
+            .unwrap();
+        let running = db.get_agent_shell_terminal_tab("chat-1").unwrap().unwrap();
+        assert_eq!(running.agent_task_id.as_deref(), Some("task-1"));
+        assert_eq!(running.task_status.as_deref(), Some("running"));
+        assert_eq!(running.task_summary.as_deref(), Some("sleep 30 && date"));
+
+        db.update_agent_shell_terminal_tab_status(
+            "chat-1",
+            Some("task-1"),
+            "completed",
+            Some("exit 0"),
+        )
+        .unwrap();
+        let completed = db.get_agent_shell_terminal_tab("chat-1").unwrap().unwrap();
+        assert_eq!(completed.agent_task_id.as_deref(), Some("task-1"));
+        assert_eq!(completed.task_status.as_deref(), Some("completed"));
+        assert_eq!(completed.task_summary.as_deref(), Some("exit 0"));
+    }
+
+    #[test]
+    fn test_agent_terminal_status_ignores_command_task_tabs() {
+        let db = setup_db_with_workspace();
+        db.insert_terminal_tab(&make_agent_terminal_tab(
+            2,
+            "w1",
+            CLAUDETTE_TERMINAL_TITLE,
+            "chat-1",
+        ))
+        .unwrap();
+        let mut command_tab = make_agent_terminal_tab(3, "w1", "Agent: sleep 30 && date", "chat-1");
+        command_tab.agent_tool_use_id = Some("toolu-command".into());
+        command_tab.task_status = Some("running".into());
+        db.insert_terminal_tab(&command_tab).unwrap();
+
+        db.update_agent_shell_terminal_tab_status(
+            "chat-1",
+            Some("task-1"),
+            "completed",
+            Some("exit 0"),
+        )
+        .unwrap();
+
+        let command_tab = db
+            .get_terminal_tab_by_tool_use_id("toolu-command")
+            .unwrap()
+            .unwrap();
+        assert_eq!(command_tab.agent_task_id, None);
+        assert_eq!(command_tab.task_status.as_deref(), Some("running"));
+        let shell = db.get_agent_shell_terminal_tab("chat-1").unwrap().unwrap();
+        assert_eq!(shell.task_status.as_deref(), Some("completed"));
+    }
+
+    #[test]
     fn test_delete_terminal_tab() {
         let db = setup_db_with_workspace();
         db.insert_terminal_tab(&make_terminal_tab(1, "w1", "Terminal 1"))

--- a/src/migrations/20260505055527_agent_task_terminal_tabs.sql
+++ b/src/migrations/20260505055527_agent_task_terminal_tabs.sql
@@ -1,0 +1,13 @@
+ALTER TABLE terminal_tabs ADD COLUMN kind TEXT NOT NULL DEFAULT 'pty';
+ALTER TABLE terminal_tabs ADD COLUMN agent_chat_session_id TEXT;
+ALTER TABLE terminal_tabs ADD COLUMN agent_tool_use_id TEXT;
+ALTER TABLE terminal_tabs ADD COLUMN agent_task_id TEXT;
+ALTER TABLE terminal_tabs ADD COLUMN output_path TEXT;
+ALTER TABLE terminal_tabs ADD COLUMN task_status TEXT;
+ALTER TABLE terminal_tabs ADD COLUMN task_summary TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_terminal_tabs_agent_tool_use
+    ON terminal_tabs(agent_tool_use_id);
+
+CREATE INDEX IF NOT EXISTS idx_terminal_tabs_agent_task
+    ON terminal_tabs(agent_chat_session_id, agent_task_id);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -164,4 +164,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260430030147_pinned_prompts.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260505055527_agent_task_terminal_tabs",
+        sql: include_str!("20260505055527_agent_task_terminal_tabs.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -26,5 +26,5 @@ pub use metrics::{
 pub use pinned_prompt::PinnedPrompt;
 pub use remote_connection::RemoteConnection;
 pub use repository::Repository;
-pub use terminal_tab::TerminalTab;
+pub use terminal_tab::{TerminalTab, TerminalTabKind};
 pub use workspace::{AgentStatus, Workspace, WorkspaceStatus};

--- a/src/model/terminal_tab.rs
+++ b/src/model/terminal_tab.rs
@@ -1,4 +1,17 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalTabKind {
+    Pty,
+    AgentTask,
+}
+
+impl Default for TerminalTabKind {
+    fn default() -> Self {
+        Self::Pty
+    }
+}
 
 /// Metadata for a terminal tab. The actual PTY process state is
 /// ephemeral and managed by the Tauri backend.
@@ -8,7 +21,15 @@ pub struct TerminalTab {
     pub id: i64,
     pub workspace_id: String,
     pub title: String,
+    #[serde(default)]
+    pub kind: TerminalTabKind,
     pub is_script_output: bool,
     pub sort_order: i32,
     pub created_at: String,
+    pub agent_chat_session_id: Option<String>,
+    pub agent_tool_use_id: Option<String>,
+    pub agent_task_id: Option<String>,
+    pub output_path: Option<String>,
+    pub task_status: Option<String>,
+    pub task_summary: Option<String>,
 }

--- a/src/model/terminal_tab.rs
+++ b/src/model/terminal_tab.rs
@@ -1,16 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TerminalTabKind {
+    #[default]
     Pty,
     AgentTask,
-}
-
-impl Default for TerminalTabKind {
-    fn default() -> Self {
-        Self::Pty
-    }
 }
 
 /// Metadata for a terminal tab. The actual PTY process state is

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub enum AgentStatus {
     Running,
     Idle,
+    IdleWithBackground,
     Stopped,
     /// Set while the CLI is context-compacting (~90s). Visually treated
     /// like Running (spinner + disabled input) but with a distinct label.
@@ -17,6 +18,7 @@ impl AgentStatus {
         match self {
             Self::Running => "Running",
             Self::Idle => "Idle",
+            Self::IdleWithBackground => "IdleWithBackground",
             Self::Stopped => "Stopped",
             Self::Compacting => "Compacting",
             Self::Error(_) => "Error",

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -36,6 +36,7 @@ function App() {
   const setSystemFonts = useAppStore((s) => s.setSystemFonts);
   const setDetectedApps = useAppStore((s) => s.setDetectedApps);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
+  const setClaudetteTerminalEnabled = useAppStore((s) => s.setClaudetteTerminalEnabled);
   const setShowSidebarRunningCommands = useAppStore((s) => s.setShowSidebarRunningCommands);
   const setPluginManagementEnabled = useAppStore((s) => s.setPluginManagementEnabled);
   const setCommunityRegistryEnabled = useAppStore(
@@ -197,6 +198,9 @@ function App() {
 
     getAppSetting("usage_insights_enabled")
       .then((val) => { if (val === "true") setUsageInsightsEnabled(true); })
+      .catch(() => {});
+    getAppSetting("claudette_terminal_enabled")
+      .then((val) => { if (val === "true") setClaudetteTerminalEnabled(true); })
       .catch(() => {});
     getAppSetting("show_sidebar_running_commands")
       .then((val) => { if (val === "true") setShowSidebarRunningCommands(true); })
@@ -447,7 +451,7 @@ function App() {
       unlistenAutoArchived.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/components/chat/AttachmentContextMenu.tsx
+++ b/src/ui/src/components/chat/AttachmentContextMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
+import { viewportLayoutSize, viewportToFixed } from "../../utils/zoom";
 import styles from "./AttachmentContextMenu.module.css";
 
 export interface AttachmentContextMenuItem {
@@ -72,14 +73,13 @@ export function buildAttachmentMenuLabels(mediaType: string): {
 
 function clampToViewport(x: number, y: number, width: number, height: number) {
   if (typeof window === "undefined") return { x, y };
-  return clampMenuToViewport(
-    x,
-    y,
-    width,
-    height,
-    window.innerWidth,
-    window.innerHeight,
-  );
+  // `x`/`y` arrive as event clientX/clientY (visual pixels under html zoom)
+  // but `position: fixed; left/top` interpret values as layout pixels — so
+  // translate the click point and the viewport bounds into the same layout
+  // frame before clamping.
+  const fixed = viewportToFixed(x, y);
+  const { width: vw, height: vh } = viewportLayoutSize();
+  return clampMenuToViewport(fixed.x, fixed.y, width, height, vw, vh);
 }
 
 export function AttachmentContextMenu({

--- a/src/ui/src/components/chat/AttachmentContextMenu.tsx
+++ b/src/ui/src/components/chat/AttachmentContextMenu.tsx
@@ -123,6 +123,15 @@ export function AttachmentContextMenu({
       style={{ left: clamped.x, top: clamped.y }}
       role="menu"
       data-testid="attachment-context-menu"
+      // A parent component sometimes attaches its own `pointerdown` /
+      // `mousedown` outside-click listener on window. Without stopping
+      // propagation here, that listener fires for clicks INSIDE the menu
+      // and unmounts it before the button's `click` event runs, silently
+      // swallowing onSelect. Stopping at the menu boundary keeps the
+      // outside-click semantics correct without requiring callers to
+      // remember the gotcha.
+      onPointerDown={(ev) => ev.stopPropagation()}
+      onMouseDown={(ev) => ev.stopPropagation()}
     >
       {items.map((item, i) => (
         <button

--- a/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
+++ b/src/ui/src/components/settings/sections/ExperimentalSettings.tsx
@@ -6,6 +6,12 @@ import styles from "../Settings.module.css";
 
 export function ExperimentalSettings() {
   const { t } = useTranslation("settings");
+  const claudetteTerminalEnabled = useAppStore(
+    (s) => s.claudetteTerminalEnabled,
+  );
+  const setClaudetteTerminalEnabled = useAppStore(
+    (s) => s.setClaudetteTerminalEnabled,
+  );
   const usageInsightsEnabled = useAppStore((s) => s.usageInsightsEnabled);
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
@@ -17,6 +23,18 @@ export function ExperimentalSettings() {
     (s) => s.setCommunityRegistryEnabled,
   );
   const [error, setError] = useState<string | null>(null);
+
+  const handleClaudetteTerminalToggle = async () => {
+    const next = !claudetteTerminalEnabled;
+    setClaudetteTerminalEnabled(next);
+    try {
+      setError(null);
+      await setAppSetting("claudette_terminal_enabled", next ? "true" : "false");
+    } catch (e) {
+      setClaudetteTerminalEnabled(!next);
+      setError(String(e));
+    }
+  };
 
   const handleUsageToggle = async () => {
     const next = !usageInsightsEnabled;
@@ -62,6 +80,29 @@ export function ExperimentalSettings() {
       <h2 className={styles.sectionTitle}>{t("experimental_title")}</h2>
 
       {error && <div className={styles.error}>{error}</div>}
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>
+            {t("experimental_claudette_terminal")}
+          </div>
+          <div className={styles.settingDescription}>
+            {t("experimental_claudette_terminal_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={claudetteTerminalEnabled}
+            aria-label={t("experimental_claudette_terminal_aria")}
+            data-checked={claudetteTerminalEnabled}
+            onClick={handleClaudetteTerminalToggle}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -123,34 +123,6 @@
   position: relative;
 }
 
-.contextMenu {
-  position: fixed;
-  z-index: 1000;
-  min-width: 132px;
-  padding: 4px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-lg);
-}
-
-.contextMenuItem {
-  width: 100%;
-  padding: 6px 8px;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-xs);
-  color: var(--text-primary);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--fs-sm);
-  text-align: left;
-}
-
-.contextMenuItem:hover {
-  background: var(--hover-bg);
-}
-
 .spawnError {
   position: absolute;
   top: 12px;

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -45,9 +45,23 @@
   white-space: nowrap;
   font-family: var(--font-mono);
   font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
 }
 
-.tabClose {
+.tabBadge {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border-radius: 999px;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  background: var(--hover-bg-subtle);
+}
+
+.tabClose,
+.tabStop {
   background: none;
   border: none;
   color: var(--text-dim);
@@ -59,9 +73,14 @@
   transition: color var(--transition-fast), background var(--transition-fast);
 }
 
-.tabClose:hover {
+.tabClose:hover,
+.tabStop:hover {
   color: var(--text-primary);
   background: var(--hover-bg);
+}
+
+.tabStop {
+  font-size: 10px;
 }
 
 .addTab {

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -123,6 +123,34 @@
   position: relative;
 }
 
+.contextMenu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 132px;
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+}
+
+.contextMenuItem {
+  width: 100%;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--fs-sm);
+  text-align: left;
+}
+
+.contextMenuItem:hover {
+  background: var(--hover-bg);
+}
+
 .spawnError {
   position: absolute;
   top: 12px;

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -15,6 +15,12 @@
   flex-shrink: 0;
 }
 
+/* While a tab drag is in progress, force the grabbing cursor everywhere in
+ * the tab bar — the user is committed to the drag until release. */
+.tabBar[data-tab-dragging="true"] {
+  cursor: grabbing;
+}
+
 .tab {
   display: flex;
   align-items: center;
@@ -26,8 +32,13 @@
   position: relative;
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
   transition: color var(--transition-fast), background var(--transition-fast),
-    border-color var(--transition-fast);
+    border-color var(--transition-fast), transform var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .tab:hover {
@@ -35,10 +46,81 @@
   color: var(--text-muted);
 }
 
+/* Hover styles on non-target tabs are noisy mid-drag; the drop indicator
+ * is the only relevant feedback while dragging. */
+.tabBar[data-tab-dragging="true"] .tab:hover {
+  background: transparent;
+  color: var(--text-dim);
+}
+
 .tabActive {
   color: var(--text-primary);
   background: transparent;
   border-bottom-color: var(--accent-primary);
+}
+
+.tabDragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+/* Floating clone of the dragged tab — portaled to <body> and pinned to
+ * the cursor by the React handler. Mirrors the tab's resting visuals
+ * (font, padding, border-radius) plus a lift shadow so it reads as
+ * "picked up". `pointer-events: none` keeps elementFromPoint reaching the
+ * tab beneath the ghost, which is essential for the drop hit-test. */
+.tabGhost {
+  position: fixed;
+  z-index: 10003;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+  background: var(--sidebar-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  font-size: 12px;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  transform: rotate(1deg);
+  transform-origin: top left;
+}
+
+.tabGhostTitle {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+
+/* Pointer-driven drop indicator: a tall accent bar with a small caret on
+ * the side of the hovered tab where the dragged tab will land on release.
+ * Wider/taller than the previous 2px sliver so the drop edge reads at a
+ * glance even on small tab bars. */
+.tab[data-drop-before="true"]::before,
+.tab[data-drop-after="true"]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  width: 3px;
+  background: var(--accent-primary);
+  border-radius: 2px;
+  pointer-events: none;
+  box-shadow: 0 0 0 1px rgba(var(--accent-primary-rgb), 0.25);
+}
+
+.tab[data-drop-before="true"]::before {
+  left: -2px;
+}
+
+.tab[data-drop-after="true"]::after {
+  right: -2px;
 }
 
 .tabTitle {
@@ -121,38 +203,6 @@
   overflow: hidden;
   background: var(--terminal-bg);
   position: relative;
-}
-
-.terminalContextMenu {
-  position: fixed;
-  z-index: 10002;
-  padding: 4px;
-  border: 1px solid var(--sidebar-border);
-  border-radius: var(--radius-md);
-  background: var(--sidebar-bg);
-  box-shadow: var(--shadow-lg);
-  user-select: none;
-}
-
-.terminalContextMenuItem {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  min-height: 30px;
-  padding: 6px 10px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-primary);
-  font: inherit;
-  font-size: var(--fs-sm);
-  line-height: 1.2;
-  text-align: left;
-  cursor: pointer;
-}
-
-.terminalContextMenuItem:hover {
-  background: var(--hover-bg);
 }
 
 .spawnError {

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -123,6 +123,38 @@
   position: relative;
 }
 
+.terminalContextMenu {
+  position: fixed;
+  z-index: 10002;
+  padding: 4px;
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-md);
+  background: var(--sidebar-bg);
+  box-shadow: var(--shadow-lg);
+  user-select: none;
+}
+
+.terminalContextMenuItem {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--fs-sm);
+  line-height: 1.2;
+  text-align: left;
+  cursor: pointer;
+}
+
+.terminalContextMenuItem:hover {
+  background: var(--hover-bg);
+}
+
 .spawnError {
   position: absolute;
   top: 12px;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -19,6 +19,7 @@ import {
   deleteTerminalTab,
   ensureClaudetteTerminalTab,
   listTerminalTabs,
+  updateTerminalTabOrder,
   openUrl,
   spawnPty,
   writePty,
@@ -56,7 +57,15 @@ import {
   shouldForwardPtyResize,
   type PtySizeSnapshot,
 } from "./terminalPtyResize";
+import {
+  reorderTerminalTabs,
+  tabDropPlacement,
+} from "./terminalPanelLogic";
 import { reclaimScrollLines } from "./terminalReclaim";
+import {
+  AttachmentContextMenu,
+  type AttachmentContextMenuItem,
+} from "../chat/AttachmentContextMenu";
 import "@xterm/xterm/css/xterm.css";
 import styles from "./TerminalPanel.module.css";
 
@@ -354,8 +363,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
-    leafId: string;
+    tabId: number;
+    leafId?: string;
   } | null>(null);
+  const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
 
   const autoCreatedRef = useRef<string | null>(null);
   // Tracks the last (tabId, leafId, visible) tuple we applied keyboard
@@ -426,6 +437,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
   const handleStopAgentTask = useCallback(async (tab: TerminalTab) => {
     if (!tab.agent_chat_session_id || !tab.agent_task_id) return;
+    const label = tab.task_summary?.trim() || tab.title || tab.agent_task_id;
+    const ok = window.confirm(
+      `Stop background task "${label}"?\n\nThis will terminate the running command.`,
+    );
+    if (!ok) return;
     try {
       await stopAgentBackgroundTask(tab.agent_chat_session_id, tab.agent_task_id);
     } catch (err) {
@@ -662,7 +678,12 @@ export const TerminalPanel = memo(function TerminalPanel() {
       const handleContextMenu = (ev: MouseEvent) => {
         ev.preventDefault();
         ev.stopPropagation();
-        setContextMenu({ x: ev.clientX, y: ev.clientY, leafId: spec.leafId });
+        setContextMenu({
+          x: ev.clientX,
+          y: ev.clientY,
+          tabId: spec.tabId,
+          leafId: spec.leafId,
+        });
       };
       container.addEventListener(
         "contextmenu",
@@ -1037,10 +1058,24 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
   const handleClearContextTerminal = useCallback(() => {
     if (!contextMenu) return;
-    const inst = instancesRef.current.get(contextMenu.leafId);
-    inst?.term.clear();
+    if (contextMenu.leafId) {
+      instancesRef.current.get(contextMenu.leafId)?.term.clear();
+    } else {
+      for (const inst of instancesRef.current.values()) {
+        if (inst.tabId === contextMenu.tabId) inst.term.clear();
+      }
+    }
     setContextMenu(null);
   }, [contextMenu]);
+  const contextMenuItems = useMemo<AttachmentContextMenuItem[]>(
+    () => [
+      {
+        label: "Clear",
+        onSelect: handleClearContextTerminal,
+      },
+    ],
+    [handleClearContextTerminal],
+  );
 
   const handleTerminalContextMenu = useCallback(
     (ev: ReactMouseEvent<HTMLDivElement>) => {
@@ -1049,9 +1084,68 @@ export const TerminalPanel = memo(function TerminalPanel() {
       if (!activeLeafId) return;
       ev.preventDefault();
       ev.stopPropagation();
-      setContextMenu({ x: ev.clientX, y: ev.clientY, leafId: activeLeafId });
+      setContextMenu({
+        x: ev.clientX,
+        y: ev.clientY,
+        tabId: activeTerminalTabId,
+        leafId: activeLeafId,
+      });
     },
     [activeTerminalPaneId, activeTerminalTabId],
+  );
+
+  const handleTabContextMenu = useCallback(
+    (ev: ReactMouseEvent<HTMLDivElement>, tab: TerminalTab) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      if (selectedWorkspaceId) setActiveTerminalTab(selectedWorkspaceId, tab.id);
+      setContextMenu({
+        x: ev.clientX,
+        y: ev.clientY,
+        tabId: tab.id,
+      });
+    },
+    [selectedWorkspaceId, setActiveTerminalTab],
+  );
+
+  const handleTabDrop = useCallback(
+    (ev: ReactMouseEvent<HTMLDivElement>, targetTab: TerminalTab) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      if (!selectedWorkspaceId || draggedTabId == null || draggedTabId === targetTab.id) {
+        setDraggedTabId(null);
+        return;
+      }
+      const currentTabs = terminalTabs[selectedWorkspaceId] ?? [];
+      const withSortOrder = reorderTerminalTabs(
+        currentTabs,
+        draggedTabId,
+        targetTab.id,
+        tabDropPlacement(
+          ev.clientX,
+          ev.currentTarget.getBoundingClientRect().left,
+          ev.currentTarget.getBoundingClientRect().width,
+        ),
+      );
+      if (!withSortOrder) {
+        setDraggedTabId(null);
+        return;
+      }
+      setTerminalTabs(selectedWorkspaceId, withSortOrder);
+      setActiveTerminalTab(selectedWorkspaceId, draggedTabId);
+      setDraggedTabId(null);
+      void updateTerminalTabOrder(
+        selectedWorkspaceId,
+        withSortOrder.map((tab) => tab.id),
+      ).catch((err) => console.error("Failed to persist terminal tab order:", err));
+    },
+    [
+      draggedTabId,
+      selectedWorkspaceId,
+      setActiveTerminalTab,
+      setTerminalTabs,
+      terminalTabs,
+    ],
   );
 
   // Destroy everything on unmount.
@@ -1099,6 +1193,21 @@ export const TerminalPanel = memo(function TerminalPanel() {
             onClick={() =>
               selectedWorkspaceId && setActiveTerminalTab(selectedWorkspaceId, tab.id)
             }
+            onContextMenu={(e) => handleTabContextMenu(e, tab)}
+            draggable
+            onDragStart={(e) => {
+              setDraggedTabId(tab.id);
+              e.dataTransfer.effectAllowed = "move";
+              e.dataTransfer.setData("text/plain", String(tab.id));
+            }}
+            onDragOver={(e) => {
+              if (draggedTabId != null && draggedTabId !== tab.id) {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+              }
+            }}
+            onDrop={(e) => handleTabDrop(e, tab)}
+            onDragEnd={() => setDraggedTabId(null)}
           >
             <span className={styles.tabTitle}>{tab.title}</span>
             {tab.kind === "agent_task" && tab.task_status && (
@@ -1139,7 +1248,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
       </div>
       <div
         className={styles.termContainer}
-        onContextMenu={handleTerminalContextMenu}
+        onContextMenuCapture={handleTerminalContextMenu}
       >
         {tabs.map((tab) => {
           const tree = terminalPaneTrees[tab.id];
@@ -1163,21 +1272,12 @@ export const TerminalPanel = memo(function TerminalPanel() {
           );
         })}
         {contextMenu && (
-          <div
-            className={styles.contextMenu}
-            style={{ left: contextMenu.x, top: contextMenu.y }}
-            onPointerDown={(ev) => ev.stopPropagation()}
-            role="menu"
-          >
-            <button
-              className={styles.contextMenuItem}
-              type="button"
-              onClick={handleClearContextTerminal}
-              role="menuitem"
-            >
-              Clear
-            </button>
-          </div>
+          <AttachmentContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            items={contextMenuItems}
+            onClose={() => setContextMenu(null)}
+          />
         )}
       </div>
     </div>

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MouseEvent as ReactMouseEvent,
 } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -329,6 +330,9 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const setActiveTerminalTab = useAppStore((s) => s.setActiveTerminalTab);
   const toggleTerminalPanel = useAppStore((s) => s.toggleTerminalPanel);
   const terminalPanelVisible = useAppStore((s) => s.terminalPanelVisible);
+  const claudetteTerminalEnabled = useAppStore(
+    (s) => s.claudetteTerminalEnabled,
+  );
   const terminalPaneTrees = useAppStore((s) => s.terminalPaneTrees);
   const activeTerminalPaneId = useAppStore((s) => s.activeTerminalPaneId);
   const ensurePaneTree = useAppStore((s) => s.ensurePaneTree);
@@ -375,8 +379,13 @@ export const TerminalPanel = memo(function TerminalPanel() {
   }, [activeTerminalTabId]);
 
   const tabs = useMemo(
-    () => (selectedWorkspaceId ? terminalTabs[selectedWorkspaceId] ?? [] : []),
-    [selectedWorkspaceId, terminalTabs],
+    () =>
+      selectedWorkspaceId
+        ? (terminalTabs[selectedWorkspaceId] ?? []).filter(
+            (tab) => claudetteTerminalEnabled || tab.kind !== "agent_task",
+          )
+        : [],
+    [claudetteTerminalEnabled, selectedWorkspaceId, terminalTabs],
   );
 
   const handleCreateTab = useCallback(async () => {
@@ -439,21 +448,27 @@ export const TerminalPanel = memo(function TerminalPanel() {
     if (!selectedWorkspaceId || !terminalPanelVisible) return;
     const wsId = selectedWorkspaceId;
     listTerminalTabs(wsId).then(async (t) => {
-      if (selectedSessionId) {
+      if (claudetteTerminalEnabled && selectedSessionId) {
         await ensureClaudetteTerminalTab(wsId, selectedSessionId);
         t = await listTerminalTabs(wsId);
       }
       if (t.length > 0) {
         setTerminalTabs(wsId, t);
+        const visibleTabs = t.filter(
+          (tab) => claudetteTerminalEnabled || tab.kind !== "agent_task",
+        );
         const currentActive = useAppStore.getState().activeTerminalTabId[wsId];
         const activeStillValid =
-          currentActive != null && t.some((tab) => tab.id === currentActive);
-        if (!activeStillValid) setActiveTerminalTab(wsId, t[0].id);
+          currentActive != null &&
+          visibleTabs.some((tab) => tab.id === currentActive);
+        if (!activeStillValid) {
+          setActiveTerminalTab(wsId, visibleTabs[0]?.id ?? t[0].id);
+        }
         if (!t.some((tab) => tab.kind !== "agent_task")) {
           try {
             const tab = await createTerminalTab(wsId);
             addTerminalTab(wsId, tab);
-            setActiveTerminalTab(wsId, t[0].id);
+            setActiveTerminalTab(wsId, claudetteTerminalEnabled ? t[0].id : tab.id);
           } catch (err) {
             console.error("Failed to create terminal tab:", err);
           }
@@ -471,6 +486,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
   }, [
     selectedWorkspaceId,
     selectedSessionId,
+    claudetteTerminalEnabled,
     terminalPanelVisible,
     setTerminalTabs,
     setActiveTerminalTab,
@@ -1026,6 +1042,18 @@ export const TerminalPanel = memo(function TerminalPanel() {
     setContextMenu(null);
   }, [contextMenu]);
 
+  const handleTerminalContextMenu = useCallback(
+    (ev: ReactMouseEvent<HTMLDivElement>) => {
+      if (!activeTerminalTabId) return;
+      const activeLeafId = activeTerminalPaneId[activeTerminalTabId] ?? null;
+      if (!activeLeafId) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      setContextMenu({ x: ev.clientX, y: ev.clientY, leafId: activeLeafId });
+    },
+    [activeTerminalPaneId, activeTerminalTabId],
+  );
+
   // Destroy everything on unmount.
   useEffect(() => {
     const instances = instancesRef.current;
@@ -1109,7 +1137,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
           −
         </button>
       </div>
-      <div className={styles.termContainer}>
+      <div
+        className={styles.termContainer}
+        onContextMenu={handleTerminalContextMenu}
+      >
         {tabs.map((tab) => {
           const tree = terminalPaneTrees[tab.id];
           if (!tree) return null;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -70,6 +70,7 @@ interface AgentTaskOutputPayload {
 }
 
 const terminalInputEncoder = new TextEncoder();
+const terminalContextMenuOptions = { capture: true };
 
 // Per-leaf xterm + PTY handle. The container is a detached <div> that we
 // appendChild into whichever target div the pane tree currently emits for
@@ -647,7 +648,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
         ev.stopPropagation();
         setContextMenu({ x: ev.clientX, y: ev.clientY, leafId: spec.leafId });
       };
-      container.addEventListener("contextmenu", handleContextMenu);
+      container.addEventListener(
+        "contextmenu",
+        handleContextMenu,
+        terminalContextMenuOptions,
+      );
 
       let currentInst: LeafInstance | null = null;
       const resizeObserver = new ResizeObserver(() => {
@@ -765,7 +770,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
     if (inst.reclaimDisposer) inst.reclaimDisposer();
     inst.resizeObserver.disconnect();
     inst.container.removeEventListener("copy", inst.handleCopy);
-    inst.container.removeEventListener("contextmenu", inst.handleContextMenu);
+    inst.container.removeEventListener(
+      "contextmenu",
+      inst.handleContextMenu,
+      terminalContextMenuOptions,
+    );
     inst.term.dispose();
     if (inst.unlisten) inst.unlisten();
     if (inst.isAgentTask) stopAgentTaskTailBestEffort(inst.tabId);

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -15,6 +15,7 @@ import { getTerminalTheme } from "../../utils/theme";
 import {
   createTerminalTab,
   deleteTerminalTab,
+  ensureClaudetteTerminalTab,
   listTerminalTabs,
   openUrl,
   spawnPty,
@@ -335,6 +336,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const setPanePtyId = useAppStore((s) => s.setPanePtyId);
   const setPaneSpawnError = useAppStore((s) => s.setPaneSpawnError);
   const terminalFontSize = useAppStore((s) => s.terminalFontSize);
+  const selectedSessionId = useAppStore((s) =>
+    s.selectedWorkspaceId
+      ? (s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null)
+      : null,
+  );
   const fontFamilyMono = useAppStore((s) => s.fontFamilyMono);
   const currentThemeId = useAppStore((s) => s.currentThemeId);
   const uiFontSize = useAppStore((s) => s.uiFontSize);
@@ -425,12 +431,25 @@ export const TerminalPanel = memo(function TerminalPanel() {
     if (!selectedWorkspaceId || !terminalPanelVisible) return;
     const wsId = selectedWorkspaceId;
     listTerminalTabs(wsId).then(async (t) => {
+      if (selectedSessionId) {
+        await ensureClaudetteTerminalTab(wsId, selectedSessionId);
+        t = await listTerminalTabs(wsId);
+      }
       if (t.length > 0) {
         setTerminalTabs(wsId, t);
         const currentActive = useAppStore.getState().activeTerminalTabId[wsId];
         const activeStillValid =
           currentActive != null && t.some((tab) => tab.id === currentActive);
         if (!activeStillValid) setActiveTerminalTab(wsId, t[0].id);
+        if (!t.some((tab) => tab.kind !== "agent_task")) {
+          try {
+            const tab = await createTerminalTab(wsId);
+            addTerminalTab(wsId, tab);
+            setActiveTerminalTab(wsId, t[0].id);
+          } catch (err) {
+            console.error("Failed to create terminal tab:", err);
+          }
+        }
       } else if (autoCreatedRef.current !== wsId) {
         autoCreatedRef.current = wsId;
         try {
@@ -443,6 +462,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
     });
   }, [
     selectedWorkspaceId,
+    selectedSessionId,
     terminalPanelVisible,
     setTerminalTabs,
     setActiveTerminalTab,
@@ -651,7 +671,6 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
       if (inst.isAgentTask) {
         term.options.cursorBlink = false;
-        term.writeln("Starting agent command...");
         safeFit(inst);
         return inst;
       }

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -1085,19 +1085,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
     return () => cancelAnimationFrame(id);
   }, [terminalPanelVisible, activeTerminalTabId]);
 
-  useEffect(() => {
-    if (!contextMenu) return;
-    const close = () => setContextMenu(null);
-    const handleKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key === "Escape") close();
-    };
-    window.addEventListener("pointerdown", close);
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("pointerdown", close);
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [contextMenu]);
+  // Outside-click and Escape handling are owned by AttachmentContextMenu
+  // (which listens for `mousedown` capture on window). A redundant
+  // `pointerdown` listener here would unmount the menu before `click` fires
+  // on the menu item, breaking onSelect entirely.
 
   const handleClearContextTerminal = useCallback(() => {
     if (!contextMenu) return;

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -5,6 +5,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -90,6 +91,7 @@ interface LeafInstance {
   reclaimTimer: ReturnType<typeof setTimeout> | null;
   reclaimDisposer: (() => void) | null;
   handleCopy: (ev: ClipboardEvent) => void;
+  handleContextMenu: (ev: MouseEvent) => void;
   keyHandler: (ev: KeyboardEvent) => boolean;
   lastPtySize: PtySizeSnapshot | null;
 }
@@ -344,6 +346,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const fontFamilyMono = useAppStore((s) => s.fontFamilyMono);
   const currentThemeId = useAppStore((s) => s.currentThemeId);
   const uiFontSize = useAppStore((s) => s.uiFontSize);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    leafId: string;
+  } | null>(null);
 
   const autoCreatedRef = useRef<string | null>(null);
   // Tracks the last (tabId, leafId, visible) tuple we applied keyboard
@@ -635,6 +642,12 @@ export const TerminalPanel = memo(function TerminalPanel() {
         );
       };
       container.addEventListener("copy", handleCopy);
+      const handleContextMenu = (ev: MouseEvent) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        setContextMenu({ x: ev.clientX, y: ev.clientY, leafId: spec.leafId });
+      };
+      container.addEventListener("contextmenu", handleContextMenu);
 
       let currentInst: LeafInstance | null = null;
       const resizeObserver = new ResizeObserver(() => {
@@ -662,6 +675,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
         reclaimTimer: null,
         reclaimDisposer: null,
         handleCopy,
+        handleContextMenu,
         keyHandler,
         lastPtySize: null,
         resizeObserver,
@@ -751,6 +765,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
     if (inst.reclaimDisposer) inst.reclaimDisposer();
     inst.resizeObserver.disconnect();
     inst.container.removeEventListener("copy", inst.handleCopy);
+    inst.container.removeEventListener("contextmenu", inst.handleContextMenu);
     inst.term.dispose();
     if (inst.unlisten) inst.unlisten();
     if (inst.isAgentTask) stopAgentTaskTailBestEffort(inst.tabId);
@@ -981,6 +996,27 @@ export const TerminalPanel = memo(function TerminalPanel() {
     return () => cancelAnimationFrame(id);
   }, [terminalPanelVisible, activeTerminalTabId]);
 
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = () => setContextMenu(null);
+    const handleKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") close();
+    };
+    window.addEventListener("pointerdown", close);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", close);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [contextMenu]);
+
+  const handleClearContextTerminal = useCallback(() => {
+    if (!contextMenu) return;
+    const inst = instancesRef.current.get(contextMenu.leafId);
+    inst?.term.clear();
+    setContextMenu(null);
+  }, [contextMenu]);
+
   // Destroy everything on unmount.
   useEffect(() => {
     const instances = instancesRef.current;
@@ -1086,6 +1122,23 @@ export const TerminalPanel = memo(function TerminalPanel() {
             </div>
           );
         })}
+        {contextMenu && (
+          <div
+            className={styles.contextMenu}
+            style={{ left: contextMenu.x, top: contextMenu.y }}
+            onPointerDown={(ev) => ev.stopPropagation()}
+            role="menu"
+          >
+            <button
+              className={styles.contextMenuItem}
+              type="button"
+              onClick={handleClearContextTerminal}
+              role="menuitem"
+            >
+              Clear
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -901,6 +901,12 @@ export const TerminalPanel = memo(function TerminalPanel() {
       stopAgentTaskTailBestEffort(inst.tabId);
       inst.agentTaskTailPath = outputPath;
       inst.term.reset();
+      const command =
+        tab?.task_summary ??
+        (tab?.title?.startsWith("Agent: ") ? tab.title.slice("Agent: ".length) : null);
+      if (tab?.agent_task_id && command?.trim()) {
+        inst.term.writeln(`$ ${command.trim()}`);
+      }
       (async () => {
         const unlistenFn = await listen<AgentTaskOutputPayload>(
           "agent-task-output",

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import { createPortal } from "react-dom";
 import { Terminal } from "@xterm/xterm";
@@ -59,10 +60,15 @@ import {
   type PtySizeSnapshot,
 } from "./terminalPtyResize";
 import {
-  clampTerminalContextMenu,
   reorderTerminalTabs,
   tabDropPlacement,
+  type TabDropPlacement,
 } from "./terminalPanelLogic";
+import {
+  AttachmentContextMenu,
+  type AttachmentContextMenuItem,
+} from "../chat/AttachmentContextMenu";
+import { viewportToFixed } from "../../utils/zoom";
 import { reclaimScrollLines } from "./terminalReclaim";
 import "@xterm/xterm/css/xterm.css";
 import styles from "./TerminalPanel.module.css";
@@ -365,7 +371,42 @@ export const TerminalPanel = memo(function TerminalPanel() {
     tabId: number;
     leafId?: string;
   } | null>(null);
-  const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
+  // Pointer-event-based tab drag — native HTML5 DnD does not deliver
+  // dragover/drop events under the html `zoom` we apply for UI font scaling
+  // (WebKit-on-macOS quirk), so we hand-roll the drag with pointer events
+  // which work correctly under zoom.
+  const tabDragRef = useRef<{
+    tabId: number;
+    startX: number;
+    startY: number;
+    pointerId: number;
+    active: boolean;
+    offsetX: number;
+    offsetY: number;
+    width: number;
+    height: number;
+    title: string;
+  } | null>(null);
+  const tabDragJustEndedRef = useRef(false);
+  const [draggingTabId, setDraggingTabId] = useState<number | null>(null);
+  const [tabDropTarget, setTabDropTarget] = useState<{
+    tabId: number;
+    placement: TabDropPlacement;
+  } | null>(null);
+  // Cursor position + dragged-tab geometry, captured at drag start so the
+  // floating ghost can mimic the source tab's size and offset relative to
+  // the click point. Coords are event clientX/Y (visual pixels under html
+  // zoom) — the ghost uses viewportToFixed to convert into layout pixels
+  // for `position: fixed`.
+  const [dragGhost, setDragGhost] = useState<{
+    cursorX: number;
+    cursorY: number;
+    offsetX: number;
+    offsetY: number;
+    width: number;
+    height: number;
+    title: string;
+  } | null>(null);
 
   const autoCreatedRef = useRef<string | null>(null);
   // Tracks the last (tabId, leafId, visible) tuple we applied keyboard
@@ -1070,6 +1111,16 @@ export const TerminalPanel = memo(function TerminalPanel() {
     setContextMenu(null);
   }, [contextMenu]);
 
+  const terminalContextMenuItems = useMemo<AttachmentContextMenuItem[]>(
+    () => [
+      {
+        label: "Clear terminal",
+        onSelect: handleClearContextTerminal,
+      },
+    ],
+    [handleClearContextTerminal],
+  );
+
   const handleTabContextMenu = useCallback(
     (ev: ReactMouseEvent<HTMLDivElement>, tab: TerminalTab) => {
       ev.preventDefault();
@@ -1084,44 +1135,156 @@ export const TerminalPanel = memo(function TerminalPanel() {
     [selectedWorkspaceId, setActiveTerminalTab],
   );
 
-  const handleTabDrop = useCallback(
-    (ev: ReactMouseEvent<HTMLDivElement>, targetTab: TerminalTab) => {
-      ev.preventDefault();
-      ev.stopPropagation();
-      if (!selectedWorkspaceId || draggedTabId == null || draggedTabId === targetTab.id) {
-        setDraggedTabId(null);
+  const handleTabPointerDown = useCallback(
+    (ev: ReactPointerEvent<HTMLDivElement>, tab: TerminalTab) => {
+      if (ev.button !== 0) return;
+      const target = ev.target as HTMLElement;
+      if (target.closest(`.${styles.tabClose}, .${styles.tabStop}`)) return;
+      const rect = ev.currentTarget.getBoundingClientRect();
+      tabDragRef.current = {
+        tabId: tab.id,
+        startX: ev.clientX,
+        startY: ev.clientY,
+        pointerId: ev.pointerId,
+        active: false,
+        offsetX: ev.clientX - rect.left,
+        offsetY: ev.clientY - rect.top,
+        width: rect.width,
+        height: rect.height,
+        title: tab.title,
+      };
+      try {
+        ev.currentTarget.setPointerCapture(ev.pointerId);
+      } catch {
+        // setPointerCapture can throw if the pointer was already released
+        // synchronously (rare, e.g. during programmatic events) — treat it
+        // as the user not committing to a drag.
+        tabDragRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const handleTabPointerMove = useCallback(
+    (ev: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = tabDragRef.current;
+      if (!drag || drag.pointerId !== ev.pointerId) return;
+      if (!drag.active) {
+        const dx = ev.clientX - drag.startX;
+        const dy = ev.clientY - drag.startY;
+        // 4px hysteresis — anything below is treated as a click.
+        if (dx * dx + dy * dy < 16) return;
+        drag.active = true;
+        setDraggingTabId(drag.tabId);
+      }
+      // Move the floating ghost to follow the cursor, preserving the
+      // offset between the cursor and the source tab's top-left so the
+      // ghost doesn't snap-jump when drag activates.
+      setDragGhost({
+        cursorX: ev.clientX,
+        cursorY: ev.clientY,
+        offsetX: drag.offsetX,
+        offsetY: drag.offsetY,
+        width: drag.width,
+        height: drag.height,
+        title: drag.title,
+      });
+      const overEl = document.elementFromPoint(ev.clientX, ev.clientY);
+      const tabEl = overEl?.closest<HTMLElement>("[data-terminal-tab-id]") ?? null;
+      const overId = tabEl ? Number(tabEl.dataset.terminalTabId) : null;
+      if (overId == null || overId === drag.tabId || !tabEl) {
+        setTabDropTarget((prev) => (prev === null ? prev : null));
+        return;
+      }
+      const r = tabEl.getBoundingClientRect();
+      const placement = tabDropPlacement(ev.clientX, r.left, r.width);
+      setTabDropTarget((prev) =>
+        prev && prev.tabId === overId && prev.placement === placement
+          ? prev
+          : { tabId: overId, placement },
+      );
+    },
+    [],
+  );
+
+  const finishTabDrag = useCallback(
+    (committedHover: typeof tabDropTarget) => {
+      const drag = tabDragRef.current;
+      tabDragRef.current = null;
+      setDraggingTabId(null);
+      setTabDropTarget(null);
+      setDragGhost(null);
+      if (!drag) return;
+      if (!drag.active) {
+        // No movement → click — onClick on the tab handles activation.
+        return;
+      }
+      // Suppress the synthetic click that follows pointerup on the captured
+      // tab, otherwise a drag would also re-activate the source tab.
+      tabDragJustEndedRef.current = true;
+      // Clear the suppressor on the next microtask, after the click handler
+      // has had a chance to run.
+      queueMicrotask(() => {
+        tabDragJustEndedRef.current = false;
+      });
+      if (
+        !committedHover ||
+        committedHover.tabId === drag.tabId ||
+        !selectedWorkspaceId
+      ) {
         return;
       }
       const currentTabs = terminalTabs[selectedWorkspaceId] ?? [];
-      const withSortOrder = reorderTerminalTabs(
+      const reordered = reorderTerminalTabs(
         currentTabs,
-        draggedTabId,
-        targetTab.id,
-        tabDropPlacement(
-          ev.clientX,
-          ev.currentTarget.getBoundingClientRect().left,
-          ev.currentTarget.getBoundingClientRect().width,
-        ),
+        drag.tabId,
+        committedHover.tabId,
+        committedHover.placement,
       );
-      if (!withSortOrder) {
-        setDraggedTabId(null);
-        return;
-      }
-      setTerminalTabs(selectedWorkspaceId, withSortOrder);
-      setActiveTerminalTab(selectedWorkspaceId, draggedTabId);
-      setDraggedTabId(null);
+      if (!reordered) return;
+      setTerminalTabs(selectedWorkspaceId, reordered);
+      setActiveTerminalTab(selectedWorkspaceId, drag.tabId);
       void updateTerminalTabOrder(
         selectedWorkspaceId,
-        withSortOrder.map((tab) => tab.id),
-      ).catch((err) => console.error("Failed to persist terminal tab order:", err));
+        reordered.map((tab) => tab.id),
+      ).catch((err) =>
+        console.error("Failed to persist terminal tab order:", err),
+      );
     },
     [
-      draggedTabId,
       selectedWorkspaceId,
       setActiveTerminalTab,
       setTerminalTabs,
       terminalTabs,
     ],
+  );
+
+  const handleTabPointerUp = useCallback(
+    (ev: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = tabDragRef.current;
+      if (!drag || drag.pointerId !== ev.pointerId) return;
+      try {
+        ev.currentTarget.releasePointerCapture(ev.pointerId);
+      } catch {
+        // Already released.
+      }
+      finishTabDrag(tabDropTarget);
+    },
+    [finishTabDrag, tabDropTarget],
+  );
+
+  const handleTabPointerCancel = useCallback(
+    (ev: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = tabDragRef.current;
+      if (!drag || drag.pointerId !== ev.pointerId) return;
+      try {
+        ev.currentTarget.releasePointerCapture(ev.pointerId);
+      } catch {
+        // Already released.
+      }
+      finishTabDrag(null);
+    },
+    [finishTabDrag],
   );
 
   // Destroy everything on unmount.
@@ -1161,29 +1324,33 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
   return (
     <div className={styles.panel}>
-      <div className={styles.tabBar}>
-        {tabs.map((tab) => (
+      <div
+        className={styles.tabBar}
+        data-tab-dragging={draggingTabId !== null || undefined}
+      >
+        {tabs.map((tab) => {
+          const isDragging = draggingTabId === tab.id;
+          const dropBefore =
+            tabDropTarget?.tabId === tab.id && tabDropTarget.placement === "before";
+          const dropAfter =
+            tabDropTarget?.tabId === tab.id && tabDropTarget.placement === "after";
+          return (
           <div
             key={tab.id}
-            className={`${styles.tab} ${activeTerminalTabId === tab.id ? styles.tabActive : ""}`}
-            onClick={() =>
-              selectedWorkspaceId && setActiveTerminalTab(selectedWorkspaceId, tab.id)
-            }
+            data-terminal-tab-id={tab.id}
+            data-drop-before={dropBefore || undefined}
+            data-drop-after={dropAfter || undefined}
+            className={`${styles.tab} ${activeTerminalTabId === tab.id ? styles.tabActive : ""} ${isDragging ? styles.tabDragging : ""}`}
+            onClick={() => {
+              if (tabDragJustEndedRef.current) return;
+              if (selectedWorkspaceId)
+                setActiveTerminalTab(selectedWorkspaceId, tab.id);
+            }}
             onContextMenu={(e) => handleTabContextMenu(e, tab)}
-            draggable
-            onDragStart={(e) => {
-              setDraggedTabId(tab.id);
-              e.dataTransfer.effectAllowed = "move";
-              e.dataTransfer.setData("text/plain", String(tab.id));
-            }}
-            onDragOver={(e) => {
-              if (draggedTabId != null && draggedTabId !== tab.id) {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-              }
-            }}
-            onDrop={(e) => handleTabDrop(e, tab)}
-            onDragEnd={() => setDraggedTabId(null)}
+            onPointerDown={(e) => handleTabPointerDown(e, tab)}
+            onPointerMove={handleTabPointerMove}
+            onPointerUp={handleTabPointerUp}
+            onPointerCancel={handleTabPointerCancel}
           >
             <span className={styles.tabTitle}>{tab.title}</span>
             {tab.kind === "agent_task" && tab.task_status && (
@@ -1213,7 +1380,8 @@ export const TerminalPanel = memo(function TerminalPanel() {
               ×
             </button>
           </div>
-        ))}
+          );
+        })}
         <button className={styles.addTab} onClick={handleCreateTab}>
           +
         </button>
@@ -1244,65 +1412,49 @@ export const TerminalPanel = memo(function TerminalPanel() {
             </div>
           );
         })}
-        {contextMenu && (
-          <TerminalContextMenu
-            x={contextMenu.x}
-            y={contextMenu.y}
-            onClear={handleClearContextTerminal}
-            onClose={() => setContextMenu(null)}
-          />
-        )}
       </div>
+      {contextMenu && (
+        <AttachmentContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={terminalContextMenuItems}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+      {dragGhost && draggingTabId !== null && <TabDragGhost ghost={dragGhost} />}
     </div>
   );
 });
 
-function TerminalContextMenu({
-  x,
-  y,
-  onClear,
-  onClose,
+function TabDragGhost({
+  ghost,
 }: {
-  x: number;
-  y: number;
-  onClear: () => void;
-  onClose: () => void;
+  ghost: {
+    cursorX: number;
+    cursorY: number;
+    offsetX: number;
+    offsetY: number;
+    width: number;
+    height: number;
+    title: string;
+  };
 }) {
-  const width = 148;
-  const height = 40;
-  const clamped =
-    typeof window === "undefined"
-      ? { x, y }
-      : clampTerminalContextMenu(
-          x,
-          y,
-          width,
-          height,
-          window.innerWidth,
-          window.innerHeight,
-        );
-  const menu = (
+  // Translate the cursor position from event coords (visual pixels under
+  // html zoom) into layout pixels for `position: fixed` placement, then
+  // anchor the ghost at the same offset within the tab where the user
+  // grabbed it. Without this, dragging mid-tab would teleport the ghost's
+  // top-left to the cursor and jitter on first move.
+  const top = viewportToFixed(0, ghost.cursorY - ghost.offsetY).y;
+  const left = viewportToFixed(ghost.cursorX - ghost.offsetX, 0).x;
+  if (typeof document === "undefined") return null;
+  return createPortal(
     <div
-      className={styles.terminalContextMenu}
-      style={{ left: clamped.x, top: clamped.y, width }}
-      role="menu"
-      onContextMenu={(ev) => ev.preventDefault()}
-      onPointerDown={(ev) => ev.stopPropagation()}
+      className={styles.tabGhost}
+      style={{ left, top, width: ghost.width, height: ghost.height }}
+      aria-hidden
     >
-      <button
-        type="button"
-        role="menuitem"
-        className={styles.terminalContextMenuItem}
-        onClick={() => {
-          onClear();
-          onClose();
-        }}
-      >
-        Clear terminal
-      </button>
-    </div>
+      <span className={styles.tabGhostTitle}>{ghost.title}</span>
+    </div>,
+    document.body,
   );
-  return typeof document === "undefined"
-    ? menu
-    : createPortal(menu, document.body);
 }

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -901,12 +901,6 @@ export const TerminalPanel = memo(function TerminalPanel() {
       stopAgentTaskTailBestEffort(inst.tabId);
       inst.agentTaskTailPath = outputPath;
       inst.term.reset();
-      const command =
-        tab?.task_summary ??
-        (tab?.title?.startsWith("Agent: ") ? tab.title.slice("Agent: ".length) : null);
-      if (tab?.agent_task_id && command?.trim()) {
-        inst.term.writeln(`$ ${command.trim()}`);
-      }
       (async () => {
         const unlistenFn = await listen<AgentTaskOutputPayload>(
           "agent-task-output",

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -21,6 +21,9 @@ import {
   writePty,
   resizePty,
   closePty,
+  startAgentTaskTail,
+  stopAgentTaskTail,
+  stopAgentBackgroundTask,
 } from "../../services/tauri";
 import {
   cycleTabId,
@@ -39,6 +42,7 @@ import {
   focusChatPrompt,
 } from "../../utils/focusTargets";
 import { TerminalPaneTree } from "./TerminalPaneTree";
+import type { TerminalTab } from "../../types/terminal";
 import {
   collectNeededLeaves,
   diffLeaves,
@@ -58,6 +62,11 @@ interface PtyOutputPayload {
   data: number[];
 }
 
+interface AgentTaskOutputPayload {
+  tab_id: number;
+  data: number[];
+}
+
 const terminalInputEncoder = new TextEncoder();
 
 // Per-leaf xterm + PTY handle. The container is a detached <div> that we
@@ -72,6 +81,8 @@ interface LeafInstance {
   term: Terminal;
   fit: FitAddon;
   ptyId: number;
+  isAgentTask: boolean;
+  agentTaskTailPath: string | null;
   unlisten: (() => void) | null;
   resizeObserver: ResizeObserver;
   fitTimer: ReturnType<typeof setTimeout> | null;
@@ -261,6 +272,12 @@ function closePtyBestEffort(ptyId: number) {
   });
 }
 
+function stopAgentTaskTailBestEffort(tabId: number) {
+  void stopAgentTaskTail(tabId).catch((err) => {
+    console.error(`Failed to stop agent task tail ${tabId}:`, err);
+  });
+}
+
 function forwardPtyResize(
   inst: LeafInstance,
   nextSize: PtySizeSnapshot = { cols: inst.term.cols, rows: inst.term.rows },
@@ -384,6 +401,15 @@ export const TerminalPanel = memo(function TerminalPanel() {
     [selectedWorkspaceId, removeTerminalTab],
   );
 
+  const handleStopAgentTask = useCallback(async (tab: TerminalTab) => {
+    if (!tab.agent_chat_session_id || !tab.agent_task_id) return;
+    try {
+      await stopAgentBackgroundTask(tab.agent_chat_session_id, tab.agent_task_id);
+    } catch (err) {
+      console.error("Failed to stop agent background task:", err);
+    }
+  }, []);
+
   // When the panel gets hidden (most often because the user just closed
   // the last tab via the X button or Cmd+W on the last pane) clear the
   // auto-create guard so that the next time the user reveals the panel
@@ -487,6 +513,8 @@ export const TerminalPanel = memo(function TerminalPanel() {
           return;
         case "split-pane": {
           if (!activePaneId) return;
+          const activeTab = (state.terminalTabs[wsId] ?? []).find((t) => t.id === tabId);
+          if (activeTab?.kind === "agent_task") return;
           splitPane(tabId, activePaneId, action.direction);
           return;
         }
@@ -588,7 +616,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
       };
       container.addEventListener("copy", handleCopy);
 
+      let currentInst: LeafInstance | null = null;
       const resizeObserver = new ResizeObserver(() => {
+        const inst = currentInst;
+        if (!inst) return;
         if (inst.fitTimer) clearTimeout(inst.fitTimer);
         inst.fitTimer = setTimeout(() => safeFit(inst), 150);
       });
@@ -601,6 +632,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
         term,
         fit,
         ptyId: -1,
+        isAgentTask:
+          Object.values(terminalTabs)
+            .flat()
+            .find((tab) => tab.id === spec.tabId)?.kind === "agent_task",
+        agentTaskTailPath: null,
         unlisten: null,
         fitTimer: null,
         reclaimTimer: null,
@@ -610,7 +646,15 @@ export const TerminalPanel = memo(function TerminalPanel() {
         lastPtySize: null,
         resizeObserver,
       };
+      currentInst = inst;
       inst.resizeObserver.observe(container);
+
+      if (inst.isAgentTask) {
+        term.options.cursorBlink = false;
+        term.writeln("Starting background task...");
+        safeFit(inst);
+        return inst;
+      }
 
       // Spawn the PTY asynchronously. If the instance has been destroyed
       // by the time we resolve, close the PTY we just spawned and bail.
@@ -677,7 +721,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
       return inst;
     },
-    [setPanePtyId, setPaneSpawnError, terminalFontSize],
+    [setPanePtyId, setPaneSpawnError, terminalFontSize, terminalTabs],
   );
 
   const destroyInstance = useCallback((leafId: string) => {
@@ -690,6 +734,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
     inst.container.removeEventListener("copy", inst.handleCopy);
     inst.term.dispose();
     if (inst.unlisten) inst.unlisten();
+    if (inst.isAgentTask) stopAgentTaskTailBestEffort(inst.tabId);
     if (inst.ptyId >= 0) closePtyBestEffort(inst.ptyId);
     inst.container.remove();
     instancesRef.current.delete(leafId);
@@ -839,6 +884,46 @@ export const TerminalPanel = memo(function TerminalPanel() {
     destroyInstance,
   ]);
 
+  useEffect(() => {
+    const tabsById = new Map<number, TerminalTab>();
+    for (const wsTabs of Object.values(terminalTabs)) {
+      for (const tab of wsTabs) tabsById.set(tab.id, tab);
+    }
+    for (const inst of instancesRef.current.values()) {
+      if (!inst.isAgentTask) continue;
+      const tab = tabsById.get(inst.tabId);
+      const outputPath = tab?.output_path ?? null;
+      if (!outputPath || inst.agentTaskTailPath === outputPath) continue;
+      if (inst.unlisten) {
+        inst.unlisten();
+        inst.unlisten = null;
+      }
+      stopAgentTaskTailBestEffort(inst.tabId);
+      inst.agentTaskTailPath = outputPath;
+      inst.term.reset();
+      inst.term.writeln(`Tailing ${outputPath}`);
+      (async () => {
+        const unlistenFn = await listen<AgentTaskOutputPayload>(
+          "agent-task-output",
+          (event) => {
+            if (event.payload.tab_id === inst.tabId) {
+              inst.term.write(new Uint8Array(event.payload.data));
+            }
+          },
+        );
+        if (instancesRef.current.get(inst.leafId) !== inst) {
+          unlistenFn();
+          stopAgentTaskTailBestEffort(inst.tabId);
+          return;
+        }
+        inst.unlisten = unlistenFn;
+        await startAgentTaskTail(inst.tabId, outputPath);
+      })().catch((err) => {
+        console.error("Failed to start agent task tail:", err);
+      });
+    }
+  }, [terminalTabs, tabs]);
+
   // Font / theme propagation across all live instances. uiFontSize is
   // bundled in here because it drives the page-zoom compensation: when
   // the user changes UI size, every terminal needs its container zoom
@@ -925,6 +1010,23 @@ export const TerminalPanel = memo(function TerminalPanel() {
             }
           >
             <span className={styles.tabTitle}>{tab.title}</span>
+            {tab.kind === "agent_task" && tab.task_status && (
+              <span className={styles.tabBadge}>{tab.task_status}</span>
+            )}
+            {tab.kind === "agent_task" &&
+              tab.agent_task_id &&
+              ["starting", "running"].includes((tab.task_status ?? "").toLowerCase()) && (
+                <button
+                  className={styles.tabStop}
+                  title="Stop background task"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleStopAgentTask(tab);
+                  }}
+                >
+                  ■
+                </button>
+              )}
             <button
               className={styles.tabClose}
               onClick={(e) => {

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -651,7 +651,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
       if (inst.isAgentTask) {
         term.options.cursorBlink = false;
-        term.writeln("Starting background task...");
+        term.writeln("Starting agent command...");
         safeFit(inst);
         return inst;
       }
@@ -901,7 +901,6 @@ export const TerminalPanel = memo(function TerminalPanel() {
       stopAgentTaskTailBestEffort(inst.tabId);
       inst.agentTaskTailPath = outputPath;
       inst.term.reset();
-      inst.term.writeln(`Tailing ${outputPath}`);
       (async () => {
         const unlistenFn = await listen<AgentTaskOutputPayload>(
           "agent-task-output",

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -58,14 +59,11 @@ import {
   type PtySizeSnapshot,
 } from "./terminalPtyResize";
 import {
+  clampTerminalContextMenu,
   reorderTerminalTabs,
   tabDropPlacement,
 } from "./terminalPanelLogic";
 import { reclaimScrollLines } from "./terminalReclaim";
-import {
-  AttachmentContextMenu,
-  type AttachmentContextMenuItem,
-} from "../chat/AttachmentContextMenu";
 import "@xterm/xterm/css/xterm.css";
 import styles from "./TerminalPanel.module.css";
 
@@ -77,6 +75,7 @@ interface PtyOutputPayload {
 interface AgentTaskOutputPayload {
   tab_id: number;
   data: number[];
+  reset?: boolean;
 }
 
 const terminalInputEncoder = new TextEncoder();
@@ -980,13 +979,16 @@ export const TerminalPanel = memo(function TerminalPanel() {
       }
       stopAgentTaskTailBestEffort(inst.tabId);
       inst.agentTaskTailPath = outputPath;
-      inst.term.reset();
+      inst.term.clear();
       (async () => {
         const unlistenFn = await listen<AgentTaskOutputPayload>(
           "agent-task-output",
           (event) => {
             if (event.payload.tab_id === inst.tabId) {
-              inst.term.write(new Uint8Array(event.payload.data));
+              if (event.payload.reset) inst.term.clear();
+              if (event.payload.data.length > 0) {
+                inst.term.write(new Uint8Array(event.payload.data));
+              }
             }
           },
         );
@@ -1067,32 +1069,6 @@ export const TerminalPanel = memo(function TerminalPanel() {
     }
     setContextMenu(null);
   }, [contextMenu]);
-  const contextMenuItems = useMemo<AttachmentContextMenuItem[]>(
-    () => [
-      {
-        label: "Clear",
-        onSelect: handleClearContextTerminal,
-      },
-    ],
-    [handleClearContextTerminal],
-  );
-
-  const handleTerminalContextMenu = useCallback(
-    (ev: ReactMouseEvent<HTMLDivElement>) => {
-      if (!activeTerminalTabId) return;
-      const activeLeafId = activeTerminalPaneId[activeTerminalTabId] ?? null;
-      if (!activeLeafId) return;
-      ev.preventDefault();
-      ev.stopPropagation();
-      setContextMenu({
-        x: ev.clientX,
-        y: ev.clientY,
-        tabId: activeTerminalTabId,
-        leafId: activeLeafId,
-      });
-    },
-    [activeTerminalPaneId, activeTerminalTabId],
-  );
 
   const handleTabContextMenu = useCallback(
     (ev: ReactMouseEvent<HTMLDivElement>, tab: TerminalTab) => {
@@ -1246,10 +1222,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
           −
         </button>
       </div>
-      <div
-        className={styles.termContainer}
-        onContextMenuCapture={handleTerminalContextMenu}
-      >
+      <div className={styles.termContainer}>
         {tabs.map((tab) => {
           const tree = terminalPaneTrees[tab.id];
           if (!tree) return null;
@@ -1272,10 +1245,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
           );
         })}
         {contextMenu && (
-          <AttachmentContextMenu
+          <TerminalContextMenu
             x={contextMenu.x}
             y={contextMenu.y}
-            items={contextMenuItems}
+            onClear={handleClearContextTerminal}
             onClose={() => setContextMenu(null)}
           />
         )}
@@ -1283,3 +1256,53 @@ export const TerminalPanel = memo(function TerminalPanel() {
     </div>
   );
 });
+
+function TerminalContextMenu({
+  x,
+  y,
+  onClear,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  onClear: () => void;
+  onClose: () => void;
+}) {
+  const width = 148;
+  const height = 40;
+  const clamped =
+    typeof window === "undefined"
+      ? { x, y }
+      : clampTerminalContextMenu(
+          x,
+          y,
+          width,
+          height,
+          window.innerWidth,
+          window.innerHeight,
+        );
+  const menu = (
+    <div
+      className={styles.terminalContextMenu}
+      style={{ left: clamped.x, top: clamped.y, width }}
+      role="menu"
+      onContextMenu={(ev) => ev.preventDefault()}
+      onPointerDown={(ev) => ev.stopPropagation()}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        className={styles.terminalContextMenuItem}
+        onClick={() => {
+          onClear();
+          onClose();
+        }}
+      >
+        Clear terminal
+      </button>
+    </div>
+  );
+  return typeof document === "undefined"
+    ? menu
+    : createPortal(menu, document.body);
+}

--- a/src/ui/src/components/terminal/terminalPanelLogic.test.ts
+++ b/src/ui/src/components/terminal/terminalPanelLogic.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { TerminalTab } from "../../types/terminal";
+import {
+  reorderTerminalTabs,
+  tabDropPlacement,
+} from "./terminalPanelLogic";
+
+function tab(id: number, sortOrder = id): TerminalTab {
+  return {
+    id,
+    workspace_id: "workspace-a",
+    title: `Terminal ${id}`,
+    is_script_output: false,
+    sort_order: sortOrder,
+    created_at: "",
+  };
+}
+
+describe("reorderTerminalTabs", () => {
+  it("moves the dragged tab before the dropped-on tab and rewrites sort order", () => {
+    const reordered = reorderTerminalTabs([tab(1), tab(2), tab(3)], 3, 1, "before");
+
+    expect(reordered?.map((t) => t.id)).toEqual([3, 1, 2]);
+    expect(reordered?.map((t) => t.sort_order)).toEqual([0, 1, 2]);
+  });
+
+  it("moves the dragged tab after the dropped-on tab", () => {
+    const reordered = reorderTerminalTabs([tab(1), tab(2), tab(3)], 3, 1, "after");
+
+    expect(reordered?.map((t) => t.id)).toEqual([1, 3, 2]);
+    expect(reordered?.map((t) => t.sort_order)).toEqual([0, 1, 2]);
+  });
+
+  it("supports moving a tab to the right before or after the target", () => {
+    const beforeTarget = reorderTerminalTabs([tab(1), tab(2), tab(3)], 1, 3, "before");
+    const afterTarget = reorderTerminalTabs([tab(1), tab(2), tab(3)], 1, 3, "after");
+
+    expect(beforeTarget?.map((t) => t.id)).toEqual([2, 1, 3]);
+    expect(afterTarget?.map((t) => t.id)).toEqual([2, 3, 1]);
+    expect(afterTarget?.map((t) => t.sort_order)).toEqual([0, 1, 2]);
+  });
+
+  it("keeps adjacent rightward after-target drops stable", () => {
+    const reordered = reorderTerminalTabs([tab(1), tab(2), tab(3)], 1, 2, "after");
+
+    expect(reordered?.map((t) => t.id)).toEqual([2, 1, 3]);
+    expect(reordered?.map((t) => t.sort_order)).toEqual([0, 1, 2]);
+  });
+
+  it("returns null for no-op or invalid drags", () => {
+    expect(reorderTerminalTabs([tab(1), tab(2)], 1, 1, "before")).toBeNull();
+    expect(reorderTerminalTabs([tab(1), tab(2)], 9, 1, "before")).toBeNull();
+    expect(reorderTerminalTabs([tab(1), tab(2)], 1, 9, "before")).toBeNull();
+  });
+});
+
+describe("tabDropPlacement", () => {
+  it("uses the target tab midpoint to choose before or after", () => {
+    expect(tabDropPlacement(124, 100, 50)).toBe("before");
+    expect(tabDropPlacement(125, 100, 50)).toBe("after");
+    expect(tabDropPlacement(149, 100, 50)).toBe("after");
+  });
+});

--- a/src/ui/src/components/terminal/terminalPanelLogic.test.ts
+++ b/src/ui/src/components/terminal/terminalPanelLogic.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TerminalTab } from "../../types/terminal";
-import {
-  clampTerminalContextMenu,
-  reorderTerminalTabs,
-  tabDropPlacement,
-} from "./terminalPanelLogic";
+import { reorderTerminalTabs, tabDropPlacement } from "./terminalPanelLogic";
 
 function tab(id: number, sortOrder = id): TerminalTab {
   return {
@@ -60,21 +56,5 @@ describe("tabDropPlacement", () => {
     expect(tabDropPlacement(124, 100, 50)).toBe("before");
     expect(tabDropPlacement(125, 100, 50)).toBe("after");
     expect(tabDropPlacement(149, 100, 50)).toBe("after");
-  });
-});
-
-describe("clampTerminalContextMenu", () => {
-  it("keeps the menu anchored near the pointer when there is room", () => {
-    expect(clampTerminalContextMenu(120, 80, 140, 36, 500, 400)).toEqual({
-      x: 120,
-      y: 80,
-    });
-  });
-
-  it("keeps the menu inside the viewport near the right and bottom edges", () => {
-    expect(clampTerminalContextMenu(490, 390, 140, 36, 500, 400)).toEqual({
-      x: 352,
-      y: 356,
-    });
   });
 });

--- a/src/ui/src/components/terminal/terminalPanelLogic.test.ts
+++ b/src/ui/src/components/terminal/terminalPanelLogic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { TerminalTab } from "../../types/terminal";
 import {
+  clampTerminalContextMenu,
   reorderTerminalTabs,
   tabDropPlacement,
 } from "./terminalPanelLogic";
@@ -59,5 +60,21 @@ describe("tabDropPlacement", () => {
     expect(tabDropPlacement(124, 100, 50)).toBe("before");
     expect(tabDropPlacement(125, 100, 50)).toBe("after");
     expect(tabDropPlacement(149, 100, 50)).toBe("after");
+  });
+});
+
+describe("clampTerminalContextMenu", () => {
+  it("keeps the menu anchored near the pointer when there is room", () => {
+    expect(clampTerminalContextMenu(120, 80, 140, 36, 500, 400)).toEqual({
+      x: 120,
+      y: 80,
+    });
+  });
+
+  it("keeps the menu inside the viewport near the right and bottom edges", () => {
+    expect(clampTerminalContextMenu(490, 390, 140, 36, 500, 400)).toEqual({
+      x: 352,
+      y: 356,
+    });
   });
 });

--- a/src/ui/src/components/terminal/terminalPanelLogic.ts
+++ b/src/ui/src/components/terminal/terminalPanelLogic.ts
@@ -29,3 +29,18 @@ export function reorderTerminalTabs(
   reordered.splice(placement === "before" ? toIndex : toIndex + 1, 0, moved);
   return reordered.map((tab, index) => ({ ...tab, sort_order: index }));
 }
+
+export function clampTerminalContextMenu(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin = 8,
+) {
+  return {
+    x: Math.max(margin, Math.min(x, viewportWidth - width - margin)),
+    y: Math.max(margin, Math.min(y, viewportHeight - height - margin)),
+  };
+}

--- a/src/ui/src/components/terminal/terminalPanelLogic.ts
+++ b/src/ui/src/components/terminal/terminalPanelLogic.ts
@@ -29,18 +29,3 @@ export function reorderTerminalTabs(
   reordered.splice(placement === "before" ? toIndex : toIndex + 1, 0, moved);
   return reordered.map((tab, index) => ({ ...tab, sort_order: index }));
 }
-
-export function clampTerminalContextMenu(
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  viewportWidth: number,
-  viewportHeight: number,
-  margin = 8,
-) {
-  return {
-    x: Math.max(margin, Math.min(x, viewportWidth - width - margin)),
-    y: Math.max(margin, Math.min(y, viewportHeight - height - margin)),
-  };
-}

--- a/src/ui/src/components/terminal/terminalPanelLogic.ts
+++ b/src/ui/src/components/terminal/terminalPanelLogic.ts
@@ -1,0 +1,31 @@
+import type { TerminalTab } from "../../types/terminal";
+
+export type TabDropPlacement = "before" | "after";
+
+export function tabDropPlacement(
+  clientX: number,
+  tabLeft: number,
+  tabWidth: number,
+): TabDropPlacement {
+  return clientX < tabLeft + tabWidth / 2 ? "before" : "after";
+}
+
+export function reorderTerminalTabs(
+  tabs: readonly TerminalTab[],
+  draggedTabId: number,
+  targetTabId: number,
+  placement: TabDropPlacement,
+): TerminalTab[] | null {
+  if (draggedTabId === targetTabId) return null;
+  const fromIndex = tabs.findIndex((tab) => tab.id === draggedTabId);
+  const targetExists = tabs.some((tab) => tab.id === targetTabId);
+  if (fromIndex < 0 || !targetExists) return null;
+
+  const reordered = [...tabs];
+  const [moved] = reordered.splice(fromIndex, 1);
+  const toIndex = reordered.findIndex((tab) => tab.id === targetTabId);
+  if (fromIndex < 0 || toIndex < 0) return null;
+
+  reordered.splice(placement === "before" ? toIndex : toIndex + 1, 0, moved);
+  return reordered.map((tab, index) => ({ ...tab, sort_order: index }));
+}

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -55,10 +55,15 @@ export function useAgentStream() {
   const thinkingBlocksRef = useRef<Record<string, Set<number>>>({});
 
   // Recompute the workspace-level `agent_status` from the current
-  // per-session statuses. A workspace is Running if ANY active session in
-  // it is Running; otherwise Idle. Called whenever a session transitions
-  // between Running and Idle so the workspace aggregate (sidebar badges,
-  // tray) stays accurate even when sessions run concurrently.
+  // per-session statuses plus active background tasks. Priority:
+  //   - `Running` if ANY active session is Running.
+  //   - `IdleWithBackground` if no session is Running but at least one
+  //     active session has a background task in `starting`/`running`.
+  //   - `Idle` otherwise.
+  // Used as a sentinel (sidebar busy badges, tray icon, auto-updater
+  // gating) — it is not displayed verbatim. Call this whenever a session
+  // or background task transitions so the aggregate stays accurate even
+  // with concurrent sessions and async task updates.
   const syncWorkspaceAgentStatus = (wsId: string) => {
     const state = useAppStore.getState();
     const sessions = state.sessionsByWorkspace[wsId] ?? [];

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -5,6 +5,7 @@ import { loadChatHistory, saveTurnToolActivities } from "../services/tauri";
 import type { AgentStreamPayload } from "../types/agent-events";
 import type { ChatMessage } from "../types/chat";
 import type { ConversationCheckpoint } from "../types/checkpoint";
+import type { TerminalTab } from "../types/terminal";
 import { extractToolSummary } from "./toolSummary";
 import { parseAskUserQuestion } from "./parseAgentQuestion";
 import {
@@ -59,13 +60,28 @@ export function useAgentStream() {
   // between Running and Idle so the workspace aggregate (sidebar badges,
   // tray) stays accurate even when sessions run concurrently.
   const syncWorkspaceAgentStatus = (wsId: string) => {
-    const sessions =
-      useAppStore.getState().sessionsByWorkspace[wsId] ?? [];
+    const state = useAppStore.getState();
+    const sessions = state.sessionsByWorkspace[wsId] ?? [];
     const anyRunning = sessions.some(
       (s) => s.status === "Active" && s.agent_status === "Running",
     );
-    useAppStore.getState().updateWorkspace(wsId, {
-      agent_status: anyRunning ? "Running" : "Idle",
+    const activeSessionIds = new Set(
+      sessions.filter((s) => s.status === "Active").map((s) => s.id),
+    );
+    const anyBackground = Object.entries(state.agentBackgroundTasksBySessionId)
+      .some(([sessionId, tabs]) =>
+        activeSessionIds.has(sessionId) &&
+        tabs.some((tab) => {
+          const status = (tab.task_status ?? "").toLowerCase();
+          return status === "starting" || status === "running";
+        }),
+      );
+    state.updateWorkspace(wsId, {
+      agent_status: anyRunning
+        ? "Running"
+        : anyBackground
+          ? "IdleWithBackground"
+          : "Idle",
     });
   };
 
@@ -770,4 +786,39 @@ export function useAgentStream() {
       unlisten.then((fn) => fn());
     };
   }, [addChatAttachments]);
+
+  useEffect(() => {
+    let active = true;
+    const unlisten = listen<{
+      kind: "starting" | "bound" | "status";
+      workspace_id: string;
+      chat_session_id: string;
+      tab: TerminalTab;
+    }>("agent-background-task", (event) => {
+      if (!active) return;
+      const { workspace_id: wsId, chat_session_id: sessionId, tab } = event.payload;
+      const store = useAppStore.getState();
+      store.upsertAgentTaskTerminalTab(wsId, sessionId, tab);
+      const nextState = useAppStore.getState();
+      const session = (nextState.sessionsByWorkspace[wsId] ?? []).find(
+        (s) => s.id === sessionId,
+      );
+      if (session?.agent_status !== "Running") {
+        const hasRunningBackground = (
+          nextState.agentBackgroundTasksBySessionId[sessionId] ?? []
+        ).some((taskTab) => {
+          const status = (taskTab.task_status ?? "").toLowerCase();
+          return status === "starting" || status === "running";
+        });
+        nextState.updateChatSession(sessionId, {
+          agent_status: hasRunningBackground ? "IdleWithBackground" : "Idle",
+        });
+      }
+      syncWorkspaceAgentStatus(wsId);
+    });
+    return () => {
+      active = false;
+      unlisten.then((fn) => fn());
+    };
+  }, []);
 }

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -219,6 +219,9 @@
   "git_delete_warning": "The branch will be permanently deleted, including any unmerged commits.",
 
   "experimental_title": "Experimental",
+  "experimental_claudette_terminal": "Claudette Terminal",
+  "experimental_claudette_terminal_desc": "Show a read-only terminal tab that mirrors agent shell commands and background task output. Background task completion handling stays enabled even when this is off.",
+  "experimental_claudette_terminal_aria": "Claudette Terminal",
   "experimental_plugin_mgmt": "Plugin Management",
   "experimental_plugin_mgmt_desc": "Show the Plugins settings section and enable the built-in plugin-management slash commands that open it.",
   "experimental_plugin_mgmt_aria": "Plugin Management",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -861,6 +861,13 @@ export function createTerminalTab(
   return invoke("create_terminal_tab", { workspaceId });
 }
 
+export function ensureClaudetteTerminalTab(
+  workspaceId: string,
+  chatSessionId: string
+): Promise<TerminalTab> {
+  return invoke("ensure_claudette_terminal_tab", { workspaceId, chatSessionId });
+}
+
 export function deleteTerminalTab(id: number): Promise<void> {
   return invoke("delete_terminal_tab", { id });
 }

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -907,6 +907,27 @@ export function closePty(ptyId: number): Promise<void> {
   return invoke("close_pty", { ptyId });
 }
 
+export function startAgentTaskTail(
+  tabId: number,
+  outputPath: string,
+): Promise<void> {
+  return invoke("start_agent_task_tail", { tabId, outputPath });
+}
+
+export function stopAgentTaskTail(tabId: number): Promise<void> {
+  return invoke("stop_agent_task_tail", { tabId });
+}
+
+export function stopAgentBackgroundTask(
+  chatSessionId: string,
+  taskId: string,
+): Promise<void> {
+  return invoke("stop_agent_background_task", {
+    chatSessionId,
+    taskId,
+  });
+}
+
 // -- Settings --
 
 export function getAppSetting(key: string): Promise<string | null> {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -878,6 +878,13 @@ export function listTerminalTabs(
   return invoke("list_terminal_tabs", { workspaceId });
 }
 
+export function updateTerminalTabOrder(
+  workspaceId: string,
+  tabIds: number[],
+): Promise<void> {
+  return invoke("update_terminal_tab_order", { workspaceId, tabIds });
+}
+
 // -- PTY --
 
 export function spawnPty(

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -33,6 +33,8 @@ export interface SettingsSlice {
   setShowSidebarRunningCommands: (v: boolean) => void;
 
   // Experimental
+  claudetteTerminalEnabled: boolean;
+  setClaudetteTerminalEnabled: (enabled: boolean) => void;
   usageInsightsEnabled: boolean;
   setUsageInsightsEnabled: (enabled: boolean) => void;
   pluginManagementEnabled: boolean;
@@ -93,6 +95,9 @@ export const createSettingsSlice: StateCreator<
   showSidebarRunningCommands: false,
   setShowSidebarRunningCommands: (v) => set({ showSidebarRunningCommands: v }),
 
+  claudetteTerminalEnabled: false,
+  setClaudetteTerminalEnabled: (enabled) =>
+    set({ claudetteTerminalEnabled: enabled }),
   usageInsightsEnabled: false,
   setUsageInsightsEnabled: (enabled) => set({ usageInsightsEnabled: enabled }),
   pluginManagementEnabled: false,

--- a/src/ui/src/stores/slices/terminalSlice.ts
+++ b/src/ui/src/stores/slices/terminalSlice.ts
@@ -17,6 +17,7 @@ import type { AppState } from "../useAppStore";
 
 export interface TerminalSlice {
   terminalTabs: Record<string, TerminalTab[]>;
+  agentBackgroundTasksBySessionId: Record<string, TerminalTab[]>;
   // Active tab id is workspace-scoped: switching workspaces preserves each
   // workspace's last-active tab independently.
   activeTerminalTabId: Record<string, number | null>;
@@ -30,6 +31,11 @@ export interface TerminalSlice {
   setTerminalTabs: (wsId: string, tabs: TerminalTab[]) => void;
   addTerminalTab: (wsId: string, tab: TerminalTab) => void;
   removeTerminalTab: (wsId: string, tabId: number) => void;
+  upsertAgentTaskTerminalTab: (
+    wsId: string,
+    sessionId: string,
+    tab: TerminalTab,
+  ) => void;
   setActiveTerminalTab: (wsId: string, id: number | null) => void;
   toggleTerminalPanel: () => void;
   setWorkspaceRunningCommand: (
@@ -88,6 +94,7 @@ export const createTerminalSlice: StateCreator<
   TerminalSlice
 > = (set, get) => ({
   terminalTabs: {},
+  agentBackgroundTasksBySessionId: {},
   activeTerminalTabId: {},
   terminalPanelVisible: false,
   workspaceTerminalCommands: {},
@@ -116,6 +123,14 @@ export const createTerminalSlice: StateCreator<
       delete nextTrees[tabId];
       const nextActivePane = { ...s.activeTerminalPaneId };
       delete nextActivePane[tabId];
+      const nextTasks = Object.fromEntries(
+        Object.entries(s.agentBackgroundTasksBySessionId)
+          .map(([sessionId, sessionTabs]) => [
+            sessionId,
+            sessionTabs.filter((t) => t.id !== tabId),
+          ])
+          .filter(([, sessionTabs]) => sessionTabs.length > 0),
+      );
       // When the user closes the last tab in the currently-selected
       // workspace, collapse the terminal panel — leaving an empty panel
       // mounted looks broken. If they re-open it later the panel's
@@ -124,12 +139,40 @@ export const createTerminalSlice: StateCreator<
         tabs.length === 0 && s.selectedWorkspaceId === wsId;
       return {
         terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
+        agentBackgroundTasksBySessionId: nextTasks,
         activeTerminalTabId: wasActive
           ? { ...s.activeTerminalTabId, [wsId]: tabs[0]?.id ?? null }
           : s.activeTerminalTabId,
         terminalPaneTrees: nextTrees,
         activeTerminalPaneId: nextActivePane,
         terminalPanelVisible: hideBecauseEmpty ? false : s.terminalPanelVisible,
+      };
+    }),
+  upsertAgentTaskTerminalTab: (wsId, sessionId, tab) =>
+    set((s) => {
+      const existingTabs = s.terminalTabs[wsId] ?? [];
+      const existingIndex = existingTabs.findIndex((t) => t.id === tab.id);
+      const tabs =
+        existingIndex >= 0
+          ? existingTabs.map((t) => (t.id === tab.id ? tab : t))
+          : [...existingTabs, tab];
+      const existingTasks = s.agentBackgroundTasksBySessionId[sessionId] ?? [];
+      const taskIndex = existingTasks.findIndex((t) => t.id === tab.id);
+      const tasks =
+        taskIndex >= 0
+          ? existingTasks.map((t) => (t.id === tab.id ? tab : t))
+          : [...existingTasks, tab];
+      return {
+        terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
+        agentBackgroundTasksBySessionId: {
+          ...s.agentBackgroundTasksBySessionId,
+          [sessionId]: tasks,
+        },
+        activeTerminalTabId:
+          existingIndex >= 0
+            ? s.activeTerminalTabId
+            : { ...s.activeTerminalTabId, [wsId]: tab.id },
+        terminalPanelVisible: true,
       };
     }),
   setActiveTerminalTab: (wsId, id) =>

--- a/src/ui/src/stores/slices/terminalSlice.ts
+++ b/src/ui/src/stores/slices/terminalSlice.ts
@@ -168,11 +168,6 @@ export const createTerminalSlice: StateCreator<
           ...s.agentBackgroundTasksBySessionId,
           [sessionId]: tasks,
         },
-        activeTerminalTabId:
-          existingIndex >= 0
-            ? s.activeTerminalTabId
-            : { ...s.activeTerminalTabId, [wsId]: tab.id },
-        terminalPanelVisible: true,
       };
     }),
   setActiveTerminalTab: (wsId, id) =>

--- a/src/ui/src/stores/slices/terminalSlice.ts
+++ b/src/ui/src/stores/slices/terminalSlice.ts
@@ -15,6 +15,17 @@ import {
 } from "../terminalPaneTree";
 import type { AppState } from "../useAppStore";
 
+function orderTerminalTabs(tabs: TerminalTab[]): TerminalTab[] {
+  return [...tabs].sort((a, b) => {
+    const aKind = a.kind === "agent_task" ? 0 : 1;
+    const bKind = b.kind === "agent_task" ? 0 : 1;
+    if (aKind !== bKind) return aKind - bKind;
+    const bySortOrder = a.sort_order - b.sort_order;
+    if (bySortOrder !== 0) return bySortOrder;
+    return a.id - b.id;
+  });
+}
+
 export interface TerminalSlice {
   terminalTabs: Record<string, TerminalTab[]>;
   agentBackgroundTasksBySessionId: Record<string, TerminalTab[]>;
@@ -100,13 +111,13 @@ export const createTerminalSlice: StateCreator<
   workspaceTerminalCommands: {},
   setTerminalTabs: (wsId, tabs) =>
     set((s) => ({
-      terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
+      terminalTabs: { ...s.terminalTabs, [wsId]: orderTerminalTabs(tabs) },
     })),
   addTerminalTab: (wsId, tab) =>
     set((s) => ({
       terminalTabs: {
         ...s.terminalTabs,
-        [wsId]: [...(s.terminalTabs[wsId] || []), tab],
+        [wsId]: orderTerminalTabs([...(s.terminalTabs[wsId] || []), tab]),
       },
       activeTerminalTabId: { ...s.activeTerminalTabId, [wsId]: tab.id },
       terminalPanelVisible: true,
@@ -151,22 +162,24 @@ export const createTerminalSlice: StateCreator<
   upsertAgentTaskTerminalTab: (wsId, sessionId, tab) =>
     set((s) => {
       const existingTabs = s.terminalTabs[wsId] ?? [];
-      const existingIndex = existingTabs.findIndex((t) => t.id === tab.id);
+      const sessionTabsPruned = existingTabs.filter(
+        (t) =>
+          !(
+            t.kind === "agent_task" &&
+            t.agent_chat_session_id === sessionId &&
+            t.id !== tab.id
+          ),
+      );
+      const existingIndex = sessionTabsPruned.findIndex((t) => t.id === tab.id);
       const tabs =
         existingIndex >= 0
-          ? existingTabs.map((t) => (t.id === tab.id ? tab : t))
-          : [...existingTabs, tab];
-      const existingTasks = s.agentBackgroundTasksBySessionId[sessionId] ?? [];
-      const taskIndex = existingTasks.findIndex((t) => t.id === tab.id);
-      const tasks =
-        taskIndex >= 0
-          ? existingTasks.map((t) => (t.id === tab.id ? tab : t))
-          : [...existingTasks, tab];
+          ? sessionTabsPruned.map((t) => (t.id === tab.id ? tab : t))
+          : [...sessionTabsPruned, tab];
       return {
-        terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
+        terminalTabs: { ...s.terminalTabs, [wsId]: orderTerminalTabs(tabs) },
         agentBackgroundTasksBySessionId: {
           ...s.agentBackgroundTasksBySessionId,
-          [sessionId]: tasks,
+          [sessionId]: [tab],
         },
       };
     }),

--- a/src/ui/src/stores/slices/terminalSlice.ts
+++ b/src/ui/src/stores/slices/terminalSlice.ts
@@ -17,9 +17,6 @@ import type { AppState } from "../useAppStore";
 
 function orderTerminalTabs(tabs: TerminalTab[]): TerminalTab[] {
   return [...tabs].sort((a, b) => {
-    const aKind = a.kind === "agent_task" ? 0 : 1;
-    const bKind = b.kind === "agent_task" ? 0 : 1;
-    if (aKind !== bKind) return aKind - bKind;
     const bySortOrder = a.sort_order - b.sort_order;
     if (bySortOrder !== 0) return bySortOrder;
     return a.id - b.id;

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -174,7 +174,7 @@ describe("terminal slice: upsertAgentTaskTerminalTab", () => {
     ).toBeUndefined();
   });
 
-  it("keeps the read-only agent terminal first and replaces legacy command tabs", () => {
+  it("defaults the read-only agent terminal first and replaces legacy command tabs", () => {
     const userTerminal = makeTab(1, WS_A);
     const legacyAgentTab: TerminalTab = {
       ...makeTab(2, WS_A),
@@ -223,6 +223,26 @@ describe("terminal slice: upsertAgentTaskTerminalTab", () => {
     expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([
       userTerminal,
       claudetteTerminal,
+    ]);
+  });
+
+  it("preserves a reordered agent terminal after the user drags it", () => {
+    const userTerminal = { ...makeTab(1, WS_A), sort_order: 0 };
+    const claudetteTerminal: TerminalTab = {
+      ...makeTab(2, WS_A),
+      sort_order: 1,
+      title: "Claudette terminal",
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+    };
+
+    useAppStore
+      .getState()
+      .setTerminalTabs(WS_A, [claudetteTerminal, userTerminal]);
+
+    expect(useAppStore.getState().terminalTabs[WS_A].map((tab) => tab.id)).toEqual([
+      1,
+      2,
     ]);
   });
 });

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -76,6 +76,63 @@ describe("terminal slice: addTerminalTab", () => {
   });
 });
 
+describe("terminal slice: upsertAgentTaskTerminalTab", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      terminalTabs: {},
+      activeTerminalTabId: { [WS_A]: 99 },
+      terminalPanelVisible: false,
+      agentBackgroundTasksBySessionId: {},
+    });
+  });
+
+  it("registers agent task tabs without opening or stealing the terminal", () => {
+    const tab: TerminalTab = {
+      ...makeTab(10, WS_A),
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+      agent_tool_use_id: "toolu_1",
+      task_status: "running",
+    };
+
+    useAppStore
+      .getState()
+      .upsertAgentTaskTerminalTab(WS_A, "session-a", tab);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([tab]);
+    expect(
+      useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
+    ).toEqual([tab]);
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(99);
+    expect(useAppStore.getState().terminalPanelVisible).toBe(false);
+  });
+
+  it("updates an existing agent task tab in place", () => {
+    const running: TerminalTab = {
+      ...makeTab(10, WS_A),
+      kind: "agent_task",
+      task_status: "running",
+    };
+    const completed: TerminalTab = {
+      ...running,
+      task_status: "completed",
+      task_summary: "done",
+    };
+
+    useAppStore
+      .getState()
+      .upsertAgentTaskTerminalTab(WS_A, "session-a", running);
+    useAppStore
+      .getState()
+      .upsertAgentTaskTerminalTab(WS_A, "session-a", completed);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([completed]);
+    expect(
+      useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
+    ).toEqual([completed]);
+  });
+});
+
 describe("terminal slice: removeTerminalTab", () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -132,6 +132,48 @@ describe("terminal slice: upsertAgentTaskTerminalTab", () => {
     ).toEqual([completed]);
   });
 
+  it("replaces prior agent tabs for the same session but preserves other sessions", () => {
+    const previousSameSession: TerminalTab = {
+      ...makeTab(10, WS_A),
+      title: "Agent: sleep 30",
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+      task_status: "running",
+    };
+    const otherSession: TerminalTab = {
+      ...makeTab(11, WS_A),
+      title: "Claudette terminal",
+      kind: "agent_task",
+      agent_chat_session_id: "session-b",
+      task_status: "running",
+    };
+    const replacement: TerminalTab = {
+      ...makeTab(12, WS_A),
+      title: "Claudette terminal",
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+      task_status: "running",
+    };
+
+    useAppStore
+      .getState()
+      .setTerminalTabs(WS_A, [previousSameSession, otherSession]);
+    useAppStore
+      .getState()
+      .upsertAgentTaskTerminalTab(WS_A, "session-a", replacement);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([
+      otherSession,
+      replacement,
+    ]);
+    expect(
+      useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
+    ).toEqual([replacement]);
+    expect(
+      useAppStore.getState().agentBackgroundTasksBySessionId["session-b"],
+    ).toBeUndefined();
+  });
+
   it("keeps the read-only agent terminal first and replaces legacy command tabs", () => {
     const userTerminal = makeTab(1, WS_A);
     const legacyAgentTab: TerminalTab = {
@@ -217,6 +259,24 @@ describe("terminal slice: removeTerminalTab", () => {
     useAppStore.getState().removeTerminalTab(WS_A, 1);
 
     expect(useAppStore.getState().activeTerminalTabId[WS_B]).toBe(99);
+  });
+
+  it("removing an agent tab clears its tracked background task entry", () => {
+    const agentTab: TerminalTab = {
+      ...makeTab(10, WS_A),
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+      task_status: "running",
+    };
+    useAppStore
+      .getState()
+      .upsertAgentTaskTerminalTab(WS_A, "session-a", agentTab);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 10);
+
+    expect(
+      useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
+    ).toBeUndefined();
   });
 });
 

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -185,6 +185,7 @@ describe("terminal slice: upsertAgentTaskTerminalTab", () => {
     };
     const claudetteTerminal: TerminalTab = {
       ...makeTab(3, WS_A),
+      sort_order: 0,
       title: "Claudette terminal",
       kind: "agent_task",
       agent_chat_session_id: "session-a",
@@ -203,6 +204,26 @@ describe("terminal slice: upsertAgentTaskTerminalTab", () => {
     expect(
       useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
     ).toEqual([claudetteTerminal]);
+  });
+
+  it("preserves explicit user tab order even when an agent terminal is present", () => {
+    const userTerminal = { ...makeTab(1, WS_A), sort_order: 0 };
+    const claudetteTerminal: TerminalTab = {
+      ...makeTab(2, WS_A),
+      sort_order: 1,
+      title: "Claudette terminal",
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+    };
+
+    useAppStore
+      .getState()
+      .setTerminalTabs(WS_A, [claudetteTerminal, userTerminal]);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([
+      userTerminal,
+      claudetteTerminal,
+    ]);
   });
 });
 

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -131,6 +131,37 @@ describe("terminal slice: upsertAgentTaskTerminalTab", () => {
       useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
     ).toEqual([completed]);
   });
+
+  it("keeps the read-only agent terminal first and replaces legacy command tabs", () => {
+    const userTerminal = makeTab(1, WS_A);
+    const legacyAgentTab: TerminalTab = {
+      ...makeTab(2, WS_A),
+      title: "Agent: sleep 30 && date",
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+      task_status: "running",
+    };
+    const claudetteTerminal: TerminalTab = {
+      ...makeTab(3, WS_A),
+      title: "Claudette terminal",
+      kind: "agent_task",
+      agent_chat_session_id: "session-a",
+      task_status: "running",
+    };
+
+    useAppStore.getState().setTerminalTabs(WS_A, [userTerminal, legacyAgentTab]);
+    useAppStore
+      .getState()
+      .upsertAgentTaskTerminalTab(WS_A, "session-a", claudetteTerminal);
+
+    expect(useAppStore.getState().terminalTabs[WS_A]).toEqual([
+      claudetteTerminal,
+      userTerminal,
+    ]);
+    expect(
+      useAppStore.getState().agentBackgroundTasksBySessionId["session-a"],
+    ).toEqual([claudetteTerminal]);
+  });
 });
 
 describe("terminal slice: removeTerminalTab", () => {

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -66,6 +66,24 @@ describe("effortLevel (per-workspace)", () => {
   });
 });
 
+describe("experimental Claudette terminal setting", () => {
+  beforeEach(() => {
+    useAppStore.setState({ claudetteTerminalEnabled: false });
+  });
+
+  it("defaults to disabled so the read-only agent terminal is opt-in", () => {
+    expect(useAppStore.getState().claudetteTerminalEnabled).toBe(false);
+  });
+
+  it("can be enabled and disabled from settings state", () => {
+    useAppStore.getState().setClaudetteTerminalEnabled(true);
+    expect(useAppStore.getState().claudetteTerminalEnabled).toBe(true);
+
+    useAppStore.getState().setClaudetteTerminalEnabled(false);
+    expect(useAppStore.getState().claudetteTerminalEnabled).toBe(false);
+  });
+});
+
 describe("streamingThinking (per-workspace)", () => {
   beforeEach(() => {
     useAppStore.setState({ streamingThinking: {}, showThinkingBlocks: {} });

--- a/src/ui/src/types/agent-events.ts
+++ b/src/ui/src/types/agent-events.ts
@@ -18,6 +18,14 @@ export type StreamEvent =
       session_id?: string | null;
       /** Only present on `subtype: "status"` events. */
       status?: string | null;
+      /** Only present on `subtype: "task_notification"` events. */
+      task_id?: string | null;
+      /** Only present on `subtype: "task_notification"` events. */
+      tool_use_id?: string | null;
+      /** Only present on `subtype: "task_notification"` events. */
+      output_file?: string | null;
+      /** Only present on `subtype: "task_notification"` events. */
+      summary?: string | null;
       /** Only present on the end-of-compaction status event. Rust
        * serializes `Option<String>` as `null` (no `skip_serializing_if`),
        * so the wire payload carries `null` when absent. */

--- a/src/ui/src/types/chat.ts
+++ b/src/ui/src/types/chat.ts
@@ -18,7 +18,7 @@ export interface ChatMessage {
 
 export type SessionStatus = "Active" | "Archived";
 export type SessionAttentionKind = "Ask" | "Plan";
-export type SessionAgentStatus = "Idle" | "Running" | "Stopped";
+export type SessionAgentStatus = "Idle" | "Running" | "IdleWithBackground" | "Stopped";
 
 /** A chat session (tab) within a workspace. Matches the Rust `ChatSession` struct. */
 export interface ChatSession {

--- a/src/ui/src/types/terminal.ts
+++ b/src/ui/src/types/terminal.ts
@@ -2,9 +2,16 @@ export interface TerminalTab {
   id: number;
   workspace_id: string;
   title: string;
+  kind?: "pty" | "agent_task";
   is_script_output: boolean;
   sort_order: number;
   created_at: string;
+  agent_chat_session_id?: string | null;
+  agent_tool_use_id?: string | null;
+  agent_task_id?: string | null;
+  output_path?: string | null;
+  task_status?: string | null;
+  task_summary?: string | null;
 }
 
 export interface WorkspaceCommandState {

--- a/src/ui/src/types/workspace.ts
+++ b/src/ui/src/types/workspace.ts
@@ -3,6 +3,7 @@ export type WorkspaceStatus = "Active" | "Archived";
 export type AgentStatus =
   | "Running"
   | "Idle"
+  | "IdleWithBackground"
   | "Stopped"
   | "Compacting"
   | { Error: string };

--- a/src/ui/src/utils/zoom.test.ts
+++ b/src/ui/src/utils/zoom.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getRootZoom,
+  viewportLayoutSize,
+  viewportToFixed,
+} from "./zoom";
+
+// vitest runs in the Node environment by default, so we hand-roll a
+// minimal `document.documentElement` and `window` surface that mirrors
+// what the helpers actually touch. Same pattern as focusTargets.test.ts.
+
+type GlobalShim = {
+  document?: { documentElement: { style: { zoom: string } } };
+  window?: { innerWidth: number; innerHeight: number };
+};
+
+function withRootZoom(zoom: string | undefined, fn: () => void) {
+  const g = globalThis as unknown as GlobalShim;
+  const prevDoc = g.document;
+  g.document = {
+    documentElement: { style: { zoom: zoom ?? "" } },
+  };
+  try {
+    fn();
+  } finally {
+    g.document = prevDoc;
+  }
+}
+
+function withViewport(width: number, height: number, fn: () => void) {
+  const g = globalThis as unknown as GlobalShim;
+  const prevWin = g.window;
+  g.window = { innerWidth: width, innerHeight: height };
+  try {
+    fn();
+  } finally {
+    g.window = prevWin;
+  }
+}
+
+afterEach(() => {
+  // Defensive: tests may early-return; ensure we don't leak document/window
+  // state into the next test.
+  const g = globalThis as unknown as GlobalShim;
+  delete g.document;
+  delete g.window;
+});
+
+describe("getRootZoom", () => {
+  it("returns 1 when zoom is unset", () => {
+    withRootZoom("", () => {
+      expect(getRootZoom()).toBe(1);
+    });
+  });
+
+  it("returns 1 when zoom parses as NaN", () => {
+    withRootZoom("not-a-number", () => {
+      expect(getRootZoom()).toBe(1);
+    });
+  });
+
+  it("returns 1 when zoom is zero or negative (defensive)", () => {
+    withRootZoom("0", () => {
+      expect(getRootZoom()).toBe(1);
+    });
+    withRootZoom("-1.5", () => {
+      expect(getRootZoom()).toBe(1);
+    });
+  });
+
+  it("parses the zoom factor when set as a unitless number", () => {
+    withRootZoom("1.153846", () => {
+      expect(getRootZoom()).toBeCloseTo(1.153846, 6);
+    });
+  });
+});
+
+describe("viewportToFixed", () => {
+  it("passes coords through unchanged at zoom=1", () => {
+    withRootZoom("", () => {
+      expect(viewportToFixed(120, 80)).toEqual({ x: 120, y: 80 });
+    });
+  });
+
+  it("divides coords by the zoom factor so `position: fixed; left: x` lands at the cursor", () => {
+    // WebKit on macOS reports event clientX/Y in visual pixels but
+    // `position: fixed; left/top` interprets values as layout pixels —
+    // so visual / zoom = layout for a fixed element to render at the
+    // visual click point.
+    withRootZoom("1.5", () => {
+      const { x, y } = viewportToFixed(300, 150);
+      expect(x).toBeCloseTo(200, 6);
+      expect(y).toBeCloseTo(100, 6);
+    });
+  });
+});
+
+describe("viewportLayoutSize", () => {
+  it("returns innerWidth/innerHeight verbatim at zoom=1", () => {
+    withRootZoom("", () => {
+      withViewport(1920, 1080, () => {
+        expect(viewportLayoutSize()).toEqual({ width: 1920, height: 1080 });
+      });
+    });
+  });
+
+  it("converts visual viewport size into layout pixels under zoom", () => {
+    // Same frame as `viewportToFixed`: layout = visual / zoom. Clamping
+    // a fixed-positioned element wants layout-pixel bounds, not visual.
+    withRootZoom("1.5", () => {
+      withViewport(1920, 1080, () => {
+        const { width, height } = viewportLayoutSize();
+        expect(width).toBeCloseTo(1280, 6);
+        expect(height).toBeCloseTo(720, 6);
+      });
+    });
+  });
+});

--- a/src/ui/src/utils/zoom.ts
+++ b/src/ui/src/utils/zoom.ts
@@ -1,0 +1,33 @@
+// Read the html-level CSS zoom that `applyUserFonts` sets to scale the UI
+// (theme.ts). Returns 1 when zoom is unset or invalid so callers can branch
+// cheaply on `zoom !== 1`.
+export function getRootZoom(): number {
+  if (typeof document === "undefined") return 1;
+  const z = parseFloat(document.documentElement.style.zoom);
+  return Number.isFinite(z) && z > 0 ? z : 1;
+}
+
+// WebKit on macOS (used by Tauri's WKWebView) reports `clientX/Y` in event
+// handlers in *visual* (post-zoom) pixels, while CSS `position: fixed; left/top`
+// interpret their values in *layout* (pre-zoom) pixels. Without compensation
+// a fixed element placed at the click coords renders shifted by the zoom
+// factor — visibly off when zoom != 1. Divide event coords by zoom to land
+// the element at the cursor.
+export function viewportToFixed(x: number, y: number) {
+  const z = getRootZoom();
+  if (z === 1) return { x, y };
+  return { x: x / z, y: y / z };
+}
+
+// Visual viewport size in layout pixels — the right reference for clamping
+// a fixed-positioned element since fixed `left/top` are layout pixels too.
+// `window.innerWidth/innerHeight` return visual pixels under html zoom, so
+// we divide back into the same frame the placement is in.
+export function viewportLayoutSize() {
+  if (typeof window === "undefined") return { width: 0, height: 0 };
+  const z = getRootZoom();
+  return {
+    width: window.innerWidth / z,
+    height: window.innerHeight / z,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a new **agent background terminal tab** that mirrors the bash output Claude is running for the active session, including long-running `run_in_background` jobs spawned via Claude Code's `<task-notification>` events. The integrated terminal panel grows from "user shell only" into the place where you can also watch what the agent is doing in a real shell — without re-running the command yourself.

Along the way, the terminal panel got the polish work the existing bespoke tab UI had been missing: **drag-to-reorder** that survives the html-level UI zoom Claudette applies for font scaling, **a unified context menu** that matches the rest of the app, and a guard against the cause of two recent regressions ("Clear terminal" silently no-op'd; tab right-click menu landed off-screen; tab drag fired no `dragover`/`drop` events under WebKit zoom).

Gated behind the existing **`claudette_terminal_enabled`** experimental setting until we're happy with the UX (see `ExperimentalSettings`).

We do **not** use the Anthropic Agent SDK for this. We shell out to the `claude` CLI as a subprocess and parse its `--output-format stream-json` stdout. Claude Code itself owns the background-job lifecycle (forks the command, writes stdout to a file under `/tmp/claude-<uid>/.../tasks/<task_id>.output`, emits `<task-notification>` system reminders for state transitions). We just observe those signals and reflect them in the UI.

## What's in the box

### Backend — `claudette` crate

- New module `src/agent/background.rs` parses tool-input JSON and `<task-notification>` system reminders to track:
  - When the agent runs `Bash` with `run_in_background: true`.
  - When Claude Code binds a `task_id` + output path to that tool call.
  - When the task transitions through `starting` / `running` / `completed` / `failed` and emits a summary.
- `src/agent/session.rs` + `src/agent/types.rs` carry the event up to a Tauri-emittable `AgentBackgroundTaskEvent` so the frontend can react in real-time.
- `src/db/terminal.rs` gains:
  - `max_terminal_tab_id`, `get_agent_shell_terminal_tab_by_workspace`, `upsert_agent_task_terminal_tab`, `update_agent_shell_terminal_tab_session`, `update_terminal_tab_sort_order`.
  - The "Claudette terminal" agent-shell tab pinned at `sort_order = -1`.
- Migration `20260505055527_agent_task_terminal_tabs.sql` adds:
  - `kind` (`pty` | `agent_task`), `agent_chat_session_id`, `agent_tool_use_id`, `agent_task_id`, `output_path`, `task_status`, `task_summary`.
  - Indexes on `agent_tool_use_id` and `(agent_chat_session_id, agent_task_id)`.
- `src-tauri/src/commands/chat/send.rs` wires the agent stream into the new event flow; `commands/chat/lifecycle.rs` and `commands/chat/session.rs` handle session start/teardown.
- `commands/terminal.rs` adds:
  - `ensure_claudette_terminal_tab` — idempotent upsert of the agent-shell tab for a given chat session.
  - `update_terminal_tab_order` — persists drag-reorder.
  - `start_agent_task_tail` / `stop_agent_task_tail` — incremental tail of the agent's background-bash output file with reset markers when Claude rotates the file. The initial read is capped to the last 64 KiB so attaching to a long-lived shell doesn't dump megabytes into xterm in one frame.

### Frontend — `src/ui`

- `TerminalPanel.tsx` learns three new modes:
  1. **Claudette terminal** — read-only, fed by the agent-task tail. Mirrors what the agent's shell is doing, with a `completed` / `running` / `failed` badge.
  2. **Background-task awareness** — when the agent starts a `run_in_background` job, the badge transitions to `running` with a stop button; on completion the summary is persisted on the tab. (One agent-shell tab per workspace tracks the most recent task; per-task multi-tab is intentionally out of scope for the gated rollout.)
  3. **Drag-to-reorder** — pointer-event-based with a portaled floating ghost that follows the cursor and an accent drop indicator on the target edge.
- The right-click context menu now reuses `AttachmentContextMenu` so it matches every other right-click menu in the app (and is portaled to body, escaping the `contain: layout` containment that was offsetting the bespoke menu under html zoom).
- New experimental settings entry: **Claudette terminal** (toggle), gated by `claudette_terminal_enabled`. Settings copy in `locales/en/settings.json`.
- Tray notifications fire when a background task completes. `tray.rs` and `commands/chat/send.rs` both flush these.
- New `utils/zoom.ts` helpers — `getRootZoom`, `viewportToFixed`, `viewportLayoutSize` — that translate between event-coord (visual pixels under html zoom) and `position: fixed` (layout pixels). Used by `AttachmentContextMenu`'s clamp logic and the floating drag ghost.

## Notable WebKit-on-macOS quirks fixed

Claudette sets `zoom` on the root `html` element to scale the whole UI proportionally for font-size preferences (`theme.ts :: applyUserFonts`). Two interactions in the terminal tab bar broke under that zoom and are fixed here:

1. **Native HTML5 drag-and-drop only fired `dragstart` and `dragend`** — no `dragover`/`drop` ever reached the React handlers, so reorder was silently a no-op. Replaced with a pointer-event-based drag (`setPointerCapture` + `elementFromPoint` hit-testing + 4px hysteresis), which works correctly under zoom.
2. **`position: fixed; left/top` is interpreted in *layout* pixels but event `clientX/Y` is in *visual* pixels** under html zoom — so a fixed menu placed at the click coords drifted by `(zoom - 1) × clientX` to the right (and similarly down). `AttachmentContextMenu` now compensates via the new `viewportToFixed` helper for both placement and viewport clamping.

## Regression also fixed in this PR

"Clear terminal" silently stopped working after the switch from the bespoke menu back to `AttachmentContextMenu`: `TerminalPanel` had a leftover `window.addEventListener("pointerdown", close)` that fired for pointerdowns inside the menu and unmounted it before the button's `click` event ran. The redundant listener is removed (the shared menu owns its own outside-click via `mousedown` capture + Escape handling) and `AttachmentContextMenu` now stops pointer/mouse propagation at its menu boundary so a future caller with a similar listener can't reintroduce the bug.

## Test plan

- [x] Rust: `cargo test --all-features` (new tests cover `agent::background` parsing of tool-input + `<task-notification>`, terminal-tab DB CRUD for agent-task variants, sort-order persistence)
- [x] Rust: `cargo clippy --workspace --all-targets` clean under `-Dwarnings`
- [x] Frontend: `bun run test` — **78 files, 1214 tests passing** (including new `zoom.test.ts` and expanded `useAppStore.terminal.test.ts`)
- [x] Frontend: `bunx tsc -b` clean
- [x] Frontend: `bun run lint:css` (design-token check) clean
- [x] UAT in dev build:
  - [x] Drag a tab — floating ghost follows the cursor, accent indicator on target edge, drop commits and persists across reload.
  - [x] Right-click a tab — menu lands at the cursor (no zoom drift), "Clear terminal" actually clears, Escape and outside-click both close it.
  - [x] Right-click an xterm pane — same menu, clears the pane's terminal.
  - [x] Run an agent prompt that does `Bash` with `run_in_background: true` (e.g. "run `date && sleep 60 && date` in the background") — tab badge transitions to `running`, output streams in, badge transitions to `completed` and a tray notification fires when the job exits.
- [x] Reviewer: confirm the experimental gate (`claudette_terminal_enabled`) hides the agent-task tab variants for users who haven't opted in.
