### PR TITLE
fix: remove 'PR' label from PR pill button to save header space

### DIFF
--- a/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
@@ -95,7 +95,7 @@ export const PrStatusBanner = memo(function PrStatusBanner() {
         title={`Open PR #${pr.number} in browser`}
       >
         <Icon size={14} />
-        <span className={styles.prNumber}>PR #{pr.number}</span>
+        <span className={styles.prNumber}>#{pr.number}</span>
         <ExternalLink size={14} className={styles.externalIcon} />
       </button>
 


### PR DESCRIPTION
## Summary

Removes the redundant \"PR\" text from the PR pill button in the right header, leaving just the icon, PR number, and external link icon. This saves horizontal space in the header bar.

The `title` tooltip attribute still reads \"Open PR #N in browser\", preserving full context for hover and accessibility.

## Test Steps

1. Open a workspace with an associated PR
2. Observe the right-side header — the pill now shows `<icon> #663 <icon>` instead of `<icon> PR #663 <icon>`
3. Hover the pill to confirm the tooltip still reads \"Open PR #N in browser\"

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)