### PR TITLE
fix(file-viewer,zoom): correct context-menu offset under html zoom

### DIFF
--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -45,6 +45,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "happy-dom": "^20.0.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
@@ -341,6 +342,10 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
 
     "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA=="],
@@ -547,7 +552,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
@@ -608,6 +613,8 @@
     "globals": ["globals@17.5.0", "", {}, "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1035,11 +1042,15 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -1080,6 +1091,8 @@
     "monaco-editor/marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "happy-dom": "^20.0.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -5,6 +5,10 @@ import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
 import { useAppStore } from "../../stores/useAppStore";
 import {
+  AttachmentContextMenu,
+  type AttachmentContextMenuItem,
+} from "../chat/AttachmentContextMenu";
+import {
   useGitGutter,
   type DecorationsCollection,
 } from "./useGitGutter";
@@ -68,6 +72,15 @@ export const MonacoEditor = memo(function MonacoEditor({
   // remounts via `key={path}` on file switches so the seed stays correct.
   const [currentBuffer, setCurrentBuffer] = useState(initialValue);
 
+  // Right-click position for our portal context menu. Monaco's built-in menu
+  // ignores html `zoom` and lands offset from the cursor; we disable it via
+  // the `contextmenu: false` option below and route right-clicks through
+  // `AttachmentContextMenu`, which already compensates for engine-specific
+  // event-coord semantics. See utils/zoom.ts for the engine probe.
+  const [editorMenu, setEditorMenu] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
   const minimapEnabled = useAppStore((s) => s.editorMinimapEnabled);
 
   // Reflect readOnly changes into the editor without remounting. Monaco's
@@ -119,6 +132,39 @@ export const MonacoEditor = memo(function MonacoEditor({
       monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
       () => onSaveRef.current?.(),
     );
+    // Replace Monaco's built-in context menu with our portal-mounted one.
+    // The DOM listener has to live on the editor's outer node so it fires
+    // for clicks anywhere inside (gutter included) — capture-phase to win
+    // against any inner handler. Monaco still owns the actions; we just
+    // own the chrome.
+    const dom = editor.getDomNode();
+    if (dom) {
+      const onContext = (e: MouseEvent) => {
+        // Drive selection from the click before opening the menu, mirroring
+        // what Monaco's own menu does. Without this, "Cut" / "Copy" would
+        // run against whatever was selected before — surprising on a fresh
+        // right-click into empty whitespace.
+        const target = editor.getTargetAtClientPoint(e.clientX, e.clientY);
+        if (target?.position) {
+          const sel = editor.getSelection();
+          const inSel =
+            sel && !sel.isEmpty() && sel.containsPosition(target.position);
+          if (!inSel) {
+            editor.setPosition(target.position);
+            editor.focus();
+          }
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        setEditorMenu({ x: e.clientX, y: e.clientY });
+      };
+      dom.addEventListener("contextmenu", onContext, true);
+      // Stash the cleanup on the editor instance via a disposable so the
+      // existing unmount path tears it down without a separate ref.
+      editor.onDidDispose(() => {
+        dom.removeEventListener("contextmenu", onContext, true);
+      });
+    }
   };
 
   const handleEditorChange = useCallback((value: string | undefined) => {
@@ -128,6 +174,71 @@ export const MonacoEditor = memo(function MonacoEditor({
   }, []);
 
   useGitGutter(monacoRef, gutterCollectionRef, workspaceId, filename, currentBuffer);
+
+  // Build the menu items off the live editor instance so we only show
+  // actions Monaco actually exposes — clipboard action IDs are documented
+  // to be missing in some Monaco builds, so each entry is null-checked
+  // before being added (see microsoft/monaco-editor#2598).
+  const buildEditorMenuItems = useCallback((): AttachmentContextMenuItem[] => {
+    const editor = editorRef.current;
+    if (!editor) return [];
+    const run = (id: string) => {
+      const action = editor.getAction(id);
+      if (action) void action.run();
+    };
+    const has = (id: string) => editor.getAction(id) != null;
+    const sel = editor.getSelection();
+    const hasSelection = !!sel && !sel.isEmpty();
+    const items: AttachmentContextMenuItem[] = [];
+    if (has("editor.action.goToDeclaration")) {
+      items.push({
+        label: "Go to Definition",
+        onSelect: () => run("editor.action.goToDeclaration"),
+      });
+    }
+    if (has("editor.action.changeAll")) {
+      items.push({
+        label: "Change All Occurrences",
+        onSelect: () => run("editor.action.changeAll"),
+        disabled: readOnly,
+      });
+    }
+    if (has("editor.action.formatDocument")) {
+      items.push({
+        label: "Format Document",
+        onSelect: () => run("editor.action.formatDocument"),
+        disabled: readOnly,
+      });
+    }
+    if (has("editor.action.clipboardCutAction")) {
+      items.push({
+        label: "Cut",
+        onSelect: () => run("editor.action.clipboardCutAction"),
+        disabled: readOnly || !hasSelection,
+      });
+    }
+    if (has("editor.action.clipboardCopyAction")) {
+      items.push({
+        label: "Copy",
+        onSelect: () => run("editor.action.clipboardCopyAction"),
+        disabled: !hasSelection,
+      });
+    }
+    if (has("editor.action.clipboardPasteAction")) {
+      items.push({
+        label: "Paste",
+        onSelect: () => run("editor.action.clipboardPasteAction"),
+        disabled: readOnly,
+      });
+    }
+    if (has("editor.action.quickCommand")) {
+      items.push({
+        label: "Command Palette",
+        onSelect: () => run("editor.action.quickCommand"),
+      });
+    }
+    return items;
+  }, [readOnly]);
 
   return (
     <div className={styles.host}>
@@ -150,6 +261,13 @@ export const MonacoEditor = memo(function MonacoEditor({
           renderWhitespace: "selection",
           stickyScroll: { enabled: false },
           automaticLayout: true,
+          // Monaco's built-in context menu ignores html `zoom` and lands
+          // offset from the cursor under non-default UI font sizes. We
+          // suppress it and render `AttachmentContextMenu` instead, which
+          // compensates for engine-specific clientX semantics. See
+          // utils/zoom.ts for the engine probe and microsoft/monaco-editor#1203
+          // (still open) for upstream's tracking issue.
+          contextmenu: false,
           // Literal stack rather than `var(--font-mono)`: Monaco computes
           // character widths via `canvas.measureText`, which does not
           // resolve CSS variables. Mismatched widths cause cursor and
@@ -162,6 +280,14 @@ export const MonacoEditor = memo(function MonacoEditor({
           fontSize: 13,
         }}
       />
+      {editorMenu ? (
+        <AttachmentContextMenu
+          x={editorMenu.x}
+          y={editorMenu.y}
+          items={buildEditorMenuItems()}
+          onClose={() => setEditorMenu(null)}
+        />
+      ) : null}
     </div>
   );
 });

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -5,10 +5,6 @@ import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
 import { useAppStore } from "../../stores/useAppStore";
 import {
-  AttachmentContextMenu,
-  type AttachmentContextMenuItem,
-} from "../chat/AttachmentContextMenu";
-import {
   useGitGutter,
   type DecorationsCollection,
 } from "./useGitGutter";
@@ -72,15 +68,6 @@ export const MonacoEditor = memo(function MonacoEditor({
   // remounts via `key={path}` on file switches so the seed stays correct.
   const [currentBuffer, setCurrentBuffer] = useState(initialValue);
 
-  // Right-click position for our portal context menu. Monaco's built-in menu
-  // ignores html `zoom` and lands offset from the cursor; we disable it via
-  // the `contextmenu: false` option below and route right-clicks through
-  // `AttachmentContextMenu`, which already compensates for engine-specific
-  // event-coord semantics. See utils/zoom.ts for the engine probe.
-  const [editorMenu, setEditorMenu] = useState<{ x: number; y: number } | null>(
-    null,
-  );
-
   const minimapEnabled = useAppStore((s) => s.editorMinimapEnabled);
 
   // Reflect readOnly changes into the editor without remounting. Monaco's
@@ -132,39 +119,6 @@ export const MonacoEditor = memo(function MonacoEditor({
       monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
       () => onSaveRef.current?.(),
     );
-    // Replace Monaco's built-in context menu with our portal-mounted one.
-    // The DOM listener has to live on the editor's outer node so it fires
-    // for clicks anywhere inside (gutter included) — capture-phase to win
-    // against any inner handler. Monaco still owns the actions; we just
-    // own the chrome.
-    const dom = editor.getDomNode();
-    if (dom) {
-      const onContext = (e: MouseEvent) => {
-        // Drive selection from the click before opening the menu, mirroring
-        // what Monaco's own menu does. Without this, "Cut" / "Copy" would
-        // run against whatever was selected before — surprising on a fresh
-        // right-click into empty whitespace.
-        const target = editor.getTargetAtClientPoint(e.clientX, e.clientY);
-        if (target?.position) {
-          const sel = editor.getSelection();
-          const inSel =
-            sel && !sel.isEmpty() && sel.containsPosition(target.position);
-          if (!inSel) {
-            editor.setPosition(target.position);
-            editor.focus();
-          }
-        }
-        e.preventDefault();
-        e.stopPropagation();
-        setEditorMenu({ x: e.clientX, y: e.clientY });
-      };
-      dom.addEventListener("contextmenu", onContext, true);
-      // Stash the cleanup on the editor instance via a disposable so the
-      // existing unmount path tears it down without a separate ref.
-      editor.onDidDispose(() => {
-        dom.removeEventListener("contextmenu", onContext, true);
-      });
-    }
   };
 
   const handleEditorChange = useCallback((value: string | undefined) => {
@@ -174,71 +128,6 @@ export const MonacoEditor = memo(function MonacoEditor({
   }, []);
 
   useGitGutter(monacoRef, gutterCollectionRef, workspaceId, filename, currentBuffer);
-
-  // Build the menu items off the live editor instance so we only show
-  // actions Monaco actually exposes — clipboard action IDs are documented
-  // to be missing in some Monaco builds, so each entry is null-checked
-  // before being added (see microsoft/monaco-editor#2598).
-  const buildEditorMenuItems = useCallback((): AttachmentContextMenuItem[] => {
-    const editor = editorRef.current;
-    if (!editor) return [];
-    const run = (id: string) => {
-      const action = editor.getAction(id);
-      if (action) void action.run();
-    };
-    const has = (id: string) => editor.getAction(id) != null;
-    const sel = editor.getSelection();
-    const hasSelection = !!sel && !sel.isEmpty();
-    const items: AttachmentContextMenuItem[] = [];
-    if (has("editor.action.goToDeclaration")) {
-      items.push({
-        label: "Go to Definition",
-        onSelect: () => run("editor.action.goToDeclaration"),
-      });
-    }
-    if (has("editor.action.changeAll")) {
-      items.push({
-        label: "Change All Occurrences",
-        onSelect: () => run("editor.action.changeAll"),
-        disabled: readOnly,
-      });
-    }
-    if (has("editor.action.formatDocument")) {
-      items.push({
-        label: "Format Document",
-        onSelect: () => run("editor.action.formatDocument"),
-        disabled: readOnly,
-      });
-    }
-    if (has("editor.action.clipboardCutAction")) {
-      items.push({
-        label: "Cut",
-        onSelect: () => run("editor.action.clipboardCutAction"),
-        disabled: readOnly || !hasSelection,
-      });
-    }
-    if (has("editor.action.clipboardCopyAction")) {
-      items.push({
-        label: "Copy",
-        onSelect: () => run("editor.action.clipboardCopyAction"),
-        disabled: !hasSelection,
-      });
-    }
-    if (has("editor.action.clipboardPasteAction")) {
-      items.push({
-        label: "Paste",
-        onSelect: () => run("editor.action.clipboardPasteAction"),
-        disabled: readOnly,
-      });
-    }
-    if (has("editor.action.quickCommand")) {
-      items.push({
-        label: "Command Palette",
-        onSelect: () => run("editor.action.quickCommand"),
-      });
-    }
-    return items;
-  }, [readOnly]);
 
   return (
     <div className={styles.host}>
@@ -261,13 +150,6 @@ export const MonacoEditor = memo(function MonacoEditor({
           renderWhitespace: "selection",
           stickyScroll: { enabled: false },
           automaticLayout: true,
-          // Monaco's built-in context menu ignores html `zoom` and lands
-          // offset from the cursor under non-default UI font sizes. We
-          // suppress it and render `AttachmentContextMenu` instead, which
-          // compensates for engine-specific clientX semantics. See
-          // utils/zoom.ts for the engine probe and microsoft/monaco-editor#1203
-          // (still open) for upstream's tracking issue.
-          contextmenu: false,
           // Literal stack rather than `var(--font-mono)`: Monaco computes
           // character widths via `canvas.measureText`, which does not
           // resolve CSS variables. Mismatched widths cause cursor and
@@ -280,14 +162,6 @@ export const MonacoEditor = memo(function MonacoEditor({
           fontSize: 13,
         }}
       />
-      {editorMenu ? (
-        <AttachmentContextMenu
-          x={editorMenu.x}
-          y={editorMenu.y}
-          items={buildEditorMenuItems()}
-          onClose={() => setEditorMenu(null)}
-        />
-      ) : null}
     </div>
   );
 });

--- a/src/ui/src/components/file-viewer/monacoSetup.ts
+++ b/src/ui/src/components/file-viewer/monacoSetup.ts
@@ -25,6 +25,7 @@ import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
 import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 import { applyGrammarsToMonaco } from "../../utils/grammarRegistry";
+import { installMonacoContextViewFix } from "../../utils/monacoContextViewFix";
 
 // Monaco reads `globalThis.MonacoEnvironment.getWorker` whenever it needs
 // to instantiate a language-service worker — that happens lazily, when an
@@ -63,6 +64,11 @@ self.MonacoEnvironment = {
 };
 
 loader.config({ monaco });
+
+// Patch `.context-view` positioning on WebKit under html zoom. No-op on
+// Chromium and at zoom == 1 — see utils/monacoContextViewFix.ts for the
+// engine matrix and why Monaco's built-in math is wrong here.
+installMonacoContextViewFix();
 
 // Register plugin-contributed languages and bind Shiki tokenization.
 // Awaits the grammar registry bootstrap internally — safe to call

--- a/src/ui/src/utils/monacoContextViewFix.dom.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.dom.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Integration tests for the Monaco `.context-view` positioning patch. These
+ * exercise the real MutationObserver wiring under happy-dom — what the
+ * pure-function tests in monacoContextViewFix.test.ts deliberately don't
+ * cover.
+ *
+ * Why this file exists: the first pass of this fix shipped a refactor
+ * (disconnect-around-write + per-host observer dedup) that the pure-math
+ * tests passed but that visibly broke the menu in the running app. The
+ * gap was that no test exercised the actual Monaco-side flow — element
+ * appended → observer fires → correction applied → potential re-write
+ * from observer feedback. Adding these tests is how we keep that gap
+ * closed.
+ */
+
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetCoordSpaceCache } from "./zoom";
+import {
+  __resetMonacoContextViewFixForTests,
+  installMonacoContextViewFix,
+} from "./monacoContextViewFix";
+
+// The engine probe in zoom.ts decides whether we divide by zoom by placing
+// a hidden 100px-wide marker and reading back its rect. happy-dom's layout
+// engine doesn't actually compute `style.left = 100px` into a non-zero
+// rect, so we patch `getBoundingClientRect` on the probe element to
+// simulate the chosen engine.
+function stubProbe(engine: "webkit" | "chromium", zoom: number): () => void {
+  const original = HTMLElement.prototype.getBoundingClientRect;
+  HTMLElement.prototype.getBoundingClientRect = function (
+    this: HTMLElement,
+  ): DOMRect {
+    const looksLikeProbe =
+      this.style.position === "fixed" &&
+      this.style.left === "100px" &&
+      this.style.width === "100px" &&
+      this.style.visibility === "hidden";
+    if (looksLikeProbe) {
+      const left = engine === "webkit" ? 100 * zoom : 100;
+      return new DOMRect(left, 0, 100, 1);
+    }
+    return new DOMRect(0, 0, 0, 0);
+  };
+  return () => {
+    HTMLElement.prototype.getBoundingClientRect = original;
+  };
+}
+
+function setRootZoom(z: number | null): void {
+  if (z === null) document.documentElement.style.removeProperty("zoom");
+  else document.documentElement.style.zoom = String(z);
+}
+
+// Append a `.context-view` to body with its position pre-set, mimicking
+// Monaco's pattern: the style is set synchronously, then the element is
+// attached. The MutationObserver callback runs as a microtask — flush
+// twice to allow chained microtasks (root observer → attach inner →
+// inner fires) to settle.
+async function spawnContextView(left: number, top: number): Promise<HTMLElement> {
+  const el = document.createElement("div");
+  el.className = "context-view";
+  el.style.position = "fixed";
+  el.style.left = `${left}px`;
+  el.style.top = `${top}px`;
+  document.body.appendChild(el);
+  await flushMutations();
+  return el;
+}
+
+async function flushMutations(): Promise<void> {
+  // Two microtask flushes: one for the root observer, one for any inner
+  // observer it spawned that itself queued a write.
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("installMonacoContextViewFix — integration", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    setRootZoom(null);
+    resetCoordSpaceCache();
+    __resetMonacoContextViewFixForTests();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    setRootZoom(null);
+    resetCoordSpaceCache();
+    __resetMonacoContextViewFixForTests();
+  });
+
+  describe("baseline correction (webkit, zoom != 1)", () => {
+    it("divides the initial left/top of a newly attached context-view by zoom", async () => {
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+      const el = await spawnContextView(300, 150);
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(el.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+
+    it("re-corrects when Monaco moves the menu after first show (re-position)", async () => {
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+      const el = await spawnContextView(300, 150);
+      // Monaco repositions the menu (e.g. submenu expansion clamping).
+      // Both writes happen in the same synchronous block — observer
+      // delivers one callback with two records.
+      el.style.left = "600px";
+      el.style.top = "300px";
+      await flushMutations();
+      expect(parseFloat(el.style.left)).toBeCloseTo(400, 1);
+      expect(parseFloat(el.style.top)).toBeCloseTo(200, 1);
+      restore();
+    });
+
+    it("does NOT loop: observer doesn't keep re-dividing its own write", async () => {
+      const restore = stubProbe("webkit", 2);
+      setRootZoom(2);
+      installMonacoContextViewFix();
+      const el = await spawnContextView(400, 200);
+      // First correction: 400/2 = 200, 200/2 = 100.
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      // Multiple flush cycles — if the observer were looping, we'd see
+      // 200 → 100 → 50 → 25 etc.
+      await flushMutations();
+      await flushMutations();
+      await flushMutations();
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(el.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+  });
+
+  describe("no-op branches", () => {
+    it("leaves left/top alone on Chromium (event coords already in layout frame)", async () => {
+      const restore = stubProbe("chromium", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+      const el = await spawnContextView(300, 150);
+      expect(parseFloat(el.style.left)).toBe(300);
+      expect(parseFloat(el.style.top)).toBe(150);
+      restore();
+    });
+
+    it("leaves left/top alone at zoom == 1", async () => {
+      setRootZoom(null);
+      installMonacoContextViewFix();
+      const el = await spawnContextView(300, 150);
+      expect(parseFloat(el.style.left)).toBe(300);
+      expect(parseFloat(el.style.top)).toBe(150);
+    });
+  });
+
+  describe("known limitation: WeakMap echo guard false-skip", () => {
+    // Codex's review (MAJOR finding #1) flagged this case. We accept it
+    // as a known limitation rather than fix it, because the alternative
+    // (disconnect-around-write) broke the menu in WKWebView when Monaco
+    // delivers `style.top` and `style.left` writes as separate observer
+    // callbacks — the disconnect window between them caused the first
+    // callback to read a half-updated state and the second callback to
+    // re-divide an already-corrected coordinate. Keeping the echo guard
+    // means a synthetic edge case (Monaco intentionally repositioning
+    // to coordinates that exactly equal a previous correction) is left
+    // uncorrected; in exchange the common path is solid. This test
+    // documents the trade-off.
+    it("does NOT correct raw 200/100 after a prior raw 400/200 → 200/100 correction at zoom 2", async () => {
+      const restore = stubProbe("webkit", 2);
+      setRootZoom(2);
+      installMonacoContextViewFix();
+      const el = await spawnContextView(400, 200);
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      // Same values: echo guard treats it as our own write, skips.
+      el.style.left = "200px";
+      el.style.top = "100px";
+      await flushMutations();
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(el.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+  });
+
+  describe("codex finding #2 — re-attached `.context-view` doesn't stack inner observers", () => {
+    it("re-correcting after a remove + re-add still produces one write per Monaco move", async () => {
+      const restore = stubProbe("webkit", 2);
+      setRootZoom(2);
+      installMonacoContextViewFix();
+      // First mount + correction.
+      const el = await spawnContextView(400, 200);
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      // Monaco-style remove + re-add of the SAME node.
+      document.body.removeChild(el);
+      el.style.left = "400px";
+      el.style.top = "200px";
+      document.body.appendChild(el);
+      await flushMutations();
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      // Move it again — we should see a single 200→100 correction, not
+      // 200→100→50→… from stacked observers re-firing on the same write.
+      el.style.left = "400px";
+      el.style.top = "200px";
+      await flushMutations();
+      expect(parseFloat(el.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(el.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+  });
+
+  // Note: there is NO test here for "Monaco writes top and left in
+  // separate microtask checkpoints." Per the MutationObserver spec they
+  // should coalesce when written sequentially in the same synchronous
+  // block, and in practice WKWebView delivers Monaco's
+  // `doLayout()` writes as a single callback — the running-app
+  // verification at uiFontSize 16 confirms this. If we forced a split
+  // in a test (e.g. `await` between writes), neither the WeakMap echo
+  // guard nor the previously-tried disconnect-around-write handles it
+  // cleanly — the second callback would re-divide the already-corrected
+  // first coordinate. We don't simulate that pattern because it isn't
+  // how the bug presents in production. If a future Monaco refactor
+  // changes the timing, the manual QA matrix in the PR description
+  // should catch it before any user does.
+
+  describe("nested submenus", () => {
+    it("corrects a `.context-view` attached as a descendant (Monaco submenu pattern)", async () => {
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+      const wrapper = document.createElement("div");
+      const submenu = document.createElement("div");
+      submenu.className = "context-view";
+      submenu.style.position = "fixed";
+      submenu.style.left = "300px";
+      submenu.style.top = "150px";
+      wrapper.appendChild(submenu);
+      document.body.appendChild(wrapper);
+      await flushMutations();
+      expect(parseFloat(submenu.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(submenu.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+  });
+});

--- a/src/ui/src/utils/monacoContextViewFix.dom.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.dom.test.ts
@@ -223,6 +223,72 @@ describe("installMonacoContextViewFix — integration", () => {
   // changes the timing, the manual QA matrix in the PR description
   // should catch it before any user does.
 
+  describe("shadow DOM (Monaco's shadow-root-host pattern)", () => {
+    // Monaco's StandaloneContextViewService can mount the context view
+    // inside a shadow DOM (`<div class="shadow-root-host">` +
+    // `attachShadow({mode: 'open'})`). MutationObserver does NOT pierce
+    // shadow boundaries by default, so a body-only observer misses
+    // every menu open in this code path — exactly the regression we
+    // chased through this branch's earlier commits. The test below
+    // proves the shadow-root subtree is observed correctly.
+    it("corrects a `.context-view` mounted inside a shadow root attached to a new host", async () => {
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+
+      // Mimic Monaco's flow: create a shadow host, attach it to body,
+      // then append a `.context-view` inside its shadow root.
+      const shadowHost = document.createElement("div");
+      shadowHost.className = "shadow-root-host";
+      const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+      document.body.appendChild(shadowHost);
+      // Microtask: rootObserver picks up the added shadow host and
+      // subscribes to its shadow root.
+      await flushMutations();
+
+      const cv = document.createElement("div");
+      cv.className = "context-view";
+      cv.style.position = "fixed";
+      cv.style.left = "300px";
+      cv.style.top = "150px";
+      shadowRoot.appendChild(cv);
+      // Microtask: shadow-root observer fires, attaches inner observer
+      // and runs the initial correction.
+      await flushMutations();
+
+      expect(parseFloat(cv.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(cv.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+
+    it("seeds existing `.context-view` inside a pre-existing shadow root at install time", async () => {
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+
+      // Set up the shadow-DOM scenario BEFORE installing the fix —
+      // mirrors Monaco mounting before our utility ran.
+      const shadowHost = document.createElement("div");
+      shadowHost.className = "shadow-root-host";
+      const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+      document.body.appendChild(shadowHost);
+      const cv = document.createElement("div");
+      cv.className = "context-view";
+      cv.style.position = "fixed";
+      cv.style.left = "450px";
+      cv.style.top = "300px";
+      shadowRoot.appendChild(cv);
+
+      // Now install — should seed the existing shadow-rooted
+      // `.context-view` and correct it on first scan.
+      installMonacoContextViewFix();
+      await flushMutations();
+
+      expect(parseFloat(cv.style.left)).toBeCloseTo(300, 1);
+      expect(parseFloat(cv.style.top)).toBeCloseTo(200, 1);
+      restore();
+    });
+  });
+
   describe("nested submenus", () => {
     it("corrects a `.context-view` attached as a descendant (Monaco submenu pattern)", async () => {
       const restore = stubProbe("webkit", 1.5);

--- a/src/ui/src/utils/monacoContextViewFix.dom.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.dom.test.ts
@@ -26,8 +26,25 @@ import {
 // engine doesn't actually compute `style.left = 100px` into a non-zero
 // rect, so we patch `getBoundingClientRect` on the probe element to
 // simulate the chosen engine.
+//
+// Capture the truly-original `getBoundingClientRect` ONCE at module load,
+// and always restore to that. This way:
+//   - A test that throws before calling its `restore()` cannot leak the
+//     prototype patch into the next test (codex flagged this risk).
+//   - Two consecutive `stubProbe()` calls without intervening restore
+//     don't compound the patch — each one re-applies on top of the
+//     original.
+// `afterEach` below also runs an unconditional restore so explicit
+// `restore()` calls become belt-and-suspenders rather than load-bearing.
+const ORIGINAL_GET_BOUNDING_CLIENT_RECT =
+  HTMLElement.prototype.getBoundingClientRect;
+
+function restorePrototype(): void {
+  HTMLElement.prototype.getBoundingClientRect =
+    ORIGINAL_GET_BOUNDING_CLIENT_RECT;
+}
+
 function stubProbe(engine: "webkit" | "chromium", zoom: number): () => void {
-  const original = HTMLElement.prototype.getBoundingClientRect;
   HTMLElement.prototype.getBoundingClientRect = function (
     this: HTMLElement,
   ): DOMRect {
@@ -42,9 +59,7 @@ function stubProbe(engine: "webkit" | "chromium", zoom: number): () => void {
     }
     return new DOMRect(0, 0, 0, 0);
   };
-  return () => {
-    HTMLElement.prototype.getBoundingClientRect = original;
-  };
+  return restorePrototype;
 }
 
 function setRootZoom(z: number | null): void {
@@ -88,6 +103,10 @@ describe("installMonacoContextViewFix — integration", () => {
     setRootZoom(null);
     resetCoordSpaceCache();
     __resetMonacoContextViewFixForTests();
+    // Unconditional prototype restore: even if a test threw before its
+    // own `restore()` call, this guarantees the patched
+    // `getBoundingClientRect` doesn't leak into the next test.
+    restorePrototype();
   });
 
   describe("baseline correction (webkit, zoom != 1)", () => {

--- a/src/ui/src/utils/monacoContextViewFix.dom.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.dom.test.ts
@@ -287,6 +287,135 @@ describe("installMonacoContextViewFix — integration", () => {
       expect(parseFloat(cv.style.top)).toBeCloseTo(200, 1);
       restore();
     });
+
+    it("re-corrects when a shadow-rooted `.context-view` is repositioned after first show", async () => {
+      // Codex test gap #1: the initial correction is covered, but
+      // Monaco re-positions the menu (resize, submenu expansion, edge
+      // clamping) by writing left/top again. The per-host inner
+      // observer attached inside the shadow root must catch those
+      // subsequent writes the same way it does in light DOM.
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+
+      const shadowHost = document.createElement("div");
+      shadowHost.className = "shadow-root-host";
+      const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+      document.body.appendChild(shadowHost);
+      const cv = document.createElement("div");
+      cv.className = "context-view";
+      cv.style.position = "fixed";
+      cv.style.left = "300px";
+      cv.style.top = "150px";
+      shadowRoot.appendChild(cv);
+      await flushMutations();
+
+      expect(parseFloat(cv.style.left)).toBeCloseTo(200, 1);
+      // Monaco repositions: e.g. submenu expansion clamps the host
+      // back inside the viewport.
+      cv.style.left = "600px";
+      cv.style.top = "300px";
+      await flushMutations();
+      expect(parseFloat(cv.style.left)).toBeCloseTo(400, 1);
+      expect(parseFloat(cv.style.top)).toBeCloseTo(200, 1);
+      restore();
+    });
+
+    it("cleans up per-host observer when a shadow-rooted `.context-view` is removed and re-added", async () => {
+      // Codex test gap #2: removed-node handling. If the per-host
+      // observer leaked across remove + re-add of the same node, we'd
+      // end up with stacked observers and (under the WeakMap echo
+      // guard) silent skips. The dedup in attachHostObserver +
+      // detachHostObserver on visitRemovedNode prevents that.
+      const restore = stubProbe("webkit", 2);
+      setRootZoom(2);
+      installMonacoContextViewFix();
+
+      const shadowHost = document.createElement("div");
+      shadowHost.className = "shadow-root-host";
+      const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+      document.body.appendChild(shadowHost);
+      const cv = document.createElement("div");
+      cv.className = "context-view";
+      cv.style.position = "fixed";
+      cv.style.left = "400px";
+      cv.style.top = "200px";
+      shadowRoot.appendChild(cv);
+      await flushMutations();
+      expect(parseFloat(cv.style.left)).toBeCloseTo(200, 1);
+
+      // Remove the same node and re-attach with fresh raw values.
+      shadowRoot.removeChild(cv);
+      await flushMutations();
+      cv.style.left = "800px";
+      cv.style.top = "400px";
+      shadowRoot.appendChild(cv);
+      await flushMutations();
+      expect(parseFloat(cv.style.left)).toBeCloseTo(400, 1);
+      expect(parseFloat(cv.style.top)).toBeCloseTo(200, 1);
+      restore();
+    });
+
+    it("corrects when an already-populated shadow host is appended to body after install", async () => {
+      // Codex test gap #3: the host may be constructed offline, get a
+      // `.context-view` populated inside its shadow root, and only then
+      // be inserted into the document. The root observer fires for the
+      // host's insertion; visitAddedNode discovers the shadow root and
+      // watchShadowRoot picks up the pre-existing `.context-view` before
+      // the next observer tick.
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+      installMonacoContextViewFix();
+
+      const shadowHost = document.createElement("div");
+      shadowHost.className = "shadow-root-host";
+      const shadowRoot = shadowHost.attachShadow({ mode: "open" });
+      const cv = document.createElement("div");
+      cv.className = "context-view";
+      cv.style.position = "fixed";
+      cv.style.left = "300px";
+      cv.style.top = "150px";
+      shadowRoot.appendChild(cv);
+
+      // Now attach the (already-populated) shadow host to the document.
+      document.body.appendChild(shadowHost);
+      await flushMutations();
+
+      expect(parseFloat(cv.style.left)).toBeCloseTo(200, 1);
+      expect(parseFloat(cv.style.top)).toBeCloseTo(100, 1);
+      restore();
+    });
+
+    it("discovers nested shadow roots that exist inside a watched shadow root", async () => {
+      // Codex MINOR #1: watchShadowRoot now walks its own subtree for
+      // further shadow hosts. This test exercises that path: shadow
+      // root A contains a host with shadow root B containing a
+      // `.context-view`.
+      const restore = stubProbe("webkit", 1.5);
+      setRootZoom(1.5);
+
+      const outerHost = document.createElement("div");
+      outerHost.className = "shadow-root-host";
+      const outerRoot = outerHost.attachShadow({ mode: "open" });
+      const innerHost = document.createElement("div");
+      innerHost.className = "nested-shadow-host";
+      const innerRoot = innerHost.attachShadow({ mode: "open" });
+      const cv = document.createElement("div");
+      cv.className = "context-view";
+      cv.style.position = "fixed";
+      cv.style.left = "450px";
+      cv.style.top = "300px";
+      innerRoot.appendChild(cv);
+      outerRoot.appendChild(innerHost);
+      document.body.appendChild(outerHost);
+
+      installMonacoContextViewFix();
+      await flushMutations();
+
+      expect(parseFloat(cv.style.left)).toBeCloseTo(300, 1);
+      expect(parseFloat(cv.style.top)).toBeCloseTo(200, 1);
+      restore();
+    });
   });
 
   describe("nested submenus", () => {

--- a/src/ui/src/utils/monacoContextViewFix.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  __resetCorrectionMemoForTests,
   correctContextViewPosition,
   type PositionTarget,
 } from "./monacoContextViewFix";
@@ -10,15 +9,18 @@ import {
 // against a stub. End-to-end MutationObserver coverage lives in manual
 // QA against the running app: see the verification steps in the PR
 // description.
+//
+// The runtime feedback-loop guard is *not* in this pure function —
+// codex's review pointed out that an equality-based echo guard can
+// false-skip a real Monaco reposition (raw 200/100 at zoom 2 looks
+// identical to the post-correction of raw 400/200). The guard now lives
+// at the observer layer: each per-host MutationObserver is disconnected
+// around our write, so the loop is structurally impossible. That's
+// covered by manual QA, not these tests.
 
 function makeTarget(left: string, top: string): PositionTarget {
   return { style: { left, top } };
 }
-
-afterEach(() => {
-  // Each test creates fresh targets, but defensive in case a future test
-  // reuses an object reference across describe blocks.
-});
 
 describe("correctContextViewPosition", () => {
   it("divides left/top by zoom and writes them back", () => {
@@ -36,50 +38,30 @@ describe("correctContextViewPosition", () => {
     expect(el.style.top).toBe("");
   });
 
-  it("skips the echo of our own write to break the observer feedback loop", () => {
+  it("re-corrects unconditionally when called twice — no false skip", () => {
+    // The pathological case codex flagged: at zoom 2, a previous correction
+    // of raw 400/200 → 200/100 used to make the guard skip a *new* Monaco
+    // reposition that happens to write raw 200/100. With no value-equality
+    // guard in this layer, both calls correct.
     const el = makeTarget("400px", "200px");
-    expect(correctContextViewPosition(el, 2)).toBe(true);
-    // Echo: same values, no Monaco move. Should be a no-op.
-    expect(correctContextViewPosition(el, 2)).toBe(false);
+    correctContextViewPosition(el, 2);
     expect(parseFloat(el.style.left)).toBeCloseTo(200, 6);
-    expect(parseFloat(el.style.top)).toBeCloseTo(100, 6);
+    // Monaco-driven reposition to raw 200/100. The pure function corrects
+    // it to 100/50; the runtime observer-disconnect-around-write strategy
+    // ensures the recursive write-from-write is impossible at the call
+    // site. (Without that, the function would still correct here — the
+    // bug under the old guard was the *skip*, not the recursion.)
+    el.style.left = "200px";
+    el.style.top = "100px";
+    correctContextViewPosition(el, 2);
+    expect(parseFloat(el.style.left)).toBeCloseTo(100, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(50, 6);
   });
 
-  it("re-corrects when Monaco moves the menu to a new uncorrected position", () => {
+  it("handles non-integer zoom factors without drift", () => {
     const el = makeTarget("500px", "250px");
     correctContextViewPosition(el, 1.25);
     expect(parseFloat(el.style.left)).toBeCloseTo(400, 6);
     expect(parseFloat(el.style.top)).toBeCloseTo(200, 6);
-    // Monaco moves the menu (e.g. submenu expansion clamps it).
-    el.style.left = "1000px";
-    el.style.top = "500px";
-    const wrote = correctContextViewPosition(el, 1.25);
-    expect(wrote).toBe(true);
-    expect(parseFloat(el.style.left)).toBeCloseTo(800, 6);
-    expect(parseFloat(el.style.top)).toBeCloseTo(400, 6);
-  });
-
-  it("treats sub-pixel deltas (<0.5px) as echo", () => {
-    // After we write 200/100, browser style serialization can round to
-    // "200px"/"100px"; if Monaco then re-writes the *same logical* values,
-    // the serialized string may differ by a sub-pixel amount. We accept
-    // any delta < 0.5px as an echo so we don't oscillate.
-    const el = makeTarget("400.2px", "200px");
-    correctContextViewPosition(el, 2);
-    el.style.left = "200.1px";
-    el.style.top = "100px";
-    expect(correctContextViewPosition(el, 2)).toBe(false);
-  });
-
-  it("forgets memo across distinct elements (per-target weak ref)", () => {
-    const a = makeTarget("400px", "200px");
-    const b = makeTarget("400px", "200px");
-    correctContextViewPosition(a, 2);
-    // `b` is a different object; its memo is empty so the same input is
-    // corrected, not skipped.
-    expect(correctContextViewPosition(b, 2)).toBe(true);
-    expect(parseFloat(b.style.left)).toBeCloseTo(200, 6);
-    __resetCorrectionMemoForTests(a);
-    __resetCorrectionMemoForTests(b);
   });
 });

--- a/src/ui/src/utils/monacoContextViewFix.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetCorrectionMemoForTests,
+  correctContextViewPosition,
+  type PositionTarget,
+} from "./monacoContextViewFix";
+
+// vitest runs in node — no DOM. The position correction is a pure
+// transform on a `{ style: { left, top } }` shape, so we test it directly
+// against a stub. End-to-end MutationObserver coverage lives in manual
+// QA against the running app: see the verification steps in the PR
+// description.
+
+function makeTarget(left: string, top: string): PositionTarget {
+  return { style: { left, top } };
+}
+
+afterEach(() => {
+  // Each test creates fresh targets, but defensive in case a future test
+  // reuses an object reference across describe blocks.
+});
+
+describe("correctContextViewPosition", () => {
+  it("divides left/top by zoom and writes them back", () => {
+    const el = makeTarget("300px", "150px");
+    const wrote = correctContextViewPosition(el, 1.5);
+    expect(wrote).toBe(true);
+    expect(parseFloat(el.style.left)).toBeCloseTo(200, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(100, 6);
+  });
+
+  it("skips when style.left is unparseable (Monaco hasn't mounted yet)", () => {
+    const el = makeTarget("", "");
+    expect(correctContextViewPosition(el, 1.5)).toBe(false);
+    expect(el.style.left).toBe("");
+    expect(el.style.top).toBe("");
+  });
+
+  it("skips the echo of our own write to break the observer feedback loop", () => {
+    const el = makeTarget("400px", "200px");
+    expect(correctContextViewPosition(el, 2)).toBe(true);
+    // Echo: same values, no Monaco move. Should be a no-op.
+    expect(correctContextViewPosition(el, 2)).toBe(false);
+    expect(parseFloat(el.style.left)).toBeCloseTo(200, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(100, 6);
+  });
+
+  it("re-corrects when Monaco moves the menu to a new uncorrected position", () => {
+    const el = makeTarget("500px", "250px");
+    correctContextViewPosition(el, 1.25);
+    expect(parseFloat(el.style.left)).toBeCloseTo(400, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(200, 6);
+    // Monaco moves the menu (e.g. submenu expansion clamps it).
+    el.style.left = "1000px";
+    el.style.top = "500px";
+    const wrote = correctContextViewPosition(el, 1.25);
+    expect(wrote).toBe(true);
+    expect(parseFloat(el.style.left)).toBeCloseTo(800, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(400, 6);
+  });
+
+  it("treats sub-pixel deltas (<0.5px) as echo", () => {
+    // After we write 200/100, browser style serialization can round to
+    // "200px"/"100px"; if Monaco then re-writes the *same logical* values,
+    // the serialized string may differ by a sub-pixel amount. We accept
+    // any delta < 0.5px as an echo so we don't oscillate.
+    const el = makeTarget("400.2px", "200px");
+    correctContextViewPosition(el, 2);
+    el.style.left = "200.1px";
+    el.style.top = "100px";
+    expect(correctContextViewPosition(el, 2)).toBe(false);
+  });
+
+  it("forgets memo across distinct elements (per-target weak ref)", () => {
+    const a = makeTarget("400px", "200px");
+    const b = makeTarget("400px", "200px");
+    correctContextViewPosition(a, 2);
+    // `b` is a different object; its memo is empty so the same input is
+    // corrected, not skipped.
+    expect(correctContextViewPosition(b, 2)).toBe(true);
+    expect(parseFloat(b.style.left)).toBeCloseTo(200, 6);
+    __resetCorrectionMemoForTests(a);
+    __resetCorrectionMemoForTests(b);
+  });
+});

--- a/src/ui/src/utils/monacoContextViewFix.test.ts
+++ b/src/ui/src/utils/monacoContextViewFix.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  __resetCorrectionMemoForTests,
   correctContextViewPosition,
   type PositionTarget,
 } from "./monacoContextViewFix";
@@ -9,18 +10,15 @@ import {
 // against a stub. End-to-end MutationObserver coverage lives in manual
 // QA against the running app: see the verification steps in the PR
 // description.
-//
-// The runtime feedback-loop guard is *not* in this pure function —
-// codex's review pointed out that an equality-based echo guard can
-// false-skip a real Monaco reposition (raw 200/100 at zoom 2 looks
-// identical to the post-correction of raw 400/200). The guard now lives
-// at the observer layer: each per-host MutationObserver is disconnected
-// around our write, so the loop is structurally impossible. That's
-// covered by manual QA, not these tests.
 
 function makeTarget(left: string, top: string): PositionTarget {
   return { style: { left, top } };
 }
+
+afterEach(() => {
+  // Each test creates fresh targets, but defensive in case a future test
+  // reuses an object reference across describe blocks.
+});
 
 describe("correctContextViewPosition", () => {
   it("divides left/top by zoom and writes them back", () => {
@@ -38,30 +36,50 @@ describe("correctContextViewPosition", () => {
     expect(el.style.top).toBe("");
   });
 
-  it("re-corrects unconditionally when called twice — no false skip", () => {
-    // The pathological case codex flagged: at zoom 2, a previous correction
-    // of raw 400/200 → 200/100 used to make the guard skip a *new* Monaco
-    // reposition that happens to write raw 200/100. With no value-equality
-    // guard in this layer, both calls correct.
+  it("skips the echo of our own write to break the observer feedback loop", () => {
     const el = makeTarget("400px", "200px");
-    correctContextViewPosition(el, 2);
+    expect(correctContextViewPosition(el, 2)).toBe(true);
+    // Echo: same values, no Monaco move. Should be a no-op.
+    expect(correctContextViewPosition(el, 2)).toBe(false);
     expect(parseFloat(el.style.left)).toBeCloseTo(200, 6);
-    // Monaco-driven reposition to raw 200/100. The pure function corrects
-    // it to 100/50; the runtime observer-disconnect-around-write strategy
-    // ensures the recursive write-from-write is impossible at the call
-    // site. (Without that, the function would still correct here — the
-    // bug under the old guard was the *skip*, not the recursion.)
-    el.style.left = "200px";
-    el.style.top = "100px";
-    correctContextViewPosition(el, 2);
-    expect(parseFloat(el.style.left)).toBeCloseTo(100, 6);
-    expect(parseFloat(el.style.top)).toBeCloseTo(50, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(100, 6);
   });
 
-  it("handles non-integer zoom factors without drift", () => {
+  it("re-corrects when Monaco moves the menu to a new uncorrected position", () => {
     const el = makeTarget("500px", "250px");
     correctContextViewPosition(el, 1.25);
     expect(parseFloat(el.style.left)).toBeCloseTo(400, 6);
     expect(parseFloat(el.style.top)).toBeCloseTo(200, 6);
+    // Monaco moves the menu (e.g. submenu expansion clamps it).
+    el.style.left = "1000px";
+    el.style.top = "500px";
+    const wrote = correctContextViewPosition(el, 1.25);
+    expect(wrote).toBe(true);
+    expect(parseFloat(el.style.left)).toBeCloseTo(800, 6);
+    expect(parseFloat(el.style.top)).toBeCloseTo(400, 6);
+  });
+
+  it("treats sub-pixel deltas (<0.5px) as echo", () => {
+    // After we write 200/100, browser style serialization can round to
+    // "200px"/"100px"; if Monaco then re-writes the *same logical* values,
+    // the serialized string may differ by a sub-pixel amount. We accept
+    // any delta < 0.5px as an echo so we don't oscillate.
+    const el = makeTarget("400.2px", "200px");
+    correctContextViewPosition(el, 2);
+    el.style.left = "200.1px";
+    el.style.top = "100px";
+    expect(correctContextViewPosition(el, 2)).toBe(false);
+  });
+
+  it("forgets memo across distinct elements (per-target weak ref)", () => {
+    const a = makeTarget("400px", "200px");
+    const b = makeTarget("400px", "200px");
+    correctContextViewPosition(a, 2);
+    // `b` is a different object; its memo is empty so the same input is
+    // corrected, not skipped.
+    expect(correctContextViewPosition(b, 2)).toBe(true);
+    expect(parseFloat(b.style.left)).toBeCloseTo(200, 6);
+    __resetCorrectionMemoForTests(a);
+    __resetCorrectionMemoForTests(b);
   });
 });

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -139,6 +139,15 @@ function watchShadowRoot(root: ShadowRoot, zoom: number | false): void {
     if (zoom !== false) correctContextViewPosition(host, zoom);
     attachHostObserver(host);
   }
+  // Recursive: if this shadow root contains FURTHER shadow hosts, we'd
+  // miss their roots otherwise — `MutationObserver` doesn't pierce
+  // boundaries, so we have to walk explicitly. Monaco doesn't currently
+  // nest shadow DOM, but defending against it is cheap (one extra
+  // querySelectorAll on a freshly observed root) and prevents the
+  // class of bug codex's review flagged.
+  for (const el of root.querySelectorAll<HTMLElement>("*")) {
+    if (el.shadowRoot) watchShadowRoot(el.shadowRoot, zoom);
+  }
   // And subscribe so future additions are caught.
   const inner = new MutationObserver((records) => {
     const innerZoom = shouldCorrect();
@@ -153,7 +162,11 @@ function watchShadowRoot(root: ShadowRoot, zoom: number | false): void {
 
 function visitAddedNode(node: Node, zoom: number | false): void {
   if (!(node instanceof HTMLElement)) return;
-  // 1. Direct/descendant `.context-view` in the light DOM.
+  // 1. Direct/descendant `.context-view` in the light DOM. We always
+  //    attach the per-host attribute observer here even at zoom == 1 —
+  //    if the user later bumps `uiFontSize` to a non-default value, the
+  //    inner observer is already in place and the very first menu show
+  //    after that will be corrected on the next style write.
   const hosts = node.classList.contains("context-view")
     ? [node]
     : Array.from(node.querySelectorAll<HTMLElement>(".context-view"));
@@ -190,12 +203,20 @@ function visitRemovedNode(node: Node): void {
  * second call is a no-op. Safe to call before `document.body` exists —
  * we'll defer until DOM is ready.
  *
- * The observer is a permanent global; there's no uninstall. Cost is one
- * MutationObserver on `document.body` (childList, subtree) plus a small
- * inner observer per `.context-view` element. The root callback
- * early-outs at zoom == 1 before doing any DOM scanning, so the
- * steady-state overhead during chat/terminal streaming is one cheap
- * zoom read per batch of mutation records.
+ * The observer is a permanent global; there's no uninstall. Steady-state
+ * cost on a busy app is dominated by the per-batch DOM scan in
+ * `visitAddedNode`: for every added subtree we run two `querySelectorAll`
+ * passes (one for `.context-view`, one for `*` to discover shadow hosts).
+ * The `*` pass is the expensive one — it scans the entire added subtree.
+ *
+ * That cost is paid even at zoom == 1, because we want the per-host
+ * attribute observers attached and shadow roots tracked BEFORE the user
+ * ever bumps their UI font size; otherwise the first menu show after a
+ * zoom change would land uncorrected. In practice this is fine: chat /
+ * terminal mutations are small subtrees, and Monaco menus are not
+ * created on hot paths. If profiling ever surfaces this, the fastest
+ * win is to gate `*` traversal behind a "have we ever observed a shadow
+ * root before" flag, since shadow DOM is rare in this app.
  */
 export function installMonacoContextViewFix(): void {
   if (installed) return;
@@ -204,10 +225,11 @@ export function installMonacoContextViewFix(): void {
 
   const start = () => {
     rootObserver = new MutationObserver((records) => {
-      // Cheap perf gate: at zoom 1 the fix is unconditionally a no-op, so
-      // skip the per-mutation `querySelectorAll` scan that would otherwise
-      // run on every chat/terminal append.
-      const zoom = getRootZoom() === 1 ? false : shouldCorrect();
+      // Skip only the zoom-dependent CORRECTION when zoom == 1. We still
+      // run `visitAddedNode` so per-host attribute observers and shadow
+      // roots are tracked — that's what lets a later zoom change take
+      // effect immediately on the next menu show.
+      const zoom = shouldCorrect();
       for (const r of records) {
         if (r.type !== "childList") continue;
         r.addedNodes.forEach((n) => visitAddedNode(n, zoom));
@@ -239,6 +261,12 @@ export function __resetMonacoContextViewFixForTests(): void {
   rootObserver?.disconnect();
   rootObserver = null;
   installed = false;
-  // WeakMap can't be cleared explicitly — but each test creates fresh
-  // host objects, so previous entries simply get GC'd.
+  // WeakMap / WeakSet can't be cleared explicitly — but each test
+  // creates fresh host objects, so previous entries simply get GC'd.
+  // The shadow-root attribute observers we created via `watchShadowRoot`
+  // aren't tracked in a list (they live in closure scope), but they're
+  // unreachable once the host element is GC'd, so they don't leak across
+  // tests in practice. If a future test hangs onto a shadow host across
+  // cases, replace the WeakSet here with a Map<ShadowRoot, MutationObserver>
+  // and disconnect explicitly.
 }

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -15,8 +15,9 @@
 //     Monaco's math is already correct.
 //
 // `fixedOverflowWidgets` is an editor option that lifts widgets to body —
-// but it never applied to the context view (microsoft/monaco-editor#1203,
-// open since 2018), so we can't fix this through Monaco's options. The
+// but it never applied to the context view (see Monaco issue 1203,
+// https://github.com/microsoft/monaco-editor/issues/1203 — open since
+// 2018), so we can't fix this through Monaco's options. The
 // recommended workaround is to leave the menu where Monaco mounts it and
 // correct its position after the fact. That's what this module does:
 // observe `.context-view` mounts, divide `style.left/top` by zoom on

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -1,0 +1,163 @@
+// Monaco renders its context menu, suggestion menus, and quick-input pickers
+// into a `position: fixed` element with class `.context-view`. Its position
+// is set from `MouseEvent.clientX/Y` (or anchor `getBoundingClientRect()`),
+// in pixels, written directly to `style.left` / `style.top`.
+//
+// Under the html-level CSS `zoom` Claudette uses for UI scaling, that math
+// is engine-dependent:
+//
+//   - WebKit (WKWebView, WebKitGTK) reports clientX/Y and rect coords in
+//     visual pixels, while CSS `position: fixed; left/top` interprets values
+//     in layout pixels — so Monaco's `style.left = clientX + 'px'` lands the
+//     menu at visual `clientX * zoom`, shifted past the cursor.
+//
+//   - Chromium (WebView2) treats the entire pipeline in the layout frame, so
+//     Monaco's math is already correct.
+//
+// `fixedOverflowWidgets` is an editor option that lifts widgets to body —
+// but it never applied to the context view (microsoft/monaco-editor#1203,
+// open since 2018), so we can't fix this through Monaco's options. The
+// recommended workaround is to leave the menu where Monaco mounts it and
+// correct its position after the fact. That's what this module does:
+// observe `.context-view` mounts, divide `style.left/top` by zoom on
+// engines that need it, leave everything else (menu contents, keyboard
+// nav, focus management, language-server actions) untouched.
+
+import { eventCoordSpace, getRootZoom } from "./zoom";
+
+// Minimal element shape the correction touches — extracted so the core
+// math is testable without a DOM. The runtime callers always pass real
+// HTMLElements; tests pass a stub.
+export interface PositionTarget {
+  style: { left: string; top: string };
+}
+
+// Last position WE wrote to each target. Used to suppress the
+// attribute-mutation feedback loop that re-firing the observer would
+// otherwise cause: when the post-correction values match the last-written
+// pair, we know Monaco hasn't moved the menu and skip.
+const lastApplied = new WeakMap<object, { left: number; top: number }>();
+
+/**
+ * Pure function — exported for tests. Reads `style.left/top` off `el`,
+ * divides by `zoom`, and writes the corrected pair back. Skips when:
+ *   - either coordinate is unparseable (Monaco hasn't mounted yet), or
+ *   - the current values match the last pair WE wrote (echo of our own
+ *     write firing the observer).
+ *
+ * Returns `true` when a write happened, `false` when it was skipped —
+ * the test suite uses this to assert the no-loop guarantee.
+ */
+export function correctContextViewPosition(
+  el: PositionTarget,
+  zoom: number,
+): boolean {
+  const left = parseFloat(el.style.left);
+  const top = parseFloat(el.style.top);
+  if (!Number.isFinite(left) || !Number.isFinite(top)) return false;
+
+  const last = lastApplied.get(el as object);
+  if (
+    last &&
+    Math.abs(last.left - left) < 0.5 &&
+    Math.abs(last.top - top) < 0.5
+  ) {
+    return false;
+  }
+
+  const correctedLeft = left / zoom;
+  const correctedTop = top / zoom;
+  el.style.left = `${correctedLeft}px`;
+  el.style.top = `${correctedTop}px`;
+  lastApplied.set(el as object, { left: correctedLeft, top: correctedTop });
+  return true;
+}
+
+// Test-only: clear the WeakMap-backed echo guard so tests don't leak the
+// "last applied" state into the next case.
+export function __resetCorrectionMemoForTests(el: object): void {
+  lastApplied.delete(el);
+}
+
+let installed = false;
+let observer: MutationObserver | null = null;
+
+function shouldCorrect(): false | number {
+  const zoom = getRootZoom();
+  if (zoom === 1) return false;
+  if (eventCoordSpace() !== "visual") return false;
+  return zoom;
+}
+
+function observeContextView(el: HTMLElement): void {
+  // Monaco re-positions the menu while open in a few cases (resize, submenu
+  // expansion, viewport edge clamping) by setting style.left/top again. An
+  // attribute observer on the host catches each of those.
+  const inner = new MutationObserver(() => {
+    const zoom = shouldCorrect();
+    if (zoom === false) return;
+    correctContextViewPosition(el, zoom);
+  });
+  inner.observe(el, { attributes: true, attributeFilter: ["style"] });
+  // The inner observer is GC'd with the element on subtree removal — we
+  // don't track it explicitly. WeakMap entries clear at the same time.
+}
+
+/**
+ * Install a single document-wide observer that corrects Monaco's
+ * `.context-view` positioning under html zoom on WebKit. Idempotent: a
+ * second call is a no-op. Safe to call before `document.body` exists —
+ * we'll defer until DOM is ready.
+ *
+ * The observer is a permanent global; there's no uninstall. Cost is one
+ * MutationObserver on `document.body` (childList, subtree) plus a small
+ * inner observer per `.context-view` element. Both branches early-out at
+ * zoom == 1 or on Chromium.
+ */
+export function installMonacoContextViewFix(): void {
+  if (installed) return;
+  if (typeof document === "undefined") return;
+  installed = true;
+
+  const start = () => {
+    // `.context-view` is mounted as a direct child of `<body>` (or in some
+    // versions, a child of the editor's overflow container). A subtree
+    // observer covers both.
+    observer = new MutationObserver((records) => {
+      for (const r of records) {
+        if (r.type !== "childList") continue;
+        r.addedNodes.forEach((n) => {
+          if (!(n instanceof HTMLElement)) return;
+          // Match both the host and any nested `.context-view` (Monaco
+          // sometimes wraps submenus in their own context-view).
+          const hosts = n.classList.contains("context-view")
+            ? [n]
+            : Array.from(n.querySelectorAll<HTMLElement>(".context-view"));
+          for (const host of hosts) {
+            const zoom = shouldCorrect();
+            if (zoom !== false) correctContextViewPosition(host, zoom);
+            observeContextView(host);
+          }
+        });
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  };
+
+  if (document.body) {
+    start();
+  } else {
+    // main.tsx imports monacoSetup lazily, so body should exist by then —
+    // but DOMContentLoaded is the safe fallback for very early boots.
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  }
+}
+
+// Test-only: tear down the global observer between cases. Production code
+// never calls this — the observer is meant to live for the lifetime of the
+// app.
+export function __resetMonacoContextViewFixForTests(): void {
+  observer?.disconnect();
+  observer = null;
+  installed = false;
+}

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -32,19 +32,21 @@ export interface PositionTarget {
   style: { left: string; top: string };
 }
 
+// Last position WE wrote to each target. Used to suppress the
+// attribute-mutation feedback loop that re-firing the observer would
+// otherwise cause: when the post-correction values match the last-written
+// pair, we know Monaco hasn't moved the menu and skip.
+const lastApplied = new WeakMap<object, { left: number; top: number }>();
+
 /**
  * Pure function — exported for tests. Reads `style.left/top` off `el`,
- * divides by `zoom`, and writes the corrected pair back. Skips silently
- * when either coordinate is unparseable (Monaco hasn't mounted yet).
+ * divides by `zoom`, and writes the corrected pair back. Skips when:
+ *   - either coordinate is unparseable (Monaco hasn't mounted yet), or
+ *   - the current values match the last pair WE wrote (echo of our own
+ *     write firing the observer).
  *
- * Returns `true` when a write happened, `false` when it was skipped.
- *
- * Note: this function does NOT guard against the observer feedback loop.
- * The runtime caller below disconnects the per-host MutationObserver
- * around its writes — which is more reliable than a value-equality echo
- * guard, because Monaco can legitimately re-position to coordinates that
- * happen to match a previous corrected pair (e.g. raw 200/100 after
- * we just corrected raw 400/200 → 200/100 at zoom 2).
+ * Returns `true` when a write happened, `false` when it was skipped —
+ * the test suite uses this to assert the no-loop guarantee.
  */
 export function correctContextViewPosition(
   el: PositionTarget,
@@ -53,18 +55,32 @@ export function correctContextViewPosition(
   const left = parseFloat(el.style.left);
   const top = parseFloat(el.style.top);
   if (!Number.isFinite(left) || !Number.isFinite(top)) return false;
-  el.style.left = `${left / zoom}px`;
-  el.style.top = `${top / zoom}px`;
+
+  const last = lastApplied.get(el as object);
+  if (
+    last &&
+    Math.abs(last.left - left) < 0.5 &&
+    Math.abs(last.top - top) < 0.5
+  ) {
+    return false;
+  }
+
+  const correctedLeft = left / zoom;
+  const correctedTop = top / zoom;
+  el.style.left = `${correctedLeft}px`;
+  el.style.top = `${correctedTop}px`;
+  lastApplied.set(el as object, { left: correctedLeft, top: correctedTop });
   return true;
 }
 
+// Test-only: clear the WeakMap-backed echo guard so tests don't leak the
+// "last applied" state into the next case.
+export function __resetCorrectionMemoForTests(el: object): void {
+  lastApplied.delete(el);
+}
+
 let installed = false;
-let rootObserver: MutationObserver | null = null;
-// Per-host attribute observers, keyed by the `.context-view` element. A
-// `WeakMap` lets the entry GC with the host if Monaco drops it without
-// going through our removed-nodes path; the explicit dedup keeps a stale
-// observer from stacking when Monaco re-attaches the same node.
-const hostObservers = new WeakMap<HTMLElement, MutationObserver>();
+let observer: MutationObserver | null = null;
 
 function shouldCorrect(): false | number {
   const zoom = getRootZoom();
@@ -73,58 +89,18 @@ function shouldCorrect(): false | number {
   return zoom;
 }
 
-// Disconnect around our own writes so the inner observer never sees them.
-// This is more robust than a value-equality echo guard: at zoom 2, raw
-// 200/100 (which Monaco can legitimately set as a NEW position) cannot be
-// distinguished from the post-correction value of a prior raw 400/200 by
-// equality alone.
-function applyCorrection(host: HTMLElement, zoom: number): void {
-  const inner = hostObservers.get(host);
-  inner?.disconnect();
-  correctContextViewPosition(host, zoom);
-  // Re-attach so future Monaco-driven style writes still trigger us.
-  inner?.observe(host, { attributes: true, attributeFilter: ["style"] });
-}
-
-function attachHostObserver(host: HTMLElement): void {
-  // Dedup: if Monaco re-adds a `.context-view` we've already seen, reuse
-  // the existing observer rather than stacking another one.
-  if (hostObservers.has(host)) return;
+function observeContextView(el: HTMLElement): void {
+  // Monaco re-positions the menu while open in a few cases (resize, submenu
+  // expansion, viewport edge clamping) by setting style.left/top again. An
+  // attribute observer on the host catches each of those.
   const inner = new MutationObserver(() => {
     const zoom = shouldCorrect();
     if (zoom === false) return;
-    applyCorrection(host, zoom);
+    correctContextViewPosition(el, zoom);
   });
-  inner.observe(host, { attributes: true, attributeFilter: ["style"] });
-  hostObservers.set(host, inner);
-}
-
-function detachHostObserver(host: HTMLElement): void {
-  const inner = hostObservers.get(host);
-  if (!inner) return;
-  inner.disconnect();
-  hostObservers.delete(host);
-}
-
-function visitAddedNode(node: Node, zoom: number | false): void {
-  if (!(node instanceof HTMLElement)) return;
-  const hosts = node.classList.contains("context-view")
-    ? [node]
-    : Array.from(node.querySelectorAll<HTMLElement>(".context-view"));
-  for (const host of hosts) {
-    if (zoom !== false) applyCorrection(host, zoom);
-    attachHostObserver(host);
-  }
-}
-
-function visitRemovedNode(node: Node): void {
-  if (!(node instanceof HTMLElement)) return;
-  if (node.classList.contains("context-view")) {
-    detachHostObserver(node);
-  }
-  for (const host of node.querySelectorAll<HTMLElement>(".context-view")) {
-    detachHostObserver(host);
-  }
+  inner.observe(el, { attributes: true, attributeFilter: ["style"] });
+  // The inner observer is GC'd with the element on subtree removal — we
+  // don't track it explicitly. WeakMap entries clear at the same time.
 }
 
 /**
@@ -134,10 +110,9 @@ function visitRemovedNode(node: Node): void {
  * we'll defer until DOM is ready.
  *
  * The observer is a permanent global; there's no uninstall. Cost is one
- * MutationObserver on `document.body` (childList, subtree). The callback
- * early-outs at zoom == 1 before doing any DOM scanning, so the steady-
- * state overhead during chat/terminal streaming is one cheap zoom read
- * per batch of mutation records.
+ * MutationObserver on `document.body` (childList, subtree) plus a small
+ * inner observer per `.context-view` element. Both branches early-out at
+ * zoom == 1 or on Chromium.
  */
 export function installMonacoContextViewFix(): void {
   if (installed) return;
@@ -145,18 +120,28 @@ export function installMonacoContextViewFix(): void {
   installed = true;
 
   const start = () => {
-    rootObserver = new MutationObserver((records) => {
-      // Cheap perf gate: at zoom 1 the fix is unconditionally a no-op, so
-      // skip the per-mutation `querySelectorAll` scan that would otherwise
-      // run on every chat/terminal append.
-      const zoom = getRootZoom() === 1 ? false : shouldCorrect();
+    // `.context-view` is mounted as a direct child of `<body>` (or in some
+    // versions, a child of the editor's overflow container). A subtree
+    // observer covers both.
+    observer = new MutationObserver((records) => {
       for (const r of records) {
         if (r.type !== "childList") continue;
-        r.addedNodes.forEach((n) => visitAddedNode(n, zoom));
-        r.removedNodes.forEach(visitRemovedNode);
+        r.addedNodes.forEach((n) => {
+          if (!(n instanceof HTMLElement)) return;
+          // Match both the host and any nested `.context-view` (Monaco
+          // sometimes wraps submenus in their own context-view).
+          const hosts = n.classList.contains("context-view")
+            ? [n]
+            : Array.from(n.querySelectorAll<HTMLElement>(".context-view"));
+          for (const host of hosts) {
+            const zoom = shouldCorrect();
+            if (zoom !== false) correctContextViewPosition(host, zoom);
+            observeContextView(host);
+          }
+        });
       }
     });
-    rootObserver.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body, { childList: true, subtree: true });
   };
 
   if (document.body) {
@@ -168,13 +153,11 @@ export function installMonacoContextViewFix(): void {
   }
 }
 
-// Test-only: tear down the global observer + per-host map between cases.
-// Production code never calls this — the observer is meant to live for
-// the lifetime of the app.
+// Test-only: tear down the global observer between cases. Production code
+// never calls this — the observer is meant to live for the lifetime of the
+// app.
 export function __resetMonacoContextViewFixForTests(): void {
-  rootObserver?.disconnect();
-  rootObserver = null;
+  observer?.disconnect();
+  observer = null;
   installed = false;
-  // WeakMap can't be cleared explicitly — but each test creates fresh
-  // host objects, so previous entries simply get GC'd.
 }

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -126,14 +126,51 @@ function detachHostObserver(host: HTMLElement): void {
   hostObservers.delete(host);
 }
 
+// Track shadow roots we've observed so we don't double-attach on
+// re-entry. Also a WeakSet because the shadow-root-host element is a
+// regular DOM node that can be removed.
+const observedShadowRoots = new WeakSet<ShadowRoot>();
+
+function watchShadowRoot(root: ShadowRoot, zoom: number | false): void {
+  if (observedShadowRoots.has(root)) return;
+  observedShadowRoots.add(root);
+  // Pick up any `.context-view` already inside.
+  for (const host of root.querySelectorAll<HTMLElement>(".context-view")) {
+    if (zoom !== false) correctContextViewPosition(host, zoom);
+    attachHostObserver(host);
+  }
+  // And subscribe so future additions are caught.
+  const inner = new MutationObserver((records) => {
+    const innerZoom = shouldCorrect();
+    for (const r of records) {
+      if (r.type !== "childList") continue;
+      r.addedNodes.forEach((n) => visitAddedNode(n, innerZoom));
+      r.removedNodes.forEach(visitRemovedNode);
+    }
+  });
+  inner.observe(root, { childList: true, subtree: true });
+}
+
 function visitAddedNode(node: Node, zoom: number | false): void {
   if (!(node instanceof HTMLElement)) return;
+  // 1. Direct/descendant `.context-view` in the light DOM.
   const hosts = node.classList.contains("context-view")
     ? [node]
     : Array.from(node.querySelectorAll<HTMLElement>(".context-view"));
   for (const host of hosts) {
     if (zoom !== false) correctContextViewPosition(host, zoom);
     attachHostObserver(host);
+  }
+  // 2. Shadow roots: Monaco's StandaloneContextViewService can mount the
+  //    context view INSIDE a shadow DOM (`<div class="shadow-root-host">`
+  //    + `attachShadow({mode: 'open'})`), and MutationObserver does not
+  //    pierce shadow boundaries. Attach a separate observer to each
+  //    shadow root we encounter so the fix reaches the menu Monaco is
+  //    actually rendering. Walk the subtree here because the shadow host
+  //    can be a deep descendant of an added node.
+  if (node.shadowRoot) watchShadowRoot(node.shadowRoot, zoom);
+  for (const el of node.querySelectorAll<HTMLElement>("*")) {
+    if (el.shadowRoot) watchShadowRoot(el.shadowRoot, zoom);
   }
 }
 
@@ -178,6 +215,12 @@ export function installMonacoContextViewFix(): void {
       }
     });
     rootObserver.observe(document.body, { childList: true, subtree: true });
+    // Seed: scan once for any `.context-view` and shadow roots that
+    // already exist at install time. Monaco's StandaloneContextViewService
+    // creates its persistent host element when the editor mounts, which
+    // typically happens BEFORE this install runs.
+    const seedZoom = shouldCorrect();
+    visitAddedNode(document.body, seedZoom);
   };
 
   if (document.body) {

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -32,21 +32,19 @@ export interface PositionTarget {
   style: { left: string; top: string };
 }
 
-// Last position WE wrote to each target. Used to suppress the
-// attribute-mutation feedback loop that re-firing the observer would
-// otherwise cause: when the post-correction values match the last-written
-// pair, we know Monaco hasn't moved the menu and skip.
-const lastApplied = new WeakMap<object, { left: number; top: number }>();
-
 /**
  * Pure function — exported for tests. Reads `style.left/top` off `el`,
- * divides by `zoom`, and writes the corrected pair back. Skips when:
- *   - either coordinate is unparseable (Monaco hasn't mounted yet), or
- *   - the current values match the last pair WE wrote (echo of our own
- *     write firing the observer).
+ * divides by `zoom`, and writes the corrected pair back. Skips silently
+ * when either coordinate is unparseable (Monaco hasn't mounted yet).
  *
- * Returns `true` when a write happened, `false` when it was skipped —
- * the test suite uses this to assert the no-loop guarantee.
+ * Returns `true` when a write happened, `false` when it was skipped.
+ *
+ * Note: this function does NOT guard against the observer feedback loop.
+ * The runtime caller below disconnects the per-host MutationObserver
+ * around its writes — which is more reliable than a value-equality echo
+ * guard, because Monaco can legitimately re-position to coordinates that
+ * happen to match a previous corrected pair (e.g. raw 200/100 after
+ * we just corrected raw 400/200 → 200/100 at zoom 2).
  */
 export function correctContextViewPosition(
   el: PositionTarget,
@@ -55,32 +53,18 @@ export function correctContextViewPosition(
   const left = parseFloat(el.style.left);
   const top = parseFloat(el.style.top);
   if (!Number.isFinite(left) || !Number.isFinite(top)) return false;
-
-  const last = lastApplied.get(el as object);
-  if (
-    last &&
-    Math.abs(last.left - left) < 0.5 &&
-    Math.abs(last.top - top) < 0.5
-  ) {
-    return false;
-  }
-
-  const correctedLeft = left / zoom;
-  const correctedTop = top / zoom;
-  el.style.left = `${correctedLeft}px`;
-  el.style.top = `${correctedTop}px`;
-  lastApplied.set(el as object, { left: correctedLeft, top: correctedTop });
+  el.style.left = `${left / zoom}px`;
+  el.style.top = `${top / zoom}px`;
   return true;
 }
 
-// Test-only: clear the WeakMap-backed echo guard so tests don't leak the
-// "last applied" state into the next case.
-export function __resetCorrectionMemoForTests(el: object): void {
-  lastApplied.delete(el);
-}
-
 let installed = false;
-let observer: MutationObserver | null = null;
+let rootObserver: MutationObserver | null = null;
+// Per-host attribute observers, keyed by the `.context-view` element. A
+// `WeakMap` lets the entry GC with the host if Monaco drops it without
+// going through our removed-nodes path; the explicit dedup keeps a stale
+// observer from stacking when Monaco re-attaches the same node.
+const hostObservers = new WeakMap<HTMLElement, MutationObserver>();
 
 function shouldCorrect(): false | number {
   const zoom = getRootZoom();
@@ -89,18 +73,58 @@ function shouldCorrect(): false | number {
   return zoom;
 }
 
-function observeContextView(el: HTMLElement): void {
-  // Monaco re-positions the menu while open in a few cases (resize, submenu
-  // expansion, viewport edge clamping) by setting style.left/top again. An
-  // attribute observer on the host catches each of those.
+// Disconnect around our own writes so the inner observer never sees them.
+// This is more robust than a value-equality echo guard: at zoom 2, raw
+// 200/100 (which Monaco can legitimately set as a NEW position) cannot be
+// distinguished from the post-correction value of a prior raw 400/200 by
+// equality alone.
+function applyCorrection(host: HTMLElement, zoom: number): void {
+  const inner = hostObservers.get(host);
+  inner?.disconnect();
+  correctContextViewPosition(host, zoom);
+  // Re-attach so future Monaco-driven style writes still trigger us.
+  inner?.observe(host, { attributes: true, attributeFilter: ["style"] });
+}
+
+function attachHostObserver(host: HTMLElement): void {
+  // Dedup: if Monaco re-adds a `.context-view` we've already seen, reuse
+  // the existing observer rather than stacking another one.
+  if (hostObservers.has(host)) return;
   const inner = new MutationObserver(() => {
     const zoom = shouldCorrect();
     if (zoom === false) return;
-    correctContextViewPosition(el, zoom);
+    applyCorrection(host, zoom);
   });
-  inner.observe(el, { attributes: true, attributeFilter: ["style"] });
-  // The inner observer is GC'd with the element on subtree removal — we
-  // don't track it explicitly. WeakMap entries clear at the same time.
+  inner.observe(host, { attributes: true, attributeFilter: ["style"] });
+  hostObservers.set(host, inner);
+}
+
+function detachHostObserver(host: HTMLElement): void {
+  const inner = hostObservers.get(host);
+  if (!inner) return;
+  inner.disconnect();
+  hostObservers.delete(host);
+}
+
+function visitAddedNode(node: Node, zoom: number | false): void {
+  if (!(node instanceof HTMLElement)) return;
+  const hosts = node.classList.contains("context-view")
+    ? [node]
+    : Array.from(node.querySelectorAll<HTMLElement>(".context-view"));
+  for (const host of hosts) {
+    if (zoom !== false) applyCorrection(host, zoom);
+    attachHostObserver(host);
+  }
+}
+
+function visitRemovedNode(node: Node): void {
+  if (!(node instanceof HTMLElement)) return;
+  if (node.classList.contains("context-view")) {
+    detachHostObserver(node);
+  }
+  for (const host of node.querySelectorAll<HTMLElement>(".context-view")) {
+    detachHostObserver(host);
+  }
 }
 
 /**
@@ -110,9 +134,10 @@ function observeContextView(el: HTMLElement): void {
  * we'll defer until DOM is ready.
  *
  * The observer is a permanent global; there's no uninstall. Cost is one
- * MutationObserver on `document.body` (childList, subtree) plus a small
- * inner observer per `.context-view` element. Both branches early-out at
- * zoom == 1 or on Chromium.
+ * MutationObserver on `document.body` (childList, subtree). The callback
+ * early-outs at zoom == 1 before doing any DOM scanning, so the steady-
+ * state overhead during chat/terminal streaming is one cheap zoom read
+ * per batch of mutation records.
  */
 export function installMonacoContextViewFix(): void {
   if (installed) return;
@@ -120,28 +145,18 @@ export function installMonacoContextViewFix(): void {
   installed = true;
 
   const start = () => {
-    // `.context-view` is mounted as a direct child of `<body>` (or in some
-    // versions, a child of the editor's overflow container). A subtree
-    // observer covers both.
-    observer = new MutationObserver((records) => {
+    rootObserver = new MutationObserver((records) => {
+      // Cheap perf gate: at zoom 1 the fix is unconditionally a no-op, so
+      // skip the per-mutation `querySelectorAll` scan that would otherwise
+      // run on every chat/terminal append.
+      const zoom = getRootZoom() === 1 ? false : shouldCorrect();
       for (const r of records) {
         if (r.type !== "childList") continue;
-        r.addedNodes.forEach((n) => {
-          if (!(n instanceof HTMLElement)) return;
-          // Match both the host and any nested `.context-view` (Monaco
-          // sometimes wraps submenus in their own context-view).
-          const hosts = n.classList.contains("context-view")
-            ? [n]
-            : Array.from(n.querySelectorAll<HTMLElement>(".context-view"));
-          for (const host of hosts) {
-            const zoom = shouldCorrect();
-            if (zoom !== false) correctContextViewPosition(host, zoom);
-            observeContextView(host);
-          }
-        });
+        r.addedNodes.forEach((n) => visitAddedNode(n, zoom));
+        r.removedNodes.forEach(visitRemovedNode);
       }
     });
-    observer.observe(document.body, { childList: true, subtree: true });
+    rootObserver.observe(document.body, { childList: true, subtree: true });
   };
 
   if (document.body) {
@@ -153,11 +168,13 @@ export function installMonacoContextViewFix(): void {
   }
 }
 
-// Test-only: tear down the global observer between cases. Production code
-// never calls this — the observer is meant to live for the lifetime of the
-// app.
+// Test-only: tear down the global observer + per-host map between cases.
+// Production code never calls this — the observer is meant to live for
+// the lifetime of the app.
 export function __resetMonacoContextViewFixForTests(): void {
-  observer?.disconnect();
-  observer = null;
+  rootObserver?.disconnect();
+  rootObserver = null;
   installed = false;
+  // WeakMap can't be cleared explicitly — but each test creates fresh
+  // host objects, so previous entries simply get GC'd.
 }

--- a/src/ui/src/utils/monacoContextViewFix.ts
+++ b/src/ui/src/utils/monacoContextViewFix.ts
@@ -36,6 +36,19 @@ export interface PositionTarget {
 // attribute-mutation feedback loop that re-firing the observer would
 // otherwise cause: when the post-correction values match the last-written
 // pair, we know Monaco hasn't moved the menu and skip.
+//
+// Trade-off vs codex's review (MAJOR finding #1): this guard CAN false-skip
+// if Monaco genuinely repositions to coordinates that happen to equal a
+// previous corrected pair (e.g. raw 200/100 after correcting raw 400/200
+// → 200/100 at zoom 2). We accept that edge case — it requires the user
+// to deliberately open a second menu at a position that exactly matches
+// the prior corrected pair, which is rare. The earlier "fix" via
+// disconnect-around-write was theoretically cleaner but shifted the
+// failure mode: WKWebView appears to deliver Monaco's separate
+// `style.top` and `style.left` writes as distinct callbacks, and the
+// disconnect window between them caused the FIRST callback to read a
+// half-updated state and re-divide the already-corrected coordinate on
+// the SECOND callback — which broke the menu in the running app.
 const lastApplied = new WeakMap<object, { left: number; top: number }>();
 
 /**
@@ -45,8 +58,7 @@ const lastApplied = new WeakMap<object, { left: number; top: number }>();
  *   - the current values match the last pair WE wrote (echo of our own
  *     write firing the observer).
  *
- * Returns `true` when a write happened, `false` when it was skipped —
- * the test suite uses this to assert the no-loop guarantee.
+ * Returns `true` when a write happened, `false` when it was skipped.
  */
 export function correctContextViewPosition(
   el: PositionTarget,
@@ -80,7 +92,12 @@ export function __resetCorrectionMemoForTests(el: object): void {
 }
 
 let installed = false;
-let observer: MutationObserver | null = null;
+let rootObserver: MutationObserver | null = null;
+// Per-host attribute observers, keyed by the `.context-view` element. A
+// `WeakMap` lets the entry GC with the host if Monaco drops it without
+// going through our removed-nodes path; the explicit dedup keeps a stale
+// observer from stacking when Monaco re-attaches the same node.
+const hostObservers = new WeakMap<HTMLElement, MutationObserver>();
 
 function shouldCorrect(): false | number {
   const zoom = getRootZoom();
@@ -89,18 +106,45 @@ function shouldCorrect(): false | number {
   return zoom;
 }
 
-function observeContextView(el: HTMLElement): void {
-  // Monaco re-positions the menu while open in a few cases (resize, submenu
-  // expansion, viewport edge clamping) by setting style.left/top again. An
-  // attribute observer on the host catches each of those.
+function attachHostObserver(host: HTMLElement): void {
+  // Dedup: if Monaco re-adds a `.context-view` we've already seen, reuse
+  // the existing observer rather than stacking another one.
+  if (hostObservers.has(host)) return;
   const inner = new MutationObserver(() => {
     const zoom = shouldCorrect();
     if (zoom === false) return;
-    correctContextViewPosition(el, zoom);
+    correctContextViewPosition(host, zoom);
   });
-  inner.observe(el, { attributes: true, attributeFilter: ["style"] });
-  // The inner observer is GC'd with the element on subtree removal — we
-  // don't track it explicitly. WeakMap entries clear at the same time.
+  inner.observe(host, { attributes: true, attributeFilter: ["style"] });
+  hostObservers.set(host, inner);
+}
+
+function detachHostObserver(host: HTMLElement): void {
+  const inner = hostObservers.get(host);
+  if (!inner) return;
+  inner.disconnect();
+  hostObservers.delete(host);
+}
+
+function visitAddedNode(node: Node, zoom: number | false): void {
+  if (!(node instanceof HTMLElement)) return;
+  const hosts = node.classList.contains("context-view")
+    ? [node]
+    : Array.from(node.querySelectorAll<HTMLElement>(".context-view"));
+  for (const host of hosts) {
+    if (zoom !== false) correctContextViewPosition(host, zoom);
+    attachHostObserver(host);
+  }
+}
+
+function visitRemovedNode(node: Node): void {
+  if (!(node instanceof HTMLElement)) return;
+  if (node.classList.contains("context-view")) {
+    detachHostObserver(node);
+  }
+  for (const host of node.querySelectorAll<HTMLElement>(".context-view")) {
+    detachHostObserver(host);
+  }
 }
 
 /**
@@ -111,8 +155,10 @@ function observeContextView(el: HTMLElement): void {
  *
  * The observer is a permanent global; there's no uninstall. Cost is one
  * MutationObserver on `document.body` (childList, subtree) plus a small
- * inner observer per `.context-view` element. Both branches early-out at
- * zoom == 1 or on Chromium.
+ * inner observer per `.context-view` element. The root callback
+ * early-outs at zoom == 1 before doing any DOM scanning, so the
+ * steady-state overhead during chat/terminal streaming is one cheap
+ * zoom read per batch of mutation records.
  */
 export function installMonacoContextViewFix(): void {
   if (installed) return;
@@ -120,28 +166,18 @@ export function installMonacoContextViewFix(): void {
   installed = true;
 
   const start = () => {
-    // `.context-view` is mounted as a direct child of `<body>` (or in some
-    // versions, a child of the editor's overflow container). A subtree
-    // observer covers both.
-    observer = new MutationObserver((records) => {
+    rootObserver = new MutationObserver((records) => {
+      // Cheap perf gate: at zoom 1 the fix is unconditionally a no-op, so
+      // skip the per-mutation `querySelectorAll` scan that would otherwise
+      // run on every chat/terminal append.
+      const zoom = getRootZoom() === 1 ? false : shouldCorrect();
       for (const r of records) {
         if (r.type !== "childList") continue;
-        r.addedNodes.forEach((n) => {
-          if (!(n instanceof HTMLElement)) return;
-          // Match both the host and any nested `.context-view` (Monaco
-          // sometimes wraps submenus in their own context-view).
-          const hosts = n.classList.contains("context-view")
-            ? [n]
-            : Array.from(n.querySelectorAll<HTMLElement>(".context-view"));
-          for (const host of hosts) {
-            const zoom = shouldCorrect();
-            if (zoom !== false) correctContextViewPosition(host, zoom);
-            observeContextView(host);
-          }
-        });
+        r.addedNodes.forEach((n) => visitAddedNode(n, zoom));
+        r.removedNodes.forEach(visitRemovedNode);
       }
     });
-    observer.observe(document.body, { childList: true, subtree: true });
+    rootObserver.observe(document.body, { childList: true, subtree: true });
   };
 
   if (document.body) {
@@ -153,11 +189,13 @@ export function installMonacoContextViewFix(): void {
   }
 }
 
-// Test-only: tear down the global observer between cases. Production code
-// never calls this — the observer is meant to live for the lifetime of the
-// app.
+// Test-only: tear down the global observer + per-host map between cases.
+// Production code never calls this — the observer is meant to live for
+// the lifetime of the app.
 export function __resetMonacoContextViewFixForTests(): void {
-  observer?.disconnect();
-  observer = null;
+  rootObserver?.disconnect();
+  rootObserver = null;
   installed = false;
+  // WeakMap can't be cleared explicitly — but each test creates fresh
+  // host objects, so previous entries simply get GC'd.
 }

--- a/src/ui/src/utils/zoom.test.ts
+++ b/src/ui/src/utils/zoom.test.ts
@@ -151,26 +151,6 @@ describe("eventCoordSpace", () => {
       expect(eventCoordSpace()).toBe("visual");
     });
   });
-
-  it("does not cache the no-DOM fallback so a later real probe wins", () => {
-    // Codex review caught this: if the first call happened during boot
-    // before document.body existed, the old cache logic locked in
-    // 'visual' even on Chromium. After the fix, the fallback is
-    // returned but NOT cached, so the next call with real DOM gets the
-    // real engine answer.
-    withRootZoom("1.5", () => {
-      // First call: no DOM → returns "visual" (default), should not cache.
-      expect(eventCoordSpace()).toBe("visual");
-    });
-    // New shim with Chromium-style rect, same session.
-    withRootZoom(
-      "1.5",
-      () => {
-        expect(eventCoordSpace()).toBe("layout");
-      },
-      { probeRectLeft: () => 100 },
-    );
-  });
 });
 
 describe("viewportToFixed", () => {

--- a/src/ui/src/utils/zoom.test.ts
+++ b/src/ui/src/utils/zoom.test.ts
@@ -151,6 +151,26 @@ describe("eventCoordSpace", () => {
       expect(eventCoordSpace()).toBe("visual");
     });
   });
+
+  it("does not cache the no-DOM fallback so a later real probe wins", () => {
+    // Codex review caught this: if the first call happened during boot
+    // before document.body existed, the old cache logic locked in
+    // 'visual' even on Chromium. After the fix, the fallback is
+    // returned but NOT cached, so the next call with real DOM gets the
+    // real engine answer.
+    withRootZoom("1.5", () => {
+      // First call: no DOM → returns "visual" (default), should not cache.
+      expect(eventCoordSpace()).toBe("visual");
+    });
+    // New shim with Chromium-style rect, same session.
+    withRootZoom(
+      "1.5",
+      () => {
+        expect(eventCoordSpace()).toBe("layout");
+      },
+      { probeRectLeft: () => 100 },
+    );
+  });
 });
 
 describe("viewportToFixed", () => {

--- a/src/ui/src/utils/zoom.test.ts
+++ b/src/ui/src/utils/zoom.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  eventCoordSpace,
   getRootZoom,
+  resetCoordSpaceCache,
   viewportLayoutSize,
   viewportToFixed,
 } from "./zoom";
@@ -9,21 +11,63 @@ import {
 // minimal `document.documentElement` and `window` surface that mirrors
 // what the helpers actually touch. Same pattern as focusTargets.test.ts.
 
+type ProbeNode = {
+  style: { cssText: string };
+  getBoundingClientRect?: () => { left: number };
+};
+
 type GlobalShim = {
-  document?: { documentElement: { style: { zoom: string } } };
+  document?: {
+    documentElement: { style: { zoom: string } };
+    body?: {
+      appendChild: (node: ProbeNode) => void;
+      removeChild: (node: ProbeNode) => void;
+    };
+    createElement?: (tag: string) => ProbeNode;
+  };
   window?: { innerWidth: number; innerHeight: number };
 };
 
-function withRootZoom(zoom: string | undefined, fn: () => void) {
+interface RootOpts {
+  // When set, attach a fake `body` + `createElement` so the engine probe
+  // can run. The factory receives the cssText that the probe assigned to
+  // the element and returns the `rect.left` it should report — this is
+  // how each test simulates a particular engine.
+  probeRectLeft?: (cssText: string) => number;
+}
+
+function withRootZoom(
+  zoom: string | undefined,
+  fn: () => void,
+  opts: RootOpts = {},
+) {
   const g = globalThis as unknown as GlobalShim;
   const prevDoc = g.document;
-  g.document = {
+  const doc: NonNullable<GlobalShim["document"]> = {
     documentElement: { style: { zoom: zoom ?? "" } },
   };
+  if (opts.probeRectLeft) {
+    const rectFor = opts.probeRectLeft;
+    doc.createElement = () => {
+      const node: ProbeNode = { style: { cssText: "" } };
+      node.getBoundingClientRect = () => ({ left: rectFor(node.style.cssText) });
+      return node;
+    };
+    doc.body = {
+      appendChild: () => {},
+      removeChild: () => {},
+    };
+  }
+  g.document = doc;
+  // The probe answer is cached at module scope to avoid re-measuring on
+  // every menu open. Reset between tests so each one exercises the branch
+  // it intends to.
+  resetCoordSpaceCache();
   try {
     fn();
   } finally {
     g.document = prevDoc;
+    resetCoordSpaceCache();
   }
 }
 
@@ -44,6 +88,7 @@ afterEach(() => {
   const g = globalThis as unknown as GlobalShim;
   delete g.document;
   delete g.window;
+  resetCoordSpaceCache();
 });
 
 describe("getRootZoom", () => {
@@ -75,6 +120,39 @@ describe("getRootZoom", () => {
   });
 });
 
+describe("eventCoordSpace", () => {
+  // The probe places a fixed-positioned 100px-wide marker and reads back
+  // its rect.left. WebKit reports rect.left ≈ 100 * zoom (the rect is in
+  // the visual frame); Chromium reports rect.left ≈ 100 (layout frame).
+  it("detects WebKit when the rect is reported in the visual frame", () => {
+    withRootZoom(
+      "1.5",
+      () => {
+        expect(eventCoordSpace()).toBe("visual");
+      },
+      { probeRectLeft: () => 150 },
+    );
+  });
+
+  it("detects Chromium when the rect is reported in the layout frame", () => {
+    withRootZoom(
+      "1.5",
+      () => {
+        expect(eventCoordSpace()).toBe("layout");
+      },
+      { probeRectLeft: () => 100 },
+    );
+  });
+
+  it("falls back to 'visual' when there's no DOM to probe", () => {
+    // No probeRectLeft → no body / createElement, mirroring the SSR / very
+    // early bootstrap window before <body> is attached.
+    withRootZoom("1.5", () => {
+      expect(eventCoordSpace()).toBe("visual");
+    });
+  });
+});
+
 describe("viewportToFixed", () => {
   it("passes coords through unchanged at zoom=1", () => {
     withRootZoom("", () => {
@@ -82,16 +160,33 @@ describe("viewportToFixed", () => {
     });
   });
 
-  it("divides coords by the zoom factor so `position: fixed; left: x` lands at the cursor", () => {
-    // WebKit on macOS reports event clientX/Y in visual pixels but
-    // `position: fixed; left/top` interprets values as layout pixels —
-    // so visual / zoom = layout for a fixed element to render at the
-    // visual click point.
-    withRootZoom("1.5", () => {
-      const { x, y } = viewportToFixed(300, 150);
-      expect(x).toBeCloseTo(200, 6);
-      expect(y).toBeCloseTo(100, 6);
-    });
+  it("divides coords by zoom on WebKit (event clientX is visual px)", () => {
+    // WebKit reports clientX/Y in visual pixels but `position: fixed;
+    // left/top` interpret values in layout pixels — so visual / zoom =
+    // layout for the fixed element to render at the visual click point.
+    withRootZoom(
+      "1.5",
+      () => {
+        const { x, y } = viewportToFixed(300, 150);
+        expect(x).toBeCloseTo(200, 6);
+        expect(y).toBeCloseTo(100, 6);
+      },
+      { probeRectLeft: () => 150 },
+    );
+  });
+
+  it("passes coords through on Chromium (event clientX is already layout px)", () => {
+    // Chromium applies zoom uniformly: event coords, rects, and the fixed
+    // used-value all share one frame. Dividing here would over-correct and
+    // shift the element toward the top-left — which is the offset that
+    // Windows devs reported before this branch existed.
+    withRootZoom(
+      "1.5",
+      () => {
+        expect(viewportToFixed(300, 150)).toEqual({ x: 300, y: 150 });
+      },
+      { probeRectLeft: () => 100 },
+    );
   });
 });
 
@@ -104,15 +199,34 @@ describe("viewportLayoutSize", () => {
     });
   });
 
-  it("converts visual viewport size into layout pixels under zoom", () => {
+  it("converts visual viewport size into layout pixels under WebKit zoom", () => {
     // Same frame as `viewportToFixed`: layout = visual / zoom. Clamping
     // a fixed-positioned element wants layout-pixel bounds, not visual.
-    withRootZoom("1.5", () => {
-      withViewport(1920, 1080, () => {
-        const { width, height } = viewportLayoutSize();
-        expect(width).toBeCloseTo(1280, 6);
-        expect(height).toBeCloseTo(720, 6);
-      });
-    });
+    withRootZoom(
+      "1.5",
+      () => {
+        withViewport(1920, 1080, () => {
+          const { width, height } = viewportLayoutSize();
+          expect(width).toBeCloseTo(1280, 6);
+          expect(height).toBeCloseTo(720, 6);
+        });
+      },
+      { probeRectLeft: () => 150 },
+    );
+  });
+
+  it("returns innerWidth/innerHeight verbatim under Chromium zoom", () => {
+    // Chromium's innerWidth/Height already live in the layout frame, so
+    // dividing would shrink the clamp bounds and let the menu drift off
+    // the right/bottom edges.
+    withRootZoom(
+      "1.5",
+      () => {
+        withViewport(1920, 1080, () => {
+          expect(viewportLayoutSize()).toEqual({ width: 1920, height: 1080 });
+        });
+      },
+      { probeRectLeft: () => 100 },
+    );
   });
 });

--- a/src/ui/src/utils/zoom.ts
+++ b/src/ui/src/utils/zoom.ts
@@ -12,21 +12,21 @@ export function getRootZoom(): number {
 // left/top` used-value live in **visual** (post-zoom) or **layout** (pre-zoom)
 // pixels:
 //
-//   - WebKit (WKWebView on macOS, WebKitGTK on Linux) reports event coords
-//     and rects in visual pixels, while CSS `left/top` are interpreted in
-//     layout pixels. To place a `position: fixed` element under the cursor
-//     the click coords must be divided by the zoom factor.
+//   - WebKit (WKWebView, WebKitGTK) reports event coords and rects in visual
+//     pixels, while CSS `left/top` are interpreted in layout pixels. To place
+//     a `position: fixed` element under the cursor the click coords must be
+//     divided by the zoom factor.
 //
-//   - Chromium (WebView2 on Windows) applies zoom uniformly: event coords,
-//     rects, and CSS used-values all live in the same (layout) frame. No
-//     compensation is needed; dividing would over-correct and shift the
-//     element toward the top-left.
+//   - Chromium (WebView2) applies zoom uniformly: event coords, rects, and
+//     CSS used-values all live in the same (layout) frame. No compensation
+//     is needed; dividing would over-correct and shift the element toward
+//     the top-left.
 //
 // We pick the right branch with a behavior probe — render a fixed element at
 // a known offset and read back its rect. If the engine reports the rect in
 // the layout frame, `clientX` is in the layout frame too (no divide). If it
 // reports in the visual frame, divide. The answer is engine-stable, so we
-// cache it once we've seen a zoom != 1 the probe can actually distinguish.
+// cache it once we've actually measured a real rect.
 type CoordSpace = "visual" | "layout";
 
 let cachedCoordSpace: CoordSpace | null = null;
@@ -37,12 +37,14 @@ export function resetCoordSpaceCache(): void {
   cachedCoordSpace = null;
 }
 
-function probeCoordSpace(): CoordSpace {
-  if (typeof document === "undefined" || !document.body) return "visual";
+// Returns the measured coord space, or `null` when we couldn't actually run
+// the probe (no DOM yet, or zoom == 1 so the two frames coincide and the
+// measurement can't distinguish them). Callers must NOT cache `null` — the
+// next call may have real DOM and a non-trivial zoom available.
+function probeCoordSpace(): CoordSpace | null {
+  if (typeof document === "undefined" || !document.body) return null;
   const z = getRootZoom();
-  // At zoom == 1 the two frames coincide, so the probe can't distinguish.
-  // Caller falls back to the WebKit-style answer; we just don't cache it.
-  if (z === 1) return "visual";
+  if (z === 1) return null;
   const probe = document.createElement("div");
   // Hidden 100px-wide marker placed at a non-zero offset. `pointer-events:
   // none` and `visibility: hidden` keep it from interfering with anything
@@ -65,17 +67,15 @@ function probeCoordSpace(): CoordSpace {
 }
 
 // Returns which frame `MouseEvent.clientX/Y` live in for the current engine.
-// Cached after the first zoom != 1 call.
+// Cached after the first successful probe (zoom != 1, document.body present).
+// Falls back to `"visual"` when we can't measure yet — but does NOT cache
+// that fallback, so a later call with real DOM gets a real answer.
 export function eventCoordSpace(): CoordSpace {
   if (cachedCoordSpace !== null) return cachedCoordSpace;
-  const result = probeCoordSpace();
-  // Only lock in the answer once the probe could actually distinguish the
-  // two frames. At zoom=1 it returns "visual" by convention; we don't want
-  // to bake that in before the user ever bumps `uiFontSize`.
-  if (typeof document !== "undefined" && getRootZoom() !== 1) {
-    cachedCoordSpace = result;
-  }
-  return result;
+  const measured = probeCoordSpace();
+  if (measured === null) return "visual";
+  cachedCoordSpace = measured;
+  return measured;
 }
 
 // Translate event clientX/Y into the frame `position: fixed; left/top` uses,

--- a/src/ui/src/utils/zoom.ts
+++ b/src/ui/src/utils/zoom.ts
@@ -7,25 +7,98 @@ export function getRootZoom(): number {
   return Number.isFinite(z) && z > 0 ? z : 1;
 }
 
-// WebKit on macOS (used by Tauri's WKWebView) reports `clientX/Y` in event
-// handlers in *visual* (post-zoom) pixels, while CSS `position: fixed; left/top`
-// interpret their values in *layout* (pre-zoom) pixels. Without compensation
-// a fixed element placed at the click coords renders shifted by the zoom
-// factor — visibly off when zoom != 1. Divide event coords by zoom to land
-// the element at the cursor.
+// CSS `zoom` is non-standard, and engines disagree about whether
+// `MouseEvent.clientX/Y`, `getBoundingClientRect()`, and the `position: fixed;
+// left/top` used-value live in **visual** (post-zoom) or **layout** (pre-zoom)
+// pixels:
+//
+//   - WebKit (WKWebView on macOS, WebKitGTK on Linux) reports event coords
+//     and rects in visual pixels, while CSS `left/top` are interpreted in
+//     layout pixels. To place a `position: fixed` element under the cursor
+//     the click coords must be divided by the zoom factor.
+//
+//   - Chromium (WebView2 on Windows) applies zoom uniformly: event coords,
+//     rects, and CSS used-values all live in the same (layout) frame. No
+//     compensation is needed; dividing would over-correct and shift the
+//     element toward the top-left.
+//
+// We pick the right branch with a behavior probe — render a fixed element at
+// a known offset and read back its rect. If the engine reports the rect in
+// the layout frame, `clientX` is in the layout frame too (no divide). If it
+// reports in the visual frame, divide. The answer is engine-stable, so we
+// cache it once we've seen a zoom != 1 the probe can actually distinguish.
+type CoordSpace = "visual" | "layout";
+
+let cachedCoordSpace: CoordSpace | null = null;
+
+// Exposed so dev tooling / tests that mutate root zoom at runtime can force
+// a re-probe. Production code never calls this — the answer is engine-stable.
+export function resetCoordSpaceCache(): void {
+  cachedCoordSpace = null;
+}
+
+function probeCoordSpace(): CoordSpace {
+  if (typeof document === "undefined" || !document.body) return "visual";
+  const z = getRootZoom();
+  // At zoom == 1 the two frames coincide, so the probe can't distinguish.
+  // Caller falls back to the WebKit-style answer; we just don't cache it.
+  if (z === 1) return "visual";
+  const probe = document.createElement("div");
+  // Hidden 100px-wide marker placed at a non-zero offset. `pointer-events:
+  // none` and `visibility: hidden` keep it from interfering with anything
+  // already on screen during the few microseconds it lives.
+  probe.style.cssText =
+    "position:fixed;left:100px;top:0;width:100px;height:1px;" +
+    "pointer-events:none;visibility:hidden;contain:strict;";
+  document.body.appendChild(probe);
+  const rect = probe.getBoundingClientRect();
+  document.body.removeChild(probe);
+  // WebKit returns rect.left ≈ 100 * z (rect is visual-frame). Chromium
+  // returns rect.left ≈ 100 (rect is layout-frame). Pick whichever the
+  // measured value is closer to so sub-pixel rounding doesn't tip the
+  // answer.
+  const visual = 100 * z;
+  const layout = 100;
+  return Math.abs(rect.left - visual) < Math.abs(rect.left - layout)
+    ? "visual"
+    : "layout";
+}
+
+// Returns which frame `MouseEvent.clientX/Y` live in for the current engine.
+// Cached after the first zoom != 1 call.
+export function eventCoordSpace(): CoordSpace {
+  if (cachedCoordSpace !== null) return cachedCoordSpace;
+  const result = probeCoordSpace();
+  // Only lock in the answer once the probe could actually distinguish the
+  // two frames. At zoom=1 it returns "visual" by convention; we don't want
+  // to bake that in before the user ever bumps `uiFontSize`.
+  if (typeof document !== "undefined" && getRootZoom() !== 1) {
+    cachedCoordSpace = result;
+  }
+  return result;
+}
+
+// Translate event clientX/Y into the frame `position: fixed; left/top` uses,
+// so a fixed element placed at the result lands under the cursor. On engines
+// where the two frames already coincide, this is a no-op — see
+// `eventCoordSpace` for the engine matrix.
 export function viewportToFixed(x: number, y: number) {
   const z = getRootZoom();
   if (z === 1) return { x, y };
+  if (eventCoordSpace() === "layout") return { x, y };
   return { x: x / z, y: y / z };
 }
 
-// Visual viewport size in layout pixels — the right reference for clamping
-// a fixed-positioned element since fixed `left/top` are layout pixels too.
-// `window.innerWidth/innerHeight` return visual pixels under html zoom, so
-// we divide back into the same frame the placement is in.
+// Visual viewport size translated into the layout frame — the right reference
+// for clamping a fixed-positioned element since fixed `left/top` are layout
+// pixels under WebKit. On Chromium `window.innerWidth/innerHeight` already
+// live in the layout frame, so we leave them alone.
 export function viewportLayoutSize() {
   if (typeof window === "undefined") return { width: 0, height: 0 };
   const z = getRootZoom();
+  if (z === 1 || eventCoordSpace() === "layout") {
+    return { width: window.innerWidth, height: window.innerHeight };
+  }
   return {
     width: window.innerWidth / z,
     height: window.innerHeight / z,

--- a/src/ui/src/utils/zoom.ts
+++ b/src/ui/src/utils/zoom.ts
@@ -12,21 +12,21 @@ export function getRootZoom(): number {
 // left/top` used-value live in **visual** (post-zoom) or **layout** (pre-zoom)
 // pixels:
 //
-//   - WebKit (WKWebView, WebKitGTK) reports event coords and rects in visual
-//     pixels, while CSS `left/top` are interpreted in layout pixels. To place
-//     a `position: fixed` element under the cursor the click coords must be
-//     divided by the zoom factor.
+//   - WebKit (WKWebView on macOS, WebKitGTK on Linux) reports event coords
+//     and rects in visual pixels, while CSS `left/top` are interpreted in
+//     layout pixels. To place a `position: fixed` element under the cursor
+//     the click coords must be divided by the zoom factor.
 //
-//   - Chromium (WebView2) applies zoom uniformly: event coords, rects, and
-//     CSS used-values all live in the same (layout) frame. No compensation
-//     is needed; dividing would over-correct and shift the element toward
-//     the top-left.
+//   - Chromium (WebView2 on Windows) applies zoom uniformly: event coords,
+//     rects, and CSS used-values all live in the same (layout) frame. No
+//     compensation is needed; dividing would over-correct and shift the
+//     element toward the top-left.
 //
 // We pick the right branch with a behavior probe — render a fixed element at
 // a known offset and read back its rect. If the engine reports the rect in
 // the layout frame, `clientX` is in the layout frame too (no divide). If it
 // reports in the visual frame, divide. The answer is engine-stable, so we
-// cache it once we've actually measured a real rect.
+// cache it once we've seen a zoom != 1 the probe can actually distinguish.
 type CoordSpace = "visual" | "layout";
 
 let cachedCoordSpace: CoordSpace | null = null;
@@ -37,14 +37,12 @@ export function resetCoordSpaceCache(): void {
   cachedCoordSpace = null;
 }
 
-// Returns the measured coord space, or `null` when we couldn't actually run
-// the probe (no DOM yet, or zoom == 1 so the two frames coincide and the
-// measurement can't distinguish them). Callers must NOT cache `null` — the
-// next call may have real DOM and a non-trivial zoom available.
-function probeCoordSpace(): CoordSpace | null {
-  if (typeof document === "undefined" || !document.body) return null;
+function probeCoordSpace(): CoordSpace {
+  if (typeof document === "undefined" || !document.body) return "visual";
   const z = getRootZoom();
-  if (z === 1) return null;
+  // At zoom == 1 the two frames coincide, so the probe can't distinguish.
+  // Caller falls back to the WebKit-style answer; we just don't cache it.
+  if (z === 1) return "visual";
   const probe = document.createElement("div");
   // Hidden 100px-wide marker placed at a non-zero offset. `pointer-events:
   // none` and `visibility: hidden` keep it from interfering with anything
@@ -67,15 +65,17 @@ function probeCoordSpace(): CoordSpace | null {
 }
 
 // Returns which frame `MouseEvent.clientX/Y` live in for the current engine.
-// Cached after the first successful probe (zoom != 1, document.body present).
-// Falls back to `"visual"` when we can't measure yet — but does NOT cache
-// that fallback, so a later call with real DOM gets a real answer.
+// Cached after the first zoom != 1 call.
 export function eventCoordSpace(): CoordSpace {
   if (cachedCoordSpace !== null) return cachedCoordSpace;
-  const measured = probeCoordSpace();
-  if (measured === null) return "visual";
-  cachedCoordSpace = measured;
-  return measured;
+  const result = probeCoordSpace();
+  // Only lock in the answer once the probe could actually distinguish the
+  // two frames. At zoom=1 it returns "visual" by convention; we don't want
+  // to bake that in before the user ever bumps `uiFontSize`.
+  if (typeof document !== "undefined" && getRootZoom() !== 1) {
+    cachedCoordSpace = result;
+  }
+  return result;
 }
 
 // Translate event clientX/Y into the frame `position: fixed; left/top` uses,


### PR DESCRIPTION
## Problem

Right-click context menus across Claudette were rendering offset from the cursor on macOS / Linux when `Settings → Appearance → uiFontSize` was set to anything other than 13 (the default). Most visible on Monaco editor menus (Peek Definition, Find All References, Cut/Copy/Paste, etc.).

Root cause is the html-level CSS `zoom` Claudette uses to scale the UI:

- WebKit (WKWebView, WebKitGTK) reports `MouseEvent.clientX/Y` and `getBoundingClientRect()` in **visual** pixels but interprets `position: fixed; left/top` in **layout** pixels — so writing `clientX` straight into `style.left` lands the element at `clientX * zoom`, shifted past the cursor.
- Chromium (WebView2) treats the entire pipeline in the layout frame; no compensation is needed.
- Monaco's `StandaloneContextViewService` mounts the context view inside a **shadow DOM** in some configurations — and `MutationObserver` does NOT pierce shadow boundaries.

## Fix

Two layers:

### 1. Engine-aware zoom probe in `utils/zoom.ts`
A one-shot behavior probe places a hidden 100px-wide fixed marker and reads back its rect. WebKit returns `rect.left ≈ 100 * zoom` (visual frame); Chromium returns `rect.left ≈ 100` (layout frame). `viewportToFixed` and `viewportLayoutSize` consume the result so Claudette-owned portal menus (`AttachmentContextMenu`, etc.) compensate correctly per engine. Cached after first successful probe.

### 2. Monaco context-view positioning patch in `utils/monacoContextViewFix.ts`
Monaco sets `style.left/top` from `clientX/Y` directly, ignoring html zoom — and the upstream `fixedOverflowWidgets` option [does not apply to the context view](https://github.com/microsoft/monaco-editor/issues/1203) (open since 2018). The documented workaround is to portal the menu and correct it after Monaco mounts.

A single document-wide `MutationObserver` watches for `.context-view` mounts (in light DOM AND inside shadow roots, recursively), divides their `style.left/top` by zoom on engines that need it, and uses a per-host attribute observer plus a WeakMap echo guard to break the feedback loop. Per-host observer dedup prevents stacking across re-attaches; `removedNodes` cleanup keeps memory tidy.

## Audit — every cursor-anchored fixed-positioned menu

| Site | Path | Routes through |
|---|---|---|
| Attachment cards (image/PDF/CSV/JSON) | `chat/ChatPanel.tsx` → `AttachmentContextMenu` | ✅ engine probe |
| Session tab strip | `chat/SessionTabs.tsx` → `AttachmentContextMenu` | ✅ engine probe |
| File tree (right sidebar) | `right-sidebar/RightSidebar.tsx` → `AttachmentContextMenu` | ✅ engine probe |
| Terminal pane | `terminal/TerminalPanel.tsx` → `AttachmentContextMenu` | ✅ engine probe |
| Tab drag ghost | `terminal/TerminalPanel.tsx` `TabDragGhost` | ✅ `viewportToFixed` |
| Monaco editor (and quick-input picker, peek view, suggestion overlay) | Monaco's own `.context-view` | ✅ shadow-aware MutationObserver |

## Test coverage

- **Pure math** (`monacoContextViewFix.test.ts`, `zoom.test.ts`) — engine probe, viewport translation, echo-guard logic, sub-pixel epsilon
- **DOM integration** (`monacoContextViewFix.dom.test.ts`, 12 tests via happy-dom) — baseline correction on WebKit, no-op on Chromium / zoom=1, no-loop guarantee, re-attach dedup, shadow-DOM mount + reposition + remove/re-add + nested shadow roots, install-time seeding

Added `happy-dom` as a dev dependency to enable real `MutationObserver` testing — the gap that let an earlier refactor (`6a1d143d`) ship green and break the menu in WKWebView.

## Verification

1. Set `Settings → Appearance → uiFontSize` to e.g. 16.
2. Right-click in: a code file (Monaco), a CSV / image attachment, a session tab, the file tree, the terminal pane.
3. Each menu should land directly under the cursor.
4. Set `uiFontSize` back to 13 — observers no-op at zoom=1, behavior identical to before this branch.
5. On Windows (WebView2, when available) — engine probe selects layout branch, no compensation applied, menus land correctly.

Verified manually in the running dev app at `uiFontSize=15` (zoom=1.153846).

## Notes

- Two codex peer reviews drove the final shape. The first (commit `6a1d143d`) shipped a refactor that broke the menu — disconnect-around-write isn't safe across separate-callback delivery — and was reverted; the second confirmed the shadow-DOM fix is sound.
- Known limitation: at zoom 2, after correcting raw 400/200 → 200/100, a NEW Monaco reposition to raw 200/100 is treated as our own echo and skipped. Documented in `monacoContextViewFix.ts` and exercised by a test that asserts the trade-off; the alternative (disconnect-around-write) caused a worse production regression.

## Related

- microsoft/monaco-editor#1203 — context-view doesn't honor `fixedOverflowWidgets`
- microsoft/monaco-editor#484 — context menu clipping; documents the portal workaround