### PR TITLE
fix(env-direnv): strip direnv's internal markers so they don't break the in-shell hook

### DIFF
--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -56,9 +56,9 @@ function M.export(args)
 
     -- Empty stdout = no vars to export (e.g. `.envrc` exists but is
     -- empty, or direnv is silently allowing without any exports).
-    local env_map = {}
+    local raw_env = {}
     if result.stdout and #result.stdout > 0 then
-        env_map = host.json_decode(result.stdout)
+        raw_env = host.json_decode(result.stdout)
     end
 
     -- Seed with `.envrc` unconditionally — it's always a watch target.
@@ -76,15 +76,42 @@ function M.export(args)
         end
     end
     add(join(worktree_of(args), ".envrc"))
-    local direnv_watches = env_map["DIRENV_WATCHES"]
+    local direnv_watches = raw_env["DIRENV_WATCHES"]
     if type(direnv_watches) == "string" and #direnv_watches > 0 then
         for _, path in ipairs(host.direnv_decode_watches(direnv_watches)) do
             add(path)
         end
     end
 
+    -- Strip direnv's internal markers (DIRENV_DIR, DIRENV_FILE,
+    -- DIRENV_DIFF, DIRENV_WATCHES, etc.) before returning. These keys
+    -- are how direnv's shell hook (`eval "$(direnv hook zsh)"`) decides
+    -- "this directory is already loaded, skip re-export" — so leaking
+    -- them into a PTY env makes the user's interactive shell short-
+    -- circuit its first-prompt evaluation and never load the .envrc's
+    -- shell-side artifacts (numtide/devshell's `menu` command,
+    -- functions defined in the .envrc, etc.). The shell hook will
+    -- emit these markers itself the first time it runs against a
+    -- clean environment. They are also useless to the agent
+    -- subprocess, which doesn't run a direnv hook.
+    --
+    -- Worse: when `direnv export json` fails to load the .envrc body
+    -- (e.g. `use flake` couldn't find `nix` because Claudette was
+    -- launched from Finder with launchd's stripped PATH and the env-
+    -- provider host_exec couldn't recover it), direnv STILL emits the
+    -- four markers as a "you tried to load" memo. Without this strip
+    -- step, that failure surfaces as a silently broken interactive
+    -- shell — env-provider returns "ok", PTY starts, direnv hook
+    -- short-circuits on the markers, no real env ever loads.
+    local env = {}
+    for k, v in pairs(raw_env) do
+        if not string.match(k, "^DIRENV_") then
+            env[k] = v
+        end
+    end
+
     return {
-        env = env_map,
+        env = env,
         watched = watched,
     }
 end

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -264,6 +264,212 @@ fn direnv_export_watches_list_tolerates_garbage_direnv_watches() {
     assert!(watched[0].ends_with(".envrc"));
 }
 
+/// Drive env-direnv's `export` with a caller-supplied env map and
+/// return the full `(env, watched)` shape the plugin returns. Used by
+/// the marker-strip regression tests to assert what the dispatcher
+/// would actually merge into the workspace env.
+fn direnv_export_returns(
+    env_in: serde_json::Value,
+) -> (
+    std::collections::HashMap<String, Option<String>>,
+    Vec<String>,
+    tempfile::TempDir,
+) {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "export FOO=bar\n").unwrap();
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+
+    let env_json = serde_json::to_string(&env_in).unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().expect("export");
+
+    let env_tbl: mlua::Table = result.get("env").expect("env field");
+    let mut env = std::collections::HashMap::new();
+    for pair in env_tbl.pairs::<String, mlua::Value>() {
+        let (k, v) = pair.unwrap();
+        // direnv encodes "unset this key" as a JSON null, which lands
+        // in Lua as `nil` (which `pairs` skips entirely) — so anything
+        // we see here is a real string value.
+        let s = match v {
+            mlua::Value::String(s) => Some(s.to_str().unwrap().to_string()),
+            mlua::Value::Nil => None,
+            other => panic!("unexpected env value type: {other:?}"),
+        };
+        env.insert(k, s);
+    }
+
+    let watched_tbl: mlua::Table = result.get("watched").expect("watched field");
+    let len = watched_tbl.len().expect("len") as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).expect("string path"))
+        .collect();
+
+    (env, watched, tmp)
+}
+
+#[test]
+fn direnv_export_strips_internal_markers_from_returned_env() {
+    // Regression for the nightly-only direnv breakage: when the env
+    // dispatcher merged the plugin's output into a PTY env, leaking
+    // direnv's own `DIRENV_DIR` / `DIRENV_FILE` / `DIRENV_DIFF` /
+    // `DIRENV_WATCHES` markers tricked the in-shell `direnv hook`
+    // into concluding "already loaded for this dir" and skipping
+    // its first-prompt re-export. The user then never saw shell-side
+    // artifacts (numtide/devshell's `menu`, .envrc-defined functions),
+    // even though `direnv reload` from inside the same shell worked
+    // because that path bypasses the markers and re-evaluates the
+    // .envrc cleanly.
+    //
+    // Pin: `direnv export json` always emits DIRENV_* memos — even
+    // when the .envrc body fails to load (e.g. `use flake` couldn't
+    // find `nix`). The plugin must strip every `DIRENV_*` key from
+    // the returned env so the in-shell hook always does its own
+    // first-prompt evaluation.
+    let stubbed = serde_json::json!({
+        "FOO": "bar",
+        "PATH": "/bin:/usr/bin",
+        "DIRENV_DIR": "-/path/to/workspace",
+        "DIRENV_FILE": "/path/to/workspace/.envrc",
+        "DIRENV_DIFF": "eJxxxx",
+        "DIRENV_WATCHES": "eJyyyy",
+    });
+    let (env, _watched, _tmp) = direnv_export_returns(stubbed);
+
+    // Real exports survive.
+    assert_eq!(
+        env.get("FOO").and_then(|v| v.clone()),
+        Some("bar".to_string())
+    );
+    assert_eq!(
+        env.get("PATH").and_then(|v| v.clone()),
+        Some("/bin:/usr/bin".to_string())
+    );
+    // Every internal marker is gone — the in-shell hook will set
+    // these itself the first time it runs.
+    for key in ["DIRENV_DIR", "DIRENV_FILE", "DIRENV_DIFF", "DIRENV_WATCHES"] {
+        assert!(
+            !env.contains_key(key),
+            "expected {key} to be stripped from returned env, got keys = {:?}",
+            env.keys().collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn direnv_export_strips_markers_but_keeps_watches_decoded_into_watched() {
+    // The strip step happens AFTER the plugin reads `DIRENV_WATCHES`
+    // for the watch list. Regressing the order would silently lose
+    // user `watch_file` directives — the cache would only invalidate
+    // on `.envrc` changes, missing edits to files like `secret.env`
+    // sourced via `dotenv`.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "export FOO=bar\n").unwrap();
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let envrc_path = format!("{worktree}/.envrc");
+    let secret_path = format!("{worktree}/secret.env");
+    let encoded = encode_direnv_watches(&[&envrc_path, &secret_path]);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+
+    // Watch list still picks up the secret.env that DIRENV_WATCHES
+    // pointed at — the strip happens AFTER we decoded the watches.
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+    assert!(
+        watched.contains(&secret_path),
+        "expected secret.env in watched after strip, got {watched:?}"
+    );
+
+    // But DIRENV_WATCHES is gone from the env we hand the dispatcher.
+    let env_tbl: mlua::Table = result.get("env").unwrap();
+    assert!(
+        env_tbl
+            .get::<mlua::Value>("DIRENV_WATCHES")
+            .map(|v| matches!(v, mlua::Value::Nil))
+            .unwrap_or(true),
+        "DIRENV_WATCHES must not survive into the returned env"
+    );
+    // FOO survives — the strip is not greedy across non-DIRENV keys.
+    assert_eq!(env_tbl.get::<String>("FOO").ok().as_deref(), Some("bar"));
+}
+
+#[test]
+fn direnv_export_strip_handles_failed_use_flake_payload() {
+    // Reproduces the exact wire-shape `direnv export json` returns
+    // when the .envrc body failed (e.g. `use flake` couldn't find
+    // `nix` because launchd-launched Claudette's host_exec PATH
+    // didn't recover the user's nix profile). direnv emits ONLY the
+    // four memos and no real env. Pre-fix, this leaked into the PTY,
+    // tricking the shell hook into a no-op. Post-fix, the dispatcher
+    // gets an empty env and the in-shell hook re-evaluates fresh.
+    let stubbed = serde_json::json!({
+        "DIRENV_DIR": "-/path/to/workspace",
+        "DIRENV_FILE": "/path/to/workspace/.envrc",
+        "DIRENV_DIFF": "eJxxxx",
+        "DIRENV_WATCHES": "eJyyyy",
+    });
+    let (env, watched, _tmp) = direnv_export_returns(stubbed);
+    assert!(
+        env.is_empty(),
+        "failed-payload export must contribute zero vars, got {env:?}"
+    );
+    // .envrc is still seeded into the watch list so editing it
+    // (e.g. fixing the `use flake` issue) still busts the cache.
+    assert_eq!(watched.len(), 1);
+    assert!(watched[0].ends_with(".envrc"));
+}
+
 // ---------------------------------------------------------------------------
 // env-mise
 // ---------------------------------------------------------------------------
@@ -622,6 +828,19 @@ async fn integration_direnv_export_returns_env() {
         Some("hello"),
         "expected CLAUDETTE_DIRENV_TEST=hello in merged env; full resolved = {resolved:#?}"
     );
+    // End-to-end strip pin: real `direnv export json` always emits
+    // DIRENV_DIR / DIRENV_FILE / DIRENV_DIFF / DIRENV_WATCHES memos.
+    // The plugin must drop them before they reach the merged env, or
+    // PTYs that inherit this env tell their `direnv hook zsh` to
+    // skip the first-prompt re-export and never load .envrc-defined
+    // shell functions.
+    for marker in ["DIRENV_DIR", "DIRENV_FILE", "DIRENV_DIFF", "DIRENV_WATCHES"] {
+        assert!(
+            !resolved.vars.contains_key(marker),
+            "expected {marker} stripped end-to-end, got {:?}",
+            resolved.vars.keys().collect::<Vec<_>>()
+        );
+    }
 }
 
 #[cfg(has_mise)]

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -445,6 +445,37 @@ fn direnv_export_strips_markers_but_keeps_watches_decoded_into_watched() {
 }
 
 #[test]
+fn direnv_export_strip_is_prefix_based_for_future_markers() {
+    // The strip matches `^DIRENV_` rather than a hardcoded deny-list,
+    // so if direnv ships a new internal marker (e.g. `DIRENV_LAYOUT_*`
+    // or anything else they add to their state machine), it won't
+    // resurface this bug. Pin the prefix-match contract here — a
+    // refactor that swaps it for an explicit list of the four known
+    // markers must update this test, which is the signal that the
+    // forward-compat property is being lost.
+    let stubbed = serde_json::json!({
+        "REAL_VAR": "keep",
+        "DIRENV_FUTURE_MARKER": "should-be-stripped",
+        "DIRENV_LAYOUT_NIX_FLAKE": "should-be-stripped",
+    });
+    let (env, _watched, _tmp) = direnv_export_returns(stubbed);
+    assert_eq!(
+        env.get("REAL_VAR").and_then(|v| v.clone()),
+        Some("keep".to_string())
+    );
+    assert!(
+        !env.contains_key("DIRENV_FUTURE_MARKER"),
+        "future direnv internal marker leaked: {:?}",
+        env.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        !env.contains_key("DIRENV_LAYOUT_NIX_FLAKE"),
+        "future direnv internal marker leaked: {:?}",
+        env.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn direnv_export_strip_handles_failed_use_flake_payload() {
     // Reproduces the exact wire-shape `direnv export json` returns
     // when the .envrc body failed (e.g. `use flake` couldn't find


### PR DESCRIPTION
## Symptom

In release / nightly builds, opening a fresh terminal tab in a workspace that uses direnv lands without the `.envrc`-defined shell artifacts — `numtide/devshell`'s `menu` command is missing, `.envrc`-defined functions are missing, etc. — even though the shell prompt's nix-shell indicator (e.g. `(claudette-env)`) suggests direnv "loaded." Running `direnv reload` from inside that same shell fixes it instantly.

UAT'd against the dev build (`scripts/dev.sh` / `cargo tauri dev`), this never reproduced — the bug appeared only after the user upgraded to the nightly build that included #750. Confirmed reproducible on the user's machine; confirmed fixed by this branch in a local release build (`build-app` from the devshell).

## Root cause

`direnv export json` always emits four internal memo keys — `DIRENV_DIR`, `DIRENV_FILE`, `DIRENV_DIFF`, `DIRENV_WATCHES` — *even when the `.envrc` body silently failed* (e.g. `use flake` couldn't find `nix` because the launchd-launched Claudette's `host.exec` PATH didn't recover the user's nix profile).

Reproduced empirically with `env -i HOME=$HOME USER=$USER SHELL=$SHELL PATH=/usr/bin:/bin:/usr/sbin:/sbin direnv export json` against a `.envrc` that does `use flake` — direnv returns only:

\`\`\`
keys: ['DIRENV_DIFF', 'DIRENV_DIR', 'DIRENV_FILE', 'DIRENV_WATCHES']
\`\`\`

… and stderr \`nix: command not found\`. No \`IN_NIX_SHELL\`, no \`PATH\`, no \`DEVSHELL_DIR\` — just the four memos.

Claudette's env-provider plugin merged those memos into the PTY env. When the user's interactive shell sourced `~/.zshrc` and ran `eval "$(direnv hook zsh)"`, the hook read those memos, concluded **"this directory is already loaded, skip the first-prompt re-export,"** and never evaluated `.envrc` itself. The shell-side artifacts (functions, devshell `menu`) only exist after that re-export, so they stayed missing. `direnv reload` worked because it bypasses the memos and re-evaluates from scratch, this time inside an interactive shell that *does* have `nix` on PATH from `.zshrc`'s nix-darwin bootstrap.

### Why dev mode didn't reproduce

`scripts/dev.sh` is launched from a nix-loaded terminal, so the Tauri process inherits a rich PATH that contains `nix`. `host.exec`'s enriched PATH already worked → `direnv export json` actually loaded the flake → real env vars (PATH, IN_NIX_SHELL, etc.) landed alongside the memos. The shell-hook short-circuit still happened, but the PTY's PATH already pointed at the devshell so `menu` resolved anyway.

Launchd-launched release builds inherit `/usr/bin:/bin:/usr/sbin:/sbin`. The login-shell probe in `enriched_path()` does recover the user's full PATH for some call sites, but `direnv` itself spawns subprocesses against its own narrower context, so `use flake` failed silently. The PTY then received *only* the leaked memos with no real PATH — exactly the broken state.

## Fix

`plugins/env-direnv/init.lua` now:

1. Decodes `DIRENV_WATCHES` for the cache invalidation watch list (unchanged behavior — user `watch_file` directives still bust the cache).
2. **Strips every `DIRENV_*` key** from the env map before returning, using `^DIRENV_` prefix match (forward-compatible if direnv adds new internal markers later).

The shell-side direnv hook now sets these memos itself the first time it runs against a clean PTY environment — same as a terminal opened anywhere else on the machine. The agent subprocess doesn't run a direnv hook, so dropping them from its inherited env is a no-op for it.

This also addresses the secondary "agent feels blocked" symptom the user reported: when env-provider failed silently in the broken case, the marker leak polluted every downstream spawn. Post-fix, a failed `direnv export json` correctly contributes zero vars and the in-shell hook is free to recover on first prompt.

## Trade-offs considered

- **Prefix match (\`^DIRENV_\`) vs hardcoded deny-list of the four known memos.** Chose prefix match so future direnv internal state names won't reintroduce this bug. The downside is a user who manually exports something like \`DIRENV_LOG_FORMAT\` from their \`.envrc\` (a direnv *config* var, not an internal marker) would have it stripped. That's vanishingly rare in practice; the bug affects every user with a \`.envrc\`. Pinned by \`direnv_export_strip_is_prefix_based_for_future_markers\`.
- **Strip in the plugin (Lua) vs the dispatcher (Rust).** Chose plugin-side. Other env-providers (mise, dotenv, nix-devshell) don't emit equivalent markers; this is a direnv-specific quirk, not a dispatcher concern. Keeping the strip co-located with the plugin keeps `env-direnv/init.lua` self-contained.
- **Surface the underlying \`use flake\` failure to the user.** Out of scope for this fix — landing the strip means the in-shell hook recovers regardless, so users get a working terminal. A follow-up could detect \`stderr\` containing common failure markers (\`nix: command not found\`, \`use flake: ...\`) and surface a hint in the Environment panel.

## Regression tests

Five new tests in `src/env_provider/plugin_tests.rs`:

| Test | Pins |
|---|---|
| `direnv_export_strips_internal_markers_from_returned_env` | The four known markers are stripped; real exports (FOO, PATH) survive |
| `direnv_export_strips_markers_but_keeps_watches_decoded_into_watched` | Strip happens AFTER `DIRENV_WATCHES` decode — \`watch_file\` directives still bust cache when the watched file changes |
| `direnv_export_strip_handles_failed_use_flake_payload` | Failure case (only memos, no real env) → empty contribution to dispatcher |
| `direnv_export_strip_is_prefix_based_for_future_markers` | Forward-compat: `^DIRENV_` matches any future internal marker (refactor to a hardcoded list fails this) |
| `integration_direnv_export_returns_env` (extended) | End-to-end via real registry — no `DIRENV_*` key survives into the dispatcher's merged env |

Run locally:

\`\`\`
nix develop -c cargo test -p claudette --lib direnv_export
\`\`\`

→ 8 tests pass (4 new + 1 extended integration + 3 existing).

## CI checks before push

- \`cargo fmt --all --check\` ✅
- \`cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features -- -Dwarnings\` ✅
- \`cargo test -p claudette -p claudette-server -p claudette-cli --all-features\` ✅ (1105 backend tests, 0 failures)
- \`cd src/ui && bunx tsc -b\` ✅ (no UI changes, sanity)

## Verified locally

Built via \`build-app\` (devshell command) → \`target/release/bundle/macos/Claudette.app\` → launched with \`open -n\` and confirmed fresh terminals in direnv-using workspaces now load \`.envrc\`-defined shell artifacts (\`menu\`, devshell commands, etc.) without needing \`direnv reload\`.