### PR TITLE
feat(editor): add user-toggleable Monaco minimap

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
     (s) => s.setCommunityRegistryEnabled,
   );
   const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
+  const setEditorMinimapEnabled = useAppStore((s) => s.setEditorMinimapEnabled);
   const setDisable1mContext = useAppStore((s) => s.setDisable1mContext);
   const setVoiceToggleHotkey = useAppStore((s) => s.setVoiceToggleHotkey);
   const setVoiceHoldHotkey = useAppStore((s) => s.setVoiceHoldHotkey);
@@ -222,6 +223,9 @@ function App() {
       .then((val) => {
         if (val === "merge_base") setEditorGitGutterBase("merge_base");
       })
+      .catch(() => {});
+    getAppSetting("editor_minimap_enabled")
+      .then((val) => { if (val === "true") setEditorMinimapEnabled(true); })
       .catch(() => {});
     Promise.all([
       listAppSettingsWithPrefix(KEYBINDING_SETTING_PREFIX),
@@ -458,7 +462,7 @@ function App() {
       unlistenAutoArchived.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setEditorMinimapEnabled, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -3,6 +3,7 @@ import Editor, { type BeforeMount, type OnMount } from "@monaco-editor/react";
 import "./monacoSetup";
 import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
+import { useAppStore } from "../../stores/useAppStore";
 import {
   useGitGutter,
   type DecorationsCollection,
@@ -67,12 +68,18 @@ export const MonacoEditor = memo(function MonacoEditor({
   // remounts via `key={path}` on file switches so the seed stays correct.
   const [currentBuffer, setCurrentBuffer] = useState(initialValue);
 
+  const minimapEnabled = useAppStore((s) => s.editorMinimapEnabled);
+
   // Reflect readOnly changes into the editor without remounting. Monaco's
   // `updateOptions` is the explicit runtime API for this; with CodeMirror
   // we had to recreate EditorState, but here it's a one-liner.
   useEffect(() => {
     editorRef.current?.updateOptions({ readOnly });
   }, [readOnly]);
+
+  useEffect(() => {
+    editorRef.current?.updateOptions({ minimap: { enabled: minimapEnabled } });
+  }, [minimapEnabled]);
 
   // Disconnect the theme observer and clear the gutter collection when
   // the editor unmounts. The collection is owned by Monaco's editor
@@ -134,7 +141,7 @@ export const MonacoEditor = memo(function MonacoEditor({
         onChange={handleEditorChange}
         options={{
           readOnly,
-          minimap: { enabled: false },
+          minimap: { enabled: minimapEnabled },
           wordWrap: "on",
           lineNumbers: "on",
           scrollBeyondLastLine: false,

--- a/src/ui/src/components/settings/sections/EditorSettings.tsx
+++ b/src/ui/src/components/settings/sections/EditorSettings.tsx
@@ -10,6 +10,8 @@ export function EditorSettings() {
   const { t } = useTranslation("settings");
   const editorGitGutterBase = useAppStore((s) => s.editorGitGutterBase);
   const setEditorGitGutterBase = useAppStore((s) => s.setEditorGitGutterBase);
+  const minimapEnabled = useAppStore((s) => s.editorMinimapEnabled);
+  const setMinimapEnabled = useAppStore((s) => s.setEditorMinimapEnabled);
   const [error, setError] = useState<string | null>(null);
   // Lock the radios while a persistence write is in flight. Without this,
   // a rapid head→merge_base→head sequence whose first two writes both
@@ -31,6 +33,18 @@ export function EditorSettings() {
       setError(String(e));
     } finally {
       setPending(false);
+    }
+  };
+
+  const handleMinimapToggle = async () => {
+    const next = !minimapEnabled;
+    setMinimapEnabled(next);
+    try {
+      setError(null);
+      await setAppSetting("editor_minimap_enabled", next ? "true" : "false");
+    } catch (e) {
+      setMinimapEnabled(!next);
+      setError(String(e));
     }
   };
 
@@ -77,6 +91,27 @@ export function EditorSettings() {
             </div>
           </div>
         </label>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("editor_minimap_label")}</div>
+          <div className={styles.settingDescription}>
+            {t("editor_minimap_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={minimapEnabled}
+            aria-label={t("editor_minimap_label")}
+            data-checked={minimapEnabled}
+            onClick={handleMinimapToggle}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/ui/src/components/settings/sections/EditorSettings.tsx
+++ b/src/ui/src/components/settings/sections/EditorSettings.tsx
@@ -13,11 +13,12 @@ export function EditorSettings() {
   const minimapEnabled = useAppStore((s) => s.editorMinimapEnabled);
   const setMinimapEnabled = useAppStore((s) => s.setEditorMinimapEnabled);
   const [error, setError] = useState<string | null>(null);
-  // Lock the radios while a persistence write is in flight. Without this,
-  // a rapid head→merge_base→head sequence whose first two writes both
-  // reject would have the second catch roll the store back to merge_base,
-  // even though the persisted value never left head — the UI would then
-  // disagree with disk until the app is restarted.
+  // Lock controls while a persistence write is in flight. Without this,
+  // a rapid sequence whose writes reject in interleaved order would have
+  // a later catch roll the store back to a stale value even though the
+  // persisted value never went there — the UI would then disagree with
+  // disk until the app is restarted. Shared across the radios and the
+  // minimap toggle so concurrent writes can't race each other either.
   const [pending, setPending] = useState(false);
 
   const handleChange = async (value: GutterBase) => {
@@ -37,14 +38,18 @@ export function EditorSettings() {
   };
 
   const handleMinimapToggle = async () => {
+    if (pending) return;
     const next = !minimapEnabled;
     setMinimapEnabled(next);
+    setPending(true);
     try {
       setError(null);
       await setAppSetting("editor_minimap_enabled", next ? "true" : "false");
     } catch (e) {
       setMinimapEnabled(!next);
       setError(String(e));
+    } finally {
+      setPending(false);
     }
   };
 
@@ -106,7 +111,9 @@ export function EditorSettings() {
             role="switch"
             aria-checked={minimapEnabled}
             aria-label={t("editor_minimap_label")}
+            aria-disabled={pending}
             data-checked={minimapEnabled}
+            disabled={pending}
             onClick={handleMinimapToggle}
           >
             <div className={styles.toggleKnob} />

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -151,6 +151,8 @@
   "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
   "editor_gutter_base_merge_base": "Workspace branch base",
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+  "editor_minimap_label": "Show minimap",
+  "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
 
   "keyboard_title": "Keyboard",
   "keyboard_search_placeholder": "Search shortcuts…",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -145,6 +145,8 @@
   "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
   "editor_gutter_base_merge_base": "Workspace branch base",
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+  "editor_minimap_label": "Show minimap",
+  "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
   "git_title": "Git",
   "git_branch_prefix": "Prefijo del nombre de la rama",
   "git_branch_prefix_desc": "Prefijo para los nombres de las ramas de los nuevos espacios de trabajo.",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -145,6 +145,8 @@
   "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
   "editor_gutter_base_merge_base": "Workspace branch base",
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+  "editor_minimap_label": "Show minimap",
+  "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
   "git_title": "Git",
   "git_branch_prefix": "ブランチ名のプレフィックス",
   "git_branch_prefix_desc": "新しいワークスペースのブランチ名に付けるプレフィックスです。",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -145,6 +145,8 @@
   "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
   "editor_gutter_base_merge_base": "Workspace branch base",
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+  "editor_minimap_label": "Show minimap",
+  "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
   "git_title": "Git",
   "git_branch_prefix": "Prefixo do nome da branch",
   "git_branch_prefix_desc": "Prefixo para nomes de branch de novos workspaces.",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -145,6 +145,8 @@
   "editor_gutter_base_head_desc": "Show only changes you haven't committed yet. Default.",
   "editor_gutter_base_merge_base": "Workspace branch base",
   "editor_gutter_base_merge_base_desc": "Show every change made on this workspace's branch since it diverged from the repository's base branch. Matches the Changes panel.",
+  "editor_minimap_label": "Show minimap",
+  "editor_minimap_desc": "Display Monaco's scaled-down overview of the file along the right edge of the editor.",
   "git_title": "Git",
   "git_branch_prefix": "分支名称前缀",
   "git_branch_prefix_desc": "新工作区分支名称的前缀。",

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -53,6 +53,8 @@ export interface SettingsSlice {
   /// from the repo's base branch (matches the Changes panel).
   editorGitGutterBase: "head" | "merge_base";
   setEditorGitGutterBase: (value: "head" | "merge_base") => void;
+  editorMinimapEnabled: boolean;
+  setEditorMinimapEnabled: (enabled: boolean) => void;
   keybindings: Record<string, string | null>;
   setKeybinding: (actionId: string, binding: string | null) => void;
   resetKeybinding: (actionId: string) => void;
@@ -128,6 +130,8 @@ export const createSettingsSlice: StateCreator<
   setDisable1mContext: (v) => set({ disable1mContext: v }),
   editorGitGutterBase: "head",
   setEditorGitGutterBase: (value) => set({ editorGitGutterBase: value }),
+  editorMinimapEnabled: false,
+  setEditorMinimapEnabled: (enabled) => set({ editorMinimapEnabled: enabled }),
   keybindings: {},
   setKeybinding: (actionId, binding) =>
     set((state) => ({ keybindings: { ...state.keybindings, [actionId]: binding } })),


### PR DESCRIPTION
## Summary

Monaco's minimap was hard-coded off in `MonacoEditor.tsx`. This PR exposes it as a user-controllable setting under **Settings → Editor → Show minimap**.

- New Zustand field `editorMinimapEnabled: boolean` (default `false` — preserves current behavior).
- Persisted in `app_settings` under key `editor_minimap_enabled`.
- Hydrated on app boot in `App.tsx` alongside other editor settings.
- `MonacoEditor` reads the value for its initial options *and* runs a `useEffect` that calls `editor.updateOptions({ minimap: { enabled } })` so flipping the toggle takes effect instantly on every open editor — no remount, no lost cursor / undo.
- New i18n keys (`editor_minimap_label`, `editor_minimap_desc`) added to all five locale files (en, es, pt-BR, ja, zh-CN). Strings ship in English in the non-en files, matching the pattern of the existing `editor_gutter_base_*` keys.

```mermaid
flowchart LR
  S[Settings UI: Show minimap toggle] -->|setAppSetting| DB[(app_settings)]
  S -->|setEditorMinimapEnabled| Z[Zustand: editorMinimapEnabled]
  Z --> ME[MonacoEditor.useEffect]
  ME -->|editor.updateOptions| M[Monaco editor instance]
  DB -->|getAppSetting on boot| Z
```

## Complexity Notes

- The toggle wires through the same optimistic-update / rollback-on-error pattern already used by `editor_git_gutter_base` (see `EditorSettings.tsx`). Less elaborate than the `pending` lock used for the radios because the toggle is a single boolean — a failed write rolls back to `!next`, which is always correct.
- `MonacoEditor.tsx` sets the minimap option in **both** the initial `options` prop and a runtime `useEffect`. The initial value matters because the file viewer can mount before `getAppSetting` resolves on cold boot; without the initial read from the store, you'd see a brief flicker as hydration flips the setting on. Since the store default is `false` and the persisted default is also `false`, the flicker only matters for users who have explicitly enabled the minimap.
- Default stays `false` to preserve existing behavior — no surprise UX change for current users.

## Test Steps

1. `cd src/ui && bun install && bun run build` — verifies tsc + vite both pass.
2. `cd src/ui && bun run test` — frontend tests should still pass (1249 tests).
3. `cargo tauri dev` — open any file in the file viewer.
4. Open **Settings → Editor**. You should see a new "Show minimap" toggle below the existing "Git gutter base" radios. Toggle it on; the minimap should appear on the right edge of the open editor *immediately*, without remount (cursor position should be preserved).
5. Toggle off again — minimap disappears live.
6. Restart the app and re-open the same file — the previous toggle state should persist across restarts.
7. Open a fresh workspace / new file with the toggle on — the minimap should appear on first paint, no flicker.

## Checklist

- [ ] Tests added/updated — N/A; existing patterns (e.g. `editor_git_gutter_base`) ship without dedicated component tests, and there is no `EditorSettings` test file. Type and store integration is covered by `tsc -b`.
- [x] Documentation updated — i18n strings added to all 5 locale files; no other docs touched.