### PR TITLE
feat(chat): add copy-to-clipboard button to plan approval card

### DIFF
--- a/src/ui/src/components/chat/PlanApprovalCard.module.css
+++ b/src/ui/src/components/chat/PlanApprovalCard.module.css
@@ -29,12 +29,18 @@
   margin-bottom: 14px;
 }
 
+.planActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
 .planLink {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 8px 14px;
-  margin-bottom: 14px;
   background: var(--hover-bg-subtle);
   border: 1px solid var(--divider);
   border-radius: 8px;
@@ -44,7 +50,8 @@
   cursor: pointer;
   transition: border-color var(--transition-fast), background var(--transition-fast);
   text-decoration: none;
-  max-width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -53,6 +60,32 @@
 .planLink:hover {
   border-color: rgba(var(--accent-primary-rgb), 0.3);
   background: rgba(var(--accent-primary-rgb), 0.05);
+}
+
+.copyBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  background: var(--hover-bg-subtle);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  color: var(--accent-primary);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.copyBtn:hover:not(:disabled) {
+  border-color: rgba(var(--accent-primary-rgb), 0.3);
+  background: rgba(var(--accent-primary-rgb), 0.05);
+}
+
+.copyBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .planContent {

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -24,6 +24,7 @@ export function PlanApprovalCard({
 }: PlanApprovalCardProps) {
   const { t } = useTranslation("chat");
   const [planContent, setPlanContent] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [feedback, setFeedback] = useState("");
@@ -60,13 +61,14 @@ export function PlanApprovalCard({
       return;
     }
     if (!approval.planFilePath) return;
+    setLoadError(null);
     setLoading(true);
     try {
       await fetchPlanContent();
       setExpanded(true);
     } catch (e) {
       console.error("Failed to read plan file:", e);
-      setPlanContent(t("plan_approval_failed_read"));
+      setLoadError(t("plan_approval_failed_read"));
       setExpanded(true);
     } finally {
       setLoading(false);
@@ -75,6 +77,7 @@ export function PlanApprovalCard({
 
   const handleCopyPlan = async () => {
     if (!approval.planFilePath) return;
+    setLoadError(null);
     setCopying(true);
     try {
       const content = await fetchPlanContent();
@@ -86,6 +89,7 @@ export function PlanApprovalCard({
       copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
     } catch (e) {
       console.error("Failed to copy plan:", e);
+      setLoadError(t("plan_approval_failed_read"));
     } finally {
       setCopying(false);
     }
@@ -104,7 +108,7 @@ export function PlanApprovalCard({
           <button
             className={styles.planLink}
             onClick={handleViewPlan}
-            disabled={loading}
+            disabled={loading || copying}
           >
             {loading
               ? t("plan_approval_loading")
@@ -140,6 +144,10 @@ export function PlanApprovalCard({
         <div className={styles.planContent}>
           <MessageMarkdown content={planContent} />
         </div>
+      )}
+
+      {expanded && !planContent && loadError && (
+        <div className={styles.planContent}>{loadError}</div>
       )}
 
       {approval.allowedPrompts.length > 0 && (

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import { MessageMarkdown } from "./MessageMarkdown";
 import type { PlanApproval } from "../../stores/useAppStore";
 import { readPlanFile, sendRemoteCommand } from "../../services/tauri";
@@ -77,7 +78,7 @@ export function PlanApprovalCard({
     setCopying(true);
     try {
       const content = await fetchPlanContent();
-      await navigator.clipboard.writeText(content);
+      await clipboardWriteText(content);
       setCopied(true);
       if (copyTimeoutRef.current !== null) {
         window.clearTimeout(copyTimeoutRef.current);

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MessageMarkdown } from "./MessageMarkdown";
 import type { PlanApproval } from "../../stores/useAppStore";
@@ -26,6 +26,32 @@ export function PlanApprovalCard({
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [feedback, setFeedback] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [copying, setCopying] = useState(false);
+  const copyTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const fetchPlanContent = async (): Promise<string> => {
+    if (planContent !== null) return planContent;
+    if (!approval.planFilePath) throw new Error("No plan file path");
+    let content: string;
+    if (remoteConnectionId) {
+      content = (await sendRemoteCommand(remoteConnectionId, "read_plan_file", {
+        path: approval.planFilePath,
+      })) as string;
+    } else {
+      content = await readPlanFile(approval.planFilePath);
+    }
+    setPlanContent(content);
+    return content;
+  };
 
   const handleViewPlan = async () => {
     if (planContent !== null) {
@@ -35,15 +61,7 @@ export function PlanApprovalCard({
     if (!approval.planFilePath) return;
     setLoading(true);
     try {
-      let content: string;
-      if (remoteConnectionId) {
-        content = (await sendRemoteCommand(remoteConnectionId, "read_plan_file", {
-          path: approval.planFilePath,
-        })) as string;
-      } else {
-        content = await readPlanFile(approval.planFilePath);
-      }
-      setPlanContent(content);
+      await fetchPlanContent();
       setExpanded(true);
     } catch (e) {
       console.error("Failed to read plan file:", e);
@@ -51,6 +69,24 @@ export function PlanApprovalCard({
       setExpanded(true);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleCopyPlan = async () => {
+    if (!approval.planFilePath) return;
+    setCopying(true);
+    try {
+      const content = await fetchPlanContent();
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      if (copyTimeoutRef.current !== null) {
+        window.clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
+    } catch (e) {
+      console.error("Failed to copy plan:", e);
+    } finally {
+      setCopying(false);
     }
   };
 
@@ -63,19 +99,40 @@ export function PlanApprovalCard({
       </div>
 
       {approval.planFilePath && (
-        <button
-          className={styles.planLink}
-          onClick={handleViewPlan}
-          disabled={loading}
-        >
-          {loading
-            ? t("plan_approval_loading")
-            : expanded
-              ? t("plan_approval_hide_plan")
-              : t("plan_approval_view_plan")}
-          {" \u2014 "}
-          {approval.planFilePath.split("/").slice(-2).join("/")}
-        </button>
+        <div className={styles.planActions}>
+          <button
+            className={styles.planLink}
+            onClick={handleViewPlan}
+            disabled={loading}
+          >
+            {loading
+              ? t("plan_approval_loading")
+              : expanded
+                ? t("plan_approval_hide_plan")
+                : t("plan_approval_view_plan")}
+            {" \u2014 "}
+            {approval.planFilePath.split("/").slice(-2).join("/")}
+          </button>
+          <button
+            type="button"
+            className={styles.copyBtn}
+            onClick={handleCopyPlan}
+            disabled={loading || copying}
+            title={copied ? t("plan_approval_copied") : t("plan_approval_copy")}
+            aria-label={copied ? t("plan_approval_copied") : t("plan_approval_copy")}
+          >
+            {copied ? (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+            )}
+          </button>
+        </div>
       )}
 
       {expanded && planContent && (

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -68,6 +68,8 @@
   "plan_approval_description": "The agent has written a plan and is requesting approval to proceed with implementation.",
   "plan_approval_view_plan": "View plan",
   "plan_approval_hide_plan": "Hide plan",
+  "plan_approval_copy": "Copy plan",
+  "plan_approval_copied": "Copied!",
   "plan_approval_loading": "Loading...",
   "plan_approval_failed_read": "(Failed to read plan file)",
   "plan_approval_requested_permissions": "Requested permissions",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -68,6 +68,8 @@
   "plan_approval_description": "El agente ha escrito un plan y solicita aprobación para proceder con la implementación.",
   "plan_approval_view_plan": "Ver plan",
   "plan_approval_hide_plan": "Ocultar plan",
+  "plan_approval_copy": "Copiar plan",
+  "plan_approval_copied": "¡Copiado!",
   "plan_approval_loading": "Cargando...",
   "plan_approval_failed_read": "(No se pudo leer el archivo del plan)",
   "plan_approval_requested_permissions": "Permisos solicitados",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -68,6 +68,8 @@
   "plan_approval_description": "エージェントがプランを作成し、実装を進めるための承認を求めています。",
   "plan_approval_view_plan": "プランを表示",
   "plan_approval_hide_plan": "プランを非表示",
+  "plan_approval_copy": "プランをコピー",
+  "plan_approval_copied": "コピーしました",
   "plan_approval_loading": "読み込み中...",
   "plan_approval_failed_read": "（プランファイルの読み込みに失敗しました）",
   "plan_approval_requested_permissions": "要求された権限",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -68,6 +68,8 @@
   "plan_approval_description": "O agente escreveu um plano e está solicitando aprovação para prosseguir com a implementação.",
   "plan_approval_view_plan": "Ver plano",
   "plan_approval_hide_plan": "Ocultar plano",
+  "plan_approval_copy": "Copiar plano",
+  "plan_approval_copied": "Copiado!",
   "plan_approval_loading": "Carregando...",
   "plan_approval_failed_read": "(Falha ao ler o arquivo do plano)",
   "plan_approval_requested_permissions": "Permissões solicitadas",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -68,6 +68,8 @@
   "plan_approval_description": "智能体已撰写计划并请求批准以继续实施。",
   "plan_approval_view_plan": "查看计划",
   "plan_approval_hide_plan": "隐藏计划",
+  "plan_approval_copy": "复制计划",
+  "plan_approval_copied": "已复制！",
   "plan_approval_loading": "加载中...",
   "plan_approval_failed_read": "（无法读取计划文件）",
   "plan_approval_requested_permissions": "请求的权限",


### PR DESCRIPTION
## Summary

Adds a one-click copy button to the **Plan Ready for Approval** card so users can grab the plan markdown without expanding the card and selecting text by hand. Useful for sharing a plan with a teammate, pasting into a doc, or asking another model for input.

The new button sits next to "View plan", lazy-loads the plan file on first click (reusing the same `readPlanFile` / `sendRemoteCommand` path that `handleViewPlan` already uses), writes to the clipboard via `navigator.clipboard.writeText`, and flashes a 1.2 s checkmark — the same icon-swap idiom already used by `TurnFooter`, `MessageCopyButton`, and `CodeBlock`.

```mermaid
flowchart LR
    A[User clicks 📋] --> B{planContent cached?}
    B -- yes --> D[clipboard.writeText]
    B -- no --> C[readPlanFile / sendRemoteCommand] --> D
    D --> E[setCopied=true · 1.2s checkmark]
    E --> F[setCopied=false]
```

i18n keys (`plan_approval_copy`, `plan_approval_copied`) added to all 5 locales: en, es, ja, pt-BR, zh-CN.

## Complexity Notes

- The new button works **before** the card is expanded — first click triggers a lazy load, second click (after content is cached in component state) is a pure clipboard write. The shared `fetchPlanContent()` helper is the source of truth for both `handleViewPlan` and `handleCopyPlan`, so the remote-vs-local branching only lives in one place.
- `.planLink` was changed from `max-width: 100%` to `min-width: 0; flex: 1 1 auto`. This is required so the file path can ellipsize inside the new flex row instead of pushing the copy button off-screen — flex items refuse to shrink below their content's intrinsic min-width by default, and `min-width: 0` is the standard escape hatch.
- No new dependencies. No backend changes. No Zustand changes.
- Used inline copy/check SVGs (matching `TurnFooter`'s style) rather than `lucide-react`'s `<Copy />` / `<Check />` to keep the visual language consistent with neighbouring components in the chat area.

## Test Steps

1. `cd src/ui && bunx tsc -b` — should pass.
2. `cd src/ui && bun run test` — 1225 tests should pass.
3. `cd src/ui && bun run lint:css` — design-token check should pass.
4. Run the app: `cargo tauri dev`.
5. Trigger plan mode in any agent (e.g. ask Claude Code to plan a refactor) and let it call `ExitPlanMode`. The `PlanApprovalCard` should appear.
6. **Without** clicking "View plan" first, click the new copy button on the right of the row. Paste somewhere — the plan markdown should be on the clipboard. The button should briefly show a checkmark for ~1.2 s.
7. Click "View plan" to expand, then click copy again — should still copy correctly with no flicker or double-load.
8. Click copy twice rapidly — the checkmark timer should reset cleanly without sticking.
9. Tab to the button — confirm it's keyboard-reachable, the `aria-label` reads "Copy plan" / "Copied!", and Enter/Space copies.
10. (Optional) Connect via remote workspace and trigger a plan there — confirm the `sendRemoteCommand("read_plan_file", …)` path also copies correctly.

## Checklist

- [ ] Tests added/updated _(no new tests — feature is a thin wrapper over existing read + clipboard primitives that are already covered; behavior is best verified via the manual UAT above)_
- [ ] Documentation updated (if applicable) _(N/A — no user-facing docs cover plan approval card affordances)_