### PR TITLE
feat: show detailed SCM checks

### DIFF
--- a/plugins/scm-github/init.lua
+++ b/plugins/scm-github/init.lua
@@ -134,7 +134,7 @@ end
 function M.ci_status(args)
     local ok, data = pcall(gh, {
         "pr", "checks", args.branch,
-        "--json", "name,state,detailsUrl,startedAt",
+        "--json", "name,state,link,startedAt",
     })
     if not ok then
         return {}
@@ -144,7 +144,7 @@ function M.ci_status(args)
         table.insert(checks, {
             name = item.name,
             status = normalize_check_status(item.state),
-            url = item.detailsUrl,
+            url = item.link,
             started_at = item.startedAt,
         })
     end

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { applyTheme, applyUserFonts, loadAllThemes, findTheme, cacheThemePrefere
 import { DEFAULT_THEME_ID, DEFAULT_LIGHT_THEME_ID } from "./styles/themes";
 import type { ThemeDefinition } from "./types/theme";
 import { adjustUiFontSize, resetUiFontSize } from "./utils/fontSettings";
+import { deriveScmCiState } from "./utils/scmChecks";
 import { KEYBINDING_SETTING_PREFIX } from "./hotkeys/bindings";
 import { useMcpStatus } from "./hooks/useMcpStatus";
 import { useViewTogglePersistence } from "./hooks/useViewTogglePersistence";
@@ -98,10 +99,14 @@ function App() {
             typeof (parsed as { state: unknown }).state === "string"
               ? (parsed as import("./types/plugin").PullRequest)
               : null;
+          const parsedChecks: unknown = row.ci_json ? JSON.parse(row.ci_json) : [];
+          const checks = Array.isArray(parsedChecks)
+            ? (parsedChecks as import("./types/plugin").CiCheck[])
+            : [];
           useAppStore.getState().setScmSummary(row.workspace_id, {
             hasPr: pr !== null,
             prState: pr?.state ?? null,
-            ciState: pr?.ci_status ?? null,
+            ciState: pr ? deriveScmCiState(pr.ci_status, checks) : null,
             lastUpdated: new Date(row.fetched_at.replace(" ", "T") + "Z").getTime(),
           });
         } catch {
@@ -411,7 +416,9 @@ function App() {
       store.setScmSummary(detail.workspace_id, {
         hasPr: detail.pull_request !== null,
         prState: detail.pull_request?.state ?? null,
-        ciState: detail.pull_request?.ci_status ?? null,
+        ciState: detail.pull_request
+          ? deriveScmCiState(detail.pull_request.ci_status, detail.ci_checks)
+          : null,
         lastUpdated: Date.now(),
       });
       // Update detail if this is the selected workspace

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -1,8 +1,8 @@
 .banner {
   display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 20px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 20px 10px;
   /* Pin to the workspace-header row height so this banner's bottom border
    * lines up with WorkspacePanelHeader's bottom border on the chat side.
    * Without it (47px vs 54px), the layout's top horizontal divider goes
@@ -14,6 +14,14 @@
   border-bottom: 1px solid var(--divider);
   box-shadow: var(--shadow-sm);
   animation: fadeIn 0.15s ease;
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: calc(var(--workspace-header-h) - 19px);
 }
 
 .bannerReady,
@@ -106,4 +114,139 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.checksPanel {
+  width: 100%;
+  border-top: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  padding-top: 7px;
+}
+
+.checksToggle {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto 16px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 3px 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.checksToggle:hover .checksTitle {
+  color: var(--text-muted);
+}
+
+.checksTitle {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.checkCount {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.chevron {
+  color: var(--text-dim);
+  transform: rotate(0deg);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+}
+
+.checksToggle:hover .chevron {
+  color: var(--text-muted);
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+.checkList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 5px;
+}
+
+.checkRow {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto 14px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 27px;
+  padding: 3px 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  text-align: left;
+}
+
+.checkRowLink {
+  cursor: pointer;
+}
+
+.checkRowLink:hover {
+  color: var(--text-primary);
+}
+
+.checkName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.checkStatus {
+  color: var(--text-dim);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.checkExternalIcon {
+  color: var(--text-dim);
+  opacity: 0;
+}
+
+.checkRowLink:hover .checkExternalIcon {
+  opacity: 0.75;
+}
+
+.checkIconSuccess {
+  color: var(--badge-done);
+  justify-self: center;
+}
+
+.checkIconFailure {
+  color: var(--status-stopped);
+  fill: currentColor;
+  justify-self: center;
+}
+
+.checkIconCancelled {
+  color: var(--text-dim);
+  fill: currentColor;
+  justify-self: center;
+}
+
+.checkIconPending {
+  color: var(--badge-ask);
+  justify-self: center;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -1,8 +1,9 @@
 .banner {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px 20px 10px;
+  align-items: center;
+  gap: 6px;
+  position: relative;
+  padding: 10px 20px;
   /* Pin to the workspace-header row height so this banner's bottom border
    * lines up with WorkspacePanelHeader's bottom border on the chat side.
    * Without it (47px vs 54px), the layout's top horizontal divider goes
@@ -14,14 +15,6 @@
   border-bottom: 1px solid var(--divider);
   box-shadow: var(--shadow-sm);
   animation: fadeIn 0.15s ease;
-}
-
-.summaryRow {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  min-height: calc(var(--workspace-header-h) - 19px);
 }
 
 .bannerReady,
@@ -110,6 +103,52 @@
 .statusText {
   font-size: 12px;
   font-weight: 500;
+  white-space: nowrap;
+}
+
+.statusButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding: 3px 0 3px 8px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.statusButton:hover .statusText {
+  color: var(--text-primary);
+}
+
+.statusCount {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 16%, transparent);
+  color: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.statusChevron {
+  color: currentColor;
+  opacity: 0.72;
+  transform: rotate(0deg);
+  transition: transform var(--transition-fast), opacity var(--transition-fast);
+}
+
+.statusButton:hover .statusChevron {
+  opacity: 1;
+}
+
+.statusSolo {
   margin-left: auto;
   white-space: nowrap;
   overflow: hidden;
@@ -117,28 +156,28 @@
 }
 
 .checksPanel {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 20;
   width: 100%;
-  border-top: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
-  padding-top: 7px;
+  box-sizing: border-box;
+  padding: 10px 20px 12px;
+  background: color-mix(in srgb, var(--chat-header-bg) 88%, var(--error-bg));
+  border-bottom: 1px solid var(--divider);
+  box-shadow: var(--shadow-md);
+  animation: dropdownIn 0.12s ease;
 }
 
-.checksToggle {
+.checksHeader {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto 16px;
+  grid-template-columns: 18px minmax(0, 1fr);
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 3px 0;
-  border: none;
-  background: transparent;
+  padding: 2px 0 6px;
   color: var(--text-primary);
-  font: inherit;
-  cursor: pointer;
-  text-align: left;
-}
-
-.checksToggle:hover .checksTitle {
-  color: var(--text-muted);
 }
 
 .checksTitle {
@@ -148,23 +187,6 @@
   white-space: nowrap;
   font-size: 12px;
   font-weight: 600;
-}
-
-.checkCount {
-  color: var(--text-dim);
-  font-size: 11px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.chevron {
-  color: var(--text-dim);
-  transform: rotate(0deg);
-  transition: transform var(--transition-fast), color var(--transition-fast);
-}
-
-.checksToggle:hover .chevron {
-  color: var(--text-muted);
 }
 
 .chevronOpen {
@@ -249,4 +271,9 @@
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+@keyframes dropdownIn {
+  from { opacity: 0; transform: translateY(-3px); }
+  to { opacity: 1; transform: translateY(0); }
 }

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -20,23 +20,28 @@
 .bannerReady,
 .bannerOpen {
   background: color-mix(in srgb, var(--badge-done) 12%, var(--chat-header-bg));
+  --checks-panel-bg: color-mix(in srgb, var(--badge-done) 10%, var(--chat-header-bg));
 }
 
 .bannerPending {
   background: color-mix(in srgb, var(--badge-ask) 12%, var(--chat-header-bg));
+  --checks-panel-bg: color-mix(in srgb, var(--badge-ask) 10%, var(--chat-header-bg));
 }
 
 .bannerFailed {
   background: var(--error-bg);
+  --checks-panel-bg: color-mix(in srgb, var(--status-stopped) 16%, var(--chat-header-bg));
 }
 
 .bannerMerged {
   background: color-mix(in srgb, var(--badge-plan) 14%, var(--chat-header-bg));
+  --checks-panel-bg: color-mix(in srgb, var(--badge-plan) 10%, var(--chat-header-bg));
 }
 
 .bannerDraft,
 .bannerClosed {
   background: var(--chat-header-bg);
+  --checks-panel-bg: var(--chat-header-bg);
 }
 
 .fgReady,
@@ -164,7 +169,7 @@
   width: 100%;
   box-sizing: border-box;
   padding: 10px 20px 12px;
-  background: color-mix(in srgb, var(--chat-header-bg) 88%, var(--error-bg));
+  background: var(--checks-panel-bg, var(--chat-header-bg));
   border-bottom: 1px solid var(--divider);
   box-shadow: var(--shadow-md);
   animation: dropdownIn 0.12s ease;

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from "react";
+import { memo, useId, useMemo, useState } from "react";
 import {
   Check,
   ChevronRight,
@@ -76,6 +76,7 @@ const STATUS_CONFIG: Record<
 export const PrStatusBanner = memo(function PrStatusBanner() {
   const { pr, checks, status } = usePrBannerData();
   const [checksOpen, setChecksOpen] = useState(false);
+  const checksPanelId = useId();
   const sortedChecks = useMemo(() => sortCiChecks(checks), [checks]);
   const checksSummary = useMemo(() => summarizeCiChecks(checks), [checks]);
 
@@ -104,6 +105,8 @@ export const PrStatusBanner = memo(function PrStatusBanner() {
           className={`${styles.statusButton} ${config.fgClass}`}
           onClick={() => setChecksOpen((open) => !open)}
           aria-expanded={checksOpen}
+          aria-controls={checksPanelId}
+          aria-haspopup="dialog"
           title={checksSummary.title}
         >
           <span className={styles.statusText}>{config.text}</span>
@@ -121,7 +124,12 @@ export const PrStatusBanner = memo(function PrStatusBanner() {
       )}
 
       {hasChecks && checksOpen && (
-        <div className={styles.checksPanel}>
+        <div
+          id={checksPanelId}
+          className={styles.checksPanel}
+          role="dialog"
+          aria-label={checksSummary.title}
+        >
           <div className={styles.checksHeader}>
             <CheckStatusIcon status={checkSummaryStatus(checksSummary)} />
             <span className={styles.checksTitle}>{checksSummary.title}</span>

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
@@ -1,13 +1,23 @@
-import { memo } from "react";
+import { memo, useMemo, useState } from "react";
 import {
+  Check,
+  ChevronRight,
+  Circle,
   GitPullRequestArrow,
   GitPullRequestDraft,
   GitMerge,
   GitPullRequestClosed,
   ExternalLink,
+  LoaderCircle,
 } from "lucide-react";
 import { openUrl } from "../../services/tauri";
 import { usePrBannerData, type BannerStatus } from "../../hooks/usePrBannerData";
+import type { CiCheck } from "../../types/plugin";
+import {
+  ciCheckStatusLabel,
+  sortCiChecks,
+  summarizeCiChecks,
+} from "../../utils/scmChecks";
 import styles from "./PrStatusBanner.module.css";
 
 const STATUS_CONFIG: Record<
@@ -64,27 +74,108 @@ const STATUS_CONFIG: Record<
 };
 
 export const PrStatusBanner = memo(function PrStatusBanner() {
-  const { pr, status } = usePrBannerData();
+  const { pr, checks, status } = usePrBannerData();
+  const [checksOpen, setChecksOpen] = useState(true);
+  const sortedChecks = useMemo(() => sortCiChecks(checks), [checks]);
+  const checksSummary = useMemo(() => summarizeCiChecks(checks), [checks]);
 
   if (!pr || !status) return null;
 
   const config = STATUS_CONFIG[status];
   const Icon = config.icon;
+  const hasChecks = sortedChecks.length > 0;
 
   return (
     <div className={`${styles.banner} ${config.bannerClass}`}>
-      <button
-        className={`${styles.prPill} ${config.fgClass}`}
-        onClick={() => openUrl(pr.url)}
-        title={`Open PR #${pr.number} in browser`}
-      >
-        <Icon size={14} />
-        <span className={styles.prNumber}>#{pr.number}</span>
-        <ExternalLink size={14} className={styles.externalIcon} />
-      </button>
-      <span className={`${styles.statusText} ${config.fgClass}`}>
-        {config.text}
-      </span>
+      <div className={styles.summaryRow}>
+        <button
+          type="button"
+          className={`${styles.prPill} ${config.fgClass}`}
+          onClick={() => openUrl(pr.url)}
+          title={`Open PR #${pr.number} in browser`}
+        >
+          <Icon size={14} />
+          <span className={styles.prNumber}>PR #{pr.number}</span>
+          <ExternalLink size={14} className={styles.externalIcon} />
+        </button>
+        <span className={`${styles.statusText} ${config.fgClass}`}>
+          {config.text}
+        </span>
+      </div>
+
+      {hasChecks && (
+        <div className={styles.checksPanel}>
+          <button
+            type="button"
+            className={styles.checksToggle}
+            onClick={() => setChecksOpen((open) => !open)}
+            aria-expanded={checksOpen}
+          >
+            <CheckStatusIcon status={checkSummaryStatus(checksSummary)} />
+            <span className={styles.checksTitle}>{checksSummary.title}</span>
+            <span className={styles.checkCount}>{checksSummary.total}</span>
+            <ChevronRight
+              size={14}
+              className={`${styles.chevron} ${checksOpen ? styles.chevronOpen : ""}`}
+              aria-hidden="true"
+            />
+          </button>
+
+          {checksOpen && (
+            <div className={styles.checkList}>
+              {sortedChecks.map((check) => (
+                <CheckRow key={`${check.name}:${check.url ?? ""}`} check={check} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 });
+
+function checkSummaryStatus(summary: ReturnType<typeof summarizeCiChecks>): CiCheck["status"] {
+  if (summary.failed > 0) return "failure";
+  if (summary.pending > 0) return "pending";
+  if (summary.cancelled > 0) return "cancelled";
+  return "success";
+}
+
+function CheckRow({ check }: { check: CiCheck }) {
+  const content = (
+    <>
+      <CheckStatusIcon status={check.status} />
+      <span className={styles.checkName}>{check.name}</span>
+      <span className={styles.checkStatus}>{ciCheckStatusLabel(check.status)}</span>
+      {check.url && <ExternalLink size={12} className={styles.checkExternalIcon} />}
+    </>
+  );
+
+  if (check.url) {
+    return (
+      <button
+        type="button"
+        className={`${styles.checkRow} ${styles.checkRowLink}`}
+        onClick={() => openUrl(check.url!)}
+        title={`Open ${check.name} check details`}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return <div className={styles.checkRow}>{content}</div>;
+}
+
+function CheckStatusIcon({ status }: { status: CiCheck["status"] }) {
+  switch (status) {
+    case "success":
+      return <Check size={16} className={styles.checkIconSuccess} aria-hidden="true" />;
+    case "failure":
+      return <Circle size={10} className={styles.checkIconFailure} aria-hidden="true" />;
+    case "cancelled":
+      return <Circle size={10} className={styles.checkIconCancelled} aria-hidden="true" />;
+    case "pending":
+      return <LoaderCircle size={14} className={styles.checkIconPending} aria-hidden="true" />;
+  }
+}

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
@@ -75,7 +75,7 @@ const STATUS_CONFIG: Record<
 
 export const PrStatusBanner = memo(function PrStatusBanner() {
   const { pr, checks, status } = usePrBannerData();
-  const [checksOpen, setChecksOpen] = useState(true);
+  const [checksOpen, setChecksOpen] = useState(false);
   const sortedChecks = useMemo(() => sortCiChecks(checks), [checks]);
   const checksSummary = useMemo(() => summarizeCiChecks(checks), [checks]);
 
@@ -87,47 +87,51 @@ export const PrStatusBanner = memo(function PrStatusBanner() {
 
   return (
     <div className={`${styles.banner} ${config.bannerClass}`}>
-      <div className={styles.summaryRow}>
+      <button
+        type="button"
+        className={`${styles.prPill} ${config.fgClass}`}
+        onClick={() => openUrl(pr.url)}
+        title={`Open PR #${pr.number} in browser`}
+      >
+        <Icon size={14} />
+        <span className={styles.prNumber}>PR #{pr.number}</span>
+        <ExternalLink size={14} className={styles.externalIcon} />
+      </button>
+
+      {hasChecks ? (
         <button
           type="button"
-          className={`${styles.prPill} ${config.fgClass}`}
-          onClick={() => openUrl(pr.url)}
-          title={`Open PR #${pr.number} in browser`}
+          className={`${styles.statusButton} ${config.fgClass}`}
+          onClick={() => setChecksOpen((open) => !open)}
+          aria-expanded={checksOpen}
+          title={checksSummary.title}
         >
-          <Icon size={14} />
-          <span className={styles.prNumber}>PR #{pr.number}</span>
-          <ExternalLink size={14} className={styles.externalIcon} />
+          <span className={styles.statusText}>{config.text}</span>
+          <span className={styles.statusCount}>{checksSummary.total}</span>
+          <ChevronRight
+            size={14}
+            className={`${styles.statusChevron} ${checksOpen ? styles.chevronOpen : ""}`}
+            aria-hidden="true"
+          />
         </button>
-        <span className={`${styles.statusText} ${config.fgClass}`}>
+      ) : (
+        <span className={`${styles.statusText} ${styles.statusSolo} ${config.fgClass}`}>
           {config.text}
         </span>
-      </div>
+      )}
 
-      {hasChecks && (
+      {hasChecks && checksOpen && (
         <div className={styles.checksPanel}>
-          <button
-            type="button"
-            className={styles.checksToggle}
-            onClick={() => setChecksOpen((open) => !open)}
-            aria-expanded={checksOpen}
-          >
+          <div className={styles.checksHeader}>
             <CheckStatusIcon status={checkSummaryStatus(checksSummary)} />
             <span className={styles.checksTitle}>{checksSummary.title}</span>
-            <span className={styles.checkCount}>{checksSummary.total}</span>
-            <ChevronRight
-              size={14}
-              className={`${styles.chevron} ${checksOpen ? styles.chevronOpen : ""}`}
-              aria-hidden="true"
-            />
-          </button>
+          </div>
 
-          {checksOpen && (
-            <div className={styles.checkList}>
-              {sortedChecks.map((check) => (
-                <CheckRow key={`${check.name}:${check.url ?? ""}`} check={check} />
-              ))}
-            </div>
-          )}
+          <div className={styles.checkList}>
+            {sortedChecks.map((check) => (
+              <CheckRow key={`${check.name}:${check.url ?? ""}`} check={check} />
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/ui/src/hooks/usePrBannerData.test.ts
+++ b/src/ui/src/hooks/usePrBannerData.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { CiCheck, PullRequest } from "../types/plugin";
+import { deriveBannerStatus } from "./usePrBannerData";
+
+const pr: PullRequest = {
+  number: 655,
+  title: "Add SCM checks",
+  state: "open",
+  url: "https://example.test/pull/655",
+  author: "octocat",
+  branch: "feat/detailed-scm-checks",
+  base: "main",
+  draft: false,
+  ci_status: null,
+};
+
+function check(status: CiCheck["status"]): CiCheck {
+  return {
+    name: status,
+    status,
+    url: null,
+    started_at: null,
+  };
+}
+
+describe("deriveBannerStatus", () => {
+  it("uses individual checks when PR aggregate status is absent", () => {
+    expect(deriveBannerStatus(pr, [check("failure")])).toBe("ci-failed");
+    expect(deriveBannerStatus(pr, [check("pending")])).toBe("ci-pending");
+    expect(deriveBannerStatus(pr, [check("success")])).toBe("ready");
+  });
+
+  it("keeps PR lifecycle states ahead of checks", () => {
+    expect(deriveBannerStatus({ ...pr, state: "draft" }, [check("success")])).toBe("draft");
+    expect(deriveBannerStatus({ ...pr, state: "closed" }, [check("failure")])).toBe("closed");
+  });
+});

--- a/src/ui/src/hooks/usePrBannerData.ts
+++ b/src/ui/src/hooks/usePrBannerData.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from "react";
 import { useAppStore } from "../stores/useAppStore";
 import { loadScmDetail } from "../services/tauri";
-import type { PullRequest } from "../types/plugin";
+import type { CiCheck, PullRequest } from "../types/plugin";
+import { summarizeCiChecks } from "../utils/scmChecks";
 
 export type BannerStatus =
   | "ready"
@@ -12,7 +13,10 @@ export type BannerStatus =
   | "merged"
   | "closed";
 
-export function deriveBannerStatus(pr: PullRequest): BannerStatus {
+export function deriveBannerStatus(
+  pr: PullRequest,
+  checks: readonly CiCheck[] = [],
+): BannerStatus {
   if (pr.state === "draft") return "draft";
   if (pr.state === "merged") return "merged";
   if (pr.state === "closed") return "closed";
@@ -20,11 +24,16 @@ export function deriveBannerStatus(pr: PullRequest): BannerStatus {
   if (pr.ci_status === "success") return "ready";
   if (pr.ci_status === "pending") return "ci-pending";
   if (pr.ci_status === "failure") return "ci-failed";
+  const checkSummary = summarizeCiChecks(checks);
+  if (checkSummary.failed > 0) return "ci-failed";
+  if (checkSummary.pending > 0) return "ci-pending";
+  if (checkSummary.total > 0 && checkSummary.cancelled === 0) return "ready";
   return "open";
 }
 
 export function usePrBannerData(): {
   pr: PullRequest | null;
+  checks: CiCheck[];
   status: BannerStatus | null;
 } {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
@@ -91,11 +100,12 @@ export function usePrBannerData(): {
     !scmDetail?.pull_request ||
     scmDetail.workspace_id !== selectedWorkspaceId
   ) {
-    return { pr: null, status: null };
+    return { pr: null, checks: [], status: null };
   }
 
   return {
     pr: scmDetail.pull_request,
-    status: deriveBannerStatus(scmDetail.pull_request),
+    checks: scmDetail.ci_checks,
+    status: deriveBannerStatus(scmDetail.pull_request, scmDetail.ci_checks),
   };
 }

--- a/src/ui/src/hooks/usePrBannerData.ts
+++ b/src/ui/src/hooks/usePrBannerData.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { useAppStore } from "../stores/useAppStore";
 import { loadScmDetail } from "../services/tauri";
 import type { CiCheck, PullRequest } from "../types/plugin";
-import { summarizeCiChecks } from "../utils/scmChecks";
+import { deriveScmCiState } from "../utils/scmChecks";
 
 export type BannerStatus =
   | "ready"
@@ -21,13 +21,10 @@ export function deriveBannerStatus(
   if (pr.state === "merged") return "merged";
   if (pr.state === "closed") return "closed";
   // pr.state === "open"
-  if (pr.ci_status === "success") return "ready";
-  if (pr.ci_status === "pending") return "ci-pending";
-  if (pr.ci_status === "failure") return "ci-failed";
-  const checkSummary = summarizeCiChecks(checks);
-  if (checkSummary.failed > 0) return "ci-failed";
-  if (checkSummary.pending > 0) return "ci-pending";
-  if (checkSummary.total > 0 && checkSummary.cancelled === 0) return "ready";
+  const ciState = deriveScmCiState(pr.ci_status, checks);
+  if (ciState === "success") return "ready";
+  if (ciState === "pending") return "ci-pending";
+  if (ciState === "failure") return "ci-failed";
   return "open";
 }
 
@@ -67,7 +64,7 @@ export function usePrBannerData(): {
           setScmSummary(selectedWorkspaceId, {
             hasPr: true,
             prState: detail.pull_request.state,
-            ciState: detail.pull_request.ci_status,
+            ciState: deriveScmCiState(detail.pull_request.ci_status, detail.ci_checks),
             lastUpdated: Date.now(),
           });
         } else {

--- a/src/ui/src/utils/scmChecks.test.ts
+++ b/src/ui/src/utils/scmChecks.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { CiCheck } from "../types/plugin";
+import { ciCheckStatusLabel, sortCiChecks, summarizeCiChecks } from "./scmChecks";
+
+function check(name: string, status: CiCheck["status"]): CiCheck {
+  return {
+    name,
+    status,
+    url: null,
+    started_at: null,
+  };
+}
+
+describe("scmChecks", () => {
+  it("summarizes failing checks first", () => {
+    expect(
+      summarizeCiChecks([
+        check("Frontend", "success"),
+        check("Lint", "failure"),
+        check("Test", "pending"),
+      ]),
+    ).toMatchObject({
+      title: "1 check failing",
+      failed: 1,
+      pending: 1,
+      passed: 1,
+      total: 3,
+    });
+  });
+
+  it("uses passed wording when every check passed", () => {
+    expect(summarizeCiChecks([check("Lint", "success"), check("Test", "success")]).title)
+      .toBe("Checks passed");
+  });
+
+  it("sorts checks by actionable status and then name", () => {
+    const sorted = sortCiChecks([
+      check("Test", "success"),
+      check("Build", "failure"),
+      check("Lint", "failure"),
+      check("Format", "pending"),
+    ]);
+
+    expect(sorted.map((item) => item.name)).toEqual(["Build", "Lint", "Format", "Test"]);
+  });
+
+  it("labels each check status for display", () => {
+    expect(ciCheckStatusLabel("success")).toBe("Passed");
+    expect(ciCheckStatusLabel("failure")).toBe("Failing");
+    expect(ciCheckStatusLabel("pending")).toBe("Running");
+    expect(ciCheckStatusLabel("cancelled")).toBe("Cancelled");
+  });
+});

--- a/src/ui/src/utils/scmChecks.test.ts
+++ b/src/ui/src/utils/scmChecks.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { CiCheck } from "../types/plugin";
-import { ciCheckStatusLabel, sortCiChecks, summarizeCiChecks } from "./scmChecks";
+import {
+  ciCheckStatusLabel,
+  deriveScmCiState,
+  sortCiChecks,
+  summarizeCiChecks,
+} from "./scmChecks";
 
 function check(name: string, status: CiCheck["status"]): CiCheck {
   return {
@@ -49,5 +54,16 @@ describe("scmChecks", () => {
     expect(ciCheckStatusLabel("failure")).toBe("Failing");
     expect(ciCheckStatusLabel("pending")).toBe("Running");
     expect(ciCheckStatusLabel("cancelled")).toBe("Cancelled");
+  });
+
+  it("derives sidebar CI state from checks when the aggregate status is absent", () => {
+    expect(deriveScmCiState(null, [check("Lint", "failure")])).toBe("failure");
+    expect(deriveScmCiState(null, [check("Test", "pending")])).toBe("pending");
+    expect(deriveScmCiState(null, [check("Build", "success")])).toBe("success");
+    expect(deriveScmCiState(null, [check("Build", "cancelled")])).toBeNull();
+  });
+
+  it("prefers the aggregate PR CI status over checks", () => {
+    expect(deriveScmCiState("success", [check("Lint", "failure")])).toBe("success");
   });
 });

--- a/src/ui/src/utils/scmChecks.ts
+++ b/src/ui/src/utils/scmChecks.ts
@@ -1,4 +1,4 @@
-import type { CiCheck } from "../types/plugin";
+import type { CiCheck, PullRequest, ScmSummary } from "../types/plugin";
 
 export type CiCheckTone = "success" | "failure" | "pending" | "cancelled";
 
@@ -56,6 +56,19 @@ export function summarizeCiChecks(checks: readonly CiCheck[]): CiCheckSummary {
     cancelled,
     passed,
   };
+}
+
+export function deriveScmCiState(
+  ciStatus: PullRequest["ci_status"],
+  checks: readonly CiCheck[],
+): ScmSummary["ciState"] {
+  if (ciStatus) return ciStatus;
+
+  const summary = summarizeCiChecks(checks);
+  if (summary.failed > 0) return "failure";
+  if (summary.pending > 0) return "pending";
+  if (summary.total > 0 && summary.cancelled === 0) return "success";
+  return null;
 }
 
 export function sortCiChecks(checks: readonly CiCheck[]): CiCheck[] {

--- a/src/ui/src/utils/scmChecks.ts
+++ b/src/ui/src/utils/scmChecks.ts
@@ -1,0 +1,67 @@
+import type { CiCheck } from "../types/plugin";
+
+export type CiCheckTone = "success" | "failure" | "pending" | "cancelled";
+
+export interface CiCheckSummary {
+  title: string;
+  total: number;
+  failed: number;
+  pending: number;
+  cancelled: number;
+  passed: number;
+}
+
+const STATUS_PRIORITY: Record<CiCheckTone, number> = {
+  failure: 0,
+  pending: 1,
+  cancelled: 2,
+  success: 3,
+};
+
+export function ciCheckStatusLabel(status: CiCheckTone): string {
+  switch (status) {
+    case "success":
+      return "Passed";
+    case "failure":
+      return "Failing";
+    case "pending":
+      return "Running";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+export function summarizeCiChecks(checks: readonly CiCheck[]): CiCheckSummary {
+  const failed = checks.filter((check) => check.status === "failure").length;
+  const pending = checks.filter((check) => check.status === "pending").length;
+  const cancelled = checks.filter((check) => check.status === "cancelled").length;
+  const passed = checks.filter((check) => check.status === "success").length;
+
+  let title = "Checks";
+  if (failed > 0) {
+    title = failed === 1 ? "1 check failing" : `${failed} checks failing`;
+  } else if (pending > 0) {
+    title = pending === 1 ? "1 check running" : `${pending} checks running`;
+  } else if (cancelled > 0) {
+    title = cancelled === 1 ? "1 check cancelled" : `${cancelled} checks cancelled`;
+  } else if (checks.length > 0) {
+    title = checks.length === 1 ? "1 check passed" : "Checks passed";
+  }
+
+  return {
+    title,
+    total: checks.length,
+    failed,
+    pending,
+    cancelled,
+    passed,
+  };
+}
+
+export function sortCiChecks(checks: readonly CiCheck[]): CiCheck[] {
+  return [...checks].sort((a, b) => {
+    const statusDelta = STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status];
+    if (statusDelta !== 0) return statusDelta;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+}


### PR DESCRIPTION
## Summary

- Show detailed SCM check results from the PR status banner.
- Keep the original one-row banner and tab divider alignment by rendering checks in a dropdown.
- Use the documented GitHub CLI check link field for check detail URLs.

## Validation

- bun run test -- scmChecks.test.ts usePrBannerData.test.ts headerAlignment.test.ts
- bunx tsc -b
- bun run lint:css
- focused eslint on touched TypeScript files
