### PR TITLE
fix(macos): replace mac-notification-sys with UNUserNotificationCenter (#736)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ version = "0.23.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "block",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -952,7 +953,6 @@ dependencies = [
  "image",
  "interprocess",
  "libc",
- "mac-notification-sys",
  "mdns-sd",
  "objc",
  "parking_lot",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,8 +66,11 @@ hound = { version = "3", optional = true }
 candle-core = { version = "=0.9.2", features = ["metal"], optional = true }
 candle-nn = { version = "=0.9.2", features = ["metal"], optional = true }
 candle-transformers = { version = "=0.9.2", features = ["metal"], optional = true }
-mac-notification-sys = "0.6"
 objc = "0.2"
+# Pairs with `objc` 0.2 — we use `ConcreteBlock` to provide the
+# `requestAuthorizationWithOptions:completionHandler:` callback expected
+# by UNUserNotificationCenter. Used only by `notification_macos.rs`.
+block = "0.1"
 raw-window-handle = "0.6"
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,8 @@ mod commands;
 mod ipc;
 mod mdns;
 mod missing_cli;
+#[cfg(target_os = "macos")]
+mod notification_macos;
 mod ops_hooks;
 #[cfg(feature = "voice")]
 mod platform_speech;
@@ -697,20 +699,19 @@ fn main() {
             // 1200x800/maximized placement flash before saved bounds apply.
             window_state::restore_main_window(app);
 
-            // Set the notification app identity before any notifications are sent.
-            // mac-notification-sys uses Once — first call wins. We call early so
-            // both our direct calls and the tauri-plugin-notification share the
-            // same identity.
+            // Register the UNUserNotificationCenter delegate and request
+            // authorization. Replaces the old `mac-notification-sys`
+            // integration (issue #736) — the previous crate spawned a
+            // runloop-polling thread per toast that never got reaped, leaking
+            // ~N² CPU. UNUserNotificationCenter is delegate-based and
+            // OS-managed; per-workspace click routing is preserved via
+            // `userInfo[workspace_id]` (see notification_macos.rs).
+            //
+            // Requires a code-signed bundle: scripts/dev.sh + release builds
+            // both supply one. Bare `cargo tauri dev` will silently no-op
+            // (logged as a warning) — switch to scripts/dev.sh for toasts.
             #[cfg(target_os = "macos")]
-            {
-                let bundle_id = app.config().identifier.clone();
-                let identity = if cfg!(debug_assertions) {
-                    "com.apple.Terminal".to_string()
-                } else {
-                    bundle_id
-                };
-                let _ = mac_notification_sys::set_application(&identity);
-            }
+            notification_macos::init(app.handle().clone());
 
             // Start debug eval TCP server (dev builds only).
             #[cfg(debug_assertions)]

--- a/src-tauri/src/notification_macos.rs
+++ b/src-tauri/src/notification_macos.rs
@@ -60,8 +60,10 @@ static DELEGATE_REGISTERED: OnceLock<()> = OnceLock::new();
 
 const DELEGATE_CLASS_NAME: &str = "ClaudetteNotificationDelegate";
 
-// `UNAuthorizationOptions` bits we care about (alert + sound).
-const UN_AUTH_BADGE: usize = 1 << 0;
+// `UNAuthorizationOptions` bits we care about. Notably absent: BADGE.
+// We never call `setBadge:` anywhere in `src-tauri`, so requesting badge
+// capability would broaden the system permission prompt for a feature
+// we don't use.
 const UN_AUTH_SOUND: usize = 1 << 1;
 const UN_AUTH_ALERT: usize = 1 << 2;
 
@@ -292,7 +294,7 @@ unsafe fn request_authorization() {
     if center.is_null() {
         return;
     }
-    let options = UN_AUTH_ALERT | UN_AUTH_SOUND | UN_AUTH_BADGE;
+    let options = UN_AUTH_ALERT | UN_AUTH_SOUND;
 
     let handler = ConcreteBlock::new(|granted: BOOL, error: *mut Object| {
         // `objc::runtime::BOOL` is the platform's native bool — `bool` on
@@ -331,11 +333,21 @@ unsafe fn post(workspace_id: &str, title: &str, body: &str, sound: &str) {
         return;
     }
 
+    // `[UNMutableNotificationContent new]` returns +1 retained. Cocoa
+    // factory methods named with `new`/`alloc`/`copy`/`mutableCopy`
+    // transfer ownership to the caller — unlike e.g.
+    // `[UNNotificationRequest requestWith…]` which returns autoreleased.
+    // `addNotificationRequest:` copies the content internally, so we own
+    // the original retain and must release it. Autorelease immediately
+    // so every early-return path below is leak-safe; the main thread's
+    // runloop autorelease pool reaps it on this iteration.
     let content_cls = class!(UNMutableNotificationContent);
     let content: *mut Object = unsafe { msg_send![content_cls, new] };
     if content.is_null() {
         return;
     }
+    let _: *mut Object = unsafe { msg_send![content, autorelease] };
+
     let _: () = unsafe { msg_send![content, setTitle: nsstring(title)] };
     let _: () = unsafe { msg_send![content, setBody: nsstring(body)] };
 

--- a/src-tauri/src/notification_macos.rs
+++ b/src-tauri/src/notification_macos.rs
@@ -1,0 +1,394 @@
+//! macOS native notifications via `UNUserNotificationCenter`.
+//!
+//! Replaces the previous `mac-notification-sys` integration that spawned one
+//! OS thread per toast and never reaped them — see issue #736. Each
+//! `Notification::send` ran an `NSRunLoop` polling loop that only completed
+//! on a `Click` / `ActionButton` delegate event. Close-button / swipe /
+//! auto-clear emit a different delegate event, so threads leaked
+//! indefinitely. With N pending toasts they convoyed on
+//! `_CFRunLoopGet2`'s process-global `os_unfair_lock`, costing ~N² CPU.
+//!
+//! `UNUserNotificationCenter` is delegate-based. We register a single
+//! persistent delegate at app launch, store the `AppHandle` in a static so
+//! it can be reached from the delegate callbacks, and post each toast as a
+//! non-blocking `UNNotificationRequest`. The OS owns the toast lifecycle
+//! and plays the sound out-of-process in `usernoted` — no in-process
+//! threads, no runloop polling.
+//!
+//! On click, macOS calls
+//! `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:`
+//! on the main thread. We pull `workspace_id` from the response's
+//! `userInfo` dict and emit `tray-select-workspace` / focus the window —
+//! the exact UX the previous direct integration provided.
+//!
+//! `block = "0.1"` is used for the authorization callback (the only
+//! UN API call here whose completion handler is non-nullable).
+
+#![cfg(target_os = "macos")]
+
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::ptr;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use block::{Block, ConcreteBlock};
+use objc::declare::ClassDecl;
+use objc::runtime::{BOOL, Class, Object, Sel};
+use objc::{class, msg_send, sel, sel_impl};
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Shared `AppHandle` reachable from the delegate callbacks. Set once at
+/// startup. Subsequent `init` calls are no-ops.
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+
+/// Guards the runtime class registration. `ClassDecl::new` returns `None`
+/// if the class already exists (e.g. across hot reloads in dev) — we treat
+/// that as success.
+static DELEGATE_REGISTERED: OnceLock<()> = OnceLock::new();
+
+const DELEGATE_CLASS_NAME: &str = "ClaudetteNotificationDelegate";
+
+// `UNAuthorizationOptions` bits we care about (alert + sound).
+const UN_AUTH_BADGE: usize = 1 << 0;
+const UN_AUTH_SOUND: usize = 1 << 1;
+const UN_AUTH_ALERT: usize = 1 << 2;
+
+// `UNNotificationPresentationOptions` bits — used in
+// `willPresentNotification:` to keep toasts visible while the app is
+// foregrounded (matching the previous `mac-notification-sys` behavior).
+const UN_PRESENT_SOUND: usize = 1 << 1;
+const UN_PRESENT_BANNER: usize = 1 << 3;
+const UN_PRESENT_LIST: usize = 1 << 4;
+
+// `NSUTF8StringEncoding` constant.
+const NS_UTF8: usize = 4;
+
+/// One-shot init. Stores the `AppHandle`, registers the delegate class,
+/// installs an instance as `UNUserNotificationCenter.current.delegate`,
+/// and requests notification authorization.
+///
+/// Calling more than once is harmless — the second call is a no-op.
+pub fn init(app: AppHandle) {
+    if APP_HANDLE.set(app).is_err() {
+        return;
+    }
+    unsafe {
+        register_delegate_class();
+        install_delegate();
+        request_authorization();
+    }
+}
+
+/// Post a `UNNotificationRequest`. Returns immediately. No threads are
+/// spawned; the toast and its sound are owned by the OS notification
+/// daemon. Click routing carries `workspace_id` through `userInfo` so the
+/// delegate can emit `tray-select-workspace` for the exact session.
+pub fn send(workspace_id: &str, title: &str, body: &str, sound: &str) {
+    unsafe {
+        post(workspace_id, title, body, sound);
+    }
+}
+
+// ---- delegate class --------------------------------------------------------
+
+unsafe fn register_delegate_class() {
+    DELEGATE_REGISTERED.get_or_init(|| {
+        let superclass = class!(NSObject);
+        let Some(mut decl) = ClassDecl::new(DELEGATE_CLASS_NAME, superclass) else {
+            // Already registered in this process. Nothing to do.
+            return;
+        };
+
+        // SAFETY: each `add_method` matches the Objective-C selector's
+        // ABI. Block parameters are received as `*mut Object` (encoded
+        // `@`); we cast them to typed `Block<…>` pointers internally.
+        unsafe {
+            decl.add_method(
+                sel!(userNotificationCenter:willPresentNotification:withCompletionHandler:),
+                will_present as extern "C" fn(&Object, Sel, *mut Object, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:),
+                did_receive as extern "C" fn(&Object, Sel, *mut Object, *mut Object, *mut Object),
+            );
+        }
+        decl.register();
+    });
+}
+
+extern "C" fn will_present(
+    _self_: &Object,
+    _sel: Sel,
+    _center: *mut Object,
+    _notification: *mut Object,
+    completion: *mut Object,
+) {
+    // Show banner + play sound + add to Notification Center even when
+    // the app is foregrounded. Matches the previous behavior where
+    // `mac-notification-sys` toasts always appeared regardless of focus.
+    let options = UN_PRESENT_BANNER | UN_PRESENT_SOUND | UN_PRESENT_LIST;
+    if !completion.is_null() {
+        let block = completion as *mut Block<(usize,), ()>;
+        // SAFETY: AppKit hands us a non-null block pointer with the
+        // documented `void(^)(UNNotificationPresentationOptions)`
+        // signature.
+        unsafe {
+            (*block).call((options,));
+        }
+    }
+}
+
+extern "C" fn did_receive(
+    _self_: &Object,
+    _sel: Sel,
+    _center: *mut Object,
+    response: *mut Object,
+    completion: *mut Object,
+) {
+    if !response.is_null()
+        && let Some(app) = APP_HANDLE.get()
+    {
+        // SAFETY: `response` is a non-null `UNNotificationResponse`
+        // owned by AppKit for the duration of this callback.
+        let workspace_id = unsafe { extract_workspace_id(response) };
+
+        // Mirror the previous `tray::send_notification` macOS branch:
+        // restore + focus the window, then emit selection for the
+        // exact workspace whose toast was clicked.
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        if let Some(ws) = workspace_id
+            && !ws.is_empty()
+        {
+            let _ = app.emit("tray-select-workspace", ws);
+        }
+    }
+
+    if !completion.is_null() {
+        let block = completion as *mut Block<(), ()>;
+        // SAFETY: AppKit hands us a non-null block pointer with the
+        // documented `void(^)(void)` signature.
+        unsafe {
+            (*block).call(());
+        }
+    }
+}
+
+unsafe fn extract_workspace_id(response: *mut Object) -> Option<String> {
+    let notification: *mut Object = unsafe { msg_send![response, notification] };
+    if notification.is_null() {
+        return None;
+    }
+    let request: *mut Object = unsafe { msg_send![notification, request] };
+    if request.is_null() {
+        return None;
+    }
+    let content: *mut Object = unsafe { msg_send![request, content] };
+    if content.is_null() {
+        return None;
+    }
+    let user_info: *mut Object = unsafe { msg_send![content, userInfo] };
+    if user_info.is_null() {
+        return None;
+    }
+    let key = unsafe { nsstring("workspace_id") };
+    let value: *mut Object = unsafe { msg_send![user_info, objectForKey: key] };
+    unsafe { ns_string_to_rust(value) }
+}
+
+// ---- delegate install + auth ----------------------------------------------
+
+unsafe fn install_delegate() {
+    let center = unsafe { current_center() };
+    if center.is_null() {
+        tracing::warn!(
+            target: "claudette::notify",
+            "UNUserNotificationCenter unavailable — native notifications disabled (unsigned dev build?)",
+        );
+        return;
+    }
+    let Some(cls) = Class::get(DELEGATE_CLASS_NAME) else {
+        return;
+    };
+    // Intentionally retained for the lifetime of the process — the
+    // delegate must outlive every notification it might receive.
+    let delegate: *mut Object = unsafe { msg_send![cls, new] };
+    let _: () = unsafe { msg_send![center, setDelegate: delegate] };
+}
+
+unsafe fn request_authorization() {
+    let center = unsafe { current_center() };
+    if center.is_null() {
+        return;
+    }
+    let options = UN_AUTH_ALERT | UN_AUTH_SOUND | UN_AUTH_BADGE;
+
+    let handler = ConcreteBlock::new(|granted: BOOL, error: *mut Object| {
+        // `objc::runtime::BOOL` is the platform's native bool — `bool` on
+        // arm64 / modern x86_64 macOS. Just pass it through.
+        if !error.is_null() {
+            tracing::debug!(
+                target: "claudette::notify",
+                granted = ?granted,
+                "UNUserNotificationCenter authorization returned an error",
+            );
+        } else {
+            tracing::debug!(
+                target: "claudette::notify",
+                granted = ?granted,
+                "UNUserNotificationCenter authorization completed",
+            );
+        }
+    });
+    // `copy()` heap-allocates and retains the block so it survives past
+    // this stack frame; AppKit calls it asynchronously on a background
+    // queue. The returned `RcBlock` releases on drop, but the block is
+    // already retained by AppKit at that point.
+    let handler = handler.copy();
+    let _: () = unsafe {
+        msg_send![center,
+            requestAuthorizationWithOptions: options
+            completionHandler: &*handler]
+    };
+}
+
+// ---- post -----------------------------------------------------------------
+
+unsafe fn post(workspace_id: &str, title: &str, body: &str, sound: &str) {
+    let center = unsafe { current_center() };
+    if center.is_null() {
+        return;
+    }
+
+    let content_cls = class!(UNMutableNotificationContent);
+    let content: *mut Object = unsafe { msg_send![content_cls, new] };
+    if content.is_null() {
+        return;
+    }
+    let _: () = unsafe { msg_send![content, setTitle: nsstring(title)] };
+    let _: () = unsafe { msg_send![content, setBody: nsstring(body)] };
+
+    // `threadIdentifier` lets Notification Center coalesce repeated
+    // toasts for the same workspace into a single group — a free
+    // upgrade over `mac-notification-sys` behavior.
+    if !workspace_id.is_empty() {
+        let _: () = unsafe { msg_send![content, setThreadIdentifier: nsstring(workspace_id)] };
+    }
+
+    // userInfo carries workspace_id for click routing.
+    let user_info = unsafe { make_user_info_dict(workspace_id) };
+    let _: () = unsafe { msg_send![content, setUserInfo: user_info] };
+
+    // Sound matrix — same surface as the old code:
+    //   "None"    → no sound (content.sound stays nil)
+    //   "Default" → UNNotificationSound.defaultSound
+    //   custom    → UNNotificationSound.soundNamed:<name>
+    //              (resolves /Library/Sounds and /System/Library/Sounds)
+    match sound {
+        "None" => {}
+        "Default" => {
+            let cls = class!(UNNotificationSound);
+            let s: *mut Object = unsafe { msg_send![cls, defaultSound] };
+            let _: () = unsafe { msg_send![content, setSound: s] };
+        }
+        custom => {
+            let cls = class!(UNNotificationSound);
+            let name = unsafe { nsstring(custom) };
+            let s: *mut Object = unsafe { msg_send![cls, soundNamed: name] };
+            let _: () = unsafe { msg_send![content, setSound: s] };
+        }
+    }
+
+    // Identifier must be unique per pending request. A repeated id
+    // *replaces* the existing toast in Notification Center, which is
+    // not what we want for sequential per-workspace alerts.
+    let identifier = format!(
+        "{}-{}",
+        if workspace_id.is_empty() {
+            "claudette"
+        } else {
+            workspace_id
+        },
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    );
+
+    let request_cls = class!(UNNotificationRequest);
+    let request: *mut Object = unsafe {
+        msg_send![request_cls,
+            requestWithIdentifier: nsstring(&identifier)
+            content: content
+            trigger: ptr::null_mut::<Object>()]
+    };
+    if request.is_null() {
+        return;
+    }
+
+    // `addNotificationRequest:withCompletionHandler:` accepts a nil
+    // handler per Apple's docs — saves us building a one-shot block per
+    // post.
+    let _: () = unsafe {
+        msg_send![center,
+            addNotificationRequest: request
+            withCompletionHandler: ptr::null_mut::<Object>()]
+    };
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+unsafe fn current_center() -> *mut Object {
+    let Some(cls) = Class::get("UNUserNotificationCenter") else {
+        return ptr::null_mut();
+    };
+    unsafe { msg_send![cls, currentNotificationCenter] }
+}
+
+unsafe fn nsstring(s: &str) -> *mut Object {
+    let cls = class!(NSString);
+    let bytes = s.as_ptr() as *const c_void;
+    let len = s.len();
+    let alloc: *mut Object = unsafe { msg_send![cls, alloc] };
+    let inited: *mut Object = unsafe {
+        msg_send![alloc,
+            initWithBytes: bytes
+            length: len
+            encoding: NS_UTF8]
+    };
+    // Autorelease so callers don't have to track the retain.
+    let _: *mut Object = unsafe { msg_send![inited, autorelease] };
+    inited
+}
+
+unsafe fn make_user_info_dict(workspace_id: &str) -> *mut Object {
+    let cls = class!(NSDictionary);
+    let key = unsafe { nsstring("workspace_id") };
+    let value = unsafe { nsstring(workspace_id) };
+    unsafe { msg_send![cls, dictionaryWithObject: value forKey: key] }
+}
+
+unsafe fn ns_string_to_rust(s: *mut Object) -> Option<String> {
+    if s.is_null() {
+        return None;
+    }
+    let utf8: *const c_char = unsafe { msg_send![s, UTF8String] };
+    if utf8.is_null() {
+        return None;
+    }
+    let cstr = unsafe { CStr::from_ptr(utf8) };
+    Some(cstr.to_string_lossy().into_owned())
+}
+
+// No unit tests in this module: every helper either calls into
+// `UNUserNotificationCenter` (which raises an Objective-C exception when
+// invoked from a non-bundled `cargo test` binary) or builds Foundation
+// objects whose lifecycle assumes an autorelease pool that the test
+// harness doesn't always provide. Coverage comes from the manual UAT
+// checklist in PR / issue #736: post 5+ unanswered toasts and confirm
+// `claudette-app` idles below ~50 % CPU with zero
+// `mac_notification_sys` frames in `sample`.

--- a/src-tauri/src/notification_macos.rs
+++ b/src-tauri/src/notification_macos.rs
@@ -38,6 +38,17 @@ use objc::runtime::{BOOL, Class, Object, Sel};
 use objc::{class, msg_send, sel, sel_impl};
 use tauri::{AppHandle, Emitter, Manager};
 
+// Force the `UserNotifications` framework to be linked at process
+// startup. We rely on runtime class lookups (`Class::get` / `class!()`)
+// — the `class!` macro panics if a class isn't registered, so we want
+// loading to be deterministic and not depend on transitive linking
+// from another crate (e.g. tauri-plugin-notification on macOS uses the
+// deprecated `NSUserNotification` path, not UserNotifications). Listing
+// it here adds `-framework UserNotifications` to the linker invocation
+// at zero runtime cost.
+#[link(name = "UserNotifications", kind = "framework")]
+unsafe extern "C" {}
+
 /// Shared `AppHandle` reachable from the delegate callbacks. Set once at
 /// startup. Subsequent `init` calls are no-ops.
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
@@ -84,10 +95,39 @@ pub fn init(app: AppHandle) {
 /// spawned; the toast and its sound are owned by the OS notification
 /// daemon. Click routing carries `workspace_id` through `userInfo` so the
 /// delegate can emit `tray-select-workspace` for the exact session.
+///
+/// Both call sites (`tray::notify_attention` and SCM PR auto-archive)
+/// reach this function from Tokio worker threads — Foundation `alloc/init`
+/// without an autorelease pool leaks, and UNUserNotificationCenter's
+/// own contracts assume main-thread access for delegate setup. We
+/// dispatch to the main runloop via `AppHandle::run_on_main_thread`
+/// (the same pattern used elsewhere in `tray.rs`) so the work runs
+/// under the main thread's existing pool.
 pub fn send(workspace_id: &str, title: &str, body: &str, sound: &str) {
-    unsafe {
-        post(workspace_id, title, body, sound);
-    }
+    let Some(app) = APP_HANDLE.get() else {
+        // `init` hasn't run yet — happens only if a notification fires
+        // during early setup before `notification_macos::init`. Drop it
+        // rather than racing.
+        tracing::debug!(
+            target: "claudette::notify",
+            "send() called before init — dropping notification",
+        );
+        return;
+    };
+
+    let workspace_id = workspace_id.to_string();
+    let title = title.to_string();
+    let body = body.to_string();
+    let sound = sound.to_string();
+
+    let _ = app.run_on_main_thread(move || {
+        // SAFETY: dispatched onto the main runloop, which always has an
+        // autorelease pool installed by AppKit. All Foundation /
+        // UserNotifications calls inside `post` are safe here.
+        unsafe {
+            post(&workspace_id, &title, &body, &sound);
+        }
+    });
 }
 
 // ---- delegate class --------------------------------------------------------
@@ -146,11 +186,25 @@ extern "C" fn did_receive(
     response: *mut Object,
     completion: *mut Object,
 ) {
-    if !response.is_null()
-        && let Some(app) = APP_HANDLE.get()
-    {
+    // `didReceiveNotificationResponse:` fires for *every* user
+    // interaction the system reports back to the app, not just
+    // clicks. We only want to navigate on the default action (the
+    // user clicked the toast body). Skip:
+    //   - `UNNotificationDismissActionIdentifier` — explicit dismiss
+    //     (only fires if a category opts in via
+    //     `UNNotificationCategoryOptionCustomDismissAction`, which
+    //     we don't currently use, but guarding keeps intent explicit
+    //     for future maintainers).
+    //   - any custom action button identifiers — none today, but
+    //     this is the right place to branch when we add them.
+    let is_default_action = !response.is_null()
         // SAFETY: `response` is a non-null `UNNotificationResponse`
         // owned by AppKit for the duration of this callback.
+        && unsafe { is_default_action(response) };
+
+    if is_default_action && let Some(app) = APP_HANDLE.get() {
+        // SAFETY: `response` is non-null per the check above; AppKit
+        // retains it for the lifetime of this callback.
         let workspace_id = unsafe { extract_workspace_id(response) };
 
         // Mirror the previous `tray::send_notification` macOS branch:
@@ -176,6 +230,19 @@ extern "C" fn did_receive(
             (*block).call(());
         }
     }
+}
+
+/// `true` iff this response represents the default action (toast body
+/// click). False for `UNNotificationDismissActionIdentifier` or any
+/// custom action button.
+unsafe fn is_default_action(response: *mut Object) -> bool {
+    let action_id: *mut Object = unsafe { msg_send![response, actionIdentifier] };
+    let Some(s) = (unsafe { ns_string_to_rust(action_id) }) else {
+        return false;
+    };
+    // Apple-defined constant string. We compare by value rather than
+    // pulling in the symbol so this stays a one-file integration.
+    s == "com.apple.UNNotificationDefaultActionIdentifier"
 }
 
 unsafe fn extract_workspace_id(response: *mut Object) -> Option<String> {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -709,47 +709,19 @@ pub(crate) fn send_notification(
     sound: &str,
     #[cfg_attr(target_os = "macos", allow(unused))] volume: f64,
 ) {
-    // On macOS, use mac-notification-sys directly so we can block for the
-    // click response. When the user clicks the notification, show the window
-    // and navigate to the session — even if the window was hidden (close-to-tray).
+    // macOS: post via UNUserNotificationCenter. Non-blocking; the OS
+    // owns the toast lifecycle and plays the sound out-of-process. Click
+    // routing is preserved by stashing workspace_id in userInfo —
+    // delegate callbacks emit `tray-select-workspace`. See issue #736
+    // for the thread-leak this replaces.
     #[cfg(target_os = "macos")]
     {
-        let app_clone = app.clone();
-        let ws_id = workspace_id.to_string();
-        let title = title.to_string();
-        let body = body.to_string();
-        let sound = sound.to_string();
-
-        std::thread::spawn(move || {
-            let mut n = mac_notification_sys::Notification::new();
-            n.title(&title).message(&body).wait_for_click(true);
-            match sound.as_str() {
-                "None" => {}
-                "Default" => {
-                    n.default_sound();
-                }
-                custom => {
-                    n.sound(custom);
-                }
-            }
-
-            if let Ok(response) = n.send()
-                && matches!(
-                    response,
-                    mac_notification_sys::NotificationResponse::Click
-                        | mac_notification_sys::NotificationResponse::ActionButton(_)
-                )
-            {
-                show_and_focus(&app_clone);
-                if !ws_id.is_empty() {
-                    let _ = app_clone.emit("tray-select-workspace", ws_id);
-                }
-            }
-        });
+        let _ = app;
+        crate::notification_macos::send(workspace_id, title, body, sound);
     }
 
-    // On non-macOS, fall back to tauri-plugin-notification (fire-and-forget)
-    // and play the configured sound via play_notification_sound.
+    // Non-macOS: tauri-plugin-notification (fire-and-forget) for the
+    // toast, plus play_notification_sound for the configured sound.
     #[cfg(not(target_os = "macos"))]
     {
         let _ = workspace_id;


### PR DESCRIPTION
Closes #736.

## TL;DR

`claudette-app` was burning ~565 % CPU after a couple of hours because each notification spawned an OS thread that never died. Verified live before the fix:

```text
%CPU:    565.9
Threads rooted in mac_notification_sys::Notification::send: 6
Each leaked thread: ~59 % of a core, all spinning in _CFRunLoopGet2 → _os_unfair_lock_lock_slow
```

This PR replaces the `mac-notification-sys` integration with a delegate-backed `UNUserNotificationCenter` wrapper. No threads spawned per toast; the OS owns the toast lifecycle and plays sound out-of-process in `usernoted`. **Click routing is preserved bit-for-bit** — each toast carries its `workspace_id` in `userInfo`, and the delegate emits `tray-select-workspace` for the exact workspace whose toast was clicked, exactly like before.

## Root cause

`mac-notification-sys` 0.6's `wait_for_click(true)` synchronously runs an `NSRunLoop` polling loop that only completes on a `Click` / `ActionButton` delegate event. Close-button, swipe, and auto-clear dismissals emit a *different* delegate event the crate's runloop pump ignores — so the spawned thread keeps polling forever from the user's perspective the toast is gone, but the thread is still hot. With N pending toasts the threads convoy on `_CFRunLoopGet2`'s **process-global** `os_unfair_lock`, costing ~N² CPU.

```
thread_start
  std::sys::backtrace::__rust_begin_short_backtrace
    mac_notification_sys::notification::Notification::send       ← entry
      [NSRunLoop currentRunLoop]
        _CFRunLoopGet2                                            ← acquires
          _os_unfair_lock_lock_slow                                 process-global
            __ulock_wait2                                            unfair lock
      [NSRunLoop runUntilDate:]
        ...                                                        ← spins
```

The leak is unrecoverable in-process — only quitting Claudette reaps the threads.

## Why not just route through `tauri-plugin-notification`?

The plugin (v2.3.3) wraps `notify-rust`, which on macOS uses `mac_notification_sys::Notification::send()` *without* `wait_for_click(true)`. That returns immediately, so it would stop the leak — **but it provides no click callback**, so per-toast → per-workspace routing would degrade to "click any toast, land on first attention session." We want to keep the existing UX where clicking a specific workspace's toast lands on *that* workspace.

Considered three options ([discussion in issue thread](https://github.com/utensils/claudette/issues/736)); landed on owning the macOS path with `UNUserNotificationCenter` because:

| Cost dimension                              | UNUserNotificationCenter (this PR) | tauri-plugin-notification path | Hybrid w/ tray submenu |
|---------------------------------------------|------------------------------------|--------------------------------|-------------------------|
| Per-notification CPU in our process         | ~0                                  | small (sound decode)           | small (sound + tray rebuild) |
| Persistent memory growth with pending count | none (OS-owned)                     | none                           | grows (submenu items)   |
| Audio thread wakeups                        | 0 (OS plays sound)                  | 1 per toast (cpal stream)      | 1 per toast             |
| Per-workspace click routing preserved       | ✅                                  | ❌ (degrades to first-attention) | ✅ via tray menu, not toast |

UNUserNotificationCenter is also Apple's recommended modern API (since macOS 11; `mac-notification-sys` uses the deprecated `NSUserNotification`).

## Architecture

`src-tauri/src/notification_macos.rs` (new, ~390 lines, mostly comments + safety scaffolding):

- **One persistent delegate** (`ClaudetteNotificationDelegate`, NSObject subclass) registered once at app launch via `OnceLock`. The delegate is intentionally retained for the lifetime of the process.
- **AppHandle stored in a static `OnceLock`** so the delegate callbacks (running on the main runloop) can reach the rest of the app.
- **Each notification** posts a non-blocking `UNNotificationRequest` carrying `workspace_id` in `userInfo`. Identifier is unique per call so sequential toasts for the same workspace don't replace each other.
- **`threadIdentifier = workspace_id`** so Notification Center coalesces repeated alerts for the same session into a group — a free UX upgrade over the old behavior.
- **On click**, macOS calls `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:` on the main thread. We pull `workspace_id` out of the response's `userInfo` dict and emit `tray-select-workspace` for the exact session, matching the previous integration's behavior bit-for-bit.
- **Authorization** requested once at startup via `requestAuthorizationWithOptions:`. The `block = "0.1"` crate is added (paired with the existing `objc = "0.2"`) for that callback — it's the only UN call here whose completion handler is non-nullable.
- **Sound matrix preserved**: `"None"` → no sound, `"Default"` → `[UNNotificationSound defaultSound]`, custom → `[UNNotificationSound soundNamed:]` (resolves `/Library/Sounds` and `/System/Library/Sounds`).

## File-level changes

| File | Change |
|---|---|
| `src-tauri/src/notification_macos.rs` (new) | Delegate-backed UN integration. ~150 LOC of objc + ~240 LOC of comments / SAFETY notes. |
| `src-tauri/src/main.rs` | `mod notification_macos` + `notification_macos::init(app.handle().clone())` from setup. Removed the old `mac_notification_sys::set_application` block. |
| `src-tauri/src/tray.rs` | `send_notification` macOS branch collapses to one call into `notification_macos::send`. The 35-line `std::thread::spawn { … }` block is gone. |
| `src-tauri/Cargo.toml` | `-mac-notification-sys = "0.6"` ; `+block = "0.1"`. |
| `Cargo.lock` | regenerated. |

Diff size: **+422 / -52** (5 files).

## Behavioral deltas

**Preserved (no UX change):**
- Per-workspace click routing — clicking a specific toast still focuses that exact workspace.
- Sound playback semantics (`"None"` / `"Default"` / custom name).
- Foreground presentation — toasts still appear when Claudette is focused (`willPresentNotification:` returns `Banner | Sound | List`).
- Both call sites (`tray::notify_attention` and SCM PR auto-archive in `commands/scm.rs:1082`) keep their existing signatures.

**Intentional bonus:**
- Notification Center coalescing per workspace via `threadIdentifier`.

**Intentionally undocumented dev-build behavior change** (calling out per `CLAUDE.md`'s "Documentation discipline"):
- The dev-build identity hack `set_application("com.apple.Terminal")` is gone. It existed only because `mac-notification-sys` couldn't deliver toasts under the unsigned `com.claudette.app` identity in bare `cargo tauri dev`. UNUserNotificationCenter requires a code-signed bundle, which `scripts/dev.sh` already provides via `macos-dev-app-runner.sh`. **Bare `cargo tauri dev` will silently no-op (warning logged) — switch to `scripts/dev.sh` for toasts.** This isn't user-facing, doesn't belong in the docs site, and matches the canonical dev workflow per `CLAUDE.md`.

## Validation

### Pre-fix evidence (live, this morning, PID 33419, 2 h uptime)

```text
%CPU: 565.9
Threads w/ stacks rooted in mac_notification_sys::notification::Notification::send: 6
Each leaked thread: 2,941 / 5,000 samples (~59 % of a core)
```

### Post-fix UAT (to run before merge)

```bash
# 1. Build dev app via signed bundle
./scripts/dev.sh

# 2. Drive 5+ workspaces to needs_attention without dismissing toasts.

# 3. Sample
sample $(pgrep -f 'claudette-app$') 10 -file /tmp/post-fix.txt
grep -c mac_notification_sys /tmp/post-fix.txt   # expected: 0

# 4. Check process CPU
top -l 1 -pid $(pgrep -f 'claudette-app$') | grep claudette-app   # expected: < 50 %

# 5. Click checks
#   - Click toast for workspace A while B and C are also waiting → app focuses workspace A specifically.
#   - Close / swipe / let auto-clear several toasts → no thread growth, no leaked stacks.
#   - Click dock icon (no visible toast) → focuses first attention session via existing RunEvent::Reopen handler.
```

### CI shape verified locally

- `cargo fmt --all --check` ✅
- `RUSTFLAGS="-Dwarnings" cargo build -p claudette-tauri --all-features` ✅
- `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` ✅ (CI's exact command)
- `cargo test -p claudette -p claudette-server -p claudette-cli --all-features` ✅
- `cargo test -p claudette-tauri --all-features --bins` ✅ (326 tests pass)

## Acceptance Checklist (revised, from issue thread)

- [x] New module `src-tauri/src/notification_macos.rs` with delegate-backed `init` + `send`.
- [x] Delegate registered exactly once at app startup; authorization requested.
- [x] `tray::send_notification` macOS branch reduced to a single call into `notification_macos::send`.
- [x] `mac-notification-sys` removed from `Cargo.toml`; the `mac_notification_sys::set_application` call in `main.rs` removed.
- [ ] **Manual UAT: trigger 5+ unanswered notifications → `claudette-app` idles below ~50 % CPU; `sample` shows zero `mac_notification_sys` frames.** (run before merge)
- [ ] **Manual UAT: click a per-workspace toast → that exact workspace is selected.** (run before merge)
- [ ] **Manual UAT: dismiss toasts via Close / swipe / auto-clear → thread count returns to baseline; no leaked stacks.** (run before merge)

## Risk assessment

- **Code-signed bundle requirement**: release builds and `scripts/dev.sh` both supply one. Bare `cargo tauri dev` is the only regression — it silently loses notifications instead of showing them as Terminal. Acceptable per CLAUDE.md (canonical dev launcher is `scripts/dev.sh`).
- **`unsafe` density**: the new module is heavy on `unsafe` `objc` calls. Each block has a SAFETY comment naming the AppKit invariant being relied on. Class registration uses `OnceLock` to guarantee the runtime sees the class exactly once.
- **First-launch authorization prompt**: users who already granted notification permission to `com.claudette.app` (via the old `NSUserNotification` path) keep that grant — the bundle ID is unchanged and macOS shares notification authorization across both APIs.
- **`block = "0.1"` future-incompat warning** is at cargo level (not a rustc `-Dwarnings` denial), and is upstream-only. Migrating off it would require switching to `objc2` + `block2`, a much larger change. We can revisit if/when objc2 lands in this codebase.

