### PR TITLE
feat: improve native app feel

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 claudette = { path = ".." }
 claudette-server = { path = "../src-server", optional = true }
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-dialog = "2"
 base64 = "0.22"
 trash = "5"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,11 +17,18 @@
         "center": true,
         "maximized": false,
         "visible": false,
+        "transparent": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "trafficLightPosition": { "x": 16, "y": 18 },
+        "windowEffects": {
+          "effects": ["sidebar", "mica", "tabbed", "windowBackground"],
+          "state": "followsWindowActiveState"
+        },
         "dragDropEnabled": true
       }
     ],
+    "macOSPrivateApi": true,
     "security": {
       "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src ipc: http://ipc.localhost https://github.com; img-src 'self' asset: http://asset.localhost data: blob:; media-src 'self' blob:; font-src 'self' data:",
       "capabilities": [

--- a/src/ui/src/components/chat/AgentQuestionCard.module.css
+++ b/src/ui/src/components/chat/AgentQuestionCard.module.css
@@ -7,7 +7,6 @@
   padding: var(--space-4) var(--space-5);
   margin: var(--space-3) 0;
   box-shadow: var(--shadow-md);
-  animation: fadeInUp 0.2s ease both;
 }
 
 .label {

--- a/src/ui/src/components/chat/AttachMenu.module.css
+++ b/src/ui/src/components/chat/AttachMenu.module.css
@@ -16,7 +16,6 @@
   padding: 4px;
   z-index: 100;
   box-shadow: var(--shadow-lg);
-  animation: scaleIn 0.12s ease;
 }
 
 .menuItem {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -22,11 +22,25 @@
   flex: 1;
   overflow-y: auto;
   overscroll-behavior-y: none;
+  margin-right: var(--scrollbar-edge-inset);
   padding: 20px 28px;
   display: flex;
   flex-direction: column;
   gap: 2px;
   contain: layout style;
+}
+
+.messages::-webkit-scrollbar {
+  width: 12px;
+}
+
+.messages::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: var(--radius-sm);
+}
+
+.messages::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
 }
 
 .empty {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -22,44 +22,29 @@
   flex: 1;
   overflow-y: auto;
   overscroll-behavior-y: none;
-  /* Reserve the scrollbar lane unconditionally so message growth that
-   * crosses the overflow threshold doesn't reflow the column under the
-   * cursor. Combined with the right-edge inset below this gives xterm /
-   * Monaco / chat the same visual gap from the panel's right wall. */
-  scrollbar-gutter: stable;
+  /* Right gap matches xterm's `inset: 8px` and Monaco's host
+   * `margin-right: var(--scrollbar-edge-inset)`. The custom slider
+   * (rendered by `<OverlayScrollbar />`) lives inside this 8px lane. */
   margin-right: var(--scrollbar-edge-inset);
   padding: 20px 28px;
   display: flex;
   flex-direction: column;
   gap: 2px;
   contain: layout style;
-  /* Override the global `* { scrollbar-width: thin }` so WebKit honors the
-   * `::-webkit-scrollbar` width below. With `thin`, macOS WKWebView falls
-   * back to the OS overlay scrollbar — which renders at a fixed device
-   * pixel width and does NOT scale with browser zoom, so chat would drift
-   * out of sync with xterm's xterm.js slider and Monaco's custom slider as
-   * the user zooms in or out. `auto` lets our explicit pixel width win and
-   * scales uniformly with the rest of the UI. */
-  scrollbar-width: auto;
-  scrollbar-color: var(--scrollbar-thumb) transparent;
+  /* Hide the host's native scrollbar — `<OverlayScrollbar />` draws a
+   * pixel-sized DOM slider that matches xterm.js / Monaco. macOS
+   * WKWebView ignores `::-webkit-scrollbar` widths when the system uses
+   * overlay scrollbars, and overlay scrollbars don't scale with browser
+   * zoom, so the custom slider is the only way to keep all three
+   * surfaces consistent. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .messages::-webkit-scrollbar {
-  width: var(--scrollbar-size);
-  height: var(--scrollbar-size);
-}
-
-.messages::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.messages::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
-  border-radius: var(--radius-sm);
-}
-
-.messages::-webkit-scrollbar-thumb:hover {
-  background: var(--scrollbar-thumb-hover);
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 .empty {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -58,7 +58,6 @@
   color: var(--status-stopped);
   white-space: pre-wrap;
   word-break: break-word;
-  animation: fadeInUp 0.15s ease;
 }
 
 /* --- Block-based message layout ---
@@ -69,7 +68,6 @@
 
 .message {
   max-width: 100%;
-  animation: fadeInUp 0.15s ease both;
 }
 
 /* User messages — compact input blocks */
@@ -259,7 +257,6 @@
   gap: 10px;
   padding: 10px 12px;
   font-size: 13px;
-  animation: fadeIn 0.2s ease;
   background: rgba(var(--accent-primary-rgb), 0.03);
   border-radius: 8px;
   border: 1px solid rgba(var(--accent-primary-rgb), 0.06);

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -22,16 +22,35 @@
   flex: 1;
   overflow-y: auto;
   overscroll-behavior-y: none;
+  /* Reserve the scrollbar lane unconditionally so message growth that
+   * crosses the overflow threshold doesn't reflow the column under the
+   * cursor. Combined with the right-edge inset below this gives xterm /
+   * Monaco / chat the same visual gap from the panel's right wall. */
+  scrollbar-gutter: stable;
   margin-right: var(--scrollbar-edge-inset);
   padding: 20px 28px;
   display: flex;
   flex-direction: column;
   gap: 2px;
   contain: layout style;
+  /* Override the global `* { scrollbar-width: thin }` so WebKit honors the
+   * `::-webkit-scrollbar` width below. With `thin`, macOS WKWebView falls
+   * back to the OS overlay scrollbar — which renders at a fixed device
+   * pixel width and does NOT scale with browser zoom, so chat would drift
+   * out of sync with xterm's xterm.js slider and Monaco's custom slider as
+   * the user zooms in or out. `auto` lets our explicit pixel width win and
+   * scales uniformly with the rest of the UI. */
+  scrollbar-width: auto;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 .messages::-webkit-scrollbar {
-  width: 12px;
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+}
+
+.messages::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .messages::-webkit-scrollbar-thumb {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -21,6 +21,7 @@
 .messages {
   flex: 1;
   overflow-y: auto;
+  overscroll-behavior-y: none;
   padding: 20px 28px;
   display: flex;
   flex-direction: column;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -64,6 +64,7 @@ import { ScrollToBottomPill } from "./ScrollToBottomPill";
 import { useStickyScroll } from "../../hooks/useStickyScroll";
 import { tooltipWithHotkey } from "../../hotkeys/display";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
+import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
 import styles from "./ChatPanel.module.css";
 import { shouldDisable1mContext, formatElapsedSeconds } from "./chatHelpers";
 import { ScrollContext } from "./ScrollContext";
@@ -292,6 +293,7 @@ export function ChatPanel() {
   // Sticky scroll: auto-follow when at bottom, stop when user scrolls up.
   const { isAtBottom, scrollToBottom, handleContentChanged } =
     useStickyScroll(messagesContainerRef);
+  usePreventScrollBounce(messagesContainerRef);
 
   // Memoize context value to avoid re-rendering StreamingMessage on every parent render.
   const scrollContextValue = useMemo(

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -7,6 +7,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { ChatSearchBar } from "./ChatSearchBar";
+import { OverlayScrollbar } from "./OverlayScrollbar";
 import { useAppStore } from "../../stores/useAppStore";
 import {
   loadAttachmentData,
@@ -1254,6 +1255,12 @@ export function ChatPanel() {
           />
         )}
         <ScrollContext.Provider value={scrollContextValue}>
+        {/* Custom DOM scrollbar overlay. Mirrors xterm.js / Monaco's
+         * always-visible 8px slider so all three surfaces stay
+         * pixel-identical at every browser zoom (the OS overlay
+         * scrollbar that WKWebView would render on `.messages` instead
+         * doesn't scale with zoom). */}
+        <OverlayScrollbar targetRef={messagesContainerRef} />
         <div className={styles.messages} ref={messagesContainerRef}>
           <CliInvocationBanner
             invocation={cliInvocation}

--- a/src/ui/src/components/chat/ModelSelector.module.css
+++ b/src/ui/src/components/chat/ModelSelector.module.css
@@ -16,7 +16,6 @@
   padding: 4px;
   z-index: 100;
   box-shadow: var(--shadow-lg);
-  animation: scaleIn 0.12s ease;
 }
 
 .groupLabel {

--- a/src/ui/src/components/chat/OverlayScrollbar.module.css
+++ b/src/ui/src/components/chat/OverlayScrollbar.module.css
@@ -1,0 +1,60 @@
+/* Custom DOM scrollbar overlay, matched to xterm.js's `.scrollbar > .slider`
+ * and Monaco's `.monaco-scrollable-element > .scrollbar > .slider`. Pure CSS
+ * scrollbars (`::-webkit-scrollbar` / `scrollbar-color`) cannot reliably be
+ * forced out of overlay mode in macOS WKWebView, and OS overlay scrollbars
+ * do not scale with browser zoom — so chat parity needs a real DOM slider
+ * sized in CSS pixels just like xterm and Monaco draw.
+ *
+ * The track lives inside the scrolling viewport's `position: relative`
+ * parent and is anchored to the right edge. The slider is a child div the
+ * component repositions via `transform: translateY(...)` and `height`.
+ *
+ * Width / radius / colors all come from the same tokens xterm and Monaco
+ * use (see TerminalPanel.module.css and monacoTheme.ts). Update those
+ * tokens — not local literals — to keep the three surfaces aligned. */
+
+.track {
+  position: absolute;
+  top: 0;
+  /* Inset from the wrapper's right wall by `--scrollbar-edge-inset` so the
+   * slider lines up with where xterm (`.paneRoot { inset: 8px }`) and
+   * Monaco (`.host { margin-right: var(--scrollbar-edge-inset) }`) draw
+   * their own custom sliders. The 8px breathing room between the slider
+   * and the panel's right wall is the visual signature shared by all
+   * three surfaces — anchoring `right: 0` would push the chat slider
+   * 8px outboard of that line. */
+  right: var(--scrollbar-edge-inset);
+  bottom: 0;
+  width: var(--scrollbar-size);
+  pointer-events: none;
+  z-index: 1;
+  /* Hide entirely when there's no overflow; the component clears the data
+   * attribute in that case. Avoids a phantom rail on short conversations. */
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.track[data-overflowing="true"] {
+  opacity: 1;
+}
+
+.slider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: var(--scrollbar-size);
+  background: var(--scrollbar-thumb);
+  border-radius: var(--radius-sm);
+  pointer-events: auto;
+  cursor: default;
+  /* Skip the property-list animation on translate/height — the slider must
+   * track scrollTop without a trailing easing or it feels rubbery. */
+  transition: background var(--transition-fast);
+  will-change: transform, height;
+}
+
+.slider:hover,
+.slider[data-dragging="true"] {
+  background: var(--scrollbar-thumb-hover);
+}

--- a/src/ui/src/components/chat/OverlayScrollbar.module.css
+++ b/src/ui/src/components/chat/OverlayScrollbar.module.css
@@ -26,6 +26,12 @@
   right: var(--scrollbar-edge-inset);
   bottom: 0;
   width: var(--scrollbar-size);
+  /* `pointer-events: none` while not overflowing means clicks in the
+   * 8px right-edge band pass through to message content underneath
+   * (the band overlaps `.messages` because the track is a sibling of
+   * `.messages` and `.messages` has a `margin-right` matching the
+   * track inset). When overflowing, the track flips to `auto` so the
+   * track click-to-page handler fires — see OverlayScrollbar.tsx. */
   pointer-events: none;
   z-index: 1;
   /* Hide entirely when there's no overflow; the component clears the data
@@ -36,6 +42,11 @@
 
 .track[data-overflowing="true"] {
   opacity: 1;
+  pointer-events: auto;
+  /* Track click-to-page wants the standard arrow cursor (clicking the
+   * rail isn't a text-selection or drag affordance). The slider keeps
+   * its own `cursor: default`. */
+  cursor: default;
 }
 
 .slider {

--- a/src/ui/src/components/chat/OverlayScrollbar.test.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.test.tsx
@@ -1,0 +1,503 @@
+// @vitest-environment happy-dom
+
+// Regression suite for the chat's custom DOM scrollbar.
+//
+// `<OverlayScrollbar />` exists because macOS WKWebView keeps using the
+// OS overlay scrollbar regardless of `::-webkit-scrollbar` styling, and
+// OS overlay scrollbars don't scale with browser zoom — so chat,
+// xterm.js's slider, and Monaco's slider would visibly drift apart at
+// non-100% zoom. This file pins:
+//
+//   1. The component renders a track + slider pair under the
+//      CSS-module classes the call site relies on.
+//   2. Overflow gating: the data attribute and slider visibility
+//      flip with the target's scrollHeight / clientHeight ratio.
+//   3. Slider geometry math (proportional height with a minimum,
+//      proportional top derived from scrollTop).
+//   4. Live updates via the target's scroll event, ResizeObserver,
+//      and MutationObserver — all three fire `update()` so streaming
+//      message growth tracks correctly.
+//   5. Drag mapping: a pointermove delta translates into the right
+//      scrollTop delta (inverse of slider/content ratio), with
+//      clamping at both ends.
+//   6. Observer + listener cleanup on unmount, so component churn
+//      doesn't leak handlers onto the messages container.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useRef, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OverlayScrollbar } from "./OverlayScrollbar";
+import styles from "./OverlayScrollbar.module.css";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(node: ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+/** Stub the three layout properties OverlayScrollbar reads. happy-dom
+ *  doesn't compute layout, so without overrides scrollHeight ===
+ *  clientHeight === 0 and the component believes nothing overflows. */
+function configureScrollMetrics(
+  el: HTMLElement,
+  metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => (el as HTMLElement & { _scrollTop?: number })._scrollTop ?? 0,
+    set: (v: number) => {
+      (el as HTMLElement & { _scrollTop?: number })._scrollTop = v;
+    },
+  });
+  if (metrics.scrollTop != null) el.scrollTop = metrics.scrollTop;
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+}
+
+/** Capturing stub of ResizeObserver / MutationObserver so tests can
+ *  trigger the callbacks and verify the component reacts. happy-dom's
+ *  ResizeObserver never fires on layout changes (since there is no
+ *  layout), and a real MutationObserver requires actual DOM mutations
+ *  inside the target — both are easier to drive by hand. */
+type Capture = {
+  resizeCallback: ResizeObserverCallback | null;
+  mutationCallback: MutationCallback | null;
+  resizeDisconnectCount: number;
+  mutationDisconnectCount: number;
+};
+
+function installObserverCaptures(): Capture {
+  const cap: Capture = {
+    resizeCallback: null,
+    mutationCallback: null,
+    resizeDisconnectCount: 0,
+    mutationDisconnectCount: 0,
+  };
+  const RO = vi
+    .fn()
+    .mockImplementation(function (cb: ResizeObserverCallback) {
+      cap.resizeCallback = cb;
+      return {
+        observe: () => undefined,
+        unobserve: () => undefined,
+        disconnect: () => {
+          cap.resizeDisconnectCount += 1;
+        },
+      };
+    });
+  const MO = vi.fn().mockImplementation(function (cb: MutationCallback) {
+    cap.mutationCallback = cb;
+    return {
+      observe: () => undefined,
+      disconnect: () => {
+        cap.mutationDisconnectCount += 1;
+      },
+      takeRecords: () => [],
+    };
+  });
+  // happy-dom defines these globally; reassign so the component picks up
+  // the stub when it constructs new observers in its effect.
+  globalThis.ResizeObserver =
+    RO as unknown as typeof globalThis.ResizeObserver;
+  globalThis.MutationObserver =
+    MO as unknown as typeof globalThis.MutationObserver;
+  return cap;
+}
+
+/**
+ * Test harness that mounts the component against a real <div> the test
+ * can resize via `configureScrollMetrics`. Returns the slider, track,
+ * and the target element so each case can drive scrollTop directly.
+ */
+function Harness({
+  metrics,
+  onTargetReady,
+}: {
+  metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number };
+  onTargetReady?: (el: HTMLDivElement) => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  return (
+    <div data-testid="wrapper" style={{ position: "relative" }}>
+      <div
+        data-testid="target"
+        ref={(el) => {
+          ref.current = el;
+          if (el) {
+            configureScrollMetrics(el, metrics);
+            onTargetReady?.(el);
+          }
+        }}
+      />
+      <OverlayScrollbar targetRef={ref} />
+    </div>
+  );
+}
+
+describe("OverlayScrollbar", () => {
+  let capture: Capture;
+  beforeEach(() => {
+    capture = installObserverCaptures();
+  });
+
+  it("renders a track + slider pair under the module's CSS-module classes", async () => {
+    const container = await render(
+      <Harness metrics={{ scrollHeight: 1000, clientHeight: 400 }} />,
+    );
+    const track = container.querySelector(`.${styles.track}`);
+    const slider = container.querySelector(`.${styles.slider}`);
+    expect(track).toBeTruthy();
+    expect(slider).toBeTruthy();
+    // Track is decoration; assistive tech should skip it.
+    expect(track?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("marks the track non-overflowing and hides the slider when content fits", async () => {
+    const container = await render(
+      <Harness metrics={{ scrollHeight: 100, clientHeight: 400 }} />,
+    );
+    const track = container.querySelector(
+      `.${styles.track}`,
+    ) as HTMLElement | null;
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement | null;
+    expect(track?.dataset.overflowing).toBe("false");
+    // Slider's display is set inline so it can't intercept pointer events
+    // while the track fades; verify that's the case when no overflow.
+    expect(slider?.style.display).toBe("none");
+  });
+
+  it("flips overflowing + reveals the slider once content exceeds the viewport", async () => {
+    const container = await render(
+      <Harness metrics={{ scrollHeight: 1000, clientHeight: 400 }} />,
+    );
+    const track = container.querySelector(
+      `.${styles.track}`,
+    ) as HTMLElement | null;
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement | null;
+    expect(track?.dataset.overflowing).toBe("true");
+    expect(slider?.style.display).toBe("block");
+  });
+
+  it("scales slider height by viewport/content ratio with a 24px minimum", async () => {
+    // 1000px content, 400px viewport: raw = 400 * (400/1000) = 160px.
+    const container = await render(
+      <Harness metrics={{ scrollHeight: 1000, clientHeight: 400 }} />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    expect(slider.style.height).toBe("160px");
+  });
+
+  it("clamps very tall content to the 24px minimum slider height", async () => {
+    // 100000px content, 400px viewport: raw = 400 * (400/100000) = 1.6px.
+    // Without the floor the user would have nothing to grab.
+    const container = await render(
+      <Harness metrics={{ scrollHeight: 100000, clientHeight: 400 }} />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    expect(slider.style.height).toBe("24px");
+  });
+
+  it("positions the slider proportional to scrollTop / scrollRange", async () => {
+    // 1000 content - 400 viewport = 600 scrollRange. Slider 160px →
+    // usable rail (clientHeight - sliderHeight) = 240px. At
+    // scrollTop=300 (50% scrolled) the slider top should be 120px.
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 300, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    expect(slider.style.transform).toBe("translateY(120px)");
+    expect(target.scrollTop).toBe(300);
+  });
+
+  it("re-runs update when the target fires a scroll event", async () => {
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    expect(slider.style.transform).toBe("translateY(0px)");
+    await act(async () => {
+      target.scrollTop = 600;
+      target.dispatchEvent(new Event("scroll"));
+    });
+    // 600 / 600 = 100% → slider top = usableTrack = 240px.
+    expect(slider.style.transform).toBe("translateY(240px)");
+  });
+
+  it("re-runs update when the ResizeObserver fires (window/flex reflow)", async () => {
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    expect(slider.style.height).toBe("160px");
+    await act(async () => {
+      configureScrollMetrics(target, { scrollHeight: 1000, clientHeight: 800 });
+      capture.resizeCallback!(
+        [] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver,
+      );
+    });
+    // 800 / 1000 ratio of new viewport: 800 * 0.8 = 640px slider.
+    expect(slider.style.height).toBe("640px");
+  });
+
+  it("re-runs update when the MutationObserver fires (streaming new content)", async () => {
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    expect(slider.style.height).toBe("160px");
+    await act(async () => {
+      // Streaming a long agent reply doubles the content; without the
+      // mutation observer firing, the slider would stay at the old
+      // 160px and feel "stuck" mid-stream.
+      configureScrollMetrics(target, {
+        scrollHeight: 2000,
+        clientHeight: 400,
+      });
+      capture.mutationCallback!(
+        [] as MutationRecord[],
+        {} as MutationObserver,
+      );
+    });
+    // 400 * (400 / 2000) = 80px.
+    expect(slider.style.height).toBe("80px");
+  });
+
+  it("disconnects observers and removes the scroll listener on unmount", async () => {
+    let target!: HTMLDivElement;
+    const removeSpy = vi.fn();
+    const container = await render(
+      <Harness
+        metrics={{ scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+          const original = target.removeEventListener.bind(target);
+          target.removeEventListener = ((
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | EventListenerOptions,
+          ) => {
+            if (type === "scroll") removeSpy();
+            return original(type, listener, options);
+          }) as typeof target.removeEventListener;
+        }}
+      />,
+    );
+    expect(capture.resizeDisconnectCount).toBe(0);
+    expect(capture.mutationDisconnectCount).toBe(0);
+    // Unmount via the harness root.
+    const root = mountedRoots[mountedRoots.length - 1];
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    mountedRoots.pop();
+    mountedContainers.pop();
+    expect(capture.resizeDisconnectCount).toBe(1);
+    expect(capture.mutationDisconnectCount).toBe(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OverlayScrollbar drag mapping", () => {
+  beforeEach(() => {
+    installObserverCaptures();
+  });
+
+  /** Build a synthetic PointerEvent. happy-dom doesn't ship a
+   *  `PointerEvent` constructor on every release, so we forge one out of
+   *  a MouseEvent + extra fields the component reads (clientY,
+   *  pointerId, button, capture helpers). */
+  function pointerDown(target: HTMLElement, clientY: number) {
+    const ev = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    }) as MouseEvent & { pointerId: number; clientY: number; button: number };
+    Object.defineProperty(ev, "pointerId", { value: 1 });
+    Object.defineProperty(ev, "clientY", { value: clientY });
+    Object.defineProperty(ev, "button", { value: 0 });
+    target.dispatchEvent(ev);
+  }
+
+  function pointerMove(target: HTMLElement, clientY: number) {
+    const ev = new MouseEvent("pointermove") as MouseEvent & {
+      pointerId: number;
+      clientY: number;
+    };
+    Object.defineProperty(ev, "pointerId", { value: 1 });
+    Object.defineProperty(ev, "clientY", { value: clientY });
+    target.dispatchEvent(ev);
+  }
+
+  function pointerUp(target: HTMLElement) {
+    const ev = new MouseEvent("pointerup") as MouseEvent & {
+      pointerId: number;
+    };
+    Object.defineProperty(ev, "pointerId", { value: 1 });
+    target.dispatchEvent(ev);
+  }
+
+  it("drags scrollTop in proportion to the inverse of the viewport/content ratio", async () => {
+    // 1000 content, 400 viewport, slider height 160 → usable rail 240,
+    // scrollRange 600. Each 1px of slider travel = 600/240 = 2.5px
+    // of scrollTop. Dragging from y=0 to y=100 should move scroll by
+    // 250.
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "offsetHeight", {
+      configurable: true,
+      value: 160,
+    });
+    // setPointerCapture / releasePointerCapture aren't implemented in
+    // happy-dom; stub them so the handler runs.
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    await act(async () => {
+      pointerDown(slider, 0);
+    });
+    expect(slider.dataset.dragging).toBe("true");
+    pointerMove(slider, 100);
+    expect(target.scrollTop).toBe(250);
+    await act(async () => {
+      pointerUp(slider);
+    });
+    expect(slider.dataset.dragging).toBe("false");
+  });
+
+  it("clamps drag-driven scrollTop to [0, scrollRange]", async () => {
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "offsetHeight", {
+      configurable: true,
+      value: 160,
+    });
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    await act(async () => {
+      pointerDown(slider, 0);
+    });
+    pointerMove(slider, 10000);
+    // Even with a runaway pointer delta the component clamps to
+    // scrollRange = scrollHeight - clientHeight = 600.
+    expect(target.scrollTop).toBe(600);
+    pointerMove(slider, -10000);
+    expect(target.scrollTop).toBe(0);
+    await act(async () => {
+      pointerUp(slider);
+    });
+  });
+
+  it("ignores non-primary mouse buttons so right-click doesn't start a drag", async () => {
+    const container = await render(
+      <Harness metrics={{ scrollHeight: 1000, clientHeight: 400 }} />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "offsetHeight", {
+      configurable: true,
+      value: 160,
+    });
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    const ev = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    }) as MouseEvent & { pointerId: number; clientY: number; button: number };
+    Object.defineProperty(ev, "pointerId", { value: 1 });
+    Object.defineProperty(ev, "clientY", { value: 0 });
+    Object.defineProperty(ev, "button", { value: 2 });
+    slider.dispatchEvent(ev);
+    expect(slider.dataset.dragging).toBe("false");
+    expect(slider.setPointerCapture).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/components/chat/OverlayScrollbar.test.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.test.tsx
@@ -17,10 +17,18 @@
 //   4. Live updates via the target's scroll event, ResizeObserver,
 //      and MutationObserver — all three fire `update()` so streaming
 //      message growth tracks correctly.
-//   5. Drag mapping: a pointermove delta translates into the right
+//   5. RAF coalescing: rapid mutations within a frame collapse to one
+//      setState batch (otherwise streaming-token mutations cause one
+//      re-render per token).
+//   6. Drag mapping: a pointermove delta translates into the right
 //      scrollTop delta (inverse of slider/content ratio), with
 //      clamping at both ends.
-//   6. Observer + listener cleanup on unmount, so component churn
+//   7. Track click-to-page: clicking the track above or below the
+//      slider pages the viewport in that direction (parity with
+//      native macOS scrollbar + Monaco).
+//   8. Edge cases: null `targetRef.current`, drag with
+//      `usableTrack === 0`, non-primary mouse buttons.
+//   9. Observer + listener cleanup on unmount, so component churn
 //      doesn't leak handlers onto the messages container.
 
 import { act } from "react";
@@ -87,22 +95,36 @@ function configureScrollMetrics(
  *  trigger the callbacks and verify the component reacts. happy-dom's
  *  ResizeObserver never fires on layout changes (since there is no
  *  layout), and a real MutationObserver requires actual DOM mutations
- *  inside the target — both are easier to drive by hand. */
+ *  inside the target — both are easier to drive by hand.
+ *
+ *  We also capture `requestAnimationFrame` so tests can flush the
+ *  component's RAF gate explicitly. Without this, post-mount events
+ *  (scroll, resize, mutation) all schedule via RAF and tests would
+ *  observe stale state. The default `flushRaf()` helper drains the
+ *  queue so callers see "what would render next frame". One specific
+ *  test in this file deliberately holds the queue back to assert that
+ *  rapid events coalesce. */
 type Capture = {
   resizeCallback: ResizeObserverCallback | null;
   mutationCallback: MutationCallback | null;
   resizeDisconnectCount: number;
   mutationDisconnectCount: number;
+  rafCalls: number;
+  rafQueue: FrameRequestCallback[];
 };
 
-function installObserverCaptures(): Capture {
+let capture: Capture;
+
+function installCaptures(): Capture {
   const cap: Capture = {
     resizeCallback: null,
     mutationCallback: null,
     resizeDisconnectCount: 0,
     mutationDisconnectCount: 0,
+    rafCalls: 0,
+    rafQueue: [],
   };
-  const RO = vi
+  globalThis.ResizeObserver = vi
     .fn()
     .mockImplementation(function (cb: ResizeObserverCallback) {
       cap.resizeCallback = cb;
@@ -113,62 +135,81 @@ function installObserverCaptures(): Capture {
           cap.resizeDisconnectCount += 1;
         },
       };
-    });
-  const MO = vi.fn().mockImplementation(function (cb: MutationCallback) {
-    cap.mutationCallback = cb;
-    return {
-      observe: () => undefined,
-      disconnect: () => {
-        cap.mutationDisconnectCount += 1;
-      },
-      takeRecords: () => [],
-    };
-  });
-  // happy-dom defines these globally; reassign so the component picks up
-  // the stub when it constructs new observers in its effect.
-  globalThis.ResizeObserver =
-    RO as unknown as typeof globalThis.ResizeObserver;
-  globalThis.MutationObserver =
-    MO as unknown as typeof globalThis.MutationObserver;
+    }) as unknown as typeof globalThis.ResizeObserver;
+  globalThis.MutationObserver = vi
+    .fn()
+    .mockImplementation(function (cb: MutationCallback) {
+      cap.mutationCallback = cb;
+      return {
+        observe: () => undefined,
+        disconnect: () => {
+          cap.mutationDisconnectCount += 1;
+        },
+        takeRecords: () => [],
+      };
+    }) as unknown as typeof globalThis.MutationObserver;
+  // Hold RAF callbacks in a queue rather than firing them synchronously
+  // so tests can assert "one RAF was scheduled per N rapid events".
+  // `flushRaf()` drains the queue when the test wants the deferred work
+  // to land.
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cap.rafCalls += 1;
+    cap.rafQueue.push(cb);
+    return cap.rafCalls;
+  }) as typeof globalThis.requestAnimationFrame;
   return cap;
+}
+
+async function flushRaf() {
+  const callbacks = capture.rafQueue.splice(0);
+  await act(async () => {
+    for (const cb of callbacks) cb(0);
+  });
 }
 
 /**
  * Test harness that mounts the component against a real <div> the test
  * can resize via `configureScrollMetrics`. Returns the slider, track,
  * and the target element so each case can drive scrollTop directly.
+ *
+ * `nullTarget` lets a test simulate the case where the parent hasn't
+ * mounted the scroll element yet (e.g., a workspace switching mid-render
+ * before `messagesContainerRef.current` is populated).
  */
 function Harness({
   metrics,
+  nullTarget,
   onTargetReady,
 }: {
-  metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number };
+  metrics?: { scrollTop?: number; scrollHeight: number; clientHeight: number };
+  nullTarget?: boolean;
   onTargetReady?: (el: HTMLDivElement) => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   return (
     <div data-testid="wrapper" style={{ position: "relative" }}>
-      <div
-        data-testid="target"
-        ref={(el) => {
-          ref.current = el;
-          if (el) {
-            configureScrollMetrics(el, metrics);
-            onTargetReady?.(el);
-          }
-        }}
-      />
+      {!nullTarget && (
+        <div
+          data-testid="target"
+          ref={(el) => {
+            ref.current = el;
+            if (el && metrics) {
+              configureScrollMetrics(el, metrics);
+              onTargetReady?.(el);
+            }
+          }}
+        />
+      )}
       <OverlayScrollbar targetRef={ref} />
     </div>
   );
 }
 
-describe("OverlayScrollbar", () => {
-  let capture: Capture;
-  beforeEach(() => {
-    capture = installObserverCaptures();
-  });
+beforeEach(() => {
+  capture = installCaptures();
+});
 
+describe("OverlayScrollbar", () => {
   it("renders a track + slider pair under the module's CSS-module classes", async () => {
     const container = await render(
       <Harness metrics={{ scrollHeight: 1000, clientHeight: 400 }} />,
@@ -268,10 +309,9 @@ describe("OverlayScrollbar", () => {
       `.${styles.slider}`,
     ) as HTMLElement;
     expect(slider.style.transform).toBe("translateY(0px)");
-    await act(async () => {
-      target.scrollTop = 600;
-      target.dispatchEvent(new Event("scroll"));
-    });
+    target.scrollTop = 600;
+    target.dispatchEvent(new Event("scroll"));
+    await flushRaf();
     // 600 / 600 = 100% → slider top = usableTrack = 240px.
     expect(slider.style.transform).toBe("translateY(240px)");
   });
@@ -290,13 +330,12 @@ describe("OverlayScrollbar", () => {
       `.${styles.slider}`,
     ) as HTMLElement;
     expect(slider.style.height).toBe("160px");
-    await act(async () => {
-      configureScrollMetrics(target, { scrollHeight: 1000, clientHeight: 800 });
-      capture.resizeCallback!(
-        [] as unknown as ResizeObserverEntry[],
-        {} as ResizeObserver,
-      );
-    });
+    configureScrollMetrics(target, { scrollHeight: 1000, clientHeight: 800 });
+    capture.resizeCallback!(
+      [] as unknown as ResizeObserverEntry[],
+      {} as ResizeObserver,
+    );
+    await flushRaf();
     // 800 / 1000 ratio of new viewport: 800 * 0.8 = 640px slider.
     expect(slider.style.height).toBe("640px");
   });
@@ -315,21 +354,69 @@ describe("OverlayScrollbar", () => {
       `.${styles.slider}`,
     ) as HTMLElement;
     expect(slider.style.height).toBe("160px");
-    await act(async () => {
-      // Streaming a long agent reply doubles the content; without the
-      // mutation observer firing, the slider would stay at the old
-      // 160px and feel "stuck" mid-stream.
-      configureScrollMetrics(target, {
-        scrollHeight: 2000,
-        clientHeight: 400,
-      });
-      capture.mutationCallback!(
-        [] as MutationRecord[],
-        {} as MutationObserver,
-      );
+    // Streaming a long agent reply doubles the content; without the
+    // mutation observer firing, the slider would stay at the old
+    // 160px and feel "stuck" mid-stream.
+    configureScrollMetrics(target, {
+      scrollHeight: 2000,
+      clientHeight: 400,
     });
+    capture.mutationCallback!(
+      [] as MutationRecord[],
+      {} as MutationObserver,
+    );
+    await flushRaf();
     // 400 * (400 / 2000) = 80px.
     expect(slider.style.height).toBe("80px");
+  });
+
+  it("coalesces a burst of events into a single RAF (avoids per-token re-renders during streaming)", async () => {
+    // Regression: useStickyScroll and OverlayScrollbar both observe the
+    // messages list. `useStickyScroll.handleContentChanged` already
+    // RAF-coalesces (see `hooks/useStickyScroll.ts`); OverlayScrollbar
+    // must do the same or else streaming token mutations trigger one
+    // setState per token. This test fires 10 events and asserts only
+    // one RAF was scheduled until we drain the queue.
+    let target!: HTMLDivElement;
+    await render(
+      <Harness
+        metrics={{ scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    // Initial mount calls update() synchronously (no RAF used) and
+    // doesn't schedule a RAF; the first scheduled RAF is the next user
+    // event. Reset the counter to isolate the burst.
+    capture.rafCalls = 0;
+    capture.rafQueue.length = 0;
+    for (let i = 0; i < 10; i++) {
+      target.dispatchEvent(new Event("scroll"));
+    }
+    expect(capture.rafCalls).toBe(1);
+    expect(capture.rafQueue.length).toBe(1);
+    // Draining the queue lets the next burst schedule a fresh RAF;
+    // verify the gate doesn't lock permanently.
+    await flushRaf();
+    target.dispatchEvent(new Event("scroll"));
+    expect(capture.rafCalls).toBe(2);
+  });
+
+  it("does not throw when targetRef.current is null at mount", async () => {
+    const container = await render(<Harness nullTarget />);
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    const track = container.querySelector(
+      `.${styles.track}`,
+    ) as HTMLElement;
+    // No target → the component renders a non-overflowing track and
+    // silently waits. No errors, no observers attached (resize/mutation
+    // ctors are still constructed, but observe() is never called on a
+    // real element); cleanup unmount runs without throwing.
+    expect(track.dataset.overflowing).toBe("false");
+    expect(slider.style.display).toBe("none");
   });
 
   it("disconnects observers and removes the scroll listener on unmount", async () => {
@@ -369,10 +456,6 @@ describe("OverlayScrollbar", () => {
 });
 
 describe("OverlayScrollbar drag mapping", () => {
-  beforeEach(() => {
-    installObserverCaptures();
-  });
-
   /** Build a synthetic PointerEvent. happy-dom doesn't ship a
    *  `PointerEvent` constructor on every release, so we forge one out of
    *  a MouseEvent + extra fields the component reads (clientY,
@@ -499,5 +582,214 @@ describe("OverlayScrollbar drag mapping", () => {
     slider.dispatchEvent(ev);
     expect(slider.dataset.dragging).toBe("false");
     expect(slider.setPointerCapture).not.toHaveBeenCalled();
+  });
+
+  it("safely no-ops the drag when slider equals viewport height (usableTrack === 0)", async () => {
+    // Edge case: at the 24px slider-height floor with a 24px viewport,
+    // usableTrack = 0 and scale = 0. The drag must not divide by zero
+    // or push scrollTop out of bounds. Construct a synthetic case
+    // where the slider fills the entire viewport.
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 100, scrollHeight: 200, clientHeight: 50 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    // Force slider to exactly the viewport height for this test.
+    Object.defineProperty(slider, "offsetHeight", {
+      configurable: true,
+      value: 50,
+    });
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    const startScroll = target.scrollTop;
+    await act(async () => {
+      pointerDown(slider, 0);
+    });
+    pointerMove(slider, 999);
+    // scale = 0, so scrollTop should be unchanged regardless of move
+    // distance. The clamp also keeps it inside [0, scrollRange = 150].
+    expect(target.scrollTop).toBe(startScroll);
+    await act(async () => {
+      pointerUp(slider);
+    });
+  });
+});
+
+describe("OverlayScrollbar track click-to-page", () => {
+  function trackPointerDown(track: HTMLElement, clientY: number) {
+    // Track click handler reads `e.target` and `e.currentTarget`.
+    // dispatchEvent on the track sets target = currentTarget (the
+    // event element) which is what we want for a "click on the track,
+    // not the slider" scenario.
+    const ev = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    }) as MouseEvent & { pointerId: number; clientY: number; button: number };
+    Object.defineProperty(ev, "pointerId", { value: 1 });
+    Object.defineProperty(ev, "clientY", { value: clientY });
+    Object.defineProperty(ev, "button", { value: 0 });
+    track.dispatchEvent(ev);
+  }
+
+  it("pages down by clientHeight when the click lands below the slider", async () => {
+    // 1000 content, 400 viewport, scrollTop 0 → page down should land
+    // at scrollTop = 400 (or clamped to scrollRange = 600).
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const track = container.querySelector(`.${styles.track}`) as HTMLElement;
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    // Slider at top: top=0, height=160 → bottom at y=160. A click at
+    // y=300 is "below the slider".
+    Object.defineProperty(slider, "getBoundingClientRect", {
+      value: () => ({
+        top: 0,
+        bottom: 160,
+        height: 160,
+        left: 0,
+        right: 8,
+        width: 8,
+        x: 0,
+        y: 0,
+        toJSON: () => null,
+      }),
+    });
+    trackPointerDown(track, 300);
+    await flushRaf();
+    expect(target.scrollTop).toBe(400);
+  });
+
+  it("pages up by clientHeight when the click lands above the slider", async () => {
+    // 1000 content, 400 viewport, scrollTop 500 → page up should land
+    // at scrollTop = 100.
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 500, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const track = container.querySelector(`.${styles.track}`) as HTMLElement;
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    // Slider mid-track at top=200 (matches scrollTop 500/600 ≈ 83% of
+    // usable rail 240 = 200 ± rounding). Click at y=50 is above.
+    Object.defineProperty(slider, "getBoundingClientRect", {
+      value: () => ({
+        top: 200,
+        bottom: 360,
+        height: 160,
+        left: 0,
+        right: 8,
+        width: 8,
+        x: 0,
+        y: 200,
+        toJSON: () => null,
+      }),
+    });
+    trackPointerDown(track, 50);
+    await flushRaf();
+    expect(target.scrollTop).toBe(100);
+  });
+
+  it("clamps page-jump to scrollRange so it doesn't run off the end", async () => {
+    // scrollTop near the bottom; page-down should clamp to
+    // scrollHeight - clientHeight, not overshoot.
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 500, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const track = container.querySelector(`.${styles.track}`) as HTMLElement;
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "getBoundingClientRect", {
+      value: () => ({
+        top: 200,
+        bottom: 360,
+        height: 160,
+        left: 0,
+        right: 8,
+        width: 8,
+        x: 0,
+        y: 200,
+        toJSON: () => null,
+      }),
+    });
+    trackPointerDown(track, 380);
+    await flushRaf();
+    expect(target.scrollTop).toBe(600);
+  });
+
+  it("ignores track clicks when the click lands on the slider (slider handler takes the event)", async () => {
+    // The slider's onPointerDown stops propagation and the track
+    // handler short-circuits when target !== currentTarget. To exercise
+    // this without a real bubbling event, dispatch directly on the
+    // slider with target === slider, and assert scrollTop didn't jump
+    // by clientHeight (the slider-drag path uses scale * delta — with
+    // delta 0 it shouldn't move).
+    let target!: HTMLDivElement;
+    const container = await render(
+      <Harness
+        metrics={{ scrollTop: 200, scrollHeight: 1000, clientHeight: 400 }}
+        onTargetReady={(el) => {
+          target = el;
+        }}
+      />,
+    );
+    const slider = container.querySelector(
+      `.${styles.slider}`,
+    ) as HTMLElement;
+    Object.defineProperty(slider, "offsetHeight", {
+      configurable: true,
+      value: 160,
+    });
+    slider.setPointerCapture = vi.fn();
+    slider.releasePointerCapture = vi.fn();
+    const startScroll = target.scrollTop;
+    const ev = new MouseEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+    }) as MouseEvent & { pointerId: number; clientY: number; button: number };
+    Object.defineProperty(ev, "pointerId", { value: 1 });
+    Object.defineProperty(ev, "clientY", { value: 0 });
+    Object.defineProperty(ev, "button", { value: 0 });
+    await act(async () => {
+      slider.dispatchEvent(ev);
+    });
+    // The slider's drag started; release without moving.
+    const upEv = new MouseEvent("pointerup") as MouseEvent & {
+      pointerId: number;
+    };
+    Object.defineProperty(upEv, "pointerId", { value: 1 });
+    await act(async () => {
+      slider.dispatchEvent(upEv);
+    });
+    // No movement → scrollTop unchanged. Crucially, no page-jump
+    // happened (page-down would have added clientHeight = 400).
+    expect(target.scrollTop).toBe(startScroll);
   });
 });

--- a/src/ui/src/components/chat/OverlayScrollbar.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.tsx
@@ -1,0 +1,158 @@
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import styles from "./OverlayScrollbar.module.css";
+
+interface OverlayScrollbarProps {
+  /**
+   * Ref to the element that actually scrolls (the one with
+   * `overflow-y: auto/scroll`). The track + slider are rendered as a
+   * sibling inside that element's positioned ancestor, not as children
+   * of the scrolling element itself (children would scroll with content).
+   */
+  targetRef: RefObject<HTMLElement | null>;
+}
+
+/**
+ * Custom DOM scrollbar that mirrors xterm.js's and Monaco's overlay
+ * scrollbar pattern. Renders an always-pixel-sized track + slider div
+ * pair, hides the host element's native scrollbar via CSS at the call
+ * site, and drives `targetRef.current.scrollTop` from drag input.
+ *
+ * Why a custom component: macOS WKWebView keeps the OS overlay scrollbar
+ * regardless of `::-webkit-scrollbar` styling when the system "Show
+ * scroll bars" preference is "Automatic" / "When scrolling", and the
+ * resulting overlay does NOT scale with browser zoom. xterm.js and
+ * Monaco both draw their own DOM sliders for exactly this reason —
+ * matching that approach is the only way the three surfaces stay in
+ * pixel-for-pixel sync at every zoom level.
+ *
+ * Tracking model: a single `update()` reads scrollTop / scrollHeight /
+ * clientHeight, computes slider top + height in CSS pixels, and pushes
+ * to a small state object. We listen to (a) scroll events on the target
+ * (b) a ResizeObserver on the target itself (window resize + flex
+ * reflows) (c) a MutationObserver for content additions (streaming
+ * messages grow scrollHeight without firing scroll events). The hook
+ * runs `update()` from each.
+ */
+export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
+  const sliderRef = useRef<HTMLDivElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const [sliderTop, setSliderTop] = useState(0);
+  const [sliderHeight, setSliderHeight] = useState(0);
+  const [dragging, setDragging] = useState(false);
+
+  const update = useCallback(() => {
+    const target = targetRef.current;
+    if (!target) return;
+    const { scrollTop, scrollHeight, clientHeight } = target;
+    const overflow = scrollHeight > clientHeight + 1;
+    setOverflowing(overflow);
+    if (!overflow) {
+      setSliderHeight(0);
+      setSliderTop(0);
+      return;
+    }
+    // Slider height proportional to viewport / content ratio, with a
+    // floor so a very long thread still shows a draggable handle.
+    const minHeight = 24;
+    const rawHeight = (clientHeight / scrollHeight) * clientHeight;
+    const height = Math.max(minHeight, rawHeight);
+    const maxTop = clientHeight - height;
+    const scrollProgress = scrollTop / (scrollHeight - clientHeight);
+    const top = Math.round(scrollProgress * maxTop);
+    setSliderHeight(height);
+    setSliderTop(top);
+  }, [targetRef]);
+
+  // Scroll + size + content observation. Reruns `update()` on each.
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+    update();
+    const onScroll = () => update();
+    target.addEventListener("scroll", onScroll, { passive: true });
+    const ro = new ResizeObserver(() => update());
+    ro.observe(target);
+    const mo = new MutationObserver(() => update());
+    mo.observe(target, { childList: true, subtree: true, characterData: true });
+    return () => {
+      target.removeEventListener("scroll", onScroll);
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, [targetRef, update]);
+
+  // Pointer-driven drag. Captures the pointer on the slider and maps
+  // pixel deltas back to scrollTop deltas via the inverse of the
+  // viewport / content ratio.
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      const target = targetRef.current;
+      const slider = sliderRef.current;
+      if (!target || !slider) return;
+      e.preventDefault();
+      slider.setPointerCapture(e.pointerId);
+      setDragging(true);
+      const startY = e.clientY;
+      const startScrollTop = target.scrollTop;
+      const { scrollHeight, clientHeight } = target;
+      const trackHeight = clientHeight;
+      const sliderH = slider.offsetHeight;
+      const usableTrack = trackHeight - sliderH;
+      const scrollRange = scrollHeight - clientHeight;
+      // Map every pixel of slider travel to (scrollRange / usableTrack)
+      // pixels of scroll travel. Clamp so dragging past the rail end
+      // doesn't push scrollTop outside its valid range.
+      const scale = usableTrack > 0 ? scrollRange / usableTrack : 0;
+      const onMove = (ev: PointerEvent) => {
+        const delta = (ev.clientY - startY) * scale;
+        const next = Math.max(
+          0,
+          Math.min(scrollRange, startScrollTop + delta),
+        );
+        target.scrollTop = next;
+      };
+      const onUp = (ev: PointerEvent) => {
+        slider.releasePointerCapture(ev.pointerId);
+        slider.removeEventListener("pointermove", onMove);
+        slider.removeEventListener("pointerup", onUp);
+        slider.removeEventListener("pointercancel", onUp);
+        setDragging(false);
+      };
+      slider.addEventListener("pointermove", onMove);
+      slider.addEventListener("pointerup", onUp);
+      slider.addEventListener("pointercancel", onUp);
+    },
+    [targetRef],
+  );
+
+  return (
+    <div
+      className={styles.track}
+      data-overflowing={overflowing ? "true" : "false"}
+      aria-hidden="true"
+    >
+      <div
+        ref={sliderRef}
+        className={styles.slider}
+        data-dragging={dragging ? "true" : "false"}
+        onPointerDown={onPointerDown}
+        style={{
+          transform: `translateY(${sliderTop}px)`,
+          height: `${sliderHeight}px`,
+          // Hide cleanly when there's no overflow; CSS hides the track
+          // too but `display: none` on the slider stops it from being
+          // briefly hit-testable during the fade.
+          display: overflowing ? "block" : "none",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/ui/src/components/chat/OverlayScrollbar.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.tsx
@@ -70,11 +70,18 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
       return;
     }
     // Slider height proportional to viewport / content ratio, with a
-    // floor so a very long thread still shows a draggable handle.
+    // floor so a very long thread still shows a draggable handle. Clamp
+    // the result to `clientHeight` so the slider never exceeds the rail
+    // — at extremely small viewports (user resizes the chat panel below
+    // 24px) the floor would otherwise produce a thumb taller than the
+    // track and a negative `maxTop` that yields a negative `translateY`.
     const minHeight = 24;
     const rawHeight = (clientHeight / scrollHeight) * clientHeight;
-    const height = Math.max(minHeight, rawHeight);
-    const maxTop = clientHeight - height;
+    const height = Math.min(clientHeight, Math.max(minHeight, rawHeight));
+    // `Math.max(0, ...)` keeps the rail upper-bound sane in the same
+    // tiny-viewport edge case (where `clientHeight < minHeight` and
+    // height === clientHeight, so clientHeight - height is 0 anyway).
+    const maxTop = Math.max(0, clientHeight - height);
     // `scrollHeight - clientHeight > 0` is guaranteed by the `overflow`
     // gate above — the divide-by-zero branch never executes here.
     const scrollProgress = scrollTop / (scrollHeight - clientHeight);

--- a/src/ui/src/components/chat/OverlayScrollbar.tsx
+++ b/src/ui/src/components/chat/OverlayScrollbar.tsx
@@ -37,11 +37,22 @@ interface OverlayScrollbarProps {
  * to a small state object. We listen to (a) scroll events on the target
  * (b) a ResizeObserver on the target itself (window resize + flex
  * reflows) (c) a MutationObserver for content additions (streaming
- * messages grow scrollHeight without firing scroll events). The hook
- * runs `update()` from each.
+ * messages grow scrollHeight without firing scroll events). Every entry
+ * point routes through the same RAF-coalesced `scheduleUpdate()` so
+ * fast streaming (one MutationObserver fire per token) collapses to one
+ * setState batch per frame instead of one per mutation.
+ *
+ * Accessibility note: the slider is intentionally not focusable. Native
+ * macOS scrollbars aren't focusable either; the underlying scroll
+ * element remains keyboard-scrollable (PageUp/Down/arrows when focused)
+ * because `scrollbar-width: none` only hides the visual scrollbar, it
+ * doesn't disable keyboard scrolling. Track click-to-page is handled
+ * explicitly below to preserve the behavior the native scrollbar gave
+ * us before the swap.
  */
 export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
   const sliderRef = useRef<HTMLDivElement | null>(null);
+  const rafPendingRef = useRef(false);
   const [overflowing, setOverflowing] = useState(false);
   const [sliderTop, setSliderTop] = useState(0);
   const [sliderHeight, setSliderHeight] = useState(0);
@@ -64,40 +75,65 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
     const rawHeight = (clientHeight / scrollHeight) * clientHeight;
     const height = Math.max(minHeight, rawHeight);
     const maxTop = clientHeight - height;
+    // `scrollHeight - clientHeight > 0` is guaranteed by the `overflow`
+    // gate above — the divide-by-zero branch never executes here.
     const scrollProgress = scrollTop / (scrollHeight - clientHeight);
     const top = Math.round(scrollProgress * maxTop);
     setSliderHeight(height);
     setSliderTop(top);
   }, [targetRef]);
 
-  // Scroll + size + content observation. Reruns `update()` on each.
+  /**
+   * RAF gate copied from `useStickyScroll` (`hooks/useStickyScroll.ts`).
+   * Streaming agent replies fire one MutationObserver per token; without
+   * this, every token would trigger up to three setState calls and a
+   * reconciliation. With it, mutations within a frame collapse to a
+   * single update. `useStickyScroll` already coalesces its own work the
+   * same way — keeping the two in step avoids one observing the chat
+   * "stuck" while the other catches up.
+   */
+  const scheduleUpdate = useCallback(() => {
+    if (rafPendingRef.current) return;
+    rafPendingRef.current = true;
+    requestAnimationFrame(() => {
+      rafPendingRef.current = false;
+      update();
+    });
+  }, [update]);
+
+  // Scroll + size + content observation. Reruns the coalesced update on
+  // each. The initial `update()` is synchronous so the first paint
+  // already reflects current scrollHeight (otherwise the slider flashes
+  // missing for one frame on every mount).
   useEffect(() => {
     const target = targetRef.current;
     if (!target) return;
     update();
-    const onScroll = () => update();
-    target.addEventListener("scroll", onScroll, { passive: true });
-    const ro = new ResizeObserver(() => update());
+    target.addEventListener("scroll", scheduleUpdate, { passive: true });
+    const ro = new ResizeObserver(scheduleUpdate);
     ro.observe(target);
-    const mo = new MutationObserver(() => update());
+    const mo = new MutationObserver(scheduleUpdate);
     mo.observe(target, { childList: true, subtree: true, characterData: true });
     return () => {
-      target.removeEventListener("scroll", onScroll);
+      target.removeEventListener("scroll", scheduleUpdate);
       ro.disconnect();
       mo.disconnect();
     };
-  }, [targetRef, update]);
+  }, [targetRef, update, scheduleUpdate]);
 
-  // Pointer-driven drag. Captures the pointer on the slider and maps
-  // pixel deltas back to scrollTop deltas via the inverse of the
-  // viewport / content ratio.
-  const onPointerDown = useCallback(
+  // Pointer-driven drag on the slider itself. Captures the pointer on
+  // the slider and maps pixel deltas back to scrollTop deltas via the
+  // inverse of the viewport / content ratio.
+  const onSliderPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
       const target = targetRef.current;
       const slider = sliderRef.current;
       if (!target || !slider) return;
+      // Stop propagation so the track's click-to-page handler doesn't
+      // also fire on the same pointerdown.
       e.preventDefault();
+      e.stopPropagation();
       slider.setPointerCapture(e.pointerId);
       setDragging(true);
       const startY = e.clientY;
@@ -133,17 +169,52 @@ export function OverlayScrollbar({ targetRef }: OverlayScrollbarProps) {
     [targetRef],
   );
 
+  // Track click-to-page. Native macOS scrollbar (and Monaco's slider)
+  // both jump by a viewport-height when the user clicks the track above
+  // or below the slider. xterm.js doesn't, but parity with native +
+  // Monaco is the more user-visible behavior, so we restore it. The
+  // track only intercepts pointer events while the data attribute says
+  // overflowing — see CSS — so on short conversations clicks pass
+  // through to message content underneath.
+  const onTrackPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      // Only act when the click landed on the track itself, not on the
+      // slider child (the slider has its own onPointerDown).
+      if (e.target !== e.currentTarget) return;
+      const target = targetRef.current;
+      const slider = sliderRef.current;
+      if (!target || !slider) return;
+      e.preventDefault();
+      const sliderRect = slider.getBoundingClientRect();
+      // Page up if click is above the slider's top edge, down if below
+      // its bottom edge. A click directly on the slider hits the slider
+      // handler instead, so we don't need a tie-breaker here.
+      const direction = e.clientY < sliderRect.top ? -1 : 1;
+      const next = Math.max(
+        0,
+        Math.min(
+          target.scrollHeight - target.clientHeight,
+          target.scrollTop + direction * target.clientHeight,
+        ),
+      );
+      target.scrollTop = next;
+    },
+    [targetRef],
+  );
+
   return (
     <div
       className={styles.track}
       data-overflowing={overflowing ? "true" : "false"}
       aria-hidden="true"
+      onPointerDown={onTrackPointerDown}
     >
       <div
         ref={sliderRef}
         className={styles.slider}
         data-dragging={dragging ? "true" : "false"}
-        onPointerDown={onPointerDown}
+        onPointerDown={onSliderPointerDown}
         style={{
           transform: `translateY(${sliderTop}px)`,
           height: `${sliderHeight}px`,

--- a/src/ui/src/components/chat/PlanApprovalCard.module.css
+++ b/src/ui/src/components/chat/PlanApprovalCard.module.css
@@ -7,7 +7,6 @@
   padding: var(--space-4) var(--space-5);
   margin: var(--space-3) 0;
   box-shadow: var(--shadow-md);
-  animation: fadeInUp 0.2s ease both;
 }
 
 .label {

--- a/src/ui/src/components/chat/ScrollToBottomPill.module.css
+++ b/src/ui/src/components/chat/ScrollToBottomPill.module.css
@@ -14,7 +14,6 @@
   font-weight: 500;
   cursor: pointer;
   box-shadow: var(--shadow-md);
-  animation: fadeInUp 0.15s ease both;
   transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 

--- a/src/ui/src/components/chat/SessionTabs.module.css
+++ b/src/ui/src/components/chat/SessionTabs.module.css
@@ -5,20 +5,22 @@
   overflow-x: auto;
   overflow-y: hidden;
   background: transparent;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-subtle) transparent;
   /* Pin to the shared second-row height so the right-sidebar tab bar (when
    * pushed under a PR banner) bottoms out at the same Y as this strip. */
   min-height: var(--tab-bar-h);
 }
 
 .tabBar::-webkit-scrollbar {
-  height: 4px;
+  height: var(--scrollbar-size);
 }
 
 .tabBar::-webkit-scrollbar-thumb {
-  background: var(--border-subtle);
-  border-radius: 2px;
+  background: var(--scrollbar-thumb);
+  border-radius: var(--radius-sm);
+}
+
+.tabBar::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
 }
 
 .tab {

--- a/src/ui/src/components/chat/WorkspaceActions.module.css
+++ b/src/ui/src/components/chat/WorkspaceActions.module.css
@@ -13,6 +13,7 @@
   background: var(--chat-input-bg);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
+  isolation: isolate;
 }
 
 .primaryButton,
@@ -134,6 +135,9 @@
 .appIconImage {
   object-fit: contain;
   background: transparent;
+  backface-visibility: hidden;
+  contain: paint;
+  transform: translateZ(0);
 }
 
 .appIconFallback {

--- a/src/ui/src/components/chat/WorkspaceActions.module.css
+++ b/src/ui/src/components/chat/WorkspaceActions.module.css
@@ -13,7 +13,6 @@
   background: var(--chat-input-bg);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
-  isolation: isolate;
 }
 
 .primaryButton,
@@ -134,10 +133,7 @@
 
 .appIconImage {
   object-fit: contain;
-  background: transparent;
-  backface-visibility: hidden;
-  contain: paint;
-  transform: translateZ(0);
+  background: var(--app-icon-image-bg);
 }
 
 .appIconFallback {

--- a/src/ui/src/components/chat/WorkspaceActions.module.css
+++ b/src/ui/src/components/chat/WorkspaceActions.module.css
@@ -133,7 +133,7 @@
 
 .appIconImage {
   overflow: hidden;
-  background-color: var(--app-icon-image-bg);
+  background-color: transparent;
   background-position: center;
   background-repeat: no-repeat;
   background-size: contain;

--- a/src/ui/src/components/chat/WorkspaceActions.module.css
+++ b/src/ui/src/components/chat/WorkspaceActions.module.css
@@ -132,8 +132,13 @@
 }
 
 .appIconImage {
-  object-fit: contain;
-  background: var(--app-icon-image-bg);
+  overflow: hidden;
+  background-color: var(--app-icon-image-bg);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  isolation: isolate;
+  transform: translateZ(0);
 }
 
 .appIconFallback {

--- a/src/ui/src/components/chat/WorkspaceActions.test.tsx
+++ b/src/ui/src/components/chat/WorkspaceActions.test.tsx
@@ -84,9 +84,11 @@ describe("WorkspaceActions", () => {
     const primaryButton = container.querySelector(
       'button[aria-label="workspace_actions_open_in:VS Code"]',
     );
-    const image = primaryButton?.querySelector("img");
+    const image = primaryButton?.querySelector("[aria-hidden='true']");
     expect(image).not.toBeNull();
-    expect(image?.getAttribute("src")).toBe("data:image/png;base64,abc123");
+    expect((image as HTMLElement | null)?.style.backgroundImage).toBe(
+      'url("data:image/png;base64,abc123")',
+    );
     expect(primaryButton?.querySelector("svg")).toBeNull();
   });
 

--- a/src/ui/src/components/chat/WorkspaceActions.tsx
+++ b/src/ui/src/components/chat/WorkspaceActions.tsx
@@ -55,10 +55,9 @@ function renderCategoryIcon(category: AppCategory) {
 export function AppIcon({ app }: { app: DetectedApp }) {
   if (app.icon_data_url) {
     return (
-      <img
+      <span
         className={styles.appIconImage}
-        src={app.icon_data_url}
-        alt=""
+        style={{ backgroundImage: `url(${app.icon_data_url})` }}
         aria-hidden="true"
       />
     );

--- a/src/ui/src/components/chat/scrollbarConsistency.test.ts
+++ b/src/ui/src/components/chat/scrollbarConsistency.test.ts
@@ -21,9 +21,16 @@
 // deliberate.
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+// Resolve from the test file's own URL — `__dirname` is undefined in
+// real ESM modules. Vitest currently shims it, but mirroring the
+// pattern used by `components/layout/headerAlignment.test.ts` keeps
+// this test portable to bare Node and isn't dependent on the shim.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const UI_SRC = join(__dirname, "..", "..");
 
 function readCss(rel: string): string {

--- a/src/ui/src/components/chat/scrollbarConsistency.test.ts
+++ b/src/ui/src/components/chat/scrollbarConsistency.test.ts
@@ -1,0 +1,201 @@
+// Cross-surface CSS regression: chat (`OverlayScrollbar`), Monaco
+// editor, and the xterm terminal must all draw their scrollbars from
+// the same shared tokens (`--scrollbar-size`, `--scrollbar-thumb`,
+// `--scrollbar-thumb-hover`, `--radius-sm`, `--scrollbar-edge-inset`).
+//
+// Why this test exists: each surface has its own CSS module and a
+// drive-by tweak in any one of them — say, hard-coding `width: 8px`
+// instead of `var(--scrollbar-size)`, or removing the `border-radius`
+// rule from MonacoEditor.module.css — would silently let the three
+// drift apart again. The bug is invisible at 100% browser zoom but
+// reappears the moment the user zooms in or out (overlay scrollbars
+// don't scale with zoom; `var()`-sized DOM sliders do). Tests in
+// happy-dom can't catch that because happy-dom doesn't lay out CSS;
+// the only way to lock the contract is to read the source files and
+// pin the tokens.
+//
+// Update notes (read before editing): if you intentionally change the
+// token strategy (e.g., introducing a separate `--chat-scrollbar-size`),
+// update both the surface AND this test in the same commit, and call
+// out the divergence in the PR description so reviewers know it was
+// deliberate.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const UI_SRC = join(__dirname, "..", "..");
+
+function readCss(rel: string): string {
+  // Strip CSS block comments so a stray `.foo` inside a comment can't
+  // shadow the real rule when ruleBody scans for selectors. Without
+  // this, a comment like `/* ...like .messages used to. */` matches
+  // before the real `.messages { ... }` rule.
+  return readFileSync(join(UI_SRC, rel), "utf8").replace(
+    /\/\*[\s\S]*?\*\//g,
+    "",
+  );
+}
+
+function ruleBody(css: string, selector: string): string {
+  // Match the literal selector up to the next `{ ... }` block. The
+  // `(?![\\w-])` lookahead pins the end of the selector to a non
+  // identifier char so `.messages` doesn't accidentally match
+  // `.messagesWrapper`. CSS modules don't nest at the top level so a
+  // flat `[^}]*` body capture is sufficient.
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${escaped}(?![\\w-])\\s*[^{]*\\{([^}]*)\\}`);
+  const match = css.match(re);
+  if (!match) {
+    throw new Error(`selector ${selector} not found`);
+  }
+  return match[1];
+}
+
+describe("chat OverlayScrollbar uses the shared scrollbar tokens", () => {
+  const css = readCss("components/chat/OverlayScrollbar.module.css");
+
+  it("track width is var(--scrollbar-size) — never a hard-coded pixel value", () => {
+    const body = ruleBody(css, ".track");
+    expect(body).toMatch(/width:\s*var\(--scrollbar-size\)/);
+    // Catch a future drive-by like `width: 8px;` that would silently
+    // break the scale-with-zoom contract.
+    expect(body).not.toMatch(/width:\s*\d+px/);
+  });
+
+  it("track is inset from the wall by --scrollbar-edge-inset to match Monaco/xterm", () => {
+    // The 8px gap between the slider and the panel right wall is the
+    // visual signature shared by xterm (`.paneRoot { inset: 8px }`)
+    // and Monaco (`.host { margin-right: var(--scrollbar-edge-inset) }`).
+    // If the chat's track moves to `right: 0` the slider drifts 8px
+    // outboard of the other two.
+    const body = ruleBody(css, ".track");
+    expect(body).toMatch(/right:\s*var\(--scrollbar-edge-inset\)/);
+  });
+
+  it("slider thumb uses --scrollbar-thumb and --scrollbar-thumb-hover, with --radius-sm corners", () => {
+    const sliderBody = ruleBody(css, ".slider");
+    expect(sliderBody).toMatch(/background:\s*var\(--scrollbar-thumb\)/);
+    expect(sliderBody).toMatch(/border-radius:\s*var\(--radius-sm\)/);
+    // Hover/drag swap to the brighter token. We assert against the file
+    // rather than the rule body because the hover/dragging selector is
+    // its own rule.
+    expect(css).toMatch(
+      /\.slider:hover[^}]*background:\s*var\(--scrollbar-thumb-hover\)/s,
+    );
+    expect(css).toMatch(
+      /\.slider\[data-dragging="true"\][^}]*background:\s*var\(--scrollbar-thumb-hover\)/s,
+    );
+  });
+});
+
+describe("ChatPanel.module.css hides the native scrollbar", () => {
+  const css = readCss("components/chat/ChatPanel.module.css");
+  const body = ruleBody(css, ".messages");
+
+  it("sets scrollbar-width: none so the OS overlay can't render alongside the custom one", () => {
+    // If this regresses to `thin` or `auto` the macOS overlay
+    // scrollbar paints over the custom slider and the user sees a
+    // doubled rail.
+    expect(body).toMatch(/scrollbar-width:\s*none/);
+  });
+
+  it("hides the WebKit scrollbar via display: none, width: 0, height: 0", () => {
+    const wkBody = ruleBody(css, ".messages::-webkit-scrollbar");
+    expect(wkBody).toMatch(/display:\s*none/);
+    expect(wkBody).toMatch(/width:\s*0/);
+    expect(wkBody).toMatch(/height:\s*0/);
+  });
+
+  it("retains the right-edge margin so the custom track sits in the same lane Monaco's host uses", () => {
+    expect(body).toMatch(
+      /margin-right:\s*var\(--scrollbar-edge-inset\)/,
+    );
+  });
+});
+
+describe("MonacoEditor rounds its slider with --radius-sm to match xterm/chat", () => {
+  const css = readCss("components/file-viewer/MonacoEditor.module.css");
+
+  it("targets the Monaco scrollbar slider via :global and applies --radius-sm", () => {
+    // Monaco's theme schema has no `borderRadius` token for the slider —
+    // it ships rectangular by default. Without this rule, the Monaco
+    // scrollbar diverges visually from the rounded chat / xterm
+    // sliders. The rule must use !important because Monaco reapplies
+    // inline width / height / transform on every scroll tick.
+    expect(css).toMatch(
+      /:global\(\s*\.monaco-scrollable-element\s*>\s*\.scrollbar\s*>\s*\.slider\s*\)/,
+    );
+    expect(css).toMatch(/border-radius:\s*var\(--radius-sm\)\s*!important/);
+  });
+});
+
+describe("TerminalPanel xterm slider uses the shared tokens", () => {
+  const css = readCss("components/terminal/TerminalPanel.module.css");
+
+  it("xterm slider width is var(--scrollbar-size) — never a literal pixel value", () => {
+    // Two rules apply width: the parent `.scrollbar.vertical` and the
+    // child `.scrollbar.vertical > .slider`. Both must use the token.
+    expect(css).toMatch(
+      /\.scrollbar\.vertical\)[\s\S]*?width:\s*var\(--scrollbar-size\)\s*!important/,
+    );
+    expect(css).toMatch(
+      /\.scrollbar\.vertical\s*>\s*\.slider\)[\s\S]*?width:\s*var\(--scrollbar-size\)\s*!important/,
+    );
+  });
+
+  it("xterm slider background + radius use --scrollbar-thumb / --radius-sm", () => {
+    // The selector that styles `.scrollbar > .slider` (no orientation)
+    // owns background + border-radius. xterm.js inlines its own
+    // background; `!important` is required to win against that.
+    expect(css).toMatch(
+      /\.scrollbar\s*>\s*\.slider\)[\s\S]*?background:\s*var\(--scrollbar-thumb\)\s*!important/,
+    );
+    expect(css).toMatch(
+      /\.scrollbar\s*>\s*\.slider\)[\s\S]*?border-radius:\s*var\(--radius-sm\)\s*!important/,
+    );
+  });
+
+  it("xterm slider hover/active swap to --scrollbar-thumb-hover", () => {
+    // Mirrors the `.slider:hover` swap on the chat's OverlayScrollbar
+    // and Monaco's `scrollbarSlider.hoverBackground` theme color, so
+    // hovering produces the same accent on every surface.
+    expect(css).toMatch(
+      /\.slider:hover[\s\S]*?background:\s*var\(--scrollbar-thumb-hover\)\s*!important/,
+    );
+    expect(css).toMatch(
+      /\.slider\.active[\s\S]*?background:\s*var\(--scrollbar-thumb-hover\)\s*!important/,
+    );
+  });
+});
+
+describe("MonacoEditor passes 8px to Monaco's scrollbar config", () => {
+  // This isn't a CSS file — Monaco's scrollbar size is set in JS via the
+  // `scrollbar` editor option. Read the source to pin both the
+  // vertical/horizontal scrollbar sizes (the rail) and slider sizes
+  // (the thumb) so they continue to match `var(--scrollbar-size) = 8px`.
+  // If this drifts from 8 the Monaco slider shows up wider/thinner
+  // than xterm and chat at 100% zoom.
+  const ts = readFileSync(
+    join(UI_SRC, "components/file-viewer/MonacoEditor.tsx"),
+    "utf8",
+  );
+
+  it("Monaco scrollbar sizes are 8 to match var(--scrollbar-size)", () => {
+    expect(ts).toMatch(/verticalScrollbarSize:\s*8/);
+    expect(ts).toMatch(/verticalSliderSize:\s*8/);
+    expect(ts).toMatch(/horizontalScrollbarSize:\s*8/);
+    expect(ts).toMatch(/horizontalSliderSize:\s*8/);
+  });
+});
+
+describe("theme.css scrollbar tokens are defined and rgba-ish", () => {
+  const css = readCss("styles/theme.css");
+
+  it("declares --scrollbar-size, --scrollbar-thumb, --scrollbar-thumb-hover, --scrollbar-edge-inset", () => {
+    expect(css).toMatch(/--scrollbar-size:\s*8px/);
+    expect(css).toMatch(/--scrollbar-edge-inset:\s*8px/);
+    expect(css).toMatch(/--scrollbar-thumb:\s*var\(--hover-bg\)/);
+    expect(css).toMatch(/--scrollbar-thumb-hover:\s*rgba\(/);
+  });
+});

--- a/src/ui/src/components/command-palette/CommandPalette.module.css
+++ b/src/ui/src/components/command-palette/CommandPalette.module.css
@@ -6,7 +6,6 @@
   justify-content: center;
   padding-top: 72px;
   z-index: 100;
-  animation: fadeIn 0.1s ease;
 }
 
 .card {
@@ -19,7 +18,6 @@
   flex-direction: column;
   overflow: hidden;
   box-shadow: var(--shadow-lg);
-  animation: scaleIn 0.15s ease;
 }
 
 /* Search input row */

--- a/src/ui/src/components/diff/DiffViewer.module.css
+++ b/src/ui/src/components/diff/DiffViewer.module.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  animation: fadeIn 0.15s ease;
 }
 
 .previewBody {

--- a/src/ui/src/components/file-viewer/FileViewer.module.css
+++ b/src/ui/src/components/file-viewer/FileViewer.module.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  animation: fadeIn 0.15s ease;
 }
 
 .viewer:focus {

--- a/src/ui/src/components/file-viewer/MonacoEditor.module.css
+++ b/src/ui/src/components/file-viewer/MonacoEditor.module.css
@@ -1,6 +1,7 @@
 .host {
   flex: 1;
   min-height: 0;
+  margin-right: var(--scrollbar-edge-inset);
   overflow: hidden;
   display: flex;
 }

--- a/src/ui/src/components/file-viewer/MonacoEditor.module.css
+++ b/src/ui/src/components/file-viewer/MonacoEditor.module.css
@@ -18,6 +18,22 @@
   width: 100%;
 }
 
+/* Monaco's slider is colored via the theme's `scrollbarSlider.background`
+ * token (see monacoTheme.ts) but Monaco's theme schema has no
+ * `borderRadius` for the slider — it ships rectangular. xterm and the
+ * chat OverlayScrollbar both round the thumb with `var(--radius-sm)`,
+ * so we round Monaco's here for visual parity across the three
+ * surfaces. The `:global(.scrollbar > .slider)` selector targets the
+ * pair Monaco renders internally; `!important` is required because
+ * Monaco re-applies its own inline width/height/transform on every
+ * scroll tick, and CSS modules don't reach inside the editor without
+ * `:global`. Targeting the `.scrollbar` parent additionally rounds the
+ * track corners so the thumb sits flush with the rail at scroll
+ * extremes. */
+.host :global(.monaco-scrollable-element > .scrollbar > .slider) {
+  border-radius: var(--radius-sm) !important;
+}
+
 /* Git gutter — colored bars in Monaco's line-numbers gutter. Decorations
    are applied via `linesDecorationsClassName`; Monaco renders the class
    on a thin strip immediately right of the line numbers. */

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -183,7 +183,9 @@ export const MonacoEditor = memo(function MonacoEditor({
           scrollBeyondLastLine: false,
           scrollbar: {
             verticalScrollbarSize: 8,
+            verticalSliderSize: 8,
             horizontalScrollbarSize: 8,
+            horizontalSliderSize: 8,
           },
           // Disable the bracket-guides / sticky scroll noise; we want a
           // clean editor surface that matches the surrounding UI density.

--- a/src/ui/src/components/file-viewer/MonacoEditor.tsx
+++ b/src/ui/src/components/file-viewer/MonacoEditor.tsx
@@ -181,6 +181,10 @@ export const MonacoEditor = memo(function MonacoEditor({
           wordWrap: "on",
           lineNumbers: "on",
           scrollBeyondLastLine: false,
+          scrollbar: {
+            verticalScrollbarSize: 8,
+            horizontalScrollbarSize: 8,
+          },
           // Disable the bracket-guides / sticky scroll noise; we want a
           // clean editor surface that matches the surrounding UI density.
           renderWhitespace: "selection",

--- a/src/ui/src/components/file-viewer/monacoTheme.ts
+++ b/src/ui/src/components/file-viewer/monacoTheme.ts
@@ -56,6 +56,8 @@ export function applyMonacoTheme(monaco: typeof MonacoType): void {
   const accentBg  = cssColorToHex(cs.getPropertyValue("--accent-bg").trim()        || (isDark ? "#1a1a1a" : "#f5f5f5"));
   const selected  = cssColorToHex(cs.getPropertyValue("--selected-bg").trim()      || (isDark ? "#3a2820" : "#f0e8e0"));
   const hovered   = cssColorToHex(cs.getPropertyValue("--hover-bg").trim()         || (isDark ? "#242220" : "#f5f5f5"));
+  const scrollbarThumb = cssColorToHex(cs.getPropertyValue("--scrollbar-thumb").trim() || (isDark ? "#242220" : "#f5f5f5"));
+  const scrollbarThumbHover = cssColorToHex(cs.getPropertyValue("--scrollbar-thumb-hover").trim() || (isDark ? "#e0785040" : "#c45a3540"));
   const divider   = cssColorToHex(cs.getPropertyValue("--divider").trim()          || (isDark ? "#3d3832" : "#e0e0e0"));
   const widgetBg  = cssColorToHex(cs.getPropertyValue("--sidebar-bg").trim()       || (isDark ? "#26221f" : "#f5f5f5"));
   const addedBg   = cssColorToHex(cs.getPropertyValue("--diff-added-bg").trim()    || (isDark ? "#1a3a20" : "#e8f5e9"));
@@ -145,9 +147,9 @@ export function applyMonacoTheme(monaco: typeof MonacoType): void {
 
       // Scrollbars
       "scrollbar.shadow":                       transparent,
-      "scrollbarSlider.background":             withAlpha(dim, "40"),
-      "scrollbarSlider.hoverBackground":        withAlpha(dim, "70"),
-      "scrollbarSlider.activeBackground":       withAlpha(accent, "70"),
+      "scrollbarSlider.background":             scrollbarThumb,
+      "scrollbarSlider.hoverBackground":        scrollbarThumbHover,
+      "scrollbarSlider.activeBackground":       scrollbarThumbHover,
 
       // Diff editor
       "diffEditor.insertedTextBackground":      addedBg,

--- a/src/ui/src/components/fuzzy-finder/FuzzyFinder.module.css
+++ b/src/ui/src/components/fuzzy-finder/FuzzyFinder.module.css
@@ -6,7 +6,6 @@
   justify-content: center;
   padding-top: var(--space-10);
   z-index: 100;
-  animation: fadeIn 0.1s ease;
 }
 
 .card {
@@ -19,7 +18,6 @@
   flex-direction: column;
   overflow: hidden;
   box-shadow: var(--shadow-lg);
-  animation: scaleIn 0.15s ease;
 }
 
 .input {

--- a/src/ui/src/components/layout/AppLayout.module.css
+++ b/src/ui/src/components/layout/AppLayout.module.css
@@ -69,6 +69,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  background: var(--app-bg);
   contain: layout style;
 }
 
@@ -77,6 +78,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  background: var(--app-bg);
   contain: layout style;
 }
 
@@ -163,4 +165,14 @@
   .rightSidebarContent {
     transition: none;
   }
+}
+
+:where([data-platform="mac"]) .sidebar,
+:where([data-platform="mac"]) .rightSidebar {
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+}
+
+:where([data-platform="mac"]) .center,
+:where([data-platform="mac"]) .content {
+  background: color-mix(in srgb, var(--app-bg) 92%, transparent);
 }

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -232,6 +232,10 @@
   margin-bottom: 4px;
 }
 
+:where([data-platform="mac"]) .toolbar {
+  background: color-mix(in srgb, var(--chat-header-bg) 88%, transparent);
+}
+
 .emptyTitle {
   font-size: 16px;
   font-weight: 600;

--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -224,7 +224,6 @@
   justify-content: center;
   color: var(--text-muted);
   gap: 12px;
-  animation: fadeIn 0.4s ease;
 }
 
 .emptyIcon {

--- a/src/ui/src/components/modals/Modal.module.css
+++ b/src/ui/src/components/modals/Modal.module.css
@@ -6,7 +6,6 @@
   align-items: center;
   justify-content: center;
   z-index: 100;
-  animation: fadeIn 0.15s ease;
 }
 
 .card {
@@ -17,7 +16,6 @@
   max-height: 80vh;
   overflow-y: auto;
   box-shadow: var(--shadow-lg);
-  animation: scaleIn 0.2s ease;
 }
 
 .header {

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -16,6 +16,10 @@
   box-shadow: var(--shadow-sm);
 }
 
+:where([data-platform="mac"]) .banner {
+  background: color-mix(in srgb, var(--chat-header-bg) 88%, transparent);
+}
+
 .bannerReady,
 .bannerOpen {
   background: color-mix(in srgb, var(--badge-done) 12%, var(--chat-header-bg));

--- a/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
+++ b/src/ui/src/components/right-sidebar/PrStatusBanner.module.css
@@ -14,7 +14,6 @@
   background: var(--chat-header-bg);
   border-bottom: 1px solid var(--divider);
   box-shadow: var(--shadow-sm);
-  animation: fadeIn 0.15s ease;
 }
 
 .bannerReady,

--- a/src/ui/src/components/right-sidebar/RightSidebar.module.css
+++ b/src/ui/src/components/right-sidebar/RightSidebar.module.css
@@ -26,6 +26,10 @@
   min-height: var(--tab-bar-h);
 }
 
+:where([data-platform="mac"]) .tabBar {
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
+}
+
 .tab {
   flex: 1;
   display: flex;

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -29,6 +29,7 @@
 
 [data-platform="mac"] .sidebar {
   padding-top: 38px;
+  background: color-mix(in srgb, var(--sidebar-bg) 88%, transparent);
 }
 
 .backLink {
@@ -111,6 +112,15 @@
   overflow-y: auto;
   padding: 32px 48px;
   background: var(--app-bg);
+}
+
+:where([data-platform="mac"]) .container {
+  background: transparent;
+}
+
+:where([data-platform="mac"]) .content,
+:where([data-platform="mac"]) .attributionBar {
+  background: color-mix(in srgb, var(--app-bg) 92%, transparent);
 }
 
 .attributionBar {

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -72,3 +72,7 @@
 [data-platform="mac"] .noSidebar {
   padding-left: 80px;
 }
+
+:where([data-platform="mac"]) .header {
+  background: color-mix(in srgb, var(--chat-header-bg) 88%, transparent);
+}

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -18,6 +18,8 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .headerRight {

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -24,10 +24,22 @@
   app-region: drag;
 }
 
+.headerLeft * {
+  -webkit-app-region: drag;
+  app-region: drag;
+}
+
 .headerRight {
   display: flex;
   align-items: center;
   gap: 8px;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.headerRight * {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 .branchInfo {

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -20,6 +20,8 @@
   min-width: 0;
   user-select: none;
   -webkit-user-select: none;
+  -webkit-app-region: drag;
+  app-region: drag;
 }
 
 .headerRight {

--- a/src/ui/src/components/shared/WorkspacePanelHeader.module.css
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.module.css
@@ -20,13 +20,13 @@
   min-width: 0;
   user-select: none;
   -webkit-user-select: none;
-  -webkit-app-region: drag;
-  app-region: drag;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 .headerLeft * {
-  -webkit-app-region: drag;
-  app-region: drag;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
 }
 
 .headerRight {

--- a/src/ui/src/components/shared/WorkspacePanelHeader.tsx
+++ b/src/ui/src/components/shared/WorkspacePanelHeader.tsx
@@ -1,3 +1,5 @@
+import type { MouseEvent } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { GitBranch } from "lucide-react";
 import { useAppStore } from "../../stores/useAppStore";
 import { WorkspaceActions } from "../chat/WorkspaceActions";
@@ -15,9 +17,17 @@ export function WorkspacePanelHeader() {
   const repo = repositories.find((r) => r.id === ws?.repository_id);
   const defaultBranch = repo ? defaultBranchesMap[repo.id] : undefined;
 
+  const handleHeaderLabelMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    void getCurrentWindow().startDragging().catch((err) => {
+      console.error("Failed to start window drag from header label:", err);
+    });
+  };
+
   return (
     <div className={`${styles.header} ${!sidebarVisible ? styles.noSidebar : ""}`} data-tauri-drag-region>
-      <div className={styles.headerLeft}>
+      <div className={styles.headerLeft} onMouseDown={handleHeaderLabelMouseDown}>
         {ws && (repo ? (
           <span className={styles.branchInfo}>
             <span className={styles.repoName}>{repo.name}</span>

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -205,6 +205,30 @@
   position: relative;
 }
 
+.termContainer :global(.xterm .xterm-viewport) {
+  background-color: var(--terminal-bg) !important;
+  scrollbar-color: var(--scrollbar-thumb) transparent !important;
+  scrollbar-width: thin !important;
+}
+
+.termContainer :global(.xterm .xterm-viewport::-webkit-scrollbar) {
+  width: var(--scrollbar-size) !important;
+  height: var(--scrollbar-size) !important;
+}
+
+.termContainer :global(.xterm .xterm-viewport::-webkit-scrollbar-track) {
+  background: transparent !important;
+}
+
+.termContainer :global(.xterm .xterm-viewport::-webkit-scrollbar-thumb) {
+  background: var(--scrollbar-thumb) !important;
+  border-radius: var(--radius-sm) !important;
+}
+
+.termContainer :global(.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover) {
+  background: var(--scrollbar-thumb-hover) !important;
+}
+
 .spawnError {
   position: absolute;
   top: 12px;

--- a/src/ui/src/components/terminal/TerminalPanel.module.css
+++ b/src/ui/src/components/terminal/TerminalPanel.module.css
@@ -229,6 +229,38 @@
   background: var(--scrollbar-thumb-hover) !important;
 }
 
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar.vertical) {
+  left: auto !important;
+  right: 0 !important;
+  width: var(--scrollbar-size) !important;
+}
+
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar.horizontal) {
+  bottom: 0 !important;
+  height: var(--scrollbar-size) !important;
+}
+
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar > .slider) {
+  background: var(--scrollbar-thumb) !important;
+  border-radius: var(--radius-sm) !important;
+}
+
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider) {
+  left: 0 !important;
+  right: 0 !important;
+  width: var(--scrollbar-size) !important;
+}
+
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar.horizontal > .slider) {
+  bottom: 0 !important;
+  height: var(--scrollbar-size) !important;
+}
+
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar > .slider:hover),
+.termContainer :global(.xterm .xterm-scrollable-element > .scrollbar > .slider.active) {
+  background: var(--scrollbar-thumb-hover) !important;
+}
+
 .spawnError {
   position: absolute;
   top: 12px;

--- a/src/ui/src/hooks/usePreventScrollBounce.test.tsx
+++ b/src/ui/src/hooks/usePreventScrollBounce.test.tsx
@@ -1,0 +1,384 @@
+// @vitest-environment happy-dom
+
+// Regression suite for `usePreventScrollBounce`. The hook's job is to
+// suppress macOS WebView's elastic overscroll on the chat messages
+// container WITHOUT breaking scroll chaining — at the boundary of the
+// container the gesture is cancelled, but if a nested scrollable widget
+// (a code block, thinking-block diff, attachment preview) can still
+// scroll in the same direction, the gesture is allowed through and
+// chains naturally.
+//
+// The hook composes a small set of pure boundary-detection helpers
+// (`canScrollVertically`, `canScrollInDirection`, `nearestScrollableWithin`,
+// `boundaryScrollTarget`); we test those directly because their logic is
+// the part that's easy to regress when someone tweaks the predicate. A
+// final end-to-end test mounts the hook against a synthetic DOM, fires a
+// wheel event, and asserts the predicates wire up correctly to actual
+// `preventDefault()` behavior.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  boundaryScrollTarget,
+  canScrollInDirection,
+  canScrollVertically,
+  nearestScrollableWithin,
+  usePreventScrollBounce,
+} from "./usePreventScrollBounce";
+import { useRef } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+/** Build an HTMLElement with stubbed layout properties so the helpers
+ *  can read scrollTop / scrollHeight / clientHeight under happy-dom
+ *  (which doesn't compute real layout). overflowY defaults to "auto"
+ *  so the element is treated as scrollable; tests that need to check
+ *  the overflow gate override it. */
+function makeScrollable(metrics: {
+  scrollTop?: number;
+  scrollHeight: number;
+  clientHeight: number;
+  overflowY?: string;
+}): HTMLElement {
+  const el = document.createElement("div");
+  // Apply via inline style so getComputedStyle().overflowY resolves.
+  el.style.overflowY = metrics.overflowY ?? "auto";
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop ?? 0,
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  document.body.appendChild(el);
+  mountedContainers.push(el);
+  return el;
+}
+
+describe("canScrollVertically", () => {
+  it("returns true when scrollHeight exceeds clientHeight by more than 1px", () => {
+    const el = makeScrollable({ scrollHeight: 200, clientHeight: 100 });
+    expect(canScrollVertically(el)).toBe(true);
+  });
+
+  it("returns false when content fits exactly", () => {
+    const el = makeScrollable({ scrollHeight: 100, clientHeight: 100 });
+    expect(canScrollVertically(el)).toBe(false);
+  });
+
+  it("returns false at the +1px tolerance boundary (avoids subpixel false positives)", () => {
+    // Float subpixel rounding sometimes leaves scrollHeight === clientHeight + 1
+    // even when there's no real overflow; the tolerance prevents the hook
+    // from treating those as scrollable surfaces.
+    const el = makeScrollable({ scrollHeight: 101, clientHeight: 100 });
+    expect(canScrollVertically(el)).toBe(false);
+  });
+});
+
+describe("canScrollInDirection", () => {
+  it("blocks upward scroll when already at the top", () => {
+    const el = makeScrollable({
+      scrollTop: 0,
+      scrollHeight: 500,
+      clientHeight: 100,
+    });
+    expect(canScrollInDirection(el, -10)).toBe(false);
+  });
+
+  it("allows upward scroll when not at the top", () => {
+    const el = makeScrollable({
+      scrollTop: 50,
+      scrollHeight: 500,
+      clientHeight: 100,
+    });
+    expect(canScrollInDirection(el, -10)).toBe(true);
+  });
+
+  it("blocks downward scroll when at the bottom", () => {
+    const el = makeScrollable({
+      scrollTop: 400,
+      scrollHeight: 500,
+      clientHeight: 100,
+    });
+    expect(canScrollInDirection(el, 10)).toBe(false);
+  });
+
+  it("allows downward scroll when not at the bottom", () => {
+    const el = makeScrollable({
+      scrollTop: 100,
+      scrollHeight: 500,
+      clientHeight: 100,
+    });
+    expect(canScrollInDirection(el, 10)).toBe(true);
+  });
+
+  it("returns false for non-scrollable elements regardless of delta", () => {
+    const el = makeScrollable({ scrollHeight: 100, clientHeight: 100 });
+    expect(canScrollInDirection(el, -10)).toBe(false);
+    expect(canScrollInDirection(el, 10)).toBe(false);
+  });
+
+  it("returns false for a deltaY of 0 (no direction implied)", () => {
+    const el = makeScrollable({
+      scrollTop: 50,
+      scrollHeight: 500,
+      clientHeight: 100,
+    });
+    expect(canScrollInDirection(el, 0)).toBe(false);
+  });
+});
+
+describe("nearestScrollableWithin", () => {
+  it("walks up to the boundary and returns the first scrollable ancestor", () => {
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    const inner = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 100,
+    });
+    const leaf = document.createElement("span");
+    inner.appendChild(leaf);
+    boundary.appendChild(inner);
+    expect(nearestScrollableWithin(leaf, boundary)).toBe(inner);
+  });
+
+  it("falls back to the boundary when no nested scrollable is found", () => {
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    const leaf = document.createElement("span");
+    boundary.appendChild(leaf);
+    expect(nearestScrollableWithin(leaf, boundary)).toBe(boundary);
+  });
+
+  it("ignores elements with overflowY visible/hidden even if they have overflow content", () => {
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    // overflowY: visible disqualifies — that element doesn't host its
+    // own scroll surface even if its content overflows.
+    const inner = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 100,
+      overflowY: "visible",
+    });
+    const leaf = document.createElement("span");
+    inner.appendChild(leaf);
+    boundary.appendChild(inner);
+    expect(nearestScrollableWithin(leaf, boundary)).toBe(boundary);
+  });
+
+  it("returns the boundary when target isn't an Element (e.g. document)", () => {
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    expect(nearestScrollableWithin(null, boundary)).toBe(boundary);
+    // EventTarget that is not a Node (synthetic in some environments)
+    // also falls through to the boundary.
+    expect(nearestScrollableWithin({} as unknown as EventTarget, boundary)).toBe(
+      boundary,
+    );
+  });
+});
+
+describe("boundaryScrollTarget", () => {
+  it("returns null when delta is zero (no direction to evaluate)", () => {
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+      scrollTop: 100,
+    });
+    expect(boundaryScrollTarget(boundary, boundary, 0)).toBeNull();
+  });
+
+  it("returns null when target is outside the boundary", () => {
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+    });
+    const stranger = makeScrollable({
+      scrollHeight: 100,
+      clientHeight: 50,
+    });
+    expect(boundaryScrollTarget(stranger, boundary, 10)).toBeNull();
+  });
+
+  it("returns null (allows the gesture through) when the active scroller can chain", () => {
+    // The chat panel is at scrollTop > 0 (mid-page); a nested code block
+    // is also mid-scroll. Wheel down: the inner scroller can scroll
+    // down, so we DON'T block — chaining is allowed.
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+      scrollTop: 100,
+    });
+    const inner = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: 50,
+    });
+    boundary.appendChild(inner);
+    expect(boundaryScrollTarget(inner, boundary, 10)).toBeNull();
+  });
+
+  it("returns the active scroller (blocks bounce) when neither active nor boundary can chain", () => {
+    // The Codex P2 regression test: chat is pinned at the bottom AND
+    // the inner code block is also at the bottom of its own scroll. A
+    // wheel-down at this point would bounce the WebView; the hook
+    // must block it.
+    const boundary = makeScrollable({
+      scrollHeight: 200,
+      clientHeight: 200, // no overflow on the boundary
+      scrollTop: 0,
+    });
+    const inner = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: 400, // already at bottom
+    });
+    boundary.appendChild(inner);
+    const result = boundaryScrollTarget(inner, boundary, 10);
+    expect(result).toBe(inner);
+  });
+
+  it("falls back to the boundary scroller when the inner has no scroll, boundary is at the edge", () => {
+    // Common case: pointer over inert message text in a chat that's
+    // already scrolled to the bottom.
+    const boundary = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 200,
+      scrollTop: 300, // at bottom: 300 + 200 = 500
+    });
+    const leaf = document.createElement("span");
+    boundary.appendChild(leaf);
+    const result = boundaryScrollTarget(leaf, boundary, 10);
+    expect(result).toBe(boundary);
+  });
+
+  it("allows chain when the boundary is mid-scroll even if the active scroller cannot chain", () => {
+    // Inner code block is at its bottom but the chat itself can still
+    // scroll down — the gesture should pass through to the chat.
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+      scrollTop: 100, // mid-scroll
+    });
+    const inner = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: 400, // at bottom
+    });
+    boundary.appendChild(inner);
+    expect(boundaryScrollTarget(inner, boundary, 10)).toBeNull();
+  });
+});
+
+describe("usePreventScrollBounce (end-to-end on a wheel event)", () => {
+  /** Mount a tiny component that wires the hook to a ref over a
+   *  pre-built boundary. Returns the boundary so the test can fire
+   *  events against it. */
+  async function mountHook(boundary: HTMLElement) {
+    const root = createRoot(document.createElement("div"));
+    mountedRoots.push(root);
+    const Wrapper = () => {
+      const ref = useRef<HTMLElement | null>(boundary);
+      usePreventScrollBounce(ref);
+      return null;
+    };
+    await act(async () => {
+      root.render(<Wrapper />);
+    });
+  }
+
+  it("calls preventDefault when the gesture would bounce off the boundary", async () => {
+    const boundary = makeScrollable({
+      scrollHeight: 200,
+      clientHeight: 200, // no overflow
+      scrollTop: 0,
+    });
+    await mountHook(boundary);
+    const wheel = new WheelEvent("wheel", {
+      deltaY: 10,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(wheel, "preventDefault");
+    // Dispatch on the boundary itself so `event.target` is inside it.
+    // The hook's listener is registered on `document` in capture phase
+    // and fires regardless of where the event was dispatched.
+    boundary.dispatchEvent(wheel);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("does NOT call preventDefault when a nested scroller can still chain", async () => {
+    // Regression target for the global `* { overscroll-behavior: contain }`
+    // removal — without this the nested scroller would lose its ability
+    // to chain into the chat scroller.
+    const boundary = makeScrollable({
+      scrollHeight: 1000,
+      clientHeight: 200,
+      scrollTop: 100,
+    });
+    const inner = makeScrollable({
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: 50, // mid-scroll, can chain in either direction
+    });
+    boundary.appendChild(inner);
+    await mountHook(boundary);
+    const wheel = new WheelEvent("wheel", {
+      deltaY: 10,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(wheel, "preventDefault");
+    // Dispatch on the inner scroller — `event.target` becomes `inner`,
+    // and the boundary detection finds it as the active scroller.
+    inner.dispatchEvent(wheel);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("ignores horizontal-dominant wheel deltas (don't fight horizontal trackpad scrolls)", async () => {
+    const boundary = makeScrollable({
+      scrollHeight: 200,
+      clientHeight: 200,
+    });
+    await mountHook(boundary);
+    const wheel = new WheelEvent("wheel", {
+      deltaX: 50,
+      deltaY: 5,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(wheel, "preventDefault");
+    boundary.dispatchEvent(wheel);
+    // |deltaX (50)| > |deltaY (5)| → horizontal gesture, not our concern.
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/hooks/usePreventScrollBounce.ts
+++ b/src/ui/src/hooks/usePreventScrollBounce.ts
@@ -1,6 +1,13 @@
 import { useEffect, type RefObject } from "react";
 
-function canScrollVertically(el: HTMLElement) {
+// The boundary-detection helpers below are exported so the test suite
+// (`usePreventScrollBounce.test.ts`) can pin their behavior directly.
+// They're pure (no DOM mutation, no side effects) and small enough that
+// testing them in isolation is faster + more readable than reaching
+// through the React hook lifecycle. The hook itself just composes these
+// with capture-phase document listeners.
+
+export function canScrollVertically(el: HTMLElement) {
   return el.scrollHeight > el.clientHeight + 1;
 }
 
@@ -9,7 +16,7 @@ function allowsVerticalScrolling(el: HTMLElement) {
   return overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
 }
 
-function canScrollInDirection(el: HTMLElement, deltaY: number) {
+export function canScrollInDirection(el: HTMLElement, deltaY: number) {
   if (!canScrollVertically(el)) return false;
   if (deltaY < 0) return el.scrollTop > 0;
   if (deltaY > 0) {
@@ -18,7 +25,7 @@ function canScrollInDirection(el: HTMLElement, deltaY: number) {
   return false;
 }
 
-function nearestScrollableWithin(
+export function nearestScrollableWithin(
   target: EventTarget | null,
   boundary: HTMLElement,
 ) {
@@ -59,7 +66,7 @@ function shouldHandleEvent(
   return eventTarget instanceof Node && boundary.contains(eventTarget);
 }
 
-function boundaryScrollTarget(
+export function boundaryScrollTarget(
   eventTarget: EventTarget | null,
   boundary: HTMLElement,
   deltaY: number,

--- a/src/ui/src/hooks/usePreventScrollBounce.ts
+++ b/src/ui/src/hooks/usePreventScrollBounce.ts
@@ -1,0 +1,98 @@
+import { useEffect, type RefObject } from "react";
+
+function canScrollVertically(el: HTMLElement) {
+  return el.scrollHeight > el.clientHeight + 1;
+}
+
+function canScrollInDirection(el: HTMLElement, deltaY: number) {
+  if (!canScrollVertically(el)) return false;
+  if (deltaY < 0) return el.scrollTop > 0;
+  if (deltaY > 0) {
+    return el.scrollTop + el.clientHeight < el.scrollHeight - 1;
+  }
+  return false;
+}
+
+function nearestScrollableWithin(
+  target: EventTarget | null,
+  boundary: HTMLElement,
+) {
+  if (!(target instanceof Element)) return boundary;
+
+  let el: Element | null = target;
+  while (el && el !== boundary) {
+    if (el instanceof HTMLElement && canScrollVertically(el)) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+
+  return boundary;
+}
+
+function shouldBlockBoundaryScroll(
+  eventTarget: EventTarget | null,
+  boundary: HTMLElement,
+  deltaY: number,
+) {
+  if (deltaY === 0) return false;
+
+  const activeScroller = nearestScrollableWithin(eventTarget, boundary);
+  if (canScrollInDirection(activeScroller, deltaY)) return false;
+  if (activeScroller !== boundary && canScrollInDirection(boundary, deltaY)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Prevents WebKit's elastic overscroll on desktop webviews. CSS
+ * `overscroll-behavior` is not reliable enough in macOS WKWebView, so this
+ * cancels wheel/touch gestures only when the active scroll surface is already
+ * at the top or bottom edge.
+ */
+export function usePreventScrollBounce(
+  containerRef: RefObject<HTMLElement | null>,
+) {
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onWheel = (event: WheelEvent) => {
+      if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+      if (!shouldBlockBoundaryScroll(event.target, el, event.deltaY)) return;
+      if (event.cancelable) event.preventDefault();
+    };
+
+    let lastTouchY: number | null = null;
+    let touchTarget: EventTarget | null = null;
+
+    const onTouchStart = (event: TouchEvent) => {
+      lastTouchY = event.touches[0]?.clientY ?? null;
+      touchTarget = event.target;
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      const currentY = event.touches[0]?.clientY ?? null;
+      if (lastTouchY == null || currentY == null) return;
+
+      const deltaY = lastTouchY - currentY;
+      lastTouchY = currentY;
+
+      if (!shouldBlockBoundaryScroll(touchTarget, el, deltaY)) return;
+      if (event.cancelable) event.preventDefault();
+    };
+
+    const options: AddEventListenerOptions = { passive: false };
+    el.addEventListener("wheel", onWheel, options);
+    el.addEventListener("touchstart", onTouchStart, options);
+    el.addEventListener("touchmove", onTouchMove, options);
+
+    return () => {
+      el.removeEventListener("wheel", onWheel, options);
+      el.removeEventListener("touchstart", onTouchStart, options);
+      el.removeEventListener("touchmove", onTouchMove, options);
+    };
+  }, [containerRef]);
+}

--- a/src/ui/src/hooks/usePreventScrollBounce.ts
+++ b/src/ui/src/hooks/usePreventScrollBounce.ts
@@ -4,6 +4,11 @@ function canScrollVertically(el: HTMLElement) {
   return el.scrollHeight > el.clientHeight + 1;
 }
 
+function allowsVerticalScrolling(el: HTMLElement) {
+  const { overflowY } = window.getComputedStyle(el);
+  return overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
+}
+
 function canScrollInDirection(el: HTMLElement, deltaY: number) {
   if (!canScrollVertically(el)) return false;
   if (deltaY < 0) return el.scrollTop > 0;
@@ -21,7 +26,11 @@ function nearestScrollableWithin(
 
   let el: Element | null = target;
   while (el && el !== boundary) {
-    if (el instanceof HTMLElement && canScrollVertically(el)) {
+    if (
+      el instanceof HTMLElement &&
+      canScrollVertically(el) &&
+      allowsVerticalScrolling(el)
+    ) {
       return el;
     }
     el = el.parentElement;
@@ -30,20 +39,47 @@ function nearestScrollableWithin(
   return boundary;
 }
 
-function shouldBlockBoundaryScroll(
+function maxScrollTop(el: HTMLElement) {
+  return Math.max(0, el.scrollHeight - el.clientHeight);
+}
+
+function clampScrollTop(el: HTMLElement) {
+  const max = maxScrollTop(el);
+  if (el.scrollTop < 0) {
+    el.scrollTop = 0;
+  } else if (el.scrollTop > max) {
+    el.scrollTop = max;
+  }
+}
+
+function shouldHandleEvent(
+  eventTarget: EventTarget | null,
+  boundary: HTMLElement,
+): eventTarget is Node {
+  return eventTarget instanceof Node && boundary.contains(eventTarget);
+}
+
+function boundaryScrollTarget(
   eventTarget: EventTarget | null,
   boundary: HTMLElement,
   deltaY: number,
 ) {
-  if (deltaY === 0) return false;
+  if (deltaY === 0 || !shouldHandleEvent(eventTarget, boundary)) return null;
 
   const activeScroller = nearestScrollableWithin(eventTarget, boundary);
-  if (canScrollInDirection(activeScroller, deltaY)) return false;
+  if (canScrollInDirection(activeScroller, deltaY)) return null;
   if (activeScroller !== boundary && canScrollInDirection(boundary, deltaY)) {
-    return false;
+    return null;
   }
 
-  return true;
+  return activeScroller;
+}
+
+function blockBoundaryScroll(event: Event, scrollTarget: HTMLElement) {
+  clampScrollTop(scrollTarget);
+  if (event.cancelable) event.preventDefault();
+  event.stopPropagation();
+  requestAnimationFrame(() => clampScrollTop(scrollTarget));
 }
 
 /**
@@ -58,17 +94,24 @@ export function usePreventScrollBounce(
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+    const document = el.ownerDocument;
 
     const onWheel = (event: WheelEvent) => {
       if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
-      if (!shouldBlockBoundaryScroll(event.target, el, event.deltaY)) return;
-      if (event.cancelable) event.preventDefault();
+      const scrollTarget = boundaryScrollTarget(event.target, el, event.deltaY);
+      if (!scrollTarget) return;
+      blockBoundaryScroll(event, scrollTarget);
     };
 
     let lastTouchY: number | null = null;
     let touchTarget: EventTarget | null = null;
 
     const onTouchStart = (event: TouchEvent) => {
+      if (!shouldHandleEvent(event.target, el)) {
+        lastTouchY = null;
+        touchTarget = null;
+        return;
+      }
       lastTouchY = event.touches[0]?.clientY ?? null;
       touchTarget = event.target;
     };
@@ -80,19 +123,26 @@ export function usePreventScrollBounce(
       const deltaY = lastTouchY - currentY;
       lastTouchY = currentY;
 
-      if (!shouldBlockBoundaryScroll(touchTarget, el, deltaY)) return;
-      if (event.cancelable) event.preventDefault();
+      const scrollTarget = boundaryScrollTarget(touchTarget, el, deltaY);
+      if (!scrollTarget) return;
+      blockBoundaryScroll(event, scrollTarget);
     };
 
-    const options: AddEventListenerOptions = { passive: false };
-    el.addEventListener("wheel", onWheel, options);
-    el.addEventListener("touchstart", onTouchStart, options);
-    el.addEventListener("touchmove", onTouchMove, options);
+    const onScroll = () => {
+      clampScrollTop(el);
+    };
+
+    const options: AddEventListenerOptions = { capture: true, passive: false };
+    document.addEventListener("wheel", onWheel, options);
+    document.addEventListener("touchstart", onTouchStart, options);
+    document.addEventListener("touchmove", onTouchMove, options);
+    el.addEventListener("scroll", onScroll, { passive: true });
 
     return () => {
-      el.removeEventListener("wheel", onWheel, options);
-      el.removeEventListener("touchstart", onTouchStart, options);
-      el.removeEventListener("touchmove", onTouchMove, options);
+      document.removeEventListener("wheel", onWheel, options);
+      document.removeEventListener("touchstart", onTouchStart, options);
+      document.removeEventListener("touchmove", onTouchMove, options);
+      el.removeEventListener("scroll", onScroll);
     };
   }, [containerRef]);
 }

--- a/src/ui/src/main.tsx
+++ b/src/ui/src/main.tsx
@@ -33,6 +33,13 @@ import { prewarmHighlighter } from "./utils/highlight";
 import { bootstrapGrammarRegistry } from "./utils/grammarRegistry";
 import App from "./App.tsx";
 
+const platform = navigator.platform.toLowerCase();
+document.documentElement.dataset.platform = platform.includes("mac")
+  ? "mac"
+  : platform.includes("win")
+    ? "windows"
+    : "linux";
+
 // Phase 2 of the log bridge: console mirroring. The early listeners
 // were already armed at `./utils/log` import time above; this call
 // only wires `console.{error,warn,info,log}` interception (gated by

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -61,8 +61,8 @@
   --hover-bg-subtle:     rgba(240, 235, 229, 0.04);
   --selected-bg:         rgba(224, 120, 80, 0.10);
   --divider:             #3d3832;
-  --app-icon-image-bg:   #ffffff;
   --scrollbar-size:      8px;
+  --scrollbar-edge-inset: 8px;
   --scrollbar-thumb:     var(--hover-bg);
   --scrollbar-thumb-hover: rgba(var(--accent-primary-rgb), 0.25);
 

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -885,6 +885,7 @@
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  overscroll-behavior: contain;
 }
 
 html,
@@ -900,6 +901,7 @@ body,
   line-height: var(--body-line);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overscroll-behavior: none;
 }
 
 h1 { font-size: var(--h1-size); font-weight: var(--h1-weight); line-height: var(--h1-line); letter-spacing: -0.02em; }
@@ -983,14 +985,15 @@ select:disabled {
   box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.5);
 }
 
-/* Scrollbars — thin, dim by default, accent on hover */
-::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb {
+/* Scrollbars — use the OS overlay scrollbars on macOS; keep a compact custom
+   gutter on Windows/Linux where always-visible bars are more common. */
+html:not([data-platform="mac"]) *::-webkit-scrollbar { width: 8px; height: 8px; }
+html:not([data-platform="mac"]) *::-webkit-scrollbar-track { background: transparent; }
+html:not([data-platform="mac"]) *::-webkit-scrollbar-thumb {
   background: var(--hover-bg);
   border-radius: var(--radius-sm);
 }
-::-webkit-scrollbar-thumb:hover {
+html:not([data-platform="mac"]) *::-webkit-scrollbar-thumb:hover {
   background: rgba(var(--accent-primary-rgb), 0.25);
 }
 

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -985,15 +985,14 @@ select:disabled {
   box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.5);
 }
 
-/* Scrollbars — use the OS overlay scrollbars on macOS; keep a compact custom
-   gutter on Windows/Linux where always-visible bars are more common. */
-html:not([data-platform="mac"]) *::-webkit-scrollbar { width: 8px; height: 8px; }
-html:not([data-platform="mac"]) *::-webkit-scrollbar-track { background: transparent; }
-html:not([data-platform="mac"]) *::-webkit-scrollbar-thumb {
+/* Scrollbars — thin, dim by default, accent on hover */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
   background: var(--hover-bg);
   border-radius: var(--radius-sm);
 }
-html:not([data-platform="mac"]) *::-webkit-scrollbar-thumb:hover {
+::-webkit-scrollbar-thumb:hover {
   background: rgba(var(--accent-primary-rgb), 0.25);
 }
 

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -61,6 +61,7 @@
   --hover-bg-subtle:     rgba(240, 235, 229, 0.04);
   --selected-bg:         rgba(224, 120, 80, 0.10);
   --divider:             #3d3832;
+  --app-icon-image-bg:   #ffffff;
 
   /* ---- Agent status ---- */
   --status-running:      #e07850;

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -889,10 +889,29 @@
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  overscroll-behavior: contain;
   scrollbar-color: var(--scrollbar-thumb) transparent;
   scrollbar-width: thin;
 }
+
+/*
+ * Overscroll guard: applied at the root scroll surfaces only, not on `*`.
+ *
+ * Earlier branches set `overscroll-behavior: contain` on `*`, which also
+ * landed it on every nested scrollable widget — code blocks, thinking
+ * blocks, attachment previews, slash-command pickers, etc. With it on
+ * those, wheel/trackpad scrolling at the top/bottom edge of a nested
+ * surface stops chaining to the chat scroller, so the user gets stuck
+ * on the inner widget until they move the cursor out. It also undermines
+ * `usePreventScrollBounce`, which deliberately allows the gesture
+ * through when a parent surface can still scroll in the same direction.
+ *
+ * The body-level rubber band is suppressed by the `html, body, #root`
+ * `overscroll-behavior: none` rule below; the chat messages container
+ * gets its WebKit-elastic-bounce treatment from the `usePreventScrollBounce`
+ * hook (`hooks/usePreventScrollBounce.ts`), which was written specifically
+ * because CSS `overscroll-behavior` is not reliable enough in macOS
+ * WKWebView. Don't reintroduce a global `*` rule for this.
+ */
 
 html,
 body,

--- a/src/ui/src/styles/theme.css
+++ b/src/ui/src/styles/theme.css
@@ -62,6 +62,9 @@
   --selected-bg:         rgba(224, 120, 80, 0.10);
   --divider:             #3d3832;
   --app-icon-image-bg:   #ffffff;
+  --scrollbar-size:      8px;
+  --scrollbar-thumb:     var(--hover-bg);
+  --scrollbar-thumb-hover: rgba(var(--accent-primary-rgb), 0.25);
 
   /* ---- Agent status ---- */
   --status-running:      #e07850;
@@ -887,6 +890,8 @@
   padding: 0;
   box-sizing: border-box;
   overscroll-behavior: contain;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
+  scrollbar-width: thin;
 }
 
 html,
@@ -986,15 +991,18 @@ select:disabled {
   box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.5);
 }
 
-/* Scrollbars — thin, dim by default, accent on hover */
-::-webkit-scrollbar { width: 8px; height: 8px; }
+/* Scrollbars — shared app style: thin, dim by default, accent on hover */
+::-webkit-scrollbar {
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+}
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-  background: var(--hover-bg);
+  background: var(--scrollbar-thumb);
   border-radius: var(--radius-sm);
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(var(--accent-primary-rgb), 0.25);
+  background: var(--scrollbar-thumb-hover);
 }
 
 /* Pixelated imagery — mascot + pixel accents only */


### PR DESCRIPTION
## Linked Issue

No linked issue — UX-polish branch curated as a single coherent improvement to overall app feel. Happy to break into per-area issues if preferred before review.

## Summary

Five tightly related improvements to how the app *feels* on macOS:

1. **Native window materials & vibrancy** — translucent panes that read as macOS-native rather than a flat WebView. Commits: `feat: enable native window materials`, `feat: make frontend panes feel more native`, `fix: enable macos private api feature`.

2. **Title-bar polish** — the workspace branch label drags the window without selecting text; clicks on header action buttons no longer accidentally drag; app-icon thumbnails render with neutral backgrounds instead of bright white. Commits: `fix: keep header branch label draggable`, `fix: prevent header branch text selection`, `fix: separate header drag and action regions`, `fix: keep app icon backgrounds neutral`, `fix: start header label window drag`.

3. **No more chat rubber-band** — the chat panel no longer elastically bounces past the top/bottom on macOS WebView. Scroll chaining from nested scrollables (code blocks, thinking blocks, attachment previews, slash-command picker) into the chat scroller works correctly. Commits: `fix: prevent chat scroll rubber band`, `fix: harden chat overscroll guard`, plus the global `* { overscroll-behavior: contain }` removed in `5462d161` after Codex flagged it as breaking scroll chaining.

4. **Scrollbars unified across chat / Monaco / xterm** — same 8px width, themed thumb color (`var(--scrollbar-thumb)`), 4px rounded corners (`var(--radius-sm)`), and 8px right-edge gap on all three surfaces. They scale together with browser zoom (previously the chat used the macOS OS overlay, which doesn't scale, so the three diverged at non-100% zoom). Implementation: a small `OverlayScrollbar.tsx` custom DOM scrollbar component mirroring xterm.js's pattern (track + slider, ResizeObserver + MutationObserver + scroll listener, RAF-coalesced updates, pointer-capture drag, track click-to-page). Monaco's slider was rounded via a `:global` rule (Monaco's theme schema has no slider-radius token).

5. **Click-to-page restored on chat scrollbar** — clicking the chat scrollbar track above or below the slider pages by a viewport-height. Matches native macOS scrollbar + Monaco. Was previously absent because the chat used the OS overlay only.

## Screenshots

Visual changes are subtle (translucent material, scrollbar geometry parity); best appreciated live rather than in screenshots. Will attach a side-by-side scrollbar comparison if requested.

## UAT Plan

- [ ] Resize chat past the viewport — slider appears, sized proportional to viewport/content, draggable
- [ ] Click chat scrollbar track above / below the slider — viewport pages by ~its own height in that direction
- [ ] At 100% zoom, chat / Monaco / xterm sliders look identical (same width, color, radius, right-edge gap)
- [ ] `Cmd+`+`/`-` to zoom the WebView — all three sliders scale together
- [ ] Hover slider — tint changes to `--scrollbar-thumb-hover`
- [ ] Stream a long agent reply — slider updates smoothly, no per-token re-render lag
- [ ] Scroll chat to top / keep scrolling — no rubber-band bounce
- [ ] Scroll a nested code block at its top — wheel chains into the chat scroller (regression check for the global `* { overscroll-behavior: contain }` removal)
- [ ] Drag the workspace branch label — window moves, no text selection
- [ ] Click any header action button — no window drag fires
- [ ] Open Settings / Files / Diff Viewer panels — they still scroll (note: those still use OS overlay scrollbars; extending parity to them is a follow-up — see below)

## Checklist

- [x] CI passes — `bunx tsc -b`, `bun run lint` (0 errors), `bun run lint:css`, `bun run test` (1694/1694)
- [x] New or updated tests cover the changed behaviour — `OverlayScrollbar.test.tsx` (20 tests: render, overflow gating, geometry math, scroll/resize/mutation reactivity, RAF coalescing, drag mapping/clamping, track click-to-page, edge cases, cleanup); `scrollbarConsistency.test.ts` (12 tests: cross-file pin that chat / Monaco / xterm CSS modules all reference the shared `--scrollbar-*` / `--radius-sm` tokens)
- [ ] Documentation updated if public behaviour changed — **intentional N/A**: changes are pure visual/interaction polish, no settings / CLI flags / persisted state introduced. Per CLAUDE.md "Documentation discipline" section, calling out the omission deliberately.
- [x] PR title follows [conventional commit](../CONTRIBUTING.md#commit-conventions) format

## Peer-review notes

Two reviewers (`codex review --base main` and a Claude general-purpose subagent) ran on the branch:

- **Codex** flagged one P2: the global `* { overscroll-behavior: contain }` rule on `theme.css:892` regressed wheel-scroll chaining for nested scrollable widgets and undermined `usePreventScrollBounce`. Addressed in `5462d161` (rule removed; `html, body, #root { overscroll-behavior: none }` and the dedicated bounce-prevention hook are sufficient).
- **Claude subagent** flagged: streaming-token MutationObserver thrash → RAF-coalesced via `scheduleUpdate()` matching `useStickyScroll`'s pattern; missing track click-to-page → added; missing edge-case tests for null `targetRef` and `usableTrack === 0` drag → added. All addressed in `5462d161`.

## Follow-up (out of scope for this PR)

The same WKWebView zoom-drift bug we just fixed for chat / Monaco / xterm exists on every other scrollable surface in the app — sidebar workspace list, right sidebar (files/changes/tasks), file tree, file viewer, diff viewer, settings, command palette, fuzzy finder, modals, several chat sub-pickers (slash-command, file-mention, thinking blocks, attachment previews), dashboard. Extending parity to those surfaces is a separate piece of work — likely lifting `OverlayScrollbar` out of `chat/` into a shared component plus a `useOverlayScrollbar(ref)` hook so other consumers can adopt it without re-implementing positioning. Worth tracking as its own issue.
