### PR TITLE
chore: add claudebook slash commands

### DIFF
--- a/.claude/commands/commit-changes.md
+++ b/.claude/commands/commit-changes.md
@@ -1,0 +1,61 @@
+Review all uncommitted changes and create a well-structured commit using conventional commit format.
+
+## Steps
+
+1. **Pre-flight checks** — Ensure the code is ready to commit:
+   - Detect the project's toolchain from config files (e.g., `package.json`, `Makefile`, `mix.exs`, `Cargo.toml`, `pyproject.toml`)
+   - Run the project's **format** command (e.g., `prettier`, `mix format`, `cargo fmt`, `ruff format`)
+   - Run the project's **lint** command (e.g., `eslint`, `mix credo`, `cargo clippy`, `ruff check`)
+   - Run the project's **typecheck** command if applicable (e.g., `tsc --noEmit`, `mypy`, `mix dialyzer`)
+   - Run the project's **test** command (e.g., `jest`, `mix test`, `cargo test`, `pytest`)
+   - If any check fails, fix the issues before proceeding
+
+2. **Review changes** — Understand what's being committed:
+   - Run `git status` to see all modified/untracked files
+   - Run `git diff` to review unstaged changes
+   - Run `git diff --cached` to review already-staged changes
+   - Run `git log --oneline -5` to see recent commit style for context
+
+3. **Stage files** — Add relevant files to staging:
+   - Stage files by name (avoid `git add -A` or `git add .`)
+   - Do NOT stage files that contain secrets (`.env`, credentials, etc.)
+   - If there are unrelated changes, group them into separate logical commits
+
+4. **Draft commit message** — Use conventional commit format:
+   - Format: `<type>(<scope>): <description>`
+   - Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `style`, `perf`, `ci`, `build`
+   - Scope: the domain or area affected (e.g., `orders`, `shipments`, `auth`, `api`)
+   - Description: concise summary of the "why", not the "what"
+   - Add a body paragraph if the change is non-trivial, explaining motivation or trade-offs
+   - Reference GitHub issues when applicable (e.g., `Closes #123`)
+
+5. **Create the commit** — Use a HEREDOC for the message to preserve formatting:
+   ```
+   git commit -m "$(cat <<'EOF'
+   type(scope): description
+
+   Optional body with more context.
+   EOF
+   )"
+   ```
+
+6. **Verify** — Run `git status` after committing to confirm success.
+
+## Examples
+
+```
+feat(orders): add bulk status update endpoint
+
+Closes #456
+```
+
+```
+fix(shipments): prevent duplicate tracking webhooks
+
+The webhook handler wasn't deduplicating by tracking number,
+causing duplicate fulfillment updates in Shopify.
+```
+
+```
+refactor(dal): migrate inventory to event buffer pattern
+```

--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,68 @@
+Implement the changes described in one or more GitHub issues passed via $ARGUMENTS.
+
+## Arguments
+
+`$ARGUMENTS` accepts one or more GitHub issue numbers in any of these formats:
+
+- `123` — single issue
+- `#123 #456` — multiple with hash prefixes
+- `123,456,789` — comma-separated
+- `#123, #456` — comma-separated with hashes
+
+**Parsing rule:** strip all `#` characters, then split on commas and/or whitespace to extract individual issue numbers.
+
+## Steps
+
+1. **Fetch the issues** — Get the full details for each issue:
+   - Parse `$ARGUMENTS` using the rule above to extract all issue numbers
+   - For each issue number, run `gh issue view <number> --json title,body,labels,comments`
+   - Read all titles, descriptions, and comments carefully for every issue
+
+2. **Understand the context** — Research the codebase before making changes:
+   - Identify which domains, files, and systems are affected across all issues
+   - Read the relevant source files to understand the current behavior
+   - Check `docs/` for any existing documentation on the affected areas
+   - Review related tests to understand expected behavior and edge cases
+   - If any issue references other issues or PRs, fetch those for additional context
+   - When working with multiple issues, identify shared concerns, overlapping files, and dependencies between the issues
+
+3. **Ask clarifying questions** — Before implementing, check for ambiguity:
+   - If any issue is underspecified, missing acceptance criteria, or has multiple valid interpretations, stop and ask the user for clarification
+   - If the combined scope seems larger than expected, confirm the approach before proceeding
+   - If there are architectural decisions to make, present the options with trade-offs
+   - When working with multiple issues, flag any conflicts or contradictions between issue requirements
+
+4. **Plan the implementation** — Outline the approach:
+   - Enter plan mode and draft a step-by-step implementation plan
+   - Plan a single unified implementation that addresses all issues cohesively
+   - Identify all files that need to be created or modified
+   - Note any migrations, new dependencies, or configuration changes required
+   - Call out where issue requirements interact or depend on each other
+   - Call out risks or areas that need extra care
+   - Wait for the user to approve the plan before proceeding
+
+5. **Implement the changes** — Execute the plan:
+   - Follow the patterns and conventions documented in CLAUDE.md
+   - Write tests alongside the implementation (not after)
+   - Reference issue numbers in code comments only when the context isn't self-evident
+   - Update documentation in `docs/` if the changes affect documented features
+   - **Leverage agents and teams for parallel work** — when the implementation involves independent workstreams (e.g., DAL + API route + UI, or multiple unrelated files), use subagents to work on them concurrently. Examples:
+     - Spawn agents to research different parts of the codebase in parallel during the planning phase
+     - Use agents to implement independent modules simultaneously (e.g., one for the data layer, one for tests)
+     - Delegate verification tasks (format, lint, typecheck, test) to a background agent while continuing work
+   - Prefer agents over sequential execution whenever tasks don't depend on each other
+
+6. **Verify** — Ensure everything works:
+   - Detect the project's toolchain from config files (e.g., `package.json`, `Makefile`, `mix.exs`, `Cargo.toml`, `pyproject.toml`)
+   - Run the project's **format** command (e.g., `prettier`, `mix format`, `cargo fmt`, `ruff format`)
+   - Run the project's **lint** command (e.g., `eslint`, `mix credo`, `cargo clippy`, `ruff check`)
+   - Run the project's **typecheck** command if applicable (e.g., `tsc --noEmit`, `mypy`, `mix dialyzer`)
+   - Run the project's **test** command (e.g., `jest`, `mix test`, `cargo test`, `pytest`)
+   - If any check fails, fix the issues before proceeding
+
+7. **Report** — Summarize what was done:
+   - List the files created or modified
+   - Describe the approach taken and any trade-offs made
+   - Note all issue numbers for commit messages (e.g., `Closes #123, Closes #456`)
+   - Summarize which changes address which issues when working with multiple
+   - Flag anything that needs manual testing or follow-up

--- a/.claude/commands/incorporate-feedback.md
+++ b/.claude/commands/incorporate-feedback.md
@@ -1,0 +1,41 @@
+Review and incorporate valid feedback from the current pull request.
+
+## Steps
+
+1. **Identify the PR** — Determine which PR to review:
+   - Run `gh pr view --json number,url,title` to get the current branch's PR
+   - If no PR exists, inform the user and stop
+
+2. **Fetch all review comments** — Gather feedback:
+   - Run `gh pr view --json reviews,comments` to get top-level PR comments and reviews
+   - Use `gh api repos/{owner}/{repo}/pulls/{number}/comments` to get inline review comments
+   - Focus on unresolved comments and actionable feedback
+
+3. **Categorize each comment** — Sort feedback into two buckets:
+   - **Clear and actionable** — The feedback points to an obvious improvement (e.g., a typo, missing error handling, a correctness bug, a straightforward refactor). Plan to incorporate these without asking.
+   - **Ambiguous or debatable** — The feedback involves a style preference, an architectural suggestion, an unclear request, or has multiple valid responses. These need user input.
+
+4. **Ask the user about ambiguous feedback** — For each ambiguous comment (or batch of related comments), present the user with a question that includes:
+   - A brief quote or summary of the reviewer's comment for context
+   - Concrete suggested options for how to address it (e.g., "Refactor to use X as suggested", "Add a code comment explaining the current approach")
+   - An **"Ignore this feedback"** option — always included so the user can decline any suggestion
+   - The user will also have the option to type a free-form response if none of the suggested options fit
+   - Batch related comments into a single question where possible to reduce back-and-forth
+
+5. **Make changes** — For feedback you're incorporating:
+   - Implement the requested changes
+   - Run the project's format, lint, typecheck (if applicable), and test commands after changes
+   - Fix any issues introduced by the changes
+
+6. **Respond to comments** — For every comment:
+   - **Incorporated**: Reply confirming the change was made (e.g., "Done — updated to use `X` instead")
+   - **Ignored by user's choice**: Reply with a clear, respectful explanation based on the user's reasoning (e.g., "We discussed this and decided to keep the current approach because..." or "Intentional — [user's reason]")
+   - **Incorporated with the user's custom approach**: Reply describing what was done and why that approach was chosen
+   - Use `gh api` to post replies to review comments
+
+7. **Commit and push** — If changes were made:
+   - Stage and commit using conventional commit format: `fix(scope): incorporate PR feedback`
+   - Include specifics in the commit body about what was addressed
+   - Push to the branch: `git push`
+
+8. **Summary** — Report back what was changed and what was declined, with reasoning.

--- a/.claude/commands/pull-request.md
+++ b/.claude/commands/pull-request.md
@@ -1,0 +1,52 @@
+Open a pull request for the current branch against `main`.
+
+## Arguments
+
+- `$ARGUMENTS` — Pass `draft` to create a draft PR (e.g., `/pull-request draft`). If omitted, creates a regular PR.
+
+## Steps
+
+1. **Pre-flight checks** — Before opening the PR, ensure the code is ready:
+   - Detect the project's toolchain from config files (e.g., `package.json`, `Makefile`, `mix.exs`, `Cargo.toml`, `pyproject.toml`)
+   - Run the project's **format** command (e.g., `prettier`, `mix format`, `cargo fmt`, `ruff format`)
+   - Run the project's **lint** command (e.g., `eslint`, `mix credo`, `cargo clippy`, `ruff check`)
+   - Run the project's **typecheck** command if applicable (e.g., `tsc --noEmit`, `mypy`, `mix dialyzer`)
+   - Run the project's **test** command (e.g., `jest`, `mix test`, `cargo test`, `pytest`)
+   - If any check fails, fix the issues before proceeding
+
+2. **Rebase on origin/main** — Ensure the branch is up to date:
+   - Run `git fetch origin main`
+   - Run `git rebase origin/main`
+   - If there are conflicts, resolve them one file at a time:
+     - Read the conflicting file to understand both sides
+     - Apply the correct resolution preserving intent from both branches
+     - Run `git add <file>` and `git rebase --continue`
+   - After rebase, re-run pre-flight checks to ensure nothing broke
+
+3. **Analyze changes** — Review all commits on this branch vs `origin/main`:
+   - Run `git log origin/main..HEAD --oneline` to see all commits
+   - Run `git diff origin/main...HEAD` to see the full diff
+
+4. **Draft the PR** — Prepare the PR title and body:
+   - **Title**: Use a concise, descriptive title (under 70 characters)
+   - **Body** should include these sections:
+
+     ### Summary
+     A succinct description of what changed and why. Include a mermaid diagram if the changes involve schema changes, new flows, or architectural changes.
+
+     ### Complexity Notes
+     Flag any areas of complexity, risk, or non-obvious behavior that reviewers should pay close attention to. If there are none, omit this section.
+
+     ### Test Steps
+     Provide concrete, numbered steps a reviewer can follow to verify the changes work correctly. Be specific — include URLs, commands, or UI flows to check.
+
+     ### Checklist
+     - [ ] Tests added/updated
+     - [ ] Documentation updated (if applicable)
+
+5. **Push and create** — Push the branch and create the PR:
+   - `git push -u origin HEAD`
+   - If `$ARGUMENTS` is `draft`, run `gh pr create --draft` with the drafted title and body
+   - Otherwise, run `gh pr create` with the drafted title and body
+
+6. **Return the PR URL** to the user when done.

--- a/.claude/commands/rebase-on-main.md
+++ b/.claude/commands/rebase-on-main.md
@@ -1,0 +1,34 @@
+Rebase the current branch on `origin/main` and resolve any conflicts.
+
+## Steps
+
+1. **Check for uncommitted changes** — Ensure the working tree is clean:
+   - Run `git status` to check for uncommitted changes
+   - If there are uncommitted changes, warn the user and stop — do not stash or discard work
+
+2. **Fetch and rebase** — Update the branch:
+   - Run `git fetch origin main`
+   - Run `git rebase origin/main`
+   - If the rebase completes cleanly, skip to step 4
+
+3. **Resolve conflicts** — For each conflicting file:
+   - Run `git diff` to see the conflict markers
+   - Read the conflicting file to understand both sides of the conflict
+   - Resolve the conflict by preserving the intent from both branches
+   - Run `git add <file>` to mark as resolved
+   - Run `git rebase --continue` to proceed
+   - Repeat until all conflicts are resolved
+   - If a conflict is ambiguous or risky, stop and ask the user for guidance
+
+4. **Verify** — Ensure the rebase didn't break anything:
+   - Detect the project's toolchain from config files (e.g., `package.json`, `Makefile`, `mix.exs`, `Cargo.toml`, `pyproject.toml`)
+   - Run the project's **format** command (e.g., `prettier`, `mix format`, `cargo fmt`, `ruff format`)
+   - Run the project's **lint** command (e.g., `eslint`, `mix credo`, `cargo clippy`, `ruff check`)
+   - Run the project's **typecheck** command if applicable (e.g., `tsc --noEmit`, `mypy`, `mix dialyzer`)
+   - Run the project's **test** command (e.g., `jest`, `mix test`, `cargo test`, `pytest`)
+   - If any check fails, investigate and fix the issue
+
+5. **Report** — Summarize what happened:
+   - How many commits were rebased
+   - Whether any conflicts were resolved (and what they were)
+   - Whether all checks pass


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/` with five slash commands sourced from [utensils/claudebook](https://github.com/utensils/claudebook/tree/main/commands)
- Contributors using the standard Claude Code CLI get `/commit-changes`, `/implement-issue`, `/incorporate-feedback`, `/pull-request`, and `/rebase-on-main` out of the box
- No changes to existing Claudette-specific skills in `.claude/skills/`

## Test Steps

1. Clone the repo and open it in Claude Code CLI (`claude`)
2. Type `/` — the five new commands should appear in the autocomplete list
3. Try `/commit-changes` on a branch with uncommitted changes to verify it runs the pre-flight checks and stages/commits correctly