### PR TITLE
feat: animate panel toggles

### DIFF
--- a/src/ui/src/components/layout/AppLayout.module.css
+++ b/src/ui/src/components/layout/AppLayout.module.css
@@ -26,8 +26,34 @@
   width: var(--sidebar-w);
   background: var(--sidebar-bg);
   border-right: 1px solid var(--sidebar-border);
-  overflow-y: auto;
+  overflow: hidden;
   contain: layout style paint;
+  transition:
+    width var(--transition-slow),
+    opacity var(--transition-normal),
+    border-color var(--transition-normal);
+  will-change: width;
+}
+
+.sidebarContent {
+  width: var(--sidebar-w);
+  height: 100%;
+  transition:
+    opacity var(--transition-normal),
+    transform var(--transition-normal);
+  will-change: opacity, transform;
+}
+
+.sidebarHidden {
+  width: 0;
+  opacity: 0;
+  pointer-events: none;
+  border-right-color: transparent;
+}
+
+.sidebarHidden .sidebarContent {
+  opacity: 0;
+  transform: translateX(-10px);
 }
 
 .center {
@@ -52,6 +78,20 @@
   border-top: 1px solid var(--sidebar-border);
   overflow: hidden;
   contain: layout style paint;
+  transition:
+    height var(--transition-slow),
+    opacity var(--transition-normal),
+    transform var(--transition-normal),
+    border-color var(--transition-normal);
+  will-change: height, opacity, transform;
+}
+
+.terminalHidden {
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(10px);
+  border-top-color: transparent;
 }
 
 .rightSidebar {
@@ -59,8 +99,34 @@
   width: var(--right-sidebar-w);
   background: var(--sidebar-bg);
   border-left: 1px solid var(--sidebar-border);
-  overflow-y: auto;
+  overflow: hidden;
   contain: layout style paint;
+  transition:
+    width var(--transition-slow),
+    opacity var(--transition-normal),
+    border-color var(--transition-normal);
+  will-change: width;
+}
+
+.rightSidebarContent {
+  width: var(--right-sidebar-w);
+  height: 100%;
+  transition:
+    opacity var(--transition-normal),
+    transform var(--transition-normal);
+  will-change: opacity, transform;
+}
+
+.rightSidebarHidden {
+  width: 0;
+  opacity: 0;
+  pointer-events: none;
+  border-left-color: transparent;
+}
+
+.rightSidebarHidden .rightSidebarContent {
+  opacity: 0;
+  transform: translateX(10px);
 }
 
 .empty {
@@ -79,4 +145,14 @@
 */
 .hidden {
   display: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar,
+  .sidebarContent,
+  .terminal,
+  .rightSidebar,
+  .rightSidebarContent {
+    transition: none;
+  }
 }

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -105,20 +105,23 @@ export function AppLayout() {
           </div>
         )}
         <div className={`${styles.viewPanel} ${settingsOpen ? styles.hidden : ""}`}>
+          <div
+            className={`${styles.sidebar} ${sidebarVisible ? "" : styles.sidebarHidden}`}
+            aria-hidden={!sidebarVisible}
+          >
+            <div className={styles.sidebarContent}>
+              <Sidebar />
+            </div>
+          </div>
           {sidebarVisible && (
-            <>
-              <div className={styles.sidebar}>
-                <Sidebar />
-              </div>
-              <ResizeHandle
-                direction="horizontal"
-                targetRef={mainRef}
-                cssVar="--sidebar-w"
-                min={150}
-                max={600}
-                onResizeEnd={handleLeftResizeEnd}
-              />
-            </>
+            <ResizeHandle
+              direction="horizontal"
+              targetRef={mainRef}
+              cssVar="--sidebar-w"
+              min={150}
+              max={600}
+              onResizeEnd={handleLeftResizeEnd}
+            />
           )}
           <div className={styles.center}>
             <div className={styles.content}>
@@ -155,25 +158,33 @@ export function AppLayout() {
             )}
             {selectedWorkspaceId && (
               <div
-                className={`${styles.terminal} ${terminalPanelVisible ? "" : styles.hidden}`}
+                className={`${styles.terminal} ${terminalPanelVisible ? "" : styles.terminalHidden}`}
+                aria-hidden={!terminalPanelVisible}
               >
                 <TerminalPanel />
               </div>
             )}
           </div>
-          {rightSidebarVisible && selectedWorkspaceId && (
+          {selectedWorkspaceId && (
             <>
-              <ResizeHandle
-                direction="horizontal"
-                targetRef={mainRef}
-                cssVar="--right-sidebar-w"
-                min={150}
-                max={600}
-                invert
-                onResizeEnd={handleRightResizeEnd}
-              />
-              <div className={styles.rightSidebar}>
-                <RightSidebar />
+              {rightSidebarVisible && (
+                <ResizeHandle
+                  direction="horizontal"
+                  targetRef={mainRef}
+                  cssVar="--right-sidebar-w"
+                  min={150}
+                  max={600}
+                  invert
+                  onResizeEnd={handleRightResizeEnd}
+                />
+              )}
+              <div
+                className={`${styles.rightSidebar} ${rightSidebarVisible ? "" : styles.rightSidebarHidden}`}
+                aria-hidden={!rightSidebarVisible}
+              >
+                <div className={styles.rightSidebarContent}>
+                  <RightSidebar />
+                </div>
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary

- Keeps the left sidebar, right sidebar, and terminal panel mounted while toggled so their dimensions can animate smoothly.
- Adds width, height, opacity, transform, and border transitions for panel open/close states.
- Respects `prefers-reduced-motion` by disabling the new layout transitions.

## Validation

- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run build`
