### PR TITLE
feat: tint files browser rows by change status

### DIFF
--- a/src/ui/src/components/files/FileTree.module.css
+++ b/src/ui/src/components/files/FileTree.module.css
@@ -76,6 +76,13 @@
   color: var(--text-muted);
 }
 
+/* When a tinted row is also selected, the previous `.rowSelected .icon`
+ * rule wins by source order (same specificity), which would blank the
+ * status tint. Re-assert the tint with a higher-specificity selector. */
+.rowSelected.rowStatusTinted .icon {
+  color: var(--row-status-color);
+}
+
 .name {
   flex: 1;
   overflow: hidden;

--- a/src/ui/src/components/files/FileTree.module.css
+++ b/src/ui/src/components/files/FileTree.module.css
@@ -47,13 +47,18 @@
 }
 
 .rowDeleted .name {
-  color: var(--text-dim);
   text-decoration: line-through;
   text-decoration-color: var(--diff-removed-text);
 }
 
-.rowDirChanged .icon {
-  color: var(--tool-task);
+/* When set, --row-status-color comes from inline style on the row and
+ * carries the change-status tint (yellow=Modified, green=Added,
+ * red=Deleted, blue=Renamed). It governs filename, folder name, folder
+ * icon, and the status badge so a row reads as a single colored unit. */
+.rowStatusTinted .name,
+.rowStatusTinted .icon,
+.rowStatusTinted .status {
+  color: var(--row-status-color);
 }
 
 .chevron {
@@ -111,23 +116,19 @@
   height: 16px;
   padding: 0 5px;
   flex-shrink: 0;
-  border: 1px solid color-mix(in srgb, var(--tool-task) 30%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--row-status-color, var(--tool-task)) 30%, transparent);
   border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--tool-task) 12%, transparent);
-  color: var(--tool-task);
+  background: color-mix(
+    in srgb,
+    var(--row-status-color, var(--tool-task)) 12%,
+    transparent
+  );
+  color: var(--row-status-color, var(--tool-task));
   font-family: var(--font-mono);
   font-size: 10px;
   font-weight: 700;
   line-height: 14px;
-}
-
-.dirStatus:empty {
-  width: 8px;
-  min-width: 8px;
-  height: 8px;
-  padding: 0;
-  border-color: var(--tool-task);
-  background: var(--tool-task);
 }
 
 .empty {

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -434,7 +434,6 @@ function Row({
   const Icon = isDir ? getFolderIcon(expanded) : getFileIcon(node.name);
   const status = node.kind === "file" ? node.git_status : null;
   const statusLayer = node.kind === "file" ? node.git_layer : null;
-  const dirChanged = node.kind === "dir" && node.statusCount > 0;
   const folderStatus = node.kind === "dir" ? node.folderStatus : null;
   const tintStatus = status ?? folderStatus;
   const statusTitle =
@@ -447,7 +446,6 @@ function Row({
     styles.row,
     selected ? styles.rowSelected : "",
     status === "Deleted" ? styles.rowDeleted : "",
-    dirChanged ? styles.rowDirChanged : "",
     tintStatus ? styles.rowStatusTinted : "",
   ]
     .filter(Boolean)

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -435,6 +435,8 @@ function Row({
   const status = node.kind === "file" ? node.git_status : null;
   const statusLayer = node.kind === "file" ? node.git_layer : null;
   const dirChanged = node.kind === "dir" && node.statusCount > 0;
+  const folderStatus = node.kind === "dir" ? node.folderStatus : null;
+  const tintStatus = status ?? folderStatus;
   const statusTitle =
     status == null
       ? null
@@ -446,15 +448,26 @@ function Row({
     selected ? styles.rowSelected : "",
     status === "Deleted" ? styles.rowDeleted : "",
     dirChanged ? styles.rowDirChanged : "",
+    tintStatus ? styles.rowStatusTinted : "",
   ]
     .filter(Boolean)
     .join(" ");
+
+  // Publish the row's tint as a custom property so the icon, name, and
+  // dirStatus badge rules in FileTree.module.css can all reference one
+  // source of truth without each receiving its own inline `style`.
+  const rowStyle = {
+    ["--depth" as string]: depth,
+    ...(tintStatus
+      ? { ["--row-status-color" as string]: statusColor(tintStatus) }
+      : {}),
+  };
 
   return (
     <div
       ref={rowRef}
       className={rowClassName}
-      style={{ ["--depth" as string]: depth }}
+      style={rowStyle}
       role="treeitem"
       tabIndex={tabbable ? 0 : -1}
       aria-selected={selected}
@@ -504,13 +517,12 @@ function Row({
           title={`${node.statusCount} changed ${node.statusCount === 1 ? "file" : "files"}`}
           aria-label={`${node.statusCount} changed ${node.statusCount === 1 ? "file" : "files"}`}
         >
-          {node.statusCount > 1 ? node.statusCount : ""}
+          {node.statusCount}
         </span>
       )}
       {status && (
         <span
           className={styles.status}
-          style={{ color: statusColor(status) }}
           title={statusTitle ?? undefined}
           aria-label={statusTitle ?? undefined}
         >

--- a/src/ui/src/utils/buildFileTree.test.ts
+++ b/src/ui/src/utils/buildFileTree.test.ts
@@ -41,6 +41,51 @@ describe("buildFileTree", () => {
     });
   });
 
+  it("picks Modified over Added when aggregating folder status", () => {
+    const entries: FileEntry[] = [
+      {
+        path: "src/added.ts",
+        is_directory: false,
+        git_status: "Added",
+        git_layer: "untracked",
+      },
+      {
+        path: "src/changed.ts",
+        is_directory: false,
+        git_status: "Modified",
+        git_layer: "unstaged",
+      },
+    ];
+
+    const tree = buildFileTree(entries);
+    const src = tree[0];
+    expect(src).toMatchObject({
+      kind: "dir",
+      folderStatus: "Modified",
+      statusCount: 2,
+    });
+  });
+
+  it("propagates folder status up through nested directories", () => {
+    const entries: FileEntry[] = [
+      {
+        path: "src/deep/nested/added.ts",
+        is_directory: false,
+        git_status: "Added",
+        git_layer: "untracked",
+      },
+    ];
+
+    const tree = buildFileTree(entries);
+    const src = tree[0];
+    expect(src.kind === "dir" ? src.folderStatus : null).toBe("Added");
+    const deep =
+      src.kind === "dir" && src.children[0].kind === "dir"
+        ? src.children[0]
+        : null;
+    expect(deep?.folderStatus).toBe("Added");
+  });
+
   it("keeps deleted virtual entries in the tree", () => {
     const entries: FileEntry[] = [
       {

--- a/src/ui/src/utils/buildFileTree.ts
+++ b/src/ui/src/utils/buildFileTree.ts
@@ -8,6 +8,9 @@ export type FileTreeNode =
       path: string;
       name: string;
       statusCount: number;
+      /** Dominant status across descendants for tinting. Modified wins over
+       *  Deleted, Renamed, then Added — see `folderStatusPriority`. */
+      folderStatus: FileStatus | null;
       children: FileTreeNode[];
     }
   | {
@@ -47,6 +50,7 @@ export function buildFileTree(entries: FileEntry[]): FileTreeNode[] {
           path: currentPath,
           name: segment,
           statusCount: 0,
+          folderStatus: null,
           children: [],
         };
         dirNodes.set(currentPath, dir);
@@ -63,22 +67,53 @@ export function buildFileTree(entries: FileEntry[]): FileTreeNode[] {
     });
   }
 
-  computeStatusCounts(root);
+  aggregateFolders(root);
   sortNodes(root);
   return root;
 }
 
-function computeStatusCounts(nodes: FileTreeNode[]): number {
-  let count = 0;
+interface FolderAggregate {
+  count: number;
+  dominant: FileStatus | null;
+}
+
+/** Post-order walk: each dir absorbs its children's count and the highest-
+ *  priority status seen below it. Modified outranks Deleted, Renamed, then
+ *  Added so a folder containing a single edit doesn't read as "added" just
+ *  because its sibling files were also new. */
+function aggregateFolders(nodes: FileTreeNode[]): FolderAggregate {
+  const result: FolderAggregate = { count: 0, dominant: null };
   for (const node of nodes) {
     if (node.kind === "file") {
-      if (node.git_status) count += 1;
+      if (node.git_status) {
+        result.count += 1;
+        result.dominant = pickHigherStatus(result.dominant, node.git_status);
+      }
     } else {
-      node.statusCount = computeStatusCounts(node.children);
-      count += node.statusCount;
+      const child = aggregateFolders(node.children);
+      node.statusCount = child.count;
+      node.folderStatus = child.dominant;
+      result.count += child.count;
+      result.dominant = pickHigherStatus(result.dominant, child.dominant);
     }
   }
-  return count;
+  return result;
+}
+
+function pickHigherStatus(
+  a: FileStatus | null,
+  b: FileStatus | null,
+): FileStatus | null {
+  if (a == null) return b;
+  if (b == null) return a;
+  return folderStatusPriority(b) > folderStatusPriority(a) ? b : a;
+}
+
+function folderStatusPriority(status: FileStatus): number {
+  if (status === "Modified") return 4;
+  if (status === "Deleted") return 3;
+  if (typeof status !== "string") return 2; // Renamed
+  return 1; // Added (covers untracked too — layer is per-file, not per-folder)
 }
 
 function sortNodes(nodes: FileTreeNode[]): void {


### PR DESCRIPTION
## Summary

Refines the Files browser so each row reads as a single colored unit driven by its git change status, rather than only the trailing one-letter badge.

- **Filenames** now adopt the status color (Modified=yellow `--tool-task`, Added/Untracked=green `--diff-added-text`, Deleted=red `--diff-removed-text`, Renamed=blue `--diff-hunk-header`).
- **Container folders** (icon + name + count badge) tint to the *dominant* status of their descendants, with priority **Modified > Deleted > Renamed > Added**, so a single edit isn't visually overridden by sibling additions/untracked files.
- **Folder count consistency**: single-changed-file folders now render `1` in the badge instead of an 8px dot, matching how multi-file badges render.

Implementation publishes a `--row-status-color` CSS custom property on each row inline; `FileTree.module.css` reads from it for filename, icon, and the `dirStatus` badge — keeping styling token-only (passes `lint:css`) without scattering inline `style={{ color }}` across child elements.

## Complexity Notes

- The folder-status priority lives in `aggregateFolders` in `src/ui/src/utils/buildFileTree.ts`. It is **independent** of the existing `combineFileStatuses` priority used for open file tabs (which prefers Deleted) — folders use a different ladder because the visual goal is different (highlight in-flight edits over new-file noise).
- Untracked files are not a `FileStatus` — they're a `git_layer`. An untracked-but-Added child still resolves to the green Added bucket, which is intentional: there's no separate "untracked" tint.
- Deleted file rows: the strike-through stays (via `.rowDeleted .name { text-decoration: line-through }`), but the name's color now comes from the row tint (red) instead of `--text-dim`.

## Test Steps

1. `cd src/ui && bun install && bunx tsc -b && bun run lint:css && bunx vitest run` — all green (pre-existing `built-html.test.ts` skipIf check is the only unrelated failure if `dist/` is absent).
2. Launch the dev app: `./scripts/dev.sh`.
3. In a workspace with a dirty git tree, open the **Files** browser in the sidebar.
4. Verify that:
   - A modified file's name renders yellow, the trailing `M` letter is yellow.
   - An added (untracked) file renders green, with `U` letter.
   - A deleted file renders red and struck-through, with `D` letter.
   - A folder containing **only** added files tints green (icon + name + count badge).
   - A folder containing **at least one** modified file tints yellow even if its other children are added.
   - A folder with exactly one changed file shows `1` in the badge (not a dot).
   - The badge color always matches the folder's tint.
5. Verify selected row highlight still looks correct on a tinted row (background changes; tint color persists).

## Checklist

- [x] Tests added/updated (`buildFileTree.test.ts` covers folder-status priority + nested propagation)
- [ ] Documentation updated (no docs touched — UI-only change)