### PR TITLE
fix(dashboard): anchor elapsed timer to store promptStartTime

### DIFF
--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -7,6 +7,7 @@ import { RepoIcon } from "../shared/RepoIcon";
 import { PanelToggles } from "../shared/PanelToggles";
 import { StatsStrip, AnalyticsSection, MicroStats } from "../metrics";
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
+import { formatElapsedSeconds } from "../chat/chatHelpers";
 import styles from "./Dashboard.module.css";
 
 /** Strip markdown syntax for a clean one-line preview. */
@@ -26,30 +27,6 @@ function stripMarkdown(s: string): string {
     .trim();
 }
 
-function formatElapsed(secs: number): string {
-  if (secs < 60) return `${secs}s`;
-  const m = Math.floor(secs / 60);
-  const s = secs % 60;
-  return `${m}m ${s}s`;
-}
-
-function useElapsed(isRunning: boolean): number {
-  const [elapsed, setElapsed] = useState(0);
-
-  useEffect(() => {
-    if (!isRunning) {
-      setElapsed(0);
-      return;
-    }
-    const start = Date.now();
-    const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - start) / 1000));
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [isRunning]);
-
-  return elapsed;
-}
 
 const WorkspaceCard = memo(function WorkspaceCard({
   ws,
@@ -71,7 +48,19 @@ const WorkspaceCard = memo(function WorkspaceCard({
   index: number;
 }) {
   const isRunning = isAgentBusy(ws.agent_status);
-  const elapsed = useElapsed(isRunning);
+  const promptStartTime = useAppStore((s) => s.promptStartTime[ws.id] ?? null);
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!isRunning || promptStartTime == null) {
+      setElapsed(0);
+      return;
+    }
+    setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - promptStartTime) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isRunning, promptStartTime]);
 
   const statusColor =
     isRunning
@@ -137,7 +126,7 @@ const WorkspaceCard = memo(function WorkspaceCard({
         <span className={styles.statusIndicator}>
           {isRunning && (
             <span className={styles.statusLabel} style={{ color: statusColor }}>
-              {formatElapsed(elapsed)}
+              {formatElapsedSeconds(elapsed)}
             </span>
           )}
           <span title={statusIconTitle} aria-label={statusIconTitle} role="img">


### PR DESCRIPTION
## Summary

The Dashboard workspace card's elapsed timer reset to `0s` on every navigation because the local `useElapsed` hook captured `Date.now()` inside its effect — so each remount re-anchored the clock instead of reflecting the true prompt start.

This change replaces the local hook with a Zustand selector for `promptStartTime[ws.id]`, the same source `ChatPanel` already uses. The slice is keyed by workspace id and persists across unmounts, so the timer now matches the chat's elapsed time and survives navigation. The duplicate local `formatElapsed` is removed in favor of the shared `formatElapsedSeconds` helper from `chatHelpers.ts`.

Closes #589.

## Complexity Notes

- The selector `(s) => s.promptStartTime[ws.id] ?? null` runs per-card; Zustand's referential equality means a re-render only fires when *this workspace's* start time changes, preserving the `memo` optimization on `WorkspaceCard`.
- `setElapsed` is called once immediately inside the effect (before `setInterval`) so the displayed value is correct on mount instead of flashing `0s` for up to one second.

## Test Steps

1. `cd src/ui && bun install && bunx tsc -b && bun run test --run` — type-check + 1226 vitest tests should pass.
2. `cargo tauri dev` — start the app.
3. Send a prompt in any workspace so the agent enters Running state.
4. Open the Dashboard, note the elapsed time on the card (e.g. `42s`).
5. Navigate to Settings or another workspace, then back to the Dashboard.
6. **Expected:** the card timer continues from the true prompt start (matches the ChatPanel's elapsed). It should NOT reset to `0s`.
7. Verify the timer also clears correctly when the agent finishes (status leaves Running).

## Checklist

- [x] Tests added/updated (existing `useAppStore.test.ts` already covers the `promptStartTime` slice; no new tests needed since the fix re-uses an established pattern)
- [ ] Documentation updated (n/a — no documented behavior change)