### PR TITLE
feat(backends): add LM Studio backend with reliable upstream error surfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **[SCM providers (GitHub, GitLab, extensible)](https://utensils.github.io/claudette/features/scm-providers/)** — pull request status, CI checks, and one-click merge without leaving the app, powered by sandboxed Lua plugins.
 - **[MCP supervision and env-providers](https://utensils.github.io/claudette/features/mcp-servers/)** — per-repo MCP server config with health monitoring, plus a pluggable env stack ([direnv, mise, dotenv, nix-devshell](https://utensils.github.io/claudette/features/scm-providers/#environment-provider-plugins)).
 - **[Voice input](https://utensils.github.io/claudette/features/voice-input/)** — push-to-talk dictation with Apple Speech (macOS) or bundled Whisper, all on-device.
-- **[Alternative providers](https://utensils.github.io/claudette/features/providers/)** _(experimental)_ — run agents through Ollama (local), the OpenAI API, or OpenAI Codex (subscription) instead of Claude. An in-process gateway translates wire formats; chat-header toggles adapt to whichever provider is active.
+- **[Alternative providers](https://utensils.github.io/claudette/features/providers/)** _(experimental)_ — run agents through Ollama (local), LM Studio (local), the OpenAI API, or OpenAI Codex (subscription) instead of Claude. An in-process gateway translates wire formats; chat-header toggles adapt to whichever provider is active.
 
 Full documentation lives at **[utensils.github.io/claudette](https://utensils.github.io/claudette/)**.
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -92,6 +92,7 @@ export default defineConfig({
           items: [
             { slug: 'features/providers' },
             { slug: 'features/providers/ollama' },
+            { slug: 'features/providers/lm-studio' },
             { slug: 'features/providers/openai-codex' },
           ],
         },

--- a/site/src/components/FeatureCards.astro
+++ b/site/src/components/FeatureCards.astro
@@ -23,8 +23,8 @@ const features = [
   },
   {
     title: 'Alternative providers',
-    desc: 'Run agents against Ollama (local), the OpenAI API, or OpenAI Codex through the Claude Code harness. An in-process gateway translates Claude\'s wire format to the OpenAI Responses API; chat-header toggles adapt to whichever provider is active.',
-    meta: 'experimental · Ollama · OpenAI · Codex',
+    desc: 'Run agents against Ollama (local), LM Studio (local), the OpenAI API, or OpenAI Codex through the Claude Code harness. An in-process gateway translates Claude\'s wire format to the OpenAI Responses API; chat-header toggles adapt to whichever provider is active.',
+    meta: 'experimental · Ollama · LM Studio · OpenAI · Codex',
     icon: '<line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/>',
     href: '/claudette/features/providers/',
   },

--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -89,13 +89,13 @@ The **Settings > Claude CLI flags** panel exposes the underlying `claude` comman
 
 ## Alternative Providers
 
-Claudette can run agents against alternative providers — [Ollama](/claudette/features/providers/ollama/) (local), or [OpenAI / Codex](/claudette/features/providers/openai-codex/) (gateway-translated) — instead of the official `claude` CLI. This is gated by the **Alternative Claude Code backends** experimental flag (the toggle keeps that wording in the UI).
+Claudette can run agents against alternative providers — [Ollama](/claudette/features/providers/ollama/) (local, Anthropic-wire), [LM Studio](/claudette/features/providers/lm-studio/) (local, gateway-translated), or [OpenAI / Codex](/claudette/features/providers/openai-codex/) (remote, gateway-translated) — instead of the official `claude` CLI. This is gated by the **Alternative Claude Code backends** experimental flag (the toggle keeps that wording in the UI).
 
 Several chat-header toggles on this page only apply to certain providers. The capability matrix in the dedicated section shows the full picture, but the highlights:
 
 - **Effort, fast mode, 1M-context auto-upgrade** — Anthropic only.
 - **Extended thinking** — Anthropic and Ollama (when the model supports it).
-- **All Claude-side toggles** — hidden on gateway providers (OpenAI / Codex), because the OpenAI Responses API has no equivalents.
+- **All Claude-side toggles** — hidden on gateway providers (OpenAI / Codex / LM Studio), because the OpenAI Responses API has no equivalents.
 
 → Full setup, capability matrix, and per-provider instructions: **[Alternative Providers](/claudette/features/providers/)**
 

--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -89,13 +89,13 @@ The **Settings > Claude CLI flags** panel exposes the underlying `claude` comman
 
 ## Alternative Providers
 
-Claudette can run agents against alternative providers — [Ollama](/claudette/features/providers/ollama/) (local, Anthropic-wire), [LM Studio](/claudette/features/providers/lm-studio/) (local, gateway-translated), or [OpenAI / Codex](/claudette/features/providers/openai-codex/) (remote, gateway-translated) — instead of the official `claude` CLI. This is gated by the **Alternative Claude Code backends** experimental flag (the toggle keeps that wording in the UI).
+Claudette can run agents against alternative providers — [Ollama](/claudette/features/providers/ollama/) (local, Anthropic-wire), [LM Studio](/claudette/features/providers/lm-studio/) (local, Anthropic-wire via `/v1/messages`), or [OpenAI / Codex](/claudette/features/providers/openai-codex/) (remote, gateway-translated) — instead of the official `claude` CLI. This is gated by the **Alternative Claude Code backends** experimental flag (the toggle keeps that wording in the UI).
 
 Several chat-header toggles on this page only apply to certain providers. The capability matrix in the dedicated section shows the full picture, but the highlights:
 
 - **Effort, fast mode, 1M-context auto-upgrade** — Anthropic only.
 - **Extended thinking** — Anthropic and Ollama (when the model supports it).
-- **All Claude-side toggles** — hidden on gateway providers (OpenAI / Codex / LM Studio), because the OpenAI Responses API has no equivalents.
+- **All Claude-side toggles** — hidden on every non-Anthropic provider (Ollama / LM Studio / OpenAI / Codex). Local models and OpenAI's Responses API implement these Anthropic-specific knobs inconsistently or not at all, so the chat header hides them rather than silently ignoring user intent.
 
 → Full setup, capability matrix, and per-provider instructions: **[Alternative Providers](/claudette/features/providers/)**
 

--- a/site/src/content/docs/features/authentication.mdx
+++ b/site/src/content/docs/features/authentication.mdx
@@ -61,7 +61,7 @@ Your Claude OAuth tokens (`claudeAiOauth.*`) are never read or written by Claude
 
 ## Alternative providers
 
-Claudette supports running an agent against [alternative providers](/claudette/features/providers/) (Ollama, OpenAI, Codex) via **Settings > Models**. Each provider has its own credential expectations — see the per-provider docs. The Anthropic Pro/Max OAuth flow described above only applies when the active provider is the official `claude` CLI.
+Claudette supports running an agent against [alternative providers](/claudette/features/providers/) (Ollama, LM Studio, OpenAI, Codex) via **Settings > Models**. Each provider has its own credential expectations — see the per-provider docs. The Anthropic Pro/Max OAuth flow described above only applies when the active provider is the official `claude` CLI.
 
 ## Signing out
 

--- a/site/src/content/docs/features/experimental-features.mdx
+++ b/site/src/content/docs/features/experimental-features.mdx
@@ -9,7 +9,7 @@ Six toggles live there today.
 
 ## Alternative Claude Code backends
 
-Exposes Ollama (local), the OpenAI API, and OpenAI Codex (subscription) in addition to the default Claude Code path. Custom Anthropic / OpenAI endpoint kinds exist in the data model but the GUI doesn't yet have an "Add backend" flow.
+Exposes Ollama (local), LM Studio (local), the OpenAI API, and OpenAI Codex (subscription) in addition to the default Claude Code path. Custom Anthropic / OpenAI endpoint kinds exist in the data model but the GUI doesn't yet have an "Add backend" flow.
 
 When this is off, every workspace runs the official `claude` CLI authenticated against Anthropic. When on, the chat header gets a provider picker and **Settings > Models** grows configuration sections for each provider.
 

--- a/site/src/content/docs/features/providers/index.mdx
+++ b/site/src/content/docs/features/providers/index.mdx
@@ -1,14 +1,15 @@
 ---
 title: Alternative Providers
-description: Run Claudette agents against Ollama, OpenAI, or OpenAI Codex instead of the default Claude Code path — architecture and capability differences, with deeper setup pages for each.
+description: Run Claudette agents against Ollama, LM Studio, OpenAI, or OpenAI Codex instead of the default Claude Code path — architecture and capability differences, with deeper setup pages for each.
 ---
 
 By default Claudette spawns the official `claude` CLI authenticated against Anthropic. Behind the **Alternative Claude Code backends** experimental flag (the UI keeps that wording for the toggle) you can also point agents at:
 
 - **[Ollama](/claudette/features/providers/ollama/)** — local LLMs running on your own machine, talking Claude's wire format directly.
-- **[OpenAI & Codex](/claudette/features/providers/openai-codex/)** — `gpt-*` models via the OpenAI API, or your ChatGPT subscription via the `codex` CLI's auth, both routed through an in-process gateway.
+- **[LM Studio](/claudette/features/providers/lm-studio/)** — local LLMs loaded in LM Studio's desktop app, served via its OpenAI-compatible local server and routed through the in-process gateway.
+- **[OpenAI & Codex](/claudette/features/providers/openai-codex/)** — `gpt-*` models via the OpenAI API, or your ChatGPT subscription via the `codex` CLI's auth, both routed through the in-process gateway.
 
-The data model also defines `CustomAnthropic` and `CustomOpenAi` kinds for self-hosted / proxied endpoints, but the Settings panel currently only renders the four built-in backends — there is no in-GUI flow to add a custom provider yet.
+The data model also defines `CustomAnthropic` and `CustomOpenAi` kinds for self-hosted / proxied endpoints, but the Settings panel currently only renders the five built-in backends — there is no in-GUI flow to add a custom provider yet.
 
 This is **experimental** because some Claude-specific features (extended thinking, effort levels, fast mode, the 1M-context auto-upgrade) only have meaningful equivalents on the official Anthropic backend.
 
@@ -26,6 +27,7 @@ When the feature is off, only the built-in `Anthropic` backend is exposed — ev
 |---|---|---|---|---|
 | `anthropic` | `Anthropic` | (uses `claude` CLI) | Inherits from Claude Code | [Authentication](/claudette/features/authentication/) |
 | `ollama` | `Ollama` | `http://localhost:11434` | None (or optional bearer token) | [Ollama](/claudette/features/providers/ollama/) |
+| `lm-studio` | `LmStudio` | `http://localhost:1234` | None (or optional bearer token) | [LM Studio](/claudette/features/providers/lm-studio/) |
 | `openai-api` | `OpenAiApi` | `https://api.openai.com` | API key (required) | [OpenAI & Codex](/claudette/features/providers/openai-codex/) |
 | `codex-subscription` | `CodexSubscription` | `https://chatgpt.com/backend-api` | `codex login` (managed by `codex` CLI) | [OpenAI & Codex](/claudette/features/providers/openai-codex/) |
 
@@ -35,7 +37,7 @@ Claudette splits providers into two architectural categories:
 
 **Anthropic-compatible** (`Anthropic`, `Ollama`, `CustomAnthropic`) — talk Claude's wire format directly. The `claude` CLI just gets a different base URL and auth token.
 
-**Gateway** (`OpenAiApi`, `CodexSubscription`, `CustomOpenAi`) — Claudette spawns a tiny in-process HTTP listener that translates Claude's wire format into the **OpenAI Responses API** (`/v1/responses`) and back. The spawned `claude` process is pointed at the gateway instead of `api.anthropic.com`. This is how the OpenAI-shaped providers work without forking the CLI.
+**Gateway** (`OpenAiApi`, `CodexSubscription`, `CustomOpenAi`, `LmStudio`) — Claudette spawns a tiny in-process HTTP listener that translates Claude's wire format into the **OpenAI Responses API** (`/v1/responses`) and back. The spawned `claude` process is pointed at the gateway instead of `api.anthropic.com`. This is how the OpenAI-shaped providers — including LM Studio's local server — work without forking the CLI.
 
 > **Heads up if you ever configure a custom OpenAI endpoint**: Claudette posts to `/v1/responses`, not `/v1/chat/completions`. Providers that only implement Chat Completions won't work behind the gateway.
 
@@ -43,14 +45,14 @@ Claudette splits providers into two architectural categories:
 
 The per-turn capabilities differ by provider (`AgentBackendCapabilities` in `src/agent_backend.rs`). The chat-header toggles for unsupported capabilities are hidden / disabled automatically:
 
-| Capability | Anthropic | Ollama | Gateway (OpenAI / Codex) |
+| Capability | Anthropic | Ollama | Gateway (OpenAI / Codex / LM Studio) |
 |---|---|---|---|
 | Extended thinking | ✅ | ✅ (when model supports) | ❌ |
 | Effort levels | ✅ | ❌ | ❌ |
 | Fast mode | ✅ | ❌ | ❌ |
 | 1M-context auto-upgrade | ✅ | ❌ | ❌ |
-| Tool use | ✅ | ✅ | ✅ |
-| Vision | ✅ | ✅ | ✅ |
+| Tool use | ✅ | ✅ | ✅ (model-dependent for LM Studio) |
+| Vision | ✅ | ✅ | ✅ (model-dependent for LM Studio) |
 
 So Ollama gets thinking / tools / vision, but not the Anthropic-only knobs. Switching a session to any non-Anthropic provider visibly disables the toggles that don't apply.
 
@@ -76,6 +78,7 @@ Per-session model selection is persisted in `app_settings` as `model:<session_id
 
 - **Default Claude Code (`anthropic`)** — best feature parity. Keep this unless you have a specific reason to switch.
 - **[Ollama](/claudette/features/providers/ollama/)** — air-gapped work, privacy-sensitive code, or offline travel. Quality varies wildly by model.
+- **[LM Studio](/claudette/features/providers/lm-studio/)** — same air-gapped use cases as Ollama, but if you already manage your local model library through LM Studio's desktop app and want to keep it as the single source of truth.
 - **[OpenAI API](/claudette/features/providers/openai-codex/#openai-api)** — if you specifically want `gpt-*` or OpenAI reasoning models, or have prepaid OpenAI credit you'd rather burn than your Claude quota.
 - **[Codex](/claudette/features/providers/openai-codex/#codex-openai-subscription)** — if you're already paying for ChatGPT Plus/Pro/Team and want to reuse that quota.
 
@@ -87,7 +90,7 @@ Per-session model selection is persisted in `app_settings` as `model:<session_id
 
 ## See also
 
-- [Ollama](/claudette/features/providers/ollama/) and [OpenAI & Codex](/claudette/features/providers/openai-codex/) — per-provider setup pages
+- [Ollama](/claudette/features/providers/ollama/), [LM Studio](/claudette/features/providers/lm-studio/), and [OpenAI & Codex](/claudette/features/providers/openai-codex/) — per-provider setup pages
 - [Experimental Features](/claudette/features/experimental-features/) — the wider experimental flag set
 - [Agent Configuration](/claudette/features/agent-configuration/) — model selection, effort, thinking, and which knobs apply per provider
 - [Authentication](/claudette/features/authentication/) — credential handling for the default Anthropic backend

--- a/site/src/content/docs/features/providers/index.mdx
+++ b/site/src/content/docs/features/providers/index.mdx
@@ -6,8 +6,8 @@ description: Run Claudette agents against Ollama, LM Studio, OpenAI, or OpenAI C
 By default Claudette spawns the official `claude` CLI authenticated against Anthropic. Behind the **Alternative Claude Code backends** experimental flag (the UI keeps that wording for the toggle) you can also point agents at:
 
 - **[Ollama](/claudette/features/providers/ollama/)** — local LLMs running on your own machine, talking Claude's wire format directly.
-- **[LM Studio](/claudette/features/providers/lm-studio/)** — local LLMs loaded in LM Studio's desktop app, talking Claude's wire format directly via LM Studio 0.4.1+'s native `/v1/messages` endpoint.
-- **[OpenAI & Codex](/claudette/features/providers/openai-codex/)** — `gpt-*` models via the OpenAI API, or your ChatGPT subscription via the `codex` CLI's auth, both routed through the in-process gateway.
+- **[LM Studio](/claudette/features/providers/lm-studio/)** — local LLMs loaded in LM Studio's desktop app, served via LM Studio 0.4.1+'s native `/v1/messages`. Routed through the in-process gateway with an Anthropic-shape pass-through (no translation, just status-code correction on errors).
+- **[OpenAI & Codex](/claudette/features/providers/openai-codex/)** — `gpt-*` models via the OpenAI API, or your ChatGPT subscription via the `codex` CLI's auth, both routed through the in-process gateway with full Anthropic ↔ OpenAI Responses translation.
 
 The data model also defines `CustomAnthropic` and `CustomOpenAi` kinds for self-hosted / proxied endpoints, but the Settings panel currently only renders the five built-in backends — there is no in-GUI flow to add a custom provider yet.
 
@@ -31,13 +31,16 @@ When the feature is off, only the built-in `Anthropic` backend is exposed — ev
 | `openai-api` | `OpenAiApi` | `https://api.openai.com` | API key (required) | [OpenAI & Codex](/claudette/features/providers/openai-codex/) |
 | `codex-subscription` | `CodexSubscription` | `https://chatgpt.com/backend-api` | `codex login` (managed by `codex` CLI) | [OpenAI & Codex](/claudette/features/providers/openai-codex/) |
 
-## Two execution paths: native vs gateway
+## Two execution paths: direct vs gateway
 
 Claudette splits providers into two architectural categories:
 
-**Anthropic-compatible / direct** (`Anthropic`, `Ollama`, `LmStudio`, `CustomAnthropic`) — speak Claude's wire format natively. The spawned `claude` CLI just gets a different base URL and auth token; there is no in-process translation layer. LM Studio joins this group via its `/v1/messages` endpoint (native Anthropic Messages API support added in 0.4.1+).
+**Direct** (`Anthropic`, `Ollama`, `CustomAnthropic`) — speak Claude's wire format natively *and* return errors with HTTP status codes the Anthropic SDK already classifies correctly. The spawned `claude` CLI just gets a different base URL and auth token; there is no in-process translation layer.
 
-**Gateway** (`OpenAiApi`, `CodexSubscription`, `CustomOpenAi`) — Claudette spawns a tiny in-process HTTP listener that translates Claude's wire format into the **OpenAI Responses API** (`/v1/responses`) and back. The spawned `claude` process is pointed at the gateway instead of `api.anthropic.com`. This is how OpenAI-shaped providers without an Anthropic wire-format compatibility layer work without forking the CLI.
+**Gateway** (`OpenAiApi`, `CodexSubscription`, `CustomOpenAi`, `LmStudio`) — Claudette spawns a tiny in-process HTTP listener that the spawned `claude` process is pointed at instead of `api.anthropic.com`. The gateway has two flavors of work depending on backend kind:
+
+- **OpenAI-Responses translation** (OpenAI / Codex / CustomOpenAi): full Anthropic ↔ OpenAI `/v1/responses` translation in both directions, since these backends don't speak Anthropic.
+- **Anthropic pass-through** (LM Studio): forward the Anthropic body verbatim to upstream `/v1/messages`, stream 2xx responses through unchanged, intercept non-2xx to fix LM Studio's HTTP 500 mis-classification of context-overflow errors. Wire format is already correct; we only translate status codes on the error path.
 
 > **Heads up if you ever configure a custom OpenAI endpoint**: Claudette posts to `/v1/responses`, not `/v1/chat/completions`. Providers that only implement Chat Completions won't work behind the gateway.
 

--- a/site/src/content/docs/features/providers/index.mdx
+++ b/site/src/content/docs/features/providers/index.mdx
@@ -6,7 +6,7 @@ description: Run Claudette agents against Ollama, LM Studio, OpenAI, or OpenAI C
 By default Claudette spawns the official `claude` CLI authenticated against Anthropic. Behind the **Alternative Claude Code backends** experimental flag (the UI keeps that wording for the toggle) you can also point agents at:
 
 - **[Ollama](/claudette/features/providers/ollama/)** — local LLMs running on your own machine, talking Claude's wire format directly.
-- **[LM Studio](/claudette/features/providers/lm-studio/)** — local LLMs loaded in LM Studio's desktop app, served via its OpenAI-compatible local server and routed through the in-process gateway.
+- **[LM Studio](/claudette/features/providers/lm-studio/)** — local LLMs loaded in LM Studio's desktop app, talking Claude's wire format directly via LM Studio 0.4.1+'s native `/v1/messages` endpoint.
 - **[OpenAI & Codex](/claudette/features/providers/openai-codex/)** — `gpt-*` models via the OpenAI API, or your ChatGPT subscription via the `codex` CLI's auth, both routed through the in-process gateway.
 
 The data model also defines `CustomAnthropic` and `CustomOpenAi` kinds for self-hosted / proxied endpoints, but the Settings panel currently only renders the five built-in backends — there is no in-GUI flow to add a custom provider yet.
@@ -35,9 +35,9 @@ When the feature is off, only the built-in `Anthropic` backend is exposed — ev
 
 Claudette splits providers into two architectural categories:
 
-**Anthropic-compatible** (`Anthropic`, `Ollama`, `CustomAnthropic`) — talk Claude's wire format directly. The `claude` CLI just gets a different base URL and auth token.
+**Anthropic-compatible / direct** (`Anthropic`, `Ollama`, `LmStudio`, `CustomAnthropic`) — speak Claude's wire format natively. The spawned `claude` CLI just gets a different base URL and auth token; there is no in-process translation layer. LM Studio joins this group via its `/v1/messages` endpoint (native Anthropic Messages API support added in 0.4.1+).
 
-**Gateway** (`OpenAiApi`, `CodexSubscription`, `CustomOpenAi`, `LmStudio`) — Claudette spawns a tiny in-process HTTP listener that translates Claude's wire format into the **OpenAI Responses API** (`/v1/responses`) and back. The spawned `claude` process is pointed at the gateway instead of `api.anthropic.com`. This is how the OpenAI-shaped providers — including LM Studio's local server — work without forking the CLI.
+**Gateway** (`OpenAiApi`, `CodexSubscription`, `CustomOpenAi`) — Claudette spawns a tiny in-process HTTP listener that translates Claude's wire format into the **OpenAI Responses API** (`/v1/responses`) and back. The spawned `claude` process is pointed at the gateway instead of `api.anthropic.com`. This is how OpenAI-shaped providers without an Anthropic wire-format compatibility layer work without forking the CLI.
 
 > **Heads up if you ever configure a custom OpenAI endpoint**: Claudette posts to `/v1/responses`, not `/v1/chat/completions`. Providers that only implement Chat Completions won't work behind the gateway.
 
@@ -45,16 +45,16 @@ Claudette splits providers into two architectural categories:
 
 The per-turn capabilities differ by provider (`AgentBackendCapabilities` in `src/agent_backend.rs`). The chat-header toggles for unsupported capabilities are hidden / disabled automatically:
 
-| Capability | Anthropic | Ollama | Gateway (OpenAI / Codex / LM Studio) |
-|---|---|---|---|
-| Extended thinking | ✅ | ✅ (when model supports) | ❌ |
-| Effort levels | ✅ | ❌ | ❌ |
-| Fast mode | ✅ | ❌ | ❌ |
-| 1M-context auto-upgrade | ✅ | ❌ | ❌ |
-| Tool use | ✅ | ✅ | ✅ (model-dependent for LM Studio) |
-| Vision | ✅ | ✅ | ✅ (model-dependent for LM Studio) |
+| Capability | Anthropic | Ollama | LM Studio | Gateway (OpenAI / Codex) |
+|---|---|---|---|---|
+| Extended thinking | ✅ | ✅ (when model supports) | ❌ | ❌ |
+| Effort levels | ✅ | ❌ | ❌ | ❌ |
+| Fast mode | ✅ | ❌ | ❌ | ❌ |
+| 1M-context auto-upgrade | ✅ | ❌ | ❌ | ❌ |
+| Tool use | ✅ | ✅ | ✅ (model-dependent) | ✅ |
+| Vision | ✅ | ✅ | ✅ (model-dependent) | ✅ |
 
-So Ollama gets thinking / tools / vision, but not the Anthropic-only knobs. Switching a session to any non-Anthropic provider visibly disables the toggles that don't apply.
+LM Studio is on the same direct path as Ollama, but its capability profile mirrors the gateway providers' (no extended-thinking / effort / fast / 1M toggles) — local models implement those Anthropic-specific knobs inconsistently or not at all, so the chat header hides them. Switching a session to any non-Anthropic provider visibly disables the toggles that don't apply.
 
 ## How the gateway runtime works
 

--- a/site/src/content/docs/features/providers/lm-studio.mdx
+++ b/site/src/content/docs/features/providers/lm-studio.mdx
@@ -1,9 +1,11 @@
 ---
 title: LM Studio
-description: Run Claudette agents against models loaded in LM Studio's local server — direct routing to LM Studio's native Anthropic /v1/messages endpoint on localhost, no remote API key required.
+description: Run Claudette agents against models loaded in LM Studio's local server — Claudette's gateway forwards Claude Code's Anthropic-shape requests to LM Studio's native /v1/messages on localhost, no remote API key required.
 ---
 
-The LM Studio provider points the spawned `claude` CLI at LM Studio's built-in local server. It's a **direct-routed** backend (same fast path as Ollama): Claudette sets `ANTHROPIC_BASE_URL=http://localhost:1234` and the CLI talks straight to LM Studio with no in-process gateway, no wire-format translation, and full streaming pass-through. LM Studio 0.4.1+ implements Anthropic's `/v1/messages` endpoint natively, so this works out of the box.
+The LM Studio provider routes the spawned `claude` CLI through Claudette's in-process gateway. The gateway forwards Claude Code's Anthropic-shape requests to LM Studio's native `/v1/messages` endpoint (added in LM Studio 0.4.1+) — there's no wire-format translation work, the body goes through verbatim and 2xx response bytes stream straight back to the CLI.
+
+The gateway is in the path because LM Studio classifies hard input errors like context-window overflow as HTTP 500 with an Anthropic-shape body whose `error.type` is `api_error`. That's a transient classification — the Anthropic SDK retries it with exponential backoff — so a permanent input failure ends up as a multi-minute spinner with no surfaced error unless we demote the status code on the way back. Claudette's gateway does exactly that: 2xx pass through unchanged, non-2xx with permanent-failure-shaped messages are rewritten to 4xx so the SDK fails fast and the user sees the actual upstream message.
 
 The capability profile is the local-first one (no extended thinking / effort / fast mode / 1M-context auto-upgrade in the chat header) — the loaded model and LM Studio's tokenizer do whatever they support, but Claudette doesn't expose those Anthropic-only knobs. Tool use and vision work whenever the underlying model handles them.
 
@@ -81,24 +83,31 @@ If a model misbehaves, try switching to a different one before assuming Claudett
 
 ## How requests flow
 
-LM Studio shares Ollama's direct-routing architecture — there is no in-process gateway:
+LM Studio uses Claudette's in-process gateway with an Anthropic-shape pass-through (NOT the OpenAI-Responses translation path the OpenAI / Codex backends use):
 
-1. Claudette sets `ANTHROPIC_BASE_URL=http://localhost:1234`, `ANTHROPIC_AUTH_TOKEN=lm-studio` (placeholder), and `ANTHROPIC_API_KEY=""` on the spawned `claude` subprocess.
-2. The `claude` CLI POSTs `/v1/messages` directly to LM Studio. LM Studio 0.4.1+ speaks the Anthropic Messages API natively, so the request shape and streaming events match what the CLI expects from `api.anthropic.com`.
-3. Streamed tokens flow from LM Studio → CLI → Claudette UI in real time. No buffering, no translation.
+1. Claudette spins up an HTTP listener on `127.0.0.1:0` per backend and exports `ANTHROPIC_BASE_URL=<gateway>`, `ANTHROPIC_AUTH_TOKEN=<random>`, `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`, and `CLAUDE_CODE_ATTRIBUTION_HEADER=0` on the spawned `claude` subprocess.
+2. The CLI POSTs `/v1/messages` to the gateway. The gateway recognizes LM Studio backends and forwards the request body verbatim to `http://localhost:1234/v1/messages` — LM Studio 0.4.1+ speaks the Anthropic Messages API natively, so no translation is needed.
+3. **Successful (2xx) responses stream through unchanged**. The gateway mirrors LM Studio's `Content-Type` and writes upstream bytes to the CLI as they arrive — per-chunk SSE events flow straight through without buffering, so first-token latency stays close to LM Studio's own TTFT.
+4. **Non-2xx responses are intercepted**. The gateway parses the upstream body (LM Studio returns Anthropic-shape errors), checks the message text, and demotes any HTTP 5xx whose body matches a permanent-failure pattern (context length, model not loaded, etc.) to HTTP 400 with `error.type = invalid_request_error`. Without that demotion the Anthropic SDK retries 5xx with exponential backoff and the user sees a multi-minute spinner instead of the actual error.
 
-Claudette also sets `CLAUDE_CODE_ATTRIBUTION_HEADER=0` for LM Studio (and Ollama). Claude Code adds a per-request user-attribution header by default for usage attribution against `api.anthropic.com`, but its rotating value invalidates LM Studio's KV-cache prefix matching on every request — a documented [~90% performance regression](https://www.roborhythms.com/stop-claude-code-slowing-local-llm-by-90/) on local backends. Disabling it keeps the cache warm across turns; LM Studio doesn't bill anything, so the header is pure overhead.
+`CLAUDE_CODE_ATTRIBUTION_HEADER=0` keeps Claude Code from adding a rotating per-request user-attribution header. With the header on, the request prefix changes every turn and LM Studio's KV-cache prefix matching is invalidated — a documented [~90% performance regression](https://www.roborhythms.com/stop-claude-code-slowing-local-llm-by-90/) on local backends. LM Studio doesn't bill anything, so the header is pure overhead.
 
 The chat header hides **Extended thinking**, **Effort**, **Fast mode**, and **1M-context** when an LM Studio model is active — `AgentBackendConfig::builtin_lm_studio()` declares those capabilities as `false`. They map cleanly to Anthropic's API but local models implement them inconsistently or not at all, and silently swallowing them would be worse than just hiding the controls.
 
+### Why not direct routing like Ollama?
+
+Ollama doesn't use Claudette's gateway: `ANTHROPIC_BASE_URL` points the CLI straight at Ollama's `/v1/messages`. We tried the same setup for LM Studio briefly — the architecture is wire-compatible — but LM Studio classifies hard input errors like context-window overflow as **HTTP 500** with an Anthropic-shape body whose `error.type` is `api_error`. The Anthropic SDK reads that as transient and retries with backoff; users get a multi-minute spinner with no surfaced error.
+
+The thin gateway pass-through gets us the best of both: 2xx flows through with the same TTFT as direct routing (no translation, no buffering), and 5xx-with-permanent-failure-message gets demoted to 4xx so the error reaches the user immediately.
+
 ### Why not the OpenAI Responses gateway?
 
-LM Studio also exposes `/v1/responses` (OpenAI's newer Responses API). Earlier iterations of this integration used that path through Claudette's gateway, but it had two structural problems compared to direct `/v1/messages`:
+LM Studio also exposes `/v1/responses` (OpenAI's newer Responses API). Earlier iterations of this integration used that path through Claudette's gateway with full Anthropic ↔ OpenAI Responses translation, but it had two structural problems:
 
-- **Translation overhead**: Claudette had to translate Anthropic ↔ OpenAI Responses on every request. The translation buffered the full response before sending anything back, so first-token latency equalled total generation time even when LM Studio's TTFT was sub-second.
+- **Translation overhead**: the translation layer buffered the full response before sending anything back, so first-token latency equalled total generation time even when LM Studio's TTFT was sub-second.
 - **Lost streaming**: OpenAI Responses streaming uses `event: response.output_text.delta` events. Translating that incrementally into Anthropic `content_block_delta` events while preserving tool-call streaming, reasoning blocks, and stop reasons is non-trivial and a regression risk.
 
-Direct `/v1/messages` is a one-line config change (set `ANTHROPIC_BASE_URL`) that gets all of this for free. The OpenAI Responses gateway is still used for OpenAI API and Codex Subscription where there's no Anthropic-shaped alternative.
+Pass-through against LM Studio's native `/v1/messages` skips all of that and only intervenes where it has to (status-code translation on errors). The OpenAI Responses gateway path is still used for OpenAI API and Codex Subscription where there's no Anthropic-shaped alternative.
 
 ## Performance notes
 

--- a/site/src/content/docs/features/providers/lm-studio.mdx
+++ b/site/src/content/docs/features/providers/lm-studio.mdx
@@ -1,0 +1,101 @@
+---
+title: LM Studio
+description: Run Claudette agents against models loaded in LM Studio's local server — OpenAI-compatible Responses API on localhost, no remote API key required.
+---
+
+The LM Studio provider points the spawned `claude` CLI at LM Studio's built-in local server. It's a gateway-routed backend (Claudette translates Claude's wire format into the OpenAI Responses API), but with the **local-first UX of Ollama**: no remote network calls, no required API key, and the runtime stays on your machine.
+
+LM Studio uses the **gateway** path because its server speaks the OpenAI Responses API (`/v1/responses`), not Anthropic's wire format. The capability profile matches OpenAI / Codex: tools and vision yes (model-dependent), but the Anthropic-only knobs (extended thinking, effort levels, fast mode, 1M-context auto-upgrade) are hidden when an LM Studio model is active.
+
+## Prerequisites
+
+1. Make sure the [Alternative Claude Code backends experimental flag](/claudette/features/providers/#enabling-the-feature) is on.
+2. Install LM Studio:
+   - **macOS / Windows / Linux**: download from [lmstudio.ai/download](https://lmstudio.ai/download).
+3. Install the `lms` CLI (bundled with LM Studio; verify with `lms --version`).
+
+## Start the local server
+
+```sh
+lms server start --port 1234
+```
+
+The server defaults to port `1234`; pass `--port` if you need a different one. Confirm it's reachable:
+
+```sh
+curl http://localhost:1234/v1/models
+```
+
+You should get back a JSON `{"data":[…]}` payload listing whatever you've loaded into LM Studio.
+
+## Load at least one model
+
+LM Studio doesn't auto-load models — pick one via the desktop UI's **My Models** tab and load it, or use the CLI:
+
+```sh
+lms get qwen2.5-coder-7b-instruct   # tool-tuned coding model
+lms load qwen2.5-coder-7b-instruct  # load it into VRAM
+```
+
+Quantized GGUF builds give the best speed-to-quality trade-off on consumer hardware. Tool-tuned models (Qwen Coder, Llama Instruct, Mistral Instruct) handle Claude-style tool calls; chat-only models will likely ignore tool definitions.
+
+## Configure in Claudette
+
+1. Open **Settings > Models**. The `lm-studio` backend appears in the list.
+2. The base URL is pre-filled to `http://localhost:1234`. Change it if your server listens elsewhere (different port, LAN host, etc.). Don't include the `/v1` suffix — Claudette appends it.
+3. (Optional) Add a bearer token in the **API key** field if you've put LM Studio behind an authenticating proxy. Local installs don't need one — Claudette substitutes a placeholder so the upstream still receives an `Authorization` header.
+4. Click **Test** — Claudette pings the server to confirm it's reachable and counts loaded models.
+5. Click **Refresh models** — Claudette queries LM Studio's `/api/v0/models` (and falls back to `/v1/models` on older builds), populating the model list with each model's `loaded_context_length` / `max_context_length`.
+6. (Optional) Set a default model.
+7. Toggle **Enabled** on. The provider is now selectable in the chat header.
+
+## Picking a session model
+
+Once enabled, the model picker in the chat header includes LM Studio models alongside Claude. Pick one and the next turn runs through LM Studio.
+
+The chat header hides the **Extended thinking**, **Effort**, **Fast mode**, and **1M-context** toggles when an LM Studio model is active — `AgentBackendConfig::builtin_lm_studio()` declares those capabilities as `false` (gateway profile). Tool use and vision stay available, but actual support depends on the loaded model.
+
+## Tool use and vision
+
+- **Tool use** — works on tool-tuned models (Qwen Coder, Llama Instruct, etc.). Plain chat models may ignore tool definitions silently.
+- **Vision** — works on multimodal models (LLaVA, MiniCPM-V, Qwen2-VL). Text-only models drop image attachments without complaining.
+
+If a model misbehaves, try switching to a different one before assuming Claudette is broken.
+
+## How requests flow
+
+LM Studio rides the same gateway architecture as the OpenAI / Codex backends:
+
+1. Claudette spins up a per-session HTTP listener on `127.0.0.1:0`. The spawned `claude` subprocess gets `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`.
+2. The `claude` CLI thinks it's talking to api.anthropic.com; it's actually hitting Claudette's local listener.
+3. The listener translates the request into a `POST /v1/responses` call against `http://localhost:1234/v1/responses` and translates the streaming response back into Claude's event format.
+
+This is why the chat-header **Thinking**, **Effort**, **Fast mode**, and **1M-context** toggles are hidden when LM Studio is active — there are no equivalents in the OpenAI Responses shape.
+
+## Performance notes
+
+- LM Studio runs on GPU when available (Metal on macOS, CUDA on Linux/Windows with the right drivers); falls back to CPU otherwise.
+- Large models need substantial VRAM/RAM. Watch LM Studio's resource gauge while a turn runs.
+- Concurrent agents amplify pressure. Keep parallelism low (1–2 workspaces at a time) when running locally, especially if the model isn't fully GPU-resident.
+- LM Studio caches loaded models in memory; the first turn after a load is slower. Subsequent turns reuse the loaded weights and are much faster.
+
+## Troubleshooting
+
+**Test fails with "LM Studio is not reachable"** — the server isn't running, or it's bound to a different port. Run `lms server start --port 1234` and confirm `curl http://localhost:1234/v1/models` works first.
+
+**Refresh models returns nothing** — you haven't loaded any models in LM Studio yet. Open the desktop app's **My Models** tab (or `lms load <model>`) and click Refresh again.
+
+**Agent immediately errors with "no models"** — same as above; LM Studio reports an empty model list when nothing is loaded.
+
+**Tool calls get ignored** — the loaded model isn't tool-tuned. Switch to a model with built-in tool-use support (Qwen Coder, Llama Instruct).
+
+**Gateway restart loop** — usually the upstream rejecting the translated request. Open the agent's terminal tab to see stderr from the listener; the most common cause is a model ID the upstream doesn't recognize. Click **Refresh models** in Settings > Models.
+
+**Agent hangs on the first turn** — LM Studio is loading the model into VRAM. First-turn latency on a cold model can be 10–60 seconds depending on size. Subsequent turns are much faster.
+
+## See also
+
+- [Alternative Providers overview](/claudette/features/providers/) — capability matrix and architecture
+- [Ollama](/claudette/features/providers/ollama/) — the native (non-gateway) local-LLM alternative
+- [OpenAI & Codex](/claudette/features/providers/openai-codex/) — the remote gateway-based alternatives
+- [Agent Configuration](/claudette/features/agent-configuration/) — chat-header toggles and how they map to provider capabilities

--- a/site/src/content/docs/features/providers/lm-studio.mdx
+++ b/site/src/content/docs/features/providers/lm-studio.mdx
@@ -1,6 +1,6 @@
 ---
 title: LM Studio
-description: Run Claudette agents against models loaded in LM Studio's local server — OpenAI-compatible Responses API on localhost, no remote API key required.
+description: Run Claudette agents against models loaded in LM Studio's local server — direct routing to LM Studio's native Anthropic /v1/messages endpoint on localhost, no remote API key required.
 ---
 
 The LM Studio provider points the spawned `claude` CLI at LM Studio's built-in local server. It's a **direct-routed** backend (same fast path as Ollama): Claudette sets `ANTHROPIC_BASE_URL=http://localhost:1234` and the CLI talks straight to LM Studio with no in-process gateway, no wire-format translation, and full streaming pass-through. LM Studio 0.4.1+ implements Anthropic's `/v1/messages` endpoint natively, so this works out of the box.

--- a/site/src/content/docs/features/providers/lm-studio.mdx
+++ b/site/src/content/docs/features/providers/lm-studio.mdx
@@ -39,6 +39,23 @@ lms load qwen2.5-coder-7b-instruct  # load it into VRAM
 
 Quantized GGUF builds give the best speed-to-quality trade-off on consumer hardware. Tool-tuned models (Qwen Coder, Llama Instruct, Mistral Instruct) handle Claude-style tool calls; chat-only models will likely ignore tool definitions.
 
+### Pick a context length that fits Claude Code
+
+LM Studio defaults newly-loaded models to **4096 tokens of context** regardless of what the underlying model supports. That's a conservative VRAM floor — but Claude Code's system prompt + bundled tool definitions alone are around **40–55 k tokens** before you've typed anything, so a 4 k context will hard-fail every send.
+
+Drag the **Context Length** slider in LM Studio's My Models panel for the loaded model and reload it. Recommended floors:
+
+| Conversation type | Minimum loaded context |
+|---|---|
+| `ping`-style smoke tests (system prompt + tools, ≤1 turn) | 64 k |
+| Light coding tasks (a few file reads + edits) | 96 k |
+| Heavy MCP tool usage (Playwright / browser sessions, lots of tool defs) | 128 k+ |
+| Long sessions with substantial transcript history | 192 k+ |
+
+The model's `max_context_length` is the absolute ceiling (whatever the underlying weights support — often 256 k for newer Qwen / Llama builds). The `loaded_context_length` is what you've actually committed VRAM to, and that's what Claudette's pre-flight check measures against. If your machine can't fit the recommended floor, switch to a smaller model with a longer-context build (e.g. a 7B Qwen at 128 k beats a 35B Qwen capped at 4 k for Claude Code workflows).
+
+You can change the slider mid-session — Claudette polls LM Studio every ~8 seconds while at least one LM Studio backend is enabled, so the composer's token-capacity indicator and the pre-flight gate update automatically without needing a Settings → Refresh click.
+
 ## Configure in Claudette
 
 1. Open **Settings > Models**. The `lm-studio` backend appears in the list.
@@ -92,6 +109,10 @@ This is why the chat-header **Thinking**, **Effort**, **Fast mode**, and **1M-co
 **Gateway restart loop** — usually the upstream rejecting the translated request. Open the agent's terminal tab to see stderr from the listener; the most common cause is a model ID the upstream doesn't recognize. Click **Refresh models** in Settings > Models.
 
 **Agent hangs on the first turn** — LM Studio is loading the model into VRAM. First-turn latency on a cold model can be 10–60 seconds depending on size. Subsequent turns are much faster.
+
+**Send fails immediately with `400 Prompt is too large for the model's loaded context window`** — the model is loaded with a context shorter than Claude Code's system prompt + tool defs. Reload the model in LM Studio with a larger Context Length slider value (see [Pick a context length that fits Claude Code](#pick-a-context-length-that-fits-claude-code)). The composer's token-capacity indicator updates within ~8 seconds of you reloading.
+
+**Composer shows a stale context size after reloading the LM Studio model** — Claudette polls LM Studio's `/api/v0/models` every ~8 seconds while an LM Studio backend is enabled, so the indicator should refresh on its own. If it doesn't, click **Refresh models** in Settings > Models for an immediate update. The polling effect is gated behind the experimental flag — disabling alternative backends pauses the poll.
 
 ## See also
 

--- a/site/src/content/docs/features/providers/lm-studio.mdx
+++ b/site/src/content/docs/features/providers/lm-studio.mdx
@@ -3,9 +3,9 @@ title: LM Studio
 description: Run Claudette agents against models loaded in LM Studio's local server — OpenAI-compatible Responses API on localhost, no remote API key required.
 ---
 
-The LM Studio provider points the spawned `claude` CLI at LM Studio's built-in local server. It's a gateway-routed backend (Claudette translates Claude's wire format into the OpenAI Responses API), but with the **local-first UX of Ollama**: no remote network calls, no required API key, and the runtime stays on your machine.
+The LM Studio provider points the spawned `claude` CLI at LM Studio's built-in local server. It's a **direct-routed** backend (same fast path as Ollama): Claudette sets `ANTHROPIC_BASE_URL=http://localhost:1234` and the CLI talks straight to LM Studio with no in-process gateway, no wire-format translation, and full streaming pass-through. LM Studio 0.4.1+ implements Anthropic's `/v1/messages` endpoint natively, so this works out of the box.
 
-LM Studio uses the **gateway** path because its server speaks the OpenAI Responses API (`/v1/responses`), not Anthropic's wire format. The capability profile matches OpenAI / Codex: tools and vision yes (model-dependent), but the Anthropic-only knobs (extended thinking, effort levels, fast mode, 1M-context auto-upgrade) are hidden when an LM Studio model is active.
+The capability profile is the local-first one (no extended thinking / effort / fast mode / 1M-context auto-upgrade in the chat header) — the loaded model and LM Studio's tokenizer do whatever they support, but Claudette doesn't expose those Anthropic-only knobs. Tool use and vision work whenever the underlying model handles them.
 
 ## Prerequisites
 
@@ -81,13 +81,24 @@ If a model misbehaves, try switching to a different one before assuming Claudett
 
 ## How requests flow
 
-LM Studio rides the same gateway architecture as the OpenAI / Codex backends:
+LM Studio shares Ollama's direct-routing architecture — there is no in-process gateway:
 
-1. Claudette spins up a per-session HTTP listener on `127.0.0.1:0`. The spawned `claude` subprocess gets `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`.
-2. The `claude` CLI thinks it's talking to api.anthropic.com; it's actually hitting Claudette's local listener.
-3. The listener translates the request into a `POST /v1/responses` call against `http://localhost:1234/v1/responses` and translates the streaming response back into Claude's event format.
+1. Claudette sets `ANTHROPIC_BASE_URL=http://localhost:1234`, `ANTHROPIC_AUTH_TOKEN=lm-studio` (placeholder), and `ANTHROPIC_API_KEY=""` on the spawned `claude` subprocess.
+2. The `claude` CLI POSTs `/v1/messages` directly to LM Studio. LM Studio 0.4.1+ speaks the Anthropic Messages API natively, so the request shape and streaming events match what the CLI expects from `api.anthropic.com`.
+3. Streamed tokens flow from LM Studio → CLI → Claudette UI in real time. No buffering, no translation.
 
-This is why the chat-header **Thinking**, **Effort**, **Fast mode**, and **1M-context** toggles are hidden when LM Studio is active — there are no equivalents in the OpenAI Responses shape.
+Claudette also sets `CLAUDE_CODE_ATTRIBUTION_HEADER=0` for LM Studio (and Ollama). Claude Code adds a per-request user-attribution header by default for usage attribution against `api.anthropic.com`, but its rotating value invalidates LM Studio's KV-cache prefix matching on every request — a documented [~90% performance regression](https://www.roborhythms.com/stop-claude-code-slowing-local-llm-by-90/) on local backends. Disabling it keeps the cache warm across turns; LM Studio doesn't bill anything, so the header is pure overhead.
+
+The chat header hides **Extended thinking**, **Effort**, **Fast mode**, and **1M-context** when an LM Studio model is active — `AgentBackendConfig::builtin_lm_studio()` declares those capabilities as `false`. They map cleanly to Anthropic's API but local models implement them inconsistently or not at all, and silently swallowing them would be worse than just hiding the controls.
+
+### Why not the OpenAI Responses gateway?
+
+LM Studio also exposes `/v1/responses` (OpenAI's newer Responses API). Earlier iterations of this integration used that path through Claudette's gateway, but it had two structural problems compared to direct `/v1/messages`:
+
+- **Translation overhead**: Claudette had to translate Anthropic ↔ OpenAI Responses on every request. The translation buffered the full response before sending anything back, so first-token latency equalled total generation time even when LM Studio's TTFT was sub-second.
+- **Lost streaming**: OpenAI Responses streaming uses `event: response.output_text.delta` events. Translating that incrementally into Anthropic `content_block_delta` events while preserving tool-call streaming, reasoning blocks, and stop reasons is non-trivial and a regression risk.
+
+Direct `/v1/messages` is a one-line config change (set `ANTHROPIC_BASE_URL`) that gets all of this for free. The OpenAI Responses gateway is still used for OpenAI API and Codex Subscription where there's no Anthropic-shaped alternative.
 
 ## Performance notes
 
@@ -106,13 +117,13 @@ This is why the chat-header **Thinking**, **Effort**, **Fast mode**, and **1M-co
 
 **Tool calls get ignored** — the loaded model isn't tool-tuned. Switch to a model with built-in tool-use support (Qwen Coder, Llama Instruct).
 
-**Gateway restart loop** — usually the upstream rejecting the translated request. Open the agent's terminal tab to see stderr from the listener; the most common cause is a model ID the upstream doesn't recognize. Click **Refresh models** in Settings > Models.
+**Send fails with `400 Bad Request` mentioning context length** — LM Studio rejected the request because the loaded `loaded_context_length` is smaller than Claude Code's prompt + tool defs. Bump the Context Length slider in LM Studio's My Models panel and reload the model; see [Pick a context length that fits Claude Code](#pick-a-context-length-that-fits-claude-code).
 
 **Agent hangs on the first turn** — LM Studio is loading the model into VRAM. First-turn latency on a cold model can be 10–60 seconds depending on size. Subsequent turns are much faster.
 
-**Send fails immediately with `400 Prompt is too large for the model's loaded context window`** — the model is loaded with a context shorter than Claude Code's system prompt + tool defs. Reload the model in LM Studio with a larger Context Length slider value (see [Pick a context length that fits Claude Code](#pick-a-context-length-that-fits-claude-code)). The composer's token-capacity indicator updates within ~8 seconds of you reloading.
-
 **Composer shows a stale context size after reloading the LM Studio model** — Claudette polls LM Studio's `/api/v0/models` every ~8 seconds while an LM Studio backend is enabled, so the indicator should refresh on its own. If it doesn't, click **Refresh models** in Settings > Models for an immediate update. The polling effect is gated behind the experimental flag — disabling alternative backends pauses the poll.
+
+**Local turns are slower than they should be** — make sure `CLAUDE_CODE_ATTRIBUTION_HEADER=0` is in effect (Claudette sets it automatically for LM Studio and Ollama; verify by checking the agent's terminal tab `env` output). With the header on, every request gets a rotating attribution string that breaks LM Studio's KV-cache prefix matching and re-runs prompt processing from scratch.
 
 ## See also
 

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -586,18 +586,25 @@ fn backend_models_contain(backend: &AgentBackendConfig, model: &str) -> bool {
         .any(|candidate| candidate.id == model)
 }
 
-/// Stable fingerprint of a backend's discovered + manual model list — used
-/// to decide whether a chat-send re-discovery actually changed anything
-/// worth persisting. Matches the freshness signal in `runtime_hash`
-/// (id + context_window_tokens) so a context-slider change in LM Studio
-/// reliably triggers both a DB write and a gateway respawn.
+/// Order-independent fingerprint of a backend's discovered + manual model
+/// list — used to decide whether a chat-send re-discovery actually changed
+/// anything worth persisting. Matches the freshness signal in
+/// `runtime_hash` (id + context_window_tokens) so a context-slider change
+/// in LM Studio reliably triggers both a DB write and a gateway respawn.
+///
+/// Sorted by model id so the same set of models in a different upstream
+/// order produces the same signature — otherwise a single discovery call
+/// that returned items in a different order would force an unnecessary DB
+/// write + gateway respawn on every chat send.
 fn backend_models_signature(backend: &AgentBackendConfig) -> Vec<(String, u32)> {
-    backend
+    let mut entries: Vec<(String, u32)> = backend
         .discovered_models
         .iter()
         .chain(backend.manual_models.iter())
         .map(|model| (model.id.clone(), model.context_window_tokens))
-        .collect()
+        .collect();
+    entries.sort();
+    entries
 }
 
 fn apply_discovered_models(backend: &mut AgentBackendConfig, discovered: Vec<AgentBackendModel>) {
@@ -899,19 +906,45 @@ async fn discover_lm_studio_models(
         .as_deref()
         .unwrap_or("http://localhost:1234")
         .trim_end_matches('/');
-    let secret = load_secure_secret(SECRET_BUCKET, &backend.id)
-        .ok()
-        .flatten();
+    // Treat secure-store failures as soft (a corrupt keychain entry is
+    // distinct from "no secret was ever set") and tell the user via the
+    // log so a discovery-fails-silently bug is debuggable. A missing /
+    // blank secret is fine — LM Studio accepts any bearer locally and
+    // we substitute a placeholder below.
+    let secret = match load_secure_secret(SECRET_BUCKET, &backend.id) {
+        Ok(maybe) => maybe,
+        Err(err) => {
+            tracing::warn!(
+                target: "claudette::backend",
+                backend_id = %backend.id,
+                error = %err,
+                "LM Studio secret unreadable from secure store — falling back to placeholder bearer for discovery"
+            );
+            None
+        }
+    };
+    // LM Studio's local server accepts any bearer — empty included — but
+    // some users front it with an authenticating proxy that rejects
+    // requests *without* an Authorization header even if the value
+    // doesn't matter. Always send a bearer (user-supplied or the
+    // `lm-studio` placeholder) so discovery works in both setups,
+    // matching what the runtime path does.
+    let bearer = secret
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("lm-studio")
+        .to_string();
     let client = reqwest::Client::new();
 
     // Prefer LM Studio's native v0 endpoint, which exposes per-model
     // max_context_length / loaded_context_length. Fall back to the OpenAI-shaped
     // /v1/models if v0 is missing (older or stripped builds).
-    let mut v0_request = client.get(format!("{base}/api/v0/models"));
-    if let Some(secret) = secret.as_deref().filter(|s| !s.trim().is_empty()) {
-        v0_request = v0_request.bearer_auth(secret);
-    }
-    let v0_response = v0_request.send().await;
+    let v0_response = client
+        .get(format!("{base}/api/v0/models"))
+        .bearer_auth(&bearer)
+        .send()
+        .await;
     if let Ok(response) = v0_response
         && response.status().is_success()
         && let Ok(value) = response.json::<Value>().await
@@ -922,11 +955,9 @@ async fn discover_lm_studio_models(
         }
     }
 
-    let mut v1_request = client.get(openai_api_url(base, "models"));
-    if let Some(secret) = secret.as_deref().filter(|s| !s.trim().is_empty()) {
-        v1_request = v1_request.bearer_auth(secret);
-    }
-    let value = v1_request
+    let value = client
+        .get(openai_api_url(base, "models"))
+        .bearer_auth(&bearer)
         .send()
         .await
         .map_err(|e| format!("Failed to query LM Studio: {e}"))?
@@ -1176,13 +1207,21 @@ fn runtime_hash(config: &AgentBackendConfig, secret: Option<&str>, model: Option
     // the gateway's pre-flight check would keep using the stale context
     // size baked into the running task. id+context is enough — label and
     // discovered-flag don't affect runtime behaviour.
-    for entry in config
+    //
+    // Sort first: upstream discovery doesn't guarantee a stable order, so
+    // hashing in iteration order would rotate the hash on every chat send
+    // even when nothing actually changed, forcing a needless gateway
+    // teardown/respawn cycle.
+    let mut model_entries: Vec<(&str, u32)> = config
         .discovered_models
         .iter()
         .chain(config.manual_models.iter())
-    {
-        entry.id.hash(&mut hasher);
-        entry.context_window_tokens.hash(&mut hasher);
+        .map(|entry| (entry.id.as_str(), entry.context_window_tokens))
+        .collect();
+    model_entries.sort();
+    for (id, ctx) in &model_entries {
+        id.hash(&mut hasher);
+        ctx.hash(&mut hasher);
     }
     format!("{:016x}", hasher.finish())
 }
@@ -1237,7 +1276,11 @@ impl GatewayUpstreamError {
                 if body.trim().is_empty() {
                     format!("upstream returned HTTP {status} with no body")
                 } else {
-                    body.to_string()
+                    // Cap the raw-body fallback so a cloud proxy's giant
+                    // HTML 502 page or an upstream debug dump can't
+                    // balloon error responses or log lines. The full
+                    // body is logged via tracing::warn for postmortem.
+                    truncate_for_error_message(body)
                 }
             });
         // 4xx → forward as-is so retries stop. 5xx that are *semantically*
@@ -1257,6 +1300,47 @@ impl GatewayUpstreamError {
             message,
         }
     }
+}
+
+/// Map an outbound HTTP status to the Anthropic error-envelope `type`
+/// string the Claude CLI / SDK expect for that class. Default is
+/// `api_error` (transient — SDK may retry); 4xx → kind-specific labels
+/// so 401/403/404/429 don't all collapse to `invalid_request_error`,
+/// which would re-classify `429`s out of the SDK's rate-limit retry path.
+fn anthropic_error_type_for(status: u16) -> &'static str {
+    match status {
+        401 => "authentication_error",
+        403 => "permission_error",
+        404 => "not_found_error",
+        413 => "request_too_large",
+        429 => "rate_limit_error",
+        400..=499 => "invalid_request_error",
+        _ => "api_error",
+    }
+}
+
+/// Cap an upstream body / payload that might end up in a user-visible
+/// error string. Keeps just enough context to be actionable; protects
+/// log files and chat UI from being flooded by upstream HTML / proxy
+/// error pages. Caller is responsible for tracing::warn-ing the full
+/// body if a postmortem-quality copy is needed.
+fn truncate_for_error_message(body: &str) -> String {
+    const MAX: usize = 512;
+    let mut trimmed = body.trim();
+    if trimmed.len() <= MAX {
+        return trimmed.to_string();
+    }
+    // Walk back to the last char boundary at or below MAX so we never
+    // slice into a multibyte UTF-8 sequence.
+    let mut cut = MAX;
+    while cut > 0 && !trimmed.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    trimmed = &trimmed[..cut];
+    format!(
+        "{trimmed}… [truncated, {total} bytes total]",
+        total = body.len()
+    )
 }
 
 /// Returns true when the upstream message describes a hard input error that
@@ -1437,15 +1521,14 @@ async fn handle_gateway_connection(
             match response {
                 Ok(message) => write_json_or_sse_response(&mut stream, message).await,
                 Err(err) => {
-                    // 4xx upstream errors (e.g. LM Studio "context length
-                    // exceeded") propagate as 4xx so the SDK fails fast
-                    // instead of looping retries. Genuine 5xx upstream
-                    // failures stay 502.
-                    let error_type = if (400..500).contains(&err.status) {
-                        "invalid_request_error"
-                    } else {
-                        "api_error"
-                    };
+                    // Map the outbound status to the closest Anthropic
+                    // error-envelope type so the SDK's retry classifier
+                    // sees the right category — 401 stays an auth
+                    // error, 429 stays a rate-limit error (still
+                    // retryable with the appropriate backoff), generic
+                    // 4xx is `invalid_request_error` (no retry), 5xx
+                    // is `api_error` (retry).
+                    let error_type = anthropic_error_type_for(err.status);
                     write_json_response(
                         &mut stream,
                         err.status,
@@ -1609,7 +1692,14 @@ async fn call_openai_responses(
         return Err(GatewayUpstreamError::from_upstream(status.as_u16(), &body));
     }
     let value = serde_json::from_str::<Value>(&body).map_err(|e| {
-        GatewayUpstreamError::internal(format!("Invalid OpenAI response: {e}: {body}"))
+        // Cap the body in the user-visible error so a non-JSON proxy
+        // page (e.g. a Cloudflare 502 HTML splash) doesn't drown the
+        // chat UI. Full body still goes to the tracing log via the
+        // gateway connection-error path.
+        GatewayUpstreamError::internal(format!(
+            "Invalid OpenAI response: {e}: {snippet}",
+            snippet = truncate_for_error_message(&body)
+        ))
     })?;
     Ok(anthropic_message_from_openai(
         &model,
@@ -2950,6 +3040,60 @@ data: [DONE]
             err.message.contains("503") && err.message.contains("no body"),
             "empty body fallback must mention the status, got: {}",
             err.message
+        );
+    }
+
+    #[test]
+    fn anthropic_error_type_for_routes_status_codes() {
+        // Specific 4xx codes get their dedicated Anthropic types so
+        // the SDK's retry classifier behaves correctly: 429 stays a
+        // rate-limit error (retryable with backoff), 401/403 stay
+        // permission/auth (non-retryable), 404 stays not_found.
+        assert_eq!(anthropic_error_type_for(401), "authentication_error");
+        assert_eq!(anthropic_error_type_for(403), "permission_error");
+        assert_eq!(anthropic_error_type_for(404), "not_found_error");
+        assert_eq!(anthropic_error_type_for(413), "request_too_large");
+        assert_eq!(anthropic_error_type_for(429), "rate_limit_error");
+        // Other 4xx fall back to invalid_request_error (the catch-all
+        // for "your request is malformed and won't succeed on retry").
+        assert_eq!(anthropic_error_type_for(400), "invalid_request_error");
+        assert_eq!(anthropic_error_type_for(422), "invalid_request_error");
+        // 5xx and anything else collapse to api_error so the SDK's
+        // retry-with-backoff path stays in effect for transient outages.
+        assert_eq!(anthropic_error_type_for(500), "api_error");
+        assert_eq!(anthropic_error_type_for(502), "api_error");
+        assert_eq!(anthropic_error_type_for(503), "api_error");
+    }
+
+    #[test]
+    fn truncate_for_error_message_caps_runaway_payloads() {
+        // Short payloads pass through unchanged.
+        assert_eq!(truncate_for_error_message("hi"), "hi");
+
+        // Payloads at the cap return as-is (no trailing marker).
+        let exact = "x".repeat(512);
+        assert_eq!(truncate_for_error_message(&exact), exact);
+
+        // Anything longer is sliced to ≤512 chars and tagged with the
+        // original byte count so the user knows the snippet is partial.
+        let huge = "y".repeat(5_000);
+        let truncated = truncate_for_error_message(&huge);
+        assert!(truncated.contains("[truncated, 5000 bytes total]"));
+        assert!(
+            truncated.len() < 600,
+            "truncated output must stay near the cap, got {} bytes",
+            truncated.len()
+        );
+
+        // Multibyte UTF-8 must not be sliced mid-character.
+        let mut wide = String::new();
+        for _ in 0..200 {
+            wide.push_str("日本語"); // 3 bytes per char
+        }
+        let truncated = truncate_for_error_message(&wide);
+        assert!(
+            truncated.is_char_boundary(truncated.len()),
+            "truncation must land on a char boundary"
         );
     }
 

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use base64::Engine as _;
+use futures_util::StreamExt;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -346,6 +347,18 @@ pub async fn resolve_backend_runtime(
                 "1".to_string(),
             ),
         ];
+        // LM Studio benefits from the same KV-cache reuse fix Ollama gets:
+        // suppress Claude Code's rotating attribution header so identical
+        // request prefixes hit LM Studio's prefix cache turn after turn.
+        // (Routing-wise LM Studio still goes through our gateway because
+        // it returns HTTP 500 for context-overflow, which the SDK retries
+        // unless we demote it to 4xx. See `proxy_anthropic_messages`.)
+        if backend.kind == AgentBackendKind::LmStudio {
+            env.push((
+                "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
+                "0".to_string(),
+            ));
+        }
         append_custom_model_env(&mut env, &backend, model);
         return Ok(AgentBackendRuntime {
             backend_id: Some(backend.id),
@@ -354,51 +367,18 @@ pub async fn resolve_backend_runtime(
         });
     }
 
-    // LM Studio shares Ollama's direct-routing path now (it speaks
-    // /v1/messages natively in 0.4.1+) but defaults to a different
-    // localhost port and uses its own placeholder token. Ollama keeps
-    // 11434 + "ollama"; LM Studio takes 1234 + "lm-studio".
-    let (default_base, default_token) = match backend.kind {
-        AgentBackendKind::LmStudio => ("http://localhost:1234", "lm-studio"),
-        _ => ("http://localhost:11434", "ollama"),
-    };
     let base_url = backend
         .base_url
         .clone()
-        .unwrap_or_else(|| default_base.to_string());
-    // Refresh discovered models for LM Studio on every chat-send so the
-    // composer's loaded_context_length and the gateway-side hash match
-    // the live LM Studio server state. The user can change the context
-    // slider mid-session and we want that reflected immediately. Cheap:
-    // single GET to localhost. Errors are non-fatal — if discovery fails
-    // we keep whatever we already have rather than blocking the send.
-    if backend.kind == AgentBackendKind::LmStudio
-        && let Ok(discovered) = discover_models(&backend).await
-        && !discovered.is_empty()
-    {
-        let pre = backend_models_signature(&backend);
-        backend.discovered_models = discovered;
-        backend.manual_models.clear();
-        let post = backend_models_signature(&backend);
-        if pre != post
-            && let Ok(mut all) = load_backend_configs(&db)
-            && let Some(slot) = all.iter_mut().find(|item| item.id == backend.id)
-        {
-            *slot = backend.clone();
-            let _ = save_backend_configs(&db, &all);
-        }
-    }
+        .unwrap_or_else(|| "http://localhost:11434".to_string());
     let mut env = vec![
         ("ANTHROPIC_BASE_URL".to_string(), base_url),
         (
             "ANTHROPIC_AUTH_TOKEN".to_string(),
-            secret.clone().unwrap_or_else(|| default_token.to_string()),
+            secret.clone().unwrap_or_else(|| "ollama".to_string()),
         ),
     ];
-    if matches!(
-        backend.kind,
-        AgentBackendKind::Ollama | AgentBackendKind::LmStudio
-    ) {
+    if backend.kind == AgentBackendKind::Ollama {
         env.push(("ANTHROPIC_API_KEY".to_string(), String::new()));
         // Disable the per-request user-attribution header. Claude Code
         // adds it for usage attribution against api.anthropic.com, but
@@ -406,8 +386,11 @@ pub async fn resolve_backend_runtime(
         // and causes a documented ~90 % perf regression on local
         // backends (see github.com/anthropics/claude-code/issues/29230,
         // roborhythms.com/stop-claude-code-slowing-local-llm-by-90).
-        // Ollama/LM Studio don't bill anything, so the header is pure
-        // overhead.
+        // Ollama doesn't bill anything, so the header is pure overhead.
+        // LM Studio gets the same env via the gateway-routed path
+        // (where we forward this env via the spawned CLI's environment
+        // and the gateway itself strips the header from upstream
+        // requests).
         env.push((
             "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
             "0".to_string(),
@@ -1517,27 +1500,27 @@ async fn handle_gateway_connection(
         ("POST", "/v1/messages") => {
             let req = serde_json::from_slice::<Value>(body)
                 .map_err(|e| format!("invalid messages request: {e}"))?;
-            let response = call_openai_responses(&config, upstream_secret.as_deref(), req).await;
-            match response {
-                Ok(message) => write_json_or_sse_response(&mut stream, message).await,
-                Err(err) => {
-                    // Map the outbound status to the closest Anthropic
-                    // error-envelope type so the SDK's retry classifier
-                    // sees the right category — 401 stays an auth
-                    // error, 429 stays a rate-limit error (still
-                    // retryable with the appropriate backoff), generic
-                    // 4xx is `invalid_request_error` (no retry), 5xx
-                    // is `api_error` (retry).
-                    let error_type = anthropic_error_type_for(err.status);
-                    write_json_response(
-                        &mut stream,
-                        err.status,
-                        json!({
-                            "type":"error",
-                            "error":{"type":error_type,"message":err.message},
-                        }),
-                    )
-                    .await
+            // LM Studio speaks Anthropic's wire format natively — there's
+            // no OpenAI-Responses translation work to do, just forward
+            // bytes. The pass-through writes the response (including
+            // streaming SSE) directly to the client TCP stream so we
+            // preserve TTFT, and intercepts non-2xx upstream responses
+            // to apply the same status-demotion logic the gateway uses
+            // for OpenAI-shape backends (otherwise LM Studio's HTTP 500
+            // for context-overflow triggers the SDK's retry-with-backoff
+            // path and the user sees a multi-minute spinner instead of
+            // the actual error message).
+            if config.kind == AgentBackendKind::LmStudio {
+                match proxy_anthropic_messages(&config, &req, &mut stream).await {
+                    Ok(()) => Ok(()),
+                    Err(err) => write_anthropic_error_response(&mut stream, err).await,
+                }
+            } else {
+                let response =
+                    call_openai_responses(&config, upstream_secret.as_deref(), req).await;
+                match response {
+                    Ok(message) => write_json_or_sse_response(&mut stream, message).await,
+                    Err(err) => write_anthropic_error_response(&mut stream, err).await,
                 }
             }
         }
@@ -1634,6 +1617,145 @@ fn preflight_context_window_check(
             label = config.label,
         ),
     })
+}
+
+/// Forward an Anthropic Messages API request to LM Studio's native
+/// `/v1/messages` endpoint. Bypasses the OpenAI Responses translation
+/// `call_openai_responses` does — LM Studio 0.4.1+ implements Anthropic's
+/// wire format natively, so the only thing we need from the gateway is
+/// **status-code translation**: LM Studio returns HTTP 500 for hard
+/// input errors like context-window overflow, which the Anthropic SDK
+/// retries with backoff. The response body is in Anthropic shape
+/// (`{type: error, error: {type, message}}`) — we just need to fix the
+/// status before forwarding to the CLI.
+///
+/// Successful (2xx) responses are streamed through unchanged so the
+/// agent UI gets per-chunk SSE events as LM Studio produces them
+/// (preserving TTFT). The pass-through writes directly to `out_stream`
+/// rather than buffering into a `Value` like the OpenAI-Responses path.
+async fn proxy_anthropic_messages(
+    config: &AgentBackendConfig,
+    anthropic_req: &Value,
+    out_stream: &mut TcpStream,
+) -> Result<(), GatewayUpstreamError> {
+    let base = config
+        .base_url
+        .as_deref()
+        .unwrap_or("http://localhost:1234")
+        .trim_end_matches('/');
+    // LM Studio's `/v1/messages` accepts any bearer locally — but a user
+    // who fronts the server with an authenticating proxy would reject a
+    // missing Authorization header. Always send the placeholder so both
+    // setups work.
+    let bearer = load_secure_secret(SECRET_BUCKET, &config.id)
+        .ok()
+        .flatten()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "lm-studio".to_string());
+    // Pre-flight: same approximation we use for OpenAI-Responses-routed
+    // backends. LM Studio enforces its own context check too, but our
+    // pre-flight wins on UX (~1 ms vs ~40 s round-trip to LM Studio's
+    // tokenizer) and produces a tailored message that names the actual
+    // numbers.
+    let model = anthropic_req
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    if !model.is_empty()
+        && let Some(err) = preflight_context_window_check(config, &model, anthropic_req)
+    {
+        return Err(err);
+    }
+
+    let stream_requested = anthropic_req
+        .get("stream")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v1/messages"))
+        .bearer_auth(&bearer)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .json(anthropic_req)
+        .send()
+        .await
+        .map_err(|e| GatewayUpstreamError::internal(format!("LM Studio request failed: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.map_err(|e| {
+            GatewayUpstreamError::internal(format!("Invalid LM Studio response body: {e}"))
+        })?;
+        return Err(GatewayUpstreamError::from_upstream(status.as_u16(), &body));
+    }
+
+    // Forward the response. We mirror the upstream Content-Type so the
+    // CLI sees `text/event-stream` for streaming requests and JSON for
+    // non-streaming ones, then close the connection at end-of-body so
+    // we can stream without committing to a Content-Length. Same
+    // `Connection: close` pattern the OpenAI-Responses fallback uses.
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            if stream_requested {
+                "text/event-stream".to_string()
+            } else {
+                "application/json".to_string()
+            }
+        });
+    let header_block = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: {content_type}\r\n\
+         Cache-Control: no-cache\r\n\
+         Connection: close\r\n\
+         \r\n"
+    );
+    out_stream
+        .write_all(header_block.as_bytes())
+        .await
+        .map_err(|e| GatewayUpstreamError::internal(format!("write headers failed: {e}")))?;
+
+    let mut body_stream = response.bytes_stream();
+    while let Some(chunk) = body_stream.next().await {
+        let chunk = chunk
+            .map_err(|e| GatewayUpstreamError::internal(format!("upstream stream error: {e}")))?;
+        out_stream
+            .write_all(&chunk)
+            .await
+            .map_err(|e| GatewayUpstreamError::internal(format!("write chunk failed: {e}")))?;
+    }
+    out_stream
+        .flush()
+        .await
+        .map_err(|e| GatewayUpstreamError::internal(format!("flush failed: {e}")))?;
+    Ok(())
+}
+
+/// Format a `GatewayUpstreamError` as the JSON error envelope the
+/// Anthropic CLI / SDK expect, picking the most accurate `error.type`
+/// for the outbound HTTP status. Centralized so every gateway code path
+/// (OpenAI-Responses translation, LM Studio pass-through) produces an
+/// identical shape.
+async fn write_anthropic_error_response(
+    stream: &mut TcpStream,
+    err: GatewayUpstreamError,
+) -> Result<(), String> {
+    let error_type = anthropic_error_type_for(err.status);
+    write_json_response(
+        stream,
+        err.status,
+        json!({
+            "type":"error",
+            "error":{"type":error_type,"message":err.message},
+        }),
+    )
+    .await
 }
 
 async fn call_openai_responses(
@@ -2397,16 +2519,18 @@ mod tests {
     }
 
     #[test]
-    fn lm_studio_routing_uses_anthropic_compatible_classification() {
-        // Pinned: LM Studio MUST stay on the direct (non-gateway) path.
-        // Flipping this back to needs_gateway() would re-introduce the
-        // OpenAI-Responses translation overhead and lose native
-        // streaming pass-through. There is no fallback — if a future
-        // LM Studio release breaks /v1/messages, fix discovery /
-        // surface a clear error rather than silently routing through
-        // the gateway with a different perf profile.
-        assert!(AgentBackendKind::LmStudio.is_anthropic_compatible());
-        assert!(!AgentBackendKind::LmStudio.needs_gateway());
+    fn lm_studio_routing_classification_pinned() {
+        // Pinned: LM Studio MUST stay on the gateway path. Direct
+        // routing (`is_anthropic_compatible() == true`) loses our
+        // status-code translation, and LM Studio's HTTP 500 for
+        // context-overflow ends up in the SDK's retry-with-backoff
+        // path — the user sees a multi-minute spinner instead of the
+        // actual error. The gateway uses `proxy_anthropic_messages`
+        // (not the OpenAI-Responses translator) so streaming
+        // pass-through is preserved; only error status codes get
+        // rewritten on the way back.
+        assert!(AgentBackendKind::LmStudio.needs_gateway());
+        assert!(!AgentBackendKind::LmStudio.is_anthropic_compatible());
         // Sanity-check the rest of the matrix to catch a copy-paste
         // misclassification of an unrelated kind.
         assert!(AgentBackendKind::Anthropic.is_anthropic_compatible());
@@ -2882,15 +3006,21 @@ data: [DONE]
         assert_eq!(backend.id, "lm-studio");
         assert_eq!(backend.kind, AgentBackendKind::LmStudio);
         assert!(
-            !backend.kind.needs_gateway(),
-            "LM Studio 0.4.1+ implements /v1/messages natively, so it takes \
-             the direct ANTHROPIC_BASE_URL path (like Ollama) instead of \
-             the OpenAI-Responses gateway"
+            backend.kind.needs_gateway(),
+            "LM Studio routes through our gateway so we can demote its \
+             HTTP 500 context-overflow responses to 4xx — without that \
+             the Anthropic SDK retries the error with backoff and the \
+             user sees a multi-minute spinner. Inside the gateway we use \
+             the `proxy_anthropic_messages` pass-through (no wire-format \
+             translation) since LM Studio 0.4.1+ speaks Anthropic /v1/messages \
+             natively."
         );
         assert!(
-            backend.kind.is_anthropic_compatible(),
-            "Direct routing requires the kind to be classified as \
-             Anthropic-compatible — same as Ollama and CustomAnthropic"
+            !backend.kind.is_anthropic_compatible(),
+            "is_anthropic_compatible() means the spawned CLI talks to the \
+             upstream directly with no in-process gateway. LM Studio is \
+             *wire-compatible* with Anthropic but still needs the gateway \
+             for status-code translation."
         );
         assert_eq!(
             backend.base_url.as_deref(),

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -354,19 +354,64 @@ pub async fn resolve_backend_runtime(
         });
     }
 
+    // LM Studio shares Ollama's direct-routing path now (it speaks
+    // /v1/messages natively in 0.4.1+) but defaults to a different
+    // localhost port and uses its own placeholder token. Ollama keeps
+    // 11434 + "ollama"; LM Studio takes 1234 + "lm-studio".
+    let (default_base, default_token) = match backend.kind {
+        AgentBackendKind::LmStudio => ("http://localhost:1234", "lm-studio"),
+        _ => ("http://localhost:11434", "ollama"),
+    };
     let base_url = backend
         .base_url
         .clone()
-        .unwrap_or_else(|| "http://localhost:11434".to_string());
+        .unwrap_or_else(|| default_base.to_string());
+    // Refresh discovered models for LM Studio on every chat-send so the
+    // composer's loaded_context_length and the gateway-side hash match
+    // the live LM Studio server state. The user can change the context
+    // slider mid-session and we want that reflected immediately. Cheap:
+    // single GET to localhost. Errors are non-fatal — if discovery fails
+    // we keep whatever we already have rather than blocking the send.
+    if backend.kind == AgentBackendKind::LmStudio
+        && let Ok(discovered) = discover_models(&backend).await
+        && !discovered.is_empty()
+    {
+        let pre = backend_models_signature(&backend);
+        backend.discovered_models = discovered;
+        backend.manual_models.clear();
+        let post = backend_models_signature(&backend);
+        if pre != post
+            && let Ok(mut all) = load_backend_configs(&db)
+            && let Some(slot) = all.iter_mut().find(|item| item.id == backend.id)
+        {
+            *slot = backend.clone();
+            let _ = save_backend_configs(&db, &all);
+        }
+    }
     let mut env = vec![
         ("ANTHROPIC_BASE_URL".to_string(), base_url),
         (
             "ANTHROPIC_AUTH_TOKEN".to_string(),
-            secret.clone().unwrap_or_else(|| "ollama".to_string()),
+            secret.clone().unwrap_or_else(|| default_token.to_string()),
         ),
     ];
-    if backend.kind == AgentBackendKind::Ollama {
+    if matches!(
+        backend.kind,
+        AgentBackendKind::Ollama | AgentBackendKind::LmStudio
+    ) {
         env.push(("ANTHROPIC_API_KEY".to_string(), String::new()));
+        // Disable the per-request user-attribution header. Claude Code
+        // adds it for usage attribution against api.anthropic.com, but
+        // its rotating value invalidates every local KV-cache prefix
+        // and causes a documented ~90 % perf regression on local
+        // backends (see github.com/anthropics/claude-code/issues/29230,
+        // roborhythms.com/stop-claude-code-slowing-local-llm-by-90).
+        // Ollama/LM Studio don't bill anything, so the header is pure
+        // overhead.
+        env.push((
+            "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
+            "0".to_string(),
+        ));
     } else if let Some(secret) = secret.clone() {
         env.push(("ANTHROPIC_API_KEY".to_string(), secret));
     }
@@ -2269,6 +2314,27 @@ mod tests {
     }
 
     #[test]
+    fn lm_studio_routing_uses_anthropic_compatible_classification() {
+        // Pinned: LM Studio MUST stay on the direct (non-gateway) path.
+        // Flipping this back to needs_gateway() would re-introduce the
+        // OpenAI-Responses translation overhead and lose native
+        // streaming pass-through. There is no fallback — if a future
+        // LM Studio release breaks /v1/messages, fix discovery /
+        // surface a clear error rather than silently routing through
+        // the gateway with a different perf profile.
+        assert!(AgentBackendKind::LmStudio.is_anthropic_compatible());
+        assert!(!AgentBackendKind::LmStudio.needs_gateway());
+        // Sanity-check the rest of the matrix to catch a copy-paste
+        // misclassification of an unrelated kind.
+        assert!(AgentBackendKind::Anthropic.is_anthropic_compatible());
+        assert!(AgentBackendKind::Ollama.is_anthropic_compatible());
+        assert!(AgentBackendKind::CustomAnthropic.is_anthropic_compatible());
+        assert!(AgentBackendKind::OpenAiApi.needs_gateway());
+        assert!(AgentBackendKind::CodexSubscription.needs_gateway());
+        assert!(AgentBackendKind::CustomOpenAi.needs_gateway());
+    }
+
+    #[test]
     fn runtime_hash_changes_when_discovered_context_window_changes() {
         // Regression: LM Studio's loaded_context_length changes when the
         // user reloads a model with a different context slider. The
@@ -2732,8 +2798,17 @@ data: [DONE]
         let backend = AgentBackendConfig::builtin_lm_studio();
         assert_eq!(backend.id, "lm-studio");
         assert_eq!(backend.kind, AgentBackendKind::LmStudio);
-        assert!(backend.kind.needs_gateway());
-        assert!(!backend.kind.is_anthropic_compatible());
+        assert!(
+            !backend.kind.needs_gateway(),
+            "LM Studio 0.4.1+ implements /v1/messages natively, so it takes \
+             the direct ANTHROPIC_BASE_URL path (like Ollama) instead of \
+             the OpenAI-Responses gateway"
+        );
+        assert!(
+            backend.kind.is_anthropic_compatible(),
+            "Direct routing requires the kind to be classified as \
+             Anthropic-compatible — same as Ollama and CustomAnthropic"
+        );
         assert_eq!(
             backend.base_url.as_deref(),
             Some("http://localhost:1234"),

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -317,7 +317,20 @@ pub async fn resolve_backend_runtime(
         if backend.kind == AgentBackendKind::OpenAiApi && secret.is_none() {
             return Err("OpenAI API backend requires an API key in Settings → Models".to_string());
         }
+        let pre_hydrate = backend.clone();
         hydrate_gateway_models_for_runtime(&mut backend, model).await?;
+        // Persist fresh discoveries (new model list, new context windows)
+        // so the UI's token-capacity indicator and the next list_agent_backends
+        // call see the live values — without requiring a manual Settings →
+        // Models refresh. Limited to a real change to keep the chat-send
+        // hot path off the DB writer when nothing has actually moved.
+        if backend_models_signature(&backend) != backend_models_signature(&pre_hydrate)
+            && let Ok(mut all) = load_backend_configs(&db)
+            && let Some(slot) = all.iter_mut().find(|item| item.id == backend.id)
+        {
+            *slot = backend.clone();
+            let _ = save_backend_configs(&db, &all);
+        }
         if let Some(model) = model.map(str::trim).filter(|model| !model.is_empty()) {
             backend.default_model = Some(model.to_string());
         }
@@ -526,6 +539,20 @@ fn backend_models_contain(backend: &AgentBackendConfig, model: &str) -> bool {
         .iter()
         .chain(backend.discovered_models.iter())
         .any(|candidate| candidate.id == model)
+}
+
+/// Stable fingerprint of a backend's discovered + manual model list — used
+/// to decide whether a chat-send re-discovery actually changed anything
+/// worth persisting. Matches the freshness signal in `runtime_hash`
+/// (id + context_window_tokens) so a context-slider change in LM Studio
+/// reliably triggers both a DB write and a gateway respawn.
+fn backend_models_signature(backend: &AgentBackendConfig) -> Vec<(String, u32)> {
+    backend
+        .discovered_models
+        .iter()
+        .chain(backend.manual_models.iter())
+        .map(|model| (model.id.clone(), model.context_window_tokens))
+        .collect()
 }
 
 fn apply_discovered_models(backend: &mut AgentBackendConfig, discovered: Vec<AgentBackendModel>) {

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -1146,10 +1146,15 @@ impl GatewayUpstreamError {
                     body.to_string()
                 }
             });
-        // 4xx → forward as-is so retries stop. Anything else collapses to
-        // 502 (bad gateway) for the SDK consumer.
+        // 4xx → forward as-is so retries stop. 5xx that are *semantically*
+        // permanent (LM Studio classifies "tokens to keep > context length"
+        // as HTTP 500 even though it's a hard input error) get demoted to
+        // 400 so the Anthropic SDK does not retry them with backoff.
+        // Anything else collapses to 502 (bad gateway) for the SDK consumer.
         let outbound = if (400..500).contains(&status) {
             status
+        } else if upstream_message_is_permanent_failure(&message) {
+            400
         } else {
             502
         };
@@ -1158,6 +1163,29 @@ impl GatewayUpstreamError {
             message,
         }
     }
+}
+
+/// Returns true when the upstream message describes a hard input error that
+/// will fail identically on retry — context-window overflow, model not
+/// loaded, model not found, etc. Matched case-insensitively against
+/// substrings observed in the wild from LM Studio, llama.cpp, vLLM, and
+/// OpenAI-compatible gateways. Keep the list narrow: false positives mean
+/// users miss out on transient-failure retries.
+fn upstream_message_is_permanent_failure(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    const NEEDLES: &[&str] = &[
+        "context length",
+        "tokens to keep",
+        "context window",
+        "exceeds the maximum",
+        "model is not loaded",
+        "model not loaded",
+        "model not found",
+        "no model is loaded",
+        "input is too long",
+        "prompt is too long",
+    ];
+    NEEDLES.iter().any(|needle| lower.contains(needle))
 }
 
 impl std::fmt::Display for GatewayUpstreamError {
@@ -1395,6 +1423,49 @@ fn openai_compatible_default_base(kind: AgentBackendKind) -> &'static str {
     }
 }
 
+/// Approximate the prompt+tools size and compare against the backend's
+/// known context window for `model`. Returns Some(error) when the request
+/// is obviously too large to fit, so we can fail fast at 400 instead of
+/// waiting on the upstream server to tokenize and reject it. Returns None
+/// when the model's context window isn't known (e.g. user added a manual
+/// model without a discovered context size) — in that case we still send
+/// upstream and let the runtime classify any overflow via
+/// `from_upstream` + `upstream_message_is_permanent_failure`.
+fn preflight_context_window_check(
+    config: &AgentBackendConfig,
+    model: &str,
+    openai_req: &Value,
+) -> Option<GatewayUpstreamError> {
+    let context = config
+        .discovered_models
+        .iter()
+        .chain(config.manual_models.iter())
+        .find(|m| m.id == model)
+        .map(|m| m.context_window_tokens)
+        .filter(|n| *n > 0)?;
+    // Body length / 4 is a deliberate over-estimate for English text and
+    // a conservative match for tokenizer-dense JSON tool schemas. Same
+    // approximation we use in /v1/messages/count_tokens, so the count
+    // and the gate stay consistent.
+    let approx_tokens = openai_req.to_string().len() / 4;
+    // Reserve some headroom for completion tokens — even a 1-token reply
+    // needs a slot. 90% of the window is a reasonable hard ceiling.
+    let limit = (context as usize).saturating_mul(9) / 10;
+    if approx_tokens <= limit {
+        return None;
+    }
+    Some(GatewayUpstreamError {
+        status: 400,
+        message: format!(
+            "Prompt is too large for the model's loaded context window. \
+             Approx {approx_tokens} tokens of input vs {context} tokens \
+             of context for `{model}`. Reload the model in {label} with a \
+             larger context length, or pick a model with a bigger window.",
+            label = config.label,
+        ),
+    })
+}
+
 async fn call_openai_responses(
     config: &AgentBackendConfig,
     secret: Option<&str>,
@@ -1416,6 +1487,14 @@ async fn call_openai_responses(
         "tools": tools_from_anthropic(&anthropic_req),
         "max_output_tokens": anthropic_req.get("max_tokens").cloned().unwrap_or(json!(4096)),
     });
+    // Pre-flight: when the backend reports a per-model context window
+    // (LM Studio's `loaded_context_length`, OpenAI's `context_window_tokens`)
+    // and the serialized request obviously won't fit, fail fast with a
+    // user-actionable message instead of waiting ~40s for LM Studio to
+    // tokenize the prompt and reject it as HTTP 500.
+    if let Some(err) = preflight_context_window_check(config, &model, &openai_req) {
+        return Err(err);
+    }
     let client = reqwest::Client::new();
     let response = client
         .post(openai_api_url(base, "responses"))
@@ -2737,5 +2816,121 @@ data: [DONE]
         let err = GatewayUpstreamError::internal("could not bind socket");
         assert_eq!(err.status, 502);
         assert_eq!(err.message, "could not bind socket");
+    }
+
+    #[test]
+    fn gateway_upstream_error_promotes_5xx_context_overflow_to_400() {
+        // LM Studio classifies "tokens to keep > context length" as HTTP
+        // 500 (verified empirically against `lms server` 0.4). Without the
+        // message-text demotion, the SDK retries this with exponential
+        // backoff and the user sees a 2-3 minute spinner. With it, the
+        // request fails fast at 400.
+        let body = serde_json::json!({
+            "error": {
+                "message": "The number of tokens to keep from the initial \
+                    prompt is greater than the context length. Try to load \
+                    the model with a larger context length, or provide a \
+                    shorter input",
+                "type": "internal_error",
+            }
+        })
+        .to_string();
+        let err = GatewayUpstreamError::from_upstream(500, &body);
+        assert_eq!(
+            err.status, 400,
+            "5xx with context-overflow message must demote to 400 so the \
+             SDK does not retry it"
+        );
+        assert!(err.message.contains("larger context length"));
+    }
+
+    #[test]
+    fn gateway_upstream_error_keeps_unknown_5xx_at_502() {
+        // A 5xx with a generic message (transient outage) must NOT be
+        // demoted — that case really should be retried.
+        let body = serde_json::json!({
+            "error": {"message": "internal server error", "type": "server_error"}
+        })
+        .to_string();
+        let err = GatewayUpstreamError::from_upstream(500, &body);
+        assert_eq!(err.status, 502);
+        assert_eq!(err.message, "internal server error");
+    }
+
+    #[test]
+    fn upstream_message_permanent_failure_classifier_recognises_known_phrases() {
+        let cases: &[(&str, bool)] = &[
+            ("tokens to keep from the initial prompt", true),
+            ("greater than the context length", true),
+            ("This exceeds the maximum context window", true),
+            ("Model is not loaded", true),
+            ("model not found", true),
+            ("Input is too long", true),
+            ("rate limit exceeded, retry after 30s", false),
+            ("upstream timed out", false),
+            ("internal server error", false),
+        ];
+        for (msg, expected) in cases {
+            assert_eq!(
+                upstream_message_is_permanent_failure(msg),
+                *expected,
+                "classifier disagreed on: {msg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn preflight_context_window_check_rejects_obvious_overflow() {
+        // 4096-token loaded context, ~12k bytes of JSON ≈ 3000 approx
+        // tokens fits comfortably. Bump to 60k bytes ≈ 15k approx tokens
+        // and we trip the 90% gate (3686-token ceiling).
+        let mut backend = AgentBackendConfig::builtin_lm_studio();
+        backend.discovered_models = vec![AgentBackendModel {
+            id: "qwen3.6-35b-a3b-ud-mlx".to_string(),
+            label: "qwen3.6-35b-a3b-ud-mlx".to_string(),
+            context_window_tokens: 4096,
+            discovered: true,
+        }];
+
+        // Small request → passes pre-flight.
+        let small = json!({
+            "model": "qwen3.6-35b-a3b-ud-mlx",
+            "input": "ping",
+        });
+        assert!(
+            preflight_context_window_check(&backend, "qwen3.6-35b-a3b-ud-mlx", &small).is_none()
+        );
+
+        // Big request → trips pre-flight with a clear message and 400.
+        let huge_input = "x".repeat(80_000); // ~20k approx tokens
+        let big = json!({
+            "model": "qwen3.6-35b-a3b-ud-mlx",
+            "input": huge_input,
+        });
+        let err = preflight_context_window_check(&backend, "qwen3.6-35b-a3b-ud-mlx", &big)
+            .expect("oversized request must trip pre-flight");
+        assert_eq!(err.status, 400);
+        assert!(
+            err.message.contains("4096"),
+            "error must cite the loaded context size, got: {}",
+            err.message
+        );
+        assert!(err.message.contains("LM Studio"));
+    }
+
+    #[test]
+    fn preflight_context_window_check_skips_when_window_unknown() {
+        // Manual-only model with no discovered context size → no gate
+        // (we don't second-guess the user's manual entry).
+        let mut backend = AgentBackendConfig::builtin_lm_studio();
+        backend.discovered_models.clear();
+        backend.manual_models = vec![AgentBackendModel {
+            id: "custom-model".to_string(),
+            label: "custom-model".to_string(),
+            context_window_tokens: 0,
+            discovered: false,
+        }];
+        let req = json!({"model": "custom-model", "input": "x".repeat(100_000)});
+        assert!(preflight_context_window_check(&backend, "custom-model", &req).is_none());
     }
 }

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -1105,6 +1105,73 @@ fn backend_kind_hash_key(kind: AgentBackendKind) -> &'static str {
     }
 }
 
+/// Error from a gateway request that needs to be turned back into an HTTP
+/// response for the Claude CLI. Carries both the upstream-extracted message
+/// and the response status we want the gateway to emit — so a 4xx from LM
+/// Studio (e.g. context-length exceeded) propagates as 4xx and the SDK does
+/// not retry it as a transient 5xx.
+#[derive(Debug, Clone)]
+struct GatewayUpstreamError {
+    status: u16,
+    message: String,
+}
+
+impl GatewayUpstreamError {
+    /// Wrap a local/internal failure (couldn't even reach the upstream).
+    /// Surfaces as 502 to the CLI.
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: 502,
+            message: message.into(),
+        }
+    }
+
+    /// Build from an upstream non-2xx response. Parses the OpenAI-shaped
+    /// `{error: {message: ...}}` envelope when present, else falls back to
+    /// the raw body. Preserves 4xx status codes so the CLI fails fast on
+    /// permanent input errors instead of retrying with backoff.
+    fn from_upstream(status: u16, body: &str) -> Self {
+        let message = serde_json::from_str::<Value>(body)
+            .ok()
+            .as_ref()
+            .and_then(|v| v.get("error"))
+            .and_then(|e| e.get("message"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                if body.trim().is_empty() {
+                    format!("upstream returned HTTP {status} with no body")
+                } else {
+                    body.to_string()
+                }
+            });
+        // 4xx → forward as-is so retries stop. Anything else collapses to
+        // 502 (bad gateway) for the SDK consumer.
+        let outbound = if (400..500).contains(&status) {
+            status
+        } else {
+            502
+        };
+        Self {
+            status: outbound,
+            message,
+        }
+    }
+}
+
+impl std::fmt::Display for GatewayUpstreamError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (status={})", self.message, self.status)
+    }
+}
+
+impl From<String> for GatewayUpstreamError {
+    fn from(message: String) -> Self {
+        Self::internal(message)
+    }
+}
+
 async fn run_gateway(
     listener: TcpListener,
     cancel: Arc<Notify>,
@@ -1248,10 +1315,22 @@ async fn handle_gateway_connection(
             match response {
                 Ok(message) => write_json_or_sse_response(&mut stream, message).await,
                 Err(err) => {
+                    // 4xx upstream errors (e.g. LM Studio "context length
+                    // exceeded") propagate as 4xx so the SDK fails fast
+                    // instead of looping retries. Genuine 5xx upstream
+                    // failures stay 502.
+                    let error_type = if (400..500).contains(&err.status) {
+                        "invalid_request_error"
+                    } else {
+                        "api_error"
+                    };
                     write_json_response(
                         &mut stream,
-                        502,
-                        json!({"type":"error","error":{"type":"api_error","message":err}}),
+                        err.status,
+                        json!({
+                            "type":"error",
+                            "error":{"type":error_type,"message":err.message},
+                        }),
                     )
                     .await
                 }
@@ -1320,7 +1399,7 @@ async fn call_openai_responses(
     config: &AgentBackendConfig,
     secret: Option<&str>,
     anthropic_req: Value,
-) -> Result<Value, String> {
+) -> Result<Value, GatewayUpstreamError> {
     if config.kind == AgentBackendKind::CodexSubscription {
         return call_codex_responses(config, secret, anthropic_req).await;
     }
@@ -1338,18 +1417,27 @@ async fn call_openai_responses(
         "max_output_tokens": anthropic_req.get("max_tokens").cloned().unwrap_or(json!(4096)),
     });
     let client = reqwest::Client::new();
-    let value = client
+    let response = client
         .post(openai_api_url(base, "responses"))
         .bearer_auth(secret)
         .json(&openai_req)
         .send()
         .await
-        .map_err(|e| format!("OpenAI request failed: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("OpenAI request failed: {e}"))?
-        .json::<Value>()
+        .map_err(|e| GatewayUpstreamError::internal(format!("OpenAI request failed: {e}")))?;
+    let status = response.status();
+    // Read the body unconditionally — on error this is where LM Studio
+    // returns the "load with larger context" message that we want to
+    // surface verbatim instead of swallowing via error_for_status().
+    let body = response
+        .text()
         .await
-        .map_err(|e| format!("Invalid OpenAI response: {e}"))?;
+        .map_err(|e| GatewayUpstreamError::internal(format!("Invalid OpenAI response: {e}")))?;
+    if !status.is_success() {
+        return Err(GatewayUpstreamError::from_upstream(status.as_u16(), &body));
+    }
+    let value = serde_json::from_str::<Value>(&body).map_err(|e| {
+        GatewayUpstreamError::internal(format!("Invalid OpenAI response: {e}: {body}"))
+    })?;
     Ok(anthropic_message_from_openai(
         &model,
         value,
@@ -1364,11 +1452,15 @@ async fn call_codex_responses(
     config: &AgentBackendConfig,
     secret: Option<&str>,
     anthropic_req: Value,
-) -> Result<Value, String> {
-    let auth = serde_json::from_str::<CodexAuthMaterial>(
-        secret.ok_or("Codex subscription backend requires Codex CLI authentication")?,
-    )
-    .map_err(|e| format!("Invalid Codex gateway auth material: {e}"))?;
+) -> Result<Value, GatewayUpstreamError> {
+    let auth = serde_json::from_str::<CodexAuthMaterial>(secret.ok_or_else(|| {
+        GatewayUpstreamError::internal(
+            "Codex subscription backend requires Codex CLI authentication",
+        )
+    })?)
+    .map_err(|e| {
+        GatewayUpstreamError::internal(format!("Invalid Codex gateway auth material: {e}"))
+    })?;
     let model = openai_compatible_request_model(config, &anthropic_req)?;
     let instructions = codex_instructions_from_anthropic(&anthropic_req);
     let request_id = uuid::Uuid::new_v4().to_string();
@@ -1402,16 +1494,16 @@ async fn call_codex_responses(
     let response = request
         .send()
         .await
-        .map_err(|e| format!("Codex request failed: {e}"))?;
+        .map_err(|e| GatewayUpstreamError::internal(format!("Codex request failed: {e}")))?;
     let status = response.status();
     let body = response
         .text()
         .await
-        .map_err(|e| format!("Invalid Codex response body: {e}"))?;
+        .map_err(|e| GatewayUpstreamError::internal(format!("Invalid Codex response body: {e}")))?;
     if !status.is_success() {
-        return Err(format!("Codex request failed ({status}): {body}"));
+        return Err(GatewayUpstreamError::from_upstream(status.as_u16(), &body));
     }
-    let value = openai_response_from_sse(&body)?;
+    let value = openai_response_from_sse(&body).map_err(GatewayUpstreamError::internal)?;
     Ok(anthropic_message_from_openai(
         &model,
         value,
@@ -2581,5 +2673,69 @@ data: [DONE]
             openai_compatible_default_base(AgentBackendKind::OpenAiApi),
             "https://api.openai.com"
         );
+    }
+
+    #[test]
+    fn gateway_upstream_error_unwraps_openai_error_message() {
+        // The exact shape LM Studio returns for context-length overflow.
+        // Body lives inside `error.message`; status is a 4xx so retries stop.
+        let body = serde_json::json!({
+            "error": {
+                "message": "The number of tokens to keep from the initial \
+                    prompt is greater than the context length. Try to load \
+                    the model with a larger context length, or provide a \
+                    shorter input",
+                "type": "internal_error",
+                "param": null,
+                "code": "unknown",
+            }
+        })
+        .to_string();
+        let err = GatewayUpstreamError::from_upstream(400, &body);
+        assert_eq!(
+            err.status, 400,
+            "4xx must propagate as 4xx so the SDK does not retry it"
+        );
+        assert!(
+            err.message
+                .contains("load the model with a larger context length"),
+            "actual upstream message must reach the user, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.starts_with('{'),
+            "raw JSON envelope must be unwrapped to error.message"
+        );
+    }
+
+    #[test]
+    fn gateway_upstream_error_falls_back_to_raw_body_when_unparseable() {
+        // Plain-text upstream body (not JSON-shaped) must still reach the
+        // user; we never silently drop it.
+        let err = GatewayUpstreamError::from_upstream(500, "upstream went boom");
+        assert_eq!(
+            err.status, 502,
+            "5xx upstream collapses to 502 (Bad Gateway) for the SDK"
+        );
+        assert_eq!(err.message, "upstream went boom");
+
+        // Empty body still produces a useful message instead of a blank string.
+        let err = GatewayUpstreamError::from_upstream(503, "");
+        assert!(
+            err.message.contains("503") && err.message.contains("no body"),
+            "empty body fallback must mention the status, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn gateway_upstream_error_internal_uses_502() {
+        // Local failures (couldn't even reach upstream) are 502 — distinct
+        // from a parsed-from-upstream 5xx, but converging on the same code
+        // is fine because both indicate "Claudette gateway can't satisfy
+        // this request right now".
+        let err = GatewayUpstreamError::internal("could not bind socket");
+        assert_eq!(err.status, 502);
+        assert_eq!(err.message, "could not bind socket");
     }
 }

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -206,7 +206,7 @@ pub async fn delete_agent_backend(
 ) -> Result<Vec<AgentBackendConfig>, String> {
     if matches!(
         backend_id.as_str(),
-        "anthropic" | "ollama" | "openai-api" | "codex-subscription"
+        "anthropic" | "ollama" | "openai-api" | "codex-subscription" | "lm-studio"
     ) {
         return Err("Built-in backends can be disabled but not deleted".to_string());
     }
@@ -481,7 +481,9 @@ async fn hydrate_gateway_models_for_runtime(
 ) -> Result<(), String> {
     if !matches!(
         backend.kind,
-        AgentBackendKind::OpenAiApi | AgentBackendKind::CodexSubscription
+        AgentBackendKind::OpenAiApi
+            | AgentBackendKind::CodexSubscription
+            | AgentBackendKind::LmStudio
     ) {
         return Ok(());
     }
@@ -524,6 +526,7 @@ fn apply_discovered_models(backend: &mut AgentBackendConfig, discovered: Vec<Age
         AgentBackendKind::Ollama
             | AgentBackendKind::OpenAiApi
             | AgentBackendKind::CodexSubscription
+            | AgentBackendKind::LmStudio
     ) && !discovered.is_empty()
     {
         backend.manual_models.clear();
@@ -584,6 +587,7 @@ fn default_backends() -> Vec<AgentBackendConfig> {
         AgentBackendConfig::builtin_ollama(),
         AgentBackendConfig::builtin_openai_api(),
         AgentBackendConfig::builtin_codex_subscription(),
+        AgentBackendConfig::builtin_lm_studio(),
     ]
 }
 
@@ -654,6 +658,7 @@ fn normalize_backend(mut backend: AgentBackendConfig) -> AgentBackendConfig {
         AgentBackendKind::Ollama
             | AgentBackendKind::OpenAiApi
             | AgentBackendKind::CodexSubscription
+            | AgentBackendKind::LmStudio
     ) {
         backend.model_discovery = true;
     }
@@ -748,6 +753,7 @@ async fn discover_models(backend: &AgentBackendConfig) -> Result<Vec<AgentBacken
         }
         AgentBackendKind::OpenAiApi => discover_openai_api_models(backend).await,
         AgentBackendKind::CodexSubscription => discover_codex_models().await,
+        AgentBackendKind::LmStudio => discover_lm_studio_models(backend).await,
         _ => Ok(backend.manual_models.clone()),
     }
 }
@@ -803,6 +809,90 @@ async fn discover_openai_api_models(
         &value,
         backend.context_window_default,
     )))
+}
+
+async fn discover_lm_studio_models(
+    backend: &AgentBackendConfig,
+) -> Result<Vec<AgentBackendModel>, String> {
+    let base = backend
+        .base_url
+        .as_deref()
+        .unwrap_or("http://localhost:1234")
+        .trim_end_matches('/');
+    let secret = load_secure_secret(SECRET_BUCKET, &backend.id)
+        .ok()
+        .flatten();
+    let client = reqwest::Client::new();
+
+    // Prefer LM Studio's native v0 endpoint, which exposes per-model
+    // max_context_length / loaded_context_length. Fall back to the OpenAI-shaped
+    // /v1/models if v0 is missing (older or stripped builds).
+    let mut v0_request = client.get(format!("{base}/api/v0/models"));
+    if let Some(secret) = secret.as_deref().filter(|s| !s.trim().is_empty()) {
+        v0_request = v0_request.bearer_auth(secret);
+    }
+    let v0_response = v0_request.send().await;
+    if let Ok(response) = v0_response
+        && response.status().is_success()
+        && let Ok(value) = response.json::<Value>().await
+    {
+        let models = lm_studio_models_from_v0(&value, backend.context_window_default);
+        if !models.is_empty() {
+            return Ok(models);
+        }
+    }
+
+    let mut v1_request = client.get(openai_api_url(base, "models"));
+    if let Some(secret) = secret.as_deref().filter(|s| !s.trim().is_empty()) {
+        v1_request = v1_request.bearer_auth(secret);
+    }
+    let value = v1_request
+        .send()
+        .await
+        .map_err(|e| format!("Failed to query LM Studio: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("LM Studio model discovery failed: {e}"))?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("Invalid LM Studio model response: {e}"))?;
+    Ok(models_from_openai_shape(
+        &value,
+        backend.context_window_default,
+    ))
+}
+
+fn lm_studio_models_from_v0(value: &Value, default_context: u32) -> Vec<AgentBackendModel> {
+    value
+        .get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|model| {
+            let id = model.get("id").and_then(Value::as_str)?;
+            // Skip embedding/vision-only entries — they aren't usable as chat
+            // backends for the agent loop. Everything else (LLM, instruct,
+            // unknown) is fair game.
+            if model
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| kind.eq_ignore_ascii_case("embeddings"))
+            {
+                return None;
+            }
+            let context = model
+                .get("loaded_context_length")
+                .or_else(|| model.get("max_context_length"))
+                .and_then(Value::as_u64)
+                .and_then(|n| u32::try_from(n).ok())
+                .unwrap_or(default_context);
+            Some(AgentBackendModel {
+                id: id.to_string(),
+                label: id.to_string(),
+                context_window_tokens: context,
+                discovered: true,
+            })
+        })
+        .collect()
 }
 
 async fn discover_codex_models() -> Result<Vec<AgentBackendModel>, String> {
@@ -1011,6 +1101,7 @@ fn backend_kind_hash_key(kind: AgentBackendKind) -> &'static str {
         AgentBackendKind::CodexSubscription => "codex_subscription",
         AgentBackendKind::CustomAnthropic => "custom_anthropic",
         AgentBackendKind::CustomOpenAi => "custom_openai",
+        AgentBackendKind::LmStudio => "lm_studio",
     }
 }
 
@@ -1202,6 +1293,29 @@ fn gateway_auth_matches(header: &str, auth_token: &str) -> bool {
     })
 }
 
+// LM Studio's local server accepts any bearer token, so its API-key field is
+// optional — substitute a stable placeholder when the user hasn't set one.
+// Every other gateway-routed backend (OpenAI, custom OpenAI-shaped) still
+// requires a real key.
+fn openai_compatible_bearer_token(
+    kind: AgentBackendKind,
+    secret: Option<&str>,
+) -> Result<String, String> {
+    match (kind, secret) {
+        (AgentBackendKind::LmStudio, Some(s)) if !s.trim().is_empty() => Ok(s.to_string()),
+        (AgentBackendKind::LmStudio, _) => Ok("lm-studio".to_string()),
+        (_, Some(s)) => Ok(s.to_string()),
+        (_, None) => Err("OpenAI-compatible backend requires an API key".to_string()),
+    }
+}
+
+fn openai_compatible_default_base(kind: AgentBackendKind) -> &'static str {
+    match kind {
+        AgentBackendKind::LmStudio => "http://localhost:1234",
+        _ => "https://api.openai.com",
+    }
+}
+
 async fn call_openai_responses(
     config: &AgentBackendConfig,
     secret: Option<&str>,
@@ -1210,11 +1324,11 @@ async fn call_openai_responses(
     if config.kind == AgentBackendKind::CodexSubscription {
         return call_codex_responses(config, secret, anthropic_req).await;
     }
-    let secret = secret.ok_or("OpenAI-compatible backend requires an API key")?;
+    let secret = openai_compatible_bearer_token(config.kind, secret)?;
     let base = config
         .base_url
         .as_deref()
-        .unwrap_or("https://api.openai.com")
+        .unwrap_or_else(|| openai_compatible_default_base(config.kind))
         .trim_end_matches('/');
     let model = openai_compatible_request_model(config, &anthropic_req)?;
     let openai_req = json!({
@@ -1948,6 +2062,10 @@ mod tests {
             backend_kind_hash_key(AgentBackendKind::CustomOpenAi),
             "custom_openai"
         );
+        assert_eq!(
+            backend_kind_hash_key(AgentBackendKind::LmStudio),
+            "lm_studio"
+        );
     }
 
     #[test]
@@ -2365,5 +2483,103 @@ data: [DONE]
         assert!(body.contains(
             r#""delta":{"partial_json":"{\"path\":\"README.md\"}","type":"input_json_delta"}"#
         ));
+    }
+
+    #[test]
+    fn lm_studio_builtin_defaults_match_local_server() {
+        let backend = AgentBackendConfig::builtin_lm_studio();
+        assert_eq!(backend.id, "lm-studio");
+        assert_eq!(backend.kind, AgentBackendKind::LmStudio);
+        assert!(backend.kind.needs_gateway());
+        assert!(!backend.kind.is_anthropic_compatible());
+        assert_eq!(
+            backend.base_url.as_deref(),
+            Some("http://localhost:1234"),
+            "URL must match LM Studio's stock `lms server start --port 1234` default"
+        );
+        assert!(backend.model_discovery);
+        assert!(!backend.enabled, "Disabled by default until user opts in");
+    }
+
+    #[test]
+    fn lm_studio_v0_parser_reads_per_model_context_lengths() {
+        // Sample shape from `GET /api/v0/models` on LM Studio 0.4+.
+        let payload = json!({
+            "data": [
+                {
+                    "id": "qwen2.5-coder-7b-instruct",
+                    "type": "llm",
+                    "loaded_context_length": 32_768,
+                    "max_context_length": 131_072,
+                },
+                {
+                    "id": "llama-3.2-3b-instruct",
+                    "type": "llm",
+                    "max_context_length": 8_192,
+                },
+                {
+                    "id": "nomic-embed-text-v1.5",
+                    "type": "embeddings",
+                    "max_context_length": 8_192,
+                },
+            ]
+        });
+        let models = lm_studio_models_from_v0(&payload, 4_096);
+        assert_eq!(models.len(), 2, "embedding entries must be filtered out");
+        assert_eq!(models[0].id, "qwen2.5-coder-7b-instruct");
+        assert_eq!(
+            models[0].context_window_tokens, 32_768,
+            "loaded_context_length wins over max_context_length when both are present"
+        );
+        assert_eq!(models[1].id, "llama-3.2-3b-instruct");
+        assert_eq!(models[1].context_window_tokens, 8_192);
+    }
+
+    #[test]
+    fn lm_studio_v0_parser_falls_back_to_default_context_when_missing() {
+        let payload = json!({
+            "data": [{"id": "model-without-context", "type": "llm"}]
+        });
+        let models = lm_studio_models_from_v0(&payload, 8_192);
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].context_window_tokens, 8_192);
+    }
+
+    #[test]
+    fn openai_compatible_bearer_token_makes_lm_studio_secret_optional() {
+        // LM Studio: missing or blank secret falls back to a placeholder so the
+        // request still carries a valid Bearer header.
+        assert_eq!(
+            openai_compatible_bearer_token(AgentBackendKind::LmStudio, None).as_deref(),
+            Ok("lm-studio")
+        );
+        assert_eq!(
+            openai_compatible_bearer_token(AgentBackendKind::LmStudio, Some("")).as_deref(),
+            Ok("lm-studio")
+        );
+        assert_eq!(
+            openai_compatible_bearer_token(AgentBackendKind::LmStudio, Some("   ")).as_deref(),
+            Ok("lm-studio")
+        );
+        assert_eq!(
+            openai_compatible_bearer_token(AgentBackendKind::LmStudio, Some("user-token"))
+                .as_deref(),
+            Ok("user-token"),
+            "user-supplied bearer must be forwarded as-is"
+        );
+
+        // OpenAI: missing secret is still a hard error.
+        assert!(openai_compatible_bearer_token(AgentBackendKind::OpenAiApi, None).is_err());
+
+        // Default base URL also branches by kind so LM Studio doesn't get
+        // pointed at api.openai.com when its base_url is unset.
+        assert_eq!(
+            openai_compatible_default_base(AgentBackendKind::LmStudio),
+            "http://localhost:1234"
+        );
+        assert_eq!(
+            openai_compatible_default_base(AgentBackendKind::OpenAiApi),
+            "https://api.openai.com"
+        );
     }
 }

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -491,7 +491,15 @@ async fn hydrate_gateway_models_for_runtime(
     let selected_is_known = model
         .map(|model| backend_models_contain(backend, model))
         .unwrap_or(true);
-    if has_models && selected_is_known {
+    // LM Studio's loaded_context_length changes every time the user
+    // reloads the model with a different context slider, so we can't
+    // trust a cached discovery response here — the pre-flight gate uses
+    // that value as ground truth. Always re-discover on the chat-send
+    // hot path; it's a single GET to localhost (typically <50ms) and a
+    // stale cache means the user sees a 4k-context error after they
+    // already reloaded the model with 256k.
+    let force_refresh = matches!(backend.kind, AgentBackendKind::LmStudio);
+    if !force_refresh && has_models && selected_is_known {
         return Ok(());
     }
 
@@ -1090,6 +1098,20 @@ fn runtime_hash(config: &AgentBackendConfig, secret: Option<&str>, model: Option
     config.model_discovery.hash(&mut hasher);
     model.hash(&mut hasher);
     secret.unwrap_or("").hash(&mut hasher);
+    // Fingerprint the per-model context windows so a fresh discovery that
+    // bumps `loaded_context_length` (LM Studio reload with a new slider)
+    // forces the gateway to respawn with the new snapshot. Without this
+    // the gateway's pre-flight check would keep using the stale context
+    // size baked into the running task. id+context is enough — label and
+    // discovered-flag don't affect runtime behaviour.
+    for entry in config
+        .discovered_models
+        .iter()
+        .chain(config.manual_models.iter())
+    {
+        entry.id.hash(&mut hasher);
+        entry.context_window_tokens.hash(&mut hasher);
+    }
     format!("{:016x}", hasher.finish())
 }
 
@@ -2217,6 +2239,28 @@ mod tests {
         let c = runtime_hash(&backend, Some("two"), Some("glm"));
         assert_ne!(a, b);
         assert_ne!(b, c);
+    }
+
+    #[test]
+    fn runtime_hash_changes_when_discovered_context_window_changes() {
+        // Regression: LM Studio's loaded_context_length changes when the
+        // user reloads a model with a different context slider. The
+        // gateway must respawn on that change so the pre-flight check
+        // doesn't keep using the stale context size.
+        let mut backend = AgentBackendConfig::builtin_lm_studio();
+        backend.discovered_models = vec![AgentBackendModel {
+            id: "qwen3.6-35b-a3b-ud-mlx".to_string(),
+            label: "qwen3.6-35b-a3b-ud-mlx".to_string(),
+            context_window_tokens: 4096,
+            discovered: true,
+        }];
+        let small = runtime_hash(&backend, None, Some("qwen3.6-35b-a3b-ud-mlx"));
+        backend.discovered_models[0].context_window_tokens = 262_144;
+        let large = runtime_hash(&backend, None, Some("qwen3.6-35b-a3b-ud-mlx"));
+        assert_ne!(
+            small, large,
+            "context-window change must rotate the hash so ensure() respawns the gateway"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -1560,12 +1560,13 @@ fn gateway_auth_matches(header: &str, auth_token: &str) -> bool {
     })
 }
 
-// All currently-supported gateway backends (OpenAi, Codex, CustomOpenAi)
-// require a real API key. LM Studio used to land here too, with a
-// placeholder-bearer fallback, but it left the gateway path entirely once
-// it shipped native /v1/messages support — its placeholder logic now
-// lives in `discover_lm_studio_models` and the runtime env-var setup in
-// `resolve_backend_runtime`.
+// Gateway backends that go through the OpenAI-Responses translation
+// path (OpenAi, Codex, CustomOpenAi) require a real API key — they
+// hit api.openai.com or chatgpt.com and need real auth. LM Studio is
+// also gateway-routed but takes the Anthropic-shape pass-through in
+// `proxy_anthropic_messages` instead of this helper, and its
+// local-first placeholder-bearer logic lives there + in
+// `discover_lm_studio_models` (where it's actually exercised).
 fn openai_compatible_bearer_token(secret: Option<&str>) -> Result<String, String> {
     secret
         .map(str::to_string)

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -1577,27 +1577,20 @@ fn gateway_auth_matches(header: &str, auth_token: &str) -> bool {
     })
 }
 
-// LM Studio's local server accepts any bearer token, so its API-key field is
-// optional — substitute a stable placeholder when the user hasn't set one.
-// Every other gateway-routed backend (OpenAI, custom OpenAI-shaped) still
-// requires a real key.
-fn openai_compatible_bearer_token(
-    kind: AgentBackendKind,
-    secret: Option<&str>,
-) -> Result<String, String> {
-    match (kind, secret) {
-        (AgentBackendKind::LmStudio, Some(s)) if !s.trim().is_empty() => Ok(s.to_string()),
-        (AgentBackendKind::LmStudio, _) => Ok("lm-studio".to_string()),
-        (_, Some(s)) => Ok(s.to_string()),
-        (_, None) => Err("OpenAI-compatible backend requires an API key".to_string()),
-    }
+// All currently-supported gateway backends (OpenAi, Codex, CustomOpenAi)
+// require a real API key. LM Studio used to land here too, with a
+// placeholder-bearer fallback, but it left the gateway path entirely once
+// it shipped native /v1/messages support — its placeholder logic now
+// lives in `discover_lm_studio_models` and the runtime env-var setup in
+// `resolve_backend_runtime`.
+fn openai_compatible_bearer_token(secret: Option<&str>) -> Result<String, String> {
+    secret
+        .map(str::to_string)
+        .ok_or_else(|| "OpenAI-compatible backend requires an API key".to_string())
 }
 
-fn openai_compatible_default_base(kind: AgentBackendKind) -> &'static str {
-    match kind {
-        AgentBackendKind::LmStudio => "http://localhost:1234",
-        _ => "https://api.openai.com",
-    }
+fn openai_compatible_default_base(_kind: AgentBackendKind) -> &'static str {
+    "https://api.openai.com"
 }
 
 /// Approximate the prompt+tools size and compare against the backend's
@@ -1651,7 +1644,7 @@ async fn call_openai_responses(
     if config.kind == AgentBackendKind::CodexSubscription {
         return call_codex_responses(config, secret, anthropic_req).await;
     }
-    let secret = openai_compatible_bearer_token(config.kind, secret)?;
+    let secret = openai_compatible_bearer_token(secret)?;
     let base = config
         .base_url
         .as_deref()
@@ -2953,39 +2946,29 @@ data: [DONE]
     }
 
     #[test]
-    fn openai_compatible_bearer_token_makes_lm_studio_secret_optional() {
-        // LM Studio: missing or blank secret falls back to a placeholder so the
-        // request still carries a valid Bearer header.
+    fn openai_compatible_bearer_token_requires_a_real_secret() {
+        // Every gateway backend that reaches `call_openai_responses`
+        // (OpenAi, Codex, CustomOpenAi) requires a real API key — the
+        // gateway does not substitute placeholders. LM Studio's
+        // local-first placeholder lives in the LM Studio code path
+        // (which is direct-routed and never enters this helper).
         assert_eq!(
-            openai_compatible_bearer_token(AgentBackendKind::LmStudio, None).as_deref(),
-            Ok("lm-studio")
-        );
-        assert_eq!(
-            openai_compatible_bearer_token(AgentBackendKind::LmStudio, Some("")).as_deref(),
-            Ok("lm-studio")
-        );
-        assert_eq!(
-            openai_compatible_bearer_token(AgentBackendKind::LmStudio, Some("   ")).as_deref(),
-            Ok("lm-studio")
-        );
-        assert_eq!(
-            openai_compatible_bearer_token(AgentBackendKind::LmStudio, Some("user-token"))
-                .as_deref(),
+            openai_compatible_bearer_token(Some("user-token")).as_deref(),
             Ok("user-token"),
             "user-supplied bearer must be forwarded as-is"
         );
+        assert!(openai_compatible_bearer_token(None).is_err());
 
-        // OpenAI: missing secret is still a hard error.
-        assert!(openai_compatible_bearer_token(AgentBackendKind::OpenAiApi, None).is_err());
-
-        // Default base URL also branches by kind so LM Studio doesn't get
-        // pointed at api.openai.com when its base_url is unset.
-        assert_eq!(
-            openai_compatible_default_base(AgentBackendKind::LmStudio),
-            "http://localhost:1234"
-        );
+        // Default base URL still defined for compatibility with the
+        // existing call site, but we no longer branch by kind because
+        // every remaining gateway-routed backend that uses this default
+        // points at the OpenAI API.
         assert_eq!(
             openai_compatible_default_base(AgentBackendKind::OpenAiApi),
+            "https://api.openai.com"
+        );
+        assert_eq!(
+            openai_compatible_default_base(AgentBackendKind::CustomOpenAi),
             "https://api.openai.com"
         );
     }

--- a/src/agent_backend.rs
+++ b/src/agent_backend.rs
@@ -11,6 +11,7 @@ pub enum AgentBackendKind {
     CustomAnthropic,
     #[serde(rename = "custom_openai")]
     CustomOpenAi,
+    LmStudio,
 }
 
 impl AgentBackendKind {
@@ -21,7 +22,7 @@ impl AgentBackendKind {
     pub fn needs_gateway(self) -> bool {
         matches!(
             self,
-            Self::OpenAiApi | Self::CodexSubscription | Self::CustomOpenAi
+            Self::OpenAiApi | Self::CodexSubscription | Self::CustomOpenAi | Self::LmStudio
         )
     }
 }
@@ -160,6 +161,27 @@ impl AgentBackendConfig {
             auth_ref: Some("codex-cli".to_string()),
             capabilities: AgentBackendCapabilities::gateway(),
             context_window_default: 400_000,
+            model_discovery: true,
+            has_secret: false,
+        }
+    }
+
+    pub fn builtin_lm_studio() -> Self {
+        Self {
+            id: "lm-studio".to_string(),
+            label: "LM Studio".to_string(),
+            kind: AgentBackendKind::LmStudio,
+            base_url: Some("http://localhost:1234".to_string()),
+            enabled: false,
+            default_model: None,
+            manual_models: Vec::new(),
+            discovered_models: Vec::new(),
+            auth_ref: Some("agent-backend:lm-studio".to_string()),
+            capabilities: AgentBackendCapabilities::gateway(),
+            // Most LM Studio loadouts default to a 4-8k context window; pick a
+            // safer floor than the OpenAI-style 400k. Per-model values from
+            // /api/v0/models override this when discovery succeeds.
+            context_window_default: 8_192,
             model_discovery: true,
             has_secret: false,
         }

--- a/src/agent_backend.rs
+++ b/src/agent_backend.rs
@@ -16,13 +16,26 @@ pub enum AgentBackendKind {
 
 impl AgentBackendKind {
     pub fn is_anthropic_compatible(self) -> bool {
-        matches!(self, Self::Anthropic | Self::Ollama | Self::CustomAnthropic)
+        // LM Studio 0.4.1+ implements `/v1/messages` natively — same
+        // Anthropic wire format Ollama uses — so we route the spawned
+        // claude CLI directly at it via ANTHROPIC_BASE_URL instead of
+        // running an in-process gateway that translates Anthropic ↔
+        // OpenAI Responses. The direct path is dramatically faster
+        // (native SSE streaming pass-through, no buffer-then-translate
+        // round trip, KV-cache prefix matching works) and doesn't need
+        // any of our gateway error-classification work — LM Studio
+        // already returns Anthropic-shaped errors. See lm-studio.mdx
+        // for the architecture comparison.
+        matches!(
+            self,
+            Self::Anthropic | Self::Ollama | Self::CustomAnthropic | Self::LmStudio
+        )
     }
 
     pub fn needs_gateway(self) -> bool {
         matches!(
             self,
-            Self::OpenAiApi | Self::CodexSubscription | Self::CustomOpenAi | Self::LmStudio
+            Self::OpenAiApi | Self::CodexSubscription | Self::CustomOpenAi
         )
     }
 }

--- a/src/agent_backend.rs
+++ b/src/agent_backend.rs
@@ -16,26 +16,32 @@ pub enum AgentBackendKind {
 
 impl AgentBackendKind {
     pub fn is_anthropic_compatible(self) -> bool {
-        // LM Studio 0.4.1+ implements `/v1/messages` natively — same
-        // Anthropic wire format Ollama uses — so we route the spawned
-        // claude CLI directly at it via ANTHROPIC_BASE_URL instead of
-        // running an in-process gateway that translates Anthropic ↔
-        // OpenAI Responses. The direct path is dramatically faster
-        // (native SSE streaming pass-through, no buffer-then-translate
-        // round trip, KV-cache prefix matching works) and doesn't need
-        // any of our gateway error-classification work — LM Studio
-        // already returns Anthropic-shaped errors. See lm-studio.mdx
-        // for the architecture comparison.
-        matches!(
-            self,
-            Self::Anthropic | Self::Ollama | Self::CustomAnthropic | Self::LmStudio
-        )
+        matches!(self, Self::Anthropic | Self::Ollama | Self::CustomAnthropic)
     }
 
     pub fn needs_gateway(self) -> bool {
+        // LM Studio 0.4.1+ implements `/v1/messages` natively (same
+        // Anthropic wire format Ollama uses), so we *could* point the
+        // spawned claude CLI directly at it. But LM Studio classifies
+        // hard input errors like context-window overflow as HTTP 500
+        // with an Anthropic-shaped body whose `error.type` is
+        // `api_error`. That's a transient classification — Anthropic's
+        // SDK retries it with exponential backoff — so a permanent
+        // input failure ends up as a multi-minute spinner with no
+        // surfaced error, even though the upstream message is right
+        // there.
+        //
+        // Routing LM Studio through our gateway gives us a place to
+        // demote those mis-classified 5xx responses to 4xx (via
+        // `GatewayUpstreamError::from_upstream` +
+        // `upstream_message_is_permanent_failure`). The gateway
+        // forwards 2xx bodies through unchanged so streaming events
+        // still flow without translation overhead — only the error
+        // path gets rewritten. See `proxy_anthropic_messages` and the
+        // matching test fixtures.
         matches!(
             self,
-            Self::OpenAiApi | Self::CodexSubscription | Self::CustomOpenAi
+            Self::OpenAiApi | Self::CodexSubscription | Self::CustomOpenAi | Self::LmStudio
         )
     }
 }

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getVersion } from "@tauri-apps/api/app";
 import { useAppStore } from "./stores/useAppStore";
-import { loadInitialData, getAppSetting, getHostEnvFlags, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, detectInstalledApps, listSystemFonts, deleteTerminalTab, listAppSettingsWithPrefix, listAgentBackends, bootOk } from "./services/tauri";
+import { loadInitialData, getAppSetting, getHostEnvFlags, listRemoteConnections, listDiscoveredServers, getLocalServerStatus, detectInstalledApps, listSystemFonts, deleteTerminalTab, listAppSettingsWithPrefix, listAgentBackends, refreshAgentBackendModels, bootOk } from "./services/tauri";
 import { applyTheme, applyUserFonts, loadAllThemes, findTheme, cacheThemePreference, getThemeDataAttr } from "./utils/theme";
 import { DEFAULT_THEME_ID, DEFAULT_LIGHT_THEME_ID } from "./styles/themes";
 import type { ThemeDefinition } from "./types/theme";
@@ -71,6 +71,13 @@ function App() {
   const setAlternativeBackendsEnabled = useAppStore((s) => s.setAlternativeBackendsEnabled);
   const setAgentBackends = useAppStore((s) => s.setAgentBackends);
   const setDefaultAgentBackendId = useAppStore((s) => s.setDefaultAgentBackendId);
+  // Live polling readers — used to keep LM Studio's loaded_context_length
+  // accurate without making the user click Settings → Refresh whenever
+  // they change the context-length slider in LM Studio's UI.
+  const agentBackends = useAppStore((s) => s.agentBackends);
+  const alternativeBackendsEnabled = useAppStore(
+    (s) => s.alternativeBackendsEnabled,
+  );
   const setVoiceToggleHotkey = useAppStore((s) => s.setVoiceToggleHotkey);
   const setVoiceHoldHotkey = useAppStore((s) => s.setVoiceHoldHotkey);
   const setKeybindings = useAppStore((s) => s.setKeybindings);
@@ -728,6 +735,53 @@ function App() {
       unlistenMissingCli.then((fn) => fn());
     };
   }, [setRepositories, setWorkspaces, setWorktreeBaseDir, setDefaultTerminalAppId, setDefaultBranches, setTerminalFontSize, setLastMessages, setRemoteConnections, setDiscoveredServers, setLocalServerRunning, setLocalServerConnectionString, setCurrentThemeId, setThemeMode, setThemeDark, setThemeLight, setUiFontSize, setFontFamilySans, setFontFamilyMono, setSystemFonts, setDetectedApps, setUsageInsightsEnabled, setClaudetteTerminalEnabled, setShowSidebarRunningCommands, setToolDisplayMode, setExtendedToolCallOutput, setPluginManagementEnabled, setClaudeRemoteControlEnabled, setCommunityRegistryEnabled, setAlternativeBackendsAvailable, setAlternativeBackendsEnabled, setAgentBackends, setDefaultAgentBackendId, setEditorGitGutterBase, setEditorMinimapEnabled, setDisable1mContext, setAppVersion, setVoiceToggleHotkey, setVoiceHoldHotkey, setKeybindings, setManualWorkspaceOrderByRepo]);
+
+  // Live freshness for LM Studio's `loaded_context_length`.
+  //
+  // LM Studio is the one backend whose per-model context window can change
+  // at any time — the user drags the Context Length slider in LM Studio's
+  // UI, hits "Reload model", and the same model id now reports a different
+  // loaded context. We need that change reflected in the composer's
+  // capacity indicator and in the gateway pre-flight without making the
+  // user click Settings → Refresh.
+  //
+  // Strategy: while at least one LM Studio backend is enabled, poll
+  // `refreshAgentBackendModels` for each one every 8 s. That command runs
+  // discovery, persists the fresh discovered_models to the DB, and
+  // returns the updated config — which we splice into the Zustand store
+  // so every consumer (model registry, ContextMeter, SegmentedMeter,
+  // ContextPopover, ModelSelector) sees the live value.
+  //
+  // Cost: one localhost GET per LM Studio backend per 8 s. Discovery
+  // round-trip is sub-50 ms in practice. We don't poll OpenAI / Codex —
+  // their context windows are immutable so the initial fetch suffices.
+  useEffect(() => {
+    if (!alternativeBackendsEnabled) return;
+    const lmStudioBackends = agentBackends
+      .filter((b) => b.kind === "lm_studio" && b.enabled)
+      .map((b) => b.id);
+    if (lmStudioBackends.length === 0) return;
+    let cancelled = false;
+    const tick = async () => {
+      for (const id of lmStudioBackends) {
+        if (cancelled) return;
+        try {
+          const refreshed = await refreshAgentBackendModels(id);
+          if (cancelled) return;
+          setAgentBackends(refreshed);
+        } catch {
+          // LM Studio not running, model not loaded, etc. — silent.
+          // The ChatPanel surfaces the friendly "backend unreachable"
+          // banner separately when the user actually tries to send.
+        }
+      }
+    };
+    const timer = window.setInterval(tick, 8_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [alternativeBackendsEnabled, agentBackends, setAgentBackends]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -71,10 +71,10 @@ function App() {
   const setAlternativeBackendsEnabled = useAppStore((s) => s.setAlternativeBackendsEnabled);
   const setAgentBackends = useAppStore((s) => s.setAgentBackends);
   const setDefaultAgentBackendId = useAppStore((s) => s.setDefaultAgentBackendId);
-  // Live polling readers — used to keep LM Studio's loaded_context_length
-  // accurate without making the user click Settings → Refresh whenever
-  // they change the context-length slider in LM Studio's UI.
-  const agentBackends = useAppStore((s) => s.agentBackends);
+  // Read for the LM Studio polling effect below. We deliberately do
+  // *not* subscribe to `agentBackends` here — the polling tick reads
+  // the live list via `useAppStore.getState()` so we don't tear the
+  // interval down whenever the list updates.
   const alternativeBackendsEnabled = useAppStore(
     (s) => s.alternativeBackendsEnabled,
   );
@@ -755,15 +755,24 @@ function App() {
   // Cost: one localhost GET per LM Studio backend per 8 s. Discovery
   // round-trip is sub-50 ms in practice. We don't poll OpenAI / Codex —
   // their context windows are immutable so the initial fetch suffices.
+  //
+  // Important: read the *current* backend list from the Zustand store
+  // inside `tick` (via `useAppStore.getState()`), not from the captured
+  // `agentBackends` snapshot. Putting `agentBackends` in the dep list
+  // would tear the interval down and recreate it on every successful
+  // tick (because each tick calls `setAgentBackends`, which produces a
+  // new array reference) — leading to canceled in-flight requests and
+  // missed refreshes. The effect now only re-runs when the experimental
+  // flag flips.
   useEffect(() => {
     if (!alternativeBackendsEnabled) return;
-    const lmStudioBackends = agentBackends
-      .filter((b) => b.kind === "lm_studio" && b.enabled)
-      .map((b) => b.id);
-    if (lmStudioBackends.length === 0) return;
     let cancelled = false;
     const tick = async () => {
-      for (const id of lmStudioBackends) {
+      const live = useAppStore.getState().agentBackends;
+      const ids = live
+        .filter((b) => b.kind === "lm_studio" && b.enabled)
+        .map((b) => b.id);
+      for (const id of ids) {
         if (cancelled) return;
         try {
           const refreshed = await refreshAgentBackendModels(id);
@@ -781,7 +790,7 @@ function App() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [alternativeBackendsEnabled, agentBackends, setAgentBackends]);
+  }, [alternativeBackendsEnabled, setAgentBackends]);
 
   // Listen for OS light/dark changes and switch theme when mode is "system".
   useEffect(() => {

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -764,9 +764,19 @@ function App() {
   // new array reference) — leading to canceled in-flight requests and
   // missed refreshes. The effect now only re-runs when the experimental
   // flag flips.
+  //
+  // Self-scheduling `setTimeout` instead of `setInterval` so the next
+  // tick is only queued *after* the current one resolves. With
+  // `setInterval`, a slow refresh (overloaded LM Studio, multiple
+  // backends, slow disk on the secret-store read) would let multiple
+  // ticks run concurrently, race `setAgentBackends`, and hammer the
+  // backend's `refresh_agent_backend_models` DB writer. The await-then-
+  // schedule pattern makes the period a *floor* (always ≥8 s between
+  // tick starts) rather than a ceiling.
   useEffect(() => {
     if (!alternativeBackendsEnabled) return;
     let cancelled = false;
+    let timer: number | null = null;
     const tick = async () => {
       const live = useAppStore.getState().agentBackends;
       const ids = live
@@ -784,11 +794,14 @@ function App() {
           // banner separately when the user actually tries to send.
         }
       }
+      if (!cancelled) {
+        timer = window.setTimeout(tick, 8_000);
+      }
     };
-    const timer = window.setInterval(tick, 8_000);
+    timer = window.setTimeout(tick, 8_000);
     return () => {
       cancelled = true;
-      window.clearInterval(timer);
+      if (timer !== null) window.clearTimeout(timer);
     };
   }, [alternativeBackendsEnabled, setAgentBackends]);
 

--- a/src/ui/src/components/settings/alternativeBackendCleanup.test.ts
+++ b/src/ui/src/components/settings/alternativeBackendCleanup.test.ts
@@ -59,4 +59,19 @@ describe("isAlternativeBackendSelection", () => {
   it("treats unknown Anthropic-provider models as unsafe when the feature is off", () => {
     expect(isAlternativeBackendSelection("future-gpt", "anthropic")).toBe(true);
   });
+
+  it("treats lm-studio sessions as alternative so the cleanup walker resets them", () => {
+    expect(isAlternativeBackendSelection("qwen2.5-coder-7b-instruct", "lm-studio")).toBe(true);
+
+    // And the planner picks them up alongside ollama / codex sessions.
+    const plan = planAlternativeBackendDisableCleanup({
+      defaultModel: "opus",
+      defaultBackend: "anthropic",
+      sessionModels: [["model:sess-1", "qwen2.5-coder-7b-instruct"]],
+      sessionProviders: [["model_provider:sess-1", "lm-studio"]],
+      selectedModels: {},
+      selectedProviders: {},
+    });
+    expect(plan.sessionIds).toContain("sess-1");
+  });
 });

--- a/src/ui/src/components/settings/backendSettingsErrors.test.ts
+++ b/src/ui/src/components/settings/backendSettingsErrors.test.ts
@@ -48,4 +48,20 @@ describe("formatBackendError", () => {
 
     expect(message).toBe("OpenAI API backend requires an API key in Settings -> Models");
   });
+
+  it("turns unreachable LM Studio into an actionable hint pointing at `lms server start`", () => {
+    const message = formatBackendError(
+      "Failed to query LM Studio: error sending request for url (http://localhost:1234/api/v0/models)",
+      backend({
+        id: "lm-studio",
+        label: "LM Studio",
+        kind: "lm_studio",
+        base_url: "http://localhost:1234",
+      }),
+    );
+
+    expect(message).toBe(
+      "LM Studio is not reachable at http://localhost:1234. Run `lms server start` or update the Base URL.",
+    );
+  });
 });

--- a/src/ui/src/components/settings/backendSettingsErrors.ts
+++ b/src/ui/src/components/settings/backendSettingsErrors.ts
@@ -5,6 +5,7 @@ function backendBaseUrl(backend: AgentBackendConfig): string | null {
   if (backend.base_url?.trim()) return backend.base_url.trim();
   if (backend.kind === "ollama") return "http://localhost:11434";
   if (backend.kind === "openai_api") return "https://api.openai.com";
+  if (backend.kind === "lm_studio") return "http://localhost:1234";
   return null;
 }
 
@@ -15,8 +16,14 @@ export function formatBackendError(error: unknown, backend: AgentBackendConfig):
   if (
     lower.includes("error sending request for url") ||
     lower.includes("connection refused") ||
-    lower.includes("failed to query ollama")
+    lower.includes("failed to query ollama") ||
+    lower.includes("failed to query lm studio")
   ) {
+    if (backend.kind === "lm_studio") {
+      return baseUrl
+        ? `LM Studio is not reachable at ${baseUrl}. Run \`lms server start\` or update the Base URL.`
+        : "LM Studio is not reachable. Run `lms server start` and try again.";
+    }
     return baseUrl
       ? `${backend.label} is not reachable at ${baseUrl}. Start the service or update the Base URL.`
       : `${backend.label} is not reachable. Check the provider and try again.`;

--- a/src/ui/src/components/settings/sections/ModelSettings.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.tsx
@@ -652,6 +652,7 @@ function isDiscoveryBackend(backend: AgentBackendConfig) {
     backend.model_discovery ||
     backend.kind === "ollama" ||
     backend.kind === "openai_api" ||
-    backend.kind === "codex_subscription"
+    backend.kind === "codex_subscription" ||
+    backend.kind === "lm_studio"
   );
 }

--- a/src/ui/src/locales/en/settings.json
+++ b/src/ui/src/locales/en/settings.json
@@ -339,7 +339,7 @@
   "experimental_usage_desc": "Show usage data from your Claude Code subscription (session limits, weekly limits, extra usage). Requires a Pro or Max plan with standard login.",
   "experimental_usage_aria": "Usage Insights",
   "experimental_alternative_backends": "Alternative Claude Code backends",
-  "experimental_alternative_backends_desc": "Expose Ollama, OpenAI-compatible, and custom backends through the Claude Code harness.",
+  "experimental_alternative_backends_desc": "Expose Ollama, LM Studio, OpenAI-compatible, and custom backends through the Claude Code harness.",
   "experimental_alternative_backends_aria": "Alternative Claude Code backends",
 
   "plugins_title": "Plugins",

--- a/src/ui/src/locales/es/settings.json
+++ b/src/ui/src/locales/es/settings.json
@@ -203,7 +203,7 @@
   "experimental_usage_desc": "Muestra los datos de uso de tu suscripción a Claude Code (límites de sesión, límites semanales, uso adicional). Requiere un plan Pro o Max con inicio de sesión estándar.",
   "experimental_usage_aria": "Información de uso",
   "experimental_alternative_backends": "Backends alternativos de Claude Code",
-  "experimental_alternative_backends_desc": "Expone Ollama, proveedores compatibles con OpenAI y backends personalizados mediante el arnés de Claude Code.",
+  "experimental_alternative_backends_desc": "Expone Ollama, LM Studio, proveedores compatibles con OpenAI y backends personalizados mediante el arnés de Claude Code.",
   "experimental_alternative_backends_aria": "Backends alternativos de Claude Code",
   "plugins_title": "Complementos",
   "plugins_loading": "Cargando…",

--- a/src/ui/src/locales/ja/settings.json
+++ b/src/ui/src/locales/ja/settings.json
@@ -203,7 +203,7 @@
   "experimental_usage_desc": "Claude Code サブスクリプションの利用状況（セッション制限、週次制限、追加利用）を表示します。標準ログインの Pro または Max プランが必要です。",
   "experimental_usage_aria": "利用状況インサイト",
   "experimental_alternative_backends": "Claude Code の代替バックエンド",
-  "experimental_alternative_backends_desc": "Ollama、OpenAI 互換プロバイダー、カスタムバックエンドを Claude Code ハーネス経由で公開します。",
+  "experimental_alternative_backends_desc": "Ollama、LM Studio、OpenAI 互換プロバイダー、カスタムバックエンドを Claude Code ハーネス経由で公開します。",
   "experimental_alternative_backends_aria": "Claude Code の代替バックエンド",
   "plugins_title": "プラグイン",
   "plugins_loading": "読み込み中…",

--- a/src/ui/src/locales/pt-BR/settings.json
+++ b/src/ui/src/locales/pt-BR/settings.json
@@ -203,7 +203,7 @@
   "experimental_usage_desc": "Mostra dados de uso da sua assinatura do Claude Code (limites de sessão, limites semanais, uso adicional). Requer um plano Pro ou Max com login padrão.",
   "experimental_usage_aria": "Insights de uso",
   "experimental_alternative_backends": "Backends alternativos do Claude Code",
-  "experimental_alternative_backends_desc": "Expõe Ollama, provedores compatíveis com OpenAI e backends personalizados por meio do harness do Claude Code.",
+  "experimental_alternative_backends_desc": "Expõe Ollama, LM Studio, provedores compatíveis com OpenAI e backends personalizados por meio do harness do Claude Code.",
   "experimental_alternative_backends_aria": "Backends alternativos do Claude Code",
   "plugins_title": "Plugins",
   "plugins_loading": "Carregando…",

--- a/src/ui/src/locales/zh-CN/settings.json
+++ b/src/ui/src/locales/zh-CN/settings.json
@@ -203,7 +203,7 @@
   "experimental_usage_desc": "显示来自 Claude Code 订阅的用量数据（会话限制、每周限制、额外用量）。需要使用标准登录的 Pro 或 Max 计划。",
   "experimental_usage_aria": "用量洞察",
   "experimental_alternative_backends": "Claude Code 替代后端",
-  "experimental_alternative_backends_desc": "通过 Claude Code harness 暴露 Ollama、OpenAI 兼容提供方和自定义后端。",
+  "experimental_alternative_backends_desc": "通过 Claude Code harness 暴露 Ollama、LM Studio、OpenAI 兼容提供方和自定义后端。",
   "experimental_alternative_backends_aria": "Claude Code 替代后端",
   "plugins_title": "插件",
   "plugins_loading": "加载中…",

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -62,7 +62,8 @@ export type AgentBackendKind =
   | "openai_api"
   | "codex_subscription"
   | "custom_anthropic"
-  | "custom_openai";
+  | "custom_openai"
+  | "lm_studio";
 
 export interface AgentBackendCapabilities {
   thinking: boolean;


### PR DESCRIPTION
## Summary

Adds **LM Studio** as a fifth alternative agent backend. LM Studio 0.4.1+ implements the Anthropic Messages API natively at `/v1/messages`, so we route through Claudette's in-process gateway with a thin **Anthropic-shape pass-through**: 2xx responses stream through verbatim (no translation, no buffering, native streaming preserved), and non-2xx responses are intercepted to fix LM Studio's mis-classification of context-overflow errors as HTTP 500. End-to-end verified: `qwen3.6-35b-a3b-ud-mlx` `ping` produces a clean assistant response with proper streaming and surfaces overflow errors immediately at HTTP 400 instead of triggering the SDK's retry-with-backoff path.

## Commits

| Commit | What it does |
|---|---|
| [`f88bb43d`](../commit/f88bb43d) `feat(backends): add LM Studio as a fifth alternative backend` | Initial backend kind, model discovery via `/api/v0/models`, optional API key, docs page, locale strings. Originally landed via OpenAI-Responses translation gateway. |
| [`e218d0b9`](../commit/e218d0b9) `fix(backends): surface upstream gateway errors with correct HTTP status` | Replace `error_for_status()` with body-aware error parsing; introduce `GatewayUpstreamError { status, message }`; route 4xx upstream → 4xx outbound (`invalid_request_error`) so SDK fails fast on permanent input errors. |
| [`099c1bfa`](../commit/099c1bfa) `fix(backends): demote 5xx context-overflow errors to 400 + add prompt pre-flight` | Pattern-match upstream messages and demote LM Studio's misclassified-as-500 input errors to 400. Add a pre-flight token estimate that rejects obvious overflow before round-tripping to the upstream. |
| [`55f33e5e`](../commit/55f33e5e) `fix(backends): refresh LM Studio context window on every chat send` | `runtime_hash` fingerprints `(model_id, context_window_tokens)`; `hydrate_gateway_models_for_runtime` force-refreshes for LM Studio. |
| [`6d0cc263`](../commit/6d0cc263) `feat(backends): live-poll LM Studio context window + persist mid-session changes` | App.tsx polls `refreshAgentBackendModels` every 8s for each enabled LM Studio backend; persists fresh discoveries to DB. |
| [`b4adee10`](../commit/b4adee10) `feat(backends): route LM Studio through native /v1/messages instead of gateway` | First pivot attempt: direct routing via `ANTHROPIC_BASE_URL=http://localhost:1234`. Reverted in `a15fb38a` after the HTTP 500 mis-classification problem resurfaced. |
| [`7662246f`](../commit/7662246f) `fix(backends): address Copilot review findings` | 8 findings: granular 4xx → Anthropic error type mapping, body truncation helper, sorted model fingerprints, polling-effect dep fix, LM Studio discovery placeholder bearer, secret-store error logging. |
| [`43461401`](../commit/43461401) `fix(backends): address Copilot follow-up review on the pivoted code` | 6 follow-up findings: setTimeout polling overlap fix, dead-code cleanup, docs alignment with the (now-superseded) direct-routing pivot. |
| [`a15fb38a`](../commit/a15fb38a) `fix(backends): route LM Studio back through gateway with /v1/messages pass-through` | **Architectural correction**: LM Studio back through the gateway, but with a new `proxy_anthropic_messages` handler that forwards Anthropic bodies verbatim, streams 2xx responses through unchanged, and only intercepts non-2xx to fix status codes. Best of both worlds: streaming TTFT + reliable error surfacing. |
| [`a4b3e4d1`](../commit/a4b3e4d1) `docs(lm-studio): describe gateway pass-through architecture` | Bring the LM Studio + providers index docs in line with `a15fb38a`. |

## What's new — LM Studio backend

```
claude CLI ──► [Claudette gateway] ──► http://localhost:1234/v1/messages
                  │                          │
                  │ pass through 2xx bytes   │
                  │ verbatim (streaming)     │
                  │                          │
                  └─ rewrite 5xx-with-       │
                     permanent-failure       │
                     message → 4xx           │
                                             │
                                          LM Studio 0.4.1+ native
                                          Anthropic Messages API
```

Per-backend defaults:
- **Default base URL**: `http://localhost:1234` (matching `lms server start`'s default port).
- **API key is optional** (Ollama-style local-first UX). Placeholder `"lm-studio"` substituted when blank.
- **Model discovery prefers `/api/v0/models`** for richer metadata (`loaded_context_length`, `max_context_length`, `state`, `capabilities`); falls back to `/v1/models` for older builds.
- **Default context window** is `8_192` (per-model values from `/api/v0/models` override).
- **`embeddings` models filtered out** of the picker.
- **Force-refresh discovered models on every chat send** so the live `loaded_context_length` flows into the runtime hash + composer indicator without a manual refresh.
- **Frontend polls `/api/v0/models` every 8s** (self-scheduling `setTimeout`, no overlap) while at least one LM Studio backend is enabled, so a context-slider change in LM Studio's UI is reflected within ~8s.
- **`CLAUDE_CODE_ATTRIBUTION_HEADER=0`** set for both LM Studio and Ollama. The header's rotating value invalidates KV-cache prefix matching on every request — [documented ~90% perf regression](https://www.roborhythms.com/stop-claude-code-slowing-local-llm-by-90/) on local backends.

Gating reuses the existing alternative-backends Cargo feature and the `alternativeBackendsEnabled` experimental flag. Capabilities match Ollama's local-first profile (tools + vision; thinking / effort / fast / 1M hidden).

## Why the architecture went through three iterations

1. **OpenAI-Responses gateway** (commit `f88bb43d` and successors): full Anthropic ↔ OpenAI `/v1/responses` translation. Worked but had two structural problems — translation overhead buffered the full response (lost TTFT), and we had to add elaborate error-classification machinery (`GatewayUpstreamError`, message-pattern-based 5xx → 400 demotion, pre-flight token check) just to surface upstream errors LM Studio would have returned in Anthropic shape natively.

2. **Direct routing** (commit `b4adee10`): `ANTHROPIC_BASE_URL=http://localhost:1234`, no gateway. Got native streaming for free, but lost the status-code translation. **LM Studio returns HTTP 500 for context-overflow** with an Anthropic-shape body whose `error.type` is `api_error` — the SDK reads that as transient and retries with backoff. Users got multi-minute spinners with no surfaced error even though the upstream message was right there.

3. **Anthropic pass-through gateway** (commit `a15fb38a`, current): back through the gateway, but with a new `proxy_anthropic_messages` handler instead of OpenAI-Responses translation. 2xx flows through verbatim (preserves TTFT — same as direct routing), non-2xx gets the status-code fix (same as the original gateway). Best of both worlds.

A pinned regression test (`lm_studio_routing_classification_pinned`) makes sure a future refactor can't silently flip LM Studio back to direct routing without realizing the trade-off.

## Behaviour change — call out for review

- **OpenAI / Codex / CustomOpenAi**: every non-2xx upstream now surfaces with the parsed `error.message` instead of a generic `OpenAI request failed`; granular 4xx → Anthropic error-type mapping (401 → `authentication_error`, 403 → `permission_error`, 404 → `not_found_error`, 413 → `request_too_large`, 429 → `rate_limit_error`, other 4xx → `invalid_request_error`); 5xx with permanent-failure-shaped messages demotes to 400; generic 5xx still 502 + `api_error` (still retried).
- **LM Studio**: routed via the gateway with Anthropic-shape pass-through (NOT OpenAI-Responses translation). Same status-code routing as OpenAI / Codex on errors; 2xx flows through verbatim. Streaming SSE events arrive in the CLI as LM Studio produces them.
- **Ollama**: gains `CLAUDE_CODE_ATTRIBUTION_HEADER=0` env var for the KV-cache reuse perf win.
- **No DB migration**: existing `lm-studio` backend configs in `app_settings` work unchanged.

## Tests

```
cargo test -p claudette-tauri agent_backends
test result: ok. 43 passed; 0 failed
```

Test highlights:
- `lm_studio_builtin_defaults_match_local_server` — LM Studio `needs_gateway() == true`, `is_anthropic_compatible() == false`. Comments explain why "wire-compatible with Anthropic" is not the same as `is_anthropic_compatible()` (the latter means *direct* routing).
- `lm_studio_routing_classification_pinned` — full backend-kind matrix; comments warn against flipping to direct routing.
- `gateway_upstream_error_promotes_5xx_context_overflow_to_400` — exact LM Studio response shape demoted correctly.
- `upstream_message_permanent_failure_classifier_recognises_known_phrases` — table-driven coverage.
- `preflight_context_window_check_rejects_obvious_overflow` / `_skips_when_window_unknown` — pre-flight gate.
- `runtime_hash_changes_when_discovered_context_window_changes` — context-window change rotates gateway hash.
- `anthropic_error_type_for_routes_status_codes` — granular 4xx mapping.
- `truncate_for_error_message_caps_runaway_payloads` — 512-byte cap, multibyte-safe.
- `backend_models_signature` is order-independent (sorts before collecting).

End-to-end driven through the Claudette dev app:

1. Killed running dev app, rebuilt with the pivoted code, relaunched via `scripts/dev.sh`.
2. Created a fresh test workspace, sent `ping` via `claudette chat send` with `--model qwen3.6-35b-a3b-ud-mlx`.
3. LM Studio server log confirms `Received request: POST to /v1/messages` (not `/v1/responses`).
4. `GET /api/v0/models` log entries every ~8s confirm the live polling.
5. Assistant response delivered cleanly. Context-overflow error (when the model is loaded with too small a window) surfaces in the chat UI within ~1s as `API Error: 400 ...` instead of triggering an SDK retry storm.

Coverage: `cargo test -p claudette --all-features` and `bunx tsc -b` clean. Format + clippy clean on the modified Rust code (the existing pre-existing clippy errors in `claudette-tauri` are unrelated and not in CI's lint scope per `CLAUDE.md`).

## Docs

- `site/src/content/docs/features/providers/lm-studio.mdx`:
  - Lead and "How requests flow" describe the gateway pass-through.
  - "Pick a context length that fits Claude Code" section with recommended-floor table.
  - "Why not direct routing like Ollama?" subsection: HTTP 500 mis-classification rationale.
  - "Why not the OpenAI Responses gateway?" subsection: translation overhead + lost streaming.
  - Troubleshooting entries for the 400 pre-flight error, auto-refresh polling, attribution-header perf gotcha.
- `site/src/content/docs/features/providers/index.mdx`: two-flavor gateway description (OpenAI-Responses translation vs Anthropic pass-through).
- Sidebar registration in `site/astro.config.mjs`.
- Capability matrix updates: `agent-configuration.mdx`, `experimental-features.mdx`, `authentication.mdx`, `FeatureCards.astro`, `README.md`.
- Locale strings (`en`, `es`, `ja`, `pt-BR`, `zh-CN`).

## Try it

1. `lms server start --port 1234` (LM Studio 0.4.1+) and load a model. **Drag the Context Length slider to at least 64k** before reloading — Claude Code's prompt + tools won't fit at the 4k default.
2. Enable `alternativeBackendsEnabled` in Claudette's experimental settings.
3. Settings → Backends → enable LM Studio. URL pre-filled to `http://localhost:1234`. API key field can stay blank.
4. Discovered models appear with their live `loaded_context_length`. Pick one in the chat header.
5. Send a message — gateway forwards `/v1/messages` straight through; tokens stream in as LM Studio produces them.

If the loaded context is too small, the gateway pre-flight returns an instant 400 with `Approx N tokens of input vs M tokens of context for <model>. Reload the model in LM Studio with a larger context length` — no retry storm, no spinner.

## Feature-flag isolation audit

All new behaviour is gated behind `alternative_backends_enabled`:
- `resolve_backend_runtime` short-circuits to Anthropic-only when the flag isn't set — gateway spawn, env-var setup, and the `proxy_anthropic_messages` dispatch all live inside that gate.
- Frontend poll has explicit `if (!alternativeBackendsEnabled) return;` and additionally filters to `kind === "lm_studio" && enabled`.
- Anthropic-only users (the default) pay zero runtime cost: no gateway spawned, no env vars added, no polling fired, no LM Studio code paths reachable.

## Branch note

Originally `james-brink/ollama-codex-llm-studio`, renamed to `feat/ollama-codex-llm-studio`. Forks at `59dfd958` (the merge base with `main`); rebase onto current `main` before merging if you want the SAPI-5.4 voice and `UNUserNotificationCenter` notification commits in the same release.
