### PR TITLE
feat(ui): help menu — keyboard shortcuts, docs, changelog, dev tools

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,7 +76,10 @@ windows-sys = { version = "0.61", features = [
 ] }
 
 [features]
-default = ["server", "voice"]
+# `devtools` is in the default set so the Help → Open dev tools menu item
+# works in release builds. The webview inspector ships in every binary;
+# users open it via the help menu rather than via a custom build flag.
+default = ["server", "voice", "devtools"]
 devtools = ["tauri/devtools"]
 server = ["dep:claudette-server"]
 voice = [

--- a/src-tauri/src/commands/devtools.rs
+++ b/src-tauri/src/commands/devtools.rs
@@ -1,0 +1,12 @@
+/// Opens the webview inspector on the calling window. Triggered from
+/// the Help → Open dev tools menu item.
+///
+/// `WebviewWindow::open_devtools()` is gated by Tauri behind
+/// `#[cfg(any(debug_assertions, feature = "devtools"))]`. We enable the
+/// `devtools` Cargo feature in the default set (see `Cargo.toml`) so this
+/// works in release builds, not just dev — otherwise users would have
+/// to do a custom build to inspect the webview.
+#[tauri::command]
+pub fn open_devtools(window: tauri::WebviewWindow) {
+    window.open_devtools();
+}

--- a/src-tauri/src/commands/devtools.rs
+++ b/src-tauri/src/commands/devtools.rs
@@ -3,10 +3,15 @@
 ///
 /// `WebviewWindow::open_devtools()` is gated by Tauri behind
 /// `#[cfg(any(debug_assertions, feature = "devtools"))]`. We enable the
-/// `devtools` Cargo feature in the default set (see `Cargo.toml`) so this
-/// works in release builds, not just dev — otherwise users would have
-/// to do a custom build to inspect the webview.
+/// `devtools` Cargo feature in the default set (see `Cargo.toml`) so
+/// release builds work, not just dev. The inner `cfg` guard is defensive
+/// against `--no-default-features` builds — the command stays registered
+/// (so the JS-side `invoke("open_devtools")` resolves cleanly) but
+/// becomes a no-op when the feature isn't compiled.
 #[tauri::command]
 pub fn open_devtools(window: tauri::WebviewWindow) {
+    #[cfg(any(debug_assertions, feature = "devtools"))]
     window.open_devtools();
+    #[cfg(not(any(debug_assertions, feature = "devtools")))]
+    let _ = window;
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod community;
 pub mod data;
 #[cfg(debug_assertions)]
 pub mod debug;
+pub mod devtools;
 pub mod diff;
 pub mod env;
 pub mod files;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -58,13 +58,16 @@ use claudette::db::Database;
 #[cfg(target_os = "macos")]
 const MACOS_CLOSE_WINDOW_ACCELERATOR: &str = "CmdOrCtrl+Shift+W";
 
-// Docs deep-link target for every Help surface (sidebar Help menu,
-// Settings → Help, macOS Help submenu). The TS side mirrors this in
-// `src/ui/src/helpUrls.ts` — keep both in sync. Pointing a deep page
-// rather than the docs root so users land on something actionable;
-// when the docs IA shifts, update here and in the TS file together.
+// URLs for the macOS Help submenu — mirrored from the TS side's single
+// source of truth at `src/ui/src/helpUrls.ts`. Update both together
+// when any of these change. The frontend Help menu and Settings → Help
+// section import the matching constants from that file.
 #[cfg(target_os = "macos")]
 const HELP_DOCS_URL: &str = "https://utensils.io/claudette/getting-started/installation/";
+#[cfg(target_os = "macos")]
+const HELP_RELEASE_URL_BASE: &str = "https://github.com/utensils/claudette/releases/tag/v";
+#[cfg(target_os = "macos")]
+const HELP_ISSUES_URL: &str = "https://github.com/utensils/claudette/issues/new";
 
 fn main() {
     // Install the rustls crypto provider before any TLS usage. Both
@@ -249,10 +252,7 @@ fn main() {
                 // Deep-link to the GitHub Release page for the running
                 // version. Stable URL — doesn't depend on CHANGELOG.md
                 // anchor formatting (which embeds the release date).
-                let url = format!(
-                    "https://github.com/utensils/claudette/releases/tag/v{}",
-                    env!("CARGO_PKG_VERSION"),
-                );
+                let url = format!("{}{}", HELP_RELEASE_URL_BASE, env!("CARGO_PKG_VERSION"));
                 if let Err(e) = commands::shell::opener::open(&url) {
                     eprintln!("[help] Failed to open changelog URL: {e}");
                 }
@@ -269,9 +269,7 @@ fn main() {
                 // GitHub issue tracker. Mirrors Aethon's "Report an
                 // Issue…" item — gives users a one-click path to file a
                 // bug report.
-                if let Err(e) = commands::shell::opener::open(
-                    "https://github.com/utensils/claudette/issues/new",
-                ) {
+                if let Err(e) = commands::shell::opener::open(HELP_ISSUES_URL) {
                     eprintln!("[help] Failed to open issues URL: {e}");
                 }
             } else if event.id().as_ref() == "zoom-in" {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -232,7 +232,23 @@ fn main() {
     #[cfg(target_os = "macos")]
     {
         builder = builder.on_menu_event(|app, event| {
-            if event.id().as_ref() == "help-open-docs" {
+            if event.id().as_ref() == "help-keyboard-shortcuts" {
+                // Bring the window forward and emit a frontend-handled event;
+                // the modal lives in React so we can't open it directly here.
+                tray::show_and_focus(app);
+                let _ = app.emit("menu://show-keyboard-shortcuts", ());
+            } else if event.id().as_ref() == "help-changelog" {
+                // Deep-link to the GitHub Release page for the running
+                // version. Stable URL — doesn't depend on CHANGELOG.md
+                // anchor formatting (which embeds the release date).
+                let url = format!(
+                    "https://github.com/utensils/claudette/releases/tag/v{}",
+                    env!("CARGO_PKG_VERSION"),
+                );
+                if let Err(e) = commands::shell::opener::open(&url) {
+                    eprintln!("[help] Failed to open changelog URL: {e}");
+                }
+            } else if event.id().as_ref() == "help-open-docs" {
                 // Open the Claudette docs root in the system browser.
                 // Root URL (not a deeper page) so the link survives
                 // doc-site reorganization.
@@ -382,7 +398,22 @@ fn main() {
                 // attached via `tauri::Builder::menu(...)`; here we go
                 // the `set_menu` route from setup, which skips that.
                 // (Compare to ../aethon/src-tauri/src/commands/extensions.rs.)
+                // The "What's New" item label embeds the running version
+                // so users can see which release the link will open before
+                // clicking. Built from `CARGO_PKG_VERSION` at compile time
+                // so it tracks `Cargo.toml` (release-please source of truth).
+                let whats_new_label = format!("What's New (v{})", env!("CARGO_PKG_VERSION"));
                 let help_menu = SubmenuBuilder::new(app_handle, "Help")
+                    .item(
+                        &MenuItemBuilder::with_id("help-keyboard-shortcuts", "Keyboard Shortcuts…")
+                            .accelerator("CmdOrCtrl+Slash")
+                            .build(app_handle)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("help-changelog", whats_new_label.as_str())
+                            .build(app_handle)?,
+                    )
+                    .separator()
                     .item(
                         &MenuItemBuilder::with_id("help-open-docs", "Claudette Documentation")
                             .build(app_handle)?,
@@ -525,6 +556,8 @@ fn main() {
             }
         })
         .invoke_handler(tauri::generate_handler![
+            // Devtools (webview inspector — Help → Open dev tools)
+            commands::devtools::open_devtools,
             // Data
             commands::data::load_initial_data,
             // Repository

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -58,6 +58,14 @@ use claudette::db::Database;
 #[cfg(target_os = "macos")]
 const MACOS_CLOSE_WINDOW_ACCELERATOR: &str = "CmdOrCtrl+Shift+W";
 
+// Docs deep-link target for every Help surface (sidebar Help menu,
+// Settings → Help, macOS Help submenu). The TS side mirrors this in
+// `src/ui/src/helpUrls.ts` — keep both in sync. Pointing a deep page
+// rather than the docs root so users land on something actionable;
+// when the docs IA shifts, update here and in the TS file together.
+#[cfg(target_os = "macos")]
+const HELP_DOCS_URL: &str = "https://utensils.io/claudette/getting-started/installation/";
+
 fn main() {
     // Install the rustls crypto provider before any TLS usage. Both
     // aws-lc-rs and ring are active (tauri-plugin-updater pulls in ring),
@@ -249,10 +257,12 @@ fn main() {
                     eprintln!("[help] Failed to open changelog URL: {e}");
                 }
             } else if event.id().as_ref() == "help-open-docs" {
-                // Open the Claudette docs root in the system browser.
-                // Root URL (not a deeper page) so the link survives
-                // doc-site reorganization.
-                if let Err(e) = commands::shell::opener::open("https://utensils.io/claudette/") {
+                // Deep-link into the Getting Started page so all three
+                // Help surfaces (sidebar, Settings, macOS menu) land
+                // users in the same place. Single source of truth for
+                // the URL is `HELP_DOCS_URL` (mirrored in TS at
+                // `src/ui/src/helpUrls.ts`).
+                if let Err(e) = commands::shell::opener::open(HELP_DOCS_URL) {
                     eprintln!("[help] Failed to open docs URL: {e}");
                 }
             } else if event.id().as_ref() == "help-report-issue" {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -67,7 +67,8 @@ const HELP_DOCS_URL: &str = "https://utensils.io/claudette/getting-started/insta
 #[cfg(target_os = "macos")]
 const HELP_RELEASE_URL_BASE: &str = "https://github.com/utensils/claudette/releases/tag/v";
 #[cfg(target_os = "macos")]
-const HELP_ISSUES_URL: &str = "https://github.com/utensils/claudette/issues/new";
+const HELP_ISSUES_URL: &str =
+    "https://github.com/utensils/claudette/issues/new?template=bug_report.md";
 
 fn main() {
     // Install the rustls crypto provider before any TLS usage. Both

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -391,6 +391,13 @@ function App() {
       useAppStore.getState().openSettings();
     });
 
+    // Listen for "Help → Keyboard Shortcuts…" menu clicks. The menu lives
+    // in Rust (src-tauri/src/main.rs) but the modal is React, so the menu
+    // emits this event and the frontend opens the modal in response.
+    const unlistenShortcuts = listen("menu://show-keyboard-shortcuts", () => {
+      useAppStore.getState().openModal("keyboard-shortcuts");
+    });
+
     // Listen for zoom events from the View menu.
     const unlistenZoomIn = listen("zoom-in", () => adjustUiFontSize(+1));
     const unlistenZoomOut = listen("zoom-out", () => adjustUiFontSize(-1));
@@ -582,6 +589,7 @@ function App() {
       });
       unlistenTray.then((fn) => fn());
       unlistenSettings.then((fn) => fn());
+      unlistenShortcuts.then((fn) => fn());
       unlistenZoomIn.then((fn) => fn());
       unlistenZoomOut.then((fn) => fn());
       unlistenResetZoom.then((fn) => fn());

--- a/src/ui/src/components/modals/KeyboardShortcutsModal.module.css
+++ b/src/ui/src/components/modals/KeyboardShortcutsModal.module.css
@@ -1,42 +1,7 @@
-.backdrop {
-  position: fixed;
-  inset: 0;
-  background: var(--overlay-bg-heavy);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  animation: fadeIn 0.15s ease;
-}
-
-.card {
-  background: var(--app-bg);
-  border: 1px solid var(--sidebar-border);
-  border-radius: var(--radius-xl);
-  width: 640px;
-  max-width: 92vw;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  box-shadow: var(--shadow-lg);
-  animation: scaleIn 0.2s ease;
-}
-
-.header {
-  padding: var(--space-4) var(--space-5) 0;
-}
-
-.title {
-  font-size: var(--fs-lg);
-  font-weight: var(--fw-semibold);
-  margin: 0 0 var(--space-3);
-}
-
-.body {
-  padding: 0 var(--space-5) var(--space-5);
-  overflow-y: auto;
-  flex: 1 1 auto;
-}
+/* Content-specific styles for the keyboard shortcuts viewer.
+ * The modal scaffold (backdrop / card / header / body / animations)
+ * lives in `Modal.module.css` and is reached via the shared `<Modal>`
+ * component with `wide` + `bodyScroll` props. */
 
 .search {
   width: 100%;
@@ -119,24 +84,4 @@
   color: var(--text-dim);
   font-size: 12px;
   font-style: italic;
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes scaleIn {
-  from {
-    transform: scale(0.96);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
 }

--- a/src/ui/src/components/modals/KeyboardShortcutsModal.module.css
+++ b/src/ui/src/components/modals/KeyboardShortcutsModal.module.css
@@ -1,0 +1,142 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg-heavy);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  animation: fadeIn 0.15s ease;
+}
+
+.card {
+  background: var(--app-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-xl);
+  width: 640px;
+  max-width: 92vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-lg);
+  animation: scaleIn 0.2s ease;
+}
+
+.header {
+  padding: var(--space-4) var(--space-5) 0;
+}
+
+.title {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  margin: 0 0 var(--space-3);
+}
+
+.body {
+  padding: 0 var(--space-5) var(--space-5);
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.search {
+  width: 100%;
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--divider);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+}
+
+.search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.empty {
+  padding: 24px 0;
+  color: var(--text-dim);
+  font-size: 13px;
+  text-align: center;
+}
+
+.group {
+  padding: 8px 0 12px;
+  border-bottom: 1px solid var(--divider);
+}
+
+.group:last-child {
+  border-bottom: none;
+}
+
+.groupLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+  color: var(--text-dim);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+.label {
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.binding {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+
+.keycap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid var(--divider);
+  border-radius: 4px;
+  background: var(--selected-bg);
+  box-shadow: inset 0 -1px 0 var(--hover-bg);
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.unbound {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-style: italic;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.96);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/src/ui/src/components/modals/KeyboardShortcutsModal.tsx
+++ b/src/ui/src/components/modals/KeyboardShortcutsModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { shortcutMatchesQuery } from "../settings/sections/keyboardSearch";
+import { Modal } from "./Modal";
 import styles from "./KeyboardShortcutsModal.module.css";
 
 export function KeyboardShortcutsModal() {
@@ -47,64 +48,56 @@ export function KeyboardShortcutsModal() {
   }, [search, keybindings, isMac, t]);
 
   return (
-    <div className={styles.backdrop} onClick={closeModal}>
-      <div
-        className={styles.card}
-        role="dialog"
-        aria-modal="true"
-        aria-label={t("shortcuts_modal_title")}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className={styles.header}>
-          <h3 className={styles.title}>{t("shortcuts_modal_title")}</h3>
-        </div>
-        <div className={styles.body}>
-          <input
-            type="search"
-            className={styles.search}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder={t("keyboard_search_placeholder")}
-            aria-label={t("keyboard_search_placeholder")}
-            autoFocus
-          />
+    <Modal
+      title={t("shortcuts_modal_title")}
+      onClose={closeModal}
+      wide
+      bodyScroll
+    >
+      <input
+        type="search"
+        className={styles.search}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder={t("keyboard_search_placeholder")}
+        aria-label={t("keyboard_search_placeholder")}
+        autoFocus
+      />
 
-          {groupedActions.length === 0 ? (
-            <div className={styles.empty}>{t("keyboard_no_results")}</div>
-          ) : null}
+      {groupedActions.length === 0 ? (
+        <div className={styles.empty}>{t("keyboard_no_results")}</div>
+      ) : null}
 
-          {groupedActions.map(([category, actions]) => (
-            <div className={styles.group} key={category}>
-              <div className={styles.groupLabel}>{tx(category)}</div>
-              {actions.map((action) => {
-                const effective = getEffectiveBinding(action, keybindings);
-                const parts = formatBindingParts(effective, isMac);
-                return (
-                  <div className={styles.row} key={action.id}>
-                    <div className={styles.label}>{tx(action.description)}</div>
-                    <div className={styles.binding}>
-                      {effective === null ? (
-                        <span className={styles.unbound}>
-                          {t("keyboard_disabled_binding")}
-                        </span>
-                      ) : (
-                        parts.map((part, index) => (
-                          <span
-                            className={styles.keycap}
-                            key={`${part}-${index}`}
-                          >
-                            {part}
-                          </span>
-                        ))
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ))}
+      {groupedActions.map(([category, actions]) => (
+        <div className={styles.group} key={category}>
+          <div className={styles.groupLabel}>{tx(category)}</div>
+          {actions.map((action) => {
+            const effective = getEffectiveBinding(action, keybindings);
+            const parts = formatBindingParts(effective, isMac);
+            return (
+              <div className={styles.row} key={action.id}>
+                <div className={styles.label}>{tx(action.description)}</div>
+                <div className={styles.binding}>
+                  {effective === null ? (
+                    <span className={styles.unbound}>
+                      {t("keyboard_disabled_binding")}
+                    </span>
+                  ) : (
+                    parts.map((part, index) => (
+                      <span
+                        className={styles.keycap}
+                        key={`${part}-${index}`}
+                      >
+                        {part}
+                      </span>
+                    ))
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
-      </div>
-    </div>
+      ))}
+    </Modal>
   );
 }

--- a/src/ui/src/components/modals/KeyboardShortcutsModal.tsx
+++ b/src/ui/src/components/modals/KeyboardShortcutsModal.tsx
@@ -1,0 +1,110 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppStore } from "../../stores/useAppStore";
+import { HOTKEY_ACTIONS, type HotkeyAction } from "../../hotkeys/actions";
+import {
+  formatBindingParts,
+  getEffectiveBinding,
+} from "../../hotkeys/bindings";
+import { isMacHotkeyPlatform } from "../../hotkeys/platform";
+import { shortcutMatchesQuery } from "../settings/sections/keyboardSearch";
+import styles from "./KeyboardShortcutsModal.module.css";
+
+export function KeyboardShortcutsModal() {
+  const { t } = useTranslation("settings");
+  // The hotkey table stores i18n keys (e.g. `keyboard_action_show_shortcuts`)
+  // in `description` and `category`. `t` is typed against a key union, so
+  // pass an unchecked key through `tx` rather than fight the generics.
+  const tx = (key: string) => t(key as never);
+  const closeModal = useAppStore((s) => s.closeModal);
+  const keybindings = useAppStore((s) => s.keybindings);
+  const isMac = isMacHotkeyPlatform();
+  const [search, setSearch] = useState("");
+
+  const groupedActions = useMemo(() => {
+    const groups = new Map<string, HotkeyAction[]>();
+    for (const action of HOTKEY_ACTIONS) {
+      const description = tx(action.description);
+      const category = tx(action.category);
+      const effective = getEffectiveBinding(action, keybindings);
+      const parts = formatBindingParts(effective, isMac);
+      const bindingLabel = [
+        parts.join(" "),
+        parts.join(""),
+        parts.join("+"),
+      ].join(" ");
+      if (!shortcutMatchesQuery({ description, category, bindingLabel }, search)) {
+        continue;
+      }
+      const list = groups.get(action.category) ?? [];
+      list.push(action);
+      groups.set(action.category, list);
+    }
+    return Array.from(groups.entries());
+    // `tx` is a stable wrapper around i18n's `t` — re-creating each render
+    // is fine and lets the filter respond to language changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, keybindings, isMac, t]);
+
+  return (
+    <div className={styles.backdrop} onClick={closeModal}>
+      <div
+        className={styles.card}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("shortcuts_modal_title")}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.header}>
+          <h3 className={styles.title}>{t("shortcuts_modal_title")}</h3>
+        </div>
+        <div className={styles.body}>
+          <input
+            type="search"
+            className={styles.search}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("keyboard_search_placeholder")}
+            aria-label={t("keyboard_search_placeholder")}
+            autoFocus
+          />
+
+          {groupedActions.length === 0 ? (
+            <div className={styles.empty}>{t("keyboard_no_results")}</div>
+          ) : null}
+
+          {groupedActions.map(([category, actions]) => (
+            <div className={styles.group} key={category}>
+              <div className={styles.groupLabel}>{tx(category)}</div>
+              {actions.map((action) => {
+                const effective = getEffectiveBinding(action, keybindings);
+                const parts = formatBindingParts(effective, isMac);
+                return (
+                  <div className={styles.row} key={action.id}>
+                    <div className={styles.label}>{tx(action.description)}</div>
+                    <div className={styles.binding}>
+                      {effective === null ? (
+                        <span className={styles.unbound}>
+                          {t("keyboard_disabled_binding")}
+                        </span>
+                      ) : (
+                        parts.map((part, index) => (
+                          <span
+                            className={styles.keycap}
+                            key={`${part}-${index}`}
+                          >
+                            {part}
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/modals/Modal.module.css
+++ b/src/ui/src/components/modals/Modal.module.css
@@ -33,3 +33,28 @@
 .body {
   padding: var(--space-4) var(--space-5) var(--space-5);
 }
+
+/* ── Modifiers (opt-in via Modal props) ── */
+
+/* Wider card for list-style modals (e.g. KeyboardShortcutsModal). The
+ * `92vw` cap keeps the modal usable on narrow windows. Defined after
+ * `.card` so the wider width wins when both classes are applied. */
+.cardWide {
+  width: 640px;
+  max-width: 92vw;
+}
+
+/* Move overflow from the card to the body so the title stays sticky
+ * when the body content scrolls. The card becomes a flex column so the
+ * body fills remaining height; the body itself scrolls (see
+ * `.bodyScrollable`). */
+.cardScrollable {
+  display: flex;
+  flex-direction: column;
+  overflow-y: visible;
+}
+
+.bodyScrollable {
+  overflow-y: auto;
+  flex: 1 1 auto;
+}

--- a/src/ui/src/components/modals/Modal.tsx
+++ b/src/ui/src/components/modals/Modal.tsx
@@ -5,16 +5,48 @@ interface ModalProps {
   title: string;
   onClose: () => void;
   children: ReactNode;
+  /**
+   * Use a wider card (640px, capped at 92vw) instead of the default 420px.
+   * For modals showing lists, multi-column content, or anything that needs
+   * to breathe horizontally — e.g. the keyboard shortcuts viewer.
+   */
+  wide?: boolean;
+  /**
+   * Move overflow scroll from the card to the body. Combined with the card
+   * becoming a flex column, this keeps the title in view while the body
+   * content scrolls — useful when the modal contains a long list with a
+   * search box that should stay sticky at the top.
+   *
+   * Without this, the entire card scrolls (default), which is fine for
+   * short confirmation dialogs but loses the title once the user scrolls.
+   */
+  bodyScroll?: boolean;
 }
 
-export function Modal({ title, onClose, children }: ModalProps) {
+export function Modal({
+  title,
+  onClose,
+  children,
+  wide,
+  bodyScroll,
+}: ModalProps) {
+  const cardClass = [
+    styles.card,
+    wide && styles.cardWide,
+    bodyScroll && styles.cardScrollable,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const bodyClass = [styles.body, bodyScroll && styles.bodyScrollable]
+    .filter(Boolean)
+    .join(" ");
   return (
     <div className={styles.backdrop} onClick={onClose}>
-      <div className={styles.card} onClick={(e) => e.stopPropagation()}>
+      <div className={cardClass} onClick={(e) => e.stopPropagation()}>
         <div className={styles.header}>
           <h3 className={styles.title}>{title}</h3>
         </div>
-        <div className={styles.body}>{children}</div>
+        <div className={bodyClass}>{children}</div>
       </div>
     </div>
   );

--- a/src/ui/src/components/modals/ModalRouter.tsx
+++ b/src/ui/src/components/modals/ModalRouter.tsx
@@ -11,6 +11,7 @@ import { McpSelectionModal } from "./McpSelectionModal";
 import { ImportWorktreesModal } from "./ImportWorktreesModal";
 import { ConfirmNightlyChannelModal } from "./ConfirmNightlyChannelModal";
 import { MissingCliModal } from "./MissingCliModal";
+import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 
 export function ModalRouter() {
   const activeModal = useAppStore((s) => s.activeModal);
@@ -40,6 +41,8 @@ export function ModalRouter() {
       return <ConfirmNightlyChannelModal />;
     case "missingCli":
       return <MissingCliModal />;
+    case "keyboard-shortcuts":
+      return <KeyboardShortcutsModal />;
     default:
       return null;
   }

--- a/src/ui/src/components/settings/SettingsPage.tsx
+++ b/src/ui/src/components/settings/SettingsPage.tsx
@@ -60,6 +60,11 @@ const KeyboardSettings = lazy(() =>
 const CliSettings = lazy(() =>
   import("./sections/CliSettings").then((m) => ({ default: m.CliSettings })),
 );
+const HelpSettings = lazy(() =>
+  import("./sections/HelpSettings").then((m) => ({
+    default: m.HelpSettings,
+  })),
+);
 
 function SectionContent({ section }: { section: string | null }) {
   const pluginManagementEnabled = useAppStore((s) => s.pluginManagementEnabled);
@@ -75,6 +80,7 @@ function SectionContent({ section }: { section: string | null }) {
   if (section === "git") return <GitSettings />;
   if (section === "keyboard") return <KeyboardSettings />;
   if (section === "cli") return <CliSettings />;
+  if (section === "help") return <HelpSettings />;
   if (section === "pinned-prompts") return <PinnedPromptsSettings />;
   if (section === "plugins") return <PluginsSettings />;
   if (section === "claude-code-plugins") {

--- a/src/ui/src/components/settings/SettingsSidebar.test.ts
+++ b/src/ui/src/components/settings/SettingsSidebar.test.ts
@@ -38,6 +38,13 @@ describe("getAppSections", () => {
     );
   });
 
+  it("always shows the Help section, regardless of plugin/community flags", () => {
+    // Help is always-on (no experimental gate) — it surfaces the
+    // shortcuts viewer + changelog link for any user.
+    expect(getAppSections(false, false).map((s) => s.id)).toContain("help");
+    expect(getAppSections(true, true).map((s) => s.id)).toContain("help");
+  });
+
   it("places the Editor section between Notifications and Git", () => {
     // The Editor section is where the git-gutter base preference lives
     // — it must sit alongside the other "how the app behaves" settings,

--- a/src/ui/src/components/settings/SettingsSidebar.tsx
+++ b/src/ui/src/components/settings/SettingsSidebar.tsx
@@ -12,6 +12,7 @@ import {
   Globe,
   Keyboard,
   Terminal,
+  HelpCircle,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
@@ -39,6 +40,7 @@ export function getAppSections(
     ...(pluginManagementEnabled
       ? [{ id: "claude-code-plugins", icon: Puzzle }]
       : []),
+    { id: "help", icon: HelpCircle },
   ] as const;
 }
 
@@ -67,6 +69,7 @@ export function SettingsSidebar() {
     if (id === "claude-code-plugins") return t("settings:nav_claude_code_plugins");
     if (id === "community") return t("settings:nav_community");
     if (id === "pinned-prompts") return t("settings:nav_pinned_prompts");
+    if (id === "help") return t("settings:nav_help");
     return id;
   };
 

--- a/src/ui/src/components/settings/sections/HelpSettings.tsx
+++ b/src/ui/src/components/settings/sections/HelpSettings.tsx
@@ -4,11 +4,12 @@ import { getVersion } from "@tauri-apps/api/app";
 import { Keyboard, ExternalLink, FileText, Bug } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { openUrl } from "../../../services/tauri";
-import { HELP_DOCS_URL } from "../../../helpUrls";
+import {
+  HELP_DOCS_URL,
+  HELP_ISSUES_URL,
+  HELP_RELEASE_URL_BASE,
+} from "../../../helpUrls";
 import styles from "../Settings.module.css";
-
-const ISSUES_URL = "https://github.com/utensils/claudette/issues/new";
-const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
 export function HelpSettings() {
   const { t } = useTranslation("settings");
@@ -21,7 +22,7 @@ export function HelpSettings() {
 
   const openChangelog = () => {
     if (!appVersion) return;
-    void openUrl(`${RELEASE_URL_BASE}${appVersion}`).catch(() => {});
+    void openUrl(`${HELP_RELEASE_URL_BASE}${appVersion}`).catch(() => {});
   };
 
   return (
@@ -93,7 +94,7 @@ export function HelpSettings() {
         <div className={styles.settingControl}>
           <button
             className={styles.iconBtn}
-            onClick={() => void openUrl(ISSUES_URL).catch(() => {})}
+            onClick={() => void openUrl(HELP_ISSUES_URL).catch(() => {})}
           >
             <Bug size={14} />
             {t("help_issues_button")}

--- a/src/ui/src/components/settings/sections/HelpSettings.tsx
+++ b/src/ui/src/components/settings/sections/HelpSettings.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getVersion } from "@tauri-apps/api/app";
+import { Keyboard, ExternalLink, FileText, Bug } from "lucide-react";
+import { useAppStore } from "../../../stores/useAppStore";
+import { openUrl } from "../../../services/tauri";
+import styles from "../Settings.module.css";
+
+const DOCS_URL = "https://utensils.io/claudette/";
+const ISSUES_URL = "https://github.com/utensils/claudette/issues/new";
+const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
+
+export function HelpSettings() {
+  const { t } = useTranslation("settings");
+  const openModal = useAppStore((s) => s.openModal);
+  const [appVersion, setAppVersion] = useState("");
+
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => {});
+  }, []);
+
+  const openChangelog = () => {
+    if (!appVersion) return;
+    void openUrl(`${RELEASE_URL_BASE}${appVersion}`).catch(() => {});
+  };
+
+  return (
+    <div>
+      <h2 className={styles.sectionTitle}>{t("help_title")}</h2>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("help_version_label")}</div>
+          <div className={styles.settingDescription}>
+            {appVersion ? `Claudette v${appVersion}` : "—"}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.iconBtn}
+            onClick={openChangelog}
+            disabled={!appVersion}
+          >
+            <ExternalLink size={14} />
+            {t("help_view_changelog")}
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("help_shortcuts_label")}</div>
+          <div className={styles.settingDescription}>
+            {t("help_shortcuts_description")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.iconBtn}
+            onClick={() => openModal("keyboard-shortcuts")}
+          >
+            <Keyboard size={14} />
+            {t("help_shortcuts_button")}
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("help_docs_label")}</div>
+          <div className={styles.settingDescription}>
+            {t("help_docs_description")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.iconBtn}
+            onClick={() => void openUrl(DOCS_URL).catch(() => {})}
+          >
+            <FileText size={14} />
+            {t("help_docs_button")}
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("help_issues_label")}</div>
+          <div className={styles.settingDescription}>
+            {t("help_issues_description")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.iconBtn}
+            onClick={() => void openUrl(ISSUES_URL).catch(() => {})}
+          >
+            <Bug size={14} />
+            {t("help_issues_button")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/settings/sections/HelpSettings.tsx
+++ b/src/ui/src/components/settings/sections/HelpSettings.tsx
@@ -4,9 +4,9 @@ import { getVersion } from "@tauri-apps/api/app";
 import { Keyboard, ExternalLink, FileText, Bug } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { openUrl } from "../../../services/tauri";
+import { HELP_DOCS_URL } from "../../../helpUrls";
 import styles from "../Settings.module.css";
 
-const DOCS_URL = "https://utensils.io/claudette/";
 const ISSUES_URL = "https://github.com/utensils/claudette/issues/new";
 const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
@@ -75,7 +75,7 @@ export function HelpSettings() {
         <div className={styles.settingControl}>
           <button
             className={styles.iconBtn}
-            onClick={() => void openUrl(DOCS_URL).catch(() => {})}
+            onClick={() => void openUrl(HELP_DOCS_URL).catch(() => {})}
           >
             <FileText size={14} />
             {t("help_docs_button")}

--- a/src/ui/src/components/sidebar/HelpMenu.module.css
+++ b/src/ui/src/components/sidebar/HelpMenu.module.css
@@ -1,0 +1,110 @@
+/* Inline-block wrapper so the trigger button sits naturally in the
+ * sidebar footer's flex row. The menu itself is rendered through a
+ * portal (see HelpMenu.tsx) and is NOT positioned relative to this
+ * element — it lives at document.body level with position: fixed. */
+.helpAnchor {
+  display: inline-flex;
+}
+
+.menu {
+  position: fixed;
+  /* Above sidebar chrome but below modals (which use z-index: 100 and
+   * the AttachmentContextMenu uses 10002). 10000 keeps us beneath the
+   * attachment lightbox / context menu while clearly clearing the
+   * sidebar/chat boundary. */
+  z-index: 10000;
+  min-width: 240px;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-lg);
+  padding: 6px;
+  box-shadow: var(--shadow-lg);
+  animation: helpMenuIn 140ms var(--ease-out-quick);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.item:hover,
+.item:focus-visible {
+  background: var(--hover-bg);
+  outline: none;
+}
+
+.item:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.itemLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.itemLabel {
+  white-space: nowrap;
+}
+
+.itemIcon {
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.externalIcon {
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+
+.keycap {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.divider {
+  height: 1px;
+  background: var(--divider);
+  margin: 4px 6px;
+}
+
+.versionFooter {
+  padding: 8px 10px 4px;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  text-align: left;
+}
+
+@keyframes helpMenuIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/ui/src/components/sidebar/HelpMenu.module.css
+++ b/src/ui/src/components/sidebar/HelpMenu.module.css
@@ -8,11 +8,12 @@
 
 .menu {
   position: fixed;
-  /* Above sidebar chrome but below modals (which use z-index: 100 and
-   * the AttachmentContextMenu uses 10002). 10000 keeps us beneath the
-   * attachment lightbox / context menu while clearly clearing the
-   * sidebar/chat boundary. */
-  z-index: 10000;
+  /* Popover layer — above sidebar/chat content, below `Modal.module.css`
+   * (z-index: 100) so any modal correctly overlays the menu if both
+   * happen to be open. Matches `ContextPopover` / `ReasoningPill`'s
+   * z-index 40-50 convention. The portal is what escapes the sidebar's
+   * `overflow: hidden` clipping; z-index doesn't fix that. */
+  z-index: 50;
   min-width: 240px;
   background: var(--sidebar-bg);
   border: 1px solid var(--sidebar-border);

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -8,9 +8,9 @@ import { openDevtools, openUrl } from "../../services/tauri";
 import { findHotkeyAction } from "../../hotkeys/actions";
 import { formatBindingParts, getEffectiveBinding } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
+import { HELP_DOCS_URL } from "../../helpUrls";
 import styles from "./HelpMenu.module.css";
 
-const DOCS_URL = "https://utensils.io/claudette/getting-started/installation/";
 const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
 // Spacing between the trigger button's top edge and the menu's bottom
@@ -105,11 +105,19 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
   // Close on Escape and outside click. The trigger and the portaled menu
   // both count as "inside" — without that, clicking the menu's items
   // would race the outside-click handler and unmount before onClick ran.
+  //
+  // The Escape listener runs in capture phase and calls stopPropagation
+  // to keep the global Esc handler in `useKeyboardShortcuts` from also
+  // firing — its `global.dismiss-or-stop` cascade would otherwise stop
+  // a running agent if one's busy when the user dismisses the menu.
+  // (HelpMenu's `open` state lives in component state, not the Zustand
+  // store, so the global handler can't tell the menu is open.)
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
+        e.stopPropagation();
         setOpen(false);
       }
     };
@@ -119,10 +127,10 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
       if (menuRef.current?.contains(target)) return;
       setOpen(false);
     };
-    window.addEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
     document.addEventListener("mousedown", onClick);
     return () => {
-      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("keydown", onKey, true);
       document.removeEventListener("mousedown", onClick);
     };
   }, [open]);
@@ -140,7 +148,7 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
 
   const handleDocs = () => {
     setOpen(false);
-    void openUrl(DOCS_URL).catch(() => {});
+    void openUrl(HELP_DOCS_URL).catch(() => {});
   };
 
   const handleChangelog = () => {

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -18,7 +18,12 @@ const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 // are both in CSS pixels and scale together under html zoom — no
 // conversion needed. (`AttachmentContextMenu`'s `viewportToFixed`
 // conversion is for `MouseEvent.clientX/Y`, which is a different beast.)
-const MENU_GAP = 6;
+//
+// 10 matches the visual breathing room of `ReasoningPill`'s dropdown
+// (`bottom: calc(100% + 8px)` plus its slightly larger button padding)
+// — enough that the trigger icon stays clear of the menu's rounded
+// bottom-left corner without floating off into the sidebar gap.
+const MENU_GAP = 10;
 // Safety margin from viewport edges when clamping.
 const VIEWPORT_MARGIN = 8;
 

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -14,10 +14,11 @@ import styles from "./HelpMenu.module.css";
 const DOCS_URL = "https://utensils.io/claudette/getting-started/installation/";
 const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
-// Spacing between the trigger button and the menu's edge, in viewport px.
-// Tight on purpose — the menu reads as "anchored to the ? button" rather
-// than floating in the middle of the sidebar/chat boundary.
-const MENU_GAP = 2;
+// Spacing between the trigger button and the menu's edge, in viewport
+// px (layout — `viewportToFixed` reconciles the rect into this frame).
+// Small enough to read as "docked to the ? button," roomy enough that
+// the rounded corner doesn't kiss the icon's hover halo.
+const MENU_GAP = 6;
 // Safety margin from viewport edges when clamping.
 const VIEWPORT_MARGIN = 8;
 

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -58,6 +58,13 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
   // avoiding a flash at (0,0). We re-measure on resize/scroll so the
   // menu follows its anchor if the layout shifts while open.
   //
+  // `appVersion` is in the dep list because it arrives asynchronously
+  // (Promise from `getVersion()`) AFTER the first render — its arrival
+  // toggles the Changelog item from disabled→enabled and renders the
+  // version footer, both of which change the menu height. Without
+  // recomputing, the menu's bottom would slide down by ~30px and could
+  // overlap the trigger.
+  //
   // No reset to null when closing — the menu unmounts via the `open`
   // guard, so stale position is invisible, and on reopen this effect
   // runs synchronously before paint and overwrites the value.
@@ -100,7 +107,7 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
       window.removeEventListener("resize", compute);
       window.removeEventListener("scroll", compute, true);
     };
-  }, [open]);
+  }, [open, appVersion]);
 
   // Close on Escape and outside click. The trigger and the portaled menu
   // both count as "inside" — without that, clicking the menu's items

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -8,13 +8,16 @@ import { openDevtools, openUrl } from "../../services/tauri";
 import { findHotkeyAction } from "../../hotkeys/actions";
 import { formatBindingParts, getEffectiveBinding } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
+import { viewportLayoutSize, viewportToFixed } from "../../utils/zoom";
 import styles from "./HelpMenu.module.css";
 
 const DOCS_URL = "https://utensils.io/claudette/getting-started/installation/";
 const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
 // Spacing between the trigger button and the menu's edge, in viewport px.
-const MENU_GAP = 8;
+// Tight on purpose — the menu reads as "anchored to the ? button" rather
+// than floating in the middle of the sidebar/chat boundary.
+const MENU_GAP = 2;
 // Safety margin from viewport edges when clamping.
 const VIEWPORT_MARGIN = 8;
 
@@ -57,25 +60,35 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
     const compute = () => {
       const trigger = triggerRef.current;
       if (!trigger) return;
+      // `getBoundingClientRect()` returns visual (post-zoom) pixels, but
+      // `position: fixed; left/top` interprets values as layout (pre-zoom)
+      // pixels — `viewportToFixed` reconciles the two when the html zoom
+      // (set by applyUserFonts) is != 1. `viewportLayoutSize` does the
+      // same for the clamping bounds. AttachmentContextMenu has the same
+      // dance for the same reason.
       const triggerRect = trigger.getBoundingClientRect();
+      const triggerTop = viewportToFixed(triggerRect.left, triggerRect.top);
+      const triggerBottom = viewportToFixed(
+        triggerRect.right,
+        triggerRect.bottom,
+      );
       const menu = menuRef.current;
       // First paint: menu hasn't rendered yet, fall back to a generous
       // estimate so we land roughly correct, then refine on the next
       // tick once we can measure the actual menu.
       const menuWidth = menu?.offsetWidth ?? 240;
       const menuHeight = menu?.offsetHeight ?? 180;
-      const vw = window.innerWidth;
-      const vh = window.innerHeight;
+      const { width: vw, height: vh } = viewportLayoutSize();
       // Anchor: open above the trigger (footer is at bottom of sidebar)
       // with the menu's left edge aligned to the trigger's left edge.
-      let left = triggerRect.left;
-      let top = triggerRect.top - menuHeight - MENU_GAP;
+      let left = triggerTop.x;
+      let top = triggerTop.y - menuHeight - MENU_GAP;
       // Clamp horizontally so the right edge stays inside the viewport.
       left = Math.min(left, vw - menuWidth - VIEWPORT_MARGIN);
       left = Math.max(VIEWPORT_MARGIN, left);
       // If there's not enough room above, drop below the trigger.
       if (top < VIEWPORT_MARGIN) {
-        top = triggerRect.bottom + MENU_GAP;
+        top = triggerBottom.y + MENU_GAP;
       }
       // Final vertical clamp (handles tiny viewports).
       top = Math.min(top, vh - menuHeight - VIEWPORT_MARGIN);

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -8,10 +8,8 @@ import { openDevtools, openUrl } from "../../services/tauri";
 import { findHotkeyAction } from "../../hotkeys/actions";
 import { formatBindingParts, getEffectiveBinding } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
-import { HELP_DOCS_URL } from "../../helpUrls";
+import { HELP_DOCS_URL, HELP_RELEASE_URL_BASE } from "../../helpUrls";
 import styles from "./HelpMenu.module.css";
-
-const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
 // Spacing between the trigger button's top edge and the menu's bottom
 // edge, in CSS px. `getBoundingClientRect()` and `position: fixed; top`
@@ -161,7 +159,7 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
   const handleChangelog = () => {
     setOpen(false);
     if (!appVersion) return;
-    void openUrl(`${RELEASE_URL_BASE}${appVersion}`).catch(() => {});
+    void openUrl(`${HELP_RELEASE_URL_BASE}${appVersion}`).catch(() => {});
   };
 
   const handleDevtools = () => {

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -2,13 +2,17 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { getVersion } from "@tauri-apps/api/app";
-import { CircleHelp, Keyboard, BookOpen, FileText, ArrowUpRight, Wrench } from "lucide-react";
+import { CircleHelp, Keyboard, BookOpen, FileText, ArrowUpRight, Wrench, Bug } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { openDevtools, openUrl } from "../../services/tauri";
 import { findHotkeyAction } from "../../hotkeys/actions";
 import { formatBindingParts, getEffectiveBinding } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
-import { HELP_DOCS_URL, HELP_RELEASE_URL_BASE } from "../../helpUrls";
+import {
+  HELP_DOCS_URL,
+  HELP_ISSUES_URL,
+  HELP_RELEASE_URL_BASE,
+} from "../../helpUrls";
 import styles from "./HelpMenu.module.css";
 
 // Spacing between the trigger button's top edge and the menu's bottom
@@ -162,6 +166,11 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
     void openUrl(`${HELP_RELEASE_URL_BASE}${appVersion}`).catch(() => {});
   };
 
+  const handleIssue = () => {
+    setOpen(false);
+    void openUrl(HELP_ISSUES_URL).catch(() => {});
+  };
+
   const handleDevtools = () => {
     setOpen(false);
     void openDevtools().catch((err) =>
@@ -226,6 +235,18 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
         <span className={styles.itemLeft}>
           <FileText size={14} className={styles.itemIcon} />
           <span className={styles.itemLabel}>{t("help_menu_changelog")}</span>
+        </span>
+        <ArrowUpRight size={12} className={styles.externalIcon} />
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className={styles.item}
+        onClick={handleIssue}
+      >
+        <span className={styles.itemLeft}>
+          <Bug size={14} className={styles.itemIcon} />
+          <span className={styles.itemLabel}>{t("help_menu_issues")}</span>
         </span>
         <ArrowUpRight size={12} className={styles.externalIcon} />
       </button>

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { getVersion } from "@tauri-apps/api/app";
+import { CircleHelp, Keyboard, BookOpen, FileText, ArrowUpRight, Wrench } from "lucide-react";
+import { useAppStore } from "../../stores/useAppStore";
+import { openDevtools, openUrl } from "../../services/tauri";
+import { findHotkeyAction } from "../../hotkeys/actions";
+import { formatBindingParts, getEffectiveBinding } from "../../hotkeys/bindings";
+import { isMacHotkeyPlatform } from "../../hotkeys/platform";
+import styles from "./HelpMenu.module.css";
+
+const DOCS_URL = "https://utensils.io/claudette/getting-started/installation/";
+const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
+
+// Spacing between the trigger button and the menu's edge, in viewport px.
+const MENU_GAP = 8;
+// Safety margin from viewport edges when clamping.
+const VIEWPORT_MARGIN = 8;
+
+interface HelpMenuProps {
+  buttonClassName: string;
+  triggerLabel: string;
+}
+
+interface MenuPosition {
+  left: number;
+  top: number;
+}
+
+export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
+  const { t } = useTranslation("settings");
+  const openModal = useAppStore((s) => s.openModal);
+  const keybindings = useAppStore((s) => s.keybindings);
+  const isMac = isMacHotkeyPlatform();
+  const [open, setOpen] = useState(false);
+  const [appVersion, setAppVersion] = useState("");
+  const [position, setPosition] = useState<MenuPosition | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open || appVersion) return;
+    getVersion().then(setAppVersion).catch(() => {});
+  }, [open, appVersion]);
+
+  // Compute fixed-viewport position from the trigger's rect. Uses
+  // useLayoutEffect so the menu lands at the right spot before paint,
+  // avoiding a flash at (0,0). We re-measure on resize/scroll so the
+  // menu follows its anchor if the layout shifts while open.
+  //
+  // No reset to null when closing — the menu unmounts via the `open`
+  // guard, so stale position is invisible, and on reopen this effect
+  // runs synchronously before paint and overwrites the value.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const compute = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const triggerRect = trigger.getBoundingClientRect();
+      const menu = menuRef.current;
+      // First paint: menu hasn't rendered yet, fall back to a generous
+      // estimate so we land roughly correct, then refine on the next
+      // tick once we can measure the actual menu.
+      const menuWidth = menu?.offsetWidth ?? 240;
+      const menuHeight = menu?.offsetHeight ?? 180;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      // Anchor: open above the trigger (footer is at bottom of sidebar)
+      // with the menu's left edge aligned to the trigger's left edge.
+      let left = triggerRect.left;
+      let top = triggerRect.top - menuHeight - MENU_GAP;
+      // Clamp horizontally so the right edge stays inside the viewport.
+      left = Math.min(left, vw - menuWidth - VIEWPORT_MARGIN);
+      left = Math.max(VIEWPORT_MARGIN, left);
+      // If there's not enough room above, drop below the trigger.
+      if (top < VIEWPORT_MARGIN) {
+        top = triggerRect.bottom + MENU_GAP;
+      }
+      // Final vertical clamp (handles tiny viewports).
+      top = Math.min(top, vh - menuHeight - VIEWPORT_MARGIN);
+      top = Math.max(VIEWPORT_MARGIN, top);
+      setPosition({ left, top });
+    };
+    compute();
+    // Re-measure once the menu has actually rendered so we use its real
+    // size rather than the estimate.
+    const id = window.requestAnimationFrame(compute);
+    window.addEventListener("resize", compute);
+    window.addEventListener("scroll", compute, true);
+    return () => {
+      window.cancelAnimationFrame(id);
+      window.removeEventListener("resize", compute);
+      window.removeEventListener("scroll", compute, true);
+    };
+  }, [open]);
+
+  // Close on Escape and outside click. The trigger and the portaled menu
+  // both count as "inside" — without that, clicking the menu's items
+  // would race the outside-click handler and unmount before onClick ran.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    const onClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onClick);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onClick);
+    };
+  }, [open]);
+
+  const shortcutsAction = findHotkeyAction("global.show-keyboard-shortcuts");
+  const shortcutBinding = shortcutsAction
+    ? getEffectiveBinding(shortcutsAction, keybindings)
+    : null;
+  const shortcutParts = formatBindingParts(shortcutBinding, isMac);
+
+  const handleShortcuts = () => {
+    setOpen(false);
+    openModal("keyboard-shortcuts");
+  };
+
+  const handleDocs = () => {
+    setOpen(false);
+    void openUrl(DOCS_URL).catch(() => {});
+  };
+
+  const handleChangelog = () => {
+    setOpen(false);
+    if (!appVersion) return;
+    void openUrl(`${RELEASE_URL_BASE}${appVersion}`).catch(() => {});
+  };
+
+  const handleDevtools = () => {
+    setOpen(false);
+    void openDevtools().catch((err) =>
+      console.warn("Failed to open devtools:", err),
+    );
+  };
+
+  const menu = open ? (
+    <div
+      ref={menuRef}
+      className={styles.menu}
+      role="menu"
+      style={{
+        left: position?.left ?? 0,
+        top: position?.top ?? 0,
+        // Hide until the first measurement lands so users never see a
+        // (0,0) flash in the top-left corner.
+        visibility: position ? "visible" : "hidden",
+      }}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        className={styles.item}
+        onClick={handleShortcuts}
+      >
+        <span className={styles.itemLeft}>
+          <Keyboard size={14} className={styles.itemIcon} />
+          <span className={styles.itemLabel}>
+            {t("help_menu_keyboard_shortcuts")}
+          </span>
+        </span>
+        {shortcutBinding && (
+          <span className={styles.shortcut} aria-hidden="true">
+            {shortcutParts.map((part, i) => (
+              <span className={styles.keycap} key={`${part}-${i}`}>
+                {part}
+              </span>
+            ))}
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className={styles.item}
+        onClick={handleDocs}
+      >
+        <span className={styles.itemLeft}>
+          <BookOpen size={14} className={styles.itemIcon} />
+          <span className={styles.itemLabel}>{t("help_menu_docs")}</span>
+        </span>
+        <ArrowUpRight size={12} className={styles.externalIcon} />
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className={styles.item}
+        onClick={handleChangelog}
+        disabled={!appVersion}
+      >
+        <span className={styles.itemLeft}>
+          <FileText size={14} className={styles.itemIcon} />
+          <span className={styles.itemLabel}>{t("help_menu_changelog")}</span>
+        </span>
+        <ArrowUpRight size={12} className={styles.externalIcon} />
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className={styles.item}
+        onClick={handleDevtools}
+      >
+        <span className={styles.itemLeft}>
+          <Wrench size={14} className={styles.itemIcon} />
+          <span className={styles.itemLabel}>{t("help_menu_devtools")}</span>
+        </span>
+      </button>
+      {appVersion && (
+        <>
+          <div className={styles.divider} />
+          <div className={styles.versionFooter}>Claudette v{appVersion}</div>
+        </>
+      )}
+    </div>
+  ) : null;
+
+  return (
+    <span className={styles.helpAnchor}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={buttonClassName}
+        onClick={() => setOpen((v) => !v)}
+        title={triggerLabel}
+        aria-label={triggerLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <CircleHelp size={16} />
+      </button>
+      {menu && typeof document !== "undefined"
+        ? createPortal(menu, document.body)
+        : menu}
+    </span>
+  );
+}

--- a/src/ui/src/components/sidebar/HelpMenu.tsx
+++ b/src/ui/src/components/sidebar/HelpMenu.tsx
@@ -8,16 +8,16 @@ import { openDevtools, openUrl } from "../../services/tauri";
 import { findHotkeyAction } from "../../hotkeys/actions";
 import { formatBindingParts, getEffectiveBinding } from "../../hotkeys/bindings";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
-import { viewportLayoutSize, viewportToFixed } from "../../utils/zoom";
 import styles from "./HelpMenu.module.css";
 
 const DOCS_URL = "https://utensils.io/claudette/getting-started/installation/";
 const RELEASE_URL_BASE = "https://github.com/utensils/claudette/releases/tag/v";
 
-// Spacing between the trigger button and the menu's edge, in viewport
-// px (layout — `viewportToFixed` reconciles the rect into this frame).
-// Small enough to read as "docked to the ? button," roomy enough that
-// the rounded corner doesn't kiss the icon's hover halo.
+// Spacing between the trigger button's top edge and the menu's bottom
+// edge, in CSS px. `getBoundingClientRect()` and `position: fixed; top`
+// are both in CSS pixels and scale together under html zoom — no
+// conversion needed. (`AttachmentContextMenu`'s `viewportToFixed`
+// conversion is for `MouseEvent.clientX/Y`, which is a different beast.)
 const MENU_GAP = 6;
 // Safety margin from viewport edges when clamping.
 const VIEWPORT_MARGIN = 8;
@@ -61,38 +61,26 @@ export function HelpMenu({ buttonClassName, triggerLabel }: HelpMenuProps) {
     const compute = () => {
       const trigger = triggerRef.current;
       if (!trigger) return;
-      // `getBoundingClientRect()` returns visual (post-zoom) pixels, but
-      // `position: fixed; left/top` interprets values as layout (pre-zoom)
-      // pixels — `viewportToFixed` reconciles the two when the html zoom
-      // (set by applyUserFonts) is != 1. `viewportLayoutSize` does the
-      // same for the clamping bounds. AttachmentContextMenu has the same
-      // dance for the same reason.
       const triggerRect = trigger.getBoundingClientRect();
-      const triggerTop = viewportToFixed(triggerRect.left, triggerRect.top);
-      const triggerBottom = viewportToFixed(
-        triggerRect.right,
-        triggerRect.bottom,
-      );
       const menu = menuRef.current;
       // First paint: menu hasn't rendered yet, fall back to a generous
       // estimate so we land roughly correct, then refine on the next
       // tick once we can measure the actual menu.
       const menuWidth = menu?.offsetWidth ?? 240;
       const menuHeight = menu?.offsetHeight ?? 180;
-      const { width: vw, height: vh } = viewportLayoutSize();
-      // Anchor: open above the trigger (footer is at bottom of sidebar)
-      // with the menu's left edge aligned to the trigger's left edge.
-      let left = triggerTop.x;
-      let top = triggerTop.y - menuHeight - MENU_GAP;
+      // Anchor: open above the trigger (footer sits at the bottom of the
+      // sidebar, so there's always more headroom than under-room) with
+      // the menu's left edge aligned to the trigger's left edge. No
+      // "drop below" fallback — clamping below handles any pathological
+      // case (tiny window) without flipping placement, which would put
+      // the menu on top of the chat content.
+      let left = triggerRect.left;
+      let top = triggerRect.top - menuHeight - MENU_GAP;
       // Clamp horizontally so the right edge stays inside the viewport.
-      left = Math.min(left, vw - menuWidth - VIEWPORT_MARGIN);
+      left = Math.min(left, window.innerWidth - menuWidth - VIEWPORT_MARGIN);
       left = Math.max(VIEWPORT_MARGIN, left);
-      // If there's not enough room above, drop below the trigger.
-      if (top < VIEWPORT_MARGIN) {
-        top = triggerBottom.y + MENU_GAP;
-      }
-      // Final vertical clamp (handles tiny viewports).
-      top = Math.min(top, vh - menuHeight - VIEWPORT_MARGIN);
+      // Vertical clamp: prefer the computed above-the-trigger position,
+      // but never let the menu run off the top of the viewport.
       top = Math.max(VIEWPORT_MARGIN, top);
       setPosition({ left, top });
     };

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -17,11 +17,11 @@ import {
   sendRemoteCommand,
   pairWithServer,
   startLocalServer,
-  openUrl,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown, CircleHelp } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { extractRemoteWorkspace } from "./remoteWorkspaceResponse";
+import { HelpMenu } from "./HelpMenu";
 import { UpdateBanner } from "../layout/UpdateBanner";
 import { getScmSortPriority } from "../../utils/scmSortPriority";
 import { useTabDragReorder } from "../../hooks/useTabDragReorder";
@@ -1062,20 +1062,10 @@ export const Sidebar = memo(function Sidebar() {
           <Globe size={16} />
         </button>
         <ShareButton openModal={openModal} />
-        <button
-          className={styles.footerBtn}
-          onClick={() => {
-            // Cross-platform docs entry. The native Help menu (macOS only,
-            // wired in src-tauri/src/main.rs) targets the same URL — use
-            // the docs root, not a deeper page, so the link survives any
-            // doc-site reorganization.
-            void openUrl("https://utensils.io/claudette/");
-          }}
-          title={t("help_open_docs")}
-          aria-label={t("help_open_docs")}
-        >
-          <CircleHelp size={16} />
-        </button>
+        <HelpMenu
+          buttonClassName={styles.footerBtn}
+          triggerLabel={t("help_menu_trigger")}
+        />
         <button
           className={styles.footerBtn}
           onClick={() => openSettings()}

--- a/src/ui/src/helpUrls.ts
+++ b/src/ui/src/helpUrls.ts
@@ -1,8 +1,19 @@
 // Single source of truth for the URLs the Help surfaces (sidebar Help
 // menu, Settings → Help, macOS Help submenu) deep-link to. Kept here
-// rather than inline so all three surfaces stay aligned — the Rust side
-// duplicates `HELP_DOCS_URL` as a `const` in `src-tauri/src/main.rs`
-// (TS and Rust can't share a literal across languages).
+// rather than inline so all surfaces stay aligned — the Rust side
+// duplicates these as `const`s in `src-tauri/src/main.rs` (TS and Rust
+// can't share a literal across languages; update both together when
+// any of these change).
 
+/** Documentation entry point — Getting Started page. */
 export const HELP_DOCS_URL =
   "https://utensils.io/claudette/getting-started/installation/";
+
+/** GitHub Releases tag URL. Append `CARGO_PKG_VERSION` to land on the
+ * release notes for the running build (e.g. `${BASE}0.23.0`). */
+export const HELP_RELEASE_URL_BASE =
+  "https://github.com/utensils/claudette/releases/tag/v";
+
+/** GitHub "new issue" entry point — bug reports / feature requests. */
+export const HELP_ISSUES_URL =
+  "https://github.com/utensils/claudette/issues/new";

--- a/src/ui/src/helpUrls.ts
+++ b/src/ui/src/helpUrls.ts
@@ -14,6 +14,9 @@ export const HELP_DOCS_URL =
 export const HELP_RELEASE_URL_BASE =
   "https://github.com/utensils/claudette/releases/tag/v";
 
-/** GitHub "new issue" entry point — bug reports / feature requests. */
+/** GitHub "new issue" entry point — bug reports / feature requests.
+ * The `?template=bug_report.md` query param pre-selects the bug-report
+ * template so users land in a structured form rather than a blank
+ * issue body. */
 export const HELP_ISSUES_URL =
-  "https://github.com/utensils/claudette/issues/new";
+  "https://github.com/utensils/claudette/issues/new?template=bug_report.md";

--- a/src/ui/src/helpUrls.ts
+++ b/src/ui/src/helpUrls.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the URLs the Help surfaces (sidebar Help
+// menu, Settings → Help, macOS Help submenu) deep-link to. Kept here
+// rather than inline so all three surfaces stay aligned — the Rust side
+// duplicates `HELP_DOCS_URL` as a `const` in `src-tauri/src/main.rs`
+// (TS and Rust can't share a literal across languages).
+
+export const HELP_DOCS_URL =
+  "https://utensils.io/claudette/getting-started/installation/";

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -18,6 +18,7 @@ export function useKeyboardShortcuts() {
   const toggleFuzzyFinder = useAppStore((s) => s.toggleFuzzyFinder);
   const toggleCommandPalette = useAppStore((s) => s.toggleCommandPalette);
   const openCommandPaletteFileMode = useAppStore((s) => s.openCommandPaletteFileMode);
+  const openModal = useAppStore((s) => s.openModal);
   const closeModal = useAppStore((s) => s.closeModal);
   const activeModal = useAppStore((s) => s.activeModal);
   const fuzzyFinderOpen = useAppStore((s) => s.fuzzyFinderOpen);
@@ -104,7 +105,8 @@ export function useKeyboardShortcuts() {
         overlayOpen &&
         action !== "global.open-settings" &&
         action !== "global.toggle-command-palette" &&
-        action !== "global.toggle-fuzzy-finder"
+        action !== "global.toggle-fuzzy-finder" &&
+        action !== "global.show-keyboard-shortcuts"
       ) return;
       if (action === "global.toggle-plan-mode" && (!activeSessionId || isInteractive)) return;
 
@@ -204,6 +206,11 @@ export function useKeyboardShortcuts() {
             else store.openSettings();
             return;
           }
+          case "global.show-keyboard-shortcuts":
+            // Idempotent when already open: openModal sets the same id.
+            // Esc closes it via the global.dismiss-or-stop branch above.
+            openModal("keyboard-shortcuts");
+            return;
           default:
             return;
         }
@@ -262,6 +269,7 @@ export function useKeyboardShortcuts() {
     toggleFuzzyFinder,
     toggleCommandPalette,
     openCommandPaletteFileMode,
+    openModal,
     closeModal,
     activeModal,
     fuzzyFinderOpen,

--- a/src/ui/src/hotkeys/actions.ts
+++ b/src/ui/src/hotkeys/actions.ts
@@ -333,6 +333,22 @@ export const HOTKEY_ACTIONS = [
     holdMode: true,
     suppressUnderOverlay: true,
   },
+  {
+    // Default `mod+/` matches `Cmd+/` on macOS and `Ctrl+/` elsewhere.
+    // The binding is the literal "/" — `parseBinding` splits on "+" and
+    // takes the trailing piece, and `normalizeKey("/")` returns "/" (no
+    // alias to "slash"). The macOS Help-menu accelerator in
+    // src-tauri/src/main.rs uses Tauri's separate accelerator format
+    // (`CmdOrCtrl+Slash`), and bindings.test.ts locks the two together.
+    id: "global.show-keyboard-shortcuts",
+    scope: "global",
+    category: "keyboard_category_help",
+    description: "keyboard_action_show_shortcuts",
+    defaultBinding: allPlatforms("mod+/"),
+    match: "key",
+    rebindable: true,
+    suppressUnderOverlay: false,
+  },
 ] as const satisfies readonly HotkeyAction[];
 
 export type HotkeyActionId = (typeof HOTKEY_ACTIONS)[number]["id"];

--- a/src/ui/src/hotkeys/bindings.test.ts
+++ b/src/ui/src/hotkeys/bindings.test.ts
@@ -138,6 +138,33 @@ describe("resolveHotkeyAction with conflict updates", () => {
   });
 });
 
+describe("global.show-keyboard-shortcuts default binding", () => {
+  // Locks the Help shortcut to Cmd/Ctrl+/ so the macOS Help-menu
+  // accelerator (`CmdOrCtrl+Slash` in src-tauri/src/main.rs) and the
+  // in-app hotkey can never silently drift apart.
+  it("resolves Cmd+/ on macOS", () => {
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "/", metaKey: true }),
+        "global",
+        {},
+        "mac",
+      ),
+    ).toBe("global.show-keyboard-shortcuts");
+  });
+
+  it("resolves Ctrl+/ on Linux/Windows", () => {
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "/", ctrlKey: true }),
+        "global",
+        {},
+        "linux",
+      ),
+    ).toBe("global.show-keyboard-shortcuts");
+  });
+});
+
 describe("bindingMatchesEvent — modifier-only codes", () => {
   // Regression: hold-to-talk on Right Alt was bound to `code:AltRight`,
   // but pressing Alt asserts e.altKey, which the matcher used to reject

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -409,5 +409,6 @@
   "help_menu_keyboard_shortcuts": "Keyboard shortcuts",
   "help_menu_docs": "Docs",
   "help_menu_changelog": "Changelog",
+  "help_menu_issues": "Submit issue",
   "help_menu_devtools": "Open dev tools"
 }

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -180,6 +180,8 @@
   "keyboard_category_editor": "Editor",
   "keyboard_category_voice": "Voice",
   "keyboard_category_chat": "Chat",
+  "keyboard_category_help": "Help",
+  "keyboard_action_show_shortcuts": "Show keyboard shortcuts",
   "keyboard_press_key": "Press keys…",
   "keyboard_cancel": "Cancel",
   "keyboard_rebind": "Rebind",
@@ -387,5 +389,25 @@
   "pinned_prompts_keep": "Keep",
   "pinned_prompts_delete_prompt": "Delete prompt",
   "pinned_prompts_confirm_delete_title": "Delete this prompt?",
-  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone."
+  "pinned_prompts_confirm_delete_subtitle": "This action cannot be undone.",
+
+  "nav_help": "Help",
+  "help_title": "Help",
+  "help_version_label": "Version",
+  "help_view_changelog": "What's new",
+  "help_shortcuts_label": "Keyboard shortcuts",
+  "help_shortcuts_description": "Browse every shortcut in a searchable viewer.",
+  "help_shortcuts_button": "Show shortcuts",
+  "help_docs_label": "Documentation",
+  "help_docs_description": "Open the Claudette docs in your browser.",
+  "help_docs_button": "Open docs",
+  "help_issues_label": "Report an issue",
+  "help_issues_description": "File a bug or feature request on GitHub.",
+  "help_issues_button": "Open tracker",
+  "shortcuts_modal_title": "Keyboard shortcuts",
+
+  "help_menu_keyboard_shortcuts": "Keyboard shortcuts",
+  "help_menu_docs": "Docs",
+  "help_menu_changelog": "Changelog",
+  "help_menu_devtools": "Open dev tools"
 }

--- a/src/ui/src/locales/en/sidebar.json
+++ b/src/ui/src/locales/en/sidebar.json
@@ -21,6 +21,7 @@
   "new_workspace": "New workspace",
   "settings": "Settings",
   "help_open_docs": "Open Claudette documentation",
+  "help_menu_trigger": "Help & resources",
   "relink": "Re-link",
   "remove": "Remove",
   "add_repository": "Add repository",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -8,6 +8,7 @@
   "nav_claude_code_plugins": "Complementos de Claude Code",
   "nav_community": "Comunidad",
   "nav_pinned_prompts": "Prompts fijados",
+  "nav_help": "Ayuda",
   "nav_experimental": "Experimental",
   "nav_usage": "Uso",
   "group_more": "Más",
@@ -344,5 +345,26 @@
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
   "keyboard_reset_all": "Reset all defaults",
-  "keyboard_disabled_binding": "Shortcut disabled"
+  "keyboard_disabled_binding": "Shortcut disabled",
+  "keyboard_category_help": "Ayuda",
+  "keyboard_action_show_shortcuts": "Mostrar atajos de teclado",
+
+  "help_title": "Ayuda",
+  "help_version_label": "Versión",
+  "help_view_changelog": "Novedades",
+  "help_shortcuts_label": "Atajos de teclado",
+  "help_shortcuts_description": "Explora todos los atajos en un visor con búsqueda.",
+  "help_shortcuts_button": "Ver atajos",
+  "help_docs_label": "Documentación",
+  "help_docs_description": "Abre la documentación de Claudette en tu navegador.",
+  "help_docs_button": "Abrir documentación",
+  "help_issues_label": "Informar un problema",
+  "help_issues_description": "Envía un reporte de error o solicitud de función en GitHub.",
+  "help_issues_button": "Abrir GitHub",
+  "shortcuts_modal_title": "Atajos de teclado",
+
+  "help_menu_keyboard_shortcuts": "Atajos de teclado",
+  "help_menu_docs": "Documentación",
+  "help_menu_changelog": "Cambios",
+  "help_menu_devtools": "Abrir herramientas de desarrollo"
 }

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -366,5 +366,6 @@
   "help_menu_keyboard_shortcuts": "Atajos de teclado",
   "help_menu_docs": "Documentación",
   "help_menu_changelog": "Cambios",
+  "help_menu_issues": "Informar problema",
   "help_menu_devtools": "Abrir herramientas de desarrollo"
 }

--- a/src/ui/src/locales/es/sidebar.json
+++ b/src/ui/src/locales/es/sidebar.json
@@ -20,6 +20,7 @@
   "status_archived": "Archivado",
   "new_workspace": "Nuevo espacio de trabajo",
   "settings": "Configuración",
+  "help_menu_trigger": "Ayuda y recursos",
   "relink": "Volver a vincular",
   "remove": "Quitar",
   "add_repository": "Añadir repositorio",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -366,5 +366,6 @@
   "help_menu_keyboard_shortcuts": "キーボードショートカット",
   "help_menu_docs": "ドキュメント",
   "help_menu_changelog": "変更履歴",
+  "help_menu_issues": "問題を報告",
   "help_menu_devtools": "開発者ツールを開く"
 }

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -8,6 +8,7 @@
   "nav_claude_code_plugins": "Claude Code プラグイン",
   "nav_community": "コミュニティ",
   "nav_pinned_prompts": "ピン留めプロンプト",
+  "nav_help": "ヘルプ",
   "nav_experimental": "実験的機能",
   "nav_usage": "利用状況",
   "group_more": "その他",
@@ -344,5 +345,26 @@
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
   "keyboard_reset_all": "Reset all defaults",
-  "keyboard_disabled_binding": "Shortcut disabled"
+  "keyboard_disabled_binding": "Shortcut disabled",
+  "keyboard_category_help": "ヘルプ",
+  "keyboard_action_show_shortcuts": "キーボードショートカットを表示",
+
+  "help_title": "ヘルプ",
+  "help_version_label": "バージョン",
+  "help_view_changelog": "新機能",
+  "help_shortcuts_label": "キーボードショートカット",
+  "help_shortcuts_description": "検索可能なビューアーですべてのショートカットを参照できます。",
+  "help_shortcuts_button": "ショートカットを表示",
+  "help_docs_label": "ドキュメント",
+  "help_docs_description": "ブラウザで Claudette のドキュメントを開きます。",
+  "help_docs_button": "ドキュメントを開く",
+  "help_issues_label": "問題を報告",
+  "help_issues_description": "GitHub にバグ報告や機能リクエストを送信します。",
+  "help_issues_button": "GitHub を開く",
+  "shortcuts_modal_title": "キーボードショートカット",
+
+  "help_menu_keyboard_shortcuts": "キーボードショートカット",
+  "help_menu_docs": "ドキュメント",
+  "help_menu_changelog": "変更履歴",
+  "help_menu_devtools": "開発者ツールを開く"
 }

--- a/src/ui/src/locales/ja/sidebar.json
+++ b/src/ui/src/locales/ja/sidebar.json
@@ -20,6 +20,7 @@
   "status_archived": "アーカイブ済み",
   "new_workspace": "新規ワークスペース",
   "settings": "設定",
+  "help_menu_trigger": "ヘルプとリソース",
   "relink": "再リンク",
   "remove": "削除",
   "add_repository": "リポジトリを追加",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -8,6 +8,7 @@
   "nav_claude_code_plugins": "Plugins do Claude Code",
   "nav_community": "Comunidade",
   "nav_pinned_prompts": "Prompts fixados",
+  "nav_help": "Ajuda",
   "nav_experimental": "Experimental",
   "nav_usage": "Uso",
   "group_more": "Mais",
@@ -344,5 +345,26 @@
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
   "keyboard_reset_all": "Reset all defaults",
-  "keyboard_disabled_binding": "Shortcut disabled"
+  "keyboard_disabled_binding": "Shortcut disabled",
+  "keyboard_category_help": "Ajuda",
+  "keyboard_action_show_shortcuts": "Mostrar atalhos de teclado",
+
+  "help_title": "Ajuda",
+  "help_version_label": "Versão",
+  "help_view_changelog": "Novidades",
+  "help_shortcuts_label": "Atalhos de teclado",
+  "help_shortcuts_description": "Veja todos os atalhos em um visualizador com busca.",
+  "help_shortcuts_button": "Ver atalhos",
+  "help_docs_label": "Documentação",
+  "help_docs_description": "Abra a documentação do Claudette no navegador.",
+  "help_docs_button": "Abrir documentação",
+  "help_issues_label": "Relatar um problema",
+  "help_issues_description": "Reporte um bug ou solicite um recurso no GitHub.",
+  "help_issues_button": "Abrir GitHub",
+  "shortcuts_modal_title": "Atalhos de teclado",
+
+  "help_menu_keyboard_shortcuts": "Atalhos de teclado",
+  "help_menu_docs": "Documentação",
+  "help_menu_changelog": "Mudanças",
+  "help_menu_devtools": "Abrir ferramentas de desenvolvimento"
 }

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -366,5 +366,6 @@
   "help_menu_keyboard_shortcuts": "Atalhos de teclado",
   "help_menu_docs": "Documentação",
   "help_menu_changelog": "Mudanças",
+  "help_menu_issues": "Relatar problema",
   "help_menu_devtools": "Abrir ferramentas de desenvolvimento"
 }

--- a/src/ui/src/locales/pt-BR/sidebar.json
+++ b/src/ui/src/locales/pt-BR/sidebar.json
@@ -20,6 +20,7 @@
   "status_archived": "Arquivado",
   "new_workspace": "Novo workspace",
   "settings": "Configurações",
+  "help_menu_trigger": "Ajuda e recursos",
   "relink": "Reconectar",
   "remove": "Remover",
   "add_repository": "Adicionar repositório",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -8,6 +8,7 @@
   "nav_claude_code_plugins": "Claude Code 插件",
   "nav_community": "社区",
   "nav_pinned_prompts": "已固定提示",
+  "nav_help": "帮助",
   "nav_experimental": "实验性",
   "nav_usage": "用量",
   "group_more": "更多",
@@ -344,5 +345,26 @@
   "keyboard_action_voice_toggle": "Toggle voice input",
   "keyboard_action_voice_hold": "Push to talk",
   "keyboard_reset_all": "Reset all defaults",
-  "keyboard_disabled_binding": "Shortcut disabled"
+  "keyboard_disabled_binding": "Shortcut disabled",
+  "keyboard_category_help": "帮助",
+  "keyboard_action_show_shortcuts": "显示键盘快捷键",
+
+  "help_title": "帮助",
+  "help_version_label": "版本",
+  "help_view_changelog": "新功能",
+  "help_shortcuts_label": "键盘快捷键",
+  "help_shortcuts_description": "在可搜索的视图中浏览所有快捷键。",
+  "help_shortcuts_button": "显示快捷键",
+  "help_docs_label": "文档",
+  "help_docs_description": "在浏览器中打开 Claudette 文档。",
+  "help_docs_button": "打开文档",
+  "help_issues_label": "反馈问题",
+  "help_issues_description": "在 GitHub 上提交错误或功能请求。",
+  "help_issues_button": "打开 GitHub",
+  "shortcuts_modal_title": "键盘快捷键",
+
+  "help_menu_keyboard_shortcuts": "键盘快捷键",
+  "help_menu_docs": "文档",
+  "help_menu_changelog": "更新日志",
+  "help_menu_devtools": "打开开发者工具"
 }

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -366,5 +366,6 @@
   "help_menu_keyboard_shortcuts": "键盘快捷键",
   "help_menu_docs": "文档",
   "help_menu_changelog": "更新日志",
+  "help_menu_issues": "反馈问题",
   "help_menu_devtools": "打开开发者工具"
 }

--- a/src/ui/src/locales/zh-CN/sidebar.json
+++ b/src/ui/src/locales/zh-CN/sidebar.json
@@ -20,6 +20,7 @@
   "status_archived": "已归档",
   "new_workspace": "新建工作区",
   "settings": "设置",
+  "help_menu_trigger": "帮助和资源",
   "relink": "重新链接",
   "remove": "移除",
   "add_repository": "添加仓库",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -1034,6 +1034,10 @@ export function openUrl(url: string): Promise<void> {
   return invoke("open_url", { url });
 }
 
+export function openDevtools(): Promise<void> {
+  return invoke("open_devtools");
+}
+
 export function getGitUsername(): Promise<string | null> {
   return invoke("get_git_username");
 }


### PR DESCRIPTION
## Summary

Replaces the sidebar's docs-only `?` button with a popover **Help menu** modeled on Conductor's, plus matching surfaces in **Settings → Help** and the **macOS Help submenu**. Closes the first slice of #588.

The menu has four items:

- **Keyboard shortcuts** — opens a new modal listing every hotkey grouped by category, driven by the existing declarative `HOTKEY_ACTIONS` table (so it can't drift from real bindings or user overrides). Globally bound to `⌘/`.
- **Docs** — deep-links to the Getting Started page.
- **Changelog** — deep-links to `https://github.com/utensils/claudette/releases/tag/v{CARGO_PKG_VERSION}`. Release-page URL chosen over CHANGELOG anchors because anchors embed the release date and would require Rust to know it.
- **Open dev tools** — invokes `WebviewWindow::open_devtools()`. `tauri/devtools` is now in default features so the inspector ships in release, not just `cargo tauri dev`.

```mermaid
flowchart LR
    A[Sidebar `?` button] --> B[HelpMenu popover<br/>portaled to document.body]
    B --> C[Keyboard shortcuts modal]
    B --> D[openUrl - Docs]
    B --> E[openUrl - Changelog]
    B --> F[openDevtools command]
    G[macOS Help menu] --> C
    G --> E
    H[Settings → Help] --> C
    H --> D
    H --> E
```

The popup is rendered through `createPortal(menu, document.body)` with `position: fixed` + `getBoundingClientRect()`-derived coordinates. This was the only working answer — the sidebar's container has `overflow: hidden`, which clips painted children regardless of `z-index`. A portal escapes the subtree entirely. Same trick the codebase already uses for `AttachmentContextMenu`.

The `⌘/` hint in the menu reads from `getEffectiveBinding(action, keybindings)` — if a user rebinds the shortcut from Settings → Keyboard, the hint updates automatically rather than silently lying.

## Complexity Notes

- **Default-feature change to `tauri/devtools`** (`src-tauri/Cargo.toml:69-72`). This bundles the webview inspector into every release binary — small binary cost. Conscious choice over the experimental-flag option so the menu item works for everyone without a custom build. If we ever change our mind, a follow-up gates the menu item on a setting and pulls the feature back to opt-in.
- **`Cmd+/` binding pitfall.** The hotkey table normalizes `e.key === "/"` to `"/"`, not to a keyword like `"slash"`. Bindings are `mod+/` (literal). The macOS Help menu accelerator is a *separate* parser (Tauri's accelerator format, `CmdOrCtrl+Slash`). `bindings.test.ts` locks the two surfaces together so they can't drift.
- **Two-pass position measurement** in `HelpMenu.tsx`: first pass uses estimated dimensions (240×180), then a `requestAnimationFrame` re-measures with the real `offsetWidth`/`offsetHeight`. Matters because the version footer ("Claudette v0.23.0") loads asynchronously and changes the menu height. `useLayoutEffect` ensures position lands pre-paint so users never see a `(0,0)` flash.
- **Outside-click handler must check both portal subtrees.** With a portal, `triggerRef.contains(target)` and `menuRef.contains(target)` cover different DOM trees; missing one drops menu-item clicks to the outside-click handler before `onClick` runs. Same gotcha is documented in `AttachmentContextMenu.tsx:127-132`.
- **Rebase included a non-trivial conflict resolution** with main's new CLI settings section. `SettingsPage.tsx`, `SettingsSidebar.tsx`, and `Sidebar.tsx` all gained an entry from each branch — kept both. Worth a quick eyeballed re-check in those three files.

## Test Steps

```bash
# From repo root
scripts/stage-cli-sidecar.sh   # stages the CLI sidecar required by tauri-build
cargo tauri dev
```

Then in the running app:

1. Click the `?` button in the sidebar footer → menu pops up **above** the button and overlays the chat/dashboard cleanly (no clipping at the sidebar/chat boundary).
2. Verify the four menu items:
   - **Keyboard shortcuts** → opens the modal; right side shows `⌘/`. Search filters by description, category, or key. `Esc` closes.
   - **Docs** → opens `https://utensils.io/claudette/getting-started/installation/` in the system browser.
   - **Changelog** → opens `https://github.com/utensils/claudette/releases/tag/v0.23.0`.
   - **Open dev tools** → webview inspector opens.
3. Press `⌘/` (Mac) or `Ctrl+/` (Linux/Win) anywhere → keyboard shortcuts modal opens directly.
4. macOS Help menu: `Help → Keyboard Shortcuts…` opens modal; `Help → What's New (v0.23.0)` opens the release page.
5. Settings → Help section: shows app version, four working buttons (What's new / Show shortcuts / Open docs / Open tracker).
6. Rebind `Cmd+/` from `Settings → Keyboard` to something else → reopen the help menu, the keycap hint reflects the new binding (does not silently keep showing `⌘/`).
7. Verify menu doesn't get clipped on a narrow window (resize horizontally with menu open).
8. **Release-build sanity check**: `cargo tauri build` and confirm `Open dev tools` still works in the bundled `.app` — that's the change that doesn't surface in dev mode (where devtools are available regardless of feature flag).

## Pre-flight

- `bunx tsc -b --force` — clean.
- `bun run lint:css` — clean.
- `bun run test` — 1288 passing (the lone "failed file" is a pre-existing env-only `builtHtml.test.ts` that needs a prior `vite build`).
- `bun run lint` — 91 problems, identical to baseline; zero added by this PR.
- `cargo fmt --all --check` — clean.
- `cargo clippy -p claudette-tauri` — 3 pre-existing warnings in `commands/chat/send.rs`, none from this PR.
- `RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-server --all-targets` (CI's exact gate) — clean.
- `cargo test -p claudette-tauri` — 201/201 pass with `tauri/devtools` in default features.

## Checklist

- [x] Tests added/updated (new `bindings.test.ts` cases lock `Cmd+/` ↔ `global.show-keyboard-shortcuts`, plus `SettingsSidebar.test.ts` covers the new Help section)
- [ ] Documentation updated (n/a — no docs/ pages affected; CLAUDE.md unchanged)

Refs #588 (umbrella issue stays open for the remaining `capture-and-share-logs` sub-feature).