### PR TITLE
fix(missing_cli): update Claude Code install options to match official docs

### DIFF
--- a/src/missing_cli.rs
+++ b/src/missing_cli.rs
@@ -163,22 +163,41 @@ pub fn guidance_for(tool: &str) -> MissingCli {
 }
 
 fn claude_options() -> Vec<InstallOption> {
-    let mut opts = vec![InstallOption::cmd(
-        "Install with npm",
-        "npm install -g @anthropic-ai/claude-code",
-    )];
     if cfg!(target_os = "windows") {
-        opts.push(InstallOption::link(
-            "Official installer",
-            "https://claude.com/product/claude-code",
-        ));
+        vec![
+            InstallOption::cmd(
+                "Install with PowerShell (recommended)",
+                "irm https://claude.ai/install.ps1 | iex",
+            ),
+            InstallOption::cmd(
+                "Install with CMD",
+                "curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd",
+            ),
+            InstallOption::cmd(
+                "Install with npm",
+                "npm install -g @anthropic-ai/claude-code",
+            ),
+            InstallOption::link(
+                "Installation guide",
+                "https://code.claude.com/docs/en/setup",
+            ),
+        ]
     } else {
-        opts.push(InstallOption::link(
-            "Installation guide",
-            "https://docs.claude.com/en/docs/claude-code/setup",
-        ));
+        vec![
+            InstallOption::cmd(
+                "Install (recommended)",
+                "curl -fsSL https://claude.ai/install.sh | bash",
+            ),
+            InstallOption::cmd(
+                "Install with npm",
+                "npm install -g @anthropic-ai/claude-code",
+            ),
+            InstallOption::link(
+                "Installation guide",
+                "https://code.claude.com/docs/en/setup",
+            ),
+        ]
     }
-    opts
 }
 
 fn git_options() -> Vec<InstallOption> {


### PR DESCRIPTION
## Summary

- Replaces the npm-only install option with the official native script (`curl -fsSL https://claude.ai/install.sh | bash`) as the recommended method on macOS/Linux, matching the current Claude Code docs
- Adds PowerShell (`irm https://claude.ai/install.ps1 | iex`) and CMD (`curl ... install.cmd`) options for Windows, replacing the stale product page link
- Updates the docs link from the old `docs.claude.com/en/docs/claude-code/setup` to `code.claude.com/docs/en/setup`

## Test Steps

1. Build and run the app in dev mode
2. Temporarily rename or remove the `claude` CLI from PATH to trigger the missing-CLI modal
3. Start a new agent session — the modal should appear
4. **macOS/Linux**: verify the first option shows the `curl` install command with a copy button, followed by npm, then the updated docs link
5. **Windows**: verify the modal shows PowerShell → CMD → npm options, then the updated docs link
6. Click the docs link — confirm it opens `https://code.claude.com/docs/en/setup`

## Checklist

- [x] Tests added/updated — existing `missing_cli` unit tests pass; the data structure is unchanged so no new test coverage needed
- [ ] Documentation updated (if applicable) — N/A, this is purely a content update matching upstream docs