### PR TITLE
fix(plugins): use unified claude CLI resolver in marketplace commands

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -369,6 +369,18 @@ pub async fn run_claude_plugin_command(
     // `MISSING_CLI:claude` sentinel so the UI can render the install-CTA
     // modal instead of leaking a bare `os error 2`.
     let claude_path = crate::agent::resolve_claude_path().await;
+    // Defensive guard: if resolution fell through to the bare-name fallback
+    // (no absolute install found anywhere on PATH or in well-known
+    // locations), surface the install-CTA modal directly instead of
+    // spawning. A bare `Command::new("claude")` would still go through the
+    // OS PATH search at exec time, and a misconfigured PATH containing a
+    // relative entry like `.` could in principle resolve to an unintended
+    // binary. The agent spawn paths tolerate the bare fallback (the spawn
+    // is wrapped in `map_spawn_err` and ENOENT is converted to MISSING_CLI
+    // anyway), but the marketplace surface has no such retry value.
+    if !Path::new(&claude_path).is_absolute() {
+        return Err(crate::missing_cli::format_err("claude"));
+    }
     let current_dir = plugin_command_cwd(repo_path);
 
     let output = tokio::process::Command::new(&claude_path)

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -356,19 +356,19 @@ pub async fn run_claude_plugin_command(
     repo_path: Option<&Path>,
     args: &[String],
 ) -> Result<String, String> {
-    // Resolve claude up front. If it genuinely isn't on the enriched PATH,
-    // return the structured `MISSING_CLI:claude` sentinel so the Tauri/UI
-    // layer can render the install-CTA modal (see `crate::missing_cli`)
-    // instead of leaking a bare `os error 2` (issue #641).
+    // Resolve claude using the same multi-step lookup as the rest of the
+    // app (process PATH → login-shell PATH → well-known install locations →
+    // bare `"claude"` fallback). This matches `agent::run_turn` and friends
+    // so a working main-app install also works for the plugin marketplace
+    // page (issue #641: GUI launches on macOS don't inherit the shell PATH,
+    // and `which_in_enriched_path` skips the well-known fallbacks that
+    // `resolve_claude_path` checks).
     //
-    // Only `CannotFindBinaryPath` means "binary not found" — other variants
-    // (`CannotGetCurrentDirAndPathListEmpty`, `CannotCanonicalize`) signal
-    // real I/O / cwd issues that the user shouldn't be told to "install
-    // claude" to fix. Surface those with their original message instead.
-    let claude_path = crate::env::which_in_enriched_path("claude").map_err(|e| match e {
-        which::Error::CannotFindBinaryPath => crate::missing_cli::format_err("claude"),
-        other => format!("Failed to resolve `claude` on PATH: {other}"),
-    })?;
+    // If `resolve_claude_path` falls through to the bare-name fallback and
+    // that fails to spawn with ENOENT, `map_spawn_err` converts it to the
+    // `MISSING_CLI:claude` sentinel so the UI can render the install-CTA
+    // modal instead of leaking a bare `os error 2`.
+    let claude_path = crate::agent::resolve_claude_path().await;
     let current_dir = plugin_command_cwd(repo_path);
 
     let output = tokio::process::Command::new(&claude_path)


### PR DESCRIPTION
Follow-up to #642 / refs #641.

`run_claude_plugin_command` (src/plugin.rs) was calling `crate::env::which_in_enriched_path("claude")`, which only walks the enriched PATH. Every other claude spawn site in the app (`agent::run_turn`, `agent::generate_branch_name`, `agent::generate_session_name`, `PersistentSession`) calls `crate::agent::resolve_claude_path()`, which layers well-known install locations on top of the PATH search.

So a user whose `claude` lives in e.g. `~/.claude/local/claude` or `/opt/homebrew/bin/claude` — and whose GUI-launched process PATH doesn't include those dirs — would have a fully working main app but a broken **Settings → Claude Code Plugins** page (issue #641's `No such file or directory (os error 2)`).

This PR consolidates onto the shared resolver, so the plugin marketplace path now matches the agent path exactly. The `MISSING_CLI:claude` install-CTA still surfaces: when the resolver falls through to the bare `claude` fallback and the spawn fails with ENOENT, `map_spawn_err` converts it to the structured sentinel — same pattern as `agent/naming.rs`.

## Audit

I checked every `claude`-binary lookup in the codebase:

| Site | Status |
|---|---|
| `agent/naming.rs`, `agent/process.rs`, `agent/session.rs` | ✅ already use `resolve_claude_path()` |
| `plugin.rs` (`run_claude_plugin_command`) | ❌ → ✅ this PR |
| `mcp_supervisor.rs:185` | n/a — generic stdio MCP `command` field, not claude-specific |
| `plugin_runtime/mod.rs:529` | n/a — generic `required_clis` checks (`gh`, `glab`) |

## Test plan

- `cargo clippy -p claudette --all-targets` — clean
- `cargo test -p claudette plugin` — 168 passed, 0 failed
- Manual: a user reporting the bug would see the marketplace list populate after this fix on a setup where their main agent already works.