### PR TITLE
fix(windows): integrated terminal PowerShell profile + env-prep UI lock recovery

### DIFF
--- a/site/src/content/docs/features/integrated-terminal.mdx
+++ b/site/src/content/docs/features/integrated-terminal.mdx
@@ -36,12 +36,24 @@ Split layouts are **ephemeral** — the app reopens each tab as a single pane on
 
 Each PTY launches your platform's interactive shell, with that shell's normal profile loading mechanism intact — so prompts, aliases, modules, and `direnv`/`mise`/etc. integrations from your dotfiles all work.
 
-| Platform | Shell resolution order |
-|---|---|
-| **macOS / Linux** | `$SHELL` → `/bin/zsh` (macOS) or `/bin/bash` (Linux) |
-| **Windows** | `pwsh.exe` on `PATH` (PowerShell 7+) → `powershell.exe` (Windows PowerShell 5.1) → `%ComSpec%` → `%WINDIR%\System32\cmd.exe` |
+### macOS / Linux
 
-On Windows, both PowerShell flavours auto-load `$PROFILE` when started in the integrated terminal (a ConPTY-backed interactive host), and `cmd.exe` honours its `HKCU\Software\Microsoft\Command Processor\AutoRun` entry. No extra arguments are passed, so the shell behaves the same as it would in a stock Windows Terminal tab.
+`$SHELL` is honoured if set; otherwise `/bin/zsh` (macOS) or `/bin/bash` (Linux). The shell's regular profile (`~/.zshrc`, `~/.bashrc`, etc.) loads as it would in any other terminal.
+
+### Windows
+
+`pwsh.exe` (PowerShell 7+) and `powershell.exe` (Windows PowerShell 5.1) read profiles from totally different paths — `Documents\PowerShell\…` vs `Documents\WindowsPowerShell\…` — so blindly preferring PS7 leaves PS5.1 users staring at an unconfigured banner. Claudette's resolution is **profile-aware**: it picks the PowerShell flavour whose profile you've actually written.
+
+1. `pwsh.exe` on `PATH` **and** a PS7 profile exists
+2. `powershell.exe` on `PATH` **and** a PS5.1 profile exists (and there's no PS7 profile)
+3. `pwsh.exe` on `PATH` (modern default when no profile signal either way)
+4. `powershell.exe` on `PATH` (in-box fallback)
+5. `%ComSpec%` (deliberate `cmd.exe` override, if set)
+6. `%WINDIR%\System32\cmd.exe` (always-present last resort)
+
+Profile detection probes both `%USERPROFILE%\Documents\…` and `%USERPROFILE%\OneDrive\Documents\…` (Office 365 and Windows 11 Backup commonly redirect Documents into OneDrive). Both per-host (`Microsoft.PowerShell_profile.ps1`) and all-hosts (`Profile.ps1`) profiles count.
+
+No extra arguments are passed, so the shell behaves the same as it would in a stock Windows Terminal tab — PowerShell auto-loads `$PROFILE`, and `cmd.exe` honours its `HKCU\Software\Microsoft\Command Processor\AutoRun` entry.
 
 ## Terminal Font Size
 

--- a/site/src/content/docs/features/integrated-terminal.mdx
+++ b/site/src/content/docs/features/integrated-terminal.mdx
@@ -32,6 +32,17 @@ Each pane runs its own independent PTY in the workspace's worktree. Up to six pa
 
 Split layouts are **ephemeral** — the app reopens each tab as a single pane on restart. Tab identity and titles are persisted; the split arrangement within a tab is not.
 
+## Default Shell
+
+Each PTY launches your platform's interactive shell, with that shell's normal profile loading mechanism intact — so prompts, aliases, modules, and `direnv`/`mise`/etc. integrations from your dotfiles all work.
+
+| Platform | Shell resolution order |
+|---|---|
+| **macOS / Linux** | `$SHELL` → `/bin/zsh` (macOS) or `/bin/bash` (Linux) |
+| **Windows** | `pwsh.exe` on `PATH` (PowerShell 7+) → `powershell.exe` (Windows PowerShell 5.1) → `%ComSpec%` → `%WINDIR%\System32\cmd.exe` |
+
+On Windows, both PowerShell flavours auto-load `$PROFILE` when started in the integrated terminal (a ConPTY-backed interactive host), and `cmd.exe` honours its `HKCU\Software\Microsoft\Command Processor\AutoRun` entry. No extra arguments are passed, so the shell behaves the same as it would in a stock Windows Terminal tab.
+
 ## Terminal Font Size
 
 Adjust the terminal font size in `Settings > Appearance > Terminal font size` (range: 8–24px, default: 11px).

--- a/src-tauri/src/commands/env.rs
+++ b/src-tauri/src/commands/env.rs
@@ -40,6 +40,16 @@ pub struct EnvCacheInvalidatedPayload {
 pub enum EnvProgressPhase {
     Started,
     Finished,
+    /// Emitted once after the resolve loop completes, regardless of
+    /// which Tauri command kicked it off (`prepare_workspace_environment`,
+    /// `spawn_pty`, agent spawn, EnvPanel reload, repo warmup). The
+    /// frontend uses this as the authoritative "all plugins are done"
+    /// signal so a stale "preparing" status set by an earlier
+    /// `Started` event can be cleared even when the command's own
+    /// response promise is dropped by WebView2 (the Windows IPC race
+    /// that originally locked the new-terminal-tab + chat composer
+    /// UI). Carries no plugin or ok field — pure terminator.
+    Complete,
 }
 
 #[derive(Clone, Serialize)]
@@ -98,6 +108,35 @@ impl claudette::env_provider::EnvProgressSink for TauriEnvProgressSink {
                 phase: EnvProgressPhase::Finished,
                 elapsed_ms: elapsed.as_millis() as u64,
                 ok: Some(ok),
+            },
+        );
+    }
+}
+
+/// Emit a `Complete` event whenever the sink is dropped. This is the
+/// authoritative terminator for the workspace's progress stream — fires
+/// after the resolve loop returns regardless of which command owned
+/// the sink and regardless of whether that command's Tauri response
+/// makes it back across the WebView2 IPC bridge.
+///
+/// Without this terminator, the symptom on Windows was: clicking the
+/// terminal new-tab button triggered a `spawn_pty` whose own env
+/// resolve emitted `Started`/`Finished` events that flipped the
+/// workspace's `workspaceEnvironment` slice to `"preparing"`, but no
+/// caller-side path then set it back to `"ready"` (the `+` click
+/// doesn't go through the dedicated `prepare_workspace_environment`
+/// command, so no `.then` fires on the JS side). The user stayed
+/// locked at "preparing" with no recovery.
+impl Drop for TauriEnvProgressSink {
+    fn drop(&mut self) {
+        let _ = self.app.emit(
+            "workspace_env_progress",
+            WorkspaceEnvProgressPayload {
+                workspace_id: self.workspace_id.clone(),
+                plugin: String::new(),
+                phase: EnvProgressPhase::Complete,
+                elapsed_ms: 0,
+                ok: None,
             },
         );
     }

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -1,16 +1,46 @@
 use serde::Serialize;
 
+// `Bash`/`Zsh`/`Fish`/`Unknown` are only constructed on POSIX targets;
+// `PowerShell`/`Cmd` only on Windows. Both halves are part of the
+// `detect_user_shell` API though, so blanket `dead_code` keeps either
+// side of the cfg compiling under CI's `-Dwarnings` without scattering
+// `cfg_attr` markers across each variant.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ShellType {
     Bash,
     Zsh,
     Fish,
+    /// PowerShell — either modern `pwsh.exe` (PowerShell 7+) or the
+    /// in-box `powershell.exe` (Windows PowerShell 5.1). Both auto-load
+    /// the user's `$PROFILE` when launched interactively in a ConPTY,
+    /// so spawning the bare exe is enough to get the user's prompt,
+    /// aliases, and module imports.
+    PowerShell,
+    /// `cmd.exe` — the last-resort Windows fallback when no PowerShell
+    /// is on PATH. Honours `HKCU\Software\Microsoft\Command Processor\AutoRun`
+    /// for any user-supplied init, so again no extra args needed.
+    Cmd,
     Unknown,
 }
 
 pub fn detect_user_shell() -> (String, ShellType) {
-    // Try $SHELL environment variable first
+    #[cfg(target_os = "windows")]
+    {
+        windows_detect_user_shell()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        posix_detect_user_shell()
+    }
+}
+
+/// POSIX-side detection: `$SHELL` is the user's stated preference; fall
+/// back to a sensible per-platform default so a launchd / systemd-spawned
+/// release build (which inherits a stripped env) still gets a real shell.
+#[cfg(not(target_os = "windows"))]
+fn posix_detect_user_shell() -> (String, ShellType) {
     if let Ok(shell) = std::env::var("SHELL") {
         let shell_type = match shell.as_str() {
             s if s.contains("bash") => ShellType::Bash,
@@ -21,17 +51,71 @@ pub fn detect_user_shell() -> (String, ShellType) {
         return (shell, shell_type);
     }
 
-    // Fallback: use system default
     #[cfg(target_os = "macos")]
-    let default = ("/bin/zsh".to_string(), ShellType::Zsh);
-
+    {
+        ("/bin/zsh".to_string(), ShellType::Zsh)
+    }
     #[cfg(target_os = "linux")]
-    let default = ("/bin/bash".to_string(), ShellType::Bash);
-
+    {
+        ("/bin/bash".to_string(), ShellType::Bash)
+    }
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    let default = ("/bin/sh".to_string(), ShellType::Unknown);
+    {
+        ("/bin/sh".to_string(), ShellType::Unknown)
+    }
+}
 
-    default
+/// Windows-side detection. portable-pty's `new_default_prog()` falls
+/// back to `cmd.exe` here, which never loads any user-customizable
+/// profile — so an integrated terminal looks nothing like the user's
+/// regular Windows Terminal session. Pick the most modern PowerShell
+/// that's actually on PATH, then degrade gracefully.
+///
+/// Resolution order:
+///   1. `pwsh.exe` on PATH    — PowerShell 7+ (cross-platform, modern)
+///   2. `powershell.exe`      — in-box Windows PowerShell 5.1
+///   3. `%ComSpec%`           — user's deliberate cmd override, if set
+///   4. `%WINDIR%\System32\cmd.exe` — guaranteed-present last resort
+#[cfg(target_os = "windows")]
+fn windows_detect_user_shell() -> (String, ShellType) {
+    let path = std::env::var_os("PATH");
+    let comspec = std::env::var_os("ComSpec");
+    let windir = std::env::var_os("WINDIR");
+    detect_windows_shell_inner(path.as_deref(), comspec.as_deref(), windir.as_deref())
+}
+
+/// Pure-function core of `windows_detect_user_shell`, parameterised on
+/// the env values it consults so tests don't have to mutate the
+/// process-wide environment (which would race with parallel tests).
+#[cfg(target_os = "windows")]
+fn detect_windows_shell_inner(
+    path_env: Option<&std::ffi::OsStr>,
+    comspec: Option<&std::ffi::OsStr>,
+    windir: Option<&std::ffi::OsStr>,
+) -> (String, ShellType) {
+    if let Some(found) = find_in_path("pwsh.exe", path_env) {
+        return (found, ShellType::PowerShell);
+    }
+    if let Some(found) = find_in_path("powershell.exe", path_env) {
+        return (found, ShellType::PowerShell);
+    }
+    if let Some(cs) = comspec.and_then(|s| s.to_str()).filter(|s| !s.is_empty()) {
+        return (cs.to_string(), ShellType::Cmd);
+    }
+    let win = windir.and_then(|s| s.to_str()).unwrap_or(r"C:\Windows");
+    (format!(r"{win}\System32\cmd.exe"), ShellType::Cmd)
+}
+
+#[cfg(target_os = "windows")]
+fn find_in_path(name: &str, path_env: Option<&std::ffi::OsStr>) -> Option<String> {
+    let path_env = path_env?;
+    for dir in std::env::split_paths(path_env) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate.to_string_lossy().into_owned());
+        }
+    }
+    None
 }
 
 #[tauri::command]
@@ -293,5 +377,133 @@ mod tests {
         // `C:foo` is a Windows-relative-to-current-dir-on-drive path —
         // unpredictable; reject.
         assert!(!is_acceptable_open_target("C:foo.csv"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Windows shell detection
+    //
+    // These tests pin the resolution order pwsh → powershell → ComSpec →
+    // %WINDIR%\System32\cmd.exe so a regression that quietly drops back
+    // to `cmd.exe` (the symptom we just fixed) gets caught in CI. They
+    // call `detect_windows_shell_inner` directly with synthetic env
+    // values rather than mutating the process environment, so the tests
+    // are safe to run under cargo's default parallel test harness.
+    // ---------------------------------------------------------------------
+    #[cfg(target_os = "windows")]
+    mod windows_shell {
+        use super::super::{ShellType, detect_windows_shell_inner};
+        use std::ffi::{OsStr, OsString};
+        use std::fs::File;
+        use std::path::Path;
+        use tempfile::TempDir;
+
+        /// Drop an empty file at `<dir>/<name>` so `Path::is_file()`
+        /// returns true for it. Content is irrelevant — the lookup is a
+        /// pure existence check.
+        fn touch(dir: &Path, name: &str) {
+            File::create(dir.join(name)).expect("create stub exe");
+        }
+
+        /// Build a `PATH`-style OsString joining the supplied dirs with
+        /// the platform separator.
+        fn join_path<P: AsRef<Path>>(dirs: &[P]) -> OsString {
+            std::env::join_paths(dirs.iter().map(|p| p.as_ref())).expect("join_paths")
+        }
+
+        #[test]
+        fn prefers_pwsh_over_powershell_when_both_present() {
+            let pwsh_dir = TempDir::new().unwrap();
+            let ps_dir = TempDir::new().unwrap();
+            touch(pwsh_dir.path(), "pwsh.exe");
+            touch(ps_dir.path(), "powershell.exe");
+
+            let path = join_path(&[pwsh_dir.path(), ps_dir.path()]);
+            let (shell, kind) = detect_windows_shell_inner(Some(path.as_os_str()), None, None);
+
+            assert_eq!(kind, ShellType::PowerShell);
+            assert!(
+                shell.ends_with("pwsh.exe"),
+                "expected pwsh.exe to win the lookup, got {shell:?}"
+            );
+        }
+
+        #[test]
+        fn falls_back_to_powershell_when_pwsh_missing() {
+            let only_ps = TempDir::new().unwrap();
+            touch(only_ps.path(), "powershell.exe");
+
+            let path = join_path(&[only_ps.path()]);
+            let (shell, kind) = detect_windows_shell_inner(Some(path.as_os_str()), None, None);
+
+            assert_eq!(kind, ShellType::PowerShell);
+            assert!(
+                shell.ends_with("powershell.exe"),
+                "expected powershell.exe fallback, got {shell:?}"
+            );
+        }
+
+        #[test]
+        fn falls_back_to_comspec_when_no_powershell() {
+            let empty = TempDir::new().unwrap();
+            let path = join_path(&[empty.path()]);
+            let comspec: OsString = r"C:\Custom\cmd.exe".into();
+
+            let (shell, kind) =
+                detect_windows_shell_inner(Some(path.as_os_str()), Some(comspec.as_os_str()), None);
+
+            assert_eq!(kind, ShellType::Cmd);
+            assert_eq!(shell, r"C:\Custom\cmd.exe");
+        }
+
+        #[test]
+        fn ignores_empty_comspec() {
+            let empty = TempDir::new().unwrap();
+            let path = join_path(&[empty.path()]);
+            let blank_comspec: OsString = "".into();
+            let windir: OsString = r"D:\WindowsTest".into();
+
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                Some(blank_comspec.as_os_str()),
+                Some(windir.as_os_str()),
+            );
+
+            assert_eq!(kind, ShellType::Cmd);
+            assert_eq!(shell, r"D:\WindowsTest\System32\cmd.exe");
+        }
+
+        #[test]
+        fn final_fallback_uses_windir_system32_cmd() {
+            let empty = TempDir::new().unwrap();
+            let path = join_path(&[empty.path()]);
+            let windir: OsString = r"D:\WindowsTest".into();
+
+            let (shell, kind) =
+                detect_windows_shell_inner(Some(path.as_os_str()), None, Some(windir.as_os_str()));
+
+            assert_eq!(kind, ShellType::Cmd);
+            assert_eq!(shell, r"D:\WindowsTest\System32\cmd.exe");
+        }
+
+        #[test]
+        fn missing_windir_uses_default_c_windows() {
+            let empty = TempDir::new().unwrap();
+            let path = join_path(&[empty.path()]);
+
+            let (shell, kind) = detect_windows_shell_inner(Some(path.as_os_str()), None, None);
+
+            assert_eq!(kind, ShellType::Cmd);
+            assert_eq!(shell, r"C:\Windows\System32\cmd.exe");
+        }
+
+        #[test]
+        fn missing_path_still_resolves_to_cmd() {
+            // No PATH at all (e.g. an exotic launchd-style minimal env)
+            // should still produce a runnable shell rather than panic.
+            let none: Option<&OsStr> = None;
+            let (shell, kind) = detect_windows_shell_inner(none, none, none);
+            assert_eq!(kind, ShellType::Cmd);
+            assert_eq!(shell, r"C:\Windows\System32\cmd.exe");
+        }
     }
 }

--- a/src-tauri/src/commands/shell.rs
+++ b/src-tauri/src/commands/shell.rs
@@ -68,20 +68,46 @@ fn posix_detect_user_shell() -> (String, ShellType) {
 /// Windows-side detection. portable-pty's `new_default_prog()` falls
 /// back to `cmd.exe` here, which never loads any user-customizable
 /// profile — so an integrated terminal looks nothing like the user's
-/// regular Windows Terminal session. Pick the most modern PowerShell
-/// that's actually on PATH, then degrade gracefully.
+/// regular Windows Terminal session.
+///
+/// `pwsh.exe` (PowerShell 7+) and `powershell.exe` (Windows PowerShell
+/// 5.1) read profiles from totally different paths
+/// (`Documents\PowerShell\…` vs `Documents\WindowsPowerShell\…`), so
+/// blindly preferring `pwsh.exe` when the user has only ever written a
+/// PS5.1 profile drops them into an empty PS7 banner with none of their
+/// prompt customizations. The fix: pick the flavour whose profile the
+/// user has actually written.
 ///
 /// Resolution order:
-///   1. `pwsh.exe` on PATH    — PowerShell 7+ (cross-platform, modern)
-///   2. `powershell.exe`      — in-box Windows PowerShell 5.1
-///   3. `%ComSpec%`           — user's deliberate cmd override, if set
-///   4. `%WINDIR%\System32\cmd.exe` — guaranteed-present last resort
+///   1. `pwsh.exe` on PATH **and** a PS7 profile exists  — modern PS, configured
+///   2. `powershell.exe` on PATH **and** a PS5.1 profile exists, **and** no PS7 profile — match what the user actually customizes
+///   3. `pwsh.exe` on PATH                               — modern default when no profile signal either way
+///   4. `powershell.exe` on PATH                         — in-box fallback
+///   5. `%ComSpec%`                                      — user's deliberate cmd override, if set
+///   6. `%WINDIR%\System32\cmd.exe`                      — guaranteed-present last resort
 #[cfg(target_os = "windows")]
 fn windows_detect_user_shell() -> (String, ShellType) {
     let path = std::env::var_os("PATH");
     let comspec = std::env::var_os("ComSpec");
     let windir = std::env::var_os("WINDIR");
-    detect_windows_shell_inner(path.as_deref(), comspec.as_deref(), windir.as_deref())
+    let userprofile = std::env::var_os("USERPROFILE");
+    detect_windows_shell_inner(
+        path.as_deref(),
+        comspec.as_deref(),
+        windir.as_deref(),
+        userprofile.as_deref(),
+    )
+}
+
+/// Which PowerShell flavour we're checking for a user profile.
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Copy)]
+enum PsFlavour {
+    /// PowerShell 7+ (`pwsh.exe`). Reads from `Documents\PowerShell\…`.
+    Pwsh,
+    /// Windows PowerShell 5.1 (`powershell.exe`). Reads from
+    /// `Documents\WindowsPowerShell\…`.
+    WindowsPs,
 }
 
 /// Pure-function core of `windows_detect_user_shell`, parameterised on
@@ -92,16 +118,42 @@ fn detect_windows_shell_inner(
     path_env: Option<&std::ffi::OsStr>,
     comspec: Option<&std::ffi::OsStr>,
     windir: Option<&std::ffi::OsStr>,
+    userprofile: Option<&std::ffi::OsStr>,
 ) -> (String, ShellType) {
-    if let Some(found) = find_in_path("pwsh.exe", path_env) {
-        return (found, ShellType::PowerShell);
+    let pwsh = find_in_path("pwsh.exe", path_env);
+    let powershell = find_in_path("powershell.exe", path_env);
+
+    let userprofile_path = userprofile.map(std::path::Path::new);
+    let has_pwsh_profile = has_powershell_profile(PsFlavour::Pwsh, userprofile_path);
+    let has_ps51_profile = has_powershell_profile(PsFlavour::WindowsPs, userprofile_path);
+
+    // 1: PS7 + PS7 profile → run the configured PS7 setup.
+    if has_pwsh_profile && let Some(p) = pwsh.clone() {
+        return (p, ShellType::PowerShell);
     }
-    if let Some(found) = find_in_path("powershell.exe", path_env) {
-        return (found, ShellType::PowerShell);
+    // 2: PS5.1 profile, no PS7 profile, PS5.1 installed → match the
+    //    user's actual customizations rather than their unconfigured
+    //    PS7. This is the fallthrough that previously left OneDrive
+    //    PS5.1 users staring at a bare `pwsh.exe` banner.
+    if has_ps51_profile
+        && !has_pwsh_profile
+        && let Some(p) = powershell.clone()
+    {
+        return (p, ShellType::PowerShell);
     }
+    // 3: No profile signal — prefer modern PS7 if installed.
+    if let Some(p) = pwsh {
+        return (p, ShellType::PowerShell);
+    }
+    // 4: Fall back to in-box Windows PowerShell.
+    if let Some(p) = powershell {
+        return (p, ShellType::PowerShell);
+    }
+    // 5: Honour an explicit cmd override.
     if let Some(cs) = comspec.and_then(|s| s.to_str()).filter(|s| !s.is_empty()) {
         return (cs.to_string(), ShellType::Cmd);
     }
+    // 6: Always-present last resort.
     let win = windir.and_then(|s| s.to_str()).unwrap_or(r"C:\Windows");
     (format!(r"{win}\System32\cmd.exe"), ShellType::Cmd)
 }
@@ -116,6 +168,42 @@ fn find_in_path(name: &str, path_env: Option<&std::ffi::OsStr>) -> Option<String
         }
     }
     None
+}
+
+/// True if the user has any per-host or all-hosts profile written for
+/// the given PowerShell flavour. We check both the regular `Documents`
+/// folder and OneDrive-redirected `OneDrive\Documents` because Office
+/// 365 / Windows 11 Backup commonly redirects Documents into OneDrive
+/// (this is exactly how the bug surfaced on the original report — the
+/// user's PS5.1 profile lived under `OneDrive\Documents\…`, so the old
+/// "always pick pwsh" heuristic missed it and they got an empty PS7
+/// banner with no prompt customizations).
+///
+/// We deliberately don't probe `$PSHOME`-rooted all-users profiles —
+/// those are sysadmin territory, much rarer than per-user profiles, and
+/// using their presence as a signal would mislead detection on
+/// corp-managed machines.
+#[cfg(target_os = "windows")]
+fn has_powershell_profile(flavour: PsFlavour, userprofile: Option<&std::path::Path>) -> bool {
+    let Some(home) = userprofile else {
+        return false;
+    };
+    let dir = match flavour {
+        PsFlavour::Pwsh => "PowerShell",
+        PsFlavour::WindowsPs => "WindowsPowerShell",
+    };
+    for docs in ["Documents", r"OneDrive\Documents"] {
+        // Per-host (`Microsoft.PowerShell_profile.ps1`) and all-hosts
+        // (`Profile.ps1`) both count: either kind of file means the
+        // user has set something up for this PowerShell flavour.
+        for filename in ["Microsoft.PowerShell_profile.ps1", "Profile.ps1"] {
+            let candidate = home.join(docs).join(dir).join(filename);
+            if candidate.is_file() {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 #[tauri::command]
@@ -382,19 +470,22 @@ mod tests {
     // ---------------------------------------------------------------------
     // Windows shell detection
     //
-    // These tests pin the resolution order pwsh → powershell → ComSpec →
+    // These tests pin the resolution order pwsh-with-profile →
+    // powershell-with-profile → pwsh → powershell → ComSpec →
     // %WINDIR%\System32\cmd.exe so a regression that quietly drops back
-    // to `cmd.exe` (the symptom we just fixed) gets caught in CI. They
-    // call `detect_windows_shell_inner` directly with synthetic env
-    // values rather than mutating the process environment, so the tests
-    // are safe to run under cargo's default parallel test harness.
+    // to `cmd.exe` (the original bug) or quietly drops the user into an
+    // unconfigured `pwsh.exe` despite a PS5.1 profile being present (the
+    // OneDrive-redirect bug surfaced in follow-up testing) gets caught
+    // in CI. They call `detect_windows_shell_inner` directly with
+    // synthetic env values rather than mutating the process environment,
+    // so the tests are safe to run under cargo's parallel test harness.
     // ---------------------------------------------------------------------
     #[cfg(target_os = "windows")]
     mod windows_shell {
         use super::super::{ShellType, detect_windows_shell_inner};
         use std::ffi::{OsStr, OsString};
-        use std::fs::File;
-        use std::path::Path;
+        use std::fs::{self, File};
+        use std::path::{Path, PathBuf};
         use tempfile::TempDir;
 
         /// Drop an empty file at `<dir>/<name>` so `Path::is_file()`
@@ -410,20 +501,162 @@ mod tests {
             std::env::join_paths(dirs.iter().map(|p| p.as_ref())).expect("join_paths")
         }
 
+        /// Which `Documents` parent we want the synthetic profile under
+        /// — `Documents\` (regular) vs `OneDrive\Documents\` (the
+        /// Office 365 / Win11 Backup redirect that originally hid the
+        /// user's PS5.1 profile from the heuristic).
+        enum DocsKind {
+            Regular,
+            OneDrive,
+        }
+
+        /// Drop a `Microsoft.PowerShell_profile.ps1` for the given
+        /// flavour under a fake USERPROFILE so `has_powershell_profile`
+        /// observes it the same way it would in production.
+        fn touch_profile(home: &Path, flavour: &str, docs: DocsKind) -> PathBuf {
+            let docs_dir = match docs {
+                DocsKind::Regular => home.join("Documents"),
+                DocsKind::OneDrive => home.join("OneDrive").join("Documents"),
+            };
+            let dir = docs_dir.join(flavour);
+            fs::create_dir_all(&dir).expect("create profile dir");
+            let path = dir.join("Microsoft.PowerShell_profile.ps1");
+            File::create(&path).expect("create profile file");
+            path
+        }
+
         #[test]
-        fn prefers_pwsh_over_powershell_when_both_present() {
+        fn prefers_pwsh_when_only_pwsh_profile_present() {
             let pwsh_dir = TempDir::new().unwrap();
             let ps_dir = TempDir::new().unwrap();
+            let home = TempDir::new().unwrap();
             touch(pwsh_dir.path(), "pwsh.exe");
             touch(ps_dir.path(), "powershell.exe");
+            touch_profile(home.path(), "PowerShell", DocsKind::Regular);
 
             let path = join_path(&[pwsh_dir.path(), ps_dir.path()]);
-            let (shell, kind) = detect_windows_shell_inner(Some(path.as_os_str()), None, None);
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                None,
+                None,
+                Some(home.path().as_os_str()),
+            );
 
             assert_eq!(kind, ShellType::PowerShell);
             assert!(
                 shell.ends_with("pwsh.exe"),
-                "expected pwsh.exe to win the lookup, got {shell:?}"
+                "pwsh.exe + PS7 profile should win, got {shell:?}"
+            );
+        }
+
+        #[test]
+        fn prefers_powershell_when_only_ps51_profile_present() {
+            // Both PowerShells installed, but the user has only ever
+            // written a Windows PowerShell profile — the original report.
+            // Spawning `pwsh.exe` here would drop them at an unconfigured
+            // PS7 banner, which is exactly the bug.
+            let pwsh_dir = TempDir::new().unwrap();
+            let ps_dir = TempDir::new().unwrap();
+            let home = TempDir::new().unwrap();
+            touch(pwsh_dir.path(), "pwsh.exe");
+            touch(ps_dir.path(), "powershell.exe");
+            touch_profile(home.path(), "WindowsPowerShell", DocsKind::Regular);
+
+            let path = join_path(&[pwsh_dir.path(), ps_dir.path()]);
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                None,
+                None,
+                Some(home.path().as_os_str()),
+            );
+
+            assert_eq!(kind, ShellType::PowerShell);
+            assert!(
+                shell.ends_with("powershell.exe"),
+                "PS5.1 profile should pull in powershell.exe over pwsh.exe, got {shell:?}"
+            );
+        }
+
+        #[test]
+        fn detects_ps51_profile_through_onedrive_redirect() {
+            // The exact shape of the original bug report: PS profile
+            // lives at `<USERPROFILE>\OneDrive\Documents\WindowsPowerShell\…`
+            // because Office/Win11 Backup redirected Documents into
+            // OneDrive. The detection must see through that redirect.
+            let pwsh_dir = TempDir::new().unwrap();
+            let ps_dir = TempDir::new().unwrap();
+            let home = TempDir::new().unwrap();
+            touch(pwsh_dir.path(), "pwsh.exe");
+            touch(ps_dir.path(), "powershell.exe");
+            touch_profile(home.path(), "WindowsPowerShell", DocsKind::OneDrive);
+
+            let path = join_path(&[pwsh_dir.path(), ps_dir.path()]);
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                None,
+                None,
+                Some(home.path().as_os_str()),
+            );
+
+            assert_eq!(kind, ShellType::PowerShell);
+            assert!(
+                shell.ends_with("powershell.exe"),
+                "OneDrive-redirected PS5.1 profile must beat unconfigured pwsh.exe, got {shell:?}"
+            );
+        }
+
+        #[test]
+        fn prefers_pwsh_when_both_profiles_present() {
+            // Both profiles → modern PS wins. PS7 users who also have a
+            // legacy PS5.1 profile around get PS7, which matches their
+            // expectation when they explicitly installed PS7.
+            let pwsh_dir = TempDir::new().unwrap();
+            let ps_dir = TempDir::new().unwrap();
+            let home = TempDir::new().unwrap();
+            touch(pwsh_dir.path(), "pwsh.exe");
+            touch(ps_dir.path(), "powershell.exe");
+            touch_profile(home.path(), "PowerShell", DocsKind::Regular);
+            touch_profile(home.path(), "WindowsPowerShell", DocsKind::Regular);
+
+            let path = join_path(&[pwsh_dir.path(), ps_dir.path()]);
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                None,
+                None,
+                Some(home.path().as_os_str()),
+            );
+
+            assert_eq!(kind, ShellType::PowerShell);
+            assert!(
+                shell.ends_with("pwsh.exe"),
+                "both profiles present → modern PS wins, got {shell:?}"
+            );
+        }
+
+        #[test]
+        fn defaults_to_pwsh_when_no_profile_signal() {
+            // Both shells installed, neither has a profile → modern PS
+            // is the right default. (PS7 in this state is not "broken";
+            // it just shows a clean prompt with no customizations,
+            // which is identical to a stock PS5.1 prompt.)
+            let pwsh_dir = TempDir::new().unwrap();
+            let ps_dir = TempDir::new().unwrap();
+            let home = TempDir::new().unwrap();
+            touch(pwsh_dir.path(), "pwsh.exe");
+            touch(ps_dir.path(), "powershell.exe");
+
+            let path = join_path(&[pwsh_dir.path(), ps_dir.path()]);
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                None,
+                None,
+                Some(home.path().as_os_str()),
+            );
+
+            assert_eq!(kind, ShellType::PowerShell);
+            assert!(
+                shell.ends_with("pwsh.exe"),
+                "no profile signal → prefer pwsh.exe, got {shell:?}"
             );
         }
 
@@ -433,7 +666,8 @@ mod tests {
             touch(only_ps.path(), "powershell.exe");
 
             let path = join_path(&[only_ps.path()]);
-            let (shell, kind) = detect_windows_shell_inner(Some(path.as_os_str()), None, None);
+            let (shell, kind) =
+                detect_windows_shell_inner(Some(path.as_os_str()), None, None, None);
 
             assert_eq!(kind, ShellType::PowerShell);
             assert!(
@@ -448,8 +682,12 @@ mod tests {
             let path = join_path(&[empty.path()]);
             let comspec: OsString = r"C:\Custom\cmd.exe".into();
 
-            let (shell, kind) =
-                detect_windows_shell_inner(Some(path.as_os_str()), Some(comspec.as_os_str()), None);
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                Some(comspec.as_os_str()),
+                None,
+                None,
+            );
 
             assert_eq!(kind, ShellType::Cmd);
             assert_eq!(shell, r"C:\Custom\cmd.exe");
@@ -466,6 +704,7 @@ mod tests {
                 Some(path.as_os_str()),
                 Some(blank_comspec.as_os_str()),
                 Some(windir.as_os_str()),
+                None,
             );
 
             assert_eq!(kind, ShellType::Cmd);
@@ -478,8 +717,12 @@ mod tests {
             let path = join_path(&[empty.path()]);
             let windir: OsString = r"D:\WindowsTest".into();
 
-            let (shell, kind) =
-                detect_windows_shell_inner(Some(path.as_os_str()), None, Some(windir.as_os_str()));
+            let (shell, kind) = detect_windows_shell_inner(
+                Some(path.as_os_str()),
+                None,
+                Some(windir.as_os_str()),
+                None,
+            );
 
             assert_eq!(kind, ShellType::Cmd);
             assert_eq!(shell, r"D:\WindowsTest\System32\cmd.exe");
@@ -490,7 +733,8 @@ mod tests {
             let empty = TempDir::new().unwrap();
             let path = join_path(&[empty.path()]);
 
-            let (shell, kind) = detect_windows_shell_inner(Some(path.as_os_str()), None, None);
+            let (shell, kind) =
+                detect_windows_shell_inner(Some(path.as_os_str()), None, None, None);
 
             assert_eq!(kind, ShellType::Cmd);
             assert_eq!(shell, r"C:\Windows\System32\cmd.exe");
@@ -501,7 +745,7 @@ mod tests {
             // No PATH at all (e.g. an exotic launchd-style minimal env)
             // should still produce a runnable shell rather than panic.
             let none: Option<&OsStr> = None;
-            let (shell, kind) = detect_windows_shell_inner(none, none, none);
+            let (shell, kind) = detect_windows_shell_inner(none, none, none, none);
             assert_eq!(kind, ShellType::Cmd);
             assert_eq!(shell, r"C:\Windows\System32\cmd.exe");
         }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -77,7 +77,19 @@ pub async fn spawn_pty(
     // a data migration.
     let working_dir = claudette::path::strip_verbatim_prefix(&working_dir).to_string();
 
-    let mut cmd = CommandBuilder::new_default_prog();
+    // Use our own shell detection rather than portable-pty's
+    // `new_default_prog()`. The portable-pty default is `$SHELL`-or-/bin/sh
+    // on Unix and `%ComSpec%`-or-cmd.exe on Windows; the latter is the
+    // bug we're fixing here — `cmd.exe` doesn't load any user-side
+    // profile, so the integrated terminal on Windows looks nothing like
+    // the user's regular shell. `detect_user_shell` prefers `pwsh.exe`
+    // (PowerShell 7+) and falls back through `powershell.exe`,
+    // `%ComSpec%`, and finally `cmd.exe`. Both PowerShell flavours
+    // auto-load `$PROFILE` when launched interactively in a ConPTY, so
+    // no extra args are needed; cmd honours its registry-based AutoRun
+    // for the same reason.
+    let (shell_path, _shell_type) = detect_user_shell();
+    let mut cmd = CommandBuilder::new(&shell_path);
     cmd.cwd(&working_dir);
     configure_pty_env(&mut cmd);
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -11,6 +11,7 @@ import { ChatSearchBar } from "./ChatSearchBar";
 import { OverlayScrollbar } from "./OverlayScrollbar";
 import { WorkspaceEmptyTabs } from "./WorkspaceEmptyTabs";
 import { useAppStore } from "../../stores/useAppStore";
+import { isWorkspaceEnvironmentPreparing } from "../../utils/workspaceEnvironment";
 import {
   loadAttachmentData,
   loadChatHistoryPage,
@@ -84,13 +85,9 @@ const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];
 export function ChatPanel() {
   const { t } = useTranslation("chat");
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
-  const workspaceEnvironmentPreparing = useAppStore((s) => {
-    if (!s.selectedWorkspaceId) return false;
-    const workspace = s.workspaces.find((w) => w.id === s.selectedWorkspaceId);
-    if (!workspace || workspace.remote_connection_id) return false;
-    const status = s.workspaceEnvironment[s.selectedWorkspaceId]?.status;
-    return status !== "ready" && status !== "error";
-  });
+  const workspaceEnvironmentPreparing = useAppStore((s) =>
+    isWorkspaceEnvironmentPreparing(s, s.selectedWorkspaceId),
+  );
   const activeSessionId = useAppStore((s) =>
     s.selectedWorkspaceId
       ? s.selectedSessionIdByWorkspaceId[s.selectedWorkspaceId] ?? null

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "@tauri-apps/plugin-clipboard-manager";
 import { useAppStore } from "../../stores/useAppStore";
 import { getTerminalTheme } from "../../utils/theme";
+import { isWorkspaceEnvironmentPreparing } from "../../utils/workspaceEnvironment";
 import { getHotkeyLabel, tooltipAttributes } from "../../hotkeys/display";
 import { isMacHotkeyPlatform } from "../../hotkeys/platform";
 import {
@@ -128,14 +129,15 @@ async function waitForWorkspaceEnvironment(workspaceId: string) {
   }
 }
 
+// Re-export under the existing in-file name so the rest of TerminalPanel
+// keeps working without churn. The actual gate logic and rationale live
+// in `utils/workspaceEnvironment.ts`, which `ChatPanel` shares — both
+// surfaces must gate identically.
 function workspaceEnvironmentPending(
   state: AppStoreState,
   workspaceId: string,
 ): boolean {
-  const workspace = state.workspaces.find((w) => w.id === workspaceId);
-  if (!workspace || workspace.remote_connection_id) return false;
-  const status = state.workspaceEnvironment[workspaceId]?.status;
-  return status !== "ready" && status !== "error";
+  return isWorkspaceEnvironmentPreparing(state, workspaceId);
 }
 
 // Per-leaf xterm + PTY handle. The container is a detached <div> that we

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -136,7 +136,15 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     expect(serviceMocks.prepareWorkspaceEnvironment).toHaveBeenCalledTimes(1);
   });
 
-  it("clears stale preparing state when selection changes before preparation finishes", async () => {
+  it("leaves status at 'preparing' when selection changes mid-flight; per-closure settled prevents stale resolution from updating state", async () => {
+    // Previously this test pinned cleanup-sets-idle behavior. That
+    // behavior was the source of a Windows-specific UI lock: when
+    // WebView2 dropped the Tauri response message, the second
+    // mount's `cancelled` guard swallowed any late resolution, and
+    // status stayed at "idle" / "preparing" forever with no path
+    // back to "ready". The cleanup no longer mutates status; a
+    // per-closure `settled` flag (and a 30s deadline, exercised in a
+    // separate test) provide the recovery guarantee instead.
     let resolvePreparation!: () => void;
     serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
       new Promise<void>((resolve) => {
@@ -157,8 +165,14 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       useAppStore.setState({ selectedWorkspaceId: null });
     });
 
+    // Cleanup ran but does NOT touch status — the in-flight prep is
+    // either going to resolve (and settle for the live closure, which
+    // is now marked settled, so its .then is a no-op) or will time
+    // out on its own deadline. Leaving status as "preparing" here
+    // means a user who returns to this workspace before the deadline
+    // sees the actual in-flight state rather than a synthetic "idle".
     expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "idle",
+      status: "preparing",
     });
 
     await act(async () => {
@@ -166,8 +180,68 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       await Promise.resolve();
     });
 
+    // The closure's `settled` was set to true by the cleanup, so
+    // this late resolution is correctly ignored — no transition to
+    // "ready" for a workspace the user has navigated away from.
     expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
-      status: "idle",
+      status: "preparing",
+    });
+  });
+
+  it("recovers from a dropped Tauri response when a 'complete' progress event arrives", async () => {
+    // The Windows regression we're guarding against: WebView2
+    // occasionally drops the response message for a short Tauri
+    // async command, so the JS-side `invoke()` promise from
+    // `prepareWorkspaceEnvironment` never settles. The backend has
+    // long since finished, though — Drop on `TauriEnvProgressSink`
+    // emits a `complete` progress event as the resolve loop tears
+    // down. This test mimics that event and pins the recovery: any
+    // workspace still showing `"preparing"` flips to `"ready"`.
+    serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+      new Promise<void>(() => undefined),
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    // Capture the listen callback so we can fire it manually below —
+    // the test harness mocks `@tauri-apps/api/event::listen` to a
+    // no-op, so we have to install our own handler this way.
+    const eventListeners: Array<(event: { payload: unknown }) => void> = [];
+    const eventMod = await import("@tauri-apps/api/event");
+    vi.mocked(eventMod.listen).mockImplementation((_name, cb) => {
+      eventListeners.push(cb as (event: { payload: unknown }) => void);
+      return Promise.resolve(() => undefined);
+    });
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "preparing",
+    });
+
+    // Fire the `complete` event the Rust-side sink would emit at the
+    // end of every resolve, regardless of which Tauri command
+    // initiated it.
+    act(() => {
+      for (const cb of eventListeners) {
+        cb({
+          payload: {
+            workspace_id: "ws-1",
+            plugin: "",
+            phase: "complete",
+            elapsed_ms: 0,
+          },
+        });
+      }
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "ready",
     });
   });
 

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -188,6 +188,38 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     });
   });
 
+  /**
+   * Build a fresh listen-callback capture and a thin emitter helper.
+   * The harness mocks `@tauri-apps/api/event::listen` to a no-op, so
+   * we install our own capture per test to fire synthetic
+   * `workspace_env_progress` events into the hook.
+   */
+  async function withCapturedProgressListener(): Promise<{
+    fire: (payload: {
+      workspace_id: string;
+      plugin: string;
+      phase: "started" | "finished" | "complete";
+      elapsed_ms: number;
+      ok?: boolean;
+    }) => void;
+  }> {
+    const listeners: Array<(event: { payload: unknown }) => void> = [];
+    const eventMod = await import("@tauri-apps/api/event");
+    vi.mocked(eventMod.listen).mockImplementation((_name, cb) => {
+      listeners.push(cb as (event: { payload: unknown }) => void);
+      return Promise.resolve(() => undefined);
+    });
+    return {
+      fire: (payload) => {
+        act(() => {
+          for (const cb of listeners) {
+            cb({ payload });
+          }
+        });
+      },
+    };
+  }
+
   it("recovers from a dropped Tauri response when a 'complete' progress event arrives", async () => {
     // The Windows regression we're guarding against: WebView2
     // occasionally drops the response message for a short Tauri
@@ -205,15 +237,7 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       workspaces: [makeWorkspace()],
     });
 
-    // Capture the listen callback so we can fire it manually below —
-    // the test harness mocks `@tauri-apps/api/event::listen` to a
-    // no-op, so we have to install our own handler this way.
-    const eventListeners: Array<(event: { payload: unknown }) => void> = [];
-    const eventMod = await import("@tauri-apps/api/event");
-    vi.mocked(eventMod.listen).mockImplementation((_name, cb) => {
-      eventListeners.push(cb as (event: { payload: unknown }) => void);
-      return Promise.resolve(() => undefined);
-    });
+    const { fire } = await withCapturedProgressListener();
 
     await renderHarness();
     await act(async () => {
@@ -227,22 +251,208 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     // Fire the `complete` event the Rust-side sink would emit at the
     // end of every resolve, regardless of which Tauri command
     // initiated it.
-    act(() => {
-      for (const cb of eventListeners) {
-        cb({
-          payload: {
-            workspace_id: "ws-1",
-            plugin: "",
-            phase: "complete",
-            elapsed_ms: 0,
-          },
-        });
-      }
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
     });
 
     expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
       status: "ready",
     });
+  });
+
+  it("does not regress a ready workspace when a stray 'complete' event arrives", async () => {
+    // The Complete event is best-effort — if it arrives for a
+    // workspace whose status has already been set to "ready" by a
+    // prior `.then`, it MUST NOT silently revert. This pin matters
+    // because the Drop-emitted Complete and the Tauri command's own
+    // `.then` race naturally; on a healthy IPC channel the `.then`
+    // wins, and Complete then arrives as a no-op terminator.
+    serviceMocks.prepareWorkspaceEnvironment.mockResolvedValue(undefined);
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    const { fire } = await withCapturedProgressListener();
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // `.then` ran first → status is ready before Complete arrives.
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "ready",
+    });
+
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "ready",
+    });
+  });
+
+  it("does not override an 'error' workspace when 'complete' arrives", async () => {
+    // The error case has the same race risk as the ready case: a
+    // backend resolve that fails (e.g. direnv blocked) sets status
+    // to "error" via the prep `.catch`; the sink's Drop fires
+    // Complete immediately after, and that terminator must NOT
+    // silently overwrite the error the user needs to see.
+    serviceMocks.prepareWorkspaceEnvironment.mockRejectedValue(
+      new Error("direnv blocked"),
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    const { fire } = await withCapturedProgressListener();
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toMatchObject({
+      status: "error",
+    });
+
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toMatchObject({
+      status: "error",
+    });
+  });
+
+  it("handles a full Started → Finished → Complete sequence from a non-prep path (e.g. spawn_pty)", async () => {
+    // The original Windows bug: `spawn_pty` runs its own env resolve
+    // that emits Started/Finished progress events (flipping status
+    // to "preparing" via `setWorkspaceEnvironmentProgress`), but no
+    // dedicated Tauri-command `.then` exists on the JS side to
+    // finalize. The Complete event from Drop on the sink is now the
+    // authoritative finalizer for these paths; this test exercises
+    // the full sequence without the prep hook ever firing.
+    useAppStore.setState({
+      selectedWorkspaceId: null, // prep effect skipped — no selected workspace
+      workspaces: [makeWorkspace()],
+      workspaceEnvironment: { "ws-1": { status: "ready" } },
+    });
+
+    const { fire } = await withCapturedProgressListener();
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Started: status flips to "preparing", current_plugin set.
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-dotenv",
+      phase: "started",
+      elapsed_ms: 0,
+    });
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toMatchObject({
+      status: "preparing",
+      current_plugin: "env-dotenv",
+    });
+
+    // Finished: current_plugin cleared, status stays "preparing"
+    // (more plugins may be coming).
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-dotenv",
+      phase: "finished",
+      elapsed_ms: 12,
+      ok: true,
+    });
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toMatchObject({
+      status: "preparing",
+    });
+    expect(
+      useAppStore.getState().workspaceEnvironment["ws-1"]?.current_plugin,
+    ).toBeUndefined();
+
+    // Complete: the resolve loop is done. Transition out of
+    // progress-induced "preparing" back to "ready".
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "ready",
+    });
+  });
+
+  it("routes progress for a non-selected workspace and still finalizes via Complete", async () => {
+    // The sidebar shows "preparing" badges for every workspace
+    // resolving env, not just the selected one. This pin matters
+    // because background paths (repo warmup, a different
+    // workspace's PTY spawn) emit progress that the listener must
+    // route by workspace_id, and Complete must finalize the
+    // intended workspace — not silently target the active one.
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [
+        makeWorkspace({ id: "ws-1" }),
+        makeWorkspace({ id: "ws-2", name: "other" }),
+      ],
+      workspaceEnvironment: { "ws-1": { status: "ready" } },
+    });
+    serviceMocks.prepareWorkspaceEnvironment.mockResolvedValue(undefined);
+
+    const { fire } = await withCapturedProgressListener();
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fire({
+      workspace_id: "ws-2",
+      plugin: "env-direnv",
+      phase: "started",
+      elapsed_ms: 0,
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-2"]).toMatchObject({
+      status: "preparing",
+      current_plugin: "env-direnv",
+    });
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]?.status).toBe(
+      "ready",
+    );
+
+    fire({
+      workspace_id: "ws-2",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-2"]).toEqual({
+      status: "ready",
+    });
+    // The selected workspace's status is untouched by the other ws's
+    // progress stream.
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]?.status).toBe(
+      "ready",
+    );
   });
 
   it("marks the workspace as errored when env preparation fails", async () => {

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -136,15 +136,17 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     expect(serviceMocks.prepareWorkspaceEnvironment).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves status at 'preparing' when selection changes mid-flight; per-closure settled prevents stale resolution from updating state", async () => {
+  it("leaves status at 'preparing' when selection changes mid-flight; cancelled guard prevents stale resolution from toasting", async () => {
     // Previously this test pinned cleanup-sets-idle behavior. That
-    // behavior was the source of a Windows-specific UI lock: when
-    // WebView2 dropped the Tauri response message, the second
-    // mount's `cancelled` guard swallowed any late resolution, and
-    // status stayed at "idle" / "preparing" forever with no path
-    // back to "ready". The cleanup no longer mutates status; a
-    // per-closure `settled` flag (and a 30s deadline, exercised in a
-    // separate test) provide the recovery guarantee instead.
+    // behaviour was the source of a Windows-specific UI lock: when
+    // WebView2 dropped the Tauri response message for the prep
+    // command, the second mount's `cancelled` guard swallowed any
+    // late resolution, and status stayed at "idle" / "preparing"
+    // forever with no path back to "ready". The cleanup no longer
+    // mutates status, and the `cancelled` flag is retained only to
+    // suppress stale toasts from `.catch`. The actual recovery for
+    // a dropped Tauri response lives in the Complete progress event
+    // — see the "recovers from a dropped Tauri response" test below.
     let resolvePreparation!: () => void;
     serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
       new Promise<void>((resolve) => {
@@ -165,12 +167,11 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       useAppStore.setState({ selectedWorkspaceId: null });
     });
 
-    // Cleanup ran but does NOT touch status — the in-flight prep is
-    // either going to resolve (and settle for the live closure, which
-    // is now marked settled, so its .then is a no-op) or will time
-    // out on its own deadline. Leaving status as "preparing" here
-    // means a user who returns to this workspace before the deadline
-    // sees the actual in-flight state rather than a synthetic "idle".
+    // Cleanup ran but does NOT touch status — the in-flight prep
+    // promise is still pending. The user-visible recovery for a
+    // mid-flight navigate-away lives in the Complete progress
+    // event (Rust-side Drop fires it regardless of where the
+    // resolve was initiated), not in this hook's cleanup.
     expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
       status: "preparing",
     });
@@ -180,9 +181,11 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       await Promise.resolve();
     });
 
-    // The closure's `settled` was set to true by the cleanup, so
-    // this late resolution is correctly ignored — no transition to
-    // "ready" for a workspace the user has navigated away from.
+    // The `.then` checks `cancelled` (set true by cleanup) and
+    // returns early — status is NOT silently flipped to "ready"
+    // for a workspace whose effect has torn down. The Complete
+    // progress event remains the lifecycle-independent recovery
+    // path for any workspace genuinely stuck at "preparing".
     expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
       status: "preparing",
     });
@@ -251,6 +254,138 @@ describe("useWorkspaceEnvironmentPreparation", () => {
     // Fire the `complete` event the Rust-side sink would emit at the
     // end of every resolve, regardless of which Tauri command
     // initiated it.
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]).toEqual({
+      status: "ready",
+    });
+  });
+
+  it("transitions to 'error' on 'complete' when any plugin reported failure (dropped Err response recovery)", async () => {
+    // The Windows IPC-drop variant where the bug bites hardest: the
+    // backend prep returned Err (e.g. direnv .envrc blocked), but
+    // WebView2 dropped the response so `.catch` never fired. Without
+    // failure tracking, the Complete handler would silently mark
+    // "ready" — hiding the trust error from the user. With failure
+    // tracking, the Complete handler sees that a plugin emitted
+    // `finished { ok: false }` during this resolve and transitions
+    // to "error" with a synthetic message pointing at the env panel
+    // (where the per-plugin error text is surfaced).
+    serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+      new Promise<void>(() => undefined),
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    const { fire } = await withCapturedProgressListener();
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Started → Finished with ok=false → Complete. Mirrors what the
+    // Rust sink emits when a plugin's detect/export errors and the
+    // dispatcher records the failure but the command's Tauri
+    // response is dropped en route to the webview.
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-direnv",
+      phase: "started",
+      elapsed_ms: 0,
+    });
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-direnv",
+      phase: "finished",
+      elapsed_ms: 8,
+      ok: false,
+    });
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+
+    const env = useAppStore.getState().workspaceEnvironment["ws-1"];
+    expect(env?.status).toBe("error");
+    expect(env?.error).toMatch(/environment provider reported errors/i);
+  });
+
+  it("clears per-workspace failure tracking after Complete so a fresh resolve isn't poisoned", async () => {
+    // The failure flag is reset on every Complete so a subsequent
+    // resolve starts with a clean slate. Without the reset, a
+    // workspace that ever saw `ok: false` would stay "stuck error"
+    // forever even after the user fixed the underlying issue
+    // (e.g. ran `direnv allow`) and the next resolve succeeded.
+    serviceMocks.prepareWorkspaceEnvironment.mockReturnValue(
+      new Promise<void>(() => undefined),
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    const { fire } = await withCapturedProgressListener();
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Resolve #1: a plugin failed.
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-direnv",
+      phase: "started",
+      elapsed_ms: 0,
+    });
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-direnv",
+      phase: "finished",
+      elapsed_ms: 8,
+      ok: false,
+    });
+    fire({
+      workspace_id: "ws-1",
+      plugin: "",
+      phase: "complete",
+      elapsed_ms: 0,
+    });
+    expect(useAppStore.getState().workspaceEnvironment["ws-1"]?.status).toBe(
+      "error",
+    );
+
+    // Reset to "preparing" so the next Complete has a status to act on
+    // (mirroring what a fresh selectWorkspace → prep call would do).
+    useAppStore
+      .getState()
+      .setWorkspaceEnvironment("ws-1", "preparing");
+
+    // Resolve #2: same workspace, this time all plugins succeed.
+    // The failure tracking from resolve #1 MUST NOT leak in.
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-dotenv",
+      phase: "started",
+      elapsed_ms: 0,
+    });
+    fire({
+      workspace_id: "ws-1",
+      plugin: "env-dotenv",
+      phase: "finished",
+      elapsed_ms: 4,
+      ok: true,
+    });
     fire({
       workspace_id: "ws-1",
       plugin: "",

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -9,8 +9,13 @@ import { useAppStore } from "../stores/useAppStore";
  * for **every** env-resolve call site (workspace creation, selection,
  * agent spawn, PTY spawn, env-panel reload), so this listener has to
  * handle progress for workspaces other than the currently selected one.
+ *
+ * `complete` fires once at the end of every resolve (via Drop on the
+ * sink in Rust) and is the authoritative "all plugins are done"
+ * signal — see the long comment over `Drop for TauriEnvProgressSink`
+ * for the Windows IPC race it defends against.
  */
-type EnvProgressPhase = "started" | "finished";
+type EnvProgressPhase = "started" | "finished" | "complete";
 interface WorkspaceEnvProgressPayload {
   workspace_id: string;
   plugin: string;
@@ -48,8 +53,23 @@ export function useWorkspaceEnvironmentPreparation() {
       const { workspace_id, plugin, phase } = event.payload;
       if (phase === "started") {
         setWorkspaceEnvironmentProgress(workspace_id, plugin);
-      } else {
+      } else if (phase === "finished") {
         setWorkspaceEnvironmentProgress(workspace_id, null);
+      } else {
+        // phase === "complete" — fires once at end of every backend
+        // resolve. Clear the active-plugin display and, critically,
+        // transition any workspace stuck at "preparing" purely from
+        // the progress-driven status bumps back to "ready". This
+        // recovers the spawn_pty / agent-spawn paths where no
+        // dedicated `.then` handler exists to finalize the status.
+        setWorkspaceEnvironmentProgress(workspace_id, null);
+        const cur =
+          useAppStore.getState().workspaceEnvironment[workspace_id]?.status;
+        if (cur === "preparing") {
+          useAppStore
+            .getState()
+            .setWorkspaceEnvironment(workspace_id, "ready");
+        }
       }
     }).then((stop) => {
       if (!mounted) {
@@ -80,9 +100,19 @@ export function useWorkspaceEnvironmentPreparation() {
     let cancelled = false;
     setWorkspaceEnvironment(workspaceId, "preparing");
 
+    // The recovery path for a dropped Tauri response on Windows
+    // lives in the progress listener above: the `Complete` phase
+    // (emitted by Drop on the Rust-side sink) transitions any
+    // workspace stuck at "preparing" purely from progress events
+    // back to "ready". So this `.then` is no longer load-bearing
+    // for unlock — it's just the authoritative success update
+    // when the IPC response does make it back. `.catch` still
+    // respects `cancelled` so navigating away mid-flight doesn't
+    // surface a stale toast for a workspace the user already left.
     prepareWorkspaceEnvironment(workspaceId)
       .then(() => {
-        if (!cancelled) setWorkspaceEnvironment(workspaceId, "ready");
+        if (cancelled) return;
+        setWorkspaceEnvironment(workspaceId, "ready");
       })
       .catch((err) => {
         if (cancelled) return;
@@ -92,13 +122,13 @@ export function useWorkspaceEnvironmentPreparation() {
       });
 
     return () => {
+      // Don't mutate status here — the previous "set to idle on
+      // cleanup" behaviour combined with the gate's old loose check
+      // to permanently lock the UI when the second-invocation
+      // closure swallowed its own resolution. The `Complete` event
+      // (Rust-side Drop) is the recovery mechanism; nothing here
+      // needs to force an interim state.
       cancelled = true;
-      if (
-        useAppStore.getState().workspaceEnvironment[workspaceId]?.status ===
-        "preparing"
-      ) {
-        setWorkspaceEnvironment(workspaceId, "idle");
-      }
     };
   }, [
     selectedWorkspaceId,

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { prepareWorkspaceEnvironment } from "../services/tauri";
 import { useAppStore } from "../stores/useAppStore";
@@ -39,6 +39,16 @@ export function useWorkspaceEnvironmentPreparation() {
   );
   const addToast = useAppStore((s) => s.addToast);
 
+  // Per-workspace flag: did any plugin emit `finished { ok: false }`
+  // during the current resolve? Used by the Complete handler to
+  // decide between transitioning to "ready" (clean resolve) vs
+  // "error" (something failed). Without this, a backend prep that
+  // returned Err whose Tauri response was dropped by the WebView2
+  // IPC bridge would still get silently marked "ready" — hiding
+  // trust errors and provider failures from the user. Cleared on
+  // each Complete so a subsequent resolve starts fresh.
+  const failedDuringResolveRef = useRef<Map<string, boolean>>(new Map());
+
   // Global listener: subscribe once per app session and route every
   // workspace_env_progress event into the store, regardless of which
   // workspace is currently selected. This lets the sidebar show a
@@ -48,27 +58,56 @@ export function useWorkspaceEnvironmentPreparation() {
   useEffect(() => {
     let mounted = true;
     let unlisten: (() => void) | undefined;
+    const failed = failedDuringResolveRef.current;
     listen<WorkspaceEnvProgressPayload>("workspace_env_progress", (event) => {
       if (!mounted) return;
-      const { workspace_id, plugin, phase } = event.payload;
+      const { workspace_id, plugin, phase, ok } = event.payload;
       if (phase === "started") {
         setWorkspaceEnvironmentProgress(workspace_id, plugin);
       } else if (phase === "finished") {
         setWorkspaceEnvironmentProgress(workspace_id, null);
+        // Track per-plugin failures so the Complete handler below
+        // can distinguish "all plugins succeeded — safe to mark
+        // ready" from "something failed — mark error so a dropped
+        // Tauri Err response doesn't silently paper over a trust
+        // error or provider failure".
+        if (ok === false) {
+          failed.set(workspace_id, true);
+        }
       } else {
         // phase === "complete" — fires once at end of every backend
         // resolve. Clear the active-plugin display and, critically,
         // transition any workspace stuck at "preparing" purely from
-        // the progress-driven status bumps back to "ready". This
-        // recovers the spawn_pty / agent-spawn paths where no
-        // dedicated `.then` handler exists to finalize the status.
+        // the progress-driven status bumps back to "ready" (or
+        // "error" if any plugin reported failure). This recovers
+        // the spawn_pty / agent-spawn paths where no dedicated
+        // `.then` handler exists to finalize the status.
         setWorkspaceEnvironmentProgress(workspace_id, null);
+        const anyFailed = failed.get(workspace_id) ?? false;
+        failed.delete(workspace_id);
         const cur =
           useAppStore.getState().workspaceEnvironment[workspace_id]?.status;
         if (cur === "preparing") {
-          useAppStore
-            .getState()
-            .setWorkspaceEnvironment(workspace_id, "ready");
+          if (anyFailed) {
+            // The progress events don't carry the per-plugin error
+            // text (only `ok: boolean`), so we can't reproduce the
+            // detailed message the prep `.catch` would have shown.
+            // A generic error pointing the user at the env panel is
+            // strictly better than silently marking "ready" and
+            // leaving them to discover the failure on the next
+            // agent spawn.
+            useAppStore
+              .getState()
+              .setWorkspaceEnvironment(
+                workspace_id,
+                "error",
+                "Environment provider reported errors during resolve. See Repo Settings → Environment for per-plugin details.",
+              );
+          } else {
+            useAppStore
+              .getState()
+              .setWorkspaceEnvironment(workspace_id, "ready");
+          }
         }
       }
     }).then((stop) => {

--- a/src/ui/src/utils/workspaceEnvironment.test.ts
+++ b/src/ui/src/utils/workspaceEnvironment.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import type { AppState } from "../stores/useAppStore";
+import type { Workspace } from "../types/workspace";
+import type { WorkspaceEnvironmentPreparation } from "../stores/slices/workspacesSlice";
+import { isWorkspaceEnvironmentPreparing } from "./workspaceEnvironment";
+
+function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: "ws-1",
+    repository_id: "repo-1",
+    name: "feature",
+    branch_name: "james/feature",
+    worktree_path: "/tmp/feature",
+    status: "Active",
+    agent_status: "Idle",
+    status_line: "",
+    created_at: "1700000000",
+    sort_order: 0,
+    remote_connection_id: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a synthetic `AppState` shaped just enough for
+ * `isWorkspaceEnvironmentPreparing` to read. Cast to `AppState` at the
+ * call boundary so the gate sees the same field shape it gets in
+ * production. Anything the gate doesn't touch can stay absent.
+ */
+function makeState(
+  workspaces: Workspace[],
+  env: Record<string, WorkspaceEnvironmentPreparation>,
+): AppState {
+  return {
+    workspaces,
+    workspaceEnvironment: env,
+  } as unknown as AppState;
+}
+
+describe("isWorkspaceEnvironmentPreparing", () => {
+  it("returns false when workspaceId is null", () => {
+    const state = makeState([makeWorkspace()], {});
+    expect(isWorkspaceEnvironmentPreparing(state, null)).toBe(false);
+  });
+
+  it("returns false when the workspace is not in the store", () => {
+    const state = makeState([], {
+      "ws-1": { status: "preparing" },
+    });
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+
+  it("returns false for remote workspaces even when status is preparing", () => {
+    // Env-providers resolve on the remote, not locally, so a local
+    // "preparing" entry should never gate the UI for a remote ws.
+    const state = makeState(
+      [makeWorkspace({ id: "ws-1", remote_connection_id: "remote-1" })],
+      { "ws-1": { status: "preparing" } },
+    );
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+
+  it("returns true only when status is 'preparing'", () => {
+    const state = makeState([makeWorkspace()], {
+      "ws-1": { status: "preparing" },
+    });
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(true);
+  });
+
+  it("returns false for status='ready'", () => {
+    const state = makeState([makeWorkspace()], {
+      "ws-1": { status: "ready" },
+    });
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+
+  it("returns false for status='error'", () => {
+    const state = makeState([makeWorkspace()], {
+      "ws-1": { status: "error", error: "direnv blocked" },
+    });
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+
+  it("returns false for status='idle' (regression: was previously true)", () => {
+    // Direct pin for the bug we just fixed. The prep hook's cleanup
+    // sets a workspace to "idle" when it tears down a stale closure
+    // (React StrictMode double-invoke, or a deps-change race during
+    // initial workspace load) without a successor re-firing the
+    // effect. Treating that stale "idle" as "still preparing" used
+    // to permanently lock the terminal new-tab button, the chat
+    // composer, and the agent-spawn path with no path back to
+    // "ready". Now it just means "no prepare in flight" and the
+    // UI is allowed through.
+    const state = makeState([makeWorkspace()], {
+      "ws-1": { status: "idle" },
+    });
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+
+  it("returns false when the workspace has no entry yet (undefined status)", () => {
+    // Pre-hook-fire state — should also not block the UI; the spawn
+    // paths resolve env on their own.
+    const state = makeState([makeWorkspace()], {});
+    expect(isWorkspaceEnvironmentPreparing(state, "ws-1")).toBe(false);
+  });
+});

--- a/src/ui/src/utils/workspaceEnvironment.ts
+++ b/src/ui/src/utils/workspaceEnvironment.ts
@@ -1,0 +1,36 @@
+import type { AppState } from "../stores/useAppStore";
+
+/**
+ * Whether the workspace is in the middle of an env-provider resolve and
+ * UI surfaces (terminal new-tab button, chat composer, etc.) should
+ * block waiting for it. Shared by `TerminalPanel` and `ChatPanel` so
+ * both surfaces gate identically.
+ *
+ * Only `"preparing"` blocks. `"idle"`, `"ready"`, `"error"`, and
+ * `undefined` all let the UI through:
+ *
+ * - `"idle"` is the state the prep hook leaves behind when its cleanup
+ *   tears down a stale closure without a successor re-firing the
+ *   effect (a React StrictMode race we've seen strand workspaces with
+ *   no path back to `"ready"`). The backend resolves env-providers
+ *   independently on every PTY/agent spawn (`pty.rs::spawn_pty`, the
+ *   agent spawn path), so blocking the UI on this stale marker
+ *   accomplishes nothing except locking the user out.
+ * - `undefined` simply means the hook hasn't fired yet — again, no
+ *   reason to block since the subprocess spawn paths will resolve
+ *   their own env on demand.
+ * - `"error"` is informational; the user already saw the toast and
+ *   shouldn't be prevented from working in the meantime.
+ *
+ * Remote workspaces always return `false` — env-provider resolution
+ * runs on the remote, not locally.
+ */
+export function isWorkspaceEnvironmentPreparing(
+  state: AppState,
+  workspaceId: string | null,
+): boolean {
+  if (!workspaceId) return false;
+  const workspace = state.workspaces.find((w) => w.id === workspaceId);
+  if (!workspace || workspace.remote_connection_id) return false;
+  return state.workspaceEnvironment[workspaceId]?.status === "preparing";
+}


### PR DESCRIPTION
## Summary

Three intertwined Windows-only bugs in the integrated terminal, fixed
on this branch. Each one was discovered while testing the previous
fix — the symptoms compounded so the user couldn''t tell them apart
until the stack was peeled back layer by layer with live diagnostics
via the `claudette-debug` skill.

## The bugs

### 1. Integrated terminal launched `cmd.exe` with no profile loaded

`src-tauri/src/pty.rs` used `portable_pty::CommandBuilder::new_default_prog()`,
which on Windows is hardcoded to `%ComSpec%`-or-`cmd.exe`. The
existing `detect_user_shell()` had no Windows branch at all. Result:
every integrated terminal session on Windows ran `cmd.exe` with none
of the user''s PowerShell `$PROFILE` (prompt, aliases, modules,
direnv hook, etc.) — nothing like their regular Windows Terminal.

### 2. After 1 was fixed, `pwsh.exe` won the lookup even when the user only had a PS5.1 profile

`pwsh.exe` (PowerShell 7+) and `powershell.exe` (Windows PowerShell
5.1) read `$PROFILE` from completely different paths:
`Documents\PowerShell\…` vs `Documents\WindowsPowerShell\…`. The
naive "prefer pwsh.exe" heuristic dropped users with only a PS5.1
profile into an empty PS7 banner with none of their customizations.
Compounded by Office 365 / Win11 Backup redirecting `Documents`
into `OneDrive\Documents`, which the original probe didn''t see.

### 3. New-tab button + chat composer locked out by stale `workspaceEnvironment` status

Once the shell launch worked, clicking the terminal "+" button (or
sending a chat message) silently disabled the UI. Backend tracing
showed `prepare_workspace_environment` resolving in 63 ms; the
frontend store still read `status: "preparing"` indefinitely.

Root cause, confirmed live via `claudette-debug`:

- `spawn_pty` for a new terminal runs its **own** env-provider
  resolve (using the same `TauriEnvProgressSink`), which emits
  `Started`/`Finished` `workspace_env_progress` events.
- Those events flip the workspace''s status to `"preparing"` via
  `setWorkspaceEnvironmentProgress`.
- Nothing on the frontend ever transitions back to `"ready"` for
  the `spawn_pty` path — the `.then` finalizer only exists on the
  dedicated `prepare_workspace_environment` Tauri command, not on
  spawn paths.
- The gate function (`isWorkspaceEnvironmentPreparing`) used a
  loose `status !== "ready" && status !== "error"` check, so it
  also blocked on `"idle"` and `undefined`. Combined with the prep
  hook''s cleanup setting `"idle"` whenever its closure tore down
  with the response unresolved (which on Windows is common —
  WebView2 IPC occasionally drops Tauri response messages), the UI
  stayed locked with no path back to `"ready"`.

**Windows-only** because on macOS / Linux the prep `.then` races the
progress stream and reliably wins, stamping `"ready"` before the user
notices. On Windows the dropped IPC response leaves no second writer.

## What this PR changes

### `src-tauri/src/commands/shell.rs` (#1, #2)

- Extend `ShellType` with `PowerShell` and `Cmd` variants.
- New Windows branch in `detect_user_shell()` with **profile-aware**
  resolution:
  1. `pwsh.exe` on PATH **and** a PS7 profile exists
  2. `powershell.exe` on PATH **and** a PS5.1 profile exists (and
     there''s no PS7 profile) — match what the user customizes
  3. `pwsh.exe` (modern default when no profile signal either way)
  4. `powershell.exe` (in-box fallback)
  5. `%ComSpec%` (deliberate cmd override, if set)
  6. `%WINDIR%\System32\cmd.exe` (always-present last resort)
- Profile probe checks both `%USERPROFILE%\Documents\…` and
  `%USERPROFILE%\OneDrive\Documents\…`, accepting both per-host
  (`Microsoft.PowerShell_profile.ps1`) and all-hosts (`Profile.ps1`)
  profiles.
- Detection core (`detect_windows_shell_inner`) takes env values as
  parameters so 11 new Windows tests pin the resolution contract
  without mutating the process-wide environment.

### `src-tauri/src/pty.rs` (#1)

Replace `CommandBuilder::new_default_prog()` with the detected
shell. Unifies all three platforms onto one detection path.
PowerShell auto-loads `$PROFILE` when launched interactively in a
ConPTY; `cmd.exe` honours its registry `AutoRun` — no extra args
needed, the shell behaves identically to a stock Windows Terminal
tab.

### `src-tauri/src/commands/env.rs` (#3)

Add a `Complete` phase to `EnvProgressPhase`, emitted **exactly
once per resolve** via `Drop` on `TauriEnvProgressSink`. Drop fires
unconditionally when the sink goes out of scope (after the resolve
loop returns), regardless of which Tauri command owns the sink and
regardless of whether that command''s response makes it back across
the WebView2 IPC bridge. Authoritative terminator for the progress
event stream from every env-resolve call site —
`prepare_workspace_environment`, `spawn_pty`, agent spawn,
EnvPanel reload, repo warmup.

### `src/ui/src/utils/workspaceEnvironment.ts` (new, #3)

Extract `isWorkspaceEnvironmentPreparing()` — the gate logic shared
by `TerminalPanel` and `ChatPanel` (was duplicated near-identically
in both files). Tightened: only `"preparing"` blocks the UI;
`"idle"`, `"ready"`, `"error"`, and `undefined` all let the user
through. Safe because backend spawn paths (`pty.rs::spawn_pty`,
agent spawn) resolve env on their own — the frontend gate is a UX
nicety, not a correctness mechanism.

### `src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts` (#3)

- Listener for `workspace_env_progress` now handles three phases:
  `started` (set current_plugin + status preparing), `finished`
  (clear current_plugin, leave status alone), and the new
  `complete` (clear current_plugin and, if status is still
  `"preparing"` purely from progress bumps, transition to `"ready"`).
- Prep effect no longer sets status to `"idle"` in cleanup — that
  was the source of the strand-no-recovery bug. The `cancelled`
  guard is retained only on `.catch` so a stale toast doesn''t fire
  for a workspace the user navigated away from. The `.then` is no
  longer load-bearing for unlock; `Complete` covers the dropped-
  response case as a separate, lifecycle-independent recovery path.

### `site/src/content/docs/features/integrated-terminal.mdx` (#1, #2)

New "Default Shell" section documenting the per-platform resolution
order including the profile-aware Windows logic and the OneDrive
redirect handling. Per CLAUDE.md, user-visible behaviour changes
get docs updates in the same PR.

## Tests

| Suite | Result |
|---|---|
| Frontend `bun run test` | **1835 / 1835 pass** (was 1830 on `main`, +5 new regression tests) |
| `bunx tsc -b` | clean |
| `bun run lint` | 0 errors (11 pre-existing warnings, none in touched files) |
| `bun run lint:css` | clean |
| `cargo fmt --all --check` | clean |
| `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` | clean |
| `cargo test -p claudette -p claudette-server -p claudette-cli --all-features` | **1090 / 1090 pass** |
| `cargo test -p claudette-tauri --bin claudette-app --no-default-features --features server,devtools commands::shell` | **30 / 30 pass** (19 existing + 11 new Windows shell tests) |

### New tests

- **`utils/workspaceEnvironment.test.ts`** — 8 cases pinning the
  gate''s behaviour for every status value (`preparing`, `idle`,
  `ready`, `error`, `undefined`), plus the remote-workspace short
  circuit and the no-workspace-id case.
- **`hooks/useWorkspaceEnvironmentPreparation.test.tsx`** — 5 new
  cases:
  - `"recovers from a dropped Tauri response when a 'complete'
    progress event arrives"` — pins the WebView2 IPC drop recovery.
  - `"does not regress a ready workspace when a stray 'complete'
    event arrives"` — pins the no-overwrite-success invariant.
  - `"does not override an 'error' workspace when 'complete'
    arrives"` — pins the no-overwrite-error invariant.
  - `"handles a full Started → Finished → Complete sequence from a
    non-prep path (e.g. spawn_pty)"` — exercises the original
    Windows bug path end-to-end without the prep effect firing.
  - `"routes progress for a non-selected workspace and still
    finalizes via Complete"` — pins the sidebar background-progress
    routing.
- **`src-tauri/src/commands/shell.rs`** — 11 Windows-only cases
  including `detects_ps51_profile_through_onedrive_redirect`, which
  directly mirrors the original user report.

## Verification

Confirmed live in the user''s running Tauri dev build via the
`claudette-debug` skill:

- Backend `prepare_workspace_environment` resolves in 63 ms.
- Before the fix: status sat at `"preparing"` for 30+ seconds
  after a `+` click, with the button disabled and the composer
  placeholder reading `"Preparing workspace environment..."`.
- After the fix: status flows `"ready"` → click `+` →
  `"preparing"` (during spawn_pty''s internal env resolve) →
  `"ready"` within ~200 ms once the resolve loop returns and Drop
  emits `Complete`. Button stays interactive.

## Commits

- `4d4cfb0` fix(windows): launch PowerShell with user profile in integrated terminal
- `5dd2361` fix(windows): make PowerShell selection profile-aware
- `591db76` fix(ui): unblock terminal/chat when env-prep status is stale
- `407b766` fix(env): emit Complete progress event so spawn_pty / agent paths unlock UI
- `d3bbff1` test(env): pin Complete-event behaviour edges in the prep hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)