### PR TITLE
fix(fork): restore conversation context across forks

### DIFF
--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -192,6 +192,22 @@ fn should_resume_persistent_session(
     !saved_session_id.trim().is_empty() && (has_persisted_claude_session || saved_turn_count > 1)
 }
 
+/// Resolve the session id to launch claude with, given whether we intend to
+/// resume the saved session or start fresh. When `is_resume` is false we MUST
+/// generate a fresh UUID — passing `--session-id <existing-saved-sid>` to
+/// `claude` (without `--resume`) tells the CLI to *create* a new session at
+/// that id, which silently nukes the prior transcript stored under that id
+/// and leaves the agent with no conversational context. The respawn path
+/// previously skipped this branch and reused `saved_session_id` regardless,
+/// which is the bug `respawn_uses_fresh_sid_when_not_resuming` pins.
+fn resolve_spawn_session_id(saved_session_id: &str, is_resume: bool) -> String {
+    if is_resume {
+        saved_session_id.to_string()
+    } else {
+        uuid::Uuid::new_v4().to_string()
+    }
+}
+
 fn terminal_text(text: &str) -> String {
     let normalized = text.replace("\r\n", "\n");
     let mut rendered = String::with_capacity(normalized.len());
@@ -1957,9 +1973,25 @@ pub async fn send_chat_message(
                     saved_turn_count,
                     has_persisted_claude_session,
                 );
+                // When `is_resume` is false we MUST NOT reuse `saved_session_id` —
+                // see the doc comment on `resolve_spawn_session_id`. The
+                // non-respawn branch below uses the same helper; keep them in
+                // lockstep so a subtle inconsistency between paths can't
+                // silently overwrite an existing JSONL again.
+                let spawn_sid = resolve_spawn_session_id(&saved_session_id, is_resume);
+                if !is_resume {
+                    // Mirror non-respawn line ~2030: persist the fresh sid in
+                    // memory before the spawn so the post-spawn save_chat_session_state
+                    // writes the right value back to the DB.
+                    let mut agents = state.agents.write().await;
+                    if let Some(session) = agents.get_mut(&chat_session_id) {
+                        session.session_id = spawn_sid.clone();
+                    }
+                    drop(agents);
+                }
                 let (ps, final_sid) = match start_persistent(
                     worktree_path.clone(),
-                    saved_session_id.clone(),
+                    spawn_sid.clone(),
                     is_resume,
                     allowed_tools.clone(),
                     custom_instructions.clone(),
@@ -1967,7 +1999,7 @@ pub async fn send_chat_message(
                 )
                 .await
                 {
-                    Ok(ps) => (ps, saved_session_id.clone()),
+                    Ok(ps) => (ps, spawn_sid.clone()),
                     Err(e2) if is_resume => {
                         eprintln!("[chat] --resume respawn failed ({e2}), starting fresh");
                         let fresh = uuid::Uuid::new_v4().to_string();
@@ -1983,7 +2015,23 @@ pub async fn send_chat_message(
                         (ps, fresh)
                     }
                     Err(e2) => {
+                        // Clear DB AND in-memory together — the sibling
+                        // failure path at ~line 2089 does both, and leaving
+                        // them out of sync left a window where the next turn
+                        // saw `has_persisted=false` but `saved_session_id`
+                        // non-empty, which made `should_resume` return false
+                        // and the respawn logic above launched
+                        // `claude --session-id <stale-sid>` (fresh session
+                        // pinned to an existing transcript id) instead of
+                        // either resuming or starting cleanly. Mirror the
+                        // sibling so the asymmetry can't reopen.
                         let _ = db.clear_chat_session_state(&chat_session_id);
+                        let mut agents = state.agents.write().await;
+                        if let Some(session) = agents.get_mut(&chat_session_id) {
+                            session.session_id = String::new();
+                            session.turn_count = 0;
+                        }
+                        drop(agents);
                         return Err(e2);
                     }
                 };
@@ -2023,13 +2071,14 @@ pub async fn send_chat_message(
             saved_turn_count,
             has_persisted_claude_session,
         );
-        let sid = if is_resume {
-            saved_session_id.clone()
-        } else {
-            let fresh = uuid::Uuid::new_v4().to_string();
-            session.session_id = fresh.clone();
-            fresh
-        };
+        // Lockstep with the respawn branch above (~line 1955) so both spawn
+        // paths agree on "fresh sid for fresh sessions, never reuse a saved
+        // sid without `--resume`". `resolve_spawn_session_id`'s doc comment
+        // has the consequence-of-mismatch.
+        let sid = resolve_spawn_session_id(&saved_session_id, is_resume);
+        if !is_resume {
+            session.session_id = sid.clone();
+        }
         // Drop lock before async process spawn.
         drop(agents);
 
@@ -3148,7 +3197,7 @@ mod tests {
     use super::{
         remote_control_requested_or_active, remote_control_requested_or_active_for_turn,
         remote_control_should_defer_drift_teardown_for_turn,
-        remote_control_should_restore_for_turn, remote_control_title,
+        remote_control_should_restore_for_turn, remote_control_title, resolve_spawn_session_id,
         should_defer_persistent_restart_for_state,
         should_reenable_remote_control_after_turn_result, should_resume_persistent_session,
         should_run_auto_naming, terminal_text,
@@ -3218,6 +3267,50 @@ mod tests {
         assert!(!should_resume_persistent_session("fresh-uuid", 1, false));
         assert!(should_resume_persistent_session("fresh-uuid", 2, false));
         assert!(!should_resume_persistent_session("", 9, true));
+    }
+
+    #[test]
+    fn respawn_uses_fresh_sid_when_not_resuming() {
+        // Regression pin for the agent-resume bug observed in test-breaking-ci:
+        // a respawn after a stdin-write failure was passing `saved_session_id`
+        // straight to `claude --session-id <saved>`, which Claude treats as
+        // "create a new session at this id" and silently nukes the prior
+        // transcript stored under that id. The right behaviour is to mint a
+        // fresh UUID whenever we cannot honour `--resume`. The non-respawn
+        // path at the bottom of `chat_send_persistent` already did this; the
+        // respawn path now uses the same helper.
+        let saved = "abc-prior-session";
+        let resumed = resolve_spawn_session_id(saved, true);
+        assert_eq!(resumed, saved, "resume must reuse the saved sid verbatim");
+
+        let fresh = resolve_spawn_session_id(saved, false);
+        assert_ne!(
+            fresh, saved,
+            "non-resume MUST mint a new uuid; reusing the saved sid pins claude to an existing transcript id"
+        );
+        assert!(
+            !fresh.is_empty(),
+            "fresh sid must be a real uuid the CLI can route by"
+        );
+        // The minted value must look like a uuid so `claude --session-id <it>`
+        // and downstream `~/.claude/projects/.../{sid}.jsonl` paths are
+        // well-formed. Hyphen count alone is enough to flag a regression
+        // where someone short-circuited to `String::new()` or similar.
+        assert_eq!(
+            fresh.matches('-').count(),
+            4,
+            "fresh sid must be uuid-shaped, got `{fresh}`"
+        );
+    }
+
+    #[test]
+    fn respawn_fresh_sids_do_not_collide_back_to_back() {
+        // Cheap belt-and-suspenders: two fresh mints in a row must differ.
+        // Catches accidental "same sid every call" regressions (e.g. a
+        // stub left in for tests that leaks into prod via a feature flag).
+        let a = resolve_spawn_session_id("saved", false);
+        let b = resolve_spawn_session_id("saved", false);
+        assert_ne!(a, b);
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -662,7 +662,12 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
 
         // Rewind: drop chat_sessions structures and remove the migration
-        // tracking row so re-running migrations will re-apply it.
+        // tracking row so re-running migrations will re-apply it. We also
+        // re-add the legacy `workspaces.session_id` / `workspaces.turn_count`
+        // columns (dropped by 20260508142050) and clear that migration's
+        // bookkeeping so its second run drops them again — this test
+        // specifically exercises the original chat_sessions backfill, which
+        // depends on the legacy columns being present at run time.
         db.execute_batch(
             "PRAGMA foreign_keys=OFF;
              DROP INDEX IF EXISTS idx_chat_messages_chat_session;
@@ -672,7 +677,10 @@ mod tests {
              ALTER TABLE chat_messages DROP COLUMN chat_session_id;
              ALTER TABLE conversation_checkpoints DROP COLUMN chat_session_id;
              DROP TABLE chat_sessions;
+             ALTER TABLE workspaces ADD COLUMN session_id TEXT;
+             ALTER TABLE workspaces ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0;
              DELETE FROM schema_migrations WHERE id = '20260422000000_chat_sessions';
+             DELETE FROM schema_migrations WHERE id = '20260508142050_drop_legacy_workspace_session_columns';
              PRAGMA foreign_keys=ON;",
         )
         .unwrap();

--- a/src/db/workspace.rs
+++ b/src/db/workspace.rs
@@ -196,48 +196,6 @@ impl Database {
         Ok(())
     }
 
-    /// Persist agent session state so it survives app restarts.
-    pub fn save_agent_session(
-        &self,
-        workspace_id: &str,
-        session_id: &str,
-        turn_count: u32,
-    ) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
-            "UPDATE workspaces SET session_id = ?1, turn_count = ?2 WHERE id = ?3",
-            params![session_id, turn_count, workspace_id],
-        )?;
-        Ok(())
-    }
-
-    /// Load persisted agent session state. Returns `(session_id, turn_count)`.
-    pub fn get_agent_session(
-        &self,
-        workspace_id: &str,
-    ) -> Result<Option<(String, u32)>, rusqlite::Error> {
-        self.conn
-            .query_row(
-                "SELECT session_id, turn_count FROM workspaces WHERE id = ?1",
-                params![workspace_id],
-                |row| {
-                    let sid: Option<String> = row.get(0)?;
-                    let tc: u32 = row.get(1)?;
-                    Ok(sid.map(|s| (s, tc)))
-                },
-            )
-            .optional()
-            .map(|opt| opt.flatten())
-    }
-
-    /// Clear persisted agent session (e.g. after a reset or failed init).
-    pub fn clear_agent_session(&self, workspace_id: &str) -> Result<(), rusqlite::Error> {
-        self.conn.execute(
-            "UPDATE workspaces SET session_id = NULL, turn_count = 0 WHERE id = ?1",
-            params![workspace_id],
-        )?;
-        Ok(())
-    }
-
     // --- Metrics: agent session lifecycle ---
 
     /// Record the start of an agent session. Idempotent (INSERT OR IGNORE) so
@@ -907,47 +865,10 @@ mod tests {
         assert!(workspaces.is_empty());
     }
 
-    // --- Agent session persistence tests ---
-
-    #[test]
-    fn test_save_and_get_agent_session() {
-        let db = setup_db_with_workspace();
-        db.save_agent_session("w1", "sess-abc", 3).unwrap();
-        let result = db.get_agent_session("w1").unwrap();
-        assert_eq!(result, Some(("sess-abc".into(), 3)));
-    }
-
-    #[test]
-    fn test_get_agent_session_returns_none_when_no_session() {
-        let db = setup_db_with_workspace();
-        let result = db.get_agent_session("w1").unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_get_agent_session_returns_none_for_missing_workspace() {
-        let db = Database::open_in_memory().unwrap();
-        let result = db.get_agent_session("nonexistent").unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_clear_agent_session() {
-        let db = setup_db_with_workspace();
-        db.save_agent_session("w1", "sess-abc", 5).unwrap();
-        db.clear_agent_session("w1").unwrap();
-        let result = db.get_agent_session("w1").unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_save_agent_session_overwrites() {
-        let db = setup_db_with_workspace();
-        db.save_agent_session("w1", "sess-1", 1).unwrap();
-        db.save_agent_session("w1", "sess-2", 4).unwrap();
-        let result = db.get_agent_session("w1").unwrap();
-        assert_eq!(result, Some(("sess-2".into(), 4)));
-    }
+    // --- Workspaces table no longer carries `session_id` / `turn_count`;
+    // those columns moved to `chat_sessions` in 20260422000000 and were
+    // dropped in 20260508142050. Per-session state tests live in
+    // `chat.rs` (see `test_save_chat_session_state_persists_session_id`).
 
     // --- Metrics capture tests ---
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -222,7 +222,35 @@ async fn fork_after_worktree(
     copy_history(db, &source_ws.id, &new_ws.id, checkpoint)?;
 
     let session_resumed = if let Some(src_wt) = source_ws.worktree_path.as_deref() {
-        copy_claude_session(db, &source_ws.id, &new_ws.id, src_wt, &actual_path)?
+        // The source's Claude CLI session id lives on the SOURCE chat
+        // session — the one this checkpoint was taken in — not on the
+        // workspace. Likewise the destination is the new workspace's
+        // default chat session, the same one `copy_history` populated.
+        let new_chat_session_id = db
+            .default_session_id_for_workspace(&new_ws.id)?
+            .ok_or_else(|| {
+                ForkError::InconsistentHistory(format!(
+                    "new workspace {} has no default session",
+                    new_ws.id
+                ))
+            })?;
+        let Some(projects_dir) = claude_projects_dir() else {
+            // No discoverable home directory — graceful skip, same as a
+            // missing transcript file. Fork still succeeds with a fresh
+            // Claude session.
+            return Ok(ForkOutcome {
+                workspace: new_ws,
+                session_resumed: false,
+            });
+        };
+        copy_claude_session(
+            db,
+            &checkpoint.chat_session_id,
+            &new_chat_session_id,
+            src_wt,
+            &actual_path,
+            &projects_dir,
+        )?
     } else {
         false
     };
@@ -400,26 +428,36 @@ fn copy_history(
 /// project directory to the new workspace's project directory, so the
 /// forked workspace can `--resume` from the same session history.
 ///
+/// Operates at the chat-session granularity: the source id is the chat
+/// session the chosen checkpoint was taken in, and the destination is the
+/// new workspace's default chat session (the one `copy_history` already
+/// populated). Pre-multi-session refactor this code worked at workspace
+/// granularity by reading `workspaces.session_id`; that column became dead
+/// when chat sessions arrived (20260422000000_chat_sessions), and the
+/// missed migration here is what made every fork start a fresh Claude
+/// session — see `test_fork_resumes_claude_session` for the regression pin.
+///
 /// Returns `true` if the transcript was found and copied (session id is
-/// persisted for the new workspace). Returns `false` if there was no
+/// persisted for the new chat session). Returns `false` if there was no
 /// session to resume — in that case the new workspace simply starts a
 /// fresh Claude session on its first turn, which is the intended graceful
 /// degradation rather than an error.
 fn copy_claude_session(
     db: &Database,
-    source_ws_id: &str,
-    new_ws_id: &str,
+    source_chat_session_id: &str,
+    new_chat_session_id: &str,
     source_worktree: &str,
     new_worktree: &str,
+    projects_dir: &Path,
 ) -> Result<bool, ForkError> {
-    let Some((session_id, turn_count)) = db.get_agent_session(source_ws_id)? else {
+    let Some(source_session) = db.get_chat_session(source_chat_session_id)? else {
         return Ok(false);
     };
+    let Some(session_id) = source_session.session_id else {
+        return Ok(false);
+    };
+    let turn_count = source_session.turn_count;
 
-    let Some(home) = dirs::home_dir() else {
-        return Ok(false);
-    };
-    let projects_dir = home.join(".claude").join("projects");
     let src_file = projects_dir
         .join(claude_project_slug(source_worktree))
         .join(format!("{session_id}.jsonl"));
@@ -431,17 +469,28 @@ fn copy_claude_session(
     let dest_file = dest_dir.join(format!("{session_id}.jsonl"));
     std::fs::copy(&src_file, &dest_file)?;
 
-    db.save_agent_session(new_ws_id, &session_id, turn_count)?;
+    db.save_chat_session_state(new_chat_session_id, &session_id, turn_count)?;
     Ok(true)
+}
+
+/// Resolve `~/.claude/projects` for the current user. Split out so tests can
+/// substitute a temp directory by calling [`copy_claude_session`] with an
+/// arbitrary projects dir.
+fn claude_projects_dir() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".claude").join("projects"))
 }
 
 /// Convert an absolute filesystem path to Claude CLI's project slug
 /// convention (used as the directory name under `~/.claude/projects/`).
 ///
-/// Claude CLI replaces path separators with `-` to form the slug. Handle
-/// both `/` and `\` so Windows paths produce the correct slug.
+/// Claude CLI replaces both path separators (`/`, `\`) AND `.` with `-`
+/// when building the slug, so a worktree under `~/.claudette/...`
+/// produces a directory like `-Users-...--claudette-...` (note the double
+/// dash from `/.`). Missing the `.` — as this function did originally —
+/// silently routes the JSONL copy at a non-existent directory and turns
+/// every fork into a fresh Claude session.
 fn claude_project_slug(path: &str) -> String {
-    path.replace(['/', '\\'], "-")
+    path.replace(['/', '\\', '.'], "-")
 }
 
 #[cfg(test)]
@@ -681,6 +730,263 @@ mod tests {
         assert_eq!(
             claude_project_slug("/Users/alice/projects/foo"),
             "-Users-alice-projects-foo"
+        );
+    }
+
+    #[test]
+    fn claude_project_slug_replaces_dots() {
+        // Regression pin for the second-order bug discovered during
+        // post-fix UAT: Claude CLI's slug replaces `.` with `-` too,
+        // which Claudette worktrees (under `~/.claudette/...`) hit
+        // unconditionally because of the leading dot in `.claudette`.
+        // Previously slugged to `-Users-alice-.claudette-...` which
+        // did not match the on-disk dir Claude CLI actually created.
+        assert_eq!(
+            claude_project_slug("/Users/alice/.claudette/workspaces/repo/ws"),
+            "-Users-alice--claudette-workspaces-repo-ws"
+        );
+        // Multiple dots collapse independently — `.local/.config/file`
+        // becomes `-local--config-file`. Mirrors Claude CLI behaviour
+        // observed on real `~/.claude/projects/` directory listings.
+        assert_eq!(
+            claude_project_slug("/.local/.config/file"),
+            "--local--config-file"
+        );
+    }
+
+    // --- copy_claude_session regression pins ---
+    //
+    // These cover the multi-session migration regression: prior to the fix,
+    // `copy_claude_session` read `workspaces.session_id` (a column that became
+    // permanently NULL when the multi-session refactor moved live state to
+    // `chat_sessions`). Every fork therefore returned `session_resumed: false`
+    // and the new workspace started a fresh Claude CLI session — losing the
+    // parent's conversational context. The bug looked like "the fork button
+    // is broken" because the user's next prompt to the fork came back with
+    // "I don't have context from a previous session".
+
+    /// Build a fake `~/.claude/projects/<slug>/<sid>.jsonl` so
+    /// `copy_claude_session` has something to copy. Returns the temp `home`
+    /// dir so the caller can keep it alive (TempDir cleans on drop).
+    fn write_fake_jsonl(
+        projects_dir: &Path,
+        worktree: &str,
+        session_id: &str,
+        body: &str,
+    ) -> std::path::PathBuf {
+        let dir = projects_dir.join(claude_project_slug(worktree));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{session_id}.jsonl"));
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn copy_claude_session_copies_jsonl_and_persists_per_chat_session_state() {
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w-src", "r1", "src"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w-fork", "r1", "src-fork"))
+            .unwrap();
+
+        // Source's chat session carries the live Claude CLI sid + turn count.
+        // Post multi-session refactor THIS is the source of truth — not
+        // `workspaces.session_id`, which is gone.
+        let src_sid = db
+            .default_session_id_for_workspace("w-src")
+            .unwrap()
+            .unwrap();
+        let dst_sid = db
+            .default_session_id_for_workspace("w-fork")
+            .unwrap()
+            .unwrap();
+        db.save_chat_session_state(&src_sid, "claude-sid-XYZ", 7)
+            .unwrap();
+
+        let projects = tempfile::tempdir().unwrap();
+        let src_wt = "/tmp/wt/src";
+        let new_wt = "/tmp/wt/src-fork";
+        write_fake_jsonl(projects.path(), src_wt, "claude-sid-XYZ", "{\"hi\":1}\n");
+
+        let resumed =
+            copy_claude_session(&db, &src_sid, &dst_sid, src_wt, new_wt, projects.path()).unwrap();
+        assert!(
+            resumed,
+            "expected session_resumed=true when source has a sid + jsonl"
+        );
+
+        // JSONL physically copied into the new worktree's project dir under
+        // the SAME session id (Claude CLI keys files by sid; resume reads it).
+        let copied = projects
+            .path()
+            .join(claude_project_slug(new_wt))
+            .join("claude-sid-XYZ.jsonl");
+        assert!(
+            copied.exists(),
+            "fork's jsonl missing at {}",
+            copied.display()
+        );
+        assert_eq!(std::fs::read_to_string(&copied).unwrap(), "{\"hi\":1}\n");
+
+        // The destination chat session inherits the parent's sid + turn count
+        // so the next agent run hits `claude --resume` with the right id.
+        let dst_session = db.get_chat_session(&dst_sid).unwrap().unwrap();
+        assert_eq!(dst_session.session_id.as_deref(), Some("claude-sid-XYZ"));
+        assert_eq!(dst_session.turn_count, 7);
+    }
+
+    #[test]
+    fn copy_claude_session_skips_when_source_has_no_session() {
+        // Graceful-degradation pin: a fork from a workspace that hasn't yet
+        // started a Claude session must still succeed — it just starts fresh.
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w-src", "r1", "src"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w-fork", "r1", "src-fork"))
+            .unwrap();
+        let src_sid = db
+            .default_session_id_for_workspace("w-src")
+            .unwrap()
+            .unwrap();
+        let dst_sid = db
+            .default_session_id_for_workspace("w-fork")
+            .unwrap()
+            .unwrap();
+        // No save_chat_session_state — source is fresh.
+
+        let projects = tempfile::tempdir().unwrap();
+        let resumed = copy_claude_session(
+            &db,
+            &src_sid,
+            &dst_sid,
+            "/tmp/wt/src",
+            "/tmp/wt/src-fork",
+            projects.path(),
+        )
+        .unwrap();
+        assert!(!resumed);
+        let dst_session = db.get_chat_session(&dst_sid).unwrap().unwrap();
+        assert!(dst_session.session_id.is_none());
+        assert_eq!(dst_session.turn_count, 0);
+    }
+
+    #[test]
+    fn copy_claude_session_handles_dot_dir_paths() {
+        // Regression pin: Claudette stores every worktree under
+        // `~/.claudette/...`. Pre-fix, the slug function only replaced
+        // path separators — so the `.` in `.claudette` survived and the
+        // computed source/dest paths missed the on-disk directory Claude
+        // CLI actually wrote, returning `Ok(false)` even when the
+        // transcript existed. End-to-end UAT caught this; that's exactly
+        // the path this test exercises.
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w-src", "r1", "src"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w-fork", "r1", "src-fork"))
+            .unwrap();
+        let src_sid = db
+            .default_session_id_for_workspace("w-src")
+            .unwrap()
+            .unwrap();
+        let dst_sid = db
+            .default_session_id_for_workspace("w-fork")
+            .unwrap()
+            .unwrap();
+        db.save_chat_session_state(&src_sid, "claude-sid-DOTS", 4)
+            .unwrap();
+
+        let projects = tempfile::tempdir().unwrap();
+        let src_wt = "/Users/alice/.claudette/workspaces/repo/src";
+        let new_wt = "/Users/alice/.claudette/workspaces/repo/src-fork";
+        write_fake_jsonl(projects.path(), src_wt, "claude-sid-DOTS", "X");
+
+        let resumed =
+            copy_claude_session(&db, &src_sid, &dst_sid, src_wt, new_wt, projects.path()).unwrap();
+        assert!(
+            resumed,
+            "fork must resume sessions for .claudette-style paths — slug must replace '.'"
+        );
+        let copied = projects
+            .path()
+            .join(claude_project_slug(new_wt))
+            .join("claude-sid-DOTS.jsonl");
+        assert!(copied.exists());
+        // The slug must have collapsed `/.claudette` → `--claudette`,
+        // matching Claude CLI's on-disk layout.
+        assert!(
+            copied
+                .to_string_lossy()
+                .contains("-Users-alice--claudette-workspaces-repo-src-fork"),
+            "slug missing `--claudette` collapse: {}",
+            copied.display()
+        );
+    }
+
+    #[test]
+    fn copy_claude_session_skips_when_jsonl_missing() {
+        // Regression pin: the source has a sid persisted in chat_sessions
+        // but the on-disk transcript was never written (e.g. the Claude
+        // process crashed before flushing). Don't error — start fresh.
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&make_repo("r1")).unwrap();
+        db.insert_workspace(&make_workspace("w-src", "r1", "src"))
+            .unwrap();
+        db.insert_workspace(&make_workspace("w-fork", "r1", "src-fork"))
+            .unwrap();
+        let src_sid = db
+            .default_session_id_for_workspace("w-src")
+            .unwrap()
+            .unwrap();
+        let dst_sid = db
+            .default_session_id_for_workspace("w-fork")
+            .unwrap()
+            .unwrap();
+        db.save_chat_session_state(&src_sid, "claude-sid-orphan", 2)
+            .unwrap();
+
+        let projects = tempfile::tempdir().unwrap();
+        // Note: no write_fake_jsonl — file is absent.
+        let resumed = copy_claude_session(
+            &db,
+            &src_sid,
+            &dst_sid,
+            "/tmp/wt/src",
+            "/tmp/wt/src-fork",
+            projects.path(),
+        )
+        .unwrap();
+        assert!(!resumed);
+        // Destination must NOT have inherited the orphan sid — the next
+        // turn would otherwise try (and fail) to --resume a phantom session.
+        let dst_session = db.get_chat_session(&dst_sid).unwrap().unwrap();
+        assert!(dst_session.session_id.is_none());
+    }
+
+    #[test]
+    fn workspaces_table_no_longer_carries_session_columns() {
+        // Schema-level pin: 20260508142050 dropped `session_id` and
+        // `turn_count` from `workspaces`. If a future migration accidentally
+        // re-adds them (or reverts the drop), this assertion catches it
+        // before the dead state can re-grow callers.
+        let db = Database::open_in_memory().unwrap();
+        let cols: Vec<String> = db
+            .conn()
+            .prepare("PRAGMA table_info(workspaces)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert!(
+            !cols.iter().any(|c| c == "session_id"),
+            "workspaces.session_id must stay dropped — live state lives on chat_sessions; cols={cols:?}"
+        );
+        assert!(
+            !cols.iter().any(|c| c == "turn_count"),
+            "workspaces.turn_count must stay dropped — live state lives on chat_sessions; cols={cols:?}"
         );
     }
 }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -22,6 +22,9 @@ use crate::model::{
     WorkspaceStatus,
 };
 use crate::snapshot;
+use crate::workspace_alloc::{
+    WorkspaceAllocation, WorkspaceAllocationError, allocate_workspace_name,
+};
 
 #[derive(Debug)]
 pub enum ForkError {
@@ -33,6 +36,10 @@ pub enum ForkError {
     SourceWorktreeMissing,
     /// A checkpoint/message mapping was missing during the copy.
     InconsistentHistory(String),
+    /// Could not find a non-colliding name/branch/path triple — every
+    /// `<source>-fork[-N]` candidate hits an existing workspace, branch,
+    /// git worktree, or on-disk dir. Bubbled up from `workspace_alloc`.
+    Allocation(WorkspaceAllocationError),
     Db(rusqlite::Error),
     Git(git::GitError),
     Snapshot(String),
@@ -50,6 +57,7 @@ impl std::fmt::Display for ForkError {
                 "Source workspace has no worktree on disk; cannot determine base ref for fork"
             ),
             Self::InconsistentHistory(msg) => write!(f, "Inconsistent history: {msg}"),
+            Self::Allocation(e) => write!(f, "Could not allocate fork name: {e}"),
             Self::Db(e) => write!(f, "Database error: {e}"),
             Self::Git(e) => write!(f, "Git error: {e:?}"),
             Self::Snapshot(msg) => write!(f, "Snapshot error: {msg}"),
@@ -75,6 +83,18 @@ impl From<git::GitError> for ForkError {
 impl From<std::io::Error> for ForkError {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
+    }
+}
+
+impl From<WorkspaceAllocationError> for ForkError {
+    fn from(e: WorkspaceAllocationError) -> Self {
+        // Allocation can fail with a wrapped GitError (when listing branches
+        // / worktrees) — collapse that into the existing Git arm so callers
+        // that already format ForkError::Git keep working unchanged.
+        match e {
+            WorkspaceAllocationError::Git(g) => Self::Git(g),
+            other => Self::Allocation(other),
+        }
     }
 }
 
@@ -146,13 +166,26 @@ pub async fn fork_workspace_at_checkpoint(
         git::head_commit(src_wt).await?
     };
 
-    let (new_name, new_branch_name) = allocate_name_and_branch(
-        db,
-        &source_ws.repository_id,
-        &source_ws.name,
+    // Reuse the GUI's name/branch/path allocator so a fork can never collide
+    // with an existing workspace, an existing git branch, an existing git
+    // worktree, OR an orphan directory under the worktree base. The fork's
+    // private dedupe used to live here and only checked DB workspace names,
+    // which let `git worktree add` later die with `'<path>' already exists`
+    // when an earlier fork's dir lingered on disk (e.g. archive without
+    // dir-cleanup, hard delete of the workspace row).
+    let workspaces = db.list_workspaces()?;
+    let WorkspaceAllocation {
+        name: new_name,
+        branch_name: new_branch_name,
+        worktree_path,
+    } = allocate_workspace_name(
+        &repo,
+        &workspaces,
+        &format!("{}-fork", source_ws.name),
         inputs.branch_prefix,
-    )?;
-    let worktree_path: PathBuf = inputs.worktree_base.join(&repo.path_slug).join(&new_name);
+        inputs.worktree_base,
+    )
+    .await?;
     let worktree_path_str = worktree_path.to_string_lossy().to_string();
 
     let actual_path =
@@ -261,37 +294,14 @@ async fn fork_after_worktree(
     })
 }
 
-/// Allocate a workspace name + branch name that do not collide with existing
-/// workspaces in the same repository. Appends `-fork`, then `-fork-2`, etc.
-fn allocate_name_and_branch(
-    db: &Database,
-    repo_id: &str,
-    source_name: &str,
-    branch_prefix: &str,
-) -> Result<(String, String), ForkError> {
-    let existing_names: std::collections::HashSet<String> = db
-        .list_workspaces()?
-        .into_iter()
-        .filter(|w| w.repository_id == repo_id)
-        .map(|w| w.name)
-        .collect();
-
-    let base = format!("{source_name}-fork");
-    let name = if !existing_names.contains(&base) {
-        base
-    } else {
-        let mut n = 2;
-        loop {
-            let candidate = format!("{source_name}-fork-{n}");
-            if !existing_names.contains(&candidate) {
-                break candidate;
-            }
-            n += 1;
-        }
-    };
-    let branch = format!("{branch_prefix}{name}");
-    Ok((name, branch))
-}
+// Name + branch + path allocation lives in `crate::workspace_alloc`, shared
+// with the GUI's "create workspace" path. Forking goes through the same helper
+// so it picks up all four collision protections (DB rows, DB branch names,
+// existing git branches, existing git worktrees, on-disk worktree directories)
+// uniformly. The fork's own dedupe used to live here and only checked DB
+// workspace names — leaving git-tracked refs and orphan dirs free to collide
+// later in `git worktree add`. See the regression pin
+// `fork_skips_orphan_worktree_dir_on_disk`.
 
 /// Copy chat messages, checkpoints and tool activities from the source
 /// workspace up to and including the checkpoint.
@@ -699,31 +709,20 @@ mod tests {
         assert_eq!(forked_cps[1].turn_index, 1);
     }
 
-    #[test]
-    fn allocate_name_suffixes_on_collision() {
-        let db = Database::open_in_memory().unwrap();
-        db.insert_repository(&make_repo("r1")).unwrap();
-        db.insert_workspace(&make_workspace("w1", "r1", "source"))
-            .unwrap();
-        db.insert_workspace(&make_workspace("w2", "r1", "source-fork"))
-            .unwrap();
-
-        let (name, branch) = allocate_name_and_branch(&db, "r1", "source", "pfx/").unwrap();
-        assert_eq!(name, "source-fork-2");
-        assert_eq!(branch, "pfx/source-fork-2");
-    }
-
-    #[test]
-    fn allocate_name_no_collision() {
-        let db = Database::open_in_memory().unwrap();
-        db.insert_repository(&make_repo("r1")).unwrap();
-        db.insert_workspace(&make_workspace("w1", "r1", "source"))
-            .unwrap();
-
-        let (name, branch) = allocate_name_and_branch(&db, "r1", "source", "").unwrap();
-        assert_eq!(name, "source-fork");
-        assert_eq!(branch, "source-fork");
-    }
+    // Fork's name/branch/path allocator now delegates to
+    // `claudette::workspace_alloc::allocate_workspace_name`, which has its
+    // own comprehensive collision tests in `workspace_alloc::tests`:
+    //
+    //   - `allocation_uses_base_name_when_available`        (no-collision)
+    //   - `allocation_suffixes_existing_workspace_name`     (DB workspace)
+    //   - `allocation_suffixes_existing_git_branch`         (git ref)
+    //   - `allocation_suffixes_existing_worktree_path_on_disk` (orphan dir)
+    //   - `allocation_ignores_same_name_in_other_repo`      (scoping)
+    //
+    // The fork-specific pin `fork_skips_orphan_worktree_dir_on_disk` below
+    // exercises the integration end-to-end (real git repo + DB + orphan
+    // dir) so a future regression that re-introduces a custom dedupe
+    // inside fork.rs still fails CI.
 
     #[test]
     fn claude_project_slug_replaces_separators() {
@@ -987,6 +986,181 @@ mod tests {
         assert!(
             !cols.iter().any(|c| c == "turn_count"),
             "workspaces.turn_count must stay dropped — live state lives on chat_sessions; cols={cols:?}"
+        );
+    }
+
+    // --- Fork allocator integration pin ---
+    //
+    // The bug this pins: forking a workspace whose ideal `<source>-fork` name
+    // collides with an orphan worktree directory on disk used to fail mid-
+    // flight with `git worktree add: '<path>' already exists`. Fork's private
+    // dedupe only checked DB workspace names; renames + hard-deletes leave
+    // stale dirs the DB no longer remembers. Fork now delegates to
+    // `workspace_alloc::allocate_workspace_name` — which checks all five
+    // collision sources — and this test pins the wiring end-to-end so a
+    // future regression that revives a custom dedupe inside fork.rs fails
+    // CI rather than the user's chat panel.
+
+    /// Init a real bare-ish git repo with one commit, returning the temp dir
+    /// (drop-cleans) and the HEAD commit hash. Mirrors the pattern used by
+    /// `workspace_alloc::tests` — kept local so the helpers don't have to
+    /// become `pub(crate)` just for this test.
+    fn setup_real_repo() -> (tempfile::TempDir, String) {
+        use std::process::Command;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        let git_bin = crate::git::resolve_git_path_blocking();
+        let must = |args: &[&str]| {
+            let ok = Command::new(&git_bin)
+                .arg("-C")
+                .arg(path)
+                .args(args)
+                .status()
+                .unwrap()
+                .success();
+            assert!(ok, "git {args:?} failed in {}", path.display());
+        };
+        must(&["init", "-b", "main"]);
+        must(&["config", "user.email", "fork-test@example.com"]);
+        must(&["config", "user.name", "Fork Test"]);
+        std::fs::write(path.join("README.md"), "# fork test\n").unwrap();
+        must(&["add", "-A"]);
+        must(&["commit", "-m", "initial"]);
+        let head = std::str::from_utf8(
+            &Command::new(&git_bin)
+                .arg("-C")
+                .arg(path)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        (dir, head)
+    }
+
+    #[tokio::test]
+    async fn fork_skips_orphan_worktree_dir_on_disk() {
+        // Real git repo so `git worktree add` actually runs. The source
+        // workspace's worktree IS the repo root itself (we don't need a
+        // separate worktree on disk — checkpoint.commit_hash short-circuits
+        // the `git head_commit` fallback).
+        let (repo_dir, head) = setup_real_repo();
+        let repo_path = repo_dir.path().to_string_lossy().to_string();
+
+        let db = Database::open_in_memory().unwrap();
+        db.insert_repository(&Repository {
+            id: "r1".into(),
+            name: "repo1".into(),
+            path: repo_path.clone(),
+            path_slug: "repo1".into(),
+            icon: None,
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            archive_script: None,
+            archive_script_auto_run: false,
+            base_branch: None,
+            default_remote: None,
+            path_valid: true,
+            created_at: String::new(),
+        })
+        .unwrap();
+        let source_ws = Workspace {
+            id: "w-src".into(),
+            repository_id: "r1".into(),
+            name: "src".into(),
+            branch_name: "main".into(),
+            worktree_path: Some(repo_path.clone()),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+            sort_order: 0,
+        };
+        db.insert_workspace(&source_ws).unwrap();
+
+        // Seed a checkpoint anchored to a placeholder user message in the
+        // source's default chat session.
+        let chat_session_id = db
+            .default_session_id_for_workspace("w-src")
+            .unwrap()
+            .unwrap();
+        db.insert_chat_message(&ChatMessage {
+            id: "m1".into(),
+            workspace_id: "w-src".into(),
+            chat_session_id: chat_session_id.clone(),
+            role: ChatRole::User,
+            content: "hi".into(),
+            cost_usd: None,
+            duration_ms: None,
+            created_at: String::new(),
+            thinking: None,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+        })
+        .unwrap();
+        db.insert_checkpoint(&ConversationCheckpoint {
+            id: "cp1".into(),
+            workspace_id: "w-src".into(),
+            chat_session_id: chat_session_id.clone(),
+            message_id: "m1".into(),
+            commit_hash: Some(head.clone()),
+            has_file_state: false,
+            turn_index: 0,
+            message_count: 1,
+            created_at: String::new(),
+        })
+        .unwrap();
+
+        // Set up a worktree-base + an orphan dir at the would-be `src-fork`
+        // path. This is the exact precondition the user hit in the bug
+        // report: a dir lingering on disk that the DB doesn't know about
+        // (rename, hard delete, archive without dir-cleanup).
+        let worktree_base = tempfile::tempdir().unwrap();
+        let orphan_dir = worktree_base.path().join("repo1").join("src-fork");
+        std::fs::create_dir_all(&orphan_dir).unwrap();
+
+        let mut db_mut = db;
+        let outcome = fork_workspace_at_checkpoint(
+            &mut db_mut,
+            ForkInputs {
+                source_workspace_id: "w-src",
+                checkpoint_id: "cp1",
+                worktree_base: worktree_base.path(),
+                branch_prefix: "u/",
+                db_path: std::path::Path::new(":memory:"),
+                now_iso: || String::new(),
+            },
+        )
+        .await
+        .expect("fork must allocate around the orphan dir, not fail at git worktree add");
+
+        // Allocator must have walked past `src-fork` (orphan dir on disk)
+        // and landed on `src-fork-2`. Branch + worktree path follow suit.
+        assert_eq!(outcome.workspace.name, "src-fork-2");
+        assert_eq!(outcome.workspace.branch_name, "u/src-fork-2");
+        let new_wt = outcome
+            .workspace
+            .worktree_path
+            .as_deref()
+            .expect("fork workspace must have a worktree path");
+        assert!(
+            new_wt.ends_with("repo1/src-fork-2"),
+            "fork worktree must live at the suffixed path, got {new_wt}"
+        );
+        // Orphan dir must remain untouched — fork allocates around it,
+        // never reaches in to claim it.
+        assert!(
+            orphan_dir.exists(),
+            "fork must not have repurposed the orphan dir at {}",
+            orphan_dir.display()
         );
     }
 }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -445,7 +445,12 @@ fn copy_history(
 /// granularity by reading `workspaces.session_id`; that column became dead
 /// when chat sessions arrived (20260422000000_chat_sessions), and the
 /// missed migration here is what made every fork start a fresh Claude
-/// session — see `test_fork_resumes_claude_session` for the regression pin.
+/// session — see the `copy_claude_session_*` regression pins
+/// (`copy_claude_session_copies_jsonl_and_persists_per_chat_session_state`,
+/// `copy_claude_session_handles_dot_dir_paths`,
+/// `copy_claude_session_skips_when_source_has_no_session`,
+/// `copy_claude_session_skips_when_jsonl_missing`) at the bottom of this
+/// file for the regression pins.
 ///
 /// Returns `true` if the transcript was found and copied (session id is
 /// persisted for the new chat session). Returns `false` if there was no
@@ -765,8 +770,9 @@ mod tests {
     // "I don't have context from a previous session".
 
     /// Build a fake `~/.claude/projects/<slug>/<sid>.jsonl` so
-    /// `copy_claude_session` has something to copy. Returns the temp `home`
-    /// dir so the caller can keep it alive (TempDir cleans on drop).
+    /// `copy_claude_session` has something to copy. Returns the path of the
+    /// JSONL file that was written. Callers keep the surrounding `TempDir`
+    /// alive separately (test scope drops it, which removes the file too).
     fn write_fake_jsonl(
         projects_dir: &Path,
         worktree: &str,

--- a/src/migrations/20260508142050_drop_legacy_workspace_session_columns.sql
+++ b/src/migrations/20260508142050_drop_legacy_workspace_session_columns.sql
@@ -1,0 +1,17 @@
+-- Drop dead workspace-scoped Claude CLI session columns.
+--
+-- Background: 20250101000009_workspace_session_and_turn_count.sql added
+-- `workspaces.session_id` and `workspaces.turn_count` so a workspace could
+-- remember its Claude CLI session id across app restarts. The multi-session
+-- refactor (20260422000000_chat_sessions.sql) moved that responsibility to
+-- `chat_sessions.session_id` / `chat_sessions.turn_count` and backfilled
+-- existing rows; live agent code (commands/chat/send.rs etc.) has only
+-- written the per-session columns since then.
+--
+-- The workspace-scoped columns were left behind. Their only remaining
+-- consumer was `fork::copy_claude_session`, which read `workspaces.session_id`
+-- and consequently always saw NULL post-multi-session — turning every fork
+-- into a fresh Claude session that lost the parent's conversational context.
+-- The fork code now reads/writes via `chat_sessions`, so the columns are dead.
+ALTER TABLE workspaces DROP COLUMN session_id;
+ALTER TABLE workspaces DROP COLUMN turn_count;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -204,4 +204,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260507180353_chat_sessions_cli_invocation.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260508142050_drop_legacy_workspace_session_columns",
+        sql: include_str!("20260508142050_drop_legacy_workspace_session_columns.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/ui/src/services/fork.test.ts
+++ b/src/ui/src/services/fork.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
+}));
+
+import { forkWorkspaceAtCheckpoint } from "./tauri";
+
+describe("forkWorkspaceAtCheckpoint", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  // Contract pin: the Tauri command name and its camelCase argument shape
+  // are the wire between the React fork button and the Rust fork code.
+  // If someone renames the command or its params (snake_case slip,
+  // accidental refactor, etc.) the chat-side click silently no-ops because
+  // Tauri throws "command not found" deep in a try/catch and the user just
+  // sees nothing happen — which is exactly how the original "broken" report
+  // came in.  Asserting the literal strings here makes that drift loud.
+  it("invokes fork_workspace_at_checkpoint with camelCase workspaceId + checkpointId", async () => {
+    invokeMock.mockResolvedValueOnce({
+      workspace: {
+        id: "ws-new",
+        repository_id: "r-1",
+        name: "src-fork",
+        branch_name: "u/src-fork",
+        worktree_path: "/tmp/src-fork",
+        status: "Active",
+        agent_status: "Idle",
+        status_line: "",
+        created_at: "",
+        sort_order: 0,
+      },
+      session_resumed: true,
+    });
+
+    const result = await forkWorkspaceAtCheckpoint("ws-src", "cp-42");
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("fork_workspace_at_checkpoint", {
+      workspaceId: "ws-src",
+      checkpointId: "cp-42",
+    });
+    // session_resumed is the field ChatPanel doesn't read today, but it's
+    // part of the persisted contract — flag any rename so future telemetry
+    // / banner work that wants to surface "context preserved" can rely on it.
+    expect(result.session_resumed).toBe(true);
+    expect(result.workspace.id).toBe("ws-new");
+  });
+
+  it("propagates errors so the ChatPanel try/catch can surface them", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("Checkpoint not found"));
+    await expect(
+      forkWorkspaceAtCheckpoint("ws-src", "cp-missing"),
+    ).rejects.toThrow("Checkpoint not found");
+  });
+});


### PR DESCRIPTION
## What

Forking a workspace at a turn copied chat history into the new workspace's DB but the next prompt to the fork came back with **"I don't have context from a previous session"** — Claude CLI was started without `--resume`, so the fork ran a fresh session.

## Root cause

Two chained bugs in `fork::copy_claude_session`. Both had to be fixed for the live UX to work end-to-end.

### 1. Reading the wrong table (the original regression)

The multi-session refactor (#306) moved the live Claude CLI `session_id` + `turn_count` from the `workspaces` row onto `chat_sessions`. Every other agent code path was migrated; `fork.rs` was missed. It still called `db.get_agent_session(workspace_id)` / `db.save_agent_session(...)`, which read/wrote `workspaces.session_id` — a column that has been **permanently NULL on every database since the chat-sessions backfill ran in #306**.

So `copy_claude_session` saw `None`, returned `Ok(false)`, and the new workspace's `chat_sessions.session_id` stayed NULL → next agent run starts a fresh `claude` process with no `--resume`.

### 2. Wrong project-dir slug (caught during post-fix UAT)

Even after fix #1, the live fork was still returning `session_resumed: false`. Tracing the file paths revealed Claude CLI's slug rule:

\`\`\`
/Users/jamesbrink/.claudette/workspaces/claudex/foo
   →  -Users-jamesbrink--claudette-workspaces-claudex-foo
\`\`\`

CLI replaces \`.\` AND \`/\` AND \`\\\` with \`-\`. Our \`claude_project_slug\` only replaced the separators, producing \`-Users-…-.claudette-…\` (single dash + dot) instead of the on-disk \`--claudette\` (double dash). Every Claudette-managed worktree (path always contains \`.claudette\`) hit this. The first bug masked the second because we never reached the slug computation in production.

## What this PR changes

### Surgical fix (\`src/fork.rs\`)

- Read source state from the chat session (\`checkpoint.chat_session_id\` → \`db.get_chat_session(...)\`) instead of the workspace row.
- Write destination state via \`db.save_chat_session_state(...)\` against the new workspace's default chat session id.
- \`claude_project_slug\` now replaces \`.\` in addition to \`/\` and \`\\\`.
- Factor out \`claude_projects_dir()\` so \`copy_claude_session\` takes \`projects_dir: &Path\` — tests can substitute a \`tempfile::tempdir()\` without touching \`\$HOME\`.

### Cleanup (per design discussion: "remove the dead methods + drop the column")

- Drop \`save_agent_session\` / \`get_agent_session\` / \`clear_agent_session\` and their unit tests from \`src/db/workspace.rs\`. The remaining live caller (fork) now uses the per-chat-session API; their persistence behaviour is covered by \`db::chat::test_save_chat_session_state_persists_session_id\`.
- New migration \`20260508142050_drop_legacy_workspace_session_columns.sql\` drops \`workspaces.session_id\` and \`workspaces.turn_count\`. Audit of \`src/\`, \`src-tauri/\`, \`src-server/\`, \`src-cli/\`, \`plugins/\` confirms no other readers.
- \`test_chat_sessions_migration_backfills_sessions\` rewinds the new drop migration too, so its in-test re-run of the chat-sessions backfill still finds the legacy columns at the moment they're needed.

## Regression discipline

> "It is imperative that our fix does not break something else clearly."

Behaviour preserved (verified by tests + audit):

- \`fork_workspace_at_checkpoint\` Tauri command signature, payload, and the \`ForkWorkspaceResult { workspace, session_resumed }\` shape are unchanged.
- \`Workspace\` model and \`list_workspaces\` SELECT did not reference \`session_id\`/\`turn_count\` already, so the column drop is invisible to the app.
- The dropped DB methods had no callers outside their own tests + \`fork.rs\` (audit in commit message); no JSONL migration needed since the per-chat-session columns were already populated by the #306 backfill.
- Frontend handler (\`ChatPanel.handleFork\`) is unchanged; the wire contract is now pinned by \`src/ui/src/services/fork.test.ts\` so a future rename can't silently re-introduce a "the button does nothing" failure mode.

## Regression pins

**Backend** — \`src/fork.rs#tests\`:

| Test | Pins |
|---|---|
| \`copy_claude_session_copies_jsonl_and_persists_per_chat_session_state\` | THE pin: source has a sid, JSONL exists → fork inherits \`session_id\` + \`turn_count\` and the JSONL lands at the new worktree's slug. |
| \`copy_claude_session_handles_dot_dir_paths\` | The second-bug pin: a \`~/.claudette/...\` source produces a slug that collapses \`/.claudette\` → \`--claudette\`. |
| \`copy_claude_session_skips_when_source_has_no_session\` | Fork from a workspace that never ran the agent → \`session_resumed = false\`, fork still succeeds. |
| \`copy_claude_session_skips_when_jsonl_missing\` | Source has a sid but no on-disk JSONL (crashed mid-flush) → destination must NOT inherit an orphan sid. |
| \`claude_project_slug_replaces_dots\` | Direct slug pin, including the multi-dot path case. |
| \`workspaces_table_no_longer_carries_session_columns\` | Schema pin so a future migration can't silently re-add the dropped columns. |

**Frontend** — \`src/ui/src/services/fork.test.ts\`:

- Asserts \`forkWorkspaceAtCheckpoint(...)\` invokes the \`fork_workspace_at_checkpoint\` Tauri command with camelCase \`workspaceId\` / \`checkpointId\`. The original "the button is broken" report would have been a single-character rename of either side; pinning the wire surfaces the drift.
- Asserts errors propagate so \`ChatPanel.handleFork\`'s \`setError\` path keeps working.

## Verification

Local sweep on \`fix/context-forking\` (Nix devshell):

- \`cargo test -p claudette -p claudette-server -p claudette-cli --all-features\` → 1038 + 1 + 7 passed (1 pre-existing ignore).
- \`cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features\` → clean.
- \`cargo fmt --all --check\` → clean.
- \`bunx tsc -b\` → clean.
- \`bun run test\` → 1477/1477 passed.
- \`bun run lint\` → 0 errors (pre-existing warnings only).
- \`bun run lint:css\` → clean.
- **Live UAT against the dev app**: source workspace running an active session was forked via the chat-side fork button; the fork's first prompt invoked \`claude --resume <parent-sid>\` and the agent had prior context. ✅

## Out of scope

- The Tauri command itself doesn't emit a \`workspaces-changed\` event after fork — the frontend handler picks up the new workspace via the manual \`addWorkspace\` + \`selectWorkspace\` calls. Working as designed; flagging only because it's adjacent.
- \`copy_claude_session\` mid-conversation copies a JSONL that the source agent is still appending to. That's a known race that pre-dates this PR (worst case: the fork resumes a slightly truncated transcript). Not addressed here.