### PR TITLE
feat: expose chat orchestration over ipc

### DIFF
--- a/.claude/skills/claudette/SKILL.md
+++ b/.claude/skills/claudette/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: claudette
-description: Drive the running Claudette desktop app from the command line — list and create workspaces, send prompts to chat sessions, fan out batch manifests across many workspaces, list pull requests via SCM plugins, invoke arbitrary plugin operations. Use when the user asks to list/create/archive workspaces, send a message to a Claudette session, kick off a phase plan or multi-workspace fan-out, check PRs from a workspace, or otherwise interact with their open Claudette app from outside the GUI.
+description: Drive the running Claudette desktop app from the command line — list and create workspaces, inspect chat transcripts/tool turns/attachments, answer or approve pending agent controls, send or steer prompts to chat sessions, fan out batch manifests across many workspaces, list pull requests via SCM plugins, invoke arbitrary plugin operations. Use when the user asks to list/create/archive workspaces, inspect or control Claudette chat sessions, send a message to a Claudette session, kick off a phase plan or multi-workspace fan-out, check PRs from a workspace, or otherwise interact with their open Claudette app from outside the GUI.
 when_to_use: |
-  Trigger when the user mentions Claudette workspaces, sessions, batch / phase plans, "send this prompt to N workspaces", "list my workspaces", "what's running in Claudette", "create a workspace for X", "show me the PR for this workspace", or asks to invoke a Claudette SCM/env plugin operation. Also use proactively when the user has Claudette open and asks for operations that would obviously route through it (e.g. "fan out these 8 prompts as separate Claudette workspaces").
+  Trigger when the user mentions Claudette workspaces, sessions, chat transcripts, pending agent questions, plan approvals, completed turns, batch / phase plans, "send this prompt to N workspaces", "get feedback from the other agents", "list my workspaces", "what's running in Claudette", "create a workspace for X", "show me the PR for this workspace", or asks to invoke a Claudette SCM/env plugin operation. Also use proactively when the user has Claudette open and asks for operations that would obviously route through it (e.g. "fan out these 8 prompts as separate Claudette workspaces").
 allowed-tools: Bash(claudette:*)
 ---
 
@@ -30,6 +30,16 @@ claudette workspace archive <ws-id>
 # Send a prompt to a chat session (kicks off an agent turn in the GUI)
 claudette chat send <session-id> "your prompt"
 claudette chat send <session-id> @prompts/feature.md --model sonnet --plan
+
+# Orchestrate a running chat session
+claudette chat list <workspace-id>
+claudette chat show <session-id> --limit 50
+claudette chat turns <session-id>
+claudette chat answer <session-id> <tool-use-id> --answers-json '{"Question?":"Answer"}'
+claudette chat approve-plan <session-id> <tool-use-id>
+claudette chat deny-plan <session-id> <tool-use-id> "revise the plan first"
+claudette chat steer <session-id> @prompts/followup.md
+claudette chat stop <session-id>
 ```
 
 ## Top-level commands
@@ -39,7 +49,7 @@ claudette chat send <session-id> @prompts/feature.md --model sonnet --plan
 | `version` | Print app + protocol version of the running GUI; warns on CLI/GUI version mismatch |
 | `capabilities` | List the JSON-RPC methods the GUI accepts |
 | `workspace` (alias `ws`) | List / create / archive workspaces |
-| `chat` | List sessions, send messages |
+| `chat` | List, inspect, send, steer, and control chat sessions |
 | `repo` | List repositories registered with the GUI |
 | `batch` | Run / validate a batch manifest (multi-workspace fan-out) |
 | `plugin` | List loaded plugins, invoke any operation directly |
@@ -88,6 +98,41 @@ Per-turn agent settings (each boolean is tri-state — pass `--flag` to force on
 | `--effort <level>` | `low` / `medium` / `high` / `xhigh` / `max` |
 | `--disable-1m-context` / `--no-disable-1m-context` | Suppress / re-enable the Max-plan 1M context auto-upgrade |
 | `--permission <level>` | `default` / `acceptEdits` / `bypassPermissions` |
+
+### Inspect and orchestrate chat sessions
+
+Use `chat show` as the primary orchestration read. It returns one bounded JSON snapshot with hydrated session metadata, recent messages, metadata-safe attachments, completed tool activity, live pending controls, and pagination fields:
+
+```bash
+claudette chat list <workspace-id>
+claudette chat show <session-id> --limit 50
+claudette chat show <session-id> --limit 50 --before <message-id>
+```
+
+`pending_controls` contains live agent controls such as `ask_user_question` and `exit_plan_mode`. Use the `tool_use_id` from that array to answer questions or approve/deny a plan:
+
+```bash
+claudette chat answer <session-id> <tool-use-id> --answers-json '{"Which branch?":"main"}'
+claudette chat approve-plan <session-id> <tool-use-id>
+claudette chat deny-plan <session-id> <tool-use-id> "Please split migration and UI work."
+claudette chat clear-attention <session-id>
+```
+
+Other chat inspection and control commands:
+
+| Command | Behavior |
+|---|---|
+| `claudette chat turns <session-id>` | Return completed turn/tool activity for the session |
+| `claudette chat attachments <session-id>` | Return attachment metadata and safe inline text snippets |
+| `claudette chat attachment-data <attachment-id>` | Fetch a full attachment body explicitly |
+| `claudette chat create <workspace-id>` | Create a new chat session in a workspace |
+| `claudette chat rename <session-id> <name>` | Rename a session |
+| `claudette chat archive <session-id>` | Archive a session |
+| `claudette chat steer <session-id> <prompt\|@file\|->` | Steer the queued message for a running session |
+| `claudette chat stop <session-id>` | Stop the live agent process |
+| `claudette chat reset <session-id>` | Reset the live agent session |
+
+Snapshots and attachment lists intentionally omit large base64 bodies so they stay under the IPC response cap. Fetch full bodies only with `attachment-data`.
 
 ### Archive a workspace
 
@@ -159,6 +204,7 @@ For methods that don't have a typed subcommand yet (or for debugging):
 ```bash
 claudette rpc list_workspaces
 claudette rpc list_chat_sessions '{"workspace_id":"<ws-id>"}'
+claudette rpc get_chat_snapshot '{"session_id":"<session-id>","limit":50}'
 ```
 
 `claudette capabilities` prints every method the running GUI accepts.
@@ -184,7 +230,7 @@ Inside a Claudette workspace shell these are already set, so `claudette pr list`
 ## Output conventions
 
 - Commands with a human-readable renderer (`workspace list`, `repo list`, `pr list`, `plugin list`) default to a table-ish format and switch to JSON when `--json` is set.
-- Other commands always emit JSON regardless of `--json` because they don't have a table renderer yet (`capabilities`, `rpc`, `chat list`, `pr show`, `workspace create` / `archive`, `batch run` summary).
+- Other commands always emit JSON regardless of `--json` because they don't have a table renderer yet (`capabilities`, `rpc`, `chat list`, `chat show`, chat control commands, `pr show`, `workspace create` / `archive`, `batch run` summary).
 - Pipe `--json` output through `jq` for scripting.
 
 ## When to NOT use this skill

--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ claudette workspace list
 claudette workspace create <repo-id> my-task
 claudette chat send <session-id> @./prompts/task.md
 
+# Inspect and orchestrate active chat sessions
+claudette chat list <workspace-id>
+claudette chat show <session-id> --limit 50
+claudette chat turns <session-id>
+claudette chat send <other-session-id> "Can you review this approach?"
+claudette chat stop <session-id>
+
 # Fan out N workspaces from a YAML manifest
 claudette batch validate plan.yaml
 claudette batch run plan.yaml
@@ -244,6 +251,8 @@ workspaces:
 ```
 
 The CLI requires the desktop app to be running — every operation flows through the GUI's own command core, so tray icons, notifications, and the workspace list update live as the CLI works. Run `claudette --help` for the full subcommand list, or `claudette completion zsh > ~/.zsh/completions/_claudette` to install shell tab completion.
+
+Main-agent orchestration uses the same IPC surface: `claudette chat show` returns session metadata, recent transcript messages, completed tool activity, attachment metadata, and pending AskUserQuestion / ExitPlanMode controls. Use `claudette chat answer <session-id> <tool-use-id> --answers-json '{"Question?":"Answer"}'`, `claudette chat approve-plan`, or `claudette chat deny-plan` to resolve pending controls from a terminal or another agent.
 
 ## Remote access
 

--- a/src-cli/src/commands/chat.rs
+++ b/src-cli/src/commands/chat.rs
@@ -432,7 +432,8 @@ fn build_answer_params(
     tool_use_id: &str,
     answers_json: &str,
 ) -> Result<serde_json::Value, Box<dyn Error>> {
-    let answers: serde_json::Value = serde_json::from_str(answers_json)
+    let raw_answers = resolve_prompt(answers_json)?;
+    let answers: serde_json::Value = serde_json::from_str(&raw_answers)
         .map_err(|e| format!("answers-json must be a JSON object: {e}"))?;
     if !answers.is_object() {
         return Err("answers-json must be a JSON object".into());
@@ -527,6 +528,20 @@ mod tests {
         assert_eq!(ok["answers"]["Question?"], "Answer");
         assert!(build_answer_params("s1", "toolu_1", "[]").is_err());
         assert!(build_answer_params("s1", "toolu_1", "not json").is_err());
+    }
+
+    #[test]
+    fn build_answer_params_reads_json_from_file() {
+        let path = std::env::temp_dir().join(format!(
+            "claudette-cli-chat-test-{}-answers.json",
+            std::process::id()
+        ));
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(br#"{"Question?":"From file"}"#).unwrap();
+
+        let params = build_answer_params("s1", "toolu_1", &format!("@{}", path.display())).unwrap();
+        assert_eq!(params["answers"]["Question?"], "From file");
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src-cli/src/commands/chat.rs
+++ b/src-cli/src/commands/chat.rs
@@ -23,6 +23,97 @@ pub enum Action {
         #[arg(long)]
         include_archived: bool,
     },
+    /// Show a session snapshot: session metadata, recent messages, tool turns, attachments, pending controls.
+    Show {
+        /// Chat session ID.
+        session: String,
+        /// Maximum number of recent messages to include.
+        #[arg(long)]
+        limit: Option<i64>,
+        /// Page backward before this message ID.
+        #[arg(long)]
+        before: Option<String>,
+    },
+    /// Show persisted completed turns and tool activity for a session.
+    Turns {
+        /// Chat session ID.
+        session: String,
+    },
+    /// Show attachment metadata for a session.
+    Attachments {
+        /// Chat session ID.
+        session: String,
+    },
+    /// Fetch a full attachment body as base64.
+    AttachmentData {
+        /// Attachment ID.
+        attachment: String,
+    },
+    /// Create a chat session in a workspace.
+    Create {
+        /// Workspace ID.
+        workspace: String,
+    },
+    /// Rename a chat session.
+    Rename {
+        /// Chat session ID.
+        session: String,
+        /// New session name.
+        name: String,
+    },
+    /// Archive a chat session.
+    Archive {
+        /// Chat session ID.
+        session: String,
+    },
+    /// Stop a running agent turn.
+    Stop {
+        /// Chat session ID.
+        session: String,
+    },
+    /// Reset the underlying Claude resume state for a session.
+    Reset {
+        /// Chat session ID.
+        session: String,
+    },
+    /// Clear the attention flag for a session.
+    ClearAttention {
+        /// Chat session ID.
+        session: String,
+    },
+    /// Answer a pending AskUserQuestion control request.
+    Answer {
+        /// Chat session ID.
+        session: String,
+        /// Pending tool_use_id.
+        tool_use_id: String,
+        /// JSON object keyed by question text.
+        #[arg(long)]
+        answers_json: String,
+    },
+    /// Approve a pending ExitPlanMode request.
+    ApprovePlan {
+        /// Chat session ID.
+        session: String,
+        /// Pending tool_use_id.
+        tool_use_id: String,
+    },
+    /// Deny a pending ExitPlanMode request with feedback.
+    DenyPlan {
+        /// Chat session ID.
+        session: String,
+        /// Pending tool_use_id.
+        tool_use_id: String,
+        /// Feedback to send to the agent.
+        reason: String,
+    },
+    /// Steer the currently running queued turn with another user message.
+    Steer {
+        /// Chat session ID.
+        session: String,
+        /// Message body. Supports literal text, @file, or - for stdin.
+        prompt: String,
+    },
     /// Send a message to a chat session, kicking off an agent turn.
     /// Mirrors every lever the GUI's chat input bar exposes. Boolean
     /// flag pairs (`--plan` / `--no-plan`, etc.) default to `false`
@@ -103,6 +194,160 @@ pub async fn run(action: Action, json: bool) -> Result<(), Box<dyn Error>> {
             .await?;
             output::print_json(&value)?;
         }
+        Action::Show {
+            session,
+            limit,
+            before,
+        } => {
+            let value = ipc::call(
+                &info,
+                "get_chat_snapshot",
+                build_show_params(&session, limit, before),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Turns { session } => {
+            let value = ipc::call(
+                &info,
+                "load_completed_turns",
+                serde_json::json!({ "session_id": session }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Attachments { session } => {
+            let value = ipc::call(
+                &info,
+                "load_attachments_for_session",
+                serde_json::json!({ "session_id": session }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::AttachmentData { attachment } => {
+            let value = ipc::call(
+                &info,
+                "load_attachment_data",
+                serde_json::json!({ "attachment_id": attachment }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Create { workspace } => {
+            let value = ipc::call(
+                &info,
+                "create_chat_session",
+                serde_json::json!({ "workspace_id": workspace }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Rename { session, name } => {
+            let value = ipc::call(
+                &info,
+                "rename_chat_session",
+                serde_json::json!({ "session_id": session, "name": name }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Archive { session } => {
+            let value = ipc::call(
+                &info,
+                "archive_chat_session",
+                serde_json::json!({ "session_id": session }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Stop { session } => {
+            let value = ipc::call(
+                &info,
+                "stop_agent",
+                serde_json::json!({ "session_id": session }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Reset { session } => {
+            let value = ipc::call(
+                &info,
+                "reset_agent_session",
+                serde_json::json!({ "session_id": session }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::ClearAttention { session } => {
+            let value = ipc::call(
+                &info,
+                "clear_attention",
+                serde_json::json!({ "session_id": session }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Answer {
+            session,
+            tool_use_id,
+            answers_json,
+        } => {
+            let value = ipc::call(
+                &info,
+                "submit_agent_answer",
+                build_answer_params(&session, &tool_use_id, &answers_json)?,
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::ApprovePlan {
+            session,
+            tool_use_id,
+        } => {
+            let value = ipc::call(
+                &info,
+                "submit_plan_approval",
+                serde_json::json!({
+                    "session_id": session,
+                    "tool_use_id": tool_use_id,
+                    "approved": true,
+                }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::DenyPlan {
+            session,
+            tool_use_id,
+            reason,
+        } => {
+            let value = ipc::call(
+                &info,
+                "submit_plan_approval",
+                serde_json::json!({
+                    "session_id": session,
+                    "tool_use_id": tool_use_id,
+                    "approved": false,
+                    "reason": reason,
+                }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
+        Action::Steer { session, prompt } => {
+            let content = resolve_prompt(&prompt)?;
+            let value = ipc::call(
+                &info,
+                "steer_queued_chat_message",
+                serde_json::json!({
+                    "session_id": session,
+                    "content": content,
+                }),
+            )
+            .await?;
+            output::print_json(&value)?;
+        }
         Action::Send {
             session,
             prompt,
@@ -121,50 +366,23 @@ pub async fn run(action: Action, json: bool) -> Result<(), Box<dyn Error>> {
             permission,
         } => {
             let content = resolve_prompt(&prompt)?;
-            let mut params = serde_json::json!({
-                "session_id": session,
-                "content": content,
+            let params = build_send_params(SendParamInput {
+                session: &session,
+                content,
+                model,
+                plan,
+                no_plan,
+                thinking,
+                no_thinking,
+                fast,
+                no_fast,
+                effort,
+                chrome,
+                no_chrome,
+                disable_1m_context,
+                no_disable_1m_context,
+                permission,
             });
-            if let Some(m) = model {
-                params["model"] = serde_json::json!(m);
-            }
-            // Tri-state booleans. `--plan` → Some(true), `--no-plan` →
-            // Some(false), neither → None (omitted from the params
-            // object). The backend currently substitutes `false` for
-            // any omitted boolean, so for now Some(false) and None
-            // produce the same agent behavior — the tri-state lives in
-            // the wire shape so a future backend change to honour
-            // workspace defaults on omission won't need a CLI bump.
-            let resolve = |yes: bool, no: bool| -> Option<bool> {
-                if yes {
-                    Some(true)
-                } else if no {
-                    Some(false)
-                } else {
-                    None
-                }
-            };
-            if let Some(v) = resolve(plan, no_plan) {
-                params["plan_mode"] = serde_json::json!(v);
-            }
-            if let Some(v) = resolve(thinking, no_thinking) {
-                params["thinking_enabled"] = serde_json::json!(v);
-            }
-            if let Some(v) = resolve(fast, no_fast) {
-                params["fast_mode"] = serde_json::json!(v);
-            }
-            if let Some(e) = effort {
-                params["effort"] = serde_json::json!(e);
-            }
-            if let Some(v) = resolve(chrome, no_chrome) {
-                params["chrome_enabled"] = serde_json::json!(v);
-            }
-            if let Some(v) = resolve(disable_1m_context, no_disable_1m_context) {
-                params["disable_1m_context"] = serde_json::json!(v);
-            }
-            if let Some(p) = permission {
-                params["permission_level"] = serde_json::json!(p);
-            }
             let value = ipc::call(&info, "send_chat_message", params).await?;
             if json {
                 output::print_json(&value)?;
@@ -174,6 +392,99 @@ pub async fn run(action: Action, json: bool) -> Result<(), Box<dyn Error>> {
         }
     }
     Ok(())
+}
+
+struct SendParamInput<'a> {
+    session: &'a str,
+    content: String,
+    model: Option<String>,
+    plan: bool,
+    no_plan: bool,
+    thinking: bool,
+    no_thinking: bool,
+    fast: bool,
+    no_fast: bool,
+    effort: Option<String>,
+    chrome: bool,
+    no_chrome: bool,
+    disable_1m_context: bool,
+    no_disable_1m_context: bool,
+    permission: Option<String>,
+}
+
+fn build_show_params(
+    session: &str,
+    limit: Option<i64>,
+    before: Option<String>,
+) -> serde_json::Value {
+    let mut params = serde_json::json!({ "session_id": session });
+    if let Some(limit) = limit {
+        params["limit"] = serde_json::json!(limit);
+    }
+    if let Some(before) = before {
+        params["before_message_id"] = serde_json::json!(before);
+    }
+    params
+}
+
+fn build_answer_params(
+    session: &str,
+    tool_use_id: &str,
+    answers_json: &str,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    let answers: serde_json::Value = serde_json::from_str(answers_json)
+        .map_err(|e| format!("answers-json must be a JSON object: {e}"))?;
+    if !answers.is_object() {
+        return Err("answers-json must be a JSON object".into());
+    }
+    Ok(serde_json::json!({
+        "session_id": session,
+        "tool_use_id": tool_use_id,
+        "answers": answers,
+    }))
+}
+
+fn build_send_params(input: SendParamInput<'_>) -> serde_json::Value {
+    let mut params = serde_json::json!({
+        "session_id": input.session,
+        "content": input.content,
+    });
+    if let Some(m) = input.model {
+        params["model"] = serde_json::json!(m);
+    }
+    // Tri-state booleans. `--plan` → Some(true), `--no-plan` →
+    // Some(false), neither → None (omitted from the params object).
+    let resolve = |yes: bool, no: bool| -> Option<bool> {
+        if yes {
+            Some(true)
+        } else if no {
+            Some(false)
+        } else {
+            None
+        }
+    };
+    if let Some(v) = resolve(input.plan, input.no_plan) {
+        params["plan_mode"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolve(input.thinking, input.no_thinking) {
+        params["thinking_enabled"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolve(input.fast, input.no_fast) {
+        params["fast_mode"] = serde_json::json!(v);
+    }
+    if let Some(e) = input.effort {
+        params["effort"] = serde_json::json!(e);
+    }
+    if let Some(v) = resolve(input.chrome, input.no_chrome) {
+        params["chrome_enabled"] = serde_json::json!(v);
+    }
+    if let Some(v) = resolve(input.disable_1m_context, input.no_disable_1m_context) {
+        params["disable_1m_context"] = serde_json::json!(v);
+    }
+    if let Some(p) = input.permission {
+        params["permission_level"] = serde_json::json!(p);
+    }
+    params
 }
 
 /// Resolve the prompt argument:
@@ -195,4 +506,73 @@ fn resolve_prompt(arg: &str) -> Result<String, Box<dyn Error>> {
         );
     }
     Ok(arg.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn build_show_params_threads_limit_and_cursor() {
+        let params = build_show_params("s1", Some(25), Some("m10".into()));
+        assert_eq!(params["session_id"], "s1");
+        assert_eq!(params["limit"], 25);
+        assert_eq!(params["before_message_id"], "m10");
+    }
+
+    #[test]
+    fn build_answer_params_requires_json_object() {
+        let ok = build_answer_params("s1", "toolu_1", r#"{"Question?":"Answer"}"#).unwrap();
+        assert_eq!(ok["answers"]["Question?"], "Answer");
+        assert!(build_answer_params("s1", "toolu_1", "[]").is_err());
+        assert!(build_answer_params("s1", "toolu_1", "not json").is_err());
+    }
+
+    #[test]
+    fn resolve_prompt_reads_literal_and_file() {
+        let path = std::env::temp_dir().join(format!(
+            "claudette-cli-chat-test-{}-prompt.md",
+            std::process::id()
+        ));
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(b"from file").unwrap();
+
+        assert_eq!(resolve_prompt("literal").unwrap(), "literal");
+        assert_eq!(
+            resolve_prompt(&format!("@{}", path.display())).unwrap(),
+            "from file"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn build_send_params_keeps_tri_state_flags() {
+        let params = build_send_params(SendParamInput {
+            session: "s1",
+            content: "hello".into(),
+            model: Some("sonnet".into()),
+            plan: true,
+            no_plan: false,
+            thinking: false,
+            no_thinking: true,
+            fast: false,
+            no_fast: false,
+            effort: Some("high".into()),
+            chrome: true,
+            no_chrome: false,
+            disable_1m_context: false,
+            no_disable_1m_context: false,
+            permission: Some("standard".into()),
+        });
+        assert_eq!(params["session_id"], "s1");
+        assert_eq!(params["content"], "hello");
+        assert_eq!(params["model"], "sonnet");
+        assert_eq!(params["plan_mode"], true);
+        assert_eq!(params["thinking_enabled"], false);
+        assert!(params.get("fast_mode").is_none());
+        assert_eq!(params["effort"], "high");
+        assert_eq!(params["chrome_enabled"], true);
+        assert_eq!(params["permission_level"], "standard");
+    }
 }

--- a/src-cli/src/ipc.rs
+++ b/src-cli/src/ipc.rs
@@ -110,11 +110,14 @@ pub async fn call(
         .map_err(|e| CallError::Transport(format!("malformed response: {e}")))?;
 
     match (response.result, response.error) {
-        (Some(value), None) => Ok(value),
         (_, Some(err)) => Err(CallError::Server(err)),
-        (None, None) => Err(CallError::Transport(
-            "response had neither result nor error".into(),
-        )),
+        (Some(value), None) => Ok(value),
+        // JSON-RPC permits `result: null` for void-returning methods.
+        // serde collapses a present `null` into `None` on the
+        // `Option<serde_json::Value>` field, so we can't distinguish
+        // missing from null here — but the absence of an `error` field
+        // means the call succeeded, so treat both the same.
+        (None, None) => Ok(serde_json::Value::Null),
     }
 }
 
@@ -147,5 +150,48 @@ mod uuid {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
     pub fn new_v4_string() -> String {
         format!("c{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use claudette::rpc::{RpcError, RpcResponse};
+
+    /// Regression: serde collapses a present `result: null` into
+    /// `None` on `Option<Value>`, so the wire shapes "no result field"
+    /// and "result: null" both surface here as `(None, None)`. Both
+    /// must be treated as successful void responses, not transport
+    /// errors. Methods like `archive_chat_session` return
+    /// `Option<ChatSession>` and intentionally serialize `null` when
+    /// archiving the last session; the CLI used to fail with
+    /// "response had neither result nor error".
+    #[test]
+    fn null_result_is_treated_as_success() {
+        // Round-trip via serde to mirror what the CLI sees on the wire.
+        let on_wire = serde_json::to_string(&RpcResponse::ok(
+            serde_json::json!(1),
+            serde_json::Value::Null,
+        ))
+        .unwrap();
+        let parsed: RpcResponse = serde_json::from_str(&on_wire).unwrap();
+        assert!(parsed.error.is_none());
+        // Whichever way serde parsed it, the CLI's match must accept it.
+        let result = match (parsed.result, parsed.error) {
+            (_, Some(_)) => panic!("expected success"),
+            (Some(v), None) => v,
+            (None, None) => serde_json::Value::Null,
+        };
+        assert_eq!(result, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn error_response_preserves_message() {
+        let on_wire =
+            serde_json::to_string(&RpcResponse::err(serde_json::json!(2), "boom".to_string()))
+                .unwrap();
+        let parsed: RpcResponse = serde_json::from_str(&on_wire).unwrap();
+        let err: RpcError = parsed.error.expect("error must round-trip");
+        assert_eq!(err.message, "boom");
+        assert_eq!(err.code, -1);
     }
 }

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -194,6 +194,7 @@ fn should_defer_persistent_restart_for_state(
     has_persistent_session && has_running_background_tasks
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_task_notification_status(
     app: &AppHandle,
     db_path: &std::path::Path,
@@ -568,13 +569,11 @@ fn schedule_background_task_wake(
                 duration_ms,
                 ..
             }) = &event
+                && let Ok(db) = Database::open(&db_path)
+                && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
+                && let Some(ref msg_id) = last_assistant_msg_id
             {
-                if let Ok(db) = Database::open(&db_path)
-                    && let (Some(cost), Some(dur)) = (total_cost_usd, duration_ms)
-                    && let Some(ref msg_id) = last_assistant_msg_id
-                {
-                    let _ = db.update_chat_message_cost(msg_id, *cost, *dur);
-                }
+                let _ = db.update_chat_message_cost(msg_id, *cost, *dur);
             }
 
             let is_done = matches!(
@@ -1999,29 +1998,28 @@ pub async fn send_chat_message(
                     &chat_session_id_for_stream,
                 )
                 .is_some()
+                    && let Ok(db) = Database::open(&db_path)
                 {
-                    if let Ok(db) = Database::open(&db_path) {
-                        let _ = db.update_agent_shell_terminal_tab_status(
+                    let _ = db.update_agent_shell_terminal_tab_status(
+                        &chat_session_id_for_stream,
+                        None,
+                        if start.run_in_background {
+                            "running"
+                        } else {
+                            "starting"
+                        },
+                        command,
+                    );
+                    if let Ok(Some(tab)) =
+                        db.get_agent_shell_terminal_tab(&chat_session_id_for_stream)
+                    {
+                        emit_agent_background_task_event(
+                            &app,
+                            AgentBackgroundTaskEventKind::Starting,
+                            &ws_id,
                             &chat_session_id_for_stream,
-                            None,
-                            if start.run_in_background {
-                                "running"
-                            } else {
-                                "starting"
-                            },
-                            command,
+                            tab,
                         );
-                        if let Ok(Some(tab)) =
-                            db.get_agent_shell_terminal_tab(&chat_session_id_for_stream)
-                        {
-                            emit_agent_background_task_event(
-                                &app,
-                                AgentBackgroundTaskEventKind::Starting,
-                                &ws_id,
-                                &chat_session_id_for_stream,
-                                tab,
-                            );
-                        }
                     }
                 }
             }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -41,7 +41,7 @@ use interprocess::local_socket::{ListenerOptions, Name};
 use rand::RngCore;
 use serde::Serialize;
 use serde_json::json;
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, State};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -88,7 +88,10 @@ const METHODS: &[&str] = &[
 
 const DEFAULT_CHAT_SNAPSHOT_LIMIT: i64 = 50;
 const MAX_CHAT_SNAPSHOT_LIMIT: i64 = 200;
-const MAX_TEXT_ATTACHMENT_INLINE_BYTES: usize = 1024 * 1024;
+// Attachment lists are preview surfaces; full bytes are fetched explicitly
+// through `load_attachment_data` so JSON-RPC responses stay bounded.
+const MAX_TEXT_ATTACHMENT_INLINE_BYTES: usize = 16 * 1024;
+const MAX_ATTACHMENT_INLINE_BYTES_PER_RESPONSE: usize = 512 * 1024;
 
 #[derive(Debug, Clone, Serialize)]
 struct ChatSnapshot {
@@ -111,6 +114,7 @@ struct IpcAttachment {
     width: Option<i32>,
     height: Option<i32>,
     size_bytes: i64,
+    created_at: String,
     origin: AttachmentOrigin,
     tool_use_id: Option<String>,
 }
@@ -128,6 +132,7 @@ struct PendingAgentControl {
 enum PendingAgentControlKind {
     AskUserQuestion,
     ExitPlanMode,
+    /// Forward-compatible bucket for future Claude tool-control kinds.
     Unknown,
 }
 
@@ -422,11 +427,14 @@ fn with_db<F>(app: &AppHandle, f: F) -> Result<serde_json::Value, String>
 where
     F: FnOnce(&Database) -> Result<serde_json::Value, String>,
 {
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     f(&db)
+}
+
+fn app_state(app: &AppHandle) -> Result<State<'_, AppState>, String> {
+    app.try_state::<AppState>()
+        .ok_or_else(|| "AppState not initialised".to_string())
 }
 
 /// Delegates to the shared `commands::workspace::create_workspace_inner`
@@ -450,9 +458,7 @@ async fn handle_create_workspace(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
 
     let result =
         crate::commands::workspace::create_workspace_inner(repo_id, name, skip_setup, app, &state)
@@ -519,10 +525,12 @@ fn pending_controls_for_session(
     out
 }
 
-fn safe_attachment(att: Attachment) -> IpcAttachment {
-    let text_content = if is_text_attachment(&att.media_type)
+fn safe_attachment(att: Attachment, remaining_inline_bytes: &mut usize) -> IpcAttachment {
+    let can_inline = is_text_attachment(&att.media_type)
         && att.data.len() <= MAX_TEXT_ATTACHMENT_INLINE_BYTES
-    {
+        && att.data.len() <= *remaining_inline_bytes;
+    let text_content = if can_inline {
+        *remaining_inline_bytes = remaining_inline_bytes.saturating_sub(att.data.len());
         std::str::from_utf8(&att.data).ok().map(str::to_owned)
     } else {
         None
@@ -536,6 +544,7 @@ fn safe_attachment(att: Attachment) -> IpcAttachment {
         width: att.width,
         height: att.height,
         size_bytes: att.size_bytes,
+        created_at: att.created_at,
         origin: att.origin,
         tool_use_id: att.tool_use_id,
     }
@@ -556,27 +565,50 @@ fn clamp_snapshot_limit(params: &serde_json::Value) -> i64 {
         .clamp(1, MAX_CHAT_SNAPSHOT_LIMIT)
 }
 
+fn parse_optional_param<T>(params: &serde_json::Value, keys: &[&str]) -> Result<Option<T>, String>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let Some((key, value)) = keys
+        .iter()
+        .find_map(|key| params.get(key).map(|value| (*key, value)))
+    else {
+        return Ok(None);
+    };
+    serde_json::from_value(value.clone())
+        .map(Some)
+        .map_err(|e| format!("invalid {key}: {e}"))
+}
+
 fn load_safe_attachments_for_message_ids(
     db: &Database,
     message_ids: &[String],
     carry_over_user_id: Option<&str>,
 ) -> Result<Vec<IpcAttachment>, String> {
+    let message_order: std::collections::HashMap<&str, usize> = message_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, id)| (id.as_str(), idx))
+        .collect();
     let att_map = db
         .list_attachments_for_messages(message_ids)
         .map_err(|e| e.to_string())?;
     let mut out = Vec::new();
+    let mut remaining_inline_bytes = MAX_ATTACHMENT_INLINE_BYTES_PER_RESPONSE;
     for (msg_id, atts) in att_map {
         let is_carry_over = carry_over_user_id == Some(msg_id.as_str());
         for att in atts {
             if is_carry_over && att.origin != AttachmentOrigin::Agent {
                 continue;
             }
-            out.push(safe_attachment(att));
+            out.push(safe_attachment(att, &mut remaining_inline_bytes));
         }
     }
     out.sort_by(|a, b| {
-        a.message_id
-            .cmp(&b.message_id)
+        message_order
+            .get(a.message_id.as_str())
+            .cmp(&message_order.get(b.message_id.as_str()))
+            .then_with(|| a.created_at.cmp(&b.created_at))
             .then_with(|| a.filename.cmp(&b.filename))
             .then_with(|| a.id.cmp(&b.id))
     });
@@ -587,18 +619,12 @@ fn build_chat_snapshot(
     db: &Database,
     session: ChatSession,
     messages: Vec<ChatMessage>,
-    limit: i64,
-    before_message_id: Option<&str>,
+    has_more: bool,
     pending_controls: Vec<PendingAgentControl>,
 ) -> Result<ChatSnapshot, String> {
     let total_count = db
         .count_chat_messages_for_session(&session.id)
         .map_err(|e| e.to_string())?;
-
-    let has_more = match before_message_id {
-        None => total_count > messages.len() as i64,
-        Some(_) => messages.len() as i64 == limit,
-    };
 
     let mut message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
     let mut carry_over_user_id: Option<String> = None;
@@ -629,6 +655,14 @@ fn build_chat_snapshot(
     })
 }
 
+fn trim_peeked_message_page(messages: &mut Vec<ChatMessage>, limit: i64) -> bool {
+    let has_more = messages.len() as i64 > limit;
+    if has_more {
+        messages.remove(0);
+    }
+    has_more
+}
+
 /// `list_chat_sessions` IPC method — read-only DB query for a single
 /// workspace's sessions, overlaid with live agent state.
 async fn handle_list_chat_sessions(
@@ -644,9 +678,7 @@ async fn handle_list_chat_sessions(
         .get("include_archived")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let sessions = db
         .list_chat_sessions_for_workspace(&workspace_id, include_archived)
@@ -664,9 +696,7 @@ async fn handle_get_chat_session(
     params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let chat_session_id = param_chat_session_id(params)?;
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let session = db
         .get_chat_session(&chat_session_id)
@@ -688,30 +718,22 @@ async fn handle_get_chat_snapshot(
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     let session = db
         .get_chat_session(&chat_session_id)
         .map_err(|e| e.to_string())?
         .ok_or("Session not found")?;
-    let messages = db
-        .list_chat_messages_page(&chat_session_id, limit, before_message_id.as_deref())
+    let mut messages = db
+        .list_chat_messages_page(&chat_session_id, limit + 1, before_message_id.as_deref())
         .map_err(|e| e.to_string())?;
+    let has_more = trim_peeked_message_page(&mut messages, limit);
     let agents = state.agents.read().await;
     let pending_controls = pending_controls_for_session(agents.get(&chat_session_id));
     let session = hydrate_session(session, &agents);
     drop(agents);
 
-    let snapshot = build_chat_snapshot(
-        &db,
-        session,
-        messages,
-        limit,
-        before_message_id.as_deref(),
-        pending_controls,
-    )?;
+    let snapshot = build_chat_snapshot(&db, session, messages, has_more, pending_controls)?;
     serde_json::to_value(snapshot).map_err(|e| e.to_string())
 }
 
@@ -769,7 +791,7 @@ async fn handle_create_chat_session(
         .and_then(|v| v.as_str())
         .ok_or("missing workspace_id")?
         .to_string();
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     let session = crate::commands::chat::session::create_chat_session(workspace_id, state).await?;
     serde_json::to_value(session).map_err(|e| e.to_string())
 }
@@ -784,7 +806,7 @@ async fn handle_rename_chat_session(
         .and_then(|v| v.as_str())
         .ok_or("missing name")?
         .to_string();
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::session::rename_chat_session(chat_session_id, name, state).await?;
     Ok(json!({ "ok": true }))
 }
@@ -794,7 +816,7 @@ async fn handle_archive_chat_session(
     params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let chat_session_id = param_chat_session_id(params)?;
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     let fresh =
         crate::commands::chat::session::archive_chat_session(app.clone(), chat_session_id, state)
             .await?;
@@ -816,7 +838,7 @@ async fn handle_send_chat_message(
 ) -> Result<serde_json::Value, String> {
     let parsed = parse_send_chat_params(params)?;
 
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::send::send_chat_message(
         parsed.session_id,
         parsed.message_id,
@@ -883,10 +905,7 @@ pub(crate) fn parse_send_chat_params(params: &serde_json::Value) -> Result<SendC
         session_id,
         message_id: str_param("message_id").or_else(|| str_param("messageId")),
         content,
-        mentioned_files: params
-            .get("mentioned_files")
-            .or_else(|| params.get("mentionedFiles"))
-            .and_then(|v| serde_json::from_value(v.clone()).ok()),
+        mentioned_files: parse_optional_param(params, &["mentioned_files", "mentionedFiles"])?,
         model: str_param("model"),
         fast_mode: bool_param("fast_mode"),
         thinking_enabled: bool_param("thinking_enabled"),
@@ -895,9 +914,7 @@ pub(crate) fn parse_send_chat_params(params: &serde_json::Value) -> Result<SendC
         chrome_enabled: bool_param("chrome_enabled"),
         disable_1m_context: bool_param("disable_1m_context"),
         permission_level: str_param("permission_level"),
-        attachments: params
-            .get("attachments")
-            .and_then(|v| serde_json::from_value(v.clone()).ok()),
+        attachments: parse_optional_param(params, &["attachments"])?,
     })
 }
 
@@ -916,14 +933,9 @@ async fn handle_steer_queued_chat_message(
         .or_else(|| params.get("messageId"))
         .and_then(|v| v.as_str())
         .map(String::from);
-    let mentioned_files = params
-        .get("mentioned_files")
-        .or_else(|| params.get("mentionedFiles"))
-        .and_then(|v| serde_json::from_value(v.clone()).ok());
-    let attachments = params
-        .get("attachments")
-        .and_then(|v| serde_json::from_value(v.clone()).ok());
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let mentioned_files = parse_optional_param(params, &["mentioned_files", "mentionedFiles"])?;
+    let attachments = parse_optional_param(params, &["attachments"])?;
+    let state = app_state(app)?;
     let checkpoint = crate::commands::chat::send::steer_queued_chat_message(
         chat_session_id,
         message_id,
@@ -941,7 +953,7 @@ async fn handle_stop_agent(
     params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let chat_session_id = param_chat_session_id(params)?;
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::lifecycle::stop_agent(chat_session_id, app.clone(), state).await?;
     Ok(json!({ "ok": true }))
 }
@@ -951,7 +963,7 @@ async fn handle_reset_agent_session(
     params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let chat_session_id = param_chat_session_id(params)?;
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::lifecycle::reset_agent_session(chat_session_id, app.clone(), state)
         .await?;
     Ok(json!({ "ok": true }))
@@ -962,7 +974,7 @@ async fn handle_clear_attention(
     params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let chat_session_id = param_chat_session_id(params)?;
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::interaction::clear_attention(chat_session_id, app.clone(), state)
         .await?;
     Ok(json!({ "ok": true }))
@@ -985,7 +997,7 @@ async fn handle_submit_agent_answer(
         .ok_or_else(|| "missing answers".to_string())
         .and_then(|v| serde_json::from_value(v).map_err(|e| e.to_string()))?;
     let annotations = params.get("annotations").cloned();
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::interaction::submit_agent_answer(
         chat_session_id,
         tool_use_id,
@@ -1016,7 +1028,7 @@ async fn handle_submit_plan_approval(
         .get("reason")
         .and_then(|v| v.as_str())
         .map(String::from);
-    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let state = app_state(app)?;
     crate::commands::chat::interaction::submit_plan_approval(
         chat_session_id,
         tool_use_id,
@@ -1045,9 +1057,7 @@ async fn handle_archive_workspace(
         .ok_or("missing workspace_id")?;
     let delete_branch_override = params.get("delete_branch").and_then(|v| v.as_bool());
 
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
     let supervisor = app
         .try_state::<Arc<claudette::mcp_supervisor::McpSupervisor>>()
         .ok_or_else(|| "McpSupervisor not initialised".to_string())?;
@@ -1075,9 +1085,7 @@ async fn handle_archive_workspace(
 /// `plugin invoke` tab-completion hints and to surface friendly per-kind
 /// shortcuts (`claudette pr …`) only when a matching provider is loaded.
 async fn handle_plugin_list(app: &AppHandle) -> Result<serde_json::Value, String> {
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
     let registry = state.plugins.read().await;
     let mut out: Vec<serde_json::Value> = registry
         .plugins
@@ -1136,9 +1144,7 @@ async fn handle_plugin_invoke(
         .to_string();
     let args = params.get("args").cloned().unwrap_or(json!({}));
 
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
 
     let ws_info = build_workspace_info(&state.db_path, &workspace_id)?;
     let registry = state.plugins.read().await;
@@ -1166,9 +1172,7 @@ async fn handle_scm_detect_provider(
         .ok_or("missing repo_id")?
         .to_string();
 
-    let state = app
-        .try_state::<AppState>()
-        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let state = app_state(app)?;
 
     let (manual_override, repo_path, default_remote) = {
         let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
@@ -1401,7 +1405,7 @@ mod tests {
 
         let session = db.get_chat_session(&session_id).unwrap().unwrap();
         let messages = db.list_chat_messages_page(&session_id, 2, None).unwrap();
-        let snapshot = build_chat_snapshot(&db, session, messages, 2, None, Vec::new()).unwrap();
+        let snapshot = build_chat_snapshot(&db, session, messages, true, Vec::new()).unwrap();
 
         assert_eq!(snapshot.total_count, 3);
         assert!(snapshot.has_more);
@@ -1425,6 +1429,71 @@ mod tests {
             .find(|a| a.id == "a-image")
             .unwrap();
         assert!(image.text_content.is_none());
+    }
+
+    #[test]
+    fn peeked_message_page_has_exact_has_more() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1")).unwrap();
+        let session_id = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+
+        for id in ["m1", "m2", "m3"] {
+            db.insert_chat_message(&make_chat_msg(id, "w1", &session_id, ChatRole::User, id))
+                .unwrap();
+        }
+
+        let mut newest = db.list_chat_messages_page(&session_id, 3, None).unwrap();
+        assert!(trim_peeked_message_page(&mut newest, 2));
+        assert_eq!(
+            newest.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["m2", "m3"]
+        );
+
+        let mut older = db
+            .list_chat_messages_page(&session_id, 3, Some("m3"))
+            .unwrap();
+        assert!(!trim_peeked_message_page(&mut older, 2));
+        assert_eq!(
+            older.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["m1", "m2"]
+        );
+    }
+
+    #[test]
+    fn safe_attachments_keep_message_order_and_cap_inline_text() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1")).unwrap();
+        let session_id = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+
+        for id in ["m1", "m2"] {
+            db.insert_chat_message(&make_chat_msg(id, "w1", &session_id, ChatRole::User, id))
+                .unwrap();
+        }
+        db.insert_attachment(&make_attachment("a1", "m1", "text/plain", b"first"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a2", "m2", "text/plain", b"second"))
+            .unwrap();
+        db.insert_attachment(&make_attachment(
+            "a-big",
+            "m2",
+            "text/plain",
+            &vec![b'x'; MAX_TEXT_ATTACHMENT_INLINE_BYTES + 1],
+        ))
+        .unwrap();
+
+        let ids = vec!["m2".to_string(), "m1".to_string()];
+        let attachments = load_safe_attachments_for_message_ids(&db, &ids, None).unwrap();
+        assert_eq!(
+            attachments
+                .iter()
+                .map(|a| a.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a-big", "a2", "a1"]
+        );
+        assert!(attachments[0].text_content.is_none());
+        assert_eq!(attachments[1].text_content.as_deref(), Some("second"));
     }
 
     #[test]
@@ -1504,6 +1573,13 @@ mod tests {
             "chrome_enabled": true,
             "disable_1m_context": true,
             "permission_level": "acceptEdits",
+            "mentioned_files": ["/tmp/a.rs"],
+            "attachments": [{
+                "filename": "note.txt",
+                "media_type": "text/plain",
+                "data_base64": "aGVsbG8=",
+                "text_content": "hello"
+            }],
         }))
         .expect("must parse");
         assert_eq!(parsed.session_id, "sess-1");
@@ -1516,6 +1592,11 @@ mod tests {
         assert_eq!(parsed.chrome_enabled, Some(true));
         assert_eq!(parsed.disable_1m_context, Some(true));
         assert_eq!(parsed.permission_level.as_deref(), Some("acceptEdits"));
+        assert_eq!(
+            parsed.mentioned_files.as_ref().unwrap(),
+            &vec!["/tmp/a.rs".to_string()]
+        );
+        assert_eq!(parsed.attachments.as_ref().map(Vec::len), Some(1));
     }
 
     #[test]
@@ -1552,6 +1633,26 @@ mod tests {
     fn parse_send_chat_params_rejects_missing_required_fields() {
         assert!(parse_send_chat_params(&json!({"content": "x"})).is_err());
         assert!(parse_send_chat_params(&json!({"session_id": "x"})).is_err());
+    }
+
+    #[test]
+    fn parse_send_chat_params_rejects_malformed_collections() {
+        assert!(
+            parse_send_chat_params(&json!({
+                "session_id": "sess-1",
+                "content": "hi",
+                "mentioned_files": [1],
+            }))
+            .is_err()
+        );
+        assert!(
+            parse_send_chat_params(&json!({
+                "session_id": "sess-1",
+                "content": "hi",
+                "attachments": [{"filename": "note.txt"}],
+            }))
+            .is_err()
+        );
     }
 
     /// Wrong types should drop to None for booleans and strings, not

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -23,7 +23,12 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use claudette::base64_encode;
 use claudette::db::Database;
+use claudette::model::{
+    AgentStatus, Attachment, AttachmentOrigin, ChatMessage, ChatRole, ChatSession,
+    CompletedTurnData,
+};
 use claudette::plugin_runtime::host_api::WorkspaceInfo;
 use claudette::rpc::{Capabilities, RpcRequest, RpcResponse};
 use claudette::scm::detect;
@@ -34,6 +39,7 @@ use interprocess::local_socket::{GenericFilePath, ToFsName};
 use interprocess::local_socket::{GenericNamespaced, ToNsName};
 use interprocess::local_socket::{ListenerOptions, Name};
 use rand::RngCore;
+use serde::Serialize;
 use serde_json::json;
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -58,13 +64,72 @@ const METHODS: &[&str] = &[
     "list_repositories",
     "list_workspaces",
     "list_chat_sessions",
+    "get_chat_session",
+    "get_chat_snapshot",
+    "load_completed_turns",
+    "load_attachments_for_session",
+    "load_attachment_data",
+    "create_chat_session",
+    "rename_chat_session",
+    "archive_chat_session",
     "create_workspace",
     "archive_workspace",
     "send_chat_message",
+    "steer_queued_chat_message",
+    "stop_agent",
+    "reset_agent_session",
+    "clear_attention",
+    "submit_agent_answer",
+    "submit_plan_approval",
     "plugin.list",
     "plugin.invoke",
     "scm.detect_provider",
 ];
+
+const DEFAULT_CHAT_SNAPSHOT_LIMIT: i64 = 50;
+const MAX_CHAT_SNAPSHOT_LIMIT: i64 = 200;
+const MAX_TEXT_ATTACHMENT_INLINE_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize)]
+struct ChatSnapshot {
+    session: ChatSession,
+    messages: Vec<ChatMessage>,
+    attachments: Vec<IpcAttachment>,
+    completed_turns: Vec<CompletedTurnData>,
+    pending_controls: Vec<PendingAgentControl>,
+    has_more: bool,
+    total_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct IpcAttachment {
+    id: String,
+    message_id: String,
+    filename: String,
+    media_type: String,
+    text_content: Option<String>,
+    width: Option<i32>,
+    height: Option<i32>,
+    size_bytes: i64,
+    origin: AttachmentOrigin,
+    tool_use_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct PendingAgentControl {
+    tool_use_id: String,
+    tool_name: String,
+    input: serde_json::Value,
+    kind: PendingAgentControlKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PendingAgentControlKind {
+    AskUserQuestion,
+    ExitPlanMode,
+    Unknown,
+}
 
 /// Live IPC server. Drop to tear down the listener and remove the socket
 /// file (Unix) — same RAII model as `agent_mcp::bridge::McpBridgeSession`.
@@ -322,10 +387,24 @@ async fn dispatch(app: &AppHandle, req: RpcRequest) -> RpcResponse {
                 .map(|v| serde_json::to_value(v).unwrap_or_default())
                 .map_err(|e| e.to_string())
         }),
-        "list_chat_sessions" => handle_list_chat_sessions(app, &req.params),
+        "list_chat_sessions" => handle_list_chat_sessions(app, &req.params).await,
+        "get_chat_session" => handle_get_chat_session(app, &req.params).await,
+        "get_chat_snapshot" => handle_get_chat_snapshot(app, &req.params).await,
+        "load_completed_turns" => handle_load_completed_turns(app, &req.params),
+        "load_attachments_for_session" => handle_load_attachments_for_session(app, &req.params),
+        "load_attachment_data" => handle_load_attachment_data(app, &req.params),
+        "create_chat_session" => handle_create_chat_session(app, &req.params).await,
+        "rename_chat_session" => handle_rename_chat_session(app, &req.params).await,
+        "archive_chat_session" => handle_archive_chat_session(app, &req.params).await,
         "create_workspace" => handle_create_workspace(app, &req.params).await,
         "archive_workspace" => handle_archive_workspace(app, &req.params).await,
         "send_chat_message" => handle_send_chat_message(app, &req.params).await,
+        "steer_queued_chat_message" => handle_steer_queued_chat_message(app, &req.params).await,
+        "stop_agent" => handle_stop_agent(app, &req.params).await,
+        "reset_agent_session" => handle_reset_agent_session(app, &req.params).await,
+        "clear_attention" => handle_clear_attention(app, &req.params).await,
+        "submit_agent_answer" => handle_submit_agent_answer(app, &req.params).await,
+        "submit_plan_approval" => handle_submit_plan_approval(app, &req.params).await,
         "plugin.list" => handle_plugin_list(app).await,
         "plugin.invoke" => handle_plugin_invoke(app, &req.params).await,
         "scm.detect_provider" => handle_scm_detect_provider(app, &req.params).await,
@@ -386,10 +465,173 @@ async fn handle_create_workspace(
     }))
 }
 
+fn param_chat_session_id(params: &serde_json::Value) -> Result<String, String> {
+    params
+        .get("chat_session_id")
+        .or_else(|| params.get("session_id"))
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "missing session_id".to_string())
+}
+
+fn hydrate_session(
+    mut session: ChatSession,
+    agents: &std::collections::HashMap<String, crate::state::AgentSessionState>,
+) -> ChatSession {
+    if let Some(agent) = agents.get(&session.id) {
+        session.agent_status = if agent.active_pid.is_some() {
+            AgentStatus::Running
+        } else if !agent.running_background_tasks.is_empty() {
+            AgentStatus::IdleWithBackground
+        } else {
+            AgentStatus::Idle
+        };
+        session.needs_attention = agent.needs_attention;
+        session.attention_kind = agent.attention_kind.map(|k| match k {
+            crate::state::AttentionKind::Ask => claudette::model::AttentionKind::Ask,
+            crate::state::AttentionKind::Plan => claudette::model::AttentionKind::Plan,
+        });
+    }
+    session
+}
+
+fn pending_controls_for_session(
+    agent: Option<&crate::state::AgentSessionState>,
+) -> Vec<PendingAgentControl> {
+    let Some(agent) = agent else {
+        return Vec::new();
+    };
+    let mut out: Vec<PendingAgentControl> = agent
+        .pending_permissions
+        .iter()
+        .map(|(tool_use_id, pending)| PendingAgentControl {
+            tool_use_id: tool_use_id.clone(),
+            tool_name: pending.tool_name.clone(),
+            input: pending.original_input.clone(),
+            kind: match pending.tool_name.as_str() {
+                "AskUserQuestion" => PendingAgentControlKind::AskUserQuestion,
+                "ExitPlanMode" => PendingAgentControlKind::ExitPlanMode,
+                _ => PendingAgentControlKind::Unknown,
+            },
+        })
+        .collect();
+    out.sort_by(|a, b| a.tool_use_id.cmp(&b.tool_use_id));
+    out
+}
+
+fn safe_attachment(att: Attachment) -> IpcAttachment {
+    let text_content = if is_text_attachment(&att.media_type)
+        && att.data.len() <= MAX_TEXT_ATTACHMENT_INLINE_BYTES
+    {
+        std::str::from_utf8(&att.data).ok().map(str::to_owned)
+    } else {
+        None
+    };
+    IpcAttachment {
+        id: att.id,
+        message_id: att.message_id,
+        filename: att.filename,
+        media_type: att.media_type,
+        text_content,
+        width: att.width,
+        height: att.height,
+        size_bytes: att.size_bytes,
+        origin: att.origin,
+        tool_use_id: att.tool_use_id,
+    }
+}
+
+fn is_text_attachment(media_type: &str) -> bool {
+    matches!(
+        media_type,
+        "text/plain" | "text/csv" | "text/markdown" | "application/json"
+    )
+}
+
+fn clamp_snapshot_limit(params: &serde_json::Value) -> i64 {
+    params
+        .get("limit")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(DEFAULT_CHAT_SNAPSHOT_LIMIT)
+        .clamp(1, MAX_CHAT_SNAPSHOT_LIMIT)
+}
+
+fn load_safe_attachments_for_message_ids(
+    db: &Database,
+    message_ids: &[String],
+    carry_over_user_id: Option<&str>,
+) -> Result<Vec<IpcAttachment>, String> {
+    let att_map = db
+        .list_attachments_for_messages(message_ids)
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for (msg_id, atts) in att_map {
+        let is_carry_over = carry_over_user_id == Some(msg_id.as_str());
+        for att in atts {
+            if is_carry_over && att.origin != AttachmentOrigin::Agent {
+                continue;
+            }
+            out.push(safe_attachment(att));
+        }
+    }
+    out.sort_by(|a, b| {
+        a.message_id
+            .cmp(&b.message_id)
+            .then_with(|| a.filename.cmp(&b.filename))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    Ok(out)
+}
+
+fn build_chat_snapshot(
+    db: &Database,
+    session: ChatSession,
+    messages: Vec<ChatMessage>,
+    limit: i64,
+    before_message_id: Option<&str>,
+    pending_controls: Vec<PendingAgentControl>,
+) -> Result<ChatSnapshot, String> {
+    let total_count = db
+        .count_chat_messages_for_session(&session.id)
+        .map_err(|e| e.to_string())?;
+
+    let has_more = match before_message_id {
+        None => total_count > messages.len() as i64,
+        Some(_) => messages.len() as i64 == limit,
+    };
+
+    let mut message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+    let mut carry_over_user_id: Option<String> = None;
+    if let Some(first) = messages.first()
+        && first.role != ChatRole::User
+        && let Some(prev_user) = db
+            .previous_user_message_id(&session.id, &first.id)
+            .map_err(|e| e.to_string())?
+    {
+        message_ids.push(prev_user.clone());
+        carry_over_user_id = Some(prev_user);
+    }
+
+    let attachments =
+        load_safe_attachments_for_message_ids(db, &message_ids, carry_over_user_id.as_deref())?;
+    let completed_turns = db
+        .list_completed_turns_for_session(&session.id)
+        .map_err(|e| e.to_string())?;
+
+    Ok(ChatSnapshot {
+        session,
+        messages,
+        attachments,
+        completed_turns,
+        pending_controls,
+        has_more,
+        total_count,
+    })
+}
+
 /// `list_chat_sessions` IPC method — read-only DB query for a single
-/// workspace's sessions. CLI callers always have a workspace context
-/// (CLI is workspace-scoped by convention), so we require `workspace_id`.
-fn handle_list_chat_sessions(
+/// workspace's sessions, overlaid with live agent state.
+async fn handle_list_chat_sessions(
     app: &AppHandle,
     params: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
@@ -402,11 +644,161 @@ fn handle_list_chat_sessions(
         .get("include_archived")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let sessions = db
+        .list_chat_sessions_for_workspace(&workspace_id, include_archived)
+        .map_err(|e| e.to_string())?;
+    let agents = state.agents.read().await;
+    let hydrated: Vec<ChatSession> = sessions
+        .into_iter()
+        .map(|s| hydrate_session(s, &agents))
+        .collect();
+    serde_json::to_value(hydrated).map_err(|e| e.to_string())
+}
+
+async fn handle_get_chat_session(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let session = db
+        .get_chat_session(&chat_session_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Session not found")?;
+    let agents = state.agents.read().await;
+    serde_json::to_value(hydrate_session(session, &agents)).map_err(|e| e.to_string())
+}
+
+async fn handle_get_chat_snapshot(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let limit = clamp_snapshot_limit(params);
+    let before_message_id = params
+        .get("before_message_id")
+        .or_else(|| params.get("beforeMessageId"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| "AppState not initialised".to_string())?;
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    let session = db
+        .get_chat_session(&chat_session_id)
+        .map_err(|e| e.to_string())?
+        .ok_or("Session not found")?;
+    let messages = db
+        .list_chat_messages_page(&chat_session_id, limit, before_message_id.as_deref())
+        .map_err(|e| e.to_string())?;
+    let agents = state.agents.read().await;
+    let pending_controls = pending_controls_for_session(agents.get(&chat_session_id));
+    let session = hydrate_session(session, &agents);
+    drop(agents);
+
+    let snapshot = build_chat_snapshot(
+        &db,
+        session,
+        messages,
+        limit,
+        before_message_id.as_deref(),
+        pending_controls,
+    )?;
+    serde_json::to_value(snapshot).map_err(|e| e.to_string())
+}
+
+fn handle_load_completed_turns(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
     with_db(app, |db| {
-        db.list_chat_sessions_for_workspace(&workspace_id, include_archived)
+        db.list_completed_turns_for_session(&chat_session_id)
             .map(|v| serde_json::to_value(v).unwrap_or_default())
             .map_err(|e| e.to_string())
     })
+}
+
+fn handle_load_attachments_for_session(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    with_db(app, |db| {
+        let messages = db
+            .list_chat_messages_for_session(&chat_session_id)
+            .map_err(|e| e.to_string())?;
+        let message_ids: Vec<String> = messages.iter().map(|m| m.id.clone()).collect();
+        let attachments = load_safe_attachments_for_message_ids(db, &message_ids, None)?;
+        serde_json::to_value(attachments).map_err(|e| e.to_string())
+    })
+}
+
+fn handle_load_attachment_data(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let attachment_id = params
+        .get("attachment_id")
+        .or_else(|| params.get("attachmentId"))
+        .and_then(|v| v.as_str())
+        .ok_or("missing attachment_id")?;
+    with_db(app, |db| {
+        let att = db
+            .get_attachment(attachment_id)
+            .map_err(|e| e.to_string())?
+            .ok_or("Attachment not found")?;
+        Ok(json!(base64_encode(&att.data)))
+    })
+}
+
+async fn handle_create_chat_session(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let workspace_id = params
+        .get("workspace_id")
+        .and_then(|v| v.as_str())
+        .ok_or("missing workspace_id")?
+        .to_string();
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let session = crate::commands::chat::session::create_chat_session(workspace_id, state).await?;
+    serde_json::to_value(session).map_err(|e| e.to_string())
+}
+
+async fn handle_rename_chat_session(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or("missing name")?
+        .to_string();
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    crate::commands::chat::session::rename_chat_session(chat_session_id, name, state).await?;
+    Ok(json!({ "ok": true }))
+}
+
+async fn handle_archive_chat_session(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let fresh =
+        crate::commands::chat::session::archive_chat_session(app.clone(), chat_session_id, state)
+            .await?;
+    serde_json::to_value(fresh).map_err(|e| e.to_string())
 }
 
 /// `send_chat_message` IPC method — delegates to the existing Tauri
@@ -427,9 +819,9 @@ async fn handle_send_chat_message(
     let state: tauri::State<'_, AppState> = app.state::<AppState>();
     crate::commands::chat::send::send_chat_message(
         parsed.session_id,
-        None,
+        parsed.message_id,
         parsed.content,
-        None,
+        parsed.mentioned_files,
         parsed.permission_level,
         parsed.model,
         parsed.fast_mode,
@@ -438,7 +830,7 @@ async fn handle_send_chat_message(
         parsed.effort,
         parsed.chrome_enabled,
         parsed.disable_1m_context,
-        None,
+        parsed.attachments,
         app.clone(),
         state,
     )
@@ -450,10 +842,12 @@ async fn handle_send_chat_message(
 /// so the IPC surface (and therefore the `claudette` CLI) can drive a
 /// turn with the same fidelity as the GUI's "Send" button. Mirrors
 /// `AgentSettings` 1:1 — a new field there should grow a field here.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Default)]
 pub(crate) struct SendChatParams {
     pub session_id: String,
+    pub message_id: Option<String>,
     pub content: String,
+    pub mentioned_files: Option<Vec<String>>,
     pub model: Option<String>,
     pub fast_mode: Option<bool>,
     pub thinking_enabled: Option<bool>,
@@ -462,6 +856,7 @@ pub(crate) struct SendChatParams {
     pub chrome_enabled: Option<bool>,
     pub disable_1m_context: Option<bool>,
     pub permission_level: Option<String>,
+    pub attachments: Option<Vec<crate::commands::chat::AttachmentInput>>,
 }
 
 /// Parse the JSON params object the IPC sends. Tolerant of both
@@ -486,7 +881,12 @@ pub(crate) fn parse_send_chat_params(params: &serde_json::Value) -> Result<SendC
     let bool_param = |key: &str| params.get(key).and_then(|v| v.as_bool());
     Ok(SendChatParams {
         session_id,
+        message_id: str_param("message_id").or_else(|| str_param("messageId")),
         content,
+        mentioned_files: params
+            .get("mentioned_files")
+            .or_else(|| params.get("mentionedFiles"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok()),
         model: str_param("model"),
         fast_mode: bool_param("fast_mode"),
         thinking_enabled: bool_param("thinking_enabled"),
@@ -495,7 +895,137 @@ pub(crate) fn parse_send_chat_params(params: &serde_json::Value) -> Result<SendC
         chrome_enabled: bool_param("chrome_enabled"),
         disable_1m_context: bool_param("disable_1m_context"),
         permission_level: str_param("permission_level"),
+        attachments: params
+            .get("attachments")
+            .and_then(|v| serde_json::from_value(v.clone()).ok()),
     })
+}
+
+async fn handle_steer_queued_chat_message(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let content = params
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or("missing content")?
+        .to_string();
+    let message_id = params
+        .get("message_id")
+        .or_else(|| params.get("messageId"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let mentioned_files = params
+        .get("mentioned_files")
+        .or_else(|| params.get("mentionedFiles"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let attachments = params
+        .get("attachments")
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    let checkpoint = crate::commands::chat::send::steer_queued_chat_message(
+        chat_session_id,
+        message_id,
+        content,
+        mentioned_files,
+        attachments,
+        state,
+    )
+    .await?;
+    serde_json::to_value(checkpoint).map_err(|e| e.to_string())
+}
+
+async fn handle_stop_agent(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    crate::commands::chat::lifecycle::stop_agent(chat_session_id, app.clone(), state).await?;
+    Ok(json!({ "ok": true }))
+}
+
+async fn handle_reset_agent_session(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    crate::commands::chat::lifecycle::reset_agent_session(chat_session_id, app.clone(), state)
+        .await?;
+    Ok(json!({ "ok": true }))
+}
+
+async fn handle_clear_attention(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    crate::commands::chat::interaction::clear_attention(chat_session_id, app.clone(), state)
+        .await?;
+    Ok(json!({ "ok": true }))
+}
+
+async fn handle_submit_agent_answer(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let tool_use_id = params
+        .get("tool_use_id")
+        .or_else(|| params.get("toolUseId"))
+        .and_then(|v| v.as_str())
+        .ok_or("missing tool_use_id")?
+        .to_string();
+    let answers: std::collections::HashMap<String, String> = params
+        .get("answers")
+        .cloned()
+        .ok_or_else(|| "missing answers".to_string())
+        .and_then(|v| serde_json::from_value(v).map_err(|e| e.to_string()))?;
+    let annotations = params.get("annotations").cloned();
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    crate::commands::chat::interaction::submit_agent_answer(
+        chat_session_id,
+        tool_use_id,
+        answers,
+        annotations,
+        state,
+    )
+    .await?;
+    Ok(json!({ "ok": true }))
+}
+
+async fn handle_submit_plan_approval(
+    app: &AppHandle,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let chat_session_id = param_chat_session_id(params)?;
+    let tool_use_id = params
+        .get("tool_use_id")
+        .or_else(|| params.get("toolUseId"))
+        .and_then(|v| v.as_str())
+        .ok_or("missing tool_use_id")?
+        .to_string();
+    let approved = params
+        .get("approved")
+        .and_then(|v| v.as_bool())
+        .ok_or("missing approved")?;
+    let reason = params
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let state: tauri::State<'_, AppState> = app.state::<AppState>();
+    crate::commands::chat::interaction::submit_plan_approval(
+        chat_session_id,
+        tool_use_id,
+        approved,
+        reason,
+        state,
+    )
+    .await?;
+    Ok(json!({ "ok": true }))
 }
 
 /// Delegates to the shared `commands::workspace::archive_workspace_inner`
@@ -704,7 +1234,257 @@ fn build_workspace_info(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claudette::model::{Repository, Workspace, WorkspaceStatus};
     use serde_json::json;
+    use std::collections::HashMap;
+
+    fn make_repo(id: &str) -> Repository {
+        Repository {
+            id: id.into(),
+            path: format!("/tmp/{id}"),
+            name: id.into(),
+            path_slug: id.into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+        }
+    }
+
+    fn make_workspace(id: &str, repo_id: &str) -> Workspace {
+        Workspace {
+            id: id.into(),
+            repository_id: repo_id.into(),
+            name: id.into(),
+            branch_name: format!("claudette/{id}"),
+            worktree_path: Some(format!("/tmp/{id}")),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+            sort_order: 0,
+        }
+    }
+
+    fn make_chat_msg(
+        id: &str,
+        workspace_id: &str,
+        chat_session_id: &str,
+        role: ChatRole,
+        content: &str,
+    ) -> ChatMessage {
+        ChatMessage {
+            id: id.into(),
+            workspace_id: workspace_id.into(),
+            chat_session_id: chat_session_id.into(),
+            role,
+            content: content.into(),
+            cost_usd: None,
+            duration_ms: None,
+            created_at: String::new(),
+            thinking: None,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        }
+    }
+
+    fn make_attachment(id: &str, message_id: &str, media_type: &str, data: &[u8]) -> Attachment {
+        Attachment {
+            id: id.into(),
+            message_id: message_id.into(),
+            filename: format!("{id}.dat"),
+            media_type: media_type.into(),
+            data: data.to_vec(),
+            width: None,
+            height: None,
+            size_bytes: data.len() as i64,
+            created_at: String::new(),
+            origin: AttachmentOrigin::User,
+            tool_use_id: None,
+        }
+    }
+
+    fn fresh_agent_state(
+        session_id: &str,
+        active_pid: Option<u32>,
+    ) -> crate::state::AgentSessionState {
+        crate::state::AgentSessionState {
+            workspace_id: "w1".into(),
+            session_id: session_id.into(),
+            turn_count: 1,
+            active_pid,
+            custom_instructions: None,
+            needs_attention: false,
+            attention_kind: None,
+            attention_notification_sent: false,
+            persistent_session: None,
+            mcp_config_dirty: false,
+            session_plan_mode: false,
+            session_allowed_tools: Vec::new(),
+            session_disable_1m_context: false,
+            pending_permissions: HashMap::new(),
+            running_background_tasks: Default::default(),
+            background_wake_active: false,
+            session_exited_plan: false,
+            session_resolved_env: Default::default(),
+            mcp_bridge: None,
+            last_user_msg_id: None,
+            posted_env_trust_warning: false,
+        }
+    }
+
+    #[test]
+    fn capabilities_methods_include_chat_orchestration_surface() {
+        for method in [
+            "get_chat_session",
+            "get_chat_snapshot",
+            "load_completed_turns",
+            "load_attachments_for_session",
+            "load_attachment_data",
+            "create_chat_session",
+            "rename_chat_session",
+            "archive_chat_session",
+            "stop_agent",
+            "reset_agent_session",
+            "clear_attention",
+            "submit_agent_answer",
+            "submit_plan_approval",
+            "steer_queued_chat_message",
+        ] {
+            assert!(METHODS.contains(&method), "{method} missing from METHODS");
+        }
+    }
+
+    #[test]
+    fn build_chat_snapshot_returns_paginated_messages_and_safe_attachments() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1")).unwrap();
+        let session_id = db.default_session_id_for_workspace("w1").unwrap().unwrap();
+
+        db.insert_chat_message(&make_chat_msg(
+            "m1",
+            "w1",
+            &session_id,
+            ChatRole::User,
+            "first",
+        ))
+        .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            "m2",
+            "w1",
+            &session_id,
+            ChatRole::Assistant,
+            "second",
+        ))
+        .unwrap();
+        db.insert_chat_message(&make_chat_msg(
+            "m3",
+            "w1",
+            &session_id,
+            ChatRole::User,
+            "third",
+        ))
+        .unwrap();
+        db.insert_attachment(&make_attachment("a-text", "m3", "text/plain", b"hello"))
+            .unwrap();
+        db.insert_attachment(&make_attachment("a-image", "m3", "image/png", b"\x89PNG"))
+            .unwrap();
+
+        let session = db.get_chat_session(&session_id).unwrap().unwrap();
+        let messages = db.list_chat_messages_page(&session_id, 2, None).unwrap();
+        let snapshot = build_chat_snapshot(&db, session, messages, 2, None, Vec::new()).unwrap();
+
+        assert_eq!(snapshot.total_count, 3);
+        assert!(snapshot.has_more);
+        assert_eq!(
+            snapshot
+                .messages
+                .iter()
+                .map(|m| m.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["m2", "m3"]
+        );
+        let text = snapshot
+            .attachments
+            .iter()
+            .find(|a| a.id == "a-text")
+            .unwrap();
+        assert_eq!(text.text_content.as_deref(), Some("hello"));
+        let image = snapshot
+            .attachments
+            .iter()
+            .find(|a| a.id == "a-image")
+            .unwrap();
+        assert!(image.text_content.is_none());
+    }
+
+    #[test]
+    fn hydrate_session_overlays_live_agent_status_and_attention() {
+        let mut session = ChatSession {
+            id: "s1".into(),
+            workspace_id: "w1".into(),
+            session_id: None,
+            name: "New chat".into(),
+            name_edited: false,
+            turn_count: 0,
+            sort_order: 0,
+            status: claudette::model::SessionStatus::Active,
+            created_at: String::new(),
+            archived_at: None,
+            agent_status: AgentStatus::Idle,
+            needs_attention: false,
+            attention_kind: None,
+        };
+        let mut agent = fresh_agent_state("claude-s1", Some(123));
+        agent.needs_attention = true;
+        agent.attention_kind = Some(crate::state::AttentionKind::Ask);
+        let agents = HashMap::from([(session.id.clone(), agent)]);
+
+        session = hydrate_session(session, &agents);
+        assert_eq!(session.agent_status, AgentStatus::Running);
+        assert!(session.needs_attention);
+        assert_eq!(
+            session.attention_kind,
+            Some(claudette::model::AttentionKind::Ask)
+        );
+    }
+
+    #[test]
+    fn pending_controls_serialize_input_and_kind() {
+        let mut agent = fresh_agent_state("claude-s1", None);
+        agent.pending_permissions.insert(
+            "toolu_ask".into(),
+            crate::state::PendingPermission {
+                request_id: "req-1".into(),
+                tool_name: "AskUserQuestion".into(),
+                original_input: json!({"questions": [{"question": "Proceed?"}]}),
+            },
+        );
+        agent.pending_permissions.insert(
+            "toolu_plan".into(),
+            crate::state::PendingPermission {
+                request_id: "req-2".into(),
+                tool_name: "ExitPlanMode".into(),
+                original_input: json!({"plan": "Do it"}),
+            },
+        );
+
+        let controls = pending_controls_for_session(Some(&agent));
+        assert_eq!(controls.len(), 2);
+        assert_eq!(controls[0].tool_use_id, "toolu_ask");
+        assert_eq!(controls[0].kind, PendingAgentControlKind::AskUserQuestion);
+        assert_eq!(controls[0].input["questions"][0]["question"], "Proceed?");
+        assert_eq!(controls[1].kind, PendingAgentControlKind::ExitPlanMode);
+    }
 
     /// Regression: the IPC handler historically dropped every agent-
     /// setting flag except model / plan_mode / permission_level. CLI

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -554,6 +554,52 @@ mod tests {
         assert!(!present);
     }
 
+    /// Regression: dev DBs that ran migration `20260505214219` before
+    /// commit `2fc1b316` amended its SQL recorded the migration id as
+    /// applied without ever picking up the late-added
+    /// `agent_tool_calls_json` column. The follow-up healing migration
+    /// `20260506170933_heal_turn_tool_activity_agent_tool_calls_json`
+    /// restores the column on those DBs and is a no-op (via the
+    /// runner's "already exists" leniency) on clean installs.
+    #[test]
+    fn test_heal_migration_restores_missing_agent_tool_calls_json_column() {
+        let db = Database::open_in_memory().unwrap();
+
+        // Simulate the broken state: drop the column that the amended
+        // migration was supposed to add, and forget that the healing
+        // migration ever ran so the runner replays it.
+        db.execute_batch("ALTER TABLE turn_tool_activities DROP COLUMN agent_tool_calls_json;")
+            .unwrap();
+        db.conn()
+            .execute(
+                "DELETE FROM schema_migrations WHERE id = ?1",
+                params!["20260506170933_heal_turn_tool_activity_agent_tool_calls_json"],
+            )
+            .unwrap();
+        let column_exists = |name: &str| -> bool {
+            db.conn()
+                .query_row(
+                    "SELECT COUNT(*) FROM pragma_table_info('turn_tool_activities') WHERE name = ?1",
+                    params![name],
+                    |r| r.get::<_, i64>(0),
+                )
+                .unwrap()
+                > 0
+        };
+        assert!(!column_exists("agent_tool_calls_json"));
+
+        // Re-running the canonical migrations should now heal the DB.
+        db.run_migrations_for_test()
+            .expect("healing migration must apply cleanly");
+        assert!(column_exists("agent_tool_calls_json"));
+
+        // And running it a second time on a healed DB must remain a
+        // no-op via the runner's duplicate-column leniency.
+        db.run_migrations_for_test()
+            .expect("healing migration must be idempotent");
+        assert!(column_exists("agent_tool_calls_json"));
+    }
+
     #[test]
     fn test_is_already_exists_error_classifier() {
         let conn = rusqlite::Connection::open_in_memory().unwrap();

--- a/src/migrations/20260506170933_heal_turn_tool_activity_agent_tool_calls_json.sql
+++ b/src/migrations/20260506170933_heal_turn_tool_activity_agent_tool_calls_json.sql
@@ -1,0 +1,10 @@
+-- Heals dev DBs that recorded migration `20260505214219` as applied
+-- before commit 2fc1b316 amended that migration to add the
+-- `agent_tool_calls_json` column. Because `schema_migrations` is keyed
+-- by id, the amended SQL is never re-run, leaving the column missing
+-- and breaking `list_completed_turns_for_session` (and therefore the
+-- `chat show` / `chat turns` IPC paths). Single statement so the
+-- runner's "already exists" leniency tolerates DBs that already have
+-- the column from a clean install.
+ALTER TABLE turn_tool_activities
+    ADD COLUMN agent_tool_calls_json TEXT NOT NULL DEFAULT '[]';

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -179,4 +179,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260505214219_turn_tool_activity_chronology.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260506170933_heal_turn_tool_activity_agent_tool_calls_json",
+        sql: include_str!("20260506170933_heal_turn_tool_activity_agent_tool_calls_json.sql"),
+        legacy_version: None,
+    },
 ];


### PR DESCRIPTION
Extends the local IPC surface from "list + send" to a full chat orchestration API so the CLI (and any future RPC consumer) can drive a session with the same fidelity as the GUI.

## What's new

**Reads** (paginated, response-bounded):
- `get_chat_session` — single session, hydrated with live agent state
- `get_chat_snapshot` — session metadata + recent messages + completed turns + attachment metadata + pending controls in one bounded call
- `load_completed_turns`, `load_attachments_for_session`, `load_attachment_data`

**Writes / control:**
- `create_chat_session`, `rename_chat_session`, `archive_chat_session`
- `send_chat_message` extended to thread `message_id`, `mentioned_files`, and `attachments` through to the same Tauri command the GUI uses
- `steer_queued_chat_message`, `stop_agent`, `reset_agent_session`, `clear_attention`
- `submit_agent_answer` (AskUserQuestion), `submit_plan_approval` (ExitPlanMode)

**CLI:**
`claudette chat show / turns / attachments / attachment-data / create / rename / archive / stop / reset / clear-attention / answer / approve-plan / deny-plan / steer`. `@file` and `-` (stdin) are honored for prompts and `--answers-json`.

**Layering:** every IPC handler is a thin wrapper that delegates to `commands::chat::{send,session,lifecycle,interaction}` — same code path as the GUI, no duplicated state-machine logic.

**Response safety:** snapshots cap inline text at 16 KiB per attachment plus 512 KiB aggregate per response (full bytes via `load_attachment_data`); pagination uses a peek-+1 strategy so `has_more` is exact; attachment lists preserve the input message order and include `created_at`; `AppState` lookup is uniform via a single `app_state()` helper that returns `Result` instead of panicking.

**Docs:** README and `.claude/skills/claudette/SKILL.md` updated; SKILL `description` / `when_to_use` broadened so the agent routes there for "inspect chat", "answer pending question", etc.

## Bug fixes uncovered while smoke-testing

- **`fix(db)`**: migration `20260505214219` was edited after release on main (commit `2fc1b316` appended `agent_tool_calls_json`). DBs that ran the original SQL have the migration's id recorded as applied → the runner skips the amended migration forever → column never lands → `list_completed_turns_for_session` fails. Added healing migration `20260506170933_heal_turn_tool_activity_agent_tool_calls_json` (single-statement so the runner's duplicate-column leniency makes it a no-op on clean installs). Tracked the broader cleanup as #649.
- **`fix(cli)`**: serde collapses present-`null` into `None` on `Option<Value>`, so `archive_chat_session` returning `null` (the "another session is still active" path) made the CLI report `response had neither result nor error` on every archive. Treat `(None, None)` as success-with-null per JSON-RPC.

## Tests

- IPC: snapshot pagination + carry-over user-message attachment filter, hydration overlay, pending-control serialization, capability-list completeness (catches "new method but forgot `METHODS`" foot-gun), tri-state send-param preservation, malformed-collection rejection, peek-+1 `has_more`, attachment ordering + inline-text cap.
- CLI: `build_show_params`, `build_answer_params` (object validation + `@file`), `build_send_params` (tri-state), `resolve_prompt`, RPC null-result regression.
- DB: regression test that drops `agent_tool_calls_json`, replays the runner, asserts heal + idempotent re-run.

## End-to-end smoke (against local dev app)

- create session → rename → `send` haiku-model prompt → poll `get_chat_session` until Idle → `chat show` returns the assistant reply with cost/duration → `chat turns` (the previously broken path) succeeds → `archive` returns `null` cleanly.
- All control endpoints (answer / approve-plan / deny-plan / steer / stop / reset / clear-attention) surface clean structured errors when called against an idle session.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- New tests pass: 12 IPC, 5 CLI chat, 1 DB regression, 2 CLI ipc round-trip
- Live round-trip against the running dev app

## Related

- #649 — harden migration runner against edited-released migrations (follow-up cleanup)