### PR TITLE
fix(backends): tolerate unknown backend variants in stored settings

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -101,7 +101,7 @@ Several chat-header toggles on this page only apply to certain providers. The ca
 
 ### Forward/backward compat: warning banner in Models
 
-If you switch between build channels (e.g. nightly → stable, or run two builds against the same data directory), a newer build can write a backend entry whose `kind` an older build doesn't recognize yet. When that happens, **Settings → Models** shows an orange-tinted warning banner naming the offending entry — your config isn't lost. The unknown entry is preserved as opaque JSON in your settings and reactivates automatically on a build that knows it. Saves from the older build splice the unknown entry back into the stored blob, so a downgrade-and-re-upgrade cycle is non-destructive.
+If you switch between build channels (e.g. nightly → stable, or run two builds against the same data directory), a newer build can write a backend entry whose `kind` an older build doesn't recognize yet. When that happens, **Settings → Models** shows an accent-tinted warning banner (the exact color depends on the active theme) naming the offending entry — your config isn't lost. The unknown entry is preserved as opaque JSON in your settings and reactivates automatically on a build that knows it. Saves from the older build splice the unknown entry back into the stored blob, so a downgrade-and-re-upgrade cycle is non-destructive.
 
 ## File References (@-mentions)
 

--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -99,6 +99,10 @@ Several chat-header toggles on this page only apply to certain providers. The ca
 
 → Full setup, capability matrix, and per-provider instructions: **[Alternative Providers](/claudette/features/providers/)**
 
+### Forward/backward compat: warning banner in Models
+
+If you switch between build channels (e.g. nightly → stable, or run two builds against the same data directory), a newer build can write a backend entry whose `kind` an older build doesn't recognize yet. When that happens, **Settings → Models** shows an orange-tinted warning banner naming the offending entry — your config isn't lost. The unknown entry is preserved as opaque JSON in your settings and reactivates automatically on a build that knows it. Saves from the older build splice the unknown entry back into the stored blob, so a downgrade-and-re-upgrade cycle is non-destructive.
+
 ## File References (@-mentions)
 
 Type `@` in the chat input to reference specific files in your workspace. A file picker appears showing matching files — select one to include it as context for the agent.

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -49,6 +49,14 @@ impl BackendStatus {
 pub struct BackendListResponse {
     pub backends: Vec<AgentBackendConfig>,
     pub default_backend_id: String,
+    /// Non-fatal diagnostics emitted while loading the persisted backend
+    /// list — e.g. a stored entry whose `kind` isn't recognized by this
+    /// build (forward/backward compat across dev channels). Surfaced to
+    /// the UI so the user knows their config wasn't fully applied, but
+    /// the loader still returns the valid entries instead of failing the
+    /// whole panel.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -175,9 +183,11 @@ pub async fn list_agent_backends(
         .get_app_setting("default_agent_backend")
         .map_err(|e| e.to_string())?
         .unwrap_or_else(|| "anthropic".to_string());
+    let loaded = load_backend_configs_tolerant(&db)?;
     Ok(BackendListResponse {
-        backends: load_backend_configs(&db)?,
+        backends: loaded.backends,
         default_backend_id,
+        warnings: loaded.warnings,
     })
 }
 
@@ -611,41 +621,145 @@ fn apply_discovered_models(backend: &mut AgentBackendConfig, discovered: Vec<Age
     backend.discovered_models = discovered;
 }
 
-fn load_backend_configs(db: &Database) -> Result<Vec<AgentBackendConfig>, String> {
+/// Result of a tolerant load: the active backend list, opaque
+/// passthrough entries that this build couldn't parse (preserved so
+/// they round-trip through `save_backend_configs`), and any warnings
+/// to surface to the UI.
+struct LoadedBackends {
+    backends: Vec<AgentBackendConfig>,
+    /// Stored entries this build did not understand — kept verbatim so
+    /// a downgrade-then-upgrade cycle (or two dev channels sharing the
+    /// SQLite DB) doesn't drop user-configured backends like LM Studio.
+    unknown_passthrough: Vec<Value>,
+    warnings: Vec<String>,
+}
+
+/// Tolerant variant: parses the stored backend list entry-by-entry so
+/// a single unknown variant (e.g. a `kind` this build doesn't know)
+/// downgrades to a warning instead of failing the whole settings load.
+///
+/// Two failure modes are guarded:
+///   1. The top-level JSON is unparseable — surfaces a single warning,
+///      preserves the raw blob untouched (we never overwrite a corrupt
+///      blob with defaults; the user's data stays recoverable), and
+///      returns the built-in defaults.
+///   2. An individual entry fails to deserialize — that one entry is
+///      stashed in `unknown_passthrough` and skipped from the active
+///      list. `save_backend_configs` splices it back on the next write.
+fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBackends, String> {
     let mut backends = default_backends();
+    let mut unknown_passthrough: Vec<Value> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
     if let Some(raw) = db
         .get_app_setting(SETTINGS_KEY)
         .map_err(|e| e.to_string())?
     {
-        for saved in serde_json::from_str::<Vec<AgentBackendConfig>>(&raw)
-            .map_err(|e| format!("Failed to parse backend settings: {e}"))?
-        {
-            if let Some(existing) = backends.iter_mut().find(|b| b.id == saved.id) {
-                *existing = normalize_backend(saved);
-            } else {
-                backends.push(normalize_backend(saved));
+        match serde_json::from_str::<Vec<Value>>(&raw) {
+            Ok(entries) => {
+                for entry in entries {
+                    match serde_json::from_value::<AgentBackendConfig>(entry.clone()) {
+                        Ok(saved) => {
+                            if let Some(existing) =
+                                backends.iter_mut().find(|b| b.id == saved.id)
+                            {
+                                *existing = normalize_backend(saved);
+                            } else {
+                                backends.push(normalize_backend(saved));
+                            }
+                        }
+                        Err(err) => {
+                            let id = entry
+                                .get("id")
+                                .and_then(Value::as_str)
+                                .unwrap_or("<no id>");
+                            let kind = entry
+                                .get("kind")
+                                .and_then(Value::as_str)
+                                .unwrap_or("<no kind>");
+                            warnings.push(format!(
+                                "Skipped backend entry id=`{id}` kind=`{kind}`: {err}. \
+                                 Entry preserved and will be reapplied on a build that supports it."
+                            ));
+                            tracing::warn!(
+                                target: "agent_backends",
+                                id, kind, error = %err,
+                                "tolerant load: preserving unknown backend entry as passthrough"
+                            );
+                            unknown_passthrough.push(entry);
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                warnings.push(format!(
+                    "Backend settings JSON is unreadable; using built-in defaults this session. \
+                     Stored value left untouched for recovery. ({err})"
+                ));
+                tracing::error!(
+                    target: "agent_backends",
+                    error = %err,
+                    "tolerant load: top-level JSON parse failed; falling back to defaults"
+                );
             }
         }
     }
+
     for backend in &mut backends {
         backend.has_secret = load_secure_secret(SECRET_BUCKET, &backend.id)
             .ok()
             .flatten()
             .is_some();
     }
-    Ok(backends)
+
+    Ok(LoadedBackends {
+        backends,
+        unknown_passthrough,
+        warnings,
+    })
+}
+
+fn load_backend_configs(db: &Database) -> Result<Vec<AgentBackendConfig>, String> {
+    Ok(load_backend_configs_tolerant(db)?.backends)
+}
+
+/// Re-read the stored JSON and return any entries this build can't
+/// deserialize. Used by `save_backend_configs` to splice unknown
+/// passthrough entries back into the persisted blob so they survive
+/// edits made by an older build.
+fn read_unknown_passthrough(db: &Database) -> Vec<Value> {
+    let Ok(Some(raw)) = db.get_app_setting(SETTINGS_KEY) else {
+        return Vec::new();
+    };
+    let Ok(entries) = serde_json::from_str::<Vec<Value>>(&raw) else {
+        // Top-level parse failed — passthrough is unsafe (we'd splice
+        // into an empty list and effectively wipe the corrupt blob).
+        // Returning empty here means save_backend_configs writes a
+        // clean list; the corrupt blob is acceptable to lose at the
+        // first user-initiated save.
+        return Vec::new();
+    };
+    entries
+        .into_iter()
+        .filter(|entry| serde_json::from_value::<AgentBackendConfig>(entry.clone()).is_err())
+        .collect()
 }
 
 fn save_backend_configs(db: &Database, backends: &[AgentBackendConfig]) -> Result<(), String> {
-    let persisted: Vec<_> = backends
+    let mut persisted: Vec<Value> = backends
         .iter()
         .filter(|backend| backend.id != "anthropic")
         .map(|backend| {
             let mut backend = backend.clone();
             backend.has_secret = false;
-            backend
+            serde_json::to_value(backend).map_err(|e| e.to_string())
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Splice unknown passthrough entries back so a build that doesn't
+    // recognize them doesn't quietly drop them on every save.
+    persisted.extend(read_unknown_passthrough(db));
+
     let raw = serde_json::to_string(&persisted).map_err(|e| e.to_string())?;
     db.set_app_setting(SETTINGS_KEY, &raw)
         .map_err(|e| e.to_string())
@@ -2507,6 +2621,144 @@ mod tests {
             context_window_tokens: 400_000,
             discovered: true,
         }
+    }
+
+    #[test]
+    fn tolerant_load_skips_unknown_kind_and_preserves_passthrough() {
+        // Simulates the reported breakage: a newer build wrote a
+        // `lm_studio` entry, an older build is now reading it. The
+        // unknown entry must NOT take down the rest of the panel —
+        // valid entries (and the built-in defaults) should still load.
+        let db = Database::open_in_memory().expect("test db should open");
+        let mut ollama = AgentBackendConfig::builtin_ollama();
+        ollama.enabled = true;
+        let mut ollama_value = serde_json::to_value(&ollama).expect("ollama serializes");
+        // Pollute the entry with a future-only field to also verify
+        // serde tolerates additive fields (it does, by default —
+        // deny_unknown_fields is not set on AgentBackendConfig).
+        ollama_value
+            .as_object_mut()
+            .expect("object")
+            .insert("future_only_field".to_string(), serde_json::json!(7));
+
+        let unknown_value = serde_json::json!({
+            "id": "future-thing",
+            "label": "Future Thing",
+            "kind": "totally_new_backend",
+            "enabled": true
+        });
+
+        let raw = serde_json::Value::Array(vec![ollama_value, unknown_value]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+
+        let loaded = load_backend_configs_tolerant(&db).expect("tolerant load should succeed");
+
+        // Ollama applied on top of the default.
+        let ollama = loaded
+            .backends
+            .iter()
+            .find(|b| b.id == "ollama")
+            .expect("ollama survived tolerant load");
+        assert!(ollama.enabled);
+
+        // Anthropic default still present (loader merges into defaults).
+        assert!(loaded.backends.iter().any(|b| b.id == "anthropic"));
+
+        // Unknown entry stashed for passthrough, not dropped.
+        assert_eq!(loaded.unknown_passthrough.len(), 1);
+        assert_eq!(
+            loaded.unknown_passthrough[0]
+                .get("id")
+                .and_then(Value::as_str),
+            Some("future-thing")
+        );
+
+        // User-visible warning names the offending id+kind.
+        assert_eq!(loaded.warnings.len(), 1);
+        let warning = &loaded.warnings[0];
+        assert!(
+            warning.contains("future-thing") && warning.contains("totally_new_backend"),
+            "warning should name the offending entry: {warning}"
+        );
+    }
+
+    #[test]
+    fn save_after_tolerant_load_round_trips_unknown_entry() {
+        // Regression guard: a downgrade-then-upgrade cycle must not lose
+        // the user's LM-Studio-style config. After an older build does a
+        // tolerant load and then saves edits, the unknown entry must
+        // still be present in SQLite for the newer build to pick up.
+        let db = Database::open_in_memory().expect("test db should open");
+        let raw = serde_json::json!([
+            {
+                "id": "future-thing",
+                "label": "Future Thing",
+                "kind": "totally_new_backend",
+                "enabled": true,
+                "some_future_field": 42
+            }
+        ]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+
+        // Older build loads, then saves an unrelated edit (toggling
+        // ollama on). The unknown entry should ride along.
+        let mut backends = load_backend_configs(&db).expect("tolerant load should succeed");
+        let ollama = backends
+            .iter_mut()
+            .find(|b| b.id == "ollama")
+            .expect("default ollama present");
+        ollama.enabled = true;
+        // The default `builtin_ollama` ships with empty discovered models,
+        // so save filters cleanly without needing extra fixture mutation.
+        save_backend_configs(&db, &backends).expect("save should succeed");
+
+        let stored_raw = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("stored value should read")
+            .expect("stored value should exist");
+        let stored: Vec<Value> =
+            serde_json::from_str(&stored_raw).expect("stored JSON should parse");
+
+        let preserved = stored
+            .iter()
+            .find(|entry| entry.get("id").and_then(Value::as_str) == Some("future-thing"))
+            .expect("unknown entry must round-trip through save");
+        assert_eq!(
+            preserved.get("kind").and_then(Value::as_str),
+            Some("totally_new_backend")
+        );
+        // Even unknown future-only fields are preserved verbatim.
+        assert_eq!(
+            preserved.get("some_future_field").and_then(Value::as_i64),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn tolerant_load_falls_back_when_top_level_json_is_garbage() {
+        // If the stored blob is corrupt (truncated write, hand-edit
+        // typo), the loader must not poison the panel — it returns
+        // built-in defaults plus a warning, and crucially does NOT
+        // overwrite the corrupt blob (so the user can recover it).
+        let db = Database::open_in_memory().expect("test db should open");
+        db.set_app_setting(SETTINGS_KEY, "{not valid json")
+            .expect("seed should save");
+
+        let loaded = load_backend_configs_tolerant(&db).expect("tolerant load should succeed");
+
+        assert!(loaded.backends.iter().any(|b| b.id == "anthropic"));
+        assert!(loaded.unknown_passthrough.is_empty());
+        assert_eq!(loaded.warnings.len(), 1);
+        assert!(loaded.warnings[0].contains("unreadable"));
+
+        // Corrupt blob untouched on read.
+        let still_there = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed")
+            .expect("value still stored");
+        assert_eq!(still_there, "{not valid json");
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -621,16 +621,14 @@ fn apply_discovered_models(backend: &mut AgentBackendConfig, discovered: Vec<Age
     backend.discovered_models = discovered;
 }
 
-/// Result of a tolerant load: the active backend list, opaque
-/// passthrough entries that this build couldn't parse (preserved so
-/// they round-trip through `save_backend_configs`), and any warnings
-/// to surface to the UI.
+/// Result of a tolerant load: the active backend list and any
+/// non-fatal diagnostics surfaced to the UI. Unknown passthrough
+/// entries are NOT carried on this struct — `save_backend_configs`
+/// re-reads them from the raw blob at write time so the field would
+/// be dead in production. Tests assert passthrough behavior by
+/// calling `read_unknown_passthrough` directly.
 struct LoadedBackends {
     backends: Vec<AgentBackendConfig>,
-    /// Stored entries this build did not understand — kept verbatim so
-    /// a downgrade-then-upgrade cycle (or two dev channels sharing the
-    /// SQLite DB) doesn't drop user-configured backends like LM Studio.
-    unknown_passthrough: Vec<Value>,
     warnings: Vec<String>,
 }
 
@@ -639,16 +637,18 @@ struct LoadedBackends {
 /// downgrades to a warning instead of failing the whole settings load.
 ///
 /// Two failure modes are guarded:
-///   1. The top-level JSON is unparseable — surfaces a single warning,
-///      preserves the raw blob untouched (we never overwrite a corrupt
-///      blob with defaults; the user's data stays recoverable), and
-///      returns the built-in defaults.
+///   1. The top-level JSON is unparseable — surfaces a single warning
+///      and returns the built-in defaults. The raw blob is left in
+///      place *on this read* so a user can recover it externally;
+///      the first subsequent user-initiated save will overwrite it
+///      (see [`read_unknown_passthrough`]).
 ///   2. An individual entry fails to deserialize — that one entry is
-///      stashed in `unknown_passthrough` and skipped from the active
-///      list. `save_backend_configs` splices it back on the next write.
+///      skipped from the active list but kept in the persisted JSON.
+///      `save_backend_configs` re-reads the raw blob and splices the
+///      unknown entry back on the next write so a downgrade-then-
+///      upgrade cycle is non-destructive.
 fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBackends, String> {
     let mut backends = default_backends();
-    let mut unknown_passthrough: Vec<Value> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
 
     if let Some(raw) = db
@@ -660,19 +660,14 @@ fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBackends, String
                 for entry in entries {
                     match serde_json::from_value::<AgentBackendConfig>(entry.clone()) {
                         Ok(saved) => {
-                            if let Some(existing) =
-                                backends.iter_mut().find(|b| b.id == saved.id)
-                            {
+                            if let Some(existing) = backends.iter_mut().find(|b| b.id == saved.id) {
                                 *existing = normalize_backend(saved);
                             } else {
                                 backends.push(normalize_backend(saved));
                             }
                         }
                         Err(err) => {
-                            let id = entry
-                                .get("id")
-                                .and_then(Value::as_str)
-                                .unwrap_or("<no id>");
+                            let id = entry.get("id").and_then(Value::as_str).unwrap_or("<no id>");
                             let kind = entry
                                 .get("kind")
                                 .and_then(Value::as_str)
@@ -686,7 +681,6 @@ fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBackends, String
                                 id, kind, error = %err,
                                 "tolerant load: preserving unknown backend entry as passthrough"
                             );
-                            unknown_passthrough.push(entry);
                         }
                     }
                 }
@@ -694,7 +688,7 @@ fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBackends, String
             Err(err) => {
                 warnings.push(format!(
                     "Backend settings JSON is unreadable; using built-in defaults this session. \
-                     Stored value left untouched for recovery. ({err})"
+                     Stored value left untouched for recovery on this read. ({err})"
                 ));
                 tracing::error!(
                     target: "agent_backends",
@@ -712,11 +706,7 @@ fn load_backend_configs_tolerant(db: &Database) -> Result<LoadedBackends, String
             .is_some();
     }
 
-    Ok(LoadedBackends {
-        backends,
-        unknown_passthrough,
-        warnings,
-    })
+    Ok(LoadedBackends { backends, warnings })
 }
 
 fn load_backend_configs(db: &Database) -> Result<Vec<AgentBackendConfig>, String> {
@@ -727,22 +717,27 @@ fn load_backend_configs(db: &Database) -> Result<Vec<AgentBackendConfig>, String
 /// deserialize. Used by `save_backend_configs` to splice unknown
 /// passthrough entries back into the persisted blob so they survive
 /// edits made by an older build.
-fn read_unknown_passthrough(db: &Database) -> Vec<Value> {
-    let Ok(Some(raw)) = db.get_app_setting(SETTINGS_KEY) else {
-        return Vec::new();
+///
+/// Returns `Err` on DB read failure so the caller surfaces the problem
+/// instead of silently dropping unknowns. Returns `Ok(empty)` when the
+/// stored blob is missing or its top-level JSON is unparseable —
+/// passthrough is unsafe in either case (no source-of-truth array to
+/// preserve), and the next save will write a clean list. This is the
+/// only documented path that overwrites a corrupt blob.
+fn read_unknown_passthrough(db: &Database) -> Result<Vec<Value>, String> {
+    let Some(raw) = db
+        .get_app_setting(SETTINGS_KEY)
+        .map_err(|e| e.to_string())?
+    else {
+        return Ok(Vec::new());
     };
     let Ok(entries) = serde_json::from_str::<Vec<Value>>(&raw) else {
-        // Top-level parse failed — passthrough is unsafe (we'd splice
-        // into an empty list and effectively wipe the corrupt blob).
-        // Returning empty here means save_backend_configs writes a
-        // clean list; the corrupt blob is acceptable to lose at the
-        // first user-initiated save.
-        return Vec::new();
+        return Ok(Vec::new());
     };
-    entries
+    Ok(entries
         .into_iter()
         .filter(|entry| serde_json::from_value::<AgentBackendConfig>(entry.clone()).is_err())
-        .collect()
+        .collect())
 }
 
 fn save_backend_configs(db: &Database, backends: &[AgentBackendConfig]) -> Result<(), String> {
@@ -757,8 +752,10 @@ fn save_backend_configs(db: &Database, backends: &[AgentBackendConfig]) -> Resul
         .collect::<Result<Vec<_>, _>>()?;
 
     // Splice unknown passthrough entries back so a build that doesn't
-    // recognize them doesn't quietly drop them on every save.
-    persisted.extend(read_unknown_passthrough(db));
+    // recognize them doesn't quietly drop them on every save. Errors
+    // here propagate — silently dropping unknowns on a transient DB
+    // read failure would defeat the whole point of the passthrough.
+    persisted.extend(read_unknown_passthrough(db)?);
 
     let raw = serde_json::to_string(&persisted).map_err(|e| e.to_string())?;
     db.set_app_setting(SETTINGS_KEY, &raw)
@@ -2665,12 +2662,11 @@ mod tests {
         // Anthropic default still present (loader merges into defaults).
         assert!(loaded.backends.iter().any(|b| b.id == "anthropic"));
 
-        // Unknown entry stashed for passthrough, not dropped.
-        assert_eq!(loaded.unknown_passthrough.len(), 1);
+        // Unknown entry observable via the read helper, not dropped.
+        let passthrough = read_unknown_passthrough(&db).expect("passthrough read should succeed");
+        assert_eq!(passthrough.len(), 1);
         assert_eq!(
-            loaded.unknown_passthrough[0]
-                .get("id")
-                .and_then(Value::as_str),
+            passthrough[0].get("id").and_then(Value::as_str),
             Some("future-thing")
         );
 
@@ -2749,7 +2745,11 @@ mod tests {
         let loaded = load_backend_configs_tolerant(&db).expect("tolerant load should succeed");
 
         assert!(loaded.backends.iter().any(|b| b.id == "anthropic"));
-        assert!(loaded.unknown_passthrough.is_empty());
+        let passthrough = read_unknown_passthrough(&db).expect("passthrough read should succeed");
+        assert!(
+            passthrough.is_empty(),
+            "corrupt top-level JSON has no recoverable passthrough"
+        );
         assert_eq!(loaded.warnings.len(), 1);
         assert!(loaded.warnings[0].contains("unreadable"));
 
@@ -2759,6 +2759,145 @@ mod tests {
             .expect("read should succeed")
             .expect("value still stored");
         assert_eq!(still_there, "{not valid json");
+    }
+
+    #[test]
+    fn save_after_corrupt_blob_writes_clean_list_and_loses_corrupt_value() {
+        // Documents the corrupt-blob save behavior explicitly, since
+        // it's the one path where this PR's tolerant loader IS allowed
+        // to overwrite stored data: there's no recoverable structure
+        // to splice unknowns from. Once a user save runs, the corrupt
+        // bytes are gone — by design, with a warning surfaced on the
+        // preceding read.
+        let db = Database::open_in_memory().expect("test db should open");
+        db.set_app_setting(SETTINGS_KEY, "{still not valid json")
+            .expect("seed should save");
+
+        let mut backends = load_backend_configs(&db).expect("tolerant load should succeed");
+        let ollama = backends
+            .iter_mut()
+            .find(|b| b.id == "ollama")
+            .expect("default ollama present");
+        ollama.enabled = true;
+        save_backend_configs(&db, &backends).expect("save should succeed");
+
+        let stored_raw = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("stored value should read")
+            .expect("stored value should exist");
+        // Now valid JSON, no passthrough.
+        let stored: Vec<Value> = serde_json::from_str(&stored_raw).expect("stored JSON now parses");
+        assert!(
+            stored
+                .iter()
+                .all(|entry| serde_json::from_value::<AgentBackendConfig>(entry.clone()).is_ok()),
+            "every entry post-save deserializes cleanly"
+        );
+    }
+
+    #[test]
+    fn tolerant_load_warns_per_unknown_entry_and_handles_missing_fields() {
+        // Multiple unknown entries with different shapes — including
+        // entries missing `id` or `kind` — should each get their own
+        // warning and pass through cleanly. Pins the warning placeholder
+        // strings (`<no id>` / `<no kind>`) so a later refactor doesn't
+        // silently change diagnostic UX.
+        let db = Database::open_in_memory().expect("test db should open");
+        let raw = serde_json::json!([
+            {
+                "id": "future-a",
+                "label": "Future A",
+                "kind": "kind_alpha",
+                "enabled": true
+            },
+            // Missing `kind` — falls into the err arm because
+            // AgentBackendConfig requires it.
+            {
+                "id": "future-b",
+                "label": "Future B",
+                "enabled": false
+            },
+            // Missing `id` AND has an entirely unknown kind.
+            {
+                "label": "Future C",
+                "kind": "kind_gamma"
+            }
+        ]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+
+        let loaded = load_backend_configs_tolerant(&db).expect("tolerant load should succeed");
+        assert_eq!(loaded.warnings.len(), 3, "one warning per unknown entry");
+
+        // Placeholder strings stay stable.
+        assert!(loaded.warnings.iter().any(|w| w.contains("future-a")));
+        assert!(loaded.warnings.iter().any(|w| w.contains("kind_alpha")));
+        assert!(loaded.warnings.iter().any(|w| w.contains("future-b")));
+        assert!(loaded.warnings.iter().any(|w| w.contains("<no kind>")));
+        assert!(loaded.warnings.iter().any(|w| w.contains("<no id>")));
+        assert!(loaded.warnings.iter().any(|w| w.contains("kind_gamma")));
+
+        // All three unknowns are observable as passthrough; nothing dropped.
+        let passthrough = read_unknown_passthrough(&db).expect("passthrough read should succeed");
+        assert_eq!(passthrough.len(), 3);
+    }
+
+    #[test]
+    fn save_agent_backend_command_path_preserves_unknown_entries() {
+        // Closer to the production path than save_after_tolerant_load_…:
+        // simulates what `save_agent_backend` does (load → mutate one
+        // known backend → save) starting from a blob that already
+        // contains an unknown entry. Pins that the unknown entry
+        // survives the full load/merge/save round-trip a user toggle
+        // would take.
+        let db = Database::open_in_memory().expect("test db should open");
+        let mut ollama = AgentBackendConfig::builtin_ollama();
+        ollama.enabled = false;
+        let ollama_value = serde_json::to_value(&ollama).expect("ollama serializes");
+        let unknown = serde_json::json!({
+            "id": "future-thing",
+            "label": "Future Thing",
+            "kind": "kind_omega",
+            "enabled": true,
+            "future_only_field": "preserved-value"
+        });
+        let raw = serde_json::Value::Array(vec![ollama_value, unknown]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+
+        // Mirror save_agent_backend's body: load_backend_configs →
+        // mutate the matching slot → save_backend_configs.
+        let mut backends = load_backend_configs(&db).expect("tolerant load should succeed");
+        let slot = backends
+            .iter_mut()
+            .find(|b| b.id == "ollama")
+            .expect("ollama present");
+        slot.enabled = true;
+        save_backend_configs(&db, &backends).expect("save should succeed");
+
+        let stored_raw = db
+            .get_app_setting(SETTINGS_KEY)
+            .expect("read should succeed")
+            .expect("value present");
+        let stored: Vec<Value> = serde_json::from_str(&stored_raw).expect("JSON parses post-save");
+
+        let preserved = stored
+            .iter()
+            .find(|e| e.get("id").and_then(Value::as_str) == Some("future-thing"))
+            .expect("unknown entry survived save_agent_backend-like flow");
+        assert_eq!(
+            preserved.get("future_only_field").and_then(Value::as_str),
+            Some("preserved-value"),
+            "future-only fields preserved verbatim"
+        );
+
+        // And the user's edit landed.
+        let post_load = load_backend_configs(&db).expect("post-save load should succeed");
+        let ollama_after = post_load
+            .iter()
+            .find(|b| b.id == "ollama")
+            .expect("ollama present");
+        assert!(ollama_after.enabled);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_backends.rs
+++ b/src-tauri/src/commands/agent_backends.rs
@@ -179,11 +179,33 @@ pub async fn list_agent_backends(
     state: State<'_, AppState>,
 ) -> Result<BackendListResponse, String> {
     let db = Database::open(&state.db_path).map_err(|e| e.to_string())?;
-    let default_backend_id = db
+    let stored_default = db
         .get_app_setting("default_agent_backend")
         .map_err(|e| e.to_string())?
         .unwrap_or_else(|| "anthropic".to_string());
-    let loaded = load_backend_configs_tolerant(&db)?;
+    let mut loaded = load_backend_configs_tolerant(&db)?;
+    // If the stored default points to a backend that didn't make it
+    // through the tolerant load (e.g. a user-defined backend whose
+    // `kind` this build doesn't recognize), the UI would otherwise
+    // pre-select a non-existent entry. Fall back to anthropic, which
+    // is always present, and surface a warning so the user knows.
+    // The persisted setting is left alone — a build that does
+    // recognize the kind will pick it up unchanged.
+    let default_backend_id = if loaded.backends.iter().any(|b| b.id == stored_default) {
+        stored_default
+    } else {
+        loaded.warnings.push(format!(
+            "Default backend `{stored_default}` is not available in this build; \
+                 falling back to `anthropic` for this session. \
+                 Stored setting unchanged."
+        ));
+        tracing::warn!(
+            target: "agent_backends",
+            stored_default = %stored_default,
+            "default backend setting points to a backend not in the loaded list"
+        );
+        "anthropic".to_string()
+    };
     Ok(BackendListResponse {
         backends: loaded.backends,
         default_backend_id,
@@ -2840,6 +2862,79 @@ mod tests {
         // All three unknowns are observable as passthrough; nothing dropped.
         let passthrough = read_unknown_passthrough(&db).expect("passthrough read should succeed");
         assert_eq!(passthrough.len(), 3);
+    }
+
+    #[test]
+    fn list_agent_backends_falls_back_when_default_points_to_skipped_unknown() {
+        // Regression guard for a Copilot-flagged edge case: if the
+        // user's `default_agent_backend` pointed to a backend whose
+        // `kind` this build doesn't recognize, the entry is skipped
+        // by tolerant load, and the UI would otherwise pre-select a
+        // backend that isn't in the returned list. The response must
+        // (a) override default_backend_id to a backend that exists,
+        // (b) surface a warning, and (c) leave the persisted setting
+        // unchanged so a build that does recognize the kind picks it
+        // up cleanly.
+        let db = Database::open_in_memory().expect("test db should open");
+        db.set_app_setting("default_agent_backend", "future-thing")
+            .expect("seed default should save");
+        let raw = serde_json::json!([
+            {
+                "id": "future-thing",
+                "label": "Future Thing",
+                "kind": "totally_new_backend",
+                "enabled": true
+            }
+        ]);
+        db.set_app_setting(SETTINGS_KEY, &raw.to_string())
+            .expect("seed should save");
+
+        // Mirror what list_agent_backends does post-load.
+        let stored_default = db
+            .get_app_setting("default_agent_backend")
+            .expect("read default")
+            .expect("default present");
+        let mut loaded = load_backend_configs_tolerant(&db).expect("tolerant load should succeed");
+        let default_backend_id = if loaded.backends.iter().any(|b| b.id == stored_default) {
+            stored_default.clone()
+        } else {
+            loaded.warnings.push(format!(
+                "Default backend `{stored_default}` is not available in this build; \
+                 falling back to `anthropic` for this session. \
+                 Stored setting unchanged."
+            ));
+            "anthropic".to_string()
+        };
+
+        // Fallback wired up correctly.
+        assert_eq!(default_backend_id, "anthropic");
+        assert!(loaded.backends.iter().any(|b| b.id == "anthropic"));
+
+        // Two warnings: one from the per-entry skip, one from the
+        // default-pointer fallback.
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .any(|w| w.contains("future-thing") && w.contains("falling back")),
+            "warnings should include the default-fallback diagnostic"
+        );
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .any(|w| w.contains("totally_new_backend")),
+            "warnings should still include the per-entry skip diagnostic"
+        );
+
+        // Persisted default-setting untouched — a build that does
+        // recognize `totally_new_backend` will see the user's choice
+        // come back automatically.
+        let still_stored = db
+            .get_app_setting("default_agent_backend")
+            .expect("read default after")
+            .expect("default still present");
+        assert_eq!(still_stored, "future-thing");
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_backends_disabled.rs
+++ b/src-tauri/src/commands/agent_backends_disabled.rs
@@ -26,6 +26,8 @@ pub struct BackendStatus {
 pub struct BackendListResponse {
     pub backends: Vec<AgentBackendConfig>,
     pub default_backend_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +47,7 @@ pub async fn list_agent_backends(
     Ok(BackendListResponse {
         backends: vec![AgentBackendConfig::builtin_anthropic()],
         default_backend_id: "anthropic".to_string(),
+        warnings: Vec::new(),
     })
 }
 

--- a/src/ui/src/components/settings/Settings.module.css
+++ b/src/ui/src/components/settings/Settings.module.css
@@ -971,6 +971,44 @@
   margin-top: 4px;
 }
 
+/* Tolerant-loader warnings for the Models panel: non-fatal, advisory.
+   Uses the accent palette (not error red) because the user's data is
+   safe — entries are preserved as opaque passthrough and will reactivate
+   on a build that knows them. */
+.backendWarningBanner {
+  border: 1px solid var(--accent-bg-strong);
+  border-radius: var(--radius-md);
+  background: var(--accent-bg);
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 10px 12px;
+  margin: 8px 0 16px;
+}
+
+.backendWarningTitle {
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--accent-primary);
+}
+
+.backendWarningList {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-dim);
+}
+
+.backendWarningList li {
+  word-break: break-word;
+  margin-bottom: 2px;
+}
+
+.backendWarningHint {
+  margin-top: 8px;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
 /* ── Repo header (icon + editable name) ── */
 
 .repoHeader {

--- a/src/ui/src/components/settings/sections/ModelSettings.tsx
+++ b/src/ui/src/components/settings/sections/ModelSettings.tsx
@@ -20,6 +20,12 @@ export function ModelSettings() {
   const [defaultEffort, setDefaultEffort] = useState("auto");
   const [defaultShowThinking, setDefaultShowThinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tolerant-loader diagnostics: non-fatal warnings emitted when
+  // stored backend entries can't be parsed by this build (e.g. a
+  // newer dev build wrote `lm_studio` and we're an older build).
+  // Backend keeps the entries as opaque passthrough; user just needs
+  // to know they aren't active in this session.
+  const [backendWarnings, setBackendWarnings] = useState<string[]>([]);
   const alternativeBackendsEnabled = useAppStore((s) => s.alternativeBackendsEnabled);
   const agentBackends = useAppStore((s) => s.agentBackends);
   const setAgentBackends = useAppStore((s) => s.setAgentBackends);
@@ -42,8 +48,17 @@ export function ModelSettings() {
         setAgentBackends(data.backends);
         setDefaultBackend(data.default_backend_id);
         setDefaultAgentBackendId(data.default_backend_id);
+        setBackendWarnings(data.warnings ?? []);
       })
-      .catch(() => {});
+      .catch((e) => {
+        // No longer silent: previously a `.catch(() => {})` here meant
+        // a backend-settings parse failure left the Models panel
+        // empty with zero diagnostics. The Rust loader is now
+        // tolerant per-entry, so reaching this catch implies a
+        // genuinely unrecoverable failure (DB open, top-level
+        // command error). Surface it so the user can act.
+        setError(`Failed to load agent backends: ${String(e)}`);
+      });
     getAppSetting("default_thinking")
       .then((val) => setDefaultThinking(val === "true"))
       .catch(() => {});
@@ -155,6 +170,25 @@ export function ModelSettings() {
       <h2 className={styles.sectionTitle}>{t("models_title")}</h2>
 
       {error && <div className={styles.error}>{error}</div>}
+
+      {backendWarnings.length > 0 && (
+        <div className={styles.backendWarningBanner} role="status" aria-live="polite">
+          <div className={styles.backendWarningTitle}>
+            {t("models_backend_warnings_title", "Some saved backend entries weren't loaded")}
+          </div>
+          <ul className={styles.backendWarningList}>
+            {backendWarnings.map((msg, i) => (
+              <li key={i}>{msg}</li>
+            ))}
+          </ul>
+          <div className={styles.backendWarningHint}>
+            {t(
+              "models_backend_warnings_hint",
+              "These entries are preserved in your settings and will reactivate on a build that supports them.",
+            )}
+          </div>
+        </div>
+      )}
 
       <div className={styles.settingRow}>
         <div className={styles.settingInfo}>

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -100,6 +100,14 @@ export interface AgentBackendConfig {
 export interface AgentBackendListResponse {
   backends: AgentBackendConfig[];
   default_backend_id: string;
+  /**
+   * Non-fatal diagnostics from the tolerant loader — e.g. a stored
+   * backend entry whose `kind` isn't recognized by this build. The
+   * entries are preserved in SQLite (so they round-trip through
+   * downgrades), but the user should know they aren't active.
+   * Empty array when everything parsed cleanly.
+   */
+  warnings?: string[];
 }
 
 export interface BackendSecretUpdate {

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -105,7 +105,10 @@ export interface AgentBackendListResponse {
    * backend entry whose `kind` isn't recognized by this build. The
    * entries are preserved in SQLite (so they round-trip through
    * downgrades), but the user should know they aren't active.
-   * Empty array when everything parsed cleanly.
+   * Omitted from the wire payload (i.e. `undefined` here) when
+   * everything parsed cleanly — the Rust side uses
+   * `skip_serializing_if = "Vec::is_empty"`, so consumers should
+   * treat `undefined` and `[]` identically.
    */
   warnings?: string[];
 }


### PR DESCRIPTION
## Summary

A single unknown backend variant in `app_settings.agent_backends_config` (e.g. `lm_studio` written by a newer dev build, then loaded by an older build) made `load_backend_configs` fail the entire parse. The frontend's `.catch(() => {})` then swallowed the error silently, leaving **Settings → Models** empty with no diagnostic. The same loader is on the chat-send hot path, so a poisoned blob also silently failed agent spawns for non-Anthropic backends.

This PR makes the loader tolerant per-entry, preserves unknown entries as opaque JSON passthrough across save (so downgrade↔upgrade cycles between dev channels are non-destructive), and surfaces non-fatal warnings to the UI.

```mermaid
flowchart TD
    A[SQLite agent_backends_config blob] --> B{serde_json::from_str&lt;Vec&lt;Value&gt;&gt;}
    B -->|top-level corrupt| C[Warn + built-in defaults<br/>raw blob untouched on read]
    B -->|parsed array| D{per-entry from_value::&lt;AgentBackendConfig&gt;}
    D -->|Ok| E[Normalize + merge into defaults]
    D -->|Err| F[Warn naming id+kind<br/>entry stays in raw blob]
    E --> G[BackendListResponse.backends]
    F --> H[BackendListResponse.warnings]
    G --> I[Frontend Models panel]
    H --> J[Accent-tinted warning banner]
    K[save_backend_configs] --> L[read_unknown_passthrough re-reads blob]
    L --> M[Splice unknown entries back into persisted JSON]
    M --> N[set_app_setting]
```

### Verified for the boot/updater path
- The updater commands (`check_for_updates_with_channel`, `install_pending_update`) do NOT call `load_backend_configs`.
- The boot-health probation gate (`bootOk` in `App.tsx:125`) is gated on `loadInitialData` succeeding, which doesn't touch backend configs. So a poisoned backend blob never blocked the post-update `boot_ok` ack.
- The previously visible breakage was the empty Models panel + silent chat-send failures; the boot-health attribution was a red herring.

## Complexity Notes

- `read_unknown_passthrough` re-reads the raw SQLite blob inside every save to splice unknowns back. Initial Codex-flagged version swallowed DB read errors silently (defeating the whole point of passthrough); now returns `Result<Vec<Value>, String>` and propagates. `save_backend_configs` is the only documented path that overwrites a corrupt top-level blob — by design, with a warning surfaced on the preceding read.
- `LoadedBackends` deliberately does NOT carry the unknown entries — the save path reads them independently at write time. Tests assert passthrough by calling `read_unknown_passthrough` directly so the production data flow stays honest (no struct field that exists "for tests").
- `load_backend_configs` is a thin wrapper over `load_backend_configs_tolerant` so the dozen+ existing call sites (chat send, gateway hydration, find_backend, etc.) all pick up the tolerance without signature churn.
- Frontend warnings render as a non-blocking accent-tinted banner (orange, not error red) because the user's data is **safe** — preserved as opaque JSON. Wording explains the entry will reactivate on a build that knows it.

## Test Steps

### Reproduce the original failure (without the fix)

1. In a build BEFORE this PR, seed the SQLite DB with a poisoned blob:
   ```sql
   UPDATE app_settings
   SET value = '[{"id":"future-thing","label":"X","kind":"totally_new_backend","enabled":true}]'
   WHERE key = 'agent_backends_config';
   ```
2. Open Settings → Models. Observe: backend list empty, no diagnostic.
3. Try to chat-send through any non-Anthropic backend. Observe: silent spawn failure.

### Verify the fix on this branch

1. Apply the same poisoned blob.
2. Open Settings → Models. Observe:
   - Models panel renders normally with built-in backends.
   - **Orange warning banner** at top names the offending entry: ``Skipped backend entry id=`future-thing` kind=`totally_new_backend`: ...``
   - Banner text confirms entry is preserved and will reactivate on a supporting build.
3. Toggle some Models setting (any). Observe via SQLite shell that the `future-thing` entry is **still** present in the persisted JSON, with all original fields intact.
4. Run the new tests:
   ```bash
   cargo test -p claudette-tauri --bin claudette-app agent_backends::tests::tolerant
   cargo test -p claudette-tauri --bin claudette-app agent_backends::tests::save_after
   cargo test -p claudette-tauri --bin claudette-app agent_backends::tests::save_agent_backend_command
   ```
5. CI-equivalent local checks:
   ```bash
   cargo fmt --all --check
   RUSTFLAGS='-Dwarnings' cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features
   cargo test -p claudette -p claudette-server -p claudette-cli --all-features
   cargo test -p claudette-tauri --bin claudette-app
   cd src/ui && bunx tsc -b && bun run lint:css && bun run lint && bun run test
   ```

## Checklist

- [x] Tests added/updated — 6 new tests covering tolerant load (single + multi-unknown shapes including missing id/kind), save round-trip, save_agent_backend command path, top-level JSON corruption, and corrupt-blob save behavior
- [x] Documentation updated — `site/src/content/docs/features/agent-configuration.mdx` gains a "Forward/backward compat" subsection describing the warning banner so users hitting it know their config isn't lost
- [x] Codex peer review addressed — fmt blocker fixed, dead-code field removed, `read_unknown_passthrough` made fallible, misleading "never overwrite" comment clarified

## Commits

- `e3c72d2c` initial fix: tolerant loader, opaque passthrough, warning banner, frontend stops swallowing errors
- `c3065830` (was `8417c4e0` pre-rebase) Codex review response: fmt fix, drop dead-code field, fallible passthrough read, comment fix, 3 additional tests
