### PR TITLE
fix: stage cli sidecar for dev builds

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -75,6 +75,8 @@ echo "▸ Vite dev server:  http://localhost:$vite_port"
 echo "▸ Debug eval port:  $debug_port"
 echo "▸ Discovery file:   $discovery_file"
 
+"$repo_root/scripts/stage-cli-sidecar.sh" --profile debug
+
 (cd src/ui && bun install)
 
 features="${CARGO_TAURI_FEATURES:-devtools,server,voice}"

--- a/scripts/stage-cli-sidecar.sh
+++ b/scripts/stage-cli-sidecar.sh
@@ -6,8 +6,9 @@
 # .deb / AppImage / Windows install dir).
 #
 # Usage:
-#   scripts/stage-cli-sidecar.sh                 # auto-detect host triple
-#   scripts/stage-cli-sidecar.sh <triple>        # explicit triple (CI)
+#   scripts/stage-cli-sidecar.sh                         # auto-detect host triple
+#   scripts/stage-cli-sidecar.sh <triple>                # explicit triple (CI)
+#   scripts/stage-cli-sidecar.sh --profile debug         # dev builds
 #   scripts/stage-cli-sidecar.sh <triple> --release-built
 #       # don't rebuild; assume `target/<triple>/release/claudette` already
 #       # exists (CI flow where claudette-cli was built in a separate step).
@@ -16,26 +17,98 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
-if [ "${1:-}" != "" ] && [ "$1" != "--release-built" ]; then
-  triple="$1"
+usage() {
+  sed -n '2,13p' "$0" >&2
+}
+
+triple=""
+profile="release"
+release_built=false
+triple_explicit=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --release-built)
+      release_built=true
+      profile="release"
+      ;;
+    --profile)
+      shift
+      if [ "${1:-}" = "" ]; then
+        echo "--profile requires 'debug' or 'release'" >&2
+        exit 64
+      fi
+      profile="$1"
+      ;;
+    --profile=*)
+      profile="${1#--profile=}"
+      ;;
+    --debug)
+      profile="debug"
+      ;;
+    --release)
+      profile="release"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      usage
+      exit 64
+      ;;
+    *)
+      if [ "$triple" != "" ]; then
+        echo "unexpected extra argument: $1" >&2
+        usage
+        exit 64
+      fi
+      triple="$1"
+      triple_explicit=true
+      ;;
+  esac
   shift
-else
+done
+
+case "$profile" in
+  debug|release) ;;
+  *)
+    echo "unsupported profile: $profile (expected debug or release)" >&2
+    exit 64
+    ;;
+esac
+
+if [ "$release_built" = "true" ] && [ "$profile" != "release" ]; then
+  echo "--release-built can only be used with the release profile" >&2
+  exit 64
+fi
+
+if [ "$triple" = "" ]; then
   triple="$(rustc -vV | awk '/host:/ {print $2}')"
 fi
-release_built=false
-for arg in "$@"; do
-  if [ "$arg" = "--release-built" ]; then release_built=true; fi
-done
 
 case "$triple" in
   *windows*) bin_name="claudette.exe" ;;
   *)         bin_name="claudette" ;;
 esac
 
-target_bin="target/${triple}/release/${bin_name}"
+if [ "$profile" = "debug" ] && [ "$triple_explicit" != "true" ]; then
+  target_bin="target/debug/${bin_name}"
+else
+  target_bin="target/${triple}/${profile}/${bin_name}"
+fi
+
 if [ "$release_built" != "true" ]; then
-  echo "▸ Building claudette-cli for ${triple}"
-  cargo build --release --target "${triple}" -p claudette-cli
+  echo "▸ Building claudette-cli (${profile}) for ${triple}"
+  cargo_args=(build -p claudette-cli)
+  if [ "$profile" = "release" ] || [ "$triple_explicit" = "true" ]; then
+    cargo_args+=(--target "${triple}")
+  fi
+  if [ "$profile" = "release" ]; then
+    cargo_args=(build --release --target "${triple}" -p claudette-cli)
+  fi
+  cargo "${cargo_args[@]}"
 fi
 
 if [ ! -f "$target_bin" ]; then

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "mainBinaryName": "claudette-app",
   "identifier": "com.claudette.app",
   "build": {
-    "beforeDevCommand": { "script": "bun install && bun run dev", "cwd": "../src/ui" },
+    "beforeDevCommand": { "script": "../../scripts/stage-cli-sidecar.sh --profile debug && bun install && bun run dev", "cwd": "../src/ui" },
     "beforeBuildCommand": { "script": "bun install && bun run build", "cwd": "../src/ui" },
     "devUrl": "http://localhost:14253",
     "frontendDist": "../src/ui/dist"


### PR DESCRIPTION
## Summary
- stage the debug claudette CLI sidecar before dev launches
- extend the sidecar staging script with debug/release profile handling
- keep direct `cargo tauri dev` working by staging from Tauri `beforeDevCommand`

## Why
Dev builds were failing during Tauri setup because `bundle.externalBin` expected `src-tauri/binaries/claudette-<target>` to exist, but local dev did not generate that sidecar before the custom build step.

## Validation
- `bash -n scripts/dev.sh`
- `bash -n scripts/stage-cli-sidecar.sh`
- `git diff --check`

Note: I could not complete a full Rust build in this shell because the local macOS linker setup fails earlier with `ld: library not found for -liconv`. This is unrelated to the sidecar path failure.