### PR TITLE
fix(chat): tab close/expand correctness + Tauri-native confirms + live tab rename + MCP arg surfacing

### DIFF
--- a/plugins/scm-github/init.lua
+++ b/plugins/scm-github/init.lua
@@ -24,11 +24,21 @@ function M.list_pull_requests(args)
     for _, item in ipairs(data) do
         local ci = nil
         if item.statusCheckRollup and #item.statusCheckRollup > 0 then
+            -- "SKIPPED" / "NEUTRAL" conclusions don't break "all pass":
+            -- they're informational (workflow `if:` was false, action
+            -- early-returned). Without this, a merged PR whose only
+            -- non-success check was SKIPPED rolled up to "pending" and
+            -- the PR card showed a phantom Running spinner.
             local all_pass = true
             local any_fail = false
             for _, check in ipairs(item.statusCheckRollup) do
                 if check.conclusion == "FAILURE" then any_fail = true end
-                if check.conclusion ~= "SUCCESS" then all_pass = false end
+                if check.conclusion ~= "SUCCESS"
+                    and check.conclusion ~= "SKIPPED"
+                    and check.conclusion ~= "NEUTRAL"
+                then
+                    all_pass = false
+                end
             end
             if any_fail then ci = "failure"
             elseif all_pass then ci = "success"
@@ -56,11 +66,19 @@ function M.get_pull_request(args)
     })
     local ci = nil
     if data.statusCheckRollup and #data.statusCheckRollup > 0 then
+        -- Mirrors the rollup in M.list_pull_requests above; see the
+        -- comment there for why SKIPPED/NEUTRAL conclusions don't break
+        -- "all pass".
         local all_pass = true
         local any_fail = false
         for _, check in ipairs(data.statusCheckRollup) do
             if check.conclusion == "FAILURE" then any_fail = true end
-            if check.conclusion ~= "SUCCESS" then all_pass = false end
+            if check.conclusion ~= "SUCCESS"
+                and check.conclusion ~= "SKIPPED"
+                and check.conclusion ~= "NEUTRAL"
+            then
+                all_pass = false
+            end
         end
         if any_fail then ci = "failure"
         elseif all_pass then ci = "success"
@@ -122,12 +140,28 @@ function M.merge_pull_request(args)
 end
 
 -- Normalize GitHub check state to canonical CiCheckStatus values.
--- gh returns: SUCCESS, FAILURE, PENDING, CANCELLED, ERROR, EXPECTED, STALE, etc.
+-- gh's `pr checks` reports check-run conclusions; values seen in the
+-- wild include SUCCESS, FAILURE, PENDING, CANCELLED, ERROR, EXPECTED,
+-- STALE, SKIPPED, NEUTRAL, ACTION_REQUIRED, TIMED_OUT.
+--
+-- Mapping onto Rust's CiCheckStatus enum:
+--   SUCCESS                          → "success"
+--   FAILURE / ERROR / TIMED_OUT      → "failure"
+--   CANCELLED                        → "cancelled"
+--   SKIPPED / NEUTRAL                → "skipped"  (didn't actually run / no-op result)
+--   PENDING / EXPECTED / STALE / etc → "pending" (in-flight or queued)
+--
+-- NEUTRAL is grouped with SKIPPED because GitHub uses it for actions
+-- that ran but produced no signal (e.g. a workflow that early-returns
+-- on a path filter mismatch); to the reviewer that's "didn't run", not
+-- "passed". Previously both SKIPPED and NEUTRAL fell through to
+-- "pending", so merged PRs displayed phantom "Running" checks.
 local function normalize_check_status(state)
     local s = string.upper(state or "")
     if s == "SUCCESS" then return "success" end
-    if s == "FAILURE" or s == "ERROR" then return "failure" end
+    if s == "FAILURE" or s == "ERROR" or s == "TIMED_OUT" then return "failure" end
     if s == "CANCELLED" or s == "CANCELED" then return "cancelled" end
+    if s == "SKIPPED" or s == "NEUTRAL" then return "skipped" end
     return "pending"
 end
 

--- a/plugins/scm-gitlab/init.lua
+++ b/plugins/scm-gitlab/init.lua
@@ -90,12 +90,26 @@ function M.merge_pull_request(args)
 end
 
 -- Normalize GitLab job status to canonical CiCheckStatus values.
--- GitLab returns: created, pending, running, success, failed, canceled, skipped, manual.
+-- GitLab returns: created, pending, running, success, failed, canceled,
+-- skipped, manual. Map them onto the four-canonical statuses Rust
+-- consumes:
+--   success                 → "success"
+--   failed                  → "failure"
+--   canceled                → "cancelled"  (note GitLab's "canceled" — single l)
+--   skipped, manual         → "skipped"   (didn't run by design / awaiting manual trigger)
+--   created, pending, running → "pending" (in-flight or queued)
+-- "manual" is grouped with "skipped" because to the user a job that
+-- requires manual triggering and hasn't been triggered behaves
+-- identically to a skipped job — it isn't running, it isn't failing,
+-- and it carries no signal until someone acts. Without this, both
+-- "skipped" and "manual" fell through to "pending" and the UI rendered
+-- merged-PR jobs as "Running".
 local function normalize_job_status(status)
     local s = string.lower(status or "")
     if s == "success" then return "success" end
     if s == "failed" then return "failure" end
     if s == "canceled" then return "cancelled" end
+    if s == "skipped" or s == "manual" then return "skipped" end
     return "pending"
 end
 

--- a/plugins/scm-gitlab/init.lua
+++ b/plugins/scm-gitlab/init.lua
@@ -91,8 +91,8 @@ end
 
 -- Normalize GitLab job status to canonical CiCheckStatus values.
 -- GitLab returns: created, pending, running, success, failed, canceled,
--- skipped, manual. Map them onto the four-canonical statuses Rust
--- consumes:
+-- skipped, manual. Map them onto the five canonical CiCheckStatus
+-- variants Rust consumes:
 --   success                 → "success"
 --   failed                  → "failure"
 --   canceled                → "cancelled"  (note GitLab's "canceled" — single l)

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -173,7 +173,13 @@ async fn collect_workspace_file_entries(worktree_path: &str) -> Result<Vec<FileE
     // Pass 1: tracked + untracked-not-ignored. Annotate with git status.
     stream_ls_files(
         worktree_path,
-        &["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        &[
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+        ],
         &mut |path| {
             if entries.len() >= MAX_FILES {
                 return StreamCallback::Stop;

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -15,6 +15,17 @@ use claudette::process::CommandWindowExt as _;
 
 const MAX_FILES: usize = 10_000;
 
+/// Per-top-level-directory cap on ignored entries.
+///
+/// Without a cap, a single noisy ignored tree (e.g. `.direnv/`, `.codex/`,
+/// `tmp/cache/`) can fill `MAX_FILES` alphabetically before any tracked
+/// file is emitted — `git ls-files` returns paths in collated order and
+/// `.`-prefixed names sort before `A-z`. Bucketing by top-level directory
+/// keeps every ignored tree below a fair-share cap so tracked content
+/// always wins. Root-level ignored files (no `/` in path) share their own
+/// bucket under the same cap.
+const MAX_IGNORED_FILES_PER_TOP_DIR: usize = 200;
+
 /// Top-level directory names that are always excluded from file listings,
 /// regardless of `.gitignore`, to avoid overwhelming the panel with
 /// dependency/build trees.
@@ -34,6 +45,16 @@ fn is_high_volume_path(path: &str) -> bool {
     SKIP_DIR_PREFIXES
         .iter()
         .any(|prefix| path.starts_with(prefix))
+}
+
+/// Return the top-level bucket key for a path: the segment before the
+/// first `/`, including the trailing slash (e.g. `.direnv/`), or the
+/// empty string for paths with no separator (root-level files).
+fn top_level_bucket(path: &str) -> &str {
+    match path.find('/') {
+        Some(idx) => &path[..=idx],
+        None => "",
+    }
 }
 
 #[derive(Clone, Serialize)]
@@ -123,36 +144,158 @@ pub async fn list_workspace_files(
     collect_workspace_file_entries(worktree_path).await
 }
 
-/// Stream `git ls-files --cached --others -z` from `worktree_path`, stopping
-/// after `MAX_FILES` accepted entries and skipping high-volume directory trees.
+/// Stream `git ls-files` from `worktree_path` in two passes:
+///
+/// 1. **Tracked + untracked-not-ignored** via `--cached --others
+///    --exclude-standard -z`. Capped at `MAX_FILES`. These are the files
+///    the user is most likely to care about; they always win.
+/// 2. **Ignored only** via `--others --ignored --exclude-standard -z`. Each
+///    top-level directory bucket (e.g. `.direnv/`, `tmp/`, root) is capped
+///    at `MAX_IGNORED_FILES_PER_TOP_DIR` so a single noisy ignored tree
+///    can't starve pass 1 alphabetically — `.`-prefixed names sort before
+///    `A-z` so without a per-bucket cap a huge `.direnv/` would consume
+///    the cap before any tracked file is emitted (this was the regression
+///    in #694).
+///
 /// Uses NUL-delimited output (`-z`) so filenames with newlines or special
 /// characters are handled correctly without git's path quoting.
 async fn collect_workspace_file_entries(worktree_path: &str) -> Result<Vec<FileEntry>, String> {
-    use tokio::io::{AsyncBufReadExt, BufReader};
-
-    let mut child = Command::new(claudette::git::resolve_git_path_blocking())
-        .no_console_window()
-        .args(["-C", worktree_path])
-        .args(["ls-files", "--cached", "--others", "-z"])
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("Failed to spawn git ls-files: {e}"))?;
-
     let file_tree_status = claudette::diff::file_tree_git_status_with_suppressed(worktree_path)
         .await
         .map_err(|e| format!("Failed to load git status: {e}"))?;
     let git_status = file_tree_status.statuses;
     let suppressed_paths = file_tree_status.suppressed_paths;
 
+    let mut dirs = std::collections::BTreeSet::new();
+    let mut seen_files = std::collections::BTreeSet::new();
+    let mut entries: Vec<FileEntry> = Vec::new();
+
+    // Pass 1: tracked + untracked-not-ignored. Annotate with git status.
+    stream_ls_files(
+        worktree_path,
+        &["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        &mut |path| {
+            if entries.len() >= MAX_FILES {
+                return StreamCallback::Stop;
+            }
+            if suppressed_paths.contains(path) || is_high_volume_path(path) {
+                return StreamCallback::Skip;
+            }
+            let status = git_status.get(path);
+            record_file_entry(
+                path,
+                status.map(|s| s.status.clone()),
+                status.map(|s| s.layer),
+                &mut entries,
+                &mut seen_files,
+                &mut dirs,
+            );
+            StreamCallback::Keep
+        },
+    )
+    .await?;
+
+    // `git status` may surface paths that `git ls-files --cached --others
+    // --exclude-standard` doesn't (e.g. unstaged deletions), so fold them
+    // in before pass 2.
+    for (path, status) in &git_status {
+        if entries.len() >= MAX_FILES || seen_files.contains(path) || is_high_volume_path(path) {
+            continue;
+        }
+        record_file_entry(
+            path,
+            Some(status.status.clone()),
+            Some(status.layer),
+            &mut entries,
+            &mut seen_files,
+            &mut dirs,
+        );
+    }
+
+    // Pass 2: ignored entries with per-top-level-dir fair-share cap.
+    let mut ignored_per_bucket: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    stream_ls_files(
+        worktree_path,
+        &[
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+        ],
+        &mut |path| {
+            if entries.len() >= MAX_FILES {
+                return StreamCallback::Stop;
+            }
+            if seen_files.contains(path)
+                || suppressed_paths.contains(path)
+                || is_high_volume_path(path)
+            {
+                return StreamCallback::Skip;
+            }
+            let bucket = top_level_bucket(path).to_string();
+            let count = ignored_per_bucket.entry(bucket).or_insert(0);
+            if *count >= MAX_IGNORED_FILES_PER_TOP_DIR {
+                return StreamCallback::Skip;
+            }
+            *count += 1;
+            // Ignored entries get no git status badge — neither tracked
+            // nor in `git status`'s untracked set.
+            record_file_entry(path, None, None, &mut entries, &mut seen_files, &mut dirs);
+            StreamCallback::Keep
+        },
+    )
+    .await?;
+
+    let dir_entries: Vec<FileEntry> = dirs
+        .into_iter()
+        .map(|path| FileEntry {
+            path,
+            is_directory: true,
+            git_status: None,
+            git_layer: None,
+        })
+        .collect();
+    entries.splice(0..0, dir_entries);
+
+    Ok(entries)
+}
+
+/// Outcome the streaming callback returns for each emitted path.
+#[derive(Clone, Copy)]
+enum StreamCallback {
+    /// Path was accepted into the result set.
+    Keep,
+    /// Path was filtered out; keep streaming the next entry.
+    Skip,
+    /// Caller-imposed cap reached; stop reading and kill the child.
+    Stop,
+}
+
+/// Spawn `git <args>` against `worktree_path` and feed each NUL-delimited
+/// path to `on_path`. Returns when git exits or the callback returns
+/// `Stop` (in which case the child is killed).
+async fn stream_ls_files(
+    worktree_path: &str,
+    args: &[&str],
+    on_path: &mut (dyn FnMut(&str) -> StreamCallback + Send),
+) -> Result<(), String> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    let mut child = Command::new(claudette::git::resolve_git_path_blocking())
+        .no_console_window()
+        .args(["-C", worktree_path])
+        .args(args)
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn git ls-files: {e}"))?;
+
     let stdout = child
         .stdout
         .take()
         .ok_or("Failed to capture git ls-files stdout")?;
     let mut reader = BufReader::new(stdout);
-
-    let mut dirs = std::collections::BTreeSet::new();
-    let mut seen_files = std::collections::BTreeSet::new();
-    let mut entries: Vec<FileEntry> = Vec::new();
     let mut buf = Vec::new();
 
     loop {
@@ -170,69 +313,47 @@ async fn collect_workspace_file_entries(worktree_path: &str) -> Result<Vec<FileE
         if buf.is_empty() {
             continue;
         }
-        let line = match std::str::from_utf8(&buf) {
+        let path = match std::str::from_utf8(&buf) {
             Ok(s) => s,
             Err(_) => continue,
         };
-
-        if suppressed_paths.contains(line) || is_high_volume_path(line) {
-            continue;
+        match on_path(path) {
+            StreamCallback::Keep | StreamCallback::Skip => {}
+            StreamCallback::Stop => {
+                let _ = child.kill().await;
+                break;
+            }
         }
-
-        if entries.len() >= MAX_FILES {
-            let _ = child.kill().await;
-            break;
-        }
-
-        let status = git_status.get(line);
-        seen_files.insert(line.to_string());
-        let mut pos = 0;
-        while let Some(slash) = line[pos..].find('/') {
-            let dir_end = pos + slash;
-            dirs.insert(line[..=dir_end].to_string());
-            pos = dir_end + 1;
-        }
-        entries.push(FileEntry {
-            path: line.to_string(),
-            is_directory: false,
-            git_status: status.map(|s| s.status.clone()),
-            git_layer: status.map(|s| s.layer),
-        });
     }
 
     let _ = child.wait().await;
+    Ok(())
+}
 
-    for (path, status) in &git_status {
-        if entries.len() >= MAX_FILES || seen_files.contains(path) || is_high_volume_path(path) {
-            continue;
-        }
-        let mut pos = 0;
-        while let Some(slash) = path[pos..].find('/') {
-            let dir_end = pos + slash;
-            dirs.insert(path[..=dir_end].to_string());
-            pos = dir_end + 1;
-        }
-        seen_files.insert(path.clone());
-        entries.push(FileEntry {
-            path: path.clone(),
-            is_directory: false,
-            git_status: Some(status.status.clone()),
-            git_layer: Some(status.layer),
-        });
+/// Insert a file entry plus all of its parent directories into the
+/// accumulator structures. Centralized so the two passes stay consistent
+/// in how they extract the directory tree.
+fn record_file_entry(
+    path: &str,
+    git_status: Option<FileStatus>,
+    git_layer: Option<GitFileLayer>,
+    entries: &mut Vec<FileEntry>,
+    seen_files: &mut std::collections::BTreeSet<String>,
+    dirs: &mut std::collections::BTreeSet<String>,
+) {
+    seen_files.insert(path.to_string());
+    let mut pos = 0;
+    while let Some(slash) = path[pos..].find('/') {
+        let dir_end = pos + slash;
+        dirs.insert(path[..=dir_end].to_string());
+        pos = dir_end + 1;
     }
-
-    let dir_entries: Vec<FileEntry> = dirs
-        .into_iter()
-        .map(|path| FileEntry {
-            path,
-            is_directory: true,
-            git_status: None,
-            git_layer: None,
-        })
-        .collect();
-    entries.splice(0..0, dir_entries);
-
-    Ok(entries)
+    entries.push(FileEntry {
+        path: path.to_string(),
+        is_directory: false,
+        git_status,
+        git_layer,
+    });
 }
 
 /// Read a file from a workspace's worktree.
@@ -1795,6 +1916,104 @@ mod tests {
         assert!(is_high_volume_path(".next/static/chunks/main.js"));
         assert!(!is_high_volume_path("src/node_modules_helper.rs"));
         assert!(!is_high_volume_path("mytarget/foo"));
+    }
+
+    #[test]
+    fn top_level_bucket_extracts_first_segment() {
+        assert_eq!(top_level_bucket(".direnv/bin/python"), ".direnv/");
+        assert_eq!(top_level_bucket("src/main.rs"), "src/");
+        assert_eq!(top_level_bucket("Cargo.toml"), "");
+        assert_eq!(top_level_bucket(""), "");
+    }
+
+    #[tokio::test]
+    async fn ignored_tree_does_not_starve_tracked_files() {
+        // Regression for the post-#694 symptom where a single noisy
+        // ignored top-level directory (`.codex/`, `.direnv/`, etc.) sorts
+        // alphabetically before tracked content and consumed the
+        // `MAX_FILES` cap, producing a Files panel that showed only
+        // ignored directories.
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "test@test.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+        }
+
+        // Tracked files at lowercase + uppercase top-level paths so any
+        // alphabetical-truncation regression would hide them behind
+        // `.heavy_ignored/` in collated order.
+        std::fs::write(root.join("Cargo.toml"), "x").unwrap();
+        std::fs::write(root.join("README.md"), "x").unwrap();
+        std::fs::create_dir(root.join("src")).unwrap();
+        std::fs::write(root.join("src").join("main.rs"), "x").unwrap();
+
+        for args in [
+            vec!["add", "Cargo.toml", "README.md", "src/main.rs"],
+            vec!["commit", "-m", "init"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(root)
+                .output()
+                .unwrap();
+        }
+
+        // Heavy ignored tree: cap (200) + headroom worth of files in a
+        // dot-prefixed dir so it sorts first.
+        std::fs::write(root.join(".gitignore"), ".heavy_ignored/\n").unwrap();
+        std::fs::create_dir(root.join(".heavy_ignored")).unwrap();
+        let extra = MAX_IGNORED_FILES_PER_TOP_DIR + 50;
+        for i in 0..extra {
+            std::fs::write(
+                root.join(".heavy_ignored").join(format!("f_{i:05}.dat")),
+                "",
+            )
+            .unwrap();
+        }
+
+        let entries = collect_workspace_file_entries(&root.to_string_lossy())
+            .await
+            .unwrap();
+        let files: Vec<&str> = entries
+            .iter()
+            .filter(|e| !e.is_directory)
+            .map(|e| e.path.as_str())
+            .collect();
+
+        assert!(
+            files.contains(&"Cargo.toml"),
+            "tracked Cargo.toml must survive heavy ignored tree; got: {files:?}"
+        );
+        assert!(
+            files.contains(&"README.md"),
+            "tracked README.md must survive heavy ignored tree"
+        );
+        assert!(
+            files.contains(&"src/main.rs"),
+            "tracked src/main.rs must survive heavy ignored tree"
+        );
+
+        let ignored_in_heavy = files
+            .iter()
+            .filter(|p| p.starts_with(".heavy_ignored/"))
+            .count();
+        assert!(
+            ignored_in_heavy <= MAX_IGNORED_FILES_PER_TOP_DIR,
+            "ignored bucket must be capped at {MAX_IGNORED_FILES_PER_TOP_DIR}; got {ignored_in_heavy}"
+        );
+        assert!(
+            ignored_in_heavy > 0,
+            "ignored bucket should still surface some entries so the user knows the directory exists"
+        );
     }
 
     #[test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -398,9 +398,8 @@ mod tests {
         // Re-execute the migration body. INSERT OR IGNORE is the
         // important guard — a user who already has a custom binding on
         // the new id keeps it; only orphaned legacy rows are migrated.
-        let migration_sql = include_str!(
-            "../migrations/20260509000540_rename_close_file_tab_keybinding.sql"
-        );
+        let migration_sql =
+            include_str!("../migrations/20260509000540_rename_close_file_tab_keybinding.sql");
         db.conn().execute_batch(migration_sql).unwrap();
 
         let new_value: Option<String> = db
@@ -438,9 +437,8 @@ mod tests {
                  ('keybinding:global.close-tab', 'new-value');",
             )
             .unwrap();
-        let migration_sql = include_str!(
-            "../migrations/20260509000540_rename_close_file_tab_keybinding.sql"
-        );
+        let migration_sql =
+            include_str!("../migrations/20260509000540_rename_close_file_tab_keybinding.sql");
         db.conn().execute_batch(migration_sql).unwrap();
 
         let new_value: String = db

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -376,6 +376,87 @@ mod tests {
         assert_eq!(count_applied(&db) as usize, MIGRATIONS.len());
     }
 
+    /// Pin the keybinding rename: after the renaming migration runs,
+    /// any user-customized override of `keybinding:file-viewer.close-file-tab`
+    /// must land at `keybinding:global.close-tab` and the legacy key
+    /// must be gone. The migration is run as part of `Database::open_in_memory`
+    /// alongside everything else, so this test seeds the *prior* state
+    /// by inserting the legacy row and re-running the migration's SQL
+    /// directly — exercising the same INSERT OR IGNORE / DELETE pair
+    /// the runtime applies.
+    #[test]
+    fn test_close_tab_keybinding_rename_migration() {
+        let db = Database::open_in_memory().unwrap();
+        // Seed the legacy row that an existing user would have had
+        // before pulling this build.
+        db.conn()
+            .execute(
+                "INSERT INTO app_settings (key, value) VALUES (?1, ?2)",
+                params!["keybinding:file-viewer.close-file-tab", "mod+x"],
+            )
+            .unwrap();
+        // Re-execute the migration body. INSERT OR IGNORE is the
+        // important guard — a user who already has a custom binding on
+        // the new id keeps it; only orphaned legacy rows are migrated.
+        let migration_sql = include_str!(
+            "../migrations/20260509000540_rename_close_file_tab_keybinding.sql"
+        );
+        db.conn().execute_batch(migration_sql).unwrap();
+
+        let new_value: Option<String> = db
+            .conn()
+            .query_row(
+                "SELECT value FROM app_settings WHERE key = 'keybinding:global.close-tab'",
+                [],
+                |r| r.get(0),
+            )
+            .ok();
+        assert_eq!(new_value.as_deref(), Some("mod+x"));
+
+        let legacy_present: bool = db
+            .conn()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM app_settings WHERE key = 'keybinding:file-viewer.close-file-tab')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(!legacy_present, "legacy row must be removed");
+    }
+
+    /// `INSERT OR IGNORE` semantics: an explicit override under the
+    /// new id wins over the legacy value when both are present (e.g.
+    /// a user who customised the binding across both versions). The
+    /// legacy row is still removed afterward.
+    #[test]
+    fn test_close_tab_keybinding_rename_preserves_existing_new_id() {
+        let db = Database::open_in_memory().unwrap();
+        db.conn()
+            .execute_batch(
+                "INSERT INTO app_settings (key, value) VALUES \
+                 ('keybinding:file-viewer.close-file-tab', 'legacy-value'), \
+                 ('keybinding:global.close-tab', 'new-value');",
+            )
+            .unwrap();
+        let migration_sql = include_str!(
+            "../migrations/20260509000540_rename_close_file_tab_keybinding.sql"
+        );
+        db.conn().execute_batch(migration_sql).unwrap();
+
+        let new_value: String = db
+            .conn()
+            .query_row(
+                "SELECT value FROM app_settings WHERE key = 'keybinding:global.close-tab'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            new_value, "new-value",
+            "explicit new-id override must not be clobbered by INSERT OR IGNORE",
+        );
+    }
+
     #[test]
     fn test_migrate_is_idempotent() {
         let db = Database::open_in_memory().unwrap();

--- a/src/migrations/20260509000540_rename_close_file_tab_keybinding.sql
+++ b/src/migrations/20260509000540_rename_close_file_tab_keybinding.sql
@@ -1,0 +1,20 @@
+-- The `file-viewer.close-file-tab` action was promoted to a global,
+-- context-aware `global.close-tab` that handles file / diff / chat
+-- equally. Persisted user overrides live in `app_settings` keyed by
+-- `keybinding:<actionId>`; without this migration any user who
+-- customized the prior binding would silently get the default on the
+-- new id and have an orphaned row pointing at the deleted id.
+--
+-- Mirrors the prior keybinding-rename pattern at
+-- `20260508181215_rename_cycle_workspace_keybindings.sql`. The
+-- `INSERT OR IGNORE` form preserves an explicit override under the
+-- new id if one already exists (e.g. a user who set both names across
+-- versions); the subsequent `DELETE` then removes the orphan legacy
+-- row whether or not we copied from it.
+INSERT OR IGNORE INTO app_settings (key, value)
+SELECT 'keybinding:global.close-tab', value
+FROM app_settings
+WHERE key = 'keybinding:file-viewer.close-file-tab';
+
+DELETE FROM app_settings
+WHERE key = 'keybinding:file-viewer.close-file-tab';

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -214,4 +214,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260508181215_rename_cycle_workspace_keybindings.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260509000540_rename_close_file_tab_keybinding",
+        sql: include_str!("20260509000540_rename_close_file_tab_keybinding.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/scm/types.rs
+++ b/src/scm/types.rs
@@ -37,6 +37,14 @@ pub enum CiCheckStatus {
     Success,
     Failure,
     Cancelled,
+    /// Check that was deliberately not run (a GitHub workflow whose
+    /// `if:` condition was false / a GitLab job whose `rules:` excluded
+    /// it / a `manual` GitLab job that wasn't triggered). Distinct from
+    /// `Cancelled` (interrupted mid-run) so the UI can render it as
+    /// informational rather than soft-fail — without this variant the
+    /// SCM plugins fell back to `Pending` and the frontend mapper
+    /// surfaced merged-PR skipped checks as "Running".
+    Skipped,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,4 +64,32 @@ pub struct CreatePrArgs {
     pub body: String,
     pub base: String,
     pub draft: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ci_check_status_serializes_to_snake_case_strings() {
+        // The Lua plugins return canonical lowercase strings; the
+        // Rust dispatcher round-trips through these snake_case names
+        // when materializing CiCheck rows. Pin every variant — adding
+        // a new one without updating Lua / frontend mappers leaves a
+        // hole at runtime, and this test gives us a fast feedback
+        // loop for the round-trip.
+        let cases: &[(CiCheckStatus, &str)] = &[
+            (CiCheckStatus::Pending, "\"pending\""),
+            (CiCheckStatus::Success, "\"success\""),
+            (CiCheckStatus::Failure, "\"failure\""),
+            (CiCheckStatus::Cancelled, "\"cancelled\""),
+            (CiCheckStatus::Skipped, "\"skipped\""),
+        ];
+        for (status, expected) in cases {
+            let serialized = serde_json::to_string(status).unwrap();
+            assert_eq!(&serialized, expected, "serializing {status:?}");
+            let round: CiCheckStatus = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(&round, status, "round-trip {status:?}");
+        }
+    }
 }

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -11,7 +11,11 @@ import {
   recordSlashCommandUsage,
 } from "../../services/tauri";
 import type { FileEntry, PinnedPrompt, SlashCommand } from "../../services/tauri";
-import type { AttachmentInput, PendingAttachment } from "../../types/chat";
+import type {
+  AttachmentInput,
+  PendingAttachment,
+  StoredAttachment,
+} from "../../types/chat";
 import { base64ToBytes } from "../../utils/base64";
 import {
   MAX_ATTACHMENTS,
@@ -58,6 +62,40 @@ function serializeComposerDraft(mode: ComposerMode, text: string): string {
 function normalizeShellCommand(value: string): string {
   const trimmed = value.trim();
   return trimmed.startsWith("!") ? trimmed.slice(1).trimStart() : trimmed;
+}
+
+/** Rebuild a `PendingAttachment[]` for a session from the slice's
+ * `StoredAttachment[]`. Image preview blob URLs are regenerated from
+ * `data_base64` (the underlying Blob is GC'd once the previous mount
+ * dropped its reference). PDFs and non-image attachments don't get a
+ * thumbnail re-generated here — that work is asynchronous and gated
+ * inside `addAttachment`; on rehydration we leave `preview_url` empty
+ * for those, so the row still renders the filename + size with no
+ * thumbnail rather than blocking the mount on PDF.js. */
+function hydratePendingFromSlice(sessionId: string): PendingAttachment[] {
+  const stored = useAppStore.getState().pendingAttachmentsBySession[sessionId];
+  if (!stored || stored.length === 0) return [];
+  return stored.map((a) => ({
+    id: a.id,
+    filename: a.filename,
+    media_type: a.media_type,
+    data_base64: a.data_base64,
+    preview_url: rehydrateImagePreviewUrl(a),
+    size_bytes: a.size_bytes,
+    text_content: a.text_content,
+  }));
+}
+
+function rehydrateImagePreviewUrl(a: StoredAttachment): string {
+  if (!SUPPORTED_IMAGE_TYPES.has(a.media_type)) return "";
+  try {
+    const bytes = base64ToBytes(a.data_base64);
+    const blob = new Blob([bytes], { type: a.media_type });
+    return URL.createObjectURL(blob);
+  } catch (e) {
+    console.error("[chat-input] failed to rehydrate preview URL", e);
+    return "";
+  }
 }
 
 /** Extract the @-query based on cursor position in the textarea. */
@@ -186,7 +224,41 @@ export function ChatInputArea({
   const { t } = useTranslation("chat");
   const filesCache = useRef<Record<string, FileEntry[]>>({});
   const mentionedFilesRef = useRef<Set<string>>(new Set());
-  const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
+  // `pendingAttachments` is the local view (with transient blob URLs);
+  // the slice (`pendingAttachmentsBySession`) is the per-session source
+  // of truth so attachments survive any composer remount — including
+  // the unmount that fires when `<ChatPanel>` is conditionally rendered
+  // out of `AppLayout` whenever the user opens a file or diff. The
+  // unmount cleanup further down revokes blob URLs on tear-down so we
+  // don't leak them; the next mount calls `hydratePendingFromSlice` to
+  // recreate the URLs from the persisted `data_base64` payload.
+  const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>(
+    () => hydratePendingFromSlice(sessionId),
+  );
+  const setPendingAttachmentsBoth = useCallback(
+    (
+      sessionForUpdate: string,
+      updater: (prev: PendingAttachment[]) => PendingAttachment[],
+    ) => {
+      setPendingAttachments((prev) => {
+        const next = updater(prev);
+        // Mirror to slice (without `preview_url` since it's transient).
+        const stored: StoredAttachment[] = next.map((a) => ({
+          id: a.id,
+          filename: a.filename,
+          media_type: a.media_type,
+          data_base64: a.data_base64,
+          size_bytes: a.size_bytes,
+          text_content: a.text_content,
+        }));
+        useAppStore
+          .getState()
+          .setPendingAttachmentsForSession(sessionForUpdate, stored);
+        return next;
+      });
+    },
+    [],
+  );
   const [dragActive, setDragActive] = useState(false);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false);
   const [contextPopoverOpen, setContextPopoverOpen] = useState(false);
@@ -308,7 +380,7 @@ export function ChatInputArea({
           if (a.preview_url.startsWith("blob:"))
             URL.revokeObjectURL(a.preview_url);
         }
-        setPendingAttachments([]);
+        setPendingAttachmentsBoth(sessionId, () => []);
         mentionedFilesRef.current = new Set();
         return;
       }
@@ -343,11 +415,16 @@ export function ChatInputArea({
       setFilesLoaded(false);
       setWorkspaceFiles([]);
       mentionedFilesRef.current = new Set();
-      setPendingAttachments((prev) => {
-        for (const a of prev) {
+      // Switch the local view to the new session's persisted
+      // attachments (rehydrated with fresh blob URLs). Revoke the
+      // previous mount's blob URLs first so we don't leak them — but
+      // leave the *slice* entry for the previous session intact, so
+      // its attachments come back when the user navigates back to it.
+      setPendingAttachments((prevList) => {
+        for (const a of prevList) {
           if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
         }
-        return [];
+        return hydratePendingFromSlice(sessionId);
       });
       voice.cancel();
     }
@@ -537,22 +614,22 @@ export function ChatInputArea({
       size_bytes: file.size,
       text_content: isText ? (textContent ?? await file.text()) : null,
     };
-    setPendingAttachments((prev) => {
+    setPendingAttachmentsBoth(sessionId, (prev) => {
       if (prev.length >= MAX_ATTACHMENTS) {
         if (preview_url.startsWith("blob:")) URL.revokeObjectURL(preview_url);
         return prev;
       }
       return [...prev, att];
     });
-  }, [isRemote]);
+  }, [isRemote, sessionId, setPendingAttachmentsBoth]);
 
   const removeAttachment = useCallback((id: string) => {
-    setPendingAttachments((prev) => {
+    setPendingAttachmentsBoth(sessionId, (prev) => {
       const att = prev.find((a) => a.id === id);
       if (att?.preview_url.startsWith("blob:")) URL.revokeObjectURL(att.preview_url);
       return prev.filter((a) => a.id !== id);
     });
-  }, []);
+  }, [sessionId, setPendingAttachmentsBoth]);
 
   // Track current attachments in a ref so the unmount cleanup always
   // revokes the latest blob URLs (not the stale initial-render snapshot).
@@ -781,7 +858,7 @@ export function ChatInputArea({
     for (const a of pendingAttachments) {
       if (a.preview_url.startsWith("blob:")) URL.revokeObjectURL(a.preview_url);
     }
-    setPendingAttachments([]);
+    setPendingAttachmentsBoth(sessionId, () => []);
     mentionedFilesRef.current = new Set();
     return { content, files, attachmentPayload };
   };

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -1107,7 +1107,17 @@ export function ChatInputArea({
         <div className={styles.attachmentStrip}>
           {pendingAttachments.map((att) => (
             <div key={att.id} className={styles.attachmentThumb} title={att.filename}>
-              {isTextFile(att.media_type) ? (
+              {isTextFile(att.media_type) || !att.preview_url ? (
+                // No preview URL: text files (always show filename
+                // chip) AND non-image attachments rehydrated from the
+                // slice without their thumbnail (PDFs lose their
+                // first-page render on composer remount because the
+                // underlying Blob is GC'd; the slice only stores
+                // `data_base64`, not the transient thumbnail URL).
+                // Without this fallback the row rendered as a broken
+                // <img> after a remount even though the attachment
+                // would still send correctly. The badge layout is
+                // identical in both cases — file icon + name + size.
                 <div className={styles.textFileBadge}>
                   <FileText size={16} />
                   <span className={styles.textFileName}>{att.filename}</span>

--- a/src/ui/src/components/chat/ChatToolbar.tsx
+++ b/src/ui/src/components/chat/ChatToolbar.tsx
@@ -17,8 +17,10 @@ interface ChatToolbarProps {
   disabled: boolean;
 }
 
-const isMac = typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
-const mod = isMac ? "⌘" : "Ctrl+";
+// `isMac` / the matching `mod` glyph were used by an inline `<kbd>` badge
+// for the (now-removed) Cmd+T thinking-mode hotkey. The remaining
+// `<kbd>⇧Tab</kbd>` plan-mode badge below uses literal characters and
+// no platform check — so this whole block was unused after the rebind.
 
 export function ChatToolbar({ sessionId, disabled }: ChatToolbarProps) {
   const selectedModel = useAppStore((s) => s.selectedModel[sessionId] ?? "opus");
@@ -146,17 +148,11 @@ export function ChatToolbar({ sessionId, disabled }: ChatToolbarProps) {
     clearPlanApproval(sessionId);
   }, [sessionId, chromeEnabled, setChromeEnabled, clearAgentQuestion, clearPlanApproval]);
 
-  // Keyboard shortcuts.
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      if (e.metaKey && e.key === "t") {
-        e.preventDefault();
-        if (!disabled) toggleThinking();
-      }
-    }
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [disabled, toggleThinking]);
+  // The Cmd/Ctrl+T thinking-mode hotkey lived here as a raw
+  // `window.addEventListener("keydown")` listener. It's been removed —
+  // Cmd+T is now the registered `global.new-tab` action (see
+  // `useKeyboardShortcuts`), and thinking remains toggleable via the
+  // chip click + the command palette ("Toggle thinking").
 
   const currentModel = useSelectedModelEntry(sessionId);
   const modelLabel = currentModel?.providerLabel
@@ -204,7 +200,6 @@ export function ChatToolbar({ sessionId, disabled }: ChatToolbarProps) {
       >
         <Brain size={14} />
         <span className={styles.chipLabel}>{t("thinking_chip")}</span>
-        <kbd className={`shortcut-badge ${metaKeyHeld ? "shortcut-badge-visible" : ""}`} aria-hidden="true">{mod}T</kbd>
       </button>
 
       <button

--- a/src/ui/src/components/chat/CliInvocationBanner.module.css
+++ b/src/ui/src/components/chat/CliInvocationBanner.module.css
@@ -4,6 +4,13 @@
   background: var(--sidebar-bg);
   border-radius: var(--radius-lg);
   font-size: var(--fs-sm);
+  /* The banner sits inside `.messages` (a `flex-direction: column`
+     scroll container). Without an explicit `flex-shrink: 0` the
+     banner could be vertically squeezed by sibling pressure when
+     content briefly exceeded the viewport — collapsing the chip down
+     to its border. The block must always reserve space for its
+     content. */
+  flex-shrink: 0;
   overflow: hidden;
   transition:
     border-color 120ms ease,
@@ -23,12 +30,21 @@
 
 /* Non-interactive flex container with two sibling buttons (toggle + copy)
    so we don't nest <button> elements — see CliInvocationBanner.tsx for
-   the rationale. */
+   the rationale.
+
+   `min-height` floor: with the chip's children able to shrink (the
+   summary uses `min-width: 0` to let the toggle wrap rather than
+   overflow), the header could collapse to almost-zero height under
+   awkward layout conditions. The 32px floor matches the toggle's
+   intrinsic height (chevron + icon at 14px each + padding) so the
+   chip is always comfortably tappable and visually present even at
+   high zoom. */
 .header {
   display: flex;
   align-items: center;
   gap: 4px;
   width: 100%;
+  min-height: 32px;
   padding: 4px 6px 4px 4px;
 }
 

--- a/src/ui/src/components/chat/CliInvocationBanner.module.css
+++ b/src/ui/src/components/chat/CliInvocationBanner.module.css
@@ -73,9 +73,17 @@
 .summary {
   font-family: var(--font-mono);
   color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Wrap rather than ellipsize: the summary line is the only header
+     affordance the user sees while collapsed, so truncating it (the
+     prior `nowrap` + `text-overflow: ellipsis` combo) hid the
+     "claude · N flags" count when the chat panel narrowed or the
+     UI zoom was bumped — and the user couldn't tell the banner had
+     content past what was visible. Letting it wrap means the header
+     grows to fit instead of vanishing. `overflow-wrap: anywhere`
+     keeps long redacted flag values (URLs, paths) from overflowing
+     the panel horizontally. */
+  white-space: normal;
+  overflow-wrap: anywhere;
   min-width: 0;
 }
 

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -9,6 +9,7 @@ import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { HighlightedPlainText } from "./HighlightedPlainText";
 import { ThinkingBlock } from "./ThinkingBlock";
+import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
 import { CompactionDivider } from "./CompactionDivider";
 import { SyntheticContinuationMessage } from "./SyntheticContinuationMessage";
 import { MessageAttachment, isTextDataMediaType } from "./MessageAttachment";
@@ -534,12 +535,27 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           // chronologically-interleaved messages split its activities;
           // each group needs its own collapse state so clicking one
           // chevron doesn't drag every sibling group's expansion with
-          // it. The first activity's `toolUseId` makes a stable
-          // per-group key (it doesn't change as more activities
-          // accumulate inside the same group). When no override has
-          // been set yet, fall back to `turn.collapsed` so the
-          // turn-level persisted state still seeds the initial view.
-          const groupKey = `${turn.id}:${activities[0]?.toolUseId ?? "empty"}`;
+          // it.
+          //
+          // The key intentionally drops `turn.id` and matches the live
+          // `GroupedToolActivityRows` key format — see
+          // `collapsedToolGroupKey` for the rationale: the same
+          // activity moves from `toolActivities[sessionId]` into
+          // `completedTurns[sessionId][N].activities` when the turn
+          // ends, but its `toolUseId` is preserved verbatim. Sharing
+          // the key across both surfaces means a user-toggled
+          // expand/collapse choice made while running survives the
+          // turn-end transition.
+          //
+          // When no override has been set yet, fall back to
+          // `turn.collapsed` so the turn-level persisted state still
+          // seeds the initial view of replayed-from-DB completed turns.
+          const groupKey =
+            collapsedToolGroupKey(activities) ??
+            // Synthetic fallback for the (impossible-in-practice)
+            // empty-activities case — keep keys session-unique without
+            // accidentally colliding with a real tool group.
+            `tools:__empty__:${turn.id}`;
           const userOverride = collapsedToolGroups?.[groupKey];
           const collapsed = userOverride ?? turn.collapsed;
           // Single-group turns also flip the legacy `turn.collapsed`

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -115,7 +115,14 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const completedTurns = useAppStore(
     (s) => s.completedTurns[sessionId] ?? EMPTY_COMPLETED_TURNS,
   );
+  // Retained for the rare path where every group of a turn shares the
+  // same id and a per-turn toggle is what we want; today's
+  // chronological-split rendering uses the per-group setter below.
   const toggleCompletedTurn = useAppStore((s) => s.toggleCompletedTurn);
+  const collapsedToolGroups = useAppStore(
+    (s) => s.collapsedToolGroupsBySession[sessionId],
+  );
+  const setCollapsedToolGroup = useAppStore((s) => s.setCollapsedToolGroup);
   const checkpoints = useAppStore(
     (s) => s.checkpoints[sessionId] ?? EMPTY_CHECKPOINTS,
   );
@@ -522,24 +529,55 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     if (groupEntries.length === 0 && footerEntries.length === 0) return null;
     return (
       <>
-        {groupEntries.map(({ turn, globalIdx, activities, label, showFooter }) => (
-          <TurnSummary
-            key={`${turn.id}:${position}:${label}:${activities[0]?.toolUseId ?? "empty"}`}
-            turn={turn}
-            activities={activities}
-            label={label}
-            inline={toolDisplayMode === "inline"}
-            showFooter={showFooter}
-            collapsed={turn.collapsed}
-            onToggle={() => toggleCompletedTurn(sessionId, globalIdx)}
-            taskProgress={showFooter ? taskProgressByTurn.get(globalIdx) : undefined}
-            assistantText={showFooter ? (assistantTextByTurnId.get(turn.id) ?? "") : ""}
-            onFork={showFooter && onForkTurn ? () => onForkTurn(turn.id) : undefined}
-            onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
-            searchQuery={searchQuery}
-            worktreePath={worktreePath}
-          />
-        ))}
+        {groupEntries.map(({ turn, globalIdx, activities, label, showFooter }) => {
+          // A single turn can produce multiple display groups when
+          // chronologically-interleaved messages split its activities;
+          // each group needs its own collapse state so clicking one
+          // chevron doesn't drag every sibling group's expansion with
+          // it. The first activity's `toolUseId` makes a stable
+          // per-group key (it doesn't change as more activities
+          // accumulate inside the same group). When no override has
+          // been set yet, fall back to `turn.collapsed` so the
+          // turn-level persisted state still seeds the initial view.
+          const groupKey = `${turn.id}:${activities[0]?.toolUseId ?? "empty"}`;
+          const userOverride = collapsedToolGroups?.[groupKey];
+          const collapsed = userOverride ?? turn.collapsed;
+          // Single-group turns also flip the legacy `turn.collapsed`
+          // flag so persistence-aware code (Cmd-A "collapse all" etc.)
+          // sees the same state without needing to consult the override
+          // map. Multi-group turns only mutate the per-group override —
+          // touching `turn.collapsed` there would re-create the original
+          // bug.
+          const isSingleGroupTurn =
+            (chronologicalTurnLayout.groupsByPosition[position] ?? []).filter(
+              (g) => g.globalIdx === globalIdx,
+            ).length === 1;
+          const onToggle = () => {
+            const next = !collapsed;
+            setCollapsedToolGroup(sessionId, groupKey, next);
+            if (isSingleGroupTurn && next !== turn.collapsed) {
+              toggleCompletedTurn(sessionId, globalIdx);
+            }
+          };
+          return (
+            <TurnSummary
+              key={`${turn.id}:${position}:${label}:${activities[0]?.toolUseId ?? "empty"}`}
+              turn={turn}
+              activities={activities}
+              label={label}
+              inline={toolDisplayMode === "inline"}
+              showFooter={showFooter}
+              collapsed={collapsed}
+              onToggle={onToggle}
+              taskProgress={showFooter ? taskProgressByTurn.get(globalIdx) : undefined}
+              assistantText={showFooter ? (assistantTextByTurnId.get(turn.id) ?? "") : ""}
+              onFork={showFooter && onForkTurn ? () => onForkTurn(turn.id) : undefined}
+              onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
+              searchQuery={searchQuery}
+              worktreePath={worktreePath}
+            />
+          );
+        })}
         {footerEntries.map(({ turn }) => (
           <TurnFooter
             key={`${turn.id}:${position}:footer`}

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -31,19 +31,6 @@ import {
 } from "./sessionTabsLogic";
 import { ask } from "@tauri-apps/plugin-dialog";
 import { chatCloseConfirmKind } from "../../hotkeys/contextActions";
-
-/** Tauri's native confirm dialog. Used everywhere the close-tab UI
- *  asks the user to confirm — `window.confirm()` is a silent no-op
- *  in Tauri 2 webviews and was the cause of the "Cmd+W kills running
- *  sessions without prompting" regression. */
-async function askToClose(message: string): Promise<boolean> {
-  return ask(message, {
-    title: "Close session",
-    kind: "warning",
-    okLabel: "Close",
-    cancelLabel: "Cancel",
-  });
-}
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
 import { DangerousFlagBadge } from "./DangerousFlagBadge";
 import { hasDangerousFlag } from "../../stores/slices/workspaceClaudeFlagsSlice";
@@ -73,6 +60,19 @@ import type {
 import styles from "./SessionTabs.module.css";
 
 type NavDirection = "prev" | "next" | "first" | "last";
+
+/** Tauri's native confirm dialog. Used everywhere the close-tab UI
+ *  asks the user to confirm — `window.confirm()` is a silent no-op
+ *  in Tauri 2 webviews and was the cause of the "Cmd+W kills running
+ *  sessions without prompting" regression. */
+async function askToClose(message: string): Promise<boolean> {
+  return ask(message, {
+    title: "Close session",
+    kind: "warning",
+    okLabel: "Close",
+    cancelLabel: "Cancel",
+  });
+}
 
 // `NavEntry` and `buildWorkspaceTabNavEntries` are imported from
 // `./sessionTabsLogic` so the cycle-tabs hotkey and this component

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -29,7 +29,21 @@ import {
   type NavEntry,
   splitUnifiedTabOrder,
 } from "./sessionTabsLogic";
+import { ask } from "@tauri-apps/plugin-dialog";
 import { chatCloseConfirmKind } from "../../hotkeys/contextActions";
+
+/** Tauri's native confirm dialog. Used everywhere the close-tab UI
+ *  asks the user to confirm — `window.confirm()` is a silent no-op
+ *  in Tauri 2 webviews and was the cause of the "Cmd+W kills running
+ *  sessions without prompting" regression. */
+async function askToClose(message: string): Promise<boolean> {
+  return ask(message, {
+    title: "Close session",
+    kind: "warning",
+    okLabel: "Close",
+    cancelLabel: "Cancel",
+  });
+}
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
 import { DangerousFlagBadge } from "./DangerousFlagBadge";
 import { hasDangerousFlag } from "../../stores/slices/workspaceClaudeFlagsSlice";
@@ -259,7 +273,7 @@ export function SessionTabs({ workspaceId }: Props) {
           : kind === "active"
             ? t("session_active_confirm_close", { name: session.name })
             : t("session_last_confirm_close", { name: session.name });
-      if (!window.confirm(message)) return;
+      if (!(await askToClose(message))) return;
     }
     await archiveSessionImmediate(session);
   };
@@ -456,14 +470,16 @@ export function SessionTabs({ workspaceId }: Props) {
           runningSessions.length === 1
             ? t("session_running_confirm_close", { name: runningSessions[0].name })
             : t("session_running_confirm_close_multi", { count: runningSessions.length });
-        if (!window.confirm(message)) return;
+        if (!(await askToClose(message))) return;
       } else if (closingActive) {
         const active = sessionsBeingClosed.find(
           (s) => s.id === selectedSessionId,
         );
         if (
           active &&
-          !window.confirm(t("session_active_confirm_close", { name: active.name }))
+          !(await askToClose(
+            t("session_active_confirm_close", { name: active.name }),
+          ))
         )
           return;
       } else if (
@@ -476,7 +492,9 @@ export function SessionTabs({ workspaceId }: Props) {
         const last = sessionsBeingClosed[0];
         if (
           last &&
-          !window.confirm(t("session_last_confirm_close", { name: last.name }))
+          !(await askToClose(
+            t("session_last_confirm_close", { name: last.name }),
+          ))
         )
           return;
       }

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -417,24 +417,70 @@ export function SessionTabs({ workspaceId }: Props) {
   // Close a list of tabs (sessions, diffs, and/or files) sequentially. Sessions
   // get archived through the same backend command as the close button; diffs
   // and files drop from the local store (file tabs route through the
-  // dirty-confirm modal). If any sessions are still running we confirm once
-  // for the whole batch instead of once per tab.
+  // dirty-confirm modal).
+  //
+  // Confirmation rules mirror the per-tab close path's
+  // `chatCloseConfirmKind` (running / active / last / none) but
+  // aggregate across the batch so the user sees one prompt — not one
+  // per tab — when bulk-closing. Priority order:
+  //
+  //   1. Any running session in the batch → "running" prompt (kept
+  //      verbatim; the multi-running plural string already exists).
+  //   2. Batch contains the currently-selected session → "active"
+  //      prompt (NEW; previously only the single-tab path guarded
+  //      this case, leaving Cmd+Shift+W "close all" able to silently
+  //      yank the visible chat).
+  //   3. Batch closes every Active session in the workspace → "last"
+  //      prompt (NEW; the auto-create path runs and the visible
+  //      history archives away).
   const closeEntries = useCallback(
     async (entries: NavEntry[]) => {
       if (entries.length === 0) return;
       const sessionEntries = entries.flatMap((e) =>
         e.kind === "session" ? [e] : [],
       );
-      const runningSessions = sessionEntries
+      const sessionsBeingClosed = sessionEntries
         .map((e) => activeSessions.find((s) => s.id === e.sessionId))
-        .filter((s): s is ChatSession => !!s && s.agent_status === "Running");
+        .filter((s): s is ChatSession => !!s);
+      const runningSessions = sessionsBeingClosed.filter(
+        (s) => s.agent_status === "Running",
+      );
+      const closingActive = sessionsBeingClosed.some(
+        (s) => s.id === selectedSessionId,
+      );
+      const remainingActiveAfterBatch =
+        activeSessions.length - sessionsBeingClosed.length;
+
       if (runningSessions.length > 0) {
         const message =
           runningSessions.length === 1
             ? t("session_running_confirm_close", { name: runningSessions[0].name })
             : t("session_running_confirm_close_multi", { count: runningSessions.length });
         if (!window.confirm(message)) return;
+      } else if (closingActive) {
+        const active = sessionsBeingClosed.find(
+          (s) => s.id === selectedSessionId,
+        );
+        if (
+          active &&
+          !window.confirm(t("session_active_confirm_close", { name: active.name }))
+        )
+          return;
+      } else if (
+        sessionsBeingClosed.length > 0 &&
+        remainingActiveAfterBatch <= 0
+      ) {
+        // Batch wipes out every Active session — surface the last-one
+        // prompt against any of them (pick the first; user can still
+        // cancel the whole batch).
+        const last = sessionsBeingClosed[0];
+        if (
+          last &&
+          !window.confirm(t("session_last_confirm_close", { name: last.name }))
+        )
+          return;
       }
+
       // File tabs: collect first, close clean ones immediately, route
       // dirty ones through a single batched confirm. Sessions and diffs
       // close inline as before.
@@ -451,7 +497,15 @@ export function SessionTabs({ workspaceId }: Props) {
       }
       requestCloseFileTabsBatch(filePaths);
     },
-    [activeSessions, archiveSessionImmediate, closeDiffTab, requestCloseFileTabsBatch, t, workspaceId],
+    [
+      activeSessions,
+      archiveSessionImmediate,
+      closeDiffTab,
+      requestCloseFileTabsBatch,
+      selectedSessionId,
+      t,
+      workspaceId,
+    ],
   );
 
   const navigateTabs = useCallback(

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -29,6 +29,7 @@ import {
   type NavEntry,
   splitUnifiedTabOrder,
 } from "./sessionTabsLogic";
+import { chatCloseConfirmKind } from "../../hotkeys/contextActions";
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
 import { DangerousFlagBadge } from "./DangerousFlagBadge";
 import { hasDangerousFlag } from "../../stores/slices/workspaceClaudeFlagsSlice";
@@ -241,11 +242,24 @@ export function SessionTabs({ workspaceId }: Props) {
   );
 
   const handleArchive = async (session: ChatSession) => {
-    if (session.agent_status === "Running") {
-      const ok = window.confirm(
-        t("session_running_confirm_close", { name: session.name }),
-      );
-      if (!ok) return;
+    // The shared `chatCloseConfirmKind` helper is also used by the
+    // global Cmd+W path in `hotkeys/contextActions.ts`, so the rules
+    // ("running" / "active" / "last" → confirm) stay in lockstep
+    // between the close button and the keystroke. Each kind maps to
+    // its own translated string so the message matches the trigger.
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions,
+      isActiveSession: session.id === selectedSessionId,
+    });
+    if (kind !== "none") {
+      const message =
+        kind === "running"
+          ? t("session_running_confirm_close", { name: session.name })
+          : kind === "active"
+            ? t("session_active_confirm_close", { name: session.name })
+            : t("session_last_confirm_close", { name: session.name });
+      if (!window.confirm(message)) return;
     }
     await archiveSessionImmediate(session);
   };

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -253,6 +253,47 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Bash");
   });
 
+  it("persists collapse state via the chatSlice so it survives running→completed transition", async () => {
+    // The unified slice key (`tools:${first toolUseId}`) is shared
+    // with `MessagesWithTurns`'s `TurnSummary` rendering, so a user's
+    // explicit collapse on a running group remains in effect when the
+    // turn ends and the same activities migrate into a CompletedTurn.
+    // Pin the write-through here; the read path is covered by the
+    // useAppStore.collapsedToolGroups.test.ts slice tests.
+    const { useAppStore } = await import("../../stores/useAppStore");
+    useAppStore.setState({ collapsedToolGroupsBySession: {} });
+
+    const runningActivities = [
+      activity("Bash", { toolUseId: "stable-1", resultText: "" }),
+    ];
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-xform"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={runningActivities}
+      />,
+    );
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+
+    await act(async () => {
+      header.click();
+    });
+
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    // The slice now holds the user's explicit collapse for this
+    // group's stable key — `MessagesWithTurns` will pick this up after
+    // the turn ends because it computes the same key.
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession["session-xform"]?.[
+        "tools:stable-1"
+      ],
+    ).toBe(true);
+  });
+
   it("preserves the user override across appended tool activities", async () => {
     // Two tools running, user collapses; a third tool joins the same
     // direct-tools run. The component is keyed by the first activity's

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -109,4 +109,141 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).not.toContain("Bash");
     expect(container.textContent).not.toContain("Read");
   });
+
+  it("renders a chevron + clickable header on grouped running activities", async () => {
+    // Pin the chevron decoration that PR #696 dropped. Without it,
+    // users had no affordance for expanding/collapsing the live tool
+    // group while the agent was running.
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Bash", { resultText: "" }),
+          activity("Read", { resultText: "" }),
+        ]}
+      />,
+    );
+
+    const header = container.querySelector('[role="button"][aria-expanded]');
+    expect(header).toBeTruthy();
+    expect(header?.getAttribute("aria-expanded")).toBe("true");
+    // Chevron is the first child of the header — open glyph while
+    // expanded, closed glyph when collapsed.
+    expect(header?.textContent).toMatch(/^⌄/);
+  });
+
+  it("lets the user collapse a still-running group via header click", async () => {
+    const runningActivities = [
+      activity("Bash", { resultText: "" }),
+      activity("Read", { resultText: "" }),
+    ];
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={runningActivities}
+      />,
+    );
+
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("Read");
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header).toBeTruthy();
+
+    await act(async () => {
+      header.click();
+    });
+
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(header.textContent).toMatch(/^›/);
+    expect(container.textContent).not.toContain("Bash");
+    expect(container.textContent).not.toContain("Read");
+  });
+
+  it("lets the user expand a finished group via header click", async () => {
+    // Default for a finished group is collapsed (matches post-#696
+    // default). The user-click override should re-open it.
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Bash", { resultText: "done" }),
+          activity("Read", { resultText: "done" }),
+        ]}
+      />,
+    );
+
+    // Sanity: the "2 tool calls" header is visible but children aren't.
+    expect(container.textContent).toContain("2 tool calls");
+    expect(container.textContent).not.toContain("Bash");
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      header.click();
+    });
+
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("Read");
+  });
+
+  it("preserves the user override across appended tool activities", async () => {
+    // Two tools running, user collapses; a third tool joins the same
+    // direct-tools run. The component is keyed by the first activity's
+    // toolUseId so React keeps the same instance and the user's
+    // collapse decision sticks.
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Bash", { toolUseId: "a", resultText: "" }),
+          activity("Read", { toolUseId: "b", resultText: "" }),
+        ]}
+      />,
+    );
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+
+    await act(async () => {
+      header.click();
+    });
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      mountedRoots[0].render(
+        <ToolActivitiesSection
+          sessionId="session-1"
+          toolDisplayMode="grouped"
+          searchQuery=""
+          activities={[
+            activity("Bash", { toolUseId: "a", resultText: "" }),
+            activity("Read", { toolUseId: "b", resultText: "" }),
+            activity("Edit", { toolUseId: "c", resultText: "" }),
+          ]}
+        />,
+      );
+    });
+
+    const headerAfter = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(headerAfter.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).toContain("3 tool calls");
+    expect(container.textContent).not.toContain("Edit");
+  });
 });

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -199,6 +199,60 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Read");
   });
 
+  it("force-expands a user-collapsed group when a search match lands inside", async () => {
+    // Regression: prior to this fix, a user-collapsed group with
+    // `userOverride === false` won the precedence check and the
+    // search-match-driven expand never fired — search would tick up
+    // its hit counter but the matching activity was hidden.
+    //
+    // Setup: a *running* group (defaults to expanded), user clicks
+    // once to collapse it. Then a search query that matches the
+    // group's content must override the user's collapse and
+    // re-expand.
+    const runningActivity = activity("Bash", {
+      resultText: "",
+      summary: "secret-token-payload",
+    });
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[runningActivity]}
+      />,
+    );
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header).toBeTruthy();
+    // Sanity: running groups default to expanded.
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    // User explicitly collapses the running group.
+    await act(async () => {
+      header.click();
+    });
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      mountedRoots[0].render(
+        <ToolActivitiesSection
+          sessionId="session-1"
+          toolDisplayMode="grouped"
+          searchQuery="secret-token"
+          activities={[runningActivity]}
+        />,
+      );
+    });
+
+    const headerAfter = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    // Search match wins: the user-collapsed override is overridden in
+    // turn so the matching activity is visible.
+    expect(headerAfter.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Bash");
+  });
+
   it("preserves the user override across appended tool activities", async () => {
     // Two tools running, user collapses; a third tool joins the same
     // direct-tools run. The component is keyed by the first activity's

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -111,7 +111,7 @@ describe("ToolActivitiesSection", () => {
   });
 
   it("renders a chevron + clickable header on grouped running activities", async () => {
-    // Pin the chevron decoration that PR #696 dropped. Without it,
+    // Pin the chevron decoration that PR 696 dropped. Without it,
     // users had no affordance for expanding/collapsing the live tool
     // group while the agent was running.
     const container = await render(
@@ -167,7 +167,7 @@ describe("ToolActivitiesSection", () => {
   });
 
   it("lets the user expand a finished group via header click", async () => {
-    // Default for a finished group is collapsed (matches post-#696
+    // Default for a finished group is collapsed (matches post-PR-696
     // default). The user-click override should re-open it.
     const container = await render(
       <ToolActivitiesSection

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
@@ -68,8 +68,14 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
             />
           ))
         ) : (
+          // Key by the first activity's toolUseId so the component
+          // instance survives across renders that append more
+          // activities to the same direct-tools run. Without this, the
+          // group key (which embeds every member's toolUseId) changes
+          // every time a new tool is added and React would unmount the
+          // child — losing the user's manual expand/collapse choice.
           <GroupedToolActivityRows
-            key={group.key}
+            key={`grouped:${group.activities[0]?.toolUseId ?? group.key}`}
             label={group.label}
             activities={group.activities}
             searchQuery={searchQuery}
@@ -92,16 +98,43 @@ function GroupedToolActivityRows({
   searchQuery: string;
   worktreePath?: string | null;
 }) {
+  // User-override expand state. `null` means "follow the default": the
+  // group auto-expands while a member is running and auto-collapses
+  // once everything has finished — matching the post-#696 default.
+  // A click overrides the default to `true`/`false` for the rest of
+  // this group's lifetime, so the user can drill into a finished group
+  // or hide a noisy still-running one. The override persists across
+  // rerenders because the parent keys this component by its first
+  // toolUseId (stable across appended activities).
+  const [userOverride, setUserOverride] = useState<boolean | null>(null);
+
   const queryHasMatch =
     !!searchQuery &&
     activities.some((activity) =>
       activityMatchesSearch(activity, searchQuery, worktreePath),
     );
-  const isExpanded = groupHasRunningActivity(activities, true) || queryHasMatch;
+  const defaultExpanded =
+    groupHasRunningActivity(activities, true) || queryHasMatch;
+  const isExpanded = userOverride ?? defaultExpanded;
+  const toggle = () => setUserOverride(!isExpanded);
 
   return (
     <div className={styles.turnSummary}>
-      <div className={styles.turnHeader}>
+      <div
+        className={styles.turnHeader}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} ${label}`}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+      >
+        <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
         <span className={styles.turnLabel}>{label}</span>
       </div>
       {isExpanded && (

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -100,7 +100,7 @@ function GroupedToolActivityRows({
 }) {
   // User-override expand state. `null` means "follow the default": the
   // group auto-expands while a member is running and auto-collapses
-  // once everything has finished — matching the post-#696 default.
+  // once everything has finished — matching the post-PR-696 default.
   // A click overrides the default to `true`/`false` for the rest of
   // this group's lifetime, so the user can drill into a finished group
   // or hide a noisy still-running one. The override persists across

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
@@ -16,6 +16,7 @@ import {
   groupHasRunningActivity,
   groupToolActivitiesForDisplay,
 } from "./toolActivityGroups";
+import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
 
 /**
  * Current tool activities section — subscribes to toolActivities for this workspace.
@@ -76,6 +77,7 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
           // child — losing the user's manual expand/collapse choice.
           <GroupedToolActivityRows
             key={`grouped:${group.activities[0]?.toolUseId ?? group.key}`}
+            sessionId={sessionId}
             label={group.label}
             activities={group.activities}
             searchQuery={searchQuery}
@@ -88,25 +90,31 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
 });
 
 function GroupedToolActivityRows({
+  sessionId,
   label,
   activities,
   searchQuery,
   worktreePath,
 }: {
+  sessionId: string;
   label: string;
   activities: readonly ToolActivity[];
   searchQuery: string;
   worktreePath?: string | null;
 }) {
-  // User-override expand state. `null` means "follow the default": the
-  // group auto-expands while a member is running and auto-collapses
-  // once everything has finished — matching the post-PR-696 default.
-  // A click overrides the default to `true`/`false` for the rest of
-  // this group's lifetime, so the user can drill into a finished group
-  // or hide a noisy still-running one. The override persists across
-  // rerenders because the parent keys this component by its first
-  // toolUseId (stable across appended activities).
-  const [userOverride, setUserOverride] = useState<boolean | null>(null);
+  // The user override lives in the shared slice (not local
+  // `useState`) so the expand choice survives the running→completed
+  // transition: when the agent's turn ends, this live group is
+  // unmounted and its activities are rendered through `TurnSummary`
+  // by `MessagesWithTurns` — which reads the same slice key. Without
+  // this unification, expanding a running group only to have it
+  // silently collapse the moment the turn finished was a frequent
+  // dogfooding complaint.
+  const groupKey = collapsedToolGroupKey(activities);
+  const userOverride = useAppStore((s) =>
+    groupKey ? s.collapsedToolGroupsBySession[sessionId]?.[groupKey] : undefined,
+  );
+  const setCollapsedToolGroup = useAppStore((s) => s.setCollapsedToolGroup);
 
   const queryHasMatch =
     !!searchQuery &&
@@ -116,12 +124,18 @@ function GroupedToolActivityRows({
   // Search matches always force the group open — otherwise marks would
   // land in detached DOM (collapsed branch never renders) and the
   // search bar's hit counter would tick up but nothing visible would
-  // change. This wins over `userOverride === false` (a user-collapsed
-  // group) on purpose: the user typed a query expecting matches, and
-  // surprise-hidden hits regress chat search.
-  const defaultExpanded = groupHasRunningActivity(activities, true);
-  const isExpanded = queryHasMatch || (userOverride ?? defaultExpanded);
-  const toggle = () => setUserOverride(!isExpanded);
+  // change. This wins over `userOverride === true` (user explicitly
+  // collapsed) on purpose: the user typed a query expecting matches,
+  // and surprise-hidden hits regress chat search. The slice's
+  // `collapsed: true` value semantically matches `userOverride` from
+  // the previous local-state version (true → collapsed).
+  const defaultCollapsed = !groupHasRunningActivity(activities, true);
+  const collapsed = userOverride ?? defaultCollapsed;
+  const isExpanded = queryHasMatch || !collapsed;
+  const toggle = () => {
+    if (!groupKey) return;
+    setCollapsedToolGroup(sessionId, groupKey, !collapsed);
+  };
 
   return (
     <div className={styles.turnSummary}>

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -113,9 +113,14 @@ function GroupedToolActivityRows({
     activities.some((activity) =>
       activityMatchesSearch(activity, searchQuery, worktreePath),
     );
-  const defaultExpanded =
-    groupHasRunningActivity(activities, true) || queryHasMatch;
-  const isExpanded = userOverride ?? defaultExpanded;
+  // Search matches always force the group open — otherwise marks would
+  // land in detached DOM (collapsed branch never renders) and the
+  // search bar's hit counter would tick up but nothing visible would
+  // change. This wins over `userOverride === false` (a user-collapsed
+  // group) on purpose: the user typed a query expecting matches, and
+  // surprise-hidden hits regress chat search.
+  const defaultExpanded = groupHasRunningActivity(activities, true);
+  const isExpanded = queryHasMatch || (userOverride ?? defaultExpanded);
   const toggle = () => setUserOverride(!isExpanded);
 
   return (

--- a/src/ui/src/components/chat/collapsedToolGroupKey.test.ts
+++ b/src/ui/src/components/chat/collapsedToolGroupKey.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { ToolActivity } from "../../stores/useAppStore";
+import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
+
+function activity(
+  toolUseId: string,
+  toolName = "Bash",
+  overrides: Partial<ToolActivity> = {},
+): ToolActivity {
+  return {
+    toolUseId,
+    toolName,
+    inputJson: "{}",
+    resultText: "",
+    collapsed: true,
+    summary: "",
+    ...overrides,
+  };
+}
+
+describe("collapsedToolGroupKey", () => {
+  it("uses the first activity's toolUseId, prefixed by tools:", () => {
+    expect(collapsedToolGroupKey([activity("a"), activity("b")])).toBe("tools:a");
+  });
+
+  it("prefixes Agent activities with agent: instead of tools:", () => {
+    expect(collapsedToolGroupKey([activity("a", "Agent")])).toBe("agent:a");
+  });
+
+  it("returns null for an empty group", () => {
+    expect(collapsedToolGroupKey([])).toBeNull();
+  });
+
+  it("ignores later activities when computing the key", () => {
+    // The first toolUseId is stable across activity-append rerenders;
+    // any later activity getting added to the same group must NOT
+    // change the key (otherwise the slice override would be 'lost'
+    // every time the agent emitted another tool call).
+    const firstKey = collapsedToolGroupKey([activity("first-id")]);
+    const laterKey = collapsedToolGroupKey([
+      activity("first-id"),
+      activity("second-id"),
+      activity("third-id"),
+    ]);
+    expect(firstKey).toBe(laterKey);
+  });
+
+  it("agrees on a group's key whether it's still running or completed", () => {
+    // The same activity object — same toolUseId — produces the same
+    // key whether it's pulled from `toolActivities[sessionId]` (still
+    // running) or `completedTurns[sessionId][N].activities`. That's
+    // the whole point: the running→completed transition preserves the
+    // user's expand/collapse choice because both sides hash to the
+    // same slice key.
+    const runningActivity = activity("ttt", "Edit", { resultText: "" });
+    const completedActivity: ToolActivity = {
+      ...runningActivity,
+      resultText: "edit applied",
+    };
+    expect(collapsedToolGroupKey([runningActivity])).toBe(
+      collapsedToolGroupKey([completedActivity]),
+    );
+  });
+});

--- a/src/ui/src/components/chat/collapsedToolGroupKey.ts
+++ b/src/ui/src/components/chat/collapsedToolGroupKey.ts
@@ -1,0 +1,39 @@
+import type { ToolActivity } from "../../stores/useAppStore";
+
+/**
+ * Stable key under which a tool-call group's user-toggled
+ * collapsed/expanded state is stored in
+ * `collapsedToolGroupsBySession`.
+ *
+ * The key is derived from the *first activity's `toolUseId`* (plus a
+ * `tools:` / `agent:` discriminator) and intentionally does **not**
+ * embed any turn-level identifier:
+ *
+ *   - While the agent is mid-turn, activities live in
+ *     `toolActivities[sessionId]` and there is no enclosing turn id.
+ *   - Once the turn ends, those same activities migrate into
+ *     `completedTurns[sessionId][N].activities`. The activities and
+ *     their `toolUseId`s are preserved verbatim — only the wrapper
+ *     changes.
+ *
+ * Keeping the key activity-based (not turn-based) means the user's
+ * expand/collapse choice survives the running→completed transition:
+ * the same key is computed on both sides of the boundary, so the
+ * slice override the live `GroupedToolActivityRows` wrote is the same
+ * one the post-turn `TurnSummary` reads.
+ *
+ * Returns `null` for an empty activity list — callers should fall
+ * back to a synthetic key (or skip rendering) in that case.
+ */
+export function collapsedToolGroupKey(
+  activities: readonly ToolActivity[],
+): string | null {
+  const first = activities[0];
+  if (!first) return null;
+  // Match the discriminator `groupToolActivitiesForDisplay` uses for
+  // its own React `key` (`agent:` for Agent tool, `tools:` otherwise)
+  // so the slice key collides with nothing user-meaningful and reads
+  // sensibly in dev tools.
+  const kind = first.toolName === "Agent" ? "agent" : "tools";
+  return `${kind}:${first.toolUseId}`;
+}

--- a/src/ui/src/components/chat/composer/ComposerToolbar.tsx
+++ b/src/ui/src/components/chat/composer/ComposerToolbar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { CircleDollarSign, Sparkles, BookOpen } from "lucide-react";
 import { useAppStore } from "../../../stores/useAppStore";
-import { getAppSetting, setAppSetting } from "../../../services/tauri";
+import { getAppSetting } from "../../../services/tauri";
 import { ModelSelector, is1mContextModel, get1mFallback } from "../ModelSelector";
 import { buildModelRegistry } from "../modelRegistry";
 import { isFastSupported, isEffortSupported, isXhighEffortAllowed, isMaxEffortAllowed } from "../modelCapabilities";
@@ -31,7 +31,6 @@ export function ComposerToolbar({
   const selectedModel = useAppStore((s) => s.selectedModel[sessionId] ?? "opus");
   const selectedProvider = useAppStore((s) => s.selectedModelProvider[sessionId] ?? "anthropic");
   const disable1mContext = useAppStore((s) => s.disable1mContext);
-  const thinkingEnabled = useAppStore((s) => s.thinkingEnabled[sessionId] ?? false);
   const planMode = useAppStore((s) => s.planMode[sessionId] ?? false);
   const modelSelectorOpen = useAppStore((s) => s.modelSelectorOpen);
   const alternativeBackendsEnabled = useAppStore((s) => s.alternativeBackendsEnabled);
@@ -119,26 +118,15 @@ export function ComposerToolbar({
     [sessionId, selectedModel, selectedProvider, setModelSelectorOpen],
   );
 
-  const toggleThinking = useCallback(async () => {
-    const next = !thinkingEnabled;
-    setThinkingEnabled(sessionId, next);
-    await setAppSetting(`thinking_enabled:${sessionId}`, String(next));
-  }, [sessionId, thinkingEnabled, setThinkingEnabled]);
-
   const togglePlan = useCallback(() => {
     setPlanMode(sessionId, !planMode);
   }, [sessionId, planMode, setPlanMode]);
 
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      if (e.metaKey && e.key === "t") {
-        e.preventDefault();
-        if (!disabled) toggleThinking();
-      }
-    }
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [disabled, toggleThinking]);
+  // The Cmd/Ctrl+T thinking-mode hotkey lived here as a raw
+  // `window.addEventListener("keydown")` listener. It's been removed —
+  // Cmd+T is now the registered `global.new-tab` action (see
+  // `useKeyboardShortcuts`), and thinking remains toggleable via the
+  // ReasoningPill click + the command palette ("Toggle thinking").
 
   useEffect(() => {
     if (!loaded || !disable1mContext) return;

--- a/src/ui/src/components/chat/composer/ReasoningPill.tsx
+++ b/src/ui/src/components/chat/composer/ReasoningPill.tsx
@@ -28,11 +28,6 @@ export function ReasoningPill({ sessionId, disabled }: ReasoningPillProps) {
   const setThinkingEnabled = useAppStore((s) => s.setThinkingEnabled);
   const setShowThinkingBlocks = useAppStore((s) => s.setShowThinkingBlocks);
   const setEffortLevel = useAppStore((s) => s.setEffortLevel);
-  const metaKeyHeld = useAppStore((s) => s.metaKeyHeld);
-
-  const isMac = typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
-  const mod = isMac ? "⌘" : "Ctrl+";
-
   const showEffort = isEffortSupported(selectedModel);
   const effortLabel = EFFORT_LEVELS.find((l) => l.id === effortLevel)?.label ?? effortLevel;
   const isActive = thinkingEnabled;
@@ -103,12 +98,6 @@ export function ReasoningPill({ sessionId, disabled }: ReasoningPillProps) {
             <Brain size={14} />
             <span className={styles.segmentLabel}>Thinking</span>
           </span>
-          <kbd
-            className={`${styles.shortcutBadge} ${metaKeyHeld ? styles.shortcutBadgeVisible : ""}`}
-            aria-hidden="true"
-          >
-            {mod}T
-          </kbd>
         </button>
 
         <span className={styles.divider} />

--- a/src/ui/src/components/chat/toolMetadata.test.ts
+++ b/src/ui/src/components/chat/toolMetadata.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { resolveToolSummary } from "./toolMetadata";
+
+describe("resolveToolSummary", () => {
+  describe("exact-match registry", () => {
+    it("surfaces the SQL field for mcp__postgres__query", () => {
+      // Pre-fix: extractToolSummary returned "" because the MCP
+      // fallback only checked description/url/query/command.
+      const result = resolveToolSummary(
+        "mcp__postgres__query",
+        JSON.stringify({ sql: "SELECT * FROM users WHERE id = 1" }),
+      );
+      expect(result.summary).toBe("SELECT * FROM users WHERE id = 1");
+      expect(result.lang).toBe("sql");
+      expect(result.fullContent).toBe("SELECT * FROM users WHERE id = 1");
+    });
+
+    it("highlights playwright browser_evaluate as javascript", () => {
+      const result = resolveToolSummary(
+        "mcp__plugin_playwright__browser_evaluate",
+        JSON.stringify({ function: "() => document.title" }),
+      );
+      expect(result.summary).toBe("() => document.title");
+      expect(result.lang).toBe("javascript");
+    });
+
+    it("renders Bash as bash regardless of input order", () => {
+      const result = resolveToolSummary(
+        "Bash",
+        JSON.stringify({ description: "list files", command: "ls -la" }),
+      );
+      expect(result.summary).toBe("ls -la");
+      expect(result.lang).toBe("bash");
+    });
+  });
+
+  describe("tool-name heuristics", () => {
+    it("infers SQL from a postgres-y MCP tool name with no registry entry", () => {
+      // A new MCP server we've never seen — its name contains
+      // "postgres", so we infer the `sql` field + sql highlighting.
+      const result = resolveToolSummary(
+        "mcp__pgcustom__exec_statement",
+        JSON.stringify({ sql: "DELETE FROM logs" }),
+      );
+      expect(result.summary).toBe("DELETE FROM logs");
+      expect(result.lang).toBe("sql");
+    });
+
+    it("infers SQL from a __query suffix on an unknown server", () => {
+      const result = resolveToolSummary(
+        "mcp__warehouse__query",
+        JSON.stringify({ sql: "SELECT 1" }),
+      );
+      expect(result.summary).toBe("SELECT 1");
+      expect(result.lang).toBe("sql");
+    });
+
+    it("infers JavaScript from an __evaluate suffix", () => {
+      const result = resolveToolSummary(
+        "mcp__customjs__evaluate",
+        JSON.stringify({ code: "1 + 1" }),
+      );
+      expect(result.summary).toBe("1 + 1");
+      expect(result.lang).toBe("javascript");
+    });
+
+    it("infers bash from a __shell-named MCP tool", () => {
+      const result = resolveToolSummary(
+        "mcp__remoteshell__exec",
+        JSON.stringify({ command: "uptime" }),
+      );
+      expect(result.summary).toBe("uptime");
+      expect(result.lang).toBe("bash");
+    });
+  });
+
+  describe("field-name heuristics", () => {
+    it("picks `sql` ahead of `description` when both are present", () => {
+      const result = resolveToolSummary(
+        "mcp__novel__exec",
+        JSON.stringify({ description: "run a query", sql: "SELECT now()" }),
+      );
+      expect(result.summary).toBe("SELECT now()");
+      expect(result.lang).toBe("sql");
+    });
+
+    it("falls through to longest string field when no known field matches", () => {
+      const result = resolveToolSummary(
+        "mcp__weird__op",
+        JSON.stringify({
+          format: "json",
+          rationale: "this is the actual content the user cares about",
+          flag: "yes",
+        }),
+      );
+      expect(result.summary).toBe(
+        "this is the actual content the user cares about",
+      );
+      expect(result.lang).toBeNull();
+    });
+
+    it("returns empty when no string-valued field is present (no good fallback)", () => {
+      // All-numeric / boolean inputs intentionally produce an empty
+      // summary rather than picking an arbitrary field — there's no
+      // reliable signal for "which number is the user-facing one"
+      // and rendering a stray `42` next to a tool name confuses more
+      // than it clarifies. Built-in tools that genuinely surface a
+      // numeric id (TaskGet, Monitor, etc.) handle their formatting in
+      // `extractToolSummary`'s composite-summary switch.
+      const result = resolveToolSummary(
+        "mcp__weird__op",
+        JSON.stringify({ count: 42, ok: true }),
+      );
+      expect(result.summary).toBe("");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns an empty display for invalid JSON", () => {
+      const result = resolveToolSummary("Bash", "{not valid json");
+      expect(result).toEqual({ summary: "", lang: null, fullContent: "" });
+    });
+
+    it("returns an empty display for a non-object input", () => {
+      const result = resolveToolSummary("Bash", JSON.stringify("just a string"));
+      expect(result).toEqual({ summary: "", lang: null, fullContent: "" });
+    });
+
+    it("truncates long content with an ellipsis", () => {
+      const longSql = "SELECT " + "x, ".repeat(100) + "y FROM t";
+      const result = resolveToolSummary(
+        "mcp__postgres__query",
+        JSON.stringify({ sql: longSql }),
+      );
+      expect(result.summary.length).toBeLessThanOrEqual(120);
+      expect(result.summary.endsWith("…")).toBe(true);
+      // fullContent retains the untruncated value for the
+      // expand-to-detail view that this scaffolds.
+      expect(result.fullContent).toBe(longSql);
+    });
+
+    it("renders TodoWrite as a count, not the array contents", () => {
+      const result = resolveToolSummary(
+        "TodoWrite",
+        JSON.stringify({ todos: [{ id: 1 }, { id: 2 }, { id: 3 }] }),
+      );
+      expect(result.summary).toBe("3 items");
+    });
+
+    it("preserves singular wording for a single-item TodoWrite", () => {
+      const result = resolveToolSummary(
+        "TodoWrite",
+        JSON.stringify({ todos: [{ id: 1 }] }),
+      );
+      expect(result.summary).toBe("1 item");
+    });
+  });
+});

--- a/src/ui/src/components/chat/toolMetadata.ts
+++ b/src/ui/src/components/chat/toolMetadata.ts
@@ -1,0 +1,332 @@
+/**
+ * Per-tool display metadata: which input field carries the "primary
+ * content" worth surfacing in the chat tool-call row, and what
+ * syntax-highlighting language that content should be rendered as.
+ *
+ * Three resolution layers, applied in order:
+ *
+ *   1. **Exact name match** in `TOOL_METADATA` — built-in tools
+ *      (`Bash`, `Read`, …) plus well-known MCP servers
+ *      (`mcp__postgres__query`, `mcp__playwright__browser_evaluate`, …)
+ *      where we know which input field carries the user-facing payload
+ *      and what language to highlight it as.
+ *
+ *   2. **Tool-name heuristics** — pattern matches on the tool name
+ *      (e.g. `mcp__*__query` strongly implies SQL; anything containing
+ *      `bash` or `shell` implies a shell command). Lets new MCP servers
+ *      that follow common naming conventions render correctly without
+ *      a registry entry.
+ *
+ *   3. **Field-name heuristics** — examine the parsed input's keys for
+ *      well-known content fields (`sql`, `code`, `command`, `prompt`,
+ *      …). The first match wins, with the language inferred from the
+ *      field name when possible. If no known field matches, fall back
+ *      to the longest string-valued field in the input.
+ *
+ * The previous implementation in `extractToolSummary` (now a thin
+ * wrapper around `resolveToolSummary`) only checked four MCP fields
+ * (`description`, `url`, `query`, `command`), so common MCP tools like
+ * `mcp__postgres__query` (which uses an `sql` field) silently fell
+ * through to an empty summary. This module exists to fix that hole
+ * once and for all by treating MCP tool naming as data, not code.
+ */
+
+export interface ToolDisplayMeta {
+  /** Input field whose value is the primary content to surface as
+   *  the tool-call summary. Must be a string-valued field. */
+  contentField: string;
+  /** Optional Shiki language id for highlighting the field's value
+   *  when rendered as a code block. `null` / absent renders plain. */
+  contentLang?: string | null;
+}
+
+/**
+ * Exact-match registry. Keep entries terse — one line per tool — and
+ * group by source (built-ins, then alphabetical MCP). Add new MCP
+ * tools as you encounter them; for tools that follow a common naming
+ * convention, the heuristics below will usually surface a reasonable
+ * default without a manual entry.
+ */
+export const TOOL_METADATA: Readonly<Record<string, ToolDisplayMeta>> = {
+  // Built-in Claude tools
+  Bash: { contentField: "command", contentLang: "bash" },
+  Read: { contentField: "file_path" },
+  Edit: { contentField: "file_path" },
+  Write: { contentField: "file_path" },
+  Glob: { contentField: "pattern" },
+  Grep: { contentField: "pattern" },
+  WebFetch: { contentField: "url" },
+  WebSearch: { contentField: "query" },
+  NotebookEdit: { contentField: "notebook_path" },
+  Agent: { contentField: "description" },
+  Skill: { contentField: "skill" },
+  AskUserQuestion: { contentField: "question" },
+  TodoWrite: { contentField: "todos" }, // array; renderer falls back to count
+  ToolSearch: { contentField: "query" },
+  CronCreate: { contentField: "schedule" },
+
+  // Well-known MCP servers — postgres / sqlite
+  mcp__postgres__query: { contentField: "sql", contentLang: "sql" },
+  mcp__postgres__execute: { contentField: "sql", contentLang: "sql" },
+  mcp__postgres__statement: { contentField: "sql", contentLang: "sql" },
+  mcp__sqlite__query: { contentField: "sql", contentLang: "sql" },
+  mcp__sqlite__execute: { contentField: "sql", contentLang: "sql" },
+  mcp__mysql__query: { contentField: "sql", contentLang: "sql" },
+  mcp__bigquery__query: { contentField: "query", contentLang: "sql" },
+  mcp__redshift__query: { contentField: "sql", contentLang: "sql" },
+
+  // Playwright / browser MCP
+  mcp__plugin_playwright__browser_evaluate: {
+    contentField: "function",
+    contentLang: "javascript",
+  },
+  mcp__plugin_playwright__browser_run_code_unsafe: {
+    contentField: "code",
+    contentLang: "javascript",
+  },
+  mcp__plugin_playwright__browser_navigate: { contentField: "url" },
+  mcp__plugin_playwright__browser_click: { contentField: "element" },
+  mcp__plugin_playwright__browser_fill_form: { contentField: "fields" },
+  mcp__plugin_playwright__browser_type: { contentField: "text" },
+
+  // GitHub / GitLab / git MCP
+  mcp__github__create_issue: { contentField: "title" },
+  mcp__github__create_pull_request: { contentField: "title" },
+  mcp__github__search_code: { contentField: "q" },
+  mcp__github__search_issues: { contentField: "q" },
+  mcp__github__get_issue: { contentField: "issue_number" },
+
+  // Filesystem MCP
+  mcp__filesystem__read_file: { contentField: "path" },
+  mcp__filesystem__write_file: { contentField: "path" },
+  mcp__filesystem__list_directory: { contentField: "path" },
+  mcp__filesystem__search_files: { contentField: "pattern" },
+
+  // Fetch / HTTP MCP
+  mcp__fetch__fetch: { contentField: "url" },
+
+  // Memory / knowledge-graph MCP
+  mcp__memory__create_entities: { contentField: "entities" },
+  mcp__memory__search_nodes: { contentField: "query" },
+};
+
+/**
+ * Tool-name heuristics. Each rule is a `(predicate, meta)` pair; the
+ * first matching rule wins. Order matters — more specific patterns
+ * (longer suffixes) before generic ones. Rules can omit `contentLang`
+ * to defer to field-name heuristics for the language.
+ */
+const TOOL_NAME_HEURISTICS: ReadonlyArray<{
+  test: (toolName: string) => boolean;
+  meta: ToolDisplayMeta;
+}> = [
+  // Anything that looks like a SQL-flavored MCP tool — server name
+  // contains "postgres"/"mysql"/"sqlite"/"redshift"/"bigquery" or the
+  // operation suffix is "_query"/"_sql"/"_execute". These reliably
+  // carry a SQL string in `sql` (or `query`).
+  {
+    test: (n) =>
+      n.startsWith("mcp__") &&
+      /(postgres|mysql|mariadb|sqlite|redshift|bigquery|snowflake|clickhouse|duckdb)/.test(
+        n,
+      ),
+    meta: { contentField: "sql", contentLang: "sql" },
+  },
+  {
+    test: (n) => n.startsWith("mcp__") && /__(query|sql|execute)$/.test(n),
+    meta: { contentField: "sql", contentLang: "sql" },
+  },
+
+  // Browser automation / JS evaluation
+  {
+    test: (n) => n.startsWith("mcp__") && /__(evaluate|run_code|exec_js)/.test(n),
+    meta: { contentField: "code", contentLang: "javascript" },
+  },
+
+  // Shell / bash MCP
+  {
+    test: (n) => n.startsWith("mcp__") && /(shell|bash|exec|cmd)/.test(n),
+    meta: { contentField: "command", contentLang: "bash" },
+  },
+];
+
+/**
+ * Field-name heuristics for unknown tools. Each entry is `(fieldName,
+ * lang)`. The first field present in the input that matches an entry
+ * wins; later entries are tie-broken by registry order. If no known
+ * field matches, callers fall back to the longest string-valued field.
+ */
+const FIELD_NAME_HEURISTICS: ReadonlyArray<[field: string, lang: string | null]> = [
+  ["sql", "sql"],
+  ["code", "javascript"],
+  ["function", "javascript"],
+  ["script", "javascript"],
+  ["command", "bash"],
+  ["cmd", "bash"],
+  ["prompt", null],
+  ["query", null],
+  ["text", null],
+  ["body", null],
+  ["title", null],
+  ["description", null],
+  ["url", null],
+  ["uri", null],
+  ["path", null],
+  ["file_path", null],
+  ["name", null],
+  ["q", null],
+  ["pattern", null],
+];
+
+const MAX_SUMMARY_LENGTH = 120;
+
+/** Resolved tool-display payload — what the renderer needs to draw a
+ *  row's summary plus optionally an expanded code block. */
+export interface ResolvedToolDisplay {
+  /** Single-line summary, truncated to `MAX_SUMMARY_LENGTH`. May be
+   *  empty if the input contained no string-valued fields and no
+   *  registry entry pointed at one. */
+  summary: string;
+  /** Shiki language id when the summary's source field carries
+   *  highlightable code. `null` → render as plain text. */
+  lang: string | null;
+  /** The full untruncated string the summary was derived from, for
+   *  use by future expand-to-detail views. May equal `summary` when
+   *  the underlying value was already short. */
+  fullContent: string;
+}
+
+const EMPTY_DISPLAY: ResolvedToolDisplay = {
+  summary: "",
+  lang: null,
+  fullContent: "",
+};
+
+/**
+ * Resolve a tool's input JSON into a display-ready summary. Pure —
+ * safe to call from render. Errors during JSON parse return an empty
+ * display rather than throwing; callers render an empty summary cell.
+ */
+export function resolveToolSummary(
+  toolName: string,
+  inputJson: string,
+): ResolvedToolDisplay {
+  let input: unknown;
+  try {
+    input = JSON.parse(inputJson);
+  } catch {
+    return EMPTY_DISPLAY;
+  }
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return EMPTY_DISPLAY;
+  }
+  const record = input as Record<string, unknown>;
+
+  // Layer 1: exact-name registry.
+  const exact = TOOL_METADATA[toolName];
+  if (exact) {
+    const display = displayFromField(record, exact.contentField, exact.contentLang ?? null);
+    if (display) return display;
+  }
+
+  // Layer 2: tool-name heuristics.
+  for (const rule of TOOL_NAME_HEURISTICS) {
+    if (!rule.test(toolName)) continue;
+    const display = displayFromField(
+      record,
+      rule.meta.contentField,
+      rule.meta.contentLang ?? null,
+    );
+    if (display) return display;
+  }
+
+  // Layer 3: field-name heuristics. First well-known field wins.
+  for (const [field, lang] of FIELD_NAME_HEURISTICS) {
+    const display = displayFromField(record, field, lang);
+    if (display) return display;
+  }
+
+  // Layer 4: longest string-valued field. Last-ditch heuristic so a
+  // brand-new MCP tool with an unfamiliar schema still shows
+  // *something* rather than an empty cell.
+  const fallback = longestStringField(record);
+  if (fallback) {
+    return {
+      summary: truncate(fallback, MAX_SUMMARY_LENGTH),
+      lang: null,
+      fullContent: fallback,
+    };
+  }
+
+  return EMPTY_DISPLAY;
+}
+
+function displayFromField(
+  record: Record<string, unknown>,
+  field: string,
+  lang: string | null,
+): ResolvedToolDisplay | null {
+  if (!(field in record)) return null;
+  const raw = record[field];
+  // Arrays/objects: special-case `todos` (count) and arrays-of-strings;
+  // otherwise JSON-stringify so the summary is at least informative.
+  if (Array.isArray(raw)) {
+    if (field === "todos") {
+      return {
+        summary: `${raw.length} item${raw.length !== 1 ? "s" : ""}`,
+        lang: null,
+        fullContent: safeStringify(raw),
+      };
+    }
+    const joined = raw
+      .map((v) => (typeof v === "string" ? v : safeStringify(v)))
+      .join(", ");
+    return {
+      summary: truncate(joined, MAX_SUMMARY_LENGTH),
+      lang,
+      fullContent: joined,
+    };
+  }
+  if (typeof raw === "string") {
+    return {
+      summary: truncate(raw, MAX_SUMMARY_LENGTH),
+      lang,
+      fullContent: raw,
+    };
+  }
+  if (typeof raw === "number" || typeof raw === "boolean") {
+    const text = String(raw);
+    return { summary: text, lang: null, fullContent: text };
+  }
+  if (raw == null) return null;
+  // Object value: stringify it so the user gets some signal.
+  const stringified = safeStringify(raw);
+  return {
+    summary: truncate(stringified, MAX_SUMMARY_LENGTH),
+    lang: lang === "sql" ? null : lang, // SQL highlighting on JSON looks wrong
+    fullContent: stringified,
+  };
+}
+
+function longestStringField(record: Record<string, unknown>): string | null {
+  let best: string | null = null;
+  for (const value of Object.values(record)) {
+    if (typeof value !== "string") continue;
+    if (best === null || value.length > best.length) best = value;
+  }
+  return best;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  if (max <= 3) return value.slice(0, max);
+  return `${value.slice(0, max - 1)}…`;
+}

--- a/src/ui/src/components/chat/toolMetadata.ts
+++ b/src/ui/src/components/chat/toolMetadata.ts
@@ -33,7 +33,12 @@
 
 export interface ToolDisplayMeta {
   /** Input field whose value is the primary content to surface as
-   *  the tool-call summary. Must be a string-valued field. */
+   *  the tool-call summary. Strings are summarized verbatim;
+   *  `displayFromField` also handles arrays (joined, with a special
+   *  `count` form for `todos`) and objects (JSON-stringified) so a
+   *  registry entry pointing at `entities` / `fields` / `todos` works
+   *  too — though `contentLang` highlighting only makes sense on
+   *  string values. */
   contentField: string;
   /** Optional Shiki language id for highlighting the field's value
    *  when rendered as a code block. `null` / absent renders plain. */

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -321,17 +321,16 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
     return () => window.removeEventListener("keydown", handler);
   }, [showMarkdownToggle, togglePreview]);
 
+  // Undo file operations (rename / delete / create) is the only
+  // file-viewer-scope hotkey left here — close-tab moved to a global
+  // action that routes through `requestCloseFileTabNonceByWorkspace`
+  // below, so a single Cmd+W binding handles file / diff / chat.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.repeat) return;
       const state = useAppStore.getState();
       const action = resolveHotkeyAction(e, "file-viewer", state.keybindings);
-      if (
-        action !== "file-viewer.undo-file-operation" &&
-        action !== "file-viewer.close-file-tab"
-      ) {
-        return;
-      }
+      if (action !== "file-viewer.undo-file-operation") return;
       if (
         state.settingsOpen ||
         state.activeModal ||
@@ -344,22 +343,35 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
       if (!el || !viewerRef.current?.contains(el)) return;
       const tag = el.tagName?.toLowerCase();
       const inMonaco = !!el.closest(".monaco-editor");
-      if (action === "file-viewer.undo-file-operation" && inMonaco) return;
-      if ((tag === "input" || tag === "textarea" || el.isContentEditable) && !inMonaco) {
+      // Inside Monaco, Ctrl/Cmd+Z is an editor command (text undo) — let
+      // Monaco handle it instead of triggering filesystem undo.
+      if (inMonaco) return;
+      if (tag === "input" || tag === "textarea" || el.isContentEditable) {
         return;
       }
-      // File-tab close is a viewer-level command; it intentionally wins while
-      // focus is inside Monaco so mod+w behaves like the tab strip shortcut.
       e.preventDefault();
-      if (action === "file-viewer.undo-file-operation") {
-        void undoLastFilePathOperation();
-      } else {
-        requestCloseFileTab();
-      }
+      void undoLastFilePathOperation();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [requestCloseFileTab, undoLastFilePathOperation]);
+  }, [undoLastFilePathOperation]);
+
+  // Bridge between the global Cmd+W handler and this viewer's
+  // dirty-aware close path. The global handler bumps the per-workspace
+  // nonce; the FileViewer reacts by running the same `requestCloseFileTab`
+  // its own close button uses, so the unsaved-changes prompt fires
+  // identically whether the user clicks × or hits the keystroke. The
+  // first-render value is treated as the baseline (no auto-close on
+  // mount).
+  const closeFileTabNonce = useAppStore(
+    (s) => s.requestCloseFileTabNonceByWorkspace[workspaceId] ?? 0,
+  );
+  const lastSeenCloseNonce = useRef(closeFileTabNonce);
+  useEffect(() => {
+    if (closeFileTabNonce === lastSeenCloseNonce.current) return;
+    lastSeenCloseNonce.current = closeFileTabNonce;
+    requestCloseFileTab();
+  }, [closeFileTabNonce, requestCloseFileTab]);
 
   const previewShortcutHint = formatBinding(
     getEffectiveBindingById(

--- a/src/ui/src/components/file-viewer/FileViewer.tsx
+++ b/src/ui/src/components/file-viewer/FileViewer.tsx
@@ -360,18 +360,23 @@ function FileViewerInner({ workspaceId, path, t }: FileViewerInnerProps) {
   // dirty-aware close path. The global handler bumps the per-workspace
   // nonce; the FileViewer reacts by running the same `requestCloseFileTab`
   // its own close button uses, so the unsaved-changes prompt fires
-  // identically whether the user clicks × or hits the keystroke. The
-  // first-render value is treated as the baseline (no auto-close on
-  // mount).
+  // identically whether the user clicks × or hits the keystroke.
+  //
+  // Handled-nonce tracking matches the FilesPanel pattern: a Map
+  // keyed by workspace, seeded at 0 so a bump that arrived while
+  // this viewer was mounting (rare but possible if `Cmd+W` fired
+  // mid-route to a fresh file tab) is still consumed.
   const closeFileTabNonce = useAppStore(
     (s) => s.requestCloseFileTabNonceByWorkspace[workspaceId] ?? 0,
   );
-  const lastSeenCloseNonce = useRef(closeFileTabNonce);
+  const handledCloseNonces = useRef<Map<string, number>>(new Map());
   useEffect(() => {
-    if (closeFileTabNonce === lastSeenCloseNonce.current) return;
-    lastSeenCloseNonce.current = closeFileTabNonce;
+    if (closeFileTabNonce === 0) return;
+    const handled = handledCloseNonces.current.get(workspaceId) ?? 0;
+    if (closeFileTabNonce === handled) return;
+    handledCloseNonces.current.set(workspaceId, closeFileTabNonce);
     requestCloseFileTab();
-  }, [closeFileTabNonce, requestCloseFileTab]);
+  }, [closeFileTabNonce, requestCloseFileTab, workspaceId]);
 
   const previewShortcutHint = formatBinding(
     getEffectiveBindingById(

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -4,6 +4,7 @@ import "./monacoSetup";
 import { applyMonacoTheme, initMonacoThemeSync } from "./monacoTheme";
 import { DEFAULT_MONO_STACK } from "../../styles/fonts";
 import { useAppStore } from "../../stores/useAppStore";
+import { executeCloseTab, executeNewTab } from "../../hotkeys/contextActions";
 import {
   useGitGutter,
   type DecorationsCollection,
@@ -134,6 +135,25 @@ export const MonacoEditor = memo(function MonacoEditor({
     editor.addCommand(
       monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyS,
       () => onSaveRef.current?.(),
+    );
+    // Override Monaco's defaults for Cmd/Ctrl+T (`gotoSymbolFromKeyboard`)
+    // and Cmd/Ctrl+W so the workspace-level new-tab / close-tab actions
+    // win when focus is inside the editor. Without these overrides the
+    // window-level keydown listener never sees the keystroke — Monaco
+    // consumes it inside its own keybinding service and we silently
+    // diverge from the rest of the app.
+    //
+    // We deliberately call into the same `executeNewTab` / `executeCloseTab`
+    // helpers used by the global keyboard hook so the routing logic
+    // (file → inline-create / chat → archive-with-confirm) lives in
+    // exactly one place.
+    editor.addCommand(
+      monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyT,
+      () => executeNewTab(),
+    );
+    editor.addCommand(
+      monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.KeyW,
+      () => executeCloseTab(),
     );
   };
 

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -28,6 +28,17 @@ export function FilesPanel() {
       ? (s.fileTreeRefreshNonceByWorkspace[selectedWorkspaceId] ?? 0)
       : 0,
   );
+  // Bumped when a global hotkey (Cmd/Ctrl+T while a file is the active
+  // workspace tab) requests "new file at workspace root" — the panel is
+  // the inline-editor owner so the request lands here, not in the
+  // hotkey handler. We only react when a file tab is actually active so
+  // a Cmd+T pressed in chat context (which never bumps this nonce) can't
+  // accidentally drop the user into a "create file" flow.
+  const newFileNonce = useAppStore((s) =>
+    selectedWorkspaceId
+      ? (s.requestNewFileNonceByWorkspace[selectedWorkspaceId] ?? 0)
+      : 0,
+  );
   const openFileTab = useAppStore((s) => s.openFileTab);
   const openDiffTab = useAppStore((s) => s.openDiffTab);
   const setDiffSelectedCommitHash = useAppStore((s) => s.setDiffSelectedCommitHash);
@@ -123,6 +134,19 @@ export function FilesPanel() {
     }, IDLE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [isRunning, selectedWorkspaceId, loadFiles]);
+
+  // React to the `requestNewFileAtRoot` nonce: open the inline create
+  // editor at the workspace root. The first effect run (nonce === 0) is
+  // skipped on purpose so opening a workspace doesn't auto-trigger the
+  // create flow.
+  const lastSeenNewFileNonce = useRef(newFileNonce);
+  useEffect(() => {
+    if (newFileNonce === lastSeenNewFileNonce.current) return;
+    lastSeenNewFileNonce.current = newFileNonce;
+    if (!selectedWorkspaceId) return;
+    setCreatingParentPath("");
+    refocusExplorer();
+  }, [newFileNonce, selectedWorkspaceId, refocusExplorer]);
 
   const handleActivateFile = useCallback(
     (path: string) => {

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -136,14 +136,25 @@ export function FilesPanel() {
   }, [isRunning, selectedWorkspaceId, loadFiles]);
 
   // React to the `requestNewFileAtRoot` nonce: open the inline create
-  // editor at the workspace root. The first effect run (nonce === 0) is
-  // skipped on purpose so opening a workspace doesn't auto-trigger the
-  // create flow.
-  const lastSeenNewFileNonce = useRef(newFileNonce);
+  // editor at the workspace root.
+  //
+  // The handled-nonce ref is keyed by workspace and seeded at 0 so a
+  // bump that landed *before* this panel mounted (e.g. Cmd+T fired
+  // while the right sidebar was on Tasks/Changes — the global handler
+  // bumps the nonce and switches the tab in the same tick, but
+  // FilesPanel only mounts after React commits the tab switch) is
+  // still consumed when we mount. A per-instance ref initialized from
+  // the current nonce would miss those mounts entirely. The Map keys
+  // by workspace so switching to a workspace whose nonce is currently
+  // lower than another workspace's last-seen value can't suppress
+  // valid bumps either.
+  const handledNewFileNonces = useRef<Map<string, number>>(new Map());
   useEffect(() => {
-    if (newFileNonce === lastSeenNewFileNonce.current) return;
-    lastSeenNewFileNonce.current = newFileNonce;
     if (!selectedWorkspaceId) return;
+    if (newFileNonce === 0) return;
+    const handled = handledNewFileNonces.current.get(selectedWorkspaceId) ?? 0;
+    if (newFileNonce === handled) return;
+    handledNewFileNonces.current.set(selectedWorkspaceId, newFileNonce);
     setCreatingParentPath("");
     refocusExplorer();
   }, [newFileNonce, selectedWorkspaceId, refocusExplorer]);

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -274,6 +274,14 @@
   animation: spin 1s linear infinite;
 }
 
+/* Skipped: deliberately not run. Match `checkIconCancelled`'s muted tone
+   (both are "didn't complete normally"), but no fill so the slash glyph
+   reads as informational rather than a soft-fail. */
+.checkIconSkipped {
+  color: var(--text-dim);
+  justify-self: center;
+}
+
 @keyframes spin {
   to { transform: rotate(360deg); }
 }

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.tsx
@@ -3,6 +3,7 @@ import {
   Check,
   ChevronRight,
   Circle,
+  CircleSlash,
   GitPullRequestArrow,
   GitPullRequestDraft,
   GitMerge,
@@ -150,6 +151,9 @@ function checkSummaryStatus(summary: ReturnType<typeof summarizeCiChecks>): CiCh
   if (summary.failed > 0) return "failure";
   if (summary.pending > 0) return "pending";
   if (summary.cancelled > 0) return "cancelled";
+  // `skipped` does not contribute to the overall status icon: a PR
+  // whose only checks were skipped reads as success at the banner
+  // level, with the per-check rows below disambiguating.
   return "success";
 }
 
@@ -189,5 +193,10 @@ function CheckStatusIcon({ status }: { status: CiCheck["status"] }) {
       return <Circle size={10} className={styles.checkIconCancelled} aria-hidden="true" />;
     case "pending":
       return <LoaderCircle size={14} className={styles.checkIconPending} aria-hidden="true" />;
+    case "skipped":
+      // CircleSlash reads as "didn't run" at a glance; the
+      // checkIconSkipped class tints it neutral / muted so it doesn't
+      // pull attention away from real CI signal.
+      return <CircleSlash size={12} className={styles.checkIconSkipped} aria-hidden="true" />;
   }
 }

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -14,6 +14,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { listen } from "@tauri-apps/api/event";
+import { ask } from "@tauri-apps/plugin-dialog";
 import {
   writeText as clipboardWriteText,
   readText as clipboardReadText,
@@ -581,8 +582,11 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const handleStopAgentTask = useCallback(async (tab: TerminalTab) => {
     if (!tab.agent_chat_session_id || !tab.agent_task_id) return;
     const label = tab.task_summary?.trim() || tab.title || tab.agent_task_id;
-    const ok = window.confirm(
+    // Tauri 2 webviews silently no-op `window.confirm()` — use the
+    // plugin-dialog's `ask()` so the user actually sees the prompt.
+    const ok = await ask(
       `Stop background task "${label}"?\n\nThis will terminate the running command.`,
+      { title: "Stop task", kind: "warning", okLabel: "Stop", cancelLabel: "Cancel" },
     );
     if (!ok) return;
     try {

--- a/src/ui/src/hooks/toolSummary.ts
+++ b/src/ui/src/hooks/toolSummary.ts
@@ -1,95 +1,69 @@
-/** Extract a short human-readable summary from a tool's input JSON. */
+import { resolveToolSummary } from "../components/chat/toolMetadata";
+
+/**
+ * Extract a short human-readable summary from a tool's input JSON.
+ *
+ * Most logic lives in `components/chat/toolMetadata.ts` so the same
+ * registry can power richer surfaces (e.g. a future expand-to-code-block
+ * view with syntax highlighting). This wrapper exists because a few
+ * built-in tools (`Grep`, `SendMessage`, `Skill`, `TaskUpdate`, …)
+ * compose two fields into the displayed summary, which the registry's
+ * single-content-field model can't express. Those keep their bespoke
+ * formatting here; everything else delegates to the registry.
+ */
 export function extractToolSummary(
   toolName: string,
-  inputJson: string
+  inputJson: string,
 ): string {
+  // Composite-summary tools: keep their hand-rolled formatting because
+  // the registry returns a single `contentField`'s value, not a
+  // string built from multiple fields.
   try {
     const input = JSON.parse(inputJson);
-
     switch (toolName) {
-      case "Bash":
-        return truncate(input.command ?? input.description ?? "", 80);
-      case "Read":
-        return input.file_path ?? "";
-      case "Edit":
-        return input.file_path ?? "";
-      case "Write":
-        return input.file_path ?? "";
-      case "Glob":
-        return input.pattern ?? "";
       case "Grep":
         return input.pattern
-          ? truncate(`${input.pattern}${input.path ? ` in ${input.path}` : ""}`, 80)
+          ? truncate(
+              `${input.pattern}${input.path ? ` in ${input.path}` : ""}`,
+              80,
+            )
           : "";
-      case "WebFetch":
-        return input.url ?? "";
-      case "WebSearch":
-        return input.query ?? "";
-      case "NotebookEdit":
-        return input.notebook_path ?? "";
-      case "Agent":
-        return truncate(input.description ?? input.prompt ?? "", 80);
       case "SendMessage":
         return input.to
-          ? truncate(`to ${input.to}${input.summary ? `: ${input.summary}` : ""}`, 80)
+          ? truncate(
+              `to ${input.to}${input.summary ? `: ${input.summary}` : ""}`,
+              80,
+            )
           : "";
-      case "ToolSearch":
-        return input.query ?? "";
-      case "TeamCreate":
-        return input.name ?? "";
-      case "TeamDelete":
-        return input.name ?? "";
-      case "TaskCreate":
-        return truncate(input.description ?? "", 80);
+      case "Skill":
+        return input.skill
+          ? truncate(
+              `${input.skill}${input.args ? ` ${input.args}` : ""}`,
+              80,
+            )
+          : "";
       case "TaskUpdate":
         return input.status ? `#${input.id ?? "?"} → ${input.status}` : "";
       case "TaskGet":
       case "TaskStop":
       case "TaskOutput":
         return input.id ? `#${input.id}` : "";
-      case "Skill":
-        return input.skill
-          ? truncate(`${input.skill}${input.args ? ` ${input.args}` : ""}`, 80)
-          : "";
-      case "AskUserQuestion":
-        return truncate(input.question ?? "", 80);
       case "Monitor":
         return input.id ? `task #${input.id}` : "";
-      case "CronCreate":
-        return truncate(input.schedule ?? input.name ?? "", 80);
       case "CronDelete":
         return input.id ?? input.name ?? "";
       case "RemoteTrigger":
         return truncate(input.name ?? input.prompt ?? "", 80);
       case "LSP":
         return input.action ?? "";
-      case "TodoWrite":
-        return Array.isArray(input.todos)
-          ? `${input.todos.length} items`
-          : "";
-      default: {
-        // MCP tools: strip the mcp__ prefix for readability.
-        if (toolName.startsWith("mcp__")) {
-          return truncate(
-            input.description ?? input.url ?? input.query ?? input.command ?? "",
-            80
-          );
-        }
-        // For unknown tools, try common field names.
-        return truncate(
-          input.command ??
-            input.file_path ??
-            input.path ??
-            input.query ??
-            input.url ??
-            "",
-          80
-        );
-      }
     }
   } catch {
     return "";
   }
+  // Default path: registry → tool-name heuristics → field-name
+  // heuristics → longest string. The registry caps its summary at
+  // 120 chars; trim to 80 here for the inline row-summary surface.
+  return truncate(resolveToolSummary(toolName, inputJson).summary, 80);
 }
 
 function truncate(s: string, max: number): string {

--- a/src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx
+++ b/src/ui/src/hooks/useAgentStream.sessionRenamed.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression test for the chat-tab auto-rename live update.
+ *
+ * The Rust side emits a `session-renamed` Tauri event from
+ * `try_generate_session_name` after Haiku produces a short label
+ * for the first user prompt. The frontend listener for that event
+ * was missing — meaning the chat tab kept its placeholder name
+ * until the user switched workspaces and came back (which forced
+ * `SessionTabs` to re-fetch the session list). The fix is a one-
+ * useEffect listener; this test pins it.
+ *
+ * Strategy: mock `@tauri-apps/api/event`'s `listen()` so we can
+ * capture every registered event handler by name, then mount
+ * `useAgentStream` in a probe component, retrieve the
+ * `session-renamed` handler, fire it with a payload, and assert
+ * the chat-session slice was updated.
+ *
+ * If a future refactor drops the listener (regression), this test
+ * fails at the `expect(handler).toBeDefined()` assertion before any
+ * payload is even fired.
+ */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture every Tauri event listener registered by the hook so the
+// test can synthesize an event without round-tripping through real
+// Tauri. The map is reset per-test in `beforeEach`.
+type HandlerRecord = (event: { payload: unknown }) => void;
+const registeredHandlers = new Map<string, HandlerRecord[]>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (eventName: string, handler: HandlerRecord) => {
+    const list = registeredHandlers.get(eventName) ?? [];
+    list.push(handler);
+    registeredHandlers.set(eventName, list);
+    return Promise.resolve(() => {
+      const after = registeredHandlers.get(eventName)?.filter((h) => h !== handler) ?? [];
+      registeredHandlers.set(eventName, after);
+    });
+  },
+}));
+
+// Stub out the heavy backend calls `useAgentStream` makes from inside
+// other listeners — they're not exercised by this test but the hook
+// imports them at module load so the mocks must exist.
+vi.mock("../services/tauri", async () => {
+  const actual = await vi.importActual<typeof import("../services/tauri")>(
+    "../services/tauri",
+  );
+  return {
+    ...actual,
+    loadChatHistory: vi.fn().mockResolvedValue([]),
+    saveTurnToolActivities: vi.fn().mockResolvedValue(undefined),
+    setSessionCliInvocation: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Imports must come AFTER the vi.mock() calls so the mocks are wired
+// before the module-under-test resolves them.
+import { useAgentStream } from "./useAgentStream";
+import { useAppStore } from "../stores/useAppStore";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function mountHook(): Promise<void> {
+  function Probe() {
+    useAgentStream();
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<Probe />);
+  });
+}
+
+beforeEach(() => {
+  registeredHandlers.clear();
+  // Seed a known chat session so the slice update has something to
+  // mutate. The test only cares about `name` flipping; other fields
+  // are placeholder values matching the `ChatSession` shape.
+  useAppStore.setState({
+    sessionsByWorkspace: {
+      "ws-1": [
+        {
+          id: "session-1",
+          workspace_id: "ws-1",
+          session_id: null,
+          name: "New chat",
+          name_edited: false,
+          turn_count: 0,
+          sort_order: 0,
+          status: "Active",
+          created_at: new Date().toISOString(),
+          archived_at: null,
+          cli_invocation: null,
+          agent_status: "Stopped",
+          needs_attention: false,
+          attention_kind: null,
+        },
+      ],
+    },
+  });
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("useAgentStream — session-renamed listener", () => {
+  it("registers a Tauri listener for the session-renamed event", async () => {
+    await mountHook();
+    expect(registeredHandlers.get("session-renamed")?.length).toBeGreaterThan(0);
+  });
+
+  it("updates the matching chat session's name when the event fires", async () => {
+    await mountHook();
+    const handlers = registeredHandlers.get("session-renamed") ?? [];
+    expect(handlers.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      for (const handler of handlers) {
+        handler({
+          payload: { session_id: "session-1", name: "Initial prompt summary" },
+        });
+      }
+    });
+
+    const sessions =
+      useAppStore.getState().sessionsByWorkspace["ws-1"] ?? [];
+    const updated = sessions.find((s) => s.id === "session-1");
+    expect(updated?.name).toBe("Initial prompt summary");
+  });
+
+  it("ignores rename payloads for unknown sessions", async () => {
+    await mountHook();
+    const handlers = registeredHandlers.get("session-renamed") ?? [];
+
+    await act(async () => {
+      for (const handler of handlers) {
+        handler({
+          payload: { session_id: "ghost-session", name: "should not surface" },
+        });
+      }
+    });
+
+    const sessions =
+      useAppStore.getState().sessionsByWorkspace["ws-1"] ?? [];
+    // The known session keeps its original name; the unknown id is a
+    // no-op (matches `updateChatSession`'s contract — it walks every
+    // workspace's session list and updates only when it finds an id
+    // match).
+    expect(sessions.find((s) => s.id === "session-1")?.name).toBe("New chat");
+  });
+});

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -886,6 +886,31 @@ export function useAgentStream() {
     };
   }, [updateWorkspace]);
 
+  // Listen for session-renamed events. The backend emits this from
+  // `try_generate_session_name` after Haiku produces a short label
+  // for the first user prompt — the same flow that renames the
+  // workspace. Without this listener the chat tab kept its `New chat`
+  // placeholder until the user switched workspaces and came back, at
+  // which point `SessionTabs`' mount effect re-fetched the session
+  // list and the renamed value finally surfaced. Mirroring the
+  // workspace-renamed handler closes that gap so the tab updates
+  // live.
+  useEffect(() => {
+    let active = true;
+    const unlisten = listen<{
+      session_id: string;
+      name: string;
+    }>("session-renamed", (event) => {
+      if (!active) return;
+      const { session_id, name } = event.payload;
+      updateChatSession(session_id, { name });
+    });
+    return () => {
+      active = false;
+      unlisten.then((fn) => fn());
+    };
+  }, [updateChatSession]);
+
   // Listen for backend-authored system messages that the chat command
   // inserts into the DB out-of-band (currently: env-provider trust
   // warnings emitted before agent spawn). The DB insert keeps the

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 import { useAppStore } from "../stores/useAppStore";
-import { stopAgent, sendRemoteCommand } from "../services/tauri";
+import {
+  createChatSession,
+  sendRemoteCommand,
+  stopAgent,
+} from "../services/tauri";
 import { isAgentBusy } from "../utils/agentStatus";
 import {
   focusActiveTerminal,
@@ -195,6 +199,44 @@ export function useKeyboardShortcuts() {
             // Esc closes it via the global.dismiss-or-stop branch above.
             openModal("keyboard-shortcuts");
             return;
+          case "global.new-tab": {
+            // Context-aware "new tab":
+            //  - File context (an `activeFileTabByWorkspace` entry exists
+            //    for the current workspace): trigger the FilesPanel's
+            //    inline "create new file at root" flow. We also unhide
+            //    the right sidebar and switch it to the Files tab so the
+            //    inline editor is actually visible — the panel owns the
+            //    editor's lifecycle so we just deliver the open-it
+            //    signal via `requestNewFileAtRoot`.
+            //  - Otherwise (chat or diff): create a new chat session in
+            //    the current workspace and switch to it. Mirrors the
+            //    SessionTabs "+ new session" button so the result is
+            //    indistinguishable from clicking it.
+            if (!selectedWorkspaceId) return;
+            const store = useAppStore.getState();
+            const activeFile =
+              store.activeFileTabByWorkspace[selectedWorkspaceId] ?? null;
+            if (activeFile) {
+              if (!store.rightSidebarVisible) store.toggleRightSidebar();
+              if (store.rightSidebarTab !== "files") {
+                store.setRightSidebarTab("files");
+              }
+              store.requestNewFileAtRoot(selectedWorkspaceId);
+              return;
+            }
+            void (async () => {
+              try {
+                const session = await createChatSession(selectedWorkspaceId);
+                const post = useAppStore.getState();
+                if (post.selectedWorkspaceId !== selectedWorkspaceId) return;
+                post.addChatSession(session);
+                post.selectSession(selectedWorkspaceId, session.id);
+              } catch (err) {
+                console.error("[hotkey] global.new-tab failed:", err);
+              }
+            })();
+            return;
+          }
           default:
             return;
         }

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -1,10 +1,6 @@
 import { useEffect } from "react";
 import { useAppStore } from "../stores/useAppStore";
-import {
-  createChatSession,
-  sendRemoteCommand,
-  stopAgent,
-} from "../services/tauri";
+import { sendRemoteCommand, stopAgent } from "../services/tauri";
 import { isAgentBusy } from "../utils/agentStatus";
 import {
   focusActiveTerminal,
@@ -13,6 +9,7 @@ import {
 } from "../utils/focusTargets";
 import { adjustUiFontSize } from "../utils/fontSettings";
 import { resolveHotkeyAction } from "../hotkeys/bindings";
+import { executeCloseTab, executeNewTab } from "../hotkeys/contextActions";
 import type { HotkeyActionId } from "../hotkeys/actions";
 
 export function useKeyboardShortcuts() {
@@ -199,44 +196,20 @@ export function useKeyboardShortcuts() {
             // Esc closes it via the global.dismiss-or-stop branch above.
             openModal("keyboard-shortcuts");
             return;
-          case "global.new-tab": {
-            // Context-aware "new tab":
-            //  - File context (an `activeFileTabByWorkspace` entry exists
-            //    for the current workspace): trigger the FilesPanel's
-            //    inline "create new file at root" flow. We also unhide
-            //    the right sidebar and switch it to the Files tab so the
-            //    inline editor is actually visible — the panel owns the
-            //    editor's lifecycle so we just deliver the open-it
-            //    signal via `requestNewFileAtRoot`.
-            //  - Otherwise (chat or diff): create a new chat session in
-            //    the current workspace and switch to it. Mirrors the
-            //    SessionTabs "+ new session" button so the result is
-            //    indistinguishable from clicking it.
-            if (!selectedWorkspaceId) return;
-            const store = useAppStore.getState();
-            const activeFile =
-              store.activeFileTabByWorkspace[selectedWorkspaceId] ?? null;
-            if (activeFile) {
-              if (!store.rightSidebarVisible) store.toggleRightSidebar();
-              if (store.rightSidebarTab !== "files") {
-                store.setRightSidebarTab("files");
-              }
-              store.requestNewFileAtRoot(selectedWorkspaceId);
-              return;
-            }
-            void (async () => {
-              try {
-                const session = await createChatSession(selectedWorkspaceId);
-                const post = useAppStore.getState();
-                if (post.selectedWorkspaceId !== selectedWorkspaceId) return;
-                post.addChatSession(session);
-                post.selectSession(selectedWorkspaceId, session.id);
-              } catch (err) {
-                console.error("[hotkey] global.new-tab failed:", err);
-              }
-            })();
+          case "global.new-tab":
+            // Routing logic lives in `hotkeys/contextActions.ts` so the
+            // Monaco-side overrides (which bypass this listener via
+            // `editor.addCommand`) and the keyboard hook share a
+            // single implementation. See that module for the
+            // file/diff/chat dispatch table.
+            executeNewTab();
             return;
-          }
+          case "global.close-tab":
+            // Same shared module. Includes the dirty-aware close path
+            // (via `requestCloseFileTabNonceByWorkspace`) and the
+            // chat-close confirmation rules.
+            executeCloseTab();
+            return;
           default:
             return;
         }

--- a/src/ui/src/hotkeys/actions.ts
+++ b/src/ui/src/hotkeys/actions.ts
@@ -339,10 +339,23 @@ export const HOTKEY_ACTIONS = [
     rebindable: true,
   },
   {
-    id: "file-viewer.close-file-tab",
-    scope: "file-viewer",
-    category: "keyboard_category_editor",
-    description: "keyboard_action_file_close_tab",
+    // Cmd/Ctrl+W: context-aware "close tab".
+    //  - File active in the right pane → routes through the FileViewer's
+    //    dirty-aware close path (preserves the existing discard-changes
+    //    confirmation modal).
+    //  - Diff active → closes the diff tab.
+    //  - Chat active → archives the active chat session, gated by the
+    //    shared confirm rules in `chatCloseConfirmMessage` (running
+    //    sessions, the active session, and the last remaining session
+    //    all prompt before close).
+    //
+    // Replaces the prior `file-viewer.close-file-tab` action; the
+    // `20260508T_rename_close_file_tab_keybinding.sql` migration carries
+    // any user-customised binding forward.
+    id: "global.close-tab",
+    scope: "global",
+    category: "keyboard_category_navigation",
+    description: "keyboard_action_close_tab",
     defaultBinding: allPlatforms("mod+w"),
     match: "key",
     rebindable: true,

--- a/src/ui/src/hotkeys/actions.ts
+++ b/src/ui/src/hotkeys/actions.ts
@@ -350,8 +350,8 @@ export const HOTKEY_ACTIONS = [
     //    all prompt before close).
     //
     // Replaces the prior `file-viewer.close-file-tab` action; the
-    // `20260508T_rename_close_file_tab_keybinding.sql` migration carries
-    // any user-customised binding forward.
+    // `20260509000540_rename_close_file_tab_keybinding.sql` migration
+    // carries any user-customised binding forward.
     id: "global.close-tab",
     scope: "global",
     category: "keyboard_category_navigation",

--- a/src/ui/src/hotkeys/actions.ts
+++ b/src/ui/src/hotkeys/actions.ts
@@ -185,6 +185,32 @@ export const HOTKEY_ACTIONS = [
     suppressUnderOverlay: false,
   },
   {
+    // Cmd/Ctrl+T: context-aware "new tab".
+    //  - When the workspace's right pane is showing a file (an
+    //    `activeFileTabByWorkspace` entry exists), this triggers the
+    //    inline "create new file" flow at the workspace root in the
+    //    Files panel — matches editor muscle memory for "new tab".
+    //  - Otherwise (chat or diff is showing), it creates a new chat
+    //    session in the current workspace.
+    //
+    // `terminal.new-tab` is independently scoped to `terminal` and still
+    // owns mod+t when the user is typing inside a terminal pane, so this
+    // doesn't fight terminal tab creation. Previously Cmd+T was wired
+    // through a raw `window.addEventListener("keydown")` in
+    // `ChatToolbar`/`ComposerToolbar` to toggle thinking mode; that
+    // bypass-the-keybinding-system shortcut is removed in favor of this
+    // registered action so users can rebind it from Keyboard Settings.
+    id: "global.new-tab",
+    scope: "global",
+    category: "keyboard_category_navigation",
+    description: "keyboard_action_new_tab",
+    defaultBinding: allPlatforms("mod+t"),
+    match: "key",
+    rebindable: true,
+    suppressUnderOverlay: true,
+    suppressInInteractive: false,
+  },
+  {
     id: "global.toggle-plan-mode",
     scope: "global",
     category: "keyboard_category_navigation",

--- a/src/ui/src/hotkeys/bindings.test.ts
+++ b/src/ui/src/hotkeys/bindings.test.ts
@@ -149,25 +149,40 @@ describe("resolveHotkeyAction with conflict updates", () => {
     expect(resolveHotkeyAction(event, "global", {}, "mac")).toBeNull();
   });
 
-  it("resolves close file tab with platform mod in file-viewer scope", () => {
+  it("resolves close-tab with platform mod in global scope", () => {
+    // Pre-rename, this binding lived in `file-viewer` scope and only
+    // fired when focus was inside the file viewer. The `global.close-tab`
+    // action moves the dispatch out so chat / diff close also work, and
+    // a SQL migration carries existing user overrides forward.
     expect(
       resolveHotkeyAction(
         macKey({ key: "w", metaKey: true }),
+        "global",
+        {},
+        "mac",
+      ),
+    ).toBe("global.close-tab");
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "w", ctrlKey: true }),
+        "global",
+        {},
+        "linux",
+      ),
+    ).toBe("global.close-tab");
+  });
+
+  it("doesn't shadow the file-viewer-scoped undo action with the new global close-tab", () => {
+    // Sanity: undo (mod+z) lives in file-viewer scope and the new
+    // global.close-tab (mod+w) shouldn't accidentally claim it.
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "z", metaKey: true }),
         "file-viewer",
         {},
         "mac",
       ),
-    ).toBe("file-viewer.close-file-tab");
-    expect(
-      resolveHotkeyAction(
-        macKey({ key: "w", ctrlKey: true }),
-        "file-viewer",
-        {},
-        "linux",
-      ),
-    ).toBe("file-viewer.close-file-tab");
-    expect(resolveHotkeyAction(macKey({ key: "w", metaKey: true }), "global", {}, "mac"))
-      .toBeNull();
+    ).toBe("file-viewer.undo-file-operation");
   });
 });
 

--- a/src/ui/src/hotkeys/bindings.test.ts
+++ b/src/ui/src/hotkeys/bindings.test.ts
@@ -198,6 +198,51 @@ describe("global.show-keyboard-shortcuts default binding", () => {
   });
 });
 
+describe("global.new-tab default binding", () => {
+  // Locks Cmd/Ctrl+T as the context-aware "new tab" shortcut. Pre-#???
+  // this binding lived as a raw `window.addEventListener("keydown")` in
+  // ChatToolbar/ComposerToolbar that toggled thinking mode — see the
+  // CHANGELOG entry / PR description for the rationale on the rebind.
+  // The terminal scope keeps its own `terminal.new-tab` on the same key
+  // so typing Cmd+T inside a terminal pane still creates a terminal tab.
+  it("resolves Cmd+T on macOS to global.new-tab", () => {
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "t", metaKey: true }),
+        "global",
+        {},
+        "mac",
+      ),
+    ).toBe("global.new-tab");
+  });
+
+  it("resolves Ctrl+T on Linux/Windows to global.new-tab", () => {
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "t", ctrlKey: true }),
+        "global",
+        {},
+        "linux",
+      ),
+    ).toBe("global.new-tab");
+  });
+
+  it("does not collide with terminal.new-tab in terminal scope on macOS", () => {
+    // Both global.new-tab and terminal.new-tab default to mod+t on
+    // macOS by design — the dispatcher routes by scope, not by the key
+    // alone. Inside a terminal pane the resolver is called with scope
+    // "terminal" and the terminal action wins.
+    expect(
+      resolveHotkeyAction(
+        macKey({ key: "t", metaKey: true }),
+        "terminal",
+        {},
+        "mac",
+      ),
+    ).toBe("terminal.new-tab");
+  });
+});
+
 describe("bindingMatchesEvent — modifier-only codes", () => {
   // Regression: hold-to-talk on Right Alt was bound to `code:AltRight`,
   // but pressing Alt asserts e.altKey, which the matcher used to reject

--- a/src/ui/src/hotkeys/contextActions.test.ts
+++ b/src/ui/src/hotkeys/contextActions.test.ts
@@ -252,10 +252,12 @@ describe("executeCloseTab", () => {
       sessionsByWorkspace: { [WS]: [session, makeSession("b")] },
       selectedSessionIdByWorkspaceId: { [WS]: "a" },
     });
-    const confirm = vi.fn().mockReturnValue(true);
+    const confirm = vi.fn().mockResolvedValue(true);
     const archiveChatSession = vi.fn().mockResolvedValue(null);
 
     executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+    // Two ticks: one for the confirm await, one for the archive await.
     await new Promise((r) => setTimeout(r, 0));
 
     // The hotkey path always targets the active session so the
@@ -272,10 +274,11 @@ describe("executeCloseTab", () => {
       sessionsByWorkspace: { [WS]: [session, makeSession("b")] },
       selectedSessionIdByWorkspaceId: { [WS]: "a" },
     });
-    const confirm = vi.fn().mockReturnValue(false);
+    const confirm = vi.fn().mockResolvedValue(false);
     const archiveChatSession = vi.fn();
 
     executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
 
     expect(confirm).toHaveBeenCalledTimes(1);
@@ -284,16 +287,45 @@ describe("executeCloseTab", () => {
     expect(useAppStore.getState().sessionsByWorkspace[WS]?.length).toBe(2);
   });
 
+  it("chat context: prompts and archives a Running session", async () => {
+    // Regression for the user-reported "Cmd+W kills running sessions
+    // without prompting" — previously synchronous `window.confirm()`
+    // returned immediately in the Tauri webview so the dialog never
+    // surfaced and the archive ran unchecked. The async-confirm
+    // contract here is the same shape Tauri's `ask()` produces.
+    const session = makeSession("a", { agent_status: "Running" });
+    useAppStore.setState({
+      sessionsByWorkspace: { [WS]: [session] },
+      selectedSessionIdByWorkspaceId: { [WS]: "a" },
+    });
+    const confirm = vi.fn().mockResolvedValue(false);
+    const archiveChatSession = vi.fn();
+
+    executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Confirm fires for a running session and a "no" answer aborts
+    // the archive — the running agent is left alive.
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(archiveChatSession).not.toHaveBeenCalled();
+    // The session is still there.
+    expect(
+      useAppStore.getState().sessionsByWorkspace[WS]?.[0]?.id,
+    ).toBe("a");
+  });
+
   it("chat context: archives a running session when the user confirms", async () => {
     const session = makeSession("a", { agent_status: "Running" });
     useAppStore.setState({
       sessionsByWorkspace: { [WS]: [session] },
       selectedSessionIdByWorkspaceId: { [WS]: "a" },
     });
-    const confirm = vi.fn().mockReturnValue(true);
+    const confirm = vi.fn().mockResolvedValue(true);
     const archiveChatSession = vi.fn().mockResolvedValue(null);
 
     executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
 
     expect(confirm).toHaveBeenCalledTimes(1);
@@ -307,10 +339,11 @@ describe("executeCloseTab", () => {
       selectedSessionIdByWorkspaceId: { [WS]: "a" },
     });
     const replacement = makeSession("auto-1");
-    const confirm = vi.fn().mockReturnValue(true);
+    const confirm = vi.fn().mockResolvedValue(true);
     const archiveChatSession = vi.fn().mockResolvedValue(replacement);
 
     executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
 
     const post = useAppStore.getState();

--- a/src/ui/src/hotkeys/contextActions.test.ts
+++ b/src/ui/src/hotkeys/contextActions.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  chatCloseConfirmKind,
+  executeCloseTab,
+  executeNewTab,
+} from "./contextActions";
+import { useAppStore } from "../stores/useAppStore";
+import type { ChatSession, SessionAgentStatus } from "../types/chat";
+
+const WS = "workspace-1";
+
+function makeSession(
+  id: string,
+  overrides: Partial<ChatSession> = {},
+): ChatSession {
+  return {
+    id,
+    workspace_id: WS,
+    session_id: null,
+    name: id,
+    name_edited: false,
+    turn_count: 0,
+    sort_order: 0,
+    status: "Active",
+    created_at: new Date().toISOString(),
+    archived_at: null,
+    cli_invocation: null,
+    agent_status: "Stopped" as SessionAgentStatus,
+    needs_attention: false,
+    attention_kind: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Reset the store to a known baseline. The slices we care about for
+ * these tests are workspaces / chat sessions / file tabs / diff
+ * selection / right-sidebar visibility — set them all explicitly so a
+ * test exercising a single branch doesn't pick up stale state from
+ * an earlier test in the same file.
+ */
+function resetStore() {
+  useAppStore.setState({
+    selectedWorkspaceId: WS,
+    activeFileTabByWorkspace: {},
+    fileTabsByWorkspace: {},
+    sessionsByWorkspace: {},
+    selectedSessionIdByWorkspaceId: {},
+    diffSelectedFile: null,
+    diffSelectedLayer: null,
+    rightSidebarVisible: false,
+    rightSidebarTab: "files",
+    requestNewFileNonceByWorkspace: {},
+    requestCloseFileTabNonceByWorkspace: {},
+  });
+}
+
+describe("chatCloseConfirmKind", () => {
+  // Pure routing logic — exercise every branch without touching the
+  // store. The four kinds are priority-ordered (running > active >
+  // last > none); each test holds two of the three triggers fixed and
+  // varies the third.
+
+  it("returns 'running' when the agent is mid-turn", () => {
+    const session = makeSession("a", { agent_status: "Running" });
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions: [session, makeSession("b"), makeSession("c")],
+      isActiveSession: false,
+    });
+    expect(kind).toBe("running");
+  });
+
+  it("returns 'running' even when also active and last (priority order)", () => {
+    const session = makeSession("a", { agent_status: "Running" });
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions: [session],
+      isActiveSession: true,
+    });
+    expect(kind).toBe("running");
+  });
+
+  it("returns 'active' when the session is selected and not running", () => {
+    const session = makeSession("a");
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions: [session, makeSession("b"), makeSession("c")],
+      isActiveSession: true,
+    });
+    expect(kind).toBe("active");
+  });
+
+  it("returns 'last' when this is the only Active session", () => {
+    const session = makeSession("a");
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions: [session],
+      isActiveSession: false,
+    });
+    expect(kind).toBe("last");
+  });
+
+  it("returns 'none' for a non-active, non-last, non-running close", () => {
+    const session = makeSession("a");
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions: [session, makeSession("b"), makeSession("c")],
+      isActiveSession: false,
+    });
+    expect(kind).toBe("none");
+  });
+
+  it("ignores Archived sessions when counting toward 'last'", () => {
+    const session = makeSession("a");
+    const kind = chatCloseConfirmKind({
+      session,
+      activeSessions: [
+        session,
+        makeSession("b", { status: "Archived" }),
+        makeSession("c", { status: "Archived" }),
+      ],
+      isActiveSession: false,
+    });
+    // Two archived siblings don't count — `a` is still the only Active
+    // one, so closing it triggers the 'last' confirm.
+    expect(kind).toBe("last");
+  });
+});
+
+describe("executeNewTab", () => {
+  beforeEach(resetStore);
+
+  it("no-ops when no workspace is selected", async () => {
+    useAppStore.setState({ selectedWorkspaceId: null });
+    const createChatSession = vi.fn();
+    executeNewTab({ createChatSession });
+    await Promise.resolve();
+    expect(createChatSession).not.toHaveBeenCalled();
+  });
+
+  it("file context: bumps requestNewFileNonceByWorkspace and shows the right sidebar", () => {
+    useAppStore.setState({
+      activeFileTabByWorkspace: { [WS]: "src/main.rs" },
+      rightSidebarVisible: false,
+      rightSidebarTab: "tasks",
+    });
+    const createChatSession = vi.fn();
+
+    executeNewTab({ createChatSession });
+
+    const post = useAppStore.getState();
+    expect(post.requestNewFileNonceByWorkspace[WS]).toBe(1);
+    expect(post.rightSidebarVisible).toBe(true);
+    expect(post.rightSidebarTab).toBe("files");
+    expect(createChatSession).not.toHaveBeenCalled();
+  });
+
+  it("file context: leaves the sidebar alone when it's already on Files + visible", () => {
+    useAppStore.setState({
+      activeFileTabByWorkspace: { [WS]: "README.md" },
+      rightSidebarVisible: true,
+      rightSidebarTab: "files",
+    });
+    const toggleRightSidebar = vi.spyOn(useAppStore.getState(), "toggleRightSidebar");
+    const setRightSidebarTab = vi.spyOn(useAppStore.getState(), "setRightSidebarTab");
+
+    executeNewTab();
+
+    expect(toggleRightSidebar).not.toHaveBeenCalled();
+    expect(setRightSidebarTab).not.toHaveBeenCalled();
+    expect(useAppStore.getState().requestNewFileNonceByWorkspace[WS]).toBe(1);
+  });
+
+  it("chat context: creates a session via the service and selects it", async () => {
+    useAppStore.setState({
+      activeFileTabByWorkspace: {},
+      sessionsByWorkspace: { [WS]: [makeSession("a")] },
+    });
+    const created = makeSession("new-1");
+    const createChatSession = vi.fn().mockResolvedValue(created);
+
+    executeNewTab({ createChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(createChatSession).toHaveBeenCalledWith(WS);
+    const post = useAppStore.getState();
+    expect(post.sessionsByWorkspace[WS]?.some((s) => s.id === "new-1")).toBe(true);
+    expect(post.selectedSessionIdByWorkspaceId[WS]).toBe("new-1");
+  });
+
+  it("chat context: drops the result if the workspace switched mid-flight", async () => {
+    useAppStore.setState({ activeFileTabByWorkspace: {} });
+    const created = makeSession("new-1");
+    const createChatSession = vi.fn(async () => {
+      // Simulate a workspace switch landing while the create call was
+      // in flight — the in-flight session must NOT get added or
+      // selected against the old workspace id.
+      useAppStore.setState({ selectedWorkspaceId: "workspace-other" });
+      return created;
+    });
+
+    executeNewTab({ createChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const post = useAppStore.getState();
+    expect(post.sessionsByWorkspace[WS]).toBeUndefined();
+    expect(post.selectedSessionIdByWorkspaceId[WS]).toBeUndefined();
+  });
+});
+
+describe("executeCloseTab", () => {
+  beforeEach(resetStore);
+
+  it("no-ops when no workspace is selected", () => {
+    useAppStore.setState({ selectedWorkspaceId: null });
+    const archiveChatSession = vi.fn();
+    executeCloseTab({ archiveChatSession });
+    expect(archiveChatSession).not.toHaveBeenCalled();
+  });
+
+  it("file context: bumps requestCloseFileTabNonceByWorkspace", () => {
+    useAppStore.setState({
+      activeFileTabByWorkspace: { [WS]: "src/main.rs" },
+    });
+    const archiveChatSession = vi.fn();
+
+    executeCloseTab({ archiveChatSession });
+
+    expect(useAppStore.getState().requestCloseFileTabNonceByWorkspace[WS]).toBe(1);
+    expect(archiveChatSession).not.toHaveBeenCalled();
+  });
+
+  it("diff context: closes the active diff tab via the slice action", () => {
+    const closeDiffTab = vi.fn();
+    useAppStore.setState({
+      diffSelectedFile: "Cargo.toml",
+      diffSelectedLayer: "unstaged",
+      closeDiffTab: closeDiffTab as unknown as ReturnType<
+        typeof useAppStore.getState
+      >["closeDiffTab"],
+    });
+
+    executeCloseTab();
+
+    expect(closeDiffTab).toHaveBeenCalledWith(WS, "Cargo.toml", "unstaged");
+  });
+
+  it("chat context: prompts before closing the active session", async () => {
+    const session = makeSession("a");
+    useAppStore.setState({
+      sessionsByWorkspace: { [WS]: [session, makeSession("b")] },
+      selectedSessionIdByWorkspaceId: { [WS]: "a" },
+    });
+    const confirm = vi.fn().mockReturnValue(true);
+    const archiveChatSession = vi.fn().mockResolvedValue(null);
+
+    executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The hotkey path always targets the active session so the
+    // confirm fires (kind = "active"). The message wording isn't
+    // pinned here — the i18n-aware copy lives in SessionTabs;
+    // contextActions uses an English fallback for the Monaco path.
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(archiveChatSession).toHaveBeenCalledWith("a");
+  });
+
+  it("chat context: cancelled confirm leaves state untouched", async () => {
+    const session = makeSession("a");
+    useAppStore.setState({
+      sessionsByWorkspace: { [WS]: [session, makeSession("b")] },
+      selectedSessionIdByWorkspaceId: { [WS]: "a" },
+    });
+    const confirm = vi.fn().mockReturnValue(false);
+    const archiveChatSession = vi.fn();
+
+    executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(archiveChatSession).not.toHaveBeenCalled();
+    // Session list unchanged — no archive happened.
+    expect(useAppStore.getState().sessionsByWorkspace[WS]?.length).toBe(2);
+  });
+
+  it("chat context: archives a running session when the user confirms", async () => {
+    const session = makeSession("a", { agent_status: "Running" });
+    useAppStore.setState({
+      sessionsByWorkspace: { [WS]: [session] },
+      selectedSessionIdByWorkspaceId: { [WS]: "a" },
+    });
+    const confirm = vi.fn().mockReturnValue(true);
+    const archiveChatSession = vi.fn().mockResolvedValue(null);
+
+    executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(archiveChatSession).toHaveBeenCalledWith("a");
+  });
+
+  it("chat context: adds + selects the auto-created replacement when archive returns one", async () => {
+    const session = makeSession("a");
+    useAppStore.setState({
+      sessionsByWorkspace: { [WS]: [session] },
+      selectedSessionIdByWorkspaceId: { [WS]: "a" },
+    });
+    const replacement = makeSession("auto-1");
+    const confirm = vi.fn().mockReturnValue(true);
+    const archiveChatSession = vi.fn().mockResolvedValue(replacement);
+
+    executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const post = useAppStore.getState();
+    expect(post.sessionsByWorkspace[WS]?.some((s) => s.id === "auto-1")).toBe(true);
+    expect(post.selectedSessionIdByWorkspaceId[WS]).toBe("auto-1");
+  });
+
+  it("file context wins over diff selection", () => {
+    // Both an active file tab AND a diff selection exist — the file
+    // path takes priority because the file viewer is what's currently
+    // visible in the right pane (see AppLayout's render order).
+    useAppStore.setState({
+      activeFileTabByWorkspace: { [WS]: "src/main.rs" },
+      diffSelectedFile: "Cargo.toml",
+    });
+    const archiveChatSession = vi.fn();
+
+    executeCloseTab({ archiveChatSession });
+
+    expect(useAppStore.getState().requestCloseFileTabNonceByWorkspace[WS]).toBe(1);
+  });
+});

--- a/src/ui/src/hotkeys/contextActions.ts
+++ b/src/ui/src/hotkeys/contextActions.ts
@@ -1,0 +1,223 @@
+/**
+ * Context-aware hotkey actions for the workspace tab strip.
+ *
+ * Two operations are wired here — "new tab" (Cmd/Ctrl+T) and "close
+ * tab" (Cmd/Ctrl+W) — and both share the same routing rule: act on
+ * whichever surface is currently active in the right pane (file
+ * viewer / diff viewer / chat). Centralising the routing keeps the
+ * keyboard shortcut hook (`useKeyboardShortcuts`) and Monaco's
+ * `editor.addCommand` overrides honest about each other; without
+ * this module, Monaco-vs-window-listener divergence is exactly how
+ * Cmd+T silently went missing inside the editor (Monaco's default
+ * "Go To Symbol" binding intercepts the keystroke before the window
+ * listener fires).
+ *
+ * The helpers are intentionally pure-ish: they read a snapshot from
+ * the zustand store, dispatch slice actions / Tauri service calls,
+ * and accept overrides for the side-effecting bits (`confirm`, the
+ * chat-session create/archive services) so the unit tests can
+ * exercise every routing branch without touching the real backend.
+ */
+
+import {
+  archiveChatSession as archiveChatSessionService,
+  createChatSession as createChatSessionService,
+} from "../services/tauri";
+import { useAppStore } from "../stores/useAppStore";
+import type { ChatSession } from "../types/chat";
+
+export interface ContextActionDeps {
+  /** Override the new-session backend call; tests pass a stub.
+   *  Defaults to the real Tauri command. */
+  createChatSession: typeof createChatSessionService;
+  /** Override the archive backend call. */
+  archiveChatSession: typeof archiveChatSessionService;
+  /** Synchronous yes/no prompt. The default uses `window.confirm` —
+   *  tests pass a stub that returns the predetermined answer. */
+  confirm: (message: string) => boolean;
+}
+
+const DEFAULT_DEPS: ContextActionDeps = {
+  createChatSession: createChatSessionService,
+  archiveChatSession: archiveChatSessionService,
+  confirm: (message) =>
+    typeof window !== "undefined" ? window.confirm(message) : true,
+};
+
+function resolveDeps(overrides?: Partial<ContextActionDeps>): ContextActionDeps {
+  return overrides ? { ...DEFAULT_DEPS, ...overrides } : DEFAULT_DEPS;
+}
+
+/**
+ * English fallback prompts for the hotkey path. The close-button path
+ * in `SessionTabs` uses the i18n-aware `t(...)` lookup; this fallback
+ * exists because Monaco's `editor.addCommand` runs outside React's
+ * tree and so can't reach react-i18next without extra plumbing. The
+ * hotkey is rare enough that the fallback drift from translated
+ * locales is acceptable for now — track localising the hotkey path
+ * separately if it becomes a real issue.
+ */
+function formatChatCloseFallbackPrompt(
+  kind: Exclude<ChatCloseConfirmKind, "none">,
+  name: string,
+): string {
+  switch (kind) {
+    case "running":
+      return `This session is still running. Stop and close "${name}"?`;
+    case "active":
+      return `Close active session "${name}"?`;
+    case "last":
+      return `Close the only remaining session "${name}"?`;
+  }
+}
+
+/**
+ * Why a chat-close should prompt before archiving. Three triggers,
+ * priority-ordered so the most-impactful reason wins when several
+ * apply (e.g. the only-running-and-also-only-session case prompts as
+ * `"running"`):
+ *
+ *   - `"running"`: the agent is still mid-turn. Closing kills it.
+ *   - `"active"`: the user is currently looking at this session.
+ *     Closing yanks the visible chat out from under them.
+ *   - `"last"`: this is the only Active session in the workspace.
+ *     Closing forces the backend's auto-create path; the existing
+ *     history is archived, not deleted, but visually it disappears.
+ *
+ * Returns `"none"` when the close is incidental (close button on a
+ * non-active, non-last, non-running tab) so callers can short-circuit
+ * the prompt entirely.
+ *
+ * Strings live in the caller because i18n's `t(...)` lookup needs the
+ * react-i18next context, which this module — used from both React
+ * components and Monaco's `editor.addCommand` — can't assume.
+ */
+export type ChatCloseConfirmKind = "none" | "running" | "active" | "last";
+
+export function chatCloseConfirmKind(args: {
+  session: ChatSession;
+  activeSessions: readonly ChatSession[];
+  isActiveSession: boolean;
+}): ChatCloseConfirmKind {
+  const { session, activeSessions, isActiveSession } = args;
+  if (session.agent_status === "Running") return "running";
+  const activeCount = activeSessions.filter((s) => s.status === "Active").length;
+  if (isActiveSession) return "active";
+  if (activeCount <= 1) return "last";
+  return "none";
+}
+
+/**
+ * Cmd/Ctrl+T — context-aware "new tab".
+ *
+ *   - File context (a file tab is the active right-pane surface):
+ *     trigger the FilesPanel inline-create flow at the workspace root.
+ *     Unhides + switches the right sidebar so the inline editor is
+ *     actually visible.
+ *   - Otherwise (chat or diff): create a fresh chat session in the
+ *     current workspace and switch to it.
+ *
+ * Returns immediately when no workspace is selected; the caller
+ * doesn't need to guard.
+ */
+export function executeNewTab(overrides?: Partial<ContextActionDeps>): void {
+  const deps = resolveDeps(overrides);
+  const store = useAppStore.getState();
+  const wsId = store.selectedWorkspaceId;
+  if (!wsId) return;
+
+  const activeFile = store.activeFileTabByWorkspace[wsId] ?? null;
+  if (activeFile) {
+    if (!store.rightSidebarVisible) store.toggleRightSidebar();
+    if (store.rightSidebarTab !== "files") store.setRightSidebarTab("files");
+    store.requestNewFileAtRoot(wsId);
+    return;
+  }
+
+  void (async () => {
+    try {
+      const session = await deps.createChatSession(wsId);
+      const post = useAppStore.getState();
+      // Workspace switch between dispatch and resolution → drop.
+      if (post.selectedWorkspaceId !== wsId) return;
+      post.addChatSession(session);
+      post.selectSession(wsId, session.id);
+    } catch (err) {
+      console.error("[hotkey] executeNewTab failed:", err);
+    }
+  })();
+}
+
+/**
+ * Cmd/Ctrl+W — context-aware "close tab".
+ *
+ *   - File active: route through `requestCloseActiveFileTab` so the
+ *     FileViewer's existing dirty-check + discard-confirm flow runs.
+ *   - Diff active: directly close the diff tab (no in-flight state to
+ *     protect).
+ *   - Chat: archive the active session, gated by the shared
+ *     `chatCloseConfirmMessage` rules. Auto-creates a fresh session
+ *     when archiving the only-remaining one (mirrors the close-button
+ *     path in `SessionTabs.handleArchive`).
+ *
+ * The terminal pane has its own scoped `terminal.close-pane` action
+ * dispatched from a different listener, so this function never runs
+ * with terminal focus.
+ */
+export function executeCloseTab(overrides?: Partial<ContextActionDeps>): void {
+  const deps = resolveDeps(overrides);
+  const store = useAppStore.getState();
+  const wsId = store.selectedWorkspaceId;
+  if (!wsId) return;
+
+  // 1. File context wins. The slice nonce reaches the mounted
+  //    FileViewer, which retains the dirty-buffer modal logic.
+  const activeFile = store.activeFileTabByWorkspace[wsId] ?? null;
+  if (activeFile) {
+    store.requestCloseActiveFileTab(wsId);
+    return;
+  }
+
+  // 2. Diff context next.
+  if (store.diffSelectedFile) {
+    store.closeDiffTab(wsId, store.diffSelectedFile, store.diffSelectedLayer);
+    return;
+  }
+
+  // 3. Chat: archive the currently-selected session if any.
+  const sessionId = store.selectedSessionIdByWorkspaceId[wsId];
+  if (!sessionId) return;
+  const sessions = store.sessionsByWorkspace[wsId] ?? [];
+  const session = sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+
+  // The hotkey path always targets the active session (there is no
+  // non-active "tab under the cursor" the way the close-button has),
+  // so `running`/`active`/`last` all matter; only "none" skips the
+  // prompt. Strings are intentionally minimal here — the i18n-aware
+  // close button in SessionTabs uses translated copy via the same
+  // `chatCloseConfirmKind` helper.
+  const kind = chatCloseConfirmKind({
+    session,
+    activeSessions: sessions,
+    isActiveSession: true,
+  });
+  if (kind !== "none") {
+    const message = formatChatCloseFallbackPrompt(kind, session.name);
+    if (!deps.confirm(message)) return;
+  }
+
+  void (async () => {
+    try {
+      const autoCreated = await deps.archiveChatSession(sessionId);
+      const post = useAppStore.getState();
+      post.removeChatSession(sessionId);
+      if (autoCreated && post.selectedWorkspaceId === wsId) {
+        post.addChatSession(autoCreated);
+        post.selectSession(wsId, autoCreated.id);
+      }
+    } catch (err) {
+      console.error("[hotkey] executeCloseTab failed:", err);
+    }
+  })();
+}

--- a/src/ui/src/hotkeys/contextActions.ts
+++ b/src/ui/src/hotkeys/contextActions.ts
@@ -19,6 +19,7 @@
  * exercise every routing branch without touching the real backend.
  */
 
+import { ask } from "@tauri-apps/plugin-dialog";
 import {
   archiveChatSession as archiveChatSessionService,
   createChatSession as createChatSessionService,
@@ -32,16 +33,25 @@ export interface ContextActionDeps {
   createChatSession: typeof createChatSessionService;
   /** Override the archive backend call. */
   archiveChatSession: typeof archiveChatSessionService;
-  /** Synchronous yes/no prompt. The default uses `window.confirm` —
-   *  tests pass a stub that returns the predetermined answer. */
-  confirm: (message: string) => boolean;
+  /** Async yes/no prompt. The default routes through Tauri's
+   *  `@tauri-apps/plugin-dialog`'s `ask()` so a real native dialog
+   *  appears — `window.confirm()` in Tauri 2 webviews is a silent
+   *  no-op that returns immediately and the user never sees the
+   *  prompt. Tests pass a stub that resolves to the predetermined
+   *  answer (and can synchronize on the resolution). */
+  confirm: (message: string) => Promise<boolean>;
 }
 
 const DEFAULT_DEPS: ContextActionDeps = {
   createChatSession: createChatSessionService,
   archiveChatSession: archiveChatSessionService,
   confirm: (message) =>
-    typeof window !== "undefined" ? window.confirm(message) : true,
+    ask(message, {
+      title: "Close session",
+      kind: "warning",
+      okLabel: "Close",
+      cancelLabel: "Cancel",
+    }),
 };
 
 function resolveDeps(overrides?: Partial<ContextActionDeps>): ContextActionDeps {
@@ -202,12 +212,36 @@ export function executeCloseTab(overrides?: Partial<ContextActionDeps>): void {
     activeSessions: sessions,
     isActiveSession: true,
   });
-  if (kind !== "none") {
-    const message = formatChatCloseFallbackPrompt(kind, session.name);
-    if (!deps.confirm(message)) return;
-  }
 
+  // The whole flow is async because Tauri's native ask() returns a
+  // Promise — sync `window.confirm` is a no-op in the webview, which
+  // is why earlier dogfooding reported Cmd+W killing running sessions
+  // without any prompt at all.
   void (async () => {
+    if (kind !== "none") {
+      const message = formatChatCloseFallbackPrompt(kind, session.name);
+      let ok: boolean;
+      try {
+        ok = await deps.confirm(message);
+      } catch (err) {
+        console.error("[hotkey] confirm dialog failed:", err);
+        return;
+      }
+      if (!ok) return;
+    }
+
+    // Re-read the store because the user may have switched sessions
+    // while the modal was up. If the active session changed mid-flight
+    // we drop the action — closing a session the user is no longer
+    // viewing would be the surprise we set out to prevent.
+    const stillActive = useAppStore.getState();
+    if (
+      stillActive.selectedWorkspaceId !== wsId ||
+      stillActive.selectedSessionIdByWorkspaceId[wsId] !== sessionId
+    ) {
+      return;
+    }
+
     try {
       const autoCreated = await deps.archiveChatSession(sessionId);
       const post = useAppStore.getState();

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -89,6 +89,8 @@
   "session_close_file": "Close file",
   "session_running_confirm_close": "This session is still running. Stop and close \"{{name}}\"?",
   "session_running_confirm_close_multi": "{{count}} sessions are still running. Stop and close them?",
+  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
+  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
 
   "tab_close": "Close",
   "tab_close_others": "Close Others",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -252,7 +252,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
-  "keyboard_action_file_close_tab": "Close file tab",
+  "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -238,6 +238,7 @@
   "keyboard_action_increase_ui_font": "Increase UI font size",
   "keyboard_action_decrease_ui_font": "Decrease UI font size",
   "keyboard_action_toggle_plan_mode": "Toggle plan mode",
+  "keyboard_action_new_tab": "New tab (chat session, or new file when a file is open)",
   "keyboard_action_terminal_new_tab": "New terminal tab",
   "keyboard_action_terminal_cycle_tab_prev": "Previous terminal tab",
   "keyboard_action_terminal_cycle_tab_next": "Next terminal tab",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -88,8 +88,8 @@
   "session_close_diff": "Cerrar diff",
   "session_running_confirm_close": "Esta sesión sigue en ejecución. ¿Detener y cerrar «{{name}}»?",
   "session_running_confirm_close_multi": "{{count}} sesiones siguen en ejecución. ¿Detener y cerrarlas?",
-  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
-  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
+  "session_active_confirm_close": "¿Cerrar la sesión activa «{{name}}»?",
+  "session_last_confirm_close": "¿Cerrar la única sesión restante «{{name}}»? Se creará una nueva en su lugar; la sesión cerrada se archivará.",
 
   "tab_close": "Cerrar",
   "tab_close_others": "Cerrar otras",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -88,6 +88,8 @@
   "session_close_diff": "Cerrar diff",
   "session_running_confirm_close": "Esta sesión sigue en ejecución. ¿Detener y cerrar «{{name}}»?",
   "session_running_confirm_close_multi": "{{count}} sesiones siguen en ejecución. ¿Detener y cerrarlas?",
+  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
+  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
 
   "tab_close": "Cerrar",
   "tab_close_others": "Cerrar otras",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -379,7 +379,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
-  "keyboard_action_file_close_tab": "Close file tab",
+  "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -365,6 +365,7 @@
   "keyboard_action_increase_ui_font": "Increase UI font size",
   "keyboard_action_decrease_ui_font": "Decrease UI font size",
   "keyboard_action_toggle_plan_mode": "Toggle plan mode",
+  "keyboard_action_new_tab": "New tab (chat session, or new file when a file is open)",
   "keyboard_action_terminal_new_tab": "New terminal tab",
   "keyboard_action_terminal_cycle_tab_prev": "Previous terminal tab",
   "keyboard_action_terminal_cycle_tab_next": "Next terminal tab",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -88,6 +88,8 @@
   "session_close_diff": "差分を閉じる",
   "session_running_confirm_close": "このセッションは実行中です。「{{name}}」を停止して閉じますか？",
   "session_running_confirm_close_multi": "{{count}} 件のセッションが実行中です。停止して閉じますか？",
+  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
+  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
 
   "tab_close": "閉じる",
   "tab_close_others": "他を閉じる",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -88,8 +88,8 @@
   "session_close_diff": "差分を閉じる",
   "session_running_confirm_close": "このセッションは実行中です。「{{name}}」を停止して閉じますか？",
   "session_running_confirm_close_multi": "{{count}} 件のセッションが実行中です。停止して閉じますか？",
-  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
-  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
+  "session_active_confirm_close": "アクティブなセッション「{{name}}」を閉じますか？",
+  "session_last_confirm_close": "最後に残っているセッション「{{name}}」を閉じますか？新しいセッションが代わりに作成され、閉じたセッションはアーカイブされます。",
 
   "tab_close": "閉じる",
   "tab_close_others": "他を閉じる",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -379,7 +379,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
-  "keyboard_action_file_close_tab": "Close file tab",
+  "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -365,6 +365,7 @@
   "keyboard_action_increase_ui_font": "Increase UI font size",
   "keyboard_action_decrease_ui_font": "Decrease UI font size",
   "keyboard_action_toggle_plan_mode": "Toggle plan mode",
+  "keyboard_action_new_tab": "New tab (chat session, or new file when a file is open)",
   "keyboard_action_terminal_new_tab": "New terminal tab",
   "keyboard_action_terminal_cycle_tab_prev": "Previous terminal tab",
   "keyboard_action_terminal_cycle_tab_next": "Next terminal tab",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -88,8 +88,8 @@
   "session_close_diff": "Fechar diff",
   "session_running_confirm_close": "Esta sessão ainda está em execução. Parar e fechar \"{{name}}\"?",
   "session_running_confirm_close_multi": "{{count}} sessões ainda estão em execução. Parar e fechá-las?",
-  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
-  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
+  "session_active_confirm_close": "Fechar a sessão ativa \"{{name}}\"?",
+  "session_last_confirm_close": "Fechar a única sessão restante \"{{name}}\"? Uma nova sessão será criada no lugar dela; a sessão fechada será arquivada.",
 
   "tab_close": "Fechar",
   "tab_close_others": "Fechar outras",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -88,6 +88,8 @@
   "session_close_diff": "Fechar diff",
   "session_running_confirm_close": "Esta sessão ainda está em execução. Parar e fechar \"{{name}}\"?",
   "session_running_confirm_close_multi": "{{count}} sessões ainda estão em execução. Parar e fechá-las?",
+  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
+  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
 
   "tab_close": "Fechar",
   "tab_close_others": "Fechar outras",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -379,7 +379,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
-  "keyboard_action_file_close_tab": "Close file tab",
+  "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -365,6 +365,7 @@
   "keyboard_action_increase_ui_font": "Increase UI font size",
   "keyboard_action_decrease_ui_font": "Decrease UI font size",
   "keyboard_action_toggle_plan_mode": "Toggle plan mode",
+  "keyboard_action_new_tab": "New tab (chat session, or new file when a file is open)",
   "keyboard_action_terminal_new_tab": "New terminal tab",
   "keyboard_action_terminal_cycle_tab_prev": "Previous terminal tab",
   "keyboard_action_terminal_cycle_tab_next": "Next terminal tab",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -88,6 +88,8 @@
   "session_close_diff": "关闭差异视图",
   "session_running_confirm_close": "此会话仍在运行中。停止并关闭 “{{name}}” 吗？",
   "session_running_confirm_close_multi": "{{count}} 个会话仍在运行中。停止并关闭它们吗？",
+  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
+  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
 
   "tab_close": "关闭",
   "tab_close_others": "关闭其他",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -88,8 +88,8 @@
   "session_close_diff": "关闭差异视图",
   "session_running_confirm_close": "此会话仍在运行中。停止并关闭 “{{name}}” 吗？",
   "session_running_confirm_close_multi": "{{count}} 个会话仍在运行中。停止并关闭它们吗？",
-  "session_active_confirm_close": "Close the active session \"{{name}}\"?",
-  "session_last_confirm_close": "Close the only remaining session \"{{name}}\"? A fresh session will replace it; the closed one will be archived.",
+  "session_active_confirm_close": "关闭当前活动的会话 “{{name}}” 吗？",
+  "session_last_confirm_close": "关闭仅剩的会话 “{{name}}” 吗？将创建一个新会话替代它；被关闭的会话会被归档。",
 
   "tab_close": "关闭",
   "tab_close_others": "关闭其他",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -379,7 +379,7 @@
   "keyboard_action_terminal_focus_pane_down": "Focus pane down",
   "keyboard_action_terminal_copy_selection": "Copy terminal selection",
   "keyboard_action_terminal_paste": "Paste into terminal",
-  "keyboard_action_file_close_tab": "Close file tab",
+  "keyboard_action_close_tab": "Close active tab (file, diff, or chat session)",
   "keyboard_action_file_undo_operation": "Undo file operation",
   "keyboard_action_file_toggle_markdown_preview": "Toggle Markdown preview",
   "keyboard_action_voice_toggle": "Toggle voice input",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -365,6 +365,7 @@
   "keyboard_action_increase_ui_font": "Increase UI font size",
   "keyboard_action_decrease_ui_font": "Decrease UI font size",
   "keyboard_action_toggle_plan_mode": "Toggle plan mode",
+  "keyboard_action_new_tab": "New tab (chat session, or new file when a file is open)",
   "keyboard_action_terminal_new_tab": "New terminal tab",
   "keyboard_action_terminal_cycle_tab_prev": "Previous terminal tab",
   "keyboard_action_terminal_cycle_tab_next": "Next terminal tab",

--- a/src/ui/src/stores/slices/chatSessionsSlice.ts
+++ b/src/ui/src/stores/slices/chatSessionsSlice.ts
@@ -91,10 +91,13 @@ export const createChatSessionsSlice: StateCreator<
       }
       const nextDrafts = { ...s.chatDrafts };
       delete nextDrafts[sessionId];
+      const nextAttachments = { ...s.pendingAttachmentsBySession };
+      delete nextAttachments[sessionId];
       return {
         sessionsByWorkspace: next,
         selectedSessionIdByWorkspaceId: nextSelected,
         chatDrafts: nextDrafts,
+        pendingAttachmentsBySession: nextAttachments,
       };
     }),
   selectSession: (workspaceId, sessionId) =>

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { ChatMessage, ChatAttachment, ChatPaginationState } from "../../types";
+import type { StoredAttachment } from "../../types/chat";
 import { debugChat } from "../../utils/chatDebug";
 import type { CompactionEvent } from "../../utils/compactionSentinel";
 import type { AppState } from "../useAppStore";
@@ -186,6 +187,27 @@ export interface ChatSlice {
   chatDrafts: Record<string, string>;
   setChatDraft: (sessionId: string, draft: string) => void;
   clearChatDraft: (sessionId: string) => void;
+  /** Per-session in-flight attachments staged in the composer before
+   *  the message is sent. Stored here (not in `ChatInputArea`'s
+   *  `useState`) so attachments survive any composer remount —
+   *  including the unmount that happens when `<ChatPanel>` is
+   *  conditionally rendered out of `AppLayout` after the user opens a
+   *  file or diff (see comment at AppLayout.tsx:130-140). The
+   *  `preview_url` field is intentionally absent from `StoredAttachment`
+   *  because blob URLs are tied to the lifetime of the underlying Blob,
+   *  which is GC'd on component unmount; the composer regenerates
+   *  preview URLs from `data_base64` on mount. */
+  pendingAttachmentsBySession: Record<string, StoredAttachment[]>;
+  setPendingAttachmentsForSession: (
+    sessionId: string,
+    attachments: StoredAttachment[],
+  ) => void;
+  addPendingAttachment: (
+    sessionId: string,
+    attachment: StoredAttachment,
+  ) => void;
+  removePendingAttachment: (sessionId: string, attachmentId: string) => void;
+  clearPendingAttachments: (sessionId: string) => void;
   lastMessages: Record<string, ChatMessage>;
   setLastMessages: (msgs: Record<string, ChatMessage>) => void;
 }
@@ -580,6 +602,46 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
       const next = { ...s.chatDrafts };
       delete next[sessionId];
       return { chatDrafts: next };
+    }),
+  pendingAttachmentsBySession: {},
+  setPendingAttachmentsForSession: (sessionId, attachments) =>
+    set((s) => ({
+      pendingAttachmentsBySession: {
+        ...s.pendingAttachmentsBySession,
+        [sessionId]: attachments,
+      },
+    })),
+  addPendingAttachment: (sessionId, attachment) =>
+    set((s) => {
+      const existing = s.pendingAttachmentsBySession[sessionId] ?? [];
+      // Functional add so concurrent paste/drop events serialize cleanly
+      // even when the caller reads a stale local copy of the list.
+      return {
+        pendingAttachmentsBySession: {
+          ...s.pendingAttachmentsBySession,
+          [sessionId]: [...existing, attachment],
+        },
+      };
+    }),
+  removePendingAttachment: (sessionId, attachmentId) =>
+    set((s) => {
+      const existing = s.pendingAttachmentsBySession[sessionId];
+      if (!existing) return s;
+      const filtered = existing.filter((a) => a.id !== attachmentId);
+      if (filtered.length === existing.length) return s;
+      return {
+        pendingAttachmentsBySession: {
+          ...s.pendingAttachmentsBySession,
+          [sessionId]: filtered,
+        },
+      };
+    }),
+  clearPendingAttachments: (sessionId) =>
+    set((s) => {
+      if (!(sessionId in s.pendingAttachmentsBySession)) return s;
+      const next = { ...s.pendingAttachmentsBySession };
+      delete next[sessionId];
+      return { pendingAttachmentsBySession: next };
     }),
   lastMessages: {},
   setLastMessages: (msgs) => set({ lastMessages: msgs }),

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -197,6 +197,29 @@ export interface ChatSlice {
    *  because blob URLs are tied to the lifetime of the underlying Blob,
    *  which is GC'd on component unmount; the composer regenerates
    *  preview URLs from `data_base64` on mount. */
+  /** Per-group user override of the collapsed/expanded state for tool
+   *  activity groups inside a completed turn. Keyed first by chat
+   *  session id, then by a stable per-group key (built in
+   *  `MessagesWithTurns` from `${turn.id}:${first activity toolUseId}`).
+   *
+   *  Lives separately from `CompletedTurn.collapsed` because a single
+   *  turn can be split into multiple chronological display groups
+   *  (the user inserted messages between tool calls, etc.); without
+   *  per-group state, clicking one chevron flipped the shared
+   *  `turn.collapsed` and every sibling group toggled in lockstep.
+   *  Unset entries fall back to `turn.collapsed`, so existing
+   *  persisted-turn behavior is preserved on first interaction. */
+  collapsedToolGroupsBySession: Record<string, Record<string, boolean>>;
+  /** Set the explicit collapse override for a single group. The caller
+   *  knows the current effective value (computed from the slice plus
+   *  `turn.collapsed` fallback) so it passes the desired new boolean
+   *  rather than asking the slice to toggle relative to a default it
+   *  can't see. */
+  setCollapsedToolGroup: (
+    sessionId: string,
+    groupKey: string,
+    collapsed: boolean,
+  ) => void;
   pendingAttachmentsBySession: Record<string, StoredAttachment[]>;
   setPendingAttachmentsForSession: (
     sessionId: string,
@@ -602,6 +625,18 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
       const next = { ...s.chatDrafts };
       delete next[sessionId];
       return { chatDrafts: next };
+    }),
+  collapsedToolGroupsBySession: {},
+  setCollapsedToolGroup: (sessionId, groupKey, collapsed) =>
+    set((s) => {
+      const wsGroups = s.collapsedToolGroupsBySession[sessionId] ?? {};
+      if (wsGroups[groupKey] === collapsed) return s;
+      return {
+        collapsedToolGroupsBySession: {
+          ...s.collapsedToolGroupsBySession,
+          [sessionId]: { ...wsGroups, [groupKey]: collapsed },
+        },
+      };
     }),
   pendingAttachmentsBySession: {},
   setPendingAttachmentsForSession: (sessionId, attachments) =>

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -144,6 +144,14 @@ export interface FileTreeSlice {
    *  into the store because the panel owns the inline editor's
    *  lifecycle (cancel, error toast, focus-back-to-tree). */
   requestNewFileNonceByWorkspace: Record<string, number>;
+  /** Monotonic per-workspace signal asking the mounted `FileViewer` to
+   *  close its active file tab — going through `requestCloseFileTab`
+   *  (its local function), so the dirty-buffer discard prompt still
+   *  fires. Bumped by the `global.close-tab` keyboard action when the
+   *  active right-pane surface is a file. Same pattern as
+   *  `requestNewFileNonceByWorkspace` above; the slice is just the
+   *  message bus, the FileViewer owns the modal lifecycle. */
+  requestCloseFileTabNonceByWorkspace: Record<string, number>;
 
   /** Per-workspace ordered list of open file-tab paths. Tabs are rendered
    *  in this order in the tab strip. */
@@ -174,6 +182,10 @@ export interface FileTreeSlice {
    *  tab and unhides it; this just delivers the open-the-inline-editor
    *  signal to the mounted panel. No-op when the panel isn't mounted. */
   requestNewFileAtRoot: (workspaceId: string) => void;
+  /** Ask the mounted `FileViewer` for `workspaceId` to close its active
+   *  file tab through its dirty-aware close path. No-op when no
+   *  `FileViewer` is mounted (e.g. the user is in chat). */
+  requestCloseActiveFileTab: (workspaceId: string) => void;
 
   // Tab management
   /** Replace the entire ordered list of file tabs for a workspace. Used by
@@ -302,6 +314,7 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
   allFilesSelectedPathByWorkspace: {},
   fileTreeRefreshNonceByWorkspace: {},
   requestNewFileNonceByWorkspace: {},
+  requestCloseFileTabNonceByWorkspace: {},
   fileTabsByWorkspace: {},
   activeFileTabByWorkspace: {},
   fileBuffers: {},
@@ -352,6 +365,14 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       requestNewFileNonceByWorkspace: {
         ...s.requestNewFileNonceByWorkspace,
         [workspaceId]: (s.requestNewFileNonceByWorkspace[workspaceId] ?? 0) + 1,
+      },
+    })),
+  requestCloseActiveFileTab: (workspaceId) =>
+    set((s) => ({
+      requestCloseFileTabNonceByWorkspace: {
+        ...s.requestCloseFileTabNonceByWorkspace,
+        [workspaceId]:
+          (s.requestCloseFileTabNonceByWorkspace[workspaceId] ?? 0) + 1,
       },
     })),
 

--- a/src/ui/src/stores/slices/fileTreeSlice.ts
+++ b/src/ui/src/stores/slices/fileTreeSlice.ts
@@ -136,6 +136,14 @@ export interface FileTreeSlice {
   allFilesSelectedPathByWorkspace: Record<string, string | null>;
   /** Monotonic per-workspace refresh signal for mounted Files panels. */
   fileTreeRefreshNonceByWorkspace: Record<string, number>;
+  /** Monotonic per-workspace signal asking the FilesPanel to enter the
+   *  inline "create new file at workspace root" flow. Bumped by the
+   *  `global.new-tab` keyboard action when the workspace is showing a
+   *  file in its right pane. The panel acknowledges the bump by setting
+   *  its local `creatingParentPath` to "" — we don't push that state
+   *  into the store because the panel owns the inline editor's
+   *  lifecycle (cancel, error toast, focus-back-to-tree). */
+  requestNewFileNonceByWorkspace: Record<string, number>;
 
   /** Per-workspace ordered list of open file-tab paths. Tabs are rendered
    *  in this order in the tab strip. */
@@ -161,6 +169,11 @@ export interface FileTreeSlice {
     path: string | null,
   ) => void;
   requestFileTreeRefresh: (workspaceId: string) => void;
+  /** Ask the FilesPanel for `workspaceId` to enter "create file at root"
+   *  mode. The hotkey handler also flips the right sidebar to the Files
+   *  tab and unhides it; this just delivers the open-the-inline-editor
+   *  signal to the mounted panel. No-op when the panel isn't mounted. */
+  requestNewFileAtRoot: (workspaceId: string) => void;
 
   // Tab management
   /** Replace the entire ordered list of file tabs for a workspace. Used by
@@ -288,6 +301,7 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
   allFilesExpandedDirsByWorkspace: {},
   allFilesSelectedPathByWorkspace: {},
   fileTreeRefreshNonceByWorkspace: {},
+  requestNewFileNonceByWorkspace: {},
   fileTabsByWorkspace: {},
   activeFileTabByWorkspace: {},
   fileBuffers: {},
@@ -331,6 +345,13 @@ export const createFileTreeSlice: StateCreator<AppState, [], [], FileTreeSlice> 
       fileTreeRefreshNonceByWorkspace: {
         ...s.fileTreeRefreshNonceByWorkspace,
         [workspaceId]: (s.fileTreeRefreshNonceByWorkspace[workspaceId] ?? 0) + 1,
+      },
+    })),
+  requestNewFileAtRoot: (workspaceId) =>
+    set((s) => ({
+      requestNewFileNonceByWorkspace: {
+        ...s.requestNewFileNonceByWorkspace,
+        [workspaceId]: (s.requestNewFileNonceByWorkspace[workspaceId] ?? 0) + 1,
       },
     })),
 

--- a/src/ui/src/stores/useAppStore.collapsedToolGroups.test.ts
+++ b/src/ui/src/stores/useAppStore.collapsedToolGroups.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "./useAppStore";
+
+const SESSION_A = "session-a";
+const SESSION_B = "session-b";
+
+describe("collapsedToolGroupsBySession", () => {
+  beforeEach(() => {
+    useAppStore.setState({ collapsedToolGroupsBySession: {} });
+  });
+
+  it("starts empty for a fresh session", () => {
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[SESSION_A],
+    ).toBeUndefined();
+  });
+
+  it("setCollapsedToolGroup sets a per-(session, groupKey) override", () => {
+    useAppStore.getState().setCollapsedToolGroup(SESSION_A, "turn1:tool-1", true);
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[SESSION_A]?.[
+        "turn1:tool-1"
+      ],
+    ).toBe(true);
+  });
+
+  it("doesn't toggle siblings sharing the same turn-id prefix", () => {
+    // Regression for the bug where chronologically-split groups all
+    // shared `turn.collapsed`: clicking one chevron should leave its
+    // siblings untouched.
+    useAppStore
+      .getState()
+      .setCollapsedToolGroup(SESSION_A, "turn1:tool-a", true);
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[SESSION_A]?.[
+        "turn1:tool-a"
+      ],
+    ).toBe(true);
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[SESSION_A]?.[
+        "turn1:tool-b"
+      ],
+    ).toBeUndefined();
+  });
+
+  it("scopes overrides per session", () => {
+    useAppStore.getState().setCollapsedToolGroup(SESSION_A, "g1", true);
+    useAppStore.getState().setCollapsedToolGroup(SESSION_B, "g1", false);
+    const state = useAppStore.getState();
+    expect(state.collapsedToolGroupsBySession[SESSION_A]?.g1).toBe(true);
+    expect(state.collapsedToolGroupsBySession[SESSION_B]?.g1).toBe(false);
+  });
+
+  it("re-setting the same value is a no-op (reference-stable)", () => {
+    useAppStore.getState().setCollapsedToolGroup(SESSION_A, "g1", true);
+    const before = useAppStore.getState().collapsedToolGroupsBySession;
+    useAppStore.getState().setCollapsedToolGroup(SESSION_A, "g1", true);
+    const after = useAppStore.getState().collapsedToolGroupsBySession;
+    // Identity preserved → no needless re-render of subscribers.
+    expect(after).toBe(before);
+  });
+
+  it("setting then clearing produces inverse boolean values", () => {
+    useAppStore.getState().setCollapsedToolGroup(SESSION_A, "g1", true);
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[SESSION_A]?.g1,
+    ).toBe(true);
+    useAppStore.getState().setCollapsedToolGroup(SESSION_A, "g1", false);
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[SESSION_A]?.g1,
+    ).toBe(false);
+  });
+});

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -210,3 +210,33 @@ describe("file path store updates", () => {
     ]);
   });
 });
+
+describe("requestNewFileAtRoot", () => {
+  beforeEach(() => {
+    useAppStore.setState({ requestNewFileNonceByWorkspace: {} });
+  });
+
+  it("bumps a per-workspace nonce so FilesPanel can detect the request", () => {
+    expect(
+      useAppStore.getState().requestNewFileNonceByWorkspace[WS],
+    ).toBeUndefined();
+
+    useAppStore.getState().requestNewFileAtRoot(WS);
+    const first = useAppStore.getState().requestNewFileNonceByWorkspace[WS];
+    expect(first).toBe(1);
+
+    useAppStore.getState().requestNewFileAtRoot(WS);
+    const second = useAppStore.getState().requestNewFileNonceByWorkspace[WS];
+    expect(second).toBe(2);
+  });
+
+  it("scopes the nonce per workspace so unrelated workspaces are unaffected", () => {
+    useAppStore.getState().requestNewFileAtRoot("workspace-a");
+    useAppStore.getState().requestNewFileAtRoot("workspace-a");
+    useAppStore.getState().requestNewFileAtRoot("workspace-b");
+
+    const state = useAppStore.getState();
+    expect(state.requestNewFileNonceByWorkspace["workspace-a"]).toBe(2);
+    expect(state.requestNewFileNonceByWorkspace["workspace-b"]).toBe(1);
+  });
+});

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -211,6 +211,38 @@ describe("file path store updates", () => {
   });
 });
 
+describe("requestCloseActiveFileTab", () => {
+  beforeEach(() => {
+    useAppStore.setState({ requestCloseFileTabNonceByWorkspace: {} });
+  });
+
+  it("bumps a per-workspace nonce so FileViewer can detect the request", () => {
+    expect(
+      useAppStore.getState().requestCloseFileTabNonceByWorkspace[WS],
+    ).toBeUndefined();
+
+    useAppStore.getState().requestCloseActiveFileTab(WS);
+    expect(
+      useAppStore.getState().requestCloseFileTabNonceByWorkspace[WS],
+    ).toBe(1);
+
+    useAppStore.getState().requestCloseActiveFileTab(WS);
+    expect(
+      useAppStore.getState().requestCloseFileTabNonceByWorkspace[WS],
+    ).toBe(2);
+  });
+
+  it("scopes the nonce per workspace", () => {
+    useAppStore.getState().requestCloseActiveFileTab("workspace-a");
+    useAppStore.getState().requestCloseActiveFileTab("workspace-a");
+    useAppStore.getState().requestCloseActiveFileTab("workspace-b");
+
+    const state = useAppStore.getState();
+    expect(state.requestCloseFileTabNonceByWorkspace["workspace-a"]).toBe(2);
+    expect(state.requestCloseFileTabNonceByWorkspace["workspace-b"]).toBe(1);
+  });
+});
+
 describe("requestNewFileAtRoot", () => {
   beforeEach(() => {
     useAppStore.setState({ requestNewFileNonceByWorkspace: {} });

--- a/src/ui/src/stores/useAppStore.pendingAttachments.test.ts
+++ b/src/ui/src/stores/useAppStore.pendingAttachments.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "./useAppStore";
+import type { StoredAttachment } from "../types/chat";
+
+const SESSION_A = "session-a";
+const SESSION_B = "session-b";
+
+function makeAttachment(id: string, filename = `${id}.png`): StoredAttachment {
+  return {
+    id,
+    filename,
+    media_type: "image/png",
+    data_base64: "iVBORw0KGgo=",
+    size_bytes: 7,
+    text_content: null,
+  };
+}
+
+describe("pendingAttachmentsBySession", () => {
+  beforeEach(() => {
+    useAppStore.setState({ pendingAttachmentsBySession: {} });
+  });
+
+  it("starts empty for a fresh session", () => {
+    expect(
+      useAppStore.getState().pendingAttachmentsBySession[SESSION_A],
+    ).toBeUndefined();
+  });
+
+  it("adds attachments preserving insertion order", () => {
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("1"));
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("2"));
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("3"));
+    const list = useAppStore.getState().pendingAttachmentsBySession[SESSION_A];
+    expect(list?.map((a) => a.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("survives session-keyed updates without leaking across sessions", () => {
+    // Regression for #??? — attachments must be per-session so that
+    // pasting images in session A and then switching to session B
+    // (which mounts a different ChatInputArea instance) doesn't bleed
+    // A's attachments into B and doesn't lose A's.
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("a1"));
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("a2"));
+    useAppStore.getState().addPendingAttachment(SESSION_B, makeAttachment("b1"));
+
+    const state = useAppStore.getState();
+    expect(state.pendingAttachmentsBySession[SESSION_A]?.map((a) => a.id)).toEqual([
+      "a1",
+      "a2",
+    ]);
+    expect(state.pendingAttachmentsBySession[SESSION_B]?.map((a) => a.id)).toEqual([
+      "b1",
+    ]);
+  });
+
+  it("removes a single attachment by id without disturbing siblings", () => {
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("1"));
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("2"));
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("3"));
+    useAppStore.getState().removePendingAttachment(SESSION_A, "2");
+    const list = useAppStore.getState().pendingAttachmentsBySession[SESSION_A];
+    expect(list?.map((a) => a.id)).toEqual(["1", "3"]);
+  });
+
+  it("removePendingAttachment is a no-op for unknown ids", () => {
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("1"));
+    const before = useAppStore.getState().pendingAttachmentsBySession[SESSION_A];
+    useAppStore.getState().removePendingAttachment(SESSION_A, "missing");
+    const after = useAppStore.getState().pendingAttachmentsBySession[SESSION_A];
+    // Reference-stable: same array, no needless re-render.
+    expect(after).toBe(before);
+  });
+
+  it("clearPendingAttachments drops the session entry entirely", () => {
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("1"));
+    useAppStore.getState().clearPendingAttachments(SESSION_A);
+    expect(
+      useAppStore.getState().pendingAttachmentsBySession[SESSION_A],
+    ).toBeUndefined();
+  });
+
+  it("setPendingAttachmentsForSession replaces the whole list", () => {
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("orig"));
+    useAppStore
+      .getState()
+      .setPendingAttachmentsForSession(SESSION_A, [
+        makeAttachment("new-1"),
+        makeAttachment("new-2"),
+      ]);
+    const list = useAppStore.getState().pendingAttachmentsBySession[SESSION_A];
+    expect(list?.map((a) => a.id)).toEqual(["new-1", "new-2"]);
+  });
+
+  it("removeChatSession drops the matching pendingAttachments entry", () => {
+    // Pin the cleanup wired in `chatSessionsSlice.removeChatSession` so
+    // archiving a session doesn't leave its attachments stranded.
+    useAppStore.setState({
+      sessionsByWorkspace: {
+        ws: [
+          {
+            id: SESSION_A,
+            workspace_id: "ws",
+            session_id: null,
+            name: "Session A",
+            name_edited: false,
+            turn_count: 0,
+            sort_order: 0,
+            status: "Active",
+            created_at: new Date().toISOString(),
+            archived_at: null,
+            cli_invocation: null,
+            agent_status: "Stopped",
+            needs_attention: false,
+            attention_kind: null,
+          },
+        ],
+      },
+    });
+    useAppStore.getState().addPendingAttachment(SESSION_A, makeAttachment("1"));
+    useAppStore.getState().removeChatSession(SESSION_A);
+    expect(
+      useAppStore.getState().pendingAttachmentsBySession[SESSION_A],
+    ).toBeUndefined();
+  });
+});

--- a/src/ui/src/types/chat.ts
+++ b/src/ui/src/types/chat.ts
@@ -110,3 +110,20 @@ export interface PendingAttachment {
   size_bytes: number;
   text_content: string | null;
 }
+
+/** Slice-stored shape: same as `PendingAttachment` minus `preview_url`,
+ * which is a transient blob URL regenerated on each component mount.
+ * Storing the blob URL would survive a remount but the underlying Blob
+ * is GC'd once the component drops its reference, leaving a dead URL —
+ * regenerating from `data_base64` is the only safe pattern. The slice
+ * is the source of truth so attachments survive when ChatPanel is
+ * unmounted (e.g. when the user opens a file or diff and chat is
+ * conditionally rendered out from `AppLayout`). */
+export interface StoredAttachment {
+  id: string;
+  filename: string;
+  media_type: string;
+  data_base64: string;
+  size_bytes: number;
+  text_content: string | null;
+}

--- a/src/ui/src/types/plugin.ts
+++ b/src/ui/src/types/plugin.ts
@@ -22,7 +22,7 @@ export interface PullRequest {
 
 export interface CiCheck {
   name: string;
-  status: "pending" | "success" | "failure" | "cancelled";
+  status: "pending" | "success" | "failure" | "cancelled" | "skipped";
   url: string | null;
   started_at: string | null;
 }

--- a/src/ui/src/utils/scmChecks.test.ts
+++ b/src/ui/src/utils/scmChecks.test.ts
@@ -54,6 +54,26 @@ describe("scmChecks", () => {
     expect(ciCheckStatusLabel("failure")).toBe("Failing");
     expect(ciCheckStatusLabel("pending")).toBe("Running");
     expect(ciCheckStatusLabel("cancelled")).toBe("Cancelled");
+    expect(ciCheckStatusLabel("skipped")).toBe("Skipped");
+  });
+
+  it("does not label a skipped check as Running (regression)", () => {
+    // Pre-fix, both the GitLab plugin (`skipped`/`manual`) and the
+    // GitHub plugin (`SKIPPED`/`NEUTRAL`) fell through to "pending",
+    // and `ciCheckStatusLabel` rendered "pending" as "Running" — so a
+    // merged PR's skipped check displayed a phantom Running spinner.
+    expect(ciCheckStatusLabel("skipped")).not.toBe("Running");
+  });
+
+  it("counts skipped checks separately in the summary", () => {
+    const summary = summarizeCiChecks([
+      check("Lint", "success"),
+      check("Skip-on-path", "skipped"),
+      check("Manual-deploy", "skipped"),
+    ]);
+    expect(summary.skipped).toBe(2);
+    expect(summary.passed).toBe(1);
+    expect(summary.title).toBe("Checks passed");
   });
 
   it("derives sidebar CI state from checks when the aggregate status is absent", () => {
@@ -61,9 +81,29 @@ describe("scmChecks", () => {
     expect(deriveScmCiState(null, [check("Test", "pending")])).toBe("pending");
     expect(deriveScmCiState(null, [check("Build", "success")])).toBe("success");
     expect(deriveScmCiState(null, [check("Build", "cancelled")])).toBeNull();
+    // Skipped-only counts as success at the aggregate level (the only
+    // checks present "didn't run by design", which is not a failure).
+    expect(deriveScmCiState(null, [check("Build", "skipped")])).toBe("success");
   });
 
   it("prefers the aggregate PR CI status over checks", () => {
     expect(deriveScmCiState("success", [check("Lint", "failure")])).toBe("success");
+  });
+
+  it("sorts skipped after cancelled but before success", () => {
+    const sorted = sortCiChecks([
+      check("Test", "success"),
+      check("Skipped-job", "skipped"),
+      check("Cancelled-job", "cancelled"),
+      check("Build", "failure"),
+      check("Format", "pending"),
+    ]);
+    expect(sorted.map((item) => item.name)).toEqual([
+      "Build",
+      "Format",
+      "Cancelled-job",
+      "Skipped-job",
+      "Test",
+    ]);
   });
 });

--- a/src/ui/src/utils/scmChecks.ts
+++ b/src/ui/src/utils/scmChecks.ts
@@ -1,6 +1,11 @@
 import type { CiCheck, PullRequest, ScmSummary } from "../types/plugin";
 
-export type CiCheckTone = "success" | "failure" | "pending" | "cancelled";
+export type CiCheckTone =
+  | "success"
+  | "failure"
+  | "pending"
+  | "cancelled"
+  | "skipped";
 
 export interface CiCheckSummary {
   title: string;
@@ -8,6 +13,11 @@ export interface CiCheckSummary {
   failed: number;
   pending: number;
   cancelled: number;
+  /** Checks that were deliberately not run (`if:` false on a GitHub
+   *  workflow, `rules:` excluded a GitLab job, manual GitLab job not
+   *  triggered). Counted separately from `cancelled` because a skipped
+   *  check is informational, not a soft-fail. */
+  skipped: number;
   passed: number;
 }
 
@@ -15,7 +25,10 @@ const STATUS_PRIORITY: Record<CiCheckTone, number> = {
   failure: 0,
   pending: 1,
   cancelled: 2,
-  success: 3,
+  // Skipped sorts after cancelled / before success so the user sees
+  // problem statuses, then in-progress, then "didn't run", then green.
+  skipped: 3,
+  success: 4,
 };
 
 export function ciCheckStatusLabel(status: CiCheckTone): string {
@@ -28,6 +41,8 @@ export function ciCheckStatusLabel(status: CiCheckTone): string {
       return "Running";
     case "cancelled":
       return "Cancelled";
+    case "skipped":
+      return "Skipped";
   }
 }
 
@@ -35,6 +50,7 @@ export function summarizeCiChecks(checks: readonly CiCheck[]): CiCheckSummary {
   const failed = checks.filter((check) => check.status === "failure").length;
   const pending = checks.filter((check) => check.status === "pending").length;
   const cancelled = checks.filter((check) => check.status === "cancelled").length;
+  const skipped = checks.filter((check) => check.status === "skipped").length;
   const passed = checks.filter((check) => check.status === "success").length;
 
   let title = "Checks";
@@ -45,6 +61,10 @@ export function summarizeCiChecks(checks: readonly CiCheck[]): CiCheckSummary {
   } else if (cancelled > 0) {
     title = cancelled === 1 ? "1 check cancelled" : `${cancelled} checks cancelled`;
   } else if (checks.length > 0) {
+    // All-skipped: rare in practice (CI has at least one always-on job)
+    // but valid in test PRs and small repos. Surface it as "passed" for
+    // the title since nothing is failing or running, then disambiguate
+    // in the per-check rows below.
     title = checks.length === 1 ? "1 check passed" : "Checks passed";
   }
 
@@ -54,6 +74,7 @@ export function summarizeCiChecks(checks: readonly CiCheck[]): CiCheckSummary {
     failed,
     pending,
     cancelled,
+    skipped,
     passed,
   };
 }
@@ -67,6 +88,9 @@ export function deriveScmCiState(
   const summary = summarizeCiChecks(checks);
   if (summary.failed > 0) return "failure";
   if (summary.pending > 0) return "pending";
+  // Skipped checks are informational — when every non-skipped check
+  // passed, the overall state is success even if the only checks present
+  // were skipped (e.g. a small PR that only triggered conditional jobs).
   if (summary.total > 0 && summary.cancelled === 0) return "success";
   return null;
 }


### PR DESCRIPTION
## Overview

Eleven commits' worth of bug fixes and small features that surfaced during dogfooding on top of #694 / #696 / #697. Themes: file panel correctness, hotkey ergonomics, chat-tab lifecycle, SCM CI status, and Tauri-webview confirm dialogs. Every commit has its own focused tests (Rust + frontend) — total **+102 test cases** added across the branch.

All checks green:
- 1598 frontend tests · `bunx tsc -b` clean · `bun run lint:css` clean · `bun run lint` 0 errors (13 pre-existing warnings, none in changed files)
- 1048 Rust lib tests · `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` with `RUSTFLAGS="-Dwarnings"` clean

---

## Commits

### `327c61f2` `fix(files): keep tracked files visible when ignored trees fill the cap`
**User report:** "after a commit/merge the file explorer only shows ignored files."

**Root cause:** PR #694 dropped `--exclude-standard` from `git ls-files --cached --others -z` so gitignored content (e.g. agent-generated docs) would surface in the Files panel. Side effect: `git ls-files` outputs paths in collated order and `.`-prefixed names sort before `A-Z` < `a-z`, so a worktree with large dot-prefixed ignored dirs (`.codex/`, `.direnv/`, `.logs/`) could exhaust `MAX_FILES = 10,000` before any tracked file was emitted. The frontend re-derives directories from emitted file paths, so the visible tree mirrored the truncated set: ignored dirs only.

**Fix:** Two-pass enumeration in `src-tauri/src/commands/files.rs` —
1. `--cached --others --exclude-standard -z`: tracked + untracked-not-ignored, capped at MAX_FILES. These always win.
2. `--others --ignored --exclude-standard -z`: ignored-only, with a per-top-level-directory cap (`MAX_IGNORED_FILES_PER_TOP_DIR = 200`) so no single noisy ignored tree can dominate.

Refactors the streaming loop into `stream_ls_files` + `record_file_entry` helpers so both passes apply identical filters. New tests pin the regression and the per-bucket fairness contract.

---

### `364f0fcf` `feat(hotkey): rebind Cmd+T to context-aware new tab`
**User report:** "rebind Cmd+T from thinking-mode to context-aware new-tab."

Removes the raw `window.addEventListener("keydown")` listener in `ChatToolbar` / `ComposerToolbar` that toggled thinking mode (and bypassed the keybinding system entirely), plus the `<kbd>⌘T</kbd>` chip-overlay badges. Adds a registered `global.new-tab` HOTKEY_ACTION (`mod+t` cross-platform) that routes by active right-pane view: file tab → triggers FilesPanel inline-create flow at workspace root via a per-workspace nonce; otherwise → creates a fresh chat session and switches to it. `terminal.new-tab` is unaffected (separate scope, dispatched from a different listener).

No DB migration — old binding lived as raw listeners, never persisted. New action appears in **Settings → Keyboard**, rebindable.

---

### `4d2744a5` `fix(scm): add Skipped CI status so merged PRs don't show phantom Running`
**User report:** Skipped CI job was rendered as "Running" on a merged PR.

Both SCM plugins were dropping non-canonical statuses into "pending", which the frontend renders as "Running" — so a merged PR whose only non-success check was `skipped` (GitLab `rules:` excluded) or `SKIPPED`/`NEUTRAL` (GitHub workflow `if:` was false) showed a phantom Running spinner.

End-to-end fix:
- Rust: new `Skipped` variant in `CiCheckStatus` (`src/scm/types.rs`) + serde-roundtrip test
- `plugins/scm-gitlab/init.lua`: `normalize_job_status` maps `skipped` and `manual` → `"skipped"`
- `plugins/scm-github/init.lua`: `normalize_check_status` maps `SKIPPED` and `NEUTRAL` → `"skipped"`; `TIMED_OUT` → `"failure"`. The `statusCheckRollup` aggregations no longer treat SKIPPED/NEUTRAL as breaking "all pass"
- Frontend: extends `CiCheck` status union, label `"Skipped"`, sort priority between cancelled and success, `CircleSlash` icon with muted tone in PrStatusBanner
- `deriveScmCiState` treats skipped-only as success at the aggregate level

---

### `03f3e833` `fix(chat): persist pending attachments across composer remounts`
**User report:** Pasting multiple images into chat then Cmd-Tabbing away loses the attachments.

Root cause: `<ChatPanel>` is conditionally unmounted in `AppLayout.tsx:130-140` whenever the right-pane view changes (file open, diff open, etc.). Component-local `useState` for `pendingAttachments` died with it. The codebase already documents the right pattern at `AppLayout.tsx:96-103` ("Always mount … swap visibility via CSS display:none") for state-bearing panels like Settings and TerminalPanel — ChatPanel was the outlier.

Fix: move attachments to `chatSlice.pendingAttachmentsBySession: Record<string, StoredAttachment[]>`, sibling to the existing `chatDrafts` slot. Composer mirrors every paste/drop/remove/send to the slice; on mount, `hydratePendingFromSlice` rebuilds preview blob URLs from `data_base64` (the underlying Blob is GC'd on the previous mount, so blob URLs intentionally aren't persisted). `removeChatSession` cleans the corresponding slice entry.

8 new tests pin per-session isolation, ordering, single-id removal, full-list replace, and cascading cleanup on session removal.

---

### `c17d9ba8` `fix(chat): restore expand toggle on running tool groups`
**User report:** "When chat messages are grouped and the session is running I should be able to expand them as needed; the chevron used to be there."

PR #696's chronological tool-display split lost two affordances on the grouped path: the chevron decoration and the click handler. The new auto-expand-while-running default was right, but with no toggle the user couldn't drill into a finished group, hide a noisy still-running one, or peek at a group whose status was about to flip.

Restores both: chevron glyph (`⌄` / `›`), `role="button"` + `tabIndex` + `aria-expanded` + `onClick`/`onKeyDown` on the header. State: `userOverride: boolean | null` inside `GroupedToolActivityRows` — `null` follows the running-or-search-match default, a click pins explicit choice. Override survives appended activities because the parent now keys this child by `${first toolUseId}`. Inline display mode unchanged (intentionally flat per #696).

---

### `3d6e0d8b` `feat(chat): surface MCP tool args via a registry + field heuristics`
**User report:** `mcp__postgres__query` shows nothing in the row — should show the SQL.

Pre-fix, `extractToolSummary`'s MCP fallback only checked four field names (`description`/`url`/`query`/`command`). The `sql` field used by every common postgres MCP server fell through silently.

Adds `src/ui/src/components/chat/toolMetadata.ts`, a 3-layer resolver returning `{ summary, lang, fullContent }`:
1. **Exact-match registry** — built-in Claude tools + well-known MCP servers (postgres / sqlite / mysql / bigquery / redshift / playwright / github / filesystem / fetch / memory). Each entry pins the input field carrying the user-facing payload + the Shiki language id.
2. **Tool-name heuristics** — patterns like `mcp__*__query` / `mcp__*__evaluate` / names containing `postgres|mysql|sqlite|redshift|bigquery|snowflake|clickhouse|duckdb` infer SQL/JS/bash. New MCP servers following common conventions get a reasonable summary without manual registry entries.
3. **Field-name heuristics** — first known content field present (sql / code / function / script / command / prompt / query / text / body / title / description / url / path / file_path / name / q / pattern). Falls through to the longest string-valued field, then empty.

15 tests cover all three layers + edge cases (invalid JSON, non-object input, ellipsis truncation, TodoWrite count).

The `lang` and `fullContent` fields are returned but not yet rendered — they scaffold a follow-up: **#698 expand-on-click tool-call details with Shiki syntax highlighting** (assigned, ready to pick up).

---

### `5cb10296` `feat(hotkey): Cmd+W global close-tab + Monaco Cmd+T/Cmd+W bypass`
**Two related user reports:**
- "Cmd+T doesn't create a new file when Monaco editor has focus" — Monaco's default `Cmd+T = Go To Symbol` swallowed the keystroke before the window listener fired.
- "Cmd+W doesn't close chat tabs" — `file-viewer.close-file-tab` was scoped to `file-viewer` only.

DRY architectural fix:
- New `src/ui/src/hotkeys/contextActions.ts` with `executeNewTab`/`executeCloseTab`/`chatCloseConfirmKind` — pure routing functions with dependency-injected services (testable without Tauri).
- `useKeyboardShortcuts` and `MonacoEditor.editor.addCommand` both call into the shared module so Monaco/window-listener never diverge.
- Renamed `file-viewer.close-file-tab` → `global.close-tab` (scope flips file-viewer → global). SQL migration `20260509000540_rename_close_file_tab_keybinding.sql` carries any user-customised binding forward (mirrors `rename_cycle_workspace_keybindings.sql`). Two Rust tests pin the rename direction + the both-keys-present case.

Confirmation rules shared between close-button and Cmd+W via `chatCloseConfirmKind`:
- `running` → existing prompt (preserved)
- `active` → NEW: closing the currently-selected chat asks first
- `last` → NEW: closing the only remaining session asks first
- `none` → close button on a non-active, non-last, non-running tab is silent

22 new tests across `contextActions.test.ts` + `bindings.test.ts` + `useAppStore.fileTree.test.ts` + `db/mod.rs` (migration).

---

### `b79bb2ce` `fix(chat): per-group tool collapse + 3 Codex review fixes + CLI banner wrap`
Bundles five small fixes from a Codex peer review and continued dogfooding:

1. **Per-group tool collapse** (user report: clicking one tool block collapsed all sibling groups in the same turn). Chronologically-split groups all read the same `turn.collapsed`. Adds `collapsedToolGroupsBySession` slice keyed by `${turn.id}:${first toolUseId}`. Single-group turns still flip `turn.collapsed` so persistence-aware code stays accurate; multi-group turns leave it alone.
2. **CLI invocation banner header wrap** (user report: "this header should always fully fit its content"). `.summary` switched from `nowrap + ellipsis` → `white-space: normal` + `overflow-wrap: anywhere` so the chip wraps and grows vertically rather than vanishing.
3. **[Codex P2] FilesPanel + FileViewer nonce mount race** — replaced per-instance number ref with a per-workspace `Map` seeded at 0 so a bump that landed during mounting still gets consumed.
4. **[Codex P2] Search match should override user-collapsed groups** — restructured `isExpanded = queryHasMatch || (userOverride ?? defaultExpanded)` so search hits never land in detached DOM.
5. **[Codex P3] PDF rehydrate fallback** — render the filename+size badge whenever `preview_url` is empty; the renderer no longer breaks PDFs into broken `<img>`s after a remount.

Plus 6 new slice tests and 1 search-regression test.

---

### `c17075b6` `fix(chat): unify tool-group expand state across running→completed + tighten close guards + CLI banner shrinkproof`
Three more bundled user-reported issues:

1. **Tool-group expand state didn't survive turn end.** Live `GroupedToolActivityRows` used local `useState`; completed `TurnSummary` used the slice. Two state sources → expanding a running group silently collapsed when the turn finished. Fix: new `collapsedToolGroupKey(activities)` helper produces `${kind}:${first toolUseId}` (no turn-id prefix) — the same key on both sides of the running→completed boundary because the `toolUseId` is preserved verbatim during `finalizeTurn`.
2. **Bulk-close path lacked active/last guards.** `closeEntries` (Cmd+Shift+W "close all") only confirmed for *running* sessions, so a single keystroke could silently yank the visible chat or wipe out the only-remaining session. Now mirrors the per-tab path's priority order (running → active → last → none) with one prompt per batch.
3. **CLI banner kept collapsing to a thin stripe** (user report: "shrinking and collapsing away"). Two defensive CSS guards: `flex-shrink: 0` on `.banner` so the block reserves vertical space even under sibling overflow pressure; `min-height: 32px` floor on `.header` so the chip is always tappable regardless of zoom.

5 new tests for `collapsedToolGroupKey` + 1 ToolActivitiesSection write-through test.

---

### `80b889dd` `fix(chat): live-update chat tab name from Haiku auto-rename event`
**User report:** "Tab should be renamed after initial prompt like the workspace is — right now it only works if you go to another project and come back."

Root cause: a perfect symmetric miss. The Rust side emitted both `workspace-renamed` and `session-renamed` events from parallel auto-rename background tasks, but the frontend only listened for the workspace half. The session-rename DB write happened correctly; the renamed value only surfaced when `SessionTabs`' mount effect re-fetched the list — which is exactly what a workspace switch triggered.

Adds the missing `session-renamed` listener in `useAgentStream.ts` mirroring the workspace-renamed pattern. New `useAgentStream.sessionRenamed.test.tsx` mounts the hook in happy-dom under a Tauri-event listener mock that captures handlers by name, then drives the captured `session-renamed` handler with payloads. 3 cases: listener IS registered, matching session updates live, unknown id is a safe no-op.

---

### `72e0ce50` `fix(chat): use Tauri's async ask() instead of window.confirm (silent no-op in webview)`
**User report:** "Cmd+W kills running sessions despite them being running or the last tab open — no confirmation appears."

Root cause: `window.confirm()` in Tauri 2's WKWebView (and the WebKit/WebView2 equivalents) does NOT show a native dialog. It returns immediately, so the close path runs unchecked even though the source code has the right `if (!window.confirm(msg)) return` guard. Earlier branch commits added the right *decision logic* (running / active / last → confirm) but kept calling `window.confirm`, so the dialog never surfaced.

**Whole-class** fix: every `window.confirm` in the codebase was a silent no-op in production. Routed through `@tauri-apps/plugin-dialog`'s async `ask()` (already permitted via `dialog:default` in `tauri.conf.json`):
- `hotkeys/contextActions.ts` — `ContextActionDeps.confirm` is now `(message) => Promise<boolean>`. `executeCloseTab` moves the confirm + archive into a single async IIFE so the dialog can be `await`ed. Adds a stale-state recheck after the modal returns — the user could've switched sessions while the dialog was open.
- `components/chat/SessionTabs.tsx` — new `askToClose(message)` helper, used by both `handleArchive` (× button) and `closeEntries` (bulk close).
- `components/terminal/TerminalPanel.tsx` — drive-by; `handleStopAgentTask` had the same bug.

New regression case in `contextActions.test.ts`: "prompts and archives a Running session" — fires Cmd+W on a running session, asserts the confirm dispatches and a "no" answer leaves the session alive. Existing tests converted from `mockReturnValue` → `mockResolvedValue` for the new async contract.

---

## Files changed

**Rust:** `src/scm/types.rs`, `src-tauri/src/commands/files.rs`, `plugins/scm-{github,gitlab}/init.lua`, `src/migrations/mod.rs` + 1 new SQL migration, `src/db/mod.rs` (migration tests)

**Frontend (TS/TSX):** ~25 files across `hotkeys/`, `hooks/`, `stores/slices/`, `components/{chat,file-viewer,files,right-sidebar,terminal}/`, `services/tauri.ts`, `types/{chat,plugin}.ts`, `utils/scmChecks.ts`

**Tests added:** ~12 new test files / suites covering the new code paths

**Locales:** all five locale `chat.json` + `settings.json` files updated for the new keyboard action descriptions and `session_active_confirm_close` / `session_last_confirm_close`

---

## Follow-up

Filed during this branch: [#698 expand-on-click tool-call details with Shiki syntax highlighting](https://github.com/utensils/claudette/issues/698) — the `lang` and `fullContent` fields returned by the new tool registry already scaffold this. Picks up cleanly on top of this PR.

