### PR TITLE
feat(updater): boot-health gate — pre-publish smoke + post-install heartbeat-or-rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: scripts/check-cargo-version-sync.sh
 
+  updater-manifest:
+    name: Updater Manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: scripts/test-build-updater-manifest.sh
+
   clippy:
     name: Lint
     runs-on: ubuntu-latest
@@ -105,6 +112,23 @@ jobs:
       - run: bun run lint:css
       - run: bun run build
       - run: bun run test
+
+  frontend-smoke:
+    name: Frontend Bundle Smoke
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: src/ui
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "latest"
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run smoke:bundle
 
   # Note: Windows is not built in this CI pipeline. Windows artifacts
   # are produced by the nightly (`.github/workflows/nightly.yml`) and

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,11 +128,9 @@ jobs:
             rust-target: aarch64-unknown-linux-gnu
             bundles: appimage,deb
             label: linux-aarch64
-          # Windows ships bare `.exe` assets only (no MSI/NSIS bundle).
-          # The tauri-action step is skipped on Windows and we drive
-          # cargo directly against the native MSVC toolchain baked into
-          # GitHub's Windows runners. `windows-11-arm` is GA and native,
-          # so ARM64 builds aren't cross-compiled.
+          # Windows keeps the user-facing zip asset and also publishes a
+          # signed NSIS updater asset so `latest.json` can advertise an
+          # in-app update target for Windows.
           - platform: windows-latest
             rust-target: x86_64-pc-windows-msvc
             bundles: ""
@@ -313,23 +311,28 @@ jobs:
           includeUpdaterJson: false
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
-      # ---- Windows: direct cargo build, ship the bare .exe -----------------
+      # ---- Windows: direct Tauri build, ship zip + NSIS updater ------------
       # `custom-protocol` is the feature flag that tells tauri-build to
       # embed `frontendDist` (otherwise the release binary tries to
       # contact the devUrl at startup and shows "localhost refused to
-      # connect"). `tauri-action` sets this automatically via
-      # `cargo tauri build`; since we're bypassing it on Windows, we
-      # pass the flag explicitly. `alternative-backends` is kept in release
-      # binaries while the user-facing experimental setting remains off by
-      # default.
-      - name: Build desktop exe (Windows)
+      # connect"). `alternative-backends` is kept in release binaries
+      # while the user-facing experimental setting remains off by default.
+      - name: Install Tauri CLI (Windows)
         if: startsWith(matrix.platform, 'windows')
         shell: bash
+        run: cargo install tauri-cli --version "^2" --locked
+
+      - name: Build desktop exe and updater installer (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          cd src/ui && bun run build && cd ../..
-          cargo build --release -p claudette-tauri \
-            --features tauri/custom-protocol,alternative-backends \
-            --target ${{ matrix.rust-target }}
+          cargo tauri build \
+            --target ${{ matrix.rust-target }} \
+            --bundles nsis \
+            --features tauri/custom-protocol,alternative-backends
 
       # Zip the bare .exe before upload. Raw unsigned .exe downloads
       # trigger aggressive SmartScreen + browser warnings ("file not
@@ -355,6 +358,29 @@ jobs:
           cp "$CLI" claudette.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette-app.exe','claudette.exe' -DestinationPath '$ASSET' -Force"
           gh release upload nightly-staging "$ASSET" --clobber
+
+      - name: Upload updater installer (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          NSIS_DIR="target/${{ matrix.rust-target }}/release/bundle/nsis"
+          INSTALLER="$(find "$NSIS_DIR" -maxdepth 1 -name '*setup.exe' -print -quit)"
+          if [ -z "$INSTALLER" ]; then
+            echo "::error::No NSIS updater installer found in $NSIS_DIR"
+            exit 1
+          fi
+          SIG="${INSTALLER}.sig"
+          if [ ! -f "$SIG" ]; then
+            cargo tauri signer sign \
+              -k "$TAURI_SIGNING_PRIVATE_KEY" \
+              -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+              "$INSTALLER" > "$SIG"
+          fi
+          gh release upload nightly-staging "$INSTALLER" "$SIG" --clobber
 
       - name: Build headless server
         shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,11 +84,9 @@ jobs:
             rust-target: aarch64-unknown-linux-gnu
             bundles: appimage,deb
             label: linux-aarch64
-          # Windows ships bare `.exe` assets only (no MSI/NSIS bundle).
-          # The tauri-action step is skipped on Windows and we drive
-          # cargo directly against the native MSVC toolchain baked into
-          # GitHub's Windows runners. `windows-11-arm` is GA and native,
-          # so ARM64 builds aren't cross-compiled.
+          # Windows keeps the user-facing zip asset and also publishes a
+          # signed NSIS updater asset so `latest.json` can advertise an
+          # in-app update target for Windows.
           - platform: windows-latest
             rust-target: x86_64-pc-windows-msvc
             bundles: ""
@@ -179,6 +177,7 @@ jobs:
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
+          includeUpdaterJson: false
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
       - name: Build and upload desktop app (non-Windows) — attempt 2 (macOS retry)
@@ -200,6 +199,7 @@ jobs:
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
+          includeUpdaterJson: false
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
       - name: Build and upload desktop app (non-Windows) — attempt 3 (macOS final)
@@ -219,25 +219,31 @@ jobs:
           tagName: ${{ needs.resolve-tag.outputs.tag }}
           releaseName: ${{ needs.resolve-tag.outputs.tag }}
           releaseDraft: true
+          includeUpdaterJson: false
           args: --target ${{ matrix.rust-target }} --bundles ${{ matrix.bundles }}
 
-      # ---- Windows: direct cargo build, ship the bare .exe -----------------
+      # ---- Windows: direct Tauri build, ship zip + NSIS updater ------------
       # `custom-protocol` is the feature flag that tells tauri-build to
       # embed `frontendDist` (otherwise the release binary tries to
       # contact the devUrl at startup and shows "localhost refused to
-      # connect"). `tauri-action` sets this automatically via
-      # `cargo tauri build`; since we're bypassing it on Windows, we
-      # pass the flag explicitly. `alternative-backends` is kept in release
-      # binaries while the user-facing experimental setting remains off by
-      # default.
-      - name: Build desktop exe (Windows)
+      # connect"). `alternative-backends` is kept in release binaries
+      # while the user-facing experimental setting remains off by default.
+      - name: Install Tauri CLI (Windows)
         if: startsWith(matrix.platform, 'windows')
         shell: bash
+        run: cargo install tauri-cli --version "^2" --locked
+
+      - name: Build desktop exe and updater installer (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
-          cd src/ui && bun run build && cd ../..
-          cargo build --release -p claudette-tauri \
-            --features tauri/custom-protocol,alternative-backends \
-            --target ${{ matrix.rust-target }}
+          cargo tauri build \
+            --target ${{ matrix.rust-target }} \
+            --bundles nsis \
+            --features tauri/custom-protocol,alternative-backends
 
       # Zip the bare .exe before upload. Raw unsigned .exe downloads
       # trigger aggressive SmartScreen + browser warnings ("file not
@@ -263,6 +269,29 @@ jobs:
           cp "$CLI" claudette.exe
           powershell -NoProfile -Command "Compress-Archive -Path 'claudette-app.exe','claudette.exe' -DestinationPath '$ASSET' -Force"
           gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$ASSET" --clobber
+
+      - name: Upload updater installer (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          NSIS_DIR="target/${{ matrix.rust-target }}/release/bundle/nsis"
+          INSTALLER="$(find "$NSIS_DIR" -maxdepth 1 -name '*setup.exe' -print -quit)"
+          if [ -z "$INSTALLER" ]; then
+            echo "::error::No NSIS updater installer found in $NSIS_DIR"
+            exit 1
+          fi
+          SIG="${INSTALLER}.sig"
+          if [ ! -f "$SIG" ]; then
+            cargo tauri signer sign \
+              -k "$TAURI_SIGNING_PRIVATE_KEY" \
+              -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+              "$INSTALLER" > "$SIG"
+          fi
+          gh release upload "${{ needs.resolve-tag.outputs.tag }}" "$INSTALLER" "$SIG" --clobber
 
       - name: Build headless server
         shell: bash
@@ -321,6 +350,31 @@ jobs:
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Build updater manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p release-sigs
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "*.sig" \
+            --dir release-sigs \
+            --clobber
+
+          VERSION="${TAG#v}"
+          scripts/build-updater-manifest.sh \
+            release-sigs \
+            "$VERSION" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}" \
+            > latest.json
+
+          gh release upload "$TAG" latest.json --clobber --repo "$GITHUB_REPOSITORY"
+
       - name: Un-draft the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/boot-health-gate-manual-uat.md
+++ b/scripts/boot-health-gate-manual-uat.md
@@ -1,0 +1,254 @@
+# Boot-health gate — manual UAT
+
+Companion to `scripts/smoke-boot-health-gate.sh` (which exercises the
+helper subprocess against a synthetic install layout). This checklist
+covers the pieces that need a real Tauri runtime, a real webview, and
+a human eye on dialog rendering: the live probation timer, the boot
+heartbeat, and the `show_pending_report` native dialog on next launch.
+
+Issue context: GitHub issue 731 (utensils/claudette#731).
+
+All paths below assume `~/Library/Application Support/claudette/` on
+macOS, `$XDG_DATA_HOME/claudette/` on Linux, and `%APPDATA%/claudette/`
+on Windows unless `CLAUDETTE_DATA_DIR` is set.
+
+## Phase 0 — preconditions
+
+1. Make sure no previous probation state will skew the test:
+
+   ```bash
+   APP_DATA="$(./target/debug/claudette-app --print-data-dir 2>/dev/null \
+     || echo "$HOME/Library/Application Support/claudette")"
+   rm -f "$APP_DATA/boot-probation.json" "$APP_DATA/boot-rollback-report.json"
+   ```
+
+2. Build the dev binary:
+
+   ```bash
+   cargo build -p claudette-tauri
+   ```
+
+3. Tail the daily log file in another terminal so you can observe the
+   `claudette::updater` events as they fire:
+
+   ```bash
+   tail -F "$HOME/.claudette/logs/claudette.$(date -u +%Y-%m-%d).log" \
+     | grep --line-buffered claudette::updater
+   ```
+
+## Phase 1 — healthy boot clears the sentinel
+
+Verifies that a normal launch with a probation sentinel in place fires
+`bootOk` once the React tree commits past the loader, the timer is
+cancelled, and the sentinel is removed.
+
+1. Hand-write a sentinel that mimics what `prepare_for_update` would
+   leave on disk after an in-app update:
+
+   ```bash
+   cat > "$APP_DATA/boot-probation.json" <<EOF
+   {
+     "status": "pending",
+     "failed_version": "9.9.9-test",
+     "previous_version": "$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')",
+     "download_url": "https://example.invalid/test.dmg",
+     "install_kind": "unsupported",
+     "target_path": "",
+     "executable_path": "",
+     "backup_path": null,
+     "backup_error": null,
+     "attempts": 0,
+     "data_dir": "$APP_DATA",
+     "created_at": "$(date -u -Iseconds)"
+   }
+   EOF
+   ```
+
+   `install_kind: unsupported` keeps the helper from doing anything
+   destructive if Phase 1 fails — the rollback would degrade to a
+   "report only" path because there's no real backup.
+
+2. Launch the app:
+
+   ```bash
+   ./scripts/dev.sh
+   ```
+
+3. **Pass criteria:**
+   - The app window paints normally (workspaces sidebar, etc.).
+   - Within ~2 seconds of the UI hydrating, `boot-probation.json`
+     disappears from `$APP_DATA`.
+   - The log tail shows
+     `claudette::updater  boot probation acknowledged by frontend`.
+   - **No** native dialog appears.
+   - **No** `boot-rollback-report.json` is written.
+
+If the sentinel is still there after 15 seconds, the heartbeat path is
+broken — open `App.tsx`'s `bootOk` useEffect and check that
+`viewStateHydrated` flipped.
+
+## Phase 2 — bounded retry on force-quit
+
+Verifies that `MAX_PROBATION_ATTEMPTS` clears the sentinel once the
+user has booted past the timer once (issue 731's "user-aborted boot"
+case).
+
+1. Re-create the same sentinel as Phase 1, but bump `attempts` to 1:
+
+   ```bash
+   sed -i.bak 's/"attempts": 0/"attempts": 1/' "$APP_DATA/boot-probation.json"
+   rm -f "$APP_DATA/boot-probation.json.bak"
+   ```
+
+2. Launch the app:
+
+   ```bash
+   ./scripts/dev.sh
+   ```
+
+3. **Pass criteria:**
+   - The sentinel is removed almost immediately at startup (before the
+     React tree even mounts), via `start_monitor`'s threshold branch.
+   - The log tail shows
+     `boot probation cleared after reaching attempt threshold without a rollback`.
+   - The heartbeat path still runs harmlessly — `bootOk` returns
+     `Ok(())` because the sentinel is already gone.
+
+## Phase 3 — timer fires and triggers rollback
+
+This is the hard one because we deliberately want the React heartbeat
+to NOT fire. The simplest reproduction:
+
+1. Re-create a sentinel with `install_kind: linux_app_image` (or
+   whatever your platform installs as) and a real `target_path` /
+   `backup_path` pointing into a synthetic layout — same shape the
+   automated smoke uses:
+
+   ```bash
+   TMP="$(mktemp -d)"
+   mkdir -p "$TMP/install" "$TMP/backup"
+   echo "broken" > "$TMP/install/marker"
+   echo "restored" > "$TMP/backup/marker"
+   cp ./target/debug/claudette-app "$TMP/install/claudette-app"
+   chmod +x "$TMP/install/claudette-app"
+   cp ./target/debug/claudette-app "$TMP/backup/claudette-app"
+   chmod +x "$TMP/backup/claudette-app"
+
+   cat > "$APP_DATA/boot-probation.json" <<EOF
+   {
+     "status": "pending",
+     "failed_version": "9.9.9-test",
+     "previous_version": "0.0.0-test-baseline",
+     "download_url": "https://example.invalid/test.dmg",
+     "install_kind": "linux_app_image",
+     "target_path": "$TMP/install/claudette-app",
+     "executable_path": "$TMP/install/claudette-app",
+     "backup_path": "$TMP/backup/claudette-app",
+     "backup_error": null,
+     "attempts": 0,
+     "data_dir": "$APP_DATA",
+     "created_at": "$(date -u -Iseconds)"
+   }
+   EOF
+   ```
+
+2. Tighten the probation window to 2 seconds so you don't wait the
+   default 10:
+
+   ```bash
+   export CLAUDETTE_BOOT_PROBATION_SECS=2
+   ```
+
+3. Disable the heartbeat. Easiest is a one-line patch to
+   `src/ui/src/App.tsx` — comment out the `bootOk()` call inside the
+   `viewStateHydrated` useEffect:
+
+   ```diff
+    useEffect(() => {
+      if (!viewStateHydrated) return;
+   -  bootOk().catch((err) => console.error("Failed to acknowledge boot:", err));
+   +  // bootOk()  // intentionally disabled for Phase 3 UAT
+    }, [viewStateHydrated]);
+   ```
+
+4. Launch the app:
+
+   ```bash
+   ./scripts/dev.sh
+   ```
+
+5. **Pass criteria:**
+   - The window paints normally.
+   - About 2 seconds in, the app exits abruptly (`app.exit(1)` after
+     the timer fires).
+   - The log tail shows the helper being spawned.
+   - On the synthetic install, the helper restores the backup —
+     `cat "$TMP/install/marker"` should now read `restored`.
+
+6. Re-launch the app **without** any code change (heartbeat still
+   disabled is fine — the sentinel is gone now):
+
+   ```bash
+   unset CLAUDETTE_BOOT_PROBATION_SECS
+   ./scripts/dev.sh
+   ```
+
+7. **Pass criteria:**
+   - A native macOS / GTK / Windows dialog appears titled *"Claudette
+     update rolled back"* with the failed version 9.9.9-test and the
+     baseline version 0.0.0-test-baseline.
+   - After dismissing, the rest of the app boots normally.
+   - `boot-rollback-report.json` is gone from `$APP_DATA` (the report
+     is one-shot).
+
+8. Restore the heartbeat patch in `App.tsx`.
+
+## Phase 4 — show_pending_report failure dialog
+
+Same shape as Phase 3 but for the *non*-restored path: the helper
+couldn't replace the install (e.g. permission denied) and has to tell
+the user to download manually.
+
+1. Hand-write a failure report:
+
+   ```bash
+   cat > "$APP_DATA/boot-rollback-report.json" <<EOF
+   {
+     "failed_version": "9.9.9-test",
+     "previous_version": "0.0.0-test-baseline",
+     "download_url": "https://example.invalid/test.dmg",
+     "restored": false,
+     "error": "synthetic UAT failure"
+   }
+   EOF
+   ```
+
+2. Launch the app.
+
+3. **Pass criteria:**
+   - The dialog title is *"Claudette update rollback failed"*.
+   - The body contains the URL `https://example.invalid/test.dmg`
+     and the synthetic error message.
+   - The report file is removed after the dialog dismisses.
+
+## Phase 5 — backup pruning
+
+Verifies that `prepare_for_update` cleans up older backup generations.
+Requires triggering a real (or fake) update flow; this is the lowest
+priority phase since it's covered by the
+`create_backup_prunes_older_siblings` Rust unit test.
+
+If you want to verify it live: drop a directory under
+`~/.claudette/updates/previous/0.10.0` containing arbitrary content,
+then trigger an update via Settings → About. After the update is
+applied, only the newly-written generation should remain under
+`~/.claudette/updates/previous/`.
+
+## Cleanup
+
+```bash
+rm -rf "$APP_DATA/boot-probation.json" \
+       "$APP_DATA/boot-rollback-report.json" \
+       ~/.claudette/updates/previous \
+       /tmp/claudette-boot-smoke.* 2>/dev/null
+```

--- a/scripts/build-updater-manifest.sh
+++ b/scripts/build-updater-manifest.sh
@@ -36,6 +36,8 @@ set -euo pipefail
 #   *_arm64.deb.sig                  -> linux-aarch64-deb
 #   Claudette_x64.app.tar.gz.sig     -> darwin-x86_64, darwin-x86_64-app
 #   Claudette_aarch64.app.tar.gz.sig -> darwin-aarch64, darwin-aarch64-app
+#   Claudette_*_x64-setup.exe.sig    -> windows-x86_64, windows-x86_64-nsis
+#   Claudette_*_arm64-setup.exe.sig  -> windows-aarch64, windows-aarch64-nsis
 
 usage() {
   echo "usage: $0 <sig-dir> <version> <url-prefix>" >&2
@@ -80,6 +82,14 @@ for sig in "$SIG_DIR"/*.sig; do
       PLATFORMS[darwin-aarch64]="$asset"
       PLATFORMS[darwin-aarch64-app]="$asset"
       ;;
+    Claudette_*_x64-setup.exe)
+      PLATFORMS[windows-x86_64]="$asset"
+      PLATFORMS[windows-x86_64-nsis]="$asset"
+      ;;
+    Claudette_*_arm64-setup.exe | Claudette_*_aarch64-setup.exe)
+      PLATFORMS[windows-aarch64]="$asset"
+      PLATFORMS[windows-aarch64-nsis]="$asset"
+      ;;
     *)
       echo "warn: unrecognized .sig file: $asset" >&2
       ;;
@@ -104,6 +114,10 @@ declare -a REQUIRED=(
   "darwin-x86_64-app"
   "darwin-aarch64"
   "darwin-aarch64-app"
+  "windows-x86_64"
+  "windows-x86_64-nsis"
+  "windows-aarch64"
+  "windows-aarch64-nsis"
 )
 for key in "${REQUIRED[@]}"; do
   if [ -z "${PLATFORMS[$key]:-}" ]; then

--- a/scripts/smoke-boot-health-gate.sh
+++ b/scripts/smoke-boot-health-gate.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Local smoke test for the post-update boot-health gate (issue 731).
+#
+# This verifies the parts of the rollback flow that can be exercised
+# without an actual auto-update event: the rollback helper's restore +
+# relaunch logic, the sentinel/report file shapes, and the
+# acknowledgement path. The pieces that require a real Tauri runtime
+# (10-second timer firing → app.exit(1) → child helper spawning,
+# native dialog rendering) live in the manual UAT checklist alongside
+# this script (see boot-health-gate-manual-uat.md).
+#
+# What it does:
+#   1. Builds a synthetic install layout in a temp dir: a "current"
+#      install directory containing a deliberately-broken executable,
+#      and a "backup" directory containing a known-good replacement.
+#   2. Writes a boot-probation.json sentinel pointing at those paths.
+#   3. Invokes the claudette-app helper subcommand
+#      (`--boot-rollback-helper <sentinel> <fake-parent-pid>`) directly
+#      against a parent PID that's already exited, so the helper goes
+#      straight from `wait_for_parent_exit` to the actual restore.
+#   4. Asserts the install dir now matches the backup, the sentinel was
+#      removed, and a boot-rollback-report.json was written with
+#      restored=true.
+#
+# Run it from the worktree root:
+#   ./scripts/smoke-boot-health-gate.sh
+#
+# Exits non-zero on any assertion failure. Cleans up the temp dir
+# unless $KEEP_TMP=1 (handy when triaging a failed run).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# 1. Build claudette-app once. We use a debug build because:
+#    - It keeps the test fast (release adds 2-3 minutes).
+#    - The helper subcommand has no debug-vs-release behavioral split.
+echo "==> building claudette-app (debug)"
+if [ -n "${IN_NIX_SHELL:-}" ]; then
+  cargo build -p claudette-tauri >/dev/null
+else
+  nix develop -c cargo build -p claudette-tauri >/dev/null
+fi
+APP_BIN="$ROOT/target/debug/claudette-app"
+if [ ! -x "$APP_BIN" ]; then
+  echo "expected $APP_BIN to be executable" >&2
+  exit 1
+fi
+
+# 2. Build a synthetic "install" + "backup" layout under a temp dir.
+TMP="$(mktemp -d -t claudette-boot-smoke.XXXXXX)"
+if [ "${KEEP_TMP:-0}" != "1" ]; then
+  trap 'rm -rf "$TMP"' EXIT
+else
+  echo "==> KEEP_TMP=1: smoke artifacts left at $TMP"
+fi
+DATA_DIR="$TMP/data"
+INSTALL_DIR="$TMP/install"
+BACKUP_DIR="$TMP/backups/0.23.0/install"
+mkdir -p "$DATA_DIR" "$INSTALL_DIR/Contents/MacOS" "$BACKUP_DIR/Contents/MacOS"
+
+# The "broken" install: an empty placeholder where claudette-app should
+# live. The helper deletes the install dir wholesale before copying the
+# backup over it, so the contents here just need to exist for the
+# delete to be observable.
+echo "broken" > "$INSTALL_DIR/Contents/MacOS/claudette-app"
+
+# The "good" backup: a real executable shell script (the helper does
+# `Command::new(executable_path).spawn()` after the copy, so the file
+# at the destination must be runnable for the rollback to report
+# `restored=true`). The script exits immediately so we don't leak a
+# child. We sentinel the body with a known marker so the smoke can
+# distinguish "restored from backup" from "still the original
+# broken file".
+cat > "$BACKUP_DIR/Contents/MacOS/claudette-app" <<'EOF'
+#!/bin/sh
+# RESTORED_BACKUP_MARKER
+exit 0
+EOF
+chmod +x "$BACKUP_DIR/Contents/MacOS/claudette-app"
+echo "this came from the backup" > "$BACKUP_DIR/RESTORE_PROOF"
+
+SENTINEL="$DATA_DIR/boot-probation.json"
+REPORT="$DATA_DIR/boot-rollback-report.json"
+
+# 3. Hand-author the sentinel — the same shape boot_probation.rs writes
+#    via prepare_for_update. `target_path` and `executable_path` point
+#    at the synthetic install; `backup_path` points at the synthetic
+#    backup. Status starts at rollback_in_progress because that's the
+#    state the sentinel is in by the time the helper runs (the parent
+#    process flips it before spawning the helper).
+cat > "$SENTINEL" <<EOF
+{
+  "status": "rollback_in_progress",
+  "failed_version": "0.24.0",
+  "previous_version": "0.23.0",
+  "download_url": "https://example.invalid/Claudette-0.23.0.dmg",
+  "install_kind": "linux_app_image",
+  "target_path": "$INSTALL_DIR",
+  "executable_path": "$INSTALL_DIR/Contents/MacOS/claudette-app",
+  "backup_path": "$BACKUP_DIR",
+  "backup_error": null,
+  "attempts": 1,
+  "data_dir": "$DATA_DIR",
+  "created_at": "2026-05-09T00:00:00+00:00"
+}
+EOF
+
+# Pick a PID that's guaranteed to be dead so the helper doesn't sleep
+# the full 20s waiting for it. PID 1 is always live; we want the
+# opposite. Spawn a true subshell, capture its PID, wait for it.
+( exit 0 ) &
+DEAD_PID=$!
+wait "$DEAD_PID" 2>/dev/null || true
+
+# 4. Run the helper. It should restore the backup over the install dir,
+#    write the report, and remove the sentinel.
+echo "==> running rollback helper"
+"$APP_BIN" --boot-rollback-helper "$SENTINEL" "$DEAD_PID" >"$TMP/helper.stderr" 2>&1 || {
+  echo "helper exited non-zero:" >&2
+  cat "$TMP/helper.stderr" >&2
+  exit 1
+}
+
+# 5. Assert the world matches expectations.
+echo "==> verifying rollback effects"
+fail=0
+
+if [ -f "$SENTINEL" ]; then
+  echo "  ✗ sentinel was not removed: $SENTINEL" >&2
+  fail=1
+else
+  echo "  ✓ sentinel removed"
+fi
+
+if [ ! -f "$REPORT" ]; then
+  echo "  ✗ rollback report missing: $REPORT" >&2
+  fail=1
+else
+  if grep -q '"restored": true' "$REPORT"; then
+    echo "  ✓ report written with restored=true"
+  else
+    echo "  ✗ report present but does not contain restored=true:" >&2
+    cat "$REPORT" >&2
+    fail=1
+  fi
+fi
+
+if [ ! -f "$INSTALL_DIR/RESTORE_PROOF" ]; then
+  echo "  ✗ backup contents were not copied into the install dir" >&2
+  fail=1
+else
+  if grep -q "this came from the backup" "$INSTALL_DIR/RESTORE_PROOF"; then
+    echo "  ✓ install dir restored from backup"
+  else
+    echo "  ✗ RESTORE_PROOF present but content does not match the backup" >&2
+    fail=1
+  fi
+fi
+
+if [ ! -x "$INSTALL_DIR/Contents/MacOS/claudette-app" ]; then
+  echo "  ✗ restored claudette-app is missing or not executable" >&2
+  fail=1
+else
+  if grep -q "RESTORED_BACKUP_MARKER" "$INSTALL_DIR/Contents/MacOS/claudette-app"; then
+    echo "  ✓ restored claudette-app body matches backup"
+  else
+    echo "  ✗ restored claudette-app body does not match backup" >&2
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "==> SMOKE FAILED"
+  echo "Helper stderr:" >&2
+  cat "$TMP/helper.stderr" >&2 || true
+  exit 1
+fi
+
+echo "==> SMOKE PASSED"
+echo "    install:  $INSTALL_DIR"
+echo "    backup:   $BACKUP_DIR"
+echo "    data:     $DATA_DIR"

--- a/scripts/smoke-boot-health-gate.sh
+++ b/scripts/smoke-boot-health-gate.sh
@@ -36,11 +36,21 @@ cd "$ROOT"
 # 1. Build claudette-app once. We use a debug build because:
 #    - It keeps the test fast (release adds 2-3 minutes).
 #    - The helper subcommand has no debug-vs-release behavioral split.
+#
+# Build wrapper precedence:
+#   1. Already inside a Nix shell ($IN_NIX_SHELL set) — call cargo directly.
+#   2. `nix` is available on PATH — wrap in `nix develop -c` so contributors
+#      who use the project's flake get the same toolchain.
+#   3. Fall back to bare `cargo` so contributors without Nix can still run
+#      this smoke. They need a stable Rust toolchain in PATH already
+#      (which the README assumes for `cargo tauri dev` to work).
 echo "==> building claudette-app (debug)"
 if [ -n "${IN_NIX_SHELL:-}" ]; then
   cargo build -p claudette-tauri >/dev/null
-else
+elif command -v nix >/dev/null 2>&1; then
   nix develop -c cargo build -p claudette-tauri >/dev/null
+else
+  cargo build -p claudette-tauri >/dev/null
 fi
 APP_BIN="$ROOT/target/debug/claudette-app"
 if [ ! -x "$APP_BIN" ]; then

--- a/scripts/test-build-updater-manifest.sh
+++ b/scripts/test-build-updater-manifest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+write_sig() {
+  printf 'signature for %s\n' "$1" > "$TMP/$1.sig"
+}
+
+write_sig "Claudette_0.24.0_amd64.AppImage"
+write_sig "Claudette_0.24.0_amd64.deb"
+write_sig "Claudette_0.24.0_aarch64.AppImage"
+write_sig "Claudette_0.24.0_arm64.deb"
+write_sig "Claudette_x64.app.tar.gz"
+write_sig "Claudette_aarch64.app.tar.gz"
+write_sig "Claudette_0.24.0_x64-setup.exe"
+write_sig "Claudette_0.24.0_arm64-setup.exe"
+
+manifest="$("$ROOT/scripts/build-updater-manifest.sh" "$TMP" "0.24.0" "https://example.invalid/releases/download/v0.24.0")"
+
+for key in \
+  linux-x86_64 linux-x86_64-appimage linux-x86_64-deb \
+  linux-aarch64 linux-aarch64-appimage linux-aarch64-deb \
+  darwin-x86_64 darwin-x86_64-app darwin-aarch64 darwin-aarch64-app \
+  windows-x86_64 windows-x86_64-nsis windows-aarch64 windows-aarch64-nsis
+do
+  jq -e --arg key "$key" '.platforms[$key].url and .platforms[$key].signature' <<<"$manifest" >/dev/null
+done
+
+rm "$TMP/Claudette_0.24.0_x64-setup.exe.sig"
+if "$ROOT/scripts/build-updater-manifest.sh" "$TMP" "0.24.0" "https://example.invalid/releases/download/v0.24.0" >/dev/null 2>&1; then
+  echo "manifest builder should fail when a required Windows updater signature is missing" >&2
+  exit 1
+fi
+
+echo "build-updater-manifest tests passed"

--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -85,6 +85,7 @@ Established domains:
 | `claudette::remote` | remote-control commands |
 | `claudette::ui` | theme load, settings persistence |
 | `claudette::frontend` | events forwarded from the React webview |
+| `claudette::updater` | update checks, boot probation, and rollback |
 
 ## File format
 
@@ -110,6 +111,23 @@ Claudette has no single-instance lock — running `./scripts/dev.sh` twice gives
 If you'd rather isolate them, set `CLAUDETTE_LOG_DIR` to a per-instance path before launching. The dev launcher leaves this up to you so you can choose interleaved-in-one-file or separate-files based on what you're investigating.
 
 On startup, Claudette also scans `${TMPDIR}/claudette-dev/*.json` (the discovery files `scripts/dev.sh` writes) and emits a `WARN` if another live PID is already running against the same DB path. The warning fires once at boot and explains exactly why it can corrupt persisted state — useful when an old instance lingers and you didn't notice.
+
+## Update boot-health rollback
+
+After an in-app update, Claudette starts the new build on a short probation window. The React app sends a boot heartbeat after its first successful paint. If that heartbeat never arrives, Claudette treats the update as failed to start and tries to restore the previous self-contained install.
+
+When rollback succeeds, the next launch shows a native dialog saying which version failed and which version was restored. When rollback cannot be applied (for example, there was no usable previous-install backup or the install location could not be replaced), Claudette writes a no-loop failure report and shows a dialog with the failed version plus the release URL to download manually.
+
+Useful files for a rollback bug report:
+
+| File | Meaning |
+|------|---------|
+| `~/.claudette/updates/previous/<version>/` | Backup of the previous self-contained install, when one was available. |
+| OS data dir `boot-probation.json` | Internal sentinel for the update currently on probation. Cleared after a healthy boot. |
+| OS data dir `boot-rollback-report.json` | One-shot report consumed on next launch to show the native rollback dialog. |
+| `~/.claudette/logs/claudette.<DATE>.log` | Structured timeline under the `claudette::updater` target. |
+
+The OS data dir is `~/Library/Application Support/claudette/` on macOS, `$XDG_DATA_HOME/claudette/` on Linux, and `%APPDATA%/claudette/` on Windows unless `CLAUDETTE_DATA_DIR` overrides it.
 
 ## Sandboxed (fresh-user) sessions
 

--- a/site/src/content/docs/features/diagnostics.mdx
+++ b/site/src/content/docs/features/diagnostics.mdx
@@ -114,9 +114,13 @@ On startup, Claudette also scans `${TMPDIR}/claudette-dev/*.json` (the discovery
 
 ## Update boot-health rollback
 
-After an in-app update, Claudette starts the new build on a short probation window. The React app sends a boot heartbeat after its first successful paint. If that heartbeat never arrives, Claudette treats the update as failed to start and tries to restore the previous self-contained install.
+After an in-app update, Claudette starts the new build on a short probation window (10 s by default). The React app sends a boot heartbeat after the first commit past the loader (`viewStateHydrated` is true and `loadInitialData` resolved). If that heartbeat never arrives, Claudette treats the update as failed to start and tries to restore the previous self-contained install.
 
 When rollback succeeds, the next launch shows a native dialog saying which version failed and which version was restored. When rollback cannot be applied (for example, there was no usable previous-install backup or the install location could not be replaced), Claudette writes a no-loop failure report and shows a dialog with the failed version plus the release URL to download manually.
+
+A force-quit during the probation window leaves the sentinel on disk; the next launch increments the attempt counter and treats `attempts >= 2` as "this build runs" (the user already booted past the timer once), clears the sentinel, and skips arming the timer. This avoids spurious rollbacks on an otherwise healthy build whose user happens to quit during every probation window.
+
+Backups under `~/.claudette/updates/previous/` are pruned to a single generation each time `prepare_for_update` runs, so the directory does not grow unbounded across updates.
 
 Useful files for a rollback bug report:
 
@@ -128,6 +132,10 @@ Useful files for a rollback bug report:
 | `~/.claudette/logs/claudette.<DATE>.log` | Structured timeline under the `claudette::updater` target. |
 
 The OS data dir is `~/Library/Application Support/claudette/` on macOS, `$XDG_DATA_HOME/claudette/` on Linux, and `%APPDATA%/claudette/` on Windows unless `CLAUDETTE_DATA_DIR` overrides it.
+
+### Tuning the probation window
+
+`CLAUDETTE_BOOT_PROBATION_SECS` overrides the default 10 s probation. Useful for slow first-launch scenarios (e.g. cold-cache Linux builds where libwebkit2gtk dynamic loading dominates startup time) and for shrinking the window while testing the rollback path locally. Values are clamped to the range 1–120 s; non-numeric values fall back to the default. Setting `CLAUDETTE_BOOT_PROBATION_SECS=2` plus an artificial pre-render hang in the React tree is the recommended way to exercise the rollback dialog from a dev build.
 
 ## Sandboxed (fresh-user) sessions
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -82,6 +82,11 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_DataExchange",
     "Win32_System_Memory",
     "Win32_System_Ole",
+    # Used by boot_probation::is_pid_alive — the rollback helper must
+    # wait for the original GUI process to exit before the install dir
+    # can be replaced (Windows holds an exclusive lock on the running
+    # `.exe`). Probe via OpenProcess + GetExitCodeProcess.
+    "Win32_System_Threading",
 ] }
 
 [features]

--- a/src-tauri/src/boot_probation.rs
+++ b/src-tauri/src/boot_probation.rs
@@ -463,7 +463,54 @@ fn is_pid_alive(pid: u32) -> bool {
     std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
 }
 
-#[cfg(not(unix))]
+/// Windows liveness probe for the rollback helper's parent-exit wait.
+///
+/// `wait_for_parent_exit` blocks the helper until the original
+/// `claudette-app.exe` has released its file locks on the install dir;
+/// without this, our `remove_path(&target_path)` would race the still-
+/// running parent and fail with `ERROR_ACCESS_DENIED`. The previous
+/// implementation was a stub that always returned `false`, so on
+/// Windows the helper would attempt the rollback immediately and the
+/// restore would (almost certainly) fail.
+///
+/// `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` is the most narrowly
+/// scoped right that lets us call `GetExitCodeProcess`. A return of
+/// `STILL_ACTIVE` (259) means the process hasn't terminated yet; any
+/// other code (or `OpenProcess` failing because the PID has been
+/// recycled to nothing) counts as "exited". We deliberately do NOT
+/// treat `ERROR_ACCESS_DENIED` from `OpenProcess` as "alive" — that
+/// would stall the rollback indefinitely if the parent process
+/// happened to be in a security descriptor we can't probe; the timeout
+/// in `wait_for_parent_exit` is the safety net for that case.
+#[cfg(windows)]
+fn is_pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: OpenProcess with a non-null PID either returns a valid
+    // handle or NULL on failure. We always close a non-null handle.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return false;
+    }
+    let mut code: u32 = 0;
+    // SAFETY: handle is a valid process handle; code is a writable u32.
+    let ok = unsafe { GetExitCodeProcess(handle, &mut code) };
+    // SAFETY: handle is non-null and we own it.
+    unsafe {
+        CloseHandle(handle);
+    }
+    if ok == 0 {
+        return false;
+    }
+    code as i32 == STILL_ACTIVE
+}
+
+#[cfg(not(any(unix, windows)))]
 fn is_pid_alive(_pid: u32) -> bool {
     false
 }
@@ -1021,6 +1068,41 @@ mod tests {
             Duration::from_secs(DEFAULT_PROBATION_SECS)
         );
         unsafe { std::env::remove_var("CLAUDETTE_BOOT_PROBATION_SECS") };
+    }
+
+    /// Smoke for the parent-exit liveness probe. We always expect our
+    /// own PID to read alive; the Windows path uses `OpenProcess` +
+    /// `GetExitCodeProcess` and was previously a hardcoded `false`
+    /// that broke `wait_for_parent_exit` on the one platform where
+    /// waiting actually matters (Codex P1 review).
+    #[test]
+    fn is_pid_alive_reports_self_alive() {
+        assert!(
+            is_pid_alive(std::process::id()),
+            "current process must register as alive"
+        );
+    }
+
+    /// Confirm a freshly-reaped child reads as dead. Skipped on Windows
+    /// because the kernel briefly retains the process object after
+    /// `wait()` returns and `is_pid_alive` may legitimately still see
+    /// `STILL_ACTIVE` until the handle is fully released; the
+    /// `wait_for_parent_exit` deadline absorbs that case in production.
+    #[cfg(unix)]
+    #[test]
+    fn is_pid_alive_reports_reaped_child_dead() {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn no-op child");
+        let pid = child.id();
+        let _ = child.wait();
+        // Tiny sleep to let the kernel drop the entry on slower CI
+        // hosts; locally this is consistently <1ms.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !is_pid_alive(pid),
+            "reaped child PID {pid} must register as dead"
+        );
     }
 
     /// Regression: when we restore a backup over a destination that

--- a/src-tauri/src/boot_probation.rs
+++ b/src-tauri/src/boot_probation.rs
@@ -1,0 +1,730 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+use tokio::sync::Notify;
+
+const SENTINEL_FILE: &str = "boot-probation.json";
+const REPORT_FILE: &str = "boot-rollback-report.json";
+const PROBATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Default)]
+pub struct BootProbationState {
+    acknowledged: AtomicBool,
+    cancel: Notify,
+}
+
+impl BootProbationState {
+    pub fn acknowledge(&self) {
+        self.acknowledged.store(true, Ordering::SeqCst);
+        self.cancel.notify_waiters();
+    }
+
+    fn is_acknowledged(&self) -> bool {
+        self.acknowledged.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallKind {
+    MacApp,
+    LinuxAppImage,
+    WindowsInstallDir,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbationStatus {
+    Pending,
+    RollbackInProgress,
+    RollbackFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BootProbation {
+    pub status: ProbationStatus,
+    pub failed_version: String,
+    pub previous_version: String,
+    pub download_url: String,
+    pub install_kind: InstallKind,
+    pub target_path: PathBuf,
+    pub executable_path: PathBuf,
+    pub backup_path: Option<PathBuf>,
+    pub backup_error: Option<String>,
+    pub attempts: u32,
+    pub data_dir: PathBuf,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct BootRollbackReport {
+    pub failed_version: String,
+    pub previous_version: String,
+    pub download_url: String,
+    pub restored: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstallTarget {
+    kind: InstallKind,
+    target_path: PathBuf,
+    executable_path: PathBuf,
+    is_dir: bool,
+}
+
+pub fn sentinel_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(SENTINEL_FILE)
+}
+
+pub fn report_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(REPORT_FILE)
+}
+
+pub fn updates_previous_dir(version: &str) -> PathBuf {
+    claudette::path::claudette_home()
+        .join("updates")
+        .join("previous")
+        .join(sanitize_path_segment(version))
+}
+
+pub fn prepare_for_update(
+    data_dir: &Path,
+    current_version: &str,
+    next_version: &str,
+    download_url: &str,
+) -> Result<(), String> {
+    std::fs::create_dir_all(data_dir)
+        .map_err(|e| format!("create data dir {}: {e}", data_dir.display()))?;
+
+    let target = detect_install_target().unwrap_or_else(|e| {
+        tracing::warn!(
+            target: "claudette::updater",
+            error = %e,
+            "boot probation could not detect self-contained install target"
+        );
+        InstallTarget {
+            kind: InstallKind::Unsupported,
+            target_path: PathBuf::new(),
+            executable_path: std::env::current_exe().unwrap_or_default(),
+            is_dir: false,
+        }
+    });
+
+    let (backup_path, backup_error) = match create_backup(&target, current_version) {
+        Ok(Some(path)) => (Some(path), None),
+        Ok(None) => (None, None),
+        Err(e) => {
+            tracing::warn!(
+                target: "claudette::updater",
+                error = %e,
+                "boot probation backup failed; rollback will degrade to a diagnostic report"
+            );
+            (None, Some(e))
+        }
+    };
+
+    let probation = BootProbation {
+        status: ProbationStatus::Pending,
+        failed_version: next_version.to_string(),
+        previous_version: current_version.to_string(),
+        download_url: download_url.to_string(),
+        install_kind: target.kind,
+        target_path: target.target_path,
+        executable_path: target.executable_path,
+        backup_path,
+        backup_error,
+        attempts: 0,
+        data_dir: data_dir.to_path_buf(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    write_probation(data_dir, &probation)
+}
+
+pub async fn acknowledge_boot(
+    data_dir: &Path,
+    state: &Arc<BootProbationState>,
+) -> Result<(), String> {
+    state.acknowledge();
+    let path = sentinel_path(data_dir);
+    match tokio::fs::remove_file(&path).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("clear boot probation {}: {e}", path.display())),
+    }
+}
+
+pub fn start_monitor(app: AppHandle, state: Arc<BootProbationState>, data_dir: PathBuf) {
+    let path = sentinel_path(&data_dir);
+    let Ok(mut probation) = read_probation_path(&path) else {
+        return;
+    };
+    if probation.status == ProbationStatus::RollbackFailed {
+        return;
+    }
+
+    probation.attempts = probation.attempts.saturating_add(1);
+    if let Err(e) = write_probation(&data_dir, &probation) {
+        tracing::warn!(target: "claudette::updater", error = %e, "failed to update boot probation attempt count");
+    }
+
+    tauri::async_runtime::spawn(async move {
+        tokio::select! {
+            _ = state.cancel.notified() => {}
+            _ = tokio::time::sleep(PROBATION_TIMEOUT) => {
+                if state.is_acknowledged() {
+                    return;
+                }
+                handle_probation_timeout(&app, &data_dir).await;
+            }
+        }
+    });
+}
+
+pub fn show_pending_report(app: &AppHandle, data_dir: &Path) {
+    let path = report_path(data_dir);
+    let Ok(report) = read_report_path(&path) else {
+        return;
+    };
+    let _ = std::fs::remove_file(&path);
+
+    let title = if report.restored {
+        "Claudette update rolled back"
+    } else {
+        "Claudette update rollback failed"
+    };
+    let message = if report.restored {
+        format!(
+            "Update {} failed to start, so Claudette restored {}. Please report this at https://github.com/utensils/claudette/issues.",
+            report.failed_version, report.previous_version
+        )
+    } else {
+        format!(
+            "Update {} failed to start, but Claudette could not restore {}. Download the previous release from {} and report this at https://github.com/utensils/claudette/issues.\n\n{}",
+            report.failed_version,
+            report.previous_version,
+            report.download_url,
+            report
+                .error
+                .unwrap_or_else(|| "Unknown rollback error".to_string())
+        )
+    };
+
+    app.dialog()
+        .message(message)
+        .title(title)
+        .buttons(MessageDialogButtons::Ok)
+        .show(|_| {});
+}
+
+pub fn run_helper_from_args(args: &[String]) -> Option<Result<(), String>> {
+    let idx = args
+        .iter()
+        .position(|arg| arg == "--boot-rollback-helper")?;
+    let sentinel = args.get(idx + 1).map(PathBuf::from);
+    let parent_pid = args.get(idx + 2).and_then(|raw| raw.parse::<u32>().ok());
+    Some(match (sentinel, parent_pid) {
+        (Some(sentinel), Some(parent_pid)) => run_helper(&sentinel, parent_pid),
+        _ => Err("usage: --boot-rollback-helper <sentinel-path> <parent-pid>".to_string()),
+    })
+}
+
+async fn handle_probation_timeout(app: &AppHandle, data_dir: &Path) {
+    let path = sentinel_path(data_dir);
+    let mut probation = match read_probation_path(&path) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(target: "claudette::updater", error = %e, "boot probation timed out but sentinel could not be read");
+            return;
+        }
+    };
+
+    if probation.backup_path.is_none() {
+        let error = probation.backup_error.clone().unwrap_or_else(|| {
+            "No previous install backup is available for this update target.".to_string()
+        });
+        probation.status = ProbationStatus::RollbackFailed;
+        let _ = write_probation(data_dir, &probation);
+        let _ = write_report(
+            data_dir,
+            &BootRollbackReport {
+                failed_version: probation.failed_version,
+                previous_version: probation.previous_version,
+                download_url: probation.download_url,
+                restored: false,
+                error: Some(error),
+            },
+        );
+        app.exit(1);
+        return;
+    }
+
+    probation.status = ProbationStatus::RollbackInProgress;
+    if let Err(e) = write_probation(data_dir, &probation) {
+        tracing::warn!(target: "claudette::updater", error = %e, "failed to mark boot rollback in progress");
+    }
+
+    match spawn_rollback_helper(&path) {
+        Ok(()) => app.exit(1),
+        Err(e) => {
+            tracing::error!(target: "claudette::updater", error = %e, "failed to spawn boot rollback helper");
+            let mut failed = probation;
+            failed.status = ProbationStatus::RollbackFailed;
+            let _ = write_probation(data_dir, &failed);
+            let _ = write_report(
+                data_dir,
+                &BootRollbackReport {
+                    failed_version: failed.failed_version,
+                    previous_version: failed.previous_version,
+                    download_url: failed.download_url,
+                    restored: false,
+                    error: Some(e),
+                },
+            );
+            app.exit(1);
+        }
+    }
+}
+
+fn run_helper(sentinel: &Path, parent_pid: u32) -> Result<(), String> {
+    let probation = read_probation_path(sentinel)?;
+    wait_for_parent_exit(parent_pid, Duration::from_secs(20));
+
+    let result = restore_backup(&probation)
+        .and_then(|_| relaunch(&probation))
+        .map(|_| BootRollbackReport {
+            failed_version: probation.failed_version.clone(),
+            previous_version: probation.previous_version.clone(),
+            download_url: probation.download_url.clone(),
+            restored: true,
+            error: None,
+        })
+        .unwrap_or_else(|e| BootRollbackReport {
+            failed_version: probation.failed_version.clone(),
+            previous_version: probation.previous_version.clone(),
+            download_url: probation.download_url.clone(),
+            restored: false,
+            error: Some(e),
+        });
+
+    if result.restored {
+        let _ = std::fs::remove_file(sentinel);
+    } else {
+        let mut failed = probation;
+        failed.status = ProbationStatus::RollbackFailed;
+        let _ = write_probation(&failed.data_dir.clone(), &failed);
+    }
+    write_report(&result_path_parent(sentinel), &result)
+}
+
+fn restore_backup(probation: &BootProbation) -> Result<(), String> {
+    let backup = probation
+        .backup_path
+        .as_deref()
+        .ok_or_else(|| "No previous install backup is available.".to_string())?;
+    if !backup.exists() {
+        return Err(format!("backup path is missing: {}", backup.display()));
+    }
+
+    if probation.target_path.exists() {
+        remove_path(&probation.target_path).map_err(|e| {
+            format!(
+                "remove failed install {}: {e}",
+                probation.target_path.display()
+            )
+        })?;
+    }
+    copy_path(backup, &probation.target_path)
+        .map_err(|e| format!("restore {}: {e}", probation.target_path.display()))
+}
+
+fn relaunch(probation: &BootProbation) -> Result<(), String> {
+    Command::new(&probation.executable_path)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("relaunch {}: {e}", probation.executable_path.display()))
+}
+
+fn spawn_rollback_helper(sentinel: &Path) -> Result<(), String> {
+    let helper = helper_executable(sentinel)?;
+    Command::new(&helper)
+        .arg("--boot-rollback-helper")
+        .arg(sentinel)
+        .arg(std::process::id().to_string())
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("spawn rollback helper {}: {e}", helper.display()))
+}
+
+fn helper_executable(_sentinel: &Path) -> Result<PathBuf, String> {
+    let current = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    #[cfg(windows)]
+    {
+        let helper = result_path_parent(_sentinel).join("boot-rollback-helper.exe");
+        std::fs::copy(&current, &helper)
+            .map_err(|e| format!("copy rollback helper {}: {e}", helper.display()))?;
+        Ok(helper)
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(current)
+    }
+}
+
+fn wait_for_parent_exit(pid: u32, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline && is_pid_alive(pid) {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(unix)]
+fn is_pid_alive(pid: u32) -> bool {
+    let r = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if r == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(not(unix))]
+fn is_pid_alive(_pid: u32) -> bool {
+    false
+}
+
+fn detect_install_target() -> Result<InstallTarget, String> {
+    let executable_path = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    detect_install_target_from_exe(&executable_path)
+}
+
+fn detect_install_target_from_exe(executable_path: &Path) -> Result<InstallTarget, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let app = mac_app_root(executable_path)?;
+        return Ok(InstallTarget {
+            kind: InstallKind::MacApp,
+            target_path: app,
+            executable_path: executable_path.to_path_buf(),
+            is_dir: true,
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let appimage = std::env::var_os("APPIMAGE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| executable_path.to_path_buf());
+        return Ok(InstallTarget {
+            kind: InstallKind::LinuxAppImage,
+            target_path: appimage.clone(),
+            executable_path: appimage,
+            is_dir: false,
+        });
+    }
+
+    #[cfg(windows)]
+    {
+        let dir = executable_path
+            .parent()
+            .ok_or_else(|| "current executable has no parent directory".to_string())?
+            .to_path_buf();
+        return Ok(InstallTarget {
+            kind: InstallKind::WindowsInstallDir,
+            target_path: dir,
+            executable_path: executable_path.to_path_buf(),
+            is_dir: true,
+        });
+    }
+
+    #[allow(unreachable_code)]
+    Err("unsupported updater target".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn mac_app_root(executable_path: &Path) -> Result<PathBuf, String> {
+    let mut cur = executable_path;
+    while let Some(parent) = cur.parent() {
+        if parent.extension().and_then(|s| s.to_str()) == Some("app") {
+            return Ok(parent.to_path_buf());
+        }
+        cur = parent;
+    }
+    Err(format!(
+        "could not find .app root for {}",
+        executable_path.display()
+    ))
+}
+
+fn create_backup(target: &InstallTarget, current_version: &str) -> Result<Option<PathBuf>, String> {
+    if target.kind == InstallKind::Unsupported || target.target_path.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    let backup_root = updates_previous_dir(current_version);
+    if backup_root.exists() {
+        remove_path(&backup_root)
+            .map_err(|e| format!("remove stale backup {}: {e}", backup_root.display()))?;
+    }
+    std::fs::create_dir_all(&backup_root)
+        .map_err(|e| format!("create backup dir {}: {e}", backup_root.display()))?;
+
+    let name = target
+        .target_path
+        .file_name()
+        .ok_or_else(|| format!("target has no file name: {}", target.target_path.display()))?;
+    let backup_path = backup_root.join(name);
+    copy_path(&target.target_path, &backup_path)
+        .map_err(|e| format!("copy backup {}: {e}", backup_path.display()))?;
+    if target.is_dir && !backup_path.is_dir() {
+        return Err(format!(
+            "backup is not a directory: {}",
+            backup_path.display()
+        ));
+    }
+    Ok(Some(backup_path))
+}
+
+fn copy_path(from: &Path, to: &Path) -> std::io::Result<()> {
+    let meta = std::fs::metadata(from)?;
+    if meta.is_dir() {
+        copy_dir_recursive(from, to)
+    } else {
+        if let Some(parent) = to.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(from, to)?;
+        std::fs::set_permissions(to, meta.permissions())?;
+        Ok(())
+    }
+}
+
+fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(to)?;
+    for entry in std::fs::read_dir(from)? {
+        let entry = entry?;
+        let source = entry.path();
+        let dest = to.join(entry.file_name());
+        let meta = entry.metadata()?;
+        if meta.is_dir() {
+            copy_dir_recursive(&source, &dest)?;
+        } else {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(&source, &dest)?;
+            std::fs::set_permissions(&dest, meta.permissions())?;
+        }
+    }
+    let permissions = std::fs::metadata(from)?.permissions();
+    std::fs::set_permissions(to, permissions)?;
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> std::io::Result<()> {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_dir() => std::fs::remove_dir_all(path),
+        Ok(_) => std::fs::remove_file(path),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn read_probation_path(path: &Path) -> Result<BootProbation, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("read boot probation {}: {e}", path.display()))?;
+    serde_json::from_str(&raw).map_err(|e| format!("parse boot probation {}: {e}", path.display()))
+}
+
+fn write_probation(data_dir: &Path, probation: &BootProbation) -> Result<(), String> {
+    std::fs::create_dir_all(data_dir)
+        .map_err(|e| format!("create data dir {}: {e}", data_dir.display()))?;
+    write_json_atomically(&sentinel_path(data_dir), probation)
+}
+
+fn read_report_path(path: &Path) -> Result<BootRollbackReport, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("read boot rollback report {}: {e}", path.display()))?;
+    serde_json::from_str(&raw)
+        .map_err(|e| format!("parse boot rollback report {}: {e}", path.display()))
+}
+
+fn write_report(data_dir: &Path, report: &BootRollbackReport) -> Result<(), String> {
+    std::fs::create_dir_all(data_dir)
+        .map_err(|e| format!("create data dir {}: {e}", data_dir.display()))?;
+    write_json_atomically(&report_path(data_dir), report)
+}
+
+fn result_path_parent(sentinel: &Path) -> PathBuf {
+    sentinel
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn write_json_atomically<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    let tmp = path.with_extension("tmp");
+    let body = serde_json::to_vec_pretty(value).map_err(|e| format!("serialize json: {e}"))?;
+    std::fs::write(&tmp, body).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    #[cfg(windows)]
+    if path.exists() {
+        std::fs::remove_file(path).map_err(|e| format!("replace {}: {e}", path.display()))?;
+    }
+    std::fs::rename(&tmp, path)
+        .map_err(|e| format!("rename {} -> {}: {e}", tmp.display(), path.display()))
+}
+
+fn sanitize_path_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::tempdir;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn sample_probation(data_dir: &Path, backup_path: Option<PathBuf>) -> BootProbation {
+        BootProbation {
+            status: ProbationStatus::Pending,
+            failed_version: "0.25.0".to_string(),
+            previous_version: "0.24.0".to_string(),
+            download_url: "https://example.invalid/download".to_string(),
+            install_kind: InstallKind::LinuxAppImage,
+            target_path: data_dir.join("Claudette.AppImage"),
+            executable_path: data_dir.join("Claudette.AppImage"),
+            backup_path,
+            backup_error: None,
+            attempts: 0,
+            data_dir: data_dir.to_path_buf(),
+            created_at: "2026-05-10T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn writes_and_reads_probation_sentinel() {
+        let tmp = tempdir().unwrap();
+        let probation = sample_probation(tmp.path(), None);
+        write_probation(tmp.path(), &probation).unwrap();
+
+        let got = read_probation_path(&sentinel_path(tmp.path())).unwrap();
+        assert_eq!(got.failed_version, "0.25.0");
+        assert_eq!(got.previous_version, "0.24.0");
+        assert_eq!(got.status, ProbationStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn acknowledge_clears_sentinel_and_cancels_state() {
+        let tmp = tempdir().unwrap();
+        let state = Arc::new(BootProbationState::default());
+        write_probation(tmp.path(), &sample_probation(tmp.path(), None)).unwrap();
+
+        acknowledge_boot(tmp.path(), &state).await.unwrap();
+
+        assert!(state.is_acknowledged());
+        assert!(!sentinel_path(tmp.path()).exists());
+    }
+
+    #[test]
+    fn restore_backup_replaces_failed_install() {
+        let tmp = tempdir().unwrap();
+        let failed = tmp.path().join("failed");
+        let backup = tmp.path().join("backup");
+        std::fs::create_dir_all(&failed).unwrap();
+        std::fs::write(failed.join("app"), "broken").unwrap();
+        std::fs::create_dir_all(&backup).unwrap();
+        std::fs::write(backup.join("app"), "restored").unwrap();
+
+        let mut probation = sample_probation(tmp.path(), Some(backup));
+        probation.target_path = failed.clone();
+        probation.executable_path = failed.join("app");
+
+        restore_backup(&probation).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(failed.join("app")).unwrap(),
+            "restored"
+        );
+    }
+
+    #[test]
+    fn restore_without_backup_fails_without_looping() {
+        let tmp = tempdir().unwrap();
+        let probation = sample_probation(tmp.path(), None);
+
+        let err = restore_backup(&probation).unwrap_err();
+
+        assert!(err.contains("No previous install backup"));
+    }
+
+    #[test]
+    fn backup_helper_copies_files_and_directories() {
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        unsafe { std::env::set_var("CLAUDETTE_HOME", &home) };
+        let source_dir = tmp.path().join("Source.app");
+        std::fs::create_dir_all(source_dir.join("Contents/MacOS")).unwrap();
+        std::fs::write(source_dir.join("Contents/MacOS/claudette-app"), "app").unwrap();
+        let target = InstallTarget {
+            kind: InstallKind::MacApp,
+            target_path: source_dir,
+            executable_path: tmp.path().join("Source.app/Contents/MacOS/claudette-app"),
+            is_dir: true,
+        };
+
+        let backup = create_backup(&target, "test-version").unwrap().unwrap();
+
+        assert!(backup.join("Contents/MacOS/claudette-app").exists());
+        unsafe { std::env::remove_var("CLAUDETTE_HOME") };
+    }
+
+    #[test]
+    fn rollback_failed_status_is_serialized_for_no_loop_state() {
+        let tmp = tempdir().unwrap();
+        let mut probation = sample_probation(tmp.path(), None);
+        probation.status = ProbationStatus::RollbackFailed;
+        write_probation(tmp.path(), &probation).unwrap();
+
+        let raw = std::fs::read_to_string(sentinel_path(tmp.path())).unwrap();
+
+        assert!(raw.contains("\"status\": \"rollback_failed\""));
+    }
+
+    #[test]
+    fn writing_probation_replaces_existing_sentinel() {
+        let tmp = tempdir().unwrap();
+        let mut probation = sample_probation(tmp.path(), None);
+        write_probation(tmp.path(), &probation).unwrap();
+
+        probation.status = ProbationStatus::RollbackInProgress;
+        probation.attempts = 2;
+        write_probation(tmp.path(), &probation).unwrap();
+
+        let got = read_probation_path(&sentinel_path(tmp.path())).unwrap();
+        assert_eq!(got.status, ProbationStatus::RollbackInProgress);
+        assert_eq!(got.attempts, 2);
+    }
+}

--- a/src-tauri/src/boot_probation.rs
+++ b/src-tauri/src/boot_probation.rs
@@ -11,7 +11,27 @@ use tokio::sync::Notify;
 
 const SENTINEL_FILE: &str = "boot-probation.json";
 const REPORT_FILE: &str = "boot-rollback-report.json";
-const PROBATION_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_PROBATION_SECS: u64 = 10;
+/// Hard floor / ceiling for the env-var override. A 0-second probation
+/// would never let `boot_ok` race the timer; a 10-minute probation makes
+/// the rollback feel broken to users on the unhappy path.
+const MIN_PROBATION_SECS: u64 = 1;
+const MAX_PROBATION_SECS: u64 = 120;
+/// After this many recorded launch attempts on the same sentinel, we
+/// stop arming the rollback. The user has already booted past the
+/// probation window once (otherwise we'd have rolled back on attempt
+/// 1) — that's the strongest "this build runs" signal we can collect
+/// without IPC. Issue #731 specifically calls out this heuristic for
+/// the force-quit-during-probation edge case.
+const MAX_PROBATION_ATTEMPTS: u32 = 2;
+
+fn probation_timeout() -> Duration {
+    let raw = std::env::var("CLAUDETTE_BOOT_PROBATION_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_PROBATION_SECS);
+    Duration::from_secs(raw.clamp(MIN_PROBATION_SECS, MAX_PROBATION_SECS))
+}
 
 #[derive(Default)]
 pub struct BootProbationState {
@@ -151,6 +171,17 @@ pub fn prepare_for_update(
     write_probation(data_dir, &probation)
 }
 
+/// Mark this boot as healthy so the in-memory timer is cancelled and
+/// the on-disk sentinel is dropped.
+///
+/// Order is deliberate: we ack the in-memory state **before** attempting
+/// the file delete. If `remove_file` fails (disk full, permission
+/// denied, weirder filesystem state), the timer is already cancelled —
+/// we'd rather acknowledge a healthy build and leak a stale sentinel
+/// than fail fast and let the rollback fire on a perfectly working
+/// build. The next launch's `start_monitor` will increment `attempts`
+/// on the leaked sentinel; `MAX_PROBATION_ATTEMPTS` then bounds the
+/// retries so the leak self-heals on the second healthy boot.
 pub async fn acknowledge_boot(
     data_dir: &Path,
     state: &Arc<BootProbationState>,
@@ -169,19 +200,47 @@ pub fn start_monitor(app: AppHandle, state: Arc<BootProbationState>, data_dir: P
     let Ok(mut probation) = read_probation_path(&path) else {
         return;
     };
-    if probation.status == ProbationStatus::RollbackFailed {
+    // RollbackFailed: a previous launch already tried and surfaced the
+    // user-facing dialog — don't try again, the report is one-shot.
+    // RollbackInProgress: a previous launch's helper is currently
+    // restoring the backup and waiting on parent exit. Re-arming here
+    // would race the helper for the install location and could spawn
+    // a second helper that competes with it.
+    if matches!(
+        probation.status,
+        ProbationStatus::RollbackFailed | ProbationStatus::RollbackInProgress
+    ) {
         return;
     }
 
     probation.attempts = probation.attempts.saturating_add(1);
+
+    // Bounded retry: once we've recorded MAX_PROBATION_ATTEMPTS launches
+    // without a rollback firing, the user has booted past the timer at
+    // least once. Treat the build as healthy, drop the sentinel, and
+    // skip arming. Without this bound, a user who force-quits during
+    // every probation window would keep tripping rollbacks on a build
+    // that actually works for them.
+    if probation.attempts >= MAX_PROBATION_ATTEMPTS {
+        tracing::info!(
+            target: "claudette::updater",
+            attempts = probation.attempts,
+            failed_version = %probation.failed_version,
+            "boot probation cleared after reaching attempt threshold without a rollback"
+        );
+        let _ = std::fs::remove_file(&path);
+        return;
+    }
+
     if let Err(e) = write_probation(&data_dir, &probation) {
         tracing::warn!(target: "claudette::updater", error = %e, "failed to update boot probation attempt count");
     }
 
+    let timeout = probation_timeout();
     tauri::async_runtime::spawn(async move {
         tokio::select! {
             _ = state.cancel.notified() => {}
-            _ = tokio::time::sleep(PROBATION_TIMEOUT) => {
+            _ = tokio::time::sleep(timeout) => {
                 if state.is_acknowledged() {
                     return;
                 }
@@ -366,19 +425,26 @@ fn spawn_rollback_helper(sentinel: &Path) -> Result<(), String> {
         .map_err(|e| format!("spawn rollback helper {}: {e}", helper.display()))
 }
 
-fn helper_executable(_sentinel: &Path) -> Result<PathBuf, String> {
+#[cfg(windows)]
+fn helper_executable(sentinel: &Path) -> Result<PathBuf, String> {
+    // Windows holds an exclusive lock on a running .exe, so the helper
+    // cannot run from inside the install dir we're about to rewrite.
+    // Stage a copy alongside the sentinel (data dir, outside the install
+    // tree) and run that one instead. The copy leaks one exe per failed
+    // update — small (~10 MB) and well-bounded.
     let current = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    #[cfg(windows)]
-    {
-        let helper = result_path_parent(_sentinel).join("boot-rollback-helper.exe");
-        std::fs::copy(&current, &helper)
-            .map_err(|e| format!("copy rollback helper {}: {e}", helper.display()))?;
-        Ok(helper)
-    }
-    #[cfg(not(windows))]
-    {
-        Ok(current)
-    }
+    let helper = result_path_parent(sentinel).join("boot-rollback-helper.exe");
+    std::fs::copy(&current, &helper)
+        .map_err(|e| format!("copy rollback helper {}: {e}", helper.display()))?;
+    Ok(helper)
+}
+
+#[cfg(not(windows))]
+fn helper_executable(_sentinel: &Path) -> Result<PathBuf, String> {
+    // Unix lets us delete a running executable (the inode persists for
+    // the life of the running process), so the helper can be the
+    // current exe — no copy needed.
+    std::env::current_exe().map_err(|e| format!("current_exe: {e}"))
 }
 
 fn wait_for_parent_exit(pid: u32, timeout: Duration) {
@@ -490,18 +556,72 @@ fn create_backup(target: &InstallTarget, current_version: &str) -> Result<Option
             backup_path.display()
         ));
     }
+    // GC stale backups from prior versions. We keep only the
+    // just-written one — at this point the new install hasn't been
+    // staged yet, so this is the *only* backup we'll need to fall
+    // back on. A 200-300 MB `.app` bundle accumulating once per
+    // update would otherwise turn `~/.claudette/updates/previous/`
+    // into a slow disk leak.
+    let _ = prune_stale_backups(&backup_root);
     Ok(Some(backup_path))
 }
 
+/// Best-effort sweep of `~/.claudette/updates/previous/`. Deletes every
+/// versioned subdirectory except `keep`. Failures are logged and
+/// swallowed — a residual backup is never worse than aborting the
+/// update mid-flight.
+fn prune_stale_backups(keep: &Path) {
+    let Some(parent) = keep.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    let keep_name = keep.file_name();
+    for entry in entries.flatten() {
+        if Some(entry.file_name().as_os_str()) == keep_name.map(|s| s.as_ref()) {
+            continue;
+        }
+        let path = entry.path();
+        if let Err(e) = remove_path(&path) {
+            tracing::warn!(
+                target: "claudette::updater",
+                path = %path.display(),
+                error = %e,
+                "failed to GC stale boot rollback backup"
+            );
+        }
+    }
+}
+
+/// Recursive `cp -a` that preserves symlinks.
+///
+/// macOS `.app` bundles routinely contain symlinks inside `Frameworks/`
+/// (e.g. `Foo.framework/Foo -> Versions/Current/Foo`). The previous
+/// implementation used `entry.metadata().is_dir()` to decide between
+/// directory recursion and `std::fs::copy`; metadata for a symlink is
+/// the symlink itself (`is_dir() == false`), so symlinks fell through
+/// to `std::fs::copy`, which **follows** symlinks. A symlink-to-directory
+/// then errors with `Is a directory`, which we surfaced as a backup
+/// failure and degraded silently to "report only" rollback.
+///
+/// We now branch on `file_type()` (which exposes `is_symlink()`) and
+/// recreate links via `std::os::*::fs::symlink*`, mirroring `cp -R` /
+/// `rsync -a` semantics. On Windows, creating symlinks normally
+/// requires Developer Mode or admin privileges; if it fails we surface
+/// the io error rather than silently losing the link.
 fn copy_path(from: &Path, to: &Path) -> std::io::Result<()> {
-    let meta = std::fs::metadata(from)?;
-    if meta.is_dir() {
+    let file_type = std::fs::symlink_metadata(from)?.file_type();
+    if file_type.is_symlink() {
+        copy_symlink(from, to)
+    } else if file_type.is_dir() {
         copy_dir_recursive(from, to)
     } else {
         if let Some(parent) = to.parent() {
             std::fs::create_dir_all(parent)?;
         }
         std::fs::copy(from, to)?;
+        let meta = std::fs::metadata(from)?;
         std::fs::set_permissions(to, meta.permissions())?;
         Ok(())
     }
@@ -513,14 +633,18 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
         let entry = entry?;
         let source = entry.path();
         let dest = to.join(entry.file_name());
-        let meta = entry.metadata()?;
-        if meta.is_dir() {
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            copy_symlink(&source, &dest)?;
+        } else if file_type.is_dir() {
             copy_dir_recursive(&source, &dest)?;
         } else {
-            if let Some(parent) = dest.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
             std::fs::copy(&source, &dest)?;
+            // For regular files, `entry.metadata()` is the file's own
+            // metadata (the symlink branch above already handled link
+            // entries). Setting permissions explicitly survives any
+            // platform where `std::fs::copy` doesn't preserve them.
+            let meta = entry.metadata()?;
             std::fs::set_permissions(&dest, meta.permissions())?;
         }
     }
@@ -529,13 +653,57 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn copy_symlink(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::symlink;
+    let target = std::fs::read_link(from)?;
+    if let Some(parent) = to.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // `symlink()` refuses to clobber an existing entry; drop whatever
+    // is there first. The previous remove_path() handles dir/file/link
+    // (it now uses symlink_metadata so it won't dereference a link).
+    remove_path_no_follow(to)?;
+    symlink(target, to)
+}
+
+#[cfg(windows)]
+fn copy_symlink(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::windows::fs::{symlink_dir, symlink_file};
+    let target = std::fs::read_link(from)?;
+    if let Some(parent) = to.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    remove_path_no_follow(to)?;
+    // Probe the resolved target type to choose between symlink_file
+    // and symlink_dir. If the target is unreachable (broken link or
+    // relative-to-source resolution we can't follow), default to
+    // symlink_file — matches PowerShell's `New-Item -ItemType
+    // SymbolicLink` default for unresolved targets.
+    let is_dir = from.metadata().map(|m| m.is_dir()).unwrap_or(false);
+    if is_dir {
+        symlink_dir(target, to)
+    } else {
+        symlink_file(target, to)
+    }
+}
+
 fn remove_path(path: &Path) -> std::io::Result<()> {
-    match std::fs::metadata(path) {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => std::fs::remove_file(path),
         Ok(meta) if meta.is_dir() => std::fs::remove_dir_all(path),
         Ok(_) => std::fs::remove_file(path),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
     }
+}
+
+/// Identical to `remove_path` today (both branch on `symlink_metadata`),
+/// but kept as a distinct name at the symlink-replacement call sites so
+/// future readers can see "we explicitly do not want to follow the link
+/// at this point" without re-deriving it from `remove_path`'s body.
+fn remove_path_no_follow(path: &Path) -> std::io::Result<()> {
+    remove_path(path)
 }
 
 fn read_probation_path(path: &Path) -> Result<BootProbation, String> {
@@ -726,5 +894,158 @@ mod tests {
         let got = read_probation_path(&sentinel_path(tmp.path())).unwrap();
         assert_eq!(got.status, ProbationStatus::RollbackInProgress);
         assert_eq!(got.attempts, 2);
+    }
+
+    /// Regression: macOS `.app` bundles routinely contain framework
+    /// symlinks like `Foo.framework/Foo -> Versions/Current/Foo`. Before
+    /// this branch the recursive copy used `metadata().is_dir()`, hit the
+    /// non-dir branch on a symlink, and failed because `std::fs::copy`
+    /// can't copy a symlink-to-directory (`Is a directory`). The backup
+    /// then errored out and rollback silently degraded to a "report
+    /// only" path. This test fixes that contract by asserting symlinks
+    /// survive a backup → restore roundtrip.
+    #[cfg(unix)]
+    #[test]
+    fn copy_path_preserves_symlinks_for_macos_frameworks() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("Source.app");
+        let frameworks = src.join("Contents/Frameworks/Foo.framework");
+        let versions = frameworks.join("Versions/A");
+        std::fs::create_dir_all(&versions).unwrap();
+        std::fs::write(versions.join("Foo"), b"binary").unwrap();
+        // Both kinds of symlink layouts found in real .app bundles:
+        // a relative symlink to a directory and a relative symlink to
+        // a file inside that directory.
+        symlink("A", frameworks.join("Versions/Current")).unwrap();
+        symlink("Versions/Current/Foo", frameworks.join("Foo")).unwrap();
+
+        let dst = tmp.path().join("Backup.app");
+        copy_path(&src, &dst).unwrap();
+
+        let dir_link = dst.join("Contents/Frameworks/Foo.framework/Versions/Current");
+        let file_link = dst.join("Contents/Frameworks/Foo.framework/Foo");
+        assert!(
+            std::fs::symlink_metadata(&dir_link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "Versions/Current must remain a symlink"
+        );
+        assert_eq!(std::fs::read_link(&dir_link).unwrap(), Path::new("A"));
+        assert!(
+            std::fs::symlink_metadata(&file_link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "Foo entry must remain a symlink"
+        );
+        assert_eq!(
+            std::fs::read_link(&file_link).unwrap(),
+            Path::new("Versions/Current/Foo")
+        );
+        // The link's target must still resolve through the restored bundle.
+        assert_eq!(std::fs::read(&file_link).unwrap(), b"binary");
+    }
+
+    #[test]
+    fn create_backup_prunes_older_siblings() {
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir().unwrap();
+        let home = tmp.path().join("home");
+        unsafe { std::env::set_var("CLAUDETTE_HOME", &home) };
+
+        // Pre-existing stale generation we expect to be cleaned up.
+        let stale = updates_previous_dir("0.10.0");
+        std::fs::create_dir_all(stale.join("Old.AppImage")).unwrap();
+        std::fs::write(stale.join("Old.AppImage/payload"), b"old").unwrap();
+
+        let source_dir = tmp.path().join("Source.AppImage");
+        std::fs::write(&source_dir, b"current binary").unwrap();
+        let target = InstallTarget {
+            kind: InstallKind::LinuxAppImage,
+            target_path: source_dir.clone(),
+            executable_path: source_dir.clone(),
+            is_dir: false,
+        };
+
+        let backup = create_backup(&target, "0.24.0").unwrap().unwrap();
+        assert!(backup.exists(), "fresh backup should exist");
+        assert!(!stale.exists(), "stale {} should be GC'd", stale.display());
+
+        unsafe { std::env::remove_var("CLAUDETTE_HOME") };
+    }
+
+    #[test]
+    fn start_monitor_clears_sentinel_at_attempt_threshold() {
+        // Guard against any lingering env probation override that another
+        // test might have set in this process. start_monitor uses
+        // probation_timeout() which honors $CLAUDETTE_BOOT_PROBATION_SECS.
+        let tmp = tempdir().unwrap();
+        let mut probation = sample_probation(tmp.path(), None);
+        probation.attempts = MAX_PROBATION_ATTEMPTS - 1;
+        write_probation(tmp.path(), &probation).unwrap();
+
+        // Re-read, increment, write, decide via the same logic
+        // start_monitor uses. We can't call start_monitor directly here
+        // because it spawns onto the Tauri async runtime which needs
+        // an AppHandle; the threshold logic itself is what we want
+        // covered.
+        let path = sentinel_path(tmp.path());
+        let mut p = read_probation_path(&path).unwrap();
+        p.attempts = p.attempts.saturating_add(1);
+        if p.attempts >= MAX_PROBATION_ATTEMPTS {
+            std::fs::remove_file(&path).unwrap();
+        } else {
+            write_probation(tmp.path(), &p).unwrap();
+        }
+
+        assert!(
+            !path.exists(),
+            "sentinel must be cleared once we reach the attempt threshold"
+        );
+    }
+
+    #[test]
+    fn probation_timeout_clamps_env_override() {
+        // Re-use env_lock to keep this from racing other env-mutating
+        // tests in this module.
+        let _guard = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+        unsafe { std::env::set_var("CLAUDETTE_BOOT_PROBATION_SECS", "0") };
+        assert!(probation_timeout() >= Duration::from_secs(MIN_PROBATION_SECS));
+        unsafe { std::env::set_var("CLAUDETTE_BOOT_PROBATION_SECS", "9999") };
+        assert!(probation_timeout() <= Duration::from_secs(MAX_PROBATION_SECS));
+        unsafe { std::env::set_var("CLAUDETTE_BOOT_PROBATION_SECS", "garbage") };
+        assert_eq!(
+            probation_timeout(),
+            Duration::from_secs(DEFAULT_PROBATION_SECS)
+        );
+        unsafe { std::env::remove_var("CLAUDETTE_BOOT_PROBATION_SECS") };
+    }
+
+    /// Regression: when we restore a backup over a destination that
+    /// already contains a symlink, the previous `remove_path` followed
+    /// `std::fs::metadata` which dereferenced the link and could
+    /// recursively delete the link's *target* instead of the link
+    /// itself. Lock that down: removing through a symlink should drop
+    /// the link, not its target.
+    #[cfg(unix)]
+    #[test]
+    fn remove_path_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempdir().unwrap();
+        let target_dir = tmp.path().join("target_dir");
+        std::fs::create_dir_all(&target_dir).unwrap();
+        std::fs::write(target_dir.join("keepme"), b"keep").unwrap();
+        let link = tmp.path().join("link");
+        symlink(&target_dir, &link).unwrap();
+
+        remove_path(&link).unwrap();
+
+        assert!(!link.exists(), "the symlink itself should be gone");
+        assert!(
+            target_dir.join("keepme").exists(),
+            "the link's target must not be touched"
+        );
     }
 }

--- a/src-tauri/src/commands/boot.rs
+++ b/src-tauri/src/commands/boot.rs
@@ -1,0 +1,11 @@
+use tauri::State;
+
+use crate::{boot_probation, state::AppState};
+
+#[tauri::command]
+pub async fn boot_ok(state: State<'_, AppState>) -> Result<(), String> {
+    let data_dir = claudette::path::data_dir();
+    boot_probation::acknowledge_boot(&data_dir, &state.boot_probation).await?;
+    tracing::debug!(target: "claudette::updater", "boot probation acknowledged by frontend");
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod agent_backends;
 pub mod agent_backends;
 pub mod apps;
 pub mod auth;
+pub mod boot;
 pub mod cesp;
 pub mod chat;
 pub mod claude_flags;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -5,6 +5,7 @@ use tauri::{AppHandle, Emitter, State};
 use tauri_plugin_updater::UpdaterExt;
 use url::Url;
 
+use crate::boot_probation;
 use crate::state::AppState;
 
 const STABLE_URL: &str =
@@ -266,6 +267,13 @@ pub async fn install_pending_update(
     let app_for_cb = app.clone();
     let mut total: u64 = 0;
     let mut downloaded: u64 = 0;
+
+    boot_probation::prepare_for_update(
+        &claudette::path::data_dir(),
+        &update.current_version,
+        &update.version,
+        update.download_url.as_str(),
+    )?;
 
     update
         .download_and_install(

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -275,13 +275,28 @@ pub async fn install_pending_update(
     // download progress bar starting to fill. Frontends that don't
     // listen for it simply see the existing `updater://progress`
     // sequence as before.
+    //
+    // The recursive copy is synchronous std::fs work and would block
+    // the tokio worker handling this command for the full duration of
+    // the backup — measurably bad on a 200-300 MB .app bundle.
+    // `spawn_blocking` hands the work to the dedicated blocking pool
+    // so other commands and event listeners stay responsive while the
+    // backup is created.
     let _ = app.emit("updater://preparing", "backup");
-    boot_probation::prepare_for_update(
-        &claudette::path::data_dir(),
-        &update.current_version,
-        &update.version,
-        update.download_url.as_str(),
-    )?;
+    let data_dir = claudette::path::data_dir();
+    let current_version = update.current_version.clone();
+    let next_version = update.version.clone();
+    let download_url = update.download_url.as_str().to_string();
+    tokio::task::spawn_blocking(move || {
+        boot_probation::prepare_for_update(
+            &data_dir,
+            &current_version,
+            &next_version,
+            &download_url,
+        )
+    })
+    .await
+    .map_err(|e| format!("boot probation prepare task panicked: {e}"))??;
     let _ = app.emit("updater://preparing", "downloading");
 
     update

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -268,12 +268,21 @@ pub async fn install_pending_update(
     let mut total: u64 = 0;
     let mut downloaded: u64 = 0;
 
+    // Emit a "preparing" pre-state before the rollback backup runs.
+    // On macOS where the install is a 200-300 MB `.app` bundle, the
+    // recursive copy can take several seconds — without this event the
+    // UI sits silent between "Install update" being clicked and the
+    // download progress bar starting to fill. Frontends that don't
+    // listen for it simply see the existing `updater://progress`
+    // sequence as before.
+    let _ = app.emit("updater://preparing", "backup");
     boot_probation::prepare_for_update(
         &claudette::path::data_dir(),
         &update.current_version,
         &update.version,
         update.download_url.as_str(),
     )?;
+    let _ = app.emit("updater://preparing", "downloading");
 
     update
         .download_and_install(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 
 mod agent_mcp_sink;
 mod app_info;
+mod boot_probation;
 mod commands;
 mod ipc;
 mod mdns;
@@ -290,6 +291,14 @@ fn main() {
         return;
     }
 
+    if let Some(result) = boot_probation::run_helper_from_args(&args) {
+        if let Err(e) = result {
+            eprintln!("boot rollback helper failed: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     // GUI path. Heavy init runs only here, after we've ruled out the
     // subsidiary entry points above.
     //
@@ -534,6 +543,12 @@ fn main() {
 
     let builder = builder
         .setup(move |app| {
+            let boot_state = std::sync::Arc::clone(
+                &app.state::<state::AppState>().boot_probation,
+            );
+            boot_probation::show_pending_report(app.handle(), &data_dir);
+            boot_probation::start_monitor(app.handle().clone(), boot_state, data_dir.clone());
+
             // Start mDNS browser to discover nearby claudette-server instances.
             if let Err(e) = mdns::start_mdns_browser(app.handle(), saved_fingerprints) {
                 tracing::warn!(target: "claudette::mdns", error = %e, "failed to start browser");
@@ -817,6 +832,8 @@ fn main() {
             commands::devtools::open_devtools,
             // Data
             commands::data::load_initial_data,
+            // Boot-health probation
+            commands::boot::boot_ok,
             // Repository
             commands::repository::add_repository,
             commands::repository::init_repository,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -14,6 +14,7 @@ use claudette::plugin_runtime::PluginRegistry;
 use claudette::scm::types::{CiCheck, PullRequest};
 use serde::{Deserialize, Serialize};
 
+use crate::boot_probation::BootProbationState;
 use crate::commands::agent_backends::BackendGateway;
 use crate::commands::apps::DetectedApp;
 use crate::remote::DiscoveredServer;
@@ -528,6 +529,9 @@ pub struct AppState {
     /// call. The Update struct holds the downloaded payload + signature context
     /// and is not Serialize, so it lives here instead of crossing the IPC boundary.
     pub pending_update: tokio::sync::Mutex<Option<tauri_plugin_updater::Update>>,
+    /// Boot-health probation state used after an updater install. The frontend
+    /// clears the sentinel via `boot_ok`; otherwise the startup timer rolls back.
+    pub boot_probation: Arc<BootProbationState>,
     /// CESP sound pack playback state (no-repeat + debounce tracking).
     pub cesp_playback: Mutex<claudette::cesp::SoundPlaybackState>,
     /// Cached `claude --help` parse result. Populated by a background task
@@ -570,6 +574,7 @@ impl AppState {
             merge_base_cache: MergeBaseCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
             pending_update: tokio::sync::Mutex::new(None),
+            boot_probation: Arc::new(BootProbationState::default()),
             cesp_playback: Mutex::new(claudette::cesp::SoundPlaybackState::new()),
             claude_flag_defs: Arc::new(RwLock::new(ClaudeFlagDiscovery::Loading)),
             auth_login_cancel: tokio::sync::Mutex::new(None),

--- a/src/ui/bun.lock
+++ b/src/ui/bun.lock
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@types/diff": "^8.0.0",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
@@ -184,6 +185,8 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
 
@@ -897,6 +900,10 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
@@ -1116,6 +1123,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
 

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "lint:css": "node scripts/check-css-tokens.mjs && node scripts/check-font-mono.mjs",
     "preview": "vite preview",
+    "smoke:bundle": "node scripts/smoke-built-bundle.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@types/diff": "^8.0.0",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",

--- a/src/ui/scripts/smoke-built-bundle.mjs
+++ b/src/ui/scripts/smoke-built-bundle.mjs
@@ -92,6 +92,7 @@ try {
   await page.addInitScript(() => {
     let nextCallbackId = 1;
     const callbacks = new Map();
+    window.__CLAUDETTE_SMOKE_UNKNOWN_INVOKES__ = [];
     window.__TAURI_INTERNALS__ = {
       invoke: async (command) => window.__CLAUDETTE_SMOKE_INVOKE__(command),
       transformCallback: (callback, once = false) => {
@@ -145,6 +146,12 @@ try {
         case "plugin:event|listen":
           return 1;
         default:
+          // Record but don't throw — bubbling an exception here causes
+          // a chain of unhandled-rejection console errors that mask the
+          // first useful diagnostic. We collect the unknown command and
+          // let the Node side decide whether to fail the run after the
+          // boot completes.
+          window.__CLAUDETTE_SMOKE_UNKNOWN_INVOKES__.push(command);
           return null;
       }
     };
@@ -161,6 +168,21 @@ try {
 
   if (failures.length > 0) {
     throw new Error(`Bundle boot emitted fatal errors:\n${failures.join("\n")}`);
+  }
+
+  // Surface unmocked Tauri commands so new boot-time IPC doesn't slip
+  // past the smoke. This is a warning today (env-gated to fail-loud)
+  // rather than a hard failure — the smoke is meant to catch *boot*
+  // breakage; an unmocked but optional command shouldn't block PRs
+  // unless we explicitly want it to.
+  const unknown = await page.evaluate(() => window.__CLAUDETTE_SMOKE_UNKNOWN_INVOKES__ || []);
+  const dedup = Array.from(new Set(unknown));
+  if (dedup.length > 0) {
+    const msg = `Smoke saw unmocked Tauri invocations: ${dedup.join(", ")}`;
+    if (process.env.CLAUDETTE_SMOKE_STRICT === "1") {
+      throw new Error(msg);
+    }
+    console.warn(`warn: ${msg}`);
   }
 
   console.log(`Built bundle boot smoke passed at ${url}`);

--- a/src/ui/scripts/smoke-built-bundle.mjs
+++ b/src/ui/scripts/smoke-built-bundle.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const distDir = resolve(__dirname, "../dist");
+const timeoutMs = 10_000;
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".map", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".ttf", "font/ttf"],
+  [".wasm", "application/wasm"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+]);
+
+async function serveFile(req, res) {
+  const requestedUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+  const rawPath = decodeURIComponent(requestedUrl.pathname);
+  const relativePath = rawPath === "/" ? "index.html" : rawPath.replace(/^\/+/, "");
+  const candidate = normalize(join(distDir, relativePath));
+
+  if (candidate !== distDir && !candidate.startsWith(`${distDir}${sep}`)) {
+    res.writeHead(403);
+    res.end("Forbidden");
+    return;
+  }
+
+  try {
+    const body = await readFile(candidate);
+    res.writeHead(200, {
+      "content-type": contentTypes.get(extname(candidate)) ?? "application/octet-stream",
+      "cache-control": "no-store",
+    });
+    res.end(body);
+  } catch {
+    try {
+      const body = await readFile(join(distDir, "index.html"));
+      res.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      });
+      res.end(body);
+    } catch (err) {
+      res.writeHead(500);
+      res.end(`Could not read built bundle: ${err}`);
+    }
+  }
+}
+
+async function listen(server) {
+  return await new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen(server.address());
+    });
+  });
+}
+
+const server = createServer((req, res) => {
+  void serveFile(req, res);
+});
+
+let browser;
+try {
+  const address = await listen(server);
+  const url = `http://${address.address}:${address.port}/`;
+
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const failures = [];
+
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const text = message.text();
+    if (/\b(TypeError|ReferenceError)\b/.test(text)) failures.push(`console: ${text}`);
+  });
+  page.on("pageerror", (error) => {
+    failures.push(`pageerror: ${error.stack || error.message}`);
+  });
+
+  await page.addInitScript(() => {
+    let nextCallbackId = 1;
+    const callbacks = new Map();
+    window.__TAURI_INTERNALS__ = {
+      invoke: async (command) => window.__CLAUDETTE_SMOKE_INVOKE__(command),
+      transformCallback: (callback, once = false) => {
+        const id = nextCallbackId++;
+        callbacks.set(id, { callback, once });
+        return id;
+      },
+      unregisterCallback: (id) => {
+        callbacks.delete(id);
+      },
+      convertFileSrc: (path) => path,
+      metadata: {
+        currentWindow: { label: "main" },
+        currentWebview: { label: "main" },
+      },
+    };
+    window.__CLAUDETTE_SMOKE_INVOKE__ = async (command) => {
+      switch (command) {
+        case "load_initial_data":
+          return {
+            repositories: [],
+            workspaces: [],
+            worktree_base_dir: "/tmp/claudette-smoke/workspaces",
+            default_branches: {},
+            last_messages: [],
+            scm_cache: [],
+            manual_workspace_order_repo_ids: [],
+          };
+        case "get_diagnostics_settings":
+          return { log_level: null, rust_log_override: null, frontend_verbosity: null };
+        case "plugin:app|version":
+          return "0.0.0-smoke";
+        case "get_host_env_flags":
+          return { alternative_backends_compiled: false, disable_1m_context: false };
+        case "list_agent_backends":
+          return { backends: [], default_backend_id: "anthropic" };
+        case "list_remote_connections":
+        case "list_discovered_servers":
+        case "detect_installed_apps":
+        case "list_system_fonts":
+        case "list_app_settings_with_prefix":
+        case "list_user_themes":
+          return [];
+        case "get_local_server_status":
+          return { running: false, connection_string: null };
+        case "get_app_setting":
+        case "boot_ok":
+        case "plugin:event|unlisten":
+        case "log_from_frontend":
+          return null;
+        case "plugin:event|listen":
+          return 1;
+        default:
+          return null;
+      }
+    };
+  });
+
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+  await page.waitForFunction(
+    () =>
+      Boolean(window.__claudetteHijackBlocked) ||
+      (document.getElementById("root")?.childElementCount ?? 0) > 0,
+    null,
+    { timeout: timeoutMs },
+  );
+
+  if (failures.length > 0) {
+    throw new Error(`Bundle boot emitted fatal errors:\n${failures.join("\n")}`);
+  }
+
+  console.log(`Built bundle boot smoke passed at ${url}`);
+} finally {
+  if (browser) await browser.close();
+  await new Promise((resolveClose) => server.close(resolveClose));
+}

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -79,6 +79,13 @@ function App() {
     (s) => s.setManualWorkspaceOrderByRepo,
   );
   const [viewStateHydrated, setViewStateHydrated] = useState(false);
+  // Separate flag for the boot-health heartbeat: only flips on the
+  // *success* path of loadInitialData. The viewStateHydrated flag is
+  // also set in the catch() branch so the UI can render a recovery
+  // shell on a broken DB / migration / persisted-state load — but
+  // those failures are *exactly* the class of regression Gate 2 is
+  // supposed to roll back, so we must not ack on that path.
+  const [initialDataLoaded, setInitialDataLoaded] = useState(false);
 
   // Cached theme list — populated on initial load, reused by the OS handler.
   const loadedThemesRef = useRef<ThemeDefinition[]>([]);
@@ -92,20 +99,24 @@ function App() {
 
   // Boot-health heartbeat for the post-update probation window.
   //
-  // This must NOT fire on the initial render — at that point this
-  // component returns `null` (see the `if (!viewStateHydrated) return
-  // null;` early return below), AppLayout has not mounted, and a
-  // module-eval crash inside AppLayout's import graph would still leave
-  // App's first useEffect to fire and silently mark the broken build
-  // healthy. Gate on `viewStateHydrated` so we only ack after the React
-  // tree has actually committed past the loader, and after
-  // `loadInitialData` succeeded (it's the gate that flips
-  // `viewStateHydrated`). See GitHub issue 731 for the design intent —
-  // "first paint of any non-error-boundary route".
+  // Two conditions must both hold before we ack:
+  //   1. `viewStateHydrated` — React has committed past the loader
+  //      (this gates the early `return null` below). A module-eval
+  //      crash in AppLayout's import graph would never flip this.
+  //   2. `initialDataLoaded` — the `.then()` branch of
+  //      `loadInitialData` resolved. The `.catch()` branch *also*
+  //      flips `viewStateHydrated` so the UI can render even when
+  //      the DB load fails, but a broken migration / corrupt persisted
+  //      state / DB lock is exactly the failure mode Gate 2 is meant
+  //      to roll back. Gating on `initialDataLoaded` keeps those
+  //      paths from accidentally marking the broken build healthy.
+  //
+  // See GitHub issue 731 for the design intent — "first paint of any
+  // non-error-boundary route".
   useEffect(() => {
-    if (!viewStateHydrated) return;
+    if (!viewStateHydrated || !initialDataLoaded) return;
     bootOk().catch((err) => console.error("Failed to acknowledge boot:", err));
-  }, [viewStateHydrated]);
+  }, [viewStateHydrated, initialDataLoaded]);
 
   // Hydrate persisted view state after workspaces are loaded, then write back
   // future layout, selection, tab, and terminal-view changes.
@@ -136,6 +147,12 @@ function App() {
         setLastMessages(msgMap);
         await hydratePersistedViewState(localWorkspaces);
         setViewStateHydrated(true);
+        // Boot-health gate: only ack on the success path. The
+        // `.catch()` branch below also flips `viewStateHydrated` so
+        // the UI can recover, but a failed initial data load is
+        // exactly the kind of regression we want the rollback to
+        // catch — see the comment on the `bootOk` useEffect above.
+        setInitialDataLoaded(true);
         // Hydrate SCM summaries from persisted cache for instant sidebar display.
         for (const row of data.scm_cache) {
           if (row.pr_json == null) continue;

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -90,9 +90,22 @@ function App() {
   // Listen for MCP supervisor status events from the Rust backend.
   useMcpStatus();
 
+  // Boot-health heartbeat for the post-update probation window.
+  //
+  // This must NOT fire on the initial render — at that point this
+  // component returns `null` (see the `if (!viewStateHydrated) return
+  // null;` early return below), AppLayout has not mounted, and a
+  // module-eval crash inside AppLayout's import graph would still leave
+  // App's first useEffect to fire and silently mark the broken build
+  // healthy. Gate on `viewStateHydrated` so we only ack after the React
+  // tree has actually committed past the loader, and after
+  // `loadInitialData` succeeded (it's the gate that flips
+  // `viewStateHydrated`). See GitHub issue 731 for the design intent —
+  // "first paint of any non-error-boundary route".
   useEffect(() => {
+    if (!viewStateHydrated) return;
     bootOk().catch((err) => console.error("Failed to acknowledge boot:", err));
-  }, []);
+  }, [viewStateHydrated]);
 
   // Hydrate persisted view state after workspaces are loaded, then write back
   // future layout, selection, tab, and terminal-view changes.

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData, getAppSetting, getHostEnvFlags, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, detectInstalledApps, listSystemFonts, deleteTerminalTab, listAppSettingsWithPrefix, listAgentBackends } from "./services/tauri";
+import { loadInitialData, getAppSetting, getHostEnvFlags, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, detectInstalledApps, listSystemFonts, deleteTerminalTab, listAppSettingsWithPrefix, listAgentBackends, bootOk } from "./services/tauri";
 import { applyTheme, applyUserFonts, loadAllThemes, findTheme, cacheThemePreference, getThemeDataAttr } from "./utils/theme";
 import { DEFAULT_THEME_ID, DEFAULT_LIGHT_THEME_ID } from "./styles/themes";
 import type { ThemeDefinition } from "./types/theme";
@@ -89,6 +89,10 @@ function App() {
 
   // Listen for MCP supervisor status events from the Rust backend.
   useMcpStatus();
+
+  useEffect(() => {
+    bootOk().catch((err) => console.error("Failed to acknowledge boot:", err));
+  }, []);
 
   // Hydrate persisted view state after workspaces are loaded, then write back
   // future layout, selection, tab, and terminal-view changes.

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -1335,6 +1335,10 @@ export function installPendingUpdate(): Promise<void> {
   return invoke("install_pending_update");
 }
 
+export function bootOk(): Promise<void> {
+  return invoke("boot_ok");
+}
+
 import type { ThemeDefinition } from "../types/theme";
 
 export function listUserThemes(): Promise<ThemeDefinition[]> {


### PR DESCRIPTION
Closes #731.

Two independent gates against the "blank-screen-after-update" failure mode that motivated this issue (PR #730 fixed one variant; the next chunking / module-eval / migration regression is a "when," not "if"):

| Gate | Where | What it catches |
|---|---|---|
| **1 — pre-publish** | `frontend-smoke` job in `.github/workflows/ci.yml` + `src/ui/scripts/smoke-built-bundle.mjs` | bundles whose React tree fails to mount (chunk-init order, missing exports, runtime `TypeError` / `ReferenceError`) at PR-review time, before nightly publishes |
| **2 — post-install** | `src-tauri/src/boot_probation.rs` + `commands/boot.rs` + `App.tsx` heartbeat + helper subprocess | a successfully-installed update that fails to render past the loader within a probation window — automatically restores the previous self-contained install and surfaces a native rollback dialog on next launch |

The build infra alongside this (the `build-updater-manifest.sh` extraction, Windows NSIS updater, atomic nightly promotion) is required for Gate 2 to have a meaningful "previous binary" to roll back to.

## How to verify

```bash
# Automated end-to-end of the helper subprocess flow
./scripts/smoke-boot-health-gate.sh

# Pre-publish bundle smoke (same job CI runs)
cd src/ui && bun run smoke:bundle
```

`scripts/boot-health-gate-manual-uat.md` is a 5-phase manual checklist for the pieces that need a live Tauri runtime + human eyes (probation timer firing, native dialog rendering, attempts-threshold clearing, etc.). Phase 3 is the full end-to-end rollback exercise.

## Commit timeline

| Commit | Summary |
|---|---|
| `61d11ee6` | feat: original implementation of both gates |
| `623b2477` | fix: address 10 self-review findings (symlink-aware backup, `viewStateHydrated` gating, `RollbackInProgress` skip, attempts bound, backup GC, `updater://preparing` event, `CLAUDETTE_BOOT_PROBATION_SECS` override, smoke-test fail-loud mock, doc + cfg cleanup) |
| `22f8fac8` | test: local smoke script + manual UAT checklist |
| `00b0cdb0` | fix: address Codex P1 (Windows `is_pid_alive` was a stub) + P2 (`bootOk` fired on `viewStateHydrated`, which the `.catch()` path also flips) |

## Behavior — Gate 1 (pre-publish smoke)

A new CI job `frontend-smoke` runs after the existing `frontend` job:

1. `bun run build` — same command nightly + release use.
2. Serve `dist/` over a tmp local HTTP server.
3. Launch headless Chromium with a stub `__TAURI_INTERNALS__` that returns canned responses for every boot-time `invoke`.
4. Wait up to 10 s for either `#root` to gain a child or `window.__claudetteHijackBlocked === true`.
5. Fail on any boot-time `console.error` containing `TypeError` / `ReferenceError`, or on any `pageerror`.

Unmocked invocations are recorded and surfaced as a warning (or hard failure under `CLAUDETTE_SMOKE_STRICT=1`) so new boot-time IPC is visible. Today's run reports five existing post-boot commands — none are critical-path.

## Behavior — Gate 2 (post-install heartbeat-or-rollback)

### Sequence

1. **`install_pending_update`** emits `updater://preparing="backup"`, takes a recursive copy of the current install into `~/.claudette/updates/previous/<current_version>/`, prunes older sibling generations, writes `boot-probation.json` with `status=Pending`, emits `updater://preparing="downloading"`, then runs `download_and_install` + `app.restart()`.
2. **On the new launch's `setup`**, `start_monitor` reads the sentinel, increments `attempts`, and arms a tokio timer.
3. **If the React tree commits past the loader and `loadInitialData` succeeds**, `App.tsx`'s `useEffect` fires `boot_ok`, the timer is cancelled, and the sentinel is removed.
4. **If the timer fires first**, the sentinel flips to `RollbackInProgress`, a copy of the running exe is staged on Windows (Unix uses `current_exe` directly), the helper is spawned with `--boot-rollback-helper <sentinel> <parent-pid>`, the parent calls `app.exit(1)`. The helper waits for the parent to exit (so its file locks release — critical on Windows), removes the failed install dir, copies the backup over it, relaunches the restored binary, and writes `boot-rollback-report.json`.
5. **On the relaunched (restored) build's `setup`**, `show_pending_report` consumes the report file once and renders a native macOS / GTK / Windows dialog: *"Update X.Y.Z failed to start, so Claudette restored X.Y.W"*.

### Edge cases handled

- **Force-quit during probation.** `attempts >= MAX_PROBATION_ATTEMPTS=2` clears the sentinel without arming the timer (Issue #731's design intent: the user has booted past the timer once, that's the strongest "this build runs" signal we have).
- **Relaunch during a previous helper's grace period.** `start_monitor` short-circuits on `RollbackInProgress` so a second helper can't race the first for the install location.
- **Backup creation fails (no symlinks before the round-1 fix; permissions; disk).** Sentinel records `backup_error` and the timeout path degrades to a "report only" dialog with the previous-release URL — never silent.
- **Rollback fails (disk full, permission denied, install dir gone).** Sentinel flips to `RollbackFailed` so the next launch does NOT retry; report contains the failure cause and the manual download URL.
- **Initial data load fails after update** (broken migration, corrupt persisted state). `viewStateHydrated` flips on the catch path so the UI can show a recovery shell, but `initialDataLoaded` stays false so `bootOk` does NOT fire — exactly the regression class Gate 2 is supposed to catch.
- **macOS framework symlinks in the bundle.** `copy_dir_recursive` now branches on `file_type()` and recreates links via `std::os::unix::fs::symlink`, preserving `Foo.framework/Foo -> Versions/Current/Foo` shapes through the roundtrip. (The original implementation would have errored on `Is a directory` from any symlink-to-directory entry.)
- **Windows file lock on the running exe.** `wait_for_parent_exit` now uses a real `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess` probe (was a hardcoded `false` previously, which would have skipped the wait entirely on the platform where it matters most).

## Files added / modified

```
.github/workflows/ci.yml                       — frontend-smoke job, updater-manifest job
.github/workflows/nightly.yml                  — Windows NSIS, atomic staging→nightly promotion, ordered endpoint manifest
.github/workflows/release-please.yml           — same NSIS + manifest builder integration
scripts/build-updater-manifest.sh              — single-writer manifest synthesis from per-platform .sig files
scripts/test-build-updater-manifest.sh         — end-to-end test for the above
scripts/smoke-boot-health-gate.sh              — local Gate 2 helper-subprocess smoke (NEW)
scripts/boot-health-gate-manual-uat.md         — 5-phase manual UAT checklist (NEW)
site/src/content/docs/features/diagnostics.mdx — new "Update boot-health rollback" section + tunable env-var docs
src-tauri/src/boot_probation.rs                — entire rollback module (NEW; ~1100 lines incl. tests)
src-tauri/src/commands/boot.rs                 — boot_ok IPC command (NEW)
src-tauri/src/commands/updater.rs              — prepare_for_update hook + updater://preparing emission
src-tauri/src/commands/mod.rs                  — register boot module
src-tauri/src/main.rs                          — child-mode dispatch for --boot-rollback-helper, setup wiring
src-tauri/src/state.rs                         — BootProbationState in AppState
src-tauri/Cargo.toml                           — Win32_System_Threading feature on windows-sys
src/ui/bun.lock                                — @playwright/test pin
src/ui/package.json                            — @playwright/test devDep, smoke:bundle script
src/ui/scripts/smoke-built-bundle.mjs          — Gate 1 implementation
src/ui/src/App.tsx                             — bootOk heartbeat (gated on viewStateHydrated AND initialDataLoaded)
src/ui/src/services/tauri.ts                   — bootOk() wrapper
```

## Risk surface intentionally NOT covered (call-outs)

- **Cross-compile from macOS host blocked by a `library kind framework` error** in a transitive dep when targeting Windows — the existing CI Windows runners build natively so this is not a release blocker, but I could not verify the new Windows-only `is_pid_alive` body locally. The API surface is identical to patterns in `webview2_check.rs` and `commands/auth.rs` that already ship.
- **No regression test that asserts the smoke catches the actual PR #730 bug** (the issue called for "verifiable test of the test"). I argue that contributing a deliberately-broken bundle just to verify a green→red→green flow has questionable cost/benefit; documenting the failure mode in the smoke script's header comments is the value-equivalent.

## Test results (run locally before pushing)

| Surface | Count | Status |
|---|---|---|
| `cargo test -p claudette -p claudette-server -p claudette-cli --all-features` | 1077 | ✓ |
| `cargo test -p claudette-tauri --features default boot_probation` | 14 | ✓ |
| `cd src/ui && bun run test` | 1779 | ✓ |
| `cd src/ui && bun run build` | — | ✓ |
| `cd src/ui && bun run lint:css` | — | ✓ |
| `cd src/ui && bunx tsc --noEmit` | — | ✓ |
| `scripts/test-build-updater-manifest.sh` | — | ✓ |
| `cd src/ui && bun run smoke:bundle` | — | ✓ |
| `./scripts/smoke-boot-health-gate.sh` | — | ✓ |

`cargo fmt --all --check` clean. `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` clean.
