### PR TITLE
fix: keep close-tab focus on left neighbor

### DIFF
--- a/src/ui/src/hotkeys/contextActions.test.ts
+++ b/src/ui/src/hotkeys/contextActions.test.ts
@@ -268,6 +268,25 @@ describe("executeCloseTab", () => {
     expect(archiveChatSession).toHaveBeenCalledWith("a");
   });
 
+  it("chat context: after Cmd+W closes a session, selects the tab to its left", async () => {
+    useAppStore.setState({
+      sessionsByWorkspace: {
+        [WS]: [makeSession("a"), makeSession("b"), makeSession("c")],
+      },
+      selectedSessionIdByWorkspaceId: { [WS]: "c" },
+    });
+    const confirm = vi.fn().mockResolvedValue(true);
+    const archiveChatSession = vi.fn().mockResolvedValue(null);
+
+    executeCloseTab({ confirm, archiveChatSession });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const post = useAppStore.getState();
+    expect(post.sessionsByWorkspace[WS]?.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(post.selectedSessionIdByWorkspaceId[WS]).toBe("b");
+  });
+
   it("chat context: cancelled confirm leaves state untouched", async () => {
     const session = makeSession("a");
     useAppStore.setState({

--- a/src/ui/src/stores/slices/chatSessionsSlice.ts
+++ b/src/ui/src/stores/slices/chatSessionsSlice.ts
@@ -75,13 +75,18 @@ export const createChatSessionsSlice: StateCreator<
       const nextSelected = { ...s.selectedSessionIdByWorkspaceId };
       for (const [wsId, sessions] of Object.entries(next)) {
         if (sessions.some((x) => x.id === sessionId)) {
+          const activeSessions = sessions.filter((x) => x.status === "Active");
+          const activeIdx = activeSessions.findIndex((x) => x.id === sessionId);
           next[wsId] = sessions.filter((x) => x.id !== sessionId);
           if (nextSelected[wsId] === sessionId) {
-            const firstActive = next[wsId].find(
-              (x) => x.status === "Active",
-            );
-            if (firstActive) {
-              nextSelected[wsId] = firstActive.id;
+            const adjacentActive =
+              activeIdx > 0
+                ? activeSessions[activeIdx - 1]
+                : activeIdx === 0
+                  ? activeSessions[1]
+                  : next[wsId].find((x) => x.status === "Active");
+            if (adjacentActive) {
+              nextSelected[wsId] = adjacentActive.id;
             } else {
               delete nextSelected[wsId];
             }

--- a/src/ui/src/stores/useAppStore.fileTree.test.ts
+++ b/src/ui/src/stores/useAppStore.fileTree.test.ts
@@ -92,6 +92,20 @@ describe("file path store updates", () => {
     expect(state.fileBuffers[`${WS}:b.ts`]).toBeUndefined();
   });
 
+  it("closes an active file tab and selects the tab to its left", () => {
+    openLoadedFile("a.ts");
+    openLoadedFile("b.ts");
+    openLoadedFile("c.ts");
+    useAppStore.getState().selectFileTab(WS, "c.ts");
+
+    useAppStore.getState().closeFileTab(WS, "c.ts");
+
+    const state = useAppStore.getState();
+    expect(state.fileTabsByWorkspace[WS]).toEqual(["a.ts", "b.ts"]);
+    expect(state.activeFileTabByWorkspace[WS]).toBe("b.ts");
+    expect(state.fileBuffers[`${WS}:c.ts`]).toBeUndefined();
+  });
+
   it("removes all child file tabs when a folder is deleted", () => {
     openLoadedFile("src/components/Button.tsx");
     openLoadedFile("src/components/Card.tsx");


### PR DESCRIPTION
## Summary

Fixes the Cmd/Ctrl+W close-tab behavior for chat sessions so focus moves to the tab immediately to the left of the closed session. Previously, the store selected the first remaining active session after removing the selected session, which made closing a rightmost or middle chat tab jump farther left than expected.

This also adds regression coverage for file tabs to lock in the matching behavior there: closing the active file tab selects the tab to its left when one exists.

## Root Cause

`removeChatSession` rebuilt the workspace session list and, when the closed session was selected, chose the first remaining active session. That did not preserve tab-strip adjacency. File tabs already had the desired left-neighbor behavior in `closeFileTab`, so the chat session selection logic was brought into alignment.

## Changes

- Update chat session removal to select the previous active session when closing the selected session.
- Fall back to the next active session only when the closed tab has no left neighbor.
- Add a Cmd+W regression test for closing the rightmost chat session and selecting the left neighbor.
- Add a file-tab regression test confirming active file tab close selects the left neighbor.

## Validation

- `cd src/ui && bun run test src/hotkeys/contextActions.test.ts src/stores/useAppStore.fileTree.test.ts`
- `cd src/ui && bunx tsc -b`