### PR TITLE
fix: render SVGs in markdown preview

### DIFF
--- a/src/ui/src/components/chat/MarkdownImage.tsx
+++ b/src/ui/src/components/chat/MarkdownImage.tsx
@@ -84,8 +84,56 @@ function dataUrlIsSvg(src: string): boolean {
   return /^data:image\/svg\+xml(?:[;,]|$)/i.test(src);
 }
 
-function firstSrcSetUrl(srcSet: string): string {
-  return srcSet.trim().split(/\s+/)[0] ?? "";
+function parseSrcSetCandidate(candidate: string): {
+  src: string;
+  descriptor: string;
+} | null {
+  const trimmed = candidate.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(\S+)(?:\s+(.+))?$/);
+  if (!match) return null;
+  return {
+    src: match[1],
+    descriptor: match[2]?.trim() ?? "",
+  };
+}
+
+function isPassThroughSrc(src: string): boolean {
+  return ABSOLUTE_HREF.test(src) || src.startsWith("data:") || src.startsWith("blob:");
+}
+
+async function resolveWorkspaceImageSrc(
+  base: MarkdownImageBase,
+  src: string,
+): Promise<string> {
+  const path = joinRelative(base.dir, src);
+  const res = await readWorkspaceFileBytes(base.workspaceId, path);
+  const mime = imageMediaType(path) ?? "image/png";
+  return imageDataUrl(mime, res.bytes_b64);
+}
+
+async function resolveWorkspaceSrcSet(
+  base: MarkdownImageBase,
+  srcSet: string,
+): Promise<string> {
+  const candidates = srcSet
+    .split(",")
+    .map(parseSrcSetCandidate)
+    .filter((candidate): candidate is NonNullable<typeof candidate> =>
+      candidate !== null,
+    );
+  if (candidates.length === 0) return srcSet;
+
+  const resolvedCandidates = await Promise.all(
+    candidates.map(async ({ src, descriptor }) => {
+      const resolvedSrc = isPassThroughSrc(src)
+        ? src
+        : await resolveWorkspaceImageSrc(base, src);
+      return descriptor ? `${resolvedSrc} ${descriptor}` : resolvedSrc;
+    }),
+  );
+
+  return resolvedCandidates.join(", ");
 }
 
 /**
@@ -110,7 +158,7 @@ export const MarkdownImage = memo(function MarkdownImage(
       setResolved(null);
       return;
     }
-    if (ABSOLUTE_HREF.test(src) || src.startsWith("data:") || src.startsWith("blob:")) {
+    if (isPassThroughSrc(src)) {
       setResolved(src);
       return;
     }
@@ -120,17 +168,16 @@ export const MarkdownImage = memo(function MarkdownImage(
       setResolved(src);
       return;
     }
-    const path = joinRelative(base.dir, src);
+    setResolved(null);
     let cancelled = false;
-    readWorkspaceFileBytes(base.workspaceId, path)
-      .then((res) => {
+    resolveWorkspaceImageSrc(base, src)
+      .then((dataUrl) => {
         if (cancelled) return;
-        const mime = imageMediaType(path) ?? "image/png";
-        setResolved(imageDataUrl(mime, res.bytes_b64));
+        setResolved(dataUrl);
       })
       .catch((err) => {
         if (cancelled) return;
-        console.warn("Failed to load markdown image:", path, err);
+        console.warn("Failed to load markdown image:", src, err);
         setErrored(true);
       });
     return () => {
@@ -182,13 +229,16 @@ export const MarkdownPictureSource = memo(function MarkdownPictureSource(
       setResolved(null);
       return;
     }
-    const src = firstSrcSetUrl(srcSet);
     if (
-      !src ||
-      ABSOLUTE_HREF.test(src) ||
-      src.startsWith("data:") ||
-      src.startsWith("blob:")
+      srcSet.trimStart().startsWith("data:") ||
+      srcSet.trimStart().startsWith("blob:")
     ) {
+      setResolved(srcSet);
+      return;
+    }
+    const firstCandidate = parseSrcSetCandidate(srcSet.split(",")[0] ?? "");
+    const src = firstCandidate?.src ?? "";
+    if (!src) {
       setResolved(srcSet);
       return;
     }
@@ -197,19 +247,16 @@ export const MarkdownPictureSource = memo(function MarkdownPictureSource(
       return;
     }
 
-    const path = joinRelative(base.dir, src);
+    setResolved(null);
     let cancelled = false;
-    readWorkspaceFileBytes(base.workspaceId, path)
-      .then((res) => {
+    resolveWorkspaceSrcSet(base, srcSet)
+      .then((resolvedSrcSet) => {
         if (cancelled) return;
-        const mime = imageMediaType(path) ?? "image/png";
-        const dataUrl = imageDataUrl(mime, res.bytes_b64);
-        const descriptor = srcSet.trim().slice(src.length).trim();
-        setResolved(descriptor ? `${dataUrl} ${descriptor}` : dataUrl);
+        setResolved(resolvedSrcSet);
       })
       .catch((err) => {
         if (cancelled) return;
-        console.warn("Failed to load markdown picture source:", path, err);
+        console.warn("Failed to load markdown picture source:", srcSet, err);
         setResolved(null);
       });
     return () => {

--- a/src/ui/src/components/chat/MarkdownImage.tsx
+++ b/src/ui/src/components/chat/MarkdownImage.tsx
@@ -1,6 +1,7 @@
 import { createContext, memo, useContext, useEffect, useState } from "react";
 import { readWorkspaceFileBytes } from "../../services/tauri";
 import { imageMediaType } from "../../utils/fileIcons";
+import { base64ToBytes } from "../../utils/base64";
 
 /**
  * Resolution context for relative `<img>` references inside `<MessageMarkdown>`.
@@ -26,20 +27,65 @@ export function useMarkdownImageBase(): MarkdownImageBase | null {
 }
 
 const ABSOLUTE_HREF = /^(?:[a-z]+:|\/\/)/i;
+const SVG_MARKDOWN_IMAGE_CLASS = "cc-markdown-image-svg";
+
+function stripUrlSuffix(href: string): string {
+  const query = href.indexOf("?");
+  const hash = href.indexOf("#");
+  const end = [query, hash].filter((i) => i !== -1).sort((a, b) => a - b)[0];
+  return end === undefined ? href : href.slice(0, end);
+}
+
+function decodePath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
 
 function joinRelative(dir: string, href: string): string {
+  const pathHref = decodePath(stripUrlSuffix(href));
   // Leading `/` — treat as workspace-root relative. Common in READMEs that
   // reference assets via paths like `/assets/logo.png` regardless of which
   // file is rendering them. Drop the slash and skip the dir prefix.
-  if (href.startsWith("/")) return href.replace(/^\/+/, "");
+  if (pathHref.startsWith("/")) return pathHref.replace(/^\/+/, "");
   // Otherwise treat as relative to the markdown file's own directory. We
   // don't try to traverse `..` — repo READMEs almost never reference parent
   // directories, and the backend enforces workspace-relative paths anyway.
   // If `..` is seen, leave it for the backend to reject so the failure
   // surfaces visibly.
-  const cleaned = href.replace(/^\.\//, "");
+  const cleaned = pathHref.replace(/^\.\//, "");
   if (!dir) return cleaned;
   return `${dir}/${cleaned}`;
+}
+
+function isSvgMediaType(mediaType: string): boolean {
+  return mediaType.toLowerCase() === "image/svg+xml";
+}
+
+function svgDataUrlFromBase64(bytesB64: string): string | null {
+  try {
+    const svg = new TextDecoder().decode(base64ToBytes(bytesB64));
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+  } catch {
+    return null;
+  }
+}
+
+function imageDataUrl(mediaType: string, bytesB64: string): string {
+  if (isSvgMediaType(mediaType)) {
+    return svgDataUrlFromBase64(bytesB64) ?? `data:${mediaType};base64,${bytesB64}`;
+  }
+  return `data:${mediaType};base64,${bytesB64}`;
+}
+
+function dataUrlIsSvg(src: string): boolean {
+  return /^data:image\/svg\+xml(?:[;,]|$)/i.test(src);
+}
+
+function firstSrcSetUrl(srcSet: string): string {
+  return srcSet.trim().split(/\s+/)[0] ?? "";
 }
 
 /**
@@ -80,7 +126,7 @@ export const MarkdownImage = memo(function MarkdownImage(
       .then((res) => {
         if (cancelled) return;
         const mime = imageMediaType(path) ?? "image/png";
-        setResolved(`data:${mime};base64,${res.bytes_b64}`);
+        setResolved(imageDataUrl(mime, res.bytes_b64));
       })
       .catch((err) => {
         if (cancelled) return;
@@ -98,5 +144,79 @@ export const MarkdownImage = memo(function MarkdownImage(
     return alt ? <span>{alt}</span> : null;
   }
   if (resolved == null) return null;
-  return <img {...rest} src={resolved} alt={alt} />;
+  const hasExplicitSize =
+    rest.width != null ||
+    rest.height != null ||
+    rest.style?.width != null ||
+    rest.style?.height != null;
+  const className = [
+    rest.className,
+    dataUrlIsSvg(resolved) && !hasExplicitSize ? SVG_MARKDOWN_IMAGE_CLASS : null,
+  ]
+    .filter(Boolean)
+    .join(" ") || undefined;
+  return <img {...rest} src={resolved} alt={alt} className={className} />;
+});
+
+/**
+ * Raw HTML GitHub README themes use:
+ *
+ *   <picture>
+ *     <source media="(prefers-color-scheme: dark)" srcset="...svg">
+ *     <img src="...svg">
+ *   </picture>
+ *
+ * The `<img>` override above resolves the fallback source, but WebKit will
+ * prefer the matching `<source srcset>` when present. Resolve that too so
+ * dark/light GitHub-style README art works inside the Tauri webview.
+ */
+export const MarkdownPictureSource = memo(function MarkdownPictureSource(
+  props: React.SourceHTMLAttributes<HTMLSourceElement> & { node?: unknown },
+) {
+  const { node: _node, srcSet, ...rest } = props;
+  const base = useMarkdownImageBase();
+  const [resolved, setResolved] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!srcSet) {
+      setResolved(null);
+      return;
+    }
+    const src = firstSrcSetUrl(srcSet);
+    if (
+      !src ||
+      ABSOLUTE_HREF.test(src) ||
+      src.startsWith("data:") ||
+      src.startsWith("blob:")
+    ) {
+      setResolved(srcSet);
+      return;
+    }
+    if (!base) {
+      setResolved(srcSet);
+      return;
+    }
+
+    const path = joinRelative(base.dir, src);
+    let cancelled = false;
+    readWorkspaceFileBytes(base.workspaceId, path)
+      .then((res) => {
+        if (cancelled) return;
+        const mime = imageMediaType(path) ?? "image/png";
+        const dataUrl = imageDataUrl(mime, res.bytes_b64);
+        const descriptor = srcSet.trim().slice(src.length).trim();
+        setResolved(descriptor ? `${dataUrl} ${descriptor}` : dataUrl);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn("Failed to load markdown picture source:", path, err);
+        setResolved(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [srcSet, base]);
+
+  if (resolved == null) return null;
+  return <source {...rest} srcSet={resolved} />;
 });

--- a/src/ui/src/components/chat/MessageMarkdown.module.css
+++ b/src/ui/src/components/chat/MessageMarkdown.module.css
@@ -213,6 +213,20 @@
   border-color: var(--accent-primary);
 }
 
+.body :where(img) {
+  max-width: 100%;
+  height: auto;
+}
+
+/* WebKit can report no intrinsic size for SVGs that rely only on a viewBox
+   when they are loaded through an <img>. Give those markdown previews a
+   visible floor while still letting normal width/height attributes win. */
+.body :global(img.cc-markdown-image-svg) {
+  min-width: min(480px, 100%);
+  min-height: min(240px, 50vh);
+  object-fit: contain;
+}
+
 /* Horizontal rules */
 .body :where(hr) {
   border: none;

--- a/src/ui/src/components/chat/MessageMarkdown.module.css
+++ b/src/ui/src/components/chat/MessageMarkdown.module.css
@@ -215,6 +215,9 @@
 
 .body :where(img) {
   max-width: 100%;
+}
+
+.body :where(img:not([height])) {
   height: auto;
 }
 

--- a/src/ui/src/components/chat/MessageMarkdown.tsx
+++ b/src/ui/src/components/chat/MessageMarkdown.tsx
@@ -8,7 +8,7 @@ import {
   REMARK_PLUGINS,
   safeUrlTransform,
 } from "../../utils/markdown";
-import { MarkdownImage } from "./MarkdownImage";
+import { MarkdownImage, MarkdownPictureSource } from "./MarkdownImage";
 import styles from "./MessageMarkdown.module.css";
 
 // Single shared component map. `MARKDOWN_COMPONENTS` covers `<a>`, `<pre>`,
@@ -19,6 +19,7 @@ import styles from "./MessageMarkdown.module.css";
 const COMPONENTS: Components = {
   ...MARKDOWN_COMPONENTS,
   img: MarkdownImage,
+  source: MarkdownPictureSource,
 };
 
 /**

--- a/src/ui/src/utils/markdown.test.ts
+++ b/src/ui/src/utils/markdown.test.ts
@@ -8,7 +8,13 @@ vi.mock("./highlight", () => ({
   highlightCode: vi.fn(),
 }));
 
-import { EXTERNAL_SCHEMES, MARKDOWN_COMPONENTS, HighlightedCode } from "./markdown";
+import {
+  EXTERNAL_SCHEMES,
+  MARKDOWN_COMPONENTS,
+  SANITIZE_SCHEMA,
+  HighlightedCode,
+  safeUrlTransform,
+} from "./markdown";
 import { getCachedHighlight, highlightCode } from "./highlight";
 
 describe("EXTERNAL_SCHEMES", () => {
@@ -81,6 +87,40 @@ describe("MARKDOWN_COMPONENTS.code wiring", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const props = (el as unknown as { props: any }).props;
     expect(props.node).toBeUndefined();
+  });
+});
+
+describe("safeUrlTransform", () => {
+  it("allows SVG data URLs only for image src/srcSet attributes", () => {
+    const svg = "data:image/svg+xml;charset=utf-8,%3Csvg%2F%3E";
+
+    expect(safeUrlTransform(svg, "src", { tagName: "img" })).toBe(svg);
+    expect(safeUrlTransform(svg, "srcSet", { tagName: "source" })).toBe(svg);
+    expect(safeUrlTransform(svg, "href", { tagName: "a" })).toBe("");
+    expect(safeUrlTransform(svg)).toBe("");
+  });
+
+  it("rejects non-image data URLs for image src attributes", () => {
+    expect(
+      safeUrlTransform("data:text/html,<script>alert(1)</script>", "src", {
+        tagName: "img",
+      }),
+    ).toBe("");
+  });
+
+  it("keeps data protocol sanitization scoped to image src", () => {
+    expect(SANITIZE_SCHEMA.protocols.src).toContain("data");
+    expect(SANITIZE_SCHEMA.protocols.srcSet).toContain("data");
+    expect(SANITIZE_SCHEMA.protocols.href).not.toContain("data");
+  });
+
+  it("preserves GitHub-style picture attributes", () => {
+    expect(SANITIZE_SCHEMA.attributes.img).toEqual(
+      expect.arrayContaining(["src", "alt", "width", "height"]),
+    );
+    expect(SANITIZE_SCHEMA.attributes.source).toEqual(
+      expect.arrayContaining(["srcSet", "media"]),
+    );
   });
 });
 

--- a/src/ui/src/utils/markdown.ts
+++ b/src/ui/src/utils/markdown.ts
@@ -115,6 +115,18 @@ export const SANITIZE_SCHEMA = {
       ),
       "className",
     ],
+    img: [
+      ...(defaultSchema.attributes?.img ?? []),
+      "alt",
+      "height",
+      "width",
+    ],
+    source: [
+      ...(defaultSchema.attributes?.source ?? []),
+      "media",
+      "sizes",
+      "type",
+    ],
     "*": [...(defaultSchema.attributes?.["*"] ?? []), "class"],
   },
   protocols: {
@@ -124,6 +136,18 @@ export const SANITIZE_SCHEMA = {
       // The trailing colon is *not* part of the scheme name in the
       // hast-util-sanitize allow-list — strip it.
       FILE_PATH_SCHEME.replace(/:$/, ""),
+    ],
+    src: [
+      ...(defaultSchema.protocols?.src ?? []),
+      // Markdown image previews may embed workspace SVG bytes as
+      // `data:image/svg+xml...` after resolving a relative repo path.
+      // `safeUrlTransform` below still restricts `data:` to image `src`
+      // attributes only; link hrefs keep the stricter default allow-list.
+      "data",
+    ],
+    srcSet: [
+      ...(defaultSchema.protocols?.srcSet ?? []),
+      "data",
     ],
   },
 };
@@ -154,8 +178,28 @@ export const EXTERNAL_SCHEMES = /^https?:|^mailto:/i;
  * `claudettepath:` autolinker scheme. This wrapper preserves the default
  * safe-list and lets our scheme through; everything else still goes
  * through the same protocol gate as upstream. */
-export function safeUrlTransform(value: string): string {
+export function safeUrlTransform(
+  value: string,
+  key?: string,
+  node?: { tagName?: string },
+): string {
   if (value.startsWith(FILE_PATH_SCHEME)) return value;
+  if (
+    key === "src" &&
+    node?.tagName === "img" &&
+    /^data:image\/(?:png|jpe?g|gif|webp|svg\+xml|x-icon|bmp|avif|apng)(?:[;,]|$)/i
+      .test(value)
+  ) {
+    return value;
+  }
+  if (
+    key === "srcSet" &&
+    node?.tagName === "source" &&
+    /^data:image\/(?:png|jpe?g|gif|webp|svg\+xml|x-icon|bmp|avif|apng)(?:[;,]|$)/i
+      .test(value)
+  ) {
+    return value;
+  }
   // Inline copy of react-markdown's defaultUrlTransform logic so we don't
   // have to import an internal export. Behavior mirrors upstream so the
   // upgrade story stays simple.


### PR DESCRIPTION
## Summary
- Resolve workspace-relative SVGs rendered from markdown preview images.
- Support GitHub-style `<picture><source srcset="...svg"><img ...>` dark/light README art.
- Preserve safe image data URLs and relevant picture/img attributes through markdown sanitization.

## Validation
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test -- markdown.test.ts`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run lint` (0 errors; existing unrelated warnings remain)
