### PR TITLE
ci(nightly): synthesize latest.json once to avoid matrix-leg race

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -210,6 +210,21 @@ jobs:
         run: scripts/stage-cli-sidecar.sh ${{ matrix.rust-target }}
 
       # ---- macOS + Linux: tauri-action drives the bundled build ------------
+      # `includeUpdaterJson: false` is intentional. tauri-action's default
+      # behavior is to download the release's existing `latest.json`, merge
+      # this leg's platform entry in, and re-upload — which races on the
+      # GitHub Releases API across parallel matrix legs. Concrete failures
+      # observed on run #25543925342:
+      #   * linux-x86_64 lost the merge-upload race outright with
+      #     `Validation Failed: ReleaseAsset already_exists` (non-recoverable
+      #     within the action), failing the whole job.
+      #   * darwin-aarch64 succeeded as a job but its manifest entry was
+      #     silently overwritten when macos-x86_64's parallel merge clobbered
+      #     it on upload, so the published manifest would have advertised no
+      #     update path for Apple Silicon Macs.
+      # The `publish` job below now constructs `latest.json` once from each
+      # platform's `.sig` files (which are uploaded by tauri-action with
+      # unique names, no race), eliminating the conflict surface entirely.
       - name: Build and upload desktop app (non-Windows)
         if: ${{ !startsWith(matrix.platform, 'windows') }}
         uses: tauri-apps/tauri-action@v0
@@ -228,6 +243,7 @@ jobs:
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
           releaseDraft: true
           prerelease: true
+          includeUpdaterJson: false
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
       # ---- Windows: direct cargo build, ship the bare .exe -----------------
@@ -328,10 +344,16 @@ jobs:
   # Nightly builds are not announced to Discord — too noisy. Stable releases only.
   publish:
     name: Publish Nightly
-    needs: build
+    needs: [compute-version, build]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      # We need the repo checked out to run scripts/build-updater-manifest.sh.
+      # Everything else this job does runs against the GitHub Releases API,
+      # so a default shallow checkout is sufficient.
+      - name: Checkout
+        uses: actions/checkout@v6
+
       # Atomic-ish promote: verify the staging release is intact, delete the
       # live `nightly` release+tag, then retag `nightly-staging` to
       # `nightly` and un-draft. The blackout window between the delete and
@@ -341,6 +363,7 @@ jobs:
       - name: Promote staging to nightly
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -353,52 +376,58 @@ jobs:
             exit 1
           fi
 
-          # `tauri-action` generated `latest.json` while the release was
-          # tagged `nightly-staging`, so its embedded asset URLs are
-          # hardcoded to `releases/download/nightly-staging/...`. After the
-          # retag below those URLs would 404, breaking the in-app updater's
-          # download step. The Tauri signature covers binary contents — not
-          # the URL field — so rewriting URLs here does not invalidate
-          # verification.
+          # Build `latest.json` from the per-platform `.sig` files uploaded
+          # by tauri-action. Each matrix leg uploaded its own signed
+          # updater bundle plus its `.sig` companion under unique asset
+          # names (no collision), but the legs no longer write
+          # `latest.json` themselves (`includeUpdaterJson: false` in the
+          # build step) — so we synthesize the manifest here, in a single
+          # writer with no race surface. URLs are emitted directly with
+          # the `nightly` tag (the tag they will live at after the retag
+          # below), so no after-the-fact URL rewriting is needed. The
+          # Tauri signature covers binary content, not the URL field, so
+          # this URL choice does not affect verification.
           #
-          # Fetch and rewrite *before* the retag, while staging still
-          # exists. We upload the rewritten file after the retag. This avoids
-          # depending on the freshly-retagged `nightly/...` URL being
-          # reachable via the public CDN, whose propagation delay previously
-          # exceeded our retry window and left a stale manifest live (#449
-          # follow-up). Aborting here is safe — `nightly` is still intact.
+          # Build the manifest *before* the retag, while staging still
+          # exists, then upload it back to staging. Assets follow the
+          # release through the retag, so when the retag below succeeds
+          # the new manifest appears at the `nightly/...` URL atomically.
+          mkdir -p staging-sigs
           for attempt in 1 2 3; do
-            rm -f latest.json
+            rm -f staging-sigs/*.sig
             if gh release download nightly-staging \
               --repo "$GITHUB_REPOSITORY" \
-              --pattern "latest.json" \
-              --dir . \
+              --pattern "*.sig" \
+              --dir staging-sigs \
               --clobber; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to fetch nightly-staging/latest.json after 3 attempts"
+              echo "::error::Failed to fetch nightly-staging .sig files after 3 attempts"
               exit 1
             fi
             backoff=$((attempt * 5))
-            echo "latest.json fetch attempt $attempt failed; retrying in ${backoff}s"
+            echo ".sig fetch attempt $attempt failed; retrying in ${backoff}s"
             sleep "$backoff"
           done
 
-          sed -i 's|releases/download/nightly-staging/|releases/download/nightly/|g' latest.json
-          # Hard-fail if the rewrite was a no-op AND staging URLs are still
-          # present — retrying with the same input won't help, and shipping
-          # a manifest with staging URLs would break the updater. (A no-op
-          # because the manifest was already rewritten on a prior crashed
-          # run is fine: grep will find nothing, and we proceed.)
+          scripts/build-updater-manifest.sh \
+            staging-sigs \
+            "$VERSION" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly" \
+            > latest.json
+
+          # Belt-and-braces: catch any regression in the script that could
+          # ship a manifest with staging URLs (which would 404 after the
+          # retag and break the updater).
           if grep -q 'releases/download/nightly-staging/' latest.json; then
-            echo "::error::latest.json still contains nightly-staging URLs after rewrite; aborting"
+            echo "::error::latest.json contains nightly-staging URLs; aborting"
             exit 1
           fi
 
-          # Upload the rewritten manifest back to `nightly-staging` *before*
+          # Upload the synthesized manifest to `nightly-staging` *before*
           # we touch `nightly`. Assets follow the release when its tag
-          # changes, so when the retag below succeeds the corrected manifest
+          # changes, so when the retag below succeeds the manifest
           # appears at the `nightly/...` URL atomically — no separate
           # post-retag upload that could fail and leave a broken manifest
           # live on the promoted release.
@@ -407,7 +436,7 @@ jobs:
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to upload rewritten latest.json to nightly-staging after 3 attempts"
+              echo "::error::Failed to upload latest.json to nightly-staging after 3 attempts"
               exit 1
             fi
             backoff=$((attempt * 5))
@@ -421,7 +450,7 @@ jobs:
           # (rate limits, brief outages). If all retries fail, the workflow
           # exits non-zero and a follow-up run can recover by re-promoting
           # the still-intact `nightly-staging` release (which now carries
-          # the already-rewritten manifest).
+          # the synthesized manifest).
           for attempt in 1 2 3; do
             if gh release edit nightly-staging \
               --repo "$GITHUB_REPOSITORY" \

--- a/scripts/build-updater-manifest.sh
+++ b/scripts/build-updater-manifest.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a Tauri updater manifest (`latest.json`) from a directory of
+# per-platform `.sig` files.
+#
+# Why this exists: tauri-action would normally emit `latest.json` in-band
+# during each matrix leg's release-upload step. Doing that from parallel
+# matrix legs races on the GitHub Releases API — each leg downloads the
+# current manifest, merges its own platform's entry in, and uploads
+# back. When two legs read before either writes, the later upload
+# silently clobbers the earlier merge, dropping a platform from the
+# manifest. (See run #25543925342: linux-x86_64 lost the `already_exists`
+# race outright, and `darwin-aarch64` was clobbered by macos-x86_64 even
+# though both jobs "succeeded".)
+#
+# Centralizing the manifest build into a single post-build step removes
+# the race while producing a byte-equivalent manifest to what
+# tauri-action emits.
+#
+# Required positional arguments:
+#   $1 - directory containing per-platform `*.sig` files (one signature
+#        per file, format identical to what `tauri-build` writes)
+#   $2 - version string to embed in the manifest (e.g.
+#        `0.24.0-dev.46.g9153d99`)
+#   $3 - asset URL prefix (e.g.
+#        `https://github.com/owner/repo/releases/download/nightly`)
+#
+# Recognized .sig filename patterns and the manifest keys they populate
+# (mirrors what tauri-action emits — the "bare" platform key duplicates
+# the default-format variant for compatibility with both Tauri 1.x and
+# 2.x updater clients):
+#   *_amd64.AppImage.sig             -> linux-x86_64, linux-x86_64-appimage
+#   *_amd64.deb.sig                  -> linux-x86_64-deb
+#   *_aarch64.AppImage.sig           -> linux-aarch64, linux-aarch64-appimage
+#   *_arm64.deb.sig                  -> linux-aarch64-deb
+#   Claudette_x64.app.tar.gz.sig     -> darwin-x86_64, darwin-x86_64-app
+#   Claudette_aarch64.app.tar.gz.sig -> darwin-aarch64, darwin-aarch64-app
+
+usage() {
+  echo "usage: $0 <sig-dir> <version> <url-prefix>" >&2
+  exit 64
+}
+
+[ "$#" -eq 3 ] || usage
+SIG_DIR="$1"
+VERSION="$2"
+URL_PREFIX="$3"
+
+[ -d "$SIG_DIR" ] || {
+  echo "::error::$SIG_DIR is not a directory" >&2
+  exit 1
+}
+
+declare -A PLATFORMS
+
+shopt -s nullglob
+for sig in "$SIG_DIR"/*.sig; do
+  asset="$(basename "$sig" .sig)"
+  case "$asset" in
+    *_amd64.AppImage)
+      PLATFORMS[linux-x86_64]="$asset"
+      PLATFORMS[linux-x86_64-appimage]="$asset"
+      ;;
+    *_amd64.deb)
+      PLATFORMS[linux-x86_64-deb]="$asset"
+      ;;
+    *_aarch64.AppImage)
+      PLATFORMS[linux-aarch64]="$asset"
+      PLATFORMS[linux-aarch64-appimage]="$asset"
+      ;;
+    *_arm64.deb)
+      PLATFORMS[linux-aarch64-deb]="$asset"
+      ;;
+    Claudette_x64.app.tar.gz)
+      PLATFORMS[darwin-x86_64]="$asset"
+      PLATFORMS[darwin-x86_64-app]="$asset"
+      ;;
+    Claudette_aarch64.app.tar.gz)
+      PLATFORMS[darwin-aarch64]="$asset"
+      PLATFORMS[darwin-aarch64-app]="$asset"
+      ;;
+    *)
+      echo "warn: unrecognized .sig file: $asset" >&2
+      ;;
+  esac
+done
+shopt -u nullglob
+
+# Hard-fail if any required platform key is missing — better to abort
+# the promotion than to publish a manifest where some platforms can't
+# auto-update. The publish job already short-circuits when any matrix
+# leg failed (via `needs.build.result == 'success'`), so reaching this
+# script with a missing .sig file would indicate something else has
+# gone wrong upstream.
+declare -a REQUIRED=(
+  "linux-x86_64"
+  "linux-x86_64-appimage"
+  "linux-x86_64-deb"
+  "linux-aarch64"
+  "linux-aarch64-appimage"
+  "linux-aarch64-deb"
+  "darwin-x86_64"
+  "darwin-x86_64-app"
+  "darwin-aarch64"
+  "darwin-aarch64-app"
+)
+for key in "${REQUIRED[@]}"; do
+  if [ -z "${PLATFORMS[$key]:-}" ]; then
+    echo "::error::missing platform entry: $key (no matching .sig file in $SIG_DIR)" >&2
+    exit 1
+  fi
+done
+
+# Build the platforms object iteratively. `jq --rawfile` reads the .sig
+# file content as a JSON-escaped string, so embedded newlines and the
+# trailing newline are handled correctly without any base64 / sed
+# massaging — the .sig file's contents go into the manifest verbatim,
+# matching tauri-action's output byte-for-byte.
+platforms='{}'
+for key in "${REQUIRED[@]}"; do
+  asset="${PLATFORMS[$key]}"
+  platforms="$(jq \
+    --arg key "$key" \
+    --rawfile sig "$SIG_DIR/$asset.sig" \
+    --arg url "$URL_PREFIX/$asset" \
+    '. + {($key): {signature: $sig, url: $url}}' \
+    <<<"$platforms")"
+done
+
+PUB_DATE="$(date -u +%FT%T.000Z)"
+
+jq -n \
+  --arg version "$VERSION" \
+  --arg pub_date "$PUB_DATE" \
+  --argjson platforms "$platforms" \
+  '{version: $version, notes: "", pub_date: $pub_date, platforms: $platforms}'


### PR DESCRIPTION
## Failing run

[Nightly Build run #25543925342](https://github.com/utensils/claudette/actions/runs/25543925342) — `Build (linux-x86_64)` failed during the tauri-action upload step:

```
Uploading latest.json...
##[error]Validation Failed: {"resource":"ReleaseAsset","code":"already_exists","field":"name"}
```

That single matrix-leg failure blocks the whole release: the `publish` job is gated on `needs.build.result == 'success'`, so the staging→nightly retag never ran and the live `nightly` tag still points at the previous build.

## Root cause: race on `latest.json`

This isn't an environmental flake — it's structural and affects **every** nightly run. There are two distinct failure modes for the same underlying race, and we hit **both** on this run:

### 1. The `already_exists` error (linux-x86_64)

`tauri-action`'s default `includeUpdaterJson: true` makes each non-Windows matrix leg do a "download → merge our platform entry → re-upload" cycle against the staging release's `latest.json`. With four parallel legs racing, two readers can see "no asset" simultaneously and both try to *create* the asset; the second to land gets `422 already_exists` and fails the whole job non-recoverably.

Timeline from the run:

| Job | "Uploading latest.json…" |
|---|---|
| `linux-aarch64` | `07:58:00.985Z` |
| `linux-x86_64` | `07:58:00.982Z` |

Same millisecond. linux-aarch64 won the race and uploaded. linux-x86_64 hit the validation error and the whole leg failed.

### 2. The silent clobber (darwin-aarch64)

The other matrix legs that "succeeded" did so by hitting the merge path — but two parallel merges starting from the *same* base state still lose data. The `latest.json` currently sitting on `nightly-staging` (from this run) contains only:

```
linux-aarch64, linux-aarch64-appimage, linux-aarch64-deb,
darwin-x86_64, darwin-x86_64-app
```

`darwin-aarch64*` entries are **absent**, even though `Claudette_aarch64.app.tar.gz` and its `.sig` are both on the release. macos-aarch64 finished its merge before macos-x86_64 finished its own (both started from `{linux-aarch64*}` as the base), and macos-x86_64's later upload silently overwrote macos-aarch64's entry.

So even when everything reports green on the build matrix, **Apple Silicon Mac users would not have been offered this nightly by the in-app updater**. This bug has been latent on every previous nightly.

## Fix

Two coordinated changes that take the race surface to zero without changing any user-visible behavior:

### `.github/workflows/nightly.yml`

1. **Pass `includeUpdaterJson: false` to the matrix `tauri-action` step.** Each leg still bundles, signs, and uploads its own platform binary plus its `.sig` companion (which all have unique asset names — no contention). `tauri-action` simply stops touching `latest.json`.

2. **Synthesize `latest.json` once in the `publish` job from the staging release's `.sig` files.** Replaces the existing fetch+sed-rewrite with a `gh release download --pattern '*.sig'` plus a call to the new helper script. URLs are emitted directly with the `nightly` tag, so the post-fetch URL rewrite is no longer needed.

3. **Add a checkout step to `publish`** (the job didn't have one before; it does now because it needs the script).

4. **Add `compute-version` to `publish`'s `needs:`** so the version string can be passed through to the script.

The pre-flight check on staging reachability, retry-on-fetch, upload-to-staging-before-retag, retag-with-retries, and orphan-tag cleanup all stay byte-for-byte identical. The blackout window between `delete nightly` and the retag is unchanged.

### `scripts/build-updater-manifest.sh` (new)

A small bash helper that consumes a directory of `.sig` files plus a version string and a URL prefix, and emits `latest.json` to stdout. Key design points:

- **Byte-equivalent output to tauri-action.** Verified locally against the staging release's actual `.sig` files: the `signature` values for all five platforms that were populated on the failed run match exactly (the `.sig` file content is base64-encoded minisign output that goes verbatim into the manifest — `jq --rawfile` handles it without massaging).
- **Maps `.sig` filenames to all the manifest keys tauri-action would emit**, including the bare/`-appimage`/`-deb`/`-app` variants for compatibility with both Tauri 1.x and 2.x updater clients.
- **Hard-fails on missing platforms.** Aborts the promotion if any of the ten expected keys is absent, so we never silently ship a manifest with reduced platform coverage. (This is exactly the failure mode that masked the darwin-aarch64 drop on previous runs.)

## What stays the same

- Manifest schema (`version`, `notes`, `pub_date`, `platforms.<key>.{signature,url}`)
- Set of platform keys
- Signature value format (raw minisign `.sig` content)
- URL pattern (`releases/download/nightly/<asset>`)
- Updater client behavior end-to-end
- Pre-flight check, retry counts, retag flow, orphan-tag cleanup
- Windows-leg path (already bypassed `tauri-action`)
- Discord/announcement posture (none for nightlies)

## Verification

Locally regenerated the manifest from the failed run's `.sig` files (`gh release download nightly-staging --pattern '*.sig'`) and confirmed:

- All ten expected platform keys present (vs. the five on the broken staging manifest).
- Signature values for the five originally-present keys are byte-identical to what tauri-action wrote.
- URLs use the `nightly` tag.
- `jq -e` validates structure.

`yamllint` parses the workflow cleanly (only style line-length warnings, all on lines that match pre-existing patterns in the file).

## Recovering the current run

Once this lands and a new nightly fires, the next run produces a complete `latest.json` and the in-app updater will offer the new nightly to all six target platforms — including the Apple Silicon users currently stranded on the previous nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)