### PR TITLE
fix(ui): inline useCreateWorkspace into main bundle to fix prod blank screen

### DIFF
--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -9,7 +9,11 @@ import {
 } from "../utils/focusTargets";
 import { adjustUiFontSize } from "../utils/fontSettings";
 import { resolveHotkeyAction } from "../hotkeys/bindings";
-import { executeCloseTab, executeNewTab } from "../hotkeys/contextActions";
+import {
+  executeCloseTab,
+  executeNewTab,
+  executeNewWorkspace,
+} from "../hotkeys/contextActions";
 import type { HotkeyActionId } from "../hotkeys/actions";
 
 export function useKeyboardShortcuts() {
@@ -236,13 +240,15 @@ export function useKeyboardShortcuts() {
             })();
             const target = fromScoped ?? fromWorkspace ?? localRepos[0] ?? null;
             if (!target) return;
-            // Lazy import keeps the workspace-creation orchestration out
-            // of this hook's main bundle (it pulls in setup-script flow
-            // and confirm-modal data). The dynamic import resolves once
-            // and is cached by the module loader.
-            void import("../hotkeys/contextActions").then(({ executeNewWorkspace }) => {
-              executeNewWorkspace(target.id);
-            });
+            // Direct call — `executeNewWorkspace` is statically imported
+            // at the top of this file. The previous `await import(...)`
+            // form looked like a code-split optimization but was an
+            // INEFFECTIVE_DYNAMIC_IMPORT (contextActions is already
+            // statically reachable via Cmd+T / Cmd+W) and made the
+            // bundler emit useCreateWorkspace into an own chunk that
+            // raced its dependencies during module init in production
+            // builds — see the static-import comment in contextActions.
+            executeNewWorkspace(target.id);
             return;
           }
           default:

--- a/src/ui/src/hotkeys/contextActions.ts
+++ b/src/ui/src/hotkeys/contextActions.ts
@@ -26,6 +26,18 @@ import {
 } from "../services/tauri";
 import { useAppStore } from "../stores/useAppStore";
 import type { ChatSession } from "../types/chat";
+// Static import (was previously a `await import(...)` inside
+// `executeNewWorkspace`). The dynamic form was ineffective in production
+// builds — Dashboard.tsx already statically pulls in
+// `useCreateWorkspace`, so the chunker's "splittable" hint here didn't
+// reduce bundle size; instead it pushed `useCreateWorkspace` into its own
+// chunk that, under Rolldown's chunking, ended up evaluating BEFORE the
+// chunk that defines the React/zustand `__toESM(require(...))` shims it
+// needs at module-init time. Result: a `TypeError: r is not a function`
+// on production launch and a blank #root. Keeping this static guarantees
+// the import lands in a chunk that has its dependencies resolved by the
+// time module init runs.
+import { createWorkspaceOrchestrated } from "../hooks/useCreateWorkspace";
 
 export interface ContextActionDeps {
   /** Override the new-session backend call; tests pass a stub.
@@ -194,16 +206,13 @@ export function executeNewTab(overrides?: Partial<ContextActionDeps>): void {
  * workspace whose `.claudette.json` setup never ran.
  */
 export function executeNewWorkspace(repoId: string): void {
-  void (async () => {
-    try {
-      const { createWorkspaceOrchestrated } = await import(
-        "../hooks/useCreateWorkspace"
-      );
-      await createWorkspaceOrchestrated(repoId);
-    } catch (err) {
-      console.error("[hotkey] executeNewWorkspace failed:", err);
-    }
-  })();
+  // Synchronous fire-and-forget — the orchestration is async internally,
+  // but we don't need to await it from the hotkey path (the UI updates
+  // via store mutations). The `.catch` keeps a thrown rejection from
+  // surfacing as an unhandled-promise warning.
+  createWorkspaceOrchestrated(repoId).catch((err) => {
+    console.error("[hotkey] executeNewWorkspace failed:", err);
+  });
 }
 
 /**


### PR DESCRIPTION
## Linked Issue

_Hot fix — installed nightly is broken in production for users who pulled the auto-update after #723 landed._

## Summary

Production builds (release / nightly) blank out at launch with this in the webview console:

```
TypeError: r is not a function. (In 'r()', 'r' is undefined)
    Module Code (useCreateWorkspace-DehBJzOA.js:1:205)
```

Root cause is a **chunk-init-order race** in Rolldown's output, triggered by `INEFFECTIVE_DYNAMIC_IMPORT` warnings the build log surfaced but we shipped past:

- `hotkeys/contextActions.ts` and `hooks/useCreateWorkspace.ts` were each statically imported from the main bundle (Dashboard, SessionTabs, MonacoEditor, etc.) AND dynamically imported by hotkey paths.
- Rolldown saw the dynamic import and emitted them as their own chunks anyway, even though they were already statically reachable.
- At module-init time those split chunks tried to call the React/zustand `__toESM(require(...))` helper exported from the main chunk — but that chunk hadn't finished defining its exports yet, so the require-shim was `undefined`. The minified line `l = e(r(), 1)` is exactly that pattern (`__toESM(require("react"), 1)`).
- A throw at module-evaluation time happens **before** any error boundary mounts → blank `#root`, no recovery UI.

Vite's own warning called this out:

```
[INEFFECTIVE_DYNAMIC_IMPORT] src/hotkeys/contextActions.ts is dynamically
imported by src/hooks/useKeyboardShortcuts.ts but also statically imported
by src/components/chat/SessionTabs.tsx, src/components/chat/WorkspaceEmptyTabs.tsx,
src/components/file-viewer/MonacoEditor.tsx, src/hooks/useKeyboardShortcuts.ts,
dynamic import will not move module into another chunk.
```

## Fix

Convert both dynamic imports to static. There's no bundle-size cost — both modules are already in the main bundle's reachable graph (the dynamic-import form was always a no-op for code splitting).

Before:
```ts
// useKeyboardShortcuts.ts
void import("../hotkeys/contextActions").then(({ executeNewWorkspace }) => {
  executeNewWorkspace(target.id);
});

// contextActions.ts
const { createWorkspaceOrchestrated } = await import("../hooks/useCreateWorkspace");
```

After:
```ts
// useKeyboardShortcuts.ts (top of file)
import { executeNewWorkspace } from "../hotkeys/contextActions";
// ... at use site:
executeNewWorkspace(target.id);

// contextActions.ts (top of file)
import { createWorkspaceOrchestrated } from "../hooks/useCreateWorkspace";
// ... at use site (no await):
createWorkspaceOrchestrated(repoId).catch(...);
```

## Verified

- `INEFFECTIVE_DYNAMIC_IMPORT` warning is **gone** from `bun run build` output.
- `useCreateWorkspace-*.js` is **no longer emitted as a separate chunk** (`ls dist/assets/ | grep useCreateWorkspace` is empty after rebuild).
- All 4 call sites still work: Dashboard hook, sidebar `+`, project-scoped CTA, `Cmd+Shift+N` hotkey.
- All 1760 frontend tests pass.
- `tsc -b` clean. ESLint 0 errors.

## Screenshots

Before: blank window with `<div id="root"></div>` (per the user report that prompted this).
After: app loads normally. Will attach a clean-build screenshot once the auto-updater rolls this out.

## UAT Plan

- [ ] After this lands and a new nightly publishes, install the updater and confirm the app launches to a non-blank window.
- [ ] `Cmd+Shift+N` still creates a workspace (the previously dynamic-imported code path).
- [ ] Open a chat tab, close it via `Cmd+W` (calls `executeCloseTab` in the same module that was being dynamically loaded) — the workspace empty-tabs view appears.

## Checklist

- [x] CI passes locally (tsc, eslint 0 errors, 1760 vitest tests).
- [x] PR title follows conventional commit format.
- [ ] Documentation update — N/A; this is a build-output fix, no user-visible API or UI change.

## Follow-up — boot-health verification gate (separate issue)

This is the second time a chunk-init-order race has shipped to nightly. Filing a separate issue for an auto-updater **boot-health gate** so the next one doesn't get installed:

- Architecture: after update install, on first launch with a "needs_heartbeat" sentinel, the React app posts a `boot_ok` IPC after first render. If the IPC doesn't arrive within ~10 s, the backend rolls back to the previous binary kept under `~/.claudette/updates/previous/<version>/`.
- This catches exactly the failure mode here (module-init throw → no React mount → no IPC) without needing a hidden-window probe before promotion.
- Pre-publish CI gate: a Playwright smoke test against the actual production bundle that reads "did the app render anything past `<div id="root"></div>`" — would have caught this before the nightly tagged.
