### PR TITLE
fix: sync sidebar status badge with session attention state

### DIFF
--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -463,8 +463,8 @@ export const Sidebar = memo(function Sidebar() {
       workspaceDrag.dropTarget?.id === ws.id &&
       workspaceDrag.dropTarget.placement === "after";
     const wsSessions = sessionsByWorkspace[ws.id] ?? [];
-    const hasQuestion = wsSessions.some((s) => s.needs_attention && s.attention_kind === "Ask");
     const hasPlan = wsSessions.some((s) => s.needs_attention && s.attention_kind === "Plan");
+    const hasQuestion = wsSessions.some((s) => s.needs_attention && s.attention_kind !== "Plan");
     const badge: "ask" | "plan" | "done" | null =
       hasQuestion ? "ask" :
       hasPlan ? "plan" :

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -63,8 +63,6 @@ export const Sidebar = memo(function Sidebar() {
   const removeWorkspace = useAppStore((s) => s.removeWorkspace);
   const addToast = useAppStore((s) => s.addToast);
   const unreadCompletions = useAppStore((s) => s.unreadCompletions);
-  const agentQuestions = useAppStore((s) => s.agentQuestions);
-  const planApprovals = useAppStore((s) => s.planApprovals);
   const sessionsByWorkspace = useAppStore((s) => s.sessionsByWorkspace);
   const scmSummary = useAppStore((s) => s.scmSummary);
   const setRepositories = useAppStore((s) => s.setRepositories);
@@ -465,8 +463,8 @@ export const Sidebar = memo(function Sidebar() {
       workspaceDrag.dropTarget?.id === ws.id &&
       workspaceDrag.dropTarget.placement === "after";
     const wsSessions = sessionsByWorkspace[ws.id] ?? [];
-    const hasQuestion = wsSessions.some((s) => agentQuestions[s.id]);
-    const hasPlan = wsSessions.some((s) => planApprovals[s.id]);
+    const hasQuestion = wsSessions.some((s) => s.needs_attention && s.attention_kind === "Ask");
+    const hasPlan = wsSessions.some((s) => s.needs_attention && s.attention_kind === "Plan");
     const badge: "ask" | "plan" | "done" | null =
       hasQuestion ? "ask" :
       hasPlan ? "plan" :


### PR DESCRIPTION
## Summary

The workspace sidebar showed an idle dotted-circle for a workspace whose tab was already showing the "plan for review" (ⓘ) icon. The two surfaces were reading from different sources of truth:

- **Tab bar** (`SessionTabs.tsx:67-73`) → `session.needs_attention` + `session.attention_kind` (DB-backed, loaded by `list_chat_sessions`).
- **Sidebar** (`Sidebar.tsx:468-469`) → `planApprovals[s.id]` / `agentQuestions[s.id]` (ephemeral Zustand stores populated only by the live `agent-permission-prompt` event).

After an app restart, sessions reload from SQLite with `needs_attention: true, attention_kind: "Plan"`, but the in-memory stores start empty — so the tab correctly showed the plan icon while the sidebar fell through to CircleDashed.

The sidebar now derives `hasQuestion` / `hasPlan` from the same session fields the tab bar uses. Both stay in sync on clear via the existing `clearSessionAttention` helper called by `clearAgentQuestion` / `clearPlanApproval`.

```mermaid
flowchart LR
  subgraph Before
    A1[agent-permission-prompt] --> A2[setPlanApproval]
    A1 --> A3[updateChatSession needs_attention]
    A2 --> A4[Sidebar badge]
    A3 --> A5[Tab icon]
    A6[App restart / list_chat_sessions] -.-> A3
    A6 -.->|empty| A2
  end
  subgraph After
    B1[agent-permission-prompt] --> B3[updateChatSession needs_attention]
    B3 --> B4[Sidebar badge]
    B3 --> B5[Tab icon]
    B6[App restart / list_chat_sessions] --> B3
  end
```

## Complexity Notes

- The `planApprovals` and `agentQuestions` stores are still required — they hold the actual prompt payload (`toolUseId`, `allowedPrompts`, question options) needed by the chat panel to render and answer the cards. This change only stops the **sidebar** from reading them as the source of truth for badge presence.
- `_shared.ts::clearSessionAttention` already keeps `needs_attention` / `attention_kind` consistent on dismiss, so the sidebar will clear correctly when a plan is approved or a question is answered.
- Side benefit: the sidebar no longer re-renders on every `agentQuestions` / `planApprovals` mutation in unrelated workspaces.

## Test Steps

1. With the dev app running, enter a workspace and trigger plan mode in Claude Code (e.g. start a request that produces an `ExitPlanMode` prompt). Confirm the sidebar shows the CircleAlert plan badge alongside the tab's ⓘ icon.
2. Quit the app entirely, then relaunch.
3. Re-open the same workspace — **both** the sidebar badge and the tab icon should still show the plan state (this is the regression being fixed; previously the sidebar reverted to CircleDashed).
4. Approve the plan — sidebar badge and tab icon should clear together.
5. Repeat steps 1-4 for AskUserQuestion (the same code path with `attention_kind === "Ask"`).
6. Run `cd src/ui && bunx tsc -b && bun run lint && bun run lint:css` — all green.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)