### PR TITLE
fix: repair attachment file copy

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,7 +72,11 @@ mac-notification-sys = "0.6"
 winreg = "0.55"
 windows-sys = { version = "0.61", features = [
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
     "Win32_Foundation",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
+    "Win32_System_Ole",
 ] }
 
 [features]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -486,6 +486,174 @@ pub fn write_attachment_to_temp_file(
     Ok(path)
 }
 
+#[cfg(target_os = "macos")]
+fn copy_file_path_to_clipboard(path: &Path) -> Result<(), String> {
+    let output = std::process::Command::new("osascript")
+        .args([
+            "-e",
+            "on run argv",
+            "-e",
+            "set the clipboard to POSIX file (item 1 of argv)",
+            "-e",
+            "end run",
+        ])
+        .arg(path)
+        .output()
+        .map_err(|e| format!("failed to run osascript: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("osascript failed: {}", stderr.trim()))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn copy_file_path_to_clipboard(path: &Path) -> Result<(), String> {
+    let uri = url::Url::from_file_path(path)
+        .map_err(|_| format!("failed to create file URI for {}", path.display()))?
+        .to_string();
+    let gnome_files = format!("copy\n{uri}\n");
+    let uri_list = format!("{uri}\n");
+
+    let attempts: [(&str, &[&str], &str); 5] = [
+        (
+            "wl-copy",
+            &["--type", "x-special/gnome-copied-files"],
+            &gnome_files,
+        ),
+        ("wl-copy", &["--type", "text/uri-list"], &uri_list),
+        (
+            "xclip",
+            &[
+                "-selection",
+                "clipboard",
+                "-t",
+                "x-special/gnome-copied-files",
+            ],
+            &gnome_files,
+        ),
+        (
+            "xclip",
+            &["-selection", "clipboard", "-t", "text/uri-list"],
+            &uri_list,
+        ),
+        ("xclip", &["-selection", "clipboard"], &uri),
+    ];
+
+    let mut errors = Vec::new();
+    for (program, args, input) in attempts {
+        match pipe_to_command(program, args, input.as_bytes()) {
+            Ok(()) => return Ok(()),
+            Err(e) => errors.push(format!("{program}: {e}")),
+        }
+    }
+    Err(format!(
+        "copying files requires wl-copy or xclip on Linux ({})",
+        errors.join("; ")
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn pipe_to_command(program: &str, args: &[&str], input: &[u8]) -> Result<(), String> {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let mut child = std::process::Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "failed to open stdin".to_string())?;
+    stdin.write_all(input).map_err(|e| e.to_string())?;
+    drop(stdin);
+    let output = child.wait_with_output().map_err(|e| e.to_string())?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+#[cfg(windows)]
+fn copy_file_path_to_clipboard(path: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
+    };
+    use windows_sys::Win32::System::Memory::{GHND, GlobalAlloc, GlobalLock, GlobalUnlock};
+    use windows_sys::Win32::System::Ole::CF_HDROP;
+    use windows_sys::Win32::UI::Shell::DROPFILES;
+
+    struct ClipboardGuard;
+    impl Drop for ClipboardGuard {
+        fn drop(&mut self) {
+            unsafe {
+                CloseClipboard();
+            }
+        }
+    }
+
+    let mut wide_path: Vec<u16> = path.as_os_str().encode_wide().collect();
+    // CF_HDROP expects one NUL after each path plus one extra NUL to end
+    // the file list.
+    wide_path.push(0);
+    wide_path.push(0);
+
+    let header_size = std::mem::size_of::<DROPFILES>();
+    let bytes_len = header_size + wide_path.len() * std::mem::size_of::<u16>();
+    unsafe {
+        let hmem = GlobalAlloc(GHND, bytes_len);
+        if hmem.is_null() {
+            return Err("GlobalAlloc failed".to_string());
+        }
+        let ptr = GlobalLock(hmem);
+        if ptr.is_null() {
+            return Err("GlobalLock failed".to_string());
+        }
+
+        let header = DROPFILES {
+            pFiles: header_size as u32,
+            pt: std::mem::zeroed(),
+            fNC: 0,
+            fWide: 1,
+        };
+        std::ptr::copy_nonoverlapping(
+            &header as *const DROPFILES as *const u8,
+            ptr as *mut u8,
+            header_size,
+        );
+        std::ptr::copy_nonoverlapping(
+            wide_path.as_ptr() as *const u8,
+            (ptr as *mut u8).add(header_size),
+            wide_path.len() * std::mem::size_of::<u16>(),
+        );
+        GlobalUnlock(hmem);
+
+        if OpenClipboard(std::ptr::null_mut()) == 0 {
+            return Err("OpenClipboard failed".to_string());
+        }
+        let _guard = ClipboardGuard;
+        if EmptyClipboard() == 0 {
+            return Err("EmptyClipboard failed".to_string());
+        }
+        if SetClipboardData(CF_HDROP as u32, hmem).is_null() {
+            return Err("SetClipboardData failed".to_string());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn copy_file_path_to_clipboard(_path: &Path) -> Result<(), String> {
+    Err("file clipboard copy is not supported on this platform".to_string())
+}
+
 /// Write `bytes` to `path`, creating the file with restrictive permissions
 /// on Unix (`0o600`). On Windows ACLs handle this differently — a regular
 /// `fs::write` is fine.
@@ -617,6 +785,28 @@ pub async fn open_attachment_with_default_app(
         crate::commands::shell::opener::open(&path.to_string_lossy())
             .map_err(|e| format!("open failed: {e}"))
     })
+}
+
+/// Stage an attachment to a temp file and put that file on the system
+/// clipboard. Used for document-like attachments such as PDFs where the
+/// browser ClipboardItem API either rejects the MIME type or reports success
+/// without producing a useful paste target.
+#[tauri::command]
+pub async fn copy_attachment_file_to_clipboard(
+    bytes: Vec<u8>,
+    filename: String,
+    media_type: String,
+) -> Result<(), String> {
+    let dir = std::env::temp_dir().join("claudette-attachments");
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        create_staging_dir(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;
+        cleanup_stale_attachments(&dir, std::time::Duration::from_secs(24 * 60 * 60));
+        let path = write_attachment_to_temp_file(&dir, &filename, &media_type, &bytes)
+            .map_err(|e| format!("write attachment: {e}"))?;
+        copy_file_path_to_clipboard(&path)
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -573,6 +573,7 @@ fn main() {
             commands::files::save_attachment_bytes,
             commands::files::open_attachment_in_browser,
             commands::files::open_attachment_with_default_app,
+            commands::files::copy_attachment_file_to_clipboard,
             // Chat
             commands::chat::send::load_chat_history,
             commands::chat::send::load_chat_history_page,

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -22,6 +22,7 @@ import {
   downloadAttachment,
   openAttachmentInBrowser,
   openAttachmentWithDefaultApp,
+  copyAttachmentFileToClipboard,
   copyAttachmentToClipboard,
   shareAttachment,
   isShareSupported,
@@ -146,6 +147,25 @@ describe("openAttachmentWithDefaultApp", () => {
   });
 });
 
+describe("copyAttachmentFileToClipboard", () => {
+  it("invokes copy_attachment_file_to_clipboard with decoded bytes", async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const pdf: DownloadableAttachment = {
+      filename: "doc.pdf",
+      media_type: "application/pdf",
+      data_base64: "JVBERi0=", // %PDF-
+    };
+
+    await copyAttachmentFileToClipboard(pdf, { invoke });
+
+    expect(invoke).toHaveBeenCalledWith("copy_attachment_file_to_clipboard", {
+      bytes: [37, 80, 68, 70, 45],
+      filename: "doc.pdf",
+      mediaType: "application/pdf",
+    });
+  });
+});
+
 describe("copyAttachmentToClipboard", () => {
   it("writes a ClipboardItem via navigator.clipboard.write", async () => {
     const write = vi.fn().mockResolvedValue(undefined);
@@ -171,6 +191,64 @@ describe("copyAttachmentToClipboard", () => {
         clipboard: { write } as unknown as Clipboard,
       }),
     ).rejects.toThrow("denied");
+  });
+
+  it("routes PDF attachments through the backend file clipboard command", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    const pdfFixture: DownloadableAttachment = {
+      filename: "doc.pdf",
+      data_base64: "JVBERi0=", // %PDF-
+      media_type: "application/pdf",
+    };
+
+    await copyAttachmentToClipboard(pdfFixture, {
+      clipboard: { write } as unknown as Clipboard,
+      invoke,
+    });
+
+    expect(invoke).toHaveBeenCalledWith("copy_attachment_file_to_clipboard", {
+      bytes: [37, 80, 68, 70, 45],
+      filename: "doc.pdf",
+      mediaType: "application/pdf",
+    });
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("writes CSV attachments as text via the injected writeText", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const csvFixture: DownloadableAttachment = {
+      filename: "people.csv",
+      data_base64: "aWQsbmFtZQoxLEFkYQo=", // base64 of 'id,name\n1,Ada\n'
+      media_type: "text/csv",
+    };
+
+    await copyAttachmentToClipboard(csvFixture, {
+      clipboard: { write } as unknown as Clipboard,
+      writeText,
+    });
+
+    expect(writeText).toHaveBeenCalledWith("id,name\n1,Ada\n");
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("writes JSON attachments as text via the injected writeText", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const jsonFixture: DownloadableAttachment = {
+      filename: "data.json",
+      data_base64: "eyJvayI6dHJ1ZX0=", // base64 of '{"ok":true}'
+      media_type: "application/json",
+    };
+
+    await copyAttachmentToClipboard(jsonFixture, {
+      clipboard: { write } as unknown as Clipboard,
+      writeText,
+    });
+
+    expect(writeText).toHaveBeenCalledWith('{"ok":true}');
+    expect(write).not.toHaveBeenCalled();
   });
 
   // WebKit silently drops image/svg+xml ClipboardItems, so a copied SVG

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -15,6 +15,33 @@ export interface DownloadableAttachment {
   data_base64: string;
 }
 
+function copiesAsText(mediaType: string): boolean {
+  return mediaType.startsWith("text/") || mediaType === "application/json";
+}
+
+async function writeDecodedTextToClipboard(
+  bytes: Uint8Array,
+  deps: {
+    clipboard?: Clipboard;
+    writeText?: (text: string) => Promise<void>;
+  },
+): Promise<void> {
+  const text = new TextDecoder("utf-8").decode(bytes);
+  if (deps.writeText) {
+    await deps.writeText(text);
+    return;
+  }
+  if (typeof window !== "undefined") {
+    await clipboardWriteText(text);
+    return;
+  }
+  if (!deps.clipboard) {
+    throw new Error("Clipboard API not available");
+  }
+  const blob = new Blob([text], { type: "text/plain" });
+  await deps.clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+}
+
 /**
  * `image/png` → `png`. Falls back to the current filename's extension, then to
  * `bin`. Keeps the save dialog's filter name accurate for uncommon types.
@@ -113,21 +140,43 @@ export async function openAttachmentWithDefaultApp(
 }
 
 /**
+ * Stage a document-shaped attachment to a temp file and ask the backend to
+ * put that file on the system clipboard. This is used for PDFs because the
+ * browser ClipboardItem API does not reliably accept `application/pdf`.
+ */
+export async function copyAttachmentFileToClipboard(
+  attachment: DownloadableAttachment,
+  deps: { invoke?: typeof invoke } = {},
+): Promise<void> {
+  const invokeFn = deps.invoke ?? invoke;
+  const bytes = base64ToBytes(attachment.data_base64);
+  await invokeFn("copy_attachment_file_to_clipboard", {
+    bytes: Array.from(bytes),
+    filename: attachment.filename,
+    mediaType: attachment.media_type,
+  });
+}
+
+/**
  * Copy the attachment image to the system clipboard using the native
  * `navigator.clipboard.write()` API. Zero IPC, zero base64→number[]
  * serialization, zero Rust round-trip — the webview writes directly to
  * the OS clipboard the same way any browser's "Copy Image" does.
  *
- * SVG is special-cased: WebKit's ClipboardItem implementation silently
+ * Text/data files are written through Tauri's text clipboard path instead
+ * of ClipboardItem because WebKit and Chromium do not reliably accept
+ * arbitrary MIME ClipboardItems such as `text/csv`.
+ *
+ * SVG is also special-cased: WebKit's ClipboardItem implementation silently
  * drops `image/svg+xml`, so a copied SVG would never reach the system
- * clipboard. Since SVG is XML, write it as `text/plain` (the markup
- * itself) — that survives the round-trip and pastes correctly into any
- * text editor, into GitHub comments, and back into Claudette's composer.
+ * clipboard. Since SVG is XML, write it as `text/plain` (the markup itself)
+ * so it survives the round-trip.
  */
 export async function copyAttachmentToClipboard(
   attachment: DownloadableAttachment,
   deps: {
     clipboard?: Clipboard;
+    invoke?: typeof invoke;
     /** Injectable text-clipboard writer — bypasses the W3C clipboard
      *  permission gate. Production wires this to Tauri's plugin so SVGs
      *  reach the system clipboard reliably. Defaults to the Tauri plugin
@@ -139,28 +188,22 @@ export async function copyAttachmentToClipboard(
     deps.clipboard ??
     (typeof navigator === "undefined" ? undefined : navigator.clipboard);
   const bytes = base64ToBytes(attachment.data_base64);
-  if (attachment.media_type === "image/svg+xml") {
+  if (attachment.media_type === "application/pdf") {
+    await copyAttachmentFileToClipboard(attachment, { invoke: deps.invoke });
+    return;
+  }
+  if (
+    copiesAsText(attachment.media_type) ||
+    attachment.media_type === "image/svg+xml"
+  ) {
     // WKWebView silently drops `image/svg+xml` ClipboardItems, so writing
     // an SVG via navigator.clipboard.write succeeds but the system
     // clipboard receives nothing. Since SVG is XML, route through the
-    // Tauri clipboard plugin's writeText, which bypasses the webview's
-    // ClipboardItem allowlist entirely. Falls back to the W3C path only
-    // when neither a writeText injection nor a window context is
-    // available (i.e. tests with a stubbed clipboard).
-    const text = new TextDecoder("utf-8").decode(bytes);
-    if (deps.writeText) {
-      await deps.writeText(text);
-      return;
-    }
-    if (typeof window !== "undefined") {
-      await clipboardWriteText(text);
-      return;
-    }
-    if (!clipboard) {
-      throw new Error("Clipboard API not available");
-    }
-    const blob = new Blob([text], { type: "text/plain" });
-    await clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+    // Tauri clipboard plugin's writeText. The same path is also used for
+    // text/data files (CSV, Markdown, JSON, plain text), because WebKit
+    // and Chromium do not reliably accept arbitrary MIME ClipboardItems
+    // such as `text/csv`.
+    await writeDecodedTextToClipboard(bytes, { ...deps, clipboard });
     return;
   }
   // Non-SVG path uses the W3C ClipboardItem API directly — this is the


### PR DESCRIPTION
## Summary
- Route supported text/data attachments through Tauri text clipboard writes so CSV, Markdown, JSON, and plain text copy useful decoded content.
- Add a backend file-copy command for PDF attachments that stages bytes to a temp file and places the file reference on the OS clipboard.
- Add regression coverage for CSV, JSON, and PDF copy behavior.

## Root Cause
The context menu copy action used browser ClipboardItem writes for non-image file types. WebKit and Chromium do not reliably accept arbitrary MIME clipboard items like text/csv or application/pdf, so the UI could report the action while nothing useful reached the system clipboard.

## Validation
- cd src/ui && bun run test src/utils/attachmentDownload.test.ts
- cd src/ui && bunx tsc -b
- cargo fmt --all --check
- git diff --check

Note: cargo check -p claudette-tauri reached the Tauri build script after configuring the local macOS linker, then stopped because this checkout is missing src-tauri/binaries/claudette-aarch64-apple-darwin.
