### PR TITLE
fix(scm): instant PR status on workspace switch, log GitHub API errors

### DIFF
--- a/plugins/scm-github/init.lua
+++ b/plugins/scm-github/init.lua
@@ -171,6 +171,7 @@ function M.ci_status(args)
         "--json", "name,state,link,startedAt",
     })
     if not ok then
+        host.log("warn", "ci_status failed for branch " .. tostring(args.branch) .. ": " .. tostring(data))
         return {}
     end
     local checks = {}

--- a/plugins/scm-gitlab/init.lua
+++ b/plugins/scm-gitlab/init.lua
@@ -120,6 +120,7 @@ function M.ci_status(args)
         "--output-format", "json",
     })
     if not ok then
+        host.log("warn", "ci_status failed for branch " .. tostring(args.branch) .. ": " .. tostring(data))
         return {}
     end
     local checks = {}

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -713,12 +713,22 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
     {
         Ok(Some(name)) => name,
         Ok(None) => {
-            // Confirmed no provider for this remote — clear any stale cache row.
+            // Confirmed no provider for this remote — clear stale cache and
+            // return an empty detail so the polling loop emits a clearing
+            // scm-data-updated event. Without this, boot-hydrated detail in
+            // the frontend is never evicted when a provider is removed, and
+            // the PR banner sticks on screen indefinitely.
             if let Ok(db) = Database::open(&app_state.db_path) {
                 let _ = db.delete_scm_status_cache(workspace_id);
             }
             app_state.scm_cache.entries.write().await.remove(&cache_key);
-            return None;
+            return Some(ScmDetail {
+                workspace_id: workspace_id.to_string(),
+                pull_request: None,
+                ci_checks: vec![],
+                provider: None,
+                error: None,
+            });
         }
         Err(e) => {
             // Transient remote-lookup failure — preserve any prior cached detail

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -257,6 +257,17 @@ pub async fn load_scm_detail(
         should_persist,
     } = outcome;
 
+    if let Some(ref e) = error {
+        tracing::warn!(
+            target: "claudette::scm",
+            workspace_id = %workspace_id,
+            branch = %cache_key.1,
+            provider = %provider_name,
+            error = %e,
+            "SCM fetch error"
+        );
+    }
+
     if should_persist {
         persist_scm_cache(
             &state.scm_cache,
@@ -770,6 +781,17 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
         error,
         should_persist,
     } = outcome;
+
+    if let Some(ref e) = error {
+        tracing::warn!(
+            target: "claudette::scm",
+            workspace_id = %workspace_id,
+            branch = %cache_key.1,
+            provider = %provider_name,
+            error = %e,
+            "SCM poll error"
+        );
+    }
 
     if should_persist {
         persist_scm_cache(

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -160,7 +160,8 @@ function App() {
         // exactly the kind of regression we want the rollback to
         // catch — see the comment on the `bootOk` useEffect above.
         setInitialDataLoaded(true);
-        // Hydrate SCM summaries from persisted cache for instant sidebar display.
+        // Hydrate SCM summaries and detail from persisted cache so sidebar
+        // badges and the PR banner show instantly without a network call.
         for (const row of data.scm_cache) {
           if (row.pr_json == null) continue;
           try {
@@ -178,12 +179,24 @@ function App() {
             const checks = Array.isArray(parsedChecks)
               ? (parsedChecks as import("./types/plugin").CiCheck[])
               : [];
-            useAppStore.getState().setScmSummary(row.workspace_id, {
+            const store = useAppStore.getState();
+            store.setScmSummary(row.workspace_id, {
               hasPr: pr !== null,
               prState: pr?.state ?? null,
               ciState: pr ? deriveScmCiState(pr.ci_status, checks) : null,
               lastUpdated: new Date(row.fetched_at.replace(" ", "T") + "Z").getTime(),
             });
+            // Also seed the per-workspace detail map so selecting any workspace
+            // shows the PR banner immediately instead of waiting for a fetch.
+            if (pr) {
+              store.setScmDetail({
+                workspace_id: row.workspace_id,
+                pull_request: pr,
+                ci_checks: checks,
+                provider: row.provider ?? null,
+                error: row.error ?? null,
+              });
+            }
           } catch {
             // Corrupted cache entry — skip silently, will be refreshed by polling.
           }
@@ -541,10 +554,9 @@ function App() {
           : null,
         lastUpdated: Date.now(),
       });
-      // Update detail if this is the selected workspace
-      if (store.selectedWorkspaceId === detail.workspace_id) {
-        store.setScmDetail(detail);
-      }
+      // Update per-workspace detail for all polled workspaces so switching
+      // to any of them shows the PR banner immediately without a new fetch.
+      store.setScmDetail(detail);
     });
 
     // Listen for missing-CLI events (claude/git/gh not on PATH). Routes to the

--- a/src/ui/src/hooks/usePrBannerData.ts
+++ b/src/ui/src/hooks/usePrBannerData.ts
@@ -37,20 +37,25 @@ export function usePrBannerData(): {
   const scmSummary = useAppStore((s) =>
     selectedWorkspaceId ? s.scmSummary[selectedWorkspaceId] : undefined
   );
-  const scmDetail = useAppStore((s) => s.scmDetail);
+  // Per-workspace detail: populated at boot from SQLite cache and kept fresh
+  // by polling events, so switching workspaces shows instant state.
+  const scmDetail = useAppStore((s) =>
+    selectedWorkspaceId ? s.scmDetails[selectedWorkspaceId] : undefined
+  );
   const setScmDetail = useAppStore((s) => s.setScmDetail);
   const setScmDetailLoading = useAppStore((s) => s.setScmDetailLoading);
   const setScmSummary = useAppStore((s) => s.setScmSummary);
 
+  // Guards against concurrent in-flight fetches for the same workspace.
   const fetchedForRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!selectedWorkspaceId) return;
     if (!scmSummary?.hasPr) return;
 
-    // Already have detail for this workspace
-    if (scmDetail?.workspace_id === selectedWorkspaceId) return;
-    // Already fetched for this workspace
+    // Detail already loaded for this workspace (from cache or prior fetch).
+    if (scmDetail) return;
+    // Fetch already in-flight for this workspace.
     if (fetchedForRef.current === selectedWorkspaceId) return;
 
     fetchedForRef.current = selectedWorkspaceId;
@@ -79,24 +84,20 @@ export function usePrBannerData(): {
         }
       })
       .catch(() => {
-        // Reset so a retry is possible on next render cycle
+        // Reset so a retry is possible on next render cycle.
         fetchedForRef.current = null;
       })
       .finally(() => setScmDetailLoading(false));
   }, [
     selectedWorkspaceId,
     scmSummary?.hasPr,
-    scmDetail?.workspace_id,
+    scmDetail,
     setScmDetail,
     setScmDetailLoading,
     setScmSummary,
   ]);
 
-  if (
-    !selectedWorkspaceId ||
-    !scmDetail?.pull_request ||
-    scmDetail.workspace_id !== selectedWorkspaceId
-  ) {
+  if (!selectedWorkspaceId || !scmDetail?.pull_request) {
     return { pr: null, checks: [], status: null };
   }
 

--- a/src/ui/src/stores/slices/repositoriesSlice.ts
+++ b/src/ui/src/stores/slices/repositoriesSlice.ts
@@ -55,9 +55,15 @@ export const createRepositoriesSlice: StateCreator<
       const newDiffTabs = { ...s.diffTabsByWorkspace };
       const newDiffSelection = { ...s.diffSelectionByWorkspace };
       const newChatDrafts = { ...s.chatDrafts };
+      // Mirror `removeWorkspace`'s SCM cleanup so deleting a repository
+      // doesn't leave orphaned PR/CI cache entries pinned in the store.
+      const newScmSummary = { ...s.scmSummary };
+      const newScmDetails = { ...s.scmDetails };
       for (const wsId of removedWsIds) {
         delete newDiffTabs[wsId];
         delete newDiffSelection[wsId];
+        delete newScmSummary[wsId];
+        delete newScmDetails[wsId];
         for (const session of s.sessionsByWorkspace[wsId] ?? []) {
           delete newChatDrafts[session.id];
         }
@@ -80,6 +86,8 @@ export const createRepositoriesSlice: StateCreator<
         diffTabsByWorkspace: newDiffTabs,
         diffSelectionByWorkspace: newDiffSelection,
         chatDrafts: newChatDrafts,
+        scmSummary: newScmSummary,
+        scmDetails: newScmDetails,
       };
     }),
 });

--- a/src/ui/src/stores/slices/scmSlice.ts
+++ b/src/ui/src/stores/slices/scmSlice.ts
@@ -4,10 +4,13 @@ import type { AppState } from "../useAppStore";
 
 export interface ScmSlice {
   scmSummary: Record<string, ScmSummary>;
-  scmDetail: ScmDetail | null;
+  /** Full PR+CI detail keyed by workspace_id. Populated at boot from SQLite
+   *  cache and kept fresh by background polling events — so workspace switches
+   *  can show instant state without a network round-trip. */
+  scmDetails: Record<string, ScmDetail>;
   scmDetailLoading: boolean;
   setScmSummary: (wsId: string, summary: ScmSummary) => void;
-  setScmDetail: (detail: ScmDetail | null) => void;
+  setScmDetail: (detail: ScmDetail) => void;
   setScmDetailLoading: (loading: boolean) => void;
 }
 
@@ -15,12 +18,15 @@ export const createScmSlice: StateCreator<AppState, [], [], ScmSlice> = (
   set,
 ) => ({
   scmSummary: {},
-  scmDetail: null,
+  scmDetails: {},
   scmDetailLoading: false,
   setScmSummary: (wsId, summary) =>
     set((s) => ({
       scmSummary: { ...s.scmSummary, [wsId]: summary },
     })),
-  setScmDetail: (detail) => set({ scmDetail: detail }),
+  setScmDetail: (detail) =>
+    set((s) => ({
+      scmDetails: { ...s.scmDetails, [detail.workspace_id]: detail },
+    })),
   setScmDetailLoading: (loading) => set({ scmDetailLoading: loading }),
 });

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -138,6 +138,16 @@ export const createWorkspacesSlice: StateCreator<
       delete newTabOrder[id];
       const newWorkspaceEnvironment = { ...s.workspaceEnvironment };
       delete newWorkspaceEnvironment[id];
+      // Drop cached SCM state so the maps don't grow unboundedly and so a
+      // workspace id reused later (restore-from-archive collision) can't
+      // surface stale PR/CI data before the next poll completes. The
+      // SQLite cache row is handled separately by the Rust archive path
+      // (ON DELETE CASCADE on scm_status_cache, plus an explicit delete
+      // in `archive_workspace_inner`).
+      const newScmSummary = { ...s.scmSummary };
+      delete newScmSummary[id];
+      const newScmDetails = { ...s.scmDetails };
+      delete newScmDetails[id];
       return {
         workspaces: s.workspaces.filter((w) => w.id !== id),
         selectedWorkspaceId:
@@ -154,6 +164,8 @@ export const createWorkspacesSlice: StateCreator<
         chatDrafts: newChatDrafts,
         tabOrderByWorkspace: newTabOrder,
         workspaceEnvironment: newWorkspaceEnvironment,
+        scmSummary: newScmSummary,
+        scmDetails: newScmDetails,
       };
     }),
   selectWorkspace: (id) =>

--- a/src/ui/src/stores/useAppStore.persistence.test.ts
+++ b/src/ui/src/stores/useAppStore.persistence.test.ts
@@ -292,3 +292,63 @@ describe("clearDiff resets selection map", () => {
     expect(useAppStore.getState().diffSelectionByWorkspace).toEqual({});
   });
 });
+
+// ---------- SCM cleanup ----------
+
+describe("SCM cleanup on workspace/repository removal", () => {
+  beforeEach(() => {
+    reset();
+    useAppStore.setState({
+      repositories: [makeRepository("r1")],
+      scmSummary: {
+        "ws-a": { hasPr: true, prState: "open", ciState: "success", lastUpdated: 0 },
+        "ws-b": { hasPr: false, prState: null, ciState: null, lastUpdated: 0 },
+      },
+      scmDetails: {
+        "ws-a": {
+          workspace_id: "ws-a",
+          pull_request: {
+            number: 1,
+            title: "t",
+            state: "open",
+            url: "",
+            author: "",
+            branch: "",
+            base: "",
+            draft: false,
+            ci_status: "success",
+          },
+          ci_checks: [],
+          provider: "github",
+          error: null,
+        },
+        "ws-b": {
+          workspace_id: "ws-b",
+          pull_request: null,
+          ci_checks: [],
+          provider: "github",
+          error: null,
+        },
+      },
+    });
+  });
+
+  // Without these cleanups the maps grow unboundedly across remove/restore
+  // cycles, and a workspace id reused later would surface stale PR/banner
+  // state before the next poll completes.
+  it("removeWorkspace evicts scmSummary and scmDetails for that id only", () => {
+    useAppStore.getState().removeWorkspace("ws-a");
+    const state = useAppStore.getState();
+    expect(state.scmSummary["ws-a"]).toBeUndefined();
+    expect(state.scmDetails["ws-a"]).toBeUndefined();
+    expect(state.scmSummary["ws-b"]).toBeDefined();
+    expect(state.scmDetails["ws-b"]).toBeDefined();
+  });
+
+  it("removeRepository evicts scmSummary and scmDetails for every workspace under it", () => {
+    useAppStore.getState().removeRepository("r1");
+    const state = useAppStore.getState();
+    expect(state.scmSummary).toEqual({});
+    expect(state.scmDetails).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

- **Per-workspace SCM detail cache**: changed `scmDetail: ScmDetail | null` (single slot) to `scmDetails: Record<string, ScmDetail>` keyed by `workspace_id`. Switching workspaces no longer evicts the prior workspace's PR data, eliminating the 1–3s `gh pr list` + `gh pr checks` round-trip on every selection.
- **Boot hydration covers both maps**: the initial data load already seeded `scmSummary` (sidebar badges) from SQLite — now it also seeds `scmDetails` for every cached workspace, so the PR banner is instant from first render.
- **Polling updates all workspaces**: the `scm-data-updated` event listener previously only wrote detail when `workspace_id === selectedWorkspaceId`, discarding results for all other polled workspaces. Now every result goes into `scmDetails[wsId]` unconditionally.
- **Structured error logging (Rust)**: `tracing::warn!(target: "claudette::scm", workspace_id, branch, provider, error)` added after `merge_scm_results` in both `load_scm_detail` and `poll_workspace_scm`.
- **Plugin error logging (Lua)**: `host.log("warn", ...)` added in the GitHub and GitLab `ci_status` functions before returning `{}` on `pcall` failure — GitHub API rate-limit and auth errors are now visible in the structured log.

## Test plan

- [x] Select multiple workspaces with open PRs in rapid succession — banner should appear immediately on each (no loading delay after boot)
- [x] Restart the app — PR badge and banner should be visible without waiting for the first poll cycle (~35s)
- [x] Verify `scm-data-updated` events update all workspace detail entries, not just the selected one (check via `/claudette-debug state scmDetails`)
- [x] With a GitHub auth failure, verify `host.log` warn appears in the Tauri log output
- [x] `bunx tsc -b` — no type errors
- [x] `bun run test` — 1788/1788 pass
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` — zero warnings