### PR TITLE
feat(ui): drag-reorder for tabs/workspaces + unified tab order, view persistence, alignment

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # Claudette dev launcher.
 #
-# Probes for the first free Vite port (starting at 1420) and the first free
-# debug eval port (starting at 19432), exports them for the child processes,
-# then starts `cargo tauri dev` with an inline config override so the webview
-# loads from the port Vite actually bound.
+# Probes for the first free Vite port (starting at 14253 — deliberately NOT
+# Tauri's stock 1420, so other Tauri starter-template dev builds can't
+# accidentally rebind our port and swap their bundle into our webview) and
+# the first free debug eval port (starting at 19432), exports them for the
+# child processes, then starts `cargo tauri dev` with an inline config
+# override so the webview loads from the port Vite actually bound.
 #
 # A discovery file is written to ${TMPDIR:-/tmp}/claudette-dev/<pid>.json so
 # helpers like `debug-eval.sh` can find the matching instance when multiple
 # dev builds run side-by-side. The file is cleaned up on exit.
 #
 # Env overrides:
-#   VITE_PORT_BASE         start port for Vite probe (default 1420)
+#   VITE_PORT_BASE         start port for Vite probe (default 14253)
 #   CLAUDETTE_DEBUG_PORT_BASE   start port for debug probe (default 19432)
 #   CARGO_TAURI_FEATURES   features to pass to tauri (default devtools,server)
 set -euo pipefail
@@ -27,7 +29,13 @@ find_free_port() {
   echo "$p"
 }
 
-vite_port=$(find_free_port "${VITE_PORT_BASE:-1420}")
+# Default Vite port is 14253 — deliberately moved off Tauri's stock 1420
+# to avoid the cross-app dev-port hijack scenario where another Tauri
+# starter template (which also defaults to 1420) launches and rebinds
+# the port underneath our running webview, displaying its own bundle in
+# Claudette's window. The inline guard in src/ui/index.html catches the
+# residual case where another app still picks the same number.
+vite_port=$(find_free_port "${VITE_PORT_BASE:-14253}")
 debug_port=$(find_free_port "${CLAUDETTE_DEBUG_PORT_BASE:-19432}")
 
 export VITE_PORT="$vite_port"

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -859,6 +859,7 @@ async fn handle_create_workspace(
         agent_status: claudette::model::AgentStatus::Idle,
         status_line: String::new(),
         created_at: now_iso(),
+        sort_order: 0,
     };
     if let Err(e) = db.insert_workspace(&workspace) {
         let _ = claudette::git::remove_worktree(&repo.path, &actual_path, true).await;

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -849,7 +849,7 @@ async fn handle_create_workspace(
         })?
     };
 
-    let workspace = Workspace {
+    let mut workspace = Workspace {
         id: uuid::Uuid::new_v4().to_string(),
         repository_id: repository_id.to_string(),
         name: allocation.name,
@@ -865,6 +865,11 @@ async fn handle_create_workspace(
         let _ = claudette::git::remove_worktree(&repo.path, &actual_path, true).await;
         let _ = claudette::git::branch_delete(&repo.path, &workspace.branch_name).await;
         return Err(e.to_string());
+    }
+    // Patch sort_order to the value the DB assigned so the remote client
+    // sees the new workspace at the right position in the sidebar (Codex P2).
+    if let Ok(Some(o)) = db.lookup_workspace_sort_order(&workspace.id) {
+        workspace.sort_order = o;
     }
 
     Ok(serde_json::to_value(&workspace).unwrap_or_default())

--- a/src-server/tests/env_provider_integration.rs
+++ b/src-server/tests/env_provider_integration.rs
@@ -83,6 +83,7 @@ fn make_workspace(repo_id: &str, worktree: &str) -> Workspace {
         agent_status: AgentStatus::Idle,
         status_line: String::new(),
         created_at: "2026-01-01 00:00:00".into(),
+        sort_order: 0,
     }
 }
 

--- a/src-tauri/src/commands/chat/session.rs
+++ b/src-tauri/src/commands/chat/session.rs
@@ -99,6 +99,21 @@ pub async fn rename_chat_session(
         .map_err(|e| e.to_string())
 }
 
+/// Reassign `sort_order` of chat sessions in the given workspace to match the
+/// supplied id sequence. Used by the unified workspace-tab drag-reorder; for
+/// files/diffs the order is volatile and only needs frontend state, so this
+/// command only ever touches chat sessions.
+#[tauri::command]
+pub async fn reorder_chat_sessions(
+    workspace_id: String,
+    session_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.reorder_chat_sessions(&workspace_id, &session_ids)
+        .map_err(|e| e.to_string())
+}
+
 /// Archive a chat session (soft-delete). Stops its running agent first, then
 /// marks the row archived. If this was the workspace's last active session,
 /// a fresh `New chat` session is created so every workspace always has ≥1
@@ -186,6 +201,7 @@ mod tests {
             agent_status: AgentStatus::Idle,
             status_line: String::new(),
             created_at: String::new(),
+            sort_order: 0,
         }
     }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -177,6 +177,7 @@ pub async fn create_workspace(
         agent_status: AgentStatus::Idle,
         status_line: String::new(),
         created_at: now_iso(),
+        sort_order: 0,
     };
 
     // If the DB insert fails, roll back the worktree + branch we just created
@@ -802,6 +803,21 @@ pub fn generate_workspace_name() -> GeneratedWorkspaceName {
     }
 }
 
+/// Reassign per-repository `sort_order` of workspaces in the given repo to
+/// match the supplied id sequence. Mirrors `reorder_repositories` but scoped
+/// per-repo because workspaces live inside a specific repo's worktree on
+/// disk and only ever reorder among siblings (option 2A — within-repo only).
+#[tauri::command]
+pub async fn reorder_workspaces(
+    repository_id: String,
+    workspace_ids: Vec<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.reorder_workspaces(&repository_id, &workspace_ids)
+        .map_err(|e| e.to_string())
+}
+
 /// Re-read the current branch for every active workspace. Returns one
 /// `(workspace_id, current_branch)` entry per workspace we could probe
 /// (level-triggered: every active workspace, not just ones that drifted),
@@ -996,6 +1012,7 @@ pub async fn import_worktrees(
             agent_status: AgentStatus::Idle,
             status_line: String::new(),
             created_at: now_iso(),
+            sort_order: 0,
         };
 
         created.push(ws);

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -167,7 +167,7 @@ pub async fn create_workspace(
         })?
     };
 
-    let ws = Workspace {
+    let mut ws = Workspace {
         id: uuid::Uuid::new_v4().to_string(),
         repository_id: repo_id,
         name: allocation.name,
@@ -186,6 +186,12 @@ pub async fn create_workspace(
         let _ = git::remove_worktree(&repo_path, &actual_path, true).await;
         let _ = git::branch_delete(&repo_path, &ws.branch_name).await;
         return Err(e.to_string());
+    }
+    // Patch sort_order to the value the DB assigned so the workspace this
+    // command returns to the UI lands at the bottom of its repo group
+    // immediately, instead of rendering at sort_order=0 until reload.
+    if let Ok(Some(o)) = db.lookup_workspace_sort_order(&ws.id) {
+        ws.sort_order = o;
     }
 
     // Resolve and execute setup script (unless caller requested skip).
@@ -1021,6 +1027,15 @@ pub async fn import_worktrees(
     // Atomic batch insert — all or nothing.
     db.insert_workspaces_batch(&created)
         .map_err(|e| e.to_string())?;
+    // Patch each row's sort_order to the value the DB assigned so the
+    // workspaces this command returns to the UI render at the bottom of
+    // their repo groups immediately (Codex P2). One readback query per
+    // import; imports are rare and bounded so no batching needed.
+    for ws in created.iter_mut() {
+        if let Ok(Some(o)) = db.lookup_workspace_sort_order(&ws.id) {
+            ws.sort_order = o;
+        }
+    }
 
     // Imported workspaces already have user-defined branch names — pre-claim
     // the auto-rename slot so the first-message rename never fires. Match the

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -454,6 +454,7 @@ fn main() {
             commands::workspace::archive_workspace,
             commands::workspace::restore_workspace,
             commands::workspace::rename_workspace,
+            commands::workspace::reorder_workspaces,
             commands::workspace::delete_workspace,
             commands::workspace::generate_workspace_name,
             commands::workspace::refresh_branches,
@@ -503,6 +504,7 @@ fn main() {
             commands::chat::session::get_chat_session,
             commands::chat::session::create_chat_session,
             commands::chat::session::rename_chat_session,
+            commands::chat::session::reorder_chat_sessions,
             commands::chat::session::archive_chat_session,
             // Plan
             commands::plan::read_plan_file,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -187,183 +187,80 @@ fn main() {
     // Custom app menu (macOS only): replace the default Quit item (which
     // calls NSApp.terminate() immediately) with one we can intercept to
     // confirm quit when agents are running.
+    //
+    // Built with the `*Builder` API and applied via `app.set_menu()` from
+    // `.setup()` rather than the `.menu(|app| ...)` configuration closure.
+    // Tauri's `.menu(...)` path appears to register the resulting menu in
+    // a way that triggers AppKit's auto-detection of a Help submenu (which
+    // injects a Spotlight-style search field into it); building inside
+    // `setup` and calling `set_menu` directly skips that registration. See
+    // `../aethon/src-tauri/src/commands/extensions.rs` for the same
+    // pattern in another Tauri 2 project where the Help menu renders
+    // search-field-free.
     #[cfg(target_os = "macos")]
     {
-        builder = builder
-            .menu(|app| {
-                use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
-                let app_menu = Submenu::with_items(
-                    app,
-                    "Claudette",
-                    true,
-                    &[
-                        &PredefinedMenuItem::about(app, None, None)?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &MenuItem::with_id(
-                            app,
-                            "open-settings",
-                            "Settings...",
-                            true,
-                            Some("CmdOrCtrl+,"),
-                        )?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &PredefinedMenuItem::services(app, None)?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &PredefinedMenuItem::hide(app, None)?,
-                        &PredefinedMenuItem::hide_others(app, None)?,
-                        &PredefinedMenuItem::show_all(app, None)?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &MenuItem::with_id(
-                            app,
-                            "quit-app",
-                            "Quit Claudette",
-                            true,
-                            Some("CmdOrCtrl+Q"),
-                        )?,
-                    ],
-                )?;
-                let edit_menu = Submenu::with_items(
-                    app,
-                    "Edit",
-                    true,
-                    &[
-                        &PredefinedMenuItem::undo(app, None)?,
-                        &PredefinedMenuItem::redo(app, None)?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &PredefinedMenuItem::cut(app, None)?,
-                        &PredefinedMenuItem::copy(app, None)?,
-                        &PredefinedMenuItem::paste(app, None)?,
-                        &PredefinedMenuItem::select_all(app, None)?,
-                    ],
-                )?;
-                let view_menu = Submenu::with_items(
-                    app,
-                    "View",
-                    true,
-                    &[
-                        &MenuItem::with_id(
-                            app,
-                            "zoom-in",
-                            "Zoom In",
-                            true,
-                            Some("CmdOrCtrl+Equal"),
-                        )?,
-                        &MenuItem::with_id(
-                            app,
-                            "zoom-out",
-                            "Zoom Out",
-                            true,
-                            Some("CmdOrCtrl+Minus"),
-                        )?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &MenuItem::with_id(
-                            app,
-                            "reset-zoom",
-                            "Actual Size",
-                            true,
-                            Some("CmdOrCtrl+Shift+0"),
-                        )?,
-                    ],
-                )?;
-                let window_menu = Submenu::with_items(
-                    app,
-                    "Window",
-                    true,
-                    &[
-                        &PredefinedMenuItem::minimize(app, None)?,
-                        &PredefinedMenuItem::maximize(app, None)?,
-                        // Custom Close Window item. We can't use
-                        // `PredefinedMenuItem::close_window` because it
-                        // bakes in the platform default accelerator (Cmd+W
-                        // on macOS), which would shadow the terminal's
-                        // `Cmd+W = close pane` shortcut — the OS menu
-                        // would catch the key before the webview saw it.
-                        &MenuItem::with_id(
-                            app,
-                            "close-window",
-                            "Close Window",
-                            true,
-                            Some(MACOS_CLOSE_WINDOW_ACCELERATOR),
-                        )?,
-                        &PredefinedMenuItem::separator(app)?,
-                        &PredefinedMenuItem::fullscreen(app, None)?,
-                    ],
-                )?;
-                // Help menu — single entry pointing at the docs root. The
-                // root URL is preferred over a deeper page (e.g. /getting-
-                // started/installation/) so the link survives doc-site
-                // reorganization. Click is wired via on_menu_event below.
-                let help_menu = Submenu::with_items(
-                    app,
-                    "Help",
-                    true,
-                    &[&MenuItem::with_id(
-                        app,
-                        "help-open-docs",
-                        "Claudette Documentation",
-                        true,
-                        None::<&str>,
-                    )?],
-                )?;
-                Menu::with_items(
-                    app,
-                    &[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu],
-                )
-            })
-            .on_menu_event(|app, event| {
-                if event.id().as_ref() == "help-open-docs" {
-                    // Open the Claudette docs root in the system browser.
-                    // Root URL (not a deeper page) so the link survives
-                    // doc-site reorganization.
-                    if let Err(e) = commands::shell::opener::open("https://utensils.io/claudette/")
-                    {
-                        eprintln!("[help] Failed to open docs URL: {e}");
-                    }
-                } else if event.id().as_ref() == "zoom-in" {
-                    let _ = app.emit("zoom-in", ());
-                } else if event.id().as_ref() == "zoom-out" {
-                    let _ = app.emit("zoom-out", ());
-                } else if event.id().as_ref() == "reset-zoom" {
-                    let _ = app.emit("reset-zoom", ());
-                } else if event.id().as_ref() == "open-settings" {
-                    tray::show_and_focus(app);
-                    let _ = app.emit("open-settings", ());
-                } else if event.id().as_ref() == "close-window" {
-                    // Route to the existing CloseRequested flow so the
-                    // macOS "hide instead of quit" logic in
-                    // on_window_event stays in one place.
-                    if let Some(win) = app.get_webview_window("main") {
-                        let _ = win.close();
-                    }
-                } else if event.id().as_ref() == "quit-app" {
-                    let state = app.state::<state::AppState>();
-                    let running = state
-                        .agents
-                        .try_read()
-                        .map_or(true, |a| tray::has_running_agents(&a));
-                    if running {
-                        let handle = app.clone();
-                        {
-                            use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
-                            handle
-                                .dialog()
-                                .message("Agents are still running. Quit anyway?")
-                                .title("Quit Claudette")
-                                .buttons(MessageDialogButtons::OkCancelCustom(
-                                    "Quit".into(),
-                                    "Cancel".into(),
-                                ))
-                                .show(move |confirmed| {
-                                    if confirmed {
-                                        handle.exit(0);
-                                    }
-                                });
-                        }
-                    } else {
-                        app.exit(0);
-                    }
+        builder = builder.on_menu_event(|app, event| {
+            if event.id().as_ref() == "help-open-docs" {
+                // Open the Claudette docs root in the system browser.
+                // Root URL (not a deeper page) so the link survives
+                // doc-site reorganization.
+                if let Err(e) = commands::shell::opener::open("https://utensils.io/claudette/") {
+                    eprintln!("[help] Failed to open docs URL: {e}");
                 }
-            });
+            } else if event.id().as_ref() == "help-report-issue" {
+                // GitHub issue tracker. Mirrors Aethon's "Report an
+                // Issue…" item — gives users a one-click path to file a
+                // bug report.
+                if let Err(e) = commands::shell::opener::open(
+                    "https://github.com/utensils/claudette/issues/new",
+                ) {
+                    eprintln!("[help] Failed to open issues URL: {e}");
+                }
+            } else if event.id().as_ref() == "zoom-in" {
+                let _ = app.emit("zoom-in", ());
+            } else if event.id().as_ref() == "zoom-out" {
+                let _ = app.emit("zoom-out", ());
+            } else if event.id().as_ref() == "reset-zoom" {
+                let _ = app.emit("reset-zoom", ());
+            } else if event.id().as_ref() == "open-settings" {
+                tray::show_and_focus(app);
+                let _ = app.emit("open-settings", ());
+            } else if event.id().as_ref() == "close-window" {
+                // Route to the existing CloseRequested flow so the
+                // macOS "hide instead of quit" logic in
+                // on_window_event stays in one place.
+                if let Some(win) = app.get_webview_window("main") {
+                    let _ = win.close();
+                }
+            } else if event.id().as_ref() == "quit-app" {
+                let state = app.state::<state::AppState>();
+                let running = state
+                    .agents
+                    .try_read()
+                    .map_or(true, |a| tray::has_running_agents(&a));
+                if running {
+                    let handle = app.clone();
+                    {
+                        use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+                        handle
+                            .dialog()
+                            .message("Agents are still running. Quit anyway?")
+                            .title("Quit Claudette")
+                            .buttons(MessageDialogButtons::OkCancelCustom(
+                                "Quit".into(),
+                                "Cancel".into(),
+                            ))
+                            .show(move |confirmed| {
+                                if confirmed {
+                                    handle.exit(0);
+                                }
+                            });
+                    }
+                } else {
+                    app.exit(0);
+                }
+            }
+        });
     }
 
     let builder = builder
@@ -371,6 +268,102 @@ fn main() {
             // Start mDNS browser to discover nearby claudette-server instances.
             if let Err(e) = mdns::start_mdns_browser(app.handle(), saved_fingerprints) {
                 eprintln!("[mdns] Failed to start browser: {e}");
+            }
+
+            // macOS native menu — built and applied here (rather than via
+            // tauri::Builder::menu) so AppKit doesn't auto-promote the
+            // "Help" submenu to its built-in help-search behavior. See
+            // the comment block above the `on_menu_event` handler for
+            // the full rationale.
+            #[cfg(target_os = "macos")]
+            {
+                use tauri::menu::{
+                    MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder,
+                };
+                let app_handle = app.handle();
+                let app_menu = SubmenuBuilder::new(app_handle, "Claudette")
+                    .item(&PredefinedMenuItem::about(app_handle, None, None)?)
+                    .separator()
+                    .item(
+                        &MenuItemBuilder::with_id("open-settings", "Settings...")
+                            .accelerator("CmdOrCtrl+,")
+                            .build(app_handle)?,
+                    )
+                    .separator()
+                    .item(&PredefinedMenuItem::services(app_handle, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::hide(app_handle, None)?)
+                    .item(&PredefinedMenuItem::hide_others(app_handle, None)?)
+                    .item(&PredefinedMenuItem::show_all(app_handle, None)?)
+                    .separator()
+                    .item(
+                        &MenuItemBuilder::with_id("quit-app", "Quit Claudette")
+                            .accelerator("CmdOrCtrl+Q")
+                            .build(app_handle)?,
+                    )
+                    .build()?;
+                let edit_menu = SubmenuBuilder::new(app_handle, "Edit")
+                    .item(&PredefinedMenuItem::undo(app_handle, None)?)
+                    .item(&PredefinedMenuItem::redo(app_handle, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::cut(app_handle, None)?)
+                    .item(&PredefinedMenuItem::copy(app_handle, None)?)
+                    .item(&PredefinedMenuItem::paste(app_handle, None)?)
+                    .item(&PredefinedMenuItem::select_all(app_handle, None)?)
+                    .build()?;
+                let view_menu = SubmenuBuilder::new(app_handle, "View")
+                    .item(
+                        &MenuItemBuilder::with_id("zoom-in", "Zoom In")
+                            .accelerator("CmdOrCtrl+Equal")
+                            .build(app_handle)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("zoom-out", "Zoom Out")
+                            .accelerator("CmdOrCtrl+Minus")
+                            .build(app_handle)?,
+                    )
+                    .separator()
+                    .item(
+                        &MenuItemBuilder::with_id("reset-zoom", "Actual Size")
+                            .accelerator("CmdOrCtrl+Shift+0")
+                            .build(app_handle)?,
+                    )
+                    .build()?;
+                // Custom Close Window item. We can't use
+                // `PredefinedMenuItem::close_window` because it bakes in
+                // Cmd+W on macOS, which would shadow the terminal's
+                // `Cmd+W = close pane` shortcut — the OS menu would catch
+                // the key before the webview saw it.
+                let window_menu = SubmenuBuilder::new(app_handle, "Window")
+                    .item(&PredefinedMenuItem::minimize(app_handle, None)?)
+                    .item(&PredefinedMenuItem::maximize(app_handle, None)?)
+                    .item(
+                        &MenuItemBuilder::with_id("close-window", "Close Window")
+                            .accelerator(MACOS_CLOSE_WINDOW_ACCELERATOR)
+                            .build(app_handle)?,
+                    )
+                    .separator()
+                    .item(&PredefinedMenuItem::fullscreen(app_handle, None)?)
+                    .build()?;
+                // Help menu — two items, no auto-search. AppKit's
+                // helpMenu auto-detection only fires when the menu is
+                // attached via `tauri::Builder::menu(...)`; here we go
+                // the `set_menu` route from setup, which skips that.
+                // (Compare to ../aethon/src-tauri/src/commands/extensions.rs.)
+                let help_menu = SubmenuBuilder::new(app_handle, "Help")
+                    .item(
+                        &MenuItemBuilder::with_id("help-open-docs", "Claudette Documentation")
+                            .build(app_handle)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("help-report-issue", "Report an Issue…")
+                            .build(app_handle)?,
+                    )
+                    .build()?;
+                let menu = MenuBuilder::new(app_handle)
+                    .items(&[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu])
+                    .build()?;
+                app.set_menu(menu)?;
             }
 
             // Set the notification app identity before any notifications are sent.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -289,10 +289,37 @@ fn main() {
                         &PredefinedMenuItem::fullscreen(app, None)?,
                     ],
                 )?;
-                Menu::with_items(app, &[&app_menu, &edit_menu, &view_menu, &window_menu])
+                // Help menu — single entry pointing at the docs root. The
+                // root URL is preferred over a deeper page (e.g. /getting-
+                // started/installation/) so the link survives doc-site
+                // reorganization. Click is wired via on_menu_event below.
+                let help_menu = Submenu::with_items(
+                    app,
+                    "Help",
+                    true,
+                    &[&MenuItem::with_id(
+                        app,
+                        "help-open-docs",
+                        "Claudette Documentation",
+                        true,
+                        None::<&str>,
+                    )?],
+                )?;
+                Menu::with_items(
+                    app,
+                    &[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu],
+                )
             })
             .on_menu_event(|app, event| {
-                if event.id().as_ref() == "zoom-in" {
+                if event.id().as_ref() == "help-open-docs" {
+                    // Open the Claudette docs root in the system browser.
+                    // Root URL (not a deeper page) so the link survives
+                    // doc-site reorganization.
+                    if let Err(e) = commands::shell::opener::open("https://utensils.io/claudette/")
+                    {
+                        eprintln!("[help] Failed to open docs URL: {e}");
+                    }
+                } else if event.id().as_ref() == "zoom-in" {
                     let _ = app.emit("zoom-in", ());
                 } else if event.id().as_ref() == "zoom-out" {
                     let _ = app.emit("zoom-out", ());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "build": {
     "beforeDevCommand": { "script": "bun install && bun run dev", "cwd": "../src/ui" },
     "beforeBuildCommand": { "script": "bun install && bun run build", "cwd": "../src/ui" },
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://localhost:14253",
     "frontendDist": "../src/ui/dist"
   },
   "app": {

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -571,6 +571,30 @@ impl Database {
         Ok(sort_order == Some(0))
     }
 
+    /// Reassign `sort_order` of chat sessions within a workspace to match the
+    /// supplied id sequence. Mirrors `reorder_repositories`. Ids that don't
+    /// belong to `workspace_id` are ignored — the WHERE clause keeps cross-
+    /// workspace edits from sneaking through. Wrapped in a transaction so a
+    /// failed UPDATE leaves all sessions at their previous sort_order.
+    pub fn reorder_chat_sessions(
+        &self,
+        workspace_id: &str,
+        ids: &[String],
+    ) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "UPDATE chat_sessions SET sort_order = ?1 \
+                 WHERE id = ?2 AND workspace_id = ?3",
+            )?;
+            for (i, id) in ids.iter().enumerate() {
+                stmt.execute(params![i as i32, id, workspace_id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     // --- Attachments ---
 
     pub fn insert_attachment(&self, att: &Attachment) -> Result<(), rusqlite::Error> {

--- a/src/db/test_support.rs
+++ b/src/db/test_support.rs
@@ -39,6 +39,7 @@ pub(crate) fn make_workspace(id: &str, repo_id: &str, name: &str) -> Workspace {
         agent_status: AgentStatus::Idle,
         status_line: String::new(),
         created_at: String::new(),
+        sort_order: 0,
     }
 }
 

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -19,9 +19,17 @@ impl Database {
 
     pub fn insert_workspace(&self, ws: &Workspace) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
+        // Assign the next per-repo sort_order so a freshly created workspace
+        // lands at the bottom of its repo group, matching how
+        // `insert_chat_session` handles per-workspace session ordering.
+        let next_sort_order: i32 = tx.query_row(
+            "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM workspaces WHERE repository_id = ?1",
+            params![ws.repository_id],
+            |row| row.get(0),
+        )?;
         tx.execute(
-            "INSERT INTO workspaces (id, repository_id, name, branch_name, worktree_path, status, status_line)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO workspaces (id, repository_id, name, branch_name, worktree_path, status, status_line, sort_order)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 ws.id,
                 ws.repository_id,
@@ -30,6 +38,7 @@ impl Database {
                 ws.worktree_path,
                 ws.status.as_str(),
                 ws.status_line,
+                next_sort_order,
             ],
         )?;
         // Every workspace starts with one active session so the multi-session
@@ -50,9 +59,15 @@ impl Database {
     pub fn insert_workspaces_batch(&self, workspaces: &[Workspace]) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
         {
+            // Inline the per-repo MAX subquery so each row in the batch lands
+            // at MAX+1 within its own repo even when multiple new workspaces
+            // share a repo. This is monotonically increasing within the
+            // transaction because subsequent rows see the just-inserted
+            // values.
             let mut ws_stmt = tx.prepare(
-                "INSERT INTO workspaces (id, repository_id, name, branch_name, worktree_path, status, status_line)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                "INSERT INTO workspaces (id, repository_id, name, branch_name, worktree_path, status, status_line, sort_order)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7,
+                    (SELECT COALESCE(MAX(sort_order), -1) + 1 FROM workspaces WHERE repository_id = ?2))",
             )?;
             let mut session_stmt = tx.prepare(
                 "INSERT INTO chat_sessions
@@ -79,8 +94,8 @@ impl Database {
 
     pub fn list_workspaces(&self) -> Result<Vec<Workspace>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, repository_id, name, branch_name, worktree_path, status, status_line, created_at
-             FROM workspaces ORDER BY created_at",
+            "SELECT id, repository_id, name, branch_name, worktree_path, status, status_line, created_at, sort_order
+             FROM workspaces ORDER BY repository_id, sort_order, created_at",
         )?;
         let rows = stmt.query_map([], |row| {
             let status_str: String = row.get(5)?;
@@ -106,9 +121,35 @@ impl Database {
                 agent_status,
                 status_line: row.get(6)?,
                 created_at: row.get(7)?,
+                sort_order: row.get(8)?,
             })
         })?;
         rows.collect()
+    }
+
+    /// Reassign per-repository `sort_order` of workspaces in the supplied
+    /// repo to match the supplied id sequence. Mirrors `reorder_repositories`
+    /// but scoped to a single repo because workspace sort_order is per-repo
+    /// (option 2A — within-repo reorder only). Ids that don't belong to
+    /// `repository_id` are ignored — the WHERE clause defends against
+    /// cross-repo edits.
+    pub fn reorder_workspaces(
+        &self,
+        repository_id: &str,
+        ids: &[String],
+    ) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "UPDATE workspaces SET sort_order = ?1 \
+                 WHERE id = ?2 AND repository_id = ?3",
+            )?;
+            for (i, id) in ids.iter().enumerate() {
+                stmt.execute(params![i as i32, id, repository_id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     pub fn update_workspace_status(

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -22,6 +22,11 @@ impl Database {
         // Assign the next per-repo sort_order so a freshly created workspace
         // lands at the bottom of its repo group, matching how
         // `insert_chat_session` handles per-workspace session ordering.
+        // Callers that hand the same `Workspace` back to the UI should
+        // call `lookup_workspace_sort_order(&ws.id)` after this returns
+        // and patch the value before optimistically updating the store —
+        // otherwise the new row appears at sort_order=0 in the UI until
+        // a full reload reads it back (Codex P2).
         let next_sort_order: i32 = tx.query_row(
             "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM workspaces WHERE repository_id = ?1",
             params![ws.repository_id],
@@ -54,8 +59,28 @@ impl Database {
         Ok(())
     }
 
+    /// Read back the persisted `sort_order` for a workspace. Used by
+    /// creation paths that need to patch the in-memory `Workspace` they
+    /// just inserted (since `insert_workspace` assigns the value via SQL
+    /// and the caller's struct still has the placeholder 0). See Codex
+    /// P2 review of the sidebar drag-reorder PR.
+    pub fn lookup_workspace_sort_order(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<i32>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT sort_order FROM workspaces WHERE id = ?1",
+                params![workspace_id],
+                |row| row.get(0),
+            )
+            .optional()
+    }
+
     /// Insert multiple workspaces atomically. All succeed or none are committed.
     /// Each workspace is seeded with one active chat session.
+    /// As with `insert_workspace`, callers that send the inserted rows back
+    /// to the UI should call `lookup_workspace_sort_order` per-id afterwards.
     pub fn insert_workspaces_batch(&self, workspaces: &[Workspace]) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
         {

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -209,6 +209,8 @@ async fn fork_after_worktree(
         agent_status: AgentStatus::Idle,
         status_line: String::new(),
         created_at: (inputs.now_iso)(),
+        // sort_order is overwritten by `insert_workspace` (MAX+1 within repo).
+        sort_order: 0,
     };
     db.insert_workspace(&new_ws)?;
 
@@ -465,6 +467,7 @@ mod tests {
             agent_status: AgentStatus::Idle,
             status_line: String::new(),
             created_at: String::new(),
+            sort_order: 0,
         }
     }
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -199,7 +199,7 @@ async fn fork_after_worktree(
             .map_err(|e| ForkError::Snapshot(e.to_string()))?;
     }
 
-    let new_ws = Workspace {
+    let mut new_ws = Workspace {
         id: uuid::Uuid::new_v4().to_string(),
         repository_id: source_ws.repository_id.clone(),
         name: new_name,
@@ -209,10 +209,15 @@ async fn fork_after_worktree(
         agent_status: AgentStatus::Idle,
         status_line: String::new(),
         created_at: (inputs.now_iso)(),
-        // sort_order is overwritten by `insert_workspace` (MAX+1 within repo).
+        // Placeholder; patched below to the value `insert_workspace` actually
+        // assigned (MAX+1 within repo) so callers handing this struct back
+        // to the UI render the new fork at the right sidebar position.
         sort_order: 0,
     };
     db.insert_workspace(&new_ws)?;
+    if let Some(o) = db.lookup_workspace_sort_order(&new_ws.id)? {
+        new_ws.sort_order = o;
+    }
 
     copy_history(db, &source_ws.id, &new_ws.id, checkpoint)?;
 

--- a/src/migrations/20260505180023_workspace_sort_order.sql
+++ b/src/migrations/20260505180023_workspace_sort_order.sql
@@ -1,0 +1,22 @@
+-- Per-repository ordering for workspaces in the sidebar. Mirrors the column
+-- added for repositories in 20250101000012. Scoped per repository_id (not
+-- globally) because workspaces live inside their repo's worktree on disk;
+-- a workspace's natural sort context is its sibling workspaces under the
+-- same repo.
+ALTER TABLE workspaces ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+
+-- Seed initial values from creation order so existing workspaces keep their
+-- current display order until the user drags them. Index is per-repo so
+-- ties between unrelated workspaces don't matter.
+UPDATE workspaces SET sort_order = (
+    SELECT COUNT(*)
+    FROM workspaces w2
+    WHERE w2.repository_id = workspaces.repository_id
+      AND (
+        w2.created_at < workspaces.created_at
+        OR (w2.created_at = workspaces.created_at AND w2.id < workspaces.id)
+      )
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_sort
+    ON workspaces(repository_id, sort_order);

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -169,4 +169,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260505055527_agent_task_terminal_tabs.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260505180023_workspace_sort_order",
+        sql: include_str!("20260505180023_workspace_sort_order.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -79,4 +79,7 @@ pub struct Workspace {
     pub agent_status: AgentStatus,
     pub status_line: String,
     pub created_at: String,
+    /// Per-repository display order for the sidebar. Persisted via the
+    /// `workspaces.sort_order` column; reassigned by `reorder_workspaces`.
+    pub sort_order: i32,
 }

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,6 +4,69 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Identity marker for the cross-app dev-port hijack guard. If another
+      Tauri app's Vite ever ends up serving on Claudette's dev port (because
+      it killed our listener and rebound the port, etc.), the foreign
+      bundle won't carry this meta tag and the inline guard below — which
+      runs BEFORE any ES module loads, so i18n / state init never touch
+      the foreign DOM — will render a hard error instead of silently
+      rendering the wrong app's UI inside Claudette's window.
+    -->
+    <meta name="x-tauri-app-id" content="com.claudette.app" />
+    <script>
+      // Cross-app dev-port hijack guard. ES module imports hoist, so this
+      // MUST be inline (and before the bundle script) to beat them.
+      // Mirrors bootIdentityGuard.ts; that module exists for tests.
+      (function () {
+        var EXPECTED = "com.claudette.app";
+        var meta = document.querySelector('meta[name="x-tauri-app-id"]');
+        var observed = (meta && meta.getAttribute("content")) || "(missing)";
+        if (observed === EXPECTED) return;
+        window.__claudetteHijackBlocked = true;
+        var esc = function (s) {
+          return String(s)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;");
+        };
+        var html =
+          '<div style="position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:#1c1815;color:#e07850;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;padding:32px;text-align:center;z-index:999999;">' +
+          '<div style="max-width:560px;">' +
+          '<h1 style="margin:0 0 16px;color:#f5a0b8;">Foreign content detected</h1>' +
+          '<p style="margin:0 0 12px;line-height:1.5;color:#e6dccf;">Claudette’s dev webview is serving content from another app. Expected app id <code style="font-family:JetBrains Mono,monospace;">' +
+          esc(EXPECTED) +
+          "</code>, observed <code style=\"font-family:JetBrains Mono,monospace;\">" +
+          esc(observed) +
+          "</code>.</p>" +
+          '<p style="margin:0 0 16px;line-height:1.5;color:#e6dccf;">A Tauri app on this machine probably grabbed the dev port that Claudette’s webview was pointed at. Quit any other Tauri dev builds, then restart Claudette via <code>scripts/dev.sh</code>.</p>' +
+          '<p style="margin:0;font-size:12px;color:#c4b5fd;">You’re seeing this instead of a silent UI swap because of the inline guard in <code>index.html</code>.</p>' +
+          "</div></div>";
+        // Replace the document so even if the foreign bundle's main script
+        // tag runs, its DOM mutations target our error overlay's <body>
+        // and most attempts to find their root element fail benignly.
+        document.open();
+        document.write(
+          '<!doctype html><html><head><meta charset="utf-8"><title>Claudette — hijack guard</title></head><body>' +
+            html +
+            "</body></html>",
+        );
+        document.close();
+        // Stop further script execution as cleanly as we can; ES modules
+        // already in flight can't be cancelled, but they'll throw against
+        // the rewritten DOM rather than render anything.
+        if (window.stop) window.stop();
+        // eslint-disable-next-line no-console
+        console.error(
+          "[claudette] Hijack guard tripped: expected x-tauri-app-id=" +
+            EXPECTED +
+            ", got " +
+            observed +
+            ". See index.html inline guard.",
+        );
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Silkscreen:wght@400;700&display=swap" rel="stylesheet" />

--- a/src/ui/scripts/check-css-tokens.sh
+++ b/src/ui/scripts/check-css-tokens.sh
@@ -18,6 +18,11 @@
 #     must match the hex in the corresponding `[data-theme]` block.
 #   * `accent_preview: "#..."` — same as above but in snake_case (the
 #     wire format used by the community-registry parsers in tests).
+#   * `src/utils/bootIdentityGuard.ts` — cross-app dev-port hijack guard
+#     that runs BEFORE React mounts (and BEFORE theme tokens are guaranteed
+#     to resolve, especially in the foreign-bundle case it's catching).
+#     Theme tokens cannot be the source of truth for an error overlay
+#     designed to render even when the surrounding app's CSS hasn't loaded.
 #
 # Runs from src/ui. Exits non-zero with a report when violations are found.
 
@@ -45,6 +50,7 @@ hex_hits=$(grep -rnE '#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b' src \
   | grep -vE 'getPropertyValue\(.*\)\.trim\(\) \|\| "#' \
   | grep -vE 'getPropertyValue\(.*\)\.trim\(\)\s*\|\| \(.*\?.*"#' \
   | grep -vE '(accentPreview|accent_preview):\s*"#' \
+  | grep -vE '^src/utils/bootIdentityGuard\.ts:' \
   || true)
 
 if [ -n "$hex_hits" ]; then

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -9,6 +9,7 @@ import type { ThemeDefinition } from "./types/theme";
 import { adjustUiFontSize, resetUiFontSize } from "./utils/fontSettings";
 import { KEYBINDING_SETTING_PREFIX } from "./hotkeys/bindings";
 import { useMcpStatus } from "./hooks/useMcpStatus";
+import { useViewTogglePersistence } from "./hooks/useViewTogglePersistence";
 import { AppLayout } from "./components/layout/AppLayout";
 import { findLeafByPtyId } from "./stores/terminalPaneTree";
 import type { CommandEvent } from "./types";
@@ -58,6 +59,12 @@ function App() {
 
   // Listen for MCP supervisor status events from the Rust backend.
   useMcpStatus();
+
+  // Hydrate sidebar / panel visibility + sizes from app_settings on mount,
+  // and write back when the user toggles or resizes anything. Without this
+  // the user's preferred layout (e.g. right sidebar closed, terminal
+  // hidden, custom widths) resets to the slice defaults on every restart.
+  useViewTogglePersistence();
 
   useEffect(() => {
     loadInitialData().then((data) => {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -28,6 +28,10 @@ import {
 } from "../../utils/voice";
 import { useVoiceInput } from "../../hooks/useVoiceInput";
 import { useVoiceHotkey } from "../../hooks/useVoiceHotkey";
+import {
+  eventToBinding,
+  getEffectiveBindingById,
+} from "../../hotkeys/bindings";
 import { ComposerToolbar } from "./composer/ComposerToolbar";
 import { ContextPopover } from "./composer/ContextPopover";
 import { SegmentedMeter } from "./composer/SegmentedMeter";
@@ -86,6 +90,7 @@ function fileToBase64(file: Blob): Promise<string> {
 // Separate component for input area to prevent full ChatPanel re-renders on every keystroke
 export function ChatInputArea({
   onSend,
+  onSendSteer,
   onStop,
   isRunning,
   isRemote,
@@ -104,6 +109,15 @@ export function ChatInputArea({
     mentionedFiles?: Set<string>,
     attachments?: AttachmentInput[],
   ) => Promise<void>;
+  /** Skip-queue / mid-turn steer entry point. Called when the user presses
+   *  the configured "send now" hotkey (defaults to Cmd/Ctrl+Enter) while
+   *  the agent is running. ChatPanel should call steerQueuedChatMessage
+   *  directly with this content instead of routing through the queue. */
+  onSendSteer?: (
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => void | Promise<void>;
   onStop: () => void | Promise<void>;
   isRunning: boolean;
   isRemote: boolean;
@@ -181,6 +195,9 @@ export function ChatInputArea({
   const voiceToggleHotkey = useAppStore((s) => s.voiceToggleHotkey);
   const voiceHoldHotkey = useAppStore((s) => s.voiceHoldHotkey);
   const focusVoiceProvider = useAppStore((s) => s.focusVoiceProvider);
+  // User-remappable bindings (`chat.steer-immediate` etc) — empty `{}` keeps
+  // defaults active until the user customises one.
+  const keybindings = useAppStore((s) => s.keybindings);
   const voice = useVoiceInput(
     insertTranscript,
     (providerId) => {
@@ -696,7 +713,12 @@ export function ChatInputArea({
     }
   }, [addAttachment]);
 
-  const handleSend = () => {
+  // Build the (content, files, attachments) payload from the current
+  // composer state and clear local UI state. Shared by the normal Enter
+  // path (handleSend) and the skip-queue / steer hotkey (handleSendSteer)
+  // so they stay in lockstep — every key press should clear the same
+  // pile of stuff.
+  const consumeComposer = () => {
     voice.cancel();
     // Only include files whose @path tokens are still in the text, so that
     // removed references don't get expanded.
@@ -716,7 +738,7 @@ export function ChatInputArea({
             text_content: a.text_content ?? undefined,
           }))
         : undefined;
-    onSend(chatInput, files, attachmentPayload);
+    const content = chatInput;
     setChatInput("");
     // Revoke blob URLs to free memory (data: URLs don't need cleanup).
     for (const a of pendingAttachments) {
@@ -724,6 +746,27 @@ export function ChatInputArea({
     }
     setPendingAttachments([]);
     mentionedFilesRef.current = new Set();
+    return { content, files, attachmentPayload };
+  };
+
+  const handleSend = () => {
+    const { content, files, attachmentPayload } = consumeComposer();
+    onSend(content, files, attachmentPayload);
+  };
+
+  const handleSendSteer = () => {
+    if (!onSendSteer) return;
+    // Steering only makes sense during a running turn — a regular send
+    // path handles the idle case, and the agent has nothing to steer
+    // when it isn't generating. Defensive guard so a misfired hotkey on
+    // an idle session doesn't double-send.
+    if (!isRunning) {
+      handleSend();
+      return;
+    }
+    if (!chatInput.trim() && pendingAttachments.length === 0) return;
+    const { content, files, attachmentPayload } = consumeComposer();
+    void onSendSteer(content, files, attachmentPayload);
   };
 
   const planMode = useAppStore(
@@ -820,6 +863,25 @@ export function ChatInputArea({
       if (e.key === "Escape") {
         e.preventDefault();
         setSlashPickerDismissed(true);
+        return;
+      }
+    }
+
+    // Skip-queue / steer: when the configured "send now" hotkey fires
+    // (default Cmd/Ctrl+Enter), bypass the queue and inject the typed
+    // content directly as a mid-turn steer. We intercept BEFORE the bare
+    // Enter handler below so a Mod+Enter press doesn't get caught by it.
+    // The binding is read from the hotkey settings system, so users can
+    // remap it (e.g. Cmd+Shift+Enter) via the Keyboard settings page.
+    const steerBinding = getEffectiveBindingById(
+      "chat.steer-immediate",
+      keybindings,
+    );
+    if (steerBinding) {
+      const pressed = eventToBinding(e.nativeEvent, "key");
+      if (pressed && pressed === steerBinding) {
+        e.preventDefault();
+        handleSendSteer();
         return;
       }
     }

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -764,6 +764,14 @@ export function ChatInputArea({
       handleSend();
       return;
     }
+    // Mid-turn steering isn't supported over the remote transport yet
+    // (Codex P2). Fall back to the normal send path — which queues for
+    // after the current turn — instead of consuming the composer and
+    // dropping the text on the floor.
+    if (isRemote) {
+      handleSend();
+      return;
+    }
     if (!chatInput.trim() && pendingAttachments.length === 0) return;
     const { content, files, attachmentPayload } = consumeComposer();
     void onSendSteer(content, files, attachmentPayload);

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -713,7 +713,12 @@ export function ChatPanel() {
     const trimmed = content.trim();
     if ((!trimmed && !attachments?.length) || !activeSessionId) return;
     if (ws?.remote_connection_id) {
-      setError("Mid-turn steering is not yet supported for remote workspaces");
+      // Mid-turn steering isn't supported over the remote transport yet,
+      // but the typed message must NOT be lost — fall back to the normal
+      // send path so it lands in the queue (which IS supported remotely).
+      // ChatInputArea also catches this earlier; this is defense in depth
+      // for any future caller that bypasses the composer (Copilot review).
+      await handleSend(content, mentionedFiles, attachments);
       return;
     }
     if (!isRunning) {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -700,6 +700,66 @@ export function ChatPanel() {
     }
   };
 
+  // Skip-queue / steer entry from the chat composer (default Cmd+Enter).
+  // Mirrors handleSteerQueuedMessage but takes content from the input area
+  // directly instead of the queued-message slot — the user is asking to
+  // inject the freshly-typed message mid-turn instead of letting it sit
+  // in the queue until the current turn finishes.
+  const handleSendSteer = async (
+    content: string,
+    mentionedFiles?: Set<string>,
+    attachments?: AttachmentInput[],
+  ) => {
+    const trimmed = content.trim();
+    if ((!trimmed && !attachments?.length) || !activeSessionId) return;
+    if (ws?.remote_connection_id) {
+      setError("Mid-turn steering is not yet supported for remote workspaces");
+      return;
+    }
+    if (!isRunning) {
+      // Defensive — ChatInputArea also falls back to handleSend when not
+      // running, but the user could conceivably trigger this from another
+      // entry point in the future. Route through the normal send path.
+      await handleSend(content, mentionedFiles, attachments);
+      return;
+    }
+    if (isSteeringQueued) return;
+
+    const sessionId = activeSessionId;
+    const messageId = crypto.randomUUID();
+    const mentionedFilesArray = mentionedFiles?.size
+      ? [...mentionedFiles]
+      : undefined;
+    setError(null);
+    setIsSteeringQueued(true);
+    try {
+      const checkpoint = await steerQueuedChatMessage(
+        sessionId,
+        content,
+        mentionedFilesArray,
+        attachments,
+        messageId,
+      );
+      if (checkpoint) {
+        addCheckpoint(sessionId, checkpoint);
+      }
+      const history = (historyRef.current[sessionId] ??= []);
+      history.push(content);
+      historyIndexRef.current = -1;
+      draftRef.current = "";
+      addPersistedUserMessageToStore(sessionId, messageId, content, attachments);
+    } catch (e) {
+      const errMsg = String(e);
+      console.error("steerQueuedChatMessage (skip-queue) failed:", errMsg);
+      // Steer failed mid-turn — fall back to queueing so the user's typed
+      // message doesn't vanish. They can re-trigger it manually.
+      setQueuedMessage(sessionId, content, mentionedFilesArray, attachments);
+      setError(errMsg);
+    } finally {
+      setIsSteeringQueued(false);
+    }
+  };
+
   const handleSteerQueuedMessage = async () => {
     if (!activeSessionId || !queuedMessage || isSteeringQueued) return;
     if (ws.remote_connection_id) {
@@ -1283,6 +1343,7 @@ export function ChatPanel() {
 
       <ChatInputArea
         onSend={handleSend}
+        onSendSteer={handleSendSteer}
         onStop={handleStop}
         isRunning={isRunning}
         isRemote={!!ws?.remote_connection_id}

--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -7,6 +7,9 @@
   background: transparent;
   scrollbar-width: thin;
   scrollbar-color: var(--border-subtle) transparent;
+  /* Pin to the shared second-row height so the right-sidebar tab bar (when
+   * pushed under a PR banner) bottoms out at the same Y as this strip. */
+  min-height: var(--tab-bar-h);
 }
 
 .tabBar::-webkit-scrollbar {

--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -29,9 +29,17 @@
   color: var(--text-dim);
   background: transparent;
   border: none;
-  cursor: pointer;
+  /* `grab` advertises drag-to-reorder; the dragging state below switches to
+   * `grabbing`. */
+  cursor: grab;
   white-space: nowrap;
+  /* WebKit (macOS Tauri) honors only the prefixed -webkit-user-select. The
+   * unprefixed property silently defaults to "text" on `<span>` descendants
+   * even when the parent says "none", which lets the browser start a text
+   * selection on mousedown before our pointer-capture fires and visually
+   * "highlights" the tab name mid-drag. Set both. */
   user-select: none;
+  -webkit-user-select: none;
   position: relative;
   transition: color 80ms ease;
 }
@@ -168,3 +176,38 @@
   opacity: 0.5;
 }
 
+/* While a tab drag is in progress, force the grabbing cursor and suppress
+ * hover styles on non-target tabs so the drop indicator is the only visible
+ * feedback. Mirrors the terminal tab bar's drag state. */
+.tabBar[data-tab-dragging="true"] {
+  cursor: grabbing;
+}
+.tabBar[data-tab-dragging="true"] .tab:hover:not(.active) {
+  color: inherit;
+}
+
+.tab.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+/* Drop-edge indicator. Sibling spans (not pseudo-elements) because the tab
+ * already uses `::after` for the active-underline; we don't want the two
+ * effects fighting for the same pseudo. The accent bar matches the
+ * terminal tab bar's drop indicator for visual consistency. */
+.dropEdge {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  width: 3px;
+  background: var(--accent-primary);
+  border-radius: 2px;
+  pointer-events: none;
+  box-shadow: 0 0 0 1px rgba(var(--accent-primary-rgb), 0.25);
+}
+.dropBefore {
+  left: -2px;
+}
+.dropAfter {
+  right: -2px;
+}

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { FileDiff as FileDiffIcon, Plus, X } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
@@ -11,7 +18,11 @@ import {
   createChatSession,
   renameChatSession,
   archiveChatSession,
+  reorderChatSessions,
 } from "../../services/tauri";
+import { useTabDragReorder } from "../../hooks/useTabDragReorder";
+import { TabDragGhost } from "../shared/TabDragGhost";
+import { splitUnifiedTabOrder } from "./sessionTabsLogic";
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
 import {
   AttachmentContextMenu,
@@ -219,6 +230,9 @@ export function SessionTabs({ workspaceId }: Props) {
   // navigation can focus any tab in the strip, regardless of kind.
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
+  const setFileTabsForWorkspace = useAppStore((s) => s.setFileTabsForWorkspace);
+  const setDiffTabsForWorkspace = useAppStore((s) => s.setDiffTabsForWorkspace);
+
   // Unified ordered list of focusable tab entries. Sessions first, diffs
   // second — the layout users see in the strip. Wrapped in useMemo so the
   // navigateTabs callback identity stays stable across unrelated re-renders.
@@ -245,6 +259,66 @@ export function SessionTabs({ workspaceId }: Props) {
     }));
     return [...sessionEntries, ...diffEntries, ...fileEntries];
   }, [activeSessions, diffTabs, fileTabs]);
+
+  // Drag-reorder over the unified strip. The hook is generic over an `Id`
+  // type — we use the unified nav key (`s:`/`d:`/`f:` prefix) as the
+  // identifier so chat sessions, diffs, and files share one drag namespace.
+  // On drop we split the new order back into three lists, push the volatile
+  // file/diff arrays to the store, and persist session sort_order via the
+  // backend.
+  const navEntryByKey = useMemo(() => {
+    const m = new Map<string, NavEntry>();
+    for (const e of navEntries) m.set(e.key, e);
+    return m;
+  }, [navEntries]);
+
+  const tabReorder = useTabDragReorder<NavEntry, string>({
+    items: navEntries,
+    dataAttr: "sessionTabKey",
+    parseId: (raw) => raw,
+    getId: (e) => e.key,
+    getTitle: (e) => {
+      if (e.kind === "session") {
+        return activeSessions.find((s) => s.id === e.sessionId)?.name ?? "";
+      }
+      if (e.kind === "diff" || e.kind === "file") {
+        return e.path.split("/").pop() || e.path;
+      }
+      return "";
+    },
+    onReorder: (next) => {
+      const split = splitUnifiedTabOrder(
+        next.map((e) =>
+          e.kind === "session"
+            ? { kind: "session" as const, sessionId: e.sessionId }
+            : e.kind === "diff"
+              ? { kind: "diff" as const, path: e.path, layer: e.layer }
+              : { kind: "file" as const, path: e.path },
+        ),
+        activeSessions,
+        diffTabs,
+        fileTabs,
+      );
+      // Apply ordering to local state immediately so the strip animates to
+      // its new layout without waiting on the round-trip.
+      // Sessions: merge the reordered active set back with archived sessions
+      // (which never appear in navEntries) so the slice still has the full
+      // list per-workspace.
+      const archivedSessions = sessions.filter((s) => s.status === "Archived");
+      setSessionsForWorkspace(workspaceId, [
+        ...split.sessions,
+        ...archivedSessions,
+      ]);
+      setFileTabsForWorkspace(workspaceId, split.files);
+      setDiffTabsForWorkspace(workspaceId, split.diffs);
+      if (split.sessionPersistIds.length > 0) {
+        void reorderChatSessions(workspaceId, split.sessionPersistIds).catch(
+          (err) =>
+            console.error("[SessionTabs] Failed to persist session order:", err),
+        );
+      }
+    },
+  });
 
   // Right-click menu state. Tracks which tab was clicked (by its NavEntry key)
   // and the click position. Rendered once at the bottom; portal'd to body so
@@ -420,10 +494,36 @@ export function SessionTabs({ workspaceId }: Props) {
     ];
   }, [contextMenu, navEntries, closeEntries, selectEntry, t]);
 
+  // Convenience helper that builds the drag-reorder slice of props each
+  // sub-tab needs. Avoids repeating `tabReorder.getTabHandlers(...)` and the
+  // drop-indicator booleans three times in the render block below.
+  const dragPropsFor = (navKey: string) => {
+    const entry = navEntryByKey.get(navKey);
+    if (!entry) return null;
+    const handlers = tabReorder.getTabHandlers(entry);
+    return {
+      navKey,
+      handlers,
+      isDragging: tabReorder.draggingId === navKey,
+      dropBefore:
+        tabReorder.dropTarget?.id === navKey &&
+        tabReorder.dropTarget?.placement === "before",
+      dropAfter:
+        tabReorder.dropTarget?.id === navKey &&
+        tabReorder.dropTarget?.placement === "after",
+      isClickSuppressed: tabReorder.justEnded,
+    };
+  };
+
   return (
-    <div className={styles.tabBar} role="tablist">
+    <div
+      className={styles.tabBar}
+      role="tablist"
+      data-tab-dragging={tabReorder.draggingId !== null || undefined}
+    >
       {activeSessions.map((session) => {
         const navKey = sessionNavKey(session.id);
+        const drag = dragPropsFor(navKey);
         return (
           <SessionTab
             key={session.id}
@@ -444,6 +544,7 @@ export function SessionTabs({ workspaceId }: Props) {
               if (el) tabRefs.current.set(navKey, el);
               else tabRefs.current.delete(navKey);
             }}
+            drag={drag}
           />
         );
       })}
@@ -456,6 +557,7 @@ export function SessionTabs({ workspaceId }: Props) {
           activeFileTab === null &&
           diffSelectedFile === tab.path &&
           diffSelectedLayer === tab.layer;
+        const drag = dragPropsFor(navKey);
         return (
           <DiffTab
             key={navKey}
@@ -469,12 +571,14 @@ export function SessionTabs({ workspaceId }: Props) {
               if (el) tabRefs.current.set(navKey, el);
               else tabRefs.current.delete(navKey);
             }}
+            drag={drag}
           />
         );
       })}
       {fileTabs.map((path) => {
         const navKey = fileNavKey(path);
         const isActive = activeFileTab === path;
+        const drag = dragPropsFor(navKey);
         return (
           <FileTab
             key={navKey}
@@ -489,6 +593,7 @@ export function SessionTabs({ workspaceId }: Props) {
               if (el) tabRefs.current.set(navKey, el);
               else tabRefs.current.delete(navKey);
             }}
+            drag={drag}
           />
         );
       })}
@@ -523,8 +628,29 @@ export function SessionTabs({ workspaceId }: Props) {
           onClose={() => setPendingClosePaths([])}
         />
       )}
+      {tabReorder.dragGhost && tabReorder.draggingId !== null && (
+        <TabDragGhost ghost={tabReorder.dragGhost} />
+      )}
     </div>
   );
+}
+
+// Drag-reorder slice of props each sub-tab consumes. Built once per render
+// by SessionTabs.dragPropsFor; passed straight through to the tab element.
+interface TabDragProps {
+  navKey: string;
+  handlers: {
+    onPointerDown: (ev: ReactPointerEvent<HTMLElement>) => void;
+    onPointerMove: (ev: ReactPointerEvent<HTMLElement>) => void;
+    onPointerUp: (ev: ReactPointerEvent<HTMLElement>) => void;
+    onPointerCancel: (ev: ReactPointerEvent<HTMLElement>) => void;
+  };
+  isDragging: boolean;
+  dropBefore: boolean;
+  dropAfter: boolean;
+  /** Reads the latest "did a drag just end" flag from the hook. Tab onClick
+   *  handlers call this to skip the synthetic post-pointerup click. */
+  isClickSuppressed: () => boolean;
 }
 
 interface TabProps {
@@ -536,6 +662,7 @@ interface TabProps {
   onNavigate: (direction: "prev" | "next" | "first" | "last") => void;
   onContextMenu: (x: number, y: number) => void;
   tabRef: (el: HTMLDivElement | null) => void;
+  drag: TabDragProps | null;
 }
 
 function SessionTab({
@@ -547,6 +674,7 @@ function SessionTab({
   onNavigate,
   onContextMenu,
   tabRef,
+  drag,
 }: TabProps) {
   const { t } = useTranslation("chat");
   const [editing, setEditing] = useState(false);
@@ -592,8 +720,10 @@ function SessionTab({
       role="tab"
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
-      className={`${styles.tab} ${isActive ? styles.active : ""}`}
+      data-session-tab-key={drag?.navKey}
+      className={`${styles.tab} ${isActive ? styles.active : ""} ${drag?.isDragging ? styles.dragging : ""}`}
       onClick={() => {
+        if (drag?.isClickSuppressed()) return;
         if (!editing) onSelect();
       }}
       onContextMenu={(e) => {
@@ -607,6 +737,10 @@ function SessionTab({
         e.stopPropagation();
         startEditing();
       }}
+      onPointerDown={drag?.handlers.onPointerDown}
+      onPointerMove={drag?.handlers.onPointerMove}
+      onPointerUp={drag?.handlers.onPointerUp}
+      onPointerCancel={drag?.handlers.onPointerCancel}
       onKeyDown={(e) => {
         if (editing) return;
         if (e.key === "Enter" || e.key === " ") {
@@ -630,6 +764,12 @@ function SessionTab({
         }
       }}
     >
+      {drag?.dropBefore && (
+        <span className={`${styles.dropEdge} ${styles.dropBefore}`} aria-hidden />
+      )}
+      {drag?.dropAfter && (
+        <span className={`${styles.dropEdge} ${styles.dropAfter}`} aria-hidden />
+      )}
       <span className={`${styles.icon} ${session.needs_attention ? styles.pulse : ""}`}>
         <SessionStatusIcon status={statusFor(session)} size={12} />
       </span>
@@ -678,6 +818,7 @@ interface FileTabProps {
   onNavigate: (direction: NavDirection) => void;
   onContextMenu: (x: number, y: number) => void;
   tabRef: (el: HTMLDivElement | null) => void;
+  drag: TabDragProps | null;
 }
 
 function FileTab({
@@ -689,6 +830,7 @@ function FileTab({
   onNavigate,
   onContextMenu,
   tabRef,
+  drag,
 }: FileTabProps) {
   const { t } = useTranslation("chat");
   // Subscribe only to dirty state for this tab's buffer. Reading the whole
@@ -708,12 +850,20 @@ function FileTab({
       role="tab"
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
-      className={`${styles.tab} ${isActive ? styles.active : ""}`}
-      onClick={onSelect}
+      data-session-tab-key={drag?.navKey}
+      className={`${styles.tab} ${isActive ? styles.active : ""} ${drag?.isDragging ? styles.dragging : ""}`}
+      onClick={() => {
+        if (drag?.isClickSuppressed()) return;
+        onSelect();
+      }}
       onContextMenu={(e) => {
         e.preventDefault();
         onContextMenu(e.clientX, e.clientY);
       }}
+      onPointerDown={drag?.handlers.onPointerDown}
+      onPointerMove={drag?.handlers.onPointerMove}
+      onPointerUp={drag?.handlers.onPointerUp}
+      onPointerCancel={drag?.handlers.onPointerCancel}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
@@ -733,6 +883,12 @@ function FileTab({
         }
       }}
     >
+      {drag?.dropBefore && (
+        <span className={`${styles.dropEdge} ${styles.dropBefore}`} aria-hidden />
+      )}
+      {drag?.dropAfter && (
+        <span className={`${styles.dropEdge} ${styles.dropAfter}`} aria-hidden />
+      )}
       <span className={styles.icon}>
         <Icon size={12} />
       </span>
@@ -766,6 +922,7 @@ interface DiffTabProps {
   onNavigate: (direction: NavDirection) => void;
   onContextMenu: (x: number, y: number) => void;
   tabRef: (el: HTMLDivElement | null) => void;
+  drag: TabDragProps | null;
 }
 
 function DiffTab({
@@ -776,6 +933,7 @@ function DiffTab({
   onNavigate,
   onContextMenu,
   tabRef,
+  drag,
 }: DiffTabProps) {
   const { t } = useTranslation("chat");
   // Show just the basename in the tab; the full path goes in the tooltip
@@ -789,12 +947,20 @@ function DiffTab({
       role="tab"
       aria-selected={isActive}
       tabIndex={isActive ? 0 : -1}
-      className={`${styles.tab} ${isActive ? styles.active : ""}`}
-      onClick={onSelect}
+      data-session-tab-key={drag?.navKey}
+      className={`${styles.tab} ${isActive ? styles.active : ""} ${drag?.isDragging ? styles.dragging : ""}`}
+      onClick={() => {
+        if (drag?.isClickSuppressed()) return;
+        onSelect();
+      }}
       onContextMenu={(e) => {
         e.preventDefault();
         onContextMenu(e.clientX, e.clientY);
       }}
+      onPointerDown={drag?.handlers.onPointerDown}
+      onPointerMove={drag?.handlers.onPointerMove}
+      onPointerUp={drag?.handlers.onPointerUp}
+      onPointerCancel={drag?.handlers.onPointerCancel}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
@@ -814,6 +980,12 @@ function DiffTab({
         }
       }}
     >
+      {drag?.dropBefore && (
+        <span className={`${styles.dropEdge} ${styles.dropBefore}`} aria-hidden />
+      )}
+      {drag?.dropAfter && (
+        <span className={`${styles.dropEdge} ${styles.dropAfter}`} aria-hidden />
+      )}
       <span className={styles.icon}>
         <FileDiffIcon size={12} />
       </span>

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -234,6 +234,12 @@ export function SessionTabs({ workspaceId }: Props) {
     (s) => s.tabOrderByWorkspace[workspaceId],
   );
   const setTabOrderForWorkspace = useAppStore((s) => s.setTabOrderForWorkspace);
+  // Per-kind setters used by `onReorder` to keep the per-kind arrays in
+  // sync with the unified order — other call sites (closeFileTab etc.)
+  // still consult the per-kind arrays for adjacency, so they have to
+  // match the visible order.
+  const setFileTabsForWorkspace = useAppStore((s) => s.setFileTabsForWorkspace);
+  const setDiffTabsForWorkspace = useAppStore((s) => s.setDiffTabsForWorkspace);
 
   // Unified ordered list of focusable tab entries. Default layout is
   // sessions → diffs → files; once the user has dragged the strip into
@@ -322,11 +328,15 @@ export function SessionTabs({ workspaceId }: Props) {
     },
     onReorder: (next) => {
       // Convert the reordered nav-entry list into the unified-tab-order
-      // shape. This drives the render directly — no need to also write the
-      // per-kind arrays back, because the render block iterates the unified
-      // order. Splitting still happens for chat-session DB persistence,
-      // since the relative order of sessions (ignoring files/diffs) is
-      // what reorder_chat_sessions cares about.
+      // shape. The render block iterates the unified order directly, but
+      // we ALSO write the per-kind arrays back so other code paths that
+      // read them — e.g. `closeFileTab` picking the adjacent tab to
+      // activate, or `closeDiffTab`/keyboard nav after-close — see the
+      // same relative order the user just dragged into. Without those
+      // writebacks, those code paths still pick from the pre-drag
+      // sequence (Copilot review of the second push). Sessions are
+      // additionally persisted via reorder_chat_sessions for restart
+      // round-tripping.
       const unified = next.map((e) =>
         e.kind === "session"
           ? { kind: "session" as const, sessionId: e.sessionId }
@@ -341,6 +351,16 @@ export function SessionTabs({ workspaceId }: Props) {
         diffTabs,
         fileTabs,
       );
+      // Sessions: merge the reordered active set back with archived
+      // sessions (which never appear in navEntries) so the slice still
+      // has the full list per-workspace.
+      const archivedSessions = sessions.filter((s) => s.status === "Archived");
+      setSessionsForWorkspace(workspaceId, [
+        ...split.sessions,
+        ...archivedSessions,
+      ]);
+      setFileTabsForWorkspace(workspaceId, split.files);
+      setDiffTabsForWorkspace(workspaceId, split.diffs);
       if (split.sessionPersistIds.length > 0) {
         void reorderChatSessions(workspaceId, split.sessionPersistIds).catch(
           (err) =>

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -230,12 +230,17 @@ export function SessionTabs({ workspaceId }: Props) {
   // navigation can focus any tab in the strip, regardless of kind.
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
-  const setFileTabsForWorkspace = useAppStore((s) => s.setFileTabsForWorkspace);
-  const setDiffTabsForWorkspace = useAppStore((s) => s.setDiffTabsForWorkspace);
+  const tabOrderForWorkspace = useAppStore(
+    (s) => s.tabOrderByWorkspace[workspaceId],
+  );
+  const setTabOrderForWorkspace = useAppStore((s) => s.setTabOrderForWorkspace);
 
-  // Unified ordered list of focusable tab entries. Sessions first, diffs
-  // second — the layout users see in the strip. Wrapped in useMemo so the
-  // navigateTabs callback identity stays stable across unrelated re-renders.
+  // Unified ordered list of focusable tab entries. Default layout is
+  // sessions → diffs → files; once the user has dragged the strip into
+  // a custom unified order (`tabOrderByWorkspace`), we honor that order
+  // instead and reconcile against the live per-kind state on every render
+  // (drop entries whose underlying tab is gone; append newly-opened tabs
+  // at the end so they don't disappear into the abyss).
   type NavEntry =
     | { key: string; kind: "session"; sessionId: string }
     | { key: string; kind: "diff"; path: string; layer: DiffLayer | null }
@@ -257,8 +262,37 @@ export function SessionTabs({ workspaceId }: Props) {
       kind: "file",
       path: p,
     }));
-    return [...sessionEntries, ...diffEntries, ...fileEntries];
-  }, [activeSessions, diffTabs, fileTabs]);
+    const defaultOrder = [...sessionEntries, ...diffEntries, ...fileEntries];
+
+    if (!tabOrderForWorkspace || tabOrderForWorkspace.length === 0) {
+      return defaultOrder;
+    }
+
+    // Reconcile saved unified order with the live per-kind state. A small
+    // map keyed by NavEntry.key lets us O(1) resolve each saved entry; new
+    // tabs (not yet in the saved order) append at the end, preserving the
+    // user's drag intent for everything they touched.
+    const byKey = new Map(defaultOrder.map((e) => [e.key, e]));
+    const out: NavEntry[] = [];
+    const used = new Set<string>();
+    for (const ord of tabOrderForWorkspace) {
+      const key =
+        ord.kind === "session"
+          ? sessionNavKey(ord.sessionId)
+          : ord.kind === "diff"
+            ? diffNavKey(ord.path, ord.layer)
+            : fileNavKey(ord.path);
+      const entry = byKey.get(key);
+      if (entry && !used.has(key)) {
+        out.push(entry);
+        used.add(key);
+      }
+    }
+    for (const e of defaultOrder) {
+      if (!used.has(e.key)) out.push(e);
+    }
+    return out;
+  }, [activeSessions, diffTabs, fileTabs, tabOrderForWorkspace]);
 
   // Drag-reorder over the unified strip. The hook is generic over an `Id`
   // type — we use the unified nav key (`s:`/`d:`/`f:` prefix) as the
@@ -287,30 +321,26 @@ export function SessionTabs({ workspaceId }: Props) {
       return "";
     },
     onReorder: (next) => {
+      // Convert the reordered nav-entry list into the unified-tab-order
+      // shape. This drives the render directly — no need to also write the
+      // per-kind arrays back, because the render block iterates the unified
+      // order. Splitting still happens for chat-session DB persistence,
+      // since the relative order of sessions (ignoring files/diffs) is
+      // what reorder_chat_sessions cares about.
+      const unified = next.map((e) =>
+        e.kind === "session"
+          ? { kind: "session" as const, sessionId: e.sessionId }
+          : e.kind === "diff"
+            ? { kind: "diff" as const, path: e.path, layer: e.layer }
+            : { kind: "file" as const, path: e.path },
+      );
+      setTabOrderForWorkspace(workspaceId, unified);
       const split = splitUnifiedTabOrder(
-        next.map((e) =>
-          e.kind === "session"
-            ? { kind: "session" as const, sessionId: e.sessionId }
-            : e.kind === "diff"
-              ? { kind: "diff" as const, path: e.path, layer: e.layer }
-              : { kind: "file" as const, path: e.path },
-        ),
+        unified,
         activeSessions,
         diffTabs,
         fileTabs,
       );
-      // Apply ordering to local state immediately so the strip animates to
-      // its new layout without waiting on the round-trip.
-      // Sessions: merge the reordered active set back with archived sessions
-      // (which never appear in navEntries) so the slice still has the full
-      // list per-workspace.
-      const archivedSessions = sessions.filter((s) => s.status === "Archived");
-      setSessionsForWorkspace(workspaceId, [
-        ...split.sessions,
-        ...archivedSessions,
-      ]);
-      setFileTabsForWorkspace(workspaceId, split.files);
-      setDiffTabsForWorkspace(workspaceId, split.diffs);
       if (split.sessionPersistIds.length > 0) {
         void reorderChatSessions(workspaceId, split.sessionPersistIds).catch(
           (err) =>
@@ -521,72 +551,79 @@ export function SessionTabs({ workspaceId }: Props) {
       role="tablist"
       data-tab-dragging={tabReorder.draggingId !== null || undefined}
     >
-      {activeSessions.map((session) => {
-        const navKey = sessionNavKey(session.id);
+      {/* Single render loop over the unified navEntries — this is what
+          honors a user-customized order. The earlier "sessions.map then
+          diffs.map then files.map" approach re-segregated tabs back into
+          their kinds after every drop, defeating cross-kind drag. */}
+      {navEntries.map((entry) => {
+        const navKey = entry.key;
         const drag = dragPropsFor(navKey);
-        return (
-          <SessionTab
-            key={session.id}
-            session={session}
-            isActive={
-              session.id === selectedSessionId &&
-              diffSelectedFile === null &&
-              activeFileTab === null
-            }
-            onSelect={() => switchToSession(session.id)}
-            onClose={() => handleArchive(session)}
-            onRename={(name) => {
-              updateChatSession(session.id, { name, name_edited: true });
-            }}
-            onNavigate={(direction) => navigateTabs(navKey, direction)}
-            onContextMenu={(x, y) => openContextMenu(navKey, x, y)}
-            tabRef={(el) => {
-              if (el) tabRefs.current.set(navKey, el);
-              else tabRefs.current.delete(navKey);
-            }}
-            drag={drag}
-          />
-        );
-      })}
-      {diffTabs.map((tab) => {
-        const navKey = diffNavKey(tab.path, tab.layer);
-        // A file tab takes visual priority — if a file is open, the diff
-        // tab is no longer the "active" pane even if its path/layer still
-        // matches the diff selection.
-        const isActive =
-          activeFileTab === null &&
-          diffSelectedFile === tab.path &&
-          diffSelectedLayer === tab.layer;
-        const drag = dragPropsFor(navKey);
-        return (
-          <DiffTab
-            key={navKey}
-            tab={tab}
-            isActive={isActive}
-            onSelect={() => switchToDiff(tab.path, tab.layer)}
-            onClose={() => closeDiffTab(workspaceId, tab.path, tab.layer)}
-            onNavigate={(direction) => navigateTabs(navKey, direction)}
-            onContextMenu={(x, y) => openContextMenu(navKey, x, y)}
-            tabRef={(el) => {
-              if (el) tabRefs.current.set(navKey, el);
-              else tabRefs.current.delete(navKey);
-            }}
-            drag={drag}
-          />
-        );
-      })}
-      {fileTabs.map((path) => {
-        const navKey = fileNavKey(path);
-        const isActive = activeFileTab === path;
-        const drag = dragPropsFor(navKey);
+        if (entry.kind === "session") {
+          const session = activeSessions.find((s) => s.id === entry.sessionId);
+          if (!session) return null;
+          return (
+            <SessionTab
+              key={navKey}
+              session={session}
+              isActive={
+                session.id === selectedSessionId &&
+                diffSelectedFile === null &&
+                activeFileTab === null
+              }
+              onSelect={() => switchToSession(session.id)}
+              onClose={() => handleArchive(session)}
+              onRename={(name) => {
+                updateChatSession(session.id, { name, name_edited: true });
+              }}
+              onNavigate={(direction) => navigateTabs(navKey, direction)}
+              onContextMenu={(x, y) => openContextMenu(navKey, x, y)}
+              tabRef={(el) => {
+                if (el) tabRefs.current.set(navKey, el);
+                else tabRefs.current.delete(navKey);
+              }}
+              drag={drag}
+            />
+          );
+        }
+        if (entry.kind === "diff") {
+          const tab = diffTabs.find(
+            (d) => d.path === entry.path && d.layer === entry.layer,
+          );
+          if (!tab) return null;
+          // A file tab takes visual priority — if a file is open, the diff
+          // tab is no longer the "active" pane even if its path/layer still
+          // matches the diff selection.
+          const isActive =
+            activeFileTab === null &&
+            diffSelectedFile === tab.path &&
+            diffSelectedLayer === tab.layer;
+          return (
+            <DiffTab
+              key={navKey}
+              tab={tab}
+              isActive={isActive}
+              onSelect={() => switchToDiff(tab.path, tab.layer)}
+              onClose={() => closeDiffTab(workspaceId, tab.path, tab.layer)}
+              onNavigate={(direction) => navigateTabs(navKey, direction)}
+              onContextMenu={(x, y) => openContextMenu(navKey, x, y)}
+              tabRef={(el) => {
+                if (el) tabRefs.current.set(navKey, el);
+                else tabRefs.current.delete(navKey);
+              }}
+              drag={drag}
+            />
+          );
+        }
+        // entry.kind === "file"
+        const isActive = activeFileTab === entry.path;
         return (
           <FileTab
             key={navKey}
             workspaceId={workspaceId}
-            path={path}
+            path={entry.path}
             isActive={isActive}
-            onSelect={() => selectFileTab(workspaceId, path)}
-            onClose={() => requestCloseFileTab(path)}
+            onSelect={() => selectFileTab(workspaceId, entry.path)}
+            onClose={() => requestCloseFileTab(entry.path)}
             onNavigate={(direction) => navigateTabs(navKey, direction)}
             onContextMenu={(x, y) => openContextMenu(navKey, x, y)}
             tabRef={(el) => {

--- a/src/ui/src/components/chat/sessionTabsLogic.test.ts
+++ b/src/ui/src/components/chat/sessionTabsLogic.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeSessionPersistOrder,
+  splitUnifiedTabOrder,
+  type UnifiedTabEntry,
+} from "./sessionTabsLogic";
+import type { ChatSession, DiffFileTab } from "../../types";
+
+const session = (id: string): ChatSession => ({
+  id,
+  workspace_id: "ws-1",
+  session_id: null,
+  name: `s-${id}`,
+  name_edited: false,
+  turn_count: 0,
+  sort_order: 0,
+  status: "Active",
+  created_at: "2026-01-01T00:00:00Z",
+  archived_at: null,
+  agent_status: "Idle",
+  needs_attention: false,
+  attention_kind: null,
+});
+
+const diff = (path: string): DiffFileTab => ({
+  path,
+  layer: null,
+});
+
+describe("computeSessionPersistOrder", () => {
+  it("walks the unified order and emits session ids in display order", () => {
+    const entries: UnifiedTabEntry[] = [
+      { kind: "session", sessionId: "s2" },
+      { kind: "file", path: "a.ts" },
+      { kind: "session", sessionId: "s1" },
+      { kind: "diff", path: "b.ts", layer: null },
+      { kind: "session", sessionId: "s3" },
+    ];
+    expect(computeSessionPersistOrder(entries)).toEqual(["s2", "s1", "s3"]);
+  });
+
+  it("returns an empty array when no session entries are present", () => {
+    const entries: UnifiedTabEntry[] = [
+      { kind: "file", path: "a.ts" },
+      { kind: "diff", path: "b.ts", layer: null },
+    ];
+    expect(computeSessionPersistOrder(entries)).toEqual([]);
+  });
+});
+
+describe("splitUnifiedTabOrder", () => {
+  it("splits a unified order back into per-kind arrays + a session persist sequence", () => {
+    const sessions = [session("s1"), session("s2")];
+    const diffs = [diff("a.ts"), diff("b.ts")];
+    const files = ["x.ts", "y.ts"];
+    const entries: UnifiedTabEntry[] = [
+      { kind: "file", path: "y.ts" },
+      { kind: "session", sessionId: "s2" },
+      { kind: "diff", path: "a.ts", layer: null },
+      { kind: "session", sessionId: "s1" },
+      { kind: "file", path: "x.ts" },
+      { kind: "diff", path: "b.ts", layer: null },
+    ];
+    const split = splitUnifiedTabOrder(entries, sessions, diffs, files);
+    expect(split.sessions.map((s) => s.id)).toEqual(["s2", "s1"]);
+    expect(split.diffs.map((d) => d.path)).toEqual(["a.ts", "b.ts"]);
+    expect(split.files).toEqual(["y.ts", "x.ts"]);
+    expect(split.sessionPersistIds).toEqual(["s2", "s1"]);
+  });
+
+  it("ignores entries that no longer exist in the current per-kind state", () => {
+    // e.g. a session was archived between the drop and the split: its entry
+    // is dropped silently rather than propagated as a phantom row.
+    const split = splitUnifiedTabOrder(
+      [
+        { kind: "session", sessionId: "s-missing" },
+        { kind: "session", sessionId: "s1" },
+      ],
+      [session("s1")],
+      [],
+      [],
+    );
+    expect(split.sessions.map((s) => s.id)).toEqual(["s1"]);
+    expect(split.sessionPersistIds).toEqual(["s-missing", "s1"]);
+  });
+});

--- a/src/ui/src/components/chat/sessionTabsLogic.ts
+++ b/src/ui/src/components/chat/sessionTabsLogic.ts
@@ -1,0 +1,114 @@
+import type { ChatSession, DiffFileTab, DiffLayer } from "../../types";
+
+// A unified entry in the workspace tab strip. SessionTabs renders sessions,
+// diffs, and files as one ordered list; the user can drag any of them to
+// any position. Persistence is asymmetric: chat sessions persist via
+// `chat_sessions.sort_order`, while file/diff openness is volatile (per the
+// 3A "volatile" decision). After a drop we need to (a) split the new
+// unified order back into per-kind arrays and (b) compute which session
+// `sort_order` values to write to the DB.
+export type UnifiedTabEntry =
+  | { kind: "session"; sessionId: string }
+  | { kind: "diff"; path: string; layer: DiffLayer | null }
+  | { kind: "file"; path: string };
+
+export interface SplitTabOrder {
+  sessions: ChatSession[];
+  diffs: DiffFileTab[];
+  files: string[];
+  /** Session ids in the order they should be persisted via
+   *  `reorder_chat_sessions`. See note on persistence semantics in
+   *  `computeSessionPersistOrder` below. */
+  sessionPersistIds: string[];
+}
+
+/**
+ * Split a reordered unified entry list back into per-kind arrays.
+ *
+ * The unified `entries` array is the post-drop visual order. Lookups from
+ * `currentSessions`, `currentDiffs`, `currentFiles` are needed because the
+ * unified entries only carry ids/paths — we have to reattach the rich
+ * objects (with their existing fields) for the per-kind state slots.
+ */
+export function splitUnifiedTabOrder(
+  entries: readonly UnifiedTabEntry[],
+  currentSessions: readonly ChatSession[],
+  currentDiffs: readonly DiffFileTab[],
+  currentFiles: readonly string[],
+): SplitTabOrder {
+  const sessionsById = new Map(currentSessions.map((s) => [s.id, s]));
+  const diffsByKey = new Map(
+    currentDiffs.map((d) => [`${d.path}\0${d.layer ?? ""}`, d]),
+  );
+  const fileSet = new Set(currentFiles);
+
+  const sessions: ChatSession[] = [];
+  const diffs: DiffFileTab[] = [];
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.kind === "session") {
+      const s = sessionsById.get(entry.sessionId);
+      if (s) sessions.push(s);
+    } else if (entry.kind === "diff") {
+      const d = diffsByKey.get(`${entry.path}\0${entry.layer ?? ""}`);
+      if (d) diffs.push(d);
+    } else if (fileSet.has(entry.path)) {
+      files.push(entry.path);
+    }
+  }
+
+  return {
+    sessions,
+    diffs,
+    files,
+    sessionPersistIds: computeSessionPersistOrder(entries),
+  };
+}
+
+/**
+ * Compute the chat-session id sequence to persist via
+ * `reorder_chat_sessions`. This is the meaningful business decision left to
+ * the human: how should session sort_order relate to a unified strip that
+ * includes non-persistent file/diff tabs?
+ *
+ * Three reasonable interpretations:
+ *
+ * (1) Dense-among-sessions: session sort_orders are 0..N-1 in the order
+ *     sessions appear in the unified strip, ignoring intervening files/
+ *     diffs. On reload (no files/diffs open) sessions appear in exactly
+ *     the relative order the user dragged them into. This is the most
+ *     "WYSIWYG-on-reload" option and matches how IDEs treat pinned vs.
+ *     unpinned tabs as separate persisted lists.
+ *
+ * (2) Unified-index-anchored: each session's sort_order is its position
+ *     in the full unified array (with gaps where files/diffs were). On
+ *     reload sessions appear in the same relative order as (1) — the gaps
+ *     are harmless because ORDER BY only sees session rows. So functionally
+ *     equivalent to (1) but with non-dense values. No real upside; mostly
+ *     here for completeness.
+ *
+ * (3) Frozen: don't write any session order on cross-kind drops; only
+ *     persist session reorders that happen between two session tabs (no
+ *     file/diff tab dragged-through). Most conservative; means dragging a
+ *     file into the middle of sessions can't change session order even if
+ *     the user later closes the file. Probably surprising to users.
+ *
+ * Default: option (1) "dense-among-sessions". Walk the unified order, pick
+ * out session entries in the order they appear, and write that sequence to
+ * `chat_sessions.sort_order`. On reload (no files/diffs persisted) sessions
+ * appear in exactly the relative order the user dragged them into.
+ *
+ * Swap to (3) "frozen" by returning [] here and only writing when a real
+ * session-vs-session move was committed; SessionTabs already skips the
+ * Tauri call when this list is empty.
+ */
+export function computeSessionPersistOrder(
+  entries: readonly UnifiedTabEntry[],
+): string[] {
+  const out: string[] = [];
+  for (const e of entries) {
+    if (e.kind === "session") out.push(e.sessionId);
+  }
+  return out;
+}

--- a/src/ui/src/components/layout/headerAlignment.test.ts
+++ b/src/ui/src/components/layout/headerAlignment.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve from the test file's own URL — `__dirname` is undefined in ESM
+// (`"type": "module"` in package.json), and while vitest happens to shim
+// it today, deriving from `import.meta.url` keeps this test portable
+// against future tooling changes (Copilot review).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Regression test for the layout's two-row top alignment.
 //

--- a/src/ui/src/components/layout/headerAlignment.test.ts
+++ b/src/ui/src/components/layout/headerAlignment.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Regression test for the layout's two-row top alignment.
+//
+// The layout has two horizontal alignment rows that must stay in sync:
+//   Row 1 (workspace-header height): WorkspacePanelHeader on the chat
+//          side, PrStatusBanner on the right side.
+//   Row 2 (tab-bar height): SessionTabs (chat tabs) on the chat side,
+//          and the RightSidebar tab bar — only when a PR banner is above
+//          it (otherwise the right tab bar takes Row 1's role).
+//
+// Both rows are pinned to CSS variables so a future refactor in any one
+// stylesheet doesn't silently desync the columns. This test reads the
+// raw module CSS and asserts the referencing min-heights are present —
+// a tiny smoke check, not a layout-engine test, but enough to fail CI
+// if someone deletes one of these lines without thinking through the
+// alignment consequences. See also the live debug-eval verification in
+// the PR description for actual rendered alignment.
+
+function readCss(relPath: string): string {
+  // From src/ui/src/components/layout/, walk up to src/ui/src/.
+  const root = resolve(__dirname, "..", "..");
+  return readFileSync(resolve(root, relPath), "utf8");
+}
+
+describe("layout header alignment", () => {
+  it("defines --workspace-header-h and --tab-bar-h tokens in theme.css", () => {
+    const theme = readCss("styles/theme.css");
+    expect(theme).toMatch(/--workspace-header-h\s*:\s*\d+px/);
+    expect(theme).toMatch(/--tab-bar-h\s*:\s*\d+px/);
+  });
+
+  it("WorkspacePanelHeader pins to --workspace-header-h", () => {
+    const css = readCss("components/shared/WorkspacePanelHeader.module.css");
+    expect(css).toMatch(/min-height:\s*var\(--workspace-header-h\)/);
+  });
+
+  it("PrStatusBanner pins to --workspace-header-h (matches Row 1)", () => {
+    const css = readCss("components/right-sidebar/PrStatusBanner.module.css");
+    expect(css).toMatch(/min-height:\s*var\(--workspace-header-h\)/);
+    // The legacy fixed `height: 47px` would defeat the min-height; keep
+    // the PR banner free to grow to match the chat header.
+    expect(css).not.toMatch(/^\s*height:\s*47px/m);
+  });
+
+  it("RightSidebar tab bar pins to --workspace-header-h by default", () => {
+    const css = readCss("components/right-sidebar/RightSidebar.module.css");
+    expect(css).toMatch(/min-height:\s*var\(--workspace-header-h\)/);
+  });
+
+  it("RightSidebar tab bar drops to --tab-bar-h when not first child (PR banner above)", () => {
+    const css = readCss("components/right-sidebar/RightSidebar.module.css");
+    // Adjacent-sibling override: when PrStatusBanner renders, the tab bar
+    // becomes the second child and must shrink to Row 2's height so its
+    // bottom border lines up with SessionTabs's bottom border.
+    expect(css).toMatch(
+      /:not\(:first-child\)[^{]*\{[^}]*min-height:\s*var\(--tab-bar-h\)/s,
+    );
+  });
+
+  it("SessionTabs (chat tab strip) pins to --tab-bar-h (Row 2)", () => {
+    const css = readCss("components/chat/SessionTabs.module.css");
+    expect(css).toMatch(/min-height:\s*var\(--tab-bar-h\)/);
+  });
+});

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -3,7 +3,11 @@
   align-items: center;
   gap: 6px;
   padding: 10px 20px;
-  height: 47px;
+  /* Pin to the workspace-header row height so this banner's bottom border
+   * lines up with WorkspacePanelHeader's bottom border on the chat side.
+   * Without it (47px vs 54px), the layout's top horizontal divider goes
+   * jagged the moment a PR appears. */
+  min-height: var(--workspace-header-h);
   box-sizing: border-box;
   flex-shrink: 0;
   background: var(--chat-header-bg);

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -6,8 +6,24 @@
 
 .tabBar {
   display: flex;
+  align-items: stretch;
   border-bottom: 1px solid var(--sidebar-border);
   flex-shrink: 0;
+  /* Match WorkspacePanelHeader height so the bottom-divider line is
+   * continuous from the chat header into the right-sidebar header. Without
+   * this, the right-sidebar tab bar bottoms out at ~32px while the chat
+   * header bottoms out at 54px, leaving a visible misalignment. */
+  min-height: var(--workspace-header-h);
+}
+
+/* When the PR banner is rendered above us (banner is the .panel's first
+ * child, tab bar becomes the second), drop to the second-row height so
+ * our bottom border lands at the same Y as the chat session tab bar's
+ * bottom border. Without this, the right column has a 2× tall header
+ * stack (banner + full-height tabs) while the chat column has a
+ * normal-height header + tab strip. */
+.tabBar:not(:first-child) {
+  min-height: var(--tab-bar-h);
 }
 
 .tab {

--- a/src/ui/src/components/shared/TabDragGhost.module.css
+++ b/src/ui/src/components/shared/TabDragGhost.module.css
@@ -1,0 +1,32 @@
+/* Floating drag-clone visuals shared across tab surfaces. Resting visuals
+ * mirror the surrounding tab; lift shadow + slight rotation read as
+ * "picked up". `pointer-events: none` keeps elementFromPoint reaching the
+ * tab beneath the ghost, which is essential for the drop hit-test. */
+.ghost {
+  position: fixed;
+  z-index: 10003;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 8px;
+  background: var(--sidebar-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  font-size: 12px;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  transform: rotate(1deg);
+  transform-origin: top left;
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}

--- a/src/ui/src/components/shared/TabDragGhost.tsx
+++ b/src/ui/src/components/shared/TabDragGhost.tsx
@@ -1,0 +1,35 @@
+import { createPortal } from "react-dom";
+import { viewportToFixed } from "../../utils/zoom";
+import type { DragGhostState } from "../../hooks/useTabDragReorder";
+import styles from "./TabDragGhost.module.css";
+
+// Floating clone of a tab pinned to the cursor. Generic across surfaces
+// (terminal tabs, workspace tabs, sidebar workspaces) — callers pass in a
+// className to override the resting visuals to match their tab.
+//
+// Why portal + position: fixed: the ghost has to escape every container
+// overflow + transform context (sidebar scrollbox, tab strip overflow, etc.)
+// or it would clip mid-drag. We translate event coords (visual pixels under
+// html zoom) to layout pixels via viewportToFixed so the ghost sits exactly
+// where the cursor is regardless of UI font-scaling.
+
+interface Props {
+  ghost: DragGhostState;
+  className?: string;
+}
+
+export function TabDragGhost({ ghost, className }: Props) {
+  if (typeof document === "undefined") return null;
+  const top = viewportToFixed(0, ghost.cursorY - ghost.offsetY).y;
+  const left = viewportToFixed(ghost.cursorX - ghost.offsetX, 0).x;
+  return createPortal(
+    <div
+      className={`${styles.ghost} ${className ?? ""}`}
+      style={{ left, top, width: ghost.width, height: ghost.height }}
+      aria-hidden
+    >
+      <span className={styles.title}>{ghost.title}</span>
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -3,6 +3,11 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 20px;
+  /* Pin to the shared layout header height so the right-sidebar's tab bar
+   * (which uses the same var) lines up with this header's bottom border.
+   * box-sizing: border-box keeps the 1px bottom border inside the height. */
+  min-height: var(--workspace-header-h);
+  box-sizing: border-box;
   background: var(--chat-header-bg);
   border-bottom: 1px solid var(--divider);
   box-shadow: var(--shadow-sm);

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -345,6 +345,37 @@
   background: var(--accent-primary);
 }
 
+/* Workspace drag-reorder visuals. Mirrors the repo-group reorder + the
+ * terminal/workspace tab reorder: a translucent dragged item, an accent
+ * bar drawn at the top/bottom edge of the hover target showing where the
+ * dropped workspace will land. Pseudo-elements are safe here — wsItem only
+ * uses ::before for the selection bar (left edge), so top/bottom indicators
+ * don't conflict. */
+.wsDragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.wsItem[data-drop-before="true"]::after,
+.wsItem[data-drop-after="true"]::after {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  height: 2px;
+  background: var(--accent-primary);
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+.wsItem[data-drop-before="true"]::after {
+  top: -1px;
+}
+
+.wsItem[data-drop-after="true"]::after {
+  bottom: -1px;
+}
+
 .wsItemLoading {
   opacity: 0.6;
   cursor: default;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -371,12 +371,28 @@ export const Sidebar = memo(function Sidebar() {
     onReorder: (next, draggedId) => {
       const moved = next.find((w) => w.id === draggedId);
       if (!moved) return;
-      // Persist only the moved workspace's repo. Other repos' relative
-      // ordering hasn't changed (cross-group is rejected upstream by
-      // isSameGroup), so we leave them alone.
-      const repoIds = next
+      // Build the persistence sequence from the visible-order ids of the
+      // moved repo, then APPEND any siblings in the same repo that the
+      // current filter (e.g. "Show archived" off) hides. Without those
+      // hidden tail entries, `reorder_workspaces` would leave them at
+      // their stale sort_order — when the user toggles archived workspaces
+      // back on, the archived rows could land mid-sequence with
+      // duplicated/interleaved values (Copilot review of the second push).
+      const visibleRepoIds = next
         .filter((w) => w.repository_id === moved.repository_id)
         .map((w) => w.id);
+      const visibleSet = new Set(visibleRepoIds);
+      const hiddenTailIds = workspaces
+        .filter(
+          (w) =>
+            w.repository_id === moved.repository_id && !visibleSet.has(w.id),
+        )
+        // Stable order for hidden siblings: preserve their existing
+        // sort_order so a later "show archived" toggle keeps them in the
+        // same relative position they were in before the drag.
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .map((w) => w.id);
+      const repoIds = [...visibleRepoIds, ...hiddenTailIds];
       const orderIndex = new Map(repoIds.map((id, i) => [id, i]));
       // Optimistic update: rewrite both the array order AND each
       // workspace's `sort_order` for the moved repo. Reordering the array

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -220,6 +220,39 @@ export const Sidebar = memo(function Sidebar() {
     [workspaces, sidebarShowArchived, sidebarRepoFilter]
   );
 
+  // Workspaces in the order the sidebar actually renders them: each repo
+  // group sorted by `sort_order` (with SCM priority as tiebreaker for legacy
+  // pre-migration rows where every workspace shares sort_order=0). The drag
+  // hook needs this visual sequence so reorderById's "from"/"to" positions
+  // match what the user sees — without it, a second drag in the same repo
+  // would compute against the unsorted DB order and persist the wrong
+  // sequence (Codex review #629, P2).
+  const visuallyOrderedWorkspaces = useMemo(() => {
+    const localRepos = repositories.filter((r) => !r.remote_connection_id);
+    const repoIndex = new Map(localRepos.map((r, i) => [r.id, i]));
+    const out: typeof workspaces = [];
+    for (const repo of localRepos) {
+      const repoWs = filteredWorkspaces
+        .filter((ws) => ws.repository_id === repo.id)
+        .sort((a, b) => {
+          if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
+          return (
+            getScmSortPriority(scmSummary[a.id]) -
+            getScmSortPriority(scmSummary[b.id])
+          );
+        });
+      out.push(...repoWs);
+    }
+    // Also include any workspaces whose repo isn't in `localRepos` (shouldn't
+    // happen because filteredWorkspaces already excludes remote, but defends
+    // against orphaned rows). Append in their existing relative order so the
+    // hook can still hit-test them if rendered.
+    for (const ws of filteredWorkspaces) {
+      if (!repoIndex.has(ws.repository_id) && !out.includes(ws)) out.push(ws);
+    }
+    return out;
+  }, [filteredWorkspaces, repositories, scmSummary]);
+
   const statusBuckets = useMemo(() => {
     const buckets = new Map<StatusBucketKey, typeof workspaces>();
     for (const key of STATUS_BUCKET_ORDER) buckets.set(key, []);
@@ -323,8 +356,13 @@ export const Sidebar = memo(function Sidebar() {
   // targets) and the reorder math; the onReorder callback persists the new
   // per-repo order.
   const workspaceDrag = useTabDragReorder<typeof workspaces[number], string>({
-    items: filteredWorkspaces,
+    items: visuallyOrderedWorkspaces,
     dataAttr: "sidebarWorkspaceId",
+    // Workspaces stack vertically, so the drop midpoint must be Y-axis.
+    // Without this, dragging a workspace toward the bottom of its repo
+    // group can never produce an "after" placement on the last sibling
+    // (the cursor would have to leave the row to cross an X midpoint).
+    orientation: "vertical",
     parseId: (raw) => raw,
     getId: (ws) => ws.id,
     getTitle: (ws) => ws.name,
@@ -338,15 +376,29 @@ export const Sidebar = memo(function Sidebar() {
       const repoIds = next
         .filter((w) => w.repository_id === moved.repository_id)
         .map((w) => w.id);
-      // Optimistic local update: assign sort_order = position-within-repo
-      // for the moved repo's workspaces so the sort comparator picks up
-      // the new order on the next render. Other repos pass through.
       const orderIndex = new Map(repoIds.map((id, i) => [id, i]));
-      const optimistic = workspaces.map((w) =>
-        w.repository_id === moved.repository_id
-          ? { ...w, sort_order: orderIndex.get(w.id) ?? w.sort_order }
-          : w,
-      );
+      // Optimistic update: rewrite both the array order AND each
+      // workspace's `sort_order` for the moved repo. Reordering the array
+      // (not just the field) ensures a second drag in this repo runs the
+      // hook against the post-drop sequence, not the stale pre-drag one
+      // (Codex P2). Workspaces in other repos pass through untouched.
+      const movedRepoIdSet = new Set(repoIds);
+      const movedRepoUpdated = repoIds
+        .map((id, i) => {
+          const ws = workspaces.find((w) => w.id === id);
+          return ws ? { ...ws, sort_order: i } : null;
+        })
+        .filter((w): w is (typeof workspaces)[number] => w !== null);
+      const replacements = movedRepoUpdated[Symbol.iterator]();
+      const optimistic = workspaces.map((w) => {
+        if (movedRepoIdSet.has(w.id)) {
+          const r = replacements.next();
+          return r.done
+            ? { ...w, sort_order: orderIndex.get(w.id) ?? w.sort_order }
+            : r.value;
+        }
+        return w;
+      });
       setWorkspaces(optimistic);
       void reorderWorkspaces(moved.repository_id, repoIds).catch((err) =>
         console.error("[Sidebar] Failed to persist workspace order:", err),

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -17,8 +17,9 @@ import {
   sendRemoteCommand,
   pairWithServer,
   startLocalServer,
+  openUrl,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown, CircleHelp } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { UpdateBanner } from "../layout/UpdateBanner";
 import { getScmSortPriority } from "../../utils/scmSortPriority";
@@ -1044,6 +1045,20 @@ export const Sidebar = memo(function Sidebar() {
           <Globe size={16} />
         </button>
         <ShareButton openModal={openModal} />
+        <button
+          className={styles.footerBtn}
+          onClick={() => {
+            // Cross-platform docs entry. The native Help menu (macOS only,
+            // wired in src-tauri/src/main.rs) targets the same URL — use
+            // the docs root, not a deeper page, so the link survives any
+            // doc-site reorganization.
+            void openUrl("https://utensils.io/claudette/");
+          }}
+          title={t("help_open_docs")}
+          aria-label={t("help_open_docs")}
+        >
+          <CircleHelp size={16} />
+        </button>
         <button
           className={styles.footerBtn}
           onClick={() => openSettings()}

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -226,7 +226,7 @@ export const Sidebar = memo(function Sidebar() {
   // hook needs this visual sequence so reorderById's "from"/"to" positions
   // match what the user sees — without it, a second drag in the same repo
   // would compute against the unsorted DB order and persist the wrong
-  // sequence (Codex review #629, P2).
+  // sequence (P2 finding from the Codex peer review on this branch).
   const visuallyOrderedWorkspaces = useMemo(() => {
     const localRepos = repositories.filter((r) => !r.remote_connection_id);
     const repoIndex = new Map(localRepos.map((r, i) => [r.id, i]));

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -22,6 +22,9 @@ import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, C
 import { RepoIcon } from "../shared/RepoIcon";
 import { UpdateBanner } from "../layout/UpdateBanner";
 import { getScmSortPriority } from "../../utils/scmSortPriority";
+import { useTabDragReorder } from "../../hooks/useTabDragReorder";
+import { TabDragGhost } from "../shared/TabDragGhost";
+import { reorderWorkspaces } from "../../services/tauri";
 import styles from "./Sidebar.module.css";
 
 type StatusBucketKey = "in-progress" | "in-review" | "draft" | "merged" | "closed" | "archived";
@@ -57,6 +60,7 @@ export const Sidebar = memo(function Sidebar() {
   const sessionsByWorkspace = useAppStore((s) => s.sessionsByWorkspace);
   const scmSummary = useAppStore((s) => s.scmSummary);
   const setRepositories = useAppStore((s) => s.setRepositories);
+  const setWorkspaces = useAppStore((s) => s.setWorkspaces);
   const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
   const isMac = navigator.platform.startsWith("Mac");
   const { t } = useTranslation("sidebar");
@@ -307,7 +311,60 @@ export const Sidebar = memo(function Sidebar() {
     setRenamingWsId(null);
   }, [renameValue, workspaces, updateWorkspace, addToast, t]);
 
-  const renderWorkspace = (ws: typeof workspaces[number]) => {
+  // Drag-reorder for workspaces inside a repo group. Disabled in "by status"
+  // grouping mode (option 2A — within-repo only): when the sidebar is grouped
+  // by status, sibling workspaces in a status bucket can come from different
+  // repos, so the within-repo invariant doesn't apply and we simply skip the
+  // pointer handlers there.
+  //
+  // Items are the full filtered workspace list; isSameGroup enforces that a
+  // dragged workspace can only land next to a sibling in the same repo. The
+  // hook handles the visual feedback (drop indicator suppressed for invalid
+  // targets) and the reorder math; the onReorder callback persists the new
+  // per-repo order.
+  const workspaceDrag = useTabDragReorder<typeof workspaces[number], string>({
+    items: filteredWorkspaces,
+    dataAttr: "sidebarWorkspaceId",
+    parseId: (raw) => raw,
+    getId: (ws) => ws.id,
+    getTitle: (ws) => ws.name,
+    isSameGroup: (a, b) => a.repository_id === b.repository_id,
+    onReorder: (next, draggedId) => {
+      const moved = next.find((w) => w.id === draggedId);
+      if (!moved) return;
+      // Persist only the moved workspace's repo. Other repos' relative
+      // ordering hasn't changed (cross-group is rejected upstream by
+      // isSameGroup), so we leave them alone.
+      const repoIds = next
+        .filter((w) => w.repository_id === moved.repository_id)
+        .map((w) => w.id);
+      // Optimistic local update: assign sort_order = position-within-repo
+      // for the moved repo's workspaces so the sort comparator picks up
+      // the new order on the next render. Other repos pass through.
+      const orderIndex = new Map(repoIds.map((id, i) => [id, i]));
+      const optimistic = workspaces.map((w) =>
+        w.repository_id === moved.repository_id
+          ? { ...w, sort_order: orderIndex.get(w.id) ?? w.sort_order }
+          : w,
+      );
+      setWorkspaces(optimistic);
+      void reorderWorkspaces(moved.repository_id, repoIds).catch((err) =>
+        console.error("[Sidebar] Failed to persist workspace order:", err),
+      );
+    },
+  });
+
+  const renderWorkspace = (ws: typeof workspaces[number], dragEnabled: boolean) => {
+    const dragHandlers = dragEnabled ? workspaceDrag.getTabHandlers(ws) : null;
+    const isDragging = dragEnabled && workspaceDrag.draggingId === ws.id;
+    const dropBefore =
+      dragEnabled &&
+      workspaceDrag.dropTarget?.id === ws.id &&
+      workspaceDrag.dropTarget.placement === "before";
+    const dropAfter =
+      dragEnabled &&
+      workspaceDrag.dropTarget?.id === ws.id &&
+      workspaceDrag.dropTarget.placement === "after";
     const wsSessions = sessionsByWorkspace[ws.id] ?? [];
     const hasQuestion = wsSessions.some((s) => agentQuestions[s.id]);
     const hasPlan = wsSessions.some((s) => planApprovals[s.id]);
@@ -319,10 +376,18 @@ export const Sidebar = memo(function Sidebar() {
     return (
       <div
         key={ws.id}
-        className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""} ${badge ? styles.wsUnread : ""}`}
+        data-sidebar-workspace-id={dragEnabled ? ws.id : undefined}
+        data-drop-before={dropBefore || undefined}
+        data-drop-after={dropAfter || undefined}
+        className={`${styles.wsItem} ${selectedWorkspaceId === ws.id ? styles.wsSelected : ""} ${badge ? styles.wsUnread : ""} ${isDragging ? styles.wsDragging : ""}`}
         onClick={() => {
+          if (dragEnabled && workspaceDrag.justEnded()) return;
           selectWorkspace(ws.id);
         }}
+        onPointerDown={dragHandlers?.onPointerDown}
+        onPointerMove={dragHandlers?.onPointerMove}
+        onPointerUp={dragHandlers?.onPointerUp}
+        onPointerCancel={dragHandlers?.onPointerCancel}
       >
         {badge === "done" ? (
           <span className={styles.badgeDone} title={t("status_badge_completed_title")} aria-label={t("status_badge_completed_aria")} role="img">
@@ -623,7 +688,7 @@ export const Sidebar = memo(function Sidebar() {
                   <span className={styles.statusGroupCount}>{bucketWorkspaces.length}</span>
                 </span>
               </div>
-              {!collapsed && bucketWorkspaces.map(renderWorkspace)}
+              {!collapsed && bucketWorkspaces.map((ws) => renderWorkspace(ws, false))}
             </div>
           );
         })}
@@ -697,9 +762,16 @@ export const Sidebar = memo(function Sidebar() {
           .filter((r) => sidebarRepoFilter === "all" || r.id === sidebarRepoFilter)
           .map((repo, repoIdx) => {
           const collapsed = repoCollapsed[repo.id];
+          // Sort by user-defined order (sort_order) as authoritative; fall
+          // back to SCM priority only as a tiebreaker so workspaces seeded
+          // with the same sort_order value (legacy DBs pre-migration) keep
+          // their previous "by PR state" arrangement.
           const repoWorkspaces = filteredWorkspaces
             .filter((ws) => ws.repository_id === repo.id)
-            .sort((a, b) => getScmSortPriority(scmSummary[a.id]) - getScmSortPriority(scmSummary[b.id]));
+            .sort((a, b) => {
+              if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
+              return getScmSortPriority(scmSummary[a.id]) - getScmSortPriority(scmSummary[b.id]);
+            });
           const runningCount = repoWorkspaces.filter(
             (ws) => isAgentBusy(ws.agent_status)
           ).length;
@@ -878,7 +950,7 @@ export const Sidebar = memo(function Sidebar() {
                 )}
               </div>
 
-              {!collapsed && repoWorkspaces.map(renderWorkspace)}
+              {!collapsed && repoWorkspaces.map((ws) => renderWorkspace(ws, true))}
               {/* Show loading workspace while creating */}
               {!collapsed && creatingWorkspace && creatingWorkspace.repoId === repo.id && (
                 <div className={`${styles.wsItem} ${styles.wsItemLoading}`}>
@@ -928,6 +1000,9 @@ export const Sidebar = memo(function Sidebar() {
           <Settings size={16} />
         </button>
       </div>
+      {workspaceDrag.dragGhost && workspaceDrag.draggingId !== null && (
+        <TabDragGhost ghost={workspaceDrag.dragGhost} />
+      )}
     </div>
   );
 });

--- a/src/ui/src/hooks/useTabDragReorder.ts
+++ b/src/ui/src/hooks/useTabDragReorder.ts
@@ -1,0 +1,298 @@
+import {
+  useState,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import {
+  reorderById,
+  tabDropPlacement,
+  type TabDropPlacement,
+} from "../utils/dragReorder";
+
+// Pointer-event drag-reorder primitive shared by all tab-style strips
+// (terminal tabs, chat/file/diff workspace tabs, sidebar workspaces). The
+// caller wires returned handlers onto each tab element + tags them with a
+// `data-{dataAttr}-id` attribute so the hook can hit-test via
+// elementFromPoint without a callback per tab. See `dragReorder.ts` for the
+// pure reorder math and the WebKit-zoom rationale.
+
+export interface DragGhostState {
+  cursorX: number;
+  cursorY: number;
+  offsetX: number;
+  offsetY: number;
+  width: number;
+  height: number;
+  title: string;
+}
+
+export interface DropTarget<Id> {
+  id: Id;
+  placement: TabDropPlacement;
+}
+
+interface UseTabDragReorderOptions<T, Id> {
+  /**
+   * The HTML data-* attribute (without the `data-` prefix) used to mark
+   * draggable tabs in the DOM. e.g. `"terminalTabId"` for terminal tabs;
+   * elements should have `data-terminal-tab-id="<id>"`. Used by the hook's
+   * pointer-move handler to identify the tab under the cursor.
+   */
+  dataAttr: string;
+
+  /**
+   * Parse the raw data-* string back into an Id. (DOM data-* is always a
+   * string; numeric ids need `Number(...)`, string ids pass through.)
+   */
+  parseId: (raw: string) => Id;
+
+  /** Extract the unique id from an item. */
+  getId: (item: T) => Id;
+
+  /** Display title for the floating drag ghost. */
+  getTitle: (item: T) => string;
+
+  /**
+   * Optional same-group predicate. Returns true if `dragged` and `target`
+   * are valid neighbours (same repo, same kind, etc.). When it returns
+   * false, the drop indicator is suppressed and the drop is rejected on
+   * release. Defaults to "always allowed".
+   */
+  isSameGroup?: (dragged: T, target: T) => boolean;
+
+  /**
+   * Called on a successful drop. Receives the reordered list. The caller
+   * applies it to local state and persists via the appropriate Tauri
+   * command. If null is returned by `reorderById` the callback is NOT
+   * invoked.
+   */
+  onReorder: (next: T[], draggedId: Id) => void;
+
+  /**
+   * Pixel hysteresis squared (default 16, i.e. 4px). Movement below this
+   * is treated as a click — tab selection still works.
+   */
+  thresholdSquared?: number;
+
+  /** Items currently rendered, in display order. */
+  items: readonly T[];
+}
+
+export interface UseTabDragReorderResult<T, Id> {
+  /** Spread these onto each draggable tab element. */
+  getTabHandlers: (item: T) => {
+    onPointerDown: (ev: ReactPointerEvent<HTMLElement>) => void;
+    onPointerMove: (ev: ReactPointerEvent<HTMLElement>) => void;
+    onPointerUp: (ev: ReactPointerEvent<HTMLElement>) => void;
+    onPointerCancel: (ev: ReactPointerEvent<HTMLElement>) => void;
+  };
+  /** Id of the tab currently being dragged, or null. */
+  draggingId: Id | null;
+  /** The hovered drop target (id + placement), or null. */
+  dropTarget: DropTarget<Id> | null;
+  /** Geometry for rendering a floating ghost; null when not dragging. */
+  dragGhost: DragGhostState | null;
+  /**
+   * True for ~one frame after a drag ends, to suppress the synthetic
+   * click that follows pointerup. Tab onClick handlers should early-return
+   * when this is true.
+   */
+  justEnded: () => boolean;
+}
+
+export function useTabDragReorder<T, Id>(
+  opts: UseTabDragReorderOptions<T, Id>,
+): UseTabDragReorderResult<T, Id> {
+  const {
+    dataAttr,
+    parseId,
+    getId,
+    getTitle,
+    isSameGroup,
+    onReorder,
+    thresholdSquared = 16,
+    items,
+  } = opts;
+
+  // dragRef + justEndedRef are pure mutable scratch state — they're only
+  // written from inside event handlers (never during render), so they don't
+  // run afoul of the React Compiler's "no-mutate-during-render" lint.
+  const dragRef = useRef<{
+    id: Id;
+    pointerId: number;
+    startX: number;
+    startY: number;
+    offsetX: number;
+    offsetY: number;
+    width: number;
+    height: number;
+    title: string;
+    active: boolean;
+  } | null>(null);
+  const justEndedRef = useRef(false);
+
+  const [draggingId, setDraggingId] = useState<Id | null>(null);
+  const [dropTarget, setDropTarget] = useState<DropTarget<Id> | null>(null);
+  const [dragGhost, setDragGhost] = useState<DragGhostState | null>(null);
+
+  const dataKebab = camelToKebab(dataAttr);
+  const dataSelector = `[data-${dataKebab}]`;
+
+  // Handlers close over the latest items / isSameGroup / onReorder via
+  // their lexical scope on each render — there's no memoization here.
+  // Re-binding pointer handlers per render is cheap (closure allocation),
+  // and importantly avoids stale closures when the items list changes
+  // between drags.
+  const finishDrag = (cancelled: boolean, hover: DropTarget<Id> | null) => {
+    const drag = dragRef.current;
+    dragRef.current = null;
+    setDraggingId(null);
+    setDropTarget(null);
+    setDragGhost(null);
+    if (!drag) return;
+    if (!drag.active) return; // pure click — let onClick handle activation
+    justEndedRef.current = true;
+    queueMicrotask(() => {
+      justEndedRef.current = false;
+    });
+    if (cancelled || !hover) return;
+    if (Object.is(hover.id, drag.id)) return;
+    const next = reorderById(items, drag.id, hover.id, hover.placement, getId);
+    if (!next) return;
+    onReorder(next, drag.id);
+  };
+
+  const getTabHandlers = (item: T) => {
+    const itemId = getId(item);
+    return {
+      onPointerDown: (ev: ReactPointerEvent<HTMLElement>) => {
+        if (ev.button !== 0) return;
+        // Don't initiate drag from buttons/inputs inside the tab.
+        const t = ev.target as HTMLElement;
+        if (t.closest("button, a, input, select, textarea")) return;
+        // Stop the browser from starting a text selection from the
+        // pointer-down before our setPointerCapture takes over. Belt-and-
+        // braces with the tab CSS's `user-select: none` — necessary on
+        // WebKit (macOS) where descendant `<span>`s can still resolve to
+        // `-webkit-user-select: text` if any cascading rule says so.
+        ev.preventDefault();
+        const rect = ev.currentTarget.getBoundingClientRect();
+        dragRef.current = {
+          id: itemId,
+          pointerId: ev.pointerId,
+          startX: ev.clientX,
+          startY: ev.clientY,
+          offsetX: ev.clientX - rect.left,
+          offsetY: ev.clientY - rect.top,
+          width: rect.width,
+          height: rect.height,
+          title: getTitle(item),
+          active: false,
+        };
+        try {
+          ev.currentTarget.setPointerCapture(ev.pointerId);
+        } catch {
+          // Already released — abandon.
+          dragRef.current = null;
+        }
+      },
+      onPointerMove: (ev: ReactPointerEvent<HTMLElement>) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== ev.pointerId) return;
+        if (!drag.active) {
+          const dx = ev.clientX - drag.startX;
+          const dy = ev.clientY - drag.startY;
+          if (dx * dx + dy * dy < thresholdSquared) return;
+          drag.active = true;
+          setDraggingId(drag.id);
+          window.getSelection()?.removeAllRanges();
+        }
+        // Once the drag is active, every pointer-move suppresses the
+        // browser's default scroll-on-drag and any lingering text-selection
+        // gesture (mirrors the existing repo-drag in Sidebar.tsx).
+        ev.preventDefault();
+        setDragGhost({
+          cursorX: ev.clientX,
+          cursorY: ev.clientY,
+          offsetX: drag.offsetX,
+          offsetY: drag.offsetY,
+          width: drag.width,
+          height: drag.height,
+          title: drag.title,
+        });
+
+        const overEl = document.elementFromPoint(ev.clientX, ev.clientY);
+        const tabEl = overEl?.closest<HTMLElement>(dataSelector) ?? null;
+        const raw = tabEl?.getAttribute(`data-${dataKebab}`);
+        if (!tabEl || raw == null) {
+          setDropTarget((prev) => (prev === null ? prev : null));
+          return;
+        }
+        const overId = parseId(raw);
+        if (Object.is(overId, drag.id)) {
+          setDropTarget((prev) => (prev === null ? prev : null));
+          return;
+        }
+        // Cross-group rejection: when the caller declares a same-group
+        // predicate and the dragged/target pair fails it, suppress the
+        // drop indicator. The drag still tracks the cursor (the ghost
+        // keeps following the pointer); we just refuse to commit.
+        if (isSameGroup) {
+          const draggedItem = items.find((i) =>
+            Object.is(getId(i), drag.id),
+          );
+          const targetItem = items.find((i) => Object.is(getId(i), overId));
+          if (
+            !draggedItem ||
+            !targetItem ||
+            !isSameGroup(draggedItem, targetItem)
+          ) {
+            setDropTarget((prev) => (prev === null ? prev : null));
+            return;
+          }
+        }
+        const r = tabEl.getBoundingClientRect();
+        const placement = tabDropPlacement(ev.clientX, r.left, r.width);
+        setDropTarget((prev) =>
+          prev &&
+          Object.is(prev.id, overId) &&
+          prev.placement === placement
+            ? prev
+            : { id: overId, placement },
+        );
+      },
+      onPointerUp: (ev: ReactPointerEvent<HTMLElement>) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== ev.pointerId) return;
+        try {
+          ev.currentTarget.releasePointerCapture(ev.pointerId);
+        } catch {
+          // Already released.
+        }
+        finishDrag(false, dropTarget);
+      },
+      onPointerCancel: (ev: ReactPointerEvent<HTMLElement>) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== ev.pointerId) return;
+        try {
+          ev.currentTarget.releasePointerCapture(ev.pointerId);
+        } catch {
+          // Already released.
+        }
+        finishDrag(true, dropTarget);
+      },
+    };
+  };
+
+  return {
+    getTabHandlers,
+    draggingId,
+    dropTarget,
+    dragGhost,
+    justEnded: () => justEndedRef.current,
+  };
+}
+
+function camelToKebab(s: string): string {
+  return s.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}

--- a/src/ui/src/hooks/useTabDragReorder.ts
+++ b/src/ui/src/hooks/useTabDragReorder.ts
@@ -6,6 +6,7 @@ import {
 import {
   reorderById,
   tabDropPlacement,
+  type DragOrientation,
   type TabDropPlacement,
 } from "../utils/dragReorder";
 
@@ -74,6 +75,15 @@ interface UseTabDragReorderOptions<T, Id> {
    */
   thresholdSquared?: number;
 
+  /**
+   * Axis along which items are arranged. "horizontal" (default) compares
+   * cursor x against tab left/width — correct for tab strips. "vertical"
+   * compares cursor y against tab top/height — correct for stacked lists
+   * like the sidebar workspace list, where the last item can only be
+   * dropped "after" by hovering its lower half (not its right half).
+   */
+  orientation?: DragOrientation;
+
   /** Items currently rendered, in display order. */
   items: readonly T[];
 }
@@ -111,6 +121,7 @@ export function useTabDragReorder<T, Id>(
     isSameGroup,
     onReorder,
     thresholdSquared = 16,
+    orientation = "horizontal",
     items,
   } = opts;
 
@@ -252,7 +263,10 @@ export function useTabDragReorder<T, Id>(
           }
         }
         const r = tabEl.getBoundingClientRect();
-        const placement = tabDropPlacement(ev.clientX, r.left, r.width);
+        const placement =
+          orientation === "vertical"
+            ? tabDropPlacement(ev.clientY, r.top, r.height)
+            : tabDropPlacement(ev.clientX, r.left, r.width);
         setDropTarget((prev) =>
           prev &&
           Object.is(prev.id, overId) &&

--- a/src/ui/src/hooks/useTabDragReorder.ts
+++ b/src/ui/src/hooks/useTabDragReorder.ts
@@ -163,9 +163,20 @@ export function useTabDragReorder<T, Id>(
     if (!drag) return;
     if (!drag.active) return; // pure click — let onClick handle activation
     justEndedRef.current = true;
-    queueMicrotask(() => {
+    // Clear AFTER the synthetic click that follows pointerup. Microtasks
+    // can drain before the browser dispatches the click on macOS WebKit
+    // (pointerup → microtask flush → click), which would re-activate the
+    // dragged tab. requestAnimationFrame fires on the NEXT paint, well
+    // after the click has been delivered, matching the rAF pattern the
+    // existing repo-group drag in Sidebar.tsx uses (Codex P2).
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => {
+        justEndedRef.current = false;
+      });
+    } else {
+      // node/test fallback — no synthetic click to suppress here.
       justEndedRef.current = false;
-    });
+    }
     if (cancelled || !hover) return;
     if (Object.is(hover.id, drag.id)) return;
     const next = reorderById(items, drag.id, hover.id, hover.placement, getId);

--- a/src/ui/src/hooks/useViewTogglePersistence.ts
+++ b/src/ui/src/hooks/useViewTogglePersistence.ts
@@ -1,0 +1,190 @@
+import { useEffect, useRef } from "react";
+import { useAppStore } from "../stores/useAppStore";
+import { getAppSetting, setAppSetting } from "../services/tauri";
+
+// Persist sidebar / panel visibility + sizes + a couple of related view
+// preferences across app restarts. State stays in Zustand (where the rest
+// of the app reads it); this hook just bridges to the `app_settings` table
+// on hydrate and on subsequent changes.
+//
+// All keys live under the `view:` namespace so they don't collide with
+// the existing flat keys (`theme_mode`, `terminal_font_size`, etc.) and
+// so a future cleanup can list+wipe them via list_app_settings_with_prefix.
+
+const KEYS = {
+  sidebarVisible: "view:sidebar_visible",
+  rightSidebarVisible: "view:right_sidebar_visible",
+  terminalPanelVisible: "view:terminal_panel_visible",
+  sidebarWidth: "view:sidebar_width",
+  rightSidebarWidth: "view:right_sidebar_width",
+  terminalHeight: "view:terminal_height",
+  rightSidebarTab: "view:right_sidebar_tab",
+  sidebarGroupBy: "view:sidebar_group_by",
+  sidebarShowArchived: "view:sidebar_show_archived",
+} as const;
+
+const RIGHT_SIDEBAR_TABS = ["files", "changes", "tasks"] as const;
+type RightSidebarTab = (typeof RIGHT_SIDEBAR_TABS)[number];
+const SIDEBAR_GROUP_BYS = ["status", "repo"] as const;
+type SidebarGroupBy = (typeof SIDEBAR_GROUP_BYS)[number];
+
+function parseBool(raw: string | null): boolean | null {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return null;
+}
+
+function parseClampedInt(
+  raw: string | null,
+  min: number,
+  max: number,
+): number | null {
+  if (raw == null) return null;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min || n > max) return null;
+  return n;
+}
+
+export function useViewTogglePersistence() {
+  // Selectors are split per-key so a change to one value only re-runs its
+  // own write effect, not all of them.
+  const sidebarVisible = useAppStore((s) => s.sidebarVisible);
+  const rightSidebarVisible = useAppStore((s) => s.rightSidebarVisible);
+  const terminalPanelVisible = useAppStore((s) => s.terminalPanelVisible);
+  const sidebarWidth = useAppStore((s) => s.sidebarWidth);
+  const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth);
+  const terminalHeight = useAppStore((s) => s.terminalHeight);
+  const rightSidebarTab = useAppStore((s) => s.rightSidebarTab);
+  const sidebarGroupBy = useAppStore((s) => s.sidebarGroupBy);
+  const sidebarShowArchived = useAppStore((s) => s.sidebarShowArchived);
+
+  // Track which keys have been hydrated. We only start writing back to
+  // app_settings AFTER the corresponding hydration read completes, so the
+  // first render's default values don't overwrite the user's saved state.
+  const hydratedRef = useRef<Set<string>>(new Set());
+
+  // ---- Hydrate on mount ----
+  useEffect(() => {
+    let cancelled = false;
+    const store = useAppStore;
+    void (async () => {
+      try {
+        const [
+          sbVis,
+          rsbVis,
+          termVis,
+          sbW,
+          rsbW,
+          termH,
+          rsbTab,
+          sbGroup,
+          sbArch,
+        ] = await Promise.all([
+          getAppSetting(KEYS.sidebarVisible),
+          getAppSetting(KEYS.rightSidebarVisible),
+          getAppSetting(KEYS.terminalPanelVisible),
+          getAppSetting(KEYS.sidebarWidth),
+          getAppSetting(KEYS.rightSidebarWidth),
+          getAppSetting(KEYS.terminalHeight),
+          getAppSetting(KEYS.rightSidebarTab),
+          getAppSetting(KEYS.sidebarGroupBy),
+          getAppSetting(KEYS.sidebarShowArchived),
+        ]);
+        if (cancelled) return;
+        // Apply each value if parseable. Direct setState (not setter
+        // actions) so we don't fire any side-effects bound to the
+        // setters; the actions are pure setters anyway, but bypassing
+        // them keeps this hook's boundary tighter.
+        const updates: Partial<ReturnType<typeof store.getState>> = {};
+        const sbVisB = parseBool(sbVis);
+        if (sbVisB !== null) updates.sidebarVisible = sbVisB;
+        const rsbVisB = parseBool(rsbVis);
+        if (rsbVisB !== null) updates.rightSidebarVisible = rsbVisB;
+        const termVisB = parseBool(termVis);
+        if (termVisB !== null) updates.terminalPanelVisible = termVisB;
+        // Width/height clamps mirror the ResizeHandle min/max in
+        // AppLayout — the persisted value should never let the user start
+        // with an unrecoverable layout.
+        const sbWN = parseClampedInt(sbW, 150, 600);
+        if (sbWN !== null) updates.sidebarWidth = sbWN;
+        const rsbWN = parseClampedInt(rsbW, 150, 600);
+        if (rsbWN !== null) updates.rightSidebarWidth = rsbWN;
+        const termHN = parseClampedInt(termH, 100, 800);
+        if (termHN !== null) updates.terminalHeight = termHN;
+        if (
+          rsbTab &&
+          (RIGHT_SIDEBAR_TABS as readonly string[]).includes(rsbTab)
+        ) {
+          updates.rightSidebarTab = rsbTab as RightSidebarTab;
+        }
+        if (
+          sbGroup &&
+          (SIDEBAR_GROUP_BYS as readonly string[]).includes(sbGroup)
+        ) {
+          updates.sidebarGroupBy = sbGroup as SidebarGroupBy;
+        }
+        const sbArchB = parseBool(sbArch);
+        if (sbArchB !== null) updates.sidebarShowArchived = sbArchB;
+        if (Object.keys(updates).length > 0) {
+          store.setState(updates);
+        }
+      } catch (err) {
+        console.error("[viewToggle] Failed to hydrate view state:", err);
+      } finally {
+        // Mark ALL keys hydrated even on partial failure so the write-back
+        // effect can take over from here. The user's interactive changes
+        // are more important than recovering a maybe-broken DB read.
+        if (!cancelled) {
+          for (const k of Object.values(KEYS)) hydratedRef.current.add(k);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ---- Write back on change (post-hydration) ----
+  // One effect per key; the dep array is just that key's value. The
+  // hydration guard prevents the initial render from overwriting a saved
+  // value with the slice's default.
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.sidebarVisible)) return;
+    void setAppSetting(KEYS.sidebarVisible, String(sidebarVisible));
+  }, [sidebarVisible]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.rightSidebarVisible)) return;
+    void setAppSetting(KEYS.rightSidebarVisible, String(rightSidebarVisible));
+  }, [rightSidebarVisible]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.terminalPanelVisible)) return;
+    void setAppSetting(
+      KEYS.terminalPanelVisible,
+      String(terminalPanelVisible),
+    );
+  }, [terminalPanelVisible]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.sidebarWidth)) return;
+    void setAppSetting(KEYS.sidebarWidth, String(sidebarWidth));
+  }, [sidebarWidth]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.rightSidebarWidth)) return;
+    void setAppSetting(KEYS.rightSidebarWidth, String(rightSidebarWidth));
+  }, [rightSidebarWidth]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.terminalHeight)) return;
+    void setAppSetting(KEYS.terminalHeight, String(terminalHeight));
+  }, [terminalHeight]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.rightSidebarTab)) return;
+    void setAppSetting(KEYS.rightSidebarTab, rightSidebarTab);
+  }, [rightSidebarTab]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.sidebarGroupBy)) return;
+    void setAppSetting(KEYS.sidebarGroupBy, sidebarGroupBy);
+  }, [sidebarGroupBy]);
+  useEffect(() => {
+    if (!hydratedRef.current.has(KEYS.sidebarShowArchived)) return;
+    void setAppSetting(KEYS.sidebarShowArchived, String(sidebarShowArchived));
+  }, [sidebarShowArchived]);
+}

--- a/src/ui/src/hotkeys/actions.ts
+++ b/src/ui/src/hotkeys/actions.ts
@@ -298,6 +298,21 @@ export const HOTKEY_ACTIONS = [
     suppressUnderOverlay: true,
   },
   {
+    // Skip the queue: while the agent is running, send the typed message
+    // immediately as a steer (mid-turn injection) instead of queuing it
+    // for after the current turn finishes. Defaults to Cmd/Ctrl+Enter so
+    // a regular Enter still queues — matches the muscle-memory of "send
+    // now" in editors and ChatGPT's web UI.
+    id: "chat.steer-immediate",
+    scope: "global",
+    category: "keyboard_category_chat",
+    description: "keyboard_action_chat_steer_immediate",
+    defaultBinding: allPlatforms("mod+enter"),
+    match: "key",
+    rebindable: true,
+    suppressUnderOverlay: true,
+  },
+  {
     id: "voice.toggle",
     scope: "global",
     category: "keyboard_category_voice",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -158,6 +158,7 @@
   "keyboard_category_terminal": "Terminal",
   "keyboard_category_editor": "Editor",
   "keyboard_category_voice": "Voice",
+  "keyboard_category_chat": "Chat",
   "keyboard_press_key": "Press keys…",
   "keyboard_cancel": "Cancel",
   "keyboard_rebind": "Rebind",
@@ -206,6 +207,7 @@
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
+  "keyboard_action_chat_steer_immediate": "Send now (skip queue / steer mid-turn)",
 
   "git_title": "Git",
   "git_branch_prefix": "Branch name prefix",

--- a/src/ui/src/locales/en/sidebar.json
+++ b/src/ui/src/locales/en/sidebar.json
@@ -20,6 +20,7 @@
   "status_archived": "Archived",
   "new_workspace": "New workspace",
   "settings": "Settings",
+  "help_open_docs": "Open Claudette documentation",
   "relink": "Re-link",
   "remove": "Remove",
   "add_repository": "Add repository",

--- a/src/ui/src/main.tsx
+++ b/src/ui/src/main.tsx
@@ -1,3 +1,16 @@
+// Cross-app webview hijack guard runs as an inline <script> in index.html
+// BEFORE any module loads — ES imports hoist over top-level statements, so
+// putting the check here would let i18n + grammar bootstrap run first
+// against a possibly-foreign DOM. The inline check is the source of truth;
+// the bootIdentityGuard module is exported only for tests.
+//
+// If the inline guard rendered an error, `window.__claudetteHijackBlocked`
+// is set; we abort early so no further side effects (state, network calls)
+// touch the foreign bundle's environment.
+if ((window as unknown as { __claudetteHijackBlocked?: boolean }).__claudetteHijackBlocked) {
+  throw new Error("Claudette hijack guard refused to mount React.");
+}
+
 import "./i18n";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -154,6 +154,18 @@ export function renameWorkspace(id: string, newName: string): Promise<void> {
   return invoke("rename_workspace", { id, newName });
 }
 
+/**
+ * Reassign per-repository workspace sort_order to match the supplied id
+ * sequence. Backend ignores ids that don't belong to `repositoryId`, so a
+ * client bug can't move workspaces across repos.
+ */
+export function reorderWorkspaces(
+  repositoryId: string,
+  workspaceIds: string[],
+): Promise<void> {
+  return invoke("reorder_workspaces", { repositoryId, workspaceIds });
+}
+
 export function deleteWorkspace(id: string): Promise<void> {
   return invoke("delete_workspace", { id });
 }
@@ -683,6 +695,18 @@ export function renameChatSession(
   name: string,
 ): Promise<void> {
   return invoke("rename_chat_session", { sessionId, name });
+}
+
+/**
+ * Reassign chat-session sort_order to match the supplied id sequence.
+ * Used by the unified workspace-tab drag-reorder; only sessions persist —
+ * file/diff tabs reorder in volatile frontend state.
+ */
+export function reorderChatSessions(
+  workspaceId: string,
+  sessionIds: string[],
+): Promise<void> {
+  return invoke("reorder_chat_sessions", { workspaceId, sessionIds });
 }
 
 /**

--- a/src/ui/src/stores/slices/diffSlice.ts
+++ b/src/ui/src/stores/slices/diffSlice.ts
@@ -62,6 +62,10 @@ export interface DiffSlice {
   setDiffPreviewLoading: (loading: boolean) => void;
   setDiffPreviewError: (error: string | null) => void;
   clearDiff: () => void;
+  // Replace the entire ordered list of diff tabs for a workspace. Used by
+  // drag-reorder (volatile — not persisted across restarts; see SessionTabs
+  // unified reorder).
+  setDiffTabsForWorkspace: (workspaceId: string, tabs: DiffFileTab[]) => void;
   // Open a diff tab for the given file (deduped by path+layer) and make it
   // the active view. The previously-selected chat session stays selected so
   // closing all diff tabs restores it.
@@ -139,6 +143,13 @@ export const createDiffSlice: StateCreator<AppState, [], [], DiffSlice> = (
       commitHistory: null,
       diffSelectedCommitHash: null,
     }),
+  setDiffTabsForWorkspace: (workspaceId, tabs) =>
+    set((s) => ({
+      diffTabsByWorkspace: {
+        ...s.diffTabsByWorkspace,
+        [workspaceId]: tabs,
+      },
+    })),
   openDiffTab: (workspaceId, path, layer) =>
     set((s) => {
       const normalizedLayer = layer ?? null;

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -82,6 +82,11 @@ export interface FileTreeSlice {
   ) => void;
 
   // Tab management
+  /** Replace the entire ordered list of file tabs for a workspace. Used by
+   *  drag-reorder (volatile — not persisted across restarts; see SessionTabs
+   *  unified reorder). Caller is responsible for keeping the active tab in
+   *  the new list. */
+  setFileTabsForWorkspace: (workspaceId: string, paths: string[]) => void;
   /** Open a file tab and make it active. If already open, just selects it. */
   openFileTab: (workspaceId: string, path: string) => void;
   /** Switch to an already-open tab (no-op if not in the workspace's tabs). */
@@ -172,6 +177,14 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       allFilesSelectedPathByWorkspace: {
         ...s.allFilesSelectedPathByWorkspace,
         [workspaceId]: path,
+      },
+    })),
+
+  setFileTabsForWorkspace: (workspaceId, paths) =>
+    set((s) => ({
+      fileTabsByWorkspace: {
+        ...s.fileTabsByWorkspace,
+        [workspaceId]: paths,
       },
     })),
 

--- a/src/ui/src/stores/slices/tabOrderSlice.ts
+++ b/src/ui/src/stores/slices/tabOrderSlice.ts
@@ -1,0 +1,50 @@
+import type { StateCreator } from "zustand";
+import type { AppState } from "../useAppStore";
+import type { UnifiedTabEntry } from "../../components/chat/sessionTabsLogic";
+
+// Per-workspace ordering for the unified workspace-tab strip (sessions /
+// files / diffs interleaved). Volatile by design — not persisted across
+// app restarts. On reload, only chat sessions come back (via their
+// `chat_sessions.sort_order` column); files/diffs are not restored, so the
+// initial unified order falls back to the default "sessions first" layout
+// each session.
+//
+// The slice stores entries in the visual order the user dragged into. The
+// SessionTabs component reconciles this with the live sessions/files/diffs
+// state on every render: items in tabOrder that no longer exist drop out,
+// and newly-opened tabs append at the end.
+
+export interface TabOrderSlice {
+  tabOrderByWorkspace: Record<string, UnifiedTabEntry[]>;
+  setTabOrderForWorkspace: (
+    workspaceId: string,
+    entries: UnifiedTabEntry[],
+  ) => void;
+  /** Drop a workspace's saved tab order. Called when a workspace is removed
+   *  so we don't leak stale UI state into the next workspace that reuses
+   *  the id (rare but possible after restore-from-archive). */
+  clearTabOrderForWorkspace: (workspaceId: string) => void;
+}
+
+export const createTabOrderSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  TabOrderSlice
+> = (set) => ({
+  tabOrderByWorkspace: {},
+  setTabOrderForWorkspace: (workspaceId, entries) =>
+    set((s) => ({
+      tabOrderByWorkspace: {
+        ...s.tabOrderByWorkspace,
+        [workspaceId]: entries,
+      },
+    })),
+  clearTabOrderForWorkspace: (workspaceId) =>
+    set((s) => {
+      if (!(workspaceId in s.tabOrderByWorkspace)) return s;
+      const next = { ...s.tabOrderByWorkspace };
+      delete next[workspaceId];
+      return { tabOrderByWorkspace: next };
+    }),
+});

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -57,6 +57,11 @@ export const createWorkspacesSlice: StateCreator<
       for (const session of s.sessionsByWorkspace[id] ?? []) {
         delete newChatDrafts[session.id];
       }
+      // Drop the unified workspace-tab order so a workspace id reused
+      // later (e.g. restore-from-archive collision) starts from default
+      // sessions→diffs→files layout instead of dredging up old entries.
+      const newTabOrder = { ...s.tabOrderByWorkspace };
+      delete newTabOrder[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -70,6 +75,7 @@ export const createWorkspacesSlice: StateCreator<
         diffTabsByWorkspace: newDiffTabs,
         diffSelectionByWorkspace: newDiffSelection,
         chatDrafts: newChatDrafts,
+        tabOrderByWorkspace: newTabOrder,
       };
     }),
   selectWorkspace: (id) =>

--- a/src/ui/src/stores/useAppStore.persistence.test.ts
+++ b/src/ui/src/stores/useAppStore.persistence.test.ts
@@ -15,6 +15,7 @@ function makeWorkspace(id: string, repoId: string = "r1"): Workspace {
     agent_status: "Idle",
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
+    sort_order: 0,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -1699,6 +1699,7 @@ function makeWorkspace(id: string, repoId: string = "r1"): Workspace {
     agent_status: "Idle",
     status_line: "",
     created_at: "2026-01-01T00:00:00Z",
+    sort_order: 0,
     remote_connection_id: null,
   };
 }

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -52,6 +52,10 @@ import {
 } from "./slices/settingsSlice";
 import { createSystemSlice, type SystemSlice } from "./slices/systemSlice";
 import {
+  createTabOrderSlice,
+  type TabOrderSlice,
+} from "./slices/tabOrderSlice";
+import {
   createTerminalSlice,
   type TerminalSlice,
 } from "./slices/terminalSlice";
@@ -90,7 +94,8 @@ export type AppState = RepositoriesSlice &
   PinnedPromptsSlice &
   SettingsSlice &
   RemoteSlice &
-  SystemSlice;
+  SystemSlice &
+  TabOrderSlice;
 
 export const useAppStore = create<AppState>()((...a) => ({
   ...createRepositoriesSlice(...a),
@@ -111,6 +116,7 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createSettingsSlice(...a),
   ...createRemoteSlice(...a),
   ...createSystemSlice(...a),
+  ...createTabOrderSlice(...a),
 }));
 
 /**

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -165,6 +165,19 @@
   --radius-pill: 999px;
   --border-radius: var(--radius-lg); /* legacy alias */
 
+  /* ---- Layout heights ----
+   * Shared header height for the workspace panel and any sibling panel
+   * (e.g. RightSidebar's FILES/CHANGES/TASKS tab strip) so their bottom
+   * borders form a continuous horizontal divider across the layout.
+   */
+  --workspace-header-h: 54px;
+  /* Second-row height: chat session tab strip and the right-sidebar tab
+   * strip when it's pushed under a PR banner. Keeping these matched lets
+   * the right side's "PR banner + tabs" stack land its second border
+   * exactly where the chat tab bar's border lives.
+   */
+  --tab-bar-h: 39px;
+
   /* ---- Spacing (4px grid) ---- */
   --space-1:  4px;
   --space-2:  8px;

--- a/src/ui/src/types/workspace.ts
+++ b/src/ui/src/types/workspace.ts
@@ -18,6 +18,9 @@ export interface Workspace {
   agent_status: AgentStatus;
   status_line: string;
   created_at: string;
+  /** Per-repository display order in the sidebar. Persisted via the
+   *  `workspaces.sort_order` column; reassigned by `reorder_workspaces`. */
+  sort_order: number;
   /** Non-null when this workspace belongs to a remote connection. */
   remote_connection_id: string | null;
 }

--- a/src/ui/src/utils/bootIdentityGuard.test.ts
+++ b/src/ui/src/utils/bootIdentityGuard.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, beforeEach, afterAll } from "vitest";
+import { bootIdentityGuard } from "./bootIdentityGuard";
+
+// Minimal `document` stub. Vitest's default environment is node (no DOM),
+// and we don't pull in jsdom or happy-dom — they'd add a CI dependency
+// just for one tiny test. The guard only touches a handful of DOM APIs
+// (querySelector, getElementById, createElement, .innerHTML), so we mock
+// just those and assert against the recorded innerHTML strings.
+
+interface FakeMeta {
+  name: string;
+  content: string;
+}
+
+interface FakeRoot {
+  innerHTML: string;
+}
+
+let metas: FakeMeta[] = [];
+let root: FakeRoot | null = null;
+let bodyHtml = "";
+
+const realGlobals = {
+  document: (globalThis as { document?: unknown }).document,
+  window: (globalThis as { window?: unknown }).window,
+};
+
+function installFakeDom() {
+  metas = [];
+  root = { innerHTML: "" };
+  bodyHtml = "";
+  (globalThis as { document?: unknown }).document = {
+    querySelector(sel: string) {
+      if (sel === 'meta[name="x-tauri-app-id"]') {
+        return metas[0] ?? null;
+      }
+      return null;
+    },
+    getElementById(id: string) {
+      if (id === "root") return root;
+      return null;
+    },
+    get body() {
+      return {
+        get innerHTML() {
+          return bodyHtml;
+        },
+        set innerHTML(v: string) {
+          bodyHtml = v;
+        },
+      };
+    },
+  };
+  (globalThis as { window?: unknown }).window = {};
+}
+
+function restoreDom() {
+  if (realGlobals.document === undefined) {
+    delete (globalThis as { document?: unknown }).document;
+  } else {
+    (globalThis as { document?: unknown }).document = realGlobals.document;
+  }
+  if (realGlobals.window === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = realGlobals.window;
+  }
+}
+
+describe("bootIdentityGuard", () => {
+  beforeEach(installFakeDom);
+  afterAll(restoreDom);
+
+  it("returns true when the meta tag matches the expected app id", () => {
+    metas = [{ name: "x-tauri-app-id", content: "com.claudette.app" }];
+    expect(bootIdentityGuard()).toBe(true);
+    // Caller mounts React; root left untouched.
+    expect(root?.innerHTML).toBe("");
+  });
+
+  it("returns false and renders an error overlay when the meta tag is missing", () => {
+    metas = [];
+    expect(bootIdentityGuard()).toBe(false);
+    expect(root?.innerHTML).toContain("Foreign content detected");
+    expect(root?.innerHTML).toContain("(missing)");
+  });
+
+  it("returns false when the meta tag has the wrong app id", () => {
+    metas = [{ name: "x-tauri-app-id", content: "com.aethon.app" }];
+    expect(bootIdentityGuard()).toBe(false);
+    expect(root?.innerHTML).toContain("Foreign content detected");
+    expect(root?.innerHTML).toContain("com.aethon.app");
+  });
+
+  it("escapes observed content in the error overlay (XSS via meta tag)", () => {
+    metas = [
+      { name: "x-tauri-app-id", content: '"><script>alert(1)</script>' },
+    ];
+    expect(bootIdentityGuard()).toBe(false);
+    const html = root?.innerHTML ?? "";
+    // Raw `<script>` must NOT appear unescaped.
+    expect(html).not.toMatch(/<script>alert/);
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("falls back to body when no #root element exists", () => {
+    metas = [{ name: "x-tauri-app-id", content: "com.aethon.app" }];
+    root = null;
+    expect(bootIdentityGuard()).toBe(false);
+    expect(bodyHtml).toContain("Foreign content detected");
+  });
+});

--- a/src/ui/src/utils/bootIdentityGuard.ts
+++ b/src/ui/src/utils/bootIdentityGuard.ts
@@ -1,0 +1,85 @@
+// Defense against cross-Tauri-app dev-port hijack.
+//
+// In dev mode, Claudette's webview loads its bundle from a Vite server
+// on a localhost port. If another Tauri app's launcher kills or rebinds
+// that port (some templates do exactly this with `lsof -ti:1420 | xargs
+// kill`), the next HMR reload will serve the FOREIGN bundle into
+// Claudette's existing webview window. Without a guard, the user sees
+// another app's UI inside Claudette's title bar — confusing and
+// dangerous (the foreign app could read state via DOM access etc).
+//
+// This guard runs synchronously at boot, before React mounts, and
+// verifies the served `index.html` carries Claudette's identity marker
+// (the `<meta name="x-tauri-app-id" content="com.claudette.app">` in
+// our index.html). If the marker is missing or the wrong value, we
+// abort the React mount and render a hard-coded HTML error so the user
+// can see exactly what happened.
+//
+// In a release build (frontendDist via Tauri's tauri:// custom protocol)
+// the bundle is loaded straight from the binary's resources, so this
+// check is a no-op there — but keeping it always-on is cheap and adds
+// defense-in-depth even against a hypothetical malicious replacement.
+
+const EXPECTED_APP_ID = "com.claudette.app";
+
+export function bootIdentityGuard(): boolean {
+  const meta = document.querySelector<HTMLMetaElement>(
+    'meta[name="x-tauri-app-id"]',
+  );
+  if (meta?.content === EXPECTED_APP_ID) return true;
+
+  // Marker is missing or wrong — render a hard error inline. We don't
+  // import any styling utilities here (those would have a dependency on
+  // the foreign bundle's modules in the worst case); plain inline styles
+  // are the safest option and read clearly even on a half-loaded page.
+  const root = document.getElementById("root");
+  const observed = meta?.content ?? "(missing)";
+  const html = `
+    <div style="
+      position: fixed; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      background: #1c1815; color: #e07850;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      padding: 32px; text-align: center; z-index: 999999;
+    ">
+      <div style="max-width: 560px;">
+        <h1 style="margin: 0 0 16px; color: #f5a0b8;">Foreign content detected</h1>
+        <p style="margin: 0 0 12px; line-height: 1.5; color: #e6dccf;">
+          Claudette's dev webview is serving content from another app.
+          Expected app id <code style="font-family: 'JetBrains Mono', monospace;">${EXPECTED_APP_ID}</code>,
+          observed <code style="font-family: 'JetBrains Mono', monospace;">${escapeHtml(observed)}</code>.
+        </p>
+        <p style="margin: 0 0 16px; line-height: 1.5; color: #e6dccf;">
+          A Tauri app on this machine probably grabbed the dev port that
+          Claudette's webview was pointed at. Quit any other Tauri dev
+          builds, then restart Claudette via <code>scripts/dev.sh</code>.
+        </p>
+        <p style="margin: 0; font-size: 12px; color: #c4b5fd;">
+          You're seeing this instead of a silent UI swap because of
+          <code>bootIdentityGuard</code> in <code>src/ui/src/utils/bootIdentityGuard.ts</code>.
+        </p>
+      </div>
+    </div>
+  `;
+  if (root) {
+    root.innerHTML = html;
+  } else {
+    document.body.innerHTML = html;
+  }
+  // Print a clear diagnostic for anyone who hits this and opens devtools.
+  console.error(
+    "[bootIdentityGuard] Expected x-tauri-app-id meta to be %o, got %o. " +
+      "Refusing to mount the Claudette React tree — see the rendered notice.",
+    EXPECTED_APP_ID,
+    observed,
+  );
+  return false;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/ui/src/utils/dragReorder.test.ts
+++ b/src/ui/src/utils/dragReorder.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { reorderById, tabDropPlacement } from "./dragReorder";
+
+describe("tabDropPlacement", () => {
+  it("returns 'before' when cursor is left of midpoint", () => {
+    expect(tabDropPlacement(124, 100, 50)).toBe("before");
+  });
+  it("returns 'after' when cursor is at or past midpoint", () => {
+    expect(tabDropPlacement(125, 100, 50)).toBe("after");
+    expect(tabDropPlacement(149, 100, 50)).toBe("after");
+  });
+});
+
+describe("reorderById", () => {
+  type Item = { id: number; name: string };
+  const item = (id: number): Item => ({ id, name: `item-${id}` });
+  const id = (i: Item) => i.id;
+
+  it("moves a tab before its target", () => {
+    const result = reorderById([item(1), item(2), item(3)], 3, 1, "before", id);
+    expect(result?.map((i) => i.id)).toEqual([3, 1, 2]);
+  });
+
+  it("moves a tab after its target", () => {
+    const result = reorderById([item(1), item(2), item(3)], 3, 1, "after", id);
+    expect(result?.map((i) => i.id)).toEqual([1, 3, 2]);
+  });
+
+  it("forward drag adjusts for the post-splice target index", () => {
+    const before = reorderById([item(1), item(2), item(3)], 1, 3, "before", id);
+    const after = reorderById([item(1), item(2), item(3)], 1, 3, "after", id);
+    expect(before?.map((i) => i.id)).toEqual([2, 1, 3]);
+    expect(after?.map((i) => i.id)).toEqual([2, 3, 1]);
+  });
+
+  it("returns null for self-drops, missing dragged, or missing target", () => {
+    expect(reorderById([item(1), item(2)], 1, 1, "before", id)).toBeNull();
+    expect(reorderById([item(1), item(2)], 9, 1, "before", id)).toBeNull();
+    expect(reorderById([item(1), item(2)], 1, 9, "before", id)).toBeNull();
+  });
+
+  it("works with string ids", () => {
+    const items = [{ id: "a" }, { id: "b" }, { id: "c" }] as const;
+    const result = reorderById(items, "c", "a", "before", (i) => i.id);
+    expect(result?.map((i) => i.id)).toEqual(["c", "a", "b"]);
+  });
+});

--- a/src/ui/src/utils/dragReorder.test.ts
+++ b/src/ui/src/utils/dragReorder.test.ts
@@ -9,6 +9,12 @@ describe("tabDropPlacement", () => {
     expect(tabDropPlacement(125, 100, 50)).toBe("after");
     expect(tabDropPlacement(149, 100, 50)).toBe("after");
   });
+  it("works for any axis — caller passes the relevant component (x or y)", () => {
+    // Vertical list: a tab at top=200, height=40 has midpoint 220.
+    // The pure helper doesn't know x from y, only "cursor vs midpoint".
+    expect(tabDropPlacement(210, 200, 40)).toBe("before");
+    expect(tabDropPlacement(230, 200, 40)).toBe("after");
+  });
 });
 
 describe("reorderById", () => {

--- a/src/ui/src/utils/dragReorder.ts
+++ b/src/ui/src/utils/dragReorder.ts
@@ -1,0 +1,58 @@
+// Generic drag-reorder helpers shared across the terminal tab bar, the
+// chat/file/diff workspace tab strip, and the sidebar workspace list.
+//
+// Why hand-rolled instead of HTML5 DnD: WebKit-on-macOS does not deliver
+// `dragover`/`drop` events under the html `zoom` we apply for UI font scaling,
+// so all of Claudette's drag interactions are pointer-event based. These
+// helpers are the bits of logic that aren't tied to a specific React
+// component — pure functions over an items list and a hovered tab geometry.
+
+export type TabDropPlacement = "before" | "after";
+
+/**
+ * Decide whether the cursor is over the left or right half of a tab.
+ * Pure geometry — `clientX` and `tabLeft` must be in the same coordinate
+ * space (typically pointer-event clientX and DOMRect.left).
+ */
+export function tabDropPlacement(
+  clientX: number,
+  tabLeft: number,
+  tabWidth: number,
+): TabDropPlacement {
+  return clientX < tabLeft + tabWidth / 2 ? "before" : "after";
+}
+
+/**
+ * Reorder an items array so `dragged` lands `placement` of `target`.
+ * Returns a new array, or `null` if the move is a no-op or invalid.
+ *
+ * Generic over any item identifier — the caller supplies a `getId` accessor.
+ * Does NOT stamp any `sort_order` field on items; persistence shape is the
+ * caller's concern. (Terminal tabs, sessions, workspaces all keep their
+ * `sort_order` column derived from array index by their respective Tauri
+ * commands — they don't need a stamped value in the local state.)
+ */
+export function reorderById<T, Id>(
+  items: readonly T[],
+  draggedId: Id,
+  targetId: Id,
+  placement: TabDropPlacement,
+  getId: (item: T) => Id,
+): T[] | null {
+  if (Object.is(draggedId, targetId)) return null;
+  const fromIndex = items.findIndex((item) => Object.is(getId(item), draggedId));
+  const targetIndex = items.findIndex((item) => Object.is(getId(item), targetId));
+  if (fromIndex < 0 || targetIndex < 0) return null;
+
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  // After splicing the dragged item out, the target's index may have shifted.
+  const adjustedTargetIndex = next.findIndex((item) =>
+    Object.is(getId(item), targetId),
+  );
+  if (adjustedTargetIndex < 0) return null;
+  const insertAt =
+    placement === "before" ? adjustedTargetIndex : adjustedTargetIndex + 1;
+  next.splice(insertAt, 0, moved);
+  return next;
+}

--- a/src/ui/src/utils/dragReorder.ts
+++ b/src/ui/src/utils/dragReorder.ts
@@ -8,18 +8,23 @@
 // component — pure functions over an items list and a hovered tab geometry.
 
 export type TabDropPlacement = "before" | "after";
+export type DragOrientation = "horizontal" | "vertical";
 
 /**
- * Decide whether the cursor is over the left or right half of a tab.
- * Pure geometry — `clientX` and `tabLeft` must be in the same coordinate
- * space (typically pointer-event clientX and DOMRect.left).
+ * Decide whether the cursor sits "before" or "after" the midpoint of a
+ * tab along the relevant axis. Horizontal lists (tab strips, where items
+ * are arranged left→right) compare on x; vertical lists (sidebar
+ * workspaces stacked top→bottom) compare on y. Mixing the axes — using x
+ * for a vertical list — leaves the user unable to drop "after" the last
+ * item, because the cursor would have to leave the item's bounding box
+ * to ever cross the midpoint along the wrong axis.
  */
 export function tabDropPlacement(
-  clientX: number,
-  tabLeft: number,
-  tabWidth: number,
+  cursor: number,
+  tabStart: number,
+  tabExtent: number,
 ): TabDropPlacement {
-  return clientX < tabLeft + tabWidth / 2 ? "before" : "after";
+  return cursor < tabStart + tabExtent / 2 ? "before" : "after";
 }
 
 /**

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -2,14 +2,23 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // Port is chosen by the devshell `dev` helper (which probes for the first
-// free port starting at 1420) and passed in via VITE_PORT. strictPort stays
-// true so a race between pre-flight and Vite startup fails loudly instead
-// of silently landing on a port Tauri isn't pointed at.
+// free port starting at CLAUDETTE_VITE_PORT_BASE) and passed in via
+// VITE_PORT. strictPort stays true so a race between pre-flight and Vite
+// startup fails loudly instead of silently landing on a port Tauri isn't
+// pointed at.
 //
-// parseInt instead of Number so an empty/garbage VITE_PORT falls back to
-// 1420 instead of failing with "port NaN already in use".
+// We deliberately moved off Tauri's stock port 1420 because every Tauri
+// starter template defaults to it — when another Tauri dev build launches
+// nearby, its dev script (often `lsof -ti:1420 | xargs kill`) can rebind
+// our port underneath the running webview, swapping in a foreign bundle.
+// A non-default port avoids the most common source of cross-app hijack;
+// the inline guard in index.html catches the rest.
+//
+// parseInt instead of Number so an empty/garbage VITE_PORT falls back
+// instead of failing with "port NaN already in use".
+const DEFAULT_VITE_PORT = 14253
 const parsed = parseInt(process.env.VITE_PORT ?? '', 10)
-const port = Number.isFinite(parsed) && parsed > 0 ? parsed : 1420
+const port = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_VITE_PORT
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/src/workspace_alloc.rs
+++ b/src/workspace_alloc.rs
@@ -153,6 +153,7 @@ mod tests {
             agent_status: AgentStatus::Idle,
             status_line: String::new(),
             created_at: String::new(),
+            sort_order: 0,
         }
     }
 

--- a/src/workspace_sync.rs
+++ b/src/workspace_sync.rs
@@ -194,6 +194,7 @@ mod tests {
             agent_status: AgentStatus::Idle,
             status_line: String::new(),
             created_at: String::new(),
+            sort_order: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

Cross-platform drag-to-reorder for the surfaces that didn't have it, plus a stack of UAT-driven follow-ups (unified tab order, view persistence, layout alignment, mid-turn steer hotkey, dev-port hijack guard, help menu).

Three commits — squash if you prefer, or keep them split since each is independently reviewable.

## What's in here

### Drag-reorder

- **Workspace tab strip** in `SessionTabs.tsx` — chat sessions, file tabs, and diff tabs reorder via pointer-event drag and **interleave freely across kinds** (option 1B from the design checkpoint). Per-workspace unified order lives in `tabOrderByWorkspace`; chat sessions persist via `chat_sessions.sort_order` + new `reorder_chat_sessions` Tauri command, file/diff openness stays volatile (option 3A).
- **Sidebar workspace list** drag-reorder, restricted to siblings in the same repo (option 2A). New `workspaces.sort_order` column (migration `20260505180023`) seeded per-repo from `created_at`, plus `reorder_workspaces(repository_id, ids)` DB method + Tauri command.
- **Reusable foundation**: `useTabDragReorder` hook (`orientation: "horizontal" | "vertical"`, optional cross-group reject, `data-*`-attribute hit-testing) + pure helpers in `dragReorder.ts` with unit tests + shared `TabDragGhost` portal component. Mirrors the recently-shipped terminal tab pattern (PR #625) so all four surfaces feel the same.

### Layout alignment

- New CSS tokens `--workspace-header-h` and `--tab-bar-h` in `theme.css`. `WorkspacePanelHeader`, `PrStatusBanner`, `SessionTabs.tabBar`, and `RightSidebar.tabBar` all pin to them so the layout's two horizontal dividers stay continuous in both states (PR banner present **and** absent).
- Right-sidebar tab bar drops to second-row height via `:not(:first-child)` when the PR banner sits above it.
- **Static regression test** (`headerAlignment.test.ts`) reads the CSS source files and asserts the shared tokens stay wired — guards against silent regressions from future refactors.

### View persistence

- `useViewTogglePersistence` hook bridges Zustand visibility/size state to `app_settings`. Persisted: sidebar/right-sidebar/terminal visibility, all three widths/heights, right-sidebar active tab, sidebar grouping mode, "show archived" toggle. Layout survives restart instead of resetting to slice defaults each launch.

### Mid-turn steer hotkey

- New `chat.steer-immediate` hotkey action (default **Cmd/Ctrl+Enter**, fully rebindable via Keyboard settings). While the agent is running, this bypasses the queue path and injects the typed message as a mid-turn steer through the existing `steerQueuedChatMessage` Tauri command. Falls back to a normal send when the session is idle, falls back to queueing on backend failure or remote workspaces (steering isn't supported over the remote transport yet).

### Cross-app dev-port hijack guard

When another Tauri app's dev script killed Claudette's listener on Tauri's stock port 1420 and rebound its own Vite, Claudette's existing webview reloaded the foreign bundle into Claudette's window chrome. Two layers of defense:

1. **Unique port** (1420 → **14253**). Most common Tauri-template launchers no longer collide with us by default. Updated in `tauri.conf.json`, `vite.config.ts`, and `scripts/dev.sh`.
2. **Inline boot guard** in `index.html` that runs strictly BEFORE any ES module imports. It verifies the served bundle carries `<meta name="x-tauri-app-id" content="com.claudette.app">`; if not, it rewrites the document to a hard error overlay and calls `window.stop()`, so a foreign bundle's `<script type="module">` can never mount its app. The same logic is exported as a testable module (`src/utils/bootIdentityGuard.ts`, 5 unit tests covering match, miss, mismatch, XSS-safe escaping, root fallback).

### Help menu

- macOS native menu gains **Help → Claudette Documentation** linking to `https://utensils.io/claudette/` (docs root, chosen so the URL survives any future doc-site reorganization).
- Sidebar footer adds a `<CircleHelp>` button with the same target — gives Linux/Windows users (no native menu bar) a parallel entry point.

### Quiet bug fixes (caught during UAT and Codex review)

- WebKit text-selection on session tab names mid-drag — explicit `-webkit-user-select: none` plus `ev.preventDefault()` in pointer handlers.
- Vertical drop placement in the sidebar — hook used `clientX` regardless of orientation, leaving the user unable to drop below the last workspace in a repo. Added the `orientation` option.
- Stale-order in repeat sidebar drags (Codex review P2) — hook's `items` was unsorted DB order while the sidebar rendered by `sort_order`. Now passes a memoised visually-sorted array; optimistic update reorders the array (not just the field).
- New workspaces rendered at sort_order=0 until reload (Codex review #2 P2) — `insert_workspace` now exposes `lookup_workspace_sort_order` and creation paths (`fork.rs`, create_workspace, import_worktrees batch, remote handler) patch the in-memory struct so the UI shows the correct position immediately.
- Cmd+Enter on a remote workspace ate the typed message (Codex review #2 P2) — `ChatInputArea` now checks `isRemote` before consuming the composer and falls back through the queue.
- Drag-end click suppression (Codex review #2 P2) — `justEndedRef` is now cleared via `requestAnimationFrame` instead of `queueMicrotask` to outlast the synthetic post-pointerup click on macOS WebKit.

## Tests

- **Frontend (vitest)**: 1249 passing (17 new — drag-reorder math, sessionTabs split logic, header-alignment regression, dragReorder vertical placement, boot identity guard)
- **Rust (cargo test --workspace --all-features)**: 963 + 4 + 194 + doc tests passing
- **Lint**: `bun run lint:css` clean, no new ESLint errors, `cargo clippy --workspace --all-targets` no new warnings, `cargo fmt --check` clean

## Local UAT

Tested in the dev build at every step via the `/claudette-debug` skill — both tab-strip surfaces and the sidebar drag work, drop indicators render correctly, layout alignment holds with and without a PR banner, view toggles round-trip across an app restart, and the boot guard renders the error overlay when the meta tag is removed manually.

## Design choices (decided early in the session)

- **1B**: cross-kind interleave allowed in workspace tab strip
- **2A**: workspace drag restricted to within-repo
- **3A**: file/diff tab openness stays volatile (only chat session order persists)

These are reflected in code comments at the relevant decision points.

## Migrations

- `src/migrations/20260505180023_workspace_sort_order.sql` — adds `sort_order` to the `workspaces` table, seeds per-repo from `created_at`, indexes `(repository_id, sort_order)`. Forward-only and additive per project conventions.

## Codex peer reviews

Two rounds via `codex review --base main`. Round 1 → 1 P2 (sidebar stale-order) addressed in the second commit. Round 2 → 3 P2s (sort_order returned to UI, remote-workspace steer message loss, drag click suppression timing) addressed in the third commit. Findings + fix commits cited inline in code comments where relevant.
