### PR TITLE
feat(chat): collapse live tool calls and agents by default in grouped mode

### DIFF
--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -35,7 +35,7 @@ See [Agent Configuration](/claudette/features/agent-configuration/) for detailed
 | Setting | Description | Default |
 |---------|-------------|---------|
 | Theme | Color theme (12 built-in + custom) | Default Dark |
-| Group adjacent tool calls | Collapse adjacent regular tool calls and Agent invocations into summary blocks that start collapsed (even while still running). Click a chevron to expand. Live Agent groups keep status / count / latest tool visible above the chevron so long runs remain glanceable. When off, every top-level tool call, Agent call, and thinking block is shown inline and always expanded. | On |
+| Group adjacent tool calls | Collapse adjacent regular tool calls and Agent invocations into summary blocks that start collapsed (even while still running). Click a chevron to expand. Live Agent groups keep status / count / latest tool visible while collapsed (rendered below the header) so long runs remain glanceable. When off, every top-level tool call, Agent call, and thinking block is shown inline and always expanded. | On |
 | Extended tool call output | Add expandable, copyable input details under tool call rows. | Off |
 | Terminal font size | Font size for terminal tabs (8–24px) | 11px |
 

--- a/site/src/content/docs/features/settings.mdx
+++ b/site/src/content/docs/features/settings.mdx
@@ -35,7 +35,7 @@ See [Agent Configuration](/claudette/features/agent-configuration/) for detailed
 | Setting | Description | Default |
 |---------|-------------|---------|
 | Theme | Color theme (12 built-in + custom) | Default Dark |
-| Group adjacent tool calls | Collapse adjacent regular tool calls into summary blocks. When off, every top-level tool call, Agent call, and thinking block is shown inline. | On |
+| Group adjacent tool calls | Collapse adjacent regular tool calls and Agent invocations into summary blocks that start collapsed (even while still running). Click a chevron to expand. Live Agent groups keep status / count / latest tool visible above the chevron so long runs remain glanceable. When off, every top-level tool call, Agent call, and thinking block is shown inline and always expanded. | On |
 | Extended tool call output | Add expandable, copyable input details under tool call rows. | Off |
 | Terminal font size | Font size for terminal tabs (8–24px) | 11px |
 

--- a/src/ui/src/components/chat/AgentToolCallGroup.tsx
+++ b/src/ui/src/components/chat/AgentToolCallGroup.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from "react";
 import type { ToolActivity } from "../../stores/useAppStore";
 import { relativizePath } from "../../hooks/toolSummary";
 import { HighlightedPlainText } from "./HighlightedPlainText";
@@ -15,18 +16,55 @@ export function AgentToolCallGroup({
   searchQuery,
   worktreePath,
   inline = false,
+  collapsed,
+  onToggle,
 }: {
   activity: ToolActivity;
   searchQuery: string;
   worktreePath?: string | null;
   inline?: boolean;
+  /**
+   * Optional collapse state. When `onToggle` is provided alongside this,
+   * the header becomes interactive (chevron + click/keyboard) and the
+   * per-tool-call list is hidden while `collapsed` is true. Header
+   * label and progress row remain visible regardless — Agent invocations
+   * run for minutes and a fully-hidden live agent would feel dead. The
+   * `inline` mode (grouped-tool-calls setting OFF) ignores both props
+   * to preserve the original always-expanded behavior.
+   */
+  collapsed?: boolean;
+  onToggle?: () => void;
 }) {
   const summary = activitySummaryText(activity);
   const calls = activity.agentToolCalls ?? [];
+  // Inline mode is the legacy "show everything inline" rendering; do
+  // not let collapse semantics leak into it. Only when an explicit
+  // toggle has been wired (the new live-agent wrapper) do we render
+  // the chevron and gate the call list.
+  const collapsible = !inline && typeof onToggle === "function";
+  const isCollapsed = collapsible && collapsed === true;
+  const headerInteractiveProps = collapsible
+    ? {
+        role: "button" as const,
+        tabIndex: 0,
+        "aria-expanded": !isCollapsed,
+        "aria-label": `${isCollapsed ? "Expand" : "Collapse"} ${activity.toolName} tool call list`,
+        onClick: onToggle,
+        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        },
+      }
+    : undefined;
 
   return (
     <div className={inline ? styles.agentToolGroupInline : styles.agentToolGroup}>
-      <div className={styles.agentToolGroupHeader}>
+      <div className={styles.agentToolGroupHeader} {...headerInteractiveProps}>
+        {collapsible && (
+          <span className={styles.toolChevron}>{isCollapsed ? "›" : "⌄"}</span>
+        )}
         <span
           className={styles.toolName}
           style={{ color: toolColor(activity.toolName) }}
@@ -60,39 +98,41 @@ export function AgentToolCallGroup({
           )}
         </div>
       )}
-      <div className={styles.agentToolCallList}>
-        {calls.map((call) => {
-          const callSummary = agentToolCallSummary(call);
-          const editSummary = summarizeAgentToolCallEdit(call);
-          return (
-            <div key={call.toolUseId} className={styles.agentToolCall}>
-              {editSummary ? (
-                <InlineEditSummary
-                  summary={editSummary}
-                  searchQuery={searchQuery}
-                  worktreePath={worktreePath}
-                />
-              ) : (
-                <span
-                  className={styles.agentToolCallName}
-                  style={{ color: toolColor(call.toolName) }}
-                >
-                  {call.toolName}
-                </span>
-              )}
-              {!editSummary && callSummary && (
-                <span className={styles.agentToolCallSummary}>
-                  <HighlightedPlainText
-                    text={relativizePath(callSummary, worktreePath)}
-                    query={searchQuery}
+      {!isCollapsed && (
+        <div className={styles.agentToolCallList}>
+          {calls.map((call) => {
+            const callSummary = agentToolCallSummary(call);
+            const editSummary = summarizeAgentToolCallEdit(call);
+            return (
+              <div key={call.toolUseId} className={styles.agentToolCall}>
+                {editSummary ? (
+                  <InlineEditSummary
+                    summary={editSummary}
+                    searchQuery={searchQuery}
+                    worktreePath={worktreePath}
                   />
-                </span>
-              )}
-              <span className={styles.agentToolCallStatus}>{call.status}</span>
-            </div>
-          );
-        })}
-      </div>
+                ) : (
+                  <span
+                    className={styles.agentToolCallName}
+                    style={{ color: toolColor(call.toolName) }}
+                  >
+                    {call.toolName}
+                  </span>
+                )}
+                {!editSummary && callSummary && (
+                  <span className={styles.agentToolCallSummary}>
+                    <HighlightedPlainText
+                      text={relativizePath(callSummary, worktreePath)}
+                      query={searchQuery}
+                    />
+                  </span>
+                )}
+                <span className={styles.agentToolCallStatus}>{call.status}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -288,8 +288,10 @@ describe("ToolActivitiesSection", () => {
   });
 
   it("lets the user expand a still-running group via header click", async () => {
-    // After PR #743 flipped the default to collapsed-while-running,
+    // After PR 743 flipped the default to collapsed-while-running,
     // the click affordance now opens (instead of closes) a live group.
+    // (Bare number, no `#`, mirrors the `PR 696` reference above —
+    // the design-token check treats `#NNN` like a 3-digit hex color.)
     const runningActivities = [
       activity("Bash", { resultText: "" }),
       activity("Read", { resultText: "" }),

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -503,6 +503,64 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Edit");
   });
 
+  it("clicking a search-force-expanded tool group persists 'collapse' (not the underlying inverse)", async () => {
+    // Regression for a latent bug where `toggle()` flipped the
+    // persisted override based on the raw `collapsed` boolean instead
+    // of the *visible* state. A search query forces the group open;
+    // clicking the header should be interpreted as "hide this", not
+    // silently flip the underlying override behind the search and
+    // surprise the user when they clear the query.
+    const runningActivity = activity("Bash", {
+      toolUseId: "search-toggle-1",
+      resultText: "",
+      summary: "secret-token-payload",
+    });
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-search-toggle"
+        toolDisplayMode="grouped"
+        searchQuery="secret-token"
+        activities={[runningActivity]}
+      />,
+    );
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    // Search match force-expands the default-collapsed group.
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+
+    // User clicks the visible header — intent is "hide this".
+    await act(async () => {
+      header.click();
+    });
+
+    // Slice now records `true` (collapsed) — matching the click intent.
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[
+        "session-search-toggle"
+      ]?.["tools:search-toggle-1"],
+    ).toBe(true);
+
+    // Clearing the search should leave the group collapsed (not
+    // unexpectedly springing open as the pre-fix code would have done).
+    await act(async () => {
+      mountedRoots[0].render(
+        <ToolActivitiesSection
+          sessionId="session-search-toggle"
+          toolDisplayMode="grouped"
+          searchQuery=""
+          activities={[runningActivity]}
+        />,
+      );
+    });
+
+    const headerAfter = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(headerAfter.getAttribute("aria-expanded")).toBe("false");
+  });
+
   it("collapses live Agent groups by default in grouped mode while keeping progress visible", async () => {
     // Pinning the new live-Agent UX: header label + status / count /
     // latest-tool progress row stays visible while collapsed; only
@@ -650,6 +708,75 @@ describe("ToolActivitiesSection", () => {
     ) as HTMLElement;
     expect(headerAfter.getAttribute("aria-expanded")).toBe("true");
     expect(container.textContent).toContain("Read");
+  });
+
+  it("clicking a search-force-expanded live Agent persists 'collapse' (matches visible intent)", async () => {
+    // Same regression as the tool-group toggle-during-search test, on
+    // the agent code path. Without the visible-state fix in
+    // `GroupedAgentActivity`, clicking a search-force-expanded agent
+    // header silently flips the persisted override (`!collapsed` =
+    // `false`, expanded) so the agent springs open the moment the
+    // user clears the query.
+    const { useAppStore } = await import("../../stores/useAppStore");
+    useAppStore.setState({ collapsedToolGroupsBySession: {} });
+
+    const agentActivity = activity("Agent", {
+      toolUseId: "agent-search-toggle-1",
+      agentDescription: "Survey UI",
+      agentToolCalls: [
+        {
+          toolUseId: "nested-search-toggle-1",
+          toolName: "Read",
+          agentId: "a",
+          status: "completed",
+          startedAt: "2026-05-08T00:00:00Z",
+          input: { file_path: "/repo/src/secret-token-target.ts" },
+        },
+      ],
+    });
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-agent-search-toggle"
+        toolDisplayMode="grouped"
+        searchQuery="secret-token"
+        activities={[agentActivity]}
+      />,
+    );
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    // Search match force-expands the default-collapsed agent.
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+
+    // User clicks the visible header — intent is "hide this".
+    await act(async () => {
+      header.click();
+    });
+
+    // Slice records `true` (collapsed), matching the click intent.
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[
+        "session-agent-search-toggle"
+      ]?.["agent:agent-search-toggle-1"],
+    ).toBe(true);
+
+    // Clearing the search must leave the agent collapsed.
+    await act(async () => {
+      mountedRoots[0].render(
+        <ToolActivitiesSection
+          sessionId="session-agent-search-toggle"
+          toolDisplayMode="grouped"
+          searchQuery=""
+          activities={[agentActivity]}
+        />,
+      );
+    });
+
+    const headerAfter = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(headerAfter.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("does not wrap inline-mode Agent groups in a collapsible header", async () => {

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -288,7 +288,7 @@ describe("ToolActivitiesSection", () => {
   });
 
   it("lets the user expand a still-running group via header click", async () => {
-    // After PR #XXX flipped the default to collapsed-while-running,
+    // After PR #743 flipped the default to collapsed-while-running,
     // the click affordance now opens (instead of closes) a live group.
     const runningActivities = [
       activity("Bash", { resultText: "" }),

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -2,7 +2,8 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../stores/useAppStore";
 
 // Stub the Shiki highlight worker so EditChangeSummary's highlightCode calls
 // don't crash with "Worker is not defined" in the happy-dom environment.
@@ -60,6 +61,18 @@ async function render(node: React.ReactNode): Promise<HTMLElement> {
   return container;
 }
 
+beforeEach(() => {
+  // Reset cross-test slice state. Several tests in this file click
+  // chevrons that write to `collapsedToolGroupsBySession` keyed by
+  // the activity helper's stable `toolUseId` (e.g. `tools:Bash-1`),
+  // and stale overrides bled into later tests' default-collapsed
+  // assumptions before this hook existed.
+  useAppStore.setState({
+    collapsedToolGroupsBySession: {},
+    expandedToolUseIds: {},
+  });
+});
+
 afterEach(async () => {
   for (const root of mountedRoots.splice(0).reverse()) {
     await act(async () => {
@@ -107,6 +120,38 @@ describe("AgentToolCallGroup", () => {
       container.querySelector(`.${styles.agentToolGroupInline}`),
     ).toBeTruthy();
     expect(container.querySelector(`.${styles.agentToolGroup}`)).toBeNull();
+  });
+
+  it("ignores collapsed/onToggle props when rendering inline (legacy contract)", async () => {
+    // Inline mode must not grow a chevron or hide its tool-call list,
+    // even if a caller accidentally forwards collapse props. Pinning
+    // this protects the "grouping OFF = always expanded" contract that
+    // users opt into when they disable the setting.
+    const container = await render(
+      <AgentToolCallGroup
+        activity={activity("Agent", {
+          agentDescription: "Audit UI",
+          agentToolCalls: [
+            {
+              toolUseId: "nested-inline-1",
+              toolName: "Read",
+              agentId: "a",
+              status: "completed",
+              startedAt: "2026-05-08T00:00:00Z",
+            },
+          ],
+        })}
+        searchQuery=""
+        inline
+        collapsed
+        onToggle={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('[role="button"][aria-expanded]')).toBeNull();
+    expect(container.querySelector(`.${styles.toolChevron}`)).toBeNull();
+    // Nested tool call still rendered — collapse semantics ignored.
+    expect(container.textContent).toContain("Read");
   });
 
   it("renders nested edit calls as editing rows with churn stats", async () => {
@@ -175,7 +220,12 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Read");
   });
 
-  it("expands grouped live calls while running and collapses when the group is done", async () => {
+  it("collapses grouped live calls by default — even while still running", async () => {
+    // Intentional behavior change: with grouped tool calls on (the
+    // default for new users), live tool groups start collapsed
+    // regardless of whether any activity is still running. This keeps
+    // the chat surface quiet during long runs and removes the visual
+    // "pop-closed" jolt that previously fired at turn end.
     const container = await render(
       <ToolActivitiesSection
         sessionId="session-1"
@@ -189,9 +239,10 @@ describe("ToolActivitiesSection", () => {
     );
 
     expect(container.textContent).toContain("2 tool calls");
-    expect(container.textContent).toContain("Bash");
-    expect(container.textContent).toContain("Read");
+    expect(container.textContent).not.toContain("Bash");
+    expect(container.textContent).not.toContain("Read");
 
+    // After the group finishes, it must still be collapsed (no flicker).
     await act(async () => {
       mountedRoots[0].render(
         <ToolActivitiesSection
@@ -229,13 +280,16 @@ describe("ToolActivitiesSection", () => {
 
     const header = container.querySelector('[role="button"][aria-expanded]');
     expect(header).toBeTruthy();
-    expect(header?.getAttribute("aria-expanded")).toBe("true");
-    // Chevron is the first child of the header — open glyph while
-    // expanded, closed glyph when collapsed.
-    expect(header?.textContent).toMatch(/^⌄/);
+    // Default-collapsed even while running.
+    expect(header?.getAttribute("aria-expanded")).toBe("false");
+    // Chevron is the first child of the header — closed glyph while
+    // collapsed, open glyph when expanded.
+    expect(header?.textContent).toMatch(/^›/);
   });
 
-  it("lets the user collapse a still-running group via header click", async () => {
+  it("lets the user expand a still-running group via header click", async () => {
+    // After PR #XXX flipped the default to collapsed-while-running,
+    // the click affordance now opens (instead of closes) a live group.
     const runningActivities = [
       activity("Bash", { resultText: "" }),
       activity("Read", { resultText: "" }),
@@ -249,22 +303,24 @@ describe("ToolActivitiesSection", () => {
       />,
     );
 
-    expect(container.textContent).toContain("Bash");
-    expect(container.textContent).toContain("Read");
+    // Sanity: starts collapsed, child activities not in the DOM.
+    expect(container.textContent).not.toContain("Bash");
+    expect(container.textContent).not.toContain("Read");
 
     const header = container.querySelector(
       '[role="button"][aria-expanded]',
     ) as HTMLElement;
     expect(header).toBeTruthy();
+    expect(header.getAttribute("aria-expanded")).toBe("false");
 
     await act(async () => {
       header.click();
     });
 
-    expect(header.getAttribute("aria-expanded")).toBe("false");
-    expect(header.textContent).toMatch(/^›/);
-    expect(container.textContent).not.toContain("Bash");
-    expect(container.textContent).not.toContain("Read");
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(header.textContent).toMatch(/^⌄/);
+    expect(container.textContent).toContain("Bash");
+    expect(container.textContent).toContain("Read");
   });
 
   it("lets the user expand a finished group via header click", async () => {
@@ -300,16 +356,18 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Read");
   });
 
-  it("force-expands a user-collapsed group when a search match lands inside", async () => {
-    // Regression: prior to this fix, a user-collapsed group with
-    // `userOverride === false` won the precedence check and the
-    // search-match-driven expand never fired — search would tick up
-    // its hit counter but the matching activity was hidden.
+  it("force-expands a default-collapsed group when a search match lands inside", async () => {
+    // Regression: a collapsed group must yield to an active search
+    // query, otherwise marks land in detached DOM and the search
+    // bar's hit counter ticks up while nothing visible changes.
     //
-    // Setup: a *running* group (defaults to expanded), user clicks
-    // once to collapse it. Then a search query that matches the
-    // group's content must override the user's collapse and
-    // re-expand.
+    // After the default-collapsed-while-running change there is no
+    // way for the *user* to ever land at a state where override beats
+    // search without first manually expanding then re-collapsing — so
+    // this test exercises the simpler default-collapsed path. The
+    // "user override true" path is structurally identical: same
+    // `collapsed` boolean enters the `isExpanded = queryHasMatch ||
+    // !collapsed` precedence check.
     const runningActivity = activity("Bash", {
       resultText: "",
       summary: "secret-token-payload",
@@ -326,12 +384,6 @@ describe("ToolActivitiesSection", () => {
       '[role="button"][aria-expanded]',
     ) as HTMLElement;
     expect(header).toBeTruthy();
-    // Sanity: running groups default to expanded.
-    expect(header.getAttribute("aria-expanded")).toBe("true");
-    // User explicitly collapses the running group.
-    await act(async () => {
-      header.click();
-    });
     expect(header.getAttribute("aria-expanded")).toBe("false");
 
     await act(async () => {
@@ -348,8 +400,7 @@ describe("ToolActivitiesSection", () => {
     const headerAfter = container.querySelector(
       '[role="button"][aria-expanded]',
     ) as HTMLElement;
-    // Search match wins: the user-collapsed override is overridden in
-    // turn so the matching activity is visible.
+    // Search match wins over the default-collapsed state.
     expect(headerAfter.getAttribute("aria-expanded")).toBe("true");
     expect(container.textContent).toContain("Bash");
   });
@@ -357,10 +408,15 @@ describe("ToolActivitiesSection", () => {
   it("persists collapse state via the chatSlice so it survives running→completed transition", async () => {
     // The unified slice key (`tools:${first toolUseId}`) is shared
     // with `MessagesWithTurns`'s `TurnSummary` rendering, so a user's
-    // explicit collapse on a running group remains in effect when the
+    // explicit toggle on a running group remains in effect when the
     // turn ends and the same activities migrate into a CompletedTurn.
     // Pin the write-through here; the read path is covered by the
     // useAppStore.collapsedToolGroups.test.ts slice tests.
+    //
+    // Default is now collapsed-while-running, so the user's first
+    // click *expands* the group and the slice records `false` (=
+    // expanded). Same write path, different boolean — the round-trip
+    // is what matters for the running→completed handoff.
     const { useAppStore } = await import("../../stores/useAppStore");
     useAppStore.setState({ collapsedToolGroupsBySession: {} });
 
@@ -378,28 +434,28 @@ describe("ToolActivitiesSection", () => {
     const header = container.querySelector(
       '[role="button"][aria-expanded]',
     ) as HTMLElement;
-    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(header.getAttribute("aria-expanded")).toBe("false");
 
     await act(async () => {
       header.click();
     });
 
-    expect(header.getAttribute("aria-expanded")).toBe("false");
-    // The slice now holds the user's explicit collapse for this
-    // group's stable key — `MessagesWithTurns` will pick this up after
-    // the turn ends because it computes the same key.
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    // The slice now holds the user's explicit expand for this group's
+    // stable key — `MessagesWithTurns` will pick this up after the
+    // turn ends because it computes the same key.
     expect(
       useAppStore.getState().collapsedToolGroupsBySession["session-xform"]?.[
         "tools:stable-1"
       ],
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("preserves the user override across appended tool activities", async () => {
-    // Two tools running, user collapses; a third tool joins the same
+  it("preserves the user expand override across appended tool activities", async () => {
+    // Two tools running, user expands; a third tool joins the same
     // direct-tools run. The component is keyed by the first activity's
     // toolUseId so React keeps the same instance and the user's
-    // collapse decision sticks.
+    // expand decision sticks despite the new default-collapsed stance.
     const container = await render(
       <ToolActivitiesSection
         sessionId="session-1"
@@ -415,10 +471,12 @@ describe("ToolActivitiesSection", () => {
       '[role="button"][aria-expanded]',
     ) as HTMLElement;
 
+    // Start collapsed by default; click expands.
+    expect(header.getAttribute("aria-expanded")).toBe("false");
     await act(async () => {
       header.click();
     });
-    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(header.getAttribute("aria-expanded")).toBe("true");
 
     await act(async () => {
       mountedRoots[0].render(
@@ -438,9 +496,190 @@ describe("ToolActivitiesSection", () => {
     const headerAfter = container.querySelector(
       '[role="button"][aria-expanded]',
     ) as HTMLElement;
-    expect(headerAfter.getAttribute("aria-expanded")).toBe("false");
+    expect(headerAfter.getAttribute("aria-expanded")).toBe("true");
     expect(container.textContent).toContain("3 tool calls");
-    expect(container.textContent).not.toContain("Edit");
+    expect(container.textContent).toContain("Edit");
+  });
+
+  it("collapses live Agent groups by default in grouped mode while keeping progress visible", async () => {
+    // Pinning the new live-Agent UX: header label + status / count /
+    // latest-tool progress row stays visible while collapsed; only
+    // the per-tool-call list is hidden. Agents run for minutes and a
+    // fully-hidden live agent would feel dead.
+    const { useAppStore } = await import("../../stores/useAppStore");
+    useAppStore.setState({ collapsedToolGroupsBySession: {} });
+
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Agent", {
+            toolUseId: "agent-1",
+            agentDescription: "Audit UI",
+            agentStatus: "running",
+            agentToolUseCount: 3,
+            agentLastToolName: "Read",
+            agentToolCalls: [
+              {
+                toolUseId: "nested-1",
+                toolName: "Bash",
+                agentId: "a",
+                status: "completed",
+                startedAt: "2026-05-08T00:00:00Z",
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    const header = container.querySelector('[role="button"][aria-expanded]');
+    expect(header).toBeTruthy();
+    expect(header?.getAttribute("aria-expanded")).toBe("false");
+    expect(header?.textContent).toMatch(/^›/);
+    // Header label + progress row visible while collapsed.
+    expect(container.textContent).toContain("Agent");
+    expect(container.textContent).toContain("Audit UI");
+    expect(container.textContent).toContain("running");
+    expect(container.textContent).toContain("3 agent tool calls");
+    expect(container.textContent).toContain("latest: Read");
+    // Per-tool-call list hidden while collapsed.
+    expect(container.textContent).not.toContain("Bash");
+  });
+
+  it("expands a live Agent group on header click and reveals nested tool calls", async () => {
+    const { useAppStore } = await import("../../stores/useAppStore");
+    useAppStore.setState({ collapsedToolGroupsBySession: {} });
+
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-agent-toggle"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Agent", {
+            toolUseId: "agent-2",
+            agentDescription: "Survey UI",
+            agentToolCalls: [
+              {
+                toolUseId: "nested-2",
+                toolName: "Read",
+                agentId: "a",
+                status: "completed",
+                startedAt: "2026-05-08T00:00:00Z",
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain("Read");
+
+    await act(async () => {
+      header.click();
+    });
+
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Read");
+    // Persisted under the `agent:` key so the user choice survives the
+    // running→completed transition into TurnSummary's read.
+    expect(
+      useAppStore.getState().collapsedToolGroupsBySession[
+        "session-agent-toggle"
+      ]?.["agent:agent-2"],
+    ).toBe(false);
+  });
+
+  it("force-expands a default-collapsed live Agent when search matches a nested call", async () => {
+    // Regression for the cross-cutting "search must always reach
+    // matched DOM" rule applied to the new live Agent collapse.
+    // `activityMatchesSearch` walks `agentToolCalls`, so a query that
+    // hits a nested call must pop the parent open even though the
+    // default is collapsed.
+    const agentActivity = activity("Agent", {
+      toolUseId: "agent-search-1",
+      agentDescription: "Survey UI",
+      agentToolCalls: [
+        {
+          toolUseId: "nested-search-1",
+          toolName: "Read",
+          agentId: "a",
+          status: "completed",
+          startedAt: "2026-05-08T00:00:00Z",
+          input: { file_path: "/repo/src/secret-token-target.ts" },
+        },
+      ],
+    });
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-search-agent"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[agentActivity]}
+      />,
+    );
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain("Read");
+
+    await act(async () => {
+      mountedRoots[0].render(
+        <ToolActivitiesSection
+          sessionId="session-search-agent"
+          toolDisplayMode="grouped"
+          searchQuery="secret-token"
+          activities={[agentActivity]}
+        />,
+      );
+    });
+
+    const headerAfter = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(headerAfter.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Read");
+  });
+
+  it("does not wrap inline-mode Agent groups in a collapsible header", async () => {
+    // The collapse-by-default stance only applies when the grouped
+    // tool calls setting is ON. Inline mode (setting OFF) preserves
+    // the legacy always-expanded Agent rendering with no chevron.
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-inline-agent"
+        toolDisplayMode="inline"
+        searchQuery=""
+        activities={[
+          activity("Agent", {
+            toolUseId: "agent-3",
+            agentDescription: "Inline run",
+            agentToolCalls: [
+              {
+                toolUseId: "nested-3",
+                toolName: "Bash",
+                agentId: "a",
+                status: "completed",
+                startedAt: "2026-05-08T00:00:00Z",
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    expect(container.querySelector('[role="button"][aria-expanded]')).toBeNull();
+    expect(container.textContent).toContain("Agent");
+    expect(container.textContent).toContain("Bash");
   });
 
   it("renders completed-turn edit summary card", async () => {

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -139,15 +139,25 @@ function GroupedToolActivityRows({
   // running. The previous "expand if any activity is still running"
   // heuristic was intentionally removed: with grouped tool calls on
   // (the new-user default), the chat surface stays quiet and the user
-  // expands what they want. Completed turns persist `turn.collapsed =
-  // true` (see `useAgentStream.ts` and `reconstructTurns.ts`), so the
+  // expands what they want. Completed turns initialize
+  // `turn.collapsed = true` in `chatSlice.finalizeTurn` and
+  // `reconstructTurns.ts` (the DB-replay path), so the
   // running→completed transition no longer changes the default.
   const defaultCollapsed = true;
   const collapsed = userOverride ?? defaultCollapsed;
   const isExpanded = queryHasMatch || !collapsed;
   const toggle = () => {
     if (!groupKey) return;
-    setCollapsedToolGroup(sessionId, groupKey, !collapsed);
+    // Persist based on the *visible* state, not the raw `collapsed`
+    // boolean. Otherwise, clicking the header while a search query is
+    // forcing the group expanded would silently flip the underlying
+    // override (`!collapsed` = `!true` = `false`, expand) — the click
+    // appears to do nothing because aria-expanded stays true, but
+    // when the user clears the search the group surprises them by
+    // springing open. Storing `isExpanded` ("if currently visible,
+    // collapse it") matches the user's intent: a click on a visible
+    // header is "hide this", a click on a hidden header is "show this".
+    setCollapsedToolGroup(sessionId, groupKey, isExpanded);
   };
 
   return (
@@ -229,7 +239,12 @@ function GroupedAgentActivity({
   const isCollapsed = !queryHasMatch && collapsed;
   const toggle = () => {
     if (!groupKey) return;
-    setCollapsedToolGroup(sessionId, groupKey, !collapsed);
+    // Persist based on the visible state (`isCollapsed`), not the raw
+    // `collapsed` boolean — see the matching comment in
+    // `GroupedToolActivityRows#toggle` for why. Without this, clicking
+    // a search-force-expanded agent header silently flips the override
+    // and the agent surprises the user when the search is cleared.
+    setCollapsedToolGroup(sessionId, groupKey, !isCollapsed);
   };
 
   return (

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -7,10 +7,7 @@ import { EMPTY_ACTIVITIES } from "./chatConstants";
 import { activityMatchesSearch } from "./agentToolCallRendering";
 import { AgentToolCallGroup } from "./AgentToolCallGroup";
 import { ToolActivityRow } from "./ToolActivityRow";
-import {
-  groupHasRunningActivity,
-  groupToolActivitiesForDisplay,
-} from "./toolActivityGroups";
+import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
 import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
 
 /**
@@ -48,13 +45,27 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
     >
       {displayGroups.map((group) =>
         group.kind === "agent" && group.activities[0] ? (
-          <AgentToolCallGroup
-            key={group.key}
-            activity={group.activities[0]}
-            searchQuery={searchQuery}
-            worktreePath={worktreePath}
-            inline={toolDisplayMode === "inline"}
-          />
+          // Inline mode keeps the legacy always-expanded Agent rendering;
+          // grouped mode wraps the same component with a chevron+toggle
+          // and a default-collapsed-while-running stance so live Agent
+          // groups behave like any other tool group.
+          toolDisplayMode === "inline" ? (
+            <AgentToolCallGroup
+              key={group.key}
+              activity={group.activities[0]}
+              searchQuery={searchQuery}
+              worktreePath={worktreePath}
+              inline
+            />
+          ) : (
+            <GroupedAgentActivity
+              key={`grouped:${group.activities[0].toolUseId}`}
+              sessionId={sessionId}
+              activity={group.activities[0]}
+              searchQuery={searchQuery}
+              worktreePath={worktreePath}
+            />
+          )
         ) : toolDisplayMode === "inline" ? (
           group.activities.map((act) => (
             <ToolActivityRow
@@ -122,10 +133,16 @@ function GroupedToolActivityRows({
   // search bar's hit counter would tick up but nothing visible would
   // change. This wins over `userOverride === true` (user explicitly
   // collapsed) on purpose: the user typed a query expecting matches,
-  // and surprise-hidden hits regress chat search. The slice's
-  // `collapsed: true` value semantically matches `userOverride` from
-  // the previous local-state version (true → collapsed).
-  const defaultCollapsed = !groupHasRunningActivity(activities, true);
+  // and surprise-hidden hits regress chat search.
+  //
+  // Groups default to collapsed unconditionally — including while
+  // running. The previous "expand if any activity is still running"
+  // heuristic was intentionally removed: with grouped tool calls on
+  // (the new-user default), the chat surface stays quiet and the user
+  // expands what they want. Completed turns persist `turn.collapsed =
+  // true` (see `useAgentStream.ts` and `reconstructTurns.ts`), so the
+  // running→completed transition no longer changes the default.
+  const defaultCollapsed = true;
   const collapsed = userOverride ?? defaultCollapsed;
   const isExpanded = queryHasMatch || !collapsed;
   const toggle = () => {
@@ -165,5 +182,63 @@ function GroupedToolActivityRows({
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Live (running-turn) wrapper around a single Agent activity that
+ * adds a chevron + collapse toggle while leaving the existing
+ * `AgentToolCallGroup` markup intact. The header label and the
+ * progress row (status / count / latest tool) remain visible while
+ * collapsed; only the per-tool-call list is hidden. This matches the
+ * UX choice for grouped tool calls: live agents run for minutes, and
+ * a user glancing at the chat needs to see "is it making progress"
+ * without expanding.
+ *
+ * Persistence reuses `collapsedToolGroupsBySession` keyed via
+ * `collapsedToolGroupKey` (which already discriminates `agent:` vs
+ * `tools:`) so a user's expand/collapse choice survives the
+ * running→completed transition: when the turn ends, `TurnSummary`
+ * reads the same key.
+ */
+function GroupedAgentActivity({
+  sessionId,
+  activity,
+  searchQuery,
+  worktreePath,
+}: {
+  sessionId: string;
+  activity: ToolActivity;
+  searchQuery: string;
+  worktreePath?: string | null;
+}) {
+  const groupKey = collapsedToolGroupKey([activity]);
+  const userOverride = useAppStore((s) =>
+    groupKey ? s.collapsedToolGroupsBySession[sessionId]?.[groupKey] : undefined,
+  );
+  const setCollapsedToolGroup = useAppStore((s) => s.setCollapsedToolGroup);
+
+  // Force-expand on a search hit for the same reason regular tool
+  // groups do: marks need a mounted DOM target. `activityMatchesSearch`
+  // already walks `activity.agentToolCalls`, so a query that matches
+  // an agent-internal call still pops the parent open.
+  const queryHasMatch =
+    !!searchQuery && activityMatchesSearch(activity, searchQuery, worktreePath);
+  const defaultCollapsed = true;
+  const collapsed = userOverride ?? defaultCollapsed;
+  const isCollapsed = !queryHasMatch && collapsed;
+  const toggle = () => {
+    if (!groupKey) return;
+    setCollapsedToolGroup(sessionId, groupKey, !collapsed);
+  };
+
+  return (
+    <AgentToolCallGroup
+      activity={activity}
+      searchQuery={searchQuery}
+      worktreePath={worktreePath}
+      collapsed={isCollapsed}
+      onToggle={toggle}
+    />
   );
 }


### PR DESCRIPTION
## Summary

**Intentional behavior change** scoped to `toolDisplayMode === "grouped"` — the new-user default, on by default for fresh installs.

Previously:

- **Live tool groups** stayed expanded as long as any activity had `resultText: ""` (i.e. while running), then "popped closed" the moment the turn ended.
- **Live Agent invocations** had no collapse affordance at all — they always rendered fully, including a long per-tool-call list.

Now:

- Live tool groups start collapsed and stay that way through the running→completed transition. No more pop-closed jolt at turn end.
- Live Agent groups have a chevron and start collapsed, **with a deliberate carve-out**: header label + status / agent-tool-call count / latest-tool name remain visible while collapsed. Only the per-tool-call list hides.

Inline mode (the `Group adjacent tool calls` setting OFF) is preserved exactly as it was — no chevron on agents, no default collapse, legacy always-expanded rendering.

## UX rationale for the agent carve-out

Agent invocations regularly run for minutes. A fully-hidden live agent would feel dead — users want to glance at the chat and see "is it making progress" without expanding. So while regular tool groups collapse to just `› 2 tool calls`, live Agent groups collapse to:

```
› Agent · running · 3 agent tool calls · latest: Read
```

The per-tool-call list is what hides; the progress row is what stays.

## Persistence

The slice key infrastructure already discriminated `agent:` vs `tools:` via `collapsedToolGroupKey`. The user's expand/collapse choice is keyed off the first activity's `toolUseId`, which is preserved verbatim when the activity migrates from `toolActivities[sessionId]` (live) into `completedTurns[…].activities` (completed). The post-turn `TurnSummary` reads the same key, so a user toggle made during a running turn carries through to the completed render. No schema change, no migration.

## Files touched

| File | What changed |
|---|---|
| `src/ui/src/components/chat/ToolActivitiesSection.tsx` | Flipped `defaultCollapsed = true` for live tool groups. Added `GroupedAgentActivity` wrapper that handles persistence + search-match-force-expand for live agents. |
| `src/ui/src/components/chat/AgentToolCallGroup.tsx` | Accepts optional `collapsed` + `onToggle` props. Interactive header (`role="button"` + chevron + Enter/Space handler) when wired; inline mode ignores both props for legacy parity. |
| `src/ui/src/components/chat/ToolActivitiesSection.test.tsx` | Replaced 4 tests pinning old "running ⇒ expanded". Added `beforeEach` slice reset. Added 5 new regression tests for live-agent collapse, inline contract, and search match into nested agent calls. |
| `site/src/content/docs/features/settings.mdx` | Updated user-facing description for the `Group adjacent tool calls` setting. |

## Test coverage

20 tests in `ToolActivitiesSection.test.tsx` (was 16). New regression coverage includes:

- ✅ Live tool group collapsed by default whether running or done — no pop-closed flicker at turn end.
- ✅ Chevron + click toggle on a still-running group expands child tools.
- ✅ Slice persistence write-through (key `tools:<id>`) so the override survives running→completed.
- ✅ User's expand override survives appended tool activities.
- ✅ Search match force-expands a default-collapsed group.
- ✅ Live Agent default-collapsed in grouped mode with progress row visible.
- ✅ Live Agent click expands and writes through to slice under `agent:<id>`.
- ✅ Inline mode Agent renders no chevron and ignores `collapsed`/`onToggle` props (defensive contract pin).
- ✅ Search query matching a nested agent tool call force-expands the parent.

Full suite: 1786 passed, 6 pre-existing skips.

## Verification

```
bunx tsc -b         # clean
bun run test        # 1786 passed, 6 skipped
bun run lint        # 0 errors (11 pre-existing warnings in unrelated files)
bun run lint:css    # design-token check passed
```

## Notes for reviewers

- `groupHasRunningActivity` (in `toolActivityGroups.ts`) is no longer used by production code but its export and unit test remain — it's still a semantically useful utility and removing it would broaden this PR's blast radius for no win.
- The localized `appearance_group_tool_calls_desc` strings (5 languages) are unchanged. The existing copy ("Collapse adjacent regular tool calls into summary blocks") remains factually correct; the new default-collapsed-while-running stance is documented on the docs site instead. Happy to refresh translations in a follow-up if reviewers want it.