### PR TITLE
fix: restore workspace auto sorting

### DIFF
--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -16,6 +16,7 @@ use crate::state::AppState;
 /// Tuned at 6 — each git probe is short, but on a cold filesystem the
 /// system call cost dominates and unbounded fan-out can wedge slow disks.
 const STARTUP_GIT_PROBE_CONCURRENCY: usize = 6;
+const WORKSPACE_ORDER_MODE_PREFIX: &str = "workspace_order_mode:";
 
 #[derive(Serialize)]
 pub struct InitialData {
@@ -27,6 +28,8 @@ pub struct InitialData {
     /// Most recent chat message per workspace (for dashboard display).
     pub last_messages: Vec<ChatMessage>,
     pub scm_cache: Vec<claudette::db::ScmStatusCacheRow>,
+    /// Repository ids whose sidebar workspace order is user-defined.
+    pub manual_workspace_order_repo_ids: Vec<String>,
 }
 
 #[tauri::command]
@@ -181,6 +184,19 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
 
     let last_messages = db.last_message_per_workspace().map_err(|e| e.to_string())?;
     let scm_cache = db.load_all_scm_status_cache().map_err(|e| e.to_string())?;
+    let manual_workspace_order_repo_ids = db
+        .list_app_settings_with_prefix(WORKSPACE_ORDER_MODE_PREFIX)
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .filter_map(|(key, value)| {
+            (value == "manual")
+                .then(|| {
+                    key.strip_prefix(WORKSPACE_ORDER_MODE_PREFIX)
+                        .map(str::to_string)
+                })
+                .flatten()
+        })
+        .collect();
 
     Ok(InitialData {
         repositories,
@@ -189,5 +205,6 @@ pub async fn load_initial_data(state: State<'_, AppState>) -> Result<InitialData
         default_branches,
         last_messages,
         scm_cache,
+        manual_workspace_order_repo_ids,
     })
 }

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use tauri::State;
 use tokio::sync::Semaphore;
 
-use claudette::db::Database;
+use claudette::db::{Database, WORKSPACE_ORDER_MODE_PREFIX};
 use claudette::git;
 use claudette::model::{ChatMessage, Repository, Workspace};
 
@@ -16,8 +16,6 @@ use crate::state::AppState;
 /// Tuned at 6 — each git probe is short, but on a cold filesystem the
 /// system call cost dominates and unbounded fan-out can wedge slow disks.
 const STARTUP_GIT_PROBE_CONCURRENCY: usize = 6;
-const WORKSPACE_ORDER_MODE_PREFIX: &str = "workspace_order_mode:";
-
 #[derive(Serialize)]
 pub struct InitialData {
     pub repositories: Vec<Repository>,

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -16,6 +16,8 @@ use claudette::process::CommandWindowExt as _;
 use crate::ops_hooks::TauriHooks;
 use crate::state::AppState;
 
+const WORKSPACE_ORDER_MODE_PREFIX: &str = "workspace_order_mode:";
+
 #[derive(Serialize)]
 pub struct CreateWorkspaceResult {
     pub workspace: Workspace,
@@ -536,7 +538,12 @@ pub async fn reorder_workspaces(
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.reorder_workspaces(&repository_id, &workspace_ids)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    db.set_app_setting(
+        &format!("{WORKSPACE_ORDER_MODE_PREFIX}{repository_id}"),
+        "manual",
+    )
+    .map_err(|e| e.to_string())
 }
 
 /// Re-read the current branch for every active workspace. Returns one

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -16,8 +16,6 @@ use claudette::process::CommandWindowExt as _;
 use crate::ops_hooks::TauriHooks;
 use crate::state::AppState;
 
-const WORKSPACE_ORDER_MODE_PREFIX: &str = "workspace_order_mode:";
-
 #[derive(Serialize)]
 pub struct CreateWorkspaceResult {
     pub workspace: Workspace,
@@ -538,12 +536,7 @@ pub async fn reorder_workspaces(
 ) -> Result<(), String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
     db.reorder_workspaces(&repository_id, &workspace_ids)
-        .map_err(|e| e.to_string())?;
-    db.set_app_setting(
-        &format!("{WORKSPACE_ORDER_MODE_PREFIX}{repository_id}"),
-        "manual",
-    )
-    .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())
 }
 
 /// Re-read the current branch for every active workspace. Returns one

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -24,6 +24,7 @@ mod checkpoint;
 mod chat;
 
 mod workspace;
+pub use workspace::WORKSPACE_ORDER_MODE_PREFIX;
 
 mod commands;
 

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -14,6 +14,8 @@ use crate::model::{Workspace, WorkspaceStatus};
 
 use super::Database;
 
+pub const WORKSPACE_ORDER_MODE_PREFIX: &str = "workspace_order_mode:";
+
 impl Database {
     // --- Workspaces ---
 
@@ -173,6 +175,10 @@ impl Database {
                 stmt.execute(params![i as i32, id, repository_id])?;
             }
         }
+        tx.execute(
+            "INSERT OR REPLACE INTO app_settings (key, value) VALUES (?1, 'manual')",
+            params![format!("{WORKSPACE_ORDER_MODE_PREFIX}{repository_id}")],
+        )?;
         tx.commit()?;
         Ok(())
     }
@@ -639,6 +645,56 @@ mod tests {
         assert_eq!(workspaces.len(), 2);
         assert_eq!(workspaces[0].name, "fix-bug");
         assert_eq!(workspaces[0].status, WorkspaceStatus::Active);
+    }
+
+    #[test]
+    fn test_reorder_workspaces_marks_repo_manual_in_same_write_path() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "add-feature"))
+            .unwrap();
+
+        db.reorder_workspaces("r1", &["w2".to_string(), "w1".to_string()])
+            .unwrap();
+
+        let mode = db
+            .get_app_setting(&format!("{WORKSPACE_ORDER_MODE_PREFIX}r1"))
+            .unwrap();
+        assert_eq!(mode.as_deref(), Some("manual"));
+    }
+
+    #[test]
+    fn test_workspace_manual_order_mode_migration_backfills_mismatched_sort_order() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1", "/tmp/repo1", "repo1"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w1", "r1", "fix-bug"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w2", "r1", "add-feature"))
+            .unwrap();
+        db.execute_batch(
+            "
+            UPDATE workspaces SET sort_order = CASE id
+                WHEN 'w1' THEN 1
+                WHEN 'w2' THEN 0
+                ELSE sort_order
+            END;
+            DELETE FROM app_settings WHERE key = 'workspace_order_mode:r1';
+            DELETE FROM schema_migrations
+                WHERE id = '20260506220711_workspace_manual_order_modes';
+            ",
+        )
+        .unwrap();
+
+        db.run_migrations_for_test().unwrap();
+
+        let mode = db
+            .get_app_setting(&format!("{WORKSPACE_ORDER_MODE_PREFIX}r1"))
+            .unwrap();
+        assert_eq!(mode.as_deref(), Some("manual"));
     }
 
     #[test]

--- a/src/migrations/20260506220711_workspace_manual_order_modes.sql
+++ b/src/migrations/20260506220711_workspace_manual_order_modes.sql
@@ -1,0 +1,23 @@
+-- Preserve manual workspace ordering created by versions that had
+-- workspaces.sort_order but no explicit "manual ordering" marker.
+--
+-- The original workspace_sort_order migration seeded sort_order from
+-- per-repo creation order. If a repo now differs from that seed, the user
+-- manually reordered it before this marker existed. Backfill the marker once
+-- so startup keeps honoring the user's existing order. Repos still matching
+-- creation order remain automatic by default.
+INSERT OR IGNORE INTO app_settings (key, value)
+SELECT 'workspace_order_mode:' || repository_id, 'manual'
+FROM (
+    SELECT
+        id,
+        repository_id,
+        sort_order,
+        ROW_NUMBER() OVER (
+            PARTITION BY repository_id
+            ORDER BY created_at, id
+        ) - 1 AS creation_order
+    FROM workspaces
+)
+WHERE sort_order <> creation_order
+GROUP BY repository_id;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -184,4 +184,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260506170933_heal_turn_tool_activity_agent_tool_calls_json.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260506220711_workspace_manual_order_modes",
+        sql: include_str!("20260506220711_workspace_manual_order_modes.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -9,6 +9,7 @@ import type { ThemeDefinition } from "./types/theme";
 import { adjustUiFontSize, resetUiFontSize } from "./utils/fontSettings";
 import { deriveScmCiState } from "./utils/scmChecks";
 import { KEYBINDING_SETTING_PREFIX } from "./hotkeys/bindings";
+import type { WorkspaceOrderModeByRepo } from "./utils/workspaceOrdering";
 import { useMcpStatus } from "./hooks/useMcpStatus";
 import { useViewTogglePersistence } from "./hooks/useViewTogglePersistence";
 import { AppLayout } from "./components/layout/AppLayout";
@@ -16,6 +17,16 @@ import { findLeafByPtyId } from "./stores/terminalPaneTree";
 import type { CommandEvent } from "./types";
 import i18n, { isSupportedLanguage } from "./i18n";
 import "./styles/theme.css";
+
+function workspaceOrderModesFromRepoIds(
+  repoIds: readonly string[],
+): WorkspaceOrderModeByRepo {
+  const modes: WorkspaceOrderModeByRepo = {};
+  for (const repoId of repoIds) {
+    modes[repoId] = "manual";
+  }
+  return modes;
+}
 
 function App() {
   const setRepositories = useAppStore((s) => s.setRepositories);
@@ -51,6 +62,9 @@ function App() {
   const setVoiceHoldHotkey = useAppStore((s) => s.setVoiceHoldHotkey);
   const setKeybindings = useAppStore((s) => s.setKeybindings);
   const setAppVersion = useAppStore((s) => s.setAppVersion);
+  const setManualWorkspaceOrderByRepo = useAppStore(
+    (s) => s.setManualWorkspaceOrderByRepo,
+  );
 
   // Cached theme list — populated on initial load, reused by the OS handler.
   const loadedThemesRef = useRef<ThemeDefinition[]>([]);
@@ -76,6 +90,9 @@ function App() {
       );
       setWorkspaces(
         data.workspaces.map((w) => ({ ...w, remote_connection_id: null }))
+      );
+      setManualWorkspaceOrderByRepo(
+        workspaceOrderModesFromRepoIds(data.manual_workspace_order_repo_ids),
       );
       setWorktreeBaseDir(data.worktree_base_dir);
       setDefaultBranches(data.default_branches);
@@ -484,6 +501,11 @@ function App() {
               const s = useAppStore.getState();
               const fresh = s.workspaces;
               const incomingIds = new Set(data.workspaces.map((w) => w.id));
+              s.setManualWorkspaceOrderByRepo(
+                workspaceOrderModesFromRepoIds(
+                  data.manual_workspace_order_repo_ids,
+                ),
+              );
               for (const ws of data.workspaces) {
                 s.addWorkspace({ ...ws, remote_connection_id: null });
               }
@@ -607,7 +629,7 @@ function App() {
       unlistenChatTurnStarted.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setEditorMinimapEnabled, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setPluginManagementEnabled, setCommunityRegistryEnabled, setEditorGitGutterBase, setEditorMinimapEnabled, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import { isAgentBusy } from "../../utils/agentStatus";
 import {
   archiveWorkspace,
   reorderRepositories,
+  reorderWorkspaces,
   renameWorkspace,
   restoreWorkspace,
   generateWorkspaceName,
@@ -23,10 +24,12 @@ import { RepoIcon } from "../shared/RepoIcon";
 import { extractRemoteWorkspace } from "./remoteWorkspaceResponse";
 import { HelpMenu } from "./HelpMenu";
 import { UpdateBanner } from "../layout/UpdateBanner";
-import { getScmSortPriority } from "../../utils/scmSortPriority";
 import { useTabDragReorder } from "../../hooks/useTabDragReorder";
 import { TabDragGhost } from "../shared/TabDragGhost";
-import { reorderWorkspaces } from "../../services/tauri";
+import {
+  isManualWorkspaceOrder,
+  orderRepoWorkspaces,
+} from "../../utils/workspaceOrdering";
 import styles from "./Sidebar.module.css";
 
 type StatusBucketKey = "in-progress" | "in-review" | "draft" | "merged" | "closed" | "archived";
@@ -63,6 +66,12 @@ export const Sidebar = memo(function Sidebar() {
   const scmSummary = useAppStore((s) => s.scmSummary);
   const setRepositories = useAppStore((s) => s.setRepositories);
   const setWorkspaces = useAppStore((s) => s.setWorkspaces);
+  const manualWorkspaceOrderByRepo = useAppStore(
+    (s) => s.manualWorkspaceOrderByRepo,
+  );
+  const markWorkspaceOrderManual = useAppStore(
+    (s) => s.markWorkspaceOrderManual,
+  );
   const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
   const isMac = navigator.platform.startsWith("Mac");
   const { t } = useTranslation("sidebar");
@@ -222,27 +231,19 @@ export const Sidebar = memo(function Sidebar() {
     [workspaces, sidebarShowArchived, sidebarRepoFilter]
   );
 
-  // Workspaces in the order the sidebar actually renders them: each repo
-  // group sorted by `sort_order` (with SCM priority as tiebreaker for legacy
-  // pre-migration rows where every workspace shares sort_order=0). The drag
-  // hook needs this visual sequence so reorderById's "from"/"to" positions
-  // match what the user sees — without it, a second drag in the same repo
-  // would compute against the unsorted DB order and persist the wrong
-  // sequence (P2 finding from the Codex peer review on this branch).
+  // Workspaces in the order the sidebar actually renders them. Repos default
+  // to the original auto-sort (SCM priority), and only switch to sort_order
+  // after the user manually drags a workspace in that repo.
   const visuallyOrderedWorkspaces = useMemo(() => {
     const localRepos = repositories.filter((r) => !r.remote_connection_id);
     const repoIndex = new Map(localRepos.map((r, i) => [r.id, i]));
     const out: typeof workspaces = [];
     for (const repo of localRepos) {
-      const repoWs = filteredWorkspaces
-        .filter((ws) => ws.repository_id === repo.id)
-        .sort((a, b) => {
-          if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
-          return (
-            getScmSortPriority(scmSummary[a.id]) -
-            getScmSortPriority(scmSummary[b.id])
-          );
-        });
+      const repoWs = orderRepoWorkspaces(
+        filteredWorkspaces.filter((ws) => ws.repository_id === repo.id),
+        scmSummary,
+        isManualWorkspaceOrder(manualWorkspaceOrderByRepo, repo.id),
+      );
       out.push(...repoWs);
     }
     // Also include any workspaces whose repo isn't in `localRepos` (shouldn't
@@ -253,7 +254,7 @@ export const Sidebar = memo(function Sidebar() {
       if (!repoIndex.has(ws.repository_id) && !out.includes(ws)) out.push(ws);
     }
     return out;
-  }, [filteredWorkspaces, repositories, scmSummary]);
+  }, [filteredWorkspaces, repositories, scmSummary, manualWorkspaceOrderByRepo]);
 
   const statusBuckets = useMemo(() => {
     const buckets = new Map<StatusBucketKey, typeof workspaces>();
@@ -418,6 +419,7 @@ export const Sidebar = memo(function Sidebar() {
         return w;
       });
       setWorkspaces(optimistic);
+      markWorkspaceOrderManual(moved.repository_id);
       void reorderWorkspaces(moved.repository_id, repoIds).catch((err) =>
         console.error("[Sidebar] Failed to persist workspace order:", err),
       );
@@ -832,16 +834,11 @@ export const Sidebar = memo(function Sidebar() {
           .filter((r) => sidebarRepoFilter === "all" || r.id === sidebarRepoFilter)
           .map((repo, repoIdx) => {
           const collapsed = repoCollapsed[repo.id];
-          // Sort by user-defined order (sort_order) as authoritative; fall
-          // back to SCM priority only as a tiebreaker so workspaces seeded
-          // with the same sort_order value (legacy DBs pre-migration) keep
-          // their previous "by PR state" arrangement.
-          const repoWorkspaces = filteredWorkspaces
-            .filter((ws) => ws.repository_id === repo.id)
-            .sort((a, b) => {
-              if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
-              return getScmSortPriority(scmSummary[a.id]) - getScmSortPriority(scmSummary[b.id]);
-            });
+          const repoWorkspaces = orderRepoWorkspaces(
+            filteredWorkspaces.filter((ws) => ws.repository_id === repo.id),
+            scmSummary,
+            isManualWorkspaceOrder(manualWorkspaceOrderByRepo, repo.id),
+          );
           const runningCount = repoWorkspaces.filter(
             (ws) => isAgentBusy(ws.agent_status)
           ).length;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "../../stores/useAppStore";
 import { isAgentBusy } from "../../utils/agentStatus";
 import {
   archiveWorkspace,
+  deleteAppSetting,
   reorderRepositories,
   reorderWorkspaces,
   renameWorkspace,
@@ -19,16 +20,18 @@ import {
   pairWithServer,
   startLocalServer,
 } from "../../services/tauri";
-import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown } from "lucide-react";
+import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown, ArrowDownAZ } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
 import { extractRemoteWorkspace } from "./remoteWorkspaceResponse";
 import { HelpMenu } from "./HelpMenu";
 import { UpdateBanner } from "../layout/UpdateBanner";
+import { ContextMenu, type ContextMenuItem } from "../shared/ContextMenu";
 import { useTabDragReorder } from "../../hooks/useTabDragReorder";
 import { TabDragGhost } from "../shared/TabDragGhost";
 import {
   isManualWorkspaceOrder,
   orderRepoWorkspaces,
+  workspaceOrderModeKey,
 } from "../../utils/workspaceOrdering";
 import styles from "./Sidebar.module.css";
 
@@ -71,6 +74,9 @@ export const Sidebar = memo(function Sidebar() {
   );
   const markWorkspaceOrderManual = useAppStore(
     (s) => s.markWorkspaceOrderManual,
+  );
+  const clearManualWorkspaceOrder = useAppStore(
+    (s) => s.clearManualWorkspaceOrder,
   );
   const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
   const isMac = navigator.platform.startsWith("Mac");
@@ -128,6 +134,27 @@ export const Sidebar = memo(function Sidebar() {
   const archivingRef = useRef<Set<string>>(new Set());
   const restoringRef = useRef<Set<string>>(new Set());
   const [creatingWorkspace, setCreatingWorkspace] = useState<{ repoId: string } | null>(null);
+  const [repoContextMenu, setRepoContextMenu] = useState<{
+    repoId: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const repoContextMenuItems = useMemo<ContextMenuItem[]>(() => {
+    if (!repoContextMenu) return [];
+    const repoId = repoContextMenu.repoId;
+    return [
+      {
+        label: "Sort Workspaces Automatically",
+        icon: <ArrowDownAZ size={14} />,
+        disabled: !isManualWorkspaceOrder(manualWorkspaceOrderByRepo, repoId),
+        onSelect: async () => {
+          await deleteAppSetting(workspaceOrderModeKey(repoId));
+          clearManualWorkspaceOrder(repoId);
+        },
+      },
+    ];
+  }, [clearManualWorkspaceOrder, manualWorkspaceOrderByRepo, repoContextMenu]);
 
   const handleCreateWorkspace = useCallback(async (repoId: string) => {
     if (creatingRef.current) return;
@@ -943,6 +970,15 @@ export const Sidebar = memo(function Sidebar() {
               <div
                 className={styles.repoHeader}
                 onClick={() => { if (!didDragRef.current) toggleRepoCollapsed(repo.id); }}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setRepoContextMenu({
+                    repoId: repo.id,
+                    x: e.clientX,
+                    y: e.clientY,
+                  });
+                }}
               >
                 <span className={styles.chevron}>
                   {collapsed ? "›" : "⌄"}
@@ -1073,6 +1109,15 @@ export const Sidebar = memo(function Sidebar() {
       </div>
       {workspaceDrag.dragGhost && workspaceDrag.draggingId !== null && (
         <TabDragGhost ghost={workspaceDrag.dragGhost} />
+      )}
+      {repoContextMenu && (
+        <ContextMenu
+          x={repoContextMenu.x}
+          y={repoContextMenu.y}
+          items={repoContextMenuItems}
+          onClose={() => setRepoContextMenu(null)}
+          dataTestId="repo-context-menu"
+        />
       )}
     </div>
   );

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -53,6 +53,7 @@ export interface InitialData {
   default_branches: Record<string, string>;
   last_messages: ChatMessage[];
   scm_cache: ScmStatusCacheRow[];
+  manual_workspace_order_repo_ids: string[];
 }
 
 export function loadInitialData(): Promise<InitialData> {

--- a/src/ui/src/stores/slices/uiSlice.test.ts
+++ b/src/ui/src/stores/slices/uiSlice.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "../useAppStore";
+
+describe("uiSlice.manualWorkspaceOrderByRepo", () => {
+  beforeEach(() => {
+    useAppStore.setState({ manualWorkspaceOrderByRepo: {} });
+  });
+
+  it("marks and clears a single repo manual workspace order", () => {
+    useAppStore.getState().markWorkspaceOrderManual("repo-a");
+    useAppStore.getState().markWorkspaceOrderManual("repo-b");
+
+    useAppStore.getState().clearManualWorkspaceOrder("repo-a");
+
+    expect(useAppStore.getState().manualWorkspaceOrderByRepo).toEqual({
+      "repo-b": "manual",
+    });
+  });
+
+  it("keeps existing state object when clearing a repo that is already automatic", () => {
+    const stateBefore = useAppStore.getState();
+
+    useAppStore.getState().clearManualWorkspaceOrder("repo-a");
+
+    expect(useAppStore.getState()).toBe(stateBefore);
+  });
+});

--- a/src/ui/src/stores/slices/uiSlice.ts
+++ b/src/ui/src/stores/slices/uiSlice.ts
@@ -18,6 +18,7 @@ export interface UiSlice {
   sidebarGroupBy: "status" | "repo";
   sidebarRepoFilter: string; // repo ID or "all"
   sidebarShowArchived: boolean;
+  manualWorkspaceOrderByRepo: Record<string, "manual">;
   repoCollapsed: Record<string, boolean>;
   statusGroupCollapsed: Record<string, boolean>;
   fuzzyFinderOpen: boolean;
@@ -32,6 +33,10 @@ export interface UiSlice {
   setSidebarGroupBy: (g: "status" | "repo") => void;
   setSidebarRepoFilter: (id: string) => void;
   setSidebarShowArchived: (show: boolean) => void;
+  setManualWorkspaceOrderByRepo: (
+    modes: Record<string, "manual">,
+  ) => void;
+  markWorkspaceOrderManual: (repoId: string) => void;
   toggleRepoCollapsed: (id: string) => void;
   toggleStatusGroupCollapsed: (id: string) => void;
   toggleFuzzyFinder: () => void;
@@ -89,6 +94,7 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (
   sidebarGroupBy: "repo",
   sidebarRepoFilter: "all",
   sidebarShowArchived: false,
+  manualWorkspaceOrderByRepo: {},
   repoCollapsed: {},
   statusGroupCollapsed: {},
   fuzzyFinderOpen: false,
@@ -102,6 +108,15 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (
   setSidebarGroupBy: (g) => set({ sidebarGroupBy: g }),
   setSidebarRepoFilter: (id) => set({ sidebarRepoFilter: id }),
   setSidebarShowArchived: (show) => set({ sidebarShowArchived: show }),
+  setManualWorkspaceOrderByRepo: (modes) =>
+    set({ manualWorkspaceOrderByRepo: modes }),
+  markWorkspaceOrderManual: (repoId) =>
+    set((s) => ({
+      manualWorkspaceOrderByRepo: {
+        ...s.manualWorkspaceOrderByRepo,
+        [repoId]: "manual",
+      },
+    })),
   toggleRepoCollapsed: (id) =>
     set((s) => ({
       repoCollapsed: {

--- a/src/ui/src/stores/slices/uiSlice.ts
+++ b/src/ui/src/stores/slices/uiSlice.ts
@@ -37,6 +37,7 @@ export interface UiSlice {
     modes: Record<string, "manual">,
   ) => void;
   markWorkspaceOrderManual: (repoId: string) => void;
+  clearManualWorkspaceOrder: (repoId: string) => void;
   toggleRepoCollapsed: (id: string) => void;
   toggleStatusGroupCollapsed: (id: string) => void;
   toggleFuzzyFinder: () => void;
@@ -117,6 +118,13 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (
         [repoId]: "manual",
       },
     })),
+  clearManualWorkspaceOrder: (repoId) =>
+    set((s) => {
+      if (!(repoId in s.manualWorkspaceOrderByRepo)) return s;
+      const next = { ...s.manualWorkspaceOrderByRepo };
+      delete next[repoId];
+      return { manualWorkspaceOrderByRepo: next };
+    }),
   toggleRepoCollapsed: (id) =>
     set((s) => ({
       repoCollapsed: {

--- a/src/ui/src/utils/workspaceOrdering.test.ts
+++ b/src/ui/src/utils/workspaceOrdering.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { ScmSummary } from "../types/plugin";
+import type { Workspace } from "../types/workspace";
+import {
+  orderRepoWorkspaces,
+  repoIdFromWorkspaceOrderModeKey,
+  WORKSPACE_ORDER_MODE_PREFIX,
+} from "./workspaceOrdering";
+
+function workspace(
+  id: string,
+  sort_order: number,
+  created_at: string,
+): Workspace {
+  return {
+    id,
+    repository_id: "repo-1",
+    name: id,
+    branch_name: id,
+    worktree_path: `/tmp/${id}`,
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at,
+    sort_order,
+    remote_connection_id: null,
+  };
+}
+
+function summary(
+  prState: ScmSummary["prState"],
+  ciState: ScmSummary["ciState"],
+  hasPr = true,
+): ScmSummary {
+  return { hasPr, prState, ciState, lastUpdated: 0 };
+}
+
+describe("orderRepoWorkspaces", () => {
+  const rows = [
+    workspace("created-first-no-pr", 0, "2026-01-01T00:00:00Z"),
+    workspace("created-second-passing", 1, "2026-01-02T00:00:00Z"),
+    workspace("created-third-draft", 2, "2026-01-03T00:00:00Z"),
+  ];
+
+  const scmSummary: Record<string, ScmSummary> = {
+    "created-first-no-pr": summary(null, null, false),
+    "created-second-passing": summary("open", "success"),
+    "created-third-draft": summary("draft", null),
+  };
+
+  it("uses the original SCM-priority order until the user manually reorders", () => {
+    expect(orderRepoWorkspaces(rows, scmSummary, false).map((w) => w.id)).toEqual([
+      "created-second-passing",
+      "created-third-draft",
+      "created-first-no-pr",
+    ]);
+  });
+
+  it("uses persisted sort_order after the repo is marked manually ordered", () => {
+    const manuallyReordered = [
+      { ...rows[0], sort_order: 2 },
+      { ...rows[1], sort_order: 1 },
+      { ...rows[2], sort_order: 0 },
+    ];
+
+    expect(
+      orderRepoWorkspaces(manuallyReordered, scmSummary, true).map((w) => w.id),
+    ).toEqual([
+      "created-third-draft",
+      "created-second-passing",
+      "created-first-no-pr",
+    ]);
+  });
+
+  it("keeps creation order as the auto-sort tie-breaker", () => {
+    const tied = [
+      workspace("created-second", 0, "2026-01-02T00:00:00Z"),
+      workspace("created-first", 1, "2026-01-01T00:00:00Z"),
+    ];
+    const noPr = {
+      "created-first": summary(null, null, false),
+      "created-second": summary(null, null, false),
+    };
+
+    expect(orderRepoWorkspaces(tied, noPr, false).map((w) => w.id)).toEqual([
+      "created-first",
+      "created-second",
+    ]);
+  });
+});
+
+describe("repoIdFromWorkspaceOrderModeKey", () => {
+  it("extracts repo ids from workspace order setting keys", () => {
+    expect(
+      repoIdFromWorkspaceOrderModeKey(`${WORKSPACE_ORDER_MODE_PREFIX}repo-1`),
+    ).toBe("repo-1");
+    expect(repoIdFromWorkspaceOrderModeKey("view:sidebar_group_by")).toBeNull();
+  });
+});

--- a/src/ui/src/utils/workspaceOrdering.test.ts
+++ b/src/ui/src/utils/workspaceOrdering.test.ts
@@ -5,6 +5,7 @@ import {
   orderRepoWorkspaces,
   repoIdFromWorkspaceOrderModeKey,
   WORKSPACE_ORDER_MODE_PREFIX,
+  workspaceOrderModeKey,
 } from "./workspaceOrdering";
 
 function workspace(
@@ -95,5 +96,11 @@ describe("repoIdFromWorkspaceOrderModeKey", () => {
       repoIdFromWorkspaceOrderModeKey(`${WORKSPACE_ORDER_MODE_PREFIX}repo-1`),
     ).toBe("repo-1");
     expect(repoIdFromWorkspaceOrderModeKey("view:sidebar_group_by")).toBeNull();
+  });
+
+  it("builds workspace order setting keys", () => {
+    expect(workspaceOrderModeKey("repo-1")).toBe(
+      `${WORKSPACE_ORDER_MODE_PREFIX}repo-1`,
+    );
   });
 });

--- a/src/ui/src/utils/workspaceOrdering.ts
+++ b/src/ui/src/utils/workspaceOrdering.ts
@@ -51,3 +51,7 @@ export function repoIdFromWorkspaceOrderModeKey(key: string): string | null {
     ? key.slice(WORKSPACE_ORDER_MODE_PREFIX.length)
     : null;
 }
+
+export function workspaceOrderModeKey(repositoryId: string): string {
+  return `${WORKSPACE_ORDER_MODE_PREFIX}${repositoryId}`;
+}

--- a/src/ui/src/utils/workspaceOrdering.ts
+++ b/src/ui/src/utils/workspaceOrdering.ts
@@ -1,0 +1,53 @@
+import type { ScmSummary } from "../types/plugin";
+import type { Workspace } from "../types/workspace";
+import { getScmSortPriority } from "./scmSortPriority";
+
+export const WORKSPACE_ORDER_MODE_PREFIX = "workspace_order_mode:";
+
+export type WorkspaceOrderModeByRepo = Record<string, "manual">;
+
+function compareCreatedAt(a: Workspace, b: Workspace): number {
+  const byCreated = a.created_at.localeCompare(b.created_at);
+  if (byCreated !== 0) return byCreated;
+  return a.id.localeCompare(b.id);
+}
+
+function compareManualOrder(a: Workspace, b: Workspace): number {
+  if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
+  return compareCreatedAt(a, b);
+}
+
+function compareAutoOrder(
+  scmSummary: Record<string, ScmSummary>,
+  a: Workspace,
+  b: Workspace,
+): number {
+  const byScm =
+    getScmSortPriority(scmSummary[a.id]) -
+    getScmSortPriority(scmSummary[b.id]);
+  if (byScm !== 0) return byScm;
+  return compareCreatedAt(a, b);
+}
+
+export function isManualWorkspaceOrder(
+  modes: WorkspaceOrderModeByRepo,
+  repositoryId: string,
+): boolean {
+  return modes[repositoryId] === "manual";
+}
+
+export function orderRepoWorkspaces(
+  repoWorkspaces: readonly Workspace[],
+  scmSummary: Record<string, ScmSummary>,
+  manualOrder: boolean,
+): Workspace[] {
+  return [...repoWorkspaces].sort((a, b) =>
+    manualOrder ? compareManualOrder(a, b) : compareAutoOrder(scmSummary, a, b),
+  );
+}
+
+export function repoIdFromWorkspaceOrderModeKey(key: string): string | null {
+  return key.startsWith(WORKSPACE_ORDER_MODE_PREFIX)
+    ? key.slice(WORKSPACE_ORDER_MODE_PREFIX.length)
+    : null;
+}


### PR DESCRIPTION
## Summary

- Restore default automatic workspace sorting in repo-grouped sidebar view.
- Keep manual workspace drag ordering available per repository after the user explicitly reorders.
- Add a project right-click action to return a repository to automatic workspace sorting.
- Cover ordering behavior and manual-order state with focused frontend tests.

## Validation

- `cd src/ui && bun run test -- workspaceOrdering.test.ts uiSlice.test.ts`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint` (passes with existing warnings)
- `cd src/ui && bun run lint:css`
- `git diff --check`

Note: local Rust compile checks were blocked by the host linker before crate diagnostics with `ld: library not found for -liconv`.
