### PR TITLE
feat: add queue steer popup

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -69,7 +69,7 @@ Toggle the Chrome chip in the chat header to enable the agent's browser tool for
 
 While an agent turn is running, you can queue follow-up messages. Type into the chat input and hit **Enter** — each message is added to the queue popover above the composer and delivered one at a time as later user turns.
 
-Use the **Steer** action in the queue popover, or press **Cmd/Ctrl + Enter**, to send a queued or freshly typed message into the currently running turn instead of waiting for the queue to drain. This is the lowest-friction way to course-correct without stopping the agent.
+Use the **Steer** action in the queue popover to send any queued item into the currently running turn instead of waiting for the queue to drain. Pressing **Cmd/Ctrl + Enter** steers the freshly typed composer text when the composer has text or attachments; when the composer is empty, the shortcut steers the top queued item. This is the lowest-friction way to course-correct without stopping the agent.
 
 From the [CLI](/claudette/features/cli-client/):
 

--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -67,7 +67,9 @@ Toggle the Chrome chip in the chat header to enable the agent's browser tool for
 
 ## Mid-turn Steering
 
-While an agent turn is running, you can queue a follow-up message. Type into the chat input and hit **Enter** — the message is queued and delivered as the next user turn the moment the current one completes. This is the lowest-friction way to course-correct without stopping the agent.
+While an agent turn is running, you can queue follow-up messages. Type into the chat input and hit **Enter** — each message is added to the queue popover above the composer and delivered one at a time as later user turns.
+
+Use the **Steer** action in the queue popover, or press **Cmd/Ctrl + Enter**, to send a queued or freshly typed message into the currently running turn instead of waiting for the queue to drain. This is the lowest-friction way to course-correct without stopping the agent.
 
 From the [CLI](/claudette/features/cli-client/):
 

--- a/src/ui/src/components/chat/ChatInputArea.test.ts
+++ b/src/ui/src/components/chat/ChatInputArea.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { shouldSteerQueuedTopOnImmediateSend } from "./ChatInputArea";
+
+describe("shouldSteerQueuedTopOnImmediateSend", () => {
+  it("uses the top queued message only when the running composer is empty", () => {
+    expect(
+      shouldSteerQueuedTopOnImmediateSend({
+        isRunning: true,
+        hasQueuedMessages: true,
+        hasComposerPayload: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps immediate send on the composer when text or attachments are present", () => {
+    expect(
+      shouldSteerQueuedTopOnImmediateSend({
+        isRunning: true,
+        hasQueuedMessages: true,
+        hasComposerPayload: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not use queued steering when the agent is idle or the queue is empty", () => {
+    expect(
+      shouldSteerQueuedTopOnImmediateSend({
+        isRunning: false,
+        hasQueuedMessages: true,
+        hasComposerPayload: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSteerQueuedTopOnImmediateSend({
+        isRunning: true,
+        hasQueuedMessages: false,
+        hasComposerPayload: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/ui/src/components/chat/ChatInputArea.test.ts
+++ b/src/ui/src/components/chat/ChatInputArea.test.ts
@@ -6,6 +6,7 @@ describe("shouldSteerQueuedTopOnImmediateSend", () => {
     expect(
       shouldSteerQueuedTopOnImmediateSend({
         isRunning: true,
+        isRemote: false,
         hasQueuedMessages: true,
         hasComposerPayload: false,
       }),
@@ -16,6 +17,7 @@ describe("shouldSteerQueuedTopOnImmediateSend", () => {
     expect(
       shouldSteerQueuedTopOnImmediateSend({
         isRunning: true,
+        isRemote: false,
         hasQueuedMessages: true,
         hasComposerPayload: true,
       }),
@@ -26,6 +28,7 @@ describe("shouldSteerQueuedTopOnImmediateSend", () => {
     expect(
       shouldSteerQueuedTopOnImmediateSend({
         isRunning: false,
+        isRemote: false,
         hasQueuedMessages: true,
         hasComposerPayload: false,
       }),
@@ -33,7 +36,19 @@ describe("shouldSteerQueuedTopOnImmediateSend", () => {
     expect(
       shouldSteerQueuedTopOnImmediateSend({
         isRunning: true,
+        isRemote: false,
         hasQueuedMessages: false,
+        hasComposerPayload: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not steer queued messages from remote workspaces", () => {
+    expect(
+      shouldSteerQueuedTopOnImmediateSend({
+        isRunning: true,
+        isRemote: true,
+        hasQueuedMessages: true,
         hasComposerPayload: false,
       }),
     ).toBe(false);

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -68,12 +68,14 @@ export function shouldSteerQueuedTopOnImmediateSend({
   isRunning,
   hasQueuedMessages,
   hasComposerPayload,
+  isRemote,
 }: {
   isRunning: boolean;
   hasQueuedMessages: boolean;
   hasComposerPayload: boolean;
+  isRemote: boolean;
 }): boolean {
-  return isRunning && hasQueuedMessages && !hasComposerPayload;
+  return isRunning && !isRemote && hasQueuedMessages && !hasComposerPayload;
 }
 
 /** Rebuild a `PendingAttachment[]` for a session from the slice's
@@ -908,6 +910,7 @@ export function ChatInputArea({
     }
     if (shouldSteerQueuedTopOnImmediateSend({
       isRunning,
+      isRemote,
       hasQueuedMessages,
       hasComposerPayload: !!chatInput.trim() || pendingAttachments.length > 0,
     }) && onSteerQueuedTop) {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -64,6 +64,18 @@ function normalizeShellCommand(value: string): string {
   return trimmed.startsWith("!") ? trimmed.slice(1).trimStart() : trimmed;
 }
 
+export function shouldSteerQueuedTopOnImmediateSend({
+  isRunning,
+  hasQueuedMessages,
+  hasComposerPayload,
+}: {
+  isRunning: boolean;
+  hasQueuedMessages: boolean;
+  hasComposerPayload: boolean;
+}): boolean {
+  return isRunning && hasQueuedMessages && !hasComposerPayload;
+}
+
 /** Rebuild a `PendingAttachment[]` for a session from the slice's
  * `StoredAttachment[]`. Image preview blob URLs are regenerated from
  * `data_base64` (the underlying Blob is GC'd once the previous mount
@@ -146,10 +158,12 @@ function fileToBase64(file: Blob): Promise<string> {
 export function ChatInputArea({
   onSend,
   onSendSteer,
+  onSteerQueuedTop,
   onRunShellCommand,
   onStop,
   isRunning,
   isRemote,
+  hasQueuedMessages,
   selectedWorkspaceId,
   sessionId,
   repoId,
@@ -174,10 +188,13 @@ export function ChatInputArea({
     mentionedFiles?: Set<string>,
     attachments?: AttachmentInput[],
   ) => void | Promise<void>;
+  /** Steer the first queued message without consuming the current composer. */
+  onSteerQueuedTop?: () => void | Promise<void>;
   onRunShellCommand: (command: string) => void | Promise<void>;
   onStop: () => void | Promise<void>;
   isRunning: boolean;
   isRemote: boolean;
+  hasQueuedMessages: boolean;
   selectedWorkspaceId: string;
   sessionId: string;
   repoId: string | undefined;
@@ -887,6 +904,14 @@ export function ChatInputArea({
     // an idle session doesn't double-send.
     if (!isRunning) {
       handleSend();
+      return;
+    }
+    if (shouldSteerQueuedTopOnImmediateSend({
+      isRunning,
+      hasQueuedMessages,
+      hasComposerPayload: !!chatInput.trim() || pendingAttachments.length > 0,
+    }) && onSteerQueuedTop) {
+      void onSteerQueuedTop();
       return;
     }
     // Mid-turn steering isn't supported over the remote transport yet

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -648,19 +648,36 @@
   background: var(--chat-input-bg);
 }
 
-/* Queued message indicator */
-.queuedMessage {
+/* Bottom queue popover */
+.queuedPopover {
+  width: min(calc(100% - 48px), 920px);
+  max-height: 180px;
+  margin: -10px auto 8px;
+  padding: 8px;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  z-index: 5;
+  flex-shrink: 0;
+}
+
+.queuedPopoverHeader {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  margin: 4px 0;
-  background: rgba(var(--accent-primary-rgb), 0.06);
-  border: 1px solid rgba(var(--accent-primary-rgb), 0.15);
-  border-radius: 6px;
-  font-size: 12px;
-  color: var(--text-muted);
-  flex-shrink: 0;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 24px;
+  padding: 0 4px 6px;
+  border-bottom: 1px solid var(--divider);
+}
+
+.queuedList {
+  display: flex;
+  flex-direction: column;
+  max-height: 132px;
+  overflow-y: auto;
+  padding-top: 4px;
 }
 
 .queuedLabel {
@@ -668,8 +685,49 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--accent-primary);
+  color: var(--text-dim);
   white-space: nowrap;
+}
+
+.queuedClearAll {
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.queuedClearAll:hover {
+  color: var(--text-primary);
+  background: var(--hover-bg-subtle);
+}
+
+.queuedMessage {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 5px 4px 5px 8px;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.queuedMessage:hover {
+  background: var(--hover-bg-subtle);
+}
+
+.queuedIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-faint);
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
 .queuedContent {
@@ -677,18 +735,19 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--text-dim);
+  color: var(--text-muted);
+  min-width: 0;
 }
 
 .queuedSteer {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  min-height: 24px;
-  padding: 3px 8px;
-  border: 1px solid rgba(var(--accent-primary-rgb), 0.25);
-  border-radius: 6px;
-  background: rgba(var(--accent-primary-rgb), 0.08);
+  gap: 5px;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
   color: var(--accent-primary);
   font-size: 11px;
   font-weight: 600;
@@ -698,8 +757,8 @@
 }
 
 .queuedSteer:hover:not(:disabled) {
-  background: rgba(var(--accent-primary-rgb), 0.14);
-  border-color: rgba(var(--accent-primary-rgb), 0.4);
+  background: var(--accent-bg);
+  border-color: rgba(var(--accent-primary-rgb), 0.24);
 }
 
 .queuedSteer:disabled {
@@ -712,17 +771,23 @@
 }
 
 .queuedCancel {
-  background: none;
-  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: 16px;
   color: var(--text-faint);
-  padding: 0 2px;
-  line-height: 1;
 }
 
 .queuedCancel:hover {
-  color: var(--text-primary);
+  color: var(--status-stopped);
+  background: var(--error-bg);
+  border-color: var(--error-border);
 }
 
 /* Input area — Composer wrapper */

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -843,6 +843,12 @@ export function ChatPanel() {
     }
   };
 
+  const handleSteerQueuedTop = () => {
+    const firstQueuedMessage = queuedMessages[0];
+    if (!firstQueuedMessage) return;
+    void handleSteerQueuedMessage(firstQueuedMessage.id);
+  };
+
   const handleRunShellCommand = async (command: string) => {
     if (!selectedWorkspaceId) return;
     if (ws?.remote_connection_id) {
@@ -1425,10 +1431,12 @@ export function ChatPanel() {
       <ChatInputArea
         onSend={handleSend}
         onSendSteer={handleSendSteer}
+        onSteerQueuedTop={handleSteerQueuedTop}
         onRunShellCommand={handleRunShellCommand}
         onStop={handleStop}
         isRunning={isRunning}
         isRemote={!!ws?.remote_connection_id}
+        hasQueuedMessages={queuedMessages.length > 0}
         selectedWorkspaceId={selectedWorkspaceId!}
         sessionId={activeSessionId!}
         repoId={repo?.id}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1382,7 +1382,8 @@ export function ChatPanel() {
             <button
               className={styles.queuedClearAll}
               onClick={() => clearQueuedMessage(activeSessionId)}
-              title={t("cancel_queued")}
+              title={t("clear_queue")}
+              aria-label={t("clear_queue")}
             >
               {t("clear_queue")}
             </button>
@@ -1399,20 +1400,22 @@ export function ChatPanel() {
                     <CornerDownRight size={14} />
                   </span>
                   <span className={styles.queuedContent}>{content || fallback}</span>
-                  <button
-                    className={styles.queuedSteer}
-                    onClick={() => handleSteerQueuedMessage(message.id)}
-                    disabled={isSteeringQueued || !isRunning}
-                    title={t("steer_queued")}
-                    aria-label={t("steer_queued")}
-                  >
-                    {isSteeringQueued ? (
-                      <LoaderCircle size={14} className={styles.queuedSteerSpinner} />
-                    ) : (
-                      <SendHorizontal size={14} />
-                    )}
-                    <span>{t("steer_queued_short")}</span>
-                  </button>
+                  {!ws?.remote_connection_id && (
+                    <button
+                      className={styles.queuedSteer}
+                      onClick={() => handleSteerQueuedMessage(message.id)}
+                      disabled={isSteeringQueued || !isRunning}
+                      title={t("steer_queued")}
+                      aria-label={t("steer_queued")}
+                    >
+                      {isSteeringQueued ? (
+                        <LoaderCircle size={14} className={styles.queuedSteerSpinner} />
+                      ) : (
+                        <SendHorizontal size={14} />
+                      )}
+                      <span>{t("steer_queued_short")}</span>
+                    </button>
+                  )}
                   <button
                     className={styles.queuedCancel}
                     onClick={() => removeQueuedMessage(activeSessionId, message.id)}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { LoaderCircle, SendHorizontal } from "lucide-react";
+import {
+  CornerDownRight,
+  LoaderCircle,
+  SendHorizontal,
+  Trash2,
+} from "lucide-react";
 import { ChatSearchBar } from "./ChatSearchBar";
 import { useAppStore } from "../../stores/useAppStore";
 import {
@@ -28,7 +33,7 @@ import {
 } from "../../services/tauri";
 import { applySelectedModel } from "./applySelectedModel";
 import { findLatestPlanFilePath } from "./planFilePath";
-import type { PermissionLevel } from "../../stores/useAppStore";
+import type { PermissionLevel, QueuedMessage } from "../../stores/useAppStore";
 import { reconstructCompletedTurns } from "../../utils/reconstructTurns";
 import { extractLatestCallUsage } from "../../utils/extractLatestCallUsage";
 import type { AttachmentInput, ChatMessage } from "../../types/chat";
@@ -67,6 +72,8 @@ import { CliInvocationBanner } from "./CliInvocationBanner";
 import { CurrentTurnTaskProgress } from "./CurrentTurnTaskProgress";
 import { ChatInputArea } from "./ChatInputArea";
 import { EMPTY_ACTIVITIES } from "./chatConstants";
+
+const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
 
 export function ChatPanel() {
   const { t } = useTranslation("chat");
@@ -225,10 +232,14 @@ export function ChatPanel() {
   );
   const clearPlanApproval = useAppStore((s) => s.clearPlanApproval);
   const setPlanMode = useAppStore((s) => s.setPlanMode);
-  const queuedMessage = useAppStore(
-    (s) => (activeSessionId ? s.queuedMessages[activeSessionId] ?? null : null)
+  const queuedMessages = useAppStore(
+    (s) =>
+      activeSessionId
+        ? s.queuedMessages[activeSessionId] ?? EMPTY_QUEUED_MESSAGES
+        : EMPTY_QUEUED_MESSAGES,
   );
   const setQueuedMessage = useAppStore((s) => s.setQueuedMessage);
+  const removeQueuedMessage = useAppStore((s) => s.removeQueuedMessage);
   const clearQueuedMessage = useAppStore((s) => s.clearQueuedMessage);
   const addCheckpoint = useAppStore((s) => s.addCheckpoint);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
@@ -659,15 +670,29 @@ export function ChatPanel() {
     mentionedFiles?: Set<string>,
     attachments?: AttachmentInput[],
   ) => void) | null>(null);
+  const autoDispatchQueuedIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (isSteeringQueued || isRunning || !activeSessionId || !queuedMessage) return;
+    const nextQueuedMessage = queuedMessages[0];
+    if (
+      isSteeringQueued ||
+      isRunning ||
+      !activeSessionId ||
+      !nextQueuedMessage ||
+      autoDispatchQueuedIdRef.current
+    ) {
+      return;
+    }
     // Agent just finished — dispatch the queued message.
-    const { content, mentionedFiles, attachments } = queuedMessage;
-    clearQueuedMessage(activeSessionId);
+    const { id, content, mentionedFiles, attachments } = nextQueuedMessage;
+    autoDispatchQueuedIdRef.current = id;
+    removeQueuedMessage(activeSessionId, id);
     const filesSet = mentionedFiles?.length ? new Set(mentionedFiles) : undefined;
     // Use a microtask to avoid calling handleSend during render.
-    queueMicrotask(() => handleSendRef.current?.(content, filesSet, attachments));
-  }, [isSteeringQueued, isRunning, activeSessionId, queuedMessage, clearQueuedMessage]);
+    queueMicrotask(() => {
+      handleSendRef.current?.(content, filesSet, attachments);
+      autoDispatchQueuedIdRef.current = null;
+    });
+  }, [isSteeringQueued, isRunning, activeSessionId, queuedMessages, removeQueuedMessage]);
 
   if (!ws) return null;
 
@@ -773,8 +798,10 @@ export function ChatPanel() {
     }
   };
 
-  const handleSteerQueuedMessage = async () => {
-    if (!activeSessionId || !queuedMessage || isSteeringQueued) return;
+  const handleSteerQueuedMessage = async (queuedMessageId: string) => {
+    if (!activeSessionId || isSteeringQueued) return;
+    const queuedMessage = queuedMessages.find((message) => message.id === queuedMessageId);
+    if (!queuedMessage) return;
     if (ws?.remote_connection_id) {
       setError("Mid-turn steering is not yet supported for remote workspaces");
       return;
@@ -789,7 +816,7 @@ export function ChatPanel() {
     const messageId = crypto.randomUUID();
     setError(null);
     setIsSteeringQueued(true);
-    clearQueuedMessage(sessionId);
+    removeQueuedMessage(sessionId, queuedMessage.id);
     try {
       const checkpoint = await steerQueuedChatMessage(
         sessionId,
@@ -806,7 +833,6 @@ export function ChatPanel() {
       historyIndexRef.current = -1;
       draftRef.current = "";
       addPersistedUserMessageToStore(sessionId, messageId, content, attachments);
-      clearQueuedMessage(sessionId);
     } catch (e) {
       const errMsg = String(e);
       console.error("steerQueuedChatMessage failed:", errMsg);
@@ -1329,13 +1355,47 @@ export function ChatPanel() {
                 </div>
               )}
 
-              {queuedMessage && activeSessionId && (
-                <div className={styles.queuedMessage}>
-                  <span className={styles.queuedLabel}>{t("queued_label")}</span>
-                  <span className={styles.queuedContent}>{queuedMessage.content}</span>
+              {error && <div className={styles.errorBanner}>{error}</div>}
+            </>
+          )}
+        </div>
+      </ScrollContext.Provider>
+      </div>
+
+      <ScrollToBottomPill
+        visible={!isAtBottom && messages.length > 0}
+        onClick={scrollToBottom}
+      />
+
+      {queuedMessages.length > 0 && activeSessionId && (
+        <div className={styles.queuedPopover}>
+          <div className={styles.queuedPopoverHeader}>
+            <span className={styles.queuedLabel}>
+              {t("queued_label")} · {queuedMessages.length}
+            </span>
+            <button
+              className={styles.queuedClearAll}
+              onClick={() => clearQueuedMessage(activeSessionId)}
+              title={t("cancel_queued")}
+            >
+              {t("clear_queue")}
+            </button>
+          </div>
+          <div className={styles.queuedList}>
+            {queuedMessages.map((message) => {
+              const content = message.content.trim();
+              const fallback = message.attachments?.length
+                ? message.attachments.map((attachment) => attachment.filename).join(", ")
+                : t("queued_attachment_fallback");
+              return (
+                <div className={styles.queuedMessage} key={message.id}>
+                  <span className={styles.queuedIcon} aria-hidden="true">
+                    <CornerDownRight size={14} />
+                  </span>
+                  <span className={styles.queuedContent}>{content || fallback}</span>
                   <button
                     className={styles.queuedSteer}
-                    onClick={handleSteerQueuedMessage}
+                    onClick={() => handleSteerQueuedMessage(message.id)}
                     disabled={isSteeringQueued || !isRunning}
                     title={t("steer_queued")}
                     aria-label={t("steer_queued")}
@@ -1349,25 +1409,18 @@ export function ChatPanel() {
                   </button>
                   <button
                     className={styles.queuedCancel}
-                    onClick={() => clearQueuedMessage(activeSessionId)}
+                    onClick={() => removeQueuedMessage(activeSessionId, message.id)}
                     title={t("cancel_queued")}
+                    aria-label={t("cancel_queued")}
                   >
-                    ×
+                    <Trash2 size={14} />
                   </button>
                 </div>
-              )}
-
-              {error && <div className={styles.errorBanner}>{error}</div>}
-            </>
-          )}
+              );
+            })}
+          </div>
         </div>
-      </ScrollContext.Provider>
-      </div>
-
-      <ScrollToBottomPill
-        visible={!isAtBottom && messages.length > 0}
-        onClick={scrollToBottom}
-      />
+      )}
 
       <ChatInputArea
         onSend={handleSend}

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -4,6 +4,8 @@
   "compacting_aria": "Compacting context, {{elapsed}} elapsed",
   "processing_aria": "Processing, {{elapsed}} elapsed",
   "queued_label": "Queued",
+  "clear_queue": "Clear",
+  "queued_attachment_fallback": "Attachment",
   "cancel_queued": "Cancel queued message",
   "steer_queued": "Send to running agent",
   "steer_queued_short": "Steer",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -4,6 +4,8 @@
   "compacting_aria": "Compactando contexto, {{elapsed}} transcurridos",
   "processing_aria": "Procesando, {{elapsed}} transcurridos",
   "queued_label": "En cola",
+  "clear_queue": "Limpiar",
+  "queued_attachment_fallback": "Adjunto",
   "cancel_queued": "Cancelar mensaje en cola",
   "steer_queued": "Enviar al agente en ejecución",
   "steer_queued_short": "Dirigir",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -4,6 +4,8 @@
   "compacting_aria": "コンテキストを圧縮中、経過時間 {{elapsed}}",
   "processing_aria": "処理中、経過時間 {{elapsed}}",
   "queued_label": "キュー登録済み",
+  "clear_queue": "クリア",
+  "queued_attachment_fallback": "添付ファイル",
   "cancel_queued": "キュー登録したメッセージをキャンセル",
   "steer_queued": "実行中のエージェントに送信",
   "steer_queued_short": "誘導",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -4,6 +4,8 @@
   "compacting_aria": "Compactando contexto, {{elapsed}} decorrido",
   "processing_aria": "Processando, {{elapsed}} decorrido",
   "queued_label": "Na fila",
+  "clear_queue": "Limpar",
+  "queued_attachment_fallback": "Anexo",
   "cancel_queued": "Cancelar mensagem na fila",
   "steer_queued": "Enviar ao agente em execução",
   "steer_queued_short": "Orientar",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -4,6 +4,8 @@
   "compacting_aria": "正在压缩上下文，已用 {{elapsed}}",
   "processing_aria": "处理中，已用 {{elapsed}}",
   "queued_label": "已排队",
+  "clear_queue": "清空",
+  "queued_attachment_fallback": "附件",
   "cancel_queued": "取消排队的消息",
   "steer_queued": "发送给正在运行的智能体",
   "steer_queued_short": "引导",

--- a/src/ui/src/stores/slices/agentInteractionSlice.ts
+++ b/src/ui/src/stores/slices/agentInteractionSlice.ts
@@ -43,8 +43,18 @@ export interface QueuedMessage {
   attachments?: AttachmentInput[];
 }
 
+let queuedMessageFallbackCounter = 0;
+
 function createQueuedMessageId(): string {
-  return globalThis.crypto?.randomUUID?.() ?? `queued-${Date.now()}-${Math.random()}`;
+  const crypto = globalThis.crypto;
+  if (crypto?.randomUUID) return crypto.randomUUID();
+  if (crypto?.getRandomValues) {
+    const values = new Uint32Array(4);
+    crypto.getRandomValues(values);
+    return `queued-${Array.from(values, (value) => value.toString(36)).join("-")}`;
+  }
+  queuedMessageFallbackCounter += 1;
+  return `queued-${Date.now()}-${queuedMessageFallbackCounter}`;
 }
 
 export interface AgentInteractionSlice {

--- a/src/ui/src/stores/slices/agentInteractionSlice.ts
+++ b/src/ui/src/stores/slices/agentInteractionSlice.ts
@@ -36,6 +36,17 @@ export interface ChatSearchState {
   matchIndex: number;
 }
 
+export interface QueuedMessage {
+  id: string;
+  content: string;
+  mentionedFiles?: string[];
+  attachments?: AttachmentInput[];
+}
+
+function createQueuedMessageId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `queued-${Date.now()}-${Math.random()}`;
+}
+
 export interface AgentInteractionSlice {
   agentQuestions: Record<string, AgentQuestion>;
   setAgentQuestion: (q: AgentQuestion) => void;
@@ -51,20 +62,14 @@ export interface AgentInteractionSlice {
   setChatSearchQuery: (wsId: string, query: string) => void;
   setChatSearchMatchIndex: (wsId: string, idx: number) => void;
 
-  queuedMessages: Record<
-    string,
-    {
-      content: string;
-      mentionedFiles?: string[];
-      attachments?: AttachmentInput[];
-    }
-  >;
+  queuedMessages: Record<string, QueuedMessage[]>;
   setQueuedMessage: (
     sessionId: string,
     content: string,
     mentionedFiles?: string[],
     attachments?: AttachmentInput[],
   ) => void;
+  removeQueuedMessage: (sessionId: string, queuedMessageId: string) => void;
   clearQueuedMessage: (sessionId: string) => void;
 }
 
@@ -165,9 +170,28 @@ export const createAgentInteractionSlice: StateCreator<
     set((s) => ({
       queuedMessages: {
         ...s.queuedMessages,
-        [sessionId]: { content, mentionedFiles, attachments },
+        [sessionId]: [
+          ...(s.queuedMessages[sessionId] || []),
+          { id: createQueuedMessageId(), content, mentionedFiles, attachments },
+        ],
       },
     })),
+  removeQueuedMessage: (sessionId, queuedMessageId) =>
+    set((s) => {
+      const remaining = (s.queuedMessages[sessionId] || []).filter(
+        (message) => message.id !== queuedMessageId,
+      );
+      if (remaining.length === 0) {
+        const { [sessionId]: _, ...rest } = s.queuedMessages;
+        return { queuedMessages: rest };
+      }
+      return {
+        queuedMessages: {
+          ...s.queuedMessages,
+          [sessionId]: remaining,
+        },
+      };
+    }),
   clearQueuedMessage: (sessionId) =>
     set((s) => {
       const { [sessionId]: _, ...rest } = s.queuedMessages;

--- a/src/ui/src/stores/useAppStore.ts
+++ b/src/ui/src/stores/useAppStore.ts
@@ -6,6 +6,7 @@ import {
   type AgentQuestionItem,
   type ChatSearchState,
   type PlanApproval,
+  type QueuedMessage,
 } from "./slices/agentInteractionSlice";
 import {
   createChatSessionsSlice,
@@ -79,6 +80,7 @@ export type {
   CompletedTurn,
   PermissionLevel,
   PlanApproval,
+  QueuedMessage,
   ToolActivity,
   TurnUsage,
 };


### PR DESCRIPTION
## Summary

Adds a bottom queue popover above the chat composer for follow-up messages typed while an agent turn is running. Queued messages now append as a list instead of replacing the previous queued message, and each queued item can be steered into the active turn or removed independently.

## Behavior

- Pressing Enter while an agent is running adds the composer payload to the queue.
- The queue popover shows all pending messages with per-item Steer and delete actions plus a clear-all control.
- When a turn finishes, Claudette dispatches the next queued message as the next user turn.
- Pressing Cmd/Ctrl + Enter steers the typed composer payload when the composer has text or attachments.
- If the composer is empty, Cmd/Ctrl + Enter steers the top queued item.
- Remote workspaces keep the existing fallback behavior because mid-turn steering is local-only.

## Documentation

Updated the Agent Configuration docs to describe the queue popover and shortcut priority.

## Validation

- `cd src/ui && bun run test ChatInputArea.test.ts`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run lint` (passes with existing warnings)
