### PR TITLE
feat(chat): collapsible file-change summary with syntax highlighting

### DIFF
--- a/site/src/content/docs/features/diff-viewer.mdx
+++ b/site/src/content/docs/features/diff-viewer.mdx
@@ -29,7 +29,7 @@ The removed version on the left, the added version on the right. Corresponding c
 
 The **right sidebar** (`⌘/Ctrl + D` to toggle) displays a list of all files that have been changed in the current workspace. Click any file to jump to its diff.
 
-When the agent edits files, the chat timeline also shows a compact change summary: live edit tool calls include the file path plus added/removed line counts, and the completed turn ends with a per-file summary card. Click a file in the card to expand a lightweight inline diff preview, then open the diff panel for full review.
+When the agent edits files, the chat timeline also shows a compact change summary: live edit tool calls include the file path plus added/removed line counts, and the completed turn ends with a collapsible per-file summary card. Click the "N files changed" header to expand the file list, then click any file row to see a lightweight inline diff preview. Open the diff panel for a full review.
 
 ## Change Groups
 

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -498,13 +498,27 @@
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
-  border-bottom: 1px solid var(--divider);
+  width: 100%;
+  background: none;
+  border: none;
+  border-bottom: 1px solid transparent;
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.turnEditSummaryHeader[aria-expanded="true"] {
+  border-bottom-color: var(--divider);
+}
+
+.turnEditSummaryHeader:hover {
+  background: var(--bg-hover);
 }
 
 .turnEditSummaryTitle {
+  flex: 1;
   min-width: 0;
 }
 
@@ -599,7 +613,9 @@
 }
 
 .turnEditDiffPreview {
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 320px;
   border-top: 1px solid var(--divider);
   background: var(--chat-bg);
   font-family: var(--font-mono);
@@ -769,7 +785,7 @@
 @keyframes editDiffReveal {
   from {
     opacity: 0;
-    transform: translateY(-3px);
+    transform: translateY(3px);
   }
   to {
     opacity: 1;

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -299,14 +299,14 @@ export function ChatPanel() {
   );
 
   // Sticky scroll: auto-follow when at bottom, stop when user scrolls up.
-  const { isAtBottom, scrollToBottom, handleContentChanged } =
+  const { isAtBottom, scrollToBottom, handleContentChanged, suppressNextAutoScrollRef } =
     useStickyScroll(messagesContainerRef);
   usePreventScrollBounce(messagesContainerRef);
 
   // Memoize context value to avoid re-rendering StreamingMessage on every parent render.
   const scrollContextValue = useMemo(
-    () => ({ handleContentChanged }),
-    [handleContentChanged],
+    () => ({ handleContentChanged, suppressNextAutoScrollRef }),
+    [handleContentChanged, suppressNextAutoScrollRef],
   );
 
   // Elapsed timer for running agent.

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -1,6 +1,7 @@
 import { memo, useContext, useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp, FilePenLine, Pencil } from "lucide-react";
 import { relativizePath } from "../../hooks/toolSummary";
+import { bootstrapGrammarRegistry } from "../../utils/grammarRegistry";
 import { getCachedHighlight, highlightCode } from "../../utils/highlight";
 import { languageForFile } from "../../utils/languageForFile";
 import { HighlightedPlainText } from "./HighlightedPlainText";
@@ -72,6 +73,17 @@ export function TurnEditSummaryCard({
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const [previewByFile, setPreviewByFile] = useState<Record<string, PreviewState>>({});
   const [cacheVersion, setCacheVersion] = useState(0);
+  // Plugin grammars register at startup; re-render once they're ready so
+  // `languageForFile` resolves plugin-contributed extensions correctly.
+  // Mirrors the same pattern used in DiffViewer.tsx.
+  const [grammarsReady, setGrammarsReady] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void bootstrapGrammarRegistry().then(() => {
+      if (!cancelled) setGrammarsReady(true);
+    });
+    return () => { cancelled = true; };
+  }, []);
   // In-flight tracker so rapid clicks before state commits can't fan
   // out duplicate `onLoadPreview` calls. A ref (not state) so the
   // check is synchronous — React Strict-Mode-safe and not re-run by
@@ -105,7 +117,10 @@ export function TurnEditSummaryCard({
     return () => {
       cancelled = true;
     };
-  }, [expandedFile, previewByFile, summary.files]);
+  // grammarsReady isn't used directly but its presence in the dep array
+  // causes the prewarm to re-run once plugin grammars finish loading.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedFile, previewByFile, summary.files, grammarsReady]);
 
   const toggleFile = (file: EditFileStat) => {
     const isOpening = expandedFile !== file.filePath;

--- a/src/ui/src/components/chat/EditChangeSummary.tsx
+++ b/src/ui/src/components/chat/EditChangeSummary.tsx
@@ -1,8 +1,11 @@
-import { useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Pencil, SquareArrowOutUpRight } from "lucide-react";
+import { memo, useContext, useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronUp, FilePenLine, Pencil } from "lucide-react";
 import { relativizePath } from "../../hooks/toolSummary";
+import { getCachedHighlight, highlightCode } from "../../utils/highlight";
+import { languageForFile } from "../../utils/languageForFile";
 import { HighlightedPlainText } from "./HighlightedPlainText";
 import type { EditFileStat, EditPreviewLine, EditSummary } from "./editActivitySummary";
+import { ScrollContext } from "./ScrollContext";
 import styles from "./ChatPanel.module.css";
 
 type PreviewState =
@@ -65,16 +68,55 @@ export function TurnEditSummaryCard({
    *  available). */
   onOpenFile?: (filePath: string) => void;
 }) {
+  const [listExpanded, setListExpanded] = useState(false);
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const [previewByFile, setPreviewByFile] = useState<Record<string, PreviewState>>({});
+  const [cacheVersion, setCacheVersion] = useState(0);
   // In-flight tracker so rapid clicks before state commits can't fan
   // out duplicate `onLoadPreview` calls. A ref (not state) so the
   // check is synchronous — React Strict-Mode-safe and not re-run by
   // a state-updater double-invoke.
   const inFlightRef = useRef<Set<string>>(new Set());
+  const { suppressNextAutoScrollRef } = useContext(ScrollContext);
+
+  // Prewarm the Shiki line cache whenever the expanded file's preview lines
+  // are available. Mirrors the same pattern used in DiffViewer.tsx: fire
+  // async highlightCode per distinct line, then bump cacheVersion so the
+  // memoized DiffPreviewLine instances re-evaluate getCachedHighlight.
+  useEffect(() => {
+    if (!expandedFile) return;
+    const lang = languageForFile(expandedFile);
+    if (!lang) return;
+    const fileStat = summary.files.find((f) => f.filePath === expandedFile);
+    if (!fileStat) return;
+    const previewState = previewByFile[expandedFile];
+    const lines =
+      fileStat.previewLines.length > 0
+        ? fileStat.previewLines
+        : (previewState?.lines ?? []);
+    const codeLines = lines.filter((l) => l.type !== "hunk").map((l) => l.content);
+    if (codeLines.length === 0) return;
+    let cancelled = false;
+    void Promise.all(
+      Array.from(new Set(codeLines)).map((code) => highlightCode(code, lang)),
+    ).then(() => {
+      if (!cancelled) setCacheVersion((v) => v + 1);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [expandedFile, previewByFile, summary.files]);
 
   const toggleFile = (file: EditFileStat) => {
+    const isOpening = expandedFile !== file.filePath;
+    if (isOpening) {
+      // Prevent useStickyScroll from auto-scrolling to bottom when the preview
+      // appears — that scroll fires before the browser paints, causing a
+      // visible upward flash before any post-hoc correction could run.
+      suppressNextAutoScrollRef.current = true;
+    }
     setExpandedFile((current) => (current === file.filePath ? null : file.filePath));
+
     if (file.previewLines.length > 0 || !onLoadPreview) return;
     // Skip ONLY for `loading`/`ready`. An `error` entry must still
     // permit a retry on the next click — the previous gate
@@ -111,13 +153,19 @@ export function TurnEditSummaryCard({
 
   return (
     <div className={styles.turnEditSummary}>
-      <div className={styles.turnEditSummaryHeader}>
+      <button
+        type="button"
+        className={styles.turnEditSummaryHeader}
+        aria-expanded={listExpanded}
+        onClick={() => setListExpanded((v) => !v)}
+      >
         <span className={styles.turnEditSummaryTitle}>
           {summary.files.length} file{summary.files.length !== 1 ? "s" : ""} changed
         </span>
         <ChangeStats added={summary.added} removed={summary.removed} />
-      </div>
-      <div className={styles.turnEditFileList}>
+        {listExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+      {listExpanded && <div className={styles.turnEditFileList}>
         {summary.files.map((file) => {
           const expanded = expandedFile === file.filePath;
           const previewState = previewByFile[file.filePath];
@@ -125,8 +173,12 @@ export function TurnEditSummaryCard({
             ? file.previewLines
             : previewState?.lines ?? [];
           const canExpand = file.previewLines.length > 0 || !!onLoadPreview;
+          const language = languageForFile(file.filePath);
           return (
-            <div key={file.filePath} className={styles.turnEditFile}>
+            <div
+              key={file.filePath}
+              className={styles.turnEditFile}
+            >
               <div className={styles.turnEditFileRowWrap}>
                 <button
                   type="button"
@@ -161,7 +213,7 @@ export function TurnEditSummaryCard({
                         onOpenFile(file.filePath);
                       }}
                     >
-                      <SquareArrowOutUpRight size={13} />
+                      <FilePenLine size={13} />
                     </button>
                   )}
                   {canExpand && (
@@ -184,12 +236,14 @@ export function TurnEditSummaryCard({
                 <InlineDiffPreview
                   lines={previewLines}
                   status={previewState?.status ?? "ready"}
+                  language={language}
+                  cacheVersion={cacheVersion}
                 />
               )}
             </div>
           );
         })}
-      </div>
+      </div>}
     </div>
   );
 }
@@ -228,9 +282,13 @@ function AnimatedStat({
 function InlineDiffPreview({
   lines,
   status,
+  language,
+  cacheVersion,
 }: {
   lines: EditPreviewLine[];
   status: PreviewState["status"];
+  language: string | null;
+  cacheVersion: number;
 }) {
   if (status === "loading") {
     return <div className={styles.turnEditDiffState}>Loading diff…</div>;
@@ -244,13 +302,28 @@ function InlineDiffPreview({
   return (
     <div className={styles.turnEditDiffPreview}>
       {lines.map((line, index) => (
-        <DiffPreviewLine key={`${index}:${line.type}`} line={line} />
+        <DiffPreviewLine
+          key={`${index}:${line.type}`}
+          line={line}
+          language={language}
+          cacheVersion={cacheVersion}
+        />
       ))}
     </div>
   );
 }
 
-function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
+const DiffPreviewLine = memo(function DiffPreviewLine({
+  line,
+  language,
+  cacheVersion: _cacheVersion,
+}: {
+  line: EditPreviewLine;
+  language: string | null;
+  // Passed solely to bust memo when the Shiki cache is primed — not
+  // read directly. Same pattern as LineContent in DiffViewer.tsx.
+  cacheVersion: number;
+}) {
   // Hunk separators get their own full-width row (no gutters):
   // optional `@@ -X,Y +A,B @@` header text inline (workspace-diff
   // path) or just a divider band (activity path, where multiple Edit
@@ -269,6 +342,7 @@ function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
       : line.type === "removed"
         ? styles.turnEditDiffLineRemoved
         : "";
+  const html = language ? getCachedHighlight(line.content, language) : null;
   return (
     <div className={`${styles.turnEditDiffLine} ${lineClass}`}>
       <span className={styles.turnEditDiffLineNumber}>
@@ -280,7 +354,14 @@ function DiffPreviewLine({ line }: { line: EditPreviewLine }) {
       <span className={styles.turnEditDiffPrefix}>
         {line.type === "added" ? "+" : line.type === "removed" ? "-" : " "}
       </span>
-      <code className={styles.turnEditDiffContent}>{line.content || " "}</code>
+      {html !== null ? (
+        <code
+          className={styles.turnEditDiffContent}
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      ) : (
+        <code className={styles.turnEditDiffContent}>{line.content || " "}</code>
+      )}
     </div>
   );
-}
+});

--- a/src/ui/src/components/chat/ScrollContext.ts
+++ b/src/ui/src/components/chat/ScrollContext.ts
@@ -1,6 +1,10 @@
-import { createContext } from "react";
+import { createContext, type MutableRefObject } from "react";
 
 /** Context to pass sticky-scroll handler into streaming sub-components. */
 export const ScrollContext = createContext<{
   handleContentChanged: () => void;
-}>({ handleContentChanged: () => {} });
+  suppressNextAutoScrollRef: MutableRefObject<boolean>;
+}>({
+  handleContentChanged: () => {},
+  suppressNextAutoScrollRef: { current: false },
+});

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -2,7 +2,17 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Stub the Shiki highlight worker so EditChangeSummary's highlightCode calls
+// don't crash with "Worker is not defined" in the happy-dom environment.
+vi.mock("../../workers/highlight.worker?worker", () => ({
+  default: class FakeWorker {
+    postMessage(): void {}
+    addEventListener(): void {}
+    terminate(): void {}
+  },
+}));
 
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -460,6 +460,13 @@ describe("ToolActivitiesSection", () => {
     );
 
     expect(container.textContent).toContain("1 file changed");
+
+    // File list is collapsed by default — expand it first.
+    const summaryHeader = container.querySelector(
+      `button.${styles.turnEditSummaryHeader}`,
+    ) as HTMLButtonElement;
+    await act(async () => { summaryHeader.click(); });
+
     expect(container.textContent).toContain("src/app.ts");
     expect(container.textContent).toContain("+2");
     expect(container.textContent).toContain("-1");
@@ -520,6 +527,13 @@ describe("ToolActivitiesSection", () => {
     );
 
     expect(container.textContent).toContain("1 file changed");
+
+    // File list is collapsed by default — expand it first.
+    const summaryHeader = container.querySelector(
+      `button.${styles.turnEditSummaryHeader}`,
+    ) as HTMLButtonElement;
+    await act(async () => { summaryHeader.click(); });
+
     expect(container.textContent).toContain("src/app.ts");
     expect(container.textContent).toContain("+9");
     expect(container.textContent).toContain("-2");

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -20,6 +20,11 @@ export function useStickyScroll(
   const programmaticScrollRef = useRef(false);
   const rafPendingRef = useRef(false);
   const suppressNextAutoScrollRef = useRef(false);
+  // Kept in a ref so the RAF callback always reads the latest value without
+  // needing threshold in its useCallback deps (which would recreate the fn
+  // and re-attach the MutationObserver on every threshold change).
+  const thresholdRef = useRef(threshold);
+  thresholdRef.current = threshold;
 
   /**
    * Auto-scroll to bottom if the user is already there.
@@ -33,7 +38,25 @@ export function useStickyScroll(
       rafPendingRef.current = false;
       const suppress = suppressNextAutoScrollRef.current;
       suppressNextAutoScrollRef.current = false;
-      if (!isAtBottomRef.current || suppress) return;
+      if (suppress) {
+        // Content grew but we intentionally skipped the auto-scroll (e.g. the
+        // user expanded an inline diff preview). Recompute the actual scroll
+        // position so the scroll-to-bottom pill and subsequent auto-scroll
+        // decisions reflect reality — without this, isAtBottomRef stays `true`
+        // and the very next DOM mutation (syntax-highlight re-render, etc.)
+        // would unexpectedly jump to bottom.
+        const el = containerRef.current;
+        if (el) {
+          const atBottom =
+            el.scrollTop + el.clientHeight >= el.scrollHeight - thresholdRef.current;
+          if (atBottom !== isAtBottomRef.current) {
+            isAtBottomRef.current = atBottom;
+            setIsAtBottom(atBottom);
+          }
+        }
+        return;
+      }
+      if (!isAtBottomRef.current) return;
       const el = containerRef.current;
       if (el) {
         const prev = el.scrollTop;

--- a/src/ui/src/hooks/useStickyScroll.ts
+++ b/src/ui/src/hooks/useStickyScroll.ts
@@ -19,6 +19,7 @@ export function useStickyScroll(
   const [isAtBottom, setIsAtBottom] = useState(true);
   const programmaticScrollRef = useRef(false);
   const rafPendingRef = useRef(false);
+  const suppressNextAutoScrollRef = useRef(false);
 
   /**
    * Auto-scroll to bottom if the user is already there.
@@ -30,7 +31,9 @@ export function useStickyScroll(
     rafPendingRef.current = true;
     requestAnimationFrame(() => {
       rafPendingRef.current = false;
-      if (!isAtBottomRef.current) return;
+      const suppress = suppressNextAutoScrollRef.current;
+      suppressNextAutoScrollRef.current = false;
+      if (!isAtBottomRef.current || suppress) return;
       const el = containerRef.current;
       if (el) {
         const prev = el.scrollTop;
@@ -118,5 +121,5 @@ export function useStickyScroll(
     });
   }, [containerRef]);
 
-  return { isAtBottom, scrollToBottom, handleContentChanged } as const;
+  return { isAtBottom, scrollToBottom, handleContentChanged, suppressNextAutoScrollRef } as const;
 }

--- a/src/ui/src/workers/highlight.worker.ts
+++ b/src/ui/src/workers/highlight.worker.ts
@@ -206,7 +206,14 @@ async function highlight(code: string, lang: string): Promise<string | null> {
     const codeEl = findCodeElement(root);
     if (!codeEl) return null;
     if (!codeEl.children.every(isStructurallySafe)) return null;
-    return toHtml({ type: "root", children: codeEl.children });
+    // Strip the trailing \n text node Shiki appends for its <pre> context — it
+    // renders as a phantom blank line inside our <code white-space:pre> cells.
+    const last = codeEl.children[codeEl.children.length - 1];
+    const children =
+      last?.type === "text" && /^\n+$/.test(last.value)
+        ? codeEl.children.slice(0, -1)
+        : codeEl.children;
+    return toHtml({ type: "root", children });
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

The file-change summary card shown after each turn now collapses behind a clickable header instead of always expanding inline. Clicking **N files changed** toggles the file list; individual file rows still expand to their inline diff preview. The inline diff preview gains Shiki syntax highlighting (same prewarm + `cacheVersion` pattern as `DiffViewer`), a scrollable `max-height` cap, and the open-file action now uses the `FilePenLine` icon consistent with the changes panel and diff viewer.

Two scroll-related visual glitches that surfaced during the work are also fixed:

- **Upward flash on expand** — `useStickyScroll`'s MutationObserver was scrolling to bottom in a rAF (before paint); the old post-hoc setTimeout correction ran *after* the paint, one frame too late. Fix: expose `suppressNextAutoScrollRef` from the hook, thread it through `ScrollContext`, and set it before the DOM mutation so the rAF skips auto-scroll entirely for that cycle.
- **Highlight layout shift** — Shiki's `codeToHast` always appends a trailing `\n` text node to the `<code>` children for its `<pre>` context. Serialised into our `white-space: pre` cells it rendered as a phantom blank line, adding one `line-height` of height the moment highlighting kicked in. Fix: strip the trailing whitespace-only text node in the highlight worker before calling `toHtml`.

## Complexity Notes

**`suppressNextAutoScrollRef` timing** — The flag must be set *before* `setExpandedFile` triggers a React re-render and the subsequent DOM mutation, because `useStickyScroll`'s MutationObserver callback (which reads the flag) fires synchronously after the DOM changes and schedules a rAF. The current call order in `toggleFile` satisfies this: flag set → `setExpandedFile` → React flush → mutation → observer → rAF (reads + clears flag). Any reordering that moves the flag set after the state update would race.

**Shiki newline stripping** — The fix targets the *last* child of the `<code>` element only. Multi-line inputs (not used here — each diff line is a separate call) could in principle have embedded newlines that are intentional; stripping only a trailing pure-whitespace node is safe for all cases.

## Test Steps

1. Run an agent task that edits several files so a turn-edit summary card appears.
2. Confirm the card shows only the **N files changed** header by default (collapsed).
3. Click the header — the file list expands; click again — it collapses.
4. Expand a file row's inline diff. Verify:
   - No upward content flash on open (was visible at the bottom of the chat).
   - Syntax highlighting appears without a vertical height jump.
   - The open-file button shows a pen-line icon (not the external-link arrow).
5. Scroll to the middle of a long session and expand a diff there — content above should not jump.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)