### PR TITLE
fix(scm): preserve cached PR status across transient poll failures

### DIFF
--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -526,6 +526,61 @@ fn scm_detail_from_previous(
     }
 }
 
+/// Hydrate the in-memory SCM cache from SQLite. Called at polling-task
+/// startup so that `merge_scm_results` can see the user's persisted PR/CI
+/// state as `previous` on the very first poll after an app restart.
+///
+/// Errors at any layer are logged and swallowed: a missing or unreadable
+/// row just means the in-memory cache stays empty for that key, which is
+/// the same state we had before this seed existed.
+async fn seed_scm_cache_from_db(db_path: &std::path::Path, cache: &crate::state::ScmCache) {
+    let rows = match Database::open(db_path) {
+        Ok(db) => match db.load_all_scm_status_cache() {
+            Ok(rows) => rows,
+            Err(e) => {
+                eprintln!("[scm] Failed to load SCM cache from DB on seed: {e}");
+                return;
+            }
+        },
+        Err(e) => {
+            eprintln!("[scm] Failed to open DB for SCM cache seed: {e}");
+            return;
+        }
+    };
+
+    // Anchor seeded entries far enough in the past that the first poll
+    // cycle after restart treats them as stale and triggers a fresh fetch
+    // — the SQLite row could be hours old. Falls back to `now()` only on
+    // platforms where `Instant` can't represent the past (none in
+    // practice on the targets we ship).
+    let stale_anchor = Instant::now()
+        .checked_sub(std::time::Duration::from_secs(60))
+        .unwrap_or_else(Instant::now);
+
+    let mut entries = cache.entries.write().await;
+    for row in rows {
+        let pull_request = row
+            .pr_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<Option<PullRequest>>(s).ok())
+            .flatten();
+        let ci_checks = row
+            .ci_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str::<Vec<CiCheck>>(s).ok())
+            .unwrap_or_default();
+        entries.insert(
+            (row.repo_id, row.branch_name),
+            ScmCacheEntry {
+                pull_request,
+                ci_checks,
+                last_fetched: stale_anchor,
+                error: row.error,
+            },
+        );
+    }
+}
+
 /// Identity for a `persist_scm_cache` write — bundles the workspace, repo,
 /// branch, and provider names so the helper signature stays under clippy's
 /// `too_many_arguments` ceiling.
@@ -567,7 +622,7 @@ async fn persist_scm_cache(
                 branch_name: cache_map_key.1,
                 provider: Some(key.provider.to_string()),
                 pr_json: serde_json::to_string(pull_request).ok(),
-                ci_json: serde_json::to_string(&ci_checks.to_vec()).ok(),
+                ci_json: serde_json::to_string(ci_checks).ok(),
                 error,
                 fetched_at: String::new(),
             }) {
@@ -748,6 +803,17 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
 pub fn start_scm_polling(app_handle: tauri::AppHandle) {
     let handle = app_handle.clone();
     tauri::async_runtime::spawn(async move {
+        // Hydrate the in-memory cache from SQLite immediately so that the
+        // first poll cycle after a restart has access to the user's prior
+        // PR/CI state via `merge_scm_results`. Without this seed, a
+        // post-restart transient outage would see `previous = None`,
+        // overwrite the still-valid SQLite row with `pr_json = "null"`,
+        // and reintroduce the disappearing-PR-badge regression.
+        {
+            let app_state = handle.state::<AppState>();
+            seed_scm_cache_from_db(&app_state.db_path, &app_state.scm_cache).await;
+        }
+
         // Small delay to let the app fully initialize
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
@@ -1198,5 +1264,123 @@ mod tests {
             "PRs for other branches must not be selected",
         );
         assert!(outcome.should_persist);
+    }
+
+    /// Build a minimal `Repository` fixture for DB tests. We can't reuse
+    /// `claudette::db::test_support::make_repo` because it's `pub(crate)`.
+    fn fixture_repo(id: &str, path: &str) -> claudette::model::Repository {
+        claudette::model::Repository {
+            id: id.into(),
+            path: path.into(),
+            name: id.into(),
+            path_slug: id.into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+        }
+    }
+
+    fn fixture_workspace(id: &str, repo_id: &str, branch: &str) -> claudette::model::Workspace {
+        claudette::model::Workspace {
+            id: id.into(),
+            repository_id: repo_id.into(),
+            name: id.into(),
+            branch_name: branch.into(),
+            worktree_path: None,
+            status: claudette::model::WorkspaceStatus::Active,
+            agent_status: claudette::model::AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+            sort_order: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_hydrates_in_memory_cache_from_sqlite() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("claudette.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&fixture_repo("r1", "/tmp/repo1"))
+            .unwrap();
+        db.insert_workspace(&fixture_workspace("w1", "r1", "feature/seed"))
+            .unwrap();
+
+        let pr = make_pr("feature/seed", 123);
+        let row = claudette::db::ScmStatusCacheRow {
+            workspace_id: "w1".into(),
+            repo_id: "r1".into(),
+            branch_name: "feature/seed".into(),
+            provider: Some("github".into()),
+            pr_json: serde_json::to_string(&Some(pr)).ok(),
+            ci_json: serde_json::to_string(&vec![make_check("ci/build", CiCheckStatus::Success)])
+                .ok(),
+            error: None,
+            fetched_at: String::new(),
+        };
+        db.upsert_scm_status_cache(&row).unwrap();
+        // Drop the synchronous DB handle before the async seed reopens it.
+        drop(db);
+
+        let cache = crate::state::ScmCache::new();
+        seed_scm_cache_from_db(&db_path, &cache).await;
+
+        let entries = cache.entries.read().await;
+        let entry = entries
+            .get(&("r1".to_string(), "feature/seed".to_string()))
+            .expect("seed should populate the cache from the SQLite row");
+        assert_eq!(entry.pull_request.as_ref().map(|pr| pr.number), Some(123));
+        assert_eq!(entry.ci_checks.len(), 1);
+        assert_eq!(entry.ci_checks[0].name, "ci/build");
+        // Seed marks entries stale enough that the first poll triggers a
+        // real fetch instead of returning the seeded row as "fresh".
+        assert!(
+            entry.last_fetched.elapsed().as_secs() >= 30,
+            "seeded last_fetched must be older than the 30s polling freshness window",
+        );
+    }
+
+    #[tokio::test]
+    async fn seed_skips_rows_with_null_pr_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("claudette.db");
+        let db = Database::open(&db_path).unwrap();
+        db.insert_repository(&fixture_repo("r1", "/tmp/repo1"))
+            .unwrap();
+        db.insert_workspace(&fixture_workspace("w1", "r1", "feature/none"))
+            .unwrap();
+
+        // Row representing "we polled and there's no PR for this branch".
+        let row = claudette::db::ScmStatusCacheRow {
+            workspace_id: "w1".into(),
+            repo_id: "r1".into(),
+            branch_name: "feature/none".into(),
+            provider: Some("github".into()),
+            pr_json: Some("null".into()),
+            ci_json: Some("[]".into()),
+            error: None,
+            fetched_at: String::new(),
+        };
+        db.upsert_scm_status_cache(&row).unwrap();
+        drop(db);
+
+        let cache = crate::state::ScmCache::new();
+        seed_scm_cache_from_db(&db_path, &cache).await;
+
+        let entries = cache.entries.read().await;
+        let entry = entries
+            .get(&("r1".to_string(), "feature/none".to_string()))
+            .expect("entry should still be created so subsequent polls see prior state");
+        assert!(
+            entry.pull_request.is_none(),
+            "null pr_json must hydrate as None, not panic",
+        );
+        assert!(entry.ci_checks.is_empty());
     }
 }

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -164,6 +164,7 @@ pub async fn load_scm_detail(
     state: State<'_, AppState>,
 ) -> Result<ScmDetail, String> {
     let ctx = lookup_workspace_context(&state.db_path, &workspace_id).await?;
+    let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
 
     let provider_name = match resolve_provider_async(
         &ctx.manual_override,
@@ -173,13 +174,15 @@ pub async fn load_scm_detail(
     )
     .await
     {
-        Some(name) => name,
-        None => {
-            // Clear any stale cache row so old badges don't persist across restarts
-            // when the provider is no longer available (e.g. plugin removed).
+        Ok(Some(name)) => name,
+        Ok(None) => {
+            // Confirmed there is no matching provider for this remote (remote
+            // URL was readable but no plugin matched). Clear any stale cache
+            // row so old badges don't persist when the provider is removed.
             if let Ok(db) = Database::open(&state.db_path) {
                 let _ = db.delete_scm_status_cache(&workspace_id);
             }
+            state.scm_cache.entries.write().await.remove(&cache_key);
             return Ok(ScmDetail {
                 workspace_id,
                 pull_request: None,
@@ -188,10 +191,20 @@ pub async fn load_scm_detail(
                 error: None,
             });
         }
+        Err(e) => {
+            // Provider resolution failed transiently (e.g. `git remote get-url`
+            // hiccup). Preserve any previously-cached detail so the UI keeps
+            // showing the last-known PR state instead of blanking.
+            return Ok(scm_detail_from_previous(
+                &workspace_id,
+                state.scm_cache.entries.read().await.get(&cache_key),
+                None,
+                Some(e),
+            ));
+        }
     };
 
     let ws_info = make_workspace_info(&ctx.workspace, &ctx.repo);
-    let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
 
     // Check cache first
     {
@@ -232,72 +245,33 @@ pub async fn load_scm_detail(
         registry.call_operation(&provider_name, "ci_status", args, ws_info),
     );
 
-    let mut pull_request: Option<PullRequest> = None;
-    let mut ci_checks: Vec<CiCheck> = vec![];
-    let mut error: Option<String> = None;
+    let outcome = {
+        let cache = state.scm_cache.entries.read().await;
+        merge_scm_results(prs_result, ci_result, &branch, cache.get(&cache_key))
+    };
 
-    match prs_result {
-        Ok(val) => {
-            if let Ok(prs) = serde_json::from_value::<Vec<PullRequest>>(val) {
-                pull_request = prs.into_iter().find(|pr| pr.branch == branch);
-            }
-        }
-        Err(e) => {
-            error = Some(e.to_string());
-        }
-    }
+    let ScmFetchOutcome {
+        pull_request,
+        ci_checks,
+        error,
+        should_persist,
+    } = outcome;
 
-    match ci_result {
-        Ok(val) => {
-            if let Ok(checks) = serde_json::from_value::<Vec<CiCheck>>(val) {
-                ci_checks = checks;
-            }
-        }
-        Err(e) => {
-            if error.is_none() {
-                error = Some(e.to_string());
-            }
-        }
-    }
-
-    // Update cache
-    {
-        let cached_error = error.clone();
-        let mut cache = state.scm_cache.entries.write().await;
-        cache.insert(
-            cache_key.clone(),
-            ScmCacheEntry {
-                pull_request: pull_request.clone(),
-                ci_checks: ci_checks.clone(),
-                last_fetched: Instant::now(),
-                error: cached_error,
+    if should_persist {
+        persist_scm_cache(
+            &state.scm_cache,
+            &state.db_path,
+            ScmCacheKey {
+                workspace_id: &workspace_id,
+                repo_id: &cache_key.0,
+                branch: &cache_key.1,
+                provider: &provider_name,
             },
-        );
-    }
-
-    // Persist to SQLite for instant display on next app launch.
-    {
-        match Database::open(&state.db_path) {
-            Ok(db) => {
-                if let Err(e) = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
-                    workspace_id: workspace_id.clone(),
-                    repo_id: cache_key.0.clone(),
-                    branch_name: cache_key.1.clone(),
-                    provider: Some(provider_name.clone()),
-                    pr_json: serde_json::to_string(&pull_request).ok(),
-                    ci_json: serde_json::to_string(&ci_checks).ok(),
-                    error: error.clone(),
-                    fetched_at: String::new(),
-                }) {
-                    eprintln!(
-                        "[scm] Failed to persist SCM cache for workspace {workspace_id}: {e}"
-                    );
-                }
-            }
-            Err(e) => {
-                eprintln!("[scm] Failed to open DB for SCM cache persistence: {e}");
-            }
-        }
+            &pull_request,
+            &ci_checks,
+            error.clone(),
+        )
+        .await;
     }
 
     Ok(ScmDetail {
@@ -329,6 +303,7 @@ pub async fn scm_create_pr(
         &state,
     )
     .await
+    .map_err(|e| format!("Failed to resolve SCM provider: {e}"))?
     .ok_or("No SCM provider configured for this repository")?;
 
     let ws_info = make_workspace_info(&ctx.workspace, &ctx.repo);
@@ -382,6 +357,7 @@ pub async fn scm_merge_pr(
         &state,
     )
     .await
+    .map_err(|e| format!("Failed to resolve SCM provider: {e}"))?
     .ok_or("No SCM provider configured for this repository")?;
 
     let ws_info = make_workspace_info(&ctx.workspace, &ctx.repo);
@@ -431,23 +407,180 @@ pub async fn scm_refresh(
 // --- Helpers ---
 
 /// Resolve provider without holding a Database reference across await points.
+///
+/// See [`resolve_provider_for_polling`] for the meaning of the three return
+/// variants — the contract is identical.
 async fn resolve_provider_async(
     manual_override: &Option<String>,
     repo_path: &str,
     default_remote: Option<&str>,
     state: &State<'_, AppState>,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     if let Some(provider) = manual_override
         && !provider.is_empty()
     {
-        return Some(provider.clone());
+        return Ok(Some(provider.clone()));
     }
 
     let remote_url = claudette::git::get_remote_url(repo_path, default_remote)
         .await
-        .ok()?;
+        .map_err(|e| e.to_string())?;
     let registry = state.plugins.read().await;
-    detect::detect_provider(&remote_url, &registry.plugins)
+    Ok(detect::detect_provider(&remote_url, &registry.plugins))
+}
+
+/// Result of merging fresh plugin call results with a prior cache entry.
+struct ScmFetchOutcome {
+    pull_request: Option<PullRequest>,
+    ci_checks: Vec<CiCheck>,
+    error: Option<String>,
+    /// `true` when at least one plugin call succeeded and so we have authoritative
+    /// new data worth persisting. `false` when both calls errored AND prior
+    /// cached data exists — in that case we leave the cache untouched so a
+    /// transient outage doesn't clobber known-good state.
+    should_persist: bool,
+}
+
+/// Merge the results of `list_pull_requests` and `ci_status` plugin calls with
+/// the prior cache entry. Pure function — no IO, no async — so it can be unit
+/// tested in isolation.
+///
+/// The key invariant: when a plugin call errors, fall back to the previous
+/// cached value for that side. Only return `pull_request: None` (or
+/// `ci_checks: vec![]`) when the call succeeded and explicitly reported no
+/// data.
+fn merge_scm_results(
+    prs_result: Result<serde_json::Value, claudette::plugin_runtime::PluginError>,
+    ci_result: Result<serde_json::Value, claudette::plugin_runtime::PluginError>,
+    branch: &str,
+    previous: Option<&ScmCacheEntry>,
+) -> ScmFetchOutcome {
+    let prs_failed = prs_result.is_err();
+    let ci_failed = ci_result.is_err();
+
+    let (pull_request, prs_err) = match prs_result {
+        Ok(val) => {
+            let parsed = serde_json::from_value::<Vec<PullRequest>>(val)
+                .ok()
+                .and_then(|prs| prs.into_iter().find(|pr| pr.branch == branch));
+            (parsed, None)
+        }
+        Err(e) => (
+            previous.and_then(|p| p.pull_request.clone()),
+            Some(e.to_string()),
+        ),
+    };
+
+    let (ci_checks, ci_err) = match ci_result {
+        Ok(val) => (
+            serde_json::from_value::<Vec<CiCheck>>(val).unwrap_or_default(),
+            None,
+        ),
+        Err(e) => (
+            previous.map(|p| p.ci_checks.clone()).unwrap_or_default(),
+            Some(e.to_string()),
+        ),
+    };
+
+    let error = prs_err.or(ci_err);
+
+    // Skip persistence only when BOTH calls failed AND we have prior cached
+    // data to preserve. If either call succeeded we have authoritative new
+    // data worth writing; if there's no prior cache there's nothing to
+    // clobber, so the empty-with-error row is acceptable.
+    let should_persist = !(prs_failed && ci_failed && previous.is_some());
+
+    ScmFetchOutcome {
+        pull_request,
+        ci_checks,
+        error,
+        should_persist,
+    }
+}
+
+/// Build a `ScmDetail` payload from a previously-cached entry, used when the
+/// current fetch couldn't run at all (e.g. transient remote-URL lookup
+/// failure). Returns an empty detail with the error message when there's no
+/// prior entry.
+fn scm_detail_from_previous(
+    workspace_id: &str,
+    previous: Option<&ScmCacheEntry>,
+    provider: Option<String>,
+    error: Option<String>,
+) -> ScmDetail {
+    match previous {
+        Some(entry) => ScmDetail {
+            workspace_id: workspace_id.to_string(),
+            pull_request: entry.pull_request.clone(),
+            ci_checks: entry.ci_checks.clone(),
+            provider,
+            error: error.or_else(|| entry.error.clone()),
+        },
+        None => ScmDetail {
+            workspace_id: workspace_id.to_string(),
+            pull_request: None,
+            ci_checks: vec![],
+            provider,
+            error,
+        },
+    }
+}
+
+/// Identity for a `persist_scm_cache` write — bundles the workspace, repo,
+/// branch, and provider names so the helper signature stays under clippy's
+/// `too_many_arguments` ceiling.
+struct ScmCacheKey<'a> {
+    workspace_id: &'a str,
+    repo_id: &'a str,
+    branch: &'a str,
+    provider: &'a str,
+}
+
+/// Write the merged SCM data to both the in-memory cache and the SQLite cache.
+async fn persist_scm_cache(
+    cache: &crate::state::ScmCache,
+    db_path: &std::path::Path,
+    key: ScmCacheKey<'_>,
+    pull_request: &Option<PullRequest>,
+    ci_checks: &[CiCheck],
+    error: Option<String>,
+) {
+    let cache_map_key = (key.repo_id.to_string(), key.branch.to_string());
+    {
+        let mut entries = cache.entries.write().await;
+        entries.insert(
+            cache_map_key.clone(),
+            ScmCacheEntry {
+                pull_request: pull_request.clone(),
+                ci_checks: ci_checks.to_vec(),
+                last_fetched: Instant::now(),
+                error: error.clone(),
+            },
+        );
+    }
+
+    match Database::open(db_path) {
+        Ok(db) => {
+            if let Err(e) = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
+                workspace_id: key.workspace_id.to_string(),
+                repo_id: cache_map_key.0,
+                branch_name: cache_map_key.1,
+                provider: Some(key.provider.to_string()),
+                pr_json: serde_json::to_string(pull_request).ok(),
+                ci_json: serde_json::to_string(&ci_checks.to_vec()).ok(),
+                error,
+                fetched_at: String::new(),
+            }) {
+                eprintln!(
+                    "[scm] Failed to persist SCM cache for workspace {}: {e}",
+                    key.workspace_id
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("[scm] Failed to open DB for SCM cache persistence: {e}");
+        }
+    }
 }
 
 fn make_workspace_info(
@@ -469,23 +602,30 @@ fn make_workspace_info(
 // --- Background polling ---
 
 /// Resolve SCM provider without a Tauri State wrapper (for background tasks).
+///
+/// Returns:
+/// - `Ok(Some(name))` — provider resolved.
+/// - `Ok(None)` — no plugin matches this remote (legitimate: not a recognised
+///   forge or no SCM plugins installed).
+/// - `Err(e)` — the remote URL lookup itself failed (transient git error). The
+///   caller MUST NOT clear cached data in this case.
 async fn resolve_provider_for_polling(
     manual_override: &Option<String>,
     repo_path: &str,
     default_remote: Option<&str>,
     app_state: &AppState,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     if let Some(provider) = manual_override
         && !provider.is_empty()
     {
-        return Some(provider.clone());
+        return Ok(Some(provider.clone()));
     }
 
     let remote_url = claudette::git::get_remote_url(repo_path, default_remote)
         .await
-        .ok()?;
+        .map_err(|e| e.to_string())?;
     let registry = app_state.plugins.read().await;
-    detect::detect_provider(&remote_url, &registry.plugins)
+    Ok(detect::detect_provider(&remote_url, &registry.plugins))
 }
 
 /// Fetch SCM data for a single workspace (used by the polling loop).
@@ -493,6 +633,7 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
     let ctx = lookup_workspace_context(&app_state.db_path, workspace_id)
         .await
         .ok()?;
+    let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
 
     let provider_name = match resolve_provider_for_polling(
         &ctx.manual_override,
@@ -502,19 +643,29 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
     )
     .await
     {
-        Some(name) => name,
-        None => {
-            // Clear any stale cache row so old badges don't persist across restarts
-            // when the provider is no longer available (e.g. plugin removed).
+        Ok(Some(name)) => name,
+        Ok(None) => {
+            // Confirmed no provider for this remote — clear any stale cache row.
             if let Ok(db) = Database::open(&app_state.db_path) {
                 let _ = db.delete_scm_status_cache(workspace_id);
             }
+            app_state.scm_cache.entries.write().await.remove(&cache_key);
             return None;
+        }
+        Err(e) => {
+            // Transient remote-lookup failure — preserve any prior cached detail
+            // so sidebar/banner don't blank out for one polling cycle.
+            let cache = app_state.scm_cache.entries.read().await;
+            return Some(scm_detail_from_previous(
+                workspace_id,
+                cache.get(&cache_key),
+                None,
+                Some(e),
+            ));
         }
     };
 
     let ws_info = make_workspace_info(&ctx.workspace, &ctx.repo);
-    let cache_key = (ctx.repo.id.clone(), ctx.workspace.branch_name.clone());
 
     // Skip if cache is fresh (< 30s for background polling)
     {
@@ -551,70 +702,33 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
         registry.call_operation(&provider_name, "ci_status", args, ws_info),
     );
 
-    let mut pull_request: Option<PullRequest> = None;
-    let mut ci_checks: Vec<CiCheck> = vec![];
-    let mut error: Option<String> = None;
+    let outcome = {
+        let cache = app_state.scm_cache.entries.read().await;
+        merge_scm_results(prs_result, ci_result, &branch, cache.get(&cache_key))
+    };
 
-    match prs_result {
-        Ok(val) => {
-            if let Ok(prs) = serde_json::from_value::<Vec<PullRequest>>(val) {
-                pull_request = prs.into_iter().find(|pr| pr.branch == branch);
-            }
-        }
-        Err(e) => error = Some(e.to_string()),
-    }
+    let ScmFetchOutcome {
+        pull_request,
+        ci_checks,
+        error,
+        should_persist,
+    } = outcome;
 
-    match ci_result {
-        Ok(val) => {
-            if let Ok(checks) = serde_json::from_value::<Vec<CiCheck>>(val) {
-                ci_checks = checks;
-            }
-        }
-        Err(e) => {
-            if error.is_none() {
-                error = Some(e.to_string());
-            }
-        }
-    }
-
-    // Update cache
-    {
-        let cached_error = error.clone();
-        let mut cache = app_state.scm_cache.entries.write().await;
-        cache.insert(
-            cache_key.clone(),
-            ScmCacheEntry {
-                pull_request: pull_request.clone(),
-                ci_checks: ci_checks.clone(),
-                last_fetched: Instant::now(),
-                error: cached_error,
+    if should_persist {
+        persist_scm_cache(
+            &app_state.scm_cache,
+            &app_state.db_path,
+            ScmCacheKey {
+                workspace_id,
+                repo_id: &cache_key.0,
+                branch: &cache_key.1,
+                provider: &provider_name,
             },
-        );
-    }
-
-    // Persist to SQLite for instant display on next app launch.
-    {
-        match Database::open(&app_state.db_path) {
-            Ok(db) => {
-                if let Err(e) = db.upsert_scm_status_cache(&claudette::db::ScmStatusCacheRow {
-                    workspace_id: workspace_id.to_string(),
-                    repo_id: cache_key.0.clone(),
-                    branch_name: cache_key.1.clone(),
-                    provider: Some(provider_name.clone()),
-                    pr_json: serde_json::to_string(&pull_request).ok(),
-                    ci_json: serde_json::to_string(&ci_checks).ok(),
-                    error: error.clone(),
-                    fetched_at: String::new(),
-                }) {
-                    eprintln!(
-                        "[scm] Failed to persist SCM cache for workspace {workspace_id}: {e}"
-                    );
-                }
-            }
-            Err(e) => {
-                eprintln!("[scm] Failed to open DB for SCM cache persistence: {e}");
-            }
-        }
+            &pull_request,
+            &ci_checks,
+            error.clone(),
+        )
+        .await;
     }
 
     Some(ScmDetail {
@@ -911,4 +1025,178 @@ async fn auto_archive_workspace(
     }
     let _ = handle.emit("workspace-auto-archived", payload);
     eprintln!("[scm] Auto-{verb} workspace '{ws_name}' ({ws_id})");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claudette::plugin_runtime::PluginError;
+    use claudette::scm::types::{CiCheckStatus, PrState};
+
+    fn make_pr(branch: &str, number: u64) -> PullRequest {
+        PullRequest {
+            number,
+            title: format!("PR #{number} on {branch}"),
+            state: PrState::Open,
+            url: format!("https://example.com/pulls/{number}"),
+            author: "octocat".into(),
+            branch: branch.into(),
+            base: "main".into(),
+            draft: false,
+            ci_status: None,
+        }
+    }
+
+    fn make_check(name: &str, status: CiCheckStatus) -> CiCheck {
+        CiCheck {
+            name: name.into(),
+            status,
+            url: None,
+            started_at: None,
+        }
+    }
+
+    fn make_entry(pr: Option<PullRequest>, checks: Vec<CiCheck>) -> ScmCacheEntry {
+        ScmCacheEntry {
+            pull_request: pr,
+            ci_checks: checks,
+            last_fetched: Instant::now(),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn preserves_prior_pr_when_list_pull_requests_errors() {
+        let prior_pr = make_pr("feature/x", 42);
+        let prior = make_entry(Some(prior_pr.clone()), vec![]);
+        let fresh_check = make_check("ci/test", CiCheckStatus::Success);
+
+        let outcome = merge_scm_results(
+            Err(PluginError::Timeout),
+            Ok(serde_json::to_value(vec![fresh_check.clone()]).unwrap()),
+            "feature/x",
+            Some(&prior),
+        );
+
+        assert_eq!(
+            outcome.pull_request.as_ref().map(|pr| pr.number),
+            Some(prior_pr.number),
+            "prior PR should survive a list_pull_requests error",
+        );
+        assert_eq!(outcome.ci_checks.len(), 1);
+        assert_eq!(outcome.ci_checks[0].name, "ci/test");
+        assert!(outcome.error.is_some());
+        assert!(
+            outcome.should_persist,
+            "ci_status succeeded so we have new authoritative data to write",
+        );
+    }
+
+    #[test]
+    fn preserves_prior_checks_when_ci_status_errors() {
+        let prior_check = make_check("ci/build", CiCheckStatus::Pending);
+        let prior = make_entry(None, vec![prior_check.clone()]);
+        let fresh_pr = make_pr("feature/y", 7);
+
+        let outcome = merge_scm_results(
+            Ok(serde_json::to_value(vec![fresh_pr.clone()]).unwrap()),
+            Err(PluginError::Timeout),
+            "feature/y",
+            Some(&prior),
+        );
+
+        assert_eq!(
+            outcome.pull_request.as_ref().map(|pr| pr.number),
+            Some(fresh_pr.number),
+            "fresh PR should be returned",
+        );
+        assert_eq!(outcome.ci_checks.len(), 1);
+        assert_eq!(
+            outcome.ci_checks[0].name, prior_check.name,
+            "prior checks should survive a ci_status error",
+        );
+        assert!(outcome.error.is_some());
+        assert!(outcome.should_persist);
+    }
+
+    #[test]
+    fn skips_persistence_when_both_calls_fail_with_prior_cache() {
+        let prior = make_entry(
+            Some(make_pr("feature/z", 99)),
+            vec![make_check("ci/lint", CiCheckStatus::Success)],
+        );
+
+        let outcome = merge_scm_results(
+            Err(PluginError::Timeout),
+            Err(PluginError::Timeout),
+            "feature/z",
+            Some(&prior),
+        );
+
+        assert_eq!(
+            outcome.pull_request.as_ref().map(|pr| pr.number),
+            Some(99),
+            "prior PR preserved",
+        );
+        assert_eq!(outcome.ci_checks.len(), 1, "prior checks preserved");
+        assert!(outcome.error.is_some());
+        assert!(
+            !outcome.should_persist,
+            "both calls failed with prior data — must not clobber the cache",
+        );
+    }
+
+    #[test]
+    fn persists_when_both_calls_fail_without_prior_cache() {
+        let outcome = merge_scm_results(
+            Err(PluginError::Timeout),
+            Err(PluginError::Timeout),
+            "feature/new",
+            None,
+        );
+
+        assert!(outcome.pull_request.is_none());
+        assert!(outcome.ci_checks.is_empty());
+        assert!(outcome.error.is_some());
+        assert!(
+            outcome.should_persist,
+            "no prior data — writing the empty error row is fine",
+        );
+    }
+
+    #[test]
+    fn clears_pr_when_list_succeeds_and_branch_has_no_match() {
+        let prior = make_entry(Some(make_pr("feature/old", 1)), vec![]);
+
+        let outcome = merge_scm_results(
+            Ok(serde_json::Value::Array(vec![])),
+            Ok(serde_json::Value::Array(vec![])),
+            "feature/old",
+            Some(&prior),
+        );
+
+        assert!(
+            outcome.pull_request.is_none(),
+            "successful empty response means PR was closed/merged — must clear",
+        );
+        assert!(outcome.ci_checks.is_empty());
+        assert!(outcome.error.is_none());
+        assert!(outcome.should_persist);
+    }
+
+    #[test]
+    fn ignores_pr_for_other_branch() {
+        let outcome = merge_scm_results(
+            Ok(serde_json::to_value(vec![make_pr("feature/other", 5)]).unwrap()),
+            Ok(serde_json::Value::Array(vec![])),
+            "feature/mine",
+            None,
+        );
+
+        assert!(
+            outcome.pull_request.is_none(),
+            "PRs for other branches must not be selected",
+        );
+        assert!(outcome.should_persist);
+    }
 }


### PR DESCRIPTION
## Summary

PR status was disappearing from the sidebar and the right-sidebar `PrStatusBanner`, then reappearing a minute later — the symptom @doomspork called out as "they came back after a while." Root cause: the SCM polling loop and the on-select fetch both treated *any* plugin-call error (e.g. `gh` rate limit, transient `git remote get-url` hiccup) as authoritative "no PR exists" and wrote `pull_request: null` straight into the SQLite cache + emitted `scm-data-updated`. The frontend then dutifully wiped `scmSummary[ws.id].hasPr`.

The fix moves the merge decision into a small pure helper (`merge_scm_results`) that falls back to the prior cached `pull_request` / `ci_checks` whenever a plugin call errors, and skips the cache write entirely when both calls failed and prior data exists. Provider resolution also now returns `Result<Option<String>, String>` so callers can distinguish "no plugin matches this remote" (legit clear) from "remote URL lookup failed" (preserve).

- New: pure `merge_scm_results` helper + `ScmFetchOutcome` (with `should_persist`)
- New: `persist_scm_cache` helper + `ScmCacheKey` arg-bundle struct
- Behavioral: `scm_create_pr` / `scm_merge_pr` now distinguish "git lookup failed" from "no provider configured" in their error messages

## Complexity Notes

- The `should_persist` semantics matter: when both plugin calls fail and prior cache exists, we deliberately leave `last_fetched` untouched so the next 30s poll still treats the entry as stale and retries. If a future change writes a fresh `last_fetched` here it would silently extend the outage by 30s per poll cycle.
- Provider resolution has three meaningful states now (`Ok(Some)`, `Ok(None)`, `Err`), not two. `scm_create_pr` / `scm_merge_pr` flatten `Err` into a different error string than `Ok(None)` — please check the wording is acceptable.
- `merge_scm_results` consumes both `Result` values, so it captures `prs_failed` / `ci_failed` boolean flags up front. That's a small ergonomic awkwardness but keeps the function pure (no `&Result` lifetimes leaking out).

## Test Steps

1. `cargo test -p claudette-tauri --bins commands::scm::tests` — runs the 6 new unit tests for `merge_scm_results`.
2. `cargo test --workspace --all-features` (226 tests) and `cargo clippy --workspace --all-targets` to confirm nothing regressed.
3. End-to-end repro of the original bug:
   1. `cargo tauri dev` and open a workspace with an open PR — confirm the sidebar PR icon and `PrStatusBanner` render.
   2. Force a transient outage: `gh auth logout` (or temporarily move `gh` off `PATH`).
   3. Wait through one polling cycle (~30s). **Expected:** sidebar PR icon and `PrStatusBanner` remain populated with the last-known PR state.
   4. Restore auth (`gh auth login`) and confirm fresh data lands on the next 30s cycle.
4. Sanity-check the SQLite cache during the simulated outage: `sqlite3 ~/.claudette/claudette.db "SELECT workspace_id, pr_json IS NULL, error, fetched_at FROM scm_status_cache ORDER BY fetched_at DESC LIMIT 10;"` — `pr_json IS NULL` should NOT flip to `1` for any workspace whose PR is still open on the server.
5. (Optional) `/claudette-debug state scmSummary` to confirm the slice stays populated for visible workspaces during the outage.

## Checklist

- [x] Tests added/updated (6 new unit tests covering all branches of `merge_scm_results`)
- [ ] Documentation updated (no user-facing docs affected)