### PR TITLE
feat(sidebar): stop running terminal commands from sidebar indicator

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -722,6 +722,7 @@ fn main() {
             pty::write_pty,
             pty::resize_pty,
             pty::close_pty,
+            pty::interrupt_pty_foreground,
             pty::detect_shell,
             // Settings
             // CLI install/uninstall (Settings → CLI)

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -284,6 +284,64 @@ pub async fn resize_pty(
         .map_err(|e| format!("Resize failed: {e}"))
 }
 
+/// Interrupt the foreground process group of a PTY — the same effect as the
+/// user pressing Ctrl+C in the terminal, invoked from outside the terminal
+/// (e.g. the sidebar's running-commands list).
+///
+/// On Unix, we read the foreground PGID from the master FD via `tcgetpgrp`
+/// and send `SIGINT` to that group. This bypasses TTY line discipline, so it
+/// works even for programs that put the terminal in raw mode (TUIs/editors).
+///
+/// On Windows there are no POSIX process groups, so we fall back to writing
+/// `\x03` (ETX) into the PTY. That delivers SIGINT-equivalent only when the
+/// child has line discipline enabled, but covers the common shell case.
+#[tauri::command]
+pub async fn interrupt_pty_foreground(
+    pty_id: u64,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let ptys = state.ptys.read().await;
+    let handle = ptys.get(&pty_id).ok_or("PTY not found")?;
+
+    #[cfg(unix)]
+    {
+        let pgrp = {
+            let master = handle
+                .master
+                .lock()
+                .map_err(|e| format!("Lock error: {e}"))?;
+            let raw = master
+                .as_raw_fd()
+                .ok_or("Master PTY does not expose a raw FD")?;
+            unsafe { libc::tcgetpgrp(raw) }
+        };
+        // No foreground group (e.g. shell exited or backgrounded the
+        // command) — treat as a no-op rather than an error so the UI
+        // doesn't surface noise when the user clicks stale entries.
+        if pgrp <= 0 {
+            return Ok(());
+        }
+        // SAFETY: `kill(-pgrp, SIGINT)` is the standard POSIX way to deliver
+        // SIGINT to every process in the group. ESRCH means the group is
+        // already gone — also a no-op.
+        unsafe { libc::kill(-pgrp, libc::SIGINT) };
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        use std::io::Write;
+        let mut writer = handle
+            .writer
+            .lock()
+            .map_err(|e| format!("Lock error: {e}"))?;
+        writer
+            .write_all(&[0x03])
+            .map_err(|e| format!("Write failed: {e}"))?;
+        Ok(())
+    }
+}
+
 #[tauri::command]
 pub async fn close_pty(pty_id: u64, state: State<'_, AppState>) -> Result<(), String> {
     // Pull the handle out under the write lock, then release it before doing
@@ -462,6 +520,38 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
         let alive_after = unsafe { libc::kill(pid as i32, 0) == 0 };
         assert!(!alive_after, "child should be dead after kill");
+    }
+
+    /// Exercises the same SIGINT-to-foreground-PGID path that
+    /// `interrupt_pty_foreground` uses: read `tcgetpgrp(master_fd)` and
+    /// `kill(-pgrp, SIGINT)`. Verifies that a sleeping child running in
+    /// the PTY's foreground group gets interrupted from outside the TTY.
+    #[test]
+    fn pty_interrupts_foreground_via_sigint_to_pgid() {
+        // Trap-and-exit makes the assertion explicit: if the kill path
+        // works, the shell traps SIGINT and exits cleanly; if SIGINT is
+        // never delivered, `sleep 30` keeps it alive past the deadline.
+        let (master, mut child, _reader) = open_sh("trap 'exit 130' INT; sleep 30");
+
+        // Briefly let the child install the trap and start sleeping.
+        std::thread::sleep(Duration::from_millis(150));
+
+        let raw_fd = master
+            .as_raw_fd()
+            .expect("master PTY should expose a raw fd");
+        let pgrp = unsafe { libc::tcgetpgrp(raw_fd) };
+        assert!(pgrp > 0, "tcgetpgrp should report a foreground pgid");
+
+        // SAFETY: kill(-pgrp, SIGINT) is the POSIX-defined way to deliver
+        // SIGINT to every process in the group identified by `pgrp`.
+        let r = unsafe { libc::kill(-pgrp, libc::SIGINT) };
+        assert_eq!(r, 0, "kill(-pgrp, SIGINT) should succeed");
+
+        let status = child.wait().expect("child should exit");
+        drop(master);
+        // We don't care exactly how the shell encodes the SIGINT exit; we
+        // care that it exited (didn't run for the full 30 seconds).
+        let _ = status;
     }
 
     /// Verifies that `configure_pty_env` (the shared helper used by

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -322,10 +322,18 @@ pub async fn interrupt_pty_foreground(
             return Ok(());
         }
         // SAFETY: `kill(-pgrp, SIGINT)` is the standard POSIX way to deliver
-        // SIGINT to every process in the group. ESRCH means the group is
-        // already gone — also a no-op.
-        unsafe { libc::kill(-pgrp, libc::SIGINT) };
-        Ok(())
+        // SIGINT to every process in the group.
+        let r = unsafe { libc::kill(-pgrp, libc::SIGINT) };
+        if r == 0 {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        // ESRCH means the group exited between our `tcgetpgrp` and `kill` —
+        // race with normal termination, not a failure the user should see.
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(());
+        }
+        Err(format!("Failed to interrupt PTY foreground group: {err}"))
     }
 
     #[cfg(not(unix))]
@@ -528,10 +536,11 @@ mod tests {
     /// the PTY's foreground group gets interrupted from outside the TTY.
     #[test]
     fn pty_interrupts_foreground_via_sigint_to_pgid() {
-        // Trap-and-exit makes the assertion explicit: if the kill path
-        // works, the shell traps SIGINT and exits cleanly; if SIGINT is
-        // never delivered, `sleep 30` keeps it alive past the deadline.
-        let (master, mut child, _reader) = open_sh("trap 'exit 130' INT; sleep 30");
+        // The shell traps SIGINT and exits with a marker code (42). If
+        // the SIGINT is never delivered, `sleep 30` keeps the child
+        // alive — the wait deadline below catches that case so the
+        // test fails fast instead of dragging out for 30 seconds.
+        let (master, mut child, _reader) = open_sh("trap 'exit 42' INT; sleep 30");
 
         // Briefly let the child install the trap and start sleeping.
         std::thread::sleep(Duration::from_millis(150));
@@ -544,14 +553,44 @@ mod tests {
 
         // SAFETY: kill(-pgrp, SIGINT) is the POSIX-defined way to deliver
         // SIGINT to every process in the group identified by `pgrp`.
+        let start = Instant::now();
         let r = unsafe { libc::kill(-pgrp, libc::SIGINT) };
         assert_eq!(r, 0, "kill(-pgrp, SIGINT) should succeed");
 
-        let status = child.wait().expect("child should exit");
+        // Poll `try_wait` with a short deadline — if SIGINT was actually
+        // delivered, the trap runs and the child exits in tens of ms.
+        // A broken signal path would let the child sleep its full 30s,
+        // which we want to catch as a failure here, not let it slide.
+        let deadline = Duration::from_secs(3);
+        let status = loop {
+            match child.try_wait().expect("try_wait should not fail") {
+                Some(status) => break status,
+                None => {
+                    if start.elapsed() > deadline {
+                        // Don't leave the child running past the test —
+                        // kill it and reap before failing.
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        drop(master);
+                        panic!(
+                            "child did not exit within {deadline:?} after SIGINT — \
+                             the kill(-pgrp, SIGINT) path is not reaching the foreground group"
+                        );
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+            }
+        };
         drop(master);
-        // We don't care exactly how the shell encodes the SIGINT exit; we
-        // care that it exited (didn't run for the full 30 seconds).
-        let _ = status;
+
+        // The shell ran our SIGINT trap (`exit 42`) — not just any exit.
+        // This rules out the case where the child died for an unrelated
+        // reason (e.g. PTY teardown) and still happened to exit fast.
+        assert_eq!(
+            status.exit_code(),
+            42,
+            "shell should have run the SIGINT trap (exit 42), got: {status:?}"
+        );
     }
 
     /// Verifies that `configure_pty_env` (the shared helper used by

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -564,6 +564,40 @@
   margin-left: 32px;
 }
 
+.terminalCommandItem .commandText {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Stop button to interrupt the foreground command on a PTY (sends SIGINT
+   to the foreground process group on Unix, writes \x03 on Windows). Hidden
+   until the row is hovered to keep the dense list visually quiet. */
+.commandStopBtn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 1px;
+  margin: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  opacity: 0;
+  border-radius: 2px;
+  line-height: 1;
+}
+
+.terminalCommandItem:hover .commandStopBtn,
+.commandStopBtn:focus-visible {
+  opacity: 1;
+}
+
+.commandStopBtn:hover {
+  color: var(--status-stopped);
+  background: var(--hover-bg);
+}
+
 .runningIcon {
   color: var(--status-running);
   animation: spin 2s linear infinite;

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   openInEditor,
   openWorkspaceInTerminal,
   listChatSessions,
+  interruptPtyForeground,
 } from "../../services/tauri";
 import { Settings, Link, X, Share2, Plus, Globe, Archive, Trash2, CircleCheck, CircleAlert, CircleQuestionMark, Cog, Filter, LayoutDashboard, CircleDashed, CircleStop, GitPullRequestArrow, GitPullRequestDraft, GitMerge, GitPullRequestClosed, ChevronRight, ChevronDown, ArrowDownAZ } from "lucide-react";
 import { RepoIcon } from "../shared/RepoIcon";
@@ -799,6 +800,20 @@ export const Sidebar = memo(function Sidebar() {
                         <span className={styles.commandText} title={command ?? ""}>
                           {truncateCommand(command ?? t("command_running_placeholder"), 40)}
                         </span>
+                        <button
+                          type="button"
+                          className={styles.commandStopBtn}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void interruptPtyForeground(Number(ptyId)).catch((err) =>
+                              console.error("[Sidebar] Failed to interrupt PTY command:", err),
+                            );
+                          }}
+                          title={t("command_stop")}
+                          aria-label={t("command_stop")}
+                        >
+                          <X size={10} />
+                        </button>
                       </div>
                     ))}
                   </div>

--- a/src/ui/src/locales/en/sidebar.json
+++ b/src/ui/src/locales/en/sidebar.json
@@ -61,7 +61,7 @@
   "command_collapse": "Collapse running commands",
   "command_expand": "Expand running commands",
   "command_count_running": "{{count}} running",
-  "command_stop": "Stop command (SIGINT)",
+  "command_stop": "Stop command",
   "new_workspace_remote": "New workspace",
   "workspace_connect": "Connect",
   "workspace_disconnect": "Disconnect",

--- a/src/ui/src/locales/en/sidebar.json
+++ b/src/ui/src/locales/en/sidebar.json
@@ -61,6 +61,7 @@
   "command_collapse": "Collapse running commands",
   "command_expand": "Expand running commands",
   "command_count_running": "{{count}} running",
+  "command_stop": "Stop command (SIGINT)",
   "new_workspace_remote": "New workspace",
   "workspace_connect": "Connect",
   "workspace_disconnect": "Disconnect",

--- a/src/ui/src/locales/es/sidebar.json
+++ b/src/ui/src/locales/es/sidebar.json
@@ -59,7 +59,7 @@
   "command_collapse": "Contraer comandos en ejecución",
   "command_expand": "Expandir comandos en ejecución",
   "command_count_running": "{{count}} en ejecución",
-  "command_stop": "Detener comando (SIGINT)",
+  "command_stop": "Detener comando",
   "new_workspace_remote": "Nuevo espacio de trabajo",
   "workspace_connect": "Conectar",
   "workspace_disconnect": "Desconectar",

--- a/src/ui/src/locales/es/sidebar.json
+++ b/src/ui/src/locales/es/sidebar.json
@@ -59,6 +59,7 @@
   "command_collapse": "Contraer comandos en ejecución",
   "command_expand": "Expandir comandos en ejecución",
   "command_count_running": "{{count}} en ejecución",
+  "command_stop": "Detener comando (SIGINT)",
   "new_workspace_remote": "Nuevo espacio de trabajo",
   "workspace_connect": "Conectar",
   "workspace_disconnect": "Desconectar",

--- a/src/ui/src/locales/ja/sidebar.json
+++ b/src/ui/src/locales/ja/sidebar.json
@@ -59,7 +59,7 @@
   "command_collapse": "実行中のコマンドを折りたたむ",
   "command_expand": "実行中のコマンドを展開する",
   "command_count_running": "{{count}} 件実行中",
-  "command_stop": "コマンドを停止 (SIGINT)",
+  "command_stop": "コマンドを停止",
   "new_workspace_remote": "新規ワークスペース",
   "workspace_connect": "接続",
   "workspace_disconnect": "切断",

--- a/src/ui/src/locales/ja/sidebar.json
+++ b/src/ui/src/locales/ja/sidebar.json
@@ -59,6 +59,7 @@
   "command_collapse": "実行中のコマンドを折りたたむ",
   "command_expand": "実行中のコマンドを展開する",
   "command_count_running": "{{count}} 件実行中",
+  "command_stop": "コマンドを停止 (SIGINT)",
   "new_workspace_remote": "新規ワークスペース",
   "workspace_connect": "接続",
   "workspace_disconnect": "切断",

--- a/src/ui/src/locales/pt-BR/sidebar.json
+++ b/src/ui/src/locales/pt-BR/sidebar.json
@@ -59,6 +59,7 @@
   "command_collapse": "Recolher comandos em execução",
   "command_expand": "Expandir comandos em execução",
   "command_count_running": "{{count}} em execução",
+  "command_stop": "Parar comando (SIGINT)",
   "new_workspace_remote": "Novo workspace",
   "workspace_connect": "Conectar",
   "workspace_disconnect": "Desconectar",

--- a/src/ui/src/locales/pt-BR/sidebar.json
+++ b/src/ui/src/locales/pt-BR/sidebar.json
@@ -59,7 +59,7 @@
   "command_collapse": "Recolher comandos em execução",
   "command_expand": "Expandir comandos em execução",
   "command_count_running": "{{count}} em execução",
-  "command_stop": "Parar comando (SIGINT)",
+  "command_stop": "Parar comando",
   "new_workspace_remote": "Novo workspace",
   "workspace_connect": "Conectar",
   "workspace_disconnect": "Desconectar",

--- a/src/ui/src/locales/zh-CN/sidebar.json
+++ b/src/ui/src/locales/zh-CN/sidebar.json
@@ -59,6 +59,7 @@
   "command_collapse": "折叠运行中的命令",
   "command_expand": "展开运行中的命令",
   "command_count_running": "{{count}} 个运行中",
+  "command_stop": "停止命令 (SIGINT)",
   "new_workspace_remote": "新建工作区",
   "workspace_connect": "连接",
   "workspace_disconnect": "断开连接",

--- a/src/ui/src/locales/zh-CN/sidebar.json
+++ b/src/ui/src/locales/zh-CN/sidebar.json
@@ -59,7 +59,7 @@
   "command_collapse": "折叠运行中的命令",
   "command_expand": "展开运行中的命令",
   "command_count_running": "{{count}} 个运行中",
-  "command_stop": "停止命令 (SIGINT)",
+  "command_stop": "停止命令",
   "new_workspace_remote": "新建工作区",
   "workspace_connect": "连接",
   "workspace_disconnect": "断开连接",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -1241,6 +1241,10 @@ export function closePty(ptyId: number): Promise<void> {
   return invoke("close_pty", { ptyId });
 }
 
+export function interruptPtyForeground(ptyId: number): Promise<void> {
+  return invoke("interrupt_pty_foreground", { ptyId });
+}
+
 export function startAgentTaskTail(
   tabId: number,
   outputPath: string,


### PR DESCRIPTION
## Summary

Adds a stop button to each row of the sidebar's expanded "running commands" list so users can interrupt a runaway command without having to navigate into the workspace and press Ctrl+C in the terminal.

- New `interrupt_pty_foreground(pty_id)` Tauri command. On Unix it reads the foreground PGID via `tcgetpgrp(master_fd)` and delivers `SIGINT` to `-pgrp` — bypassing TTY line discipline so it works even for raw-mode TUIs (editors, full-screen UIs). On Windows it writes `\x03` to the PTY master as a v1 fallback.
- Stop button (X icon) per row in `Sidebar.tsx`, hover-revealed to keep the dense list visually quiet. Click handler invokes the new command; the existing `pty-command-stopped` event removes the row when the process exits.
- New `command_stop` translation key in all five locales (en/es/ja/pt-BR/zh-CN).
- New CSS class in `Sidebar.module.css`, all colors via existing tokens.

Closes #664.

## Complexity Notes

- **`tcgetpgrp` returning `<= 0`** is treated as a no-op rather than an error, so stale rows or already-exited commands don't surface UI noise.
- **Locking:** the Unix path holds `handle.master.lock()` only for the syscall itself, then drops before the `kill(2)`, so an interrupt can't deadlock with a concurrent `resize_pty`.
- **Windows fallback** intentionally won't interrupt programs that put the TTY in raw mode — covers the common shell case; a proper `GenerateConsoleCtrlEvent` path is left for a future PR (called out in the issue).

## Test Steps

1. Build & run: `cargo tauri dev` (or `./scripts/dev.sh`).
2. Enable the **Show running commands in sidebar** setting.
3. Open a workspace, go to its terminal, and start a long-running command (`sleep 60`, `cargo build`, `vim` etc.). The sidebar row expands to show "1 running".
4. Click the chevron to expand the running-commands list. Hover a row — a small `X` button appears at the right.
5. Click the X. The command should be interrupted (Ctrl+C-equivalent) and the row should disappear from the list within a few hundred ms (when `pty-command-stopped` fires).
6. Repeat against `vim` (raw-mode TTY) on macOS / Linux to confirm the bypass-line-discipline path works there too.
7. Automated: `cargo test -p claudette-tauri pty::tests::pty_interrupts_foreground_via_sigint_to_pgid` passes.

## Checklist

- [x] Tests added/updated (new `pty_interrupts_foreground_via_sigint_to_pgid` integration test against a real PTY)
- [ ] Documentation updated (n/a)