### PR TITLE
fix: preserve terminals across workspace navigation

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1147,6 +1147,7 @@ fn shutdown_runtime_handler(_app: &tauri::AppHandle, _event: tauri::RunEvent) {
         // the "Address already in use" error on next launch.
         tauri::RunEvent::Exit => {
             let app_state = _app.state::<state::AppState>();
+            state::APP_SHUTTING_DOWN.store(true, std::sync::atomic::Ordering::SeqCst);
 
             // Kill all spawned children (PTY shells + Claude CLI agent
             // subprocesses) before our process dies, otherwise they

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
 use std::sync::Mutex;
+use std::sync::atomic::Ordering;
 
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::Serialize;
@@ -202,9 +203,16 @@ pub async fn spawn_pty(
                 Err(_) => break,
             }
         }
-        // Reader saw EOF (or read error) — the shell process closed its end
-        // of the PTY. Notify the frontend so it can tear down the pane and
-        // tab. Closing via the user typing `exit` is the common case.
+        // Reader saw EOF (or read error). If the app is shutting down, this
+        // EOF was caused by our own subprocess cleanup; do not let the
+        // frontend mistake it for a natural shell exit and delete the
+        // persisted terminal tab.
+        if crate::state::APP_SHUTTING_DOWN.load(Ordering::SeqCst) {
+            return;
+        }
+        // Otherwise the shell process closed its end of the PTY. Notify the
+        // frontend so it can tear down the pane and tab. Closing via the user
+        // typing `exit` is the common case.
         let _ = emitter_app.emit(
             "pty-exit",
             &PtyExitPayload {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -20,6 +20,11 @@ use crate::remote::DiscoveredServer;
 use crate::usage::UsageCacheEntry;
 #[cfg(feature = "voice")]
 use crate::voice::VoiceProviderRegistry;
+
+/// Set during `RunEvent::Exit` before we tear down PTY shells and agent
+/// subprocesses. PTY reader threads use this to avoid reporting shutdown
+/// cleanup as a natural shell exit to the frontend.
+pub static APP_SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 
 /// Re-export for use in tray module without direct tauri::tray import.
 pub type TrayIcon = tauri::tray::TrayIcon;

--- a/src/ui/src/components/layout/AppLayout.terminal.test.tsx
+++ b/src/ui/src/components/layout/AppLayout.terminal.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const store = vi.hoisted(() => ({
+  sidebarVisible: true,
+  sidebarWidth: 260,
+  setSidebarWidth: vi.fn(),
+  rightSidebarVisible: true,
+  rightSidebarWidth: 320,
+  setRightSidebarWidth: vi.fn(),
+  selectedWorkspaceId: null as string | null,
+  diffSelectedFile: null as string | null,
+  terminalPanelVisible: false,
+  terminalHeight: 300,
+  setTerminalHeight: vi.fn(),
+  settingsOpen: false,
+  fuzzyFinderOpen: false,
+  commandPaletteOpen: false,
+}));
+
+vi.mock("../../stores/useAppStore", () => ({
+  selectActiveFileTabPath: () => null,
+  useAppStore: <T,>(selector: (state: typeof store) => T): T => selector(store),
+}));
+
+vi.mock("../sidebar/Sidebar", () => ({ Sidebar: () => <div /> }));
+vi.mock("../chat/ChatPanel", () => ({ ChatPanel: () => <div /> }));
+vi.mock("../diff/DiffViewer", () => ({ DiffViewer: () => <div /> }));
+vi.mock("../file-viewer/FileViewer", () => ({ FileViewer: () => <div /> }));
+vi.mock("../terminal/TerminalPanel", () => ({
+  TerminalPanel: () => <div data-testid="terminal-panel" />,
+}));
+vi.mock("../right-sidebar/RightSidebar", () => ({ RightSidebar: () => <div /> }));
+vi.mock("../fuzzy-finder/FuzzyFinder", () => ({ FuzzyFinder: () => <div /> }));
+vi.mock("../command-palette/CommandPalette", () => ({ CommandPalette: () => <div /> }));
+vi.mock("./Dashboard", () => ({ Dashboard: () => <div /> }));
+vi.mock("../modals/ModalRouter", () => ({ ModalRouter: () => <div /> }));
+vi.mock("../settings/SettingsPage", () => ({ SettingsPage: () => <div /> }));
+vi.mock("./ResizeHandle", () => ({ ResizeHandle: () => <div /> }));
+vi.mock("./Toast", () => ({ ToastContainer: () => <div /> }));
+vi.mock("../shared/AppTooltip", () => ({ AppTooltip: () => <div /> }));
+vi.mock("../../hooks/useAgentStream", () => ({ useAgentStream: vi.fn() }));
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: vi.fn() }));
+vi.mock("../../hooks/useBranchRefresh", () => ({ useBranchRefresh: vi.fn() }));
+vi.mock("../../hooks/useAutoUpdater", () => ({ useAutoUpdater: vi.fn() }));
+vi.mock("../../hooks/useWorkspaceFileWatcher", () => ({ useWorkspaceFileWatcher: vi.fn() }));
+vi.mock("../../hooks/useWorkspaceEnvironmentPreparation", () => ({
+  useWorkspaceEnvironmentPreparation: vi.fn(),
+}));
+
+import { AppLayout } from "./AppLayout";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function renderAppLayout() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<AppLayout />);
+  });
+  return container;
+}
+
+describe("AppLayout terminal owner", () => {
+  afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+      act(() => root.unmount());
+    }
+    for (const container of mountedContainers.splice(0)) {
+      container.remove();
+    }
+    store.selectedWorkspaceId = null;
+    store.terminalPanelVisible = false;
+  });
+
+  it("keeps TerminalPanel mounted when no workspace is selected", async () => {
+    const container = await renderAppLayout();
+
+    expect(container.querySelector('[data-testid="terminal-panel"]')).not.toBeNull();
+  });
+});

--- a/src/ui/src/components/layout/AppLayout.tsx
+++ b/src/ui/src/components/layout/AppLayout.tsx
@@ -143,12 +143,13 @@ export function AppLayout() {
               )}
             </div>
             {/*
-              Always mount the terminal panel when a workspace is selected;
-              drive visibility via a CSS class. Unmounting on collapse would
-              dispose every xterm instance and kill every PTY child —
-              toggling the panel must NOT destroy running shells.
-              The ResizeHandle has no state worth preserving and is only
-              useful when the panel is visible, so we conditionally render it.
+              Always mount the terminal panel; drive visibility via a CSS
+              class. TerminalPanel owns every live xterm/PTY instance across
+              workspaces, so unmounting it on collapse, dashboard/project view,
+              or settings swaps would dispose xterm instances and kill PTY
+              children. The ResizeHandle has no state worth preserving and is
+              only useful when a selected workspace's panel is visible, so we
+              conditionally render it.
             */}
             {selectedWorkspaceId && terminalPanelVisible && (
               <ResizeHandle
@@ -161,14 +162,14 @@ export function AppLayout() {
                 onResizeEnd={handleTerminalResizeEnd}
               />
             )}
-            {selectedWorkspaceId && (
-              <div
-                className={`${styles.terminal} ${terminalPanelVisible ? "" : styles.terminalHidden}`}
-                aria-hidden={!terminalPanelVisible}
-              >
-                <TerminalPanel />
-              </div>
-            )}
+            <div
+              className={`${styles.terminal} ${
+                selectedWorkspaceId && terminalPanelVisible ? "" : styles.terminalHidden
+              }`}
+              aria-hidden={!selectedWorkspaceId || !terminalPanelVisible}
+            >
+              <TerminalPanel />
+            </div>
           </div>
           {selectedWorkspaceId && (
             <>


### PR DESCRIPTION
## Summary

This fixes a silent terminal teardown path where navigating away from a selected workspace could unmount the shared terminal owner and close every live PTY.

## Root Cause

`AppLayout` only rendered `TerminalPanel` while `selectedWorkspaceId` was set. `TerminalPanel` owns the xterm instances and PTY subscriptions for all workspaces, and its unmount cleanup destroys those instances. When the user changed to a dashboard/project/settings-style view with no selected workspace, the cleanup path closed PTYs, which killed running processes. The backend then emitted `pty-exit`, and the frontend treated that like a natural shell exit, deleting persisted terminal tabs. On return, the workspace looked like it had reset to a fresh `Terminal 1`.

## Changes

- Keep `TerminalPanel` mounted globally and control visibility with CSS/ARIA state instead of conditional rendering.
- Keep the terminal resize handle scoped to the selected-workspace visible-panel case.
- Add an app-shutdown flag so PTY reader EOF caused by Rust-side shutdown cleanup is not reported to the frontend as a natural terminal exit.
- Add a focused React regression test that verifies `TerminalPanel` stays mounted when no workspace is selected.

## User Impact

Switching projects, opening dashboard/project views, or moving through settings should no longer kill active integrated terminal processes or delete their persisted tabs.

## Validation

All checks were run through `nix develop -c`:

- `cargo fmt --all --check`
- `cd src/ui && bun install --frozen-lockfile`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test`
- `cargo test -p claudette -p claudette-server -p claudette-cli --all-features`

