### PR TITLE
fix(windows): editor gutter CRLF, settings drag-region click offset, NSIS install defaults

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -71,6 +71,12 @@
       "minimumSystemVersion": "11.0",
       "entitlements": "Entitlements.plist",
       "infoPlist": "Info.plist"
+    },
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser",
+        "displayLanguageSelector": false
+      }
     }
   },
   "plugins": {

--- a/src/ui/src/components/file-viewer/gitGutter.test.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.test.ts
@@ -63,6 +63,30 @@ describe("computeLineChanges", () => {
     const changes = computeLineChanges("a\nb\n", "");
     expect(changes).toEqual([{ line: 1, kind: "delete-above" }]);
   });
+
+  // Regression: on Windows the working-tree buffer is typically CRLF while
+  // the git blob returned by `read_workspace_file_at_revision` is LF. Without
+  // CRLF normalization `diffLines` would mark every line as `modify`, painting
+  // a solid blue stripe down the entire gutter. See gitGutter.ts::stripCr.
+  it("treats CRLF buffer vs LF head as unchanged when content matches", () => {
+    const head = "alpha\nbeta\ngamma\n";
+    const buffer = "alpha\r\nbeta\r\ngamma\r\n";
+    expect(computeLineChanges(head, buffer)).toEqual([]);
+  });
+
+  it("only marks the genuinely-modified line when CRLF and LF mix", () => {
+    const head = "alpha\nbeta\ngamma\n";
+    const buffer = "alpha\r\nBETA\r\ngamma\r\n";
+    expect(computeLineChanges(head, buffer)).toEqual([
+      { line: 2, kind: "modify" },
+    ]);
+  });
+
+  it("normalizes CRLF on the head side too (defensive)", () => {
+    const head = "alpha\r\nbeta\r\n";
+    const buffer = "alpha\nbeta\n";
+    expect(computeLineChanges(head, buffer)).toEqual([]);
+  });
 });
 
 // Minimal Monaco stub for the Range constructor and the

--- a/src/ui/src/components/file-viewer/gitGutter.ts
+++ b/src/ui/src/components/file-viewer/gitGutter.ts
@@ -22,7 +22,14 @@ export interface LineChange {
  * An `added` chunk not preceded by a `removed` chunk is a pure addition.
  */
 export function computeLineChanges(head: string, buffer: string): LineChange[] {
-  const chunks = diffLines(head, buffer);
+  // Normalize line endings before diffing. On Windows the working-tree buffer
+  // is typically CRLF (e.g. `core.autocrlf=true` checkout) while `git show`
+  // returns the blob verbatim — usually LF. Without this normalization every
+  // line differs by `\r` and `diffLines` would mark the entire file as
+  // modified, painting a solid blue stripe down the gutter.
+  const headLf = stripCr(head);
+  const bufferLf = stripCr(buffer);
+  const chunks = diffLines(headLf, bufferLf);
   const changes: LineChange[] = [];
 
   // Track the 1-based line number in the *buffer* as we walk chunks. Lines
@@ -77,6 +84,17 @@ export function computeLineChanges(head: string, buffer: string): LineChange[] {
   }
 
   return changes;
+}
+
+/**
+ * Strip `\r` from `\r\n` sequences so CRLF normalizes to LF. Bare `\r`
+ * (legacy Mac) is left alone — it would alter line counts and is rare
+ * enough that we'd rather show a real diff than silently coalesce it.
+ */
+function stripCr(s: string): string {
+  // No `\r` at all is the common case (LF or empty); skip the allocation.
+  if (s.indexOf("\r") === -1) return s;
+  return s.replace(/\r\n/g, "\n");
 }
 
 function countLines(s: string): number {

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -6,13 +6,22 @@
   position: relative;
 }
 
+/* macOS-only: fills the 38px overlay-title-bar gap so the user can drag the
+   window from the area above the sidebar back-link. On Windows/Linux the
+   native title bar already handles dragging, and rendering this overlay
+   would sit on top of (and steal clicks from) the back-link button. */
 .dragRegion {
+  display: none;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   height: 38px;
   z-index: 1;
+}
+
+[data-platform="mac"] .dragRegion {
+  display: block;
 }
 
 /* ── Settings sidebar ── */


### PR DESCRIPTION
Three Windows-only polish fixes bundled together since they share a platform-specific theme. Each is independently small and reviewable; grouping keeps the user-visible "Windows feels weird" pile collapsing in one PR.

## 1. Monaco git gutter painted every line as "modified" (solid blue stripe)

**Symptom:** Open any file on Windows → entire gutter is a continuous blue stripe, even when the file is unmodified.

**Root cause:** `git show <rev>:<path>` (called from `useGitGutter` → `read_workspace_file_at_revision`) returns the blob verbatim — typically **LF**. The working-tree buffer Monaco edits is **CRLF** on Windows whenever `core.autocrlf=true` (Git for Windows default). `diffLines()` is byte-exact, so every line differs by `\r` and `gitGutter::computeLineChanges` marks the whole file `modify`.

**Fix:** `src/ui/src/components/file-viewer/gitGutter.ts` — normalize both sides via a new `stripCr` helper before `diffLines()`. Bare `\r` (legacy Mac) is intentionally left intact: coalescing it would alter line counts, and it's rare enough that we'd rather show a real diff than silently merge lines. `stripCr` short-circuits via `indexOf("\r")` so the common LF case allocates nothing.

**Tests:** 3 new regression cases in `gitGutter.test.ts`:
- CRLF buffer vs LF head, identical content → `[]`
- CRLF buffer vs LF head, one modified line → only that line marked
- LF buffer vs CRLF head → `[]` (defensive symmetry)

## 2. Settings "← Back to app" had a ~38px hit-target offset on Windows

**Symptom:** Clicking visibly on the "Back to app" link in Settings did nothing on Windows. The actual clickable area was offset ~38px below the visible text.

**Root cause:** `SettingsPage.tsx:124` unconditionally renders a 38px-tall absolute overlay with `data-tauri-drag-region` (`z-index: 1`) at the top of the container. `Settings.module.css:30` only padded the sidebar (`padding-top: 38px`) under `[data-platform="mac"]`, so on Windows the back-link button sat directly under the drag overlay. Clicks on the visible text hit the drag region (which on Windows is a real DOM-level swallowing layer, unlike macOS where the OS handles it). The actual button was reachable only ~38px below the rendered text.

**Fix:** `src/ui/src/components/settings/Settings.module.css` — gate the overlay to mac via CSS:

```css
.dragRegion { display: none; /* …existing positioning… */ }
[data-platform="mac"] .dragRegion { display: block; }
```

The overlay only exists to fill the gap left by macOS `titleBarStyle: "Overlay"`. On Windows/Linux the native title bar handles window dragging. Keeping the JSX render unconditional avoids any layout shift on a platform-attribute change; only the click-stealing layer drops on non-mac.

## 3. NSIS installer — Start Menu shortcut presents as "Claudette"

**Goal stated in the issue:** Installer should call the app "Claudette" in Start Menu while keeping the binary name `claudette-app.exe` and the CLI sidecar (`claudette.exe`) installed alongside.

**Audit result:** Already correct end-to-end. Tauri's bundled NSIS template names the shortcut `${PRODUCTNAME}.lnk` (`tauri-bundler-2.9.1/.../installer.nsi:945`), and `productName` is `"Claudette"`. So:

- Start Menu shortcut: `%AppData%\Microsoft\Windows\Start Menu\Programs\Claudette.lnk` → `%LOCALAPPDATA%\Claudette\claudette-app.exe` ✓
- Add/Remove Programs entry: "Claudette" ✓
- Install path: `%LOCALAPPDATA%\Claudette\` ✓
- CLI sidecar: `claudette.exe` shipped alongside via existing `externalBin` config ✓
- Binary name: unchanged (`claudette-app.exe`) per request ✓

**Negative finding:** Tauri 2.11.1 has no `bundle.windows.nsis.shortcutName` field — the shortcut name is always derived from `productName`, no override exists. Confirmed against `tauri-cli-2.11.1/schema.json`.

**Change:** `src-tauri/tauri.conf.json` — added explicit `installMode: "currentUser"` and `displayLanguageSelector: false` defaults under `bundle.windows.nsis`. Both match Tauri's current defaults; the value is having a documented anchor for future installer tweaks (e.g. flipping to `perMachine`, adding NSIS hooks) rather than relying on Tauri defaults silently changing across upgrades.

**Not in scope (declined during planning):** overriding the .exe's embedded `FileDescription` resource so users pinning the bare zip-extracted `claudette-app.exe` to Start see "Claudette" instead of the filename. Requires Cargo metadata plumbing; deferred.

## Files

- `src/ui/src/components/file-viewer/gitGutter.ts` — `stripCr` + use in `computeLineChanges`
- `src/ui/src/components/file-viewer/gitGutter.test.ts` — 3 CRLF regression tests
- `src/ui/src/components/settings/Settings.module.css` — `.dragRegion` mac-gated
- `src-tauri/tauri.conf.json` — explicit `bundle.windows.nsis` defensive defaults

## Validation

- `bunx tsc -b` — clean
- `bun run lint:css` — clean (token check + Monaco font-stack drift check)
- `bun run test -- file-viewer settings --run` — 137/137 pass (16 test files)
- `cargo tauri info` — config parses cleanly

## Regression risk

- **Gutter normalization:** Behavior change only when input contains `\r\n`. LF-only inputs are bit-identical (`indexOf` short-circuits, no allocation, no replace). Existing tests still pass unchanged.
- **Drag region:** macOS path is byte-identical (CSS `display: block` is the layout default). Linux/Windows lose the overlay — fine, they don't use `titleBarStyle: "Overlay"` so no gap to fill. Window-drag still works via native title bar.
- **NSIS config:** Both new keys match Tauri's documented defaults; behavior is unchanged on a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
