### PR TITLE
fix: suppress unexpected_cfgs warnings from objc 0.2 macro expansion

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -100,6 +100,12 @@ voice = [
     "dep:hound",
 ]
 
+[lints.rust]
+# objc 0.2.x uses the old `feature = "cargo-clippy"` pattern to detect Clippy
+# (predating `cfg(clippy)`). Declare it as a known value so rustc's check-cfg
+# exhaustiveness check doesn't flag macro expansion sites in this crate.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [dev-dependencies]
 tempfile = "3"
 


### PR DESCRIPTION
## Summary

The `objc 0.2.x` crate uses a historical Clippy-detection pattern — `#[cfg_attr(feature = "cargo-clippy", ...)]` — inside its `sel_impl` macro, which predates the proper `cfg(clippy)` predicate. When `msg_send!` expands at call sites in `window_state.rs`, rustc 1.80+'s exhaustive `check-cfg` validation fires three `unexpected_cfgs` warnings because `"cargo-clippy"` is not in the declared feature set for `claudette-tauri`.

The fix adds a `[lints.rust]` section to `src-tauri/Cargo.toml` that registers `cfg(feature, values("cargo-clippy"))` as a known cfg value. This:
- Marks `"cargo-clippy"` as an *expected* (but inactive) feature value so no warning fires
- Does **not** disable `unexpected_cfgs` for other cfgs
- Does **not** add a spurious Cargo feature
- Keeps CI's `RUSTFLAGS="-Dwarnings"` happy — check-cfg suppresses the warning at the source rather than muting it

## Complexity Notes

The three warning sites are all inside `unsafe` Objective-C interop code in `window_state.rs`. The `[lints.rust]` section is a Cargo 1.73+ feature and is the idiomatic fix for inherited macro-expansion cfg warnings from third-party crates.

## Test Steps

1. Pull the branch and run `cargo check -p claudette-tauri` (after staging the CLI sidecar via `./scripts/dev.sh` or `scripts/stage-cli-sidecar.sh`)
2. Confirm none of these three warnings appear:
   - `unexpected cfg condition value: cargo-clippy` at `window_state.rs:695`
   - `unexpected cfg condition value: cargo-clippy` at `window_state.rs:700`
   - `unexpected cfg condition value: cargo-clippy` at `window_state.rs:718`
3. Confirm `cargo clippy -p claudette -p claudette-server --all-targets` still passes with zero warnings

## Checklist

- [x] Tests added/updated — N/A (config-only change)
- [x] Documentation updated — N/A