### PR TITLE
fix: use body-size token for sidebar font sizes

### DIFF
--- a/src/ui/src/components/files/FileTree.module.css
+++ b/src/ui/src/components/files/FileTree.module.css
@@ -10,7 +10,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  font-size: 12px;
+  font-size: var(--body-size);
   font-family: var(--font-sans);
   color: var(--text-muted);
   cursor: pointer;
@@ -134,5 +134,5 @@
   padding: 16px;
   text-align: center;
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--body-size);
 }

--- a/src/ui/src/components/files/FilesPanel.module.css
+++ b/src/ui/src/components/files/FilesPanel.module.css
@@ -9,5 +9,5 @@
   padding: 16px;
   text-align: center;
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--body-size);
 }

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -95,7 +95,7 @@
 }
 
 .prNumber {
-  font-size: 12px;
+  font-size: var(--body-size);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -106,7 +106,7 @@
 }
 
 .statusText {
-  font-size: 12px;
+  font-size: var(--body-size);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -190,7 +190,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--body-size);
   font-weight: 600;
 }
 
@@ -233,7 +233,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--body-size);
 }
 
 .checkStatus {

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -74,7 +74,7 @@
   padding: 16px;
   text-align: center;
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--body-size);
 }
 
 .file {
@@ -84,7 +84,7 @@
   padding: 5px 8px;
   border-radius: 6px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--body-size);
   font-family: var(--font-mono);
   transition: background var(--transition-fast);
 }

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -37,7 +37,7 @@
   border: none;
   border-bottom: 2px solid transparent;
   color: var(--text-dim);
-  font-size: 11px;
+  font-size: var(--body-size);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -55,7 +55,7 @@
 }
 
 .tabBadge {
-  font-size: 10px;
+  font-size: var(--body-size);
   font-weight: 600;
   background: var(--hover-bg);
   color: var(--text-dim);
@@ -154,7 +154,7 @@
   width: 14px;
   text-align: center;
   flex-shrink: 0;
-  font-size: 11px;
+  font-size: var(--body-size);
 }
 
 .path {
@@ -167,7 +167,7 @@
 .stats {
   display: flex;
   gap: 6px;
-  font-size: 11px;
+  font-size: var(--body-size);
   font-family: var(--font-mono);
   margin-left: auto;
   flex-shrink: 0;
@@ -194,7 +194,7 @@
   width: 100%;
   padding: 4px 8px;
   color: var(--text-dim);
-  font-size: 10px;
+  font-size: var(--body-size);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -278,7 +278,7 @@
 }
 
 .groupCount {
-  font-size: 10px;
+  font-size: var(--body-size);
   font-weight: 600;
   background: var(--hover-bg);
   color: var(--text-dim);
@@ -301,7 +301,7 @@
   background: none;
   border: none;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: var(--body-size);
   cursor: pointer;
   border-radius: 4px;
   text-align: left;
@@ -324,7 +324,7 @@
 
 .commitHash {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--body-size);
   color: var(--diff-added-text);
   flex-shrink: 0;
 }
@@ -334,11 +334,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 11px;
+  font-size: var(--body-size);
 }
 
 .commitDate {
-  font-size: 10px;
+  font-size: var(--body-size);
   color: var(--text-dim);
   flex-shrink: 0;
 }
@@ -353,7 +353,7 @@
 
 .commitNoFiles {
   padding: 4px 12px 4px 20px;
-  font-size: 11px;
+  font-size: var(--body-size);
   color: var(--text-dim);
   font-style: italic;
 }

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -151,7 +151,7 @@
 
 .status {
   font-weight: 700;
-  width: 14px;
+  width: 1.1em;
   text-align: center;
   flex-shrink: 0;
   font-size: var(--body-size);

--- a/src/ui/src/components/right-sidebar/TaskList.module.css
+++ b/src/ui/src/components/right-sidebar/TaskList.module.css
@@ -27,7 +27,7 @@
 
 .statusIcon {
   flex-shrink: 0;
-  width: 14px;
+  width: 1.1em;
   text-align: center;
   font-size: var(--body-size);
   line-height: 18px;

--- a/src/ui/src/components/right-sidebar/TaskList.module.css
+++ b/src/ui/src/components/right-sidebar/TaskList.module.css
@@ -8,7 +8,7 @@
   padding: 16px;
   text-align: center;
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--body-size);
 }
 
 .task {
@@ -17,7 +17,7 @@
   gap: 8px;
   padding: 5px 8px;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: var(--body-size);
   transition: background var(--transition-fast);
 }
 
@@ -29,7 +29,7 @@
   flex-shrink: 0;
   width: 14px;
   text-align: center;
-  font-size: 12px;
+  font-size: var(--body-size);
   line-height: 18px;
 }
 

--- a/src/ui/src/components/sidebar/HelpMenu.module.css
+++ b/src/ui/src/components/sidebar/HelpMenu.module.css
@@ -34,7 +34,7 @@
   border: none;
   border-radius: var(--radius-md);
   color: var(--text-primary);
-  font-size: 13px;
+  font-size: var(--body-size);
   text-align: left;
   cursor: pointer;
   transition: background var(--transition-fast);

--- a/src/ui/src/components/sidebar/HelpMenu.module.css
+++ b/src/ui/src/components/sidebar/HelpMenu.module.css
@@ -82,7 +82,7 @@
 
 .keycap {
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--body-size);
 }
 
 .divider {

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -273,7 +273,7 @@
 .invalidBadge {
   color: var(--status-stopped);
   font-weight: bold;
-  font-size: 12px;
+  font-size: var(--body-size);
 }
 
 .repoIcon {
@@ -621,7 +621,7 @@
 }
 
 .emptyStateMessage {
-  font-size: 12px;
+  font-size: var(--body-size);
   line-height: 1.4;
   color: var(--text-muted);
 }
@@ -639,7 +639,7 @@
   color: var(--text-primary);
   padding: 4px 10px;
   border-radius: 4px;
-  font-size: 12px;
+  font-size: var(--body-size);
   cursor: pointer;
   transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
 }


### PR DESCRIPTION
## Summary

- Replace all hardcoded font sizes (`10px`, `11px`, `12px`) in sidebar CSS modules with `var(--body-size)`
- Affected components: file tree, files panel, changes tab (including file rows, group headers, status glyphs, diff stats, commit rows), tasks tab, PR status banner, left sidebar, and help menu
- `var(--body-size)` resolves to `var(--fs-base)` (13px default) — the same token used on `html, body, #root` — so sidebar text now matches the rest of the UI and scales with the **UI Size** and **Interface Font** settings
- Icon slot widths (`.status`, `.statusIcon`) switched from `14px` to `1.1em` so they scale proportionally with the font size

## Test Steps

1. Open Claudette with a workspace that has git changes
2. Open **Settings → Appearance** and adjust **UI Size** (e.g. change from 13 to 16)
3. Verify the sidebar (file tree, Changes tab, Tasks tab) text scales to match the rest of the UI
4. Change the **Interface Font** setting and verify the sidebar picks up the new font
5. Confirm the PR status banner, help menu shortcuts, and empty-state messages all scale consistently

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)