### PR TITLE
fix(dev): --clean also sandboxes ~/.claude/ via CLAUDE_CONFIG_DIR

### DIFF
--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -278,9 +278,29 @@ Write-Host "▸ Discovery file:   $discoveryFile"
 #                       auth, or marketplaces writes those changes into
 #                       the user's real ~/.claude/, defeating the
 #                       "simulate a new user" purpose of the flag.
+#
+# Env-var lifetime: when this script is invoked from an interactive
+# PowerShell prompt (the common case via the `dev` profile function),
+# `$env:NAME = ...` mutates the *caller's* process environment because
+# `&` runs the script in the same process. Without restoring the
+# original values on exit, the user's shell would still have
+# CLAUDE_CONFIG_DIR / CLAUDETTE_HOME / CLAUDETTE_DATA_DIR pointing at
+# the now-deleted clean root after `dev --clean` completes — silently
+# affecting any subsequent Claudette CLI usage from that prompt. We
+# therefore snapshot the prior values (or absence) up front and put
+# the unset/restore in the same PowerShell.Exiting handler that
+# removes the temp tree.
 $cleanRoot = $null
+$prevClaudetteHome     = $null
+$prevClaudetteDataDir  = $null
+$prevClaudeConfigDir   = $null
+$cleanSandboxEnvVars   = $false
 if ($cleanSession) {
     $cleanRoot = Join-Path $discoveryDir "clean-$PID"
+    $prevClaudetteHome    = if (Test-Path Env:\CLAUDETTE_HOME)     { $env:CLAUDETTE_HOME }     else { $null }
+    $prevClaudetteDataDir = if (Test-Path Env:\CLAUDETTE_DATA_DIR) { $env:CLAUDETTE_DATA_DIR } else { $null }
+    $prevClaudeConfigDir  = if (Test-Path Env:\CLAUDE_CONFIG_DIR)  { $env:CLAUDE_CONFIG_DIR }  else { $null }
+    $cleanSandboxEnvVars  = $true
     $env:CLAUDETTE_HOME      = Join-Path $cleanRoot 'home'
     $env:CLAUDETTE_DATA_DIR  = Join-Path $cleanRoot 'data'
     $env:CLAUDE_CONFIG_DIR   = Join-Path $cleanRoot 'claude-config'
@@ -302,7 +322,18 @@ if ($cleanSession) {
 # `"@` with any leading whitespace, which fights `scripts/` indent).
 # Use a string fallback rather than `??` so the script parses in
 # Windows PowerShell 5.1 (no null-coalescing) as well as pwsh 7+.
+#
+# The env-var section restores each of the three sandbox vars to its
+# pre-launch value (or removes it entirely if it wasn't set), so the
+# caller's PowerShell session is left exactly as it was before
+# `dev --clean` ran. Sentinel literal `__UNSET__` rides through the
+# format string to distinguish "wasn't set" from "was set to empty
+# string" — both legal pre-states, but they need different handling.
 $cleanRootForCleanup = if ($null -eq $cleanRoot) { '' } else { $cleanRoot }
+$envScrubFlag        = if ($cleanSandboxEnvVars) { '1' } else { '' }
+$prevHomeForCleanup       = if ($null -eq $prevClaudetteHome)    { '__UNSET__' } else { $prevClaudetteHome }
+$prevDataDirForCleanup    = if ($null -eq $prevClaudetteDataDir) { '__UNSET__' } else { $prevClaudetteDataDir }
+$prevConfigDirForCleanup  = if ($null -eq $prevClaudeConfigDir)  { '__UNSET__' } else { $prevClaudeConfigDir }
 $cleanupBody = @'
 if (Test-Path -LiteralPath '{0}') {{
     Remove-Item -LiteralPath '{0}' -Force -ErrorAction SilentlyContinue
@@ -310,7 +341,16 @@ if (Test-Path -LiteralPath '{0}') {{
 if ('{1}' -ne '' -and (Test-Path -LiteralPath '{1}')) {{
     Remove-Item -LiteralPath '{1}' -Recurse -Force -ErrorAction SilentlyContinue
 }}
-'@ -f $discoveryFile, $cleanRootForCleanup
+if ('{2}' -ne '') {{
+    if ('{3}' -eq '__UNSET__') {{ Remove-Item Env:\CLAUDETTE_HOME -ErrorAction SilentlyContinue }}
+    else {{ $env:CLAUDETTE_HOME = '{3}' }}
+    if ('{4}' -eq '__UNSET__') {{ Remove-Item Env:\CLAUDETTE_DATA_DIR -ErrorAction SilentlyContinue }}
+    else {{ $env:CLAUDETTE_DATA_DIR = '{4}' }}
+    if ('{5}' -eq '__UNSET__') {{ Remove-Item Env:\CLAUDE_CONFIG_DIR -ErrorAction SilentlyContinue }}
+    else {{ $env:CLAUDE_CONFIG_DIR = '{5}' }}
+}}
+'@ -f $discoveryFile, $cleanRootForCleanup, $envScrubFlag,
+       $prevHomeForCleanup, $prevDataDirForCleanup, $prevConfigDirForCleanup
 $cleanupAction = [ScriptBlock]::Create($cleanupBody)
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action $cleanupAction | Out-Null
 

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -29,8 +29,12 @@
 #   $env:CARGO_TAURI_FEATURES       features (default devtools,server,alternative-backends)
 #
 # Flags:
-#   --clean              Run as a fresh user (per-PID CLAUDETTE_HOME +
-#                        CLAUDETTE_DATA_DIR). See -h for details.
+#   --clean              Run as a fresh user — points CLAUDETTE_HOME,
+#                        CLAUDETTE_DATA_DIR, and CLAUDE_CONFIG_DIR at
+#                        per-PID tmp dirs so the launch sees no existing
+#                        repos, settings, plugins, or Claude auth, and
+#                        nothing it does writes back to the real user
+#                        state. Cleaned up on exit. See -h for details.
 #   -h, --help           Print usage and exit.
 #
 # Usage from any PowerShell prompt in the repo:
@@ -60,12 +64,21 @@ and the IPv4-bound Vite + custom-protocol-off configuration that Windows
 needs for the WebView2 + /claudette-debug combination to work.
 
 Flags:
-  --clean              Run as a fresh user — points CLAUDETTE_HOME and
-                       CLAUDETTE_DATA_DIR at a per-PID tmp tree so the
-                       launch sees no existing repos, workspaces, or
-                       settings. Cleaned up on exit. Useful for testing
-                       first-run UX (welcome card, onboarding) without
-                       nuking the real ~/.claudette/ tree.
+  --clean              Run as a fresh user — points three env vars at a
+                       per-PID tmp tree so the launch sees no existing
+                       state and nothing it writes leaks back to the
+                       real user:
+
+                         CLAUDETTE_HOME      ~/.claudette/ (workspaces,
+                                             themes, logs, packs)
+                         CLAUDETTE_DATA_DIR  OS data dir for claudette.db
+                         CLAUDE_CONFIG_DIR   ~/.claude/ (Claude CLI
+                                             settings, credentials,
+                                             plugins, marketplaces)
+
+                       Cleaned up on exit. Useful for testing first-run
+                       UX (welcome card, onboarding) and plugin/auth
+                       flows without nuking real user data.
   -h, --help           Print this usage and exit.
   --                   Pass everything after this flag straight to
                        ``cargo run`` (e.g. --release, --quiet).
@@ -85,6 +98,11 @@ Env vars (each consulted at process start):
                        plugins, themes, logs, models, packs, apps.json).
   `$env:CLAUDETTE_DATA_DIR
                        Override the OS data dir holding claudette.db.
+  `$env:CLAUDE_CONFIG_DIR
+                       Override the Claude CLI's ~/.claude/ tree
+                       (settings.json, .credentials.json, plugins,
+                       marketplaces). Read by both the Claude CLI itself
+                       and Claudette's plugin / auth code paths.
   `$env:CLAUDETTE_LOG_DIR
                        Per-instance log dir (otherwise derived from
                        CLAUDETTE_HOME).
@@ -247,16 +265,32 @@ Write-Host "▸ Discovery file:   $discoveryFile"
 # discovery dir so the cleanup sweep finds it predictably. The trap
 # below removes the directory on script exit; a hard kill leaves it
 # behind, but it's under $env:TEMP so it won't leak forever.
+#
+# Three env vars get pointed at the sandbox — only the first two are
+# Claudette-specific:
+#
+#   CLAUDETTE_HOME      ~/.claudette/ tree (workspaces, themes, logs, packs)
+#   CLAUDETTE_DATA_DIR  OS data dir holding claudette.db
+#   CLAUDE_CONFIG_DIR   ~/.claude/ tree, owned by the *Claude CLI* but
+#                       actively read+written by Claudette: settings.json,
+#                       .credentials.json, plugins/, plugins/marketplaces/.
+#                       Without this, a --clean run that touches plugins,
+#                       auth, or marketplaces writes those changes into
+#                       the user's real ~/.claude/, defeating the
+#                       "simulate a new user" purpose of the flag.
 $cleanRoot = $null
 if ($cleanSession) {
     $cleanRoot = Join-Path $discoveryDir "clean-$PID"
     $env:CLAUDETTE_HOME      = Join-Path $cleanRoot 'home'
     $env:CLAUDETTE_DATA_DIR  = Join-Path $cleanRoot 'data'
+    $env:CLAUDE_CONFIG_DIR   = Join-Path $cleanRoot 'claude-config'
     New-Item -ItemType Directory -Force -Path $env:CLAUDETTE_HOME | Out-Null
     New-Item -ItemType Directory -Force -Path $env:CLAUDETTE_DATA_DIR | Out-Null
-    Write-Host "▸ Clean session:    $cleanRoot"
-    Write-Host "▸ CLAUDETTE_HOME:   $env:CLAUDETTE_HOME"
+    New-Item -ItemType Directory -Force -Path $env:CLAUDE_CONFIG_DIR | Out-Null
+    Write-Host "▸ Clean session:      $cleanRoot"
+    Write-Host "▸ CLAUDETTE_HOME:     $env:CLAUDETTE_HOME"
     Write-Host "▸ CLAUDETTE_DATA_DIR: $env:CLAUDETTE_DATA_DIR"
+    Write-Host "▸ CLAUDE_CONFIG_DIR:  $env:CLAUDE_CONFIG_DIR"
 }
 
 # Best-effort cleanup. PowerShell can't trap SIGTERM/SIGINT identically

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -20,12 +20,14 @@
 #   CARGO_TAURI_FEATURES   features to pass to tauri (default devtools,server,voice,alternative-backends)
 #
 # Flags:
-#   --clean                Run as a fresh user — points CLAUDETTE_HOME and
-#                          CLAUDETTE_DATA_DIR at a per-PID tmp tree so the
-#                          launch sees no existing repos, workspaces, or
-#                          settings. Useful for testing first-run UX (the
-#                          welcome empty state, onboarding) without nuking
-#                          the real ~/.claudette/ tree.
+#   --clean                Run as a fresh user — points CLAUDETTE_HOME,
+#                          CLAUDETTE_DATA_DIR, and CLAUDE_CONFIG_DIR at a
+#                          per-PID tmp tree so the launch sees no existing
+#                          state and nothing it writes leaks back to the
+#                          real user (workspaces, settings, plugins, or
+#                          Claude auth). Useful for testing first-run UX,
+#                          plugin/marketplace flows, and login flows
+#                          without touching ~/.claudette/ or ~/.claude/.
 set -euo pipefail
 
 print_usage() {
@@ -37,12 +39,21 @@ and (on macOS) the signed-bundle runner so TCC permissions attach to
 Claudette rather than the terminal.
 
 Flags:
-  --clean              Run as a fresh user — points CLAUDETTE_HOME and
-                       CLAUDETTE_DATA_DIR at a per-PID tmp tree so the
-                       launch sees no existing repos, workspaces, or
-                       settings. Cleaned up on exit. Useful for testing
-                       first-run UX (welcome card, onboarding) without
-                       nuking the real ~/.claudette/ tree.
+  --clean              Run as a fresh user — points three env vars at a
+                       per-PID tmp tree so the launch sees no existing
+                       state and nothing it writes leaks back to the
+                       real user:
+
+                         CLAUDETTE_HOME      ~/.claudette/ (workspaces,
+                                             themes, logs, packs)
+                         CLAUDETTE_DATA_DIR  OS data dir for claudette.db
+                         CLAUDE_CONFIG_DIR   ~/.claude/ (Claude CLI
+                                             settings, credentials,
+                                             plugins, marketplaces)
+
+                       Cleaned up on exit. Useful for testing first-run
+                       UX (welcome card, onboarding) and plugin/auth
+                       flows without nuking real user data.
   -h, --help           Print this usage and exit.
   --                   Pass everything after this flag straight to the
                        Tauri CLI (e.g. --release, --no-default-features).
@@ -57,6 +68,10 @@ Env vars (each consulted at process start):
                        plugins, themes, logs, models, packs, apps.json).
   CLAUDETTE_DATA_DIR   Override the OS data dir holding claudette.db
                        (\`dirs::data_dir()/claudette/\` by default).
+  CLAUDE_CONFIG_DIR    Override the Claude CLI's ~/.claude/ tree
+                       (settings.json, .credentials.json, plugins,
+                       marketplaces). Read by both the Claude CLI
+                       itself and Claudette's plugin / auth code paths.
   CLAUDETTE_LOG_DIR    Per-instance log dir override (otherwise derived
                        from CLAUDETTE_HOME).
 
@@ -168,15 +183,25 @@ with open(out, "w") as f:
 
 if (( clean_session )); then
   # Per-PID sandbox so a parallel `dev --clean` doesn't reuse this session's
-  # state. The cleanup trap removes both directories on exit, but they're
+  # state. The cleanup trap removes the directory on exit, but it lives
   # under TMPDIR anyway so a forgotten kill -9 won't leak forever.
+  #
+  # Three env vars get pointed at the sandbox — only the first two are
+  # Claudette-specific. CLAUDE_CONFIG_DIR routes the *Claude CLI's*
+  # ~/.claude/ tree, which Claudette actively reads and writes
+  # (settings.json, .credentials.json, plugins/, plugins/marketplaces/).
+  # Without that override, a --clean run that touches plugins, auth, or
+  # marketplaces silently writes those changes into the user's real
+  # ~/.claude/, defeating the "simulate a new user" purpose of the flag.
   clean_root="$discovery_dir/clean-$$"
   export CLAUDETTE_HOME="$clean_root/home"
   export CLAUDETTE_DATA_DIR="$clean_root/data"
-  mkdir -p "$CLAUDETTE_HOME" "$CLAUDETTE_DATA_DIR"
-  echo "▸ Clean session:    $clean_root"
-  echo "▸ CLAUDETTE_HOME:   $CLAUDETTE_HOME"
+  export CLAUDE_CONFIG_DIR="$clean_root/claude-config"
+  mkdir -p "$CLAUDETTE_HOME" "$CLAUDETTE_DATA_DIR" "$CLAUDE_CONFIG_DIR"
+  echo "▸ Clean session:      $clean_root"
+  echo "▸ CLAUDETTE_HOME:     $CLAUDETTE_HOME"
   echo "▸ CLAUDETTE_DATA_DIR: $CLAUDETTE_DATA_DIR"
+  echo "▸ CLAUDE_CONFIG_DIR:  $CLAUDE_CONFIG_DIR"
 fi
 
 cleanup() {

--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -114,15 +114,17 @@ On startup, Claudette also scans `${TMPDIR}/claudette-dev/*.json` (the discovery
 For testing first-run UX (the welcome card, onboarding, plugin seeding) you can launch Claudette with a completely empty data tree:
 
 ```bash
-./scripts/dev.sh --clean
+./scripts/dev.sh --clean         # macOS / Linux
+.\scripts\dev.ps1 --clean        # Windows (PowerShell)
 ```
 
-The flag points two env vars at a per-PID directory under `${TMPDIR}/claudette-dev/clean-<pid>/` and removes the tree on exit:
+The flag points three env vars at a per-PID directory under `${TMPDIR}/claudette-dev/clean-<pid>/` (`$env:TEMP\claudette-dev\clean-<pid>\` on Windows) and removes the tree on exit:
 
 - **`CLAUDETTE_HOME`** overrides the `~/.claudette/` tree (workspaces, plugins, themes, logs, models, packs).
 - **`CLAUDETTE_DATA_DIR`** overrides the OS data directory holding `claudette.db`.
+- **`CLAUDE_CONFIG_DIR`** overrides the **Claude CLI's** `~/.claude/` tree, which Claudette reads and writes for `settings.json`, `.credentials.json`, installed plugins, and marketplace registrations. Without this override, a `--clean` run that touches plugins or auth would write into the real `~/.claude/` and survive the sandbox tear-down — defeating the "simulate a new user" purpose of the flag.
 
-You can also set either env var manually for a longer-lived sandbox — e.g. `CLAUDETTE_HOME=/tmp/claudette-demo CLAUDETTE_DATA_DIR=/tmp/claudette-demo/data ./scripts/dev.sh` keeps the sandbox across restarts.
+You can also set any of these env vars manually for a longer-lived sandbox — e.g. `CLAUDETTE_HOME=/tmp/claudette-demo CLAUDETTE_DATA_DIR=/tmp/claudette-demo/data CLAUDE_CONFIG_DIR=/tmp/claudette-demo/claude ./scripts/dev.sh` keeps the sandbox across restarts.
 
 ## Filing a bug report
 

--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -3,6 +3,8 @@ title: Diagnostics & Logging
 description: Where Claudette writes its logs, how to change verbosity, and how to capture frontend errors for bug reports.
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 Claudette writes structured, daily-rotated logs to disk so user-reported bugs can be reconstructed from the file alone — without needing the user to reproduce while the app is attached to a debugger. The pipeline is on by default in every build.
 
 ## Where logs live
@@ -113,10 +115,18 @@ On startup, Claudette also scans `${TMPDIR}/claudette-dev/*.json` (the discovery
 
 For testing first-run UX (the welcome card, onboarding, plugin seeding) you can launch Claudette with a completely empty data tree:
 
-```bash
-./scripts/dev.sh --clean         # macOS / Linux
-.\scripts\dev.ps1 --clean        # Windows (PowerShell)
-```
+<Tabs>
+  <TabItem label="macOS / Linux">
+    ```bash
+    ./scripts/dev.sh --clean
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```powershell
+    .\scripts\dev.ps1 --clean
+    ```
+  </TabItem>
+</Tabs>
 
 The flag points three env vars at a per-PID directory under `${TMPDIR}/claudette-dev/clean-<pid>/` (`$env:TEMP\claudette-dev\clean-<pid>\` on Windows) and removes the tree on exit:
 
@@ -124,7 +134,26 @@ The flag points three env vars at a per-PID directory under `${TMPDIR}/claudette
 - **`CLAUDETTE_DATA_DIR`** overrides the OS data directory holding `claudette.db`.
 - **`CLAUDE_CONFIG_DIR`** overrides the **Claude CLI's** `~/.claude/` tree, which Claudette reads and writes for `settings.json`, `.credentials.json`, installed plugins, and marketplace registrations. Without this override, a `--clean` run that touches plugins or auth would write into the real `~/.claude/` and survive the sandbox tear-down — defeating the "simulate a new user" purpose of the flag.
 
-You can also set any of these env vars manually for a longer-lived sandbox — e.g. `CLAUDETTE_HOME=/tmp/claudette-demo CLAUDETTE_DATA_DIR=/tmp/claudette-demo/data CLAUDE_CONFIG_DIR=/tmp/claudette-demo/claude ./scripts/dev.sh` keeps the sandbox across restarts.
+You can also set any of these env vars manually for a longer-lived sandbox:
+
+<Tabs>
+  <TabItem label="macOS / Linux">
+    ```bash
+    CLAUDETTE_HOME=/tmp/claudette-demo \
+    CLAUDETTE_DATA_DIR=/tmp/claudette-demo/data \
+    CLAUDE_CONFIG_DIR=/tmp/claudette-demo/claude \
+      ./scripts/dev.sh
+    ```
+  </TabItem>
+  <TabItem label="Windows">
+    ```powershell
+    $env:CLAUDETTE_HOME      = "$env:TEMP\claudette-demo"
+    $env:CLAUDETTE_DATA_DIR  = "$env:TEMP\claudette-demo\data"
+    $env:CLAUDE_CONFIG_DIR   = "$env:TEMP\claudette-demo\claude"
+    .\scripts\dev.ps1
+    ```
+  </TabItem>
+</Tabs>
 
 ## Filing a bug report
 


### PR DESCRIPTION
## Summary

`scripts/dev.ps1 --clean` (and its `dev.sh` twin) was supposed to simulate a fresh-install user — empty workspaces, no settings, no plugins — but in practice it could *modify the real user's settings*. The flag pointed Claudette's two roots at a per-PID temp tree:

- `CLAUDETTE_HOME` → `\$TMPDIR/claudette-dev/clean-<pid>/home`
- `CLAUDETTE_DATA_DIR` → `\$TMPDIR/claudette-dev/clean-<pid>/data`

…but Claudette also reads and writes the **Claude CLI's** `~/.claude/` tree: `settings.json`, `.credentials.json`, installed plugins, and marketplace registrations. (See `src/plugin.rs::claude_config_home_dir`.) That tree wasn't covered, so a `--clean` run that touched plugins, auth, or marketplaces silently wrote those changes into the real `~/.claude/` and they survived the sandbox tear-down — defeating the entire purpose of the flag.

This PR makes `--clean` set a third env var, `CLAUDE_CONFIG_DIR`, alongside the existing two so all three Claudette-touched roots live in the same per-PID temp tree.

## Why CLAUDE_CONFIG_DIR

It's the standard override the Claude CLI itself honours, and the same name `src/plugin.rs::claude_config_home_dir` and `src/agent/naming.rs::claude_config_home_dir` already check for. Setting it routes every `~/.claude/...` read and write the app does — including auth tokens, plugin installs, and marketplace operations — into the sandbox.

## Changes

- **`scripts/dev.ps1`** — `--clean` block now creates and exports `CLAUDE_CONFIG_DIR = <cleanRoot>\claude-config`. Header comment, `Show-Usage`'s flag block, and the env-var table all updated to describe the third variable and its rationale.
- **`scripts/dev.sh`** — same treatment, mirroring the PowerShell change so muscle memory carries across platforms (CLAUDE.md commits to keeping the two scripts aligned).
- **`site/src/content/docs/features/diagnostics.mdx`** — the user-facing "Sandboxed (fresh-user) sessions" section gains the third env var, the Windows command variant, and a one-line rationale.

The cleanup paths in both scripts already remove `\$cleanRoot` recursively on exit, so the new directory is collected for free.

## Verification

- `dev.ps1 --help` renders the new flag text correctly (verified locally).
- `bash -n scripts/dev.sh` passes.
- `[Parser]::ParseFile('scripts/dev.ps1')` returns no parse errors.
- The fix only adds new env-var exports; nothing destructive on the user side.

## Out of scope

Tauri's WebView2 user-data folder (`%LOCALAPPDATA%\com.claudette.app\EBWebView\`) is technically also shared between regular and `--clean` sessions, so localStorage (theme cache) and cookies bleed across. That's a much smaller footprint than `~/.claude/` and can be addressed separately if it becomes a real problem — flagging it here so the next person looking at `--clean` isolation knows what's still uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)