### PR TITLE
feat: render filetree icons via material-icon-theme

### DIFF
--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ui",
@@ -20,6 +19,7 @@
         "hast-util-to-html": "^9.0.5",
         "i18next": "^26.0.8",
         "lucide-react": "^1.7.0",
+        "material-icon-theme": "^5.34.0",
         "mermaid": "^11.14.0",
         "monaco-editor": "^0.55.1",
         "pdfjs-dist": "^5.6.205",
@@ -438,6 +438,8 @@
 
     "chevrotain-allstar": ["chevrotain-allstar@0.4.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA=="],
 
+    "chroma-js": ["chroma-js@3.2.0", "", {}, "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -538,6 +540,8 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "deep-rename-keys": ["deep-rename-keys@0.2.1", "", { "dependencies": { "kind-of": "^3.0.2", "rename-keys": "^1.1.2" } }, "sha512-RHd9ABw4Fvk+gYDWqwOftG849x0bYOySl/RgX0tLI9i27ZIeSO91mLZJEp7oPHOMFqHvpgu21YptmDt0FYD/0A=="],
+
     "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
@@ -583,6 +587,10 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@2.0.3", "", {}, "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
@@ -664,6 +672,8 @@
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
@@ -695,6 +705,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
 
     "langium": ["langium@4.2.2", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.1", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ=="],
 
@@ -743,6 +755,8 @@
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "material-icon-theme": ["material-icon-theme@5.34.0", "", { "dependencies": { "chroma-js": "^3.1.2", "events": "^3.3.0", "fast-deep-equal": "^3.1.3", "svgson": "^5.3.1" } }, "sha512-m+ZgtdtJMkfOwxpfUH8FqyJbfnAJuxMBNv4XRvz3m808Is42RbeYc/5W0bk5qGJJLxzF5Cupj6Or52aQISwz3A=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -922,6 +936,8 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "rename-keys": ["rename-keys@1.2.0", "", {}, "sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg=="],
+
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
@@ -967,6 +983,8 @@
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "svgson": ["svgson@5.3.1", "", { "dependencies": { "deep-rename-keys": "^0.2.1", "xml-reader": "2.4.3" } }, "sha512-qdPgvUNWb40gWktBJnbJRelWcPzkLed/ShhnRsjbayXz8OtdPOzbil9jtiZdrYvSDumAz/VNQr6JaNfPx/gvPA=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1051,6 +1069,10 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "xml-lexer": ["xml-lexer@0.2.2", "", { "dependencies": { "eventemitter3": "^2.0.0" } }, "sha512-G0i98epIwiUEiKmMcavmVdhtymW+pCAohMRgybyIME9ygfVu8QheIi+YoQh3ngiThsT0SQzJT4R0sKDEv8Ou0w=="],
+
+    "xml-reader": ["xml-reader@2.4.3", "", { "dependencies": { "eventemitter3": "^2.0.0", "xml-lexer": "^0.2.2" } }, "sha512-xWldrIxjeAMAu6+HSf9t50ot1uL5M+BtOidRCWHXIeewvSeIpscWCsp4Zxjk8kHHhdqFBrfK8U0EJeCcnyQ/gA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -29,6 +29,7 @@
     "hast-util-to-html": "^9.0.5",
     "i18next": "^26.0.8",
     "lucide-react": "^1.7.0",
+    "material-icon-theme": "^5.34.0",
     "mermaid": "^11.14.0",
     "monaco-editor": "^0.55.1",
     "pdfjs-dist": "^5.6.205",

--- a/src/ui/src/components/files/FileTree.tsx
+++ b/src/ui/src/components/files/FileTree.tsx
@@ -8,13 +8,17 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { useIsLightTheme } from "../../hooks/useIsLightTheme";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   buildFileTree,
   flattenVisible,
   type FileTreeNode,
 } from "../../utils/buildFileTree";
-import { getFileIcon, getFolderIcon } from "../../utils/fileIcons";
+import {
+  getMaterialFileIconUrl,
+  getMaterialFolderIconUrl,
+} from "../../utils/materialIcons";
 import type { FileEntry } from "../../services/tauri";
 import type { DiffLayer } from "../../types/diff";
 import type { FileContextTarget } from "./fileContextMenu";
@@ -97,6 +101,9 @@ export const FileTree = memo(function FileTree({
     () => flattenVisible(tree, expanded),
     [tree, expanded],
   );
+  // Light/dark drives which material-icon-theme variant we render for
+  // folders (and the handful of files that ship a `_light` SVG).
+  const isLight = useIsLightTheme();
 
   const containerRef = useRef<HTMLDivElement>(null);
   // Map of treeitem element refs keyed by node path. Used to programmatically
@@ -281,6 +288,7 @@ export const FileTree = memo(function FileTree({
         <CreateRow
           depth={0}
           parentPath={creatingParentPath}
+          isLight={isLight}
           onCreateCommit={onCreateCommit}
           onCreateCancel={onCreateCancel}
         />
@@ -296,6 +304,7 @@ export const FileTree = memo(function FileTree({
               expanded={node.kind === "dir" ? !!expanded[node.path] : false}
               selected={selected === node.path}
               renaming={renamingPath === node.path}
+              isLight={isLight}
               // Roving tabindex: exactly one row in the tree is in the tab
               // order at any time. Tab moves focus into the tree (or out of
               // it); arrow keys move within.
@@ -348,6 +357,7 @@ export const FileTree = memo(function FileTree({
               <CreateRow
                 depth={depth + 1}
                 parentPath={creatingParentPath}
+                isLight={isLight}
                 onCreateCommit={onCreateCommit}
                 onCreateCancel={onCreateCancel}
               />
@@ -366,6 +376,7 @@ function stripTrailingSlash(path: string): string {
 interface CreateRowProps {
   depth: number;
   parentPath: string;
+  isLight: boolean;
   onCreateCommit: (parentPath: string, name: string) => Promise<boolean>;
   onCreateCancel: () => void;
 }
@@ -373,10 +384,11 @@ interface CreateRowProps {
 function CreateRow({
   depth,
   parentPath,
+  isLight,
   onCreateCommit,
   onCreateCancel,
 }: CreateRowProps) {
-  const Icon = getFileIcon("untitled");
+  const iconUrl = getMaterialFileIconUrl("untitled", isLight);
   return (
     <div
       className={styles.row}
@@ -385,8 +397,14 @@ function CreateRow({
       aria-level={depth + 1}
     >
       <span className={styles.chevron} style={{ width: 12, height: 12 }} />
-      {/* eslint-disable-next-line react-hooks/static-components -- fileIcons returns stable module-level lucide components. */}
-      <Icon size={14} className={styles.icon} aria-hidden="true" />
+      <img
+        src={iconUrl}
+        width={14}
+        height={14}
+        className={styles.icon}
+        alt=""
+        aria-hidden="true"
+      />
       <InlineRenameInput
         name="untitled"
         className={styles.renameInput}
@@ -405,6 +423,7 @@ interface RowProps {
   selected: boolean;
   renaming: boolean;
   tabbable: boolean;
+  isLight: boolean;
   rowRef: (el: HTMLDivElement | null) => void;
   onClick: () => void;
   onContextMenu: (x: number, y: number) => void;
@@ -419,6 +438,7 @@ function Row({
   selected,
   renaming,
   tabbable,
+  isLight,
   rowRef,
   onClick,
   onContextMenu,
@@ -431,7 +451,9 @@ function Row({
       ? ChevronDown
       : ChevronRight
     : null;
-  const Icon = isDir ? getFolderIcon(expanded) : getFileIcon(node.name);
+  const iconUrl = isDir
+    ? getMaterialFolderIconUrl(node.name, expanded, isLight)
+    : getMaterialFileIconUrl(node.name, isLight);
   const status = node.kind === "file" ? node.git_status : null;
   const statusLayer = node.kind === "file" ? node.git_layer : null;
   const folderStatus = node.kind === "dir" ? node.folderStatus : null;
@@ -496,8 +518,14 @@ function Row({
         // 12-px spacer keeps file rows aligned with their sibling folders.
         <span className={styles.chevron} style={{ width: 12, height: 12 }} />
       )}
-      {/* eslint-disable-next-line react-hooks/static-components -- fileIcons returns stable module-level lucide components. */}
-      <Icon size={14} className={styles.icon} aria-hidden="true" />
+      <img
+        src={iconUrl}
+        width={14}
+        height={14}
+        className={styles.icon}
+        alt=""
+        aria-hidden="true"
+      />
       {renaming ? (
         <InlineRenameInput
           name={node.name}

--- a/src/ui/src/hooks/useIsLightTheme.ts
+++ b/src/ui/src/hooks/useIsLightTheme.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+function readIsLight(): boolean {
+  return (
+    getComputedStyle(document.documentElement)
+      .getPropertyValue("color-scheme")
+      .trim() === "light"
+  );
+}
+
+/**
+ * Tracks whether the active Claudette theme is light or dark by reading the
+ * computed `color-scheme` CSS variable on `<html>`. Re-evaluates whenever
+ * `data-theme` or inline style changes on the root element — same trigger
+ * surface used by the Monaco theme sync.
+ */
+export function useIsLightTheme(): boolean {
+  const [isLight, setIsLight] = useState(readIsLight);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const next = readIsLight();
+      setIsLight((prev) => (prev === next ? prev : next));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme", "style"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return isLight;
+}

--- a/src/ui/src/hooks/useIsLightTheme.ts
+++ b/src/ui/src/hooks/useIsLightTheme.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 
 function readIsLight(): boolean {
+  // vitest defaults to a Node environment in this repo (happy-dom is opt-in
+  // per file via `// @vitest-environment happy-dom`), so any non-DOM caller
+  // — including a future test that imports a component using this hook —
+  // gets the dark default rather than a `document is not defined` crash.
+  if (typeof document === "undefined") return false;
   return (
     getComputedStyle(document.documentElement)
       .getPropertyValue("color-scheme")
@@ -10,7 +15,7 @@ function readIsLight(): boolean {
 
 /**
  * Tracks whether the active Claudette theme is light or dark by reading the
- * computed `color-scheme` CSS variable on `<html>`. Re-evaluates whenever
+ * computed `color-scheme` CSS property on `<html>`. Re-evaluates whenever
  * `data-theme` or inline style changes on the root element — same trigger
  * surface used by the Monaco theme sync.
  */
@@ -18,6 +23,7 @@ export function useIsLightTheme(): boolean {
   const [isLight, setIsLight] = useState(readIsLight);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
     const observer = new MutationObserver(() => {
       const next = readIsLight();
       setIsLight((prev) => (prev === next ? prev : next));

--- a/src/ui/src/utils/fileIcons.tsx
+++ b/src/ui/src/utils/fileIcons.tsx
@@ -8,8 +8,6 @@ import {
   FileSpreadsheet,
   FileText,
   FileVideo,
-  Folder,
-  FolderOpen,
   type LucideProps,
 } from "lucide-react";
 import type { ComponentType } from "react";
@@ -129,10 +127,6 @@ export function getFileIcon(filename: string): IconComponent {
   if (dot === -1) return File;
   const ext = filename.slice(dot + 1).toLowerCase();
   return EXT_TO_ICON[ext] ?? File;
-}
-
-export function getFolderIcon(expanded: boolean): IconComponent {
-  return expanded ? FolderOpen : Folder;
 }
 
 export function isImagePath(filename: string): boolean {

--- a/src/ui/src/utils/materialIcons.ts
+++ b/src/ui/src/utils/materialIcons.ts
@@ -1,0 +1,122 @@
+// Material Icon Theme integration. Maps file/folder names to data-URL-encoded
+// SVGs from the `material-icon-theme` npm package (the source of the VS Code
+// extension of the same name). The manifest declares which icon to use for
+// each extension / exact filename / folder name; we resolve through it on
+// every lookup.
+//
+// SVGs are eager-bundled via `import.meta.glob` with `?raw` so each icon is
+// inlined as a string at build time, then URL-encoded once per icon into a
+// data URL (`data:image/svg+xml;utf8,...`) at module load. Lookups are pure
+// table reads after that.
+
+import manifestJson from "material-icon-theme/dist/material-icons.json";
+
+interface IconDefinition {
+  iconPath: string;
+}
+
+interface ManifestSection {
+  fileExtensions?: Record<string, string>;
+  fileNames?: Record<string, string>;
+  folderNames?: Record<string, string>;
+  folderNamesExpanded?: Record<string, string>;
+  file?: string;
+  folder?: string;
+  folderExpanded?: string;
+}
+
+interface MaterialManifest extends ManifestSection {
+  iconDefinitions: Record<string, IconDefinition>;
+  light?: ManifestSection;
+}
+
+const manifest = manifestJson as unknown as MaterialManifest;
+
+// Eager-load every SVG in the package as a raw string. Vite resolves the
+// glob pattern at build time and emits each SVG inline; nothing is fetched
+// at runtime.
+const SVG_RAW_MODULES = import.meta.glob<string>(
+  "/node_modules/material-icon-theme/icons/*.svg",
+  { eager: true, query: "?raw", import: "default" },
+);
+
+// filename ("typescript.svg") -> data URL. Built once at module load.
+const SVG_DATA_URLS: Record<string, string> = (() => {
+  const out: Record<string, string> = {};
+  for (const [path, raw] of Object.entries(SVG_RAW_MODULES)) {
+    const filename = path.slice(path.lastIndexOf("/") + 1);
+    out[filename] = `data:image/svg+xml;utf8,${encodeURIComponent(raw)}`;
+  }
+  return out;
+})();
+
+function dataUrlForIconName(name: string | undefined): string | null {
+  if (!name) return null;
+  const def = manifest.iconDefinitions[name];
+  if (!def) return null;
+  const filename = def.iconPath.slice(def.iconPath.lastIndexOf("/") + 1);
+  return SVG_DATA_URLS[filename] ?? null;
+}
+
+const FALLBACK_FILE_URL = dataUrlForIconName(manifest.file ?? "file") ?? "";
+const FALLBACK_FOLDER_URL = dataUrlForIconName(manifest.folder ?? "folder") ?? "";
+const FALLBACK_FOLDER_OPEN_URL =
+  dataUrlForIconName(manifest.folderExpanded ?? "folder-open") ?? FALLBACK_FOLDER_URL;
+
+/**
+ * Resolve the data URL for a file's material icon. Lookup order matches the
+ * VS Code extension: exact filename → progressively shorter compound
+ * extensions (e.g. `routing.test.ts` → `test.ts` → `ts`) → default file icon.
+ * When `light` is true, light-variant overrides take precedence at each step.
+ */
+export function getMaterialFileIconUrl(filename: string, light: boolean): string {
+  const lower = filename.toLowerCase();
+
+  const lightSection = light ? manifest.light : undefined;
+
+  // 1. Exact filename match.
+  let iconName: string | undefined =
+    lightSection?.fileNames?.[lower] ?? manifest.fileNames?.[lower];
+
+  // 2. Compound extension match: split on `.` and try each suffix from
+  //    longest to shortest. Skip the leading segment (which is the basename).
+  //    Example: "Component.module.scss" -> ["module.scss", "scss"].
+  if (!iconName) {
+    const parts = lower.split(".");
+    for (let i = 1; i < parts.length; i++) {
+      const ext = parts.slice(i).join(".");
+      iconName =
+        lightSection?.fileExtensions?.[ext] ?? manifest.fileExtensions?.[ext];
+      if (iconName) break;
+    }
+  }
+
+  return dataUrlForIconName(iconName) ?? FALLBACK_FILE_URL;
+}
+
+/**
+ * Resolve the data URL for a folder's material icon. Lookup uses the
+ * folder's basename against `folderNames` / `folderNamesExpanded`, falling
+ * back to the generic folder/folder-open icon. Light variants take
+ * precedence when available.
+ */
+export function getMaterialFolderIconUrl(
+  folderName: string,
+  expanded: boolean,
+  light: boolean,
+): string {
+  const lower = folderName.toLowerCase();
+  const lightSection = light ? manifest.light : undefined;
+
+  const fromLight = expanded
+    ? lightSection?.folderNamesExpanded?.[lower]
+    : lightSection?.folderNames?.[lower];
+  const fromDark = expanded
+    ? manifest.folderNamesExpanded?.[lower]
+    : manifest.folderNames?.[lower];
+  const iconName = fromLight ?? fromDark;
+
+  const url = dataUrlForIconName(iconName);
+  if (url) return url;
+  return expanded ? FALLBACK_FOLDER_OPEN_URL : FALLBACK_FOLDER_URL;
+}

--- a/src/ui/src/utils/materialIcons.ts
+++ b/src/ui/src/utils/materialIcons.ts
@@ -6,8 +6,8 @@
 //
 // SVGs are eager-bundled via `import.meta.glob` with `?raw` so each icon is
 // inlined as a string at build time, then URL-encoded once per icon into a
-// data URL (`data:image/svg+xml;utf8,...`) at module load. Lookups are pure
-// table reads after that.
+// data URL (`data:image/svg+xml;charset=utf-8,...`) at module load. Lookups
+// are pure table reads after that.
 
 import manifestJson from "material-icon-theme/dist/material-icons.json";
 
@@ -45,7 +45,7 @@ const SVG_DATA_URLS: Record<string, string> = (() => {
   const out: Record<string, string> = {};
   for (const [path, raw] of Object.entries(SVG_RAW_MODULES)) {
     const filename = path.slice(path.lastIndexOf("/") + 1);
-    out[filename] = `data:image/svg+xml;utf8,${encodeURIComponent(raw)}`;
+    out[filename] = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(raw)}`;
   }
   return out;
 })();
@@ -58,10 +58,25 @@ function dataUrlForIconName(name: string | undefined): string | null {
   return SVG_DATA_URLS[filename] ?? null;
 }
 
-const FALLBACK_FILE_URL = dataUrlForIconName(manifest.file ?? "file") ?? "";
-const FALLBACK_FOLDER_URL = dataUrlForIconName(manifest.folder ?? "folder") ?? "";
-const FALLBACK_FOLDER_OPEN_URL =
-  dataUrlForIconName(manifest.folderExpanded ?? "folder-open") ?? FALLBACK_FOLDER_URL;
+// Resolve a required fallback once at module init. Throwing here instead of
+// silently returning "" surfaces an upstream package change loudly during
+// build/dev — `<img src="">` would otherwise re-request the document URL
+// and produce a noisy broken-image render.
+function requireDataUrl(name: string): string {
+  const url = dataUrlForIconName(name);
+  if (!url) {
+    throw new Error(
+      `material-icon-theme: required fallback icon "${name}" not found in manifest`,
+    );
+  }
+  return url;
+}
+
+const FALLBACK_FILE_URL = requireDataUrl(manifest.file ?? "file");
+const FALLBACK_FOLDER_URL = requireDataUrl(manifest.folder ?? "folder");
+const FALLBACK_FOLDER_OPEN_URL = requireDataUrl(
+  manifest.folderExpanded ?? "folder-open",
+);
 
 /**
  * Resolve the data URL for a file's material icon. Lookup order matches the


### PR DESCRIPTION
## Summary

Wires the upstream [material-icon-theme](https://github.com/material-extensions/vscode-material-icon-theme) manifest and SVG set into the file tree so each row renders the icon matched to its file or folder — `nodejs` for `package.json`, `react_ts` for `*.tsx`, `folder-src` for `src/`, etc. Lookup walks the manifest the same way the VS Code extension does: exact filename → progressively shorter compound extensions (`routing.test.ts` → `test.ts` → `ts`) → fallback. Folder names match against `folderNames` / `folderNamesExpanded` with separate open/closed variants.

The manifest carries 4,618 folder mappings, 2,079 special filenames, and 1,171 extensions across 1,238 icons. SVGs are eager-bundled via `import.meta.glob('?raw', { eager: true })` and converted to `data:image/svg+xml;utf8,…` URLs once at module load — runtime lookups are pure table reads.

Light/dark variants follow Claudette's active theme via a `MutationObserver` on `<html>`'s `data-theme` / `style` attributes (the same trigger surface the Monaco theme sync uses), exposed through a new `useIsLightTheme()` hook.

\`\`\`mermaid
flowchart LR
  Theme[useIsLightTheme<br/>MutationObserver on data-theme] -->|isLight| FT[FileTree]
  FT -->|name, expanded, isLight| MI[materialIcons<br/>getMaterialFileIconUrl<br/>getMaterialFolderIconUrl]
  Manifest[material-icons.json<br/>fileExtensions / fileNames /<br/>folderNames / iconDefinitions] --> MI
  SVGs[~1238 *.svg<br/>eager glob, ?raw] -->|encoded once| DataURLs[data: URLs]
  DataURLs --> MI
  MI -->|src= dataUrl| Img[<img> in Row]
\`\`\`

## Complexity Notes

- **Scope is filetree-only.** `SessionTabs` and the image media-type helpers still consume `getFileIcon` / `imageMediaType` from `fileIcons.tsx`. Only the unused `getFolderIcon` and the `Folder`/`FolderOpen` lucide imports were removed.
- **Two CSS rules become no-ops on file rows:** `.rowDirChanged .icon { color: … }` and `.rowSelected .icon { color: … }` previously tinted lucide's `currentColor`. Material icons have baked-in colors so the tint never applies — same behavior as VS Code itself, and the directory-changed signal still surfaces through the existing right-aligned `statusCount` badge.
- **Bundle size grew:** ~700KB of inlined SVG strings in the main chunk. This was an explicit choice (eager bundling) over lazy `?url` assets so icons paint immediately on first render with zero network/cache round-trips.
- **Folder icons are theme-agnostic in material-icon-theme.** The light section's `folderNames` / `folderNamesExpanded` are mostly empty — only file-pun icons (`scons`, etc.) ship `_light` variants. The light cascade still works for files; folders just get the same SVG in both themes.
- **Compound extension matching is intentional.** `Component.module.scss` resolves to `sass` (via the trailing `scss`), `app.test.ts` resolves to `test-ts` (the manifest has explicit `test.ts` entries). The lookup tries longer suffixes first.

## Test Steps

1. Run `cd src/ui && bun install` to pull `material-icon-theme@^5.34.0`.
2. Launch the dev app: `./scripts/dev.sh`.
3. Open any workspace and inspect the **Files** tree — verify icons render correctly:
   - `package.json` → green Node hex
   - `tsconfig.json` → blue TS gear
   - `Dockerfile` → docker whale
   - `*.tsx` → React+TS hybrid
   - `*.test.ts` → test tube
   - `src/` → labeled folder (different open vs closed state)
   - `node_modules/` → folder-node
   - `.github/` → folder-github
   - `.gitignore` → git icon
   - Random unknown extensions → generic file icon
4. Expand/collapse a directory — confirm the open variant swaps in (e.g. `folder-src-open` vs `folder-src`).
5. Switch theme via Command Palette between a dark and a light theme — folder icons remain consistent (theme-agnostic in upstream manifest); file icons that ship `_light` variants swap.
6. Select a file row — file icon keeps its material color (no longer tints with selection — matches VS Code).
7. Confirm `cd src/ui && bunx tsc -b && bun run lint && bun run lint:css && bun run test` all pass (1,408 tests).
8. Run `cd src/ui && bun run build` and confirm a single chunk grows by ~700KB of inlined SVG strings (1,239 `viewBox` occurrences in the main bundle).

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)