### PR TITLE
fix(terminal): activate left neighbor tab instead of first tab on close

### DIFF
--- a/src/ui/src/stores/slices/terminalSlice.ts
+++ b/src/ui/src/stores/slices/terminalSlice.ts
@@ -129,7 +129,8 @@ export const createTerminalSlice: StateCreator<
     })),
   removeTerminalTab: (wsId, tabId) =>
     set((s) => {
-      const tabs = (s.terminalTabs[wsId] || []).filter((t) => t.id !== tabId);
+      const allTabs = s.terminalTabs[wsId] || [];
+      const tabs = allTabs.filter((t) => t.id !== tabId);
       const wasActive = s.activeTerminalTabId[wsId] === tabId;
       // Drop the tab's pane tree and active-pane entry. The terminal panel
       // cleans up xterm instances by observing the terminalTabs map, and
@@ -157,7 +158,15 @@ export const createTerminalSlice: StateCreator<
         terminalTabs: { ...s.terminalTabs, [wsId]: tabs },
         agentBackgroundTasksBySessionId: nextTasks,
         activeTerminalTabId: wasActive
-          ? { ...s.activeTerminalTabId, [wsId]: tabs[0]?.id ?? null }
+          ? {
+              ...s.activeTerminalTabId,
+              [wsId]: (() => {
+                const closedIndex = allTabs.findIndex((t) => t.id === tabId);
+                // Prefer the tab immediately to the left; fall back to the
+                // new first tab when closing the leftmost tab.
+                return (closedIndex > 0 ? tabs[closedIndex - 1] : tabs[0])?.id ?? null;
+              })(),
+            }
           : s.activeTerminalTabId,
         terminalPaneTrees: nextTrees,
         activeTerminalPaneId: nextActivePane,

--- a/src/ui/src/stores/useAppStore.terminal.test.ts
+++ b/src/ui/src/stores/useAppStore.terminal.test.ts
@@ -265,11 +265,33 @@ describe("terminal slice: removeTerminalTab", () => {
     expect(remaining.map((t) => t.id)).toEqual([2]);
   });
 
-  it("when removing the active tab, falls back to the first remaining tab in that workspace", () => {
+  it("when removing the leftmost active tab, activates the new first (right neighbor) tab", () => {
     useAppStore.getState().setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A)]);
     useAppStore.getState().setActiveTerminalTab(WS_A, 1);
 
     useAppStore.getState().removeTerminalTab(WS_A, 1);
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(2);
+  });
+
+  it("when removing a non-leftmost active tab, activates the left neighbor", () => {
+    useAppStore
+      .getState()
+      .setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A), makeTab(3, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 2);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 2);
+
+    expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(1);
+  });
+
+  it("when removing the rightmost active tab, activates the left neighbor", () => {
+    useAppStore
+      .getState()
+      .setTerminalTabs(WS_A, [makeTab(1, WS_A), makeTab(2, WS_A), makeTab(3, WS_A)]);
+    useAppStore.getState().setActiveTerminalTab(WS_A, 3);
+
+    useAppStore.getState().removeTerminalTab(WS_A, 3);
 
     expect(useAppStore.getState().activeTerminalTabId[WS_A]).toBe(2);
   });


### PR DESCRIPTION
## Summary

- **Bug:** Closing the active terminal tab always jumped to the first (leftmost) tab regardless of which tab was closed.
- **Fix:** `removeTerminalTab` in `terminalSlice.ts` now finds the closed tab's original index and selects the tab immediately to the left. When closing the leftmost tab, it falls through to the new first tab (right neighbor) — the only case where behavior is unchanged.
- **Code paths:** All close paths (X button click, keyboard shortcut that closes the last pane in a tab) already go through `removeTerminalTab`, so no other sites needed changing.

## Test plan

- [x] Existing 32 terminal store tests still pass
- [x] New: "when removing a non-leftmost active tab, activates the left neighbor" — tabs [1,2,3], close 2 → active = 1
- [x] New: "when removing the rightmost active tab, activates the left neighbor" — tabs [1,2,3], close 3 → active = 2
- [x] New: "when removing the leftmost active tab, activates the new first tab" — tabs [1,2], close 1 → active = 2 (right neighbor)
- [x] TypeScript type-check (`bunx tsc -b`) passes clean