### PR TITLE
fix: correct soundpack detail link domain to openpeon.com

### DIFF
--- a/src/ui/src/components/settings/sections/SoundPackBrowser.tsx
+++ b/src/ui/src/components/settings/sections/SoundPackBrowser.tsx
@@ -13,7 +13,7 @@ import type {
 } from "../../../types/soundpacks";
 import styles from "../Settings.module.css";
 
-const REGISTRY_BASE = "https://peonping.github.io/registry/packs/";
+const REGISTRY_BASE = "https://openpeon.com/packs/";
 
 function packRegistryUrl(name: string): string {
   return `${REGISTRY_BASE}${encodeURIComponent(name)}`;


### PR DESCRIPTION
## Summary

- Fixes the broken link when clicking a soundpack name in the browser — the URL was pointing to `peonping.github.io/registry/packs/<name>` (404) instead of the correct `openpeon.com/packs/<name>`.
- Single-line change to the `REGISTRY_BASE` constant in `SoundPackBrowser.tsx`.

## Test Steps

1. Open Settings → Notifications → Sound Packs
2. Click on any pack name (e.g., Alan Rickman)
3. Verify the browser opens `https://openpeon.com/packs/alan-rickman` (previously would 404)

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)