### PR TITLE
feat(chat): add configurable tool call display

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -54,6 +54,7 @@ function App() {
   const setUsageInsightsEnabled = useAppStore((s) => s.setUsageInsightsEnabled);
   const setClaudetteTerminalEnabled = useAppStore((s) => s.setClaudetteTerminalEnabled);
   const setShowSidebarRunningCommands = useAppStore((s) => s.setShowSidebarRunningCommands);
+  const setToolDisplayMode = useAppStore((s) => s.setToolDisplayMode);
   const setPluginManagementEnabled = useAppStore((s) => s.setPluginManagementEnabled);
   const setClaudeRemoteControlEnabled = useAppStore(
     (s) => s.setClaudeRemoteControlEnabled,
@@ -253,6 +254,11 @@ function App() {
       .catch(() => {});
     getAppSetting("show_sidebar_running_commands")
       .then((val) => { if (val === "true") setShowSidebarRunningCommands(true); })
+      .catch(() => {});
+    getAppSetting("tool_display_mode")
+      .then((val) => {
+        if (val === "inline" || val === "grouped") setToolDisplayMode(val);
+      })
       .catch(() => {});
     getAppSetting("plugin_management_enabled")
       .then((val) => { if (val === "true") setPluginManagementEnabled(true); })

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -386,6 +386,26 @@
   margin: 0;
 }
 
+.inlineTurnActivities {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.inlineTurnActivities .toolActivity {
+  border: none;
+  border-radius: 0;
+}
+
+.inlineTurnActivities .toolHeader {
+  padding: 2px 8px;
+  cursor: default;
+}
+
+.inlineTurnActivities .toolHeader:hover {
+  background: transparent;
+}
+
 /* Footer below a completed turn: elapsed time + copy + fork actions. */
 .turnFooter {
   display: flex;
@@ -549,7 +569,8 @@
 }
 
 .agentToolGroup {
-  border-top: 1px solid var(--divider);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
 }
 
 .agentToolGroupHeader {

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -243,6 +243,7 @@ export function ChatPanel() {
   const addCheckpoint = useAppStore((s) => s.addCheckpoint);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
+  const toolDisplayMode = useAppStore((s) => s.toolDisplayMode);
   const activeSessionStatus = useAppStore((s) => {
     if (!activeSessionId || !selectedWorkspaceId) return "Idle" as const;
     const sessions = s.sessionsByWorkspace[selectedWorkspaceId];
@@ -1250,11 +1251,12 @@ export function ChatPanel() {
                   liveToolActivityStartedAt={
                     activitiesCount > 0 ? firstToolActivityStartedAt : null
                   }
+                  toolDisplayMode={toolDisplayMode}
                   liveToolActivityNode={
                     activitiesCount > 0 ? (
                       <ToolActivitiesSection
                         sessionId={activeSessionId}
-                        isRunning={isRunning ?? false}
+                        toolDisplayMode={toolDisplayMode}
                         searchQuery={searchQuery}
                         worktreePath={ws?.worktree_path}
                       />
@@ -1265,22 +1267,24 @@ export function ChatPanel() {
                       <CurrentTurnTaskProgress sessionId={activeSessionId} />
                     ) : null
                   }
-                />
-              )}
-
-              {activeSessionId && hasThinking && showThinkingBlocks && (
-                <StreamingThinkingBlock
-                  sessionId={activeSessionId}
-                  isStreaming={isRunning ?? false}
-                  searchQuery={searchQuery}
-                />
-              )}
-
-              {activeSessionId && (hasStreaming || hasPendingTypewriter) && (
-                <StreamingMessage
-                  sessionId={activeSessionId}
-                  isStreaming={isRunning ?? false}
-                  searchQuery={searchQuery}
+                  streamingThinkingNode={
+                    hasThinking && showThinkingBlocks ? (
+                      <StreamingThinkingBlock
+                        sessionId={activeSessionId}
+                        isStreaming={isRunning ?? false}
+                        searchQuery={searchQuery}
+                      />
+                    ) : null
+                  }
+                  streamingMessageNode={
+                    hasStreaming || hasPendingTypewriter ? (
+                      <StreamingMessage
+                        sessionId={activeSessionId}
+                        isStreaming={isRunning ?? false}
+                        searchQuery={searchQuery}
+                      />
+                    ) : null
+                  }
                 />
               )}
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -64,9 +64,9 @@ import { StreamingThinkingBlock } from "./StreamingThinkingBlock";
 import { StreamingMessage } from "./StreamingMessage";
 import { MessagesWithTurns } from "./MessagesWithTurns";
 import { CliInvocationBanner } from "./CliInvocationBanner";
-import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { CurrentTurnTaskProgress } from "./CurrentTurnTaskProgress";
 import { ChatInputArea } from "./ChatInputArea";
+import { EMPTY_ACTIVITIES } from "./chatConstants";
 
 export function ChatPanel() {
   const { t } = useTranslation("chat");
@@ -204,19 +204,10 @@ export function ChatPanel() {
   const showThinkingBlocks = useAppStore(
     (s) => activeSessionId ? s.showThinkingBlocks[activeSessionId] === true : false
   );
-  // Subscribe only to count — avoids re-render on tool activity content changes
-  const activitiesCount = useAppStore(
-    (s) => (activeSessionId ? (s.toolActivities[activeSessionId] || []).length : 0)
+  const liveToolActivities = useAppStore((s) =>
+    activeSessionId ? (s.toolActivities[activeSessionId] ?? EMPTY_ACTIVITIES) : EMPTY_ACTIVITIES,
   );
-  const firstToolActivityStartedAt = useAppStore((s) => {
-    if (!activeSessionId) return null;
-    return (
-      (s.toolActivities[activeSessionId] || [])
-        .map((activity) => activity.startedAt)
-        .filter((startedAt): startedAt is string => !!startedAt)
-        .sort()[0] ?? null
-    );
-  });
+  const activitiesCount = liveToolActivities.length;
   const completedTurnsCount = useAppStore(
     (s) => (activeSessionId ? (s.completedTurns[activeSessionId] || []).length : 0)
   );
@@ -1248,20 +1239,8 @@ export function ChatPanel() {
                   onAttachmentClick={openLightbox}
                   searchQuery={searchQuery}
                   globalOffset={globalOffset}
-                  liveToolActivityStartedAt={
-                    activitiesCount > 0 ? firstToolActivityStartedAt : null
-                  }
+                  liveToolActivities={liveToolActivities}
                   toolDisplayMode={toolDisplayMode}
-                  liveToolActivityNode={
-                    activitiesCount > 0 ? (
-                      <ToolActivitiesSection
-                        sessionId={activeSessionId}
-                        toolDisplayMode={toolDisplayMode}
-                        searchQuery={searchQuery}
-                        worktreePath={ws?.worktree_path}
-                      />
-                    ) : null
-                  }
                   liveTaskProgressNode={
                     activitiesCount > 0 ? (
                       <CurrentTurnTaskProgress sessionId={activeSessionId} />

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -204,10 +204,9 @@ export function ChatPanel() {
   const showThinkingBlocks = useAppStore(
     (s) => activeSessionId ? s.showThinkingBlocks[activeSessionId] === true : false
   );
-  const liveToolActivities = useAppStore((s) =>
-    activeSessionId ? (s.toolActivities[activeSessionId] ?? EMPTY_ACTIVITIES) : EMPTY_ACTIVITIES,
+  const activitiesCount = useAppStore(
+    (s) => (activeSessionId ? (s.toolActivities[activeSessionId] ?? EMPTY_ACTIVITIES).length : 0),
   );
-  const activitiesCount = liveToolActivities.length;
   const completedTurnsCount = useAppStore(
     (s) => (activeSessionId ? (s.completedTurns[activeSessionId] || []).length : 0)
   );
@@ -1239,7 +1238,6 @@ export function ChatPanel() {
                   onAttachmentClick={openLightbox}
                   searchQuery={searchQuery}
                   globalOffset={globalOffset}
-                  liveToolActivities={liveToolActivities}
                   toolDisplayMode={toolDisplayMode}
                   liveTaskProgressNode={
                     activitiesCount > 0 ? (

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
+import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import type { CompletedTurn } from "../../stores/useAppStore";
 import { loadAttachmentData } from "../../services/tauri";
 import type { ChatMessage, ChatAttachment } from "../../types/chat";
@@ -66,8 +67,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   searchQuery,
   globalOffset = 0,
   liveToolActivityStartedAt,
+  toolDisplayMode,
   liveToolActivityNode,
   liveTaskProgressNode,
+  streamingThinkingNode,
+  streamingMessageNode,
 }: {
   messages: ChatMessage[];
   /** The enclosing workspace id — forwarded into rollback data so the modal
@@ -104,8 +108,11 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
    *  positions (which are global) against the local message array. */
   globalOffset?: number;
   liveToolActivityStartedAt?: string | null;
+  toolDisplayMode: ToolDisplayMode;
   liveToolActivityNode?: React.ReactNode;
   liveTaskProgressNode?: React.ReactNode;
+  streamingThinkingNode?: React.ReactNode;
+  streamingMessageNode?: React.ReactNode;
 }) {
   const { t } = useTranslation("chat");
   const completedTurns = useAppStore(
@@ -260,7 +267,10 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       let hasFinalGroup = false;
       for (const [position, activities] of activitiesByPosition) {
         positions.add(position);
-        const displayGroups = groupToolActivitiesForDisplay(activities);
+        const displayGroups = groupToolActivitiesForDisplay(
+          activities,
+          toolDisplayMode,
+        );
         const finalGroupIndex =
           position === turn.afterMessageIndex ? displayGroups.length - 1 : -1;
         hasFinalGroup ||= finalGroupIndex >= 0;
@@ -285,7 +295,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     });
 
     return { groupsByPosition, finalFooterByPosition, positions };
-  }, [completedTurns, findTriggeringUserIdx, globalOffset, messages]);
+  }, [completedTurns, findTriggeringUserIdx, globalOffset, messages, toolDisplayMode]);
 
   const completedTurnPositions = chronologicalTurnLayout.positions;
 
@@ -492,6 +502,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
             turn={turn}
             activities={activities}
             label={label}
+            inline={toolDisplayMode === "inline"}
             showFooter={showFooter}
             collapsed={turn.collapsed}
             onToggle={() => toggleCompletedTurn(sessionId, globalIdx)}
@@ -527,6 +538,21 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       <React.Fragment key={`live-tool-activity-${position}`}>
         {liveToolActivityNode}
         {liveTaskProgressNode}
+      </React.Fragment>
+    );
+  };
+
+  const renderStreamingTail = (position: number) => {
+    if (
+      position !== globalOffset + messages.length ||
+      (!streamingThinkingNode && !streamingMessageNode)
+    ) {
+      return null;
+    }
+    return (
+      <React.Fragment key={`streaming-tail-${position}`}>
+        {streamingThinkingNode}
+        {streamingMessageNode}
       </React.Fragment>
     );
   };
@@ -570,7 +596,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           <React.Fragment key={msg.id}>
             {renderTurns(globalOffset + idx)}
             {renderLiveToolActivity(globalOffset + idx)}
-            {msg.id === pendingMessageId ? null : (
+            {msg.id === pendingMessageId ? streamingMessageNode : (
               <div className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}`}>
                 {msg.role === "User" && (
                   <div className={styles.roleLabel}>{t("you_label")}</div>
@@ -695,6 +721,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       })}
       {/* Turn activity groups that land after the last loaded message */}
       {renderTurns(globalOffset + messages.length)}
+      {renderStreamingTail(globalOffset + messages.length)}
       {renderLiveToolActivity(globalOffset + messages.length)}
     </>
   );

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -45,6 +45,7 @@ import { PdfThumbnail } from "./PdfThumbnail";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
 import {
+  EMPTY_ACTIVITIES,
   EMPTY_ATTACHMENTS,
   EMPTY_CHECKPOINTS,
   EMPTY_COMPLETED_TURNS,
@@ -66,7 +67,6 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   onAttachmentClick,
   searchQuery,
   globalOffset = 0,
-  liveToolActivities,
   toolDisplayMode,
   liveTaskProgressNode,
   streamingThinkingNode,
@@ -106,7 +106,6 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
    *  have not been fetched yet (pagination). Used to match CompletedTurn
    *  positions (which are global) against the local message array. */
   globalOffset?: number;
-  liveToolActivities: readonly ToolActivity[];
   toolDisplayMode: ToolDisplayMode;
   liveTaskProgressNode?: React.ReactNode;
   streamingThinkingNode?: React.ReactNode;
@@ -135,6 +134,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   );
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
+  );
+  const liveToolActivities = useAppStore(
+    (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
 
   // Pre-build a Map keyed by message_id for O(1) lookup in the render loop.
@@ -569,8 +571,14 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     );
   };
 
+  const pendingMessageInWindow = useMemo(
+    () => !!pendingMessageId && messages.some((msg) => msg.id === pendingMessageId),
+    [messages, pendingMessageId],
+  );
+
   const renderStreamingTail = (position: number) => {
     if (
+      pendingMessageInWindow ||
       position !== globalOffset + messages.length ||
       (!streamingThinkingNode && !streamingMessageNode)
     ) {

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
-import type { CompletedTurn } from "../../stores/useAppStore";
+import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import { loadAttachmentData } from "../../services/tauri";
 import type { ChatMessage, ChatAttachment } from "../../types/chat";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
@@ -26,7 +26,6 @@ import {
   buildPlainTurnFooters,
   findTriggeringUserIndex,
 } from "../../utils/chatTurnFooter";
-import { parseChatTimestamp } from "../../utils/parseChatTimestamp";
 import {
   parseCompactionSentinel,
   parseSyntheticSummarySentinel,
@@ -40,6 +39,7 @@ import type { TaskTrackerResult, TrackedTask } from "../../hooks/useTaskTracker"
 import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 import { TurnSummary } from "./TurnSummary";
+import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { TurnFooter } from "./TurnFooter";
 import { PdfThumbnail } from "./PdfThumbnail";
 import { MessageCopyButton } from "./MessageCopyButton";
@@ -66,9 +66,8 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   onAttachmentClick,
   searchQuery,
   globalOffset = 0,
-  liveToolActivityStartedAt,
+  liveToolActivities,
   toolDisplayMode,
-  liveToolActivityNode,
   liveTaskProgressNode,
   streamingThinkingNode,
   streamingMessageNode,
@@ -107,9 +106,8 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
    *  have not been fetched yet (pagination). Used to match CompletedTurn
    *  positions (which are global) against the local message array. */
   globalOffset?: number;
-  liveToolActivityStartedAt?: string | null;
+  liveToolActivities: readonly ToolActivity[];
   toolDisplayMode: ToolDisplayMode;
-  liveToolActivityNode?: React.ReactNode;
   liveTaskProgressNode?: React.ReactNode;
   streamingThinkingNode?: React.ReactNode;
   streamingMessageNode?: React.ReactNode;
@@ -299,18 +297,44 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
 
   const completedTurnPositions = chronologicalTurnLayout.positions;
 
-  const liveToolActivityPosition = useMemo(() => {
-    if (!liveToolActivityStartedAt || !liveToolActivityNode) return null;
-    const startedAtMs = parseChatTimestamp(liveToolActivityStartedAt);
-    if (!Number.isFinite(startedAtMs)) return globalOffset + messages.length;
-    const laterIndex = messages.findIndex((msg) => {
-      const createdAtMs = parseChatTimestamp(msg.created_at);
-      return Number.isFinite(createdAtMs) && createdAtMs > startedAtMs;
-    });
-    return laterIndex === -1
-      ? globalOffset + messages.length
-      : globalOffset + laterIndex;
-  }, [globalOffset, liveToolActivityNode, liveToolActivityStartedAt, messages]);
+  const liveToolActivitiesByPosition = useMemo(() => {
+    const activitiesByPosition = new Map<number, ToolActivity[]>();
+    if (liveToolActivities.length === 0) return activitiesByPosition;
+
+    let userIdx = -1;
+    for (let idx = messages.length - 1; idx >= 0; idx--) {
+      if (messages[idx]?.role === "User") {
+        userIdx = idx;
+        break;
+      }
+    }
+
+    const assistantPositions: number[] = [];
+    if (userIdx !== -1) {
+      for (let idx = userIdx + 1; idx < messages.length; idx++) {
+        if (messages[idx]?.role === "Assistant") {
+          assistantPositions.push(globalOffset + idx + 1);
+        }
+      }
+    }
+
+    const positionForOrdinal = (ordinal: number | undefined) => {
+      const tailPosition = globalOffset + messages.length;
+      if (userIdx === -1) return tailPosition;
+      if (typeof ordinal !== "number" || ordinal < 0) return tailPosition;
+      if (ordinal === 0) return globalOffset + userIdx + 1;
+      return assistantPositions[ordinal - 1] ?? tailPosition;
+    };
+
+    for (const activity of liveToolActivities) {
+      const position = positionForOrdinal(activity.assistantMessageOrdinal);
+      const existing = activitiesByPosition.get(position);
+      if (existing) existing.push(activity);
+      else activitiesByPosition.set(position, [activity]);
+    }
+
+    return activitiesByPosition;
+  }, [globalOffset, liveToolActivities, messages]);
 
   // Local version of completedTurnPositions with global indices shifted to
   // local array indices. Used by buildPlainTurnFooters, which works in local
@@ -531,14 +555,17 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   };
 
   const renderLiveToolActivity = (position: number) => {
-    if (liveToolActivityPosition !== position || !liveToolActivityNode) {
-      return null;
-    }
+    const activities = liveToolActivitiesByPosition.get(position);
+    if (!activities) return null;
     return (
-      <React.Fragment key={`live-tool-activity-${position}`}>
-        {liveToolActivityNode}
-        {liveTaskProgressNode}
-      </React.Fragment>
+      <ToolActivitiesSection
+        key={`live-tool-activity-${position}`}
+        sessionId={sessionId}
+        toolDisplayMode={toolDisplayMode}
+        searchQuery={searchQuery}
+        worktreePath={worktreePath}
+        activities={activities}
+      />
     );
   };
 
@@ -723,6 +750,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       {renderTurns(globalOffset + messages.length)}
       {renderStreamingTail(globalOffset + messages.length)}
       {renderLiveToolActivity(globalOffset + messages.length)}
+      {liveTaskProgressNode}
     </>
   );
 });

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { ToolActivity } from "../../stores/useAppStore";
+import { AgentToolCallGroup } from "./AgentToolCallGroup";
+import { ToolActivitiesSection } from "./ToolActivitiesSection";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+function activity(
+  toolName: string,
+  overrides: Partial<ToolActivity> = {},
+): ToolActivity {
+  return {
+    toolUseId: `${toolName}-1`,
+    toolName,
+    inputJson: "{}",
+    resultText: "done",
+    collapsed: true,
+    summary: "",
+    ...overrides,
+  };
+}
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("AgentToolCallGroup", () => {
+  it("colors only the Agent tool name and leaves the agent description in summary styling", async () => {
+    const container = await render(
+      <AgentToolCallGroup
+        activity={activity("Agent", {
+          summary: "AgentRandom",
+          agentDescription: "AgentRandom",
+        })}
+        searchQuery=""
+      />,
+    );
+
+    const coloredName = container.querySelector("span[style]");
+    expect(coloredName?.textContent).toBe("Agent");
+    expect(coloredName?.getAttribute("style") ?? "").toContain("color:");
+
+    const summary = Array.from(container.querySelectorAll("span")).find(
+      (span) => span.textContent === "AgentRandom",
+    );
+    expect(summary).toBeTruthy();
+    expect(summary?.getAttribute("style")).toBeNull();
+  });
+});
+
+describe("ToolActivitiesSection", () => {
+  it("expands grouped live calls while running and collapses when the group is done", async () => {
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Bash", { resultText: "" }),
+          activity("Read", { resultText: "done" }),
+        ]}
+      />,
+    );
+
+    expect(container.textContent).toContain("2 tool calls");
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("Read");
+
+    await act(async () => {
+      mountedRoots[0].render(
+        <ToolActivitiesSection
+          sessionId="session-1"
+          toolDisplayMode="grouped"
+          searchQuery=""
+          activities={[
+            activity("Bash", { resultText: "done" }),
+            activity("Read", { resultText: "done" }),
+          ]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("2 tool calls");
+    expect(container.textContent).not.toContain("Bash");
+    expect(container.textContent).not.toContain("Read");
+  });
+});

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -7,9 +7,15 @@ import { HighlightedPlainText } from "./HighlightedPlainText";
 import styles from "./ChatPanel.module.css";
 import { toolColor } from "./chatHelpers";
 import { EMPTY_ACTIVITIES } from "./chatConstants";
-import { activitySummaryText } from "./agentToolCallRendering";
+import {
+  activityMatchesSearch,
+  activitySummaryText,
+} from "./agentToolCallRendering";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
-import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
+import {
+  groupHasRunningActivity,
+  groupToolActivitiesForDisplay,
+} from "./toolActivityGroups";
 
 /**
  * Current tool activities section — subscribes to toolActivities for this workspace.
@@ -63,26 +69,58 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
             />
           ))
         ) : (
-          <div key={group.key} className={styles.turnSummary}>
-            <div className={styles.turnHeader}>
-              <span className={styles.turnLabel}>{group.label}</span>
-            </div>
-            <div className={styles.turnActivities}>
-              {group.activities.map((act) => (
-                <ToolActivityRow
-                  key={act.toolUseId}
-                  activity={act}
-                  searchQuery={searchQuery}
-                  worktreePath={worktreePath}
-                />
-              ))}
-            </div>
-          </div>
+          <GroupedToolActivityRows
+            key={group.key}
+            label={group.label}
+            activities={group.activities}
+            searchQuery={searchQuery}
+            worktreePath={worktreePath}
+          />
         ),
       )}
     </div>
   );
 });
+
+function GroupedToolActivityRows({
+  label,
+  activities,
+  searchQuery,
+  worktreePath,
+}: {
+  label: string;
+  activities: readonly ToolActivity[];
+  searchQuery: string;
+  worktreePath?: string | null;
+}) {
+  const queryHasMatch =
+    !!searchQuery &&
+    activities.some((activity) =>
+      activityMatchesSearch(activity, searchQuery, worktreePath),
+    );
+  const isExpanded = groupHasRunningActivity(activities, true) || queryHasMatch;
+
+  return (
+    <div className={styles.turnSummary}>
+      <div className={styles.turnHeader}>
+        <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
+        <span className={styles.turnLabel}>{label}</span>
+      </div>
+      {isExpanded && (
+        <div className={styles.turnActivities}>
+          {activities.map((act) => (
+            <ToolActivityRow
+              key={act.toolUseId}
+              activity={act}
+              searchQuery={searchQuery}
+              worktreePath={worktreePath}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function ToolActivityRow({
   activity,

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -1,21 +1,15 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity } from "../../stores/useAppStore";
+import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedPlainText } from "./HighlightedPlainText";
 import styles from "./ChatPanel.module.css";
 import { toolColor } from "./chatHelpers";
 import { EMPTY_ACTIVITIES } from "./chatConstants";
-import {
-  activityMatchesSearch,
-  activitySummaryText,
-} from "./agentToolCallRendering";
+import { activitySummaryText } from "./agentToolCallRendering";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
-import {
-  groupHasRunningActivity,
-  groupToolActivitiesForDisplay,
-  isAgentActivity,
-} from "./toolActivityGroups";
+import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
 
 /**
  * Current tool activities section — subscribes to toolActivities for this workspace.
@@ -23,110 +17,97 @@ import {
  */
 export const ToolActivitiesSection = memo(function ToolActivitiesSection({
   sessionId,
-  isRunning,
+  toolDisplayMode,
   searchQuery,
   worktreePath,
 }: {
   sessionId: string;
-  isRunning: boolean;
+  toolDisplayMode: ToolDisplayMode;
   searchQuery: string;
   worktreePath?: string | null;
 }) {
   const activities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
-  const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>(
-    {},
-  );
-
-  // Auto-collapse when a new turn starts (activities goes from 0 to non-zero)
-  const prevLengthRef = useRef(0);
-  useEffect(() => {
-    if (isRunning && activities.length > 0 && prevLengthRef.current === 0) {
-      setCollapsedGroups({});
-    }
-    prevLengthRef.current = activities.length;
-  }, [isRunning, activities.length]);
-
-  if (activities.length === 0) return null;
-
-  const groups = groupToolActivitiesForDisplay(activities);
+  const displayGroups = groupToolActivitiesForDisplay(activities, toolDisplayMode);
+  if (displayGroups.length === 0) return null;
 
   return (
-    <div className={styles.toolActivities} aria-live="polite" aria-atomic="true">
-      {groups.map((group) => {
-        const groupHasMatch =
-          !!searchQuery &&
-          group.activities.some((activity) =>
-            activityMatchesSearch(activity, searchQuery, worktreePath),
-          );
-        const isExpanded = !(collapsedGroups[group.key] ?? true) || groupHasMatch;
-        const toggleGroup = () =>
-          setCollapsedGroups((current) => ({
-            ...current,
-            [group.key]: !(current[group.key] ?? true),
-          }));
-        return (
+    <div
+      className={
+        toolDisplayMode === "inline"
+          ? `${styles.toolActivities} ${styles.inlineTurnActivities}`
+          : styles.toolActivities
+      }
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {displayGroups.map((group) =>
+        group.kind === "agent" && group.activities[0] ? (
+          <AgentToolCallGroup
+            key={group.key}
+            activity={group.activities[0]}
+            searchQuery={searchQuery}
+            worktreePath={worktreePath}
+          />
+        ) : toolDisplayMode === "inline" ? (
+          group.activities.map((act) => (
+            <ToolActivityRow
+              key={act.toolUseId}
+              activity={act}
+              searchQuery={searchQuery}
+              worktreePath={worktreePath}
+            />
+          ))
+        ) : (
           <div key={group.key} className={styles.turnSummary}>
-            <div
-              className={styles.turnHeader}
-              role="button"
-              tabIndex={0}
-              onClick={toggleGroup}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  toggleGroup();
-                }
-              }}
-            >
-              <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
-              <span className={styles.turnLabel}>
-                {group.label}
-                {groupHasRunningActivity(group.activities, isRunning) && (
-                  <span className={styles.inProgressNote}> in progress</span>
-                )}
-              </span>
+            <div className={styles.turnHeader}>
+              <span className={styles.turnLabel}>{group.label}</span>
             </div>
-            {isExpanded && (
-              <div className={styles.turnActivities}>
-                {group.activities.map((act: ToolActivity) =>
-                  isAgentActivity(act) ? (
-                    <AgentToolCallGroup
-                      key={act.toolUseId}
-                      activity={act}
-                      searchQuery={searchQuery}
-                      worktreePath={worktreePath}
-                    />
-                  ) : (
-                    <div key={act.toolUseId} className={styles.toolActivity}>
-                      <div className={styles.toolHeader}>
-                        <span
-                          className={styles.toolName}
-                          style={{ color: toolColor(act.toolName) }}
-                        >
-                          {act.toolName}
-                        </span>
-                        {activitySummaryText(act) && (
-                          <span className={styles.toolSummary}>
-                            <HighlightedPlainText
-                              text={relativizePath(
-                                activitySummaryText(act),
-                                worktreePath,
-                              )}
-                              query={searchQuery}
-                            />
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  ),
-                )}
-              </div>
-            )}
+            <div className={styles.turnActivities}>
+              {group.activities.map((act) => (
+                <ToolActivityRow
+                  key={act.toolUseId}
+                  activity={act}
+                  searchQuery={searchQuery}
+                  worktreePath={worktreePath}
+                />
+              ))}
+            </div>
           </div>
-        );
-      })}
+        ),
+      )}
     </div>
   );
 });
+
+function ToolActivityRow({
+  activity,
+  searchQuery,
+  worktreePath,
+}: {
+  activity: ToolActivity;
+  searchQuery: string;
+  worktreePath?: string | null;
+}) {
+  return (
+    <div className={styles.toolActivity}>
+      <div className={styles.toolHeader}>
+        <span
+          className={styles.toolName}
+          style={{ color: toolColor(activity.toolName) }}
+        >
+          {activity.toolName}
+        </span>
+        {activitySummaryText(activity) && (
+          <span className={styles.toolSummary}>
+            <HighlightedPlainText
+              text={relativizePath(activitySummaryText(activity), worktreePath)}
+              query={searchQuery}
+            />
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -34,10 +34,9 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
   worktreePath?: string | null;
   activities?: readonly ToolActivity[];
 }) {
-  const storeActivities = useAppStore(
-    (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
+  const activities = useAppStore(
+    (s) => activityOverride ?? s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
-  const activities = activityOverride ?? storeActivities;
   const displayGroups = groupToolActivitiesForDisplay(activities, toolDisplayMode);
   if (displayGroups.length === 0) return null;
 
@@ -103,7 +102,6 @@ function GroupedToolActivityRows({
   return (
     <div className={styles.turnSummary}>
       <div className={styles.turnHeader}>
-        <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
         <span className={styles.turnLabel}>{label}</span>
       </div>
       {isExpanded && (

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -20,15 +20,18 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
   toolDisplayMode,
   searchQuery,
   worktreePath,
+  activities: activityOverride,
 }: {
   sessionId: string;
   toolDisplayMode: ToolDisplayMode;
   searchQuery: string;
   worktreePath?: string | null;
+  activities?: readonly ToolActivity[];
 }) {
-  const activities = useAppStore(
+  const storeActivities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
+  const activities = activityOverride ?? storeActivities;
   const displayGroups = groupToolActivitiesForDisplay(activities, toolDisplayMode);
   if (displayGroups.length === 0) return null;
 

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -29,6 +29,7 @@ export function TurnSummary({
   searchQuery,
   worktreePath,
   label,
+  inline = false,
 }: {
   turn: CompletedTurn;
   activities?: ToolActivity[];
@@ -50,6 +51,7 @@ export function TurnSummary({
   searchQuery: string;
   worktreePath?: string | null;
   label?: string;
+  inline?: boolean;
 }) {
   const visibleActivities = activities ?? turn.activities;
   const hasElapsed = typeof turn.durationMs === "number" && turn.durationMs > 0;
@@ -73,66 +75,67 @@ export function TurnSummary({
     visibleActivities.some((activity) =>
       activityMatchesSearch(activity, searchQuery, worktreePath),
     );
-  const isExpanded = !collapsed || queryHasMatch;
+  const isExpanded = inline || !collapsed || queryHasMatch;
+  const renderedActivities = visibleActivities.map((act: ToolActivity) =>
+    isAgentActivity(act) ? (
+      <AgentToolCallGroup
+        key={act.toolUseId}
+        activity={act}
+        searchQuery={searchQuery}
+        worktreePath={worktreePath}
+      />
+    ) : (
+      <div key={act.toolUseId} className={styles.toolActivity}>
+        <div className={styles.toolHeader}>
+          <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
+            {act.toolName}
+          </span>
+          {activitySummaryText(act) && (
+            <span className={styles.toolSummary}>
+              <HighlightedPlainText
+                text={relativizePath(activitySummaryText(act), worktreePath)}
+                query={searchQuery}
+              />
+            </span>
+          )}
+        </div>
+      </div>
+    ),
+  );
 
   return (
     <div className={styles.turnSummaryWrapper}>
-      <div
-        className={styles.turnSummary}
-        role="button"
-        tabIndex={0}
-        onClick={onToggle}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            onToggle();
-          }
-        }}
-      >
-        <div className={styles.turnHeader}>
-          <span className={styles.toolChevron}>
-            {isExpanded ? "⌄" : "›"}
-          </span>
-          <span className={styles.turnLabel}>
-            {label ??
-              `${visibleActivities.length} tool call${
-                visibleActivities.length !== 1 ? "s" : ""
-              }`}
-            {showFooter && turn.messageCount > 0 &&
-              `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
-          </span>
-        </div>
-        {isExpanded && (
-          <div className={styles.turnActivities}>
-            {visibleActivities.map((act: ToolActivity) =>
-              isAgentActivity(act) ? (
-                <AgentToolCallGroup
-                  key={act.toolUseId}
-                  activity={act}
-                  searchQuery={searchQuery}
-                  worktreePath={worktreePath}
-                />
-              ) : (
-                <div key={act.toolUseId} className={styles.toolActivity}>
-                  <div className={styles.toolHeader}>
-                    <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
-                      {act.toolName}
-                    </span>
-                    {activitySummaryText(act) && (
-                      <span className={styles.toolSummary}>
-                        <HighlightedPlainText
-                          text={relativizePath(activitySummaryText(act), worktreePath)}
-                          query={searchQuery}
-                        />
-                      </span>
-                    )}
-                  </div>
-                </div>
-              ),
-            )}
+      {inline ? (
+        <div className={styles.inlineTurnActivities}>{renderedActivities}</div>
+      ) : (
+        <div
+          className={styles.turnSummary}
+          role="button"
+          tabIndex={0}
+          onClick={onToggle}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onToggle();
+            }
+          }}
+        >
+          <div className={styles.turnHeader}>
+            <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
+            <span className={styles.turnLabel}>
+              {label ??
+                `${visibleActivities.length} tool call${
+                  visibleActivities.length !== 1 ? "s" : ""
+                }`}
+              {showFooter && turn.messageCount > 0 &&
+                `, ${turn.messageCount} message${turn.messageCount !== 1 ? "s" : ""}`}
+            </span>
           </div>
-        )}
-      </div>
+          {isExpanded && (
+            <div className={styles.turnActivities}>{renderedActivities}</div>
+          )}
+        </div>
+      )}
       {taskProgress && taskProgress.totalCount > 0 && (
         <TaskProgressBar
           completedCount={taskProgress.completedCount}

--- a/src/ui/src/components/chat/toolActivityGroups.test.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.test.ts
@@ -21,7 +21,7 @@ function activity(
 }
 
 describe("toolActivityGroups", () => {
-  it("keeps direct tools together and splits agents into their own groups", () => {
+  it("groups adjacent regular tools and preserves chronological agent positions", () => {
     const groups = groupToolActivitiesForDisplay([
       activity("Bash"),
       activity("Glob"),
@@ -41,6 +41,28 @@ describe("toolActivityGroups", () => {
       ["Agent"],
       ["Read"],
       ["Agent"],
+    ]);
+  });
+
+  it("renders one item per top-level activity in inline mode", () => {
+    const groups = groupToolActivitiesForDisplay(
+      [
+        activity("Bash"),
+        activity("Agent", { agentDescription: "Survey UI" }),
+        activity("Glob"),
+      ],
+      "inline",
+    );
+
+    expect(groups.map((group) => group.label)).toEqual([
+      "Bash",
+      "Agent Survey UI",
+      "Glob",
+    ]);
+    expect(groups.map((group) => group.activities.map((item) => item.toolName))).toEqual([
+      ["Bash"],
+      ["Agent"],
+      ["Glob"],
     ]);
   });
 

--- a/src/ui/src/components/chat/toolActivityGroups.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.ts
@@ -9,7 +9,7 @@ export type ToolActivityDisplayGroup = {
 };
 
 export function groupToolActivitiesForDisplay(
-  activities: ToolActivity[],
+  activities: readonly ToolActivity[],
   mode: ToolDisplayMode = "grouped",
 ): ToolActivityDisplayGroup[] {
   if (mode === "inline") {
@@ -48,7 +48,7 @@ export function isAgentActivity(activity: ToolActivity): boolean {
 }
 
 export function groupHasRunningActivity(
-  activities: ToolActivity[],
+  activities: readonly ToolActivity[],
   parentIsRunning = false,
 ): boolean {
   return activities.some((activity) => {

--- a/src/ui/src/components/chat/toolActivityGroups.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.ts
@@ -1,3 +1,4 @@
+import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import type { ToolActivity } from "../../stores/useAppStore";
 
 export type ToolActivityDisplayGroup = {
@@ -9,7 +10,12 @@ export type ToolActivityDisplayGroup = {
 
 export function groupToolActivitiesForDisplay(
   activities: ToolActivity[],
+  mode: ToolDisplayMode = "grouped",
 ): ToolActivityDisplayGroup[] {
+  if (mode === "inline") {
+    return activities.map((activity) => activityDisplayGroup(activity));
+  }
+
   const groups: ToolActivityDisplayGroup[] = [];
   let directTools: ToolActivity[] = [];
 
@@ -27,12 +33,7 @@ export function groupToolActivitiesForDisplay(
   for (const activity of activities) {
     if (isAgentActivity(activity)) {
       flushDirectTools();
-      groups.push({
-        key: `agent:${activity.toolUseId}`,
-        kind: "agent",
-        label: agentGroupLabel(activity),
-        activities: [activity],
-      });
+      groups.push(activityDisplayGroup(activity));
       continue;
     }
     directTools.push(activity);
@@ -62,6 +63,16 @@ export function groupHasRunningActivity(
 
 function toolCallLabel(count: number): string {
   return `${count} tool call${count !== 1 ? "s" : ""}`;
+}
+
+function activityDisplayGroup(activity: ToolActivity): ToolActivityDisplayGroup {
+  const agent = isAgentActivity(activity);
+  return {
+    key: `${agent ? "agent" : "tool"}:${activity.toolUseId}`,
+    kind: agent ? "agent" : "tools",
+    label: agent ? agentGroupLabel(activity) : activity.toolName,
+    activities: [activity],
+  };
 }
 
 function agentGroupLabel(activity: ToolActivity): string {

--- a/src/ui/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/ui/src/components/settings/sections/AppearanceSettings.tsx
@@ -33,6 +33,8 @@ export function AppearanceSettings() {
   const systemFonts = useAppStore((s) => s.systemFonts);
   const showSidebarRunningCommands = useAppStore((s) => s.showSidebarRunningCommands);
   const setShowSidebarRunningCommands = useAppStore((s) => s.setShowSidebarRunningCommands);
+  const toolDisplayMode = useAppStore((s) => s.toolDisplayMode);
+  const setToolDisplayMode = useAppStore((s) => s.setToolDisplayMode);
 
   const isFollowSystem = themeMode === "system";
 
@@ -400,6 +402,38 @@ export function AppearanceSettings() {
             onChange={(e) => setTermFontSize(e.target.value)}
             onBlur={handleTermFontSizeBlur}
           />
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("appearance_group_tool_calls")}</div>
+          <div className={styles.settingDescription}>
+            {t("appearance_group_tool_calls_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={toolDisplayMode === "grouped"}
+            aria-label={t("appearance_group_tool_calls")}
+            data-checked={toolDisplayMode === "grouped"}
+            onClick={async () => {
+              const previous = toolDisplayMode;
+              const next = previous === "grouped" ? "inline" : "grouped";
+              setToolDisplayMode(next);
+              try {
+                setError(null);
+                await setAppSetting("tool_display_mode", next);
+              } catch (e) {
+                setToolDisplayMode(previous);
+                setError(String(e));
+              }
+            }}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
         </div>
       </div>
 

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -83,6 +83,8 @@
   "appearance_terminal_font_size_desc": "8–24px (default: 11)",
   "appearance_show_running_commands": "Show running commands in sidebar",
   "appearance_show_running_commands_desc": "Display a collapsible list of foreground processes running in each workspace's terminals. Off by default.",
+  "appearance_group_tool_calls": "Group tool calls",
+  "appearance_group_tool_calls_desc": "Combine adjacent regular tool calls while keeping Agent calls separate and preserving conversation order.",
   "appearance_interface_font": "Interface font",
   "appearance_interface_font_desc": "Font for UI text. Themes may set a default.",
   "appearance_custom_interface_font": "Custom interface font",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -64,6 +64,8 @@
   "appearance_terminal_font_size_desc": "8–24px (predeterminado: 11)",
   "appearance_show_running_commands": "Mostrar comandos en ejecución en la barra lateral",
   "appearance_show_running_commands_desc": "Muestra una lista plegable de los procesos en primer plano que se ejecutan en los terminales de cada espacio de trabajo. Desactivado por defecto.",
+  "appearance_group_tool_calls": "Agrupar llamadas a herramientas",
+  "appearance_group_tool_calls_desc": "Combina llamadas normales adyacentes mientras mantiene separadas las llamadas de Agent y conserva el orden de la conversación.",
   "appearance_interface_font": "Fuente de la interfaz",
   "appearance_interface_font_desc": "Fuente para el texto de la interfaz. Los temas pueden establecer una predeterminada.",
   "appearance_custom_interface_font": "Fuente de interfaz personalizada",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -64,6 +64,8 @@
   "appearance_terminal_font_size_desc": "8〜24px（既定値: 11）",
   "appearance_show_running_commands": "実行中のコマンドをサイドバーに表示",
   "appearance_show_running_commands_desc": "各ワークスペースのターミナルで実行中のフォアグラウンドプロセスを折りたたみ可能なリストとして表示します。既定ではオフです。",
+  "appearance_group_tool_calls": "ツール呼び出しをグループ化",
+  "appearance_group_tool_calls_desc": "隣接する通常のツール呼び出しをまとめ、Agent 呼び出しは分けたまま会話順を保持します。",
   "appearance_interface_font": "インターフェースのフォント",
   "appearance_interface_font_desc": "UI テキストのフォント。テーマが既定値を設定する場合があります。",
   "appearance_custom_interface_font": "カスタムインターフェースフォント",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -64,6 +64,8 @@
   "appearance_terminal_font_size_desc": "8–24px (padrão: 11)",
   "appearance_show_running_commands": "Mostrar comandos em execução na barra lateral",
   "appearance_show_running_commands_desc": "Exibe uma lista recolhível dos processos em primeiro plano executando nos terminais de cada workspace. Desativado por padrão.",
+  "appearance_group_tool_calls": "Agrupar chamadas de ferramentas",
+  "appearance_group_tool_calls_desc": "Combina chamadas regulares adjacentes mantendo chamadas de Agent separadas e preservando a ordem da conversa.",
   "appearance_interface_font": "Fonte da interface",
   "appearance_interface_font_desc": "Fonte para o texto da interface. Os temas podem definir um padrão.",
   "appearance_custom_interface_font": "Fonte de interface personalizada",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -64,6 +64,8 @@
   "appearance_terminal_font_size_desc": "8–24px（默认：11）",
   "appearance_show_running_commands": "在侧边栏显示运行中的命令",
   "appearance_show_running_commands_desc": "显示每个工作区终端中前台进程的可折叠列表。默认关闭。",
+  "appearance_group_tool_calls": "分组显示工具调用",
+  "appearance_group_tool_calls_desc": "合并相邻的常规工具调用，同时保持 Agent 调用独立并保留对话顺序。",
   "appearance_interface_font": "界面字体",
   "appearance_interface_font_desc": "界面文本的字体。主题可设置默认字体。",
   "appearance_custom_interface_font": "自定义界面字体",

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -4,6 +4,8 @@ import type { ClaudeFlagDef } from "../../services/claudeFlags";
 import type { AppState } from "../useAppStore";
 import type { AgentBackendConfig } from "../../services/tauri";
 
+export type ToolDisplayMode = "grouped" | "inline";
+
 export interface SettingsSlice {
   worktreeBaseDir: string;
   setWorktreeBaseDir: (dir: string) => void;
@@ -33,6 +35,8 @@ export interface SettingsSlice {
   /// Off by default — opt in via Settings → Appearance.
   showSidebarRunningCommands: boolean;
   setShowSidebarRunningCommands: (v: boolean) => void;
+  toolDisplayMode: ToolDisplayMode;
+  setToolDisplayMode: (mode: ToolDisplayMode) => void;
 
   // Experimental
   claudetteTerminalEnabled: boolean;
@@ -114,6 +118,8 @@ export const createSettingsSlice: StateCreator<
 
   showSidebarRunningCommands: false,
   setShowSidebarRunningCommands: (v) => set({ showSidebarRunningCommands: v }),
+  toolDisplayMode: "grouped",
+  setToolDisplayMode: (mode) => set({ toolDisplayMode: mode }),
 
   claudetteTerminalEnabled: false,
   setClaudetteTerminalEnabled: (enabled) =>


### PR DESCRIPTION
## Summary
- Add an Appearance setting for grouped vs inline tool call display, defaulting new users to grouped mode via the existing app settings table.
- Render live tool calls through the same assistant-message ordinal positioning model as settled completed turns so realtime tools no longer jump after turn completion.
- Preserve chronological ordering in both display modes, keep Agent tool calls grouped, and collapse grouped live tool cards once all calls in that group finish.
- Add regression coverage for grouped/inline activity grouping, live grouped collapse behavior, and the current Agent label styling contract where only the `Agent` tool name is colored.

## Test plan
- [x] `nix develop -c bash -lc 'cd src/ui && bun run test toolActivityGroups.test.ts ToolActivitiesSection.test.tsx'`
- [x] `nix develop -c bash -lc 'cd src/ui && bunx tsc -b'`
- [x] `nix develop -c bash -lc 'cd src/ui && bun run lint:css'`

## Notes
- No migration is needed: the new `tool_display_mode` preference uses the existing generic `app_settings` key/value table.
- The branch was rebased onto `origin/main` before opening this PR.