### PR TITLE
fix: keep turn edit summaries session-scoped

### DIFF
--- a/src/ui/src/components/chat/MessagesWithTurns.test.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useAppStore, type CompletedTurn, type ToolActivity } from "../../stores/useAppStore";
+import type { ChatMessage } from "../../types/chat";
+import { MessagesWithTurns } from "./MessagesWithTurns";
+
+const WORKSPACE_ID = "workspace-1";
+const SESSION_ID = "session-1";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+function message(
+  id: string,
+  role: ChatMessage["role"],
+  content: string,
+): ChatMessage {
+  return {
+    id,
+    workspace_id: WORKSPACE_ID,
+    chat_session_id: SESSION_ID,
+    role,
+    content,
+    cost_usd: null,
+    duration_ms: null,
+    created_at: "2026-05-08T00:00:00.000Z",
+    thinking: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cache_creation_tokens: null,
+  };
+}
+
+function activity(toolName: string): ToolActivity {
+  return {
+    toolUseId: `${toolName}-1`,
+    toolName,
+    inputJson: JSON.stringify({ query: "select 1" }),
+    resultText: "1 row",
+    collapsed: true,
+    summary: "1 row",
+  };
+}
+
+function completedTurn(activities: ToolActivity[]): CompletedTurn {
+  return {
+    id: "turn-1",
+    activities,
+    messageCount: 2,
+    collapsed: false,
+    afterMessageIndex: 2,
+  };
+}
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    workspaces: [
+      {
+        id: WORKSPACE_ID,
+        repository_id: "repo-1",
+        name: "Workspace",
+        worktree_path: "/repo",
+        branch_name: "main",
+        status: "Active",
+        status_line: "",
+        created_at: "2026-05-08T00:00:00.000Z",
+        sort_order: 0,
+        remote_connection_id: null,
+        agent_status: "Idle",
+      },
+    ],
+    chatMessages: {},
+    chatAttachments: {},
+    chatPagination: {},
+    completedTurns: {},
+    toolActivities: {},
+    collapsedToolGroupsBySession: {},
+    checkpoints: {},
+    diffFiles: [],
+    diffMergeBase: "base-sha",
+  });
+});
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("MessagesWithTurns edit summaries", () => {
+  it("does not show workspace dirty files for a non-editing session turn", async () => {
+    const messages = [
+      message("user-1", "User", "Query production data"),
+      message("assistant-1", "Assistant", "The query returned one row."),
+    ];
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [completedTurn([activity("mcp__postgres__query")])],
+      },
+      diffFiles: [
+        {
+          path: "src/dirty-from-other-session.ts",
+          status: "Modified",
+          additions: 8,
+          deletions: 3,
+        },
+      ],
+    });
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    expect(container.textContent).toContain("mcp__postgres__query");
+    expect(container.textContent).not.toContain("1 file changed");
+    expect(container.textContent).not.toContain("dirty-from-other-session.ts");
+  });
+
+  it("still shows files parsed from this turn's own edit activity", async () => {
+    const messages = [
+      message("user-1", "User", "Update the app"),
+      message("assistant-1", "Assistant", "Updated."),
+    ];
+    useAppStore.setState({
+      completedTurns: {
+        [SESSION_ID]: [
+          completedTurn([
+            {
+              ...activity("Edit"),
+              inputJson: JSON.stringify({
+                file_path: "/repo/src/app.ts",
+                old_string: "old",
+                new_string: "new",
+              }),
+            },
+          ]),
+        ],
+      },
+      diffFiles: [
+        {
+          path: "src/dirty-from-other-session.ts",
+          status: "Modified",
+          additions: 8,
+          deletions: 3,
+        },
+      ],
+    });
+
+    const container = await render(
+      <MessagesWithTurns
+        messages={messages}
+        workspaceId={WORKSPACE_ID}
+        sessionId={SESSION_ID}
+        isRunning={false}
+        searchQuery=""
+        toolDisplayMode="grouped"
+      />,
+    );
+
+    expect(container.textContent).toContain("1 file changed");
+    expect(container.textContent).toContain("src/app.ts");
+    expect(container.textContent).not.toContain("dirty-from-other-session.ts");
+  });
+});

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
-import { loadAttachmentData, loadFileDiff } from "../../services/tauri";
+import { loadAttachmentData } from "../../services/tauri";
 import type { ChatMessage, ChatAttachment } from "../../types/chat";
 import { roleClassKey, shouldRenderAsMarkdown } from "./messageRendering";
 import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
@@ -45,8 +45,6 @@ import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { TurnFooter } from "./TurnFooter";
 import { TurnEditSummaryCard } from "./EditChangeSummary";
 import {
-  previewLinesFromFileDiff,
-  summarizeDiffFiles,
   summarizeTurnEdits,
 } from "./editActivitySummary";
 import { PdfThumbnail } from "./PdfThumbnail";
@@ -150,8 +148,6 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
   const worktreePath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.worktree_path,
   );
-  const diffFiles = useAppStore((s) => s.diffFiles);
-  const diffMergeBase = useAppStore((s) => s.diffMergeBase);
   const liveToolActivities = useAppStore(
     (s) => s.toolActivities[sessionId] ?? EMPTY_ACTIVITIES,
   );
@@ -433,20 +429,6 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     }
     return map;
   }, [completedTurns]);
-  const workspaceDiffSummary = useMemo(
-    () => summarizeDiffFiles(diffFiles),
-    [diffFiles],
-  );
-  const latestCompletedTurnId =
-    completedTurns[completedTurns.length - 1]?.id ?? null;
-  const loadWorkspaceDiffPreview = useCallback(
-    async (filePath: string) => {
-      if (!worktreePath || !diffMergeBase) return [];
-      const diff = await loadFileDiff(worktreePath, diffMergeBase, filePath);
-      return previewLinesFromFileDiff(diff);
-    },
-    [diffMergeBase, worktreePath],
-  );
   const openFileTab = useAppStore((s) => s.openFileTab);
   // Open the file in the Monaco editor tab (not the diff viewer).
   // Activity-derived edits use absolute paths (the agent's full path
@@ -580,16 +562,6 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     return (
       <>
         {groupEntries.map(({ turn, globalIdx, activities, label, showFooter }) => {
-          const isLatestCompletedTurn = turn.id === latestCompletedTurnId;
-          // The card prefers per-turn activity-derived edits ("files
-          // THIS turn touched"). Workspace-diff summary is offered as a
-          // rescue only on the latest turn — `TurnSummary` uses it only
-          // when the activity parser couldn't recognize any edits
-          // (Bash heredoc, MCP write tool, etc.). Older turns get no
-          // rescue: their workspace-diff entry would include later
-          // turns' churn, which would mislead.
-          const fallbackEditSummary =
-            showFooter && isLatestCompletedTurn ? workspaceDiffSummary : null;
           // A single turn can produce multiple display groups when
           // chronologically-interleaved messages split its activities;
           // each group needs its own collapse state so clicking one
@@ -650,35 +622,19 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
               onRollback={showFooter ? buildOnRollback(turn.id) : undefined}
               searchQuery={searchQuery}
               worktreePath={worktreePath}
-              editSummaryFallback={fallbackEditSummary}
-              onLoadEditPreview={
-                showFooter && isLatestCompletedTurn
-                  ? loadWorkspaceDiffPreview
-                  : undefined
-              }
               onOpenEditFile={showFooter ? openFileInMonaco : undefined}
             />
           );
         })}
         {footerEntries.map(({ turn }) => {
-          const isLatestCompletedTurn = turn.id === latestCompletedTurnId;
-          // Same precedence as the group-entries path above: turn-scoped
-          // activity edits win; workspace diff only rescues the latest
-          // turn when activities can't be parsed into edit churn.
           const turnActivitySummary = editSummaryByTurnId.get(turn.id) ?? null;
-          const editSummary =
-            turnActivitySummary ??
-            (isLatestCompletedTurn ? workspaceDiffSummary : null);
           return (
             <React.Fragment key={`${turn.id}:${position}:footer`}>
-              {editSummary && (
+              {turnActivitySummary && (
                 <TurnEditSummaryCard
-                  summary={editSummary}
+                  summary={turnActivitySummary}
                   searchQuery={searchQuery}
                   worktreePath={worktreePath}
-                  onLoadPreview={
-                    isLatestCompletedTurn ? loadWorkspaceDiffPreview : undefined
-                  }
                   onOpenFile={openFileInMonaco}
                 />
               )}


### PR DESCRIPTION
## Summary

- Remove the workspace-wide diff fallback from chat turn edit summaries.
- Keep edit summary cards scoped to files detected from the turn[39;49;00m's own tool activity.
- Add regression coverage for a non-editing MCP/query turn in a workspace that has unrelated dirty files.
- Preserve the positive path where a real edit tool still renders the edited file for that turn.

## Root Cause

The latest completed turn could use `diffFiles` as a fallback when its tool activities did not parse into edit activity. `diffFiles` is workspace-scoped, not chat-session or turn-scoped, so opening another session/window in the same workspace could make unrelated dirty files appear as if they were modified by the active turn.

## User Impact

Session tabs no longer leak modified-file summaries from other sessions. A turn only shows changed files when those files can be attributed to that turn through its own edit/write/patch tool activity.

## Validation

- `nix develop -c bash -lc 'cd src/ui && bun run test -- src/components/chat/MessagesWithTurns.test.tsx src/components/chat/ToolActivitiesSection.test.tsx'`
- `nix develop -c bash -lc 'cd src/ui && bunx tsc -b'`
