### PR TITLE
ci(nightly): split promote retag from draft flip; verify post-state + URL

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -583,7 +583,11 @@ jobs:
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::nightly release is still draft after 3 attempts (current state: $draft_state)"
+              # `unknown` here means the post-state query itself failed;
+              # "still draft" would be misleading in that case. Phrase
+              # the error so it differentiates the two without forcing
+              # the reader to remember the special sentinel.
+              echo "::error::nightly release is still not draft=false after 3 attempts (current state: $draft_state — \"unknown\" means the gh api query failed)"
               exit 1
             fi
             echo "Un-draft attempt $attempt left draft=$draft_state; retrying in 5s"
@@ -597,7 +601,14 @@ jobs:
           # normal; retry a few times before failing.
           MANIFEST_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
           for attempt in 1 2 3 4 5; do
-            http=$(curl -sIL -o /dev/null -w "%{http_code}" "$MANIFEST_URL")
+            # `set -e` is active for this step; `var=$(failing-cmd)`
+            # exits the script on transient curl failures (DNS, TLS,
+            # timeout) before the retry loop can even consider them.
+            # `|| echo "000"` makes the substitution always exit 0 and
+            # surfaces a non-2xx-shaped value to the next branch, which
+            # then drives the retry. Same pattern as stage 2's gh api
+            # fallback to "unknown".
+            http=$(curl -sIL -o /dev/null -w "%{http_code}" "$MANIFEST_URL" || echo "000")
             if [ "$http" = "200" ]; then
               echo "latest.json reachable at $MANIFEST_URL (HTTP 200)"
               break

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -539,25 +539,75 @@ jobs:
 
           gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
 
-          # Retry the retag a few times to ride out transient API hiccups
-          # (rate limits, brief outages). If all retries fail, the workflow
-          # exits non-zero and a follow-up run can recover by re-promoting
-          # the still-intact `nightly-staging` release (which now carries
-          # the synthesized manifest).
+          # Promotion runs in three explicitly-verified stages because
+          # combining the tag rename and the draft flip in a single
+          # `gh release edit nightly-staging --tag nightly --draft=false
+          # --prerelease` call has intermittently landed only the rename
+          # server-side while the release stayed draft=true. The CLI
+          # prints the new release URL and exits 0 either way, so the
+          # workflow can't tell from the exit status alone. A draft
+          # release returns 404 on anonymous downloads, so the updater
+          # can't fetch `latest.json` and users silently miss the
+          # update. See: this PR's commit message + manual recovery of
+          # `0.24.0-dev.105.g68df742` on 2026-05-11.
+          #
+          # Stage 1: retag `nightly-staging` → `nightly` and mark
+          # prerelease. Independent retry loop.
           for attempt in 1 2 3; do
             if gh release edit nightly-staging \
               --repo "$GITHUB_REPOSITORY" \
               --tag nightly \
-              --draft=false \
               --prerelease; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
-              echo "::error::Failed to promote nightly-staging to nightly after 3 attempts"
+              echo "::error::Failed to retag nightly-staging→nightly after 3 attempts"
               exit 1
             fi
-            echo "Promotion attempt $attempt failed; retrying in 5s"
+            echo "Retag attempt $attempt failed; retrying in 5s"
             sleep 5
+          done
+
+          # Stage 2: un-draft the (now-renamed) release as a separate
+          # PATCH so the API can't drop the flip on the floor. Verify
+          # the post-state via `gh api releases/tags/nightly` rather
+          # than trusting `gh release edit`'s exit code — it has been
+          # observed to print the release URL and return 0 while
+          # `draft` stayed `true`.
+          for attempt in 1 2 3; do
+            gh release edit nightly --repo "$GITHUB_REPOSITORY" --draft=false || true
+            draft_state=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '.draft' 2>/dev/null || echo "unknown")
+            if [ "$draft_state" = "false" ]; then
+              echo "nightly release is now draft=false"
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::nightly release is still draft after 3 attempts (current state: $draft_state)"
+              exit 1
+            fi
+            echo "Un-draft attempt $attempt left draft=$draft_state; retrying in 5s"
+            sleep 5
+          done
+
+          # Stage 3: anonymous-fetch smoke. This is the actual contract
+          # the in-app updater relies on — a 200 here proves the release
+          # is reachable by clients that don't carry a GitHub auth
+          # token. A short CDN propagation lag after the un-draft is
+          # normal; retry a few times before failing.
+          MANIFEST_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/nightly/latest.json"
+          for attempt in 1 2 3 4 5; do
+            http=$(curl -sIL -o /dev/null -w "%{http_code}" "$MANIFEST_URL")
+            if [ "$http" = "200" ]; then
+              echo "latest.json reachable at $MANIFEST_URL (HTTP 200)"
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::latest.json at $MANIFEST_URL returned HTTP $http after promotion"
+              exit 1
+            fi
+            echo "latest.json HTTP $http (attempt $attempt); retrying in 10s"
+            sleep 10
           done
 
           # `gh release edit --tag` creates the new tag (`nightly`) at the


### PR DESCRIPTION
## Why

`v0.24.0-dev.105.g68df742` finished building successfully tonight, and the in-app updater never picked it up.

Root cause: the promote step did this in **one** call —

```bash
gh release edit nightly-staging --tag nightly --draft=false --prerelease
```

`gh` printed the release URL and exited `0`, so the existing retry-on-exit-status loop never fired. But the resulting GitHub PATCH only applied the **rename**; the **draft flip** was silently dropped server-side, leaving the live release with `draft: true`. Anonymous `https://github.com/utensils/claudette/releases/download/nightly/latest.json` returns 404 for draft releases, so the in-app updater couldn't fetch the manifest and users silently missed the build.

I recovered today's nightly manually (`gh release edit nightly --draft=false`), but James reported this has been happening intermittently for a while, which matches the "sometimes the API drops one flag from a multi-flag PATCH" pattern. The fix is structural rather than additive retries.

## What changes

`Publish Nightly` → "Promote staging to nightly" now runs three explicitly-verified stages:

1. **Retag.** `gh release edit nightly-staging --tag nightly --prerelease` only — no `--draft` flag. Independent retry loop.
2. **Un-draft.** `gh release edit nightly --draft=false` as a separate PATCH so the API can't drop the flip alongside an unrelated edit. **After each attempt**, `gh api repos/.../releases/tags/nightly --jq .draft` is consulted; the workflow fails loudly with the actual current state if the flip never lands, instead of trusting `gh`'s exit code.
3. **Anonymous-fetch smoke.** `curl -sIL` against the public `releases/download/nightly/latest.json` URL with five retries (10s apart) to absorb short CDN propagation. This is the contract the in-app updater actually depends on; a 200 here proves the release is reachable by an unauthenticated client. If this fails, the publish job fails — no more "workflow green, users stuck."

## Concrete instance

| | before fix |
|---|---|
| `gh release view nightly` | shows release with 33 assets |
| `gh api releases/tags/nightly` | `"draft": true` |
| `curl ... /releases/download/nightly/latest.json` | HTTP 404 |
| Workflow result | "Publish Nightly: success" ✅ |
| Users on `dev.104` | never offered the update |

With this change, stage 2's verification step would have observed `draft != false`, retried, and (if still stuck) exited non-zero — surfacing the regression in CI rather than to users.

## What this does **not** change

- Staging release name (`nightly-staging`) — unchanged.
- Asset generation, signing, `latest.json` synthesis (stages above stage 1) — unchanged.
- `nightly-staging` git-tag cleanup at the very end — unchanged.
- All other matrix legs and build steps — untouched.

## Verification

- `yaml.safe_load(...)` on the modified file parses clean.
- The next merge to `main` will exercise the full path end-to-end. If the flake doesn't recur, the new smoke check will pass invisibly; if it does, the workflow will fail at stage 2 or 3 with a useful error message instead of silently succeeding.