### PR TITLE
fix(remote): reuse saved connection when re-pairing same host:port

### DIFF
--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -61,22 +61,47 @@ pub async fn pair_with_server(
         .authenticate_pairing(&pairing_token, &hostname)
         .await?;
 
-    let connection_id = uuid::Uuid::new_v4().to_string();
+    // Pairing must yield a session token; sessions established via session
+    // re-auth (not pairing) wouldn't, but we're on the pairing path here.
+    let session_token = auth
+        .session_token
+        .clone()
+        .ok_or("Server did not return a session token after pairing")?;
 
-    // Persist to DB.
+    // Persist to DB. If we already have a saved connection to this host:port,
+    // refresh it in place so re-pairing doesn't create a duplicate sidebar entry.
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let db_conn = claudette::model::RemoteConnection {
-        id: connection_id.clone(),
-        name: auth.server_name.clone(),
-        host: host.clone(),
-        port,
-        session_token: auth.session_token.clone(),
-        cert_fingerprint: Some(cert_fingerprint.clone()),
-        auto_connect: false,
-        created_at: String::new(),
+    let connection_id = match db
+        .find_remote_connection_by_host(&host, port)
+        .map_err(|e| e.to_string())?
+    {
+        Some(existing) => {
+            db.update_remote_connection_session(
+                &existing.id,
+                &auth.server_name,
+                &session_token,
+                &cert_fingerprint,
+            )
+            .map_err(|e| e.to_string())?;
+            existing.id
+        }
+        None => {
+            let id = uuid::Uuid::new_v4().to_string();
+            let db_conn = claudette::model::RemoteConnection {
+                id: id.clone(),
+                name: auth.server_name.clone(),
+                host: host.clone(),
+                port,
+                session_token: Some(session_token),
+                cert_fingerprint: Some(cert_fingerprint.clone()),
+                auto_connect: false,
+                created_at: String::new(),
+            };
+            db.insert_remote_connection(&db_conn)
+                .map_err(|e| e.to_string())?;
+            id
+        }
     };
-    db.insert_remote_connection(&db_conn)
-        .map_err(|e| e.to_string())?;
 
     // Re-fetch to get the DB-generated created_at timestamp.
     let saved = db

--- a/src/db/remote.rs
+++ b/src/db/remote.rs
@@ -86,15 +86,45 @@ impl Database {
             .optional()
     }
 
+    pub fn find_remote_connection_by_host(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> Result<Option<RemoteConnection>, rusqlite::Error> {
+        self.conn
+            .query_row(
+                "SELECT id, name, host, port, session_token, cert_fingerprint, auto_connect, created_at
+                 FROM remote_connections WHERE host = ?1 AND port = ?2
+                 ORDER BY created_at LIMIT 1",
+                params![host, port as i32],
+                |row| {
+                    let auto_connect_int: i32 = row.get(6)?;
+                    Ok(RemoteConnection {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        host: row.get(2)?,
+                        port: Self::parse_port(row, 3)?,
+                        session_token: row.get(4)?,
+                        cert_fingerprint: row.get(5)?,
+                        auto_connect: auto_connect_int != 0,
+                        created_at: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+    }
+
     pub fn update_remote_connection_session(
         &self,
         id: &str,
+        name: &str,
         session_token: &str,
         cert_fingerprint: &str,
     ) -> Result<(), rusqlite::Error> {
         self.conn.execute(
-            "UPDATE remote_connections SET session_token = ?1, cert_fingerprint = ?2 WHERE id = ?3",
-            params![session_token, cert_fingerprint, id],
+            "UPDATE remote_connections SET name = ?1, session_token = ?2, cert_fingerprint = ?3
+             WHERE id = ?4",
+            params![name, session_token, cert_fingerprint, id],
         )?;
         Ok(())
     }
@@ -160,11 +190,39 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         db.insert_remote_connection(&make_remote_conn("rc1", "Server A", "host-a.local", 7683))
             .unwrap();
-        db.update_remote_connection_session("rc1", "tok-123", "fp-abc")
+        db.update_remote_connection_session("rc1", "Server A (renamed)", "tok-123", "fp-abc")
             .unwrap();
         let conn = db.get_remote_connection("rc1").unwrap().unwrap();
+        assert_eq!(conn.name, "Server A (renamed)");
         assert_eq!(conn.session_token.as_deref(), Some("tok-123"));
         assert_eq!(conn.cert_fingerprint.as_deref(), Some("fp-abc"));
+    }
+
+    #[test]
+    fn test_find_remote_connection_by_host() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc1", "Server A", "host-a.local", 7683))
+            .unwrap();
+        db.insert_remote_connection(&make_remote_conn("rc2", "Server B", "host-b.local", 9000))
+            .unwrap();
+
+        let found = db
+            .find_remote_connection_by_host("host-a.local", 7683)
+            .unwrap()
+            .expect("connection by host:port");
+        assert_eq!(found.id, "rc1");
+
+        // Different port on same host: no match.
+        let none = db
+            .find_remote_connection_by_host("host-a.local", 9999)
+            .unwrap();
+        assert!(none.is_none());
+
+        // Unknown host.
+        let none = db
+            .find_remote_connection_by_host("nope.local", 7683)
+            .unwrap();
+        assert!(none.is_none());
     }
 
     #[test]

--- a/src/ui/src/stores/slices/remoteSlice.test.ts
+++ b/src/ui/src/stores/slices/remoteSlice.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "../useAppStore";
+import type { RemoteConnectionInfo } from "../../types";
+
+const makeConn = (
+  id: string,
+  host: string,
+  overrides: Partial<RemoteConnectionInfo> = {},
+): RemoteConnectionInfo => ({
+  id,
+  name: `Server ${id}`,
+  host,
+  port: 7683,
+  session_token: `tok-${id}`,
+  cert_fingerprint: `fp-${id}`,
+  auto_connect: false,
+  created_at: "",
+  ...overrides,
+});
+
+describe("remoteSlice.addRemoteConnection", () => {
+  beforeEach(() => {
+    useAppStore.setState({ remoteConnections: [], activeRemoteIds: [] });
+  });
+
+  it("appends when the id is new", () => {
+    useAppStore.getState().addRemoteConnection(makeConn("rc1", "host-a.local"));
+    useAppStore.getState().addRemoteConnection(makeConn("rc2", "host-b.local"));
+    const conns = useAppStore.getState().remoteConnections;
+    expect(conns.map((c) => c.id)).toEqual(["rc1", "rc2"]);
+  });
+
+  // Re-pairing with the same host yields the same persisted id from the
+  // backend; the slice must replace in place so the sidebar doesn't show a
+  // duplicate alongside the now-defunct entry.
+  it("replaces in place when an entry with the same id already exists", () => {
+    useAppStore
+      .getState()
+      .addRemoteConnection(makeConn("rc1", "host-a.local", { name: "old" }));
+    useAppStore
+      .getState()
+      .addRemoteConnection(makeConn("rc1", "host-a.local", { name: "new" }));
+    const conns = useAppStore.getState().remoteConnections;
+    expect(conns).toHaveLength(1);
+    expect(conns[0].name).toBe("new");
+  });
+
+  it("preserves array order when replacing", () => {
+    useAppStore.getState().addRemoteConnection(makeConn("rc1", "host-a.local"));
+    useAppStore.getState().addRemoteConnection(makeConn("rc2", "host-b.local"));
+    useAppStore.getState().addRemoteConnection(makeConn("rc3", "host-c.local"));
+    useAppStore
+      .getState()
+      .addRemoteConnection(makeConn("rc2", "host-b.local", { name: "B!" }));
+    const conns = useAppStore.getState().remoteConnections;
+    expect(conns.map((c) => c.id)).toEqual(["rc1", "rc2", "rc3"]);
+    expect(conns[1].name).toBe("B!");
+  });
+});

--- a/src/ui/src/stores/slices/remoteSlice.ts
+++ b/src/ui/src/stores/slices/remoteSlice.ts
@@ -50,7 +50,15 @@ export const createRemoteSlice: StateCreator<
   activeRemoteIds: [],
   setRemoteConnections: (conns) => set({ remoteConnections: conns }),
   addRemoteConnection: (conn) =>
-    set((s) => ({ remoteConnections: [...s.remoteConnections, conn] })),
+    set((s) => {
+      const idx = s.remoteConnections.findIndex((c) => c.id === conn.id);
+      if (idx >= 0) {
+        const next = s.remoteConnections.slice();
+        next[idx] = conn;
+        return { remoteConnections: next };
+      }
+      return { remoteConnections: [...s.remoteConnections, conn] };
+    }),
   removeRemoteConnection: (id) =>
     set((s) => ({
       remoteConnections: s.remoteConnections.filter((c) => c.id !== id),


### PR DESCRIPTION
## Summary

Re-pairing with a host that already had a saved connection minted a fresh UUID and INSERTed a new row, so the sidebar would show a duplicate entry alongside the original — and the original was now defunct because the new pairing had invalidated its session token on the server side.

The fix looks up the saved connection by `(host, port)` before pairing; if one exists, it updates `name` / `session_token` / `cert_fingerprint` in place and reuses the existing id. `RemoteConnectionManager::add` already replaces in-memory connections that share an id, so the old transport is closed cleanly and the new one takes over.

As defense in depth, the Zustand `addRemoteConnection` action now upserts by `id` rather than blindly appending, so any future caller that re-emits a connection won't reintroduce the duplicate.

```mermaid
sequenceDiagram
  participant UI
  participant pair_with_server
  participant DB
  participant Manager
  UI->>pair_with_server: host, port, token
  pair_with_server->>DB: find_remote_connection_by_host(host, port)
  alt existing row
    DB-->>pair_with_server: Some(existing)
    pair_with_server->>DB: update name + session_token + cert_fingerprint
    Note right of pair_with_server: reuses existing.id
  else no row
    pair_with_server->>DB: insert(new uuid)
  end
  pair_with_server->>Manager: add(info, transport) (replaces same-id in-memory connection)
```

## Complexity Notes

- `RemoteConnectionManager::add` matches by `info.id` and closes the prior transport when an id collides — that's load-bearing for the reuse path. Already covered by existing logic at `src-tauri/src/remote.rs:52`.
- `update_remote_connection_session` gained a `name` parameter; only its existing test calls it, so no other call sites needed updating.
- Matching by `(host, port)` means a user can't keep two distinct saved connections to the same address. Intentional: `host:port` is the user-meaningful identity for a saved server.

## Test Steps

1. Pair with a remote server (e.g. via mDNS "Connect" in the sidebar) — confirm a single sidebar entry appears.
2. Disconnect the server (toggle the active state off, or stop the remote server).
3. Re-pair with the same host (issue a fresh pairing token from the server, click "Connect" again, paste the new token).
4. **Expected:** the sidebar still shows a *single* entry for that host, now active again. **Before this fix:** a second duplicate entry appeared, and the first remained in a defunct/unusable state.
5. Run the unit tests:
   - `cargo test -p claudette --lib db::remote` — 7 passing (includes new `test_find_remote_connection_by_host` and updated `test_update_remote_connection_session`).
   - `cd src/ui && bunx vitest run src/stores/slices/remoteSlice.test.ts` — 3 passing (append / replace-in-place / preserve order).

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (n/a — no user-facing docs cover saved-connection storage)