### PR TITLE
feat(modals): create new project from within Claudette

### DIFF
--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -418,53 +418,65 @@ pub async fn init_repository(
     let dir = Path::new(&parent_path).join(&name);
     std::fs::create_dir(&dir).map_err(|e| format!("Failed to create directory: {e}"))?;
 
-    let dir_str = dir.to_str().unwrap_or("").to_string();
+    // All error paths from here must clean up the directory we just created.
+    let result = init_repository_inner(&dir, &name, &app, state).await;
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    result
+}
 
+async fn init_repository_inner(
+    dir: &Path,
+    name: &str,
+    app: &AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Repository, String> {
     let init_ok = tokio::process::Command::new("git")
-        .args(["-C", &dir_str, "init", "-b", "main"])
+        .arg("-C")
+        .arg(dir)
+        .args(["init", "-b", "main"])
         .output()
         .await
         .map(|o| o.status.success())
         .unwrap_or(false);
     if !init_ok {
-        let _ = std::fs::remove_dir(&dir);
         return Err("git init failed — is git installed?".to_string());
     }
 
     // Set a repo-local identity so the empty commit succeeds even when the
     // user has no global git config. These values live only in .git/config.
     let _ = tokio::process::Command::new("git")
-        .args([
-            "-C",
-            &dir_str,
-            "config",
-            "user.email",
-            "claudette@localhost",
-        ])
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "user.email", "claudette@localhost"])
         .output()
         .await;
     let _ = tokio::process::Command::new("git")
-        .args(["-C", &dir_str, "config", "user.name", "Claudette"])
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "user.name", "Claudette"])
         .output()
         .await;
 
     let commit_ok = tokio::process::Command::new("git")
-        .args(["-C", &dir_str, "commit", "--allow-empty", "-m", "init"])
+        .arg("-C")
+        .arg(dir)
+        .args(["commit", "--allow-empty", "-m", "init"])
         .output()
         .await
         .map(|o| o.status.success())
         .unwrap_or(false);
     if !commit_ok {
-        let _ = std::fs::remove_dir_all(&dir);
         return Err("Failed to create initial commit".to_string());
     }
 
-    let canon = std::fs::canonicalize(&dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canon = std::fs::canonicalize(dir).map_err(|e| format!("Invalid path: {e}"))?;
     let canon_str = canon.to_string_lossy().to_string();
     let repo_name = canon
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| name.clone());
+        .unwrap_or_else(|| name.to_string());
     let path_slug = slug_from_path(&canon_str);
 
     let repo = Repository {
@@ -487,9 +499,16 @@ pub async fn init_repository(
     };
 
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    db.insert_repository(&repo).map_err(|e| e.to_string())?;
+    db.insert_repository(&repo).map_err(|e| {
+        if is_duplicate_repository_path_error(&e) {
+            "This repository is already in Claudette.".to_string()
+        } else {
+            e.to_string()
+        }
+    })?;
 
-    crate::tray::rebuild_tray(&app);
+    crate::tray::rebuild_tray(app);
+    crate::commands::env::spawn_repo_env_warmup(app.clone(), repo.id.clone());
 
     Ok(repo)
 }

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -403,6 +403,97 @@ pub async fn reorder_repositories(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn init_repository(
+    parent_path: String,
+    name: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<Repository, String> {
+    let name = name.trim().to_string();
+    if name.is_empty() || name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return Err("Invalid project name".to_string());
+    }
+
+    let dir = Path::new(&parent_path).join(&name);
+    std::fs::create_dir(&dir).map_err(|e| format!("Failed to create directory: {e}"))?;
+
+    let dir_str = dir.to_str().unwrap_or("").to_string();
+
+    let init_ok = tokio::process::Command::new("git")
+        .args(["-C", &dir_str, "init", "-b", "main"])
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !init_ok {
+        let _ = std::fs::remove_dir(&dir);
+        return Err("git init failed — is git installed?".to_string());
+    }
+
+    // Set a repo-local identity so the empty commit succeeds even when the
+    // user has no global git config. These values live only in .git/config.
+    let _ = tokio::process::Command::new("git")
+        .args([
+            "-C",
+            &dir_str,
+            "config",
+            "user.email",
+            "claudette@localhost",
+        ])
+        .output()
+        .await;
+    let _ = tokio::process::Command::new("git")
+        .args(["-C", &dir_str, "config", "user.name", "Claudette"])
+        .output()
+        .await;
+
+    let commit_ok = tokio::process::Command::new("git")
+        .args(["-C", &dir_str, "commit", "--allow-empty", "-m", "init"])
+        .output()
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !commit_ok {
+        let _ = std::fs::remove_dir_all(&dir);
+        return Err("Failed to create initial commit".to_string());
+    }
+
+    let canon = std::fs::canonicalize(&dir).map_err(|e| format!("Invalid path: {e}"))?;
+    let canon_str = canon.to_string_lossy().to_string();
+    let repo_name = canon
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| name.clone());
+    let path_slug = slug_from_path(&canon_str);
+
+    let repo = Repository {
+        id: uuid::Uuid::new_v4().to_string(),
+        path: canon_str,
+        name: repo_name,
+        path_slug,
+        icon: None,
+        created_at: now_iso(),
+        setup_script: None,
+        custom_instructions: None,
+        sort_order: 0,
+        branch_rename_preferences: None,
+        setup_script_auto_run: false,
+        archive_script: None,
+        archive_script_auto_run: false,
+        base_branch: Some("main".to_string()),
+        default_remote: None,
+        path_valid: true,
+    };
+
+    let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
+    db.insert_repository(&repo).map_err(|e| e.to_string())?;
+
+    crate::tray::rebuild_tray(&app);
+
+    Ok(repo)
+}
+
 fn slug_from_path(path: &str) -> String {
     Path::new(path)
         .file_name()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -827,6 +827,7 @@ fn main() {
             commands::data::load_initial_data,
             // Repository
             commands::repository::add_repository,
+            commands::repository::init_repository,
             commands::repository::update_repository_settings,
             commands::repository::relink_repository,
             commands::repository::remove_repository,

--- a/src/ui/src/components/modals/AddRepoModal.module.css
+++ b/src/ui/src/components/modals/AddRepoModal.module.css
@@ -1,0 +1,31 @@
+.tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 16px;
+  background: var(--chat-input-bg);
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  padding: 3px;
+}
+
+.tab,
+.tabActive {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: background 0.1s, color 0.1s;
+}
+
+.tab:hover {
+  color: var(--text-primary);
+}
+
+.tabActive {
+  background: var(--selected-bg);
+  color: var(--text-primary);
+}

--- a/src/ui/src/components/modals/AddRepoModal.tsx
+++ b/src/ui/src/components/modals/AddRepoModal.tsx
@@ -101,6 +101,7 @@ export function AddRepoModal() {
     try {
       const repo = await initRepository(parentPath.trim(), projectName.trim());
       addRepo(repo);
+      setDefaultBranches({ ...defaultBranches, [repo.id]: "main" });
       closeModal();
     } catch (e) {
       setError(String(e));

--- a/src/ui/src/components/modals/AddRepoModal.tsx
+++ b/src/ui/src/components/modals/AddRepoModal.tsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "../../stores/useAppStore";
-import { addRepository, getDefaultBranch, discoverWorktrees } from "../../services/tauri";
+import { addRepository, initRepository, getDefaultBranch, discoverWorktrees } from "../../services/tauri";
 import { detectMcpServers } from "../../services/mcp";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
+import styles from "./AddRepoModal.module.css";
+
+type Mode = "open" | "create";
 
 export function AddRepoModal() {
   const { t } = useTranslation("modals");
@@ -15,11 +18,15 @@ export function AddRepoModal() {
   const addRepo = useAppStore((s) => s.addRepository);
   const setDefaultBranches = useAppStore((s) => s.setDefaultBranches);
   const defaultBranches = useAppStore((s) => s.defaultBranches);
+
+  const [mode, setMode] = useState<Mode>("open");
   const [path, setPath] = useState("");
+  const [parentPath, setParentPath] = useState("");
+  const [projectName, setProjectName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleBrowse = async () => {
+  const handleBrowseExisting = async () => {
     try {
       const selected = await open({ directory: true, multiple: false });
       if (selected) {
@@ -31,7 +38,19 @@ export function AddRepoModal() {
     }
   };
 
-  const handleSubmit = async () => {
+  const handleBrowseParent = async () => {
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (selected) {
+        setParentPath(selected);
+        setError(null);
+      }
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handleOpenExisting = async () => {
     if (!path.trim()) return;
     setLoading(true);
     setError(null);
@@ -75,25 +94,92 @@ export function AddRepoModal() {
     }
   };
 
+  const handleCreateNew = async () => {
+    if (!parentPath.trim() || !projectName.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const repo = await initRepository(parentPath.trim(), projectName.trim());
+      addRepo(repo);
+      closeModal();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = mode === "open" ? handleOpenExisting : handleCreateNew;
+  const submitDisabled =
+    loading || (mode === "open" ? !path.trim() : !parentPath.trim() || !projectName.trim());
+
   return (
     <Modal title={t("add_repo_title")} onClose={closeModal}>
-      <div className={shared.field}>
-        <label className={shared.label}>{t("add_repo_path_label")}</label>
-        <div className={shared.inputRow}>
-          <input
-            className={shared.input}
-            value={path}
-            onChange={(e) => setPath(e.target.value)}
-            placeholder={t("add_repo_path_placeholder")}
-            onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
-            autoFocus
-          />
-          <button className={shared.btn} onClick={handleBrowse}>
-            {tCommon("browse")}
-          </button>
-        </div>
-        {error && <div className={shared.error}>{error}</div>}
+      <div className={styles.tabs}>
+        <button
+          className={mode === "open" ? styles.tabActive : styles.tab}
+          onClick={() => { setMode("open"); setError(null); }}
+        >
+          {t("add_repo_tab_open")}
+        </button>
+        <button
+          className={mode === "create" ? styles.tabActive : styles.tab}
+          onClick={() => { setMode("create"); setError(null); }}
+        >
+          {t("add_repo_tab_create")}
+        </button>
       </div>
+
+      {mode === "open" ? (
+        <div className={shared.field}>
+          <label className={shared.label}>{t("add_repo_path_label")}</label>
+          <div className={shared.inputRow}>
+            <input
+              className={shared.input}
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              placeholder={t("add_repo_path_placeholder")}
+              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              autoFocus
+            />
+            <button className={shared.btn} onClick={handleBrowseExisting}>
+              {tCommon("browse")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className={shared.field}>
+            <label className={shared.label}>{t("add_repo_create_location_label")}</label>
+            <div className={shared.inputRow}>
+              <input
+                className={shared.input}
+                value={parentPath}
+                onChange={(e) => setParentPath(e.target.value)}
+                placeholder={t("add_repo_create_location_placeholder")}
+                onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              />
+              <button className={shared.btn} onClick={handleBrowseParent}>
+                {tCommon("browse")}
+              </button>
+            </div>
+          </div>
+          <div className={shared.field}>
+            <label className={shared.label}>{t("add_repo_create_name_label")}</label>
+            <input
+              className={shared.input}
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value)}
+              placeholder={t("add_repo_create_name_placeholder")}
+              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              autoFocus
+            />
+          </div>
+        </>
+      )}
+
+      {error && <div className={shared.error}>{error}</div>}
+
       <div className={shared.actions}>
         <button className={shared.btn} onClick={closeModal}>
           {tCommon("cancel")}
@@ -101,9 +187,11 @@ export function AddRepoModal() {
         <button
           className={shared.btnPrimary}
           onClick={handleSubmit}
-          disabled={loading || !path.trim()}
+          disabled={submitDisabled}
         >
-          {loading ? t("add_repo_adding") : t("add_repo_confirm")}
+          {loading
+            ? mode === "open" ? t("add_repo_adding") : t("add_repo_creating")
+            : mode === "open" ? t("add_repo_confirm") : t("add_repo_create_confirm")}
         </button>
       </div>
     </Modal>

--- a/src/ui/src/locales/en/modals.json
+++ b/src/ui/src/locales/en/modals.json
@@ -5,10 +5,18 @@
   "delete_workspace_confirm": "Delete",
 
   "add_repo_title": "Add repository",
+  "add_repo_tab_open": "Open existing",
+  "add_repo_tab_create": "Create new",
   "add_repo_path_label": "Repository path",
   "add_repo_path_placeholder": "/path/to/repository",
   "add_repo_adding": "Adding...",
   "add_repo_confirm": "Add",
+  "add_repo_create_location_label": "Location",
+  "add_repo_create_location_placeholder": "/path/to/parent/directory",
+  "add_repo_create_name_label": "Project name",
+  "add_repo_create_name_placeholder": "my-project",
+  "add_repo_creating": "Creating...",
+  "add_repo_create_confirm": "Create",
 
   "add_remote_title": "Add remote server",
   "add_remote_conn_label": "Connection string",

--- a/src/ui/src/locales/es/modals.json
+++ b/src/ui/src/locales/es/modals.json
@@ -5,10 +5,18 @@
   "delete_workspace_confirm": "Eliminar",
 
   "add_repo_title": "Añadir repositorio",
+  "add_repo_tab_open": "Abrir existente",
+  "add_repo_tab_create": "Crear nuevo",
   "add_repo_path_label": "Ruta del repositorio",
   "add_repo_path_placeholder": "/path/to/repository",
   "add_repo_adding": "Añadiendo...",
   "add_repo_confirm": "Añadir",
+  "add_repo_create_location_label": "Ubicación",
+  "add_repo_create_location_placeholder": "/ruta/al/directorio",
+  "add_repo_create_name_label": "Nombre del proyecto",
+  "add_repo_create_name_placeholder": "mi-proyecto",
+  "add_repo_creating": "Creando...",
+  "add_repo_create_confirm": "Crear",
 
   "add_remote_title": "Añadir servidor remoto",
   "add_remote_conn_label": "Cadena de conexión",

--- a/src/ui/src/locales/ja/modals.json
+++ b/src/ui/src/locales/ja/modals.json
@@ -5,10 +5,18 @@
   "delete_workspace_confirm": "削除",
 
   "add_repo_title": "リポジトリを追加",
+  "add_repo_tab_open": "既存を開く",
+  "add_repo_tab_create": "新規作成",
   "add_repo_path_label": "リポジトリのパス",
   "add_repo_path_placeholder": "/path/to/repository",
   "add_repo_adding": "追加中...",
   "add_repo_confirm": "追加",
+  "add_repo_create_location_label": "場所",
+  "add_repo_create_location_placeholder": "/parent/directory",
+  "add_repo_create_name_label": "プロジェクト名",
+  "add_repo_create_name_placeholder": "my-project",
+  "add_repo_creating": "作成中...",
+  "add_repo_create_confirm": "作成",
 
   "add_remote_title": "リモートサーバーを追加",
   "add_remote_conn_label": "接続文字列",

--- a/src/ui/src/locales/pt-BR/modals.json
+++ b/src/ui/src/locales/pt-BR/modals.json
@@ -5,10 +5,18 @@
   "delete_workspace_confirm": "Excluir",
 
   "add_repo_title": "Adicionar repositório",
+  "add_repo_tab_open": "Abrir existente",
+  "add_repo_tab_create": "Criar novo",
   "add_repo_path_label": "Caminho do repositório",
   "add_repo_path_placeholder": "/caminho/para/repositorio",
   "add_repo_adding": "Adicionando...",
   "add_repo_confirm": "Adicionar",
+  "add_repo_create_location_label": "Local",
+  "add_repo_create_location_placeholder": "/caminho/para/diretório",
+  "add_repo_create_name_label": "Nome do projeto",
+  "add_repo_create_name_placeholder": "meu-projeto",
+  "add_repo_creating": "Criando...",
+  "add_repo_create_confirm": "Criar",
 
   "add_remote_title": "Adicionar servidor remoto",
   "add_remote_conn_label": "String de conexão",

--- a/src/ui/src/locales/zh-CN/modals.json
+++ b/src/ui/src/locales/zh-CN/modals.json
@@ -5,10 +5,18 @@
   "delete_workspace_confirm": "删除",
 
   "add_repo_title": "添加仓库",
+  "add_repo_tab_open": "打开现有",
+  "add_repo_tab_create": "新建项目",
   "add_repo_path_label": "仓库路径",
   "add_repo_path_placeholder": "/path/to/repository",
   "add_repo_adding": "正在添加...",
   "add_repo_confirm": "添加",
+  "add_repo_create_location_label": "位置",
+  "add_repo_create_location_placeholder": "/parent/directory",
+  "add_repo_create_name_label": "项目名称",
+  "add_repo_create_name_placeholder": "my-project",
+  "add_repo_creating": "正在创建...",
+  "add_repo_create_confirm": "创建",
 
   "add_remote_title": "添加远程服务器",
   "add_remote_conn_label": "连接字符串",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -158,6 +158,10 @@ export function addRepository(path: string): Promise<Repository> {
   return invoke("add_repository", { path });
 }
 
+export function initRepository(parentPath: string, name: string): Promise<Repository> {
+  return invoke("init_repository", { parentPath, name });
+}
+
 export function updateRepositorySettings(
   id: string,
   name: string,


### PR DESCRIPTION
## Summary

- Adds a **Create new** tab to the Add Repository modal alongside the existing **Open existing** tab.
- The Create tab lets the user pick a parent directory and enter a project name, then calls a new `init_repository` backend command that creates the directory, runs `git init -b main`, sets a repo-local git identity, and creates an empty initial commit so the worktree mechanism has a HEAD to branch from.
- The directory is cleaned up on any failure (failed `git init` or failed initial commit).
- Adds the `initRepository` service wrapper in `tauri.ts` and i18n keys across all five supported locales (en, es, ja, pt-BR, zh-CN).
- Registers `init_repository` in the Tauri command handler list alongside `add_repository`.

## Validation

- `cargo fmt --all --check` — passes
- `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — no warnings
- `cd src/ui && bunx tsc -b` — passes
- `cd src/ui && bun run lint` — passes (existing warnings only, no new errors)