### PR TITLE
fix(env-provider): treat missing CLI as unavailable, not error

### DIFF
--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -74,7 +74,7 @@ Bundled env-providers:
 
 Toggle individual providers in **Settings > Plugins**. Each plugin's manifest declares any user-configurable settings — for example, `env-direnv` exposes `auto_allow` to skip the per-path `direnv allow` safeguard if you'd rather trust your own `.envrc` files automatically.
 
-If a bundled provider's required CLI isn't installed (e.g. `nix` missing on a non-Nix host), Claudette marks it **not installed** in the Environment panel and silently skips it on every workspace spawn — no toast, no error. The toggle is locked in this state; install the underlying tool and the provider re-activates on the next workspace switch.
+If a bundled provider's required CLI isn't installed (e.g. `nix` missing on a non-Nix host), Claudette marks it **not installed** in the Environment panel and silently skips it on every workspace spawn — no toast, no error. The toggle is locked in this state. CLI availability is probed once at startup, so if you install the underlying tool while Claudette is running, restart the app to pick up the change.
 
 When Claudette creates a new workspace, it resolves env-providers before the workspace appears as ready. Selecting an existing workspace also performs the same warmup before fresh agent turns or terminal PTYs can start. That first warmup primes tools like `direnv` for the worktree, then setup scripts, terminal tabs, agent subprocesses, and MCP servers inherit the same merged environment.
 

--- a/site/src/content/docs/features/scm-providers.mdx
+++ b/site/src/content/docs/features/scm-providers.mdx
@@ -74,6 +74,8 @@ Bundled env-providers:
 
 Toggle individual providers in **Settings > Plugins**. Each plugin's manifest declares any user-configurable settings — for example, `env-direnv` exposes `auto_allow` to skip the per-path `direnv allow` safeguard if you'd rather trust your own `.envrc` files automatically.
 
+If a bundled provider's required CLI isn't installed (e.g. `nix` missing on a non-Nix host), Claudette marks it **not installed** in the Environment panel and silently skips it on every workspace spawn — no toast, no error. The toggle is locked in this state; install the underlying tool and the provider re-activates on the next workspace switch.
+
 When Claudette creates a new workspace, it resolves env-providers before the workspace appears as ready. Selecting an existing workspace also performs the same warmup before fresh agent turns or terminal PTYs can start. That first warmup primes tools like `direnv` for the worktree, then setup scripts, terminal tabs, agent subprocesses, and MCP servers inherit the same merged environment.
 
 The merged environment is computed once per worktree and reused across processes; if you change `.envrc` or `mise.toml`, terminate the running agent or terminal tab and Claudette picks up the new env on the next spawn.

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -89,6 +89,13 @@ pub struct EnvSourceInfo {
     pub display_name: String,
     pub detected: bool,
     pub enabled: bool,
+    /// True when the plugin's required CLI (e.g. `nix`, `mise`,
+    /// `direnv`) is not on PATH. The dispatcher records this via the
+    /// "unavailable" error marker; we surface it as a dedicated flag
+    /// so the EnvPanel can render a distinct "not installed" badge
+    /// (with the toggle disabled) rather than the generic error
+    /// treatment. See issue #718.
+    pub unavailable: bool,
     pub vars_contributed: usize,
     pub cached: bool,
     /// Milliseconds since the Unix epoch. Frontend formats this
@@ -171,11 +178,20 @@ pub async fn get_env_sources(
                 .cloned()
                 .unwrap_or_else(|| s.plugin_name.clone());
             let enabled = !disabled.contains(&s.plugin_name);
+            // The dispatcher writes `error: Some("unavailable")` to
+            // signal "required CLI isn't on PATH". Promote that to a
+            // dedicated flag and clear the error string so the UI
+            // doesn't render it as a generic provider failure — and
+            // the EnvPanel can disable the toggle with a clear
+            // "Install <cli> to enable" hint instead. See issue #718.
+            let unavailable = s.error.as_deref() == Some("unavailable");
+            let error = if unavailable { None } else { s.error };
             EnvSourceInfo {
                 plugin_name: s.plugin_name,
                 display_name,
                 detected: s.detected,
                 enabled,
+                unavailable,
                 vars_contributed: s.vars_contributed,
                 cached: s.cached,
                 evaluated_at_ms: s
@@ -183,7 +199,7 @@ pub async fn get_env_sources(
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_millis())
                     .unwrap_or(0),
-                error: s.error,
+                error,
             }
         })
         .collect();
@@ -209,6 +225,11 @@ fn prepare_workspace_error(resolved: &claudette::env_provider::ResolvedEnv) -> O
         return Some(format!("Environment setup needed: {summaries}"));
     }
 
+    // "disabled" = user toggled it off (per-repo or globally).
+    // "unavailable" = required CLI not on PATH; bundled env-providers
+    // ship for everyone, so most users won't have all of nix/mise/
+    // direnv installed and that is not a user-actionable error
+    // (issue #718). Both are silent skips at the toast layer.
     let summaries = resolved
         .sources
         .iter()
@@ -216,7 +237,7 @@ fn prepare_workspace_error(resolved: &claudette::env_provider::ResolvedEnv) -> O
             source
                 .error
                 .as_deref()
-                .is_some_and(|error| error != "disabled")
+                .is_some_and(|error| error != "disabled" && error != "unavailable")
         })
         .map(source_error_summary)
         .collect::<Vec<_>>();
@@ -725,6 +746,40 @@ mod tests {
         source.error = Some("disabled".to_string());
         let resolved = ResolvedEnv {
             sources: vec![source],
+            ..Default::default()
+        };
+
+        assert_eq!(prepare_workspace_error(&resolved), None);
+    }
+
+    #[test]
+    fn prepare_workspace_error_ignores_unavailable_sources() {
+        // Regression for issue #718: an env-provider with a missing
+        // required CLI must not produce a workspace-switch toast.
+        let mut source = src("env-nix-devshell");
+        source.error = Some("unavailable".to_string());
+        let resolved = ResolvedEnv {
+            sources: vec![source],
+            ..Default::default()
+        };
+
+        assert_eq!(prepare_workspace_error(&resolved), None);
+    }
+
+    #[test]
+    fn prepare_workspace_error_ignores_mixed_disabled_and_unavailable() {
+        // The common case for a fresh Linux install without nix:
+        // env-direnv detected fine, env-mise was disabled per-repo,
+        // env-nix-devshell is unavailable. None should trigger a toast.
+        let mut direnv = src("env-direnv");
+        direnv.detected = true;
+        direnv.error = None;
+        let mut mise = src("env-mise");
+        mise.error = Some("disabled".to_string());
+        let mut nix = src("env-nix-devshell");
+        nix.error = Some("unavailable".to_string());
+        let resolved = ResolvedEnv {
+            sources: vec![direnv, mise, nix],
             ..Default::default()
         };
 

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -97,6 +97,16 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
     }
 
     fn is_plugin_unavailable(&self, plugin: &str) -> bool {
+        // Re-consent must always surface (#580): if the live manifest
+        // grew a CLI requirement the user hasn't approved, the
+        // dispatcher must NOT swallow that as a silent "not installed"
+        // skip — the user needs to see the prompt regardless of
+        // whether the new tool is on PATH yet. Falling through here
+        // lets `call_operation` return `NeedsReconsent` from the
+        // detect/export call, which `resolve_one` records as an error.
+        if self.registry.needs_reconsent(plugin) {
+            return false;
+        }
         !self.registry.is_cli_available(plugin)
     }
 

--- a/src/env_provider/backend.rs
+++ b/src/env_provider/backend.rs
@@ -39,6 +39,19 @@ pub trait EnvProviderBackend: Send + Sync {
         false
     }
 
+    /// True when the plugin's required CLI (e.g. `nix`, `mise`,
+    /// `direnv`) is not on PATH and so the plugin cannot run. Distinct
+    /// from `is_plugin_disabled` — the user did not turn this off; the
+    /// system simply doesn't have the tool. The dispatcher treats this
+    /// as a silent skip with `error: "unavailable"` rather than letting
+    /// the runtime's `CliNotFound` bubble up to a user-facing toast on
+    /// every workspace switch. See issue #718. Default `false` keeps
+    /// existing callers (including [`mock::MockBackend`] in non-`unavailable`
+    /// tests) on the prior behavior.
+    fn is_plugin_unavailable(&self, _plugin: &str) -> bool {
+        false
+    }
+
     /// Run the plugin's `detect` operation. Returns `true` if the
     /// plugin wants to contribute env for this worktree.
     fn detect(
@@ -81,6 +94,10 @@ impl EnvProviderBackend for PluginRegistryBackend<'_> {
 
     fn is_plugin_disabled(&self, plugin: &str) -> bool {
         self.registry.is_disabled(plugin)
+    }
+
+    fn is_plugin_unavailable(&self, plugin: &str) -> bool {
+        !self.registry.is_cli_available(plugin)
     }
 
     async fn detect(
@@ -187,6 +204,10 @@ pub(crate) mod mock {
         pub calls: Mutex<HashMap<String, (usize, usize)>>,
         /// Plugin names that should report as globally disabled.
         pub globally_disabled: std::collections::HashSet<String>,
+        /// Plugin names whose required CLI is not on PATH. Surfaced via
+        /// [`EnvProviderBackend::is_plugin_unavailable`]; the dispatcher
+        /// then short-circuits the same way it does for `disabled`.
+        pub unavailable: std::collections::HashSet<String>,
     }
 
     impl MockBackend {
@@ -197,11 +218,17 @@ pub(crate) mod mock {
                 export_results: HashMap::new(),
                 calls: Mutex::new(HashMap::new()),
                 globally_disabled: std::collections::HashSet::new(),
+                unavailable: std::collections::HashSet::new(),
             }
         }
 
         pub fn with_globally_disabled(mut self, name: &str) -> Self {
             self.globally_disabled.insert(name.to_string());
+            self
+        }
+
+        pub fn with_unavailable(mut self, name: &str) -> Self {
+            self.unavailable.insert(name.to_string());
             self
         }
 
@@ -243,6 +270,10 @@ pub(crate) mod mock {
 
         fn is_plugin_disabled(&self, plugin: &str) -> bool {
             self.globally_disabled.contains(plugin)
+        }
+
+        fn is_plugin_unavailable(&self, plugin: &str) -> bool {
+            self.unavailable.contains(plugin)
         }
 
         async fn detect(

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -302,6 +302,26 @@ pub async fn resolve_for_workspace(
             });
             continue;
         }
+        // "Unavailable" means the plugin's required CLI (e.g. `nix`,
+        // `mise`, `direnv`) is not on PATH. Bundled env-providers ship
+        // for every user — most won't have all three CLIs installed —
+        // so this is the canonical "doesn't apply, skip silently"
+        // signal, NOT a hard error. We treat it like `disabled`
+        // (drop cache, record reason, no toast) but use a distinct
+        // marker so the EnvPanel can render "not installed" instead
+        // of "disabled". See issue #718.
+        if backend.is_plugin_unavailable(&name) {
+            cache.invalidate(worktree, Some(&name));
+            sources.push(ResolvedSource {
+                plugin_name: name,
+                detected: false,
+                vars_contributed: 0,
+                cached: false,
+                evaluated_at: SystemTime::now(),
+                error: Some("unavailable".to_string()),
+            });
+            continue;
+        }
         let source = resolve_one(backend, cache, &name, worktree, ws_info, &mut merged).await;
         sources.push(source);
     }
@@ -1018,6 +1038,131 @@ mod tests {
         // Sanity: still valid UTF-8 (push to String would have panicked
         // if the cut landed mid-char).
         assert!(s.is_char_boundary(s.len()));
+    }
+
+    #[tokio::test]
+    async fn unavailable_provider_is_skipped_silently() {
+        // Regression for issue #718: an env-provider whose required CLI
+        // is not on PATH must skip with `error: "unavailable"` rather
+        // than letting `CliNotFound` bubble up as a noisy toast.
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = MockBackend::new()
+            .with_plugin("env-nix-devshell")
+            .with_unavailable("env-nix-devshell")
+            // Even if detect were Ok(true), it must not run for an
+            // unavailable plugin — assert call counts below.
+            .detects("env-nix-devshell", true);
+        let cache = EnvCache::new();
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+
+        let (detects, exports) = backend.call_counts("env-nix-devshell");
+        assert_eq!(detects, 0, "unavailable provider must not run detect");
+        assert_eq!(exports, 0, "unavailable provider must not run export");
+        assert_eq!(resolved.sources.len(), 1);
+        assert_eq!(resolved.sources[0].error.as_deref(), Some("unavailable"));
+        assert!(!resolved.sources[0].detected);
+    }
+
+    #[tokio::test]
+    async fn unavailable_provider_evicts_stale_cache() {
+        // If the user had the CLI installed last session and we cached
+        // an export, then uninstalled it, the next resolve must drop
+        // that cache entry instead of leaking stale env vars.
+        let tmp = tempfile::tempdir().unwrap();
+        let envrc = tmp.path().join(".envrc");
+        std::fs::write(&envrc, "x").unwrap();
+        let cache = EnvCache::new();
+        cache.put(
+            tmp.path(),
+            "env-direnv",
+            &export_of(&[("STALE", Some("yes"))], vec![envrc.clone()]),
+        );
+        assert!(cache.get_fresh(tmp.path(), "env-direnv").is_some());
+
+        let backend = MockBackend::new()
+            .with_plugin("env-direnv")
+            .with_unavailable("env-direnv");
+        let resolved = resolve_for_workspace(
+            &backend,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+
+        assert!(resolved.vars.is_empty());
+        assert_eq!(resolved.sources[0].error.as_deref(), Some("unavailable"));
+        assert!(
+            cache.get_fresh(tmp.path(), "env-direnv").is_none(),
+            "unavailable must invalidate any cached export"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_with_registry_treats_missing_cli_as_unavailable() {
+        // End-to-end through the real PluginRegistry: a manifest that
+        // requires a CLI which is guaranteed-not-on-PATH should resolve
+        // to `error: "unavailable"`, not `error: "detect: CLI tool ...
+        // is not installed"`. Without this, every workspace switch
+        // toasts for users without nix/mise/direnv installed.
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_dir = tempfile::tempdir().unwrap();
+        let pdir = plugin_dir.path().join("env-fakecli");
+        std::fs::create_dir_all(&pdir).unwrap();
+        std::fs::write(
+            pdir.join("plugin.json"),
+            r#"{
+                "name": "env-fakecli",
+                "display_name": "Fake CLI",
+                "version": "1.0.0",
+                "description": "test",
+                "kind": "env-provider",
+                "operations": ["detect", "export"],
+                "required_clis": ["claudette-test-definitely-not-on-path"]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            pdir.join("init.lua"),
+            r#"
+            local M = {}
+            function M.detect() return true end
+            function M.export() return { env = {}, watched = {} } end
+            return M
+            "#,
+        )
+        .unwrap();
+
+        let registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+        // Sanity: the plugin loaded, but its CLI was not found.
+        assert!(registry.plugins.contains_key("env-fakecli"));
+        assert!(!registry.is_cli_available("env-fakecli"));
+
+        let cache = EnvCache::new();
+        let resolved = resolve_with_registry(
+            &registry,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+
+        let source = resolved
+            .sources
+            .iter()
+            .find(|s| s.plugin_name == "env-fakecli")
+            .expect("plugin must appear in sources");
+        assert_eq!(source.error.as_deref(), Some("unavailable"));
+        assert!(!source.detected);
     }
 
     #[tokio::test]

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -1166,6 +1166,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unavailable_does_not_swallow_pending_reconsent() {
+        // Codex peer review: a community env-provider whose live
+        // manifest grew an unapproved CLI requirement which is ALSO
+        // not on PATH must still surface re-consent, not silently
+        // disappear as "not installed". The dispatcher should fall
+        // through to call_operation, which returns NeedsReconsent and
+        // bubbles up as an error in the resolved source.
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_dir = tempfile::tempdir().unwrap();
+        let pdir = plugin_dir.path().join("env-community");
+        std::fs::create_dir_all(&pdir).unwrap();
+        // Discovery sees an empty required_clis (so cli_available =
+        // true) and a community .install_meta.json. We then mutate
+        // the manifest in-place to simulate post-install drift that
+        // grew a CLI requirement, mirroring the existing reconsent
+        // tests in plugin_runtime::mod.rs.
+        std::fs::write(
+            pdir.join("plugin.json"),
+            r#"{
+                "name": "env-community",
+                "display_name": "Community env",
+                "version": "1.0.0",
+                "description": "test",
+                "kind": "env-provider",
+                "operations": ["detect", "export"]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            pdir.join("init.lua"),
+            r#"
+            local M = {}
+            function M.detect() return true end
+            function M.export() return { env = {}, watched = {} } end
+            return M
+            "#,
+        )
+        .unwrap();
+        let empty_grants: Vec<String> = Vec::new();
+        let meta = serde_json::json!({
+            "source": "community",
+            "kind": "plugin:env-provider",
+            "registry_sha": "0".repeat(40),
+            "contribution_sha": "1".repeat(40),
+            "sha256": "2".repeat(64),
+            "installed_at": "2026-05-02T00:00:00Z",
+            "granted_capabilities": empty_grants,
+            "version": "1.0.0",
+        });
+        std::fs::write(
+            pdir.join(".install_meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+
+        let mut registry = crate::plugin_runtime::PluginRegistry::discover(plugin_dir.path());
+        // Drift: manifest now requires a CLI the user never granted,
+        // and that same CLI is not on PATH. Without the reconsent
+        // guard this would resolve as "unavailable" and hide the
+        // capability-grant prompt entirely.
+        let plugin = registry.plugins.get_mut("env-community").unwrap();
+        plugin.manifest.required_clis = vec!["claudette-test-not-on-path".to_string()];
+        plugin.cli_available = false;
+
+        assert!(registry.needs_reconsent("env-community"));
+        assert!(!registry.is_cli_available("env-community"));
+
+        let cache = EnvCache::new();
+        let resolved = resolve_with_registry(
+            &registry,
+            &cache,
+            tmp.path(),
+            &ws_info(),
+            &Default::default(),
+        )
+        .await;
+        let source = resolved
+            .sources
+            .iter()
+            .find(|s| s.plugin_name == "env-community")
+            .expect("plugin must appear in sources");
+        // Must NOT be the silent "unavailable" skip — the runtime's
+        // re-consent error must propagate so the user sees it.
+        assert_ne!(source.error.as_deref(), Some("unavailable"));
+        let err = source.error.as_deref().expect("must surface an error");
+        assert!(
+            err.contains("re-consent") || err.contains("Reconsent") || err.contains("reconsent"),
+            "expected reconsent error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn resolve_with_registry_treats_globally_disabled_as_disabled() {
         // Regression guard for the UAT finding: globally-disabled plugins
         // used to surface as `detect` errors with "Plugin '...' is

--- a/src/env_provider/mod.rs
+++ b/src/env_provider/mod.rs
@@ -1117,19 +1117,22 @@ mod tests {
         let plugin_dir = tempfile::tempdir().unwrap();
         let pdir = plugin_dir.path().join("env-fakecli");
         std::fs::create_dir_all(&pdir).unwrap();
-        std::fs::write(
-            pdir.join("plugin.json"),
-            r#"{
-                "name": "env-fakecli",
-                "display_name": "Fake CLI",
-                "version": "1.0.0",
-                "description": "test",
-                "kind": "env-provider",
-                "operations": ["detect", "export"],
-                "required_clis": ["claudette-test-definitely-not-on-path"]
-            }"#,
-        )
-        .unwrap();
+        // Generate a UUID-suffixed CLI name so the test stays
+        // deterministic even on (admittedly unlikely) machines where
+        // a binary with our hardcoded sentinel name happens to exist.
+        // No image we ship to / build on uses uuid-suffixed names, so
+        // collision is mathematically impossible here.
+        let fake_cli = format!("claudette-test-{}", uuid::Uuid::new_v4());
+        let manifest = serde_json::json!({
+            "name": "env-fakecli",
+            "display_name": "Fake CLI",
+            "version": "1.0.0",
+            "description": "test",
+            "kind": "env-provider",
+            "operations": ["detect", "export"],
+            "required_clis": [fake_cli],
+        });
+        std::fs::write(pdir.join("plugin.json"), manifest.to_string()).unwrap();
         std::fs::write(
             pdir.join("init.lua"),
             r#"

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -358,9 +358,9 @@ impl PluginRegistry {
 
     /// Whether the plugin's `manifest.required_clis` were all on PATH at
     /// registry discovery. Returns `true` for unknown plugin names so
-    /// the CLI-availability check is not the surface that surfaces
-    /// "missing plugin" errors — `call_operation` already does that with
-    /// a clearer error.
+    /// this method isn't the place that reports "missing plugin"
+    /// errors — `call_operation` already does that with a clearer
+    /// `PluginNotFound` error.
     ///
     /// Used by the env-provider dispatcher to treat an env-provider
     /// whose CLI is missing as "skip silently" rather than as a hard

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -375,6 +375,28 @@ impl PluginRegistry {
             .unwrap_or(true)
     }
 
+    /// Whether the plugin's live manifest declares `required_clis`
+    /// that the user-approved `granted_capabilities` does not cover.
+    /// Returns `false` for unknown plugins, bundled plugins, and
+    /// pre-redesign user-installed plugins (`PluginTrust::Unknown`).
+    /// Non-zero only for community plugins whose post-install manifest
+    /// grew a CLI requirement that the user hasn't yet approved.
+    ///
+    /// Dispatchers that soft-skip on `is_cli_available` (env-provider)
+    /// must consult this *first*: a community plugin that needs
+    /// re-consent and is also missing its CLI should still surface the
+    /// re-consent prompt, not vanish silently as "not installed".
+    pub fn needs_reconsent(&self, plugin_name: &str) -> bool {
+        self.plugins
+            .get(plugin_name)
+            .map(|p| {
+                !p.trust
+                    .missing_capabilities(&p.manifest.required_clis)
+                    .is_empty()
+            })
+            .unwrap_or(false)
+    }
+
     /// Execute an operation on a plugin.
     ///
     /// Creates a fresh Lua VM, loads the plugin script, calls the specified

--- a/src/plugin_runtime/mod.rs
+++ b/src/plugin_runtime/mod.rs
@@ -356,6 +356,25 @@ impl PluginRegistry {
         self.disabled.read().unwrap().contains(plugin_name)
     }
 
+    /// Whether the plugin's `manifest.required_clis` were all on PATH at
+    /// registry discovery. Returns `true` for unknown plugin names so
+    /// the CLI-availability check is not the surface that surfaces
+    /// "missing plugin" errors — `call_operation` already does that with
+    /// a clearer error.
+    ///
+    /// Used by the env-provider dispatcher to treat an env-provider
+    /// whose CLI is missing as "skip silently" rather than as a hard
+    /// error (issue #718). For SCM plugins the existing
+    /// `cli_available`-gated `CliNotFound` short-circuit in
+    /// `call_operation` still applies — only consumers that explicitly
+    /// query this method get the soft-skip behavior.
+    pub fn is_cli_available(&self, plugin_name: &str) -> bool {
+        self.plugins
+            .get(plugin_name)
+            .map(|p| p.cli_available)
+            .unwrap_or(true)
+    }
+
     /// Execute an operation on a plugin.
     ///
     /// Creates a fresh Lua VM, loads the plugin script, calls the specified

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -122,15 +122,19 @@ function stateBadge(source: EnvSourceInfo): string {
  * never claim it's a specific tool we don't know about.
  */
 function unavailableTooltip(pluginName: string): string {
+  // CLI availability is probed once at PluginRegistry discovery; the
+  // user has to restart Claudette to pick up a newly-installed tool.
+  // Be explicit so the toggle's tooltip doesn't promise live recovery.
+  const restartHint = "Install it and restart Claudette to enable this provider.";
   switch (pluginName) {
     case "env-nix-devshell":
-      return "Install `nix` to enable this provider.";
+      return `Install \`nix\` and restart Claudette to enable this provider.`;
     case "env-mise":
-      return "Install `mise` to enable this provider.";
+      return `Install \`mise\` and restart Claudette to enable this provider.`;
     case "env-direnv":
-      return "Install `direnv` to enable this provider.";
+      return `Install \`direnv\` and restart Claudette to enable this provider.`;
     default:
-      return "The required CLI for this provider is not on PATH. Install it to enable.";
+      return `The required CLI for this provider is not on PATH. ${restartHint}`;
   }
 }
 
@@ -385,9 +389,10 @@ export function EnvPanel({ target }: EnvPanelProps) {
           const isOpen = expanded.has(source.plugin_name);
           // Treat the toggle as locked-off while unavailable: visually
           // off, non-actionable, and tooltip points at the fix
-          // (install the missing CLI). Persisting the user's intent
-          // separately from system capability means re-installing the
-          // CLI auto-recovers without forcing them to re-toggle.
+          // (install the missing CLI, then restart Claudette to
+          // re-probe PATH). The per-repo `enabled` setting is left
+          // untouched so the user's intent survives the install +
+          // restart cycle without forcing them to re-toggle.
           const toggleOn = source.enabled && !source.unavailable;
           const toggleDisabled = !resolvedOnce || source.unavailable;
           const toggleTitle = source.unavailable

--- a/src/ui/src/components/settings/sections/EnvPanel.tsx
+++ b/src/ui/src/components/settings/sections/EnvPanel.tsx
@@ -93,9 +93,10 @@ function trustablePluginFromError(
  *   green  — active + fresh eval
  *   blue   — active + cache hit (same semantic as MCP "connected")
  *   red    — error (direnv blocked, mise untrusted, flake eval failed)
- *   dim    — not detected (plugin's detect() returned false) OR disabled
+ *   dim    — not detected, disabled, OR required CLI not installed
  */
 function stateColor(source: EnvSourceInfo): string {
+  if (source.unavailable) return "var(--text-faint)";
   if (!source.enabled) return "var(--text-faint)";
   if (source.error) return "var(--status-stopped)";
   if (!source.detected) return "var(--text-faint)";
@@ -103,10 +104,34 @@ function stateColor(source: EnvSourceInfo): string {
 }
 
 function stateBadge(source: EnvSourceInfo): string {
+  // "not installed" is a system-capability state — distinct from
+  // "disabled" (user toggled off) so users know whether the fix is
+  // toggling Claudette or installing the underlying tool.
+  if (source.unavailable) return "not installed";
   if (!source.enabled) return "disabled";
   if (source.error) return "error";
   if (!source.detected) return "not detected";
   return source.cached ? "cached" : "fresh";
+}
+
+/**
+ * Required-CLI hint per bundled provider — names the tool the user
+ * needs to install for the plugin to apply. Returned as the toggle's
+ * tooltip when the plugin is in the `unavailable` state. Generic
+ * fallback for third-party providers names "the required CLI" so we
+ * never claim it's a specific tool we don't know about.
+ */
+function unavailableTooltip(pluginName: string): string {
+  switch (pluginName) {
+    case "env-nix-devshell":
+      return "Install `nix` to enable this provider.";
+    case "env-mise":
+      return "Install `mise` to enable this provider.";
+    case "env-direnv":
+      return "Install `direnv` to enable this provider.";
+    default:
+      return "The required CLI for this provider is not on PATH. Install it to enable.";
+  }
 }
 
 function formatRelativeTime(ms: number): string {
@@ -202,6 +227,11 @@ export function EnvPanel({ target }: EnvPanelProps) {
               display_name: p.display_name,
               detected: false,
               enabled: true,
+              // Placeholder rows pre-resolve. The real resolve fills in
+              // the actual unavailable state from the registry's CLI
+              // probe; until then assume installed so we don't flicker
+              // a "not installed" badge for a tool the user does have.
+              unavailable: false,
               vars_contributed: 0,
               cached: false,
               evaluated_at_ms: 0,
@@ -344,9 +374,27 @@ export function EnvPanel({ target }: EnvPanelProps) {
 
       <div className={styles.mcpList}>
         {sources.map((source) => {
+          // `unavailable` is a system-capability state — the plugin's
+          // CLI isn't on PATH, so there is no error to expand and the
+          // toggle is meaningless until the user installs the tool.
           const hasError =
-            source.enabled && !!source.error && source.error !== "disabled";
+            source.enabled &&
+            !source.unavailable &&
+            !!source.error &&
+            source.error !== "disabled";
           const isOpen = expanded.has(source.plugin_name);
+          // Treat the toggle as locked-off while unavailable: visually
+          // off, non-actionable, and tooltip points at the fix
+          // (install the missing CLI). Persisting the user's intent
+          // separately from system capability means re-installing the
+          // CLI auto-recovers without forcing them to re-toggle.
+          const toggleOn = source.enabled && !source.unavailable;
+          const toggleDisabled = !resolvedOnce || source.unavailable;
+          const toggleTitle = source.unavailable
+            ? unavailableTooltip(source.plugin_name)
+            : !resolvedOnce
+              ? "Resolving environment providers…"
+              : undefined;
           return (
             <div key={source.plugin_name}>
               <div className={styles.mcpRow}>
@@ -357,20 +405,32 @@ export function EnvPanel({ target }: EnvPanelProps) {
                     title={stateBadge(source)}
                   />
                   <span
-                    className={`${styles.mcpName} ${!source.enabled ? styles.mcpNameDisabled : ""}`}
+                    className={`${styles.mcpName} ${!source.enabled || source.unavailable ? styles.mcpNameDisabled : ""}`}
                   >
                     {source.display_name}
                   </span>
-                  <span className={styles.mcpBadge}>{stateBadge(source)}</span>
-                  {source.enabled && source.detected && !source.error && (
-                    <span className={styles.settingDescription}>
-                      {source.vars_contributed} var
-                      {source.vars_contributed === 1 ? "" : "s"}
-                      {source.evaluated_at_ms > 0 && (
-                        <> · {formatRelativeTime(source.evaluated_at_ms)}</>
-                      )}
-                    </span>
-                  )}
+                  <span
+                    className={styles.mcpBadge}
+                    title={
+                      source.unavailable
+                        ? unavailableTooltip(source.plugin_name)
+                        : undefined
+                    }
+                  >
+                    {stateBadge(source)}
+                  </span>
+                  {source.enabled &&
+                    !source.unavailable &&
+                    source.detected &&
+                    !source.error && (
+                      <span className={styles.settingDescription}>
+                        {source.vars_contributed} var
+                        {source.vars_contributed === 1 ? "" : "s"}
+                        {source.evaluated_at_ms > 0 && (
+                          <> · {formatRelativeTime(source.evaluated_at_ms)}</>
+                        )}
+                      </span>
+                    )}
                 </div>
                 <div className={styles.mcpActions}>
                   {hasError && (
@@ -385,19 +445,15 @@ export function EnvPanel({ target }: EnvPanelProps) {
                   )}
                   <button
                     type="button"
-                    className={`${styles.mcpToggle} ${source.enabled ? styles.mcpToggleOn : ""}`}
+                    className={`${styles.mcpToggle} ${toggleOn ? styles.mcpToggleOn : ""}`}
                     onClick={() =>
                       handleToggle(source.plugin_name, !source.enabled)
                     }
                     role="switch"
-                    aria-checked={source.enabled}
-                    aria-label={`${source.enabled ? "Disable" : "Enable"} ${source.display_name}`}
-                    disabled={!resolvedOnce}
-                    title={
-                      !resolvedOnce
-                        ? "Resolving environment providers…"
-                        : undefined
-                    }
+                    aria-checked={toggleOn}
+                    aria-label={`${toggleOn ? "Disable" : "Enable"} ${source.display_name}`}
+                    disabled={toggleDisabled}
+                    title={toggleTitle}
                   >
                     <span className={styles.mcpToggleKnob} />
                   </button>

--- a/src/ui/src/types/env.ts
+++ b/src/ui/src/types/env.ts
@@ -24,6 +24,14 @@ export interface EnvSourceInfo {
   detected: boolean;
   /** Whether the user has this provider enabled for the workspace's repo. */
   enabled: boolean;
+  /**
+   * True when the plugin's required CLI (e.g. `nix`, `mise`, `direnv`)
+   * is not on PATH. Distinct from `enabled` (user intent) and `error`
+   * (runtime failure): the system can't run this provider until the
+   * tool is installed. The toggle is locked off in this state. See
+   * GitHub issue 718.
+   */
+  unavailable: boolean;
   /** How many env vars this plugin contributed to the merged result. */
   vars_contributed: number;
   /** `true` when this plugin's contribution came from the mtime cache. */


### PR DESCRIPTION
Closes #718.

## Symptom

Every workspace switch fired a toast for users without one of the bundled env-provider CLIs (`nix`, `mise`, `direnv`) on PATH:

> Workspace environment failed: Environment provider failed: env-nix-devshell: detect: CLI tool 'nix' is not installed

Most visible to non-Nix Linux users; reproduces consistently regardless of whether the plugin is toggled off in **Settings → Plugins**, because the per-repo \`disabled\` set is what the dispatcher's silent-skip path checks against.

## Root cause

The plugin runtime preflights \`manifest.required_clis\` against PATH once at registry init and caches the result in \`LoadedPlugin.cli_available\` (\`src/plugin_runtime/mod.rs:240\`). On every \`call_operation\`, the runtime short-circuits with \`PluginError::CliNotFound\` before \`init.lua\` is even read. For SCM plugins this is correct — \`gh\`/\`glab\` is essential — but env-providers ship for everyone with the model \"many bundled providers, each one self-skips when it doesn't apply.\" \`env-nix-devshell\`'s \`detect\` is a pure-filesystem check (\`flake.nix\` / \`shell.nix\` existence) and would never need to call \`nix\`, but it never gets the chance.

The \`CliNotFound\` then bubbled up through \`resolve_one\` as a stringified error and \`prepare_workspace_error\` collected it into the workspace-prep toast.

## Fix

Introduce a third state — **\`unavailable\`** — distinct from \`disabled\` (user intent) and \`error\` (runtime failure):

- **\`PluginRegistry::is_cli_available()\`** exposes the discovery-time PATH probe.
- **\`PluginRegistry::needs_reconsent()\`** wraps \`PluginTrust::missing_capabilities\` so the dispatcher can keep #580's fail-closed re-consent flow intact.
- **\`EnvProviderBackend::is_plugin_unavailable()\`** (default \`false\`) lets the env-provider dispatcher silently skip plugins whose CLI is missing, evict stale cache, and record \`error: \"unavailable\"\` in the resolved source. The production impl returns \`false\` when re-consent is pending, so a community plugin whose manifest grew an unapproved CLI requirement still surfaces the consent prompt instead of vanishing as \"not installed\".
- **\`prepare_workspace_error\`** filters \`\"unavailable\"\` alongside \`\"disabled\"\` — no toast.
- **\`EnvSourceInfo\`** gains an \`unavailable: bool\` field; **EnvPanel** renders a dim \"not installed\" badge with the toggle locked off and a tooltip that names the missing tool (\`Install \\\`nix\\\` and restart Claudette to enable…\`). The error string is cleared at the IPC boundary so the UI doesn't render the marker as a generic provider failure.

CLI availability is probed once at \`PluginRegistry::discover\`, not per-resolve, so installing the tool later requires a Claudette restart — the docs, tooltip, and inline comments all say so explicitly. Re-probing on every workspace switch would add PATH lookups to a hot path and is out of scope.

SCM plugins keep the existing \"missing CLI = hard error\" semantics; the SCM consumer (\`src/scm/\`) doesn't go through \`resolve_with_registry\`, so the change is naturally scoped.

## Tests

- \`env_provider::tests::unavailable_provider_is_skipped_silently\` — \`MockBackend.with_unavailable()\` confirms detect/export are not called.
- \`env_provider::tests::unavailable_provider_evicts_stale_cache\` — uninstalling the CLI between sessions drops cached env vars instead of leaking them.
- \`env_provider::tests::resolve_with_registry_treats_missing_cli_as_unavailable\` — end-to-end through the real \`PluginRegistry\` with a manifest declaring a guaranteed-not-on-PATH CLI; pins the \`cli_available\` → dispatcher seam.
- \`env_provider::tests::unavailable_does_not_swallow_pending_reconsent\` — community plugin with empty \`granted_capabilities\` and post-install manifest drift surfaces re-consent rather than the silent \"unavailable\" marker (Codex peer-review finding).
- \`commands::env::tests::prepare_workspace_error_ignores_unavailable_sources\` and \`prepare_workspace_error_ignores_mixed_disabled_and_unavailable\` — pin the toast-filter behavior.

## Verification

- \`cargo test -p claudette -p claudette-server -p claudette-cli --all-features\` → 1057 passed, 1 ignored
- \`cargo clippy ... -- -Dwarnings\` → clean
- \`cargo fmt --all --check\` → clean
- \`bunx tsc -b\` → clean
- \`bun run test\` → 1733 passed
- \`bun run lint:css\` → clean
- \`bun run lint\` → only pre-existing warnings, none from these files

## Docs

\`site/src/content/docs/features/scm-providers.mdx\` describes the new state and the restart requirement.