### PR TITLE
feat(chat): redesign CLI invocation banner as collapsible structured chip

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1220,7 +1220,10 @@ export function ChatPanel() {
         )}
         <ScrollContext.Provider value={scrollContextValue}>
         <div className={styles.messages} ref={messagesContainerRef}>
-          <CliInvocationBanner invocation={cliInvocation} />
+          <CliInvocationBanner
+            invocation={cliInvocation}
+            sessionId={activeChatSessionRecord?.id}
+          />
           {messages.length === 0 && !hasStreaming ? (
             <div className={styles.empty}>
               Send a message to start a conversation

--- a/src/ui/src/components/chat/CliInvocationBanner.module.css
+++ b/src/ui/src/components/chat/CliInvocationBanner.module.css
@@ -1,19 +1,198 @@
 .banner {
-  margin: 8px 0 12px 0;
+  margin: 6px 0 14px 0;
+  border: 1px solid var(--divider);
+  background: var(--sidebar-bg);
+  border-radius: var(--radius-lg);
   font-size: var(--fs-sm);
+  overflow: hidden;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease;
 }
 
-.codeBlock {
+.banner:hover {
+  border-color: rgba(var(--accent-primary-rgb), 0.35);
+}
+
+.expanded {
+  border-color: rgba(var(--accent-primary-rgb), 0.35);
+  background: var(--chat-input-bg);
+}
+
+/* ── Header (always visible — collapsed pill) ── */
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px 8px 8px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--fs-sm);
+  text-align: left;
+}
+
+.header:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+  border-radius: var(--radius-lg);
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  transition: transform 140ms ease;
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+  color: var(--accent-primary);
+}
+
+.binaryIcon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.summary {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.copyButton {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.copyButton:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+/* ── Expanded body ── */
+
+.body {
+  padding: 4px 12px 12px 30px;
+  border-top: 1px dashed var(--divider);
+  font-family: var(--font-mono);
+  /* Match existing design language: fade in expanded content rather than
+     a hard pop. Keeps the banner feeling like a single surface. */
+  animation: cliBannerReveal 140ms ease-out;
+}
+
+@keyframes cliBannerReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.binaryRow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 0 6px;
+  border-bottom: 1px dashed var(--divider);
+  margin-bottom: 6px;
+}
+
+.binaryName {
+  color: var(--accent-primary);
+  font-weight: 500;
+}
+
+.binaryPath {
+  color: var(--text-faint);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.flagList {
+  list-style: none;
+  padding: 0;
   margin: 0;
-  padding: 8px 12px;
-  background: var(--sidebar-bg);
-  border: 1px solid var(--sidebar-border);
-  border-radius: var(--radius-md);
-  overflow-x: auto;
+  display: grid;
+  /* `auto` for the flag name column lets all rows align on the value
+     column so values form a clean vertical band even with varying flag
+     name lengths. minmax(0, 1fr) lets long values truncate instead of
+     overflowing the card. */
+  grid-template-columns: max-content minmax(0, 1fr);
+  column-gap: 18px;
+  row-gap: 2px;
+}
+
+.flagRow {
+  display: contents;
+}
+
+.flagRow > .flagName,
+.flagRow > .flagValue,
+.flagRow > .positionalLabel {
+  padding: 2px 0;
+}
+
+.flagName {
+  color: var(--accent-primary);
   white-space: nowrap;
 }
 
-.code {
-  font-family: var(--font-mono);
+.flagValue {
   color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.flagValueRedacted {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+/* Empty value cell for boolean flags. Renders nothing visually but reserves
+   the grid column so flags after a boolean stay aligned. */
+.flagValueEmpty::before {
+  content: "";
+}
+
+.flagRowPositional > .positionalLabel {
+  color: var(--text-dim);
+  font-style: italic;
+  white-space: nowrap;
+}
+
+.flagRowPositional > .flagValue {
+  color: var(--text-muted);
+  font-style: italic;
 }

--- a/src/ui/src/components/chat/CliInvocationBanner.module.css
+++ b/src/ui/src/components/chat/CliInvocationBanner.module.css
@@ -21,12 +21,24 @@
 
 /* ── Header (always visible — collapsed pill) ── */
 
+/* Non-interactive flex container with two sibling buttons (toggle + copy)
+   so we don't nest <button> elements — see CliInvocationBanner.tsx for
+   the rationale. */
 .header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
   width: 100%;
-  padding: 8px 10px 8px 8px;
+  padding: 4px 6px 4px 4px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  padding: 4px 6px;
   background: transparent;
   border: 0;
   cursor: pointer;
@@ -34,12 +46,12 @@
   font-family: inherit;
   font-size: var(--fs-sm);
   text-align: left;
+  border-radius: var(--radius-md);
 }
 
-.header:focus-visible {
+.toggle:focus-visible {
   outline: 2px solid var(--accent-primary);
   outline-offset: -2px;
-  border-radius: var(--radius-lg);
 }
 
 .chevron {
@@ -65,10 +77,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
-}
-
-.spacer {
-  flex: 1;
 }
 
 .copyButton {

--- a/src/ui/src/components/chat/CliInvocationBanner.tsx
+++ b/src/ui/src/components/chat/CliInvocationBanner.tsx
@@ -1,24 +1,165 @@
-import { CodeBlock } from "./CodeBlock";
-import { shouldShowBanner } from "./cliInvocationBannerLogic";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronRight, Terminal } from "lucide-react";
+import { CopyButton } from "../shared/CopyButton";
+import {
+  parseInvocation,
+  shouldShowBanner,
+  summarizeInvocation,
+} from "./cliInvocationBannerLogic";
 import styles from "./CliInvocationBanner.module.css";
 
 interface Props {
+  /** The redacted shell-quoted invocation persisted on the chat session. */
   invocation: string | null;
+  /**
+   * Stable identifier for this banner instance. Used to scope expand/collapse
+   * state to a single chat session — switching tabs should not bleed the
+   * previous tab's expanded state across.
+   */
+  sessionId?: string;
 }
 
 /**
  * The literal `claude` invocation that started this session, redacted of
  * sensitive flag values and with the prompt positional replaced by
- * `<prompt>`. Pinned above the message list so it's always the first block
- * in the tab.
+ * `<prompt>`. Pinned above the message list as the first block in the tab.
+ *
+ * Renders as a compact chip by default that expands on click into a
+ * structured per-flag list. Per-session state lives in `sessionStorage` so
+ * the user's last expand choice survives a refresh but doesn't bleed across
+ * unrelated chat tabs.
  */
-export function CliInvocationBanner({ invocation }: Props) {
-  if (!shouldShowBanner(invocation)) return null;
+export function CliInvocationBanner({ invocation, sessionId }: Props) {
+  const { t } = useTranslation("chat");
+  const storageKey = sessionId
+    ? `claudette.cliInvocationBanner.expanded:${sessionId}`
+    : null;
+
+  const [expanded, setExpanded] = useState<boolean>(() => {
+    if (!storageKey) return false;
+    try {
+      return sessionStorage.getItem(storageKey) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  const parsed = useMemo(
+    () => (invocation ? parseInvocation(invocation) : null),
+    [invocation],
+  );
+
+  const summary = useMemo(
+    () => (parsed ? summarizeInvocation(parsed) : ""),
+    [parsed],
+  );
+
+  const handleToggle = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev;
+      if (storageKey) {
+        try {
+          sessionStorage.setItem(storageKey, next ? "1" : "0");
+        } catch {
+          /* ignore quota / privacy errors */
+        }
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  const copySource = useCallback(() => parsed?.raw ?? null, [parsed]);
+
+  if (!shouldShowBanner(invocation) || !parsed) return null;
+
   return (
-    <div className={styles.banner}>
-      <CodeBlock className={styles.codeBlock}>
-        <code className={styles.code}>{invocation}</code>
-      </CodeBlock>
+    <div
+      className={`${styles.banner} ${expanded ? styles.expanded : ""}`}
+      data-testid="cli-invocation-banner"
+    >
+      <button
+        type="button"
+        className={styles.header}
+        onClick={handleToggle}
+        aria-expanded={expanded}
+        aria-controls={
+          storageKey ? `${storageKey}-body` : "cli-invocation-banner-body"
+        }
+        title={
+          expanded
+            ? t("cli_invocation_collapse")
+            : t("cli_invocation_expand")
+        }
+      >
+        <ChevronRight
+          size={14}
+          className={`${styles.chevron} ${expanded ? styles.chevronOpen : ""}`}
+          aria-hidden
+        />
+        <Terminal size={13} className={styles.binaryIcon} aria-hidden />
+        <span className={styles.summary}>{summary}</span>
+        <span className={styles.spacer} />
+        <CopyButton
+          variant="bare"
+          className={styles.copyButton}
+          source={copySource}
+          tooltip={{
+            copy: t("cli_invocation_copy"),
+            copied: t("cli_invocation_copied"),
+          }}
+          ariaLabel={t("cli_invocation_copy")}
+          stopPropagation
+        />
+      </button>
+
+      {expanded && (
+        <div
+          id={
+            storageKey ? `${storageKey}-body` : "cli-invocation-banner-body"
+          }
+          className={styles.body}
+        >
+          <div className={styles.binaryRow}>
+            <span className={styles.binaryName}>{parsed.binary}</span>
+            {parsed.binaryFullPath !== parsed.binary && (
+              <span
+                className={styles.binaryPath}
+                title={parsed.binaryFullPath}
+              >
+                {parsed.binaryFullPath}
+              </span>
+            )}
+          </div>
+          <ul className={styles.flagList}>
+            {parsed.flags.map((flag, i) => (
+              <li key={`${flag.name}-${i}`} className={styles.flagRow}>
+                <span className={styles.flagName}>{flag.name}</span>
+                {/* Always emit the value cell, even when null. With
+                    `display: contents` rows, a missing cell would let the
+                    next flag's name slide into this row's value column —
+                    breaking column alignment for every following row. */}
+                <span
+                  className={`${styles.flagValue} ${flag.value === "<redacted>" ? styles.flagValueRedacted : ""} ${flag.value === null ? styles.flagValueEmpty : ""}`}
+                  aria-hidden={flag.value === null}
+                >
+                  {flag.value ?? ""}
+                </span>
+              </li>
+            ))}
+            {parsed.prompt && (
+              <li
+                className={`${styles.flagRow} ${styles.flagRowPositional}`}
+              >
+                <span className={styles.positionalLabel}>
+                  {t("cli_invocation_prompt_label")}
+                </span>
+                <span className={styles.flagValue}>{parsed.prompt}</span>
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/src/components/chat/CliInvocationBanner.tsx
+++ b/src/ui/src/components/chat/CliInvocationBanner.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronRight, Terminal } from "lucide-react";
 import { CopyButton } from "../shared/CopyButton";
@@ -45,6 +45,23 @@ export function CliInvocationBanner({ invocation, sessionId }: Props) {
     }
   });
 
+  // `useState`'s lazy initializer only runs on first mount. When the user
+  // switches chat tabs, ChatPanel keeps the banner mounted and just hands
+  // it a new `sessionId` — without this resync the previous tab's expand
+  // state would bleed over until the user toggled. Per-session state must
+  // really be per-session.
+  useEffect(() => {
+    if (!storageKey) {
+      setExpanded(false);
+      return;
+    }
+    try {
+      setExpanded(sessionStorage.getItem(storageKey) === "1");
+    } catch {
+      setExpanded(false);
+    }
+  }, [storageKey]);
+
   const parsed = useMemo(
     () => (invocation ? parseInvocation(invocation) : null),
     [invocation],
@@ -78,28 +95,34 @@ export function CliInvocationBanner({ invocation, sessionId }: Props) {
       className={`${styles.banner} ${expanded ? styles.expanded : ""}`}
       data-testid="cli-invocation-banner"
     >
-      <button
-        type="button"
-        className={styles.header}
-        onClick={handleToggle}
-        aria-expanded={expanded}
-        aria-controls={
-          storageKey ? `${storageKey}-body` : "cli-invocation-banner-body"
-        }
-        title={
-          expanded
-            ? t("cli_invocation_collapse")
-            : t("cli_invocation_expand")
-        }
-      >
-        <ChevronRight
-          size={14}
-          className={`${styles.chevron} ${expanded ? styles.chevronOpen : ""}`}
-          aria-hidden
-        />
-        <Terminal size={13} className={styles.binaryIcon} aria-hidden />
-        <span className={styles.summary}>{summary}</span>
-        <span className={styles.spacer} />
+      {/* Header is a non-interactive container with two sibling buttons.
+          Nesting <button>s (toggle around CopyButton) is invalid HTML and
+          breaks keyboard / screen-reader behavior — see the discussion in
+          the PR review. The toggle button takes the wide left region; the
+          copy button is its own click target on the right. */}
+      <div className={styles.header}>
+        <button
+          type="button"
+          className={styles.toggle}
+          onClick={handleToggle}
+          aria-expanded={expanded}
+          aria-controls={
+            storageKey ? `${storageKey}-body` : "cli-invocation-banner-body"
+          }
+          title={
+            expanded
+              ? t("cli_invocation_collapse")
+              : t("cli_invocation_expand")
+          }
+        >
+          <ChevronRight
+            size={14}
+            className={`${styles.chevron} ${expanded ? styles.chevronOpen : ""}`}
+            aria-hidden
+          />
+          <Terminal size={13} className={styles.binaryIcon} aria-hidden />
+          <span className={styles.summary}>{summary}</span>
+        </button>
         <CopyButton
           variant="bare"
           className={styles.copyButton}
@@ -111,7 +134,7 @@ export function CliInvocationBanner({ invocation, sessionId }: Props) {
           ariaLabel={t("cli_invocation_copy")}
           stopPropagation
         />
-      </button>
+      </div>
 
       {expanded && (
         <div

--- a/src/ui/src/components/chat/cliInvocationBannerLogic.test.ts
+++ b/src/ui/src/components/chat/cliInvocationBannerLogic.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { shouldShowBanner } from "./cliInvocationBannerLogic";
+import {
+  parseInvocation,
+  shouldShowBanner,
+  summarizeInvocation,
+  tokenizeShellLine,
+  truncateMiddle,
+} from "./cliInvocationBannerLogic";
 
 describe("shouldShowBanner", () => {
   it("returns false when invocation is null", () => {
@@ -18,5 +24,155 @@ describe("shouldShowBanner", () => {
     expect(
       shouldShowBanner("/bin/claude --print --session-id abc <prompt>"),
     ).toBe(true);
+  });
+});
+
+describe("tokenizeShellLine", () => {
+  it("splits on whitespace", () => {
+    expect(tokenizeShellLine("a b  c\td")).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("preserves single-quoted strings verbatim", () => {
+    expect(tokenizeShellLine("a 'b c' d")).toEqual(["a", "b c", "d"]);
+  });
+
+  it("preserves double-quoted strings", () => {
+    expect(tokenizeShellLine('a "b c" d')).toEqual(["a", "b c", "d"]);
+  });
+
+  it("decodes backslash-escaped chars inside double quotes", () => {
+    expect(tokenizeShellLine('"a\\"b" c')).toEqual(['a"b', "c"]);
+  });
+
+  it("handles empty quoted token", () => {
+    expect(tokenizeShellLine('a "" b')).toEqual(["a", "", "b"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(tokenizeShellLine("")).toEqual([]);
+  });
+});
+
+describe("parseInvocation", () => {
+  it("returns null for empty input", () => {
+    expect(parseInvocation("")).toBeNull();
+  });
+
+  it("derives binary name from the last path segment", () => {
+    const parsed = parseInvocation("/Users/jb/.local/bin/claude --print");
+    expect(parsed?.binary).toBe("claude");
+    expect(parsed?.binaryFullPath).toBe("/Users/jb/.local/bin/claude");
+  });
+
+  it("groups --flag value pairs", () => {
+    const parsed = parseInvocation(
+      "/bin/claude --model opus --session-id abc-123 <prompt>",
+    );
+    expect(parsed?.flags).toEqual([
+      { name: "--model", value: "opus" },
+      { name: "--session-id", value: "abc-123" },
+    ]);
+    expect(parsed?.prompt).toBe("<prompt>");
+  });
+
+  it("identifies boolean flags (no value before next flag)", () => {
+    const parsed = parseInvocation(
+      "/bin/claude --print --verbose --model opus",
+    );
+    expect(parsed?.flags).toEqual([
+      { name: "--print", value: null },
+      { name: "--verbose", value: null },
+      { name: "--model", value: "opus" },
+    ]);
+    expect(parsed?.prompt).toBeNull();
+  });
+
+  it("splits inline --flag=value form", () => {
+    const parsed = parseInvocation("/bin/claude --output-format=stream-json");
+    expect(parsed?.flags).toEqual([
+      { name: "--output-format", value: "stream-json" },
+    ]);
+  });
+
+  it("preserves the original raw string for copy", () => {
+    const raw = "/bin/claude --model opus <prompt>";
+    expect(parseInvocation(raw)?.raw).toBe(raw);
+  });
+
+  it("captures redacted values as the flag value", () => {
+    const parsed = parseInvocation(
+      "/bin/claude --mcp-config <redacted> --print",
+    );
+    expect(parsed?.flags).toEqual([
+      { name: "--mcp-config", value: "<redacted>" },
+      { name: "--print", value: null },
+    ]);
+  });
+
+  it("matches the real invocation shape from the screenshot", () => {
+    const parsed = parseInvocation(
+      "/Users/jamesbrink/.local/bin/claude --print --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --session-id 9cde1d6d-6c9b-48df-9765-5c8bcf522919 --model opus <prompt>",
+    );
+    expect(parsed?.binary).toBe("claude");
+    expect(parsed?.flags.map((f) => f.name)).toEqual([
+      "--print",
+      "--output-format",
+      "--input-format",
+      "--verbose",
+      "--include-partial-messages",
+      "--permission-prompt-tool",
+      "--session-id",
+      "--model",
+    ]);
+    expect(parsed?.prompt).toBe("<prompt>");
+  });
+});
+
+describe("truncateMiddle", () => {
+  it("passes short values through", () => {
+    expect(truncateMiddle("opus")).toBe("opus");
+  });
+
+  it("inserts ellipsis with default head/tail", () => {
+    expect(truncateMiddle("9cde1d6d-6c9b-48df-9765-5c8bcf522919")).toBe(
+      "9cde…2919",
+    );
+  });
+});
+
+describe("summarizeInvocation", () => {
+  // These cases pin the contract for the user-implemented summary line.
+  // Whatever shape the contributor picks, the result must:
+  //   - start with the binary's display name
+  //   - never include the redacted positional `<prompt>`
+  //   - never include sensitive `<redacted>` values verbatim
+  //   - stay reasonably short (< 80 chars on a typical invocation)
+  it("starts with the binary display name", () => {
+    const parsed = parseInvocation(
+      "/Users/jb/.local/bin/claude --print --model opus",
+    )!;
+    const summary = summarizeInvocation(parsed);
+    expect(summary.startsWith("claude")).toBe(true);
+  });
+
+  it("never leaks the <prompt> placeholder", () => {
+    const parsed = parseInvocation(
+      "/bin/claude --model opus <prompt>",
+    )!;
+    expect(summarizeInvocation(parsed)).not.toContain("<prompt>");
+  });
+
+  it("never leaks raw <redacted> bodies", () => {
+    const parsed = parseInvocation(
+      "/bin/claude --mcp-config <redacted> --model opus",
+    )!;
+    expect(summarizeInvocation(parsed)).not.toContain("<redacted>");
+  });
+
+  it("stays short on a realistic invocation", () => {
+    const parsed = parseInvocation(
+      "/Users/jamesbrink/.local/bin/claude --print --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --session-id 9cde1d6d-6c9b-48df-9765-5c8bcf522919 --model opus <prompt>",
+    )!;
+    expect(summarizeInvocation(parsed).length).toBeLessThan(80);
   });
 });

--- a/src/ui/src/components/chat/cliInvocationBannerLogic.test.ts
+++ b/src/ui/src/components/chat/cliInvocationBannerLogic.test.ts
@@ -48,6 +48,18 @@ describe("tokenizeShellLine", () => {
     expect(tokenizeShellLine('a "" b')).toEqual(["a", "", "b"]);
   });
 
+  it("decodes the backend's `'\\''` idiom to a literal single quote", () => {
+    // src/agent/args.rs::shell_quote closes the single-quote span, emits
+    // an escaped quote (`\'`), and reopens. The whole thing must round-trip
+    // back to a single token containing a literal `'`.
+    expect(tokenizeShellLine("'O'\\''Reilly'")).toEqual(["O'Reilly"]);
+  });
+
+  it("treats a bare `\\x` outside quotes as the literal `x`", () => {
+    expect(tokenizeShellLine("\\'")).toEqual(["'"]);
+    expect(tokenizeShellLine("a\\ b")).toEqual(["a b"]);
+  });
+
   it("returns empty array for empty input", () => {
     expect(tokenizeShellLine("")).toEqual([]);
   });

--- a/src/ui/src/components/chat/cliInvocationBannerLogic.ts
+++ b/src/ui/src/components/chat/cliInvocationBannerLogic.ts
@@ -1,3 +1,208 @@
+/**
+ * Pure logic for the in-chat CLI invocation banner.
+ *
+ * The Rust side (see `src/agent/args.rs::format_redacted_invocation`) emits a
+ * single line of POSIX-shell-quoted argv. We tokenize that line, identify the
+ * binary path, group flags with their (optional) values, and locate the
+ * trailing `<prompt>` placeholder. The structured form lets the banner render
+ * each flag on its own row instead of as one ugly horizontally-scrolling pre.
+ */
+
+export interface ParsedFlag {
+  /** The flag name including its leading dashes — e.g. `--model`. */
+  name: string;
+  /** Value following the flag, or null for boolean / standalone flags. */
+  value: string | null;
+}
+
+export interface ParsedInvocation {
+  /** Display name of the binary (last path segment of the original argv[0]). */
+  binary: string;
+  /** Original, fully-qualified binary path as emitted by the backend. */
+  binaryFullPath: string;
+  /** Ordered flag list. */
+  flags: ParsedFlag[];
+  /** Trailing positional, typically `<prompt>` or null when absent. */
+  prompt: string | null;
+  /** The original raw invocation string, preserved verbatim for copy. */
+  raw: string;
+}
+
 export function shouldShowBanner(invocation: string | null): boolean {
   return typeof invocation === "string" && invocation.trim().length > 0;
+}
+
+/**
+ * POSIX-ish shell tokenizer. The backend only ever emits double-/single-quoted
+ * strings or unquoted bare words (see `shell_quote` in `src/agent/args.rs`),
+ * so we don't need to handle environment expansion, command substitution, or
+ * here-docs. We do honor backslash-escapes inside double quotes and
+ * `'\''`-style literal-quote sequences inside single quotes since that's what
+ * the backend emits when an argv contains a `'`.
+ */
+export function tokenizeShellLine(line: string): string[] {
+  const tokens: string[] = [];
+  let buf = "";
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let hasContent = false;
+
+  const pushToken = () => {
+    if (hasContent) {
+      tokens.push(buf);
+      buf = "";
+      hasContent = false;
+    }
+  };
+
+  while (i < line.length) {
+    const ch = line[i];
+
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+        i += 1;
+        continue;
+      }
+      buf += ch;
+      hasContent = true;
+      i += 1;
+      continue;
+    }
+
+    if (inDouble) {
+      if (ch === "\\" && i + 1 < line.length) {
+        const next = line[i + 1];
+        if (next === '"' || next === "\\" || next === "$" || next === "`") {
+          buf += next;
+        } else {
+          buf += ch + next;
+        }
+        hasContent = true;
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        inDouble = false;
+        i += 1;
+        continue;
+      }
+      buf += ch;
+      hasContent = true;
+      i += 1;
+      continue;
+    }
+
+    if (ch === " " || ch === "\t") {
+      pushToken();
+      i += 1;
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      hasContent = true;
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      hasContent = true;
+      i += 1;
+      continue;
+    }
+    buf += ch;
+    hasContent = true;
+    i += 1;
+  }
+  pushToken();
+  return tokens;
+}
+
+function looksLikeFlag(token: string): boolean {
+  return token.startsWith("-") && token !== "-";
+}
+
+function basename(path: string): string {
+  // Handle both POSIX and Windows-style separators because dev users live
+  // on both. Strip a trailing separator before basename so `C:/foo/` →
+  // `foo`, not empty string.
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
+
+/**
+ * Parse a redacted invocation string into its structured form. Returns null
+ * when the line is unusable (no binary token).
+ */
+export function parseInvocation(invocation: string): ParsedInvocation | null {
+  const tokens = tokenizeShellLine(invocation);
+  if (tokens.length === 0) return null;
+
+  const binaryFullPath = tokens[0];
+  const binary = basename(binaryFullPath) || binaryFullPath;
+
+  const flags: ParsedFlag[] = [];
+  let prompt: string | null = null;
+
+  let i = 1;
+  while (i < tokens.length) {
+    const token = tokens[i];
+
+    // Trailing `<prompt>` marker (or any non-flag positional) closes the list.
+    if (!looksLikeFlag(token)) {
+      // Only the very last token is a positional in well-formed input. If
+      // there are tokens after a non-flag, treat them as additional
+      // positionals concatenated into `prompt` so we don't silently drop them.
+      const rest = tokens.slice(i).join(" ");
+      prompt = rest;
+      break;
+    }
+
+    // Inline `--flag=value` form — split on the first `=`.
+    const eq = token.indexOf("=");
+    if (token.startsWith("--") && eq > 2) {
+      flags.push({ name: token.slice(0, eq), value: token.slice(eq + 1) });
+      i += 1;
+      continue;
+    }
+
+    const next = i + 1 < tokens.length ? tokens[i + 1] : null;
+    if (next !== null && !looksLikeFlag(next)) {
+      // Look one more ahead: if the token after `next` is also non-flag and
+      // we're at the tail, `next` was a value and the tail is the prompt.
+      flags.push({ name: token, value: next });
+      i += 2;
+      continue;
+    }
+    // Boolean flag (or last token) — no value.
+    flags.push({ name: token, value: null });
+    i += 1;
+  }
+
+  return { binary, binaryFullPath, flags, prompt, raw: invocation };
+}
+
+/**
+ * Truncate a long opaque value (UUID, hash, path) to a head…tail form so the
+ * collapsed banner stays scannable. Short values pass through untouched.
+ */
+export function truncateMiddle(value: string, head = 4, tail = 4): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * Build the one-line summary shown in the collapsed banner.
+ *
+ * TODO(user contribution): see `cliInvocationBannerLogic.test.ts` for the
+ * cases this needs to satisfy. The shape is up to you — see the prompt for
+ * trade-offs.
+ */
+export function summarizeInvocation(parsed: ParsedInvocation): string {
+  // Placeholder fallback so the component renders something sensible until
+  // the user defines this. Counts non-prompt flags only.
+  const flagCount = parsed.flags.length;
+  return `${parsed.binary} · ${flagCount} flag${flagCount === 1 ? "" : "s"}`;
 }

--- a/src/ui/src/components/chat/cliInvocationBannerLogic.ts
+++ b/src/ui/src/components/chat/cliInvocationBannerLogic.ts
@@ -36,9 +36,11 @@ export function shouldShowBanner(invocation: string | null): boolean {
  * POSIX-ish shell tokenizer. The backend only ever emits double-/single-quoted
  * strings or unquoted bare words (see `shell_quote` in `src/agent/args.rs`),
  * so we don't need to handle environment expansion, command substitution, or
- * here-docs. We do honor backslash-escapes inside double quotes and
- * `'\''`-style literal-quote sequences inside single quotes since that's what
- * the backend emits when an argv contains a `'`.
+ * here-docs. We do honor backslash-escapes inside double quotes, and the
+ * `'\''` idiom the Rust backend emits to embed a literal single quote inside
+ * a single-quoted span — which decomposes to "close single quote, escaped
+ * single quote, open single quote" and only round-trips correctly if `\'`
+ * outside quotes is treated as a literal `'` (POSIX semantics).
  */
 export function tokenizeShellLine(line: string): string[] {
   const tokens: string[] = [];
@@ -109,6 +111,17 @@ export function tokenizeShellLine(line: string): string[] {
       inDouble = true;
       hasContent = true;
       i += 1;
+      continue;
+    }
+    if (ch === "\\" && i + 1 < line.length) {
+      // POSIX: outside quotes, backslash escapes the following character to
+      // its literal value. Critically, this is what makes the backend's
+      // `'\''` idiom round-trip correctly: the close-quote/escape-quote/
+      // open-quote sandwich emits a literal `'` between two single-quoted
+      // spans that get concatenated into a single token.
+      buf += line[i + 1];
+      hasContent = true;
+      i += 2;
       continue;
     }
     buf += ch;

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -116,6 +116,12 @@
   "message_copied": "Copied",
   "attachment_close_lightbox": "Close image preview",
 
+  "cli_invocation_expand": "Show full claude command",
+  "cli_invocation_collapse": "Hide claude command",
+  "cli_invocation_copy": "Copy claude command",
+  "cli_invocation_copied": "Copied",
+  "cli_invocation_prompt_label": "prompt",
+
   "mcp_unknown_error": "unknown",
 
   "diff_loading": "Loading diff...",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -115,6 +115,12 @@
   "message_copied": "Copiado",
   "attachment_close_lightbox": "Cerrar vista previa de imagen",
 
+  "cli_invocation_expand": "Mostrar comando claude completo",
+  "cli_invocation_collapse": "Ocultar comando claude",
+  "cli_invocation_copy": "Copiar comando claude",
+  "cli_invocation_copied": "Copiado",
+  "cli_invocation_prompt_label": "prompt",
+
   "mcp_unknown_error": "desconocido",
 
   "diff_loading": "Cargando diff...",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -113,6 +113,12 @@
   "code_block_copied": "コピーしました",
   "attachment_close_lightbox": "画像プレビューを閉じる",
 
+  "cli_invocation_expand": "claude コマンド全体を表示",
+  "cli_invocation_collapse": "claude コマンドを隠す",
+  "cli_invocation_copy": "claude コマンドをコピー",
+  "cli_invocation_copied": "コピーしました",
+  "cli_invocation_prompt_label": "プロンプト",
+
   "mcp_unknown_error": "不明",
 
   "diff_loading": "差分を読み込み中...",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -115,6 +115,12 @@
   "message_copied": "Copiado",
   "attachment_close_lightbox": "Fechar visualização da imagem",
 
+  "cli_invocation_expand": "Mostrar comando claude completo",
+  "cli_invocation_collapse": "Ocultar comando claude",
+  "cli_invocation_copy": "Copiar comando claude",
+  "cli_invocation_copied": "Copiado",
+  "cli_invocation_prompt_label": "prompt",
+
   "mcp_unknown_error": "desconhecido",
 
   "diff_loading": "Carregando diff...",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -113,6 +113,12 @@
   "code_block_copied": "已复制",
   "attachment_close_lightbox": "关闭图片预览",
 
+  "cli_invocation_expand": "显示完整 claude 命令",
+  "cli_invocation_collapse": "隐藏 claude 命令",
+  "cli_invocation_copy": "复制 claude 命令",
+  "cli_invocation_copied": "已复制",
+  "cli_invocation_prompt_label": "提示",
+
   "mcp_unknown_error": "未知",
 
   "diff_loading": "加载差异...",


### PR DESCRIPTION
## What

Replaces the single-line horizontally-scrolling pre block at the top of every chat tab with a chip-style banner that summarizes the invocation when collapsed and expands to a column-aligned per-flag list on click.

## Before / After

**Before** — one long horizontally-scrolling line, no structure, no copy affordance, full binary path always visible:

```
/Users/jamesbrink/.local/bin/claude --print --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --session-id 9cde1d6d-6c9b-48df-9765-5c8bcf522919 --model opus --mcp-conf…
```

**After (collapsed):**

```
▸ ⌨ claude · 12 flags                                              ⧉
```

**After (expanded):** binary name + faint full path on the first row, then a 2-column grid of flag names and values, with redacted values rendered in muted italic.

## Why

The previous banner read as raw terminal dump — visually noisy, no hierarchy, no copy button, and only the first ~120 chars were visible without horizontal scrolling. The new banner stays out of the way by default and reveals structure on demand.

## Implementation notes

- **Collapsed by default.** Per-session expand state lives in `sessionStorage` keyed by `sessionId` — it survives a refresh but doesn't bleed across tabs or bloat the Zustand store.
- **POSIX-aware tokenizer.** `tokenizeShellLine` honors single/double quotes and backslash escapes (matching what `src/agent/args.rs::shell_quote` emits). Splitting on whitespace alone would break paths-with-spaces.
- **Structured parser.** `parseInvocation` walks tokens to produce `{ binary, flags, prompt }`, recognizing `--flag=value`, `--flag value`, and boolean-flag forms.
- **Empty value cells.** Boolean flags emit an empty grid cell so the 2-column `display: contents` layout stays aligned across rows. (An earlier draft conditionally rendered the value cell, which let subsequent flag names slide into the value column — that's fixed.)
- **Redaction is unchanged.** `src/agent/args.rs::REDACTED_VALUE_FLAGS` (`--mcp-config`, `--settings`, `--append-system-prompt`, `--system-prompt`, `--agents`, `--betas`, `--json-schema`) already replaces sensitive values with `<redacted>` before persistence. The banner renders what's stored — no new redaction surface area.
- **Summary line is a placeholder.** `summarizeInvocation` currently returns `"${binary} · N flags"`. It's pinned by contract tests (must start with binary, never leak `<prompt>` or `<redacted>`, stay under ~80 chars) so future iterations can reshape the summary without breaking callers.

## i18n

5 new chat-namespace keys (`cli_invocation_expand`, `_collapse`, `_copy`, `_copied`, `_prompt_label`) translated across all five locales (en, es, ja, pt-BR, zh-CN).

## Tests

- 24 logic tests covering tokenizer edge cases (quoted strings, escapes, empty input), parser shapes (`--flag=value`, boolean flags, redacted values, the real screenshot invocation), `truncateMiddle`, and the `summarizeInvocation` contract.
- All 1473 existing tests still pass.
- Type check (`bunx tsc -b`), `bun run lint`, `bun run lint:css` clean.

## Out of scope

The companion `ClaudeFlagsSettings` / `ClaudeFlagRow` UI was prototyped in this branch but reverted before commit — the existing layout deserves a different rethink (semantic grouping or quick-toggle/all-flags split) rather than the card-row polish I tried first. Tracking separately.