### PR TITLE
fix: prevent thinking hotkey overlap

### DIFF
--- a/src/ui/src/components/chat/composer/ReasoningPill.module.css
+++ b/src/ui/src/components/chat/composer/ReasoningPill.module.css
@@ -63,6 +63,18 @@
   line-height: 1;
 }
 
+.shortcutContent {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition: opacity 0.5s ease;
+}
+
+.segment:has(.shortcutBadgeVisible) .shortcutContent {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
 .effortLabel {
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
@@ -99,6 +111,14 @@
   color: var(--text-muted);
   font-size: var(--fs-xs);
   font-family: var(--font-mono);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0s;
+}
+
+.shortcutBadgeVisible {
+  opacity: 1;
+  transition: opacity 0.5s ease;
 }
 
 /* ── Dropdown ── */

--- a/src/ui/src/components/chat/composer/ReasoningPill.tsx
+++ b/src/ui/src/components/chat/composer/ReasoningPill.tsx
@@ -99,11 +99,16 @@ export function ReasoningPill({ sessionId, disabled }: ReasoningPillProps) {
           aria-expanded={dropdownOpen}
           aria-label="Reasoning settings"
         >
-          <Brain size={14} />
-          <span className={styles.segmentLabel}>Thinking</span>
-          {metaKeyHeld && (
-            <kbd className={styles.shortcutBadge} aria-hidden="true">{mod}T</kbd>
-          )}
+          <span className={styles.shortcutContent}>
+            <Brain size={14} />
+            <span className={styles.segmentLabel}>Thinking</span>
+          </span>
+          <kbd
+            className={`${styles.shortcutBadge} ${metaKeyHeld ? styles.shortcutBadgeVisible : ""}`}
+            aria-hidden="true"
+          >
+            {mod}T
+          </kbd>
         </button>
 
         <span className={styles.divider} />


### PR DESCRIPTION
## Summary
- Prevent the ReasoningPill thinking shortcut badge from rendering over the visible Thinking label/icon.
- Keep the shortcut badge mounted and crossfade the pill content out while the modifier key is held.

## Validation
- cd src/ui && bun run lint:css
- cd src/ui && bunx tsc -b