### PR TITLE
fix(windows): notification sounds and OpenPeon sound packs play correctly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,8 +221,9 @@ Do not trigger CoreAudio or Speech.framework permission prompts at app launch �
 
 - Notification sound and commands run on the **Rust side** (not in the webview) — macOS suspends webview JS when the window is hidden
 - `tray.rs` handles attention notifications (AskUserQuestion/ExitPlanMode); `commands/chat.rs` handles agent-finished notifications
-- Both paths use the shared `build_notification_command` helper in `commands/settings.rs`
-- `mac-notification-sys` for native macOS notifications with click-to-navigate; `tauri-plugin-notification` on Linux
+- Both paths use the shared `build_notification_command` helper in `commands/settings.rs` — `sh -c <cmd>` on macOS/Linux, `cmd.exe /S /C <cmd>` on Windows
+- Native notification banners: `mac-notification-sys` on macOS (click-to-navigate), `tauri-plugin-notification` on Linux/Windows
+- **Sound playback** is platform-specific. macOS/Linux shell out to `afplay` / `paplay` / `ffplay` inline. Windows uses `claudette::audio` (`src/audio.rs`): `PlaySoundW` for built-in `C:\Windows\Media` system sounds (no decoder, no per-call volume) and `rodio` (cpal + Symphonia, gated to Windows-only deps) for OpenPeon sound packs that ship MP3/OGG/WAV. New Windows audio code belongs in `audio.rs` so the `unsafe` FFI and feature gating stay in one place.
 
 ### Database conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +864,7 @@ dependencies = [
  "notify",
  "open",
  "rand 0.8.5",
+ "rodio",
  "rusqlite",
  "serde",
  "serde_json",
@@ -871,6 +878,7 @@ dependencies = [
  "url",
  "uuid",
  "which",
+ "windows-sys 0.61.2",
  "winreg 0.55.0",
 ]
 
@@ -1646,6 +1654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1766,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fallible-iterator"
@@ -5344,6 +5367,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rodio"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
+dependencies = [
+ "cpal",
+ "dasp_sample",
+ "num-rational",
+ "symphonia",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rubato"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6181,6 +6217,90 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,15 @@ chrono = "0.4"
 # PATH updates made after claudette started (winget/installer edits) without
 # forcing the user to log out and back in.
 winreg = "0.55"
+# `PlaySoundW` for Windows notification audio (see `audio.rs`). Tiny —
+# we only enable the audio submodule and Foundation, no extra runtime.
+windows-sys = { version = "0.61", features = ["Win32_Media_Audio", "Win32_Foundation"] }
+# Pure-Rust audio playback, Windows-only (macOS/Linux already shell out
+# to native players). Used for OpenPeon sound packs that ship MP3 / OGG
+# — `PlaySoundW` only handles PCM WAV. Default features pull in legacy
+# decoders (minimp3, lewton, claxon); we route everything through
+# Symphonia instead for one decoder pipeline and a smaller binary.
+rodio = { version = "0.22", default-features = false, features = ["playback", "symphonia-wav", "symphonia-mp3", "symphonia-vorbis"] }
 
 [target.'cfg(unix)'.dependencies]
 # Used by `ops::workspace` to SIGKILL the process group of a setup script

--- a/site/src/content/docs/features/notifications.mdx
+++ b/site/src/content/docs/features/notifications.mdx
@@ -85,7 +85,7 @@ Sound playback is platform-specific and uses each OS's native audio path:
 - **macOS** — plays AIFF files from `/System/Library/Sounds` via `afplay`. The sound dropdown enumerates the same directory.
 - **Linux** — plays via `canberra-gtk-play` (with `paplay` as fallback) using freedesktop sound names.
 - **Windows** — has two paths depending on which kind of sound is playing:
-  - **System sounds** (the dropdown items resolved from `C:\Windows\Media`) play via the `PlaySoundW` Win32 API. "Default" maps to the system Notification Default alias, which respects whatever you've picked in **Settings → System → Sound → More sound settings**. PlaySoundW plays at the user's system volume — fine for short beeps, no decoder cost.
+  - **System sounds** (the dropdown items resolved from `%WINDIR%\Media`, typically `C:\Windows\Media`) play via the `PlaySoundW` Win32 API. "Default" maps to the system Notification Default alias, which respects whatever you've picked in **Settings → System → Sound → More sound settings**. PlaySoundW plays at the user's system volume — fine for short beeps, no decoder cost.
   - **OpenPeon sound packs** decode in-process via [`rodio`](https://crates.io/crates/rodio) (cpal + Symphonia). WAV, MP3, and OGG all work, and the volume slider attenuates per-call playback exactly the way it does on macOS / Linux.
 
 The split is intentional: short system beeps don't need a decoder pipeline, and rodio is only spun up when a user actually opts into a sound pack.

--- a/site/src/content/docs/features/notifications.mdx
+++ b/site/src/content/docs/features/notifications.mdx
@@ -78,8 +78,25 @@ Native notifications are integrated with the system tray:
 
 The tray icon and sidebar also reflect unattended workspaces, so even with sound muted you'll see a visual indicator when a workspace needs your attention.
 
+## Sound Playback by Platform
+
+Sound playback is platform-specific and uses each OS's native audio path:
+
+- **macOS** — plays AIFF files from `/System/Library/Sounds` via `afplay`. The sound dropdown enumerates the same directory.
+- **Linux** — plays via `canberra-gtk-play` (with `paplay` as fallback) using freedesktop sound names.
+- **Windows** — has two paths depending on which kind of sound is playing:
+  - **System sounds** (the dropdown items resolved from `C:\Windows\Media`) play via the `PlaySoundW` Win32 API. "Default" maps to the system Notification Default alias, which respects whatever you've picked in **Settings → System → Sound → More sound settings**. PlaySoundW plays at the user's system volume — fine for short beeps, no decoder cost.
+  - **OpenPeon sound packs** decode in-process via [`rodio`](https://crates.io/crates/rodio) (cpal + Symphonia). WAV, MP3, and OGG all work, and the volume slider attenuates per-call playback exactly the way it does on macOS / Linux.
+
+The split is intentional: short system beeps don't need a decoder pipeline, and rodio is only spun up when a user actually opts into a sound pack.
+
 ## Custom Notification Command
 
 If you want a notification to fire your own script — pipe to a Slack webhook, blink a Hue bulb, anything — Settings → Notifications has a **custom command** field. Claudette runs the command when a notification fires, with a small set of environment variables describing the event.
+
+The command runs in your platform's default shell:
+
+- **macOS / Linux** — `sh -c "<your command>"`
+- **Windows** — `cmd.exe /S /C "<your command>"`. If you need bash semantics, just call it explicitly: `bash -c "..."` (e.g. via Git Bash or WSL).
 
 This is independent of the sound system: you can use it together with sound packs, or instead of them.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -128,6 +128,25 @@ pub fn list_notification_sounds() -> Vec<String> {
         system.sort();
         sounds.extend(system);
     }
+    #[cfg(windows)]
+    if let Ok(entries) = std::fs::read_dir(claudette::audio::WINDOWS_MEDIA_DIR) {
+        let mut system: Vec<String> = entries
+            .flatten()
+            .filter_map(|e| {
+                let path = e.path();
+                if path
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("wav"))
+                {
+                    path.file_stem().map(|n| n.to_string_lossy().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        system.sort();
+        sounds.extend(system);
+    }
     sounds
 }
 
@@ -259,7 +278,33 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
             spawn_and_reap(child);
         }
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(windows)]
+    {
+        // PlaySoundW plays at system volume — `vol` is treated as a mute
+        // toggle (handled above by the `<= 0.0` early return). For named
+        // sounds we look up `C:\Windows\Media\<name>.wav`; "Default" maps
+        // to the system "Notification.Default" alias which respects the
+        // user's chosen Default Beep in Sound settings.
+        if sound == "Default" {
+            // Try the modern "Notification.Default" alias first; fall
+            // back to `SystemDefault` (NT-era) for older Windows. Both
+            // are Win32 PlaySound aliases — no file paths involved.
+            if !claudette::audio::play_alias_async("Notification.Default") {
+                claudette::audio::play_alias_async("SystemDefault");
+            }
+        } else {
+            let path = std::path::Path::new(claudette::audio::WINDOWS_MEDIA_DIR)
+                .join(format!("{sound}.wav"));
+            if !claudette::audio::play_wav_file_async(&path) {
+                tracing::debug!(
+                    target: "claudette::ui",
+                    path = %path.display(),
+                    "notification sound not found or failed to play"
+                );
+            }
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
     {
         let _ = (sound, vol);
     }
@@ -267,6 +312,15 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
 
 /// Build a Command for the notification shell command with workspace env vars.
 /// Returns None if the command is empty.
+///
+/// Shell selection:
+/// - macOS / Linux: `sh -c <cmd>` (POSIX-compatible)
+/// - Windows: `cmd.exe /S /C <cmd>` (the shell every Windows install has;
+///   `/S` disables `cmd`'s special-character mangling so the user's
+///   command is passed verbatim, and `/C` runs and exits)
+///
+/// Users who want `bash` semantics on Windows can write `bash -c "..."`
+/// inside their command — `cmd /C` will resolve `bash` from PATH.
 pub(crate) fn build_notification_command(
     cmd: &str,
     ws_env: &claudette::env::WorkspaceEnv,
@@ -277,12 +331,25 @@ pub(crate) fn build_notification_command(
     }
     // Reject bare shell reserved keywords that will always fail with `sh -c`.
     // Users sometimes enter "done" instead of `say "done"`.
+    // (Harmless on Windows — `cmd /C done` would error for the same reason.)
     if is_bare_shell_keyword(cmd) {
         return None;
     }
-    let mut command = std::process::Command::new("sh");
+    #[cfg(not(windows))]
+    let mut command = {
+        let mut c = std::process::Command::new("sh");
+        c.arg("-c").arg(cmd);
+        c
+    };
+    #[cfg(windows)]
+    let mut command = {
+        let mut c = std::process::Command::new("cmd.exe");
+        // /S = leave the command line alone (no double-quote stripping);
+        // /C = execute the command and terminate.
+        c.arg("/S").arg("/C").arg(cmd);
+        c
+    };
     command.no_console_window();
-    command.arg("-c").arg(cmd);
     ws_env.apply_std(&mut command);
     Some(command)
 }
@@ -433,6 +500,21 @@ mod tests {
         assert!(sounds.len() > 2, "Expected system sounds on macOS");
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn test_list_notification_sounds_includes_system_sounds_windows() {
+        let sounds = list_notification_sounds();
+        // Every Windows install ships several `.wav` files under
+        // C:\Windows\Media (chimes, ding, notify, tada, …). If this
+        // assertion ever fails on a stripped CI image, fall back to
+        // gating it the same way Linux is gated above.
+        assert!(
+            sounds.len() > 2,
+            "Expected system sounds enumerated from {}",
+            claudette::audio::WINDOWS_MEDIA_DIR
+        );
+    }
+
     #[test]
     fn test_play_notification_sound_none_is_noop() {
         // Should not panic or spawn any process.
@@ -461,12 +543,27 @@ mod tests {
     fn test_build_notification_command_sets_shell_and_args() {
         let cmd = build_notification_command("echo hello", &sample_ws_env()).unwrap();
         let program = cmd.get_program().to_string_lossy().to_string();
-        assert_eq!(program, "sh");
         let args: Vec<String> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
             .collect();
-        assert_eq!(args, vec!["-c", "echo hello"]);
+        #[cfg(not(windows))]
+        {
+            assert_eq!(program, "sh");
+            assert_eq!(args, vec!["-c", "echo hello"]);
+        }
+        #[cfg(windows)]
+        {
+            // `cmd.exe` keeps its `.exe` suffix when constructed via
+            // `Command::new("cmd.exe")` — assert on the basename so a
+            // future switch to bare `"cmd"` (or full path) doesn't break
+            // this test.
+            assert!(
+                program.eq_ignore_ascii_case("cmd.exe") || program.eq_ignore_ascii_case("cmd"),
+                "expected cmd shell on Windows, got {program}"
+            );
+            assert_eq!(args, vec!["/S", "/C", "echo hello"]);
+        }
     }
 
     #[test]
@@ -500,17 +597,26 @@ mod tests {
 
     #[test]
     fn test_notification_command_runs_and_receives_env() {
-        // Actually spawn a process and verify env vars are passed through.
-        let tmp = std::env::temp_dir().join("claudette-test-notify-cmd.txt");
-        let cmd_str = format!(
-            "echo $CLAUDETTE_WORKSPACE_NAME,$CLAUDETTE_ROOT_PATH > {}",
-            tmp.display()
-        );
+        // Verify env vars are passed through to the spawned shell. Shell
+        // syntax differs by platform: `sh` reads `$VAR`, `cmd.exe` reads
+        // `%VAR%`. We capture stdout rather than shell-redirecting to a
+        // temp file — the latter forces us into platform-specific quote
+        // rules (`cmd /S /C` does not honour `\"` the way Rust's stock
+        // arg-quoter emits them) and the captured-stdout path is just as
+        // good a check that env vars reached the child.
+        #[cfg(not(windows))]
+        let cmd_str = "echo $CLAUDETTE_WORKSPACE_NAME,$CLAUDETTE_ROOT_PATH".to_string();
+        #[cfg(windows)]
+        let cmd_str = "echo %CLAUDETTE_WORKSPACE_NAME%,%CLAUDETTE_ROOT_PATH%".to_string();
         let mut command = build_notification_command(&cmd_str, &sample_ws_env()).unwrap();
-        let mut child = command.spawn().expect("Failed to spawn test command");
-        child.wait().expect("Failed to wait for test command");
-        let output = std::fs::read_to_string(&tmp).expect("Failed to read output file");
-        std::fs::remove_file(&tmp).ok();
-        assert_eq!(output.trim(), "my-workspace,/home/user/repo");
+        let output = command.output().expect("Failed to run test command");
+        assert!(
+            output.status.success(),
+            "shell command failed: status={:?} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8(output.stdout).expect("stdout was not utf-8");
+        assert_eq!(stdout.trim(), "my-workspace,/home/user/repo");
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -129,7 +129,7 @@ pub fn list_notification_sounds() -> Vec<String> {
         sounds.extend(system);
     }
     #[cfg(windows)]
-    if let Ok(entries) = std::fs::read_dir(claudette::audio::WINDOWS_MEDIA_DIR) {
+    if let Ok(entries) = std::fs::read_dir(claudette::audio::windows_media_dir()) {
         let mut system: Vec<String> = entries
             .flatten()
             .filter_map(|e| {
@@ -282,9 +282,9 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
     {
         // PlaySoundW plays at system volume — `vol` is treated as a mute
         // toggle (handled above by the `<= 0.0` early return). For named
-        // sounds we look up `C:\Windows\Media\<name>.wav`; "Default" maps
-        // to the system "Notification.Default" alias which respects the
-        // user's chosen Default Beep in Sound settings.
+        // sounds we look up `<windows-media-dir>\<name>.wav`; "Default"
+        // maps to the system "Notification.Default" alias which respects
+        // the user's chosen Default Beep in Sound settings.
         if sound == "Default" {
             // Try the modern "Notification.Default" alias first; fall
             // back to `SystemDefault` (NT-era) for older Windows. Both
@@ -292,9 +292,20 @@ pub fn play_notification_sound(sound: String, volume: Option<f64>) {
             if !claudette::audio::play_alias_async("Notification.Default") {
                 claudette::audio::play_alias_async("SystemDefault");
             }
+        } else if !is_safe_sound_name(&sound) {
+            // Reject path separators, drive letters, and `..` so a
+            // setting like "..\..\Users\foo\secret" can't make us play
+            // arbitrary WAV files outside the system Media directory.
+            // `Path::join(absolute)` discards its base, so without this
+            // guard a maliciously edited DB row could read any file the
+            // user account can.
+            tracing::warn!(
+                target: "claudette::ui",
+                sound = %sound,
+                "notification sound name contains path syntax — refusing"
+            );
         } else {
-            let path = std::path::Path::new(claudette::audio::WINDOWS_MEDIA_DIR)
-                .join(format!("{sound}.wav"));
+            let path = claudette::audio::windows_media_dir().join(format!("{sound}.wav"));
             if !claudette::audio::play_wav_file_async(&path) {
                 tracing::debug!(
                     target: "claudette::ui",
@@ -330,8 +341,11 @@ pub(crate) fn build_notification_command(
         return None;
     }
     // Reject bare shell reserved keywords that will always fail with `sh -c`.
-    // Users sometimes enter "done" instead of `say "done"`.
-    // (Harmless on Windows — `cmd /C done` would error for the same reason.)
+    // Users sometimes enter "done" instead of `say "done"`. The check is
+    // POSIX-shell-specific — on Windows, `done` / `fi` / `esac` aren't
+    // reserved words in `cmd.exe`, and a `done.bat` on PATH is a legitimate
+    // command we shouldn't reject.
+    #[cfg(not(windows))]
     if is_bare_shell_keyword(cmd) {
         return None;
     }
@@ -354,13 +368,67 @@ pub(crate) fn build_notification_command(
     Some(command)
 }
 
-/// Returns true if `cmd` is a single shell reserved keyword that cannot
-/// be executed standalone (e.g. `done`, `then`, `fi`, `esac`).
+/// Returns true if `cmd` is a single POSIX-shell reserved keyword that
+/// cannot be executed standalone (e.g. `done`, `then`, `fi`, `esac`).
+/// Only consulted on the `sh -c` code path; Windows uses `cmd.exe`,
+/// where these aren't keywords and may be the names of real commands.
+#[cfg(not(windows))]
 fn is_bare_shell_keyword(cmd: &str) -> bool {
     matches!(
         cmd,
         "done" | "then" | "else" | "elif" | "fi" | "esac" | "do" | "in"
     )
+}
+
+/// Validate that a notification sound name is a bare filename — no path
+/// separators, no `..` segments, no drive prefixes. Used on Windows
+/// where the name is concatenated into `<windows-media-dir>\<name>.wav`
+/// and `Path::join(absolute)` would discard the base, opening a path-
+/// traversal vector if a bad value made it into the settings DB.
+#[cfg(windows)]
+fn is_safe_sound_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    if name.contains(['/', '\\']) || name.contains("..") {
+        return false;
+    }
+    // Drive prefix like `C:` (any ASCII letter + colon at the start).
+    let bytes = name.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return false;
+    }
+    // Reserved DOS device names — Windows treats these specially even
+    // without an extension. Belt-and-braces against malicious values
+    // like `CON.wav` causing kernel-side weirdness.
+    let stem = name.split('.').next().unwrap_or(name).to_ascii_uppercase();
+    matches!(
+        stem.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
+    .then_some(false)
+    .unwrap_or(true)
 }
 
 /// Run the user-configured notification command (if set) with workspace env vars.
@@ -504,15 +572,57 @@ mod tests {
     #[test]
     fn test_list_notification_sounds_includes_system_sounds_windows() {
         let sounds = list_notification_sounds();
-        // Every Windows install ships several `.wav` files under
-        // C:\Windows\Media (chimes, ding, notify, tada, …). If this
+        // Every Windows install ships several `.wav` files under the
+        // Media directory (chimes, ding, notify, tada, …). If this
         // assertion ever fails on a stripped CI image, fall back to
         // gating it the same way Linux is gated above.
+        let media_dir = claudette::audio::windows_media_dir();
         assert!(
             sounds.len() > 2,
             "Expected system sounds enumerated from {}",
-            claudette::audio::WINDOWS_MEDIA_DIR
+            media_dir.display()
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_is_safe_sound_name_rejects_path_syntax() {
+        // Bare filenames pass — they're what the dropdown produces.
+        assert!(super::is_safe_sound_name("Windows Notify"));
+        assert!(super::is_safe_sound_name("chimes"));
+        assert!(super::is_safe_sound_name("Speech On"));
+        // Path traversal: separators, drive prefixes, parent refs.
+        assert!(!super::is_safe_sound_name("../../etc/passwd"));
+        assert!(!super::is_safe_sound_name("..\\..\\Windows\\System32\\foo"));
+        assert!(!super::is_safe_sound_name("C:\\Windows\\Media\\chimes"));
+        assert!(!super::is_safe_sound_name("D:foo"));
+        assert!(!super::is_safe_sound_name("subdir/chimes"));
+        assert!(!super::is_safe_sound_name("subdir\\chimes"));
+        // Empty.
+        assert!(!super::is_safe_sound_name(""));
+        // Reserved DOS device names — case-insensitive.
+        assert!(!super::is_safe_sound_name("CON"));
+        assert!(!super::is_safe_sound_name("nul"));
+        assert!(!super::is_safe_sound_name("LPT1"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_build_notification_command_allows_done_dot_bat_on_windows() {
+        // POSIX shells reject bare `done`; Windows users may have a
+        // `done.bat` on PATH that is a real command. The check must be
+        // gated to non-Windows so legitimate `cmd.exe` invocations
+        // aren't rejected.
+        assert!(build_notification_command("done.bat", &sample_ws_env()).is_some());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_build_notification_command_rejects_bare_done_posix() {
+        // On macOS / Linux the rejection still applies — running bare
+        // `done` against `sh -c` is always a parse error from the user
+        // forgetting to quote the surrounding say/echo.
+        assert!(build_notification_command("done", &sample_ws_env()).is_none());
     }
 
     #[test]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -9,9 +9,9 @@
 //! drive playback in-process via two complementary backends:
 //!
 //! 1. **`PlaySoundW`** (Win32) for system-sound aliases like `SystemDefault`
-//!    and bare WAV files from `C:\Windows\Media`. Zero decoder cost, plays
-//!    at the user's system volume, and respects whatever sound the user
-//!    has assigned to the *Default Beep* in Sound settings.
+//!    and bare WAV files from `<windows-media-dir>()`. Zero decoder cost,
+//!    plays at the user's system volume, and respects whatever sound the
+//!    user has assigned to the *Default Beep* in Sound settings.
 //!
 //! 2. **`rodio`** (pure Rust on top of `cpal` + `symphonia`) for OpenPeon
 //!    sound packs that ship MP3 / OGG. `PlaySoundW` only handles PCM WAV,
@@ -36,15 +36,24 @@ mod win {
     }
 
     /// Play a `.wav` file asynchronously via `PlaySoundW`. Returns `true`
-    /// on success.
+    /// on success, `false` if the file is missing or `PlaySoundW`
+    /// rejected the request.
     ///
     /// Uses `SND_FILENAME | SND_ASYNC | SND_NODEFAULT` — the call returns
-    /// immediately, Windows owns playback, and on failure (missing file,
-    /// codec mismatch) it stays silent rather than playing the system
-    /// default beep. PlaySoundW always plays at the system volume; for
-    /// per-call volume control on WAV / MP3 / OGG, use
-    /// `play_audio_file_async` instead.
+    /// immediately, Windows owns playback, and on failure (codec
+    /// mismatch, etc.) it stays silent rather than playing the system
+    /// default beep. Because `SND_ASYNC` defers file resolution, missing
+    /// files often *also* return success from `PlaySoundW`; we therefore
+    /// pre-flight `path.exists()` so a missing file is a clean `false`
+    /// for the caller (used by `play_notification_sound` to log a
+    /// breadcrumb when a configured sound disappears).
+    ///
+    /// PlaySoundW always plays at the system volume; for per-call volume
+    /// control on WAV / MP3 / OGG, use `play_audio_file_async` instead.
     pub fn play_wav_file_async(path: &Path) -> bool {
+        if !path.exists() {
+            return false;
+        }
         let wide = to_wide_nul(path.as_os_str());
         // SAFETY: `wide` is a valid, NUL-terminated UTF-16 buffer that
         // outlives the `PlaySoundW` call. With `SND_ASYNC | SND_FILENAME`
@@ -81,60 +90,69 @@ mod win {
 
     /// Play any audio file rodio can decode (WAV / MP3 / OGG with our
     /// `symphonia-*` features) at the given attenuation. Returns `true`
-    /// once playback has been queued — the call returns immediately and
-    /// the sound finishes in a detached thread that owns the
-    /// `OutputStream`. Volume is clamped to `[0.0, 1.0]`.
+    /// once playback has been *committed* (file opened and decoder
+    /// built) and the worker thread spawned; the sound finishes in a
+    /// detached thread that owns the `MixerDeviceSink`. Volume is
+    /// clamped to `[0.0, 1.0]`.
     ///
-    /// Failure modes (file missing, no audio device, decode error, queue
-    /// full) all return `false` and emit a `tracing::warn` so a stuck
-    /// notification has a breadcrumb in the log without crashing the app.
+    /// Returns `false` for failures we can detect synchronously — file
+    /// missing, file unreadable, or the decoder rejecting the format.
+    /// Audio-device errors (no default output, no audio service) are
+    /// caught inside the worker thread and surface as a `tracing::warn`
+    /// rather than a `false` return; the caller has already chosen to
+    /// queue a sound at that point, so it makes more sense to log and
+    /// move on than to lie to a fire-and-forget caller.
     pub fn play_audio_file_async(path: &Path, volume: f32) -> bool {
+        // Pre-flight everything we can without booting an audio device,
+        // so the boolean return value is meaningful for callers that
+        // log on failure (`cesp::play_audio_file`, the settings preview).
         if !path.exists() {
             return false;
         }
+        let file = match std::fs::File::open(path) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!(
+                    target: "claudette::audio",
+                    path = %path.display(),
+                    error = %e,
+                    "could not open sound file"
+                );
+                return false;
+            }
+        };
+        let reader = std::io::BufReader::new(file);
+        let decoder = match rodio::Decoder::new(reader) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    target: "claudette::audio",
+                    path = %path.display(),
+                    error = %e,
+                    "could not decode sound file (unsupported format?)"
+                );
+                return false;
+            }
+        };
         let owned: PathBuf = path.to_path_buf();
         let vol = volume.clamp(0.0, 1.0);
 
         // rodio's `MixerDeviceSink` owns the cpal stream and is not safe
-        // to move *while held*, so we construct + own it entirely inside
-        // the spawned thread. Dropping it before playback finishes cuts
-        // the sound mid-play, hence the explicit `sleep_until_end()`
-        // before the thread returns. This mirrors the macOS/Linux
-        // pattern where the spawned `afplay` / `paplay` child owns its
-        // own audio context for the duration of one sound.
+        // to move *while held*, so we open it inside the spawned thread.
+        // Dropping it before playback finishes cuts the sound mid-play,
+        // hence the explicit `sleep_until_end()` before the thread
+        // returns. This mirrors the macOS/Linux pattern where the
+        // spawned `afplay` / `paplay` child owns its own audio context
+        // for the duration of one sound.
         std::thread::spawn(move || {
             let device_sink = match rodio::DeviceSinkBuilder::open_default_sink() {
                 Ok(s) => s,
                 Err(e) => {
                     tracing::warn!(
                         target: "claudette::audio",
+                        path = %owned.display(),
                         error = %e,
                         "no default audio output device — skipping playback"
-                    );
-                    return;
-                }
-            };
-            let file = match std::fs::File::open(&owned) {
-                Ok(f) => f,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "claudette::audio",
-                        path = %owned.display(),
-                        error = %e,
-                        "could not open sound file"
-                    );
-                    return;
-                }
-            };
-            let reader = std::io::BufReader::new(file);
-            let decoder = match rodio::Decoder::new(reader) {
-                Ok(d) => d,
-                Err(e) => {
-                    tracing::warn!(
-                        target: "claudette::audio",
-                        path = %owned.display(),
-                        error = %e,
-                        "could not decode sound file (unsupported format?)"
                     );
                     return;
                 }
@@ -154,57 +172,100 @@ mod win {
 #[cfg(windows)]
 pub use win::{play_alias_async, play_audio_file_async, play_wav_file_async};
 
-/// Directory holding Windows' built-in system sound files. Used by the
-/// settings command module to enumerate available sounds and to resolve
-/// a sound name → on-disk path.
+/// Directory holding Windows' built-in system sound files. Reads
+/// `%WINDIR%` so non-default install drives (Windows on `D:`, Windows
+/// PE, custom system roots) still find their sounds; falls back to
+/// `C:\Windows\Media` only when `WINDIR` isn't set, which on a real
+/// Windows install would mean something is very wrong.
 #[cfg(windows)]
-pub const WINDOWS_MEDIA_DIR: &str = r"C:\Windows\Media";
+pub fn windows_media_dir() -> std::path::PathBuf {
+    let windir = std::env::var_os("WINDIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(r"C:\Windows"));
+    windir.join("Media")
+}
 
 #[cfg(test)]
 mod tests {
     #[cfg(windows)]
     #[test]
-    fn windows_media_dir_constant_is_set() {
-        // Guards against an accidental empty/typo'd path. We don't check
-        // existence — the directory is part of any Windows install but
-        // could be absent in stripped CI images.
-        assert!(super::WINDOWS_MEDIA_DIR.ends_with("Media"));
+    fn windows_media_dir_uses_windir() {
+        // The function honours $WINDIR — guard the wiring so a refactor
+        // can't silently re-hardcode `C:\Windows`.
+        let prev = std::env::var_os("WINDIR");
+        // SAFETY: `cargo test` runs a single test binary single-threaded
+        // when `--test-threads=1` is set; the rest of the suite doesn't
+        // mutate WINDIR, so a transient reset is safe in practice. (The
+        // assertion below restores the original value on either branch.)
+        unsafe { std::env::set_var("WINDIR", r"D:\WinPE") };
+        let dir = super::windows_media_dir();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("WINDIR", v) },
+            None => unsafe { std::env::remove_var("WINDIR") },
+        }
+        assert_eq!(dir, std::path::PathBuf::from(r"D:\WinPE\Media"));
     }
 
     #[cfg(windows)]
     #[test]
-    fn play_missing_file_does_not_panic() {
-        // We can't assert on the return value: with `SND_ASYNC`, Windows
-        // queues the request and resolves the file later, so missing
-        // paths often return `TRUE` anyway. The point of this test is
-        // just to confirm the FFI signature, lifetimes, and pointer
-        // discipline don't crash on a syntactically valid path that
-        // happens not to exist.
-        let _ =
+    fn windows_media_dir_falls_back_when_unset() {
+        let prev = std::env::var_os("WINDIR");
+        unsafe { std::env::remove_var("WINDIR") };
+        let dir = super::windows_media_dir();
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("WINDIR", v) };
+        }
+        assert_eq!(dir, std::path::PathBuf::from(r"C:\Windows\Media"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn play_missing_file_returns_false() {
+        // With the path-exists pre-flight, missing files are a clean
+        // `false` regardless of how `PlaySoundW` resolves SND_ASYNC
+        // requests internally. Guards against a regression where the
+        // pre-flight gets refactored away.
+        let ok =
             super::play_wav_file_async(std::path::Path::new(r"C:\definitely\not\here\nope.wav"));
+        assert!(!ok);
     }
 
     #[cfg(windows)]
     #[test]
     fn play_alias_does_not_panic() {
         // `SystemDefault` is a stock alias present on every Windows
-        // install. As above, we don't assert success — audio devices
-        // may not exist in CI — only that the FFI path is sound.
+        // install. We don't assert success — audio devices may not
+        // exist in CI — only that the FFI path is sound.
         let _ = super::play_alias_async("SystemDefault");
     }
 
     #[cfg(windows)]
     #[test]
     fn rodio_play_missing_file_returns_false() {
-        // `play_audio_file_async` short-circuits on a missing path before
-        // touching rodio — so this test runs cleanly even on a CI host
-        // with no audio device, and protects against a regression where
-        // we accidentally start spawning threads for paths that won't
-        // resolve.
+        // `play_audio_file_async` short-circuits on a missing path
+        // before touching rodio — so this test runs cleanly even on a
+        // CI host with no audio device, and protects against a
+        // regression where we accidentally start spawning threads for
+        // paths that won't resolve.
         let ok = super::play_audio_file_async(
             std::path::Path::new(r"C:\definitely\not\here\nope.mp3"),
             0.5,
         );
+        assert!(!ok);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rodio_play_undecodable_file_returns_false() {
+        // Synchronous pre-flight catches decoder failures: writing a
+        // small text file with `.mp3` extension makes the path exist
+        // but the decoder reject it. The function should return
+        // `false`, log a warning, and NOT spawn the worker thread.
+        // Validates the contract documented on `play_audio_file_async`.
+        let tmp = std::env::temp_dir().join("claudette-audio-bogus.mp3");
+        std::fs::write(&tmp, b"not actually mp3").expect("write tmp");
+        let ok = super::play_audio_file_async(&tmp, 0.5);
+        std::fs::remove_file(&tmp).ok();
         assert!(!ok);
     }
 }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,210 @@
+//! Cross-platform audio primitives used by the notification system.
+//!
+//! macOS and Linux already shell out to native players (`afplay`, `paplay`,
+//! `ffplay`) inline at the call sites in `cesp.rs` and the `settings`
+//! command module — adding a wrapper there would just duplicate trivial
+//! `Command::new(...)` boilerplate.
+//!
+//! Windows is different: there is no equivalent shipped CLI player, so we
+//! drive playback in-process via two complementary backends:
+//!
+//! 1. **`PlaySoundW`** (Win32) for system-sound aliases like `SystemDefault`
+//!    and bare WAV files from `C:\Windows\Media`. Zero decoder cost, plays
+//!    at the user's system volume, and respects whatever sound the user
+//!    has assigned to the *Default Beep* in Sound settings.
+//!
+//! 2. **`rodio`** (pure Rust on top of `cpal` + `symphonia`) for OpenPeon
+//!    sound packs that ship MP3 / OGG. `PlaySoundW` only handles PCM WAV,
+//!    so packs like Alan Rickman / Elise (which the registry promotes)
+//!    need a real decoder. Rodio also gives us per-call volume control
+//!    that matches `afplay -v` / `paplay --volume` on the other platforms.
+//!
+//! The two paths are kept independent so the rodio dep cost is paid only
+//! when a user opts into a sound pack — system-sound playback stays
+//! decoder-free.
+
+#[cfg(windows)]
+mod win {
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::{Path, PathBuf};
+    use windows_sys::Win32::Media::Audio::{
+        PlaySoundW, SND_ALIAS, SND_ASYNC, SND_FILENAME, SND_NODEFAULT,
+    };
+
+    fn to_wide_nul(s: &std::ffi::OsStr) -> Vec<u16> {
+        s.encode_wide().chain(std::iter::once(0)).collect()
+    }
+
+    /// Play a `.wav` file asynchronously via `PlaySoundW`. Returns `true`
+    /// on success.
+    ///
+    /// Uses `SND_FILENAME | SND_ASYNC | SND_NODEFAULT` — the call returns
+    /// immediately, Windows owns playback, and on failure (missing file,
+    /// codec mismatch) it stays silent rather than playing the system
+    /// default beep. PlaySoundW always plays at the system volume; for
+    /// per-call volume control on WAV / MP3 / OGG, use
+    /// `play_audio_file_async` instead.
+    pub fn play_wav_file_async(path: &Path) -> bool {
+        let wide = to_wide_nul(path.as_os_str());
+        // SAFETY: `wide` is a valid, NUL-terminated UTF-16 buffer that
+        // outlives the `PlaySoundW` call. With `SND_ASYNC | SND_FILENAME`
+        // Windows opens the file synchronously inside the call and starts
+        // a background play — it does not retain the pointer past return.
+        // The lpModule argument is null, which is required when SND_ALIAS
+        // / SND_RESOURCE are not set.
+        let ok = unsafe {
+            PlaySoundW(
+                wide.as_ptr(),
+                std::ptr::null_mut(),
+                SND_FILENAME | SND_ASYNC | SND_NODEFAULT,
+            )
+        };
+        ok != 0
+    }
+
+    /// Play a Windows system-sound alias asynchronously (e.g. `"SystemAsterisk"`,
+    /// `"SystemDefault"`, `"MailBeep"`). Returns `true` on success.
+    pub fn play_alias_async(alias: &str) -> bool {
+        let os: std::ffi::OsString = alias.into();
+        let wide = to_wide_nul(os.as_os_str());
+        // SAFETY: as above, with `SND_ALIAS` the lpszSound buffer must be
+        // valid for the duration of the call only.
+        let ok = unsafe {
+            PlaySoundW(
+                wide.as_ptr(),
+                std::ptr::null_mut(),
+                SND_ALIAS | SND_ASYNC | SND_NODEFAULT,
+            )
+        };
+        ok != 0
+    }
+
+    /// Play any audio file rodio can decode (WAV / MP3 / OGG with our
+    /// `symphonia-*` features) at the given attenuation. Returns `true`
+    /// once playback has been queued — the call returns immediately and
+    /// the sound finishes in a detached thread that owns the
+    /// `OutputStream`. Volume is clamped to `[0.0, 1.0]`.
+    ///
+    /// Failure modes (file missing, no audio device, decode error, queue
+    /// full) all return `false` and emit a `tracing::warn` so a stuck
+    /// notification has a breadcrumb in the log without crashing the app.
+    pub fn play_audio_file_async(path: &Path, volume: f32) -> bool {
+        if !path.exists() {
+            return false;
+        }
+        let owned: PathBuf = path.to_path_buf();
+        let vol = volume.clamp(0.0, 1.0);
+
+        // rodio's `MixerDeviceSink` owns the cpal stream and is not safe
+        // to move *while held*, so we construct + own it entirely inside
+        // the spawned thread. Dropping it before playback finishes cuts
+        // the sound mid-play, hence the explicit `sleep_until_end()`
+        // before the thread returns. This mirrors the macOS/Linux
+        // pattern where the spawned `afplay` / `paplay` child owns its
+        // own audio context for the duration of one sound.
+        std::thread::spawn(move || {
+            let device_sink = match rodio::DeviceSinkBuilder::open_default_sink() {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "claudette::audio",
+                        error = %e,
+                        "no default audio output device — skipping playback"
+                    );
+                    return;
+                }
+            };
+            let file = match std::fs::File::open(&owned) {
+                Ok(f) => f,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "claudette::audio",
+                        path = %owned.display(),
+                        error = %e,
+                        "could not open sound file"
+                    );
+                    return;
+                }
+            };
+            let reader = std::io::BufReader::new(file);
+            let decoder = match rodio::Decoder::new(reader) {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "claudette::audio",
+                        path = %owned.display(),
+                        error = %e,
+                        "could not decode sound file (unsupported format?)"
+                    );
+                    return;
+                }
+            };
+            let player = rodio::Player::connect_new(device_sink.mixer());
+            player.set_volume(vol);
+            player.append(decoder);
+            // Block this background thread until the sound finishes so
+            // `device_sink` and `player` remain alive for the duration
+            // of playback. Returning here drops both, ending the sound.
+            player.sleep_until_end();
+        });
+        true
+    }
+}
+
+#[cfg(windows)]
+pub use win::{play_alias_async, play_audio_file_async, play_wav_file_async};
+
+/// Directory holding Windows' built-in system sound files. Used by the
+/// settings command module to enumerate available sounds and to resolve
+/// a sound name → on-disk path.
+#[cfg(windows)]
+pub const WINDOWS_MEDIA_DIR: &str = r"C:\Windows\Media";
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    #[test]
+    fn windows_media_dir_constant_is_set() {
+        // Guards against an accidental empty/typo'd path. We don't check
+        // existence — the directory is part of any Windows install but
+        // could be absent in stripped CI images.
+        assert!(super::WINDOWS_MEDIA_DIR.ends_with("Media"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn play_missing_file_does_not_panic() {
+        // We can't assert on the return value: with `SND_ASYNC`, Windows
+        // queues the request and resolves the file later, so missing
+        // paths often return `TRUE` anyway. The point of this test is
+        // just to confirm the FFI signature, lifetimes, and pointer
+        // discipline don't crash on a syntactically valid path that
+        // happens not to exist.
+        let _ =
+            super::play_wav_file_async(std::path::Path::new(r"C:\definitely\not\here\nope.wav"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn play_alias_does_not_panic() {
+        // `SystemDefault` is a stock alias present on every Windows
+        // install. As above, we don't assert success — audio devices
+        // may not exist in CI — only that the FFI path is sound.
+        let _ = super::play_alias_async("SystemDefault");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rodio_play_missing_file_returns_false() {
+        // `play_audio_file_async` short-circuits on a missing path before
+        // touching rodio — so this test runs cleanly even on a CI host
+        // with no audio device, and protects against a regression where
+        // we accidentally start spawning threads for paths that won't
+        // resolve.
+        let ok = super::play_audio_file_async(
+            std::path::Path::new(r"C:\definitely\not\here\nope.mp3"),
+            0.5,
+        );
+        assert!(!ok);
+    }
+}

--- a/src/cesp.rs
+++ b/src/cesp.rs
@@ -482,9 +482,21 @@ pub fn play_audio_file(path: &Path, volume: f64) {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(windows)]
     {
-        let _ = (path, volume);
+        // Windows has no shipped CLI player, so we decode in-process via
+        // `rodio`. This handles WAV / MP3 / OGG — the formats the curated
+        // OpenPeon packs (Alan Rickman, Elise, …) actually ship. Volume
+        // is honoured exactly the way `afplay -v` / `paplay --volume` do
+        // it on the other platforms.
+        let played = crate::audio::play_audio_file_async(path, volume as f32);
+        if !played {
+            tracing::warn!(
+                target: "claudette::cesp",
+                path = %path.display(),
+                "rodio playback failed to queue — see earlier audio log for the underlying error"
+            );
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod agent_backend;
 pub mod agent_mcp;
+pub mod audio;
 pub mod cesp;
 pub mod chat;
 pub mod claude_flags_store;


### PR DESCRIPTION
## Summary

Notification audio was effectively silent on Windows. Three Windows-stubbed functions and one incompatible shell:

| Symptom | Site | Behaviour |
|---|---|---|
| Built-in system sounds silent | `commands/settings.rs::play_notification_sound` | `let _ = (sound, vol);` no-op |
| OpenPeon sound packs silent | `cesp.rs::play_audio_file` | `let _ = (path, volume);` no-op |
| Sound dropdown empty | `commands/settings.rs::list_notification_sounds` | Only enumerated `/System/Library/Sounds` (macOS) |
| Custom notification commands never ran | `commands/settings.rs::build_notification_command` | Always `sh -c`, which a vanilla Windows install does not have |

UAT confirmed working on the reporter's Surface Pro 11 (Windows 11 ARM64) with the **Alan Rickman** OpenPeon pack, which ships MP3.

## Root cause

The Windows branches were stubbed to `let _ = ...` from the original implementation. Because `play_notification_sound` is the entry point the non-macOS notification path calls (`tray.rs:759`), every system-sound notification fell through silently. CESP / OpenPeon packs hit the same fate via `play_audio_file`. The custom-command path picked the wrong shell.

## Fix

A small `claudette::audio` module (`src/audio.rs`) holds the Windows audio primitives. Two backends, picked per use case:

- **`PlaySoundW`** (Win32, no decoder cost) for system-sound aliases (`SystemDefault`) and `C:\Windows\Media\*.wav`. Plays at system volume — fine for short beeps.
- **`rodio`** (cpal + Symphonia, default features off, only `symphonia-{wav,mp3,vorbis}`) for OpenPeon sound packs. WAV / MP3 / OGG all decode in-process, with per-call volume that matches `afplay -v` / `paplay --volume` on the other platforms.

Wired up:
- `play_audio_file` (cesp.rs) → `claudette::audio::play_audio_file_async` on Windows
- `play_notification_sound` (settings.rs) → `claudette::audio::play_alias_async` for "Default", `play_wav_file_async` for named system sounds
- `list_notification_sounds` enumerates `C:\Windows\Media\*.wav` on Windows (alongside the existing macOS branch)
- `build_notification_command` uses `cmd.exe /S /C` on Windows, `sh -c` elsewhere. `/S` preserves the verbatim command line so the embedded command reaches the shell unmangled.

`windows-sys` (`Win32_Media_Audio` feature) and `rodio` are gated to `[target.'cfg(windows)'.dependencies]`. Zero impact on macOS / Linux dependency graphs and binary sizes. macOS / Linux audio paths are untouched.

All `unsafe` `PlaySoundW` FFI lives in one module behind safe wrappers, with documented SAFETY comments covering the `lpszSound` lifetime under `SND_ASYNC`.

## Tests

- `audio::tests` — FFI smoke tests (no audio device required): missing-file paths, alias paths, rodio early-return on missing files
- `commands::settings::tests::test_list_notification_sounds_includes_system_sounds_windows` — Windows enumeration via `claudette::audio::WINDOWS_MEDIA_DIR`
- `test_build_notification_command_sets_shell_and_args` — branches on `cfg(windows)` to assert `cmd.exe /S /C` vs `sh -c`
- `test_notification_command_runs_and_receives_env` — switched from shell-redirect to stdout capture (sidesteps `cmd.exe`'s vs Rust's quote-handling mismatch); verifies `%CLAUDETTE_*%` / `\$CLAUDETTE_*` env vars reach the shell child on each platform

All clean: `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` zero warnings, `cargo fmt --all --check` clean.

## Docs

- `site/src/content/docs/features/notifications.mdx` — adds a per-platform "Sound Playback by Platform" section explaining the PlaySoundW vs rodio split and the per-shell custom-command behaviour
- `CLAUDE.md` — Notification architecture section now points new contributors at `src/audio.rs` and explains why the two-backend split exists

## Live verification

Inspected the reporter's running Claudette via `/claudette-debug`:
- `sound_source = "openpeon"`, `cesp_active_pack = "alan-rickman"`, `cesp_volume = "1.00"`
- Pack ships MP3 (`input_required_01.mp3`, …). PlaySoundW alone would not have played these — that's what drove the rodio decision.
- After rebuild, the user confirms UAT passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)