### PR TITLE
fix(sidebar): surface rename failures via toast

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -50,6 +50,7 @@ export const Sidebar = memo(function Sidebar() {
   const openSettings = useAppStore((s) => s.openSettings);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const removeWorkspace = useAppStore((s) => s.removeWorkspace);
+  const addToast = useAppStore((s) => s.addToast);
   const unreadCompletions = useAppStore((s) => s.unreadCompletions);
   const agentQuestions = useAppStore((s) => s.agentQuestions);
   const planApprovals = useAppStore((s) => s.planApprovals);
@@ -301,9 +302,10 @@ export const Sidebar = memo(function Sidebar() {
       updateWorkspace(wsId, { name: trimmed });
     } catch (e) {
       console.error("Failed to rename workspace:", e);
+      addToast(t("rename_workspace_failed", { error: String(e) }));
     }
     setRenamingWsId(null);
-  }, [renameValue, workspaces, updateWorkspace]);
+  }, [renameValue, workspaces, updateWorkspace, addToast, t]);
 
   const renderWorkspace = (ws: typeof workspaces[number]) => {
     const wsSessions = sessionsByWorkspace[ws.id] ?? [];

--- a/src/ui/src/locales/en/sidebar.json
+++ b/src/ui/src/locales/en/sidebar.json
@@ -28,6 +28,7 @@
   "filter_workspaces": "Filter workspaces",
   "workspace_filters_aria": "Workspace filters",
   "rename_workspace_aria": "Rename workspace",
+  "rename_workspace_failed": "Couldn't rename workspace: {{error}}",
   "archive_workspace": "Archive",
   "restore_workspace": "Restore",
   "delete_workspace": "Delete",


### PR DESCRIPTION
## Summary

- The inline workspace rename input in the sidebar caught all errors silently with `console.error` and then closed the editor, making validation rejections (only `[a-zA-Z0-9-]` allowed; no leading/trailing hyphen) and UNIQUE-name collisions look like the rename "didn't save".
- Pipe the backend's error message into a toast via the existing `addToast` action so users can see why and correct the name.

## Test plan

- [ ] Double-click a workspace name in the sidebar, change it to a name containing a space or underscore, press Enter toast shows `Couldn't rename workspace: Invalid workspace name. Use letters, numbers, and hyphens only.`
- [ ] Rename two workspaces in the same repo to colliding names second one shows `A workspace with this name already exists in this repository`.
- [ ] Rename to a valid lowercase-with-hyphens name — persists, no toast.
- [ ] Press Escape while editing — exits without toast.