### PR TITLE
fix: make CSV attachment headers opaque

### DIFF
--- a/src/ui/src/components/chat/MessageAttachment.module.css
+++ b/src/ui/src/components/chat/MessageAttachment.module.css
@@ -28,7 +28,7 @@
   gap: 8px;
   padding: 6px 10px;
   border-bottom: 1px solid var(--divider);
-  background: var(--surface-bg);
+  background: var(--chat-input-bg);
   color: var(--text-muted);
   font-size: 12px;
   user-select: none;
@@ -174,15 +174,16 @@
 }
 
 .csvTable th {
-  background: var(--surface-bg);
+  background: var(--chat-input-bg);
   color: var(--text-muted);
   font-weight: 600;
   position: sticky;
   top: 0;
+  z-index: 1;
 }
 
 .csvTable tbody tr:nth-child(even) {
-  background: var(--surface-bg);
+  background: var(--chat-input-bg);
 }
 
 .csvTruncated {
@@ -190,7 +191,7 @@
   color: var(--text-faint);
   font-size: 11px;
   border-top: 1px solid var(--divider);
-  background: var(--surface-bg);
+  background: var(--chat-input-bg);
 }
 
 .error {


### PR DESCRIPTION
## Summary
- Replace the undefined `--surface-bg` attachment backgrounds with `--chat-input-bg`
- Give sticky CSV table headers a stacking layer so scrolled rows do not bleed through

## Root Cause
`--surface-bg` is not defined in the theme tokens, so those background declarations were dropped by CSS and sticky CSV headers rendered transparent.

## Validation
- `cd src/ui && bun run lint:css`