### PR TITLE
fix(ui): un-break release boot from Vite-mangled inline hijack guard

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -18,12 +18,41 @@
       // Cross-app dev-port hijack guard. ES module imports hoist, so this
       // MUST be inline (and before the bundle script) to beat them.
       // Mirrors bootIdentityGuard.ts; that module exists for tests.
+      //
+      // IMPORTANT: do NOT introduce raw HEAD / BODY / TITLE element open
+      // or close tags as substrings anywhere in this script's source —
+      // not in code, not in string literals, and (yes, really) not even
+      // in COMMENTS. Vite's HTML transform is regex/string-based and
+      // will splice production-mode asset preloads before the first such
+      // substring it finds, mangling whatever it lands inside. An
+      // earlier version of this guard used document.open() + document.write
+      // with a full-document HTML string and shipped a SyntaxError-broken
+      // bundle to release for exactly that reason; we now build the
+      // overlay imperatively from a body fragment with no doctype or
+      // root-element wrappers.
       (function () {
+        // Threat model is cross-app Vite dev port hijack (another Tauri
+        // starter template's dev script kills our listener and rebinds
+        // the port, so our webview reloads into a foreign bundle).
+        // Release builds load via the tauri:// custom protocol (or
+        // https://tauri.localhost on Windows) directly from the binary's
+        // resources — there's no localhost port to squat, so the guard
+        // is a no-op there. Skip immediately on any non-dev protocol so
+        // the rest of this script can never affect production boot.
+        if (location.protocol !== "http:") return;
         var EXPECTED = "com.claudette.app";
         var meta = document.querySelector('meta[name="x-tauri-app-id"]');
         var observed = (meta && meta.getAttribute("content")) || "(missing)";
         if (observed === EXPECTED) return;
         window.__claudetteHijackBlocked = true;
+
+        // Halt the foreign bundle as best we can. window.stop() aborts
+        // pending fetches (so the bundle script tag below us never
+        // executes if it hadn't fetched yet). ES modules already in
+        // flight can't be cancelled, but main.tsx re-checks
+        // __claudetteHijackBlocked and bails before mounting React.
+        if (window.stop) window.stop();
+
         var esc = function (s) {
           return String(s)
             .replace(/&/g, "&amp;")
@@ -31,6 +60,7 @@
             .replace(/>/g, "&gt;")
             .replace(/"/g, "&quot;");
         };
+        // Body-fragment only — no document/head/body/title wrappers.
         var html =
           '<div style="position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:#1c1815;color:#e07850;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;padding:32px;text-align:center;z-index:999999;">' +
           '<div style="max-width:560px;">' +
@@ -43,20 +73,19 @@
           '<p style="margin:0 0 16px;line-height:1.5;color:#e6dccf;">A Tauri app on this machine probably grabbed the dev port that Claudette’s webview was pointed at. Quit any other Tauri dev builds, then restart Claudette via <code>scripts/dev.sh</code>.</p>' +
           '<p style="margin:0;font-size:12px;color:#c4b5fd;">You’re seeing this instead of a silent UI swap because of the inline guard in <code>index.html</code>.</p>' +
           "</div></div>";
-        // Replace the document so even if the foreign bundle's main script
-        // tag runs, its DOM mutations target our error overlay's <body>
-        // and most attempts to find their root element fail benignly.
-        document.open();
-        document.write(
-          '<!doctype html><html><head><meta charset="utf-8"><title>Claudette — hijack guard</title></head><body>' +
-            html +
-            "</body></html>",
-        );
-        document.close();
-        // Stop further script execution as cleanly as we can; ES modules
-        // already in flight can't be cancelled, but they'll throw against
-        // the rewritten DOM rather than render anything.
-        if (window.stop) window.stop();
+
+        function paint() {
+          // document.body may not exist yet — the parser is still inside
+          // <head> when this script runs synchronously. If so, paint as
+          // soon as the body is parsed.
+          if (!document.body) {
+            document.addEventListener("DOMContentLoaded", paint);
+            return;
+          }
+          document.body.innerHTML = html;
+        }
+        paint();
+
         // eslint-disable-next-line no-console
         console.error(
           "[claudette] Hijack guard tripped: expected x-tauri-app-id=" +

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -17,7 +17,15 @@
     <script>
       // Cross-app dev-port hijack guard. ES module imports hoist, so this
       // MUST be inline (and before the bundle script) to beat them.
-      // Mirrors bootIdentityGuard.ts; that module exists for tests.
+      //
+      // bootIdentityGuard.ts is a logic mirror used only by unit tests —
+      // it covers the meta-tag-check / overlay-render branches without
+      // requiring a browser harness. The inline version diverges
+      // intentionally: it gates on location.protocol so release builds
+      // skip the guard entirely, and calls window.stop() to abort
+      // foreign asset fetches. The TS mirror has neither because it's
+      // exercised in a fake-DOM environment where neither would make
+      // sense.
       //
       // IMPORTANT: do NOT introduce raw HEAD / BODY / TITLE element open
       // or close tags as substrings anywhere in this script's source —
@@ -46,13 +54,6 @@
         if (observed === EXPECTED) return;
         window.__claudetteHijackBlocked = true;
 
-        // Halt the foreign bundle as best we can. window.stop() aborts
-        // pending fetches (so the bundle script tag below us never
-        // executes if it hadn't fetched yet). ES modules already in
-        // flight can't be cancelled, but main.tsx re-checks
-        // __claudetteHijackBlocked and bails before mounting React.
-        if (window.stop) window.stop();
-
         var esc = function (s) {
           return String(s)
             .replace(/&/g, "&amp;")
@@ -74,17 +75,28 @@
           '<p style="margin:0;font-size:12px;color:#c4b5fd;">You’re seeing this instead of a silent UI swap because of the inline guard in <code>index.html</code>.</p>' +
           "</div></div>";
 
-        function paint() {
-          // document.body may not exist yet — the parser is still inside
-          // <head> when this script runs synchronously. If so, paint as
-          // soon as the body is parsed.
-          if (!document.body) {
-            document.addEventListener("DOMContentLoaded", paint);
-            return;
-          }
-          document.body.innerHTML = html;
-        }
-        paint();
+        // Paint the overlay synchronously before halting the parser.
+        // document.body may not exist yet (we're inside <head>), but
+        // documentElement always does — and waiting on DOMContentLoaded
+        // is unsafe here because the window.stop() below can halt the
+        // parser in some webviews and prevent that event from firing,
+        // which would leave the user staring at a half-loaded foreign
+        // page with no error overlay. position:fixed in the overlay
+        // CSS means it doesn't need to live inside <body> to render
+        // correctly. We attach to <body> when it's already parsed
+        // (just so devtools' element tree looks normal), otherwise
+        // straight to <html>.
+        var holder = document.createElement("div");
+        holder.innerHTML = html;
+        var fragment = document.createDocumentFragment();
+        while (holder.firstChild) fragment.appendChild(holder.firstChild);
+        (document.body || document.documentElement).appendChild(fragment);
+
+        // Now that the overlay is attached, abort any pending fetches
+        // for the foreign bundle. ES modules already in flight can't
+        // be cancelled, but main.tsx re-checks __claudetteHijackBlocked
+        // and bails before mounting React.
+        if (window.stop) window.stop();
 
         // eslint-disable-next-line no-console
         console.error(

--- a/src/ui/src/utils/builtHtml.test.ts
+++ b/src/ui/src/utils/builtHtml.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression test for the production-build dist/index.html.
+//
+// Vite's HTML transform is regex-based and has historically spliced
+// production-mode asset preloads inside any HEAD/BODY/TITLE close-tag
+// substring it encounters — including ones inside inline <script>
+// string literals or comments. The first variant produces a SyntaxError
+// in the inline guard and a release build that boots to a blank window;
+// the second variant silently dumps <link rel="modulepreload"> tags
+// inside a JS comment, where they're never honored as preloads.
+//
+// CI's frontend job runs `bun run build` immediately before `bun run
+// test`, so dist/ exists when this test runs there. Locally, devs who
+// run vitest without first building skip these checks (with a clear
+// hint above the assertions).
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DIST_HTML = resolve(__dirname, "../../dist/index.html");
+
+// Match <script>...</script> blocks WITHOUT a `src=` attribute (i.e.
+// inline scripts only). The negative-lookahead in the opening tag
+// rejects external references so we don't accidentally try to "parse"
+// a self-closing-by-empty-content reference like
+// <script src="/foo.js"></script>.
+const INLINE_SCRIPT_RE = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g;
+
+function extractInlineScripts(html: string): string[] {
+  const out: string[] = [];
+  // Use a fresh regex instance per call — RegExp with /g state is
+  // notoriously easy to corrupt across describe blocks.
+  const re = new RegExp(INLINE_SCRIPT_RE.source, INLINE_SCRIPT_RE.flags);
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    out.push(m[1]);
+  }
+  return out;
+}
+
+describe.skipIf(!existsSync(DIST_HTML))("built dist/index.html", () => {
+  const html = readFileSync(DIST_HTML, "utf-8");
+  const inlineScripts = extractInlineScripts(html);
+
+  // ---- Strategy A: every inline <script> parses as valid JavaScript ----
+  //
+  // Catches the original failure mode: Vite spliced asset tags inside a
+  // single-quoted string literal in document.write(), breaking the JS
+  // across multiple lines and producing a SyntaxError that knocked out
+  // the entire boot path.
+
+  it("has at least one inline <script> block (sanity)", () => {
+    expect(inlineScripts.length).toBeGreaterThan(0);
+  });
+
+  it("every inline <script> body parses as valid JavaScript", () => {
+    inlineScripts.forEach((body, i) => {
+      // new Function() throws SyntaxError on parse failure; the body is
+      // wrapped as a function body so top-level IIFEs / declarations
+      // are fine.
+      expect(
+        () => new Function(body),
+        `inline <script> ${i + 1} of ${inlineScripts.length} is not valid JS`,
+      ).not.toThrow();
+    });
+  });
+
+  // ---- Strategy B: marker assertions on the build output ----
+  //
+  // Catches subtler Vite-mangling that doesn't break parsing — e.g. the
+  // case where preloads were spliced inside a JS comment. Still valid
+  // JS, but the asset tags now sit inside an inline script instead of
+  // being honored as <link>/<script src=> at document level.
+
+  it("preserves the x-tauri-app-id identity meta tag", () => {
+    expect(html).toMatch(
+      /<meta\s+name="x-tauri-app-id"\s+content="com\.claudette\.app"\s*\/?>/,
+    );
+  });
+
+  it("never embeds modulepreload or bundle script tags inside inline <script>", () => {
+    // The bundle entry and asset preloads must live at document level,
+    // not inside any inline script's body, comment, or string literal.
+    for (const body of inlineScripts) {
+      expect(body).not.toMatch(/<link\s+rel="modulepreload"/);
+      expect(body).not.toMatch(/<script\s+type="module"\s+crossorigin\s+src=/);
+    }
+  });
+
+  it("emits the bundle <script type=\"module\"> tag at document level", () => {
+    expect(html).toMatch(
+      /<script\s+type="module"\s+crossorigin\s+src="\/assets\/[^"]+\.js"><\/script>/,
+    );
+  });
+
+  it("keeps the inline hijack guard's IIFE wrapper intact", () => {
+    // Find the inline script tagged with our hijack-blocked marker; both
+    // its IIFE opener and closer must survive the build pipeline.
+    const guard = inlineScripts.find((s) =>
+      s.includes("__claudetteHijackBlocked"),
+    );
+    expect(
+      guard,
+      "no inline <script> with __claudetteHijackBlocked marker found",
+    ).toBeDefined();
+    expect(guard).toMatch(/\(function \(\) \{/);
+    expect(guard).toMatch(/\}\)\(\);/);
+  });
+});

--- a/src/ui/src/utils/builtHtml.test.ts
+++ b/src/ui/src/utils/builtHtml.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as vm from "node:vm";
 
 // Regression test for the production-build dist/index.html.
 //
@@ -57,11 +58,14 @@ describe.skipIf(!existsSync(DIST_HTML))("built dist/index.html", () => {
 
   it("every inline <script> body parses as valid JavaScript", () => {
     inlineScripts.forEach((body, i) => {
-      // new Function() throws SyntaxError on parse failure; the body is
-      // wrapped as a function body so top-level IIFEs / declarations
-      // are fine.
+      // Use vm.Script for parse-only validation against actual Script
+      // grammar (an inline <script> is a Script, not a FunctionBody —
+      // top-level `return`, for example, is a SyntaxError in a Script
+      // but not in `new Function(body)`). The script never runs; the
+      // constructor throws SyntaxError on parse failure and that's all
+      // we care about.
       expect(
-        () => new Function(body),
+        () => new vm.Script(body),
         `inline <script> ${i + 1} of ${inlineScripts.length} is not valid JS`,
       ).not.toThrow();
     });
@@ -105,7 +109,11 @@ describe.skipIf(!existsSync(DIST_HTML))("built dist/index.html", () => {
       guard,
       "no inline <script> with __claudetteHijackBlocked marker found",
     ).toBeDefined();
-    expect(guard).toMatch(/\(function \(\) \{/);
-    expect(guard).toMatch(/\}\)\(\);/);
+    // Allow arbitrary whitespace and an optional trailing semicolon —
+    // we only care that the IIFE structure survives the build, not
+    // that it preserves source-style spacing (which a future
+    // minification pass could legitimately change).
+    expect(guard).toMatch(/\(\s*function\s*\(\s*\)\s*\{/);
+    expect(guard).toMatch(/\}\s*\)\s*\(\s*\)\s*;?/);
   });
 });


### PR DESCRIPTION
## What

Release builds were booting to a blank window because Vite's HTML transform was splicing production-mode asset preloads inside the inline cross-app dev-port hijack guard's `document.write(...)` string literal. The result was a `SyntaxError` on the inline guard **and** the bundle `<script type="module" src=...>` getting absorbed into the broken JS string instead of staying at document level — no React mount, no overlay, nothing.

The guard itself protects against a dev-only threat (another Tauri starter template killing our Vite dev port and rebinding it so our webview reloads into a foreign bundle — see screenshot in conversation). Release builds load via Tauri's `tauri://` custom protocol from the binary's resources; there is no localhost listener to squat, so the guard is a no-op there.

## Changes

1. **Gate the inline guard on `location.protocol === "http:"`.** Release builds short-circuit on the first statement of the IIFE. Future regressions of this class can no longer affect production boot.
2. **Drop `document.open()` / `document.write` of full-document HTML.** The overlay is now built imperatively from a body fragment with no doctype, head, body, or title wrappers — Vite has no `<head>`/`</head>`/etc. literals to splice into.
3. **Strip the same literals from the script's *comments*.** Vite's regex doesn't care whether a substring is in code or a comment (this exact variant bit me mid-fix — first rebuild after fixing the strings, Vite happily mangled the cautionary comment that warned against using those literals).
4. **`src/utils/builtHtml.test.ts`** — regression test that runs against `dist/index.html` after `bun run build` and asserts both:
   - every inline `<script>` body parses as valid JavaScript (Strategy A — catches the original `SyntaxError` variant), and
   - no inline-script body contains `modulepreload` or bundle `<script type="module" src=...>` substrings, while the document-level bundle script *is* present and the inline guard's IIFE wrapper is intact (Strategy B — catches subtler Vite-mangling that happens to remain valid JS, e.g. injection inside a comment).

   Verified against synthesized broken `dist/index.html` files for both the original `document.write` SyntaxError variant and the comment-mangling variant; both fail loudly.

## Why this slipped past CI

`bun run build` exits 0 on the corrupted output, `tsc -b` and unit tests don't load `dist/index.html`, and `bun run lint:css` doesn't parse JS. Nothing in the pipeline ever validated the *built* HTML or booted it. The new test plugs that gap — CI's frontend job already runs `bun run build` before `bun run test`, so the assertion fires automatically.

## Testing

```
nix develop -c bash -c 'cd src/ui && bun run lint:css && bunx tsc -b && bun run build && bun run test'
```

- `bun run lint:css` — clean
- `bunx tsc -b` — clean
- `bun run build` — clean; verified `dist/index.html` has preloads at the real `</head>` (line 126) with the inline guard intact
- `bun run test` — 1255 tests pass (was 1249; +6 new in `builtHtml.test.ts`)
