### PR TITLE
ci: retry macOS bundle step to absorb notarization flakes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -225,8 +225,31 @@ jobs:
       # The `publish` job below now constructs `latest.json` once from each
       # platform's `.sig` files (which are uploaded by tauri-action with
       # unique names, no race), eliminating the conflict surface entirely.
-      - name: Build and upload desktop app (non-Windows)
+      # The bundle step is duplicated up to 3x to absorb transient
+      # Apple-notarization flakes. Run #25608625502 (macos-aarch64) failed
+      # at the very last hop with `NSURLErrorDomain Code=-1009
+      # "The Internet connection appears to be offline"` while polling
+      # https://appstoreconnect.apple.com/notary/v2/submissions/<uuid>?
+      # — even though `NSURLErrorNWPathKey=satisfied` reported the
+      # runner network as fine. That's a transient hiccup against
+      # Apple's notary service, not a code or config problem, so we
+      # retry the whole bundle. tauri-action is a JS action and can't
+      # be wrapped by `nick-fields/retry`; duplicated steps with
+      # `continue-on-error` + `outcome` checks is the native pattern.
+      #
+      # Retries are macOS-only because that's the documented failure
+      # mode. Linux failures here (rare) are usually `gh release
+      # upload` 422 conflicts, which retrying does not fix.
+      #
+      # Compile artifacts survive between attempts, so retries skip
+      # straight to bundle → codesign → notarize → upload (~1–2 min
+      # each). If the first attempt got past notarization and started
+      # uploading, a retry could trip on duplicate assets — accepted
+      # cost; the common flake is pre-upload.
+      - name: Build and upload desktop app (non-Windows) — attempt 1
+        id: bundle1
         if: ${{ !startsWith(matrix.platform, 'windows') }}
+        continue-on-error: ${{ runner.os == 'macOS' }}
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -238,6 +261,50 @@ jobs:
           APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
+        with:
+          tagName: nightly-staging
+          releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
+          releaseDraft: true
+          prerelease: true
+          includeUpdaterJson: false
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      - name: Build and upload desktop app (non-Windows) — attempt 2 (macOS retry)
+        id: bundle2
+        if: ${{ runner.os == 'macOS' && steps.bundle1.outcome == 'failure' }}
+        continue-on-error: true
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: nightly-staging
+          releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"
+          releaseDraft: true
+          prerelease: true
+          includeUpdaterJson: false
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      - name: Build and upload desktop app (non-Windows) — attempt 3 (macOS final)
+        if: ${{ runner.os == 'macOS' && steps.bundle1.outcome == 'failure' && steps.bundle2.outcome == 'failure' }}
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: nightly-staging
           releaseName: "Nightly ${{ needs.compute-version.outputs.version }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -156,8 +156,14 @@ jobs:
         run: scripts/stage-cli-sidecar.sh ${{ matrix.rust-target }}
 
       # ---- macOS + Linux: tauri-action drives the bundled build ------------
-      - name: Build and upload desktop app (non-Windows)
+      # macOS bundles get up to 3 attempts to absorb transient
+      # Apple-notarization flakes (NSURLErrorDomain -1009 polling
+      # appstoreconnect.apple.com — see nightly.yml for the full
+      # rationale and the run that motivated this). Linux runs once.
+      - name: Build and upload desktop app (non-Windows) — attempt 1
+        id: bundle1
         if: ${{ !startsWith(matrix.platform, 'windows') }}
+        continue-on-error: ${{ runner.os == 'macOS' }}
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,6 +175,46 @@ jobs:
           APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
           APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
           APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
+        with:
+          tagName: ${{ needs.resolve-tag.outputs.tag }}
+          releaseName: ${{ needs.resolve-tag.outputs.tag }}
+          releaseDraft: true
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      - name: Build and upload desktop app (non-Windows) — attempt 2 (macOS retry)
+        id: bundle2
+        if: ${{ runner.os == 'macOS' && steps.bundle1.outcome == 'failure' }}
+        continue-on-error: true
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: ${{ needs.resolve-tag.outputs.tag }}
+          releaseName: ${{ needs.resolve-tag.outputs.tag }}
+          releaseDraft: true
+          args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
+
+      - name: Build and upload desktop app (non-Windows) — attempt 3 (macOS final)
+        if: ${{ runner.os == 'macOS' && steps.bundle1.outcome == 'failure' && steps.bundle2.outcome == 'failure' }}
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}


### PR DESCRIPTION
## What

Wrap the macOS bundle/upload step in `nightly.yml` and `release-please.yml` with up to **3 attempts** to absorb transient Apple-notarization HTTP flakes. Linux still runs once; Windows is unaffected.

## Why

[Run #25608625502 (`macos-aarch64`)](https://github.com/utensils/claudette/actions/runs/25608625502/job/75174805907) failed at the very last hop of `tauri build`:

```
failed to bundle project failed codesign application: failed to notarize app:
Error: HTTPError(statusCode: nil,
  error: ... NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline."
  ... NSErrorFailingURLStringKey=https://appstoreconnect.apple.com/notary/v2/submissions/<uuid>?
  ... _NSURLErrorNWPathKey=satisfied (Path is satisfied)
)
```

The submission UUID had already been issued — the bundler was *polling* the notary API for status when DNS/connectivity glitched briefly, despite the runner reporting its network path as satisfied. Pure flake against Apple's notary service, not reproducible from code or config.

## How

- `tauri-apps/tauri-action@v0` is a JS action, so `nick-fields/retry` (which only wraps `run:` shell) can't loop it.
- Native pattern instead: duplicate the step with `continue-on-error: true` + `if: steps.<id>.outcome == 'failure'` gating.
- Up to 3 attempts on macOS; the 3rd has no `continue-on-error` so a real outage still fails the job (preserving visibility of non-transient failures).
- Linux still runs only attempt 1 — its failure modes (mostly `gh release upload` 422 conflicts) aren't fixed by retry.

## Behavior matrix

| Platform | Attempt 1 | Attempt 2 | Attempt 3 |
|---|---|---|---|
| Linux | runs; failure fails job | skipped (`runner.os == 'macOS'`) | skipped |
| macOS, all pass | runs ✓ | skipped (`outcome != 'failure'`) | skipped |
| macOS, 1st fails | fails (swallowed) | runs ✓ → done | skipped |
| macOS, 1+2 fail | fails | fails (swallowed) | runs; failure fails job |
| Windows | skipped (`!startsWith(matrix.platform, 'windows')`) | skipped | skipped |

## Cost

Compile artifacts persist between attempts, so each retry skips straight to bundle → codesign → notarize → upload (~1–2 min on the macOS runner). 

## Caveat

If a future failure happens *after* the first attempt has started uploading assets, the retry could trip on duplicate uploads. Not addressed here — the documented failure mode is pre-upload. A more invasive fix (split bundle/notarize/upload into separate retryable steps) would solve that, but isn't justified by the current flake rate.

## Validation

- YAML parses cleanly (`yq` confirms 3 attempt steps in each workflow with correct `id` / `if` / `continue-on-error` wiring).
- Codex peer review (`codex review --base main`) found no issues — confirms scope is contained and step-outcome semantics are correct.
- Cannot test end-to-end locally; this only exercises on a real GitHub Actions macOS runner with the notary secrets. First nightly run after merge will validate.