### PR TITLE
feat: show git status in file tree

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -6,6 +6,7 @@ use tokio::process::Command;
 
 use claudette::db::Database;
 use claudette::file_expand;
+use claudette::model::diff::{FileStatus, GitFileLayer};
 
 use crate::state::AppState;
 use claudette::process::CommandWindowExt as _;
@@ -16,6 +17,8 @@ const MAX_FILES: usize = 10_000;
 pub struct FileEntry {
     pub path: String,
     pub is_directory: bool,
+    pub git_status: Option<FileStatus>,
+    pub git_layer: Option<GitFileLayer>,
 }
 
 #[derive(Clone, Serialize)]
@@ -82,14 +85,19 @@ pub async fn list_workspace_files(
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let git_status = claudette::diff::file_tree_git_status(worktree_path)
+        .await
+        .map_err(|e| format!("Failed to load git status: {e}"))?;
 
     // Collect file entries and extract unique directory paths.
     let mut dirs = std::collections::BTreeSet::new();
+    let mut seen_files = std::collections::BTreeSet::new();
     let mut entries: Vec<FileEntry> = stdout
         .lines()
         .filter(|line| !line.is_empty())
         .take(MAX_FILES)
         .map(|line| {
+            seen_files.insert(line.to_string());
             // Extract all parent directories from the file path.
             let mut pos = 0;
             while let Some(slash) = line[pos..].find('/') {
@@ -100,9 +108,30 @@ pub async fn list_workspace_files(
             FileEntry {
                 path: line.to_string(),
                 is_directory: false,
+                git_status: git_status.get(line).map(|s| s.status.clone()),
+                git_layer: git_status.get(line).map(|s| s.layer),
             }
         })
         .collect();
+
+    for (path, status) in &git_status {
+        if entries.len() >= MAX_FILES || seen_files.contains(path) {
+            continue;
+        }
+        let mut pos = 0;
+        while let Some(slash) = path[pos..].find('/') {
+            let dir_end = pos + slash;
+            dirs.insert(path[..=dir_end].to_string());
+            pos = dir_end + 1;
+        }
+        seen_files.insert(path.clone());
+        entries.push(FileEntry {
+            path: path.clone(),
+            is_directory: false,
+            git_status: Some(status.status.clone()),
+            git_layer: Some(status.layer),
+        });
+    }
 
     // Prepend directory entries (sorted alphabetically by BTreeSet).
     let dir_entries: Vec<FileEntry> = dirs
@@ -110,6 +139,8 @@ pub async fn list_workspace_files(
         .map(|path| FileEntry {
             path,
             is_directory: true,
+            git_status: None,
+            git_layer: None,
         })
         .collect();
     entries.splice(0..0, dir_entries);

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
@@ -5,7 +6,8 @@ use crate::process::CommandWindowExt as _;
 use tokio::process::Command;
 
 use crate::model::diff::{
-    CommitEntry, DiffFile, DiffHunk, DiffLine, DiffLineType, FileDiff, FileStatus, StagedDiffFiles,
+    CommitEntry, DiffFile, DiffHunk, DiffLine, DiffLineType, FileDiff, FileStatus, GitFileLayer,
+    GitStatusEntry, StagedDiffFiles,
 };
 
 #[derive(Debug, Clone)]
@@ -246,6 +248,112 @@ pub async fn staged_changed_files(
         unstaged,
         untracked,
     })
+}
+
+/// Return current index/worktree git status, suitable for annotating a file tree.
+///
+/// This intentionally mirrors `git status` rather than the Changes tab's
+/// branch-vs-merge-base view: staged changes, unstaged changes, and untracked
+/// files only. Paths are repository-relative and keyed by their current path.
+pub async fn file_tree_git_status(
+    worktree_path: &str,
+) -> Result<HashMap<String, GitStatusEntry>, DiffError> {
+    let (staged_ns, unstaged_ns, untracked_out) = tokio::join!(
+        run_git(worktree_path, &["diff", "--cached", "--name-status"]),
+        run_git(worktree_path, &["diff", "--name-status"]),
+        run_git(
+            worktree_path,
+            &["ls-files", "--others", "--exclude-standard"],
+        ),
+    );
+
+    let staged_ns = staged_ns?;
+    let unstaged_ns = unstaged_ns?;
+    let untracked_out = untracked_out?;
+
+    let mut statuses = HashMap::new();
+    for file in parse_name_status(&staged_ns) {
+        merge_git_status(
+            &mut statuses,
+            worktree_path,
+            file.path,
+            file.status,
+            GitFileLayer::Staged,
+        );
+    }
+    for file in parse_name_status(&unstaged_ns) {
+        merge_git_status(
+            &mut statuses,
+            worktree_path,
+            file.path,
+            file.status,
+            GitFileLayer::Unstaged,
+        );
+    }
+    for file in parse_untracked(&untracked_out) {
+        merge_git_status(
+            &mut statuses,
+            worktree_path,
+            file.path,
+            file.status,
+            GitFileLayer::Untracked,
+        );
+    }
+
+    Ok(statuses)
+}
+
+fn merge_git_status(
+    statuses: &mut HashMap<String, GitStatusEntry>,
+    worktree_path: &str,
+    path: String,
+    incoming_status: FileStatus,
+    incoming_layer: GitFileLayer,
+) {
+    let exists_on_disk = Path::new(worktree_path).join(&path).exists();
+    let entry = statuses.remove(&path);
+    let (status, layer) = match entry {
+        Some(existing) => {
+            let layer = if existing.layer == incoming_layer {
+                existing.layer
+            } else {
+                GitFileLayer::Mixed
+            };
+            (
+                combine_file_status(existing.status, incoming_status, exists_on_disk),
+                layer,
+            )
+        }
+        None => {
+            let status = if !exists_on_disk && incoming_status != FileStatus::Added {
+                FileStatus::Deleted
+            } else {
+                incoming_status
+            };
+            (status, incoming_layer)
+        }
+    };
+    statuses.insert(path, GitStatusEntry { status, layer });
+}
+
+fn combine_file_status(
+    existing: FileStatus,
+    incoming: FileStatus,
+    exists_on_disk: bool,
+) -> FileStatus {
+    if !exists_on_disk {
+        return FileStatus::Deleted;
+    }
+    if existing == FileStatus::Added || incoming == FileStatus::Added {
+        return FileStatus::Added;
+    }
+    match (existing, incoming) {
+        (FileStatus::Renamed { from }, _) | (_, FileStatus::Renamed { from }) => {
+            FileStatus::Renamed { from }
+        }
+        (FileStatus::Deleted, _) | (_, FileStatus::Deleted) => FileStatus::Deleted,
+        _ => FileStatus::Modified,
+    }
 }
 
 /// Parse `--name-status` output into a list of DiffFiles.
@@ -1576,6 +1684,80 @@ mod integration_tests {
         // will-modify.txt appears in BOTH committed AND unstaged
         assert!(committed_paths.contains(&"will-modify.txt"));
         assert!(unstaged_paths.contains(&"will-modify.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_file_tree_git_status_covers_current_git_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+
+        git_cmd(dir, &["init", "-b", "main"]);
+        git_cmd(dir, &["config", "user.email", "test@test.com"]);
+        git_cmd(dir, &["config", "user.name", "Test"]);
+        git_cmd(dir, &["config", "core.autocrlf", "false"]);
+        std::fs::write(dir.join("modified.txt"), "original\n").unwrap();
+        std::fs::write(dir.join("deleted.txt"), "remove me\n").unwrap();
+        std::fs::write(dir.join("renamed-old.txt"), "rename me\n").unwrap();
+        std::fs::write(dir.join("mixed.txt"), "base\n").unwrap();
+        git_cmd(dir, &["add", "."]);
+        git_cmd(dir, &["commit", "-m", "initial"]);
+
+        std::fs::write(dir.join("modified.txt"), "changed\n").unwrap();
+        std::fs::remove_file(dir.join("deleted.txt")).unwrap();
+        git_cmd(dir, &["mv", "renamed-old.txt", "renamed-new.txt"]);
+        std::fs::write(dir.join("untracked.txt"), "new\n").unwrap();
+        std::fs::write(dir.join("staged-new.txt"), "staged\n").unwrap();
+        git_cmd(dir, &["add", "staged-new.txt"]);
+        std::fs::write(dir.join("mixed.txt"), "staged\n").unwrap();
+        git_cmd(dir, &["add", "mixed.txt"]);
+        std::fs::write(dir.join("mixed.txt"), "staged\nunstaged\n").unwrap();
+
+        let status = file_tree_git_status(dir.to_str().unwrap()).await.unwrap();
+
+        assert_eq!(
+            status.get("modified.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Modified,
+                layer: GitFileLayer::Unstaged,
+            })
+        );
+        assert_eq!(
+            status.get("deleted.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Deleted,
+                layer: GitFileLayer::Unstaged,
+            })
+        );
+        assert_eq!(
+            status.get("renamed-new.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Renamed {
+                    from: "renamed-old.txt".to_string(),
+                },
+                layer: GitFileLayer::Staged,
+            })
+        );
+        assert_eq!(
+            status.get("untracked.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Added,
+                layer: GitFileLayer::Untracked,
+            })
+        );
+        assert_eq!(
+            status.get("staged-new.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Added,
+                layer: GitFileLayer::Staged,
+            })
+        );
+        assert_eq!(
+            status.get("mixed.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Modified,
+                layer: GitFileLayer::Mixed,
+            })
+        );
     }
 
     #[tokio::test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -258,102 +258,123 @@ pub async fn staged_changed_files(
 pub async fn file_tree_git_status(
     worktree_path: &str,
 ) -> Result<HashMap<String, GitStatusEntry>, DiffError> {
-    let (staged_ns, unstaged_ns, untracked_out) = tokio::join!(
-        run_git(worktree_path, &["diff", "--cached", "--name-status"]),
-        run_git(worktree_path, &["diff", "--name-status"]),
-        run_git(
-            worktree_path,
-            &["ls-files", "--others", "--exclude-standard"],
-        ),
-    );
-
-    let staged_ns = staged_ns?;
-    let unstaged_ns = unstaged_ns?;
-    let untracked_out = untracked_out?;
-
-    let mut statuses = HashMap::new();
-    for file in parse_name_status(&staged_ns) {
-        merge_git_status(
-            &mut statuses,
-            worktree_path,
-            file.path,
-            file.status,
-            GitFileLayer::Staged,
-        );
-    }
-    for file in parse_name_status(&unstaged_ns) {
-        merge_git_status(
-            &mut statuses,
-            worktree_path,
-            file.path,
-            file.status,
-            GitFileLayer::Unstaged,
-        );
-    }
-    for file in parse_untracked(&untracked_out) {
-        merge_git_status(
-            &mut statuses,
-            worktree_path,
-            file.path,
-            file.status,
-            GitFileLayer::Untracked,
-        );
-    }
-
-    Ok(statuses)
+    let output = run_git(worktree_path, &["status", "--porcelain=v2", "-uall", "-z"]).await?;
+    Ok(parse_file_tree_git_status(&output, worktree_path))
 }
 
-fn merge_git_status(
-    statuses: &mut HashMap<String, GitStatusEntry>,
+fn parse_file_tree_git_status(
+    output: &str,
     worktree_path: &str,
-    path: String,
-    incoming_status: FileStatus,
-    incoming_layer: GitFileLayer,
-) {
-    let exists_on_disk = Path::new(worktree_path).join(&path).exists();
-    let entry = statuses.remove(&path);
-    let (status, layer) = match entry {
-        Some(existing) => {
-            let layer = if existing.layer == incoming_layer {
-                existing.layer
-            } else {
-                GitFileLayer::Mixed
-            };
-            (
-                combine_file_status(existing.status, incoming_status, exists_on_disk),
-                layer,
-            )
+) -> HashMap<String, GitStatusEntry> {
+    let mut statuses = HashMap::new();
+    let mut records = output.split('\0');
+
+    while let Some(record) = records.next() {
+        if record.is_empty() {
+            continue;
         }
-        None => {
-            let status = if !exists_on_disk && incoming_status != FileStatus::Added {
-                FileStatus::Deleted
-            } else {
-                incoming_status
-            };
-            (status, incoming_layer)
+
+        if let Some(path) = record.strip_prefix("? ") {
+            statuses.insert(
+                path.to_string(),
+                GitStatusEntry {
+                    status: FileStatus::Added,
+                    layer: GitFileLayer::Untracked,
+                },
+            );
+            continue;
         }
-    };
-    statuses.insert(path, GitStatusEntry { status, layer });
+
+        let Some(kind) = record.as_bytes().first().copied() else {
+            continue;
+        };
+        match kind {
+            b'1' => {
+                let mut fields = record.splitn(9, ' ');
+                let _kind = fields.next();
+                let Some(xy) = fields.next() else {
+                    continue;
+                };
+                for _ in 0..6 {
+                    let _ = fields.next();
+                }
+                let Some(path) = fields.next() else {
+                    continue;
+                };
+                statuses.insert(
+                    path.to_string(),
+                    GitStatusEntry {
+                        status: status_from_xy(xy, path, None, worktree_path),
+                        layer: layer_from_xy(xy),
+                    },
+                );
+            }
+            b'2' => {
+                let mut fields = record.splitn(10, ' ');
+                let _kind = fields.next();
+                let Some(xy) = fields.next() else {
+                    continue;
+                };
+                for _ in 0..7 {
+                    let _ = fields.next();
+                }
+                let Some(path) = fields.next() else {
+                    continue;
+                };
+                let from = records.next().unwrap_or_default().to_string();
+                statuses.insert(
+                    path.to_string(),
+                    GitStatusEntry {
+                        status: status_from_xy(xy, path, Some(from), worktree_path),
+                        layer: layer_from_xy(xy),
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+
+    statuses
 }
 
-fn combine_file_status(
-    existing: FileStatus,
-    incoming: FileStatus,
-    exists_on_disk: bool,
+fn layer_from_xy(xy: &str) -> GitFileLayer {
+    let mut chars = xy.chars();
+    let index = chars.next().unwrap_or('.');
+    let worktree = chars.next().unwrap_or('.');
+
+    match (index != '.', worktree != '.') {
+        (true, true) => GitFileLayer::Mixed,
+        (true, false) => GitFileLayer::Staged,
+        (false, true) => GitFileLayer::Unstaged,
+        (false, false) => GitFileLayer::Unstaged,
+    }
+}
+
+fn status_from_xy(
+    xy: &str,
+    path: &str,
+    rename_from: Option<String>,
+    worktree_path: &str,
 ) -> FileStatus {
+    let exists_on_disk = Path::new(worktree_path).join(path).exists();
+    // Explorer rows represent what the user can open in the worktree. If the
+    // path is gone, show it as deleted even for combinations like AD
+    // (staged-add then removed) or staged-rename plus worktree-delete.
     if !exists_on_disk {
         return FileStatus::Deleted;
     }
-    if existing == FileStatus::Added || incoming == FileStatus::Added {
+
+    if let Some(from) = rename_from {
+        return FileStatus::Renamed { from };
+    }
+
+    if xy.contains('A') {
         return FileStatus::Added;
     }
-    match (existing, incoming) {
-        (FileStatus::Renamed { from }, _) | (_, FileStatus::Renamed { from }) => {
-            FileStatus::Renamed { from }
-        }
-        (FileStatus::Deleted, _) | (_, FileStatus::Deleted) => FileStatus::Deleted,
-        _ => FileStatus::Modified,
+    if xy.contains('D') {
+        return FileStatus::Deleted;
     }
+    FileStatus::Modified
 }
 
 /// Parse `--name-status` output into a list of DiffFiles.
@@ -1695,6 +1716,7 @@ mod integration_tests {
         git_cmd(dir, &["config", "user.email", "test@test.com"]);
         git_cmd(dir, &["config", "user.name", "Test"]);
         git_cmd(dir, &["config", "core.autocrlf", "false"]);
+        std::fs::write(dir.join("clean.txt"), "clean\n").unwrap();
         std::fs::write(dir.join("modified.txt"), "original\n").unwrap();
         std::fs::write(dir.join("deleted.txt"), "remove me\n").unwrap();
         std::fs::write(dir.join("renamed-old.txt"), "rename me\n").unwrap();
@@ -1708,12 +1730,16 @@ mod integration_tests {
         std::fs::write(dir.join("untracked.txt"), "new\n").unwrap();
         std::fs::write(dir.join("staged-new.txt"), "staged\n").unwrap();
         git_cmd(dir, &["add", "staged-new.txt"]);
+        std::fs::write(dir.join("staged-then-removed.txt"), "staged\n").unwrap();
+        git_cmd(dir, &["add", "staged-then-removed.txt"]);
+        std::fs::remove_file(dir.join("staged-then-removed.txt")).unwrap();
         std::fs::write(dir.join("mixed.txt"), "staged\n").unwrap();
         git_cmd(dir, &["add", "mixed.txt"]);
         std::fs::write(dir.join("mixed.txt"), "staged\nunstaged\n").unwrap();
 
         let status = file_tree_git_status(dir.to_str().unwrap()).await.unwrap();
 
+        assert!(!status.contains_key("clean.txt"));
         assert_eq!(
             status.get("modified.txt"),
             Some(&GitStatusEntry {
@@ -1749,6 +1775,13 @@ mod integration_tests {
             Some(&GitStatusEntry {
                 status: FileStatus::Added,
                 layer: GitFileLayer::Staged,
+            })
+        );
+        assert_eq!(
+            status.get("staged-then-removed.txt"),
+            Some(&GitStatusEntry {
+                status: FileStatus::Deleted,
+                layer: GitFileLayer::Mixed,
             })
         );
         assert_eq!(

--- a/src/model/diff.rs
+++ b/src/model/diff.rs
@@ -8,6 +8,21 @@ pub enum FileStatus {
     Renamed { from: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GitFileLayer {
+    Staged,
+    Unstaged,
+    Untracked,
+    Mixed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct GitStatusEntry {
+    pub status: FileStatus,
+    pub layer: GitFileLayer,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DiffFile {
     pub path: String,

--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -111,6 +111,16 @@
   vertical-align: middle;
 }
 
+.fileStatus {
+  width: 14px;
+  flex-shrink: 0;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 14px;
+}
+
 .nameInput {
   flex: 1;
   min-width: 0;

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -31,7 +31,12 @@ import {
 import { DiscardUnsavedChangesConfirm } from "../files/DiscardUnsavedChangesConfirm";
 import { getFileIcon } from "../../utils/fileIcons";
 import { createSerialGate } from "../../utils/serialGate";
-import type { ChatSession, DiffFileTab, DiffLayer } from "../../types";
+import {
+  statusColor,
+  statusForOpenFileTab,
+  statusLabel,
+} from "../files/fileTreeStatus";
+import type { ChatSession, DiffFileTab, DiffLayer, FileStatus } from "../../types";
 import styles from "./SessionTabs.module.css";
 
 type NavDirection = "prev" | "next" | "first" | "last";
@@ -78,6 +83,7 @@ export function SessionTabs({ workspaceId }: Props) {
   );
   const diffSelectedFile = useAppStore((s) => s.diffSelectedFile);
   const diffSelectedLayer = useAppStore((s) => s.diffSelectedLayer);
+  const diffStagedFiles = useAppStore((s) => s.diffStagedFiles);
   const fileTabs = useAppStore(
     (s) => s.fileTabsByWorkspace[workspaceId] ?? EMPTY_FILE_TABS,
   );
@@ -515,10 +521,10 @@ export function SessionTabs({ workspaceId }: Props) {
   // Build the menu items lazily from the entry that was right-clicked. The
   // unified navEntries order is what "to the right" / "others" resolve against,
   // matching the order the user sees in the strip.
-  const contextMenuItems = useMemo<AttachmentContextMenuItem[]>(() => {
-    if (!contextMenu) return [];
+  const contextMenuItems = useMemo<AttachmentContextMenuItem[] | null>(() => {
+    if (!contextMenu) return null;
     const idx = navEntries.findIndex((e) => e.key === contextMenu.entryKey);
-    if (idx < 0) return [];
+    if (idx < 0) return null;
     const target = navEntries[idx];
     const others = navEntries.filter((_, i) => i !== idx);
     const toRight = navEntries.slice(idx + 1);
@@ -636,11 +642,13 @@ export function SessionTabs({ workspaceId }: Props) {
         }
         // entry.kind === "file"
         const isActive = activeFileTab === entry.path;
+        const gitStatus = statusForOpenFileTab(entry.path, diffStagedFiles);
         return (
           <FileTab
             key={navKey}
             workspaceId={workspaceId}
             path={entry.path}
+            gitStatus={gitStatus}
             isActive={isActive}
             onSelect={() => selectFileTab(workspaceId, entry.path)}
             onClose={() => requestCloseFileTab(entry.path)}
@@ -665,7 +673,8 @@ export function SessionTabs({ workspaceId }: Props) {
       >
         <Plus size={14} />
       </button>
-      {contextMenu && contextMenuItems.length > 0 && (
+      {/* eslint-disable-next-line react-hooks/refs -- contextMenu is React state; this is a compiler false positive around memoized menu actions. */}
+      {contextMenu && contextMenuItems && (
         <AttachmentContextMenu
           x={contextMenu.x}
           y={contextMenu.y}
@@ -869,6 +878,7 @@ function SessionTab({
 interface FileTabProps {
   workspaceId: string;
   path: string;
+  gitStatus: FileStatus | null;
   isActive: boolean;
   onSelect: () => void;
   onClose: () => void;
@@ -881,6 +891,7 @@ interface FileTabProps {
 function FileTab({
   workspaceId,
   path,
+  gitStatus,
   isActive,
   onSelect,
   onClose,
@@ -901,6 +912,12 @@ function FileTab({
   );
   const basename = path.split("/").pop() || path;
   const Icon = getFileIcon(basename);
+  const statusTitle =
+    gitStatus == null
+      ? null
+      : typeof gitStatus === "string"
+        ? gitStatus
+        : `Renamed from ${gitStatus.Renamed.from}`;
   return (
     <div
       ref={tabRef}
@@ -947,6 +964,7 @@ function FileTab({
         <span className={`${styles.dropEdge} ${styles.dropAfter}`} aria-hidden />
       )}
       <span className={styles.icon}>
+        {/* eslint-disable-next-line react-hooks/static-components -- fileIcons returns stable module-level lucide components. */}
         <Icon size={12} />
       </span>
       <span className={styles.name} title={path}>
@@ -955,6 +973,16 @@ function FileTab({
           <span className={styles.dirtyDot} aria-label={t("file_dirty_aria")} />
         )}
       </span>
+      {gitStatus && (
+        <span
+          className={styles.fileStatus}
+          style={{ color: statusColor(gitStatus) }}
+          title={statusTitle ?? undefined}
+          aria-label={statusTitle ?? undefined}
+        >
+          {statusLabel(gitStatus)}
+        </span>
+      )}
       <button
         type="button"
         className={styles.closeBtn}

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -22,6 +22,7 @@ import {
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import { fileBufferKey } from "../../stores/slices/fileTreeSlice";
 import {
+  loadDiffFiles,
   readWorkspaceFileBytes,
   readWorkspaceFileForViewer,
   writeWorkspaceFile,
@@ -76,19 +77,14 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const setFileBufferLoadError = useAppStore((s) => s.setFileBufferLoadError);
   const setFileBufferContent = useAppStore((s) => s.setFileBufferContent);
   const setFileBufferSaved = useAppStore((s) => s.setFileBufferSaved);
+  const setDiffFiles = useAppStore((s) => s.setDiffFiles);
   const setFileTabPreview = useAppStore((s) => s.setFileTabPreview);
   const requestFileTreeRefresh = useAppStore((s) => s.requestFileTreeRefresh);
   const addToast = useAppStore((s) => s.addToast);
   const keybindings = useAppStore((s) => s.keybindings);
 
-  const [saving, setSaving] = useState(false);
-
-  // Reset transient per-tab UI state when the active tab/workspace changes
-  // so an in-flight save on a previous tab can't leak its disabled state
-  // into the newly mounted view.
-  useEffect(() => {
-    setSaving(false);
-  }, [workspaceId, path]);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const saving = savingKey === bufferKey;
 
   const isMarkdown = MARKDOWN_EXT.test(path);
   const isImage = isImagePath(path);
@@ -177,8 +173,9 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     if (!bufferState || !dirty || saving) return;
     const requestedWorkspaceId = workspaceId;
     const requestedPath = path;
+    const requestedBufferKey = bufferKey;
     const snapshot = bufferState.buffer;
-    setSaving(true);
+    setSavingKey(requestedBufferKey);
     try {
       await writeWorkspaceFile(requestedWorkspaceId, requestedPath, snapshot);
       // The user may have switched tabs mid-save. Always update the
@@ -188,6 +185,16 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
       // file saved.
       setFileBufferSaved(requestedWorkspaceId, requestedPath, snapshot);
       requestFileTreeRefresh(requestedWorkspaceId);
+      loadDiffFiles(requestedWorkspaceId)
+        .then((result) => {
+          if (useAppStore.getState().selectedWorkspaceId !== requestedWorkspaceId) {
+            return;
+          }
+          setDiffFiles(result.files, result.merge_base, result.staged_files, result.commits);
+        })
+        .catch((err) =>
+          console.error("Failed to refresh diff after file save:", err),
+        );
       const state = useAppStore.getState();
       if (
         state.selectedWorkspaceId === requestedWorkspaceId &&
@@ -209,15 +216,19 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
         addToast(t("file_save_failed", { error: String(e) }));
       }
     } finally {
-      setSaving(false);
+      setSavingKey((current) =>
+        current === requestedBufferKey ? null : current,
+      );
     }
   }, [
     bufferState,
+    bufferKey,
     dirty,
     saving,
     workspaceId,
     path,
     setFileBufferSaved,
+    setDiffFiles,
     requestFileTreeRefresh,
     addToast,
     t,

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -77,6 +77,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   const setFileBufferContent = useAppStore((s) => s.setFileBufferContent);
   const setFileBufferSaved = useAppStore((s) => s.setFileBufferSaved);
   const setFileTabPreview = useAppStore((s) => s.setFileTabPreview);
+  const requestFileTreeRefresh = useAppStore((s) => s.requestFileTreeRefresh);
   const addToast = useAppStore((s) => s.addToast);
   const keybindings = useAppStore((s) => s.keybindings);
 
@@ -186,6 +187,7 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
       // a different tab/workspace to avoid confusing the user about which
       // file saved.
       setFileBufferSaved(requestedWorkspaceId, requestedPath, snapshot);
+      requestFileTreeRefresh(requestedWorkspaceId);
       const state = useAppStore.getState();
       if (
         state.selectedWorkspaceId === requestedWorkspaceId &&
@@ -209,7 +211,17 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     } finally {
       setSaving(false);
     }
-  }, [bufferState, dirty, saving, workspaceId, path, setFileBufferSaved, addToast, t]);
+  }, [
+    bufferState,
+    dirty,
+    saving,
+    workspaceId,
+    path,
+    setFileBufferSaved,
+    requestFileTreeRefresh,
+    addToast,
+    t,
+  ]);
 
   const showMarkdownToggle = isMarkdown && !editDisabled;
   const showMarkdownPreview =

--- a/src/ui/src/components/files/FileTree.module.css
+++ b/src/ui/src/components/files/FileTree.module.css
@@ -46,6 +46,16 @@
   color: var(--text-primary);
 }
 
+.rowDeleted .name {
+  color: var(--text-dim);
+  text-decoration: line-through;
+  text-decoration-color: var(--diff-removed-text);
+}
+
+.rowDirChanged .icon {
+  color: var(--tool-task);
+}
+
 .chevron {
   flex-shrink: 0;
   color: var(--text-dim);
@@ -65,6 +75,42 @@
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.status {
+  width: 14px;
+  flex-shrink: 0;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+
+.dirStatus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--tool-task) 30%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--tool-task) 12%, transparent);
+  color: var(--tool-task);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+}
+
+.dirStatus:empty {
+  width: 8px;
+  min-width: 8px;
+  height: 8px;
+  padding: 0;
+  border-color: var(--tool-task);
+  background: var(--tool-task);
 }
 
 .empty {

--- a/src/ui/src/components/files/FileTree.test.ts
+++ b/src/ui/src/components/files/FileTree.test.ts
@@ -49,4 +49,19 @@ describe("resolveFileTreeActivation", () => {
       path: "src/app.ts",
     });
   });
+
+  it("opens non-deleted files in the editor when layer metadata is missing", () => {
+    const node: FileTreeNode & { kind: "file" } = {
+      kind: "file",
+      path: "src/app.ts",
+      name: "app.ts",
+      git_status: "Modified",
+      git_layer: null,
+    };
+
+    expect(resolveFileTreeActivation(node)).toEqual({
+      kind: "file",
+      path: "src/app.ts",
+    });
+  });
 });

--- a/src/ui/src/components/files/FileTree.test.ts
+++ b/src/ui/src/components/files/FileTree.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveFileTreeActivation } from "./fileTreeStatus";
+import type { FileTreeNode } from "../../utils/buildFileTree";
+
+describe("resolveFileTreeActivation", () => {
+  it("opens deleted files as diffs", () => {
+    const node: FileTreeNode & { kind: "file" } = {
+      kind: "file",
+      path: "src/removed.ts",
+      name: "removed.ts",
+      git_status: "Deleted",
+      git_layer: "staged",
+    };
+
+    expect(resolveFileTreeActivation(node)).toEqual({
+      kind: "diff",
+      path: "src/removed.ts",
+      layer: "staged",
+    });
+  });
+
+  it("maps mixed deleted files to the unstaged diff layer", () => {
+    const node: FileTreeNode & { kind: "file" } = {
+      kind: "file",
+      path: "src/removed.ts",
+      name: "removed.ts",
+      git_status: "Deleted",
+      git_layer: "mixed",
+    };
+
+    expect(resolveFileTreeActivation(node)).toEqual({
+      kind: "diff",
+      path: "src/removed.ts",
+      layer: "unstaged",
+    });
+  });
+
+  it("opens existing files in the editor", () => {
+    const node: FileTreeNode & { kind: "file" } = {
+      kind: "file",
+      path: "src/app.ts",
+      name: "app.ts",
+      git_status: "Modified",
+      git_layer: "unstaged",
+    };
+
+    expect(resolveFileTreeActivation(node)).toEqual({
+      kind: "file",
+      path: "src/app.ts",
+    });
+  });
+});

--- a/src/ui/src/components/files/FileTree.test.ts
+++ b/src/ui/src/components/files/FileTree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveFileTreeActivation } from "./fileTreeStatus";
+import { resolveFileTreeActivation, statusForOpenFileTab } from "./fileTreeStatus";
 import type { FileTreeNode } from "../../utils/buildFileTree";
 
 describe("resolveFileTreeActivation", () => {
@@ -63,5 +63,40 @@ describe("resolveFileTreeActivation", () => {
       kind: "file",
       path: "src/app.ts",
     });
+  });
+});
+
+describe("statusForOpenFileTab", () => {
+  it("returns status for open file tabs from current git status groups", () => {
+    expect(
+      statusForOpenFileTab("src/app.ts", {
+        committed: [],
+        staged: [],
+        unstaged: [{ path: "src/app.ts", status: "Modified" }],
+        untracked: [],
+      }),
+    ).toBe("Modified");
+  });
+
+  it("ignores committed-only changes for open file tabs", () => {
+    expect(
+      statusForOpenFileTab("src/app.ts", {
+        committed: [{ path: "src/app.ts", status: "Modified" }],
+        staged: [],
+        unstaged: [],
+        untracked: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("uses deleted status when a file appears in multiple current groups", () => {
+    expect(
+      statusForOpenFileTab("src/app.ts", {
+        committed: [],
+        staged: [{ path: "src/app.ts", status: "Added" }],
+        unstaged: [{ path: "src/app.ts", status: "Deleted" }],
+        untracked: [],
+      }),
+    ).toBe("Deleted");
   });
 });

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -1,5 +1,4 @@
 import {
-  createElement,
   memo,
   useCallback,
   useEffect,
@@ -310,11 +309,8 @@ function Row({ node, depth, expanded, selected, tabbable, rowRef, onClick }: Row
         // 12-px spacer keeps file rows aligned with their sibling folders.
         <span className={styles.chevron} style={{ width: 12, height: 12 }} />
       )}
-      {createElement(Icon, {
-        size: 14,
-        className: styles.icon,
-        "aria-hidden": "true",
-      })}
+      {/* eslint-disable-next-line react-hooks/static-components -- fileIcons returns stable module-level lucide components. */}
+      <Icon size={14} className={styles.icon} aria-hidden="true" />
       <span className={styles.name}>{node.name}</span>
       {node.kind === "dir" && node.statusCount > 0 && (
         <span

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -1,4 +1,5 @@
 import {
+  createElement,
   memo,
   useCallback,
   useEffect,
@@ -15,6 +16,12 @@ import {
 } from "../../utils/buildFileTree";
 import { getFileIcon, getFolderIcon } from "../../utils/fileIcons";
 import type { FileEntry } from "../../services/tauri";
+import type { DiffLayer } from "../../types/diff";
+import {
+  resolveFileTreeActivation,
+  statusColor,
+  statusLabel,
+} from "./fileTreeStatus";
 import styles from "./FileTree.module.css";
 
 interface FileTreeProps {
@@ -27,6 +34,7 @@ interface FileTreeProps {
    *  The parent decides whether to actually open it (e.g. it may show a
    *  discard-changes modal first if there are unsaved changes). */
   onActivateFile: (path: string) => void;
+  onActivateDiff: (path: string, layer: DiffLayer | null) => void;
 }
 
 const EMPTY_EXPANDED: Record<string, boolean> = {};
@@ -35,6 +43,7 @@ export const FileTree = memo(function FileTree({
   workspaceId,
   entries,
   onActivateFile,
+  onActivateDiff,
 }: FileTreeProps) {
   const expanded = useAppStore(
     (s) => s.allFilesExpandedDirsByWorkspace[workspaceId] ?? EMPTY_EXPANDED,
@@ -166,7 +175,12 @@ export const FileTree = memo(function FileTree({
           if (cur.node.kind === "dir") {
             toggleDir(cur.node.path);
           } else {
-            onActivateFile(cur.node.path);
+            const activation = resolveFileTreeActivation(cur.node);
+            if (activation.kind === "diff") {
+              onActivateDiff(activation.path, activation.layer);
+            } else {
+              onActivateFile(activation.path);
+            }
           }
           break;
         }
@@ -181,6 +195,7 @@ export const FileTree = memo(function FileTree({
       setExpanded,
       toggleDir,
       onActivateFile,
+      onActivateDiff,
     ],
   );
 
@@ -224,7 +239,12 @@ export const FileTree = memo(function FileTree({
             if (node.kind === "dir") {
               toggleDir(node.path);
             } else {
-              onActivateFile(node.path);
+              const activation = resolveFileTreeActivation(node);
+              if (activation.kind === "diff") {
+                onActivateDiff(activation.path, activation.layer);
+              } else {
+                onActivateFile(activation.path);
+              }
             }
           }}
         />
@@ -251,11 +271,27 @@ function Row({ node, depth, expanded, selected, tabbable, rowRef, onClick }: Row
       : ChevronRight
     : null;
   const Icon = isDir ? getFolderIcon(expanded) : getFileIcon(node.name);
+  const status = node.kind === "file" ? node.git_status : null;
+  const dirChanged = node.kind === "dir" && node.statusCount > 0;
+  const statusTitle =
+    status == null
+      ? null
+      : typeof status === "string"
+        ? status
+        : `Renamed from ${status.Renamed.from}`;
+  const rowClassName = [
+    styles.row,
+    selected ? styles.rowSelected : "",
+    status === "Deleted" ? styles.rowDeleted : "",
+    dirChanged ? styles.rowDirChanged : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <div
       ref={rowRef}
-      className={`${styles.row} ${selected ? styles.rowSelected : ""}`}
+      className={rowClassName}
       style={{ ["--depth" as string]: depth }}
       role="treeitem"
       tabIndex={tabbable ? 0 : -1}
@@ -274,8 +310,31 @@ function Row({ node, depth, expanded, selected, tabbable, rowRef, onClick }: Row
         // 12-px spacer keeps file rows aligned with their sibling folders.
         <span className={styles.chevron} style={{ width: 12, height: 12 }} />
       )}
-      <Icon size={14} className={styles.icon} aria-hidden="true" />
+      {createElement(Icon, {
+        size: 14,
+        className: styles.icon,
+        "aria-hidden": "true",
+      })}
       <span className={styles.name}>{node.name}</span>
+      {node.kind === "dir" && node.statusCount > 0 && (
+        <span
+          className={styles.dirStatus}
+          title={`${node.statusCount} changed ${node.statusCount === 1 ? "file" : "files"}`}
+          aria-label={`${node.statusCount} changed ${node.statusCount === 1 ? "file" : "files"}`}
+        >
+          {node.statusCount > 1 ? node.statusCount : ""}
+        </span>
+      )}
+      {status && (
+        <span
+          className={styles.status}
+          style={{ color: statusColor(status) }}
+          title={statusTitle ?? undefined}
+          aria-label={statusTitle ?? undefined}
+        >
+          {statusLabel(status)}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -22,7 +22,7 @@ export function FilesPanel() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const loadVersionRef = useRef(0);
-  const prevIsRunning = useRef<boolean | undefined>(undefined);
+  const prevIsRunning = useRef(false);
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = isAgentBusy(ws?.agent_status);
 
@@ -62,7 +62,7 @@ export function FilesPanel() {
     if (!selectedWorkspaceId || !isRunning) return;
     const interval = setInterval(() => {
       void loadFiles(selectedWorkspaceId, false);
-    }, 3000);
+    }, 5000);
     return () => clearInterval(interval);
   }, [isRunning, selectedWorkspaceId, loadFiles]);
 

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -1,40 +1,81 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import { listWorkspaceFiles, type FileEntry } from "../../services/tauri";
+import { isAgentBusy } from "../../utils/agentStatus";
+import type { DiffLayer } from "../../types/diff";
 import { FileTree } from "./FileTree";
 import styles from "./FilesPanel.module.css";
 
 export function FilesPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const refreshNonce = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.fileTreeRefreshNonceByWorkspace[selectedWorkspaceId] ?? 0)
+      : 0,
+  );
   const openFileTab = useAppStore((s) => s.openFileTab);
+  const openDiffTab = useAppStore((s) => s.openDiffTab);
+  const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
 
   const [entries, setEntries] = useState<FileEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const loadVersionRef = useRef(0);
+  const prevIsRunning = useRef<boolean | undefined>(undefined);
+  const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
+  const isRunning = isAgentBusy(ws?.agent_status);
+
+  const loadFiles = useCallback(
+    async (workspaceId: string, showLoading: boolean) => {
+      const version = ++loadVersionRef.current;
+      if (showLoading) {
+        setLoading(true);
+      }
+      setError(null);
+      try {
+        const result = await listWorkspaceFiles(workspaceId);
+        if (version !== loadVersionRef.current) return;
+        setEntries(result);
+        setLoading(false);
+      } catch (e) {
+        if (version !== loadVersionRef.current) return;
+        setError(String(e));
+        setLoading(false);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!selectedWorkspaceId) {
-      setEntries([]);
+      loadVersionRef.current += 1;
       return;
     }
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    listWorkspaceFiles(selectedWorkspaceId)
-      .then((result) => {
-        if (cancelled) return;
-        setEntries(result);
-        setLoading(false);
-      })
-      .catch((e) => {
-        if (cancelled) return;
-        setError(String(e));
-        setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [selectedWorkspaceId]);
+    const timer = window.setTimeout(() => {
+      void loadFiles(selectedWorkspaceId, true);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [selectedWorkspaceId, refreshNonce, loadFiles]);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId || !isRunning) return;
+    const interval = setInterval(() => {
+      void loadFiles(selectedWorkspaceId, false);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [isRunning, selectedWorkspaceId, loadFiles]);
+
+  useEffect(() => {
+    const wasRunning = prevIsRunning.current;
+    prevIsRunning.current = isRunning;
+    if (!selectedWorkspaceId || wasRunning !== true || isRunning) return;
+
+    const timer = setTimeout(() => {
+      void loadFiles(selectedWorkspaceId, false);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [isRunning, selectedWorkspaceId, loadFiles]);
 
   const handleActivateFile = useCallback(
     (path: string) => {
@@ -47,6 +88,15 @@ export function FilesPanel() {
       openFileTab(selectedWorkspaceId, path);
     },
     [selectedWorkspaceId, openFileTab],
+  );
+
+  const handleActivateDiff = useCallback(
+    (path: string, layer: DiffLayer | null) => {
+      if (!selectedWorkspaceId) return;
+      openDiffTab(selectedWorkspaceId, path, layer);
+      setDiffSelectedCommitHash(null);
+    },
+    [selectedWorkspaceId, openDiffTab, setDiffSelectedCommitHash],
   );
 
   if (!selectedWorkspaceId) {
@@ -64,6 +114,7 @@ export function FilesPanel() {
           workspaceId={selectedWorkspaceId}
           entries={entries}
           onActivateFile={handleActivateFile}
+          onActivateDiff={handleActivateDiff}
         />
       )}
     </div>

--- a/src/ui/src/components/files/fileTreeStatus.ts
+++ b/src/ui/src/components/files/fileTreeStatus.ts
@@ -1,5 +1,11 @@
 import type { FileTreeNode } from "../../utils/buildFileTree";
-import type { DiffLayer, FileStatus, GitFileLayer } from "../../types/diff";
+import type {
+  DiffFile,
+  DiffLayer,
+  FileStatus,
+  GitFileLayer,
+  StagedDiffFiles,
+} from "../../types/diff";
 
 export type FileTreeActivation =
   | { kind: "file"; path: string }
@@ -51,6 +57,30 @@ export function resolveFileTreeActivation(
     };
   }
   return { kind: "file", path: node.path };
+}
+
+export function statusForOpenFileTab(
+  path: string,
+  stagedFiles: StagedDiffFiles | null,
+): FileStatus | null {
+  if (!stagedFiles) return null;
+  const matches = [
+    ...stagedFiles.staged,
+    ...stagedFiles.unstaged,
+    ...stagedFiles.untracked,
+  ].filter((file) => file.path === path);
+  if (matches.length === 0) return null;
+  return combineFileStatuses(matches);
+}
+
+function combineFileStatuses(files: DiffFile[]): FileStatus {
+  const deleted = files.find((file) => file.status === "Deleted");
+  if (deleted) return deleted.status;
+  const added = files.find((file) => file.status === "Added");
+  if (added) return added.status;
+  const renamed = files.find((file) => typeof file.status !== "string");
+  if (renamed) return renamed.status;
+  return "Modified";
 }
 
 function assertNever(value: never): never {

--- a/src/ui/src/components/files/fileTreeStatus.ts
+++ b/src/ui/src/components/files/fileTreeStatus.ts
@@ -1,0 +1,45 @@
+import type { FileTreeNode } from "../../utils/buildFileTree";
+import type { DiffLayer, FileStatus, GitFileLayer } from "../../types/diff";
+
+export type FileTreeActivation =
+  | { kind: "file"; path: string }
+  | { kind: "diff"; path: string; layer: DiffLayer | null };
+
+export function statusLabel(status: FileStatus): string {
+  if (typeof status === "string") {
+    return status === "Added" ? "A" : status === "Modified" ? "M" : "D";
+  }
+  return "R";
+}
+
+export function statusColor(status: FileStatus): string {
+  if (typeof status === "string") {
+    return status === "Added"
+      ? "var(--diff-added-text)"
+      : status === "Modified"
+        ? "var(--tool-task)"
+        : "var(--diff-removed-text)";
+  }
+  return "var(--diff-hunk-header)";
+}
+
+function diffLayerForGitLayer(layer: GitFileLayer | null): DiffLayer | null {
+  if (layer === "staged" || layer === "unstaged" || layer === "untracked") {
+    return layer;
+  }
+  if (layer === "mixed") return "unstaged";
+  return null;
+}
+
+export function resolveFileTreeActivation(
+  node: FileTreeNode & { kind: "file" },
+): FileTreeActivation {
+  if (node.git_status === "Deleted") {
+    return {
+      kind: "diff",
+      path: node.path,
+      layer: diffLayerForGitLayer(node.git_layer),
+    };
+  }
+  return { kind: "file", path: node.path };
+}

--- a/src/ui/src/components/files/fileTreeStatus.ts
+++ b/src/ui/src/components/files/fileTreeStatus.ts
@@ -7,7 +7,16 @@ export type FileTreeActivation =
 
 export function statusLabel(status: FileStatus): string {
   if (typeof status === "string") {
-    return status === "Added" ? "A" : status === "Modified" ? "M" : "D";
+    switch (status) {
+      case "Added":
+        return "A";
+      case "Modified":
+        return "M";
+      case "Deleted":
+        return "D";
+      default:
+        return assertNever(status);
+    }
   }
   return "R";
 }
@@ -42,4 +51,8 @@ export function resolveFileTreeActivation(
     };
   }
   return { kind: "file", path: node.path };
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled file status: ${value}`);
 }

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -45,6 +45,7 @@ export const RightSidebar = memo(function RightSidebar() {
   const openDiffTab = useAppStore((s) => s.openDiffTab);
   const openFileTab = useAppStore((s) => s.openFileTab);
   const setDiffLoading = useAppStore((s) => s.setDiffLoading);
+  const requestFileTreeRefresh = useAppStore((s) => s.requestFileTreeRefresh);
   const commitHistory = useAppStore((s) => s.commitHistory);
   const diffSelectedCommitHash = useAppStore((s) => s.diffSelectedCommitHash);
   const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
@@ -363,12 +364,20 @@ export const RightSidebar = memo(function RightSidebar() {
         const result = await loadDiff(selectedWorkspaceId);
         if (useAppStore.getState().selectedWorkspaceId === selectedWorkspaceId) {
           applyDiffResult(result);
+          requestFileTreeRefresh(selectedWorkspaceId);
         }
       } finally {
         setGitOpInFlight(false);
       }
     },
-    [worktreePath, selectedWorkspaceId, loadDiff, applyDiffResult, gitOpInFlight],
+    [
+      worktreePath,
+      selectedWorkspaceId,
+      loadDiff,
+      applyDiffResult,
+      requestFileTreeRefresh,
+      gitOpInFlight,
+    ],
   );
 
   // Clear the diff selection when the currently-selected row is about to

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -36,6 +36,13 @@ import type {
   PluginMarketplace,
 } from "../types/plugins";
 import type { ConversationCheckpoint } from "../types/checkpoint";
+import type {
+  CommitEntry,
+  DiffLayer,
+  FileStatus,
+  GitFileLayer,
+  StagedDiffFiles,
+} from "../types/diff";
 
 // -- Data --
 
@@ -485,6 +492,8 @@ export function savePluginChannelConfiguration(
 export interface FileEntry {
   path: string;
   is_directory: boolean;
+  git_status?: FileStatus | null;
+  git_layer?: GitFileLayer | null;
 }
 
 export function listWorkspaceFiles(
@@ -727,8 +736,6 @@ export function readPlanFile(path: string): Promise<string> {
 }
 
 // -- Diff --
-
-import type { CommitEntry, DiffLayer, StagedDiffFiles } from "../types/diff";
 
 export interface DiffFilesResult {
   files: DiffFile[];

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -57,6 +57,8 @@ export interface FileTreeSlice {
   allFilesExpandedDirsByWorkspace: Record<string, Record<string, boolean>>;
   /** Per-workspace path of the row focused in the tree (file or folder). */
   allFilesSelectedPathByWorkspace: Record<string, string | null>;
+  /** Monotonic per-workspace refresh signal for mounted Files panels. */
+  fileTreeRefreshNonceByWorkspace: Record<string, number>;
 
   /** Per-workspace ordered list of open file-tab paths. Tabs are rendered
    *  in this order in the tab strip. */
@@ -80,6 +82,7 @@ export interface FileTreeSlice {
     workspaceId: string,
     path: string | null,
   ) => void;
+  requestFileTreeRefresh: (workspaceId: string) => void;
 
   // Tab management
   /** Replace the entire ordered list of file tabs for a workspace. Used by
@@ -142,6 +145,7 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
 ) => ({
   allFilesExpandedDirsByWorkspace: {},
   allFilesSelectedPathByWorkspace: {},
+  fileTreeRefreshNonceByWorkspace: {},
   fileTabsByWorkspace: {},
   activeFileTabByWorkspace: {},
   fileBuffers: {},
@@ -177,6 +181,13 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       allFilesSelectedPathByWorkspace: {
         ...s.allFilesSelectedPathByWorkspace,
         [workspaceId]: path,
+      },
+    })),
+  requestFileTreeRefresh: (workspaceId) =>
+    set((s) => ({
+      fileTreeRefreshNonceByWorkspace: {
+        ...s.fileTreeRefreshNonceByWorkspace,
+        [workspaceId]: (s.fileTreeRefreshNonceByWorkspace[workspaceId] ?? 0) + 1,
       },
     })),
 

--- a/src/ui/src/types/diff.ts
+++ b/src/ui/src/types/diff.ts
@@ -12,6 +12,7 @@ export interface DiffFile {
 }
 
 export type DiffLayer = "committed" | "staged" | "unstaged" | "untracked";
+export type GitFileLayer = "staged" | "unstaged" | "untracked" | "mixed";
 
 export interface DiffFileTab {
   path: string;

--- a/src/ui/src/utils/buildFileTree.test.ts
+++ b/src/ui/src/utils/buildFileTree.test.ts
@@ -55,6 +55,7 @@ describe("buildFileTree", () => {
     const src = tree[0];
     const removed = src.kind === "dir" ? src.children[0] : null;
 
+    expect(src.path).toBe("src/");
     expect(src).toMatchObject({
       kind: "dir",
       path: "src/",

--- a/src/ui/src/utils/buildFileTree.test.ts
+++ b/src/ui/src/utils/buildFileTree.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildFileTree } from "./buildFileTree";
+import type { FileEntry } from "../services/tauri";
+
+describe("buildFileTree", () => {
+  it("propagates file status and descendant counts", () => {
+    const entries: FileEntry[] = [
+      {
+        path: "src/app.ts",
+        is_directory: false,
+        git_status: "Modified",
+        git_layer: "unstaged",
+      },
+      {
+        path: "src/nested/new.ts",
+        is_directory: false,
+        git_status: "Added",
+        git_layer: "untracked",
+      },
+      {
+        path: "README.md",
+        is_directory: false,
+        git_status: null,
+        git_layer: null,
+      },
+    ];
+
+    const tree = buildFileTree(entries);
+    const src = tree.find((node) => node.kind === "dir" && node.path === "src/");
+
+    expect(src).toMatchObject({
+      kind: "dir",
+      path: "src/",
+      statusCount: 2,
+    });
+    expect(src?.kind === "dir" ? src.children[1] : null).toMatchObject({
+      kind: "file",
+      path: "src/app.ts",
+      git_status: "Modified",
+      git_layer: "unstaged",
+    });
+  });
+
+  it("keeps deleted virtual entries in the tree", () => {
+    const entries: FileEntry[] = [
+      {
+        path: "src/removed.ts",
+        is_directory: false,
+        git_status: "Deleted",
+        git_layer: "staged",
+      },
+    ];
+
+    const tree = buildFileTree(entries);
+    const src = tree[0];
+    const removed = src.kind === "dir" ? src.children[0] : null;
+
+    expect(src).toMatchObject({
+      kind: "dir",
+      path: "src/",
+      statusCount: 1,
+    });
+    expect(removed).toMatchObject({
+      kind: "file",
+      path: "src/removed.ts",
+      git_status: "Deleted",
+      git_layer: "staged",
+    });
+  });
+});

--- a/src/ui/src/utils/buildFileTree.ts
+++ b/src/ui/src/utils/buildFileTree.ts
@@ -1,4 +1,5 @@
 import type { FileEntry } from "../services/tauri";
+import type { FileStatus, GitFileLayer } from "../types/diff";
 
 export type FileTreeNode =
   | {
@@ -6,6 +7,7 @@ export type FileTreeNode =
       /** Full path including trailing slash, e.g. `src/components/`. */
       path: string;
       name: string;
+      statusCount: number;
       children: FileTreeNode[];
     }
   | {
@@ -13,6 +15,8 @@ export type FileTreeNode =
       /** Full relative path, e.g. `src/components/Button.tsx`. */
       path: string;
       name: string;
+      git_status: FileStatus | null;
+      git_layer: GitFileLayer | null;
     };
 
 /** Build a hierarchical tree from the flat `FileEntry[]` returned by
@@ -42,6 +46,7 @@ export function buildFileTree(entries: FileEntry[]): FileTreeNode[] {
           kind: "dir",
           path: currentPath,
           name: segment,
+          statusCount: 0,
           children: [],
         };
         dirNodes.set(currentPath, dir);
@@ -49,11 +54,31 @@ export function buildFileTree(entries: FileEntry[]): FileTreeNode[] {
       }
       currentChildren = dir.children;
     }
-    currentChildren.push({ kind: "file", path: entry.path, name: fileName });
+    currentChildren.push({
+      kind: "file",
+      path: entry.path,
+      name: fileName,
+      git_status: entry.git_status ?? null,
+      git_layer: entry.git_layer ?? null,
+    });
   }
 
+  computeStatusCounts(root);
   sortNodes(root);
   return root;
+}
+
+function computeStatusCounts(nodes: FileTreeNode[]): number {
+  let count = 0;
+  for (const node of nodes) {
+    if (node.kind === "file") {
+      if (node.git_status) count += 1;
+    } else {
+      node.statusCount = computeStatusCounts(node.children);
+      count += node.statusCount;
+    }
+  }
+  return count;
 }
 
 function sortNodes(nodes: FileTreeNode[]): void {


### PR DESCRIPTION
## Summary

Adds git status awareness to the Files sidebar and open file tabs for local workspaces. The Files tree now annotates current working tree changes with the same status semantics and color tokens used by the Changes sidebar: `A`, `M`, `D`, and `R`.

This PR keeps committed branch changes exclusive to the Changes tab. File tree and tab indicators are scoped to local `git status` style changes: staged, unstaged, untracked, deleted, and renamed paths.

## What Changed

- Extended `list_workspace_files` responses with per-file git status metadata and git layer information.
- Added backend git-status collection for staged, unstaged, untracked, deleted, and renamed paths.
- Included tracked deleted files as virtual file-tree entries so users can still see and activate them even though they no longer exist on disk.
- Added status precedence for combined states:
  - deleted wins when the worktree path is gone
  - added wins for untracked or staged-new files
  - renamed wins for rename entries unless the current path is deleted
  - otherwise modified is shown
  - staged plus unstaged changes are represented as `mixed`
- Rendered trailing file-row status badges using existing diff/theme tokens.
- Added VS Code-style directory descendant indicators so collapsed folders reveal nested changes without relying only on subtle counts.
- Routed deleted file activation to a diff tab instead of trying to open the missing file in the editor.
- Refreshed file-tree status when the selected workspace changes, while an agent is running, after agent stop, after saves, and after stage/unstage/discard actions.
- Added matching status markers to open file tabs so the selected/open editor state reflects the same git status as the file tree.

## Review Follow-Up

This includes the peer-review follow-up work:

- Consolidated file-tree git status collection through porcelain-style status handling to reduce process count and avoid merging inconsistent snapshots.
- Restored JSX icon rendering style in the file tree.
- Documented the staged-add/worktree-delete precedence behavior.
- Made status label rendering exhaustive for future `FileStatus` variants.
- Cleaned up touched React lint issues while adding tab badges.

## User Impact

Users can now scan both the Files tree and open editor tabs to understand which files are added, modified, deleted, or renamed without switching to the Changes tab. Deleted files remain discoverable from the tree and open directly to their deletion diff, which avoids a dead editor path for files that no longer exist.

## Validation

- `nix develop -c cargo test -p claudette diff`
- `nix develop -c cargo check -p claudette-tauri`
- `nix develop -c cargo clippy -p claudette --all-targets`
- `nix develop -c bash -lc 'cd src/ui && bunx tsc -b'`
- `nix develop -c bash -lc 'cd src/ui && bun run lint:css'`
- `nix develop -c bash -lc 'cd src/ui && bun run test -- src/components/files/FileTree.test.ts src/utils/buildFileTree.test.ts'`
- Targeted ESLint over touched frontend files:
  - `src/components/files/fileTreeStatus.ts`
  - `src/components/files/FileTree.test.ts`
  - `src/components/chat/SessionTabs.tsx`
  - `src/components/file-viewer/FileViewer.tsx`
