### PR TITLE
fix(hotkeys): restore push-to-talk on Right Alt and add keyboard-shortcut search

### DIFF
--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -398,6 +398,19 @@
   line-height: 1;
 }
 
+.keyboardSearch {
+  composes: input;
+  width: 100%;
+  margin: 0 0 8px;
+}
+
+.keyboardEmpty {
+  padding: 24px 0;
+  color: var(--text-dim);
+  font-size: 13px;
+  text-align: center;
+}
+
 .keyboardGroup {
   padding: 20px 0;
   border-bottom: 1px solid var(--divider);

--- a/src/ui/src/components/settings/sections/KeyboardSettings.tsx
+++ b/src/ui/src/components/settings/sections/KeyboardSettings.tsx
@@ -41,7 +41,17 @@ export function KeyboardSettings() {
       const description = tx(action.description);
       const category = tx(action.category);
       const effective = getEffectiveBinding(action, keybindings);
-      const bindingLabel = formatBindingParts(effective, isMac).join(" ");
+      // Include three representations of the binding so common query forms
+      // all hit: "⌘ B" (visual / hint UI), "⌘B" (no separator), "⌘+B" / "Ctrl+B"
+      // (cross-platform written form). The matcher AND-tokens its query, so
+      // duplicating into one space-delimited string is safe — each variant
+      // is its own searchable substring.
+      const parts = formatBindingParts(effective, isMac);
+      const bindingLabel = [
+        parts.join(" "),
+        parts.join(""),
+        parts.join("+"),
+      ].join(" ");
       if (!shortcutMatchesQuery({ description, category, bindingLabel }, search)) {
         continue;
       }

--- a/src/ui/src/components/settings/sections/KeyboardSettings.tsx
+++ b/src/ui/src/components/settings/sections/KeyboardSettings.tsx
@@ -12,6 +12,7 @@ import { isMacHotkeyPlatform } from "../../../hotkeys/platform";
 import { useAppStore } from "../../../stores/useAppStore";
 import { deleteAppSetting, setAppSetting } from "../../../services/tauri";
 import styles from "../Settings.module.css";
+import { shortcutMatchesQuery } from "./keyboardSearch";
 
 function isCaptureMatchByCode(action: HotkeyAction): boolean {
   return action.match === "code" || action.holdMode === true;
@@ -32,16 +33,27 @@ export function KeyboardSettings() {
   const setKeybindings = useAppStore((s) => s.setKeybindings);
   const [rebinding, setRebinding] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
 
-  const actionsByCategory = useMemo(() => {
+  const filteredActionsByCategory = useMemo(() => {
     const groups = new Map<string, HotkeyAction[]>();
     for (const action of HOTKEY_ACTIONS) {
+      const description = tx(action.description);
+      const category = tx(action.category);
+      const effective = getEffectiveBinding(action, keybindings);
+      const bindingLabel = formatBindingParts(effective, isMac).join(" ");
+      if (!shortcutMatchesQuery({ description, category, bindingLabel }, search)) {
+        continue;
+      }
       const list = groups.get(action.category) ?? [];
       list.push(action);
       groups.set(action.category, list);
     }
     return Array.from(groups.entries());
-  }, []);
+    // `tx` is a stable wrapper around the i18n `t` function — re-running on
+    // every render is fine and lets the filter respond to language changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, keybindings, isMac, t]);
 
   const saveBinding = useCallback(async (action: HotkeyAction, binding: string | null) => {
     const updates = buildRebindUpdates(action.id, binding, keybindings);
@@ -125,7 +137,20 @@ export function KeyboardSettings() {
       </div>
       {error && <div className={styles.error}>{error}</div>}
 
-      {actionsByCategory.map(([category, actions]) => (
+      <input
+        type="search"
+        className={styles.keyboardSearch}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder={t("keyboard_search_placeholder")}
+        aria-label={t("keyboard_search_placeholder")}
+      />
+
+      {filteredActionsByCategory.length === 0 ? (
+        <div className={styles.keyboardEmpty}>{t("keyboard_no_results")}</div>
+      ) : null}
+
+      {filteredActionsByCategory.map(([category, actions]) => (
         <div className={styles.keyboardGroup} key={category}>
           <div className={styles.keyboardGroupLabel}>{tx(category)}</div>
           {actions.map((action) => {

--- a/src/ui/src/components/settings/sections/keyboardSearch.test.ts
+++ b/src/ui/src/components/settings/sections/keyboardSearch.test.ts
@@ -34,6 +34,20 @@ describe("shortcutMatchesQuery", () => {
     ).toBe(false);
   });
 
+  it("matches the binding regardless of separator style", () => {
+    // KeyboardSettings.tsx includes three forms in the haystack so users
+    // can type the binding however they think of it — see the comment at
+    // the bindingLabel construction site.
+    const action = mk(
+      "Toggle left sidebar",
+      "Navigation",
+      "⌘ B ⌘B ⌘+B",
+    );
+    expect(shortcutMatchesQuery(action, "⌘B")).toBe(true);
+    expect(shortcutMatchesQuery(action, "⌘+B")).toBe(true);
+    expect(shortcutMatchesQuery(action, "⌘ B")).toBe(true);
+  });
+
   it("ANDs whitespace-separated tokens — order doesn't matter", () => {
     const action = mk("Split terminal side by side", "Terminal");
     expect(shortcutMatchesQuery(action, "terminal split")).toBe(true);

--- a/src/ui/src/components/settings/sections/keyboardSearch.test.ts
+++ b/src/ui/src/components/settings/sections/keyboardSearch.test.ts
@@ -21,7 +21,7 @@ describe("shortcutMatchesQuery", () => {
 
   it("matches against the category name", () => {
     expect(
-      shortcutMatchesQuery(mk("Hold to talk", "Voice"), "voice"),
+      shortcutMatchesQuery(mk("Push to talk", "Voice"), "voice"),
     ).toBe(true);
   });
 
@@ -41,10 +41,11 @@ describe("shortcutMatchesQuery", () => {
     expect(shortcutMatchesQuery(action, "terminal panel")).toBe(false);
   });
 
-  it("finds the push-to-talk shortcut by `talk` or `hold`", () => {
-    const action = mk("Hold to talk", "Voice", "Right ⌥");
+  it("finds the push-to-talk shortcut by `talk` or `push`", () => {
+    const action = mk("Push to talk", "Voice", "Right ⌥");
     expect(shortcutMatchesQuery(action, "talk")).toBe(true);
-    expect(shortcutMatchesQuery(action, "hold")).toBe(true);
-    expect(shortcutMatchesQuery(action, "push to talk")).toBe(false);
+    expect(shortcutMatchesQuery(action, "push")).toBe(true);
+    expect(shortcutMatchesQuery(action, "push to talk")).toBe(true);
+    expect(shortcutMatchesQuery(action, "hold")).toBe(false);
   });
 });

--- a/src/ui/src/components/settings/sections/keyboardSearch.test.ts
+++ b/src/ui/src/components/settings/sections/keyboardSearch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { shortcutMatchesQuery } from "./keyboardSearch";
+
+const mk = (description: string, category = "Navigation", bindingLabel = "") => ({
+  description,
+  category,
+  bindingLabel,
+});
+
+describe("shortcutMatchesQuery", () => {
+  it("returns every shortcut when the query is empty or whitespace", () => {
+    expect(shortcutMatchesQuery(mk("Toggle left sidebar"), "")).toBe(true);
+    expect(shortcutMatchesQuery(mk("Toggle left sidebar"), "   ")).toBe(true);
+  });
+
+  it("matches the action description case-insensitively", () => {
+    expect(shortcutMatchesQuery(mk("Open fuzzy finder"), "FUZZY")).toBe(true);
+    expect(shortcutMatchesQuery(mk("Open fuzzy finder"), "fuz")).toBe(true);
+    expect(shortcutMatchesQuery(mk("Open fuzzy finder"), "settings")).toBe(false);
+  });
+
+  it("matches against the category name", () => {
+    expect(
+      shortcutMatchesQuery(mk("Hold to talk", "Voice"), "voice"),
+    ).toBe(true);
+  });
+
+  it("matches against the formatted binding label", () => {
+    expect(
+      shortcutMatchesQuery(mk("Toggle left sidebar", "Navigation", "⌘ B"), "⌘"),
+    ).toBe(true);
+    expect(
+      shortcutMatchesQuery(mk("Toggle left sidebar", "Navigation", "⌘ B"), "ctrl"),
+    ).toBe(false);
+  });
+
+  it("ANDs whitespace-separated tokens — order doesn't matter", () => {
+    const action = mk("Split terminal side by side", "Terminal");
+    expect(shortcutMatchesQuery(action, "terminal split")).toBe(true);
+    expect(shortcutMatchesQuery(action, "split terminal")).toBe(true);
+    expect(shortcutMatchesQuery(action, "terminal panel")).toBe(false);
+  });
+
+  it("finds the push-to-talk shortcut by `talk` or `hold`", () => {
+    const action = mk("Hold to talk", "Voice", "Right ⌥");
+    expect(shortcutMatchesQuery(action, "talk")).toBe(true);
+    expect(shortcutMatchesQuery(action, "hold")).toBe(true);
+    expect(shortcutMatchesQuery(action, "push to talk")).toBe(false);
+  });
+});

--- a/src/ui/src/components/settings/sections/keyboardSearch.ts
+++ b/src/ui/src/components/settings/sections/keyboardSearch.ts
@@ -1,0 +1,34 @@
+/**
+ * Filter logic for the Keyboard Settings search box.
+ *
+ * Pulled out of the component so it can be unit-tested without React. The
+ * goal is "intuitive simple search" — a case-insensitive substring match
+ * over the label the user actually sees: the action description, the
+ * category, and the formatted binding (e.g. "⌘B" or "Ctrl+B").
+ *
+ * Tokens are AND-ed: typing `terminal split` matches "Split terminal side
+ * by side" but not "Toggle terminal panel". This makes it easy to combine a
+ * domain word ("terminal") with a verb ("split") without remembering the
+ * exact phrasing.
+ */
+export interface SearchableShortcut {
+  description: string;
+  category: string;
+  bindingLabel: string;
+}
+
+export function shortcutMatchesQuery(
+  shortcut: SearchableShortcut,
+  query: string,
+): boolean {
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return true;
+  const haystack = [
+    shortcut.description,
+    shortcut.category,
+    shortcut.bindingLabel,
+  ]
+    .join(" ")
+    .toLowerCase();
+  return tokens.every((token) => haystack.includes(token));
+}

--- a/src/ui/src/hotkeys/bindings.test.ts
+++ b/src/ui/src/hotkeys/bindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  bindingMatchesEvent,
   buildRebindUpdates,
   eventToBinding,
   getEffectiveBindingById,
@@ -134,6 +135,58 @@ describe("resolveHotkeyAction with conflict updates", () => {
     ).toBe("global.toggle-sidebar");
     expect(getEffectiveBindingById("global.toggle-right-sidebar", updates, "mac"))
       .toBeNull();
+  });
+});
+
+describe("bindingMatchesEvent — modifier-only codes", () => {
+  // Regression: hold-to-talk on Right Alt was bound to `code:AltRight`,
+  // but pressing Alt asserts e.altKey, which the matcher used to reject
+  // because the binding string had no explicit `alt+` prefix.
+  it("matches code:AltRight when Right Alt is pressed alone", () => {
+    expect(
+      bindingMatchesEvent(
+        "code:AltRight",
+        macKey({ key: "Alt", code: "AltRight", altKey: true }),
+        "mac",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches code:ShiftRight when Right Shift is pressed alone", () => {
+    expect(
+      bindingMatchesEvent(
+        "code:ShiftRight",
+        macKey({ key: "Shift", code: "ShiftRight", shiftKey: true }),
+        "mac",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a different modifier code than the one bound", () => {
+    expect(
+      bindingMatchesEvent(
+        "code:AltRight",
+        macKey({ key: "Alt", code: "AltLeft", altKey: true }),
+        "mac",
+      ),
+    ).toBe(false);
+  });
+
+  it("still requires bound modifiers when binding is compound", () => {
+    expect(
+      bindingMatchesEvent(
+        "shift+code:KeyA",
+        macKey({ key: "a", code: "KeyA", shiftKey: true }),
+        "mac",
+      ),
+    ).toBe(true);
+    expect(
+      bindingMatchesEvent(
+        "shift+code:KeyA",
+        macKey({ key: "a", code: "KeyA" }),
+        "mac",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/ui/src/hotkeys/bindings.ts
+++ b/src/ui/src/hotkeys/bindings.ts
@@ -7,6 +7,21 @@ export const KEYBINDING_SETTING_PREFIX = "keybinding:";
 
 const MODIFIER_KEYS = new Set(["Meta", "Control", "Shift", "Alt", "AltGraph"]);
 
+/** Event `code` values that ARE themselves a modifier. Pressing them asserts
+ * the corresponding `e.altKey`/`e.shiftKey`/etc. flag, so a binding like
+ * `code:AltRight` (used for hold-to-talk on Right Alt) must not require the
+ * `alt` modifier flag to be absent — it would always be present. */
+const MODIFIER_CODE_TO_FLAG: Record<string, "alt" | "shift" | "mod"> = {
+  altleft: "alt",
+  altright: "alt",
+  shiftleft: "shift",
+  shiftright: "shift",
+  controlleft: "mod",
+  controlright: "mod",
+  metaleft: "mod",
+  metaright: "mod",
+};
+
 function normalizeKey(key: string): string {
   if (key === "+") return "plus";
   if (key === " ") return "space";
@@ -97,10 +112,21 @@ export function bindingMatchesEvent(
   const hasMod = platform === "mac"
     ? e.metaKey && !e.ctrlKey
     : e.ctrlKey && !e.metaKey;
+
+  // When the bound key is itself a modifier (e.g. `code:AltRight` for
+  // hold-to-talk), pressing it asserts the matching modifier flag on the
+  // event. Mask out that flag from the equality check so the binding
+  // resolves on its own — without forcing the user to also tick the
+  // implicit modifier in the rebind UI.
+  const selfMod = parsed.match === "code" ? MODIFIER_CODE_TO_FLAG[parsed.key] : undefined;
+  const eventShift = selfMod === "shift" ? parsed.shift : e.shiftKey;
+  const eventAlt = selfMod === "alt" ? parsed.alt : e.altKey;
+  const eventMod = selfMod === "mod" ? parsed.mod : hasMod;
+
   return (
-    parsed.mod === hasMod &&
-    parsed.shift === e.shiftKey &&
-    parsed.alt === e.altKey
+    parsed.mod === eventMod &&
+    parsed.shift === eventShift &&
+    parsed.alt === eventAlt
   );
 }
 

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -205,7 +205,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
-  "keyboard_action_voice_hold": "Hold to talk",
+  "keyboard_action_voice_hold": "Push to talk",
 
   "git_title": "Git",
   "git_branch_prefix": "Branch name prefix",
@@ -370,7 +370,7 @@
   "keyboard_voice_section": "Voice input",
   "keyboard_voice_toggle_label": "Toggle recording",
   "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Hold to talk",
+  "keyboard_voice_hold_label": "Push to talk",
   "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_rebind": "Rebind",
   "keyboard_press_key": "Press a key…",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -152,6 +152,8 @@
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
 
   "keyboard_title": "Keyboard",
+  "keyboard_search_placeholder": "Search shortcuts…",
+  "keyboard_no_results": "No shortcuts match",
   "keyboard_category_navigation": "Navigation",
   "keyboard_category_terminal": "Terminal",
   "keyboard_category_editor": "Editor",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -364,17 +364,5 @@
   "pinned_prompts_keep": "Keep",
   "pinned_prompts_delete_prompt": "Delete prompt",
   "pinned_prompts_confirm_delete_title": "Delete this prompt?",
-  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone.",
-
-  "keyboard_title": "Keyboard Shortcuts",
-  "keyboard_voice_section": "Voice input",
-  "keyboard_voice_toggle_label": "Toggle recording",
-  "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Push to talk",
-  "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
-  "keyboard_rebind": "Rebind",
-  "keyboard_press_key": "Press a key…",
-  "keyboard_reset": "Reset",
-  "keyboard_disable": "Disable",
-  "keyboard_cancel": "Cancel"
+  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone."
 }

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -339,11 +339,11 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
-  "keyboard_action_voice_hold": "Hold to talk",
+  "keyboard_action_voice_hold": "Push to talk",
   "keyboard_voice_section": "Voice input",
   "keyboard_voice_toggle_label": "Toggle recording",
   "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Hold to talk",
+  "keyboard_voice_hold_label": "Push to talk",
   "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -340,11 +340,6 @@
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
-  "keyboard_voice_section": "Voice input",
-  "keyboard_voice_toggle_label": "Toggle recording",
-  "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Push to talk",
-  "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"
 }

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -288,6 +288,8 @@
   "pinned_prompts_inherited_label": "Heredados de los globales",
   "pinned_prompts_overridden_badge": "Sustituido",
   "keyboard_title": "Keyboard Shortcuts",
+  "keyboard_search_placeholder": "Search shortcuts…",
+  "keyboard_no_results": "No shortcuts match",
   "keyboard_category_navigation": "Navigation",
   "keyboard_category_terminal": "Terminal",
   "keyboard_category_editor": "Editor",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -339,11 +339,11 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
-  "keyboard_action_voice_hold": "Hold to talk",
+  "keyboard_action_voice_hold": "Push to talk",
   "keyboard_voice_section": "Voice input",
   "keyboard_voice_toggle_label": "Toggle recording",
   "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Hold to talk",
+  "keyboard_voice_hold_label": "Push to talk",
   "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -288,6 +288,8 @@
   "pinned_prompts_inherited_label": "グローバルから継承",
   "pinned_prompts_overridden_badge": "上書き",
   "keyboard_title": "Keyboard Shortcuts",
+  "keyboard_search_placeholder": "Search shortcuts…",
+  "keyboard_no_results": "No shortcuts match",
   "keyboard_category_navigation": "Navigation",
   "keyboard_category_terminal": "Terminal",
   "keyboard_category_editor": "Editor",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -340,11 +340,6 @@
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
-  "keyboard_voice_section": "Voice input",
-  "keyboard_voice_toggle_label": "Toggle recording",
-  "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Push to talk",
-  "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"
 }

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -339,11 +339,11 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
-  "keyboard_action_voice_hold": "Hold to talk",
+  "keyboard_action_voice_hold": "Push to talk",
   "keyboard_voice_section": "Voice input",
   "keyboard_voice_toggle_label": "Toggle recording",
   "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Hold to talk",
+  "keyboard_voice_hold_label": "Push to talk",
   "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -288,6 +288,8 @@
   "pinned_prompts_inherited_label": "Herdados dos globais",
   "pinned_prompts_overridden_badge": "Substituído",
   "keyboard_title": "Keyboard Shortcuts",
+  "keyboard_search_placeholder": "Search shortcuts…",
+  "keyboard_no_results": "No shortcuts match",
   "keyboard_category_navigation": "Navigation",
   "keyboard_category_terminal": "Terminal",
   "keyboard_category_editor": "Editor",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -340,11 +340,6 @@
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
-  "keyboard_voice_section": "Voice input",
-  "keyboard_voice_toggle_label": "Toggle recording",
-  "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Push to talk",
-  "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"
 }

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -339,11 +339,11 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
-  "keyboard_action_voice_hold": "Hold to talk",
+  "keyboard_action_voice_hold": "Push to talk",
   "keyboard_voice_section": "Voice input",
   "keyboard_voice_toggle_label": "Toggle recording",
   "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Hold to talk",
+  "keyboard_voice_hold_label": "Push to talk",
   "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -288,6 +288,8 @@
   "pinned_prompts_inherited_label": "从全局继承",
   "pinned_prompts_overridden_badge": "已覆盖",
   "keyboard_title": "Keyboard Shortcuts",
+  "keyboard_search_placeholder": "Search shortcuts…",
+  "keyboard_no_results": "No shortcuts match",
   "keyboard_category_navigation": "Navigation",
   "keyboard_category_terminal": "Terminal",
   "keyboard_category_editor": "Editor",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -340,11 +340,6 @@
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
-  "keyboard_voice_section": "Voice input",
-  "keyboard_voice_toggle_label": "Toggle recording",
-  "keyboard_voice_toggle_desc": "Start or stop voice recording without touching the mouse.",
-  "keyboard_voice_hold_label": "Push to talk",
-  "keyboard_voice_hold_desc": "Hold the key to record, release to stop and transcribe.",
   "keyboard_reset_all": "Reset all defaults",
   "keyboard_disabled_binding": "Shortcut disabled"
 }


### PR DESCRIPTION
## What

- Restore the push-to-talk hotkey (Right Alt / Option on macOS by default) that stopped firing after the hotkey-unification refactor in #621.
- Add a search box at the top of **Settings → Keyboard** for finding shortcuts by description, category, or formatted binding.
- Rename the voice hold-key label from "Hold to talk" → "Push to talk" across all five locales (it's the established term users actually search for).

## Why push-to-talk broke

The unified hotkey system shipped in #621 stores the hold binding as `code:AltRight` and routes it through `bindingMatchesEvent` (`src/ui/src/hotkeys/bindings.ts`). The matcher requires `parsed.alt === e.altKey`, but pressing the Alt key itself asserts `e.altKey = true`, while the binding string has no `alt+` prefix → permanent mismatch, hold-to-talk never fires.

The fix introduces a `MODIFIER_CODE_TO_FLAG` table for the eight modifier-key codes (`AltLeft/Right`, `ShiftLeft/Right`, `ControlLeft/Right`, `MetaLeft/Right`). When the bound key *is* one of those codes, the matcher masks out the corresponding event modifier flag from the equality check. Compound bindings like `shift+code:KeyA` still require modifiers exactly.

## Search

Filter logic lives in `src/ui/src/components/settings/sections/keyboardSearch.ts` so it's covered by tests without mounting the component. Whitespace-separated tokens are AND-ed (so `terminal split` finds "Split terminal side by side" regardless of word order), and the haystack includes the action description, category, and formatted binding label (so "⌘" / "Ctrl" / "⌥" all work).

## Tests

- 4 new regression tests in `bindings.test.ts` covering Right Alt, Right Shift, modifier-code mismatch, and the compound-binding non-regression case.
- 7 new tests in `keyboardSearch.test.ts` covering empty input, case-folding, category match, binding label match, AND semantics, and the user-facing "find push-to-talk by typing 'push'" use case.
- Full suite: 1224 / 1224 passing locally.
- `tsc -b`, `lint:css` clean. ESLint clean on touched files (pre-existing lint debt elsewhere is untouched).

## Related

- Closes #619 — the unified rebindable hotkey registry tracked in that issue shipped in #621; this PR fixes a regression and rounds out the UX with the search box the issue's UX section called for.
- Follow-up to #621.