### PR TITLE
fix: improve tool call summary and detail rendering

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -49,7 +49,7 @@ Set defaults in `Settings > Models`:
 
 ## Tool Call Details
 
-Tool-call rows in the chat timeline include an expand chevron for inspecting the exact input the agent sent to that tool. Code-like inputs such as SQL queries, JavaScript browser evaluations, shell commands, and JSON payloads render in a syntax-highlighted block; plain inputs such as file paths render as monospace text.
+When `Settings > Appearance > Extended tool call output` is enabled, tool-call rows in the chat timeline include an expand chevron for inspecting the exact input the agent sent to that tool. Code-like inputs such as SQL queries, JavaScript browser evaluations, shell commands, and JSON payloads render in a syntax-highlighted block; plain inputs such as file paths render as monospace text.
 
 The expanded state sticks to each tool call while the chat panel re-renders, so you can keep a long query or command open while later tool activity streams in.
 

--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -47,6 +47,12 @@ Set defaults in `Settings > Models`:
 - **Default thinking** — enable/disable for new sessions
 - **Show thinking blocks** — show/hide by default
 
+## Tool Call Details
+
+Tool-call rows in the chat timeline include an expand chevron for inspecting the exact input the agent sent to that tool. Code-like inputs such as SQL queries, JavaScript browser evaluations, shell commands, and JSON payloads render in a syntax-highlighted block; plain inputs such as file paths render as monospace text.
+
+The expanded state sticks to each tool call while the chat panel re-renders, so you can keep a long query or command open while later tool activity streams in.
+
 ## Fast Mode
 
 Fast mode prioritizes speed over depth. When enabled, the agent uses quicker, more concise responses.

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -35,6 +35,7 @@ See [Agent Configuration](/claudette/features/agent-configuration/) for detailed
 |---------|-------------|---------|
 | Theme | Color theme (12 built-in + custom) | Default Dark |
 | Group adjacent tool calls | Collapse adjacent regular tool calls into summary blocks. When off, every top-level tool call, Agent call, and thinking block is shown inline. | On |
+| Extended tool call output | Add expandable, copyable input details under tool call rows. | Off |
 | Terminal font size | Font size for terminal tabs (8–24px) | 11px |
 
 See [Theming](/claudette/features/theming/) for details on built-in themes and creating custom themes.

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -56,6 +56,7 @@ function App() {
   const setClaudetteTerminalEnabled = useAppStore((s) => s.setClaudetteTerminalEnabled);
   const setShowSidebarRunningCommands = useAppStore((s) => s.setShowSidebarRunningCommands);
   const setToolDisplayMode = useAppStore((s) => s.setToolDisplayMode);
+  const setExtendedToolCallOutput = useAppStore((s) => s.setExtendedToolCallOutput);
   const setPluginManagementEnabled = useAppStore((s) => s.setPluginManagementEnabled);
   const setClaudeRemoteControlEnabled = useAppStore(
     (s) => s.setClaudeRemoteControlEnabled,
@@ -263,6 +264,9 @@ function App() {
       .then((val) => {
         if (val === "inline" || val === "grouped") setToolDisplayMode(val);
       })
+      .catch(() => {});
+    getAppSetting("extended_tool_call_output")
+      .then((val) => { if (val === "true") setExtendedToolCallOutput(true); })
       .catch(() => {});
     getAppSetting("plugin_management_enabled")
       .then((val) => { if (val === "true") setPluginManagementEnabled(true); })
@@ -689,7 +693,7 @@ function App() {
       unlistenChatTurnStarted.then((fn) => fn());
       unlistenMissingCli.then((fn) => fn());
     };
-  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setPluginManagementEnabled, setClaudeRemoteControlEnabled, setCommunityRegistryEnabled, setAlternativeBackendsAvailable, setAlternativeBackendsEnabled, setAgentBackends, setDefaultAgentBackendId, setEditorGitGutterBase, setEditorMinimapEnabled, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
+  }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setPluginManagementEnabled, setClaudeRemoteControlEnabled, setCommunityRegistryEnabled, setAlternativeBackendsAvailable, setAlternativeBackendsEnabled, setAgentBackends, setDefaultAgentBackendId, setEditorGitGutterBase, setEditorMinimapEnabled, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -669,6 +669,7 @@
 .inlineEditSummary {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
   min-width: 0;
   color: var(--text-faint);
@@ -687,10 +688,11 @@
 }
 
 .inlineEditPath {
+  flex: 1 1 0;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
   color: var(--accent-primary);
 }
 
@@ -805,7 +807,7 @@
 
 .toolHeader {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 6px;
   width: 100%;
   padding: 4px 10px;
@@ -840,9 +842,10 @@
 .toolSummary {
   color: var(--text-faint);
   font-family: var(--font-mono);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  flex: 1 1 0;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
   min-width: 0;
   font-size: 11px;
 }
@@ -855,6 +858,7 @@
 .agentToolProgress {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 0 8px 4px 8px;
   color: var(--text-faint);
@@ -878,7 +882,7 @@
 
 .agentToolGroupHeader {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0;
   padding: 6px 8px 2px 8px;
   min-width: 0;
@@ -902,7 +906,7 @@
   display: flex;
   min-width: 0;
   gap: 8px;
-  align-items: center;
+  align-items: flex-start;
   color: var(--text-faint);
   font-family: var(--font-mono);
   font-size: 11px;
@@ -913,11 +917,12 @@
 }
 
 .agentToolCallSummary {
+  flex: 1 1 0;
   min-width: 0;
   color: var(--text-faint);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .agentToolCallSummary::before {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -831,6 +831,40 @@
   transition: transform var(--transition-fast);
 }
 
+.toolDetailsToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin: -1px 0;
+  padding: 0;
+  color: var(--text-faint);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.toolDetailsToggle:hover {
+  color: var(--text-dim);
+  background: var(--hover-bg-subtle);
+}
+
+.toolDetailsToggle:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 1px;
+}
+
+.toolDetailsToggle svg {
+  transition: transform var(--transition-fast);
+}
+
+.toolDetailsToggleExpanded svg {
+  transform: rotate(90deg);
+}
+
 .toolName {
   font-weight: 500;
   color: var(--text-muted);
@@ -853,6 +887,33 @@
 .toolSummary::before {
   content: "  ";
   color: var(--text-faint);
+}
+
+.toolDetailsCode {
+  max-height: 320px;
+  margin: 0;
+  padding: 10px 12px 12px 32px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  color: var(--text-dim);
+  background: var(--chat-input-bg);
+  border-top: 1px solid var(--divider);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  position: relative;
+}
+
+.toolDetailsCode code {
+  display: block;
+  min-width: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .agentToolProgress {

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -466,7 +466,7 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).not.toContain("old");
 
     const row = container.querySelector(
-      "button[aria-expanded]",
+      `button.${styles.turnEditFileRow}`,
     ) as HTMLButtonElement;
     expect(row).toBeTruthy();
     expect(row.getAttribute("aria-expanded")).toBe("false");
@@ -525,7 +525,7 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("-2");
 
     const row = container.querySelector(
-      "button[aria-expanded]",
+      `button.${styles.turnEditFileRow}`,
     ) as HTMLButtonElement;
     expect(row).toBeTruthy();
 

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -2,23 +2,16 @@ import { memo } from "react";
 import { useAppStore } from "../../stores/useAppStore";
 import type { ToolActivity } from "../../stores/useAppStore";
 import type { ToolDisplayMode } from "../../stores/slices/settingsSlice";
-import { relativizePath } from "../../hooks/toolSummary";
-import { HighlightedPlainText } from "./HighlightedPlainText";
 import styles from "./ChatPanel.module.css";
-import { toolColor } from "./chatHelpers";
 import { EMPTY_ACTIVITIES } from "./chatConstants";
-import {
-  activityMatchesSearch,
-  activitySummaryText,
-} from "./agentToolCallRendering";
+import { activityMatchesSearch } from "./agentToolCallRendering";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
+import { ToolActivityRow } from "./ToolActivityRow";
 import {
   groupHasRunningActivity,
   groupToolActivitiesForDisplay,
 } from "./toolActivityGroups";
 import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
-import { InlineEditSummary } from "./EditChangeSummary";
-import { summarizeToolActivityEdit } from "./editActivitySummary";
 
 /**
  * Current tool activities section — subscribes to toolActivities for this workspace.
@@ -171,46 +164,6 @@ function GroupedToolActivityRows({
           ))}
         </div>
       )}
-    </div>
-  );
-}
-
-function ToolActivityRow({
-  activity,
-  searchQuery,
-  worktreePath,
-}: {
-  activity: ToolActivity;
-  searchQuery: string;
-  worktreePath?: string | null;
-}) {
-  const editSummary = summarizeToolActivityEdit(activity);
-  return (
-    <div className={styles.toolActivity}>
-      <div className={styles.toolHeader}>
-        {editSummary ? (
-          <InlineEditSummary
-            summary={editSummary}
-            searchQuery={searchQuery}
-            worktreePath={worktreePath}
-          />
-        ) : (
-          <span
-            className={styles.toolName}
-            style={{ color: toolColor(activity.toolName) }}
-          >
-            {activity.toolName}
-          </span>
-        )}
-        {!editSummary && activitySummaryText(activity) && (
-          <span className={styles.toolSummary}>
-            <HighlightedPlainText
-              text={relativizePath(activitySummaryText(activity), worktreePath)}
-              query={searchQuery}
-            />
-          </span>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/ui/src/components/chat/ToolActivityRow.test.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.test.tsx
@@ -177,4 +177,51 @@ describe("ToolActivityRow", () => {
     expect(container.querySelector("pre")?.textContent).toContain('"pattern"');
     expect(container.innerHTML).toContain('data-highlight-lang="json"');
   });
+
+  it("renders edit details with real multiline strings instead of JSON escapes", async () => {
+    const input = {
+      file_path: "/repo/src/types.rs",
+      old_string: "impl Cost {\n    fn label(&self) -> &str {\n        \"Sonnet\"\n    }\n}",
+      new_string:
+        "impl Cost {\n    fn label(&self) -> &str {\n        self.tier_label\n    }\n}",
+    };
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Edit", {
+          inputJson: JSON.stringify(input),
+        })}
+        searchQuery=""
+      />,
+    );
+
+    await act(async () => {
+      (container.querySelector("button") as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+
+    const text = container.querySelector("pre")?.textContent ?? "";
+    expect(highlightCalls).toEqual([
+      {
+        code:
+          'file_path: "/repo/src/types.rs"\n' +
+          "old_string: |-\n" +
+          "  impl Cost {\n" +
+          "      fn label(&self) -> &str {\n" +
+          '          "Sonnet"\n' +
+          "      }\n" +
+          "  }\n" +
+          "new_string: |-\n" +
+          "  impl Cost {\n" +
+          "      fn label(&self) -> &str {\n" +
+          "          self.tier_label\n" +
+          "      }\n" +
+          "  }",
+        lang: "yaml",
+      },
+    ]);
+    expect(text).toContain("old_string: |-");
+    expect(text).toContain("new_string: |-");
+    expect(text).toContain("self.tier_label");
+    expect(text).not.toContain("\\n");
+  });
 });

--- a/src/ui/src/components/chat/ToolActivityRow.test.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.test.tsx
@@ -56,11 +56,17 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
 beforeEach(() => {
   highlightCalls.length = 0;
   highlightCache.clear();
-  useAppStore.setState({ expandedToolUseIds: {} });
+  useAppStore.setState({
+    expandedToolUseIds: {},
+    extendedToolCallOutput: true,
+  });
 });
 
 afterEach(async () => {
-  useAppStore.setState({ expandedToolUseIds: {} });
+  useAppStore.setState({
+    expandedToolUseIds: {},
+    extendedToolCallOutput: false,
+  });
   for (const root of mountedRoots.splice(0).reverse()) {
     await act(async () => {
       root.unmount();
@@ -72,6 +78,24 @@ afterEach(async () => {
 });
 
 describe("ToolActivityRow", () => {
+  it("uses the compact row without a detail chevron when extended output is disabled", async () => {
+    useAppStore.setState({ extendedToolCallOutput: false });
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Bash", {
+          inputJson: JSON.stringify({ command: "echo one" }),
+        })}
+        searchQuery=""
+      />,
+    );
+
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("echo one");
+    expect(container.querySelector("button[aria-expanded]")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+    expect(highlightCalls).toEqual([]);
+  });
+
   it("toggles highlighted full input details for code-like tools", async () => {
     const sql = "WITH users AS (\n  SELECT * FROM users\n)\nSELECT * FROM users";
     const container = await render(

--- a/src/ui/src/components/chat/ToolActivityRow.test.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolActivity } from "../../stores/useAppStore";
+import { useAppStore } from "../../stores/useAppStore";
+import { ToolActivityRow } from "./ToolActivityRow";
+
+const { highlightCalls, highlightCache } = vi.hoisted(() => ({
+  highlightCalls: [] as Array<{ code: string; lang: string }>,
+  highlightCache: new Map<string, string>(),
+}));
+
+vi.mock("../../utils/highlight", () => ({
+  getCachedHighlight: (code: string, lang: string) =>
+    highlightCache.get(`${lang}\0${code}`) ?? null,
+  highlightCode: async (code: string, lang: string) => {
+    highlightCalls.push({ code, lang });
+    const html = `<span data-highlight-lang="${lang}">${code}</span>`;
+    highlightCache.set(`${lang}\0${code}`, html);
+    return html;
+  },
+}));
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+function activity(
+  toolName: string,
+  overrides: Partial<ToolActivity> = {},
+): ToolActivity {
+  return {
+    toolUseId: `${toolName}-1`,
+    toolName,
+    inputJson: "{}",
+    resultText: "done",
+    collapsed: true,
+    summary: "",
+    ...overrides,
+  };
+}
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+beforeEach(() => {
+  highlightCalls.length = 0;
+  highlightCache.clear();
+  useAppStore.setState({ expandedToolUseIds: {} });
+});
+
+afterEach(async () => {
+  useAppStore.setState({ expandedToolUseIds: {} });
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+describe("ToolActivityRow", () => {
+  it("toggles highlighted full input details for code-like tools", async () => {
+    const sql = "WITH users AS (\n  SELECT * FROM users\n)\nSELECT * FROM users";
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("mcp__postgres__query", {
+          inputJson: JSON.stringify({ sql }),
+        })}
+        searchQuery=""
+      />,
+    );
+
+    const toggle = container.querySelector(
+      'button[aria-label="Expand mcp__postgres__query input details"]',
+    ) as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector("pre")).toBeNull();
+
+    await act(async () => {
+      toggle.click();
+      await Promise.resolve();
+    });
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(highlightCalls).toEqual([{ code: sql, lang: "sql" }]);
+    expect(container.querySelector("pre")?.textContent).toContain("WITH users");
+    expect(container.innerHTML).toContain('data-highlight-lang="sql"');
+    expect(container.querySelector("pre button")).toBeTruthy();
+
+    await act(async () => {
+      toggle.click();
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("persists expanded state across row re-renders", async () => {
+    const row = (
+      <ToolActivityRow
+        activity={activity("Bash", {
+          toolUseId: "stable-tool-id",
+          inputJson: JSON.stringify({ command: "echo one" }),
+        })}
+        searchQuery=""
+      />
+    );
+    const container = await render(row);
+    const toggle = container.querySelector("button") as HTMLButtonElement;
+
+    await act(async () => {
+      toggle.click();
+      await Promise.resolve();
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    await act(async () => {
+      mountedRoots[0].render(row);
+    });
+
+    const toggleAfterRender = container.querySelector("button") as HTMLButtonElement;
+    expect(toggleAfterRender.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector("pre")?.textContent).toContain("echo one");
+  });
+
+  it("renders single-field non-code inputs as plain monospace details", async () => {
+    const filePath = "/repo/src/ui.tsx";
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Read", {
+          inputJson: JSON.stringify({ file_path: filePath }),
+        })}
+        searchQuery=""
+      />,
+    );
+
+    await act(async () => {
+      (container.querySelector("button") as HTMLButtonElement).click();
+    });
+
+    expect(highlightCalls).toEqual([]);
+    expect(container.querySelector("pre")?.textContent).toBe(filePath);
+    expect(container.querySelector("code")?.className).toBe("");
+  });
+
+  it("renders structured non-code inputs as highlighted pretty JSON", async () => {
+    const input = { pattern: "*.tsx", path: "/repo/src" };
+    const pretty = JSON.stringify(input, null, 2);
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Glob", {
+          inputJson: JSON.stringify(input),
+        })}
+        searchQuery=""
+      />,
+    );
+
+    await act(async () => {
+      (container.querySelector("button") as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+
+    expect(highlightCalls).toEqual([{ code: pretty, lang: "json" }]);
+    expect(container.querySelector("pre")?.textContent).toContain('"pattern"');
+    expect(container.innerHTML).toContain('data-highlight-lang="json"');
+  });
+});

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -30,6 +30,7 @@ export function ToolActivityRow({
 }: ToolActivityRowProps) {
   const expanded = useAppStore((s) => !!s.expandedToolUseIds[activity.toolUseId]);
   const toggleToolUseExpanded = useAppStore((s) => s.toggleToolUseExpanded);
+  const extendedToolCallOutput = useAppStore((s) => s.extendedToolCallOutput);
   const editSummary = summarizeToolActivityEdit(activity);
   const summary = activitySummaryText(activity);
   const details = useMemo(() => toolDetails(activity), [activity]);
@@ -39,7 +40,9 @@ export function ToolActivityRow({
   const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
 
   useEffect(() => {
-    if (!expanded || !details.lang || cachedHtml != null) return;
+    if (!extendedToolCallOutput || !expanded || !details.lang || cachedHtml != null) {
+      return;
+    }
     let cancelled = false;
     void highlightCode(details.content, details.lang).then((html) => {
       if (!cancelled && html != null) forceUpdate();
@@ -47,28 +50,30 @@ export function ToolActivityRow({
     return () => {
       cancelled = true;
     };
-  }, [cachedHtml, details.content, details.lang, expanded]);
+  }, [cachedHtml, details.content, details.lang, expanded, extendedToolCallOutput]);
 
   const label = `${expanded ? "Collapse" : "Expand"} ${activity.toolName} input details`;
 
   return (
     <div key={activity.toolUseId} className={styles.toolActivity}>
       <div className={styles.toolHeader}>
-        <button
-          type="button"
-          role="button"
-          className={`${styles.toolDetailsToggle} ${
-            expanded ? styles.toolDetailsToggleExpanded : ""
-          }`}
-          aria-expanded={expanded}
-          aria-label={label}
-          onClick={(event) => {
-            event.stopPropagation();
-            toggleToolUseExpanded(activity.toolUseId);
-          }}
-        >
-          <ChevronRight size={13} aria-hidden="true" />
-        </button>
+        {extendedToolCallOutput && (
+          <button
+            type="button"
+            role="button"
+            className={`${styles.toolDetailsToggle} ${
+              expanded ? styles.toolDetailsToggleExpanded : ""
+            }`}
+            aria-expanded={expanded}
+            aria-label={label}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleToolUseExpanded(activity.toolUseId);
+            }}
+          >
+            <ChevronRight size={13} aria-hidden="true" />
+          </button>
+        )}
         {editSummary ? (
           <InlineEditSummary
             summary={editSummary}
@@ -92,7 +97,7 @@ export function ToolActivityRow({
           </span>
         )}
       </div>
-      {expanded && (
+      {extendedToolCallOutput && expanded && (
         <CodeBlock
           className={styles.toolDetailsCode}
           onClick={(event: MouseEvent<HTMLPreElement>) => event.stopPropagation()}

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useReducer, type MouseEvent } from "react";
+import { ChevronRight } from "lucide-react";
+import type { ToolActivity } from "../../stores/useAppStore";
+import { useAppStore } from "../../stores/useAppStore";
+import { extractToolSummary, relativizePath } from "../../hooks/toolSummary";
+import { getCachedHighlight, highlightCode } from "../../utils/highlight";
+import { HighlightedPlainText } from "./HighlightedPlainText";
+import styles from "./ChatPanel.module.css";
+import { toolColor } from "./chatHelpers";
+import { CodeBlock } from "./CodeBlock";
+import { InlineEditSummary } from "./EditChangeSummary";
+import { summarizeToolActivityEdit } from "./editActivitySummary";
+import { resolveToolSummary } from "./toolMetadata";
+
+interface ToolActivityRowProps {
+  activity: ToolActivity;
+  searchQuery: string;
+  worktreePath?: string | null;
+}
+
+interface ToolDetails {
+  content: string;
+  lang: string | null;
+}
+
+export function ToolActivityRow({
+  activity,
+  searchQuery,
+  worktreePath,
+}: ToolActivityRowProps) {
+  const expanded = useAppStore((s) => !!s.expandedToolUseIds[activity.toolUseId]);
+  const toggleToolUseExpanded = useAppStore((s) => s.toggleToolUseExpanded);
+  const editSummary = summarizeToolActivityEdit(activity);
+  const summary = activitySummaryText(activity);
+  const details = useMemo(() => toolDetails(activity), [activity]);
+  const cachedHtml = details.lang
+    ? getCachedHighlight(details.content, details.lang)
+    : null;
+  const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
+
+  useEffect(() => {
+    if (!expanded || !details.lang || cachedHtml != null) return;
+    let cancelled = false;
+    void highlightCode(details.content, details.lang).then((html) => {
+      if (!cancelled && html != null) forceUpdate();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [cachedHtml, details.content, details.lang, expanded]);
+
+  const label = `${expanded ? "Collapse" : "Expand"} ${activity.toolName} input details`;
+
+  return (
+    <div key={activity.toolUseId} className={styles.toolActivity}>
+      <div className={styles.toolHeader}>
+        <button
+          type="button"
+          role="button"
+          className={`${styles.toolDetailsToggle} ${
+            expanded ? styles.toolDetailsToggleExpanded : ""
+          }`}
+          aria-expanded={expanded}
+          aria-label={label}
+          onClick={(event) => {
+            event.stopPropagation();
+            toggleToolUseExpanded(activity.toolUseId);
+          }}
+        >
+          <ChevronRight size={13} aria-hidden="true" />
+        </button>
+        {editSummary ? (
+          <InlineEditSummary
+            summary={editSummary}
+            searchQuery={searchQuery}
+            worktreePath={worktreePath}
+          />
+        ) : (
+          <span
+            className={styles.toolName}
+            style={{ color: toolColor(activity.toolName) }}
+          >
+            {activity.toolName}
+          </span>
+        )}
+        {!editSummary && summary && (
+          <span className={styles.toolSummary}>
+            <HighlightedPlainText
+              text={relativizePath(summary, worktreePath)}
+              query={searchQuery}
+            />
+          </span>
+        )}
+      </div>
+      {expanded && (
+        <CodeBlock
+          className={styles.toolDetailsCode}
+          onClick={(event: MouseEvent<HTMLPreElement>) => event.stopPropagation()}
+        >
+          {details.lang && cachedHtml != null ? (
+            <code
+              className={`language-${details.lang}`}
+              dangerouslySetInnerHTML={{ __html: cachedHtml }}
+            />
+          ) : (
+            <code className={details.lang ? `language-${details.lang}` : undefined}>
+              {details.content}
+            </code>
+          )}
+        </CodeBlock>
+      )}
+    </div>
+  );
+}
+
+function activitySummaryText(activity: ToolActivity): string {
+  return (
+    activity.summary ||
+    activity.agentDescription ||
+    extractToolSummary(activity.toolName, activity.inputJson) ||
+    ""
+  );
+}
+
+function toolDetails(activity: ToolActivity): ToolDetails {
+  const input = parseObject(activity.inputJson);
+  const display = resolveToolSummary(activity.toolName, activity.inputJson);
+
+  if (input && shouldShowStructuredInput(input, display.lang)) {
+    return { content: JSON.stringify(input, null, 2), lang: "json" };
+  }
+
+  if (display.fullContent) {
+    return { content: display.fullContent, lang: display.lang };
+  }
+
+  if (input) {
+    return { content: JSON.stringify(input, null, 2), lang: "json" };
+  }
+
+  return { content: activity.inputJson || "{}", lang: null };
+}
+
+function parseObject(inputJson: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(inputJson);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function shouldShowStructuredInput(
+  input: Record<string, unknown>,
+  summaryLang: string | null,
+): boolean {
+  if (summaryLang) return false;
+  return Object.keys(input).length > 1;
+}

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -125,6 +125,9 @@ function activitySummaryText(activity: ToolActivity): string {
 function toolDetails(activity: ToolActivity): ToolDetails {
   const input = parseObject(activity.inputJson);
   const display = resolveToolSummary(activity.toolName, activity.inputJson);
+  const readableInput = input ? readableToolInput(activity.toolName, input) : null;
+
+  if (readableInput) return readableInput;
 
   if (input && shouldShowStructuredInput(input, display.lang)) {
     return { content: JSON.stringify(input, null, 2), lang: "json" };
@@ -157,4 +160,142 @@ function shouldShowStructuredInput(
 ): boolean {
   if (summaryLang) return false;
   return Object.keys(input).length > 1;
+}
+
+function readableToolInput(
+  toolName: string,
+  input: Record<string, unknown>,
+): ToolDetails | null {
+  const normalized = toolName.toLowerCase();
+
+  if (normalized === "edit") {
+    return replacementDetails(input, {
+      pathFields: ["file_path"],
+      oldFields: ["old_string"],
+      newFields: ["new_string"],
+      oldLabel: "old_string",
+      newLabel: "new_string",
+    });
+  }
+
+  if (normalized === "multiedit") {
+    const filePath = stringField(input, "file_path");
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    if (!filePath || edits.length === 0) return null;
+
+    const lines = [`file_path: ${yamlScalar(filePath)}`, "edits:"];
+    edits.forEach((edit, index) => {
+      const record = recordFromUnknown(edit);
+      if (!record) return;
+      const oldString = stringField(record, "old_string");
+      const newString = stringField(record, "new_string");
+      lines.push(`  - index: ${index + 1}`);
+      if (oldString !== null) appendBlock(lines, "    ", "old_string", oldString);
+      if (newString !== null) appendBlock(lines, "    ", "new_string", newString);
+    });
+    return { content: lines.join("\n"), lang: "yaml" };
+  }
+
+  if (normalized === "write") {
+    const filePath = stringField(input, "file_path");
+    const content = stringField(input, "content");
+    if (!filePath || content === null) return null;
+    const lines = [`file_path: ${yamlScalar(filePath)}`];
+    appendBlock(lines, "", "content", content);
+    return { content: lines.join("\n"), lang: "yaml" };
+  }
+
+  if (normalized === "notebookedit") {
+    return replacementDetails(input, {
+      pathFields: ["notebook_path"],
+      oldFields: ["old_source", "source"],
+      newFields: ["new_source"],
+      oldLabel: "old_source",
+      newLabel: "new_source",
+    });
+  }
+
+  if (normalized.includes("str_replace")) {
+    return replacementDetails(input, {
+      pathFields: ["path", "file_path"],
+      oldFields: ["old_str", "old_string"],
+      newFields: ["new_str", "new_string"],
+      oldLabel: "old_str",
+      newLabel: "new_str",
+    });
+  }
+
+  const patch = patchTextFromInput(input);
+  if (patch) return { content: patch, lang: "diff" };
+
+  return null;
+}
+
+function replacementDetails(
+  input: Record<string, unknown>,
+  options: {
+    pathFields: readonly string[];
+    oldFields: readonly string[];
+    newFields: readonly string[];
+    oldLabel: string;
+    newLabel: string;
+  },
+): ToolDetails | null {
+  const filePath = firstStringField(input, options.pathFields);
+  const oldString = firstStringField(input, options.oldFields);
+  const newString = firstStringField(input, options.newFields);
+  if (!filePath || (oldString === null && newString === null)) return null;
+
+  const lines = [`file_path: ${yamlScalar(filePath)}`];
+  if (oldString !== null) appendBlock(lines, "", options.oldLabel, oldString);
+  if (newString !== null) appendBlock(lines, "", options.newLabel, newString);
+  return { content: lines.join("\n"), lang: "yaml" };
+}
+
+function patchTextFromInput(input: Record<string, unknown>): string | null {
+  for (const field of ["patch", "input", "cmd", "command"] as const) {
+    const value = stringField(input, field);
+    if (value && value.includes("\n") && /(?:^|\n)(diff --git|@@ |\+\+\+ |--- )/.test(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function appendBlock(
+  lines: string[],
+  indent: string,
+  label: string,
+  value: string,
+): void {
+  lines.push(`${indent}${label}: |-`);
+  if (value.length === 0) return;
+  for (const line of value.split("\n")) {
+    lines.push(`${indent}  ${line}`);
+  }
+}
+
+function firstStringField(
+  input: Record<string, unknown>,
+  fields: readonly string[],
+): string | null {
+  for (const field of fields) {
+    const value = stringField(input, field);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function stringField(input: Record<string, unknown>, field: string): string | null {
+  const value = input[field];
+  return typeof value === "string" ? value : null;
+}
+
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function yamlScalar(value: string): string {
+  return JSON.stringify(value);
 }

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -1,23 +1,17 @@
 import { useMemo } from "react";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import type { TaskTrackerResult } from "../../hooks/useTaskTracker";
-import { relativizePath } from "../../hooks/toolSummary";
-import { HighlightedPlainText } from "./HighlightedPlainText";
 import styles from "./ChatPanel.module.css";
-import { toolColor } from "./chatHelpers";
 import { TurnFooter } from "./TurnFooter";
 import { TaskProgressBar } from "./TaskProgressBar";
-import {
-  activityMatchesSearch,
-  activitySummaryText,
-} from "./agentToolCallRendering";
+import { activityMatchesSearch } from "./agentToolCallRendering";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
+import { ToolActivityRow } from "./ToolActivityRow";
 import { isAgentActivity } from "./toolActivityGroups";
-import { InlineEditSummary, TurnEditSummaryCard } from "./EditChangeSummary";
+import { TurnEditSummaryCard } from "./EditChangeSummary";
 import {
   type EditPreviewLine,
   type EditSummary,
-  summarizeToolActivityEdit,
   summarizeTurnEdits,
 } from "./editActivitySummary";
 
@@ -118,31 +112,13 @@ export function TurnSummary({
       );
     }
 
-    const editSummaryForActivity = summarizeToolActivityEdit(act);
     return (
-      <div key={act.toolUseId} className={styles.toolActivity}>
-        <div className={styles.toolHeader}>
-          {editSummaryForActivity ? (
-            <InlineEditSummary
-              summary={editSummaryForActivity}
-              searchQuery={searchQuery}
-              worktreePath={worktreePath}
-            />
-          ) : (
-            <span className={styles.toolName} style={{ color: toolColor(act.toolName) }}>
-              {act.toolName}
-            </span>
-          )}
-          {!editSummaryForActivity && activitySummaryText(act) && (
-            <span className={styles.toolSummary}>
-              <HighlightedPlainText
-                text={relativizePath(activitySummaryText(act), worktreePath)}
-                query={searchQuery}
-              />
-            </span>
-          )}
-        </div>
-      </div>
+      <ToolActivityRow
+        key={act.toolUseId}
+        activity={act}
+        searchQuery={searchQuery}
+        worktreePath={worktreePath}
+      />
     );
   });
 

--- a/src/ui/src/components/chat/agentToolCallRendering.ts
+++ b/src/ui/src/components/chat/agentToolCallRendering.ts
@@ -33,8 +33,8 @@ export function activitySummaryText(activity: ToolActivity): string {
 export function agentToolCallSummary(call: AgentToolCall): string {
   const inputSummary = extractToolSummary(call.toolName, safeJson(call.input));
   if (inputSummary) return inputSummary;
-  if (call.error) return truncate(call.error, 100);
-  return truncate(valuePreview(call.input ?? call.response), 100);
+  if (call.error) return call.error;
+  return valuePreview(call.input ?? call.response);
 }
 
 function safeJson(value: unknown): string {
@@ -53,9 +53,4 @@ function valuePreview(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function truncate(value: string, max: number): string {
-  if (value.length <= max) return value;
-  return `${value.slice(0, max - 3)}...`;
 }

--- a/src/ui/src/components/chat/chatLayoutCss.test.ts
+++ b/src/ui/src/components/chat/chatLayoutCss.test.ts
@@ -45,6 +45,16 @@ describe("ChatPanel.module.css invariants", () => {
     // half is caught.
     expect(body).toMatch(/overflow:\s*hidden\s*;/);
   });
+
+  it("tool-call summaries wrap instead of ellipsizing the command or path", () => {
+    const css = readCss("ChatPanel.module.css");
+    for (const selector of [".toolSummary", ".agentToolCallSummary", ".inlineEditPath"]) {
+      const body = ruleBody(css, selector);
+      expect(body).not.toMatch(/text-overflow:\s*ellipsis\s*;/);
+      expect(body).toMatch(/white-space:\s*pre-wrap\s*;/);
+      expect(body).toMatch(/overflow-wrap:\s*anywhere\s*;/);
+    }
+  });
 });
 
 describe("ThinkingBlock.module.css invariants", () => {

--- a/src/ui/src/components/chat/chatLayoutCss.test.ts
+++ b/src/ui/src/components/chat/chatLayoutCss.test.ts
@@ -55,6 +55,14 @@ describe("ChatPanel.module.css invariants", () => {
       expect(body).toMatch(/overflow-wrap:\s*anywhere\s*;/);
     }
   });
+
+  it("expanded tool details wrap long code lines instead of horizontal scrolling", () => {
+    const css = readCss("ChatPanel.module.css");
+    const body = ruleBody(css, ".toolDetailsCode");
+    expect(body).toMatch(/overflow-x:\s*hidden\s*;/);
+    expect(body).toMatch(/white-space:\s*pre-wrap\s*;/);
+    expect(body).toMatch(/overflow-wrap:\s*anywhere\s*;/);
+  });
 });
 
 describe("ThinkingBlock.module.css invariants", () => {

--- a/src/ui/src/components/chat/toolMetadata.test.ts
+++ b/src/ui/src/components/chat/toolMetadata.test.ts
@@ -126,16 +126,13 @@ describe("resolveToolSummary", () => {
       expect(result).toEqual({ summary: "", lang: null, fullContent: "" });
     });
 
-    it("truncates long content with an ellipsis", () => {
+    it("preserves long content in the row summary", () => {
       const longSql = "SELECT " + "x, ".repeat(100) + "y FROM t";
       const result = resolveToolSummary(
         "mcp__postgres__query",
         JSON.stringify({ sql: longSql }),
       );
-      expect(result.summary.length).toBeLessThanOrEqual(120);
-      expect(result.summary.endsWith("…")).toBe(true);
-      // fullContent retains the untruncated value for the
-      // expand-to-detail view that this scaffolds.
+      expect(result.summary).toBe(longSql);
       expect(result.fullContent).toBe(longSql);
     });
 

--- a/src/ui/src/components/chat/toolMetadata.ts
+++ b/src/ui/src/components/chat/toolMetadata.ts
@@ -183,14 +183,12 @@ const FIELD_NAME_HEURISTICS: ReadonlyArray<[field: string, lang: string | null]>
   ["pattern", null],
 ];
 
-const MAX_SUMMARY_LENGTH = 120;
-
 /** Resolved tool-display payload — what the renderer needs to draw a
  *  row's summary plus optionally an expanded code block. */
 export interface ResolvedToolDisplay {
-  /** Single-line summary, truncated to `MAX_SUMMARY_LENGTH`. May be
-   *  empty if the input contained no string-valued fields and no
-   *  registry entry pointed at one. */
+  /** Summary text for the tool-call row. May be empty if the input
+   *  contained no string-valued fields and no registry entry pointed
+   *  at one. */
   summary: string;
   /** Shiki language id when the summary's source field carries
    *  highlightable code. `null` → render as plain text. */
@@ -257,7 +255,7 @@ export function resolveToolSummary(
   const fallback = longestStringField(record);
   if (fallback) {
     return {
-      summary: truncate(fallback, MAX_SUMMARY_LENGTH),
+      summary: fallback,
       lang: null,
       fullContent: fallback,
     };
@@ -287,14 +285,14 @@ function displayFromField(
       .map((v) => (typeof v === "string" ? v : safeStringify(v)))
       .join(", ");
     return {
-      summary: truncate(joined, MAX_SUMMARY_LENGTH),
+      summary: joined,
       lang,
       fullContent: joined,
     };
   }
   if (typeof raw === "string") {
     return {
-      summary: truncate(raw, MAX_SUMMARY_LENGTH),
+      summary: raw,
       lang,
       fullContent: raw,
     };
@@ -307,7 +305,7 @@ function displayFromField(
   // Object value: stringify it so the user gets some signal.
   const stringified = safeStringify(raw);
   return {
-    summary: truncate(stringified, MAX_SUMMARY_LENGTH),
+    summary: stringified,
     lang: lang === "sql" ? null : lang, // SQL highlighting on JSON looks wrong
     fullContent: stringified,
   };
@@ -328,10 +326,4 @@ function safeStringify(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function truncate(value: string, max: number): string {
-  if (value.length <= max) return value;
-  if (max <= 3) return value.slice(0, max);
-  return `${value.slice(0, max - 1)}…`;
 }

--- a/src/ui/src/components/settings/sections/AppearanceSettings.tsx
+++ b/src/ui/src/components/settings/sections/AppearanceSettings.tsx
@@ -35,6 +35,8 @@ export function AppearanceSettings() {
   const setShowSidebarRunningCommands = useAppStore((s) => s.setShowSidebarRunningCommands);
   const toolDisplayMode = useAppStore((s) => s.toolDisplayMode);
   const setToolDisplayMode = useAppStore((s) => s.setToolDisplayMode);
+  const extendedToolCallOutput = useAppStore((s) => s.extendedToolCallOutput);
+  const setExtendedToolCallOutput = useAppStore((s) => s.setExtendedToolCallOutput);
 
   const isFollowSystem = themeMode === "system";
 
@@ -428,6 +430,37 @@ export function AppearanceSettings() {
                 await setAppSetting("tool_display_mode", next);
               } catch (e) {
                 setToolDisplayMode(previous);
+                setError(String(e));
+              }
+            }}
+          >
+            <div className={styles.toggleKnob} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <div className={styles.settingLabel}>{t("appearance_extended_tool_call_output")}</div>
+          <div className={styles.settingDescription}>
+            {t("appearance_extended_tool_call_output_desc")}
+          </div>
+        </div>
+        <div className={styles.settingControl}>
+          <button
+            className={styles.toggle}
+            role="switch"
+            aria-checked={extendedToolCallOutput}
+            aria-label={t("appearance_extended_tool_call_output")}
+            data-checked={extendedToolCallOutput}
+            onClick={async () => {
+              const next = !extendedToolCallOutput;
+              setExtendedToolCallOutput(next);
+              try {
+                setError(null);
+                await setAppSetting("extended_tool_call_output", next ? "true" : "false");
+              } catch (e) {
+                setExtendedToolCallOutput(!next);
                 setError(String(e));
               }
             }}

--- a/src/ui/src/hooks/toolSummary.test.ts
+++ b/src/ui/src/hooks/toolSummary.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { relativizePath } from "./toolSummary";
+import { extractToolSummary, relativizePath } from "./toolSummary";
+
+describe("extractToolSummary", () => {
+  it("preserves long built-in tool summaries instead of pre-truncating them", () => {
+    const longPath =
+      "/Users/me/project/src/components/chat/ToolActivitiesSection.with.a.very.long.name.test.tsx";
+    expect(
+      extractToolSummary(
+        "Grep",
+        JSON.stringify({ pattern: "agentToolCallSummary", path: longPath }),
+      ),
+    ).toBe(`agentToolCallSummary in ${longPath}`);
+  });
+
+  it("preserves long registry summaries instead of applying an inline cap", () => {
+    const command =
+      "tail -5 /Users/me/.claude/projects/-Users-jamesbrink-claudette-workspaces/example/logs/session-output.log 2>&1";
+    expect(extractToolSummary("Bash", JSON.stringify({ command }))).toBe(command);
+  });
+});
 
 describe("relativizePath", () => {
   it("returns the original text when root is null/undefined/empty", () => {

--- a/src/ui/src/hooks/toolSummary.ts
+++ b/src/ui/src/hooks/toolSummary.ts
@@ -23,24 +23,15 @@ export function extractToolSummary(
     switch (toolName) {
       case "Grep":
         return input.pattern
-          ? truncate(
-              `${input.pattern}${input.path ? ` in ${input.path}` : ""}`,
-              80,
-            )
+          ? `${input.pattern}${input.path ? ` in ${input.path}` : ""}`
           : "";
       case "SendMessage":
         return input.to
-          ? truncate(
-              `to ${input.to}${input.summary ? `: ${input.summary}` : ""}`,
-              80,
-            )
+          ? `to ${input.to}${input.summary ? `: ${input.summary}` : ""}`
           : "";
       case "Skill":
         return input.skill
-          ? truncate(
-              `${input.skill}${input.args ? ` ${input.args}` : ""}`,
-              80,
-            )
+          ? `${input.skill}${input.args ? ` ${input.args}` : ""}`
           : "";
       case "TaskUpdate":
         return input.status ? `#${input.id ?? "?"} → ${input.status}` : "";
@@ -53,7 +44,7 @@ export function extractToolSummary(
       case "CronDelete":
         return input.id ?? input.name ?? "";
       case "RemoteTrigger":
-        return truncate(input.name ?? input.prompt ?? "", 80);
+        return input.name ?? input.prompt ?? "";
       case "LSP":
         return input.action ?? "";
     }
@@ -61,15 +52,8 @@ export function extractToolSummary(
     return "";
   }
   // Default path: registry → tool-name heuristics → field-name
-  // heuristics → longest string. The registry caps its summary at
-  // 120 chars; trim to 80 here for the inline row-summary surface.
-  return truncate(resolveToolSummary(toolName, inputJson).summary, 80);
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  if (max <= 3) return s.slice(0, max);
-  return s.slice(0, max - 3) + "...";
+  // heuristics → longest string.
+  return resolveToolSummary(toolName, inputJson).summary;
 }
 
 /** Strip the workspace root prefix from a summary string, leaving a relative path.

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -91,6 +91,8 @@
   "appearance_show_running_commands_desc": "Display a collapsible list of foreground processes running in each workspace's terminals. Off by default.",
   "appearance_group_tool_calls": "Group adjacent tool calls",
   "appearance_group_tool_calls_desc": "Collapse adjacent regular tool calls into summary blocks. Turn off to show every top-level tool call, Agent call, and thinking block inline.",
+  "appearance_extended_tool_call_output": "Extended tool call output",
+  "appearance_extended_tool_call_output_desc": "Add expandable, copyable input details under tool call rows. Off by default.",
   "appearance_interface_font": "Interface font",
   "appearance_interface_font_desc": "Font for UI text. Themes may set a default.",
   "appearance_custom_interface_font": "Custom interface font",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -71,6 +71,8 @@
   "appearance_show_running_commands_desc": "Muestra una lista plegable de los procesos en primer plano que se ejecutan en los terminales de cada espacio de trabajo. Desactivado por defecto.",
   "appearance_group_tool_calls": "Agrupar llamadas adyacentes",
   "appearance_group_tool_calls_desc": "Contrae llamadas normales adyacentes en bloques de resumen. Desactívalo para mostrar cada llamada principal de herramienta, llamada de Agent y bloque de pensamiento en línea.",
+  "appearance_extended_tool_call_output": "Salida extendida de llamadas de herramientas",
+  "appearance_extended_tool_call_output_desc": "Agrega detalles de entrada expandibles y copiables debajo de las filas de llamadas de herramientas. Desactivado por defecto.",
   "appearance_interface_font": "Fuente de la interfaz",
   "appearance_interface_font_desc": "Fuente para el texto de la interfaz. Los temas pueden establecer una predeterminada.",
   "appearance_custom_interface_font": "Fuente de interfaz personalizada",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -71,6 +71,8 @@
   "appearance_show_running_commands_desc": "各ワークスペースのターミナルで実行中のフォアグラウンドプロセスを折りたたみ可能なリストとして表示します。既定ではオフです。",
   "appearance_group_tool_calls": "隣接するツール呼び出しをグループ化",
   "appearance_group_tool_calls_desc": "隣接する通常のツール呼び出しを要約ブロックに折りたたみます。オフにすると、各トップレベルのツール呼び出し、Agent 呼び出し、思考ブロックをインライン表示します。",
+  "appearance_extended_tool_call_output": "ツール呼び出しの詳細出力",
+  "appearance_extended_tool_call_output_desc": "ツール呼び出し行の下に、展開可能でコピー可能な入力詳細を追加します。既定ではオフです。",
   "appearance_interface_font": "インターフェースのフォント",
   "appearance_interface_font_desc": "UI テキストのフォント。テーマが既定値を設定する場合があります。",
   "appearance_custom_interface_font": "カスタムインターフェースフォント",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -71,6 +71,8 @@
   "appearance_show_running_commands_desc": "Exibe uma lista recolhível dos processos em primeiro plano executando nos terminais de cada workspace. Desativado por padrão.",
   "appearance_group_tool_calls": "Agrupar chamadas adjacentes",
   "appearance_group_tool_calls_desc": "Recolhe chamadas regulares adjacentes em blocos de resumo. Desative para mostrar cada chamada principal de ferramenta, chamada de Agent e bloco de pensamento em linha.",
+  "appearance_extended_tool_call_output": "Saída estendida de chamadas de ferramenta",
+  "appearance_extended_tool_call_output_desc": "Adiciona detalhes de entrada expansíveis e copiáveis abaixo das linhas de chamadas de ferramenta. Desativado por padrão.",
   "appearance_interface_font": "Fonte da interface",
   "appearance_interface_font_desc": "Fonte para o texto da interface. Os temas podem definir um padrão.",
   "appearance_custom_interface_font": "Fonte de interface personalizada",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -71,6 +71,8 @@
   "appearance_show_running_commands_desc": "显示每个工作区终端中前台进程的可折叠列表。默认关闭。",
   "appearance_group_tool_calls": "分组相邻工具调用",
   "appearance_group_tool_calls_desc": "将相邻的常规工具调用折叠为摘要块。关闭后，每个顶层工具调用、Agent 调用和思考块都会以内联方式显示。",
+  "appearance_extended_tool_call_output": "扩展工具调用输出",
+  "appearance_extended_tool_call_output_desc": "在工具调用行下方添加可展开、可复制的输入详情。默认关闭。",
   "appearance_interface_font": "界面字体",
   "appearance_interface_font_desc": "界面文本的字体。主题可设置默认字体。",
   "appearance_custom_interface_font": "自定义界面字体",

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -220,6 +220,8 @@ export interface ChatSlice {
     groupKey: string,
     collapsed: boolean,
   ) => void;
+  expandedToolUseIds: Record<string, true>;
+  toggleToolUseExpanded: (toolUseId: string) => void;
   pendingAttachmentsBySession: Record<string, StoredAttachment[]>;
   setPendingAttachmentsForSession: (
     sessionId: string,
@@ -635,6 +637,21 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
         collapsedToolGroupsBySession: {
           ...s.collapsedToolGroupsBySession,
           [sessionId]: { ...wsGroups, [groupKey]: collapsed },
+        },
+      };
+    }),
+  expandedToolUseIds: {},
+  toggleToolUseExpanded: (toolUseId) =>
+    set((s) => {
+      if (s.expandedToolUseIds[toolUseId]) {
+        const next = { ...s.expandedToolUseIds };
+        delete next[toolUseId];
+        return { expandedToolUseIds: next };
+      }
+      return {
+        expandedToolUseIds: {
+          ...s.expandedToolUseIds,
+          [toolUseId]: true,
         },
       };
     }),

--- a/src/ui/src/stores/slices/settingsSlice.test.ts
+++ b/src/ui/src/stores/slices/settingsSlice.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "../useAppStore";
 
+describe("settingsSlice appearance defaults", () => {
+  beforeEach(() => {
+    useAppStore.setState({ extendedToolCallOutput: false });
+  });
+
+  it("keeps extended tool call output disabled by default", () => {
+    expect(useAppStore.getState().extendedToolCallOutput).toBe(false);
+  });
+
+  it("toggles extended tool call output explicitly", () => {
+    useAppStore.getState().setExtendedToolCallOutput(true);
+    expect(useAppStore.getState().extendedToolCallOutput).toBe(true);
+
+    useAppStore.getState().setExtendedToolCallOutput(false);
+    expect(useAppStore.getState().extendedToolCallOutput).toBe(false);
+  });
+});
+
 describe("settingsSlice alternative backend gates", () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/src/ui/src/stores/slices/settingsSlice.ts
+++ b/src/ui/src/stores/slices/settingsSlice.ts
@@ -39,6 +39,8 @@ export interface SettingsSlice {
   setShowSidebarRunningCommands: (v: boolean) => void;
   toolDisplayMode: ToolDisplayMode;
   setToolDisplayMode: (mode: ToolDisplayMode) => void;
+  extendedToolCallOutput: boolean;
+  setExtendedToolCallOutput: (enabled: boolean) => void;
 
   // Experimental
   claudetteTerminalEnabled: boolean;
@@ -124,6 +126,9 @@ export const createSettingsSlice: StateCreator<
   setShowSidebarRunningCommands: (v) => set({ showSidebarRunningCommands: v }),
   toolDisplayMode: "grouped",
   setToolDisplayMode: (mode) => set({ toolDisplayMode: mode }),
+  extendedToolCallOutput: false,
+  setExtendedToolCallOutput: (enabled) =>
+    set({ extendedToolCallOutput: enabled }),
 
   claudetteTerminalEnabled: false,
   setClaudetteTerminalEnabled: (enabled) =>

--- a/src/ui/src/stores/useAppStore.collapsedToolGroups.test.ts
+++ b/src/ui/src/stores/useAppStore.collapsedToolGroups.test.ts
@@ -6,7 +6,10 @@ const SESSION_B = "session-b";
 
 describe("collapsedToolGroupsBySession", () => {
   beforeEach(() => {
-    useAppStore.setState({ collapsedToolGroupsBySession: {} });
+    useAppStore.setState({
+      collapsedToolGroupsBySession: {},
+      expandedToolUseIds: {},
+    });
   });
 
   it("starts empty for a fresh session", () => {
@@ -69,5 +72,28 @@ describe("collapsedToolGroupsBySession", () => {
     expect(
       useAppStore.getState().collapsedToolGroupsBySession[SESSION_A]?.g1,
     ).toBe(false);
+  });
+});
+
+describe("expandedToolUseIds", () => {
+  beforeEach(() => {
+    useAppStore.setState({ expandedToolUseIds: {} });
+  });
+
+  it("toggles a tool use id on and off", () => {
+    useAppStore.getState().toggleToolUseExpanded("tool-1");
+    expect(useAppStore.getState().expandedToolUseIds["tool-1"]).toBe(true);
+
+    useAppStore.getState().toggleToolUseExpanded("tool-1");
+    expect(useAppStore.getState().expandedToolUseIds["tool-1"]).toBeUndefined();
+  });
+
+  it("keeps different tool use ids independent", () => {
+    useAppStore.getState().toggleToolUseExpanded("tool-1");
+    useAppStore.getState().toggleToolUseExpanded("tool-2");
+    useAppStore.getState().toggleToolUseExpanded("tool-1");
+
+    expect(useAppStore.getState().expandedToolUseIds["tool-1"]).toBeUndefined();
+    expect(useAppStore.getState().expandedToolUseIds["tool-2"]).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Keep compact tool-call summaries readable by removing pre-truncation and allowing long commands, paths, and SQL snippets to wrap.
- Add optional expanded tool-call input details for users who want exact tool payloads, including Shiki-highlighted code blocks and the existing copy-code affordance.
- Gate expanded details behind `Settings > Appearance > Extended tool call output`, defaulting off so new users keep the original compact row behavior.
- Render edit-like tool inputs (`Edit`, `MultiEdit`, `Write`, notebook edits, str_replace tools, patch tools) in readable multiline blocks instead of JSON-escaped strings.
- Document the new Appearance setting and update localized settings strings.

Closes #698.

## Regression Coverage

- `ToolActivityRow.test.tsx` covers the default-off compact row, opt-in expansion, persisted expanded state, highlighted SQL/JSON details, plain non-code details, and readable multiline edit details without `\\n` escapes.
- `toolSummary.test.ts` and `toolMetadata.test.ts` cover preserving long summaries before they reach the DOM.
- `chatLayoutCss.test.ts` pins wrapping/no-ellipsis behavior for summaries and no horizontal scrolling for expanded details.
- `settingsSlice.test.ts` pins the default-off setting and explicit toggling.
- Existing `ToolActivitiesSection` tests continue covering live grouped rows, completed turn rows, and edit summary interactions.

## Validation

- `cd src/ui && bun run test -- ToolActivityRow.test.tsx settingsSlice.test.ts ToolActivitiesSection.test.tsx toolSummary.test.ts toolMetadata.test.ts chatLayoutCss.test.ts`
- `cd src/ui && bun run test`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run lint` (exits 0; existing warnings remain)
- `git diff --check`
