### PR TITLE
feat(chat): per-turn edit summary card with inline diffs and Monaco open

### DIFF
--- a/site/src/content/docs/features/diff-viewer.mdx
+++ b/site/src/content/docs/features/diff-viewer.mdx
@@ -29,7 +29,7 @@ The removed version on the left, the added version on the right. Corresponding c
 
 The **right sidebar** (`⌘/Ctrl + D` to toggle) displays a list of all files that have been changed in the current workspace. Click any file to jump to its diff.
 
-When the agent edits files, the chat timeline also shows a compact change summary: live edit tool calls include the file path plus added/removed line counts, and the completed turn ends with a per-file summary card. Use that as a quick scan, then open the diff panel for full review.
+When the agent edits files, the chat timeline also shows a compact change summary: live edit tool calls include the file path plus added/removed line counts, and the completed turn ends with a per-file summary card. Click a file in the card to expand a lightweight inline diff preview, then open the diff panel for full review.
 
 ## Change Groups
 

--- a/site/src/content/docs/features/diff-viewer.mdx
+++ b/site/src/content/docs/features/diff-viewer.mdx
@@ -29,6 +29,8 @@ The removed version on the left, the added version on the right. Corresponding c
 
 The **right sidebar** (`⌘/Ctrl + D` to toggle) displays a list of all files that have been changed in the current workspace. Click any file to jump to its diff.
 
+When the agent edits files, the chat timeline also shows a compact change summary: live edit tool calls include the file path plus added/removed line counts, and the completed turn ends with a per-file summary card. Use that as a quick scan, then open the diff panel for full review.
+
 ## Change Groups
 
 The changed files list organizes files into collapsible sections, one per git layer:

--- a/src/ui/src/components/chat/AgentToolCallGroup.tsx
+++ b/src/ui/src/components/chat/AgentToolCallGroup.tsx
@@ -7,6 +7,8 @@ import {
   activitySummaryText,
   agentToolCallSummary,
 } from "./agentToolCallRendering";
+import { InlineEditSummary } from "./EditChangeSummary";
+import { summarizeAgentToolCallEdit } from "./editActivitySummary";
 
 export function AgentToolCallGroup({
   activity,
@@ -61,15 +63,24 @@ export function AgentToolCallGroup({
       <div className={styles.agentToolCallList}>
         {calls.map((call) => {
           const callSummary = agentToolCallSummary(call);
+          const editSummary = summarizeAgentToolCallEdit(call);
           return (
             <div key={call.toolUseId} className={styles.agentToolCall}>
-              <span
-                className={styles.agentToolCallName}
-                style={{ color: toolColor(call.toolName) }}
-              >
-                {call.toolName}
-              </span>
-              {callSummary && (
+              {editSummary ? (
+                <InlineEditSummary
+                  summary={editSummary}
+                  searchQuery={searchQuery}
+                  worktreePath={worktreePath}
+                />
+              ) : (
+                <span
+                  className={styles.agentToolCallName}
+                  style={{ color: toolColor(call.toolName) }}
+                >
+                  {call.toolName}
+                </span>
+              )}
+              {!editSummary && callSummary && (
                 <span className={styles.agentToolCallSummary}>
                   <HighlightedPlainText
                     text={relativizePath(callSummary, worktreePath)}

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -289,21 +289,24 @@ export function ChatInputArea({
     const ta = textareaRef.current;
     const start = ta?.selectionStart ?? cursorPos;
     const end = ta?.selectionEnd ?? cursorPos;
-    setChatInput((currentInput) => {
-      const next = insertTranscriptAtSelection(
-        currentInput,
-        transcript,
-        start,
-        end,
-      );
-      setCursorPos(next.cursor);
-      requestAnimationFrame(() => {
-        const current = textareaRef.current;
-        if (!current) return;
-        current.focus();
-        current.selectionStart = current.selectionEnd = next.cursor;
-      });
-      return next.text;
+    // Compute the next state outside the updater so the updater stays
+    // pure. React may run a `setX(updater)` updater multiple times
+    // (Strict Mode, concurrent rendering); calling other setters from
+    // inside it triggers the "Cannot update a component while
+    // rendering" dev warning and risks compounding side-effects.
+    const next = insertTranscriptAtSelection(
+      ta?.value ?? "",
+      transcript,
+      start,
+      end,
+    );
+    setChatInput(next.text);
+    setCursorPos(next.cursor);
+    requestAnimationFrame(() => {
+      const current = textareaRef.current;
+      if (!current) return;
+      current.focus();
+      current.selectionStart = current.selectionEnd = next.cursor;
     });
   }, [cursorPos]);
 

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -461,6 +461,102 @@
   outline-offset: 1px;
 }
 
+.turnEditSummary {
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  margin: 4px 0;
+  overflow: hidden;
+  background: var(--chat-input-bg);
+}
+
+.turnEditSummaryHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--divider);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.turnEditSummaryTitle {
+  min-width: 0;
+}
+
+.turnEditFileList {
+  display: flex;
+  flex-direction: column;
+}
+
+.turnEditFileRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 7px 10px;
+  border-top: 1px solid var(--divider);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.turnEditFileRow:first-child {
+  border-top: none;
+}
+
+.turnEditFilePath {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inlineEditSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.inlineEditIcon {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.inlineEditVerb {
+  flex: 0 0 auto;
+  color: var(--text-dim);
+}
+
+.inlineEditPath {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--accent-primary);
+}
+
+.changeStats {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.changeStatsAdded {
+  color: var(--diff-added-text);
+}
+
+.changeStatsRemoved {
+  color: var(--diff-removed-text);
+}
+
 .taskProgressBar {
   display: flex;
   align-items: center;

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -568,7 +568,11 @@
 
 .turnEditDiffLine {
   display: grid;
-  grid-template-columns: 44px 44px 18px minmax(0, 1fr);
+  /* No +/- prefix column — the row background and line-number gutter
+   * already encode added/removed. Matches Codex chat and the GitHub
+   * PR view. Compact 40px gutters keep four-digit line numbers
+   * legible without dominating the row. */
+  grid-template-columns: 40px 40px minmax(0, 1fr);
   min-height: 22px;
   color: var(--text-dim);
 }
@@ -589,24 +593,9 @@
   border-right: 1px solid var(--divider);
 }
 
-.turnEditDiffPrefix {
-  text-align: center;
-  color: var(--text-faint);
-}
-
-.turnEditDiffLineAdded .turnEditDiffPrefix {
-  color: var(--diff-added-text);
-  font-weight: 600;
-}
-
-.turnEditDiffLineRemoved .turnEditDiffPrefix {
-  color: var(--diff-removed-text);
-  font-weight: 600;
-}
-
 .turnEditDiffContent {
   min-width: 0;
-  padding-left: 4px;
+  padding-left: 8px;
   overflow: hidden;
   color: var(--text-primary);
   font: inherit;

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -489,27 +489,121 @@
   flex-direction: column;
 }
 
+.turnEditFile {
+  border-top: 1px solid var(--divider);
+}
+
+.turnEditFile:first-child {
+  border-top: none;
+}
+
 .turnEditFileRow {
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
   min-width: 0;
   padding: 7px 10px;
-  border-top: 1px solid var(--divider);
+  border: none;
+  background: transparent;
   color: var(--text-dim);
   font-family: var(--font-mono);
   font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.turnEditFileRow:first-child {
-  border-top: none;
+.turnEditFileRow:hover:not(:disabled) {
+  background: var(--hover-bg-subtle);
+  color: var(--text-primary);
+}
+
+.turnEditFileRow:disabled {
+  cursor: default;
+  opacity: 1;
 }
 
 .turnEditFilePath {
   min-width: 0;
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.turnEditFileChevron {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.turnEditDiffPreview {
+  overflow: hidden;
+  border-top: 1px solid var(--divider);
+  background: var(--chat-bg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  animation: editDiffReveal 0.16s ease-out;
+}
+
+.turnEditDiffState {
+  border-top: 1px solid var(--divider);
+  padding: 8px 10px;
+  background: var(--chat-bg);
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  animation: editDiffReveal 0.16s ease-out;
+}
+
+.turnEditDiffLine {
+  display: grid;
+  grid-template-columns: 44px 44px 18px minmax(0, 1fr);
+  min-height: 22px;
+  color: var(--text-dim);
+}
+
+.turnEditDiffLineAdded {
+  background: var(--diff-added-bg);
+}
+
+.turnEditDiffLineRemoved {
+  background: var(--diff-removed-bg);
+}
+
+.turnEditDiffLineNumber {
+  padding-right: 8px;
+  text-align: right;
+  color: var(--diff-line-number);
+  user-select: none;
+  border-right: 1px solid var(--divider);
+}
+
+.turnEditDiffPrefix {
+  text-align: center;
+  color: var(--text-faint);
+}
+
+.turnEditDiffLineAdded .turnEditDiffPrefix {
+  color: var(--diff-added-text);
+  font-weight: 600;
+}
+
+.turnEditDiffLineRemoved .turnEditDiffPrefix {
+  color: var(--diff-removed-text);
+  font-weight: 600;
+}
+
+.turnEditDiffContent {
+  min-width: 0;
+  padding-left: 4px;
+  overflow: hidden;
+  color: var(--text-primary);
+  font: inherit;
+  text-overflow: ellipsis;
+  white-space: pre;
 }
 
 .inlineEditSummary {
@@ -549,12 +643,60 @@
   font-variant-numeric: tabular-nums;
 }
 
+.changeStatsValue {
+  display: inline-block;
+  animation-duration: 0.24s;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+.changeStatsValueUp {
+  animation-name: changeStatRise;
+}
+
+.changeStatsValueDown {
+  animation-name: changeStatDrop;
+}
+
 .changeStatsAdded {
   color: var(--diff-added-text);
 }
 
 .changeStatsRemoved {
   color: var(--diff-removed-text);
+}
+
+@keyframes changeStatRise {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes changeStatDrop {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes editDiffReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .taskProgressBar {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -505,11 +505,26 @@
   border-top: none;
 }
 
+/* Wraps the file-row button (path + stats) plus the trailing
+ * action cluster (popout + chevron) so they sit on the same baseline.
+ * Nested buttons aren't valid HTML, so the actions live as siblings
+ * of the main row button. */
+.turnEditFileRowWrap {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-width: 0;
+}
+
+.turnEditFileRowWrap:hover {
+  background: var(--hover-bg-subtle);
+}
+
 .turnEditFileRow {
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 100%;
+  flex: 1;
   min-width: 0;
   padding: 7px 10px;
   border: none;
@@ -519,11 +534,10 @@
   font-size: 12px;
   text-align: left;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition: color var(--transition-fast);
 }
 
 .turnEditFileRow:hover:not(:disabled) {
-  background: var(--hover-bg-subtle);
   color: var(--text-primary);
 }
 
@@ -540,10 +554,32 @@
   white-space: nowrap;
 }
 
-.turnEditFileChevron {
-  display: inline-flex;
+.turnEditFileActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 6px;
   flex: 0 0 auto;
+}
+
+.turnEditFileActionBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
   color: var(--text-faint);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.turnEditFileActionBtn:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
 }
 
 .turnEditDiffPreview {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -568,11 +568,7 @@
 
 .turnEditDiffLine {
   display: grid;
-  /* No +/- prefix column — the row background and line-number gutter
-   * already encode added/removed. Matches Codex chat and the GitHub
-   * PR view. Compact 40px gutters keep four-digit line numbers
-   * legible without dominating the row. */
-  grid-template-columns: 40px 40px minmax(0, 1fr);
+  grid-template-columns: 40px 40px 18px minmax(0, 1fr);
   min-height: 22px;
   color: var(--text-dim);
 }
@@ -593,9 +589,40 @@
   border-right: 1px solid var(--divider);
 }
 
+.turnEditDiffPrefix {
+  text-align: center;
+  color: var(--text-faint);
+}
+
+.turnEditDiffLineAdded .turnEditDiffPrefix {
+  color: var(--diff-added-text);
+  font-weight: 600;
+}
+
+.turnEditDiffLineRemoved .turnEditDiffPrefix {
+  color: var(--diff-removed-text);
+  font-weight: 600;
+}
+
+/* Hunk header row that breaks up multi-region diffs vertically. The
+ * `@@ -OLD,N +NEW,M @@` text sits on a faint band so it reads as a
+ * separator without competing with added/removed rows. */
+.turnEditDiffHunk {
+  padding: 4px 12px;
+  background: var(--hover-bg-subtle);
+  border-top: 1px solid var(--divider);
+  border-bottom: 1px solid var(--divider);
+  color: var(--diff-hunk-header);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .turnEditDiffContent {
   min-width: 0;
-  padding-left: 8px;
+  padding-left: 4px;
   overflow: hidden;
   color: var(--text-primary);
   font: inherit;

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -465,6 +465,14 @@
   border: 1px solid var(--divider);
   border-radius: 6px;
   margin: 4px 0;
+  /* The messages list is `display: flex; flex-direction: column;
+   * overflow: auto`. Per the flex spec, a flex item whose own
+   * `overflow` is not `visible` gets `min-height: 0` implicitly —
+   * the `overflow: hidden` we set for the rounded corners would
+   * collapse this card to its border height (~2px) and hide the file
+   * list entirely. Pin `flex-shrink: 0` so the card always lays out
+   * at its intrinsic content height. */
+  flex-shrink: 0;
   overflow: hidden;
   background: var(--chat-input-bg);
 }

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -184,15 +184,24 @@ function InlineDiffPreview({
 }
 
 function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
+  // Hunk separators get their own full-width row (no gutters):
+  // optional `@@ -X,Y +A,B @@` header text inline (workspace-diff
+  // path) or just a divider band (activity path, where multiple Edit
+  // calls merge into one file). Either way it visually breaks a
+  // multi-region diff into chunks instead of one tall blob.
+  if (line.type === "hunk") {
+    return (
+      <div className={styles.turnEditDiffHunk}>
+        {line.content ? <code>{line.content}</code> : null}
+      </div>
+    );
+  }
   const lineClass =
     line.type === "added"
       ? styles.turnEditDiffLineAdded
       : line.type === "removed"
         ? styles.turnEditDiffLineRemoved
         : "";
-  // No `+`/`-` prefix — the row's background color + line-number
-  // gutter already convey added/removed. Matches Codex chat and the
-  // GitHub PR view.
   return (
     <div className={`${styles.turnEditDiffLine} ${lineClass}`}>
       <span className={styles.turnEditDiffLineNumber}>
@@ -200,6 +209,9 @@ function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
       </span>
       <span className={styles.turnEditDiffLineNumber}>
         {line.newLineNumber ?? ""}
+      </span>
+      <span className={styles.turnEditDiffPrefix}>
+        {line.type === "added" ? "+" : line.type === "removed" ? "-" : " "}
       </span>
       <code className={styles.turnEditDiffContent}>{line.content || " "}</code>
     </div>

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -1,0 +1,74 @@
+import { Pencil } from "lucide-react";
+import { relativizePath } from "../../hooks/toolSummary";
+import { HighlightedPlainText } from "./HighlightedPlainText";
+import type { EditSummary } from "./editActivitySummary";
+import styles from "./ChatPanel.module.css";
+
+export function InlineEditSummary({
+  summary,
+  searchQuery,
+  worktreePath,
+}: {
+  summary: EditSummary;
+  searchQuery: string;
+  worktreePath?: string | null;
+}) {
+  const file = summary.files[0];
+  if (!file) return null;
+  return (
+    <span className={styles.inlineEditSummary}>
+      <Pencil size={12} aria-hidden="true" className={styles.inlineEditIcon} />
+      <span className={styles.inlineEditVerb}>Editing</span>
+      <span className={styles.inlineEditPath}>
+        <HighlightedPlainText
+          text={relativizePath(file.filePath, worktreePath)}
+          query={searchQuery}
+        />
+      </span>
+      <ChangeStats added={summary.added} removed={summary.removed} />
+    </span>
+  );
+}
+
+export function TurnEditSummaryCard({
+  summary,
+  searchQuery,
+  worktreePath,
+}: {
+  summary: EditSummary;
+  searchQuery: string;
+  worktreePath?: string | null;
+}) {
+  return (
+    <div className={styles.turnEditSummary}>
+      <div className={styles.turnEditSummaryHeader}>
+        <span className={styles.turnEditSummaryTitle}>
+          {summary.files.length} file{summary.files.length !== 1 ? "s" : ""} changed
+        </span>
+        <ChangeStats added={summary.added} removed={summary.removed} />
+      </div>
+      <div className={styles.turnEditFileList}>
+        {summary.files.map((file) => (
+          <div key={file.filePath} className={styles.turnEditFileRow}>
+            <span className={styles.turnEditFilePath}>
+              <HighlightedPlainText
+                text={relativizePath(file.filePath, worktreePath)}
+                query={searchQuery}
+              />
+            </span>
+            <ChangeStats added={file.added} removed={file.removed} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChangeStats({ added, removed }: { added: number; removed: number }) {
+  return (
+    <span className={styles.changeStats}>
+      <span className={styles.changeStatsAdded}>+{added}</span>
+      <span className={styles.changeStatsRemoved}>-{removed}</span>
+    </span>
+  );
+}

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
+import { ChevronDown, ChevronUp, Pencil, SquareArrowOutUpRight } from "lucide-react";
 import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedPlainText } from "./HighlightedPlainText";
 import type { EditFileStat, EditPreviewLine, EditSummary } from "./editActivitySummary";
@@ -42,11 +42,17 @@ export function TurnEditSummaryCard({
   searchQuery,
   worktreePath,
   onLoadPreview,
+  onOpenFile,
 }: {
   summary: EditSummary;
   searchQuery: string;
   worktreePath?: string | null;
   onLoadPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
+  /** Open the file's diff in the workspace's diff panel (Monaco).
+   *  Wired from `MessagesWithTurns` to `openDiffTab(workspaceId, ...)`.
+   *  Undefined hides the popout button (e.g. when the workspace is
+   *  unknown or the file isn't in the worktree diff). */
+  onOpenFile?: (filePath: string) => void;
 }) {
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const [previewByFile, setPreviewByFile] = useState<Record<string, PreviewState>>({});
@@ -93,26 +99,58 @@ export function TurnEditSummaryCard({
           const canExpand = file.previewLines.length > 0 || !!onLoadPreview;
           return (
             <div key={file.filePath} className={styles.turnEditFile}>
-              <button
-                type="button"
-                className={styles.turnEditFileRow}
-                aria-expanded={expanded}
-                disabled={!canExpand}
-                onClick={() => toggleFile(file)}
-              >
-                <span className={styles.turnEditFilePath}>
-                  <HighlightedPlainText
-                    text={relativizePath(file.filePath, worktreePath)}
-                    query={searchQuery}
-                  />
-                </span>
-                <ChangeStats added={file.added} removed={file.removed} />
-                {canExpand && (
-                  <span className={styles.turnEditFileChevron} aria-hidden="true">
-                    {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              <div className={styles.turnEditFileRowWrap}>
+                <button
+                  type="button"
+                  className={styles.turnEditFileRow}
+                  aria-expanded={expanded}
+                  disabled={!canExpand}
+                  onClick={() => toggleFile(file)}
+                >
+                  <span className={styles.turnEditFilePath}>
+                    <HighlightedPlainText
+                      text={relativizePath(file.filePath, worktreePath)}
+                      query={searchQuery}
+                    />
                   </span>
-                )}
-              </button>
+                  <ChangeStats added={file.added} removed={file.removed} />
+                </button>
+                {/* Action cluster: popout (open diff in Monaco panel) +
+                 * chevron (expand inline preview). Kept as siblings of
+                 * the row button so the popout click doesn't toggle
+                 * expansion — distinct intents, distinct buttons.
+                 * Mirrors the Codex / GitHub PR file-row affordance. */}
+                <div className={styles.turnEditFileActions}>
+                  {onOpenFile && (
+                    <button
+                      type="button"
+                      className={styles.turnEditFileActionBtn}
+                      title="Open in editor"
+                      aria-label={`Open ${file.filePath} in editor`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onOpenFile(file.filePath);
+                      }}
+                    >
+                      <SquareArrowOutUpRight size={13} />
+                    </button>
+                  )}
+                  {canExpand && (
+                    <button
+                      type="button"
+                      className={styles.turnEditFileActionBtn}
+                      aria-label={expanded ? "Collapse preview" : "Expand preview"}
+                      aria-expanded={expanded}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleFile(file);
+                      }}
+                    >
+                      {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </button>
+                  )}
+                </div>
+              </div>
               {expanded && (
                 <InlineDiffPreview
                   lines={previewLines}

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -1,8 +1,15 @@
-import { Pencil } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedPlainText } from "./HighlightedPlainText";
-import type { EditSummary } from "./editActivitySummary";
+import type { EditFileStat, EditPreviewLine, EditSummary } from "./editActivitySummary";
 import styles from "./ChatPanel.module.css";
+
+type PreviewState =
+  | { status: "idle"; lines: EditPreviewLine[] }
+  | { status: "loading"; lines: EditPreviewLine[] }
+  | { status: "ready"; lines: EditPreviewLine[] }
+  | { status: "error"; lines: EditPreviewLine[] };
 
 export function InlineEditSummary({
   summary,
@@ -34,11 +41,40 @@ export function TurnEditSummaryCard({
   summary,
   searchQuery,
   worktreePath,
+  onLoadPreview,
 }: {
   summary: EditSummary;
   searchQuery: string;
   worktreePath?: string | null;
+  onLoadPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
 }) {
+  const [expandedFile, setExpandedFile] = useState<string | null>(null);
+  const [previewByFile, setPreviewByFile] = useState<Record<string, PreviewState>>({});
+
+  const toggleFile = (file: EditFileStat) => {
+    setExpandedFile((current) => (current === file.filePath ? null : file.filePath));
+    if (file.previewLines.length > 0 || !onLoadPreview || previewByFile[file.filePath]) {
+      return;
+    }
+    setPreviewByFile((current) => ({
+      ...current,
+      [file.filePath]: { status: "loading", lines: [] },
+    }));
+    onLoadPreview(file.filePath)
+      .then((lines) => {
+        setPreviewByFile((current) => ({
+          ...current,
+          [file.filePath]: { status: "ready", lines },
+        }));
+      })
+      .catch(() => {
+        setPreviewByFile((current) => ({
+          ...current,
+          [file.filePath]: { status: "error", lines: [] },
+        }));
+      });
+  };
+
   return (
     <div className={styles.turnEditSummary}>
       <div className={styles.turnEditSummaryHeader}>
@@ -48,17 +84,44 @@ export function TurnEditSummaryCard({
         <ChangeStats added={summary.added} removed={summary.removed} />
       </div>
       <div className={styles.turnEditFileList}>
-        {summary.files.map((file) => (
-          <div key={file.filePath} className={styles.turnEditFileRow}>
-            <span className={styles.turnEditFilePath}>
-              <HighlightedPlainText
-                text={relativizePath(file.filePath, worktreePath)}
-                query={searchQuery}
-              />
-            </span>
-            <ChangeStats added={file.added} removed={file.removed} />
-          </div>
-        ))}
+        {summary.files.map((file) => {
+          const expanded = expandedFile === file.filePath;
+          const previewState = previewByFile[file.filePath];
+          const previewLines = file.previewLines.length > 0
+            ? file.previewLines
+            : previewState?.lines ?? [];
+          const canExpand = file.previewLines.length > 0 || !!onLoadPreview;
+          return (
+            <div key={file.filePath} className={styles.turnEditFile}>
+              <button
+                type="button"
+                className={styles.turnEditFileRow}
+                aria-expanded={expanded}
+                disabled={!canExpand}
+                onClick={() => toggleFile(file)}
+              >
+                <span className={styles.turnEditFilePath}>
+                  <HighlightedPlainText
+                    text={relativizePath(file.filePath, worktreePath)}
+                    query={searchQuery}
+                  />
+                </span>
+                <ChangeStats added={file.added} removed={file.removed} />
+                {canExpand && (
+                  <span className={styles.turnEditFileChevron} aria-hidden="true">
+                    {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                  </span>
+                )}
+              </button>
+              {expanded && (
+                <InlineDiffPreview
+                  lines={previewLines}
+                  status={previewState?.status ?? "ready"}
+                />
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -67,8 +130,78 @@ export function TurnEditSummaryCard({
 function ChangeStats({ added, removed }: { added: number; removed: number }) {
   return (
     <span className={styles.changeStats}>
-      <span className={styles.changeStatsAdded}>+{added}</span>
-      <span className={styles.changeStatsRemoved}>-{removed}</span>
+      <AnimatedStat value={added} prefix="+" className={styles.changeStatsAdded} />
+      <AnimatedStat value={removed} prefix="-" className={styles.changeStatsRemoved} />
     </span>
+  );
+}
+
+function AnimatedStat({
+  value,
+  prefix,
+  className,
+}: {
+  value: number;
+  prefix: "+" | "-";
+  className: string;
+}) {
+  return (
+    <span
+      key={`${prefix}${value}`}
+      className={`${styles.changeStatsValue} ${
+        prefix === "+" ? styles.changeStatsValueUp : styles.changeStatsValueDown
+      } ${className}`}
+    >
+      {prefix}
+      {value}
+    </span>
+  );
+}
+
+function InlineDiffPreview({
+  lines,
+  status,
+}: {
+  lines: EditPreviewLine[];
+  status: PreviewState["status"];
+}) {
+  if (status === "loading") {
+    return <div className={styles.turnEditDiffState}>Loading diff…</div>;
+  }
+  if (status === "error") {
+    return <div className={styles.turnEditDiffState}>Diff unavailable</div>;
+  }
+  if (lines.length === 0) {
+    return <div className={styles.turnEditDiffState}>No preview lines</div>;
+  }
+  return (
+    <div className={styles.turnEditDiffPreview}>
+      {lines.map((line, index) => (
+        <DiffPreviewLine key={`${index}:${line.type}`} line={line} />
+      ))}
+    </div>
+  );
+}
+
+function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
+  const lineClass =
+    line.type === "added"
+      ? styles.turnEditDiffLineAdded
+      : line.type === "removed"
+        ? styles.turnEditDiffLineRemoved
+        : "";
+  return (
+    <div className={`${styles.turnEditDiffLine} ${lineClass}`}>
+      <span className={styles.turnEditDiffLineNumber}>
+        {line.oldLineNumber ?? ""}
+      </span>
+      <span className={styles.turnEditDiffLineNumber}>
+        {line.newLineNumber ?? ""}
+      </span>
+      <span className={styles.turnEditDiffPrefix}>
+        {line.type === "added" ? "+" : line.type === "removed" ? "-" : " "}
+      </span>
+      <code className={styles.turnEditDiffContent}>{line.content || " "}</code>
+    </div>
   );
 }

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { ChevronDown, ChevronUp, Pencil, SquareArrowOutUpRight } from "lucide-react";
 import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedPlainText } from "./HighlightedPlainText";
@@ -22,15 +22,25 @@ export function InlineEditSummary({
 }) {
   const file = summary.files[0];
   if (!file) return null;
+  // Single-file is the common case (one Edit / Write call). Multi-file
+  // happens when a tool (e.g. apply_patch / `diff --git` blob) touches
+  // several files in one shot — render an "Editing N files" label so
+  // the +/- totals match the surface, instead of misattributing the
+  // aggregate churn to just `files[0]`.
+  const isMulti = summary.files.length > 1;
   return (
     <span className={styles.inlineEditSummary}>
       <Pencil size={12} aria-hidden="true" className={styles.inlineEditIcon} />
       <span className={styles.inlineEditVerb}>Editing</span>
       <span className={styles.inlineEditPath}>
-        <HighlightedPlainText
-          text={relativizePath(file.filePath, worktreePath)}
-          query={searchQuery}
-        />
+        {isMulti ? (
+          `${summary.files.length} files`
+        ) : (
+          <HighlightedPlainText
+            text={relativizePath(file.filePath, worktreePath)}
+            query={searchQuery}
+          />
+        )}
       </span>
       <ChangeStats added={summary.added} removed={summary.removed} />
     </span>
@@ -48,20 +58,35 @@ export function TurnEditSummaryCard({
   searchQuery: string;
   worktreePath?: string | null;
   onLoadPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
-  /** Open the file's diff in the workspace's diff panel (Monaco).
-   *  Wired from `MessagesWithTurns` to `openDiffTab(workspaceId, ...)`.
-   *  Undefined hides the popout button (e.g. when the workspace is
-   *  unknown or the file isn't in the worktree diff). */
+  /** Open the file in the Monaco editor tab. Wired from
+   *  `MessagesWithTurns` to `openFileTab(workspaceId, ...)` — same
+   *  action the FILES tree uses, not the diff viewer. Undefined
+   *  hides the popout button (e.g. when no workspace context is
+   *  available). */
   onOpenFile?: (filePath: string) => void;
 }) {
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const [previewByFile, setPreviewByFile] = useState<Record<string, PreviewState>>({});
+  // In-flight tracker so rapid clicks before state commits can't fan
+  // out duplicate `onLoadPreview` calls. A ref (not state) so the
+  // check is synchronous — React Strict-Mode-safe and not re-run by
+  // a state-updater double-invoke.
+  const inFlightRef = useRef<Set<string>>(new Set());
 
   const toggleFile = (file: EditFileStat) => {
     setExpandedFile((current) => (current === file.filePath ? null : file.filePath));
-    if (file.previewLines.length > 0 || !onLoadPreview || previewByFile[file.filePath]) {
+    if (file.previewLines.length > 0 || !onLoadPreview) return;
+    // Skip ONLY for `loading`/`ready`. An `error` entry must still
+    // permit a retry on the next click — the previous gate
+    // (`previewByFile[file.filePath]` truthy) permanently locked an
+    // error out, so a transient backend failure was unrecoverable
+    // without a remount.
+    const existing = previewByFile[file.filePath];
+    if (existing && (existing.status === "loading" || existing.status === "ready")) {
       return;
     }
+    if (inFlightRef.current.has(file.filePath)) return;
+    inFlightRef.current.add(file.filePath);
     setPreviewByFile((current) => ({
       ...current,
       [file.filePath]: { status: "loading", lines: [] },
@@ -78,6 +103,9 @@ export function TurnEditSummaryCard({
           ...current,
           [file.filePath]: { status: "error", lines: [] },
         }));
+      })
+      .finally(() => {
+        inFlightRef.current.delete(file.filePath);
       });
   };
 
@@ -115,11 +143,12 @@ export function TurnEditSummaryCard({
                   </span>
                   <ChangeStats added={file.added} removed={file.removed} />
                 </button>
-                {/* Action cluster: popout (open diff in Monaco panel) +
-                 * chevron (expand inline preview). Kept as siblings of
-                 * the row button so the popout click doesn't toggle
-                 * expansion — distinct intents, distinct buttons.
-                 * Mirrors the Codex / GitHub PR file-row affordance. */}
+                {/* Action cluster: popout (open file in Monaco
+                 * editor) + chevron (expand inline preview). Kept as
+                 * siblings of the row button so the popout click
+                 * doesn't toggle expansion — distinct intents,
+                 * distinct buttons. Mirrors the Codex / GitHub PR
+                 * file-row affordance. */}
                 <div className={styles.turnEditFileActions}>
                   {onOpenFile && (
                     <button

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -190,6 +190,9 @@ function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
       : line.type === "removed"
         ? styles.turnEditDiffLineRemoved
         : "";
+  // No `+`/`-` prefix — the row's background color + line-number
+  // gutter already convey added/removed. Matches Codex chat and the
+  // GitHub PR view.
   return (
     <div className={`${styles.turnEditDiffLine} ${lineClass}`}>
       <span className={styles.turnEditDiffLineNumber}>
@@ -197,9 +200,6 @@ function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
       </span>
       <span className={styles.turnEditDiffLineNumber}>
         {line.newLineNumber ?? ""}
-      </span>
-      <span className={styles.turnEditDiffPrefix}>
-        {line.type === "added" ? "+" : line.type === "removed" ? "-" : " "}
       </span>
       <code className={styles.turnEditDiffContent}>{line.content || " "}</code>
     </div>

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -42,6 +42,8 @@ import styles from "./ChatPanel.module.css";
 import { TurnSummary } from "./TurnSummary";
 import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { TurnFooter } from "./TurnFooter";
+import { TurnEditSummaryCard } from "./EditChangeSummary";
+import { summarizeTurnEdits } from "./editActivitySummary";
 import { PdfThumbnail } from "./PdfThumbnail";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
@@ -594,18 +596,29 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
             />
           );
         })}
-        {footerEntries.map(({ turn }) => (
-          <TurnFooter
-            key={`${turn.id}:${position}:footer`}
-            durationMs={turn.durationMs}
-            inputTokens={turn.inputTokens}
-            outputTokens={turn.outputTokens}
-            assistantText={assistantTextByTurnId.get(turn.id) || undefined}
-            onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
-            onRollback={buildOnRollback(turn.id)}
-            className={styles.messageTurnFooter}
-          />
-        ))}
+        {footerEntries.map(({ turn }) => {
+          const editSummary = summarizeTurnEdits(turn.activities);
+          return (
+            <React.Fragment key={`${turn.id}:${position}:footer`}>
+              {editSummary && (
+                <TurnEditSummaryCard
+                  summary={editSummary}
+                  searchQuery={searchQuery}
+                  worktreePath={worktreePath}
+                />
+              )}
+              <TurnFooter
+                durationMs={turn.durationMs}
+                inputTokens={turn.inputTokens}
+                outputTokens={turn.outputTokens}
+                assistantText={assistantTextByTurnId.get(turn.id) || undefined}
+                onFork={onForkTurn ? () => onForkTurn(turn.id) : undefined}
+                onRollback={buildOnRollback(turn.id)}
+                className={styles.messageTurnFooter}
+              />
+            </React.Fragment>
+          );
+        })}
       </>
     );
   };

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -562,6 +562,13 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
       <>
         {groupEntries.map(({ turn, globalIdx, activities, label, showFooter }) => {
           const isLatestCompletedTurn = turn.id === latestCompletedTurnId;
+          // The card prefers per-turn activity-derived edits ("files
+          // THIS turn touched"). Workspace-diff summary is offered as a
+          // rescue only on the latest turn — `TurnSummary` uses it only
+          // when the activity parser couldn't recognize any edits
+          // (Bash heredoc, MCP write tool, etc.). Older turns get no
+          // rescue: their workspace-diff entry would include later
+          // turns' churn, which would mislead.
           const fallbackEditSummary =
             showFooter && isLatestCompletedTurn ? workspaceDiffSummary : null;
           // A single turn can produce multiple display groups when
@@ -624,20 +631,24 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
               onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
               searchQuery={searchQuery}
               worktreePath={worktreePath}
-              editSummaryOverride={fallbackEditSummary}
+              editSummaryFallback={fallbackEditSummary}
               onLoadEditPreview={
-                fallbackEditSummary ? loadWorkspaceDiffPreview : undefined
+                showFooter && isLatestCompletedTurn
+                  ? loadWorkspaceDiffPreview
+                  : undefined
               }
             />
           );
         })}
         {footerEntries.map(({ turn }) => {
           const isLatestCompletedTurn = turn.id === latestCompletedTurnId;
-          const workspaceSummary = isLatestCompletedTurn
-            ? workspaceDiffSummary
-            : null;
+          // Same precedence as the group-entries path above: turn-scoped
+          // activity edits win; workspace diff only rescues the latest
+          // turn when activities can't be parsed into edit churn.
+          const turnActivitySummary = editSummaryByTurnId.get(turn.id) ?? null;
           const editSummary =
-            workspaceSummary ?? editSummaryByTurnId.get(turn.id) ?? null;
+            turnActivitySummary ??
+            (isLatestCompletedTurn ? workspaceDiffSummary : null);
           return (
             <React.Fragment key={`${turn.id}:${position}:footer`}>
               {editSummary && (
@@ -646,7 +657,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                   searchQuery={searchQuery}
                   worktreePath={worktreePath}
                   onLoadPreview={
-                    workspaceSummary ? loadWorkspaceDiffPreview : undefined
+                    isLatestCompletedTurn ? loadWorkspaceDiffPreview : undefined
                   }
                 />
               )}

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -8,6 +8,7 @@ import type { ChatMessage, ChatAttachment } from "../../types/chat";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 import { HighlightedPlainText } from "./HighlightedPlainText";
+import { relativizePath } from "../../hooks/toolSummary";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
 import { CompactionDivider } from "./CompactionDivider";
@@ -451,12 +452,15 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   // Activity-derived edits use absolute paths (the agent's full path
   // including the worktree prefix); the file-tab store keys by repo-
   // relative path, so strip the worktree prefix when present.
+  // `relativizePath` handles both `/` and `\` so this works on Windows
+  // worktrees too. If the result still looks absolute (POSIX `/...`
+  // or Windows `C:\...` / `C:/...`), the file isn't reachable via the
+  // current worktree — bail rather than passing a bad key into the
+  // file-tab store.
   const openFileInMonaco = useCallback(
     (filePath: string) => {
-      const rel =
-        worktreePath && filePath.startsWith(worktreePath + "/")
-          ? filePath.slice(worktreePath.length + 1)
-          : filePath;
+      const rel = relativizePath(filePath, worktreePath);
+      if (/^([a-zA-Z]:[\\/]|[\\/])/.test(rel)) return;
       openFileTab(workspaceId, rel);
     },
     [openFileTab, workspaceId, worktreePath],

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -446,6 +446,21 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     },
     [diffMergeBase, worktreePath],
   );
+  const openFileTab = useAppStore((s) => s.openFileTab);
+  // Open the file in the Monaco editor tab (not the diff viewer).
+  // Activity-derived edits use absolute paths (the agent's full path
+  // including the worktree prefix); the file-tab store keys by repo-
+  // relative path, so strip the worktree prefix when present.
+  const openFileInMonaco = useCallback(
+    (filePath: string) => {
+      const rel =
+        worktreePath && filePath.startsWith(worktreePath + "/")
+          ? filePath.slice(worktreePath.length + 1)
+          : filePath;
+      openFileTab(workspaceId, rel);
+    },
+    [openFileTab, workspaceId, worktreePath],
+  );
 
   // Per-turn rollback data, keyed by turn.id. Completed turns are only
   // persisted for tool-using turns, so the triggering user is the nearest
@@ -637,6 +652,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                   ? loadWorkspaceDiffPreview
                   : undefined
               }
+              onOpenEditFile={showFooter ? openFileInMonaco : undefined}
             />
           );
         })}
@@ -659,6 +675,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                   onLoadPreview={
                     isLatestCompletedTurn ? loadWorkspaceDiffPreview : undefined
                   }
+                  onOpenFile={openFileInMonaco}
                 />
               )}
               <TurnFooter

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
-import { loadAttachmentData } from "../../services/tauri";
+import { loadAttachmentData, loadFileDiff } from "../../services/tauri";
 import type { ChatMessage, ChatAttachment } from "../../types/chat";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
@@ -43,7 +43,11 @@ import { TurnSummary } from "./TurnSummary";
 import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { TurnFooter } from "./TurnFooter";
 import { TurnEditSummaryCard } from "./EditChangeSummary";
-import { summarizeTurnEdits } from "./editActivitySummary";
+import {
+  previewLinesFromFileDiff,
+  summarizeDiffFiles,
+  summarizeTurnEdits,
+} from "./editActivitySummary";
 import { PdfThumbnail } from "./PdfThumbnail";
 import { MessageCopyButton } from "./MessageCopyButton";
 import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
@@ -145,6 +149,8 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
   );
+  const diffFiles = useAppStore((s) => s.diffFiles);
+  const diffMergeBase = useAppStore((s) => s.diffMergeBase);
   const liveToolActivities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
@@ -419,6 +425,28 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     return map;
   }, [completedTurns, findTriggeringUserIdx, messages, globalOffset]);
 
+  const editSummaryByTurnId = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof summarizeTurnEdits>>();
+    for (const turn of completedTurns) {
+      map.set(turn.id, summarizeTurnEdits(turn.activities));
+    }
+    return map;
+  }, [completedTurns]);
+  const workspaceDiffSummary = useMemo(
+    () => summarizeDiffFiles(diffFiles),
+    [diffFiles],
+  );
+  const latestCompletedTurnId =
+    completedTurns[completedTurns.length - 1]?.id ?? null;
+  const loadWorkspaceDiffPreview = useCallback(
+    async (filePath: string) => {
+      if (!worktreePath || !diffMergeBase) return [];
+      const diff = await loadFileDiff(worktreePath, diffMergeBase, filePath);
+      return previewLinesFromFileDiff(diff);
+    },
+    [diffMergeBase, worktreePath],
+  );
+
   // Per-turn rollback data, keyed by turn.id. Completed turns are only
   // persisted for tool-using turns, so the triggering user is the nearest
   // user message before the completed turn boundary.
@@ -533,6 +561,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     return (
       <>
         {groupEntries.map(({ turn, globalIdx, activities, label, showFooter }) => {
+          const isLatestCompletedTurn = turn.id === latestCompletedTurnId;
+          const fallbackEditSummary =
+            showFooter && isLatestCompletedTurn ? workspaceDiffSummary : null;
           // A single turn can produce multiple display groups when
           // chronologically-interleaved messages split its activities;
           // each group needs its own collapse state so clicking one
@@ -593,11 +624,20 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
               onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
               searchQuery={searchQuery}
               worktreePath={worktreePath}
+              editSummaryOverride={fallbackEditSummary}
+              onLoadEditPreview={
+                fallbackEditSummary ? loadWorkspaceDiffPreview : undefined
+              }
             />
           );
         })}
         {footerEntries.map(({ turn }) => {
-          const editSummary = summarizeTurnEdits(turn.activities);
+          const isLatestCompletedTurn = turn.id === latestCompletedTurnId;
+          const workspaceSummary = isLatestCompletedTurn
+            ? workspaceDiffSummary
+            : null;
+          const editSummary =
+            workspaceSummary ?? editSummaryByTurnId.get(turn.id) ?? null;
           return (
             <React.Fragment key={`${turn.id}:${position}:footer`}>
               {editSummary && (
@@ -605,6 +645,9 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                   summary={editSummary}
                   searchQuery={searchQuery}
                   worktreePath={worktreePath}
+                  onLoadPreview={
+                    workspaceSummary ? loadWorkspaceDiffPreview : undefined
+                  }
                 />
               )}
               <TurnFooter

--- a/src/ui/src/components/chat/ThinkingBlock.module.css
+++ b/src/ui/src/components/chat/ThinkingBlock.module.css
@@ -85,4 +85,10 @@
   padding: 2px 8px 4px 28px;
   border-top: none;
   background: transparent;
+  /* Inline thinking blocks live inside the chat scroller — they must
+   * not introduce a second scrollbar inside that surface. The boxed
+   * variant caps height at 400px and scrolls; the inline variant
+   * lets long thoughts grow naturally. */
+  max-height: none;
+  overflow-y: visible;
 }

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -7,8 +7,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
 import styles from "./ChatPanel.module.css";
-import { TurnSummary } from "./TurnSummary";
 import { ToolActivitiesSection } from "./ToolActivitiesSection";
+import { TurnSummary } from "./TurnSummary";
 
 const mountedRoots: Root[] = [];
 const mountedContainers: HTMLElement[] = [];
@@ -97,6 +97,36 @@ describe("AgentToolCallGroup", () => {
       container.querySelector(`.${styles.agentToolGroupInline}`),
     ).toBeTruthy();
     expect(container.querySelector(`.${styles.agentToolGroup}`)).toBeNull();
+  });
+
+  it("renders nested edit calls as editing rows with churn stats", async () => {
+    const container = await render(
+      <AgentToolCallGroup
+        activity={activity("Agent", {
+          agentToolCalls: [
+            {
+              toolUseId: "edit-1",
+              toolName: "Edit",
+              agentId: "agent-1",
+              input: {
+                file_path: "/repo/src/app.ts",
+                old_string: "one\ntwo",
+                new_string: "one\nthree\nfour",
+              },
+              status: "completed",
+              startedAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+        })}
+        searchQuery=""
+        worktreePath="/repo"
+      />,
+    );
+
+    expect(container.textContent).toContain("Editing");
+    expect(container.textContent).toContain("src/app.ts");
+    expect(container.textContent).toContain("+3");
+    expect(container.textContent).toContain("-2");
   });
 });
 
@@ -401,6 +431,38 @@ describe("ToolActivitiesSection", () => {
     expect(headerAfter.getAttribute("aria-expanded")).toBe("false");
     expect(container.textContent).toContain("3 tool calls");
     expect(container.textContent).not.toContain("Edit");
+  });
+
+  it("renders completed-turn edit summary card", async () => {
+    const editActivity = activity("Edit", {
+      inputJson: JSON.stringify({
+        file_path: "/repo/src/app.ts",
+        old_string: "old",
+        new_string: "new\nnext",
+      }),
+    });
+
+    const container = await render(
+      <TurnSummary
+        turn={{
+          id: "turn-1",
+          activities: [editActivity],
+          messageCount: 1,
+          collapsed: false,
+          afterMessageIndex: 1,
+        }}
+        collapsed={false}
+        onToggle={() => {}}
+        assistantText=""
+        searchQuery=""
+        worktreePath="/repo"
+      />,
+    );
+
+    expect(container.textContent).toContain("1 file changed");
+    expect(container.textContent).toContain("src/app.ts");
+    expect(container.textContent).toContain("+2");
+    expect(container.textContent).toContain("-1");
   });
 });
 

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -496,7 +496,7 @@ describe("ToolActivitiesSection", () => {
         assistantText=""
         searchQuery=""
         worktreePath="/repo"
-        editSummaryOverride={{
+        editSummaryFallback={{
           added: 9,
           removed: 2,
           files: [
@@ -535,6 +535,67 @@ describe("ToolActivitiesSection", () => {
 
     expect(row.getAttribute("aria-expanded")).toBe("true");
     expect(container.textContent).toContain("const next = true;");
+  });
+
+  it("prefers turn-scoped activity edits over the workspace-diff fallback", async () => {
+    // Regression for the bug fixed alongside `editSummaryFallback`:
+    // before this, the workspace-diff override always won, so the
+    // latest turn's card listed *every* file with worktree changes
+    // even if the turn itself only touched a subset. The activity
+    // parser is the source of truth for "files THIS turn touched";
+    // the workspace diff is just a rescue when no edit tools matched.
+    const editActivity = activity("Edit", {
+      inputJson: JSON.stringify({
+        file_path: "/repo/src/app.ts",
+        old_string: "old",
+        new_string: "new",
+      }),
+    });
+
+    const container = await render(
+      <TurnSummary
+        turn={{
+          id: "turn-1",
+          activities: [editActivity],
+          messageCount: 1,
+          collapsed: false,
+          afterMessageIndex: 1,
+        }}
+        collapsed={false}
+        onToggle={() => {}}
+        assistantText=""
+        searchQuery=""
+        worktreePath="/repo"
+        editSummaryFallback={{
+          added: 99,
+          removed: 99,
+          files: [
+            {
+              filePath: "/repo/src/app.ts",
+              added: 50,
+              removed: 50,
+              previewLines: [],
+            },
+            {
+              filePath: "/repo/src/other.ts",
+              added: 49,
+              removed: 49,
+              previewLines: [],
+            },
+          ],
+        }}
+      />,
+    );
+
+    // Turn-scoped: 1 file (the Edit's file_path), +1 -1 (one new line,
+    // one old line). The fallback's 2-file / +99 -99 view must NOT win.
+    expect(container.textContent).toContain("1 file changed");
+    expect(container.textContent).toContain("src/app.ts");
+    expect(container.textContent).not.toContain("other.ts");
+    expect(container.textContent).toContain("+1");
+    expect(container.textContent).toContain("-1");
+    expect(container.textContent).not.toContain("+99");
+    expect(container.textContent).not.toContain("-99");
   });
 });
 

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -463,6 +463,78 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("src/app.ts");
     expect(container.textContent).toContain("+2");
     expect(container.textContent).toContain("-1");
+    expect(container.textContent).not.toContain("old");
+
+    const row = container.querySelector(
+      "button[aria-expanded]",
+    ) as HTMLButtonElement;
+    expect(row).toBeTruthy();
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      row.click();
+    });
+
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("old");
+    expect(container.textContent).toContain("new");
+    expect(container.textContent).toContain("next");
+  });
+
+  it("renders completed-turn workspace diff fallback when activities have no edit payload", async () => {
+    const container = await render(
+      <TurnSummary
+        turn={{
+          id: "turn-1",
+          activities: [],
+          messageCount: 1,
+          collapsed: false,
+          afterMessageIndex: 1,
+        }}
+        collapsed={false}
+        onToggle={() => {}}
+        assistantText=""
+        searchQuery=""
+        worktreePath="/repo"
+        editSummaryOverride={{
+          added: 9,
+          removed: 2,
+          files: [
+            {
+              filePath: "/repo/src/app.ts",
+              added: 9,
+              removed: 2,
+              previewLines: [],
+            },
+          ],
+        }}
+        onLoadEditPreview={async () => [
+          {
+            type: "added",
+            oldLineNumber: null,
+            newLineNumber: 12,
+            content: "const next = true;",
+          },
+        ]}
+      />,
+    );
+
+    expect(container.textContent).toContain("1 file changed");
+    expect(container.textContent).toContain("src/app.ts");
+    expect(container.textContent).toContain("+9");
+    expect(container.textContent).toContain("-2");
+
+    const row = container.querySelector(
+      "button[aria-expanded]",
+    ) as HTMLButtonElement;
+    expect(row).toBeTruthy();
+
+    await act(async () => {
+      row.click();
+    });
+
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("const next = true;");
   });
 });
 

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -17,6 +17,8 @@ import {
   groupToolActivitiesForDisplay,
 } from "./toolActivityGroups";
 import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
+import { InlineEditSummary } from "./EditChangeSummary";
+import { summarizeToolActivityEdit } from "./editActivitySummary";
 
 /**
  * Current tool activities section — subscribes to toolActivities for this workspace.
@@ -182,16 +184,25 @@ function ToolActivityRow({
   searchQuery: string;
   worktreePath?: string | null;
 }) {
+  const editSummary = summarizeToolActivityEdit(activity);
   return (
     <div className={styles.toolActivity}>
       <div className={styles.toolHeader}>
-        <span
-          className={styles.toolName}
-          style={{ color: toolColor(activity.toolName) }}
-        >
-          {activity.toolName}
-        </span>
-        {activitySummaryText(activity) && (
+        {editSummary ? (
+          <InlineEditSummary
+            summary={editSummary}
+            searchQuery={searchQuery}
+            worktreePath={worktreePath}
+          />
+        ) : (
+          <span
+            className={styles.toolName}
+            style={{ color: toolColor(activity.toolName) }}
+          >
+            {activity.toolName}
+          </span>
+        )}
+        {!editSummary && activitySummaryText(activity) && (
           <span className={styles.toolSummary}>
             <HighlightedPlainText
               text={relativizePath(activitySummaryText(activity), worktreePath)}

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import type { TaskTrackerResult } from "../../hooks/useTaskTracker";
 import { relativizePath } from "../../hooks/toolSummary";
@@ -14,6 +15,8 @@ import { AgentToolCallGroup } from "./AgentToolCallGroup";
 import { isAgentActivity } from "./toolActivityGroups";
 import { InlineEditSummary, TurnEditSummaryCard } from "./EditChangeSummary";
 import {
+  type EditPreviewLine,
+  type EditSummary,
   summarizeToolActivityEdit,
   summarizeTurnEdits,
 } from "./editActivitySummary";
@@ -35,6 +38,8 @@ export function TurnSummary({
   worktreePath,
   label,
   inline = false,
+  editSummaryOverride,
+  onLoadEditPreview,
 }: {
   turn: CompletedTurn;
   activities?: ToolActivity[];
@@ -57,6 +62,8 @@ export function TurnSummary({
   worktreePath?: string | null;
   label?: string;
   inline?: boolean;
+  editSummaryOverride?: EditSummary | null;
+  onLoadEditPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
 }) {
   const visibleActivities = activities ?? turn.activities;
   const hasElapsed = typeof turn.durationMs === "number" && turn.durationMs > 0;
@@ -67,7 +74,13 @@ export function TurnSummary({
   const hasRollback = !!onRollback;
   const shouldShowFooter =
     showFooter && (hasElapsed || hasTokens || hasCopy || hasFork || hasRollback);
-  const editSummary = showFooter ? summarizeTurnEdits(turn.activities) : null;
+  const activityEditSummary = useMemo(
+    () => (showFooter ? summarizeTurnEdits(turn.activities) : null),
+    [showFooter, turn.activities],
+  );
+  const editSummary = showFooter
+    ? editSummaryOverride ?? activityEditSummary
+    : null;
 
   // Force-expand if the query matches in any activity summary or the
   // resolved tool-summary fallback. Without this, marks would land in
@@ -167,6 +180,7 @@ export function TurnSummary({
           summary={editSummary}
           searchQuery={searchQuery}
           worktreePath={worktreePath}
+          onLoadPreview={onLoadEditPreview}
         />
       )}
       {shouldShowFooter && (

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -40,6 +40,7 @@ export function TurnSummary({
   inline = false,
   editSummaryFallback,
   onLoadEditPreview,
+  onOpenEditFile,
 }: {
   turn: CompletedTurn;
   activities?: ToolActivity[];
@@ -69,6 +70,9 @@ export function TurnSummary({
    *  scoped to what THIS turn touched, not the cumulative worktree diff. */
   editSummaryFallback?: EditSummary | null;
   onLoadEditPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
+  /** Open a file's diff in the workspace diff panel (Monaco). Wired
+   *  by `MessagesWithTurns` to `openDiffTab(workspaceId, filePath)`. */
+  onOpenEditFile?: (filePath: string) => void;
 }) {
   const visibleActivities = activities ?? turn.activities;
   const hasElapsed = typeof turn.durationMs === "number" && turn.durationMs > 0;
@@ -186,6 +190,7 @@ export function TurnSummary({
           searchQuery={searchQuery}
           worktreePath={worktreePath}
           onLoadPreview={onLoadEditPreview}
+          onOpenFile={onOpenEditFile}
         />
       )}
       {shouldShowFooter && (

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -38,7 +38,7 @@ export function TurnSummary({
   worktreePath,
   label,
   inline = false,
-  editSummaryOverride,
+  editSummaryFallback,
   onLoadEditPreview,
 }: {
   turn: CompletedTurn;
@@ -62,7 +62,12 @@ export function TurnSummary({
   worktreePath?: string | null;
   label?: string;
   inline?: boolean;
-  editSummaryOverride?: EditSummary | null;
+  /** Rescue summary used only when activity-derived edits return null —
+   *  typically the workspace-diff summary for the latest turn, where the
+   *  agent's tools couldn't be parsed (Bash heredoc, MCP write tool, etc.).
+   *  Activity-derived data wins when present so per-turn churn stays
+   *  scoped to what THIS turn touched, not the cumulative worktree diff. */
+  editSummaryFallback?: EditSummary | null;
   onLoadEditPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
 }) {
   const visibleActivities = activities ?? turn.activities;
@@ -79,7 +84,7 @@ export function TurnSummary({
     [showFooter, turn.activities],
   );
   const editSummary = showFooter
-    ? editSummaryOverride ?? activityEditSummary
+    ? activityEditSummary ?? editSummaryFallback ?? null
     : null;
 
   // Force-expand if the query matches in any activity summary or the

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -12,6 +12,11 @@ import {
 } from "./agentToolCallRendering";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
 import { isAgentActivity } from "./toolActivityGroups";
+import { InlineEditSummary, TurnEditSummaryCard } from "./EditChangeSummary";
+import {
+  summarizeToolActivityEdit,
+  summarizeTurnEdits,
+} from "./editActivitySummary";
 
 /**
  * Render a single completed turn summary (collapsible tool call list).
@@ -62,6 +67,7 @@ export function TurnSummary({
   const hasRollback = !!onRollback;
   const shouldShowFooter =
     showFooter && (hasElapsed || hasTokens || hasCopy || hasFork || hasRollback);
+  const editSummary = showFooter ? summarizeTurnEdits(turn.activities) : null;
 
   // Force-expand if the query matches in any activity summary or the
   // resolved tool-summary fallback. Without this, marks would land in
@@ -76,22 +82,35 @@ export function TurnSummary({
       activityMatchesSearch(activity, searchQuery, worktreePath),
     );
   const isExpanded = inline || !collapsed || queryHasMatch;
-  const renderedActivities = visibleActivities.map((act: ToolActivity) =>
-    isAgentActivity(act) ? (
-      <AgentToolCallGroup
-        key={act.toolUseId}
-        activity={act}
-        searchQuery={searchQuery}
-        worktreePath={worktreePath}
-        inline={inline}
-      />
-    ) : (
+  const renderedActivities = visibleActivities.map((act: ToolActivity) => {
+    if (isAgentActivity(act)) {
+      return (
+        <AgentToolCallGroup
+          key={act.toolUseId}
+          activity={act}
+          searchQuery={searchQuery}
+          worktreePath={worktreePath}
+          inline={inline}
+        />
+      );
+    }
+
+    const editSummaryForActivity = summarizeToolActivityEdit(act);
+    return (
       <div key={act.toolUseId} className={styles.toolActivity}>
         <div className={styles.toolHeader}>
-          <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
-            {act.toolName}
-          </span>
-          {activitySummaryText(act) && (
+          {editSummaryForActivity ? (
+            <InlineEditSummary
+              summary={editSummaryForActivity}
+              searchQuery={searchQuery}
+              worktreePath={worktreePath}
+            />
+          ) : (
+            <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
+              {act.toolName}
+            </span>
+          )}
+          {!editSummaryForActivity && activitySummaryText(act) && (
             <span className={styles.toolSummary}>
               <HighlightedPlainText
                 text={relativizePath(activitySummaryText(act), worktreePath)}
@@ -101,8 +120,8 @@ export function TurnSummary({
           )}
         </div>
       </div>
-    ),
-  );
+    );
+  });
 
   return (
     <div className={styles.turnSummaryWrapper}>
@@ -141,6 +160,13 @@ export function TurnSummary({
         <TaskProgressBar
           completedCount={taskProgress.completedCount}
           totalCount={taskProgress.totalCount}
+        />
+      )}
+      {editSummary && (
+        <TurnEditSummaryCard
+          summary={editSummary}
+          searchQuery={searchQuery}
+          worktreePath={worktreePath}
         />
       )}
       {shouldShowFooter && (

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -70,8 +70,9 @@ export function TurnSummary({
    *  scoped to what THIS turn touched, not the cumulative worktree diff. */
   editSummaryFallback?: EditSummary | null;
   onLoadEditPreview?: (filePath: string) => Promise<EditPreviewLine[]>;
-  /** Open a file's diff in the workspace diff panel (Monaco). Wired
-   *  by `MessagesWithTurns` to `openDiffTab(workspaceId, filePath)`. */
+  /** Open a file in the Monaco editor tab. Wired by
+   *  `MessagesWithTurns` to `openFileTab(workspaceId, filePath)` —
+   *  same action the FILES tree uses, NOT the diff viewer. */
   onOpenEditFile?: (filePath: string) => void;
 }) {
   const visibleActivities = activities ?? turn.activities;

--- a/src/ui/src/components/chat/WorkspaceActions.tsx
+++ b/src/ui/src/components/chat/WorkspaceActions.tsx
@@ -35,16 +35,20 @@ function preferredPrimaryApp(apps: DetectedApp[]): DetectedApp | null {
   return null;
 }
 
-function categoryIcon(category: AppCategory) {
+// Render the icon directly rather than returning the lucide component
+// constructor — `react-hooks/static-components` rejects assigning a
+// component to a local variable inside render, since it can't see that
+// the value is module-stable. Returning JSX here sidesteps that.
+function renderCategoryIcon(category: AppCategory) {
   switch (category) {
     case "editor":
-      return Code2;
+      return <Code2 size={14} strokeWidth={2.2} />;
     case "file_manager":
-      return FolderOpen;
+      return <FolderOpen size={14} strokeWidth={2.2} />;
     case "terminal":
-      return Terminal;
+      return <Terminal size={14} strokeWidth={2.2} />;
     case "ide":
-      return MonitorCog;
+      return <MonitorCog size={14} strokeWidth={2.2} />;
   }
 }
 
@@ -60,13 +64,12 @@ function AppIcon({ app }: { app: DetectedApp }) {
     );
   }
 
-  const Icon = categoryIcon(app.category);
   return (
     <span
       className={`${styles.appIconFallback} ${styles[`appIcon_${app.category}`]}`}
       aria-hidden="true"
     >
-      <Icon size={14} strokeWidth={2.2} />
+      {renderCategoryIcon(app.category)}
     </span>
   );
 }

--- a/src/ui/src/components/chat/chatLayoutCss.test.ts
+++ b/src/ui/src/components/chat/chatLayoutCss.test.ts
@@ -1,0 +1,73 @@
+// CSS invariants that can't be exercised in happy-dom (which doesn't run
+// real layout or apply CSS Modules). Pin them by reading the source CSS
+// and asserting the offending properties are present — brittle to
+// reformatting, but worth it because both bugs were silent: the DOM
+// looked fine, only `getBoundingClientRect` in a real browser revealed
+// the collapse / scrollbar.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CSS_DIR = join(__dirname);
+
+function readCss(file: string): string {
+  return readFileSync(join(CSS_DIR, file), "utf8");
+}
+
+/** Extract the body of a single CSS rule by selector (`.turnEditSummary`).
+ *  Greedy match up to the matching closing brace. Throws if not found so
+ *  the test fails loudly when a rule is renamed or deleted rather than
+ *  silently passing because the search returned an empty string. */
+function ruleBody(css: string, selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\s*{([^}]*)}`,
+  );
+  const match = css.match(re);
+  if (!match) throw new Error(`selector ${selector} not found in CSS`);
+  return match[1];
+}
+
+describe("ChatPanel.module.css invariants", () => {
+  // Regression: when `.turnEditSummary` lives inside a flex column whose
+  // parent has `overflow: auto` (the messages list), the spec-mandated
+  // implicit `min-height: 0` (because the card has its own
+  // `overflow: hidden` for rounded corners) shrinks the card to the
+  // border height. `scrollHeight` reads ~158px while the rendered box
+  // is ~2px — the file list is invisible.
+  // See `fix(chat): keep edit summary card from collapsing inside flex column`.
+  it("turnEditSummary pins flex-shrink: 0 so the card can't collapse in a flex column", () => {
+    const css = readCss("ChatPanel.module.css");
+    const body = ruleBody(css, ".turnEditSummary");
+    expect(body).toMatch(/flex-shrink:\s*0\s*;/);
+    // overflow: hidden is the trigger — verify it's still there so the
+    // pairing is intentional and a future drive-by removal of either
+    // half is caught.
+    expect(body).toMatch(/overflow:\s*hidden\s*;/);
+  });
+});
+
+describe("ThinkingBlock.module.css invariants", () => {
+  // Regression: inline thinking (Brink Mode / grouping disabled) lives
+  // inside the chat scroller. The default `.content` rule caps the
+  // box at 400px and adds an inner scrollbar; inline must not nest a
+  // second scroll surface inside the chat scroll. See
+  // `fix(chat): keep edit summary card ...` — same commit drops the
+  // inline scrollbar.
+  it("contentInline resets max-height and overflow so it can't introduce a nested scroll", () => {
+    const css = readCss("ThinkingBlock.module.css");
+    const body = ruleBody(css, ".contentInline");
+    expect(body).toMatch(/max-height:\s*none\s*;/);
+    expect(body).toMatch(/overflow-y:\s*visible\s*;/);
+  });
+
+  it("default content rule still caps height (sanity — only inline opts out)", () => {
+    // Pin that the cap on the default boxed variant isn't accidentally
+    // removed. Without it, very long thinking dumps would push the
+    // turn footer offscreen.
+    const css = readCss("ThinkingBlock.module.css");
+    const body = ruleBody(css, ".content");
+    expect(body).toMatch(/max-height:\s*\d+px\s*;/);
+    expect(body).toMatch(/overflow-y:\s*auto\s*;/);
+  });
+});

--- a/src/ui/src/components/chat/editActivitySummary.test.ts
+++ b/src/ui/src/components/chat/editActivitySummary.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { ToolActivity } from "../../stores/useAppStore";
+import {
+  summarizeAgentToolCallEdit,
+  summarizeTurnEdits,
+} from "./editActivitySummary";
+
+function activity(overrides: Partial<ToolActivity>): ToolActivity {
+  return {
+    toolUseId: "tool-1",
+    toolName: "Edit",
+    inputJson: "{}",
+    resultText: "done",
+    collapsed: true,
+    summary: "",
+    ...overrides,
+  };
+}
+
+describe("editActivitySummary", () => {
+  it("summarizes direct Edit line churn", () => {
+    const summary = summarizeTurnEdits([
+      activity({
+        inputJson: JSON.stringify({
+          file_path: "/repo/src/app.ts",
+          old_string: "one\ntwo\n",
+          new_string: "one\nthree\nfour\n",
+        }),
+      }),
+    ]);
+
+    expect(summary).toMatchObject({
+      added: 3,
+      removed: 2,
+      files: [{ filePath: "/repo/src/app.ts", added: 3, removed: 2 }],
+    });
+  });
+
+  it("aggregates MultiEdit and nested agent edit calls by file", () => {
+    const summary = summarizeTurnEdits([
+      activity({
+        toolName: "MultiEdit",
+        inputJson: JSON.stringify({
+          file_path: "src/app.ts",
+          edits: [
+            { old_string: "a", new_string: "a\nb" },
+            { old_string: "c\nd", new_string: "c" },
+          ],
+        }),
+        agentToolCalls: [
+          {
+            toolUseId: "nested-1",
+            toolName: "Edit",
+            agentId: "agent-1",
+            input: {
+              file_path: "src/app.ts",
+              old_string: "old",
+              new_string: "new\nnext",
+            },
+            status: "completed",
+            startedAt: "2026-05-08T00:00:00.000Z",
+          },
+        ],
+      }),
+    ]);
+
+    expect(summary).toMatchObject({
+      added: 5,
+      removed: 4,
+      files: [{ filePath: "src/app.ts", added: 5, removed: 4 }],
+    });
+  });
+
+  it("summarizes patch-shaped tool input", () => {
+    const summary = summarizeAgentToolCallEdit({
+      toolUseId: "patch-1",
+      toolName: "apply_patch",
+      agentId: "agent-1",
+      input: {
+        patch: [
+          "*** Begin Patch",
+          "*** Update File: src/app.ts",
+          "@@",
+          "-old",
+          "+new",
+          "+next",
+          "*** End Patch",
+        ].join("\n"),
+      },
+      status: "completed",
+      startedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary).toMatchObject({
+      added: 2,
+      removed: 1,
+      files: [{ filePath: "src/app.ts", added: 2, removed: 1 }],
+    });
+  });
+});

--- a/src/ui/src/components/chat/editActivitySummary.test.ts
+++ b/src/ui/src/components/chat/editActivitySummary.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { ToolActivity } from "../../stores/useAppStore";
 import {
+  previewLinesFromFileDiff,
+  summarizeDiffFiles,
   summarizeAgentToolCallEdit,
   summarizeTurnEdits,
 } from "./editActivitySummary";
@@ -34,6 +36,13 @@ describe("editActivitySummary", () => {
       removed: 2,
       files: [{ filePath: "/repo/src/app.ts", added: 3, removed: 2 }],
     });
+    expect(summary?.files[0].previewLines).toMatchObject([
+      { type: "removed", content: "one" },
+      { type: "removed", content: "two" },
+      { type: "added", content: "one" },
+      { type: "added", content: "three" },
+      { type: "added", content: "four" },
+    ]);
   });
 
   it("aggregates MultiEdit and nested agent edit calls by file", () => {
@@ -96,5 +105,90 @@ describe("editActivitySummary", () => {
       removed: 1,
       files: [{ filePath: "src/app.ts", added: 2, removed: 1 }],
     });
+    expect(summary?.files[0].previewLines).toMatchObject([
+      { type: "removed", content: "old" },
+      { type: "added", content: "new" },
+      { type: "added", content: "next" },
+    ]);
+  });
+
+  it("detects apply_patch content inside shell command tools", () => {
+    const summary = summarizeTurnEdits([
+      activity({
+        toolName: "Bash",
+        inputJson: JSON.stringify({
+          command: [
+            "apply_patch <<'PATCH'",
+            "*** Begin Patch",
+            "*** Update File: src/ui/App.tsx",
+            "@@",
+            "-old",
+            "+new",
+            "*** End Patch",
+            "PATCH",
+          ].join("\n"),
+        }),
+      }),
+    ]);
+
+    expect(summary).toMatchObject({
+      added: 1,
+      removed: 1,
+      files: [{ filePath: "src/ui/App.tsx", added: 1, removed: 1 }],
+    });
+  });
+
+  it("summarizes workspace diff files and builds lazy preview lines", () => {
+    const summary = summarizeDiffFiles([
+      { path: "src/app.ts", status: "Modified", additions: 4, deletions: 1 },
+      { path: "src/empty.ts", status: "Added" },
+    ]);
+
+    expect(summary).toMatchObject({
+      added: 4,
+      removed: 1,
+      files: [
+        { filePath: "src/app.ts", added: 4, removed: 1, previewLines: [] },
+        { filePath: "src/empty.ts", added: 0, removed: 0, previewLines: [] },
+      ],
+    });
+
+    expect(
+      previewLinesFromFileDiff({
+        path: "src/app.ts",
+        is_binary: false,
+        hunks: [
+          {
+            old_start: 2,
+            new_start: 2,
+            header: "@@ -2 +2 @@",
+            lines: [
+              {
+                line_type: "Context",
+                old_line_number: 2,
+                new_line_number: 2,
+                content: "same",
+              },
+              {
+                line_type: "Removed",
+                old_line_number: 3,
+                new_line_number: null,
+                content: "old",
+              },
+              {
+                line_type: "Added",
+                old_line_number: null,
+                new_line_number: 3,
+                content: "new",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toMatchObject([
+      { type: "context", content: "same" },
+      { type: "removed", content: "old" },
+      { type: "added", content: "new" },
+    ]);
   });
 });

--- a/src/ui/src/components/chat/editActivitySummary.ts
+++ b/src/ui/src/components/chat/editActivitySummary.ts
@@ -14,7 +14,7 @@ export interface EditSummary {
   removed: number;
 }
 
-export type EditPreviewLineType = "added" | "removed" | "context";
+export type EditPreviewLineType = "added" | "removed" | "context" | "hunk";
 
 export interface EditPreviewLine {
   type: EditPreviewLineType;
@@ -67,9 +67,22 @@ export function summarizeDiffFiles(files: readonly DiffFile[]): EditSummary | nu
 
 export function previewLinesFromFileDiff(diff: FileDiff): EditPreviewLine[] {
   const lines: EditPreviewLine[] = [];
-  for (const hunk of diff.hunks) {
+  diff.hunks.forEach((hunk, idx) => {
+    if (lines.length >= MAX_PREVIEW_LINES_PER_FILE) return;
+    // Separator between hunks (skip before the first one) so a file
+    // edited in distant regions visually breaks into chunks instead
+    // of running as one long block. The header carries the
+    // `@@ -OLD,N +NEW,M @@` text the backend already produced.
+    if (idx > 0) {
+      lines.push({
+        type: "hunk",
+        oldLineNumber: null,
+        newLineNumber: null,
+        content: hunk.header,
+      });
+    }
     for (const line of hunk.lines) {
-      if (lines.length >= MAX_PREVIEW_LINES_PER_FILE) return lines;
+      if (lines.length >= MAX_PREVIEW_LINES_PER_FILE) return;
       lines.push({
         type:
           line.line_type === "Added"
@@ -82,7 +95,7 @@ export function previewLinesFromFileDiff(diff: FileDiff): EditPreviewLine[] {
         content: line.content,
       });
     }
-  }
+  });
   return lines;
 }
 
@@ -194,10 +207,24 @@ function mergeStats(stats: readonly EditFileStat[]): EditSummary | null {
     if (existing) {
       existing.added += stat.added;
       existing.removed += stat.removed;
-      existing.previewLines = capPreviewLines([
-        ...existing.previewLines,
-        ...stat.previewLines,
-      ]);
+      // Separate each merged contribution with a hunk row so multiple
+      // Edit calls to the same file render as visually distinct
+      // chunks instead of one tall blob. Skip when either side is
+      // empty (avoids a leading or trailing separator with no
+      // surrounding content).
+      const merged = stat.previewLines.length > 0 && existing.previewLines.length > 0
+        ? [
+            ...existing.previewLines,
+            {
+              type: "hunk" as const,
+              oldLineNumber: null,
+              newLineNumber: null,
+              content: "",
+            },
+            ...stat.previewLines,
+          ]
+        : [...existing.previewLines, ...stat.previewLines];
+      existing.previewLines = capPreviewLines(merged);
     } else {
       byPath.set(stat.filePath, {
         ...stat,
@@ -257,6 +284,18 @@ function parsePatchStats(patch: string): EditFileStat[] {
     if (hunkMatch) {
       oldLineNumber = Number(hunkMatch[1]);
       newLineNumber = Number(hunkMatch[2]);
+      // Emit a separator row for every `@@` after the first one in
+      // this file, so multi-hunk patches break up vertically. Skip
+      // the leading separator since the file header already opens
+      // the first hunk visually.
+      if (active.previewLines.length > 0) {
+        pushPreviewLine(active, {
+          type: "hunk",
+          oldLineNumber: null,
+          newLineNumber: null,
+          content: line,
+        });
+      }
       continue;
     }
     if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("***")) {

--- a/src/ui/src/components/chat/editActivitySummary.ts
+++ b/src/ui/src/components/chat/editActivitySummary.ts
@@ -1,9 +1,11 @@
 import type { AgentToolCall, ToolActivity } from "../../stores/useAppStore";
+import type { DiffFile, FileDiff } from "../../types/diff";
 
 export interface EditFileStat {
   filePath: string;
   added: number;
   removed: number;
+  previewLines: EditPreviewLine[];
 }
 
 export interface EditSummary {
@@ -12,7 +14,18 @@ export interface EditSummary {
   removed: number;
 }
 
+export type EditPreviewLineType = "added" | "removed" | "context";
+
+export interface EditPreviewLine {
+  type: EditPreviewLineType;
+  oldLineNumber: number | null;
+  newLineNumber: number | null;
+  content: string;
+}
+
 type JsonRecord = Record<string, unknown>;
+
+const MAX_PREVIEW_LINES_PER_FILE = 80;
 
 export function summarizeToolActivityEdit(
   activity: ToolActivity,
@@ -39,6 +52,38 @@ export function summarizeTurnEdits(
     }
   }
   return mergeStats(stats);
+}
+
+export function summarizeDiffFiles(files: readonly DiffFile[]): EditSummary | null {
+  return mergeStats(
+    files.map((file) => ({
+      filePath: file.path,
+      added: file.additions ?? 0,
+      removed: file.deletions ?? 0,
+      previewLines: [],
+    })),
+  );
+}
+
+export function previewLinesFromFileDiff(diff: FileDiff): EditPreviewLine[] {
+  const lines: EditPreviewLine[] = [];
+  for (const hunk of diff.hunks) {
+    for (const line of hunk.lines) {
+      if (lines.length >= MAX_PREVIEW_LINES_PER_FILE) return lines;
+      lines.push({
+        type:
+          line.line_type === "Added"
+            ? "added"
+            : line.line_type === "Removed"
+              ? "removed"
+              : "context",
+        oldLineNumber: line.old_line_number,
+        newLineNumber: line.new_line_number,
+        content: line.content,
+      });
+    }
+  }
+  return lines;
 }
 
 function summarizeEditToolInput(
@@ -75,7 +120,14 @@ function summarizeEditToolInput(
     const filePath = stringField(input, "file_path");
     const content = stringField(input, "content");
     if (!filePath || content === null) return null;
-    return mergeStats([{ filePath, added: changedLineCount(content), removed: 0 }]);
+    return mergeStats([
+      {
+        filePath,
+        added: changedLineCount(content),
+        removed: 0,
+        previewLines: linesFromText(content, "added"),
+      },
+    ]);
   }
 
   if (normalized === "notebookedit") {
@@ -95,15 +147,24 @@ function summarizeEditToolInput(
   }
 
   if (normalized.includes("apply_patch") || normalized.includes("patch")) {
-    const patch =
-      stringField(input, "patch") ??
-      stringField(input, "input") ??
-      stringField(input, "cmd") ??
-      stringField(input, "command");
+    const patch = patchTextFromInput(input);
     return patch ? mergeStats(parsePatchStats(patch)) : null;
   }
 
+  const patch = patchTextFromInput(input);
+  return patch ? mergeStats(parsePatchStats(patch)) : null;
+}
+
+function patchTextFromInput(input: JsonRecord): string | null {
+  for (const field of ["patch", "input", "cmd", "command"] as const) {
+    const value = stringField(input, field);
+    if (value && looksLikePatch(value)) return value;
+  }
   return null;
+}
+
+function looksLikePatch(value: string): boolean {
+  return value.includes("*** Begin Patch") || value.includes("diff --git ");
 }
 
 function statFromReplacement(
@@ -117,6 +178,10 @@ function statFromReplacement(
       filePath,
       added: changedLineCount(newText ?? ""),
       removed: changedLineCount(oldText ?? ""),
+      previewLines: [
+        ...linesFromText(oldText ?? "", "removed"),
+        ...linesFromText(newText ?? "", "added"),
+      ],
     },
   ]);
 }
@@ -129,8 +194,15 @@ function mergeStats(stats: readonly EditFileStat[]): EditSummary | null {
     if (existing) {
       existing.added += stat.added;
       existing.removed += stat.removed;
+      existing.previewLines = capPreviewLines([
+        ...existing.previewLines,
+        ...stat.previewLines,
+      ]);
     } else {
-      byPath.set(stat.filePath, { ...stat });
+      byPath.set(stat.filePath, {
+        ...stat,
+        previewLines: capPreviewLines(stat.previewLines),
+      });
     }
   }
   const files = [...byPath.values()].sort((a, b) => a.filePath.localeCompare(b.filePath));
@@ -148,10 +220,17 @@ function parsePatchStats(patch: string): EditFileStat[] {
 
   const beginCurrent = (filePath: string | null): EditFileStat | null => {
     if (!filePath || filePath === "/dev/null") return null;
-    const next = { filePath: stripDiffPrefix(filePath), added: 0, removed: 0 };
+    const next = {
+      filePath: stripDiffPrefix(filePath),
+      added: 0,
+      removed: 0,
+      previewLines: [],
+    };
     stats.push(next);
     return next;
   };
+  let oldLineNumber: number | null = null;
+  let newLineNumber: number | null = null;
 
   for (const line of patch.split(/\r\n|\r|\n/)) {
     const fileMatch =
@@ -159,22 +238,58 @@ function parsePatchStats(patch: string): EditFileStat[] {
       line.match(/^diff --git a\/.+ b\/(.+)$/);
     if (fileMatch) {
       current = beginCurrent(fileMatch[1]);
+      oldLineNumber = null;
+      newLineNumber = null;
       continue;
     }
 
     const nextFile = line.match(/^\+\+\+ (.+)$/);
     if (nextFile && !current) {
       current = beginCurrent(nextFile[1]);
+      oldLineNumber = null;
+      newLineNumber = null;
       continue;
     }
 
     const active = current;
     if (!active) continue;
+    const hunkMatch = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      oldLineNumber = Number(hunkMatch[1]);
+      newLineNumber = Number(hunkMatch[2]);
+      continue;
+    }
     if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("***")) {
       continue;
     }
-    if (line.startsWith("+")) active.added += 1;
-    else if (line.startsWith("-")) active.removed += 1;
+    if (line.startsWith("+")) {
+      active.added += 1;
+      pushPreviewLine(active, {
+        type: "added",
+        oldLineNumber: null,
+        newLineNumber,
+        content: line.slice(1),
+      });
+      if (newLineNumber !== null) newLineNumber += 1;
+    } else if (line.startsWith("-")) {
+      active.removed += 1;
+      pushPreviewLine(active, {
+        type: "removed",
+        oldLineNumber,
+        newLineNumber: null,
+        content: line.slice(1),
+      });
+      if (oldLineNumber !== null) oldLineNumber += 1;
+    } else if (line.startsWith(" ")) {
+      pushPreviewLine(active, {
+        type: "context",
+        oldLineNumber,
+        newLineNumber,
+        content: line.slice(1),
+      });
+      if (oldLineNumber !== null) oldLineNumber += 1;
+      if (newLineNumber !== null) newLineNumber += 1;
+    }
   }
 
   return stats.filter((stat) => stat.added > 0 || stat.removed > 0);
@@ -190,6 +305,36 @@ function changedLineCount(value: string): number {
   const trimmed = normalized.endsWith("\n") ? normalized.slice(0, -1) : normalized;
   if (trimmed.length === 0) return 0;
   return trimmed.split("\n").length;
+}
+
+function linesFromText(
+  value: string,
+  type: Exclude<EditPreviewLineType, "context">,
+): EditPreviewLine[] {
+  return splitChangedLines(value)
+    .slice(0, MAX_PREVIEW_LINES_PER_FILE)
+    .map((content, index) => ({
+      type,
+      oldLineNumber: type === "removed" ? index + 1 : null,
+      newLineNumber: type === "added" ? index + 1 : null,
+      content,
+    }));
+}
+
+function splitChangedLines(value: string): string[] {
+  if (value.length === 0) return [];
+  const normalized = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const trimmed = normalized.endsWith("\n") ? normalized.slice(0, -1) : normalized;
+  return trimmed.length === 0 ? [] : trimmed.split("\n");
+}
+
+function pushPreviewLine(stat: EditFileStat, line: EditPreviewLine) {
+  if (stat.previewLines.length >= MAX_PREVIEW_LINES_PER_FILE) return;
+  stat.previewLines.push(line);
+}
+
+function capPreviewLines(lines: readonly EditPreviewLine[]): EditPreviewLine[] {
+  return lines.slice(0, MAX_PREVIEW_LINES_PER_FILE);
 }
 
 function parseJsonRecord(inputJson: string): JsonRecord | null {

--- a/src/ui/src/components/chat/editActivitySummary.ts
+++ b/src/ui/src/components/chat/editActivitySummary.ts
@@ -1,0 +1,212 @@
+import type { AgentToolCall, ToolActivity } from "../../stores/useAppStore";
+
+export interface EditFileStat {
+  filePath: string;
+  added: number;
+  removed: number;
+}
+
+export interface EditSummary {
+  files: EditFileStat[];
+  added: number;
+  removed: number;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+export function summarizeToolActivityEdit(
+  activity: ToolActivity,
+): EditSummary | null {
+  return summarizeEditToolInput(activity.toolName, parseJsonRecord(activity.inputJson));
+}
+
+export function summarizeAgentToolCallEdit(
+  call: AgentToolCall,
+): EditSummary | null {
+  return summarizeEditToolInput(call.toolName, recordFromUnknown(call.input));
+}
+
+export function summarizeTurnEdits(
+  activities: readonly ToolActivity[],
+): EditSummary | null {
+  const stats: EditFileStat[] = [];
+  for (const activity of activities) {
+    const direct = summarizeToolActivityEdit(activity);
+    if (direct) stats.push(...direct.files);
+    for (const call of activity.agentToolCalls ?? []) {
+      const nested = summarizeAgentToolCallEdit(call);
+      if (nested) stats.push(...nested.files);
+    }
+  }
+  return mergeStats(stats);
+}
+
+function summarizeEditToolInput(
+  toolName: string,
+  input: JsonRecord | null,
+): EditSummary | null {
+  if (!input) return null;
+  const normalized = toolName.toLowerCase();
+
+  if (normalized === "edit") {
+    return statFromReplacement(
+      stringField(input, "file_path"),
+      stringField(input, "old_string"),
+      stringField(input, "new_string"),
+    );
+  }
+
+  if (normalized === "multiedit") {
+    const filePath = stringField(input, "file_path");
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    const stats = edits
+      .map((edit) =>
+        statFromReplacement(
+          filePath,
+          stringField(recordFromUnknown(edit), "old_string"),
+          stringField(recordFromUnknown(edit), "new_string"),
+        ),
+      )
+      .flatMap((summary) => summary?.files ?? []);
+    return mergeStats(stats);
+  }
+
+  if (normalized === "write") {
+    const filePath = stringField(input, "file_path");
+    const content = stringField(input, "content");
+    if (!filePath || content === null) return null;
+    return mergeStats([{ filePath, added: changedLineCount(content), removed: 0 }]);
+  }
+
+  if (normalized === "notebookedit") {
+    return statFromReplacement(
+      stringField(input, "notebook_path"),
+      stringField(input, "old_source") ?? stringField(input, "source"),
+      stringField(input, "new_source"),
+    );
+  }
+
+  if (normalized.includes("str_replace")) {
+    return statFromReplacement(
+      stringField(input, "path") ?? stringField(input, "file_path"),
+      stringField(input, "old_str") ?? stringField(input, "old_string"),
+      stringField(input, "new_str") ?? stringField(input, "new_string"),
+    );
+  }
+
+  if (normalized.includes("apply_patch") || normalized.includes("patch")) {
+    const patch =
+      stringField(input, "patch") ??
+      stringField(input, "input") ??
+      stringField(input, "cmd") ??
+      stringField(input, "command");
+    return patch ? mergeStats(parsePatchStats(patch)) : null;
+  }
+
+  return null;
+}
+
+function statFromReplacement(
+  filePath: string | null,
+  oldText: string | null,
+  newText: string | null,
+): EditSummary | null {
+  if (!filePath || (oldText === null && newText === null)) return null;
+  return mergeStats([
+    {
+      filePath,
+      added: changedLineCount(newText ?? ""),
+      removed: changedLineCount(oldText ?? ""),
+    },
+  ]);
+}
+
+function mergeStats(stats: readonly EditFileStat[]): EditSummary | null {
+  const byPath = new Map<string, EditFileStat>();
+  for (const stat of stats) {
+    if (!stat.filePath) continue;
+    const existing = byPath.get(stat.filePath);
+    if (existing) {
+      existing.added += stat.added;
+      existing.removed += stat.removed;
+    } else {
+      byPath.set(stat.filePath, { ...stat });
+    }
+  }
+  const files = [...byPath.values()].sort((a, b) => a.filePath.localeCompare(b.filePath));
+  if (files.length === 0) return null;
+  return {
+    files,
+    added: files.reduce((sum, file) => sum + file.added, 0),
+    removed: files.reduce((sum, file) => sum + file.removed, 0),
+  };
+}
+
+function parsePatchStats(patch: string): EditFileStat[] {
+  const stats: EditFileStat[] = [];
+  let current: EditFileStat | null = null;
+
+  const beginCurrent = (filePath: string | null): EditFileStat | null => {
+    if (!filePath || filePath === "/dev/null") return null;
+    const next = { filePath: stripDiffPrefix(filePath), added: 0, removed: 0 };
+    stats.push(next);
+    return next;
+  };
+
+  for (const line of patch.split(/\r\n|\r|\n/)) {
+    const fileMatch =
+      line.match(/^\*\*\* (?:Add|Update|Delete) File: (.+)$/) ??
+      line.match(/^diff --git a\/.+ b\/(.+)$/);
+    if (fileMatch) {
+      current = beginCurrent(fileMatch[1]);
+      continue;
+    }
+
+    const nextFile = line.match(/^\+\+\+ (.+)$/);
+    if (nextFile && !current) {
+      current = beginCurrent(nextFile[1]);
+      continue;
+    }
+
+    const active = current;
+    if (!active) continue;
+    if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("***")) {
+      continue;
+    }
+    if (line.startsWith("+")) active.added += 1;
+    else if (line.startsWith("-")) active.removed += 1;
+  }
+
+  return stats.filter((stat) => stat.added > 0 || stat.removed > 0);
+}
+
+function stripDiffPrefix(filePath: string): string {
+  return filePath.replace(/^[ab]\//, "");
+}
+
+function changedLineCount(value: string): number {
+  if (value.length === 0) return 0;
+  const normalized = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const trimmed = normalized.endsWith("\n") ? normalized.slice(0, -1) : normalized;
+  if (trimmed.length === 0) return 0;
+  return trimmed.split("\n").length;
+}
+
+function parseJsonRecord(inputJson: string): JsonRecord | null {
+  try {
+    return recordFromUnknown(JSON.parse(inputJson));
+  } catch {
+    return null;
+  }
+}
+
+function recordFromUnknown(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function stringField(record: JsonRecord | null, field: string): string | null {
+  const value = record?.[field];
+  return typeof value === "string" ? value : null;
+}


### PR DESCRIPTION
## Summary

Adds a per-turn **edit summary card** at the end of every tool-using turn in the chat: a compact "_N files changed +A −B_" header plus an expandable per-file list with inline diffs. Each row gets a popout that opens the file in the Monaco editor, and a chevron that reveals an inline diff preview with hunk separators for multi-region changes. Inline `Editing path +A −B` rows also appear in the live tool-activity list as the agent runs.

## Screenshots

| End-of-turn card | Inline editing row |
|---|---|
| _N files changed_ header with per-file rows. Click the popout (↗) to open the file in Monaco; click the chevron to expand an inline diff with hunk separators. | `Editing src/foo.ts +9 −4` shown next to the live `Edit` tool call so churn is visible while the agent works. |

## What's in this PR

### `feat: show edit change summaries in chat` (`d7f796fe`)

- New `editActivitySummary.ts` helper parses tool inputs into `{file, +added, −removed, previewLines}` shaped data.
  - Handles `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `str_replace_*`-style, and `*** Begin Patch` / `diff --git` patches.
  - Walks one level into `Agent` activities' nested `agentToolCalls[]` so subagent edits roll up into the parent turn.
- `InlineEditSummary` (used inside `ToolActivitiesSection`, `TurnSummary`, `AgentToolCallGroup`) replaces the bare tool name with `Editing <path> +A −B` for any tool the parser recognizes.
- `TurnEditSummaryCard` (rendered at the bottom of `TurnSummary` / `MessagesWithTurns` footer entries) shows the aggregated per-file list with click-to-expand inline previews.

### `fix: show turn edit summaries from workspace diff` (`dd7f329f`)

The latest completed turn falls back to the right-sidebar's workspace diff (`summarizeDiffFiles`) so turns whose tools couldn't be parsed (Bash heredoc, MCP write tools) still get a card. Lazy preview load wires `loadFileDiff` for the latest-turn rows so users can expand any file in the cumulative diff.

### `fix: scope turn edit summary card to files this turn touched` (`c9987b86`)

The "fix" above had unintentionally let the workspace-diff summary stomp the activity-derived data. Result: a turn that edited 4 files showed every modified file in the worktree (e.g. 13). Reframed the rescue prop:

- Renamed `editSummaryOverride` → `editSummaryFallback` on `TurnSummary`.
- Flipped precedence to `activityEditSummary ?? editSummaryFallback ?? null` so per-turn data wins; workspace diff only rescues when the parser found nothing.
- Added regression test pinning that turn-scoped data wins over a `+99 −99` fallback.

### `fix: keep edit summary card from collapsing inside flex column` (`dd965260`)

The messages list is `display: flex; flex-direction: column; overflow: auto`. Per the flex spec, a flex item whose own `overflow` is not `visible` gets `min-height: 0` implicitly — the `overflow: hidden` we set on `.turnEditSummary` for rounded corners collapsed the card to its border height (~2px) while `scrollHeight` still reported the full ~158px. Pin `flex-shrink: 0` so the card always lays out at its intrinsic content height.

Bonus in the same commit: `.contentInline` on `ThinkingBlock` resets `max-height: none; overflow-y: visible` so inline thinking blocks (Brink Mode / grouping disabled) no longer nest a second scrollbar inside the chat scroller.

### `fix(workspace-actions): satisfy react-hooks/static-components` (`511d1008`)

The new `react-hooks/static-components` lint rule rejects assigning a component to a local variable inside render (`const Icon = categoryIcon(...)`). Inlined the lucide dispatch into a function that returns JSX directly so component identity stays at module scope. Clears the only `bun run lint` error blocking CI.

### `fix: drop +/- prefix column from inline diff` (`1de29fb2`)

Brief detour: matched Codex / GitHub PR view by dropping the prefix column. Reverted in the next commit per user feedback to keep the prefix for app consistency.

### `feat(chat): hunk separators + restored +/- prefix on inline diff` (`bc40ceff`)

Two changes:

1. **Restore the `+/−` prefix column** (40px / 40px / 18px / 1fr grid). Per user feedback, keep it for consistency with other +/− displays in the app.
2. **Hunk separator rows** between distinct hunks so multi-region diffs break up vertically instead of running as one tall blob:
   - `previewLinesFromFileDiff` (workspace-diff path): separator between hunks, header text from `hunk.header` (e.g. `@@ -28,6 +29,10 @@ impl ModelSessionStats {`).
   - `parsePatchStats` (apply_patch path): separator at every `@@` after the first inside a file.
   - `mergeStats` (activity merge path): separator between contributions when multiple Edit calls hit the same file (rendered as a plain divider band since the activity payload has no header text).

A new `EditPreviewLineType` value `"hunk"` carries the separator; `DiffPreviewLine` renders it as a full-width band (no gutters).

Also defensively fixes one impure-state-updater pattern in `ChatInputArea`: `setCursorPos` was called from inside a `setChatInput` updater function, which can fire under concurrent rendering and is the canonical source of "Cannot update a component while rendering" warnings.

### `feat(chat): open file in Monaco from per-turn edit summary card` (`e23f711b`)

Each file row in the card now gets a popout icon (lucide `SquareArrowOutUpRight`) that opens the file in Monaco via `openFileTab(workspaceId, repoRelativePath)` — the same action the FILES tree uses. Sits in a sibling action cluster with the existing chevron; nested buttons are invalid HTML so the row + actions are split into separate buttons inside a flex wrap.

`MessagesWithTurns` strips the worktree prefix from activity-derived absolute paths before calling `openFileTab`. New CSS classes: `.turnEditFileRowWrap`, `.turnEditFileActions`, `.turnEditFileActionBtn` (drops the orphaned `.turnEditFileChevron`).

## File tour

```text
src/ui/src/components/chat/
├── editActivitySummary.ts          NEW   parses tool inputs → EditSummary
├── editActivitySummary.test.ts     NEW   covers Edit/MultiEdit/apply_patch/Bash-heredoc/workspace-diff
├── EditChangeSummary.tsx           NEW   InlineEditSummary + TurnEditSummaryCard + InlineDiffPreview
├── chatLayoutCss.test.ts           NEW   pins flex-shrink and contentInline overflow rules
├── MessagesWithTurns.tsx                 wires per-turn cards + workspace-diff fallback + Monaco open
├── TurnSummary.tsx                       editSummaryFallback prop + onOpenEditFile plumbing
├── ToolActivitiesSection.tsx             InlineEditSummary in live tool rows
├── AgentToolCallGroup.tsx                InlineEditSummary in nested agent tool calls
├── ChatPanel.module.css                  card / hunk / file-row / action-button styles (~300 lines)
├── ToolActivitiesSection.test.tsx        +5 new tests
├── ChatInputArea.tsx                     impure-updater fix
└── WorkspaceActions.tsx                  static-components lint fix

src/ui/src/components/chat/ThinkingBlock.module.css   contentInline overflow override
site/src/content/docs/features/diff-viewer.mdx        one-line mention of the in-chat summary
```

## Testing

- 131 frontend test files, **1640 tests** pass (up from ~1628 on `main`).
- New tests:
  - `editActivitySummary.test.ts` — 5 cases covering each parser path.
  - `chatLayoutCss.test.ts` — 3 CSS invariants (flex-shrink, contentInline overflow, default `.content` cap).
  - `ToolActivitiesSection.test.tsx` — 5 new cases: nested-edit rendering, completed-turn card, workspace-diff fallback, turn-scoped vs fallback precedence, completed inline Agent calls.
- `bunx tsc -b` clean.
- `bun run lint` clean (0 errors). The 13 warnings are pre-existing on main.
- `bun run lint:css` clean.
- Live-verified in dev build: card height 172px (was 2px), 4-file scoped list (was 13 cumulative), inline thinking has `overflow-y: visible`, popout sets `activeFileTabByWorkspace[ws]` correctly.

## Out-of-scope follow-ups noted during this work

- **Default-terminal picker** — filed as #709 (right-click "Open in Terminal" hardcodes Terminal.app on macOS).
- **Tauri listener cleanup** — repeated `listeners[eventId].handlerId is undefined` errors observed under heavy session churn; the `useWorkspaceFileWatcher.ts:88` cleanup `unlisten.then((fn) => fn())` doesn't await. Cleared by app restart; worth filing if it recurs.
- **`ChatInputArea` setState-during-render warning** — original capture during boot was a one-shot, couldn't reproduce live. Defensively fixed the only suspicious render-time updater pattern in this PR; if a new repro surfaces, the warning's component-name hint should localize the next root cause quickly.

## Out-of-scope intentionally not done

Per user feedback, regression tests for live-only behaviors (the listener-cleanup error, the file-not-opening-Monaco issue in one specific workspace) were skipped — both were transient and unrelated to this branch.

