### PR TITLE
fix: preserve CLI workspace names

### DIFF
--- a/src-cli/src/batch.rs
+++ b/src-cli/src/batch.rs
@@ -232,7 +232,11 @@ async fn dispatch(
     let create_value = ipc::call(
         info,
         "create_workspace",
-        serde_json::json!({ "repo_id": repo_id, "name": name }),
+        serde_json::json!({
+            "repo_id": repo_id,
+            "name": name,
+            "preserve_name": true,
+        }),
     )
     .await?;
     let workspace_id = create_value

--- a/src-cli/src/commands/workspace.rs
+++ b/src-cli/src/commands/workspace.rs
@@ -56,7 +56,11 @@ pub async fn run(action: Action, json: bool) -> Result<(), Box<dyn Error>> {
             let value = ipc::call(
                 &info,
                 "create_workspace",
-                serde_json::json!({ "repo_id": repo, "name": name }),
+                serde_json::json!({
+                    "repo_id": repo,
+                    "name": name,
+                    "preserve_name": true,
+                }),
             )
             .await?;
             output::print_json(&value)?;

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -114,7 +114,11 @@ pub async fn handle_request(
         "create_workspace" => {
             let repository_id = param_str(&params, "repository_id");
             let name = param_str(&params, "name");
-            handle_create_workspace(state, &repository_id, &name).await
+            let preserve_supplied_name = params
+                .get("preserve_name")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            handle_create_workspace(state, &repository_id, &name, preserve_supplied_name).await
         }
         "archive_workspace" => {
             let workspace_id = param_str(&params, "workspace_id");
@@ -801,6 +805,7 @@ async fn handle_create_workspace(
     state: &ServerState,
     repository_id: &str,
     name: &str,
+    preserve_supplied_name: bool,
 ) -> Result<serde_json::Value, String> {
     use claudette::ops::{NoopHooks, workspace as ops_workspace};
 
@@ -824,6 +829,7 @@ async fn handle_create_workspace(
             repo_id: repository_id,
             name,
             branch_prefix: &branch_prefix,
+            preserve_supplied_name,
         },
     )
     .await

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -821,18 +821,22 @@ async fn handle_create_workspace(
     // prefix from app settings; harmonizing the two is a follow-up.
     let branch_prefix = format!("{}/", repo.path_slug);
 
-    let out = ops_workspace::create(
-        &mut db,
-        &NoopHooks,
-        worktree_base_dir.as_path(),
-        ops_workspace::CreateParams {
-            repo_id: repository_id,
-            name,
-            branch_prefix: &branch_prefix,
-            preserve_supplied_name,
-        },
-    )
-    .await
+    let params = ops_workspace::CreateParams {
+        repo_id: repository_id,
+        name,
+        branch_prefix: &branch_prefix,
+    };
+    let out = if preserve_supplied_name {
+        ops_workspace::create_preserving_supplied_name(
+            &mut db,
+            &NoopHooks,
+            worktree_base_dir.as_path(),
+            params,
+        )
+        .await
+    } else {
+        ops_workspace::create(&mut db, &NoopHooks, worktree_base_dir.as_path(), params).await
+    }
     .map_err(|e| e.to_string())?;
 
     // Run the setup script (if configured) for parity with the GUI path.

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -36,7 +36,15 @@ pub async fn create_workspace(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<CreateWorkspaceResult, String> {
-    create_workspace_inner(&repo_id, &name, skip_setup.unwrap_or(false), &app, &state).await
+    create_workspace_inner(
+        &repo_id,
+        &name,
+        skip_setup.unwrap_or(false),
+        false,
+        &app,
+        &state,
+    )
+    .await
 }
 
 /// Shared implementation of the GUI's `create_workspace` command.
@@ -51,6 +59,7 @@ pub(crate) async fn create_workspace_inner(
     repo_id: &str,
     name: &str,
     skip_setup: bool,
+    preserve_supplied_name: bool,
     app: &AppHandle,
     state: &AppState,
 ) -> Result<CreateWorkspaceResult, String> {
@@ -67,6 +76,7 @@ pub(crate) async fn create_workspace_inner(
             repo_id,
             name,
             branch_prefix: &prefix,
+            preserve_supplied_name,
         },
     )
     .await

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -68,18 +68,23 @@ pub(crate) async fn create_workspace_inner(
     let prefix = ops_workspace::resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
     let worktree_base = state.worktree_base_dir.read().await.clone();
 
-    let out = ops_workspace::create(
-        &mut db,
-        TauriHooks::new(app.clone()).as_ref(),
-        worktree_base.as_path(),
-        CreateParams {
-            repo_id,
-            name,
-            branch_prefix: &prefix,
-            preserve_supplied_name,
-        },
-    )
-    .await
+    let hooks = TauriHooks::new(app.clone());
+    let params = CreateParams {
+        repo_id,
+        name,
+        branch_prefix: &prefix,
+    };
+    let out = if preserve_supplied_name {
+        ops_workspace::create_preserving_supplied_name(
+            &mut db,
+            hooks.as_ref(),
+            worktree_base.as_path(),
+            params,
+        )
+        .await
+    } else {
+        ops_workspace::create(&mut db, hooks.as_ref(), worktree_base.as_path(), params).await
+    }
     .map_err(|e| e.to_string())?;
 
     // Setup script runs after the workspace exists so we can resolve the

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -457,12 +457,22 @@ async fn handle_create_workspace(
         .get("skip_setup")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let preserve_supplied_name = params
+        .get("preserve_name")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let state = app_state(app)?;
 
-    let result =
-        crate::commands::workspace::create_workspace_inner(repo_id, name, skip_setup, app, &state)
-            .await?;
+    let result = crate::commands::workspace::create_workspace_inner(
+        repo_id,
+        name,
+        skip_setup,
+        preserve_supplied_name,
+        app,
+        &state,
+    )
+    .await?;
 
     Ok(json!({
         "workspace": result.workspace,

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -63,13 +63,6 @@ pub struct CreateParams<'a> {
     /// Branch prefix already resolved by the caller (e.g.
     /// `"jamesbrink/"`). Empty string is allowed.
     pub branch_prefix: &'a str,
-    /// Preserve the supplied workspace name/branch after the first prompt.
-    ///
-    /// GUI-created workspaces use the normal first-prompt auto-rename path.
-    /// CLI and batch callers pass an explicit script-facing name and need it
-    /// to remain stable, so they pre-claim the one-shot rename slot at
-    /// creation time.
-    pub preserve_supplied_name: bool,
 }
 
 /// Result of a successful [`create`]. `default_session_id` is the chat
@@ -108,6 +101,29 @@ pub async fn create(
     hooks: &dyn OpsHooks,
     worktree_base: &Path,
     params: CreateParams<'_>,
+) -> Result<CreateOutput, OpsError> {
+    create_inner(db, hooks, worktree_base, params, false).await
+}
+
+/// Create a workspace while preserving the supplied display name and branch
+/// name after the first prompt. This is intended for script-driven callers
+/// such as the CLI and batch runner, where the provided name is a stable
+/// handle rather than a throwaway default.
+pub async fn create_preserving_supplied_name(
+    db: &mut Database,
+    hooks: &dyn OpsHooks,
+    worktree_base: &Path,
+    params: CreateParams<'_>,
+) -> Result<CreateOutput, OpsError> {
+    create_inner(db, hooks, worktree_base, params, true).await
+}
+
+async fn create_inner(
+    db: &mut Database,
+    hooks: &dyn OpsHooks,
+    worktree_base: &Path,
+    params: CreateParams<'_>,
+    preserve_supplied_name: bool,
 ) -> Result<CreateOutput, OpsError> {
     if !is_valid_workspace_name(params.name) {
         return Err(OpsError::Validation(format!(
@@ -195,7 +211,7 @@ pub async fn create(
         ws.sort_order = o;
     }
 
-    if params.preserve_supplied_name {
+    if preserve_supplied_name {
         db.claim_branch_auto_rename(&ws.id)?;
     }
 
@@ -817,7 +833,6 @@ mod tests {
                 repo_id: &repo.id,
                 name: "scratch",
                 branch_prefix: "test/",
-                preserve_supplied_name: false,
             },
         )
         .await
@@ -836,7 +851,7 @@ mod tests {
         let worktree_base = tempfile::tempdir().unwrap();
         let hooks = RecordingHooks::default();
 
-        let created = create(
+        let created = create_preserving_supplied_name(
             &mut db,
             &hooks,
             worktree_base.path(),
@@ -844,7 +859,6 @@ mod tests {
                 repo_id: &repo.id,
                 name: "agent-pipeline",
                 branch_prefix: "test/",
-                preserve_supplied_name: true,
             },
         )
         .await
@@ -877,7 +891,6 @@ mod tests {
                 repo_id: &repo.id,
                 name: "feature",
                 branch_prefix: "test/",
-                preserve_supplied_name: false,
             },
         )
         .await
@@ -925,7 +938,6 @@ mod tests {
                 repo_id: &repo.id,
                 name: "feature",
                 branch_prefix: "test/",
-                preserve_supplied_name: false,
             },
         )
         .await

--- a/src/ops/workspace.rs
+++ b/src/ops/workspace.rs
@@ -63,6 +63,13 @@ pub struct CreateParams<'a> {
     /// Branch prefix already resolved by the caller (e.g.
     /// `"jamesbrink/"`). Empty string is allowed.
     pub branch_prefix: &'a str,
+    /// Preserve the supplied workspace name/branch after the first prompt.
+    ///
+    /// GUI-created workspaces use the normal first-prompt auto-rename path.
+    /// CLI and batch callers pass an explicit script-facing name and need it
+    /// to remain stable, so they pre-claim the one-shot rename slot at
+    /// creation time.
+    pub preserve_supplied_name: bool,
 }
 
 /// Result of a successful [`create`]. `default_session_id` is the chat
@@ -186,6 +193,10 @@ pub async fn create(
     // of rendering at sort_order=0 until the next workspace-list reload.
     if let Ok(Some(o)) = db.lookup_workspace_sort_order(&ws.id) {
         ws.sort_order = o;
+    }
+
+    if params.preserve_supplied_name {
+        db.claim_branch_auto_rename(&ws.id)?;
     }
 
     let default_session_id = db
@@ -792,6 +803,62 @@ mod tests {
         (repo_dir, db_dir, db, repo)
     }
 
+    #[tokio::test]
+    async fn create_leaves_auto_rename_available_by_default() {
+        let (_repo_dir, _db_dir, mut db, repo) = setup_repo_and_db().await;
+        let worktree_base = tempfile::tempdir().unwrap();
+        let hooks = RecordingHooks::default();
+
+        let created = create(
+            &mut db,
+            &hooks,
+            worktree_base.path(),
+            CreateParams {
+                repo_id: &repo.id,
+                name: "scratch",
+                branch_prefix: "test/",
+                preserve_supplied_name: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !db.is_branch_auto_rename_claimed(&created.workspace.id)
+                .unwrap()
+        );
+        assert!(db.claim_branch_auto_rename(&created.workspace.id).unwrap());
+    }
+
+    #[tokio::test]
+    async fn create_can_preserve_supplied_name_by_claiming_auto_rename() {
+        let (_repo_dir, _db_dir, mut db, repo) = setup_repo_and_db().await;
+        let worktree_base = tempfile::tempdir().unwrap();
+        let hooks = RecordingHooks::default();
+
+        let created = create(
+            &mut db,
+            &hooks,
+            worktree_base.path(),
+            CreateParams {
+                repo_id: &repo.id,
+                name: "agent-pipeline",
+                branch_prefix: "test/",
+                preserve_supplied_name: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(created.workspace.name, "agent-pipeline");
+        assert_eq!(created.workspace.branch_name, "test/agent-pipeline");
+        assert!(
+            db.is_branch_auto_rename_claimed(&created.workspace.id)
+                .unwrap()
+        );
+        assert!(!db.claim_branch_auto_rename(&created.workspace.id).unwrap());
+    }
+
     /// Regression for the `claudette workspace archive --delete-branch`
     /// IPC flow: when the row is hard-deleted, the hook must announce
     /// `Deleted` (not `Archived`) so the frontend can `removeWorkspace`
@@ -810,6 +877,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "feature",
                 branch_prefix: "test/",
+                preserve_supplied_name: false,
             },
         )
         .await
@@ -857,6 +925,7 @@ mod tests {
                 repo_id: &repo.id,
                 name: "feature",
                 branch_prefix: "test/",
+                preserve_supplied_name: false,
             },
         )
         .await


### PR DESCRIPTION
## Summary

- add a `preserve_name` create-workspace IPC flag for script-driven workspace creation
- make `claudette workspace create` and `claudette batch run` preserve their supplied workspace names by pre-claiming the first-prompt auto-rename slot
- keep GUI and default remote workspace creation on the normal first-prompt auto-rename path
- add regression coverage for both default auto-rename eligibility and preserve-mode creation

## Root Cause

The first chat turn intentionally auto-renames a workspace and branch by claiming `branch_auto_rename_claimed`, but CLI-created workspaces pass explicit names that scripts expect to remain stable. The CLI used the same create path as the GUI without a way to opt out of that later auto-rename.

## Validation

- `nix develop -c cargo fmt --all --check`
- `nix develop -c cargo test -p claudette workspace::tests::create_ -- --nocapture`
- `nix develop -c cargo check -p claudette-cli -p claudette-server`
- `nix develop -c cargo check -p claudette-tauri --no-default-features --features tauri/custom-protocol,server`
- `nix develop -c cargo clippy -p claudette -p claudette-cli -p claudette-server --all-targets -- -D warnings`
- `nix develop -c bash -lc 'cd src/ui && bun run build'`