### PR TITLE
fix: load env providers before workspace use

### DIFF
--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -74,7 +74,8 @@ Bundled env-providers:
 
 Toggle individual providers in **Settings > Plugins**. Each plugin's manifest declares any user-configurable settings — for example, `env-direnv` exposes `auto_allow` to skip the per-path `direnv allow` safeguard if you'd rather trust your own `.envrc` files automatically.
 
+When Claudette creates a new workspace, it resolves env-providers before the workspace appears as ready. That first warmup primes tools like `direnv` for the worktree, then setup scripts, terminal tabs, agent subprocesses, and MCP servers inherit the same merged environment.
+
 The merged environment is computed once per worktree and reused across processes; if you change `.envrc` or `mise.toml`, terminate the running agent or terminal tab and Claudette picks up the new env on the next spawn.
 
 Drop your own env-provider into `~/.claudette/plugins/<name>/` (one `plugin.json` + one `init.lua`) and Claudette discovers it at startup.
-

--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -74,7 +74,7 @@ Bundled env-providers:
 
 Toggle individual providers in **Settings > Plugins**. Each plugin's manifest declares any user-configurable settings — for example, `env-direnv` exposes `auto_allow` to skip the per-path `direnv allow` safeguard if you'd rather trust your own `.envrc` files automatically.
 
-When Claudette creates a new workspace, it resolves env-providers before the workspace appears as ready. That first warmup primes tools like `direnv` for the worktree, then setup scripts, terminal tabs, agent subprocesses, and MCP servers inherit the same merged environment.
+When Claudette creates a new workspace, it resolves env-providers before the workspace appears as ready. Selecting an existing workspace also performs the same warmup before fresh agent turns or terminal PTYs can start. That first warmup primes tools like `direnv` for the worktree, then setup scripts, terminal tabs, agent subprocesses, and MCP servers inherit the same merged environment.
 
 The merged environment is computed once per worktree and reused across processes; if you change `.envrc` or `mise.toml`, terminate the running agent or terminal tab and Claudette picks up the new env on the next spawn.
 

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -190,9 +190,48 @@ pub async fn get_env_sources(
     Ok(sources)
 }
 
-/// Resolve env-providers for a workspace without returning diagnostic details.
-/// Used on workspace selection to warm direnv/mise/dotenv/nix-devshell before
-/// the user can start a fresh agent process or terminal PTY.
+fn source_error_summary(source: &claudette::env_provider::ResolvedSource) -> String {
+    format!(
+        "{}: {}",
+        source.plugin_name,
+        source.error.as_deref().unwrap_or("unknown error")
+    )
+}
+
+fn prepare_workspace_error(resolved: &claudette::env_provider::ResolvedEnv) -> Option<String> {
+    let trust_errors = resolved.trust_errors();
+    if !trust_errors.is_empty() {
+        let summaries = trust_errors
+            .into_iter()
+            .map(source_error_summary)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Some(format!("Environment setup needed: {summaries}"));
+    }
+
+    let summaries = resolved
+        .sources
+        .iter()
+        .filter(|source| {
+            source
+                .error
+                .as_deref()
+                .is_some_and(|error| error != "disabled")
+        })
+        .map(source_error_summary)
+        .collect::<Vec<_>>();
+    if summaries.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "Environment provider failed: {}",
+            summaries.join("; ")
+        ))
+    }
+}
+
+/// Resolve env-providers for a workspace before the user can start a fresh
+/// agent process or terminal PTY.
 #[tauri::command]
 pub async fn prepare_workspace_environment(
     workspace_id: String,
@@ -214,6 +253,9 @@ pub async fn prepare_workspace_environment(
     )
     .await;
     register_resolved_with_watcher(&state, Path::new(&worktree), &resolved.sources).await;
+    if let Some(error) = prepare_workspace_error(&resolved) {
+        return Err(error);
+    }
     Ok(())
 }
 
@@ -627,7 +669,7 @@ pub fn get_host_env_flags() -> HostEnvFlags {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use claudette::env_provider::ResolvedSource;
+    use claudette::env_provider::{ResolvedEnv, ResolvedSource};
     use std::collections::HashSet;
     use std::time::SystemTime;
 
@@ -675,5 +717,52 @@ mod tests {
     fn filter_globally_disabled_empty_passes_through() {
         let visible = filter_globally_disabled(Vec::new(), |_| true);
         assert!(visible.is_empty());
+    }
+
+    #[test]
+    fn prepare_workspace_error_ignores_disabled_sources() {
+        let mut source = src("env-direnv");
+        source.error = Some("disabled".to_string());
+        let resolved = ResolvedEnv {
+            sources: vec![source],
+            ..Default::default()
+        };
+
+        assert_eq!(prepare_workspace_error(&resolved), None);
+    }
+
+    #[test]
+    fn prepare_workspace_error_surfaces_trust_errors() {
+        let mut source = src("env-direnv");
+        source.error = Some(
+            "direnv: error /repo/.envrc is blocked. Run `direnv allow` to approve its content"
+                .to_string(),
+        );
+        let resolved = ResolvedEnv {
+            sources: vec![source],
+            ..Default::default()
+        };
+
+        let message = prepare_workspace_error(&resolved).unwrap();
+
+        assert!(message.starts_with("Environment setup needed: env-direnv:"));
+        assert!(message.contains("direnv allow"));
+    }
+
+    #[test]
+    fn prepare_workspace_error_surfaces_generic_provider_errors() {
+        let mut source = src("env-mise");
+        source.error = Some("mise failed to export env".to_string());
+        let resolved = ResolvedEnv {
+            sources: vec![source],
+            ..Default::default()
+        };
+
+        let message = prepare_workspace_error(&resolved).unwrap();
+
+        assert_eq!(
+            message,
+            "Environment provider failed: env-mise: mise failed to export env"
+        );
     }
 }

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -190,6 +190,33 @@ pub async fn get_env_sources(
     Ok(sources)
 }
 
+/// Resolve env-providers for a workspace without returning diagnostic details.
+/// Used on workspace selection to warm direnv/mise/dotenv/nix-devshell before
+/// the user can start a fresh agent process or terminal PTY.
+#[tauri::command]
+pub async fn prepare_workspace_environment(
+    workspace_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let target = EnvTarget::Workspace { workspace_id };
+    let (worktree, ws_info, repo_id) = resolve_target(&state, &target).await?;
+    let disabled = {
+        let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+        load_disabled_providers(&db, &repo_id)
+    };
+    let registry = state.plugins.read().await;
+    let resolved = claudette::env_provider::resolve_with_registry(
+        &registry,
+        &state.env_cache,
+        Path::new(&worktree),
+        &ws_info,
+        &disabled,
+    )
+    .await;
+    register_resolved_with_watcher(&state, Path::new(&worktree), &resolved.sources).await;
+    Ok(())
+}
+
 /// Toggle whether an env-provider plugin runs for the target's repo.
 /// The toggle is persisted per-repo, so the change applies to every
 /// worktree under that repo. This evicts the cache for the repo's

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -11,6 +11,7 @@ use claudette::mcp_supervisor::McpSupervisor;
 use claudette::model::{AgentStatus, ChatMessage, ChatRole, Workspace, WorkspaceStatus};
 use claudette::names::NameGenerator;
 use claudette::ops::workspace::{self as ops_workspace, CreateParams, SetupResult};
+use claudette::ops::{NoopHooks, NotificationEvent, OpsHooks, WorkspaceChangeKind};
 use claudette::process::CommandWindowExt as _;
 
 use crate::commands::apps::{self, DEFAULT_TERMINAL_APP_SETTING_KEY};
@@ -74,7 +75,6 @@ pub(crate) async fn create_workspace_inner(
     let prefix = ops_workspace::resolve_branch_prefix(&prefix_mode, &prefix_custom).await;
     let worktree_base = state.worktree_base_dir.read().await.clone();
 
-    let hooks = TauriHooks::new(app.clone());
     let params = CreateParams {
         repo_id,
         name,
@@ -83,30 +83,32 @@ pub(crate) async fn create_workspace_inner(
     let out = if preserve_supplied_name {
         ops_workspace::create_preserving_supplied_name(
             &mut db,
-            hooks.as_ref(),
+            &NoopHooks,
             worktree_base.as_path(),
             params,
         )
         .await
     } else {
-        ops_workspace::create(&mut db, hooks.as_ref(), worktree_base.as_path(), params).await
+        ops_workspace::create(&mut db, &NoopHooks, worktree_base.as_path(), params).await
     }
     .map_err(|e| e.to_string())?;
 
-    // Setup script runs after the workspace exists so we can resolve the
-    // env-provider stack against the worktree path, then thread the
-    // resulting env into the script's process. The op intentionally
-    // stays out of env resolution because the plugin registry lives in
-    // AppState — only the GUI has it today.
+    // Resolve env-provider output before the workspace is announced to the
+    // frontend. That makes a newly-created worktree wait for direnv/mise/etc.
+    // warmup (including env-direnv's optional auto-allow) before the user can
+    // launch an agent from the normal UI path. Setup scripts reuse the same
+    // resolved env below so they run in the exact environment the first agent
+    // process will inherit.
+    let repos = db.list_repositories().map_err(|e| e.to_string())?;
+    let repo = repos
+        .iter()
+        .find(|r| r.id == repo_id)
+        .ok_or("Repository not found")?;
+    let resolved_env = resolve_env_for_workspace(state, &out.workspace, &repo.path).await;
+
     let setup_result = if skip_setup {
         None
     } else {
-        let repos = db.list_repositories().map_err(|e| e.to_string())?;
-        let repo = repos
-            .iter()
-            .find(|r| r.id == repo_id)
-            .ok_or("Repository not found")?;
-        let resolved_env = resolve_env_for_workspace(state, &out.workspace, &repo.path).await;
         ops_workspace::resolve_and_run_setup(
             &out.workspace,
             Path::new(&repo.path),
@@ -118,6 +120,14 @@ pub(crate) async fn create_workspace_inner(
         )
         .await
     };
+
+    // The shared op intentionally writes the DB row before env/setup can run,
+    // but the GUI should not observe the row until the environment is ready.
+    // Emit the lifecycle hook after the warmup/setup phase instead of using
+    // TauriHooks inside the op.
+    let hooks = TauriHooks::new(app.clone());
+    hooks.workspace_changed(&out.workspace.id, WorkspaceChangeKind::Created);
+    hooks.notification(NotificationEvent::SessionStart);
 
     Ok(CreateWorkspaceResult {
         workspace: out.workspace,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1049,6 +1049,7 @@ fn main() {
             // Env-provider diagnostic UI
             commands::env::get_env_sources,
             commands::env::get_env_target_worktree,
+            commands::env::prepare_workspace_environment,
             commands::env::reload_env,
             commands::env::set_env_provider_enabled,
             commands::env::run_env_trust,

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -166,6 +166,7 @@ export function ChatInputArea({
   onRunShellCommand,
   onStop,
   isRunning,
+  workspaceEnvironmentPreparing,
   isRemote,
   hasQueuedMessages,
   selectedWorkspaceId,
@@ -197,6 +198,7 @@ export function ChatInputArea({
   onRunShellCommand: (command: string) => void | Promise<void>;
   onStop: () => void | Promise<void>;
   isRunning: boolean;
+  workspaceEnvironmentPreparing: boolean;
   isRemote: boolean;
   hasQueuedMessages: boolean;
   selectedWorkspaceId: string;
@@ -909,6 +911,7 @@ export function ChatInputArea({
   };
 
   const handleSend = () => {
+    if (workspaceEnvironmentPreparing) return;
     if (composerMode === "shell") {
       const command = normalizeShellCommand(chatInput);
       if (!command) return;
@@ -925,6 +928,7 @@ export function ChatInputArea({
   };
 
   const handleSendSteer = () => {
+    if (workspaceEnvironmentPreparing) return;
     if (!onSendSteer) return;
     // Steering only makes sense during a running turn — a regular send
     // path handles the idle case, and the agent has nothing to steer
@@ -1282,7 +1286,9 @@ export function ChatInputArea({
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           placeholder={
-            composerMode === "shell"
+            workspaceEnvironmentPreparing
+              ? t("composer_placeholder_preparing_env")
+              : composerMode === "shell"
               ? t("composer_placeholder_shell")
               : isRunning
                 ? t("composer_placeholder_queued")
@@ -1297,6 +1303,7 @@ export function ChatInputArea({
               className={`${styles.attachBtn} ${attachMenuOpen ? styles.attachBtnActive : ""}`}
               onClick={() => setAttachMenuOpen((v) => !v)}
               title={t("add_files_connectors")}
+              disabled={workspaceEnvironmentPreparing}
             >
               <Plus size={16} />
             </button>
@@ -1316,7 +1323,7 @@ export function ChatInputArea({
             sessionId={sessionId}
             workspaceId={selectedWorkspaceId}
             repoId={repoId ?? null}
-            disabled={isRunning}
+            disabled={isRunning || workspaceEnvironmentPreparing}
             isRemote={isRemote}
           />
         </div>
@@ -1391,7 +1398,7 @@ export function ChatInputArea({
                 voice.cancel();
               else void voice.start();
             }}
-            disabled={isRunning}
+            disabled={isRunning || workspaceEnvironmentPreparing}
             data-tooltip={voiceButtonTooltip}
             aria-label={voiceButtonLabel}
           >
@@ -1406,7 +1413,10 @@ export function ChatInputArea({
           <button
             className={`${styles.sendBtn} ${isRunning ? styles.sendBtnStop : ""}`}
             onClick={isRunning ? onStop : handleSend}
-            disabled={!isRunning && !chatInput.trim() && pendingAttachments.length === 0}
+            disabled={
+              workspaceEnvironmentPreparing ||
+              (!isRunning && !chatInput.trim() && pendingAttachments.length === 0)
+            }
             data-tooltip={sendButtonTooltip}
             aria-label={sendButtonLabel}
           >

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -80,6 +80,11 @@ const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
 export function ChatPanel() {
   const { t } = useTranslation("chat");
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaceEnvironmentPreparing = useAppStore((s) =>
+    s.selectedWorkspaceId
+      ? s.workspaceEnvironment[s.selectedWorkspaceId]?.status === "preparing"
+      : false,
+  );
   const activeSessionId = useAppStore((s) =>
     s.selectedWorkspaceId
       ? s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null
@@ -1449,6 +1454,7 @@ export function ChatPanel() {
         onRunShellCommand={handleRunShellCommand}
         onStop={handleStop}
         isRunning={isRunning}
+        workspaceEnvironmentPreparing={workspaceEnvironmentPreparing}
         isRemote={!!ws?.remote_connection_id}
         hasQueuedMessages={queuedMessages.length > 0}
         selectedWorkspaceId={selectedWorkspaceId!}

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -80,11 +80,13 @@ const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
 export function ChatPanel() {
   const { t } = useTranslation("chat");
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
-  const workspaceEnvironmentPreparing = useAppStore((s) =>
-    s.selectedWorkspaceId
-      ? s.workspaceEnvironment[s.selectedWorkspaceId]?.status === "preparing"
-      : false,
-  );
+  const workspaceEnvironmentPreparing = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return false;
+    const workspace = s.workspaces.find((w) => w.id === s.selectedWorkspaceId);
+    if (!workspace || workspace.remote_connection_id) return false;
+    const status = s.workspaceEnvironment[s.selectedWorkspaceId]?.status;
+    return status !== "ready" && status !== "error";
+  });
   const activeSessionId = useAppStore((s) =>
     s.selectedWorkspaceId
       ? s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -22,6 +22,7 @@ import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useBranchRefresh } from "../../hooks/useBranchRefresh";
 import { useAutoUpdater } from "../../hooks/useAutoUpdater";
 import { useWorkspaceFileWatcher } from "../../hooks/useWorkspaceFileWatcher";
+import { useWorkspaceEnvironmentPreparation } from "../../hooks/useWorkspaceEnvironmentPreparation";
 import styles from "./AppLayout.module.css";
 
 export function AppLayout() {
@@ -46,6 +47,7 @@ export function AppLayout() {
   useBranchRefresh();
   useAutoUpdater();
   useWorkspaceFileWatcher();
+  useWorkspaceEnvironmentPreparation();
 
 
   // Main-pane priority: an explicitly opened file from the Files tree

--- a/src/ui/src/components/sidebar/Sidebar.module.css
+++ b/src/ui/src/components/sidebar/Sidebar.module.css
@@ -224,11 +224,19 @@
 
 .repoName {
   flex: 1;
+  min-width: 0;
   font-size: 13px;
   font-weight: 600;
   display: flex;
   align-items: center;
   gap: 6px;
+}
+
+.repoTitle {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .iconBtn {
@@ -243,9 +251,11 @@
   display: flex;
   align-items: center;
   border-radius: 4px;
+  flex-shrink: 0;
 }
 
 .repoHeader:hover .iconBtn,
+.repoHeader:focus-within .iconBtn,
 .wsItem:hover .iconBtn {
   opacity: 1;
 }

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -1187,7 +1187,7 @@ export const Sidebar = memo(function Sidebar() {
                 </span>
                 <span className={styles.repoName}>
                   {repo.icon && <RepoIcon icon={repo.icon} className={styles.repoIcon} />}
-                  {repo.name}
+                  <span className={styles.repoTitle}>{repo.name}</span>
                   {runningCount > 0 && (
                     <span className={styles.runningBadge}>{runningCount}</span>
                   )}
@@ -1598,7 +1598,7 @@ function RemoteConnectionGroup({
           }`}
         />
         <span className={`${styles.repoName} ${styles.sectionLabel}`}>
-          {conn.name}
+          <span className={styles.repoTitle}>{conn.name}</span>
         </span>
         {!isActive && !isConnecting && (
           <button
@@ -1643,7 +1643,7 @@ function RemoteConnectionGroup({
                   {repo.icon && (
                     <RepoIcon icon={repo.icon} className={styles.repoIcon} />
                   )}
-                  {repo.name}
+                  <span className={styles.repoTitle}>{repo.name}</span>
                   {runningCount > 0 && (
                     <span className={styles.runningBadge}>{runningCount}</span>
                   )}

--- a/src/ui/src/components/sidebar/sidebarCss.test.ts
+++ b/src/ui/src/components/sidebar/sidebarCss.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CSS_DIR = join(__dirname);
+
+function readCss(file: string): string {
+  return readFileSync(join(CSS_DIR, file), "utf8");
+}
+
+function ruleBody(css: string, selector: string): string {
+  const re = new RegExp(
+    `${selector.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\s*{([^}]*)}`,
+  );
+  const match = css.match(re);
+  if (!match) throw new Error(`selector ${selector} not found in CSS`);
+  return match[1];
+}
+
+describe("Sidebar.module.css invariants", () => {
+  it("keeps project hover actions inside narrow sidebar rows", () => {
+    const css = readCss("Sidebar.module.css");
+    const repoName = ruleBody(css, ".repoName");
+    const repoTitle = ruleBody(css, ".repoTitle");
+    const iconBtn = ruleBody(css, ".iconBtn");
+
+    expect(repoName).toMatch(/min-width:\s*0\s*;/);
+    expect(repoTitle).toMatch(/overflow:\s*hidden\s*;/);
+    expect(repoTitle).toMatch(/text-overflow:\s*ellipsis\s*;/);
+    expect(repoTitle).toMatch(/white-space:\s*nowrap\s*;/);
+    expect(iconBtn).toMatch(/flex-shrink:\s*0\s*;/);
+  });
+
+  it("reveals project action buttons on hover and keyboard focus", () => {
+    const css = readCss("Sidebar.module.css");
+
+    expect(css).toMatch(/\.repoHeader:hover\s+\.iconBtn,/);
+    expect(css).toMatch(/\.repoHeader:focus-within\s+\.iconBtn,/);
+    expect(css).toMatch(/\.wsItem:hover\s+\.iconBtn\s*{\s*opacity:\s*1\s*;/);
+  });
+});

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -94,6 +94,7 @@ interface AgentTaskOutputPayload {
 
 const terminalInputEncoder = new TextEncoder();
 const terminalContextMenuOptions = { capture: true };
+type AppStoreState = ReturnType<typeof useAppStore.getState>;
 
 function encodeTerminalCommand(command: string): number[] {
   const normalized = command.replace(/\r?\n/g, "\r");
@@ -103,11 +104,21 @@ function encodeTerminalCommand(command: string): number[] {
 
 async function waitForWorkspaceEnvironment(workspaceId: string) {
   for (let attempt = 0; attempt < 300; attempt += 1) {
-    const status =
-      useAppStore.getState().workspaceEnvironment[workspaceId]?.status;
-    if (status !== "preparing") return;
+    if (!workspaceEnvironmentPending(useAppStore.getState(), workspaceId)) {
+      return;
+    }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
+}
+
+function workspaceEnvironmentPending(
+  state: AppStoreState,
+  workspaceId: string,
+): boolean {
+  const workspace = state.workspaces.find((w) => w.id === workspaceId);
+  if (!workspace || workspace.remote_connection_id) return false;
+  const status = state.workspaceEnvironment[workspaceId]?.status;
+  return status !== "ready" && status !== "error";
 }
 
 // Per-leaf xterm + PTY handle. The container is a detached <div> that we
@@ -358,7 +369,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const workspaceEnvironmentPreparing = useAppStore((s) =>
     s.selectedWorkspaceId
-      ? s.workspaceEnvironment[s.selectedWorkspaceId]?.status === "preparing"
+      ? workspaceEnvironmentPending(s, s.selectedWorkspaceId)
       : false,
   );
   const workspaces = useAppStore((s) => s.workspaces);
@@ -477,7 +488,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const handleCreateTab = useCallback(async () => {
     const wsId = selectedWorkspaceIdRef.current;
     if (!wsId) return;
-    if (useAppStore.getState().workspaceEnvironment[wsId]?.status === "preparing") return;
+    if (workspaceEnvironmentPending(useAppStore.getState(), wsId)) return;
     try {
       const tab = await createTerminalTab(wsId);
       addTerminalTab(wsId, tab);

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -101,6 +101,15 @@ function encodeTerminalCommand(command: string): number[] {
   return Array.from(terminalInputEncoder.encode(withReturn));
 }
 
+async function waitForWorkspaceEnvironment(workspaceId: string) {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const status =
+      useAppStore.getState().workspaceEnvironment[workspaceId]?.status;
+    if (status !== "preparing") return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
 // Per-leaf xterm + PTY handle. The container is a detached <div> that we
 // appendChild into whichever target div the pane tree currently emits for
 // this leafId — that's the trick that keeps xterm alive across splits.
@@ -347,6 +356,11 @@ function forwardPtyResize(
  */
 export const TerminalPanel = memo(function TerminalPanel() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const workspaceEnvironmentPreparing = useAppStore((s) =>
+    s.selectedWorkspaceId
+      ? s.workspaceEnvironment[s.selectedWorkspaceId]?.status === "preparing"
+      : false,
+  );
   const workspaces = useAppStore((s) => s.workspaces);
   const terminalTabs = useAppStore((s) => s.terminalTabs);
   const pendingTerminalCommands = useAppStore((s) => s.pendingTerminalCommands);
@@ -463,6 +477,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
   const handleCreateTab = useCallback(async () => {
     const wsId = selectedWorkspaceIdRef.current;
     if (!wsId) return;
+    if (useAppStore.getState().workspaceEnvironment[wsId]?.status === "preparing") return;
     try {
       const tab = await createTerminalTab(wsId);
       addTerminalTab(wsId, tab);
@@ -498,6 +513,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
 
   const dispatchTerminalCommand = useCallback(
     async (queued: { id: string; workspaceId: string; command: string }) => {
+      await waitForWorkspaceEnvironment(queued.workspaceId);
       let tabs = useAppStore.getState().terminalTabs[queued.workspaceId] ?? null;
       if (!tabs) {
         tabs = await listTerminalTabs(queued.workspaceId);
@@ -613,6 +629,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
   // Load tabs on workspace + panel-visibility change.
   useEffect(() => {
     if (!selectedWorkspaceId || !terminalPanelVisible) return;
+    if (workspaceEnvironmentPreparing) return;
     const wsId = selectedWorkspaceId;
     listTerminalTabs(wsId).then(async (t) => {
       if (claudetteTerminalEnabled && selectedSessionId) {
@@ -655,6 +672,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
     selectedSessionId,
     claudetteTerminalEnabled,
     terminalPanelVisible,
+    workspaceEnvironmentPreparing,
     setTerminalTabs,
     setActiveTerminalTab,
     addTerminalTab,
@@ -928,6 +946,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
             ? state.repositories.find((r) => r.id === currentWs.repository_id)
             : undefined;
           const defaults = state.defaultBranches;
+          await waitForWorkspaceEnvironment(spec.workspaceId);
           const ptyId = await spawnPty(
             spec.worktreePath,
             currentWs?.name ?? "",
@@ -1564,6 +1583,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
         <button
           className={styles.addTab}
           onClick={handleCreateTab}
+          disabled={workspaceEnvironmentPreparing}
           aria-label="New terminal tab"
           {...tooltipAttributes("New terminal tab", "terminal.new-tab", keybindings, hotkeyIsMac, "bottom")}
         >

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Workspace } from "../types/workspace";
+import { useAppStore } from "../stores/useAppStore";
+
+const serviceMocks = vi.hoisted(() => ({
+  prepareWorkspaceEnvironment: vi.fn(),
+}));
+
+vi.mock("../services/tauri", () => serviceMocks);
+
+import { useWorkspaceEnvironmentPreparation } from "./useWorkspaceEnvironmentPreparation";
+
+function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "ws-1",
+    repository_id: "repo-1",
+    name: "feature",
+    branch_name: "james/feature",
+    worktree_path: "/tmp/feature",
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "1700000000",
+    sort_order: 0,
+    remote_connection_id: null,
+    ...overrides,
+  };
+}
+
+function Harness() {
+  useWorkspaceEnvironmentPreparation();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderHarness() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Harness />);
+  });
+}
+
+describe("useWorkspaceEnvironmentPreparation", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    serviceMocks.prepareWorkspaceEnvironment.mockReset();
+    serviceMocks.prepareWorkspaceEnvironment.mockResolvedValue(undefined);
+    useAppStore.setState({
+      selectedWorkspaceId: null,
+      workspaces: [],
+      workspaceEnvironment: {},
+      toasts: [],
+    });
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+  });
+
+  it("prepares env providers when an existing local workspace is selected", async () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.prepareWorkspaceEnvironment).toHaveBeenCalledWith("ws-1");
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "ready",
+    });
+  });
+
+  it("does not run local env providers for remote workspaces", async () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-remote",
+      workspaces: [
+        makeWorkspace({
+          id: "ws-remote",
+          remote_connection_id: "remote-1",
+        }),
+      ],
+    });
+
+    await renderHarness();
+
+    expect(serviceMocks.prepareWorkspaceEnvironment).not.toHaveBeenCalled();
+    expect(useAppStore.getState().workspaceEnvironment["ws-remote"]).toEqual({
+      status: "ready",
+    });
+  });
+});

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -107,4 +107,82 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       status: "ready",
     });
   });
+
+  it("does not restart env preparation when unrelated workspace fields update", async () => {
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      useAppStore
+        .getState()
+        .updateWorkspace("ws-1", { status_line: "agent is still running" });
+    });
+
+    expect(serviceMocks.prepareWorkspaceEnvironment).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears stale preparing state when selection changes before preparation finishes", async () => {
+    let resolvePreparation!: () => void;
+    serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolvePreparation = resolve;
+      }),
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    await renderHarness();
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "preparing",
+    });
+
+    act(() => {
+      useAppStore.setState({ selectedWorkspaceId: null });
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "idle",
+    });
+
+    await act(async () => {
+      resolvePreparation();
+      await Promise.resolve();
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "idle",
+    });
+  });
+
+  it("marks the workspace as errored when env preparation fails", async () => {
+    serviceMocks.prepareWorkspaceEnvironment.mockRejectedValue(
+      new Error("direnv blocked"),
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "error",
+      error: "Error: direnv blocked",
+    });
+    expect(useAppStore.getState().toasts.at(-1)?.message).toBe(
+      "Workspace environment failed: Error: direnv blocked",
+    );
+  });
 });

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -4,41 +4,51 @@ import { useAppStore } from "../stores/useAppStore";
 
 export function useWorkspaceEnvironmentPreparation() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
-  const selectedWorkspace = useAppStore((s) =>
-    s.selectedWorkspaceId
-      ? s.workspaces.find((w) => w.id === s.selectedWorkspaceId) ?? null
-      : null,
-  );
+  const selectedWorkspaceRemoteConnectionId = useAppStore((s) => {
+    if (!s.selectedWorkspaceId) return null;
+    const selectedWorkspace = s.workspaces.find(
+      (w) => w.id === s.selectedWorkspaceId,
+    );
+    return selectedWorkspace?.remote_connection_id;
+  });
   const setWorkspaceEnvironment = useAppStore((s) => s.setWorkspaceEnvironment);
   const addToast = useAppStore((s) => s.addToast);
 
   useEffect(() => {
-    if (!selectedWorkspaceId || !selectedWorkspace) return;
-    if (selectedWorkspace.remote_connection_id) {
+    if (!selectedWorkspaceId) return;
+    if (selectedWorkspaceRemoteConnectionId === undefined) return;
+    if (selectedWorkspaceRemoteConnectionId) {
       setWorkspaceEnvironment(selectedWorkspaceId, "ready");
       return;
     }
 
+    const workspaceId = selectedWorkspaceId;
     let cancelled = false;
-    setWorkspaceEnvironment(selectedWorkspaceId, "preparing");
+    setWorkspaceEnvironment(workspaceId, "preparing");
 
-    prepareWorkspaceEnvironment(selectedWorkspaceId)
+    prepareWorkspaceEnvironment(workspaceId)
       .then(() => {
-        if (!cancelled) setWorkspaceEnvironment(selectedWorkspaceId, "ready");
+        if (!cancelled) setWorkspaceEnvironment(workspaceId, "ready");
       })
       .catch((err) => {
         if (cancelled) return;
         const message = String(err);
-        setWorkspaceEnvironment(selectedWorkspaceId, "error", message);
+        setWorkspaceEnvironment(workspaceId, "error", message);
         addToast(`Workspace environment failed: ${message}`);
       });
 
     return () => {
       cancelled = true;
+      if (
+        useAppStore.getState().workspaceEnvironment[workspaceId]?.status ===
+        "preparing"
+      ) {
+        setWorkspaceEnvironment(workspaceId, "idle");
+      }
     };
   }, [
     selectedWorkspaceId,
-    selectedWorkspace,
+    selectedWorkspaceRemoteConnectionId,
     setWorkspaceEnvironment,
     addToast,
   ]);

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import { prepareWorkspaceEnvironment } from "../services/tauri";
+import { useAppStore } from "../stores/useAppStore";
+
+export function useWorkspaceEnvironmentPreparation() {
+  const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
+  const selectedWorkspace = useAppStore((s) =>
+    s.selectedWorkspaceId
+      ? s.workspaces.find((w) => w.id === s.selectedWorkspaceId) ?? null
+      : null,
+  );
+  const setWorkspaceEnvironment = useAppStore((s) => s.setWorkspaceEnvironment);
+  const addToast = useAppStore((s) => s.addToast);
+
+  useEffect(() => {
+    if (!selectedWorkspaceId || !selectedWorkspace) return;
+    if (selectedWorkspace.remote_connection_id) {
+      setWorkspaceEnvironment(selectedWorkspaceId, "ready");
+      return;
+    }
+
+    let cancelled = false;
+    setWorkspaceEnvironment(selectedWorkspaceId, "preparing");
+
+    prepareWorkspaceEnvironment(selectedWorkspaceId)
+      .then(() => {
+        if (!cancelled) setWorkspaceEnvironment(selectedWorkspaceId, "ready");
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = String(err);
+        setWorkspaceEnvironment(selectedWorkspaceId, "error", message);
+        addToast(`Workspace environment failed: ${message}`);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    selectedWorkspaceId,
+    selectedWorkspace,
+    setWorkspaceEnvironment,
+    addToast,
+  ]);
+}

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -22,6 +22,7 @@
   "remove_attachment": "Remove",
   "composer_placeholder_idle": "Send a message...",
   "composer_placeholder_queued": "Type to queue a message...",
+  "composer_placeholder_preparing_env": "Preparing workspace environment...",
   "composer_placeholder_shell": "Run a shell command...",
   "shell_mode_label": "Shell",
   "voice_input": "Voice input",

--- a/src/ui/src/locales/en/sidebar.json
+++ b/src/ui/src/locales/en/sidebar.json
@@ -7,7 +7,7 @@
   "filter_all_repos": "All repos",
   "filter_show_archived": "Show archived",
   "clear_repo_filter": "Clear repo filter",
-  "creating_workspace": "Creating workspace…",
+  "creating_workspace": "Preparing workspace environment…",
   "share_active_title": "Sharing — click to view connection string",
   "share_inactive_title": "Share this machine",
   "nearby_section": "Nearby",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -22,6 +22,7 @@
   "remove_attachment": "Quitar",
   "composer_placeholder_idle": "Envía un mensaje...",
   "composer_placeholder_queued": "Escribe para encolar un mensaje...",
+  "composer_placeholder_preparing_env": "Preparando el entorno del espacio de trabajo...",
   "composer_placeholder_shell": "Ejecuta un comando shell...",
   "shell_mode_label": "Shell",
   "voice_input": "Entrada de voz",

--- a/src/ui/src/locales/es/sidebar.json
+++ b/src/ui/src/locales/es/sidebar.json
@@ -7,7 +7,7 @@
   "filter_all_repos": "Todos los repositorios",
   "filter_show_archived": "Mostrar archivados",
   "clear_repo_filter": "Limpiar filtro",
-  "creating_workspace": "Creando espacio de trabajo…",
+  "creating_workspace": "Preparando el entorno del espacio de trabajo…",
   "share_active_title": "Compartiendo — haz clic para ver la cadena de conexión",
   "share_inactive_title": "Compartir esta máquina",
   "nearby_section": "Cercanos",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -22,6 +22,7 @@
   "remove_attachment": "削除",
   "composer_placeholder_idle": "メッセージを送信...",
   "composer_placeholder_queued": "メッセージをキューに入れるには入力...",
+  "composer_placeholder_preparing_env": "ワークスペース環境を準備中...",
   "composer_placeholder_shell": "シェルコマンドを実行...",
   "shell_mode_label": "シェル",
   "voice_input": "音声入力",

--- a/src/ui/src/locales/ja/sidebar.json
+++ b/src/ui/src/locales/ja/sidebar.json
@@ -7,7 +7,7 @@
   "filter_all_repos": "すべてのリポジトリ",
   "filter_show_archived": "アーカイブ済みを表示",
   "clear_repo_filter": "リポジトリフィルターをクリア",
-  "creating_workspace": "ワークスペースを作成中…",
+  "creating_workspace": "ワークスペース環境を準備中…",
   "share_active_title": "共有中 — クリックして接続文字列を表示",
   "share_inactive_title": "このマシンを共有",
   "nearby_section": "近くのデバイス",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -22,6 +22,7 @@
   "remove_attachment": "Remover",
   "composer_placeholder_idle": "Envie uma mensagem...",
   "composer_placeholder_queued": "Digite para enfileirar uma mensagem...",
+  "composer_placeholder_preparing_env": "Preparando ambiente do workspace...",
   "composer_placeholder_shell": "Execute um comando shell...",
   "shell_mode_label": "Shell",
   "voice_input": "Entrada de voz",

--- a/src/ui/src/locales/pt-BR/sidebar.json
+++ b/src/ui/src/locales/pt-BR/sidebar.json
@@ -7,7 +7,7 @@
   "filter_all_repos": "Todos os repositórios",
   "filter_show_archived": "Mostrar arquivados",
   "clear_repo_filter": "Limpar filtro de repositório",
-  "creating_workspace": "Criando workspace…",
+  "creating_workspace": "Preparando ambiente do workspace…",
   "share_active_title": "Compartilhando — clique para ver a string de conexão",
   "share_inactive_title": "Compartilhar esta máquina",
   "nearby_section": "Próximos",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -22,6 +22,7 @@
   "remove_attachment": "移除",
   "composer_placeholder_idle": "发送消息...",
   "composer_placeholder_queued": "输入以排队消息...",
+  "composer_placeholder_preparing_env": "正在准备工作区环境...",
   "composer_placeholder_shell": "运行 shell 命令...",
   "shell_mode_label": "Shell",
   "voice_input": "语音输入",

--- a/src/ui/src/locales/zh-CN/sidebar.json
+++ b/src/ui/src/locales/zh-CN/sidebar.json
@@ -7,7 +7,7 @@
   "filter_all_repos": "所有仓库",
   "filter_show_archived": "显示已归档",
   "clear_repo_filter": "清除仓库筛选",
-  "creating_workspace": "正在创建工作区…",
+  "creating_workspace": "正在准备工作区环境…",
   "share_active_title": "正在共享 — 点击查看连接字符串",
   "share_inactive_title": "共享此设备",
   "nearby_section": "附近",

--- a/src/ui/src/services/fork.test.ts
+++ b/src/ui/src/services/fork.test.ts
@@ -5,7 +5,7 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (cmd: string, args?: unknown) => invokeMock(cmd, args),
 }));
 
-import { forkWorkspaceAtCheckpoint } from "./tauri";
+import { forkWorkspaceAtCheckpoint, prepareWorkspaceEnvironment } from "./tauri";
 
 describe("forkWorkspaceAtCheckpoint", () => {
   beforeEach(() => {
@@ -55,5 +55,21 @@ describe("forkWorkspaceAtCheckpoint", () => {
     await expect(
       forkWorkspaceAtCheckpoint("ws-src", "cp-missing"),
     ).rejects.toThrow("Checkpoint not found");
+  });
+});
+
+describe("prepareWorkspaceEnvironment", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("warms env providers for an existing workspace before subprocess use", async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+
+    await prepareWorkspaceEnvironment("ws-old");
+
+    expect(invokeMock).toHaveBeenCalledWith("prepare_workspace_environment", {
+      workspaceId: "ws-old",
+    });
   });
 });

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -250,6 +250,10 @@ export function runWorkspaceSetup(
   return invoke("run_workspace_setup", { workspaceId });
 }
 
+export function prepareWorkspaceEnvironment(workspaceId: string): Promise<void> {
+  return invoke("prepare_workspace_environment", { workspaceId });
+}
+
 export function archiveWorkspace(id: string, skipArchiveScript?: boolean): Promise<boolean> {
   return invoke("archive_workspace", { id, skipArchiveScript: skipArchiveScript ?? false });
 }

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -147,4 +147,26 @@ describe("workspacesSlice.addWorkspace", () => {
       error: "direnv failed",
     });
   });
+
+  it("marks a local workspace as preparing as soon as it is selected", () => {
+    useAppStore.getState().addWorkspace(makeWorkspace());
+
+    useAppStore.getState().selectWorkspace("ws-1");
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "preparing",
+    });
+  });
+
+  it("marks a remote workspace ready as soon as it is selected", () => {
+    useAppStore.getState().addWorkspace(
+      makeWorkspace({ id: "ws-remote", remote_connection_id: "remote-1" }),
+    );
+
+    useAppStore.getState().selectWorkspace("ws-remote");
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-remote"]).toEqual({
+      status: "ready",
+    });
+  });
 });

--- a/src/ui/src/stores/slices/workspacesSlice.test.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.test.ts
@@ -21,7 +21,11 @@ function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
 
 describe("workspacesSlice.addWorkspace", () => {
   beforeEach(() => {
-    useAppStore.setState({ workspaces: [], selectedWorkspaceId: null });
+    useAppStore.setState({
+      workspaces: [],
+      selectedWorkspaceId: null,
+      workspaceEnvironment: {},
+    });
   });
 
   it("appends a workspace when the id is new", () => {
@@ -127,5 +131,20 @@ describe("workspacesSlice.addWorkspace", () => {
     useAppStore.getState().addWorkspace(makeWorkspace({ id: "ws-2", name: "other" }));
     const result = useAppStore.getState().workspaces;
     expect(result.map((w) => w.id)).toEqual(["ws-1", "ws-2"]);
+  });
+
+  it("tracks workspace environment preparation status", () => {
+    useAppStore.getState().setWorkspaceEnvironment("ws-1", "preparing");
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "preparing",
+    });
+
+    useAppStore
+      .getState()
+      .setWorkspaceEnvironment("ws-1", "error", "direnv failed");
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "error",
+      error: "direnv failed",
+    });
   });
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -2,14 +2,27 @@ import type { StateCreator } from "zustand";
 import type { Workspace } from "../../types";
 import type { AppState } from "../useAppStore";
 
+export type WorkspaceEnvironmentStatus = "idle" | "preparing" | "ready" | "error";
+
+export interface WorkspaceEnvironmentPreparation {
+  status: WorkspaceEnvironmentStatus;
+  error?: string;
+}
+
 export interface WorkspacesSlice {
   workspaces: Workspace[];
   selectedWorkspaceId: string | null;
+  workspaceEnvironment: Record<string, WorkspaceEnvironmentPreparation>;
   setWorkspaces: (workspaces: Workspace[]) => void;
   addWorkspace: (ws: Workspace) => void;
   updateWorkspace: (id: string, updates: Partial<Workspace>) => void;
   removeWorkspace: (id: string) => void;
   selectWorkspace: (id: string | null) => void;
+  setWorkspaceEnvironment: (
+    id: string,
+    status: WorkspaceEnvironmentStatus,
+    error?: string,
+  ) => void;
 }
 
 export const createWorkspacesSlice: StateCreator<
@@ -20,6 +33,7 @@ export const createWorkspacesSlice: StateCreator<
 > = (set) => ({
   workspaces: [],
   selectedWorkspaceId: null,
+  workspaceEnvironment: {},
   setWorkspaces: (workspaces) => set({ workspaces }),
   // Idempotent by id: workspace creates can race between the Tauri
   // command's response (Sidebar calls `addWorkspace` after the await
@@ -100,6 +114,8 @@ export const createWorkspacesSlice: StateCreator<
       // sessions→diffs→files layout instead of dredging up old entries.
       const newTabOrder = { ...s.tabOrderByWorkspace };
       delete newTabOrder[id];
+      const newWorkspaceEnvironment = { ...s.workspaceEnvironment };
+      delete newWorkspaceEnvironment[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -115,6 +131,7 @@ export const createWorkspacesSlice: StateCreator<
         diffSelectionByWorkspace: newDiffSelection,
         chatDrafts: newChatDrafts,
         tabOrderByWorkspace: newTabOrder,
+        workspaceEnvironment: newWorkspaceEnvironment,
       };
     }),
   selectWorkspace: (id) =>
@@ -178,4 +195,11 @@ export const createWorkspacesSlice: StateCreator<
       }
       return updates;
     }),
+  setWorkspaceEnvironment: (id, status, error) =>
+    set((s) => ({
+      workspaceEnvironment: {
+        ...s.workspaceEnvironment,
+        [id]: error ? { status, error } : { status },
+      },
+    })),
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -188,6 +188,17 @@ export const createWorkspacesSlice: StateCreator<
         // SHA leaks across the boundary.
         diffMergeBase: null,
       };
+      if (id) {
+        const incoming = s.workspaces.find((w) => w.id === id);
+        if (incoming) {
+          updates.workspaceEnvironment = {
+            ...s.workspaceEnvironment,
+            [id]: {
+              status: incoming.remote_connection_id ? "ready" : "preparing",
+            },
+          };
+        }
+      }
       if (id && s.unreadCompletions.has(id)) {
         const next = new Set(s.unreadCompletions);
         next.delete(id);


### PR DESCRIPTION
## Summary

Fixes env-provider activation timing so workspaces are not usable until their env providers have been resolved. This specifically covers `env-direnv` / `.envrc` and the existing `auto_allow` path, plus the old-session case where a user returns to a workspace weeks later.

## Root Cause

Claudette already applied env-provider output when spawning an agent process or PTY, but there were two timing gaps:

- New workspace creation emitted the workspace-created lifecycle event before env-provider warmup completed, so the UI could select/start from a worktree before `direnv` had been allowed/resolved.
- Existing workspace selection only changed frontend state. Old sessions were still resolved lazily on the first chat turn or PTY spawn, but the workspace itself did not have an explicit "prepare environment first" gate.

Separately, a sidebar flex regression let long project names consume the whole row and push the hover `+` / settings buttons offscreen in narrow sidebars.

## Changes

- Gate workspace creation lifecycle events until env-provider resolution finishes.
- Add `prepare_workspace_environment` as an explicit backend command for existing workspace warmup.
- Run workspace env preparation whenever a local workspace is selected.
- Block chat sends / shell composer sends while selected workspace env preparation is running.
- Delay terminal tab auto-create and PTY spawn until env preparation is complete.
- Keep remote workspaces out of the local env-provider warmup path.
- Fix project-row hover actions by making repo titles shrink/ellipsis and action buttons non-shrinking.
- Update docs and localized loading/placeholder copy for the new environment-preparation UX.
- Add regression tests for workspace selection env warmup, env preparation store state, Tauri service wiring, and sidebar hover-action layout invariants.

## Validation

All commands were run through `nix develop -c`.

- `cargo fmt --all --check`
- `cd src/ui && bun run test -- src/components/sidebar/sidebarCss.test.ts`
- `cd src/ui && bun run test -- src/hooks/useWorkspaceEnvironmentPreparation.test.tsx src/stores/slices/workspacesSlice.test.ts src/services/fork.test.ts`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint:css`
- `cargo check -p claudette-tauri --no-default-features --features tauri/custom-protocol,server`
- `cd src/ui && bun run lint` — passed with existing warnings, no errors
- `cd src/ui && bun run build`
- `cargo test -p claudette env_provider --all-features`
