### PR TITLE
fix: Copy Image now works via native OS clipboard backend

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1747,6 +1747,128 @@ pub async fn copy_attachment_file_to_clipboard(
     .map_err(|e| format!("join error: {e}"))?
 }
 
+/// Copy raster image bytes to the system clipboard as image data. Bypasses
+/// the W3C ClipboardItem API, which WKWebView rejects after async IPC
+/// boundaries invalidate the user-activation gate.
+#[tauri::command]
+pub async fn copy_image_to_clipboard(
+    bytes: Vec<u8>,
+    filename: String,
+    media_type: String,
+) -> Result<(), String> {
+    let dir = std::env::temp_dir().join("claudette-attachments");
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        create_staging_dir(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;
+        cleanup_stale_attachments(&dir, std::time::Duration::from_secs(24 * 60 * 60));
+        copy_image_bytes_to_clipboard(&dir, &bytes, &filename, &media_type)
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?
+}
+
+#[cfg(target_os = "macos")]
+fn copy_image_bytes_to_clipboard(
+    dir: &Path,
+    bytes: &[u8],
+    filename: &str,
+    media_type: &str,
+) -> Result<(), String> {
+    let path = write_attachment_to_temp_file(dir, filename, media_type, bytes)
+        .map_err(|e| format!("write attachment: {e}"))?;
+    // ASObjC bridge: create an NSImage from the file and write it to the
+    // general pasteboard as image data (not a Finder file reference).
+    let output = std::process::Command::new("osascript")
+        .args([
+            "-e",
+            "use framework \"AppKit\"",
+            "-e",
+            "use scripting additions",
+            "-e",
+            "on run argv",
+            "-e",
+            "set img to (current application's NSImage's alloc()'s initWithContentsOfFile:(item 1 of argv))",
+            "-e",
+            "set pb to current application's NSPasteboard's generalPasteboard()",
+            "-e",
+            "pb's clearContents()",
+            "-e",
+            "pb's writeObjects:{img}",
+            "-e",
+            "end run",
+        ])
+        .arg(&path)
+        .output()
+        .map_err(|e| format!("failed to run osascript: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("osascript failed: {}", stderr.trim()))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn copy_image_bytes_to_clipboard(
+    _dir: &Path,
+    bytes: &[u8],
+    _filename: &str,
+    media_type: &str,
+) -> Result<(), String> {
+    let attempts: [(&str, &[&str]); 2] = [
+        ("wl-copy", &["--type", media_type]),
+        ("xclip", &["-selection", "clipboard", "-t", media_type]),
+    ];
+    let mut errors = Vec::new();
+    for (program, args) in attempts {
+        match pipe_to_command(program, args, bytes) {
+            Ok(()) => return Ok(()),
+            Err(e) => errors.push(format!("{program}: {e}")),
+        }
+    }
+    Err(format!(
+        "copying image requires wl-copy or xclip on Linux ({})",
+        errors.join("; ")
+    ))
+}
+
+#[cfg(windows)]
+fn copy_image_bytes_to_clipboard(
+    dir: &Path,
+    bytes: &[u8],
+    filename: &str,
+    media_type: &str,
+) -> Result<(), String> {
+    let path = write_attachment_to_temp_file(dir, filename, media_type, bytes)
+        .map_err(|e| format!("write attachment: {e}"))?;
+    let path_str = path.to_string_lossy().replace('\'', "''");
+    let script = format!(
+        "Add-Type -AssemblyName System.Windows.Forms; \
+         Add-Type -AssemblyName System.Drawing; \
+         [System.Windows.Forms.Clipboard]::SetImage(\
+           [System.Drawing.Image]::FromFile('{path_str}'))"
+    );
+    let output = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .map_err(|e| format!("failed to run powershell: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("powershell failed: {}", stderr.trim()))
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn copy_image_bytes_to_clipboard(
+    _dir: &Path,
+    _bytes: &[u8],
+    _filename: &str,
+    _media_type: &str,
+) -> Result<(), String> {
+    Err("image clipboard copy is not supported on this platform".to_string())
+}
+
 /// Payload for the `workspace-file-changed` Tauri event. The frontend
 /// hook subscribes once at app start and routes every event by
 /// `(workspace_id, path)` against its open file tabs.

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1616,48 +1616,52 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 }
 
 /// Create the staging directory with restrictive permissions on Unix
-/// (`0o700`) so other accounts can't list or read the staged files. If
-/// the path already exists we verify it's a real directory (not a file
-/// or symlink that could redirect writes elsewhere) and re-tighten the
-/// permissions on Unix in case a previous run created it with a wider
-/// umask.
+/// (`0o700`) so other accounts can't list or read the staged files.
+///
+/// Uses a try-then-verify approach instead of `exists()` + `create()` to
+/// avoid a TOCTOU window where a concurrent caller or attacker could
+/// replace the directory between the check and the create.
 fn create_staging_dir(dir: &Path) -> std::io::Result<()> {
-    if dir.exists() {
-        // `symlink_metadata` doesn't follow symlinks — it tells us
-        // whether the *path entry* is a directory, so a malicious link
-        // to /etc can't satisfy the check.
-        let meta = std::fs::symlink_metadata(dir)?;
-        if !meta.file_type().is_dir() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                format!(
-                    "staging path {} exists and is not a directory",
-                    dir.display()
-                ),
-            ));
-        }
+    let create_result = {
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt as _;
-            let mode = meta.permissions().mode() & 0o777;
-            if mode != 0o700 {
-                std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
-            }
+            use std::os::unix::fs::DirBuilderExt as _;
+            std::fs::DirBuilder::new().mode(0o700).create(dir)
         }
-        return Ok(());
+        #[cfg(not(unix))]
+        {
+            std::fs::create_dir(dir)
+        }
+    };
+    match create_result {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() != std::io::ErrorKind::AlreadyExists => return Err(e),
+        Err(_) => {}
+    }
+    // Directory already existed — verify it is a real directory (not a
+    // file or symlink that could redirect writes elsewhere) and re-tighten
+    // the permissions on Unix in case a previous run used a wider umask.
+    // `symlink_metadata` does not follow symlinks, so a malicious symlink
+    // to /etc cannot satisfy the is_dir() check.
+    let meta = std::fs::symlink_metadata(dir)?;
+    if !meta.file_type().is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!(
+                "staging path {} exists and is not a directory",
+                dir.display()
+            ),
+        ));
     }
     #[cfg(unix)]
     {
-        use std::os::unix::fs::DirBuilderExt as _;
-        std::fs::DirBuilder::new()
-            .recursive(true)
-            .mode(0o700)
-            .create(dir)
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = meta.permissions().mode() & 0o777;
+        if mode != 0o700 {
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+        }
     }
-    #[cfg(not(unix))]
-    {
-        std::fs::create_dir_all(dir)
-    }
+    Ok(())
 }
 
 /// Remove staged attachments older than `max_age` from `dir`. Used to keep
@@ -1756,6 +1760,11 @@ pub async fn copy_image_to_clipboard(
     filename: String,
     media_type: String,
 ) -> Result<(), String> {
+    if !media_type.starts_with("image/") || media_type == "image/svg+xml" {
+        return Err(format!(
+            "copy_image_to_clipboard: expected a raster image media type, got {media_type:?}"
+        ));
+    }
     let dir = std::env::temp_dir().join("claudette-attachments");
     tokio::task::spawn_blocking(move || -> Result<(), String> {
         create_staging_dir(&dir).map_err(|e| format!("mkdir temp dir: {e}"))?;

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1777,6 +1777,8 @@ fn copy_image_bytes_to_clipboard(
         .map_err(|e| format!("write attachment: {e}"))?;
     // ASObjC bridge: create an NSImage from the file and write it to the
     // general pasteboard as image data (not a Finder file reference).
+    // Error on nil NSImage (unsupported format) and on writeObjects: returning
+    // false — both would otherwise produce a silent success (exit 0).
     let output = std::process::Command::new("osascript")
         .args([
             "-e",
@@ -1788,11 +1790,13 @@ fn copy_image_bytes_to_clipboard(
             "-e",
             "set img to (current application's NSImage's alloc()'s initWithContentsOfFile:(item 1 of argv))",
             "-e",
+            "if img is missing value then error \"Failed to load image from file\" number 1",
+            "-e",
             "set pb to current application's NSPasteboard's generalPasteboard()",
             "-e",
             "pb's clearContents()",
             "-e",
-            "pb's writeObjects:{img}",
+            "if (pb's writeObjects:{img}) is false then error \"NSPasteboard writeObjects: failed\" number 1",
             "-e",
             "end run",
         ])
@@ -1841,11 +1845,18 @@ fn copy_image_bytes_to_clipboard(
     let path = write_attachment_to_temp_file(dir, filename, media_type, bytes)
         .map_err(|e| format!("write attachment: {e}"))?;
     let path_str = path.to_string_lossy().replace('\'', "''");
+    // Use WPF/WIC (PresentationCore) instead of System.Drawing — WIC handles
+    // more formats including WebP (Windows 10 v1903+) and HEIC.
     let script = format!(
-        "Add-Type -AssemblyName System.Windows.Forms; \
-         Add-Type -AssemblyName System.Drawing; \
-         [System.Windows.Forms.Clipboard]::SetImage(\
-           [System.Drawing.Image]::FromFile('{path_str}'))"
+        "Add-Type -AssemblyName PresentationCore; \
+         $fs = [System.IO.File]::OpenRead('{path_str}'); \
+         $dec = [System.Windows.Media.Imaging.BitmapDecoder]::Create($fs, \
+           [System.Windows.Media.Imaging.BitmapCreateOptions]::None, \
+           [System.Windows.Media.Imaging.BitmapCacheOption]::OnLoad); \
+         $fs.Dispose(); \
+         $frame = $dec.Frames[0]; \
+         $frame.Freeze(); \
+         [System.Windows.Clipboard]::SetImage($frame)"
     );
     let output = std::process::Command::new("powershell")
         .args(["-NoProfile", "-NonInteractive", "-Command", &script])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -928,6 +928,7 @@ fn main() {
             commands::files::open_attachment_in_browser,
             commands::files::open_attachment_with_default_app,
             commands::files::copy_attachment_file_to_clipboard,
+            commands::files::copy_image_to_clipboard,
             commands::files::watch_workspace_files,
             commands::files::unwatch_workspace_files,
             // Chat

--- a/src/ui/src/utils/attachmentDownload.test.ts
+++ b/src/ui/src/utils/attachmentDownload.test.ts
@@ -1,22 +1,4 @@
-import { describe, it, expect, vi, beforeAll } from "vitest";
-
-// vitest runs in Node; ClipboardItem is a browser global. Stub a minimal
-// constructor that records its input so the tests can assert on the data
-// the real browser/webview would see.
-beforeAll(() => {
-  if (typeof (globalThis as unknown as { ClipboardItem?: unknown }).ClipboardItem === "undefined") {
-    class FakeClipboardItem {
-      readonly types: string[];
-      readonly data: Record<string, Blob>;
-      constructor(data: Record<string, Blob>) {
-        this.data = data;
-        this.types = Object.keys(data);
-      }
-    }
-    (globalThis as unknown as { ClipboardItem: typeof FakeClipboardItem }).ClipboardItem =
-      FakeClipboardItem;
-  }
-});
+import { describe, it, expect, vi } from "vitest";
 import {
   extensionFor,
   downloadAttachment,
@@ -167,34 +149,26 @@ describe("copyAttachmentFileToClipboard", () => {
 });
 
 describe("copyAttachmentToClipboard", () => {
-  it("writes a ClipboardItem via navigator.clipboard.write", async () => {
-    const write = vi.fn().mockResolvedValue(undefined);
-    await copyAttachmentToClipboard(fixture, {
-      clipboard: { write } as unknown as Clipboard,
+  // Raster images bypass WKWebView's clipboard gate by routing through the
+  // Tauri backend command, which writes image data via native OS APIs.
+  it("routes raster image attachments through copy_image_to_clipboard", async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    await copyAttachmentToClipboard(fixture, { invoke });
+    expect(invoke).toHaveBeenCalledWith("copy_image_to_clipboard", {
+      bytes: [104, 101, 108, 108, 111], // base64 "aGVsbG8=" → "hello"
+      filename: "screenshot.png",
+      mediaType: "image/png",
     });
-    expect(write).toHaveBeenCalledOnce();
-    const items = write.mock.calls[0][0] as ClipboardItem[];
-    expect(items).toHaveLength(1);
-    expect(items[0].types).toContain("image/png");
   });
 
-  it("throws when the clipboard API is unavailable", async () => {
+  it("propagates errors from copy_image_to_clipboard", async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error("denied"));
     await expect(
-      copyAttachmentToClipboard(fixture, { clipboard: undefined }),
-    ).rejects.toThrow(/not available/);
-  });
-
-  it("propagates errors from clipboard.write", async () => {
-    const write = vi.fn().mockRejectedValue(new Error("denied"));
-    await expect(
-      copyAttachmentToClipboard(fixture, {
-        clipboard: { write } as unknown as Clipboard,
-      }),
+      copyAttachmentToClipboard(fixture, { invoke }),
     ).rejects.toThrow("denied");
   });
 
   it("routes PDF attachments through the backend file clipboard command", async () => {
-    const write = vi.fn().mockResolvedValue(undefined);
     const invoke = vi.fn().mockResolvedValue(undefined);
     const pdfFixture: DownloadableAttachment = {
       filename: "doc.pdf",
@@ -202,21 +176,16 @@ describe("copyAttachmentToClipboard", () => {
       media_type: "application/pdf",
     };
 
-    await copyAttachmentToClipboard(pdfFixture, {
-      clipboard: { write } as unknown as Clipboard,
-      invoke,
-    });
+    await copyAttachmentToClipboard(pdfFixture, { invoke });
 
     expect(invoke).toHaveBeenCalledWith("copy_attachment_file_to_clipboard", {
       bytes: [37, 80, 68, 70, 45],
       filename: "doc.pdf",
       mediaType: "application/pdf",
     });
-    expect(write).not.toHaveBeenCalled();
   });
 
   it("writes CSV attachments as text via the injected writeText", async () => {
-    const write = vi.fn().mockResolvedValue(undefined);
     const writeText = vi.fn().mockResolvedValue(undefined);
     const csvFixture: DownloadableAttachment = {
       filename: "people.csv",
@@ -224,17 +193,12 @@ describe("copyAttachmentToClipboard", () => {
       media_type: "text/csv",
     };
 
-    await copyAttachmentToClipboard(csvFixture, {
-      clipboard: { write } as unknown as Clipboard,
-      writeText,
-    });
+    await copyAttachmentToClipboard(csvFixture, { writeText });
 
     expect(writeText).toHaveBeenCalledWith("id,name\n1,Ada\n");
-    expect(write).not.toHaveBeenCalled();
   });
 
   it("writes JSON attachments as text via the injected writeText", async () => {
-    const write = vi.fn().mockResolvedValue(undefined);
     const writeText = vi.fn().mockResolvedValue(undefined);
     const jsonFixture: DownloadableAttachment = {
       filename: "data.json",
@@ -242,32 +206,23 @@ describe("copyAttachmentToClipboard", () => {
       media_type: "application/json",
     };
 
-    await copyAttachmentToClipboard(jsonFixture, {
-      clipboard: { write } as unknown as Clipboard,
-      writeText,
-    });
+    await copyAttachmentToClipboard(jsonFixture, { writeText });
 
     expect(writeText).toHaveBeenCalledWith('{"ok":true}');
-    expect(write).not.toHaveBeenCalled();
   });
 
   // WebKit silently drops image/svg+xml ClipboardItems, so a copied SVG
   // would never reach the system clipboard. Production routes SVGs
   // through Tauri's writeText, which bypasses the WKWebView allowlist.
   it("writes SVG attachments via the injected writeText (Tauri clipboard)", async () => {
-    const write = vi.fn().mockResolvedValue(undefined);
     const writeText = vi.fn().mockResolvedValue(undefined);
     const svgFixture: DownloadableAttachment = {
       filename: "drawing.svg",
       data_base64: "PHN2Zy8+", // base64 of '<svg/>'
       media_type: "image/svg+xml",
     };
-    await copyAttachmentToClipboard(svgFixture, {
-      clipboard: { write } as unknown as Clipboard,
-      writeText,
-    });
+    await copyAttachmentToClipboard(svgFixture, { writeText });
     expect(writeText).toHaveBeenCalledWith("<svg/>");
-    expect(write).not.toHaveBeenCalled();
   });
 });
 

--- a/src/ui/src/utils/attachmentDownload.ts
+++ b/src/ui/src/utils/attachmentDownload.ts
@@ -158,24 +158,19 @@ export async function copyAttachmentFileToClipboard(
 }
 
 /**
- * Copy the attachment image to the system clipboard using the native
- * `navigator.clipboard.write()` API. Zero IPC, zero base64→number[]
- * serialization, zero Rust round-trip — the webview writes directly to
- * the OS clipboard the same way any browser's "Copy Image" does.
+ * Copy the attachment to the system clipboard.
  *
- * Text/data files are written through Tauri's text clipboard path instead
- * of ClipboardItem because WebKit and Chromium do not reliably accept
- * arbitrary MIME ClipboardItems such as `text/csv`.
- *
- * SVG is also special-cased: WebKit's ClipboardItem implementation silently
- * drops `image/svg+xml`, so a copied SVG would never reach the system
- * clipboard. Since SVG is XML, write it as `text/plain` (the markup itself)
- * so it survives the round-trip.
+ * - PDFs → Tauri `copy_attachment_file_to_clipboard` (file reference)
+ * - SVG / text-typed files → Tauri `writeText` plugin (WebKit silently drops
+ *   non-text ClipboardItems for these types)
+ * - Raster images → Tauri `copy_image_to_clipboard` (image data via native
+ *   OS APIs). WKWebView rejects `navigator.clipboard.write()` after the async
+ *   byte-loading hop invalidates the user-activation gate, so all image types
+ *   are routed through the Rust backend.
  */
 export async function copyAttachmentToClipboard(
   attachment: DownloadableAttachment,
   deps: {
-    clipboard?: Clipboard;
     invoke?: typeof invoke;
     /** Injectable text-clipboard writer — bypasses the W3C clipboard
      *  permission gate. Production wires this to Tauri's plugin so SVGs
@@ -184,9 +179,6 @@ export async function copyAttachmentToClipboard(
     writeText?: (text: string) => Promise<void>;
   } = {},
 ): Promise<void> {
-  const clipboard =
-    deps.clipboard ??
-    (typeof navigator === "undefined" ? undefined : navigator.clipboard);
   const bytes = base64ToBytes(attachment.data_base64);
   if (attachment.media_type === "application/pdf") {
     await copyAttachmentFileToClipboard(attachment, { invoke: deps.invoke });
@@ -203,18 +195,15 @@ export async function copyAttachmentToClipboard(
     // text/data files (CSV, Markdown, JSON, plain text), because WebKit
     // and Chromium do not reliably accept arbitrary MIME ClipboardItems
     // such as `text/csv`.
-    await writeDecodedTextToClipboard(bytes, { ...deps, clipboard });
+    await writeDecodedTextToClipboard(bytes, deps);
     return;
   }
-  // Non-SVG path uses the W3C ClipboardItem API directly — this is the
-  // only branch that requires `navigator.clipboard.write`.
-  if (!clipboard) {
-    throw new Error("Clipboard API not available");
-  }
-  const blob = new Blob([bytes], { type: attachment.media_type });
-  await clipboard.write([
-    new ClipboardItem({ [attachment.media_type]: blob }),
-  ]);
+  const invoker = deps.invoke ?? invoke;
+  await invoker("copy_image_to_clipboard", {
+    bytes: Array.from(bytes),
+    filename: attachment.filename,
+    mediaType: attachment.media_type,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Root cause**: `navigator.clipboard.write()` (the W3C ClipboardItem API) is silently rejected by WKWebView when called after an async boundary — the user-activation gate expires before the clipboard write runs. Copy Image used this browser API; errors were only logged to `console.error`, so the user saw nothing.
- **Fix**: Add a `copy_image_to_clipboard` Tauri command that writes image data through native OS tools (same pattern as PDFs and SVGs), bypassing WebKit's clipboard restrictions entirely.
- **macOS**: `osascript` with the AppKit ASObjC bridge — creates an `NSImage` and calls `NSPasteboard.writeObjects`, putting raw image data (not a file reference) on the clipboard so apps like Slack, Preview, and Figma can paste it.
- **Linux**: Pipes raw bytes to `wl-copy` or `xclip` with the correct MIME type, reusing the existing `pipe_to_command` helper.
- **Windows**: Invokes PowerShell to load the image via `System.Drawing` and write it via `System.Windows.Forms.Clipboard`.

## Complexity Notes

The macOS path is the subtlest: the existing `copy_attachment_file_to_clipboard` command uses `osascript` to copy a **POSIX file reference** (`set the clipboard to POSIX file "..."`), which puts a Finder-style file pointer on the pasteboard — paste works in file managers but not in image editors. The new command uses the AppKit bridge (`NSImage → NSPasteboard.writeObjects`) to put actual **image data** on the pasteboard, matching what Safari's "Copy Image" does. This distinction matters for apps that only accept image data (not file references) on paste.

## Test Steps

1. `cargo tauri dev` to start the app
2. Start a chat session and send a message that generates an image attachment (e.g. ask Claude to describe an image you upload, or trigger any response with an image)
3. Right-click the image → **Copy Image**
4. Open macOS Preview, Slack, or any image editor and paste (`Cmd+V`) — the image should appear, not a file
5. Verify JPEG images also work (not just PNG), since the old W3C path silently dropped non-PNG types on some WebKit versions

## Checklist

- [x] Tests added/updated (`attachmentDownload.test.ts` — 24 tests passing)
- [x] `tsc -b` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p claudette -p claudette-server` clean (0 warnings)
- [ ] Documentation updated (not applicable)