### PR TITLE
fix(plugins): show install CTA when claude CLI is missing

### DIFF
--- a/src-tauri/src/commands/plugin.rs
+++ b/src-tauri/src/commands/plugin.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use claudette::db::Database;
 use claudette::plugin::{
@@ -12,31 +12,48 @@ use serde_json::Value;
 
 use crate::state::AppState;
 
+/// Translate a `claudette::plugin::*` error into a user-facing string,
+/// emitting the missing-dependency event when the underlying cause is a
+/// missing CLI (issue #641). Mirrors the pattern in `repository.rs` /
+/// `scm.rs`.
+fn map_plugin_err(app: &AppHandle, err: String) -> String {
+    crate::missing_cli::handle_err(app, &err).unwrap_or(err)
+}
+
 #[tauri::command]
 pub async fn list_plugins(
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Vec<InstalledPlugin>, String> {
     let repo_path = resolve_optional_repo_path(&state, repo_id.as_deref())?;
-    plugin::list_installed_plugins(repo_path.as_deref()).await
+    plugin::list_installed_plugins(repo_path.as_deref())
+        .await
+        .map_err(|e| map_plugin_err(&app, e))
 }
 
 #[tauri::command]
 pub async fn list_plugin_catalog(
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<PluginCatalog, String> {
     let repo_path = resolve_optional_repo_path(&state, repo_id.as_deref())?;
-    plugin::list_plugin_catalog(repo_path.as_deref()).await
+    plugin::list_plugin_catalog(repo_path.as_deref())
+        .await
+        .map_err(|e| map_plugin_err(&app, e))
 }
 
 #[tauri::command]
 pub async fn list_plugin_marketplaces(
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<Vec<PluginMarketplace>, String> {
     let repo_path = resolve_optional_repo_path(&state, repo_id.as_deref())?;
-    plugin::list_marketplaces(repo_path.as_deref()).await
+    plugin::list_marketplaces(repo_path.as_deref())
+        .await
+        .map_err(|e| map_plugin_err(&app, e))
 }
 
 #[tauri::command]
@@ -44,6 +61,7 @@ pub async fn install_plugin(
     target: String,
     scope: PluginScope,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     require_non_managed_scope(scope)?;
@@ -52,7 +70,8 @@ pub async fn install_plugin(
         repo_path.as_deref(),
         &build_install_args(&target, scope),
     )
-    .await?;
+    .await
+    .map_err(|e| map_plugin_err(&app, e))?;
     mark_plugin_sessions_dirty(&state, repo_id.as_deref(), scope).await?;
     Ok(output)
 }
@@ -63,6 +82,7 @@ pub async fn uninstall_plugin(
     scope: PluginScope,
     keep_data: Option<bool>,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     require_non_managed_scope(scope)?;
@@ -71,7 +91,8 @@ pub async fn uninstall_plugin(
         repo_path.as_deref(),
         &build_uninstall_args(&plugin_id, scope, keep_data.unwrap_or(false)),
     )
-    .await?;
+    .await
+    .map_err(|e| map_plugin_err(&app, e))?;
     plugin::cleanup_plugin_configuration_if_not_installed(&plugin_id)?;
     mark_plugin_sessions_dirty(&state, repo_id.as_deref(), scope).await?;
     Ok(output)
@@ -82,6 +103,7 @@ pub async fn enable_plugin(
     plugin_id: String,
     scope: PluginScope,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     require_non_managed_scope(scope)?;
@@ -90,7 +112,8 @@ pub async fn enable_plugin(
         repo_path.as_deref(),
         &build_enable_args(&plugin_id, scope),
     )
-    .await?;
+    .await
+    .map_err(|e| map_plugin_err(&app, e))?;
     mark_plugin_sessions_dirty(&state, repo_id.as_deref(), scope).await?;
     Ok(output)
 }
@@ -100,6 +123,7 @@ pub async fn disable_plugin(
     plugin_id: String,
     scope: PluginScope,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     require_non_managed_scope(scope)?;
@@ -108,7 +132,8 @@ pub async fn disable_plugin(
         repo_path.as_deref(),
         &build_disable_args(&plugin_id, scope),
     )
-    .await?;
+    .await
+    .map_err(|e| map_plugin_err(&app, e))?;
     mark_plugin_sessions_dirty(&state, repo_id.as_deref(), scope).await?;
     Ok(output)
 }
@@ -118,6 +143,7 @@ pub async fn update_plugin(
     plugin_id: String,
     scope: PluginScope,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let repo_path = resolve_scope_repo_path(&state, repo_id.as_deref(), scope)?;
@@ -125,7 +151,8 @@ pub async fn update_plugin(
         repo_path.as_deref(),
         &build_update_args(&plugin_id, scope),
     )
-    .await?;
+    .await
+    .map_err(|e| map_plugin_err(&app, e))?;
     mark_plugin_sessions_dirty(&state, repo_id.as_deref(), scope).await?;
     Ok(output)
 }
@@ -133,10 +160,13 @@ pub async fn update_plugin(
 #[tauri::command]
 pub async fn update_all_plugins(
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<BulkPluginUpdateResult, String> {
     let repo_path = resolve_optional_repo_path(&state, repo_id.as_deref())?;
-    let installed = plugin::list_installed_plugins(repo_path.as_deref()).await?;
+    let installed = plugin::list_installed_plugins(repo_path.as_deref())
+        .await
+        .map_err(|e| map_plugin_err(&app, e))?;
     let update_targets = plugin_entries_for_bulk_update(&installed);
 
     let mut failed = Vec::new();
@@ -187,6 +217,7 @@ pub async fn add_plugin_marketplace(
     source: String,
     scope: PluginScope,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     require_non_managed_scope(scope)?;
@@ -196,23 +227,27 @@ pub async fn add_plugin_marketplace(
         &build_marketplace_add_args(&source, scope),
     )
     .await
+    .map_err(|e| map_plugin_err(&app, e))
 }
 
 #[tauri::command]
 pub async fn remove_plugin_marketplace(
     name: String,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let repo_path = resolve_optional_repo_path(&state, repo_id.as_deref())?;
     plugin::run_claude_plugin_command(repo_path.as_deref(), &build_marketplace_remove_args(&name))
         .await
+        .map_err(|e| map_plugin_err(&app, e))
 }
 
 #[tauri::command]
 pub async fn update_plugin_marketplace(
     name: Option<String>,
     repo_id: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     let repo_path = resolve_optional_repo_path(&state, repo_id.as_deref())?;
@@ -221,6 +256,7 @@ pub async fn update_plugin_marketplace(
         &build_marketplace_update_args(name.as_deref()),
     )
     .await
+    .map_err(|e| map_plugin_err(&app, e))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/plugin.rs
+++ b/src-tauri/src/commands/plugin.rs
@@ -171,7 +171,11 @@ pub async fn update_all_plugins(
 
     let mut failed = Vec::new();
     let mut succeeded = 0;
-
+    // Per-plugin spawn failures might also be `MISSING_CLI:claude` — route
+    // each one through `map_plugin_err` so the missing-dependency event
+    // fires (and the sentinel becomes a user-facing string in the bulk
+    // result). `handle_err` is cheap and the modal only opens once even if
+    // we emit the event multiple times, so we don't need to dedupe here.
     for plugin_entry in &update_targets {
         match plugin::run_claude_plugin_command(
             repo_path.as_deref(),
@@ -184,7 +188,7 @@ pub async fn update_all_plugins(
                 "{} ({}) — {}",
                 plugin_entry.plugin_id,
                 plugin_entry.scope.as_cli_arg(),
-                error
+                map_plugin_err(&app, error)
             )),
         }
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -356,12 +356,19 @@ pub async fn run_claude_plugin_command(
     repo_path: Option<&Path>,
     args: &[String],
 ) -> Result<String, String> {
-    // Resolve claude up front. If it isn't on the enriched PATH, return the
-    // structured `MISSING_CLI:claude` sentinel so the Tauri/UI layer can render
-    // the install-CTA modal (see `crate::missing_cli`) instead of leaking a
-    // bare `os error 2` (issue #641).
-    let claude_path = crate::env::which_in_enriched_path("claude")
-        .map_err(|_| crate::missing_cli::format_err("claude"))?;
+    // Resolve claude up front. If it genuinely isn't on the enriched PATH,
+    // return the structured `MISSING_CLI:claude` sentinel so the Tauri/UI
+    // layer can render the install-CTA modal (see `crate::missing_cli`)
+    // instead of leaking a bare `os error 2` (issue #641).
+    //
+    // Only `CannotFindBinaryPath` means "binary not found" — other variants
+    // (`CannotGetCurrentDirAndPathListEmpty`, `CannotCanonicalize`) signal
+    // real I/O / cwd issues that the user shouldn't be told to "install
+    // claude" to fix. Surface those with their original message instead.
+    let claude_path = crate::env::which_in_enriched_path("claude").map_err(|e| match e {
+        which::Error::CannotFindBinaryPath => crate::missing_cli::format_err("claude"),
+        other => format!("Failed to resolve `claude` on PATH: {other}"),
+    })?;
     let current_dir = plugin_command_cwd(repo_path);
 
     let output = tokio::process::Command::new(&claude_path)

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -356,8 +356,12 @@ pub async fn run_claude_plugin_command(
     repo_path: Option<&Path>,
     args: &[String],
 ) -> Result<String, String> {
-    let claude_path =
-        crate::env::which_in_enriched_path("claude").unwrap_or_else(|_| PathBuf::from("claude"));
+    // Resolve claude up front. If it isn't on the enriched PATH, return the
+    // structured `MISSING_CLI:claude` sentinel so the Tauri/UI layer can render
+    // the install-CTA modal (see `crate::missing_cli`) instead of leaking a
+    // bare `os error 2` (issue #641).
+    let claude_path = crate::env::which_in_enriched_path("claude")
+        .map_err(|_| crate::missing_cli::format_err("claude"))?;
     let current_dir = plugin_command_cwd(repo_path);
 
     let output = tokio::process::Command::new(&claude_path)
@@ -369,7 +373,11 @@ pub async fn run_claude_plugin_command(
         .env("PATH", crate::env::enriched_path())
         .output()
         .await
-        .map_err(|e| format!("Failed to run `{}`: {e}", command_preview(args)))?;
+        .map_err(|e| {
+            crate::missing_cli::map_spawn_err(&e, "claude", || {
+                format!("Failed to run `{}`: {e}", command_preview(args))
+            })
+        })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();


### PR DESCRIPTION
Refs #641 (does not close — leaving open until the reporter confirms the dialog appears on their setup).

## Problem

The Claude Code plugins settings page reported:

> Failed to run \`claude plugin marketplace list --json\`: No such file or directory (os error 2)

…with no install guidance, regardless of OS or how Claude Code was installed.

## Root cause

`src/plugin.rs::run_claude_plugin_command` resolved the `claude` binary via `which_in_enriched_path("claude")` and **silently fell back to `PathBuf::from("claude")` on failure**. Tokio then asked the OS to spawn a bare `"claude"`, the kernel returned ENOENT, and that raw `os error 2` was forwarded to the UI.

This affects any user whose login-shell PATH does not include the directory containing `claude` — common on macOS when the CLI is installed under `~/.local/bin`, `~/.npm-global/bin`, `/opt/homebrew/bin`, etc., and the directory is added in `.zshrc` (interactive) rather than `.zprofile` (login).

## Reproduction

Drive `claudette::plugin::list_marketplaces` through a fake login shell that emits a PATH without `claude`:

```bash
TMPSHELL=/tmp/fake-zsh
cat > "$TMPSHELL" <<'SHELL'
#!/bin/sh
[ "$1" = "-l" ] && [ "$2" = "-c" ] && { printf '%s\n' "/usr/bin:/bin:/usr/sbin:/sbin"; exit 0; }
exec /bin/sh "$@"
SHELL
chmod +x "$TMPSHELL"
SHELL="$TMPSHELL" PATH=/usr/bin:/bin cargo run --example repro_641
# → ERR: Failed to run `claude plugin marketplace list --json`: No such file or directory (os error 2)
```

Same byte-for-byte error as the issue.

## Fix

Wire the existing `missing_cli` infrastructure (already used by `git`/`gh`/`claude` paths in `repository.rs`, `scm.rs`, `chat/send.rs`) into the plugin code path:

- `run_claude_plugin_command` now returns the `MISSING_CLI:claude` sentinel both when `which_in_enriched_path` reports the binary missing up front and when the eventual `.output()` call returns `io::ErrorKind::NotFound`.
- The `plugin` Tauri commands intercept that sentinel via the shared `crate::missing_cli::handle_err` helper, which emits the `missing-dependency` event the frontend already listens for in `App.tsx`. The existing `MissingCliModal` then renders the platform-specific install options dialog (npm/Homebrew/native installer) instead of the raw error string.

No frontend changes — the modal, event listener, and `claude` guidance entry already existed; the plugin path just wasn't plugged into them.

## Verification

After fix, the same reproduction returns:

```
ERR: MISSING_CLI:claude
```

…which the Tauri layer translates to the `missing-dependency` event + friendly fallback string (`"Claude CLI is not installed. See the install options dialog."`).

Happy path with `claude` on PATH continues to return the marketplace list normally.

`cargo clippy -p claudette -p claudette-server --all-targets` (with `RUSTFLAGS=-Dwarnings`), `cargo test -p claudette`, and `bun run build` (which runs `tsc -b`) all pass.