### PR TITLE
fix: prevent smart quote substitutions in repo settings

### DIFF
--- a/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
+++ b/src/ui/src/components/settings/sections/PinnedPromptsManager.tsx
@@ -13,6 +13,7 @@ import {
 import { useAppStore } from "../../../stores/useAppStore";
 import { EMPTY_PINNED_PROMPTS } from "../../../stores/slices/pinnedPromptsSlice";
 import { useSlashAutocomplete } from "../../../hooks/useSlashAutocomplete";
+import { PLAIN_TEXT_INPUT_PROPS } from "../../../utils/textInput";
 import { SlashCommandPicker } from "../../chat/SlashCommandPicker";
 import styles from "./PinnedPromptsManager.module.css";
 
@@ -527,6 +528,7 @@ function PromptRow({
           placeholder={t("pinned_prompts_display_name_placeholder")}
           aria-label={t("pinned_prompts_display_name_label")}
           disabled={mode === "confirm-delete"}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
       </div>
       <div className={styles.textareaWrapper}>
@@ -541,6 +543,7 @@ function PromptRow({
           placeholder={t("pinned_prompts_prompt_placeholder")}
           aria-label={t("pinned_prompts_prompt_label")}
           disabled={mode === "confirm-delete"}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
         {mode === "editing" && slash.showPicker && (
           <SlashCommandPicker
@@ -714,6 +717,7 @@ function DraftRowView({
           placeholder={t("pinned_prompts_display_name_placeholder")}
           aria-label={t("pinned_prompts_display_name_label")}
           autoFocus
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
       </div>
       <div className={styles.textareaWrapper}>
@@ -727,6 +731,7 @@ function DraftRowView({
           rows={3}
           placeholder={t("pinned_prompts_prompt_placeholder")}
           aria-label={t("pinned_prompts_prompt_label")}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
         {slash.showPicker && (
           <SlashCommandPicker

--- a/src/ui/src/components/settings/sections/RepoSettings.tsx
+++ b/src/ui/src/components/settings/sections/RepoSettings.tsx
@@ -21,6 +21,10 @@ import {
   PinnedPromptsManager,
 } from "./PinnedPromptsManager";
 import { EMPTY_PINNED_PROMPTS } from "../../../stores/slices/pinnedPromptsSlice";
+import {
+  normalizeShellScriptInput,
+  PLAIN_TEXT_INPUT_PROPS,
+} from "../../../utils/textInput";
 import styles from "../Settings.module.css";
 
 interface RepoSettingsProps {
@@ -329,6 +333,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           onChange={(e) => setName(e.target.value)}
           onBlur={() => save({ name })}
           aria-label={t("repo_display_name_aria")}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
       </div>
 
@@ -418,10 +423,18 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         <textarea
           className={`${styles.textarea}${repoScriptOverrides ? ` ${styles.overriddenInput}` : ""}`}
           value={setupScript}
-          onChange={(e) => setSetupScript(e.target.value)}
-          onBlur={() => save({ setup_script: setupScript.trim() || null })}
+          onChange={(e) =>
+            setSetupScript(normalizeShellScriptInput(e.target.value))
+          }
+          onBlur={() =>
+            save({
+              setup_script:
+                normalizeShellScriptInput(setupScript).trim() || null,
+            })
+          }
           placeholder={t("repo_setup_script_placeholder")}
           rows={3}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
         <div className={styles.fieldHint}>
           {t("repo_setup_script_hint")}
@@ -462,10 +475,18 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
         <textarea
           className={`${styles.textarea}${repoArchiveScriptOverrides ? ` ${styles.overriddenInput}` : ""}`}
           value={archiveScript}
-          onChange={(e) => setArchiveScript(e.target.value)}
-          onBlur={() => save({ archive_script: archiveScript.trim() || null })}
+          onChange={(e) =>
+            setArchiveScript(normalizeShellScriptInput(e.target.value))
+          }
+          onBlur={() =>
+            save({
+              archive_script:
+                normalizeShellScriptInput(archiveScript).trim() || null,
+            })
+          }
           placeholder={t("repo_archive_script_placeholder")}
           rows={3}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
         <div className={styles.fieldHint}>
           {t("repo_archive_script_hint")}
@@ -517,6 +538,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           }
           placeholder={t("repo_custom_instructions_placeholder")}
           rows={4}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
         <div className={styles.fieldHint}>
           {t("repo_custom_instructions_hint")}
@@ -542,6 +564,7 @@ export function RepoSettings({ repoId }: RepoSettingsProps) {
           }
           placeholder={t("repo_branch_rename_placeholder")}
           rows={3}
+          {...PLAIN_TEXT_INPUT_PROPS}
         />
       </div>
 

--- a/src/ui/src/utils/textInput.test.ts
+++ b/src/ui/src/utils/textInput.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeShellScriptInput, PLAIN_TEXT_INPUT_PROPS } from "./textInput";
+
+describe("textInput helpers", () => {
+  it("normalizes smart quotes in shell script text", () => {
+    expect(
+      normalizeShellScriptInput(
+        "export PATH=\u201ctest\u201d; echo \u2018ok\u2019",
+      ),
+    ).toBe("export PATH=\"test\"; echo 'ok'");
+  });
+
+  it("disables browser typing substitutions for exact-text fields", () => {
+    expect(PLAIN_TEXT_INPUT_PROPS).toEqual({
+      autoCapitalize: "off",
+      autoCorrect: "off",
+      spellCheck: false,
+    });
+  });
+});

--- a/src/ui/src/utils/textInput.ts
+++ b/src/ui/src/utils/textInput.ts
@@ -1,0 +1,11 @@
+export const PLAIN_TEXT_INPUT_PROPS = {
+  autoCapitalize: "off",
+  autoCorrect: "off",
+  spellCheck: false,
+} as const;
+
+export function normalizeShellScriptInput(value: string): string {
+  return value
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/[\u2018\u2019]/g, "'");
+}


### PR DESCRIPTION
## Summary
- Disable browser text substitutions for repo settings text fields and repo pinned-prompt fields.
- Normalize curly single and double quotes back to ASCII quotes in setup/archive shell scripts.
- Add focused tests for the shared text-input helper.

## Root Cause
WebKit text substitutions could convert typed straight quotes into smart quotes inside script textareas, producing invalid shell snippets such as export PATH=“test”.

## Validation
- cd src/ui && bunx tsc -b
- cd src/ui && bun run test src/utils/textInput.test.ts
- git diff --check

ESLint was also run on the touched paths; it reported 0 errors and existing warnings elsewhere in the app.