### PR TITLE
fix(env-direnv): drop direnv allow/deny stamps from watched list

### DIFF
--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -81,10 +81,31 @@ function M.export(args)
     -- and our own per-repo trust state cover the rare case where the
     -- user revokes direnv permission manually; we don't need to react
     -- to the stamp file's mtime to stay correct.
+    -- Stamps live at `<direnv_data_dir>/allow/<sha>` or
+    -- `<direnv_data_dir>/deny/<sha>`. The basename is a SHA256 hash of
+    -- the `.envrc` path (64 hex chars in current direnv; we accept any
+    -- run of 32+ lowercase hex chars to stay tolerant if direnv ever
+    -- truncates or upgrades the hash). The two-part check — adjacent
+    -- `direnv/allow|deny/` segments AND a hex-hash basename — keeps
+    -- the filter scoped to direnv's own data dir even when a user has
+    -- a worktree path that contains the substring `/direnv/allow/`
+    -- (e.g. working on direnv itself, or a `watch_file` target that
+    -- lives under such a directory). Without the basename check, a
+    -- legitimate `<repo>/direnv/allow/.envrc` would be silently
+    -- dropped from `watched`, leaving the EnvCache unable to notice
+    -- .envrc edits until the user hit Reload — a worse failure mode
+    -- than the cache thrash this filter exists to prevent.
     local function is_direnv_stamp(path)
         if type(path) ~= "string" then return false end
-        return path:find("/direnv/allow/", 1, true) ~= nil
+        local under_stamp_dir = path:find("/direnv/allow/", 1, true) ~= nil
             or path:find("/direnv/deny/", 1, true) ~= nil
+        if not under_stamp_dir then return false end
+        local basename = path:match("([^/]+)$")
+        if not basename then return false end
+        -- 32+ lowercase hex characters, nothing else. Tight enough to
+        -- exclude human-readable filenames; loose enough to survive a
+        -- hash-format change in direnv.
+        return basename:match("^[0-9a-f]+$") ~= nil and #basename >= 32
     end
     local watched = {}
     local seen = {}

--- a/plugins/env-direnv/init.lua
+++ b/plugins/env-direnv/init.lua
@@ -63,14 +63,33 @@ function M.export(args)
 
     -- Seed with `.envrc` unconditionally — it's always a watch target.
     -- Then merge in whatever direnv itself tracks via `DIRENV_WATCHES`
-    -- (user `watch_file` directives, files sourced by `dotenv ...`,
-    -- direnv's own allow/deny cache entries whose mtime flips when the
-    -- user runs `direnv allow`/`deny`). Dedupe so `.envrc` isn't listed
-    -- twice when direnv includes it too.
+    -- (user `watch_file` directives, files sourced by `dotenv ...`).
+    -- Dedupe so `.envrc` isn't listed twice when direnv includes it too.
+    --
+    -- We deliberately DROP direnv's own per-`.envrc` allow/deny stamps
+    -- (the `<data_dir>/direnv/allow/<sha>` / `<data_dir>/direnv/deny/<sha>`
+    -- files) from the watch list, even though direnv reports them in
+    -- `DIRENV_WATCHES` for its shell-hook's "re-evaluate on permission
+    -- change" semantics. The host watcher (`src/env_provider/watcher.rs`)
+    -- subscribes AFTER `cache.put` stores the entry, and on macOS
+    -- FSEvents reliably delivers the write event from the `direnv allow`
+    -- call we just made (when `repo_trust == "allow"` retries a blocked
+    -- export above) shortly after — which fires `on_change` and
+    -- evicts the cache entry we just populated. Net effect was a 5s
+    -- cold export on every workspace switch even when the underlying
+    -- `.envrc` / `flake.lock` hadn't changed. The "Reload env" UI action
+    -- and our own per-repo trust state cover the rare case where the
+    -- user revokes direnv permission manually; we don't need to react
+    -- to the stamp file's mtime to stay correct.
+    local function is_direnv_stamp(path)
+        if type(path) ~= "string" then return false end
+        return path:find("/direnv/allow/", 1, true) ~= nil
+            or path:find("/direnv/deny/", 1, true) ~= nil
+    end
     local watched = {}
     local seen = {}
     local function add(path)
-        if path and not seen[path] then
+        if path and not seen[path] and not is_direnv_stamp(path) then
             seen[path] = true
             table.insert(watched, path)
         end

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -544,13 +544,17 @@ fn direnv_export_stamp_filter_matches_xdg_and_macos_locations() {
     std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
     let worktree = tmp.path().to_string_lossy().into_owned();
     let envrc_path = format!("{worktree}/.envrc");
+    // Real direnv stamps are 64-char lowercase hex SHA256 of the .envrc
+    // path. The narrowed filter requires both adjacent
+    // `direnv/allow|deny/` segments AND a hex-hash basename, so each
+    // entry here must use a realistic 64-char hex name.
     let stamps = [
         // Linux default + macOS with XDG honored (the user's machine).
-        "/home/alice/.local/share/direnv/allow/abc123",
+        "/home/alice/.local/share/direnv/allow/fe1027c058958e4fa4ccd571e85ff9b21da87436db6bebdae55526e1c8a1a6ef",
         // macOS configurations that land direnv in Application Support.
-        "/Users/bob/Library/Application Support/direnv/allow/def456",
+        "/Users/bob/Library/Application Support/direnv/allow/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         // Non-default XDG_DATA_HOME.
-        "/srv/data/direnv/deny/789xyz",
+        "/srv/data/direnv/deny/fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
     ];
     let mut paths: Vec<&str> = vec![envrc_path.as_str()];
     paths.extend(stamps.iter().copied());
@@ -592,6 +596,92 @@ fn direnv_export_stamp_filter_matches_xdg_and_macos_locations() {
             "stamp {stamp} should be filtered out, watched = {watched:?}"
         );
     }
+    assert!(watched.contains(&envrc_path));
+}
+
+#[test]
+fn direnv_export_stamp_filter_keeps_legit_paths_containing_direnv_segments() {
+    // Regression for Codex peer-review P2: an earlier substring-only
+    // filter dropped *any* path with `/direnv/allow/` or `/direnv/deny/`
+    // anywhere in it, including legitimate watched files inside a user
+    // worktree that happened to contain those segments (e.g. someone
+    // working on direnv itself, or a `watch_file` target under such a
+    // directory). That regressed correctness: a dropped `.envrc` means
+    // the EnvCache no longer notices edits to it, leaving the user
+    // stuck with stale env values until they hit "Reload env".
+    //
+    // The narrowed predicate requires BOTH:
+    //   1. adjacent `/direnv/allow/` or `/direnv/deny/` segments, AND
+    //   2. a basename that looks like a direnv SHA256 stamp (32+ lowercase hex chars).
+    // The cases below exercise the narrowing: each path contains the
+    // gate substring, but their basenames are not hex-hash-shaped, so
+    // they MUST survive the filter.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let envrc_path = format!("{worktree}/.envrc");
+    let legit_paths = [
+        // A user working on direnv-the-tool, with the project itself
+        // under a `direnv/allow/` subdir.
+        "/home/alice/repos/direnv/allow/.envrc",
+        // A watch_file target with a human-readable basename living
+        // under a `direnv/deny/` directory in their worktree.
+        "/home/alice/repos/example/direnv/deny/policy.toml",
+        // Edge case: basename happens to be hex but well under the
+        // 32-char minimum (so cannot be a SHA256 stamp).
+        "/srv/data/direnv/allow/abcd",
+        // Edge case: basename has hex but also a non-hex char.
+        "/srv/data/direnv/allow/fe1027c058958e4fa4ccd571e85ff9b21da87436db6bebdae55526e1c8a1a6ef.bak",
+    ];
+    let mut paths: Vec<&str> = vec![envrc_path.as_str()];
+    paths.extend(legit_paths.iter().copied());
+    // Also include a real stamp so the test pins the WHOLE predicate:
+    // legit paths survive, the stamp gets dropped.
+    let real_stamp = "/home/alice/.local/share/direnv/allow/fe1027c058958e4fa4ccd571e85ff9b21da87436db6bebdae55526e1c8a1a6ef";
+    paths.push(real_stamp);
+    let encoded = encode_direnv_watches(&paths);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+
+    for legit in legit_paths {
+        assert!(
+            watched.iter().any(|p| p == legit),
+            "legitimate path {legit} must survive the narrowed stamp filter; got {watched:?}"
+        );
+    }
+    assert!(
+        !watched.iter().any(|p| p == real_stamp),
+        "real stamp {real_stamp} must still be filtered; got {watched:?}"
+    );
     assert!(watched.contains(&envrc_path));
 }
 

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -458,10 +458,12 @@ fn direnv_export_watches_list_drops_direnv_allow_and_deny_stamps() {
     // a Nix flake). Stamps must be dropped from the watch list so
     // the cache stays warm across selects.
     //
-    // The plugin compares against the path substrings `/direnv/allow/`
-    // and `/direnv/deny/` so this works across XDG_DATA_HOME on Linux,
-    // `~/Library/Application Support` on macOS configurations where
-    // direnv lands there, and any non-default `$XDG_DATA_HOME`.
+    // The plugin's stamp predicate is two-part: it requires both an
+    // adjacent `/direnv/allow/` or `/direnv/deny/` path segment AND a
+    // 32+ lowercase hex basename (direnv writes SHA256 stamps). That
+    // pair holds across XDG_DATA_HOME on Linux, `~/Library/Application
+    // Support` on macOS configurations where direnv lands there, and
+    // any non-default `$XDG_DATA_HOME`.
     let tmp = tempfile::tempdir().unwrap();
     std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
     let worktree = tmp.path().to_string_lossy().into_owned();
@@ -487,10 +489,16 @@ fn direnv_export_watches_list_drops_direnv_allow_and_deny_stamps() {
         "DIRENV_WATCHES": encoded,
     }))
     .unwrap();
+    // Assert args shape matches the rest of the env-direnv tests so
+    // an accidental change to how the plugin invokes direnv fails
+    // this regression test loudly instead of silently succeeding.
     let stub = format!(
         r#"
         host.exec = function(cmd, args)
             if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
             return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
         end
         "#
@@ -566,10 +574,16 @@ fn direnv_export_stamp_filter_matches_xdg_and_macos_locations() {
         "DIRENV_WATCHES": encoded,
     }))
     .unwrap();
+    // Assert args shape matches the rest of the env-direnv tests so
+    // an accidental change to how the plugin invokes direnv fails
+    // this regression test loudly instead of silently succeeding.
     let stub = format!(
         r#"
         host.exec = function(cmd, args)
             if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
             return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
         end
         "#
@@ -647,10 +661,16 @@ fn direnv_export_stamp_filter_keeps_legit_paths_containing_direnv_segments() {
         "DIRENV_WATCHES": encoded,
     }))
     .unwrap();
+    // Assert args shape matches the rest of the env-direnv tests so
+    // an accidental change to how the plugin invokes direnv fails
+    // this regression test loudly instead of silently succeeding.
     let stub = format!(
         r#"
         host.exec = function(cmd, args)
             if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            if type(args) ~= "table" or args[1] ~= "export" or args[2] ~= "json" or args[3] ~= nil then
+                error("expected args={{'export','json'}}")
+            end
             return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
         end
         "#

--- a/src/env_provider/plugin_tests.rs
+++ b/src/env_provider/plugin_tests.rs
@@ -445,6 +445,157 @@ fn direnv_export_strips_markers_but_keeps_watches_decoded_into_watched() {
 }
 
 #[test]
+fn direnv_export_watches_list_drops_direnv_allow_and_deny_stamps() {
+    // Regression for the "constant direnv reloads when jumping
+    // workspaces" thrash: with `repo_trust = "allow"` set, the lua
+    // plugin runs `direnv allow` on a blocked .envrc, which writes
+    // `<data_dir>/direnv/allow/<sha>`. If we then included that
+    // path in `watched`, the host's FSEvents watcher (subscribed
+    // immediately after `cache.put`) would receive the buffered
+    // Create/Modify event for that very write and invalidate the
+    // cache entry we just populated — making every subsequent
+    // workspace select pay another full `direnv export json` (5s on
+    // a Nix flake). Stamps must be dropped from the watch list so
+    // the cache stays warm across selects.
+    //
+    // The plugin compares against the path substrings `/direnv/allow/`
+    // and `/direnv/deny/` so this works across XDG_DATA_HOME on Linux,
+    // `~/Library/Application Support` on macOS configurations where
+    // direnv lands there, and any non-default `$XDG_DATA_HOME`.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let envrc_path = format!("{worktree}/.envrc");
+    let flake_lock = format!("{worktree}/flake.lock");
+    let allow_stamp = format!(
+        "/Users/test/.local/share/direnv/allow/{}",
+        "fe1027c058958e4fa4ccd571e85ff9b21da87436db6bebdae55526e1c8a1a6ef"
+    );
+    let deny_stamp = format!(
+        "/Users/test/.local/share/direnv/deny/{}",
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    );
+    // direnv's own DIRENV_WATCHES payload mirrors exactly what we saw
+    // on the bug-reporter's machine: the .envrc, the allow stamp, and
+    // the flake.lock. Add a deny stamp too so the regression covers
+    // both halves of the filter.
+    let encoded = encode_direnv_watches(&[&envrc_path, &allow_stamp, &deny_stamp, &flake_lock]);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+
+    // Real user-visible paths survive — these are the legitimate cache
+    // invalidation triggers the watcher should react to.
+    assert!(
+        watched.contains(&envrc_path),
+        "envrc must survive the stamp filter, got {watched:?}"
+    );
+    assert!(
+        watched.contains(&flake_lock),
+        "flake.lock must survive the stamp filter, got {watched:?}"
+    );
+    // Stamps are filtered. A failure here means the cache will thrash
+    // on every workspace select for users with repo_trust = "allow".
+    assert!(
+        !watched.contains(&allow_stamp),
+        "direnv allow stamp leaked into watched; cache will thrash. got {watched:?}"
+    );
+    assert!(
+        !watched.contains(&deny_stamp),
+        "direnv deny stamp leaked into watched; cache will thrash. got {watched:?}"
+    );
+}
+
+#[test]
+fn direnv_export_stamp_filter_matches_xdg_and_macos_locations() {
+    // Belt-and-suspenders for the prior test: prove the substring
+    // match catches stamp paths from any direnv data-dir configuration
+    // we've observed in the wild. Failure means a user with an
+    // unusual `$XDG_DATA_HOME` still gets cache thrash.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(".envrc"), "use flake\n").unwrap();
+    let worktree = tmp.path().to_string_lossy().into_owned();
+    let envrc_path = format!("{worktree}/.envrc");
+    let stamps = [
+        // Linux default + macOS with XDG honored (the user's machine).
+        "/home/alice/.local/share/direnv/allow/abc123",
+        // macOS configurations that land direnv in Application Support.
+        "/Users/bob/Library/Application Support/direnv/allow/def456",
+        // Non-default XDG_DATA_HOME.
+        "/srv/data/direnv/deny/789xyz",
+    ];
+    let mut paths: Vec<&str> = vec![envrc_path.as_str()];
+    paths.extend(stamps.iter().copied());
+    let encoded = encode_direnv_watches(&paths);
+
+    let lua = make_vm("env-direnv", &["direnv"], tmp.path());
+    let env_json = serde_json::to_string(&serde_json::json!({
+        "FOO": "bar",
+        "DIRENV_WATCHES": encoded,
+    }))
+    .unwrap();
+    let stub = format!(
+        r#"
+        host.exec = function(cmd, args)
+            if cmd ~= "direnv" then error("expected cmd='direnv', got: " .. tostring(cmd)) end
+            return {{ stdout = [==[{env_json}]==], stderr = "", code = 0 }}
+        end
+        "#
+    );
+    lua.load(&stub).exec().unwrap();
+
+    let script = format!(
+        r#"
+        local M = (function() {src} end)()
+        return M.export({{ worktree = "{path}" }})
+        "#,
+        src = DIRENV_SRC,
+        path = worktree.replace('\\', "\\\\"),
+    );
+    let result: mlua::Table = lua.load(&script).eval().unwrap();
+    let watched_tbl: mlua::Table = result.get("watched").unwrap();
+    let len = watched_tbl.len().unwrap() as usize;
+    let watched: Vec<String> = (1..=len)
+        .map(|i| watched_tbl.get::<String>(i).unwrap())
+        .collect();
+    for stamp in stamps {
+        assert!(
+            !watched.iter().any(|p| p == stamp),
+            "stamp {stamp} should be filtered out, watched = {watched:?}"
+        );
+    }
+    assert!(watched.contains(&envrc_path));
+}
+
+#[test]
 fn direnv_export_strip_is_prefix_based_for_future_markers() {
     // The strip matches `^DIRENV_` rather than a hardcoded deny-list,
     // so if direnv ships a new internal marker (e.g. `DIRENV_LAYOUT_*`


### PR DESCRIPTION
## Symptom

With `repo_trust = "allow"` set on a repo, every workspace switch
triggered a fresh 5s `direnv export json` even though `.envrc` /
`flake.nix` / `flake.lock` had not changed. The chat composer and
terminal panel both showed *"Preparing direnv (Ns)…"* / *"Loading
direnv environment (Ns)…"* on every select, making jumping across
workspaces feel like a grind. Terminals appeared to "go to sleep"
because PTY spawn waited on the bogus 5s env resolve.

## Root cause

`direnv export json` lists `<data_dir>/direnv/allow/<sha>` in
`DIRENV_WATCHES` so its shell hook can re-evaluate when the user
runs `direnv allow` / `deny`. We piped that path straight into the
plugin's `watched` list. The host's reactive FSEvents watcher
(`src/env_provider/watcher.rs`) subscribes to those paths
immediately after `EnvCache::put` runs. On a cold worktree the lua
plugin had just written that very allow stamp (via the `direnv
allow` retry at `init.lua:43-48`), so macOS delivers a buffered
Create/Modify event to the watcher microseconds after subscribe →
`on_change` invalidates the cache we just populated → next workspace
select misses → another 5s export → repeat.

Confirmed in the wild against `/Users/jamesbrink/.claudette/workspaces/nyc-real-estate/dusty-cornflower`:
- `.envrc` / `flake.nix` / `flake.lock` mtimes match worktree
  creation (≈1h before observation).
- The direnv allow-stamp mtime is **14 minutes newer** than the
  worktree, drifting forward across the session — proof the
  watcher-fired invalidations were forcing repeated re-runs of the
  `direnv allow` retry path.

## Fix

The plugin filters out direnv's own per-`.envrc` allow/deny stamp
files from the returned `watched` list. The predicate requires
**both**:

1. Adjacent `/direnv/allow/` or `/direnv/deny/` path segments, AND
2. Basename of 32+ lowercase hex characters (direnv SHA256 stamp
   shape; current direnv emits 64 hex chars, the looser bound stays
   tolerant of future hash changes).

Both conditions are required, scoped via `init.lua`'s existing
`add()` helper. The two-part check keeps real user-visible watched
paths (`.envrc`, `flake.lock`, user `watch_file` / `dotenv`
targets) intact even on worktrees whose path happens to contain
`/direnv/allow/` as a substring (Codex peer-review P2 — addressed
in the second commit on this branch).

The "Reload env" UI action and per-repo trust state still cover the
rare case where the user runs `direnv deny` / `revoke` manually —
we don't need stamp-mtime invalidation to stay correct.

## What the user feels

- No more `Preparing direnv (5s)…` flash on every workspace switch.
  First visit to a brand-new worktree is still cold once (real
  direnv run); every visit after is instant.
- Terminals spawn immediately instead of waiting on the bogus
  resolve.
- Trust behavior unchanged; no new settings; no UI difference.

## Tests

Three new regression tests in `src/env_provider/plugin_tests.rs`:

- `direnv_export_watches_list_drops_direnv_allow_and_deny_stamps`
  — replays the exact `DIRENV_WATCHES` payload from the bug
  reporter's worktree (envrc + allow stamp + flake.lock + a
  synthetic deny stamp); asserts only the stamps are filtered.
- `direnv_export_stamp_filter_matches_xdg_and_macos_locations`
  — pins the filter against three real-world direnv data-dir
  layouts (Linux XDG default, macOS Application Support, custom
  `$XDG_DATA_HOME`).
- `direnv_export_stamp_filter_keeps_legit_paths_containing_direnv_segments`
  — narrowing regression for the Codex P2: legitimate paths
  containing `/direnv/{allow,deny}/` substrings but lacking a
  hex-hash basename must survive the filter (worktree on
  direnv-the-tool, human-readable watch target, short hex
  basename, hex-with-extension). Pinned alongside a real
  64-char-hex stamp to prove the predicate still drops actual
  stamps.

12 direnv plugin tests pass; clippy + fmt clean.

## Commits

- `83135050` — initial fix (substring filter)
- `b59086e7` — narrow to `direnv/{allow,deny}/` + hex-hash basename
  per Codex peer review P2, plus the third regression test