### PR TITLE
docs: add Copilot repository instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# Claudette Repository Instructions
+
+Claudette is a cross-platform desktop orchestrator for parallel Claude Code agents. It uses a Tauri 2 Rust backend, a React/TypeScript frontend, SQLite via rusqlite, Tokio process management, git worktrees, xterm.js terminals, Lua plugins, and a local CLI that talks to the running GUI over IPC.
+
+Follow the existing architecture. Core behavior belongs in the `claudette` crate under `src/`. `src-tauri/src/commands/` should stay thin Tauri wrappers. Shared data types belong in `src/model/` and must derive `Serialize`. Frontend state lives in Zustand slices under `src/ui/src/stores/slices/`, not ad hoc globals.
+
+Treat regressions as the main risk. Before changing behavior, identify the current contract: persisted DB fields, Tauri command payloads, CLI output, plugin manifests, settings keys, localized strings, terminal/session semantics, worktree behavior, and visible UI workflows. Do not remove, rename, or silently reinterpret any of these unless the task explicitly asks for that change.
+
+If a behavior change is intentional, call it out plainly in the PR summary or review response and add/update tests that pin the new behavior. If the change was incidental, preserve compatibility instead.
+
+Do not fix type, lint, or test failures by deleting tests, removing UI controls, dropping state fields, weakening assertions, or broadening types. Fix the underlying mismatch and keep existing user-visible capabilities intact.
+
+Control god files. Do not make already-large files the default destination for new behavior. Prefer a focused module, helper, slice, hook, or component near the owning feature, then wire it through the existing entry point. Be especially cautious with `src/diff.rs`, `src/git.rs`, `src/plugin.rs`, `src/mcp.rs`, `src/mcp_supervisor.rs`, `src-tauri/src/commands/*`, `src-tauri/src/voice.rs`, `src-tauri/src/ipc.rs`, `src/ui/src/components/sidebar/Sidebar.tsx`, `src/ui/src/components/chat/ChatPanel.tsx`, `src/ui/src/components/chat/ChatInputArea.tsx`, `src/ui/src/components/terminal/TerminalPanel.tsx`, `src/ui/src/services/tauri.ts`, and large CSS modules.
+
+When touching a god file, keep the diff surgical or extract cohesive behavior first. New code should reduce or isolate complexity, not add another unrelated responsibility.
+
+Use the repo's tools. Rust CI expects `cargo fmt --all --check`, `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` with `RUSTFLAGS=-Dwarnings`, and `cargo test --all-features`. Frontend CI expects `cd src/ui && bun install --frozen-lockfile`, `bunx tsc --noEmit`, `bun run lint:css`, `bun run build`, and `bun run test`.
+
+Always run `cd src/ui && bunx tsc -b` after TypeScript changes. Vitest uses esbuild and does not type-check the project.
+
+Never edit, rename, or delete released SQL migrations under `src/migrations/*.sql`. Add a new forward migration and register it in `src/migrations/mod.rs`.
+
+Use `bun`, not npm. Keep TypeScript strict and avoid `any`. Keep Rust cross-platform with explicit `#[cfg(...)]` gates for OS-specific code.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "src/ui/**/*.ts,src/ui/**/*.tsx,src/ui/**/*.css"
+---
+
+Frontend code is React, TypeScript strict mode, Zustand, CSS modules, Vite, Bun, and Vitest. Do not use `any`; read the actual type definitions before constructing fixtures or Tauri payloads.
+
+State belongs in the existing Zustand slices under `src/ui/src/stores/slices/`. Add or update a domain slice instead of growing component-local state that must survive navigation, workspace switching, or event replay.
+
+Keep large components from becoming god files. Before adding substantial logic to `Sidebar.tsx`, `ChatPanel.tsx`, `ChatInputArea.tsx`, `TerminalPanel.tsx`, settings sections, or large CSS modules, prefer a focused child component, hook, pure helper, or testable logic module in the same feature folder.
+
+Preserve established workflows and UI affordances. Treat removed buttons, changed keyboard behavior, lost selection, broken scrolling, altered terminal sizing, dropped context-menu actions, changed tab/session ordering, and missing loading/error states as regressions unless explicitly requested.
+
+Use existing service wrappers in `src/ui/src/services/` for Tauri IPC. Keep command names and payload shapes aligned with Rust models and commands. Do not bypass typed wrappers for one-off `invoke` calls when a service module owns the domain.
+
+All colors outside `src/ui/src/styles/theme.css` must use CSS custom properties, usually `var(--token-name)` or `rgba(var(--token-rgb), alpha)`. Do not add raw hex/rgb/rgba literals to components or CSS modules.
+
+Prefer logic tests for behavior-heavy UI. Put pure behavior in helpers when possible and cover it with Vitest. For TypeScript changes, run `cd src/ui && bunx tsc -b`; test passing alone is not enough.
+
+Do not update `bun.lock` unless dependency changes are intentional. Use Bun commands, not npm or yarn.

--- a/.github/instructions/regression-review.instructions.md
+++ b/.github/instructions/regression-review.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "**"
+---
+
+When reviewing or generating a PR, explicitly look for regressions before style issues. Ask: what existing user workflow, persisted value, IPC contract, CLI command, plugin API, terminal behavior, worktree operation, or localization path could this change break?
+
+Flag any intended behavior change clearly. A PR that changes semantics should say so in the summary or UAT plan and should include tests for the new contract. Silent behavior changes are defects, even when the new behavior looks reasonable.
+
+Check for accidental clobbering from agent work: unrelated file rewrites, deleted tests, loosened assertions, dropped translation keys, removed settings, renamed command fields, changed sort order, changed default values, and UI controls that vanish while nearby code is being refactored.
+
+Prefer additive compatibility for persisted data and public-ish contracts. Existing databases, settings rows, plugin manifests, CLI output, Tauri command parameters, and saved workspace/session state should keep working across upgrades.
+
+Every non-trivial fix should include the narrowest test that would have failed before the fix. If tests are impractical, the PR should include a concrete manual UAT checklist with the exact workflow and expected result.
+
+For large-file edits, verify the change is local to the requested feature. If a god file grew because new behavior was added, consider whether a helper module, child component, store slice, or service function would better preserve ownership and reduce future regression risk.

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "**/*.rs"
+---
+
+Rust code uses edition 2024, default rustfmt, and clippy with warnings denied in CI. Prefer clear ownership, explicit error handling, and small focused modules over large multi-purpose functions.
+
+Keep crate boundaries intact. Business logic belongs in the `claudette` crate under `src/`. Tauri command files should parse inputs, open state/resources, call core services, and return serializable results. Do not move durable logic into the webview or into Tauri wrappers just because the caller is UI-driven.
+
+Model types belong in `src/model/`, should be IO-free, and should derive `Serialize`. Database code should open fresh rusqlite connections per command because `Connection` is not `Send`.
+
+For migrations, create a new timestamped SQL file and add a `Migration` entry. Do not modify released migration SQL. Prefer additive, forward-only migrations and include `IF NOT EXISTS` where appropriate.
+
+For process, git, terminal, MCP, plugin, workspace, and agent changes, preserve current lifecycle semantics unless the task explicitly changes them: cancellation, cleanup, event ordering, worktree branch state, persisted session state, and streaming message chronology are regression-sensitive.
+
+When adding backend behavior, add focused tests close to the changed module. Use `tempfile::tempdir()` for git repos and transient DBs. Use `#[tokio::test]` for async behavior.
+
+Avoid expanding god files. If adding a separate concern to `src/diff.rs`, `src/git.rs`, `src/plugin.rs`, `src/mcp.rs`, `src/mcp_supervisor.rs`, `src-tauri/src/ipc.rs`, `src-tauri/src/voice.rs`, or a large command file, extract a helper module or domain file and keep the entry point as orchestration.
+
+Gate OS-specific code with `#[cfg(windows)]`, `#[cfg(unix)]`, `#[cfg(target_os = "macos")]`, or matching negative cfgs. Do not assume Unix paths or shells in cross-platform code.


### PR DESCRIPTION
## Linked Issue

N/A

## Summary

- Add repository-wide Copilot instructions for Claudette architecture and workflow expectations.
- Add scoped Rust and frontend instructions for ownership boundaries, testing, and large-file discipline.
- Add regression-review instructions that require intentional behavior changes to be called out and tested.

## Screenshots

N/A

## UAT Plan

- [x] Confirmed instruction files use GitHub Copilot supported paths and frontmatter.
- [x] Confirmed each instruction file is under Copilot code review's 4,000-character read limit.

## Checklist

- [x] CI passes (tests, clippy, fmt, tsc -b) - Markdown-only change; not run locally.
- [x] New or updated tests cover the changed behaviour - N/A, documentation-only.
- [x] Documentation updated if public behaviour changed - N/A.
- [x] PR title follows conventional commit format.