### PR TITLE
feat: add mid-turn steering for queued messages

### DIFF
--- a/scripts/macos-dev-app-runner.sh
+++ b/scripts/macos-dev-app-runner.sh
@@ -182,7 +182,11 @@ for var in VITE_PORT CLAUDETTE_DEBUG_PORT CLAUDETTE_DEV_OVERRIDE RUST_LOG RUST_B
 done
 
 echo "▸ Launching $bundle_dir via Launch Services"
-open -W -a "$bundle_dir" \
+# `-n` matters for dev loops: the bundle identifier is stable, so Launch
+# Services may otherwise activate an already-running Claudette Dev instance
+# and return immediately. That makes cargo-tauri tear down Vite, which Bun
+# reports as exit 143.
+open -n -W -a "$bundle_dir" \
   --stdout "$stdout_fifo" \
   --stderr "$stderr_fifo" \
   "${env_args[@]}" \

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -75,6 +75,9 @@ pub async fn handle_request(
             )
             .await
         }
+        "steer_queued_chat_message" => {
+            Err("Mid-turn steering is not yet supported for remote sessions".to_string())
+        }
         "stop_agent" => {
             let chat_session_id = param_chat_session_id(&params);
             handle_stop_agent(state, &chat_session_id).await

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -912,7 +912,7 @@ pub async fn steer_queued_chat_message(
     mentioned_files: Option<Vec<String>>,
     attachments: Option<Vec<AttachmentInput>>,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<Option<claudette::model::ConversationCheckpoint>, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
 
     let chat_session_id = session_id;
@@ -957,6 +957,24 @@ pub async fn steer_queued_chat_message(
         &content,
         attachments.as_deref(),
     )?;
+
+    let anchor_msg_id = db
+        .list_chat_messages_for_session(&chat_session_id)
+        .map_err(|e| e.to_string())?
+        .last()
+        .map(|msg| msg.id.clone())
+        .ok_or("Cannot steer before chat history has a message")?;
+    let pre_steer_checkpoint = create_turn_checkpoint(CheckpointArgs {
+        db_path: &state.db_path,
+        workspace_id: &workspace_id,
+        chat_session_id: &chat_session_id,
+        anchor_msg_id: &anchor_msg_id,
+        worktree_path: &worktree_path,
+        created_at: now_iso(),
+    })
+    .await
+    .ok_or("Failed to create pre-steer checkpoint")?;
+
     let prompt = claudette::file_expand::expand_file_mentions(
         std::path::Path::new(&worktree_path),
         &content,
@@ -972,7 +990,8 @@ pub async fn steer_queued_chat_message(
         }
     }
     ps.steer_user_message(&prompt, &prepared_user_send.cli_atts)
-        .await
+        .await?;
+    Ok(Some(pre_steer_checkpoint))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -904,6 +904,20 @@ fn persist_user_send(db: &Database, prepared: &PreparedUserSend) -> Result<(), S
     Ok(())
 }
 
+fn cleanup_failed_steer_persistence(
+    db: &Database,
+    checkpoint_id: &str,
+    message_id: &str,
+    cause: &str,
+) {
+    if let Err(e) = db.delete_chat_message(message_id) {
+        eprintln!("[chat] failed to clean up steered user message after {cause}: {e}");
+    }
+    if let Err(e) = db.delete_checkpoint(checkpoint_id) {
+        eprintln!("[chat] failed to clean up pre-steer checkpoint after {cause}: {e}");
+    }
+}
+
 #[tauri::command]
 pub async fn steer_queued_chat_message(
     session_id: String,
@@ -959,10 +973,8 @@ pub async fn steer_queued_chat_message(
     )?;
 
     let anchor_msg_id = db
-        .list_chat_messages_for_session(&chat_session_id)
+        .last_chat_message_id_for_session(&chat_session_id)
         .map_err(|e| e.to_string())?
-        .last()
-        .map(|msg| msg.id.clone())
         .ok_or("Cannot steer before chat history has a message")?;
     let pre_steer_checkpoint = create_turn_checkpoint(CheckpointArgs {
         db_path: &state.db_path,
@@ -974,6 +986,7 @@ pub async fn steer_queued_chat_message(
     })
     .await
     .ok_or("Failed to create pre-steer checkpoint")?;
+    let pre_steer_checkpoint_id = pre_steer_checkpoint.id.clone();
 
     let prompt = claudette::file_expand::expand_file_mentions(
         std::path::Path::new(&worktree_path),
@@ -982,15 +995,27 @@ pub async fn steer_queued_chat_message(
     )
     .await;
 
-    persist_user_send(&db, &prepared_user_send)?;
-    {
-        let mut agents = state.agents.write().await;
-        if let Some(session) = agents.get_mut(&chat_session_id) {
-            session.last_user_msg_id = Some(prepared_user_send.user_msg.id.clone());
-        }
+    if let Err(e) = persist_user_send(&db, &prepared_user_send) {
+        cleanup_failed_steer_persistence(
+            &db,
+            &pre_steer_checkpoint_id,
+            &prepared_user_send.user_msg.id,
+            "persist failure",
+        );
+        return Err(e);
     }
-    ps.steer_user_message(&prompt, &prepared_user_send.cli_atts)
-        .await?;
+    if let Err(e) = ps
+        .steer_user_message(&prompt, &prepared_user_send.cli_atts)
+        .await
+    {
+        cleanup_failed_steer_persistence(
+            &db,
+            &pre_steer_checkpoint_id,
+            &prepared_user_send.user_msg.id,
+            "stdin write failure",
+        );
+        return Err(e);
+    }
     Ok(Some(pre_steer_checkpoint))
 }
 

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -755,56 +755,55 @@ pub async fn load_chat_history_page(
     })
 }
 
-#[tauri::command]
-#[allow(clippy::too_many_arguments)]
-pub async fn send_chat_message(
-    session_id: String,
+struct PreparedUserSend {
+    user_msg: ChatMessage,
+    att_models: Vec<claudette::model::Attachment>,
+    cli_atts: Vec<FileAttachment>,
+}
+
+// Mirrors the agent-side allow-list in
+// `src/agent_mcp/tools/send_to_user.rs::policy`. Keep the two in sync —
+// outbound (agent → user) symmetry with inbound (user → agent) is the
+// documented invariant.
+const ALLOWED_ATTACHMENT_MIME: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+    "application/pdf",
+    "text/plain",
+    "text/csv",
+    "text/markdown",
+    "application/json",
+];
+const MAX_IMAGE_BYTES: usize = 3_932_160; // 3.75 MB
+const MAX_PDF_BYTES: usize = 20 * 1024 * 1024; // 20 MB
+const MAX_TEXT_BYTES: usize = 1024 * 1024; // 1 MB
+const MAX_CSV_BYTES: usize = 2 * 1024 * 1024; // 2 MB
+const MAX_MARKDOWN_BYTES: usize = 1024 * 1024; // 1 MB
+const MAX_JSON_BYTES: usize = 1024 * 1024; // 1 MB
+
+fn is_text_attachment_kind(media_type: &str) -> bool {
+    matches!(
+        media_type,
+        "text/plain" | "text/csv" | "text/markdown" | "application/json"
+    )
+}
+
+fn prepare_user_send(
+    workspace_id: &str,
+    chat_session_id: &str,
     message_id: Option<String>,
-    content: String,
-    mentioned_files: Option<Vec<String>>,
-    permission_level: Option<String>,
-    model: Option<String>,
-    fast_mode: Option<bool>,
-    thinking_enabled: Option<bool>,
-    plan_mode: Option<bool>,
-    effort: Option<String>,
-    chrome_enabled: Option<bool>,
-    disable_1m_context: Option<bool>,
-    attachments: Option<Vec<AttachmentInput>>,
-    app: AppHandle,
-    state: State<'_, AppState>,
-) -> Result<(), String> {
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-
-    let chat_session_id = session_id;
-    let chat_session = db
-        .get_chat_session(&chat_session_id)
-        .map_err(|e| e.to_string())?
-        .ok_or("Chat session not found")?;
-    let workspace_id = chat_session.workspace_id.clone();
-    let _is_first_session = chat_session.sort_order == 0;
-    let session_name_already_edited = chat_session.name_edited;
-
-    // Look up workspace for worktree path.
-    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
-    let ws = workspaces
-        .iter()
-        .find(|w| w.id == workspace_id)
-        .ok_or("Workspace not found")?;
-    let worktree_path = ws
-        .worktree_path
-        .as_ref()
-        .ok_or("Workspace has no worktree")?
-        .clone();
-
-    // Save user message to DB. Use the frontend-provided ID so optimistic
-    // UI state (attachments keyed by message ID) stays consistent.
+    content: &str,
+    attachments: Option<&[AttachmentInput]>,
+) -> Result<PreparedUserSend, String> {
     let user_msg = ChatMessage {
         id: message_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
-        workspace_id: workspace_id.clone(),
-        chat_session_id: chat_session_id.clone(),
+        workspace_id: workspace_id.to_string(),
+        chat_session_id: chat_session_id.to_string(),
         role: ChatRole::User,
-        content: content.clone(),
+        content: content.to_string(),
         cost_usd: None,
         duration_ms: None,
         created_at: now_iso(),
@@ -814,45 +813,13 @@ pub async fn send_chat_message(
         cache_read_tokens: None,
         cache_creation_tokens: None,
     };
-    // Decode, validate, and persist attachments alongside the user message.
-    // Both inserts share a transaction so the message and its attachments are
-    // atomic — a failed attachment decode won't leave an orphaned message.
-    // Mirrors the agent-side allow-list in
-    // `src/agent_mcp/tools/send_to_user.rs::policy`. Keep the two in sync —
-    // outbound (agent → user) symmetry with inbound (user → agent) is the
-    // documented invariant.
-    const ALLOWED_MIME: &[&str] = &[
-        "image/png",
-        "image/jpeg",
-        "image/gif",
-        "image/webp",
-        "image/svg+xml",
-        "application/pdf",
-        "text/plain",
-        "text/csv",
-        "text/markdown",
-        "application/json",
-    ];
-    const MAX_IMAGE_BYTES: usize = 3_932_160; // 3.75 MB
-    const MAX_PDF_BYTES: usize = 20 * 1024 * 1024; // 20 MB
-    const MAX_TEXT_BYTES: usize = 1024 * 1024; // 1 MB
-    const MAX_CSV_BYTES: usize = 2 * 1024 * 1024; // 2 MB
-    const MAX_MARKDOWN_BYTES: usize = 1024 * 1024; // 1 MB
-    const MAX_JSON_BYTES: usize = 1024 * 1024; // 1 MB
-
-    fn is_text_kind(media_type: &str) -> bool {
-        matches!(
-            media_type,
-            "text/plain" | "text/csv" | "text/markdown" | "application/json"
-        )
-    }
 
     let mut att_models: Vec<claudette::model::Attachment> = Vec::new();
     let mut cli_atts: Vec<FileAttachment> = Vec::new();
 
-    if let Some(ref inputs) = attachments {
+    if let Some(inputs) = attachments {
         for input in inputs {
-            if !ALLOWED_MIME.contains(&input.media_type.as_str()) {
+            if !ALLOWED_ATTACHMENT_MIME.contains(&input.media_type.as_str()) {
                 return Err(format!("Unsupported attachment type: {}", input.media_type));
             }
             let data = base64_decode(&input.data_base64).map_err(|e| format!("Bad base64: {e}"))?;
@@ -874,7 +841,7 @@ pub async fn send_chat_message(
             if input.media_type == "application/pdf" && !data.starts_with(b"%PDF-") {
                 return Err("Invalid PDF: missing %PDF- header".to_string());
             }
-            let text_content = if is_text_kind(&input.media_type) {
+            let text_content = if is_text_attachment_kind(&input.media_type) {
                 let check_len = data.len().min(8192);
                 if data[..check_len].contains(&0) {
                     return Err(format!(
@@ -920,14 +887,148 @@ pub async fn send_chat_message(
         }
     }
 
-    // Atomic insert: message + attachments in one transaction.
-    db.insert_chat_message(&user_msg)
+    Ok(PreparedUserSend {
+        user_msg,
+        att_models,
+        cli_atts,
+    })
+}
+
+fn persist_user_send(db: &Database, prepared: &PreparedUserSend) -> Result<(), String> {
+    db.insert_chat_message(&prepared.user_msg)
         .map_err(|e| e.to_string())?;
-    if !att_models.is_empty() {
-        db.insert_attachments_batch(&att_models)
+    if !prepared.att_models.is_empty() {
+        db.insert_attachments_batch(&prepared.att_models)
             .map_err(|e| e.to_string())?;
     }
-    let image_attachments = cli_atts;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn steer_queued_chat_message(
+    session_id: String,
+    message_id: Option<String>,
+    content: String,
+    mentioned_files: Option<Vec<String>>,
+    attachments: Option<Vec<AttachmentInput>>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    let chat_session_id = session_id;
+    let chat_session = db
+        .get_chat_session(&chat_session_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Chat session not found")?;
+    let workspace_id = chat_session.workspace_id.clone();
+
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or("Workspace has no worktree")?
+        .clone();
+
+    let ps = {
+        let agents = state.agents.read().await;
+        let session = agents
+            .get(&chat_session_id)
+            .ok_or("No active local Claude session for this chat")?;
+        if session.persistent_session.is_none() {
+            return Err("No active persistent Claude session for this chat".to_string());
+        }
+        if session.active_pid.is_none() {
+            return Err("No running Claude turn to steer".to_string());
+        }
+        session
+            .persistent_session
+            .clone()
+            .ok_or("No active persistent Claude session for this chat")?
+    };
+
+    let prepared_user_send = prepare_user_send(
+        &workspace_id,
+        &chat_session_id,
+        message_id,
+        &content,
+        attachments.as_deref(),
+    )?;
+    let prompt = claudette::file_expand::expand_file_mentions(
+        std::path::Path::new(&worktree_path),
+        &content,
+        mentioned_files.as_deref().unwrap_or(&[]),
+    )
+    .await;
+
+    persist_user_send(&db, &prepared_user_send)?;
+    {
+        let mut agents = state.agents.write().await;
+        if let Some(session) = agents.get_mut(&chat_session_id) {
+            session.last_user_msg_id = Some(prepared_user_send.user_msg.id.clone());
+        }
+    }
+    ps.steer_user_message(&prompt, &prepared_user_send.cli_atts)
+        .await
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)]
+pub async fn send_chat_message(
+    session_id: String,
+    message_id: Option<String>,
+    content: String,
+    mentioned_files: Option<Vec<String>>,
+    permission_level: Option<String>,
+    model: Option<String>,
+    fast_mode: Option<bool>,
+    thinking_enabled: Option<bool>,
+    plan_mode: Option<bool>,
+    effort: Option<String>,
+    chrome_enabled: Option<bool>,
+    disable_1m_context: Option<bool>,
+    attachments: Option<Vec<AttachmentInput>>,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+
+    let chat_session_id = session_id;
+    let chat_session = db
+        .get_chat_session(&chat_session_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Chat session not found")?;
+    let workspace_id = chat_session.workspace_id.clone();
+    let _is_first_session = chat_session.sort_order == 0;
+    let session_name_already_edited = chat_session.name_edited;
+
+    // Look up workspace for worktree path.
+    let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == workspace_id)
+        .ok_or("Workspace not found")?;
+    let worktree_path = ws
+        .worktree_path
+        .as_ref()
+        .ok_or("Workspace has no worktree")?
+        .clone();
+
+    // Save user message to DB. Use the frontend-provided ID so optimistic
+    // UI state (attachments keyed by message ID) stays consistent.
+    let prepared_user_send = prepare_user_send(
+        &workspace_id,
+        &chat_session_id,
+        message_id,
+        &content,
+        attachments.as_deref(),
+    )?;
+    persist_user_send(&db, &prepared_user_send)?;
+    let user_msg = prepared_user_send.user_msg.clone();
+    let image_attachments = prepared_user_send.cli_atts;
 
     // Resolve allowed tools from permission level.
     let level = permission_level.as_deref().unwrap_or("full");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -485,6 +485,7 @@ fn main() {
             commands::chat::send::load_chat_history,
             commands::chat::send::load_chat_history_page,
             commands::chat::send::send_chat_message,
+            commands::chat::send::steer_queued_chat_message,
             commands::chat::attachments::load_attachments_for_session,
             commands::chat::attachments::load_attachment_data,
             commands::chat::attachments::read_file_as_base64,

--- a/src/agent/args.rs
+++ b/src/agent/args.rs
@@ -129,6 +129,19 @@ pub fn build_claude_args(
 /// prompt, then one block per attachment — text files become `"text"` blocks,
 /// PDFs become `"document"` blocks, and images become `"image"` blocks.
 pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> String {
+    build_stdin_message_inner(prompt, attachments, None)
+}
+
+/// Build a stdin SDK user message that should be delivered to the active turn.
+pub fn build_steering_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> String {
+    build_stdin_message_inner(prompt, attachments, Some("next"))
+}
+
+fn build_stdin_message_inner(
+    prompt: &str,
+    attachments: &[FileAttachment],
+    priority: Option<&str>,
+) -> String {
     let mut content_blocks = Vec::new();
 
     // Only add a text block if the prompt is non-empty — the API rejects
@@ -163,7 +176,7 @@ pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> Stri
         }
     }
 
-    serde_json::json!({
+    let mut payload = serde_json::json!({
         "type": "user",
         "uuid": uuid::Uuid::new_v4().to_string(),
         "message": {
@@ -171,8 +184,16 @@ pub fn build_stdin_message(prompt: &str, attachments: &[FileAttachment]) -> Stri
             "content": content_blocks,
         },
         "parent_tool_use_id": null,
-    })
-    .to_string()
+    });
+    if let Some(priority) = priority
+        && let Some(obj) = payload.as_object_mut()
+    {
+        obj.insert(
+            "priority".to_string(),
+            serde_json::Value::String(priority.to_string()),
+        );
+    }
+    payload.to_string()
 }
 
 #[cfg(test)]
@@ -602,6 +623,7 @@ mod tests {
         let msg = build_stdin_message("hello", &[]);
         let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
         assert_eq!(parsed["type"], "user");
+        assert!(parsed.get("priority").is_none());
         assert!(
             parsed["uuid"]
                 .as_str()
@@ -612,6 +634,17 @@ mod tests {
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], "hello");
+    }
+
+    #[test]
+    fn test_build_steering_stdin_message_sets_next_priority() {
+        let msg = build_steering_stdin_message("steer this turn", &[]);
+        let parsed: serde_json::Value = serde_json::from_str(&msg).unwrap();
+        assert_eq!(parsed["type"], "user");
+        assert_eq!(parsed["priority"], "next");
+        assert_eq!(parsed["message"]["role"], "user");
+        let content = parsed["message"]["content"].as_array().unwrap();
+        assert_eq!(content[0]["text"], "steer this turn");
     }
 
     #[test]

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -9,7 +9,7 @@ use crate::env::WorkspaceEnv;
 use crate::process::CommandWindowExt as _;
 
 use super::AgentSettings;
-use super::args::build_stdin_message;
+use super::args::{build_stdin_message, build_steering_stdin_message};
 use super::binary::resolve_claude_path;
 use super::process::{AgentEvent, TurnHandle};
 use super::types::{FileAttachment, StreamEvent, parse_stream_line};
@@ -175,27 +175,12 @@ impl PersistentSession {
         prompt: &str,
         attachments: &[FileAttachment],
     ) -> Result<TurnHandle, String> {
-        use tokio::io::AsyncWriteExt;
-
         // Subscribe BEFORE writing to stdin to avoid a race where a fast turn
         // emits events before the receiver exists (broadcast doesn't replay).
         let mut broadcast_rx = self.event_tx.subscribe();
 
-        let message = build_stdin_message(prompt, attachments);
-        let mut stdin = self.stdin.lock().await;
-        stdin
-            .write_all(message.as_bytes())
-            .await
-            .map_err(|e| format!("Failed to write to persistent session: {e}"))?;
-        stdin
-            .write_all(b"\n")
-            .await
-            .map_err(|e| format!("Failed to write newline: {e}"))?;
-        stdin
-            .flush()
-            .await
-            .map_err(|e| format!("Failed to flush stdin: {e}"))?;
-        drop(stdin); // Release lock so other code can check process state.
+        self.write_user_message(build_stdin_message(prompt, attachments))
+            .await?;
         let (mpsc_tx, mpsc_rx) = mpsc::channel::<AgentEvent>(128);
         tokio::spawn(async move {
             loop {
@@ -224,6 +209,37 @@ impl PersistentSession {
             event_rx: mpsc_rx,
             pid: self.pid,
         })
+    }
+
+    /// Send a user message to the currently active turn without creating a
+    /// new per-turn receiver. This is used for mid-turn steering, where the
+    /// existing active `TurnHandle` must continue to own stream attribution.
+    pub async fn steer_user_message(
+        &self,
+        prompt: &str,
+        attachments: &[FileAttachment],
+    ) -> Result<(), String> {
+        self.write_user_message(build_steering_stdin_message(prompt, attachments))
+            .await
+    }
+
+    async fn write_user_message(&self, message: String) -> Result<(), String> {
+        use tokio::io::AsyncWriteExt;
+
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(message.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write to persistent session: {e}"))?;
+        stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| format!("Failed to write newline: {e}"))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| format!("Failed to flush stdin: {e}"))?;
+        Ok(())
     }
 
     /// Subscribe to the persistent process's raw stream-json events without

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -122,6 +122,22 @@ impl Database {
         rows.collect()
     }
 
+    pub fn last_chat_message_id_for_session(
+        &self,
+        chat_session_id: &str,
+    ) -> Result<Option<String>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT id FROM chat_messages
+                 WHERE chat_session_id = ?1
+                 ORDER BY created_at DESC, rowid DESC
+                 LIMIT 1",
+                params![chat_session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+    }
+
     /// Count all non-legacy messages for a session (legacy = empty assistant
     /// rows; see `NON_LEGACY_MESSAGE_PREDICATE`). Used to compute pagination
     /// metadata (`total_count`) so callers can derive the global index offset
@@ -291,6 +307,14 @@ impl Database {
         self.conn.execute(
             "DELETE FROM chat_messages WHERE chat_session_id = ?1",
             params![chat_session_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_chat_message(&self, message_id: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM chat_messages WHERE id = ?1",
+            params![message_id],
         )?;
         Ok(())
     }
@@ -712,6 +736,44 @@ mod tests {
     }
 
     #[test]
+    fn test_last_chat_message_id_for_session_uses_rowid_tie_break() {
+        let db = setup_db_with_workspace();
+        let sid = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+        let other_session = db.create_chat_session("w1").unwrap();
+
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            &db,
+            "m2",
+            "w1",
+            ChatRole::Assistant,
+            "second",
+        ))
+        .unwrap();
+        let mut other = make_chat_msg(&db, "m3", "w1", ChatRole::User, "other session");
+        other.chat_session_id = other_session.id.clone();
+        db.insert_chat_message(&other).unwrap();
+
+        assert_eq!(
+            db.last_chat_message_id_for_session(&sid)
+                .unwrap()
+                .as_deref(),
+            Some("m2")
+        );
+        assert_eq!(
+            db.last_chat_message_id_for_session(&other_session.id)
+                .unwrap()
+                .as_deref(),
+            Some("m3")
+        );
+        assert_eq!(
+            db.last_chat_message_id_for_session("missing").unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn test_chat_messages_filtered_by_workspace() {
         let db = setup_db_with_workspace();
         db.insert_workspace(&make_workspace("w2", "r1", "feature"))
@@ -1067,6 +1129,27 @@ mod tests {
         db.delete_chat_messages_for_workspace("w1").unwrap();
         let atts = db.list_attachments_for_message("m1").unwrap();
         assert!(atts.is_empty());
+    }
+
+    #[test]
+    fn test_delete_chat_message_deletes_exact_row_and_cascades_attachments() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::User, "first"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "m2", "w1", ChatRole::User, "second"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a1", "m1", "first.png"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a2", "m2", "second.png"))
+            .unwrap();
+
+        db.delete_chat_message("m2").unwrap();
+
+        let msgs = db.list_chat_messages("w1").unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].id, "m1");
+        assert_eq!(db.list_attachments_for_message("m1").unwrap().len(), 1);
+        assert!(db.list_attachments_for_message("m2").unwrap().is_empty());
     }
 
     #[test]

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -93,6 +93,14 @@ impl Database {
         Ok(deleted)
     }
 
+    pub fn delete_checkpoint(&self, checkpoint_id: &str) -> Result<(), rusqlite::Error> {
+        self.conn.execute(
+            "DELETE FROM conversation_checkpoints WHERE id = ?1",
+            params![checkpoint_id],
+        )?;
+        Ok(())
+    }
+
     pub fn get_checkpoint(
         &self,
         id: &str,
@@ -672,6 +680,34 @@ mod tests {
 
         let turns = db.list_completed_turns("w1").unwrap();
         assert!(turns.is_empty());
+    }
+
+    #[test]
+    fn test_delete_checkpoint_deletes_exact_row_and_cascades_activities() {
+        let db = setup_db_with_workspace();
+        db.insert_chat_message(&make_chat_msg(&db, "m1", "w1", ChatRole::Assistant, "a1"))
+            .unwrap();
+        db.insert_chat_message(&make_chat_msg(&db, "m2", "w1", ChatRole::Assistant, "a2"))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp1", "w1", "m1", 0))
+            .unwrap();
+        db.insert_checkpoint(&make_checkpoint(&db, "cp2", "w1", "m2", 1))
+            .unwrap();
+        db.insert_turn_tool_activities(&[
+            make_tool_activity("a1", "cp1", "Read", 0),
+            make_tool_activity("a2", "cp2", "Edit", 0),
+        ])
+        .unwrap();
+
+        db.delete_checkpoint("cp1").unwrap();
+
+        assert!(db.get_checkpoint("cp1").unwrap().is_none());
+        assert!(db.get_checkpoint("cp2").unwrap().is_some());
+        let turns = db.list_completed_turns("w1").unwrap();
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].checkpoint_id, "cp2");
+        assert_eq!(turns[0].activities.len(), 1);
+        assert_eq!(turns[0].activities[0].id, "a2");
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -596,6 +596,37 @@
   color: var(--text-dim);
 }
 
+.queuedSteer {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 24px;
+  padding: 3px 8px;
+  border: 1px solid rgba(var(--accent-primary-rgb), 0.25);
+  border-radius: 6px;
+  background: rgba(var(--accent-primary-rgb), 0.08);
+  color: var(--accent-primary);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.queuedSteer:hover:not(:disabled) {
+  background: rgba(var(--accent-primary-rgb), 0.14);
+  border-color: rgba(var(--accent-primary-rgb), 0.4);
+}
+
+.queuedSteer:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.queuedSteerSpinner {
+  animation: spin 0.8s linear infinite;
+}
+
 .queuedCancel {
   background: none;
   border: none;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -652,14 +652,14 @@ export function ChatPanel() {
     attachments?: AttachmentInput[],
   ) => void) | null>(null);
   useEffect(() => {
-    if (isRunning || !activeSessionId || !queuedMessage) return;
+    if (isSteeringQueued || isRunning || !activeSessionId || !queuedMessage) return;
     // Agent just finished — dispatch the queued message.
     const { content, mentionedFiles, attachments } = queuedMessage;
     clearQueuedMessage(activeSessionId);
     const filesSet = mentionedFiles?.length ? new Set(mentionedFiles) : undefined;
     // Use a microtask to avoid calling handleSend during render.
     queueMicrotask(() => handleSendRef.current?.(content, filesSet, attachments));
-  }, [isRunning, activeSessionId, queuedMessage, clearQueuedMessage]);
+  }, [isSteeringQueued, isRunning, activeSessionId, queuedMessage, clearQueuedMessage]);
 
   if (!ws) return null;
 
@@ -716,6 +716,7 @@ export function ChatPanel() {
     const messageId = crypto.randomUUID();
     setError(null);
     setIsSteeringQueued(true);
+    clearQueuedMessage(sessionId);
     try {
       const checkpoint = await steerQueuedChatMessage(
         sessionId,
@@ -736,6 +737,7 @@ export function ChatPanel() {
     } catch (e) {
       const errMsg = String(e);
       console.error("steerQueuedChatMessage failed:", errMsg);
+      setQueuedMessage(sessionId, content, mentionedFiles, attachments);
       setError(errMsg);
     } finally {
       setIsSteeringQueued(false);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -231,6 +231,7 @@ export function ChatPanel() {
   );
   const setQueuedMessage = useAppStore((s) => s.setQueuedMessage);
   const clearQueuedMessage = useAppStore((s) => s.clearQueuedMessage);
+  const addCheckpoint = useAppStore((s) => s.addCheckpoint);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
   const activeSessionStatus = useAppStore((s) => {
@@ -716,13 +717,16 @@ export function ChatPanel() {
     setError(null);
     setIsSteeringQueued(true);
     try {
-      await steerQueuedChatMessage(
+      const checkpoint = await steerQueuedChatMessage(
         sessionId,
         content,
         mentionedFiles,
         attachments,
         messageId,
       );
+      if (checkpoint) {
+        addCheckpoint(sessionId, checkpoint);
+      }
       const history = (historyRef.current[sessionId] ??= []);
       history.push(content);
       historyIndexRef.current = -1;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { LoaderCircle } from "lucide-react";
+import { LoaderCircle, SendHorizontal } from "lucide-react";
 import { ChatSearchBar } from "./ChatSearchBar";
 import { useAppStore } from "../../stores/useAppStore";
 import {
@@ -15,6 +15,7 @@ import {
   recordSlashCommandUsage,
   sendChatMessage,
   sendRemoteCommand,
+  steerQueuedChatMessage,
   stopAgent,
   submitAgentAnswer,
   submitPlanApproval,
@@ -97,6 +98,7 @@ export function ChatPanel() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const processingRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isSteeringQueued, setIsSteeringQueued] = useState(false);
 
   // Cmd/Ctrl+F search bar state. `searchQuery` flows down to message
   // renderers as the highlight trigger; an empty string short-circuits the
@@ -660,6 +662,82 @@ export function ChatPanel() {
 
   if (!ws) return null;
 
+  const addPersistedUserMessageToStore = (
+    sessionId: string,
+    messageId: string,
+    content: string,
+    attachments?: AttachmentInput[],
+  ) => {
+    addChatMessage(sessionId, {
+      id: messageId,
+      workspace_id: ws.id,
+      chat_session_id: sessionId,
+      role: "User",
+      content,
+      cost_usd: null,
+      duration_ms: null,
+      created_at: new Date().toISOString(),
+      thinking: null,
+      input_tokens: null,
+      output_tokens: null,
+      cache_read_tokens: null,
+      cache_creation_tokens: null,
+    });
+    if (attachments?.length) {
+      const optimisticAtts = attachments.map((a) => ({
+        id: crypto.randomUUID(),
+        message_id: messageId,
+        filename: a.filename,
+        media_type: a.media_type,
+        data_base64: a.data_base64,
+        text_content: a.text_content ?? null,
+        width: null,
+        height: null,
+        size_bytes: Math.ceil(a.data_base64.length * 0.75),
+      }));
+      useAppStore.getState().addChatAttachments(sessionId, optimisticAtts);
+    }
+  };
+
+  const handleSteerQueuedMessage = async () => {
+    if (!activeSessionId || !queuedMessage || isSteeringQueued) return;
+    if (ws.remote_connection_id) {
+      setError("Mid-turn steering is not yet supported for remote workspaces");
+      return;
+    }
+    if (!isRunning) {
+      setError("No running agent turn to steer");
+      return;
+    }
+
+    const sessionId = activeSessionId;
+    const { content, mentionedFiles, attachments } = queuedMessage;
+    const messageId = crypto.randomUUID();
+    setError(null);
+    setIsSteeringQueued(true);
+    try {
+      await steerQueuedChatMessage(
+        sessionId,
+        content,
+        mentionedFiles,
+        attachments,
+        messageId,
+      );
+      const history = (historyRef.current[sessionId] ??= []);
+      history.push(content);
+      historyIndexRef.current = -1;
+      draftRef.current = "";
+      addPersistedUserMessageToStore(sessionId, messageId, content, attachments);
+      clearQueuedMessage(sessionId);
+    } catch (e) {
+      const errMsg = String(e);
+      console.error("steerQueuedChatMessage failed:", errMsg);
+      setError(errMsg);
+    } finally {
+      setIsSteeringQueued(false);
+    }
+  };
+
   const handleSend = async (
     content: string,
     mentionedFiles?: Set<string>,
@@ -929,36 +1007,7 @@ export function ChatPanel() {
     historyIndexRef.current = -1;
     draftRef.current = "";
     const optimisticMsgId = crypto.randomUUID();
-    addChatMessage(sessionId, {
-      id: optimisticMsgId,
-      workspace_id: selectedWorkspaceId,
-      chat_session_id: sessionId,
-      role: "User",
-      content: trimmed,
-      cost_usd: null,
-      duration_ms: null,
-      created_at: new Date().toISOString(),
-      thinking: null,
-      input_tokens: null,
-      output_tokens: null,
-      cache_read_tokens: null,
-      cache_creation_tokens: null,
-    });
-    // Add optimistic attachment data so images display immediately.
-    if (attachments?.length) {
-      const optimisticAtts = attachments.map((a) => ({
-        id: crypto.randomUUID(),
-        message_id: optimisticMsgId,
-        filename: a.filename,
-        media_type: a.media_type,
-        data_base64: a.data_base64,
-        text_content: a.text_content ?? null,
-        width: null,
-        height: null,
-        size_bytes: Math.ceil(a.data_base64.length * 0.75),
-      }));
-      useAppStore.getState().addChatAttachments(sessionId, optimisticAtts);
-    }
+    addPersistedUserMessageToStore(sessionId, optimisticMsgId, trimmed, attachments);
     // Keep both the workspace aggregate AND the per-session status fresh.
     // The tab icon, sidebar badge, and ChatToolbar disable-state all read
     // session-level status; the workspace row still drives tray + unread.
@@ -1190,6 +1239,20 @@ export function ChatPanel() {
                 <div className={styles.queuedMessage}>
                   <span className={styles.queuedLabel}>{t("queued_label")}</span>
                   <span className={styles.queuedContent}>{queuedMessage.content}</span>
+                  <button
+                    className={styles.queuedSteer}
+                    onClick={handleSteerQueuedMessage}
+                    disabled={isSteeringQueued || !isRunning}
+                    title={t("steer_queued")}
+                    aria-label={t("steer_queued")}
+                  >
+                    {isSteeringQueued ? (
+                      <LoaderCircle size={14} className={styles.queuedSteerSpinner} />
+                    ) : (
+                      <SendHorizontal size={14} />
+                    )}
+                    <span>{t("steer_queued_short")}</span>
+                  </button>
                   <button
                     className={styles.queuedCancel}
                     onClick={() => clearQueuedMessage(activeSessionId)}

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -5,6 +5,8 @@
   "processing_aria": "Processing, {{elapsed}} elapsed",
   "queued_label": "Queued",
   "cancel_queued": "Cancel queued message",
+  "steer_queued": "Send to running agent",
+  "steer_queued_short": "Steer",
   "stop_agent": "Stop agent",
   "send_message": "Send message",
   "add_files_connectors": "Add files or connectors",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -5,6 +5,8 @@
   "processing_aria": "Procesando, {{elapsed}} transcurridos",
   "queued_label": "En cola",
   "cancel_queued": "Cancelar mensaje en cola",
+  "steer_queued": "Enviar al agente en ejecución",
+  "steer_queued_short": "Dirigir",
   "stop_agent": "Detener agente",
   "send_message": "Enviar mensaje",
   "add_files_connectors": "Añadir archivos o conectores",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -5,6 +5,8 @@
   "processing_aria": "処理中、経過時間 {{elapsed}}",
   "queued_label": "キュー登録済み",
   "cancel_queued": "キュー登録したメッセージをキャンセル",
+  "steer_queued": "実行中のエージェントに送信",
+  "steer_queued_short": "誘導",
   "stop_agent": "エージェントを停止",
   "send_message": "メッセージを送信",
   "add_files_connectors": "ファイルまたはコネクタを追加",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -5,6 +5,8 @@
   "processing_aria": "Processando, {{elapsed}} decorrido",
   "queued_label": "Na fila",
   "cancel_queued": "Cancelar mensagem na fila",
+  "steer_queued": "Enviar ao agente em execução",
+  "steer_queued_short": "Orientar",
   "stop_agent": "Parar agente",
   "send_message": "Enviar mensagem",
   "add_files_connectors": "Adicionar arquivos ou conectores",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -5,6 +5,8 @@
   "processing_aria": "处理中，已用 {{elapsed}}",
   "queued_label": "已排队",
   "cancel_queued": "取消排队的消息",
+  "steer_queued": "发送给正在运行的智能体",
+  "steer_queued_short": "引导",
   "stop_agent": "停止智能体",
   "send_message": "发送消息",
   "add_files_connectors": "添加文件或连接器",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -35,6 +35,7 @@ import type {
   PluginConfiguration,
   PluginMarketplace,
 } from "../types/plugins";
+import type { ConversationCheckpoint } from "../types/checkpoint";
 
 // -- Data --
 
@@ -536,7 +537,7 @@ export function steerQueuedChatMessage(
   mentionedFiles?: string[],
   attachments?: AttachmentInput[],
   messageId?: string,
-): Promise<void> {
+): Promise<ConversationCheckpoint | null> {
   return invoke("steer_queued_chat_message", {
     sessionId,
     messageId: messageId ?? null,
@@ -611,8 +612,6 @@ export function submitPlanApproval(
 }
 
 // -- Checkpoints --
-
-import type { ConversationCheckpoint } from "../types/checkpoint";
 
 export function listCheckpoints(
   sessionId: string,

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -530,6 +530,22 @@ export function sendChatMessage(
   });
 }
 
+export function steerQueuedChatMessage(
+  sessionId: string,
+  content: string,
+  mentionedFiles?: string[],
+  attachments?: AttachmentInput[],
+  messageId?: string,
+): Promise<void> {
+  return invoke("steer_queued_chat_message", {
+    sessionId,
+    messageId: messageId ?? null,
+    content,
+    mentionedFiles: mentionedFiles ?? null,
+    attachments: attachments ?? null,
+  });
+}
+
 export function loadAttachmentsForSession(
   sessionId: string,
 ): Promise<ChatAttachment[]> {

--- a/src/ui/src/utils/checkpointUtils.test.ts
+++ b/src/ui/src/utils/checkpointUtils.test.ts
@@ -191,6 +191,17 @@ describe("buildRollbackMap", () => {
     expect(result.get(2)?.id).toBe("cp1");
   });
 
+  it("maps a steered user message to a pre-steer checkpoint in the same turn", () => {
+    const messages = [
+      msg("m1", "User"),
+      msg("m2", "User"),
+      msg("m3", "Assistant"),
+    ];
+    const cps = [{ ...cp("cp-pre-steer", null, 0), message_id: "m1" }];
+    const result = buildRollbackMap(messages, cps);
+    expect(result.get(1)?.id).toBe("cp-pre-steer");
+  });
+
   it("scans backward past interrupted turn to find checkpoint", () => {
     // Turn 1: user → assistant (checkpoint), Turn 2: user → assistant (no checkpoint, stopped)
     const messages = [


### PR DESCRIPTION
## Summary

Closes #628.

- Add mid-turn steering for queued local agent messages through a dedicated Tauri command instead of the normal `send_turn` path.
- Write steered prompts into the active persistent Claude session with `priority: "next"`, while preserving default queueing, queued-message cancellation, and end-of-turn auto-send.
- Persist steered user messages with expanded file mentions and supported attachments, and add rollback checkpoints before steered messages.
- Surface clear errors when steering is unsupported, including remote sessions and missing active persistent sessions.
- Fix the macOS dev app runner so dev launches use a fresh app instance and avoid the observed `beforeDevCommand` SIGTERM path.

## Validation

- `nix develop -c cargo fmt --all`
- `nix develop -c bash -lc 'cd src/ui && bun install --frozen-lockfile'`
- `nix develop -c bash -lc 'cd src/ui && bunx tsc -b'`
- `nix develop -c cargo test -p claudette agent::args::tests::`
- `nix develop -c cargo test -p claudette-tauri --no-default-features`
- `nix develop -c cargo test -p claudette-server`
- `nix develop -c bash -lc 'cd src/ui && bun run test src/utils/checkpointUtils.test.ts'`
- `nix develop -c cargo test -p claudette-tauri --no-default-features commands::chat::send::tests::`
- `bash -n scripts/macos-dev-app-runner.sh`
- `git diff --check`
