### PR TITLE
fix(chat): toggle context meter popover correctly on re-click

### DIFF
--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ui",

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -262,6 +262,7 @@ export function ChatInputArea({
   const [dragActive, setDragActive] = useState(false);
   const [attachMenuOpen, setAttachMenuOpen] = useState(false);
   const [contextPopoverOpen, setContextPopoverOpen] = useState(false);
+  const meterRef = useRef<HTMLButtonElement>(null);
   const pluginRefreshToken = useAppStore((s) => s.pluginRefreshToken);
   const openSettings = useAppStore((s) => s.openSettings);
 
@@ -1268,6 +1269,7 @@ export function ChatInputArea({
         </div>
         <div className={styles.inputControlsRight}>
           <SegmentedMeter
+            ref={meterRef}
             sessionId={sessionId}
             onClick={() => setContextPopoverOpen((v) => !v)}
           />
@@ -1391,6 +1393,7 @@ export function ChatInputArea({
               onClose={() => setContextPopoverOpen(false)}
               onCompact={() => { onSend("/compact"); }}
               onClear={() => { onSend("/clear"); }}
+              triggerRef={meterRef}
             />
           )}
         </div>

--- a/src/ui/src/components/chat/composer/ContextPopover.test.tsx
+++ b/src/ui/src/components/chat/composer/ContextPopover.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../stores/useAppStore", () => ({
+  useAppStore: vi.fn(() => ({
+    totalTokens: 5000,
+    inputTokens: 4000,
+    cacheReadTokens: 500,
+    cacheWriteTokens: 500,
+  })),
+}));
+
+vi.mock("../contextMeterLogic", () => ({
+  computeMeterState: vi.fn(() => ({
+    totalTokens: 5000,
+    capacity: 200000,
+    fillPercent: 2.5,
+    percentRounded: 3,
+  })),
+}));
+
+vi.mock("../useSelectedModelEntry", () => ({
+  useSelectedModelEntry: vi.fn(() => ({ contextWindowTokens: 200000 })),
+}));
+
+vi.mock("./segmentedMeterLogic", () => ({
+  segmentedBand: vi.fn(() => "normal"),
+  segmentedColor: vi.fn(() => "green"),
+  stateLabel: vi.fn(() => "Normal"),
+}));
+
+vi.mock("./formatCost", () => ({
+  estimateCost: vi.fn(() => 0.05),
+  formatCost: vi.fn(() => "$0.05"),
+}));
+
+vi.mock("../formatTokens", () => ({
+  formatTokens: vi.fn((n: number) => String(n)),
+}));
+
+import type { RefObject } from "react";
+import { ContextPopover } from "./ContextPopover";
+
+function fireMousedown(target: EventTarget) {
+  target.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, composed: true }));
+}
+
+describe("ContextPopover", () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+  });
+
+  describe("click-outside handling with triggerRef", () => {
+    it("does not call onClose when mousedown originates from the trigger element", async () => {
+      const onClose = vi.fn();
+      const triggerEl = document.createElement("button");
+      document.body.appendChild(triggerEl);
+      const triggerRef = { current: triggerEl } as RefObject<HTMLElement | null>;
+
+      await act(async () => {
+        root.render(
+          <ContextPopover
+            sessionId="s1"
+            onClose={onClose}
+            onCompact={vi.fn()}
+            onClear={vi.fn()}
+            triggerRef={triggerRef}
+          />,
+        );
+      });
+
+      fireMousedown(triggerEl);
+      expect(onClose).not.toHaveBeenCalled();
+
+      triggerEl.remove();
+    });
+
+    it("calls onClose when mousedown originates outside the popover and trigger", async () => {
+      const onClose = vi.fn();
+      const triggerEl = document.createElement("button");
+      const outsideEl = document.createElement("div");
+      document.body.appendChild(triggerEl);
+      document.body.appendChild(outsideEl);
+      const triggerRef = { current: triggerEl } as RefObject<HTMLElement | null>;
+
+      await act(async () => {
+        root.render(
+          <ContextPopover
+            sessionId="s1"
+            onClose={onClose}
+            onCompact={vi.fn()}
+            onClear={vi.fn()}
+            triggerRef={triggerRef}
+          />,
+        );
+      });
+
+      fireMousedown(outsideEl);
+      expect(onClose).toHaveBeenCalledOnce();
+
+      triggerEl.remove();
+      outsideEl.remove();
+    });
+
+    it("does not call onClose when mousedown originates inside the popover", async () => {
+      const onClose = vi.fn();
+
+      await act(async () => {
+        root.render(
+          <ContextPopover
+            sessionId="s1"
+            onClose={onClose}
+            onCompact={vi.fn()}
+            onClear={vi.fn()}
+          />,
+        );
+      });
+
+      fireMousedown(container.firstElementChild!);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ui/src/components/chat/composer/ContextPopover.tsx
+++ b/src/ui/src/components/chat/composer/ContextPopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { type RefObject, useEffect, useRef } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { computeMeterState } from "../contextMeterLogic";
 import { formatTokens } from "../formatTokens";
@@ -12,6 +12,7 @@ interface ContextPopoverProps {
   onClose: () => void;
   onCompact: () => void;
   onClear: () => void;
+  triggerRef?: RefObject<HTMLElement | null>;
 }
 
 const SEGMENTS = [
@@ -26,7 +27,7 @@ const SEGMENT_COLORS = [
   "var(--accent-dim)",
 ];
 
-export function ContextPopover({ sessionId, onClose, onCompact, onClear }: ContextPopoverProps) {
+export function ContextPopover({ sessionId, onClose, onCompact, onClear, triggerRef }: ContextPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const usage = useAppStore((s) => s.latestTurnUsage[sessionId]);
 
@@ -46,13 +47,15 @@ export function ContextPopover({ sessionId, onClose, onCompact, onClear }: Conte
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (triggerRef?.current?.contains(target)) return;
+      if (popoverRef.current && !popoverRef.current.contains(target)) {
         onClose();
       }
     }
     document.addEventListener("mousedown", handleClick);
     return () => document.removeEventListener("mousedown", handleClick);
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   if (!state) return null;
 

--- a/src/ui/src/components/chat/composer/SegmentedMeter.tsx
+++ b/src/ui/src/components/chat/composer/SegmentedMeter.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { type CSSProperties, forwardRef } from "react";
 import { useAppStore } from "../../../stores/useAppStore";
 import { computeMeterState } from "../contextMeterLogic";
 import { formatTokens } from "../formatTokens";
@@ -13,7 +13,8 @@ interface SegmentedMeterProps {
   onClick: () => void;
 }
 
-export function SegmentedMeter({ sessionId, onClick }: SegmentedMeterProps) {
+export const SegmentedMeter = forwardRef<HTMLButtonElement, SegmentedMeterProps>(
+function SegmentedMeter({ sessionId, onClick }, ref) {
   const usage = useAppStore((s) => s.latestTurnUsage[sessionId]);
 
   const model = useSelectedModelEntry(sessionId);
@@ -31,6 +32,7 @@ export function SegmentedMeter({ sessionId, onClick }: SegmentedMeterProps) {
 
   return (
     <button
+      ref={ref}
       type="button"
       className={`${styles.meter} ${urgent ? styles.meterUrgent : ""}`}
       onClick={onClick}
@@ -84,4 +86,4 @@ export function SegmentedMeter({ sessionId, onClick }: SegmentedMeterProps) {
       </span>
     </button>
   );
-}
+});


### PR DESCRIPTION
## Summary

- `SegmentedMeter` is now wrapped with `React.forwardRef` so callers can hold a ref to its underlying `<button>`
- `ContextPopover` gains an optional `triggerRef` prop; its `mousedown` click-outside handler now skips `onClose()` when the event originated from the trigger element
- `ChatInputArea` threads a `meterRef` through both components to wire the toggle shut

**Root cause:** The popover's `document.addEventListener("mousedown")` always fires before a button's `click` event. When the meter was open and the user clicked it again, the mousedown handler closed the popover, then the button's `onClick` toggled it back open — causing a visible flash.

## Test Steps

1. Start a chat session so the `SegmentedMeter` appears in the composer toolbar (requires some token usage to be present)
2. Click the meter — the context popover should open
3. Click the meter again — the popover should close **without flashing**
4. Click outside the popover — it should still close normally
5. Press Escape while the popover is open — it should close normally

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)