### PR TITLE
fix(diff): prevent git-poll pileup on divergent forks

### DIFF
--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -1,10 +1,59 @@
+use std::path::Path;
+
 use tauri::State;
 
 use claudette::db::Database;
 use claudette::diff;
 use claudette::model::diff::{CommitEntry, DiffFile, FileDiff, StagedDiffFiles};
 
-use crate::state::AppState;
+use crate::state::{AppState, MERGE_BASE_CACHE_TTL, MergeBaseCache, MergeBaseCacheEntry};
+
+/// Cache-aware wrapper around `diff::resolve_workspace_merge_base`.
+///
+/// On a fresh cache hit (entry younger than `MERGE_BASE_CACHE_TTL`), returns
+/// the stored `(sha, worktree_path)` without touching the database or git.
+/// On miss or expiry, runs the full resolution and stores the result.
+///
+/// `merge-base` against a divergent fork can take 4–6 seconds; the polling
+/// callers in the right sidebar (`load_diff_files`) and the file viewer
+/// gutter (`compute_workspace_merge_base`) both consult this so a steady
+/// stream of polls only hits `git` once per TTL window per workspace.
+///
+/// Takes `&MergeBaseCache` and `db_path: &Path` directly rather than
+/// `&AppState` so unit tests can exercise the cache against a temp
+/// `Database` without standing up a full `AppState`.
+async fn cached_resolve_workspace_merge_base(
+    cache: &MergeBaseCache,
+    db_path: &Path,
+    workspace_id: &str,
+) -> Result<(String, String), String> {
+    // Cache lookup first — held only across the read guard, so the slow git
+    // path on miss is never serialized by the lock.
+    {
+        let entries = cache.entries.read().await;
+        if let Some(entry) = entries.get(workspace_id) {
+            if entry.fetched_at.elapsed() < MERGE_BASE_CACHE_TTL {
+                return Ok((entry.sha.clone(), entry.worktree_path.clone()));
+            }
+        }
+    }
+
+    // Miss or expired — resolve the slow way and populate.
+    let db = Database::open(db_path).map_err(|e| e.to_string())?;
+    let (sha, worktree_path) = diff::resolve_workspace_merge_base(&db, workspace_id).await?;
+
+    let mut entries = cache.entries.write().await;
+    entries.insert(
+        workspace_id.to_string(),
+        MergeBaseCacheEntry {
+            sha: sha.clone(),
+            worktree_path: worktree_path.clone(),
+            fetched_at: std::time::Instant::now(),
+        },
+    );
+
+    Ok((sha, worktree_path))
+}
 
 #[derive(serde::Serialize)]
 pub struct DiffFilesResult {
@@ -19,10 +68,9 @@ pub async fn load_diff_files(
     workspace_id: String,
     state: State<'_, AppState>,
 ) -> Result<DiffFilesResult, String> {
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-
     let (merge_base, worktree_path) =
-        diff::resolve_workspace_merge_base(&db, &workspace_id).await?;
+        cached_resolve_workspace_merge_base(&state.merge_base_cache, &state.db_path, &workspace_id)
+            .await?;
     let worktree_path = &worktree_path;
 
     // Get both the flat file list (backward compat) and staged groups
@@ -54,8 +102,7 @@ pub async fn compute_workspace_merge_base(
     workspace_id: String,
     state: State<'_, AppState>,
 ) -> Result<String, String> {
-    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    diff::resolve_workspace_merge_base(&db, &workspace_id)
+    cached_resolve_workspace_merge_base(&state.merge_base_cache, &state.db_path, &workspace_id)
         .await
         .map(|(sha, _)| sha)
 }
@@ -157,4 +204,215 @@ pub async fn load_commit_file_diff(
         .await
         .map_err(|e| e.to_string())?;
     Ok(diff::parse_unified_diff(&raw, &file_path))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for `cached_resolve_workspace_merge_base`.
+    //!
+    //! Pins the contract that motivated the cache: a TTL-fresh repeat call
+    //! for the same workspace must serve from cache without touching the
+    //! database or git. Without this guarantee the polling callers
+    //! (right-sidebar Changes tab, file-viewer git gutter) re-pay the full
+    //! `git merge-base` cost every tick, which on a divergent fork is
+    //! 4–6 seconds each — the exact root cause that produced ~195 stuck
+    //! `git` processes from a single workspace before the fix landed.
+    //!
+    //! The "did the cache really hit?" assertion uses a delete-the-DB
+    //! trick: after the first call populates the cache, we remove the
+    //! SQLite file. A second call within the TTL must succeed anyway —
+    //! proving the path through `Database::open()` was not taken — and
+    //! must return the same SHA it stored on the first miss.
+    use super::*;
+    use claudette::db::Database;
+    use claudette::model::{AgentStatus, Repository, Workspace, WorkspaceStatus};
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git command failed to spawn");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn make_repo_row(id: &str, path: &str) -> Repository {
+        Repository {
+            id: id.into(),
+            path: path.into(),
+            name: "test-repo".into(),
+            path_slug: "test-repo".into(),
+            icon: None,
+            created_at: String::new(),
+            setup_script: None,
+            custom_instructions: None,
+            sort_order: 0,
+            branch_rename_preferences: None,
+            setup_script_auto_run: false,
+            archive_script: None,
+            archive_script_auto_run: false,
+            base_branch: Some("main".into()),
+            default_remote: None,
+            path_valid: true,
+        }
+    }
+
+    fn make_workspace_row(id: &str, repo_id: &str, worktree: &str) -> Workspace {
+        Workspace {
+            // Mirror id into the human-visible name so two workspaces in the
+            // same repo don't collide on the `(repository_id, name)` UNIQUE
+            // constraint.
+            id: id.into(),
+            repository_id: repo_id.into(),
+            name: format!("ws-{id}"),
+            branch_name: format!("branch-{id}"),
+            worktree_path: Some(worktree.into()),
+            status: WorkspaceStatus::Active,
+            agent_status: AgentStatus::Idle,
+            status_line: String::new(),
+            created_at: String::new(),
+            sort_order: 0,
+        }
+    }
+
+    /// Build a tempdir with a divergent main/feature repo + a file-backed
+    /// SQLite db pre-seeded with one repository row and one workspace row
+    /// pointing at the worktree. Returns `(tempdir guard, db_path)`. The
+    /// tempdir owns both the repo and the db file so dropping it cleans
+    /// everything up.
+    fn setup_repo_and_db() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo_dir = tmp.path().join("repo");
+        std::fs::create_dir(&repo_dir).unwrap();
+
+        git(&repo_dir, &["init", "-b", "main"]);
+        git(&repo_dir, &["config", "user.email", "test@test.com"]);
+        git(&repo_dir, &["config", "user.name", "Test"]);
+        git(&repo_dir, &["config", "core.autocrlf", "false"]);
+        std::fs::write(repo_dir.join("a.txt"), "initial\n").unwrap();
+        git(&repo_dir, &["add", "."]);
+        git(&repo_dir, &["commit", "-m", "initial"]);
+        git(&repo_dir, &["checkout", "-b", "feature"]);
+        std::fs::write(repo_dir.join("a.txt"), "feature change\n").unwrap();
+        git(&repo_dir, &["add", "."]);
+        git(&repo_dir, &["commit", "-m", "feature"]);
+
+        let db_path = tmp.path().join("test.sqlite");
+        let db = Database::open(&db_path).expect("open test db");
+        db.insert_repository(&make_repo_row("r1", repo_dir.to_str().unwrap()))
+            .expect("insert repo");
+        db.insert_workspace(&make_workspace_row("w1", "r1", repo_dir.to_str().unwrap()))
+            .expect("insert workspace");
+        // Drop the DB connection so the file is not held open when we
+        // delete it later in the test.
+        drop(db);
+
+        (tmp, db_path)
+    }
+
+    /// Within the TTL window, a repeat call must serve the stored answer
+    /// without re-opening the database. We delete the DB file between calls
+    /// so a recompute would fail loudly — if the test passes, the cache
+    /// truly skipped both DB and git.
+    #[tokio::test]
+    async fn cache_hit_within_ttl_skips_db_and_git() {
+        let (_tmp, db_path) = setup_repo_and_db();
+        let cache = MergeBaseCache::new();
+
+        // First call: miss → resolves and populates.
+        let (sha_first, worktree_first) =
+            cached_resolve_workspace_merge_base(&cache, &db_path, "w1")
+                .await
+                .expect("first call should resolve");
+        assert!(!sha_first.is_empty(), "first SHA must be populated");
+
+        let fetched_at_first = {
+            let entries = cache.entries.read().await;
+            entries
+                .get("w1")
+                .expect("entry must exist after miss")
+                .fetched_at
+        };
+
+        // Make a recompute impossible. If the cache is broken and the next
+        // call falls through to `Database::open(...)`, it will fail.
+        std::fs::remove_file(&db_path).expect("delete db file");
+
+        // Second call within the TTL window must hit cache.
+        let (sha_second, worktree_second) =
+            cached_resolve_workspace_merge_base(&cache, &db_path, "w1")
+                .await
+                .expect("cached hit must succeed even with the database removed");
+
+        assert_eq!(
+            sha_first, sha_second,
+            "cache must return the same SHA on hit"
+        );
+        assert_eq!(
+            worktree_first, worktree_second,
+            "cache must return the same worktree path on hit"
+        );
+
+        let fetched_at_second = {
+            let entries = cache.entries.read().await;
+            entries
+                .get("w1")
+                .expect("entry must still exist on hit")
+                .fetched_at
+        };
+        assert_eq!(
+            fetched_at_first, fetched_at_second,
+            "cache hit must not refresh the entry's fetched_at — that would imply a recompute"
+        );
+    }
+
+    /// A different `workspace_id` must not be served by another workspace's
+    /// cache entry. Pins the cache key contract (workspace_id, not repo_id
+    /// or worktree path).
+    #[tokio::test]
+    async fn cache_does_not_cross_workspaces() {
+        let (tmp, db_path) = setup_repo_and_db();
+
+        // Add a second workspace pointing at the same worktree (a real DB
+        // would have a separate worktree per workspace, but the cache logic
+        // doesn't care — we only need a distinct workspace_id that the DB
+        // can resolve).
+        let db = Database::open(&db_path).expect("reopen db");
+        db.insert_workspace(&make_workspace_row(
+            "w2",
+            "r1",
+            tmp.path().join("repo").to_str().unwrap(),
+        ))
+        .expect("insert second workspace");
+        drop(db);
+
+        let cache = MergeBaseCache::new();
+
+        // Populate w1.
+        let _ = cached_resolve_workspace_merge_base(&cache, &db_path, "w1")
+            .await
+            .expect("populate w1");
+
+        // w2 must miss — its entry doesn't exist yet.
+        {
+            let entries = cache.entries.read().await;
+            assert!(entries.contains_key("w1"));
+            assert!(!entries.contains_key("w2"));
+        }
+
+        let _ = cached_resolve_workspace_merge_base(&cache, &db_path, "w2")
+            .await
+            .expect("populate w2");
+
+        // Both must now be cached as distinct entries.
+        let entries = cache.entries.read().await;
+        assert!(entries.contains_key("w1"));
+        assert!(entries.contains_key("w2"));
+    }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use claudette::agent::PersistentSession;
 use tokio::sync::{RwLock, Semaphore};
@@ -411,6 +411,54 @@ impl ScmCache {
     }
 }
 
+/// Cached `git merge-base <base_branch> HEAD` lookup for a single workspace.
+///
+/// Note `base_branch` is intentionally NOT part of the entry. If the user
+/// changes the repo's base branch in Settings, a stale entry can serve the
+/// previous-branch SHA for up to one TTL window, after which the natural
+/// expiration recomputes against the new branch. We accept that 10s
+/// transient over the alternative — a synchronous DB read on every cache
+/// hit just to detect a near-zero-frequency config change.
+pub struct MergeBaseCacheEntry {
+    pub sha: String,
+    pub worktree_path: String,
+    pub fetched_at: Instant,
+}
+
+/// Short-TTL cache for `git merge-base` lookups, keyed by `workspace_id`.
+///
+/// Exists because `merge-base` is by far the slowest piece of
+/// `load_diff_files`: on a huge repo whose `origin/<base>` has drifted
+/// far from `HEAD` (e.g. a `nixpkgs` fork whose master is 60k+ commits
+/// behind upstream after a fast-forward of `upstream/master`), each call
+/// can take 4–6 seconds. The right-sidebar Changes tab and the file
+/// viewer's git gutter both call it on a polling cadence whether anything
+/// moved or not, so without a cache every tick spawns a `git` process even
+/// though the answer is the same.
+///
+/// The frontend dedup guards against pile-up within a single panel; this
+/// cache cuts the baseline cost so even the unguarded one-shot callers
+/// (workspace selection, post-stop refresh, file viewer gutter) stop
+/// paying full price when the answer hasn't moved. TTL is intentionally
+/// short — `merge-base` only changes when HEAD or `origin/<base>` move,
+/// both of which are user-initiated git ops, so a 10s window is invisible
+/// in practice while still bounding staleness after a manual `git fetch`.
+pub struct MergeBaseCache {
+    pub entries: RwLock<HashMap<String, MergeBaseCacheEntry>>,
+}
+
+impl MergeBaseCache {
+    pub fn new() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+/// TTL for `MergeBaseCache` entries. See `MergeBaseCache` doc comment for
+/// the full rationale on why this is short.
+pub const MERGE_BASE_CACHE_TTL: Duration = Duration::from_secs(10);
+
 /// Application-wide managed state, shared across all Tauri commands.
 pub struct AppState {
     pub db_path: PathBuf,
@@ -471,6 +519,9 @@ pub struct AppState {
     pub file_watcher: RwLock<Option<Arc<FileWatcher>>>,
     /// Cached PR/CI status data keyed by (repo_id, branch_name).
     pub scm_cache: ScmCache,
+    /// Short-TTL cache for `git merge-base <base_branch> HEAD`, keyed by
+    /// workspace_id. See `MergeBaseCache` doc comment for the full rationale.
+    pub merge_base_cache: MergeBaseCache,
     /// Limits concurrent SCM CLI invocations.
     pub scm_semaphore: Arc<Semaphore>,
     /// Pending updater handle from the most recent `check_for_updates_with_channel`
@@ -516,6 +567,7 @@ impl AppState {
             env_watcher: RwLock::new(None),
             file_watcher: RwLock::new(None),
             scm_cache: ScmCache::new(),
+            merge_base_cache: MergeBaseCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),
             cesp_playback: Mutex::new(claudette::cesp::SoundPlaybackState::new()),

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -67,11 +67,21 @@ export function FilesPanel() {
   // `listWorkspaceFiles` can outlive the polling cadence, in which case
   // unguarded ticks would pile up faster than they drain — the same shape
   // that produced ~195 stuck `git` processes from RightSidebar's diff
-  // polling on a divergent nixpkgs fork. Polling ticks consult this ref
-  // and skip when the previous load is still in flight; one-shot loads
-  // (workspace select, post-stop refresh) always run but flip the ref so
-  // a polling tick that fires inside their window doesn't double-up.
-  const loadFilesInFlightRef = useRef(false);
+  // polling on a divergent nixpkgs fork. Polling ticks consult this counter
+  // and skip when any previous load is still in flight; one-shot loads
+  // (workspace select, post-stop refresh, refreshNonce-driven reload)
+  // always run but bump the counter so a polling tick fired inside their
+  // window doesn't double up.
+  //
+  // A counter (rather than a boolean) is required because overlapping loads
+  // are possible across rapid workspace switches or back-to-back
+  // `refreshNonce` bumps: switching to workspace B while workspace A's
+  // load is still pending kicks off B while A keeps running, and A's
+  // earlier-resolving `.finally` would clear a boolean flag while B is
+  // still in flight, reopening the polling gate. Decrementing only when
+  // each individual call's `finally` runs keeps the gate closed until the
+  // last in-flight load drains.
+  const loadFilesInFlightCount = useRef(0);
   const prevIsRunning = useRef(false);
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = isAgentBusy(ws?.agent_status);
@@ -87,7 +97,7 @@ export function FilesPanel() {
         setLoading(true);
       }
       setError(null);
-      loadFilesInFlightRef.current = true;
+      loadFilesInFlightCount.current += 1;
       try {
         const result = await listWorkspaceFiles(workspaceId);
         if (version !== loadVersionRef.current) return;
@@ -100,7 +110,7 @@ export function FilesPanel() {
         setError(String(e));
         setLoading(false);
       } finally {
-        loadFilesInFlightRef.current = false;
+        loadFilesInFlightCount.current -= 1;
       }
     },
     [],
@@ -121,8 +131,8 @@ export function FilesPanel() {
     if (!selectedWorkspaceId || !isRunning) return;
     const interval = setInterval(() => {
       // Skip when a previous load is still in flight — see
-      // `loadFilesInFlightRef` declaration above for the pileup rationale.
-      if (loadFilesInFlightRef.current) return;
+      // `loadFilesInFlightCount` declaration above for the pileup rationale.
+      if (loadFilesInFlightCount.current > 0) return;
       void loadFiles(selectedWorkspaceId, false);
     }, FILES_AGENT_RUNNING_INTERVAL_MS);
     return () => clearInterval(interval);
@@ -148,8 +158,8 @@ export function FilesPanel() {
     if (!selectedWorkspaceId || isRunning) return;
     const interval = setInterval(() => {
       // Skip when a previous load is still in flight — see
-      // `loadFilesInFlightRef` declaration above for the pileup rationale.
-      if (loadFilesInFlightRef.current) return;
+      // `loadFilesInFlightCount` declaration above for the pileup rationale.
+      if (loadFilesInFlightCount.current > 0) return;
       void loadFiles(selectedWorkspaceId, false);
     }, IDLE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);

--- a/src/ui/src/components/files/FilesPanel.tsx
+++ b/src/ui/src/components/files/FilesPanel.tsx
@@ -61,6 +61,17 @@ export function FilesPanel() {
   );
   const [focusRequest, setFocusRequest] = useState(0);
   const loadVersionRef = useRef(0);
+  // Dedup guard for the active + idle polling intervals. The version-token
+  // above coalesces overlapping responses (latest wins for UI state) but
+  // does not prevent overlapping dispatches. On a slow worktree
+  // `listWorkspaceFiles` can outlive the polling cadence, in which case
+  // unguarded ticks would pile up faster than they drain — the same shape
+  // that produced ~195 stuck `git` processes from RightSidebar's diff
+  // polling on a divergent nixpkgs fork. Polling ticks consult this ref
+  // and skip when the previous load is still in flight; one-shot loads
+  // (workspace select, post-stop refresh) always run but flip the ref so
+  // a polling tick that fires inside their window doesn't double-up.
+  const loadFilesInFlightRef = useRef(false);
   const prevIsRunning = useRef(false);
   const ws = workspaces.find((w) => w.id === selectedWorkspaceId);
   const isRunning = isAgentBusy(ws?.agent_status);
@@ -76,6 +87,7 @@ export function FilesPanel() {
         setLoading(true);
       }
       setError(null);
+      loadFilesInFlightRef.current = true;
       try {
         const result = await listWorkspaceFiles(workspaceId);
         if (version !== loadVersionRef.current) return;
@@ -87,6 +99,8 @@ export function FilesPanel() {
         if (useAppStore.getState().selectedWorkspaceId !== workspaceId) return;
         setError(String(e));
         setLoading(false);
+      } finally {
+        loadFilesInFlightRef.current = false;
       }
     },
     [],
@@ -106,6 +120,9 @@ export function FilesPanel() {
   useEffect(() => {
     if (!selectedWorkspaceId || !isRunning) return;
     const interval = setInterval(() => {
+      // Skip when a previous load is still in flight — see
+      // `loadFilesInFlightRef` declaration above for the pileup rationale.
+      if (loadFilesInFlightRef.current) return;
       void loadFiles(selectedWorkspaceId, false);
     }, FILES_AGENT_RUNNING_INTERVAL_MS);
     return () => clearInterval(interval);
@@ -130,6 +147,9 @@ export function FilesPanel() {
   useEffect(() => {
     if (!selectedWorkspaceId || isRunning) return;
     const interval = setInterval(() => {
+      // Skip when a previous load is still in flight — see
+      // `loadFilesInFlightRef` declaration above for the pileup rationale.
+      if (loadFilesInFlightRef.current) return;
       void loadFiles(selectedWorkspaceId, false);
     }, IDLE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -76,12 +76,20 @@ export const RightSidebar = memo(function RightSidebar() {
   // upstream/master, exceeding the 3s active polling cadence), unguarded
   // ticks pile up faster than they drain — each tick fans out 4 git
   // invocations on the Rust side and the resulting `git` swarm pegs the
-  // machine. The interval ticks consult this ref and skip a tick whenever
-  // the previous fetch is still in flight; one-shot loads (initial select,
-  // post-stop refresh) always run but still flip the ref so a polling tick
-  // that fires inside their window doesn't double-up either. Cleared in
-  // `.finally` so an error path can't permanently wedge the guard.
-  const loadDiffInFlightRef = useRef(false);
+  // machine. The interval ticks consult this counter and skip a tick
+  // whenever any previous fetch is still in flight; one-shot loads (initial
+  // select, post-stop refresh) always run but still bump the counter so a
+  // polling tick that fires inside their window doesn't double up.
+  //
+  // A counter (rather than a boolean) is required because overlapping loads
+  // are possible across workspace switches: switching to workspace B while
+  // workspace A's load is still pending starts B's load while A is still
+  // running, and A's earlier-resolving `.finally` would open the gate while
+  // B is still in flight if the guard were a boolean. Decrementing only
+  // when each individual dispatch resolves keeps the gate closed until the
+  // last in-flight load drains. Decrement lives in `.finally` so an error
+  // path can't permanently wedge the gate.
+  const loadDiffInFlightCount = useRef(0);
 
   const activeSessionId = useAppStore(selectActiveSessionId);
   const { totalCount: taskCount } = useTaskTracker(activeSessionId);
@@ -182,7 +190,7 @@ export const RightSidebar = memo(function RightSidebar() {
     setDiffLoading(true);
     const version = ++diffLoadVersion.current;
     const workspaceId = selectedWorkspaceId;
-    loadDiffInFlightRef.current = true;
+    loadDiffInFlightCount.current += 1;
     loadDiff(workspaceId)
       .then((result) => {
         if (!isDiffResultStillValid(workspaceId, version)) return;
@@ -194,7 +202,7 @@ export const RightSidebar = memo(function RightSidebar() {
         setDiffLoading(false);
       })
       .finally(() => {
-        loadDiffInFlightRef.current = false;
+        loadDiffInFlightCount.current -= 1;
       });
   }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid]);
 
@@ -207,9 +215,9 @@ export const RightSidebar = memo(function RightSidebar() {
       // Skip this tick if the previous fetch hasn't resolved. Without this,
       // on a slow repo each `git merge-base` outlives the 3s polling
       // cadence and the swarm grows linearly until the machine melts.
-      if (loadDiffInFlightRef.current) return;
+      if (loadDiffInFlightCount.current > 0) return;
       const version = ++diffLoadVersion.current;
-      loadDiffInFlightRef.current = true;
+      loadDiffInFlightCount.current += 1;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
@@ -217,7 +225,7 @@ export const RightSidebar = memo(function RightSidebar() {
         })
         .catch(() => {})
         .finally(() => {
-          loadDiffInFlightRef.current = false;
+          loadDiffInFlightCount.current -= 1;
         });
     }, DIFF_AGENT_RUNNING_INTERVAL_MS);
 
@@ -235,7 +243,7 @@ export const RightSidebar = memo(function RightSidebar() {
     const timer = setTimeout(() => {
       setDiffLoading(true);
       const version = ++diffLoadVersion.current;
-      loadDiffInFlightRef.current = true;
+      loadDiffInFlightCount.current += 1;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
@@ -248,7 +256,7 @@ export const RightSidebar = memo(function RightSidebar() {
           setDiffLoading(false);
         })
         .finally(() => {
-          loadDiffInFlightRef.current = false;
+          loadDiffInFlightCount.current -= 1;
         });
     }, 500);
 
@@ -267,9 +275,9 @@ export const RightSidebar = memo(function RightSidebar() {
       // See active-polling effect above: skip tick when previous fetch is
       // still in flight. The 10s idle cadence rarely overlaps in practice,
       // but a concurrent `git fetch` can push merge-base latency past it.
-      if (loadDiffInFlightRef.current) return;
+      if (loadDiffInFlightCount.current > 0) return;
       const version = ++diffLoadVersion.current;
-      loadDiffInFlightRef.current = true;
+      loadDiffInFlightCount.current += 1;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
@@ -277,7 +285,7 @@ export const RightSidebar = memo(function RightSidebar() {
         })
         .catch(() => {})
         .finally(() => {
-          loadDiffInFlightRef.current = false;
+          loadDiffInFlightCount.current -= 1;
         });
     }, IDLE_REFRESH_INTERVAL_MS);
 

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -69,6 +69,19 @@ export const RightSidebar = memo(function RightSidebar() {
   // preserved) means stale data from workspace A would render until B's
   // fetch resolves.
   const diffLoadVersion = useRef(0);
+  // Dedup guard for the two polling intervals. The version-token above is a
+  // *coalescing* pattern (latest response wins for UI state); it does not
+  // prevent overlapping dispatches. On a slow repo (e.g. nixpkgs where
+  // `git merge-base origin/master HEAD` takes ~6s after a fast-forward of
+  // upstream/master, exceeding the 3s active polling cadence), unguarded
+  // ticks pile up faster than they drain — each tick fans out 4 git
+  // invocations on the Rust side and the resulting `git` swarm pegs the
+  // machine. The interval ticks consult this ref and skip a tick whenever
+  // the previous fetch is still in flight; one-shot loads (initial select,
+  // post-stop refresh) always run but still flip the ref so a polling tick
+  // that fires inside their window doesn't double-up either. Cleared in
+  // `.finally` so an error path can't permanently wedge the guard.
+  const loadDiffInFlightRef = useRef(false);
 
   const activeSessionId = useAppStore(selectActiveSessionId);
   const { totalCount: taskCount } = useTaskTracker(activeSessionId);
@@ -169,6 +182,7 @@ export const RightSidebar = memo(function RightSidebar() {
     setDiffLoading(true);
     const version = ++diffLoadVersion.current;
     const workspaceId = selectedWorkspaceId;
+    loadDiffInFlightRef.current = true;
     loadDiff(workspaceId)
       .then((result) => {
         if (!isDiffResultStillValid(workspaceId, version)) return;
@@ -178,6 +192,9 @@ export const RightSidebar = memo(function RightSidebar() {
       .catch(() => {
         if (!isDiffResultStillValid(workspaceId, version)) return;
         setDiffLoading(false);
+      })
+      .finally(() => {
+        loadDiffInFlightRef.current = false;
       });
   }, [selectedWorkspaceId, loadDiff, applyDiffResult, setDiffLoading, clearDiff, isDiffResultStillValid]);
 
@@ -187,13 +204,21 @@ export const RightSidebar = memo(function RightSidebar() {
     const workspaceId = selectedWorkspaceId;
 
     const interval = setInterval(() => {
+      // Skip this tick if the previous fetch hasn't resolved. Without this,
+      // on a slow repo each `git merge-base` outlives the 3s polling
+      // cadence and the swarm grows linearly until the machine melts.
+      if (loadDiffInFlightRef.current) return;
       const version = ++diffLoadVersion.current;
+      loadDiffInFlightRef.current = true;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
           applyDiffResult(result);
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => {
+          loadDiffInFlightRef.current = false;
+        });
     }, DIFF_AGENT_RUNNING_INTERVAL_MS);
 
     return () => clearInterval(interval);
@@ -210,6 +235,7 @@ export const RightSidebar = memo(function RightSidebar() {
     const timer = setTimeout(() => {
       setDiffLoading(true);
       const version = ++diffLoadVersion.current;
+      loadDiffInFlightRef.current = true;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
@@ -220,6 +246,9 @@ export const RightSidebar = memo(function RightSidebar() {
           if (!isDiffResultStillValid(workspaceId, version)) return;
           console.error("Failed to refresh diff files:", e);
           setDiffLoading(false);
+        })
+        .finally(() => {
+          loadDiffInFlightRef.current = false;
         });
     }, 500);
 
@@ -235,13 +264,21 @@ export const RightSidebar = memo(function RightSidebar() {
     const workspaceId = selectedWorkspaceId;
 
     const interval = setInterval(() => {
+      // See active-polling effect above: skip tick when previous fetch is
+      // still in flight. The 10s idle cadence rarely overlaps in practice,
+      // but a concurrent `git fetch` can push merge-base latency past it.
+      if (loadDiffInFlightRef.current) return;
       const version = ++diffLoadVersion.current;
+      loadDiffInFlightRef.current = true;
       loadDiff(workspaceId)
         .then((result) => {
           if (!isDiffResultStillValid(workspaceId, version)) return;
           applyDiffResult(result);
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => {
+          loadDiffInFlightRef.current = false;
+        });
     }, IDLE_REFRESH_INTERVAL_MS);
 
     return () => clearInterval(interval);


### PR DESCRIPTION
## Summary

Fixes a polling pileup that produced ~195 stuck `git` processes from a single workspace and pegged WindowServer + fseventsd hard enough to make the machine unusable.

**Root cause:** The right-sidebar Changes panel and the file-viewer git gutter both poll `load_diff_files` on a fixed `setInterval` (3 s active / 10 s idle). Each tick fans out four git invocations (`merge-base`, two `diff --name-status/--numstat` pairs, `log --pretty=...`). The existing `diffLoadVersion` ref is a *coalescing* token (latest response wins for UI state); it does not prevent overlapping dispatches.

On a huge repo whose `origin/<base>` has drifted from `HEAD` — concretely: a nixpkgs fork whose `origin/master` is 60k+ commits behind `HEAD` after a fast-forward of `upstream/master` without a corresponding push — `git merge-base origin/master HEAD` takes 4–6 seconds. New ticks pile up faster than they drain. Linear growth, no recovery.

**Two complementary fixes:**

| Layer | File(s) | Change |
|---|---|---|
| Frontend dedup | `RightSidebar.tsx`, `FilesPanel.tsx` | `useRef<boolean>` in-flight guard. Polling ticks bail when the previous fetch is still pending; one-shot loads (workspace selection, post-stop refresh) still run unconditionally but flip the ref so a tick that fires inside their window doesn't double up. Cleared in `.finally` so an error path can't permanently wedge the guard. |
| Backend cache | `state.rs`, `commands/diff.rs` | New `MergeBaseCache` in `AppState` (mirroring `ScmCache`'s shape), keyed by `workspace_id`. `cached_resolve_workspace_merge_base` checks the cache before opening the database or invoking git; hits within the **10 s TTL** skip both. |

**TTL choice rationale:** 10 s matches the idle polling cadence, so steady-state polls touch git at most once per workspace per 10 s. `merge-base` only changes when HEAD or `origin/<base>` move — both are user-initiated git ops — so the staleness window is invisible in practice. `base_branch` is intentionally NOT part of the cache entry: TTL bounds staleness after a settings change without paying a synchronous DB read on every cache hit.

## Complexity Notes

**Coalescing vs deduplication (the trap behind this bug).** The version-token pattern that was already in `RightSidebar` (`diffLoadVersion.current`) is a *coalescing* pattern — last response wins for UI state. It's structurally distinct from a *deduplication* pattern, which prevents overlapping invocations in the first place. They look identical at a glance because both involve refs and bumping counters. The trap: coalescing is correct when the upstream work is cheap, and silently fatal when it isn't. The same file's `gitOpInFlight` state (used for stage/unstage/discard, line 95) is the dedup pattern done right; the polling loop just never adopted it. Inline comments call out which is which so the next refactor doesn't reintroduce the bug.

**Out of scope:** The `claudette-server` crate (`src-server/src/handler.rs:952`) has its own copy of merge-base resolution for remote-connection clients. The frontend dedup still covers the remote path, but a parallel backend cache there would need a separate PR — it's a different `state` shape and lifetime.

**Cache-helper signature.** I narrowed `cached_resolve_workspace_merge_base` to take `(&MergeBaseCache, &Path, &str)` rather than `&AppState` so the regression tests can exercise it against a real temp DB without standing up a full `AppState` (which would pull in voice, plugins, etc.). The two Tauri commands pass `&state.merge_base_cache, &state.db_path, ...` at the call site.

## Test Steps

**Automated (already passing):**

```bash
# Backend tests (includes the two new cache regression tests)
nix develop -c cargo test -p claudette-tauri --all-features commands::diff::tests
# → cache_hit_within_ttl_skips_db_and_git ... ok
# → cache_does_not_cross_workspaces        ... ok

# CI suite
nix develop -c cargo test -p claudette -p claudette-server -p claudette-cli --all-features
RUSTFLAGS="-Dwarnings" nix develop -c cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features
nix develop -c cargo fmt --all --check
cd src/ui && nix develop --command bash -c 'bunx tsc -b && bun run test && bun run lint && bun run lint:css'
```

**Manual repro (verifies the fix end-to-end):**

1. Add a workspace pointing at any large fork. Cheapest setup that reproduces:
   ```bash
   cd /tmp && git clone https://github.com/<your-fork>/nixpkgs.git
   cd nixpkgs && git remote add upstream https://github.com/NixOS/nixpkgs.git
   git fetch upstream && git merge upstream/master   # creates the divergence (do NOT push)
   ```
   Then add it to Claudette as a repo and create a workspace from `feature` (or any branch).
2. Open the workspace in Claudette and select the **Changes** panel. Start any chat turn so the agent is "running" (active polling cadence kicks in at 3 s).
3. **Before the fix** (revert this commit and rerun): `ps -Ao pid,etime,command | grep merge-base | wc -l` climbs steadily past 50 → 100 → 200 within minutes.
4. **With the fix:** the same `ps` output stays at 0–1 ongoing `merge-base` processes regardless of how long the agent runs. The Changes panel still updates as files change.
5. Idle test: stop the agent. With Changes panel open and selected, leave it idle for a minute. Same `ps` invocation should show essentially no merge-base activity (steady-state hits the 10 s cache).

**Cache-hit observability** (optional, for verifying the cache is actually engaged):

```bash
# Manually time a single load_diff_files invocation cold vs warm:
# 1. Open the workspace fresh (cold cache) — Changes panel takes 4–6 s.
# 2. Switch tabs and back within 10 s — Changes panel renders instantly.
# 3. Wait > 10 s, switch back — first refresh pays full cost again.
```

## Checklist

- [x] Tests added (`cache_hit_within_ttl_skips_db_and_git`, `cache_does_not_cross_workspaces`)
- [x] No documentation changes needed — pure performance/correctness fix; no new settings, commands, or user-visible UI
- [x] Lint, clippy, fmt, tsc, vitest all green locally
- [x] Rebased on current `origin/main`
