### PR TITLE
fix(diff): copy button silently failing on >100KB files; unify clipboard logic

### DIFF
--- a/src/ui/src/components/chat/CodeBlock.module.css
+++ b/src/ui/src/components/chat/CodeBlock.module.css
@@ -38,6 +38,7 @@ pre:hover > .copyButton:hover {
   opacity: 1;
 }
 
-.copied {
+.copyButton[data-state="copied"] {
   color: var(--accent-primary);
+  opacity: 1;
 }

--- a/src/ui/src/components/chat/CodeBlock.tsx
+++ b/src/ui/src/components/chat/CodeBlock.tsx
@@ -1,80 +1,37 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useCallback, useRef, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { CopyButton } from "../shared/CopyButton";
 import styles from "./CodeBlock.module.css";
 
 export function CodeBlock({
   children,
   ...props
 }: {
-  children?: React.ReactNode;
+  children?: ReactNode;
   [key: string]: unknown;
 }) {
   const { t } = useTranslation("chat");
   const preRef = useRef<HTMLPreElement>(null);
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<number | null>(null);
 
-  const handleCopy = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    const text =
+  const readCodeText = useCallback((): string | null => {
+    return (
       preRef.current?.querySelector("code")?.textContent ??
       preRef.current?.textContent ??
-      "";
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        setCopied(true);
-        if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
-        timeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
-      })
-      .catch((err) => console.error("Copy code failed:", err));
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
-    };
+      null
+    );
   }, []);
 
   return (
     <pre ref={preRef} {...props}>
       {children}
-      <button
-        type="button"
-        className={`${styles.copyButton} ${copied ? styles.copied : ""}`}
-        onClick={handleCopy}
-        title={copied ? t("code_block_copied") : t("code_block_copy")}
-        aria-label={t("code_block_copy")}
-      >
-        {copied ? (
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <polyline points="20 6 9 17 4 12" />
-          </svg>
-        ) : (
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-          </svg>
-        )}
-      </button>
+      <CopyButton
+        variant="bare"
+        className={styles.copyButton}
+        source={readCodeText}
+        tooltip={{ copy: t("code_block_copy"), copied: t("code_block_copied") }}
+        ariaLabel={t("code_block_copy")}
+        stopPropagation
+      />
     </pre>
   );
 }

--- a/src/ui/src/components/chat/MessageCopyButton.tsx
+++ b/src/ui/src/components/chat/MessageCopyButton.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { CopyButton } from "../shared/CopyButton";
 
 export function MessageCopyButton({
   text,
@@ -9,66 +9,15 @@ export function MessageCopyButton({
   className?: string;
 }) {
   const { t } = useTranslation("chat");
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<number | null>(null);
-
-  const handleCopy = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      navigator.clipboard
-        .writeText(text)
-        .then(() => {
-          setCopied(true);
-          if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
-          timeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
-        })
-        .catch((err) => console.error("Copy message failed:", err));
-    },
-    [text],
-  );
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
-    };
-  }, []);
 
   return (
-    <button
-      type="button"
+    <CopyButton
+      variant="bare"
       className={className}
-      onClick={handleCopy}
-      title={copied ? t("message_copied") : t("message_copy")}
-      aria-label={t("message_copy")}
-    >
-      {copied ? (
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
-      ) : (
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-        </svg>
-      )}
-    </button>
+      source={text}
+      tooltip={{ copy: t("message_copy"), copied: t("message_copied") }}
+      ariaLabel={t("message_copy")}
+      stopPropagation
+    />
   );
 }

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MessageMarkdown } from "./MessageMarkdown";
 import type { PlanApproval } from "../../stores/useAppStore";
@@ -28,20 +28,32 @@ export function PlanApprovalCard({
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [feedback, setFeedback] = useState("");
+  // Memoize an in-flight read so concurrent callers (e.g. user clicks
+  // Copy and View Plan in quick succession) share a single network call
+  // instead of issuing duplicate `readPlanFile` / `sendRemoteCommand`
+  // requests. Cleared in a `finally` so a failed fetch can be retried.
+  const inFlightFetchRef = useRef<Promise<string> | null>(null);
 
-  const fetchPlanContent = async (): Promise<string> => {
-    if (planContent !== null) return planContent;
-    if (!approval.planFilePath) throw new Error("No plan file path");
-    let content: string;
-    if (remoteConnectionId) {
-      content = (await sendRemoteCommand(remoteConnectionId, "read_plan_file", {
-        path: approval.planFilePath,
-      })) as string;
-    } else {
-      content = await readPlanFile(approval.planFilePath);
+  const fetchPlanContent = (): Promise<string> => {
+    if (planContent !== null) return Promise.resolve(planContent);
+    if (inFlightFetchRef.current) return inFlightFetchRef.current;
+    if (!approval.planFilePath) {
+      return Promise.reject(new Error("No plan file path"));
     }
-    setPlanContent(content);
-    return content;
+    const planFilePath = approval.planFilePath;
+    const promise = (async () => {
+      const content = remoteConnectionId
+        ? ((await sendRemoteCommand(remoteConnectionId, "read_plan_file", {
+            path: planFilePath,
+          })) as string)
+        : await readPlanFile(planFilePath);
+      setPlanContent(content);
+      return content;
+    })().finally(() => {
+      inFlightFetchRef.current = null;
+    });
+    inFlightFetchRef.current = promise;
+    return promise;
   };
 
   const handleViewPlan = async () => {

--- a/src/ui/src/components/chat/PlanApprovalCard.tsx
+++ b/src/ui/src/components/chat/PlanApprovalCard.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
 import { MessageMarkdown } from "./MessageMarkdown";
 import type { PlanApproval } from "../../stores/useAppStore";
 import { readPlanFile, sendRemoteCommand } from "../../services/tauri";
+import { CopyButton } from "../shared/CopyButton";
 import styles from "./PlanApprovalCard.module.css";
 
 interface PlanApprovalCardProps {
@@ -28,17 +28,6 @@ export function PlanApprovalCard({
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [feedback, setFeedback] = useState("");
-  const [copied, setCopied] = useState(false);
-  const [copying, setCopying] = useState(false);
-  const copyTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current);
-      }
-    };
-  }, []);
 
   const fetchPlanContent = async (): Promise<string> => {
     if (planContent !== null) return planContent;
@@ -75,26 +64,6 @@ export function PlanApprovalCard({
     }
   };
 
-  const handleCopyPlan = async () => {
-    if (!approval.planFilePath) return;
-    setLoadError(null);
-    setCopying(true);
-    try {
-      const content = await fetchPlanContent();
-      await clipboardWriteText(content);
-      setCopied(true);
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current);
-      }
-      copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
-    } catch (e) {
-      console.error("Failed to copy plan:", e);
-      setLoadError(t("plan_approval_failed_read"));
-    } finally {
-      setCopying(false);
-    }
-  };
-
   return (
     <div className={styles.card}>
       <div className={styles.label}>{t("plan_approval_label")}</div>
@@ -108,7 +77,7 @@ export function PlanApprovalCard({
           <button
             className={styles.planLink}
             onClick={handleViewPlan}
-            disabled={loading || copying}
+            disabled={loading}
           >
             {loading
               ? t("plan_approval_loading")
@@ -118,25 +87,20 @@ export function PlanApprovalCard({
             {" \u2014 "}
             {approval.planFilePath.split("/").slice(-2).join("/")}
           </button>
-          <button
-            type="button"
+          <CopyButton
+            variant="bare"
             className={styles.copyBtn}
-            onClick={handleCopyPlan}
-            disabled={loading || copying}
-            title={copied ? t("plan_approval_copied") : t("plan_approval_copy")}
-            aria-label={copied ? t("plan_approval_copied") : t("plan_approval_copy")}
-          >
-            {copied ? (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="20 6 9 17 4 12"></polyline>
-              </svg>
-            ) : (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-              </svg>
-            )}
-          </button>
+            source={fetchPlanContent}
+            tooltip={{
+              copy: t("plan_approval_copy"),
+              copied: t("plan_approval_copied"),
+            }}
+            disabled={loading}
+            onError={(e) => {
+              console.error("Failed to copy plan:", e);
+              setLoadError(t("plan_approval_failed_read"));
+            }}
+          />
         </div>
       )}
 

--- a/src/ui/src/components/chat/TurnFooter.tsx
+++ b/src/ui/src/components/chat/TurnFooter.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { RotateCcw, Split } from "lucide-react";
+import { CopyButton } from "../shared/CopyButton";
 import styles from "./ChatPanel.module.css";
 import { formatTokens } from "./formatTokens";
 import { formatDurationMs } from "./chatHelpers";
@@ -25,32 +26,6 @@ export function TurnFooter({
   className?: string;
 }) {
   const { t } = useTranslation("chat");
-  const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<number | null>(null);
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current !== null) {
-        window.clearTimeout(copyTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const handleCopy = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!assistantText) return;
-    navigator.clipboard
-      .writeText(assistantText)
-      .then(() => {
-        setCopied(true);
-        if (copyTimeoutRef.current !== null) {
-          window.clearTimeout(copyTimeoutRef.current);
-        }
-        copyTimeoutRef.current = window.setTimeout(() => setCopied(false), 1200);
-      })
-      .catch((err) => {
-        console.error("Copy to clipboard failed:", err);
-      });
-  };
 
   const handleFork = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -79,26 +54,15 @@ export function TurnFooter({
   const actionButtons: React.ReactNode[] = [];
   if (assistantText) {
     actionButtons.push(
-      <button
+      <CopyButton
         key="copy"
-        type="button"
+        variant="bare"
         className={styles.turnFooterButton}
-        onClick={handleCopy}
-        title={copied ? t("copy_output_done") : t("copy_output")}
-        aria-label={t("copy_agent_output_aria")}
-      >
-        {copied ? (
-          // Checkmark feedback for ~1.2s after successful copy.
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <polyline points="20 6 9 17 4 12"></polyline>
-          </svg>
-        ) : (
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-          </svg>
-        )}
-      </button>,
+        source={assistantText}
+        tooltip={{ copy: t("copy_output"), copied: t("copy_output_done") }}
+        ariaLabel={t("copy_agent_output_aria")}
+        stopPropagation
+      />,
     );
   }
   if (onFork) {

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -291,6 +291,13 @@ export function DiffViewer() {
           actions={
             <>
               <CopyButton
+                // Force a fresh CopyButton (and a fresh hook state) on each
+                // file switch. Without this, a stale in-flight read from
+                // the previous file could resolve to `null` (race-guarded
+                // by `fetchFileForCopy`) and flip the new file's button
+                // into the error state. Remount makes the late `setState`
+                // land on an unmounted fiber, which React silently drops.
+                key={diffSelectedFile}
                 source={fetchFileForCopy}
                 tooltip={{
                   copy: t("diff_tooltip_copy_contents"),

--- a/src/ui/src/components/diff/DiffViewer.tsx
+++ b/src/ui/src/components/diff/DiffViewer.tsx
@@ -1,13 +1,18 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AlignJustify, Check, Columns2, Copy, Eye, FilePenLine, GitCompare } from "lucide-react";
-import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
+import { AlignJustify, Columns2, Eye, FilePenLine, GitCompare } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
-import { loadCommitFileDiff, loadFileDiff, readWorkspaceFile } from "../../services/tauri";
+import {
+  loadCommitFileDiff,
+  loadFileDiff,
+  readWorkspaceFile,
+  readWorkspaceFileForViewer,
+} from "../../services/tauri";
 import { WorkspacePanelHeader } from "../shared/WorkspacePanelHeader";
 import { PaneToolbar } from "../shared/PaneToolbar";
 import { SegmentedControl } from "../shared/SegmentedControl";
 import { IconButton } from "../shared/IconButton";
+import { CopyButton } from "../shared/CopyButton";
 import { SessionTabs } from "../chat/SessionTabs";
 import { MessageMarkdown } from "../chat/MessageMarkdown";
 import { getCachedHighlight, highlightCode } from "../../utils/highlight";
@@ -118,48 +123,19 @@ export function DiffViewer() {
   const isMarkdown = !!diffSelectedFile && MARKDOWN_EXT.test(diffSelectedFile);
   const showRendered = isMarkdown && diffPreviewMode === "rendered";
 
-  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
-  const copyResetRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    setCopyState("idle");
-    if (copyResetRef.current !== null) {
-      window.clearTimeout(copyResetRef.current);
-      copyResetRef.current = null;
-    }
-  }, [diffSelectedFile]);
-
-  useEffect(() => {
-    return () => {
-      if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
-    };
-  }, []);
-
-  const handleCopyContents = useCallback(async () => {
-    if (!selectedWorkspaceId || !diffSelectedFile) return;
+  const fetchFileForCopy = useCallback(async (): Promise<string | null> => {
+    if (!selectedWorkspaceId || !diffSelectedFile) return null;
     // Capture path at invocation; if the user switches files before the
-    // async work resolves we bail so the copy result doesn't apply to a
-    // different file's button (would show a stale checkmark).
+    // async work resolves we drop the result so the copy doesn't land on
+    // a different file's clipboard.
     const requestedFile = diffSelectedFile;
-    let nextState: "copied" | "error";
-    try {
-      const file = await readWorkspaceFile(selectedWorkspaceId, requestedFile);
-      // The backend caps reads at 100 KB. Copying a truncated prefix would
-      // silently mislead the user — treat truncation as a copy failure.
-      if (file.is_binary || file.content === null || file.truncated) {
-        nextState = "error";
-      } else {
-        await clipboardWriteText(file.content);
-        nextState = "copied";
-      }
-    } catch (e) {
-      console.error("Copy file contents failed:", e);
-      nextState = "error";
-    }
-    if (useAppStore.getState().diffSelectedFile !== requestedFile) return;
-    setCopyState(nextState);
-    if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
-    copyResetRef.current = window.setTimeout(() => setCopyState("idle"), 1500);
+    const file = await readWorkspaceFileForViewer(
+      selectedWorkspaceId,
+      requestedFile,
+    );
+    if (useAppStore.getState().diffSelectedFile !== requestedFile) return null;
+    if (file.is_binary || file.content === null || file.truncated) return null;
+    return file.content;
   }, [selectedWorkspaceId, diffSelectedFile]);
 
   // Monotonic version token: each new fetch bumps it so a stale in-flight
@@ -314,23 +290,14 @@ export function DiffViewer() {
           path={diffSelectedFile}
           actions={
             <>
-              <IconButton
-                onClick={handleCopyContents}
-                tooltip={
-                  copyState === "copied"
-                    ? t("diff_tooltip_copied")
-                    : copyState === "error"
-                      ? t("diff_tooltip_copy_failed")
-                      : t("diff_tooltip_copy_contents")
-                }
-                aria-live="polite"
-              >
-                {copyState === "copied" ? (
-                  <Check size={14} aria-hidden="true" />
-                ) : (
-                  <Copy size={14} aria-hidden="true" />
-                )}
-              </IconButton>
+              <CopyButton
+                source={fetchFileForCopy}
+                tooltip={{
+                  copy: t("diff_tooltip_copy_contents"),
+                  copied: t("diff_tooltip_copied"),
+                  failed: t("diff_tooltip_copy_failed"),
+                }}
+              />
               {selectedWorkspaceId && diffSelectedFile && (
                 <IconButton
                   onClick={() => openFileTab(selectedWorkspaceId, diffSelectedFile)}

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -301,6 +301,10 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
         actions={
           <>
             <CopyButton
+              // Same rationale as DiffViewer: remount on tab switch so a
+              // late clipboard write from the previous tab can't flash a
+              // checkmark/error on the new tab's button.
+              key={`${workspaceId}/${path}`}
               source={copySource}
               tooltip={{
                 copy: t("diff_tooltip_copy_contents"),

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -9,8 +9,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { BookOpen, Check, Code, Copy, Save } from "lucide-react";
-import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
+import { BookOpen, Code, Save } from "lucide-react";
 import {
   selectActiveFileTabPath,
   useAppStore,
@@ -31,6 +30,7 @@ import { WorkspacePanelHeader } from "../shared/WorkspacePanelHeader";
 import { PaneToolbar } from "../shared/PaneToolbar";
 import { SegmentedControl } from "../shared/SegmentedControl";
 import { IconButton } from "../shared/IconButton";
+import { CopyButton } from "../shared/CopyButton";
 import { SessionTabs } from "../chat/SessionTabs";
 import { MessageMarkdown } from "../chat/MessageMarkdown";
 import { MarkdownImageBaseProvider } from "../chat/MarkdownImage";
@@ -80,29 +80,14 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const addToast = useAppStore((s) => s.addToast);
   const keybindings = useAppStore((s) => s.keybindings);
 
-  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
-    "idle",
-  );
   const [saving, setSaving] = useState(false);
-  const copyResetRef = useRef<number | null>(null);
 
   // Reset transient per-tab UI state when the active tab/workspace changes
-  // so an in-flight save/copy on a previous tab can't leak its disabled state
-  // or pending callbacks into the newly mounted view.
+  // so an in-flight save on a previous tab can't leak its disabled state
+  // into the newly mounted view.
   useEffect(() => {
-    setCopyState("idle");
     setSaving(false);
-    if (copyResetRef.current !== null) {
-      window.clearTimeout(copyResetRef.current);
-      copyResetRef.current = null;
-    }
   }, [workspaceId, path]);
-
-  useEffect(() => {
-    return () => {
-      if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
-    };
-  }, []);
 
   const isMarkdown = MARKDOWN_EXT.test(path);
   const isImage = isImagePath(path);
@@ -182,35 +167,10 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     [workspaceId, path, setFileBufferContent],
   );
 
-  const handleCopy = useCallback(async () => {
-    if (!bufferState) return;
-    const requestedWorkspaceId = workspaceId;
-    const requestedPath = path;
-    let nextState: "copied" | "error";
-    try {
-      if (isImage || bufferState.isBinary) {
-        nextState = "error";
-      } else {
-        await clipboardWriteText(bufferState.buffer);
-        nextState = "copied";
-      }
-    } catch (e) {
-      console.error("Copy file contents failed:", e);
-      nextState = "error";
-    }
-    // Bail if the user switched tabs (or workspaces) mid-async — otherwise a
-    // late completion would flip copy state on a different file.
-    const state = useAppStore.getState();
-    if (
-      state.selectedWorkspaceId !== requestedWorkspaceId ||
-      selectActiveFileTabPath(state) !== requestedPath
-    ) {
-      return;
-    }
-    setCopyState(nextState);
-    if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
-    copyResetRef.current = window.setTimeout(() => setCopyState("idle"), 1500);
-  }, [bufferState, isImage, workspaceId, path]);
+  const copySource = useCallback((): string | null => {
+    if (!bufferState || isImage || bufferState.isBinary) return null;
+    return bufferState.buffer;
+  }, [bufferState, isImage]);
 
   const handleSave = useCallback(async () => {
     if (!bufferState || !dirty || saving) return;
@@ -340,24 +300,15 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
         dirty={dirty}
         actions={
           <>
-            <IconButton
-              onClick={handleCopy}
-              tooltip={
-                copyState === "copied"
-                  ? t("diff_tooltip_copied")
-                  : copyState === "error"
-                    ? t("diff_tooltip_copy_failed")
-                    : t("diff_tooltip_copy_contents")
-              }
-              aria-live="polite"
+            <CopyButton
+              source={copySource}
+              tooltip={{
+                copy: t("diff_tooltip_copy_contents"),
+                copied: t("diff_tooltip_copied"),
+                failed: t("diff_tooltip_copy_failed"),
+              }}
               disabled={isImage || !bufferState?.loaded || bufferState?.isBinary}
-            >
-              {copyState === "copied" ? (
-                <Check size={14} aria-hidden="true" />
-              ) : (
-                <Copy size={14} aria-hidden="true" />
-              )}
-            </IconButton>
+            />
             {showMarkdownToggle && (
               <SegmentedControl
                 ariaLabel={t("file_markdown_view_mode_aria")}

--- a/src/ui/src/components/modals/MissingCliModal.tsx
+++ b/src/ui/src/components/modals/MissingCliModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { openUrl } from "../../services/tauri";
 import { Modal } from "./Modal";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import shared from "./shared.module.css";
 import styles from "./MissingCliModal.module.css";
 
@@ -54,39 +54,11 @@ export function MissingCliModal() {
   const { t: tCommon } = useTranslation("common");
   const closeModal = useAppStore((s) => s.closeModal);
   const modalData = useAppStore((s) => s.modalData);
-  const [copied, setCopied] = useState<number | null>(null);
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(
-    () => () => {
-      if (copyTimerRef.current !== null) {
-        clearTimeout(copyTimerRef.current);
-        copyTimerRef.current = null;
-      }
-    },
-    [],
-  );
 
   const data = isMissingCliData(modalData) ? modalData : null;
   if (!data) return null;
 
   const platformLabel = PLATFORM_LABEL[data.platform] ?? data.platform;
-
-  const handleCopy = async (cmd: string, idx: number) => {
-    try {
-      await navigator.clipboard.writeText(cmd);
-      setCopied(idx);
-      if (copyTimerRef.current !== null) {
-        clearTimeout(copyTimerRef.current);
-      }
-      copyTimerRef.current = setTimeout(() => {
-        copyTimerRef.current = null;
-        setCopied((c) => (c === idx ? null : c));
-      }, 1500);
-    } catch {
-      // Clipboard API can reject in some sandboxes — silently ignore.
-    }
-  };
 
   const handleOpen = (url: string) => {
     void openUrl(url).catch(() => {});
@@ -106,13 +78,11 @@ export function MissingCliModal() {
               {opt.command && (
                 <div className={styles.commandRow}>
                   <code className={styles.code}>{opt.command}</code>
-                  <button
-                    type="button"
-                    className={shared.btn}
-                    onClick={() => void handleCopy(opt.command!, idx)}
-                  >
-                    {copied === idx ? t("missing_cli_copied") : tCommon("copy")}
-                  </button>
+                  <CommandCopyButton
+                    command={opt.command}
+                    copyLabel={tCommon("copy")}
+                    copiedLabel={t("missing_cli_copied")}
+                  />
                 </div>
               )}
               {opt.url && (
@@ -138,5 +108,26 @@ export function MissingCliModal() {
         </button>
       </div>
     </Modal>
+  );
+}
+
+function CommandCopyButton({
+  command,
+  copyLabel,
+  copiedLabel,
+}: {
+  command: string;
+  copyLabel: string;
+  copiedLabel: string;
+}) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <button
+      type="button"
+      className={shared.btn}
+      onClick={() => void copy(command)}
+    >
+      {copied ? copiedLabel : copyLabel}
+    </button>
   );
 }

--- a/src/ui/src/components/modals/ShareModal.tsx
+++ b/src/ui/src/components/modals/ShareModal.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { stopLocalServer } from "../../services/tauri";
 import { Modal } from "./Modal";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import shared from "./shared.module.css";
 
 export function ShareModal() {
@@ -11,6 +12,7 @@ export function ShareModal() {
   const connectionString = useAppStore((s) => s.localServerConnectionString);
   const setRunning = useAppStore((s) => s.setLocalServerRunning);
   const setConnectionString = useAppStore((s) => s.setLocalServerConnectionString);
+  const { copied, copy } = useCopyToClipboard();
 
   const handleStop = async () => {
     try {
@@ -20,12 +22,6 @@ export function ShareModal() {
       closeModal();
     } catch (e) {
       console.error("Failed to stop server:", e);
-    }
-  };
-
-  const handleCopy = () => {
-    if (connectionString) {
-      navigator.clipboard.writeText(connectionString);
     }
   };
 
@@ -40,8 +36,13 @@ export function ShareModal() {
             readOnly
             onClick={(e) => (e.target as HTMLInputElement).select()}
           />
-          <button className={shared.btn} onClick={handleCopy}>
-            {tCommon("copy")}
+          <button
+            type="button"
+            className={shared.btn}
+            onClick={() => void copy(connectionString ?? "")}
+            disabled={!connectionString}
+          >
+            {copied ? tCommon("copied") : tCommon("copy")}
           </button>
         </div>
         <div className={shared.smallHint}>

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { useCallback, useEffect, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import {
   getEnvSources,
   getEnvTargetWorktree,
@@ -454,48 +454,10 @@ function ErrorCard({
   onRunTrust: () => void;
 }) {
   const insight = analyzeError(pluginName, error);
-  const [copiedCmd, setCopiedCmd] = useState(false);
-  const [copiedRaw, setCopiedRaw] = useState(false);
-  // Track the "Copied" flag reset timer per-flag so a fast second copy
-  // (or an unmount from collapsing/target-change) cancels the pending
-  // setState instead of firing after the component is gone.
-  const cmdResetRef = useRef<number | null>(null);
-  const rawResetRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (cmdResetRef.current !== null) {
-        window.clearTimeout(cmdResetRef.current);
-      }
-      if (rawResetRef.current !== null) {
-        window.clearTimeout(rawResetRef.current);
-      }
-    };
-  }, []);
-
-  const copy = useCallback(
-    async (
-      text: string,
-      setFlag: (v: boolean) => void,
-      timerRef: React.MutableRefObject<number | null>,
-    ) => {
-      try {
-        await writeText(text);
-        setFlag(true);
-        if (timerRef.current !== null) {
-          window.clearTimeout(timerRef.current);
-        }
-        timerRef.current = window.setTimeout(() => {
-          setFlag(false);
-          timerRef.current = null;
-        }, 1500);
-      } catch {
-        // Clipboard access can fail in hardened webviews; silently no-op —
-        // the raw text is still visible in the <pre> for manual selection.
-      }
-    },
-    [],
-  );
+  // Two independent hook instances so the "Copied" flag tracks per button
+  // (the suggested command and the raw error each get their own timer).
+  const { copied: copiedCmd, copy: copyCmd } = useCopyToClipboard();
+  const { copied: copiedRaw, copy: copyRaw } = useCopyToClipboard();
 
   return (
     <div className={styles.envErrorCard} role="alert">
@@ -525,9 +487,7 @@ function ErrorCard({
             <button
               type="button"
               className={styles.envErrorCopyBtn}
-              onClick={() =>
-                copy(insight.suggestedCommand!, setCopiedCmd, cmdResetRef)
-              }
+              onClick={() => void copyCmd(insight.suggestedCommand!)}
             >
               {copiedCmd ? "Copied" : "Copy"}
             </button>
@@ -540,7 +500,7 @@ function ErrorCard({
         <button
           type="button"
           className={styles.envErrorCopyBtn}
-          onClick={() => copy(error, setCopiedRaw, rawResetRef)}
+          onClick={() => void copyRaw(error)}
         >
           {copiedRaw ? "Copied" : "Copy full error"}
         </button>

--- a/src/ui/src/components/shared/CopyButton.module.css
+++ b/src/ui/src/components/shared/CopyButton.module.css
@@ -1,0 +1,11 @@
+/* Shared visual hooks for the copy button across both variants.
+   The bare variant inherits font/color/border from its parent
+   (chat surfaces apply their own .copyButton styles); we only
+   contribute the error-state tint here. */
+.copyButton {
+  transition: color var(--transition-fast);
+}
+
+.copyButton[data-state="error"] {
+  color: var(--status-stopped);
+}

--- a/src/ui/src/components/shared/CopyButton.tsx
+++ b/src/ui/src/components/shared/CopyButton.tsx
@@ -1,0 +1,99 @@
+import type { MouseEvent, ReactNode } from "react";
+import { Check, Copy } from "lucide-react";
+import { IconButton } from "./IconButton";
+import {
+  type CopySource,
+  useCopyToClipboard,
+  type UseCopyToClipboardOptions,
+} from "../../hooks/useCopyToClipboard";
+import styles from "./CopyButton.module.css";
+
+interface TooltipLabels {
+  copy: string;
+  copied: string;
+  failed?: string;
+}
+
+interface CopyButtonProps extends UseCopyToClipboardOptions {
+  source: CopySource;
+  tooltip: TooltipLabels;
+  className?: string;
+  iconSize?: number;
+  /** "icon-button" wraps `<IconButton>` (toolbar buttons in DiffViewer/
+   *  FileViewer). "bare" renders a plain `<button>` so chat call sites
+   *  keep their CSS-driven styling. */
+  variant?: "icon-button" | "bare";
+  disabled?: boolean;
+  ariaLabel?: string;
+  /** Optional render node for "extra" content next to the icon (e.g. a
+   *  text label for compact toolbars that don't have room for both). */
+  children?: ReactNode;
+  stopPropagation?: boolean;
+}
+
+export function CopyButton({
+  source,
+  tooltip,
+  className,
+  iconSize = 14,
+  variant = "icon-button",
+  disabled,
+  ariaLabel,
+  resetMs,
+  onError,
+  children,
+  stopPropagation,
+}: CopyButtonProps) {
+  const { state, copy } = useCopyToClipboard({ resetMs, onError });
+
+  const tooltipText =
+    state === "copied"
+      ? tooltip.copied
+      : state === "error"
+        ? (tooltip.failed ?? tooltip.copy)
+        : tooltip.copy;
+
+  const handleClick = (e: MouseEvent) => {
+    if (stopPropagation) e.stopPropagation();
+    void copy(source);
+  };
+
+  const icon =
+    state === "copied" ? (
+      <Check size={iconSize} aria-hidden="true" />
+    ) : (
+      <Copy size={iconSize} aria-hidden="true" />
+    );
+
+  if (variant === "icon-button") {
+    return (
+      <IconButton
+        onClick={handleClick}
+        tooltip={tooltipText}
+        aria-live="polite"
+        disabled={disabled}
+        className={`${styles.copyButton} ${className ?? ""}`}
+        data-state={state}
+      >
+        {icon}
+        {children}
+      </IconButton>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={`${styles.copyButton} ${className ?? ""}`}
+      onClick={handleClick}
+      title={tooltipText}
+      aria-label={ariaLabel ?? tooltip.copy}
+      aria-live="polite"
+      disabled={disabled}
+      data-state={state}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/src/ui/src/components/shared/CopyButton.tsx
+++ b/src/ui/src/components/shared/CopyButton.tsx
@@ -87,7 +87,11 @@ export function CopyButton({
       className={`${styles.copyButton} ${className ?? ""}`}
       onClick={handleClick}
       title={tooltipText}
-      aria-label={ariaLabel ?? tooltip.copy}
+      // Default to the state-aware tooltipText so screen readers announce
+      // the same "Copied!" / "Copy failed" feedback the sighted user gets.
+      // Callers that want a static label (e.g. "Copy message") can pass an
+      // explicit `ariaLabel` to opt out.
+      aria-label={ariaLabel ?? tooltipText}
       aria-live="polite"
       disabled={disabled}
       data-state={state}

--- a/src/ui/src/hooks/useCopyToClipboard.test.ts
+++ b/src/ui/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveCopySource } from "./useCopyToClipboard";
+
+describe("resolveCopySource", () => {
+  it("returns the literal string", async () => {
+    expect(await resolveCopySource("hello")).toBe("hello");
+  });
+
+  it("calls a sync thunk and returns its string", async () => {
+    expect(await resolveCopySource(() => "sync result")).toBe("sync result");
+  });
+
+  it("awaits an async thunk and returns the resolved string", async () => {
+    expect(
+      await resolveCopySource(async () => "async result"),
+    ).toBe("async result");
+  });
+
+  it("returns null for an empty string source", async () => {
+    expect(await resolveCopySource("")).toBeNull();
+  });
+
+  it("returns null when a thunk resolves to null", async () => {
+    // Callers (DiffViewer, FileViewer) signal "intentionally invalid" by
+    // returning null from their content-fetch thunk. This must not surface
+    // as a thrown error — it should flow through as a silent error state.
+    expect(await resolveCopySource(() => null)).toBeNull();
+    expect(await resolveCopySource(async () => null)).toBeNull();
+  });
+
+  it("returns null when a thunk resolves to an empty string", async () => {
+    expect(await resolveCopySource(() => "")).toBeNull();
+  });
+
+  it("propagates errors thrown by a sync thunk", async () => {
+    await expect(
+      resolveCopySource(() => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("propagates errors rejected by an async thunk", async () => {
+    await expect(
+      resolveCopySource(async () => {
+        throw new Error("async boom");
+      }),
+    ).rejects.toThrow("async boom");
+  });
+});

--- a/src/ui/src/hooks/useCopyToClipboard.ts
+++ b/src/ui/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { writeText as clipboardWriteText } from "@tauri-apps/plugin-clipboard-manager";
+
+/** A copy source: a literal string, or a (sync/async) thunk that resolves
+ *  one. Returning `null` from the thunk signals "intentionally invalid"
+ *  (e.g. binary/truncated/missing) — the hook flips to `error` state
+ *  without invoking `onError`, matching the existing silent-fail UX. */
+export type CopySource =
+  | string
+  | (() => string | null | Promise<string | null>);
+
+export type CopyState = "idle" | "copied" | "error";
+
+export interface UseCopyToClipboardOptions {
+  resetMs?: number;
+  onError?: (err: unknown) => void;
+}
+
+export interface UseCopyToClipboardResult {
+  state: CopyState;
+  copied: boolean;
+  copy: (source: CopySource) => Promise<boolean>;
+  reset: () => void;
+}
+
+const DEFAULT_RESET_MS = 1500;
+
+/** Resolve a copy source to its final string. Returns `null` to signal a
+ *  silent invalid result (empty string treated the same — copying nothing
+ *  is never useful). Thunks that throw bubble up so the caller can route
+ *  them to `onError`. Pure so it can be unit-tested. */
+export async function resolveCopySource(
+  source: CopySource,
+): Promise<string | null> {
+  const resolved = typeof source === "function" ? await source() : source;
+  if (resolved == null || resolved === "") return null;
+  return resolved;
+}
+
+export function useCopyToClipboard(
+  options: UseCopyToClipboardOptions = {},
+): UseCopyToClipboardResult {
+  const { resetMs = DEFAULT_RESET_MS, onError } = options;
+  const [state, setState] = useState<CopyState>("idle");
+  const resetRef = useRef<number | null>(null);
+  // Latest `onError` without re-creating `copy` on every render — callers
+  // commonly pass an inline closure, and we don't want each render to
+  // invalidate `useCallback` dependents downstream (e.g. memoized JSX).
+  const onErrorRef = useRef(onError);
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  const clearTimer = useCallback(() => {
+    if (resetRef.current !== null) {
+      window.clearTimeout(resetRef.current);
+      resetRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setState("idle");
+  }, [clearTimer]);
+
+  const scheduleReset = useCallback(
+    (next: CopyState) => {
+      clearTimer();
+      setState(next);
+      resetRef.current = window.setTimeout(() => {
+        resetRef.current = null;
+        setState("idle");
+      }, resetMs);
+    },
+    [clearTimer, resetMs],
+  );
+
+  const copy = useCallback(
+    async (source: CopySource): Promise<boolean> => {
+      let text: string | null;
+      try {
+        text = await resolveCopySource(source);
+      } catch (err) {
+        onErrorRef.current?.(err);
+        scheduleReset("error");
+        return false;
+      }
+      if (text === null) {
+        scheduleReset("error");
+        return false;
+      }
+      try {
+        await clipboardWriteText(text);
+      } catch (err) {
+        onErrorRef.current?.(err);
+        scheduleReset("error");
+        return false;
+      }
+      scheduleReset("copied");
+      return true;
+    },
+    [scheduleReset],
+  );
+
+  return {
+    state,
+    copied: state === "copied",
+    copy,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary

The diff viewer's copy icon looked broken on any moderately large file: clicking it never swapped to a checkmark and nothing landed on the clipboard.

**Root cause.** `DiffViewer.handleCopyContents` read content via `readWorkspaceFile`, whose backend command (`commands/files.rs:read_workspace_file`) caps text reads at **100 KB** and returns `truncated: true` past that. The handler then took the `error` branch — which **never called `clipboardWriteText` and never changed the icon**. Only the tooltip flipped to *Copy failed*, which is invisible at a glance.

**Fix.** Use `readWorkspaceFileForViewer` (10 MB cap), the same call the file viewer already uses for its copy button. Whatever the user can open in the editor, they can now copy from the diff toolbar.

**Why a broader change.** Auditing surfaced **nine separate copy implementations** in the frontend, split across two APIs (`navigator.clipboard.writeText` and `@tauri-apps/plugin-clipboard-manager`) with inconsistent reset timeouts (1200 ms vs 1500 ms) and three feedback styles. Each new copy site was getting re-implemented from scratch — that's the dynamic that let this bug land. This PR introduces a shared `useCopyToClipboard` hook + `<CopyButton>` component that all sites now share.

```mermaid
flowchart LR
  subgraph before["Before — 9 bespoke implementations"]
    a1[DiffViewer]:::broken
    a2[FileViewer]
    a3[PlanApprovalCard]
    a4[MessageCopyButton]
    a5[CodeBlock]
    a6[TurnFooter]
    a7[ShareModal]
    a8[MissingCliModal]
    a9[EnvPanel]
    a1 -.->|navigator.clipboard| W1[Web API]
    a2 -.->|Tauri plugin| W2[Tauri clipboard]
    a3 -.->|Tauri plugin| W2
    a4 -.->|navigator.clipboard| W1
    a5 -.->|navigator.clipboard| W1
    a6 -.->|navigator.clipboard| W1
    a7 -.->|navigator.clipboard| W1
    a8 -.->|navigator.clipboard| W1
    a9 -.->|Tauri plugin| W2
  end
  subgraph after["After — single source of truth"]
    H[useCopyToClipboard]
    C["&lt;CopyButton&gt;"]
    H --> P[Tauri clipboard]
    C --> H
    icon[icon-button surfaces<br/>DiffViewer, FileViewer,<br/>PlanApprovalCard,<br/>MessageCopyButton,<br/>CodeBlock, TurnFooter] --> C
    text[text-label surfaces<br/>ShareModal,<br/>MissingCliModal,<br/>EnvPanel] --> H
  end
  classDef broken stroke:#c00,stroke-width:2px;
```

Net diff: **+410 / −432** despite four new files.

## Complexity Notes

- **`useCopyToClipboard` source semantics.** The hook accepts either a string or a thunk returning `string | null`. Returning `null` is the *silent invalid* signal: the hook flips to `error` state without invoking `onError`. This intentionally preserves the existing UX where binary/truncated/missing content failed without a console log. Real exceptions (file read fails, plugin throws) still go through `onError`. DiffViewer/FileViewer use the `null` path; PlanApprovalCard wires `onError` to `setLoadError`.
- **`MissingCliModal` per-row hook instances.** Each install row gets its own `<CommandCopyButton>` so we can drop the index-tracked `copied` state and the per-row reset-timer `useRef`. That's one of the bigger conceptual simplifications — worth a glance to make sure the row identity is doing what you'd expect.
- **DiffViewer file-switch race guard.** The thunk still captures `requestedFile` at invocation and bails (returns `null`) if `useAppStore.getState().diffSelectedFile` has changed by the time the read resolves, so a stale checkmark can't leak onto a different file's button.
- **`CodeBlock` styling.** Replaced the conditional `${styles.copyButton} ${copied ? styles.copied : ""}` className with a single class plus a `[data-state="copied"]` attribute selector in the same stylesheet. Visually identical; structurally cleaner.
- **`navigator.clipboard.writeText` is gone from the frontend.** Anyone adding a future copy button needs to use the hook/component — there's no precedent left for the Web API.

## Test Steps

1. `cd src/ui && bun install --frozen-lockfile`
2. `cd src/ui && bunx tsc -b` — clean (0 errors)
3. `cd src/ui && bun run lint:css` — clean
4. `cd src/ui && bun run test` — 1234 passing (8 new in `useCopyToClipboard.test.ts`)
5. `cargo tauri dev` and verify in the running app:
   - Open a large CSV (1000+ lines) in the diff viewer; click the copy icon. Checkmark appears for ~1.5 s; pasting into a separate text editor shows the full file.
   - Open a binary file in the diff viewer; click copy. Icon briefly tints red, tooltip says *Copy failed*, clipboard unchanged.
   - In a chat turn, click copy on a code block, the message footer (TurnFooter), a user message, and the plan approval card if you have one — each shows its own copied affordance and the clipboard contents match.
   - Open the Share modal (start local server first); click *Copy*, verify it swaps to *Copied* for ~1.5 s.
   - Trigger the Missing CLI modal (e.g. by removing a tool from `PATH`); click *Copy* on multiple install rows in quick succession — each row tracks its own *Copied* label independently.
   - Trigger an env-provider error (e.g. `direnv allow` on an untrusted directory); click both *Copy* and *Copy full error* — both buttons swap independently.

## Checklist

- [x] Tests added/updated (`useCopyToClipboard.test.ts` — 8 cases covering string, sync/async thunks, null/empty propagation, and error bubbling)
- [ ] Documentation updated (no docs reference clipboard internals; n/a)