### PR TITLE
perf(scm): tier polling by workspace focus and activity to reduce idle churn

### DIFF
--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -1333,6 +1333,15 @@ pub async fn send_chat_message(
     // supervision, broadcast emit) inherits both `chat_session_id` and
     // `workspace_id` without re-passing them through helpers.
     tracing::Span::current().record("workspace_id", workspace_id.as_str());
+    // Stamp this workspace as freshly active so the SCM polling loop keeps
+    // it on the 30s hot-tier cadence for ~1h past the last turn. (Workspaces
+    // with an in-flight agent are also hot, but this keeps them hot after
+    // the agent finishes too — exactly when CI/PR status churn matters most.)
+    state
+        .workspace_activity
+        .write()
+        .await
+        .insert(workspace_id.clone(), std::time::Instant::now());
     let _is_first_session = chat_session.sort_order == 0;
     let session_name_already_edited = chat_session.name_edited;
 

--- a/src-tauri/src/commands/scm.rs
+++ b/src-tauri/src/commands/scm.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::stream::{self, StreamExt};
 use serde::Serialize;
@@ -830,11 +831,86 @@ async fn poll_workspace_scm(app_state: &AppState, workspace_id: &str) -> Option<
     })
 }
 
+/// Seed the per-workspace activity map from the most recent chat-message
+/// timestamp on each workspace. Without this, every workspace looks
+/// "infinitely idle" after an app restart and would land in the slowest
+/// polling tier even if the user was actively working in it five minutes
+/// before the restart.
+///
+/// Errors at any layer are logged and swallowed — a missing seed just
+/// means a workspace starts as stale and escalates back into the hot tier
+/// on its next selection or agent turn.
+async fn seed_workspace_activity_from_db(
+    db_path: &std::path::Path,
+    activity: &tokio::sync::RwLock<HashMap<String, Instant>>,
+) {
+    let db = match Database::open(db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            tracing::warn!(target: "claudette::scm", error = %e, "failed to open DB for workspace activity seed");
+            return;
+        }
+    };
+    let rows = match db.workspace_last_activity_seconds_ago() {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(target: "claudette::scm", error = %e, "workspace activity query failed");
+            return;
+        }
+    };
+
+    let now = Instant::now();
+    let mut map = activity.write().await;
+    for (workspace_id, seconds_ago) in rows {
+        let secs = seconds_ago.max(0) as u64;
+        let instant = now.checked_sub(Duration::from_secs(secs)).unwrap_or(now);
+        map.insert(workspace_id, instant);
+    }
+}
+
+/// How often a workspace should be polled, given its current focus and
+/// activity state. The smallest interval (30s) matches the outer poll
+/// loop's tick rate so the focused workspace polls every tick; longer
+/// intervals cause workspaces to be skipped on most ticks.
+///
+/// Tiers (from `workspace_activity` last-touch timestamp):
+/// - **Hot** (30s):  selected, agent running, or active within 1h
+/// - **Warm** (5m):  active within 24h
+/// - **Cold** (30m): active within 7d
+/// - **Stale** (1h): everything older, including never-seen workspaces
+fn tier_interval(
+    workspace_id: &str,
+    selected: Option<&str>,
+    agent_running: bool,
+    activity: &HashMap<String, Instant>,
+) -> Duration {
+    if selected == Some(workspace_id) || agent_running {
+        return Duration::from_secs(30);
+    }
+    // No activity entry → treat as fully stale rather than hot, so a fresh
+    // app with no chat history doesn't accidentally hammer every workspace.
+    let Some(last) = activity.get(workspace_id) else {
+        return Duration::from_secs(60 * 60);
+    };
+    let idle = last.elapsed();
+    if idle < Duration::from_secs(60 * 60) {
+        Duration::from_secs(30)
+    } else if idle < Duration::from_secs(60 * 60 * 24) {
+        Duration::from_secs(5 * 60)
+    } else if idle < Duration::from_secs(60 * 60 * 24 * 7) {
+        Duration::from_secs(30 * 60)
+    } else {
+        Duration::from_secs(60 * 60)
+    }
+}
+
 /// Start the background SCM polling loop.
 ///
-/// Runs every 30 seconds, iterating all active workspaces and emitting
-/// `scm-data-updated` events to the frontend so sidebar badges and the
-/// PR status banner stay fresh without user interaction.
+/// Ticks every 30s — the smallest tier interval — but only polls each
+/// workspace when its tier interval has elapsed since the last successful
+/// poll. The focused workspace and workspaces with running agents stay on
+/// the 30s cadence; everything else backs off to 5m/30m/1h based on
+/// `workspace_activity` recency. See [`tier_interval`].
 pub fn start_scm_polling(app_handle: tauri::AppHandle) {
     let handle = app_handle.clone();
     tauri::async_runtime::spawn(async move {
@@ -847,6 +923,8 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
         {
             let app_state = handle.state::<AppState>();
             seed_scm_cache_from_db(&app_state.db_path, &app_state.scm_cache).await;
+            seed_workspace_activity_from_db(&app_state.db_path, &app_state.workspace_activity)
+                .await;
         }
 
         // Small delay to let the app fully initialize
@@ -895,9 +973,53 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
                 (active, global, per_repo)
             };
 
-            // Poll all workspaces concurrently. The semaphore inside
+            // Snapshot the per-tick decision inputs once so all tier
+            // checks see a consistent view (no torn reads if a workspace
+            // is selected mid-cycle).
+            let selected_snapshot = app_state.selected_workspace_id.read().await.clone();
+            let activity_snapshot = app_state.workspace_activity.read().await.clone();
+            let last_polled_snapshot = app_state.scm_last_polled.read().await.clone();
+            let running_workspaces: std::collections::HashSet<String> = {
+                let agents = app_state.agents.read().await;
+                agents
+                    .values()
+                    .filter(|s| s.active_pid.is_some())
+                    .map(|s| s.workspace_id.clone())
+                    .collect()
+            };
+            let now = Instant::now();
+
+            // Filter down to workspaces that are actually due on this tick.
+            let due: Vec<(String, String)> = workspace_ids
+                .into_iter()
+                .filter(|(ws_id, _)| {
+                    let interval = tier_interval(
+                        ws_id,
+                        selected_snapshot.as_deref(),
+                        running_workspaces.contains(ws_id),
+                        &activity_snapshot,
+                    );
+                    match last_polled_snapshot.get(ws_id) {
+                        // Never polled in this app run → always due.
+                        None => true,
+                        Some(last) => now.duration_since(*last) >= interval,
+                    }
+                })
+                .collect();
+
+            if !due.is_empty() {
+                tracing::debug!(
+                    target: "claudette::scm",
+                    due_count = due.len(),
+                    selected = selected_snapshot.as_deref().unwrap_or("none"),
+                    running_count = running_workspaces.len(),
+                    "polling cycle"
+                );
+            }
+
+            // Poll due workspaces concurrently. The semaphore inside
             // poll_workspace_scm limits actual CLI invocations to 4 at a time.
-            let results: Vec<((String, String), Option<ScmDetail>)> = stream::iter(workspace_ids)
+            let results: Vec<((String, String), Option<ScmDetail>)> = stream::iter(due)
                 .map(|(ws_id, repo_id)| {
                     let state = &*app_state;
                     async move {
@@ -911,6 +1033,16 @@ pub fn start_scm_polling(app_handle: tauri::AppHandle) {
 
             for ((ws_id, repo_id), detail) in results {
                 if let Some(detail) = detail {
+                    // Stamp last-polled regardless of whether the poll
+                    // returned PR/CI data — even an empty result counts
+                    // as a successful "we checked, nothing's there" tick
+                    // and should respect the tier cadence.
+                    app_state
+                        .scm_last_polled
+                        .write()
+                        .await
+                        .insert(ws_id.clone(), Instant::now());
+
                     let _ = handle.emit("scm-data-updated", &detail);
 
                     let should_archive = per_repo_archive
@@ -1430,5 +1562,95 @@ mod tests {
             "null pr_json must hydrate as None, not panic",
         );
         assert!(entry.ci_checks.is_empty());
+    }
+
+    /// Helper: build an activity map where workspace `ws` was last active
+    /// `secs_ago` seconds in the past.
+    fn activity_with(ws: &str, secs_ago: u64) -> HashMap<String, Instant> {
+        let mut m = HashMap::new();
+        let when = Instant::now()
+            .checked_sub(Duration::from_secs(secs_ago))
+            .unwrap_or_else(Instant::now);
+        m.insert(ws.to_string(), when);
+        m
+    }
+
+    #[test]
+    fn tier_selected_is_hot() {
+        let activity = activity_with("ws1", 60 * 60 * 24 * 30); // 30 days idle
+        assert_eq!(
+            tier_interval("ws1", Some("ws1"), false, &activity),
+            Duration::from_secs(30),
+            "selected workspace must be hot even if activity is ancient",
+        );
+    }
+
+    #[test]
+    fn tier_agent_running_is_hot() {
+        let activity = activity_with("ws1", 60 * 60 * 24 * 30);
+        assert_eq!(
+            tier_interval("ws1", None, true, &activity),
+            Duration::from_secs(30),
+            "running agent must be hot even if activity is ancient",
+        );
+    }
+
+    #[test]
+    fn tier_recent_activity_under_1h_is_hot() {
+        let activity = activity_with("ws1", 60 * 30); // 30 min ago
+        assert_eq!(
+            tier_interval("ws1", None, false, &activity),
+            Duration::from_secs(30),
+        );
+    }
+
+    #[test]
+    fn tier_under_24h_is_warm() {
+        let activity = activity_with("ws1", 60 * 60 * 6); // 6h ago
+        assert_eq!(
+            tier_interval("ws1", None, false, &activity),
+            Duration::from_secs(5 * 60),
+        );
+    }
+
+    #[test]
+    fn tier_under_7d_is_cold() {
+        let activity = activity_with("ws1", 60 * 60 * 24 * 3); // 3 days ago
+        assert_eq!(
+            tier_interval("ws1", None, false, &activity),
+            Duration::from_secs(30 * 60),
+        );
+    }
+
+    #[test]
+    fn tier_older_than_7d_is_stale() {
+        let activity = activity_with("ws1", 60 * 60 * 24 * 30); // 30 days ago
+        assert_eq!(
+            tier_interval("ws1", None, false, &activity),
+            Duration::from_secs(60 * 60),
+        );
+    }
+
+    #[test]
+    fn tier_unknown_workspace_is_stale() {
+        let activity: HashMap<String, Instant> = HashMap::new();
+        assert_eq!(
+            tier_interval("ws1", None, false, &activity),
+            Duration::from_secs(60 * 60),
+            "workspace with no recorded activity should land in the stale tier, \
+             not the hot tier — otherwise a fresh app with empty maps would \
+             hammer every workspace on startup",
+        );
+    }
+
+    #[test]
+    fn tier_selected_vs_other_workspace() {
+        // A different workspace being selected should not affect ws1's tier.
+        let activity = activity_with("ws1", 60 * 60 * 24 * 3); // 3 days
+        assert_eq!(
+            tier_interval("ws1", Some("ws2"), false, &activity),
+            Duration::from_secs(30 * 60),
+            "selection of an unrelated workspace must not promote ws1 to hot",
+        );
     }
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1151,3 +1151,32 @@ fn now_iso() -> String {
         .unwrap_or_default();
     format!("{}", dur.as_secs())
 }
+
+/// Tell the backend which workspace the user is currently viewing.
+///
+/// The SCM polling loop reads this to keep the selected workspace on a
+/// 30s cadence while letting other workspaces fall into longer polling
+/// tiers. `workspace_id == None` means the user is on the dashboard or a
+/// repository overview rather than a specific workspace.
+///
+/// Also marks the workspace as freshly active and clears its last-polled
+/// stamp so the next polling tick picks it up immediately.
+#[tauri::command]
+pub async fn notify_workspace_selected(
+    workspace_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    *state.selected_workspace_id.write().await = workspace_id.clone();
+    if let Some(id) = workspace_id {
+        let now = std::time::Instant::now();
+        state
+            .workspace_activity
+            .write()
+            .await
+            .insert(id.clone(), now);
+        // Force the next polling tick to refresh this workspace even if it
+        // was polled within the previous 30s — the user just looked at it.
+        state.scm_last_polled.write().await.remove(&id);
+    }
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -900,6 +900,7 @@ fn main() {
             commands::workspace::discover_worktrees,
             commands::workspace::import_worktrees,
             commands::workspace::open_workspace_in_terminal,
+            commands::workspace::notify_workspace_selected,
             // Slash commands
             commands::slash_commands::list_slash_commands,
             commands::slash_commands::record_slash_command_usage,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -545,6 +545,20 @@ pub struct AppState {
     pub merge_base_cache: MergeBaseCache,
     /// Limits concurrent SCM CLI invocations.
     pub scm_semaphore: Arc<Semaphore>,
+    /// The workspace the user is currently viewing. The polling loop reads
+    /// this to keep the focused workspace on a 30s cadence while other
+    /// workspaces back off. `None` when the user is on the dashboard or a
+    /// repository overview rather than a specific workspace.
+    pub selected_workspace_id: RwLock<Option<String>>,
+    /// Last-known activity instant per workspace. Written on workspace
+    /// selection and on agent turn start; read by the SCM polling loop to
+    /// compute the tier interval. Seeded at startup from `chat_sessions`
+    /// so workspaces with recent chat history don't all start as stale.
+    pub workspace_activity: RwLock<HashMap<String, Instant>>,
+    /// When each workspace was last successfully polled by the SCM loop.
+    /// Combined with `workspace_activity` to decide whether a workspace is
+    /// due for another poll on the current tick.
+    pub scm_last_polled: RwLock<HashMap<String, Instant>>,
     /// Pending updater handle from the most recent `check_for_updates_with_channel`
     /// call. The Update struct holds the downloaded payload + signature context
     /// and is not Serialize, so it lives here instead of crossing the IPC boundary.
@@ -593,6 +607,9 @@ impl AppState {
             scm_cache: ScmCache::new(),
             merge_base_cache: MergeBaseCache::new(),
             scm_semaphore: Arc::new(Semaphore::new(4)),
+            selected_workspace_id: RwLock::new(None),
+            workspace_activity: RwLock::new(HashMap::new()),
+            scm_last_polled: RwLock::new(HashMap::new()),
             pending_update: tokio::sync::Mutex::new(None),
             boot_probation: Arc::new(BootProbationState::default()),
             cesp_playback: Mutex::new(claudette::cesp::SoundPlaybackState::new()),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -552,8 +552,9 @@ pub struct AppState {
     pub selected_workspace_id: RwLock<Option<String>>,
     /// Last-known activity instant per workspace. Written on workspace
     /// selection and on agent turn start; read by the SCM polling loop to
-    /// compute the tier interval. Seeded at startup from `chat_sessions`
-    /// so workspaces with recent chat history don't all start as stale.
+    /// compute the tier interval. Seeded at startup from the most recent
+    /// `chat_messages.created_at` per workspace so workspaces with recent
+    /// chat history don't all start as stale.
     pub workspace_activity: RwLock<HashMap<String, Instant>>,
     /// When each workspace was last successfully polled by the SCM loop.
     /// Combined with `workspace_activity` to decide whether a workspace is

--- a/src/db/chat.rs
+++ b/src/db/chat.rs
@@ -95,6 +95,25 @@ impl Database {
         "NOT (role = 'assistant' AND TRIM(content) = '' AND COALESCE(TRIM(thinking), '') = '')";
 
     #[allow(dead_code)]
+    /// For each workspace that has at least one chat message, return the
+    /// number of seconds elapsed since its most recent message. Used to
+    /// seed the SCM polling loop's per-workspace activity map after an
+    /// app restart so workspaces with recent chat history start in the
+    /// hot tier rather than the stale tier.
+    pub fn workspace_last_activity_seconds_ago(
+        &self,
+    ) -> Result<Vec<(String, i64)>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT workspace_id, \
+                    CAST(strftime('%s', 'now') - strftime('%s', MAX(created_at)) AS INTEGER) \
+             FROM chat_messages GROUP BY workspace_id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        rows.collect()
+    }
+
     pub fn list_chat_messages(
         &self,
         workspace_id: &str,

--- a/src/ui/src/hooks/useCreateWorkspace.test.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.test.ts
@@ -18,6 +18,11 @@ vi.mock("../services/tauri", () => ({
   createWorkspace: mockCreateWorkspace,
   getRepoConfig: mockGetRepoConfig,
   runWorkspaceSetup: mockRunWorkspaceSetup,
+  // Tests exercise `selectWorkspace` on the store, which now notifies the
+  // backend so the SCM polling loop can promote the new workspace into its
+  // hot tier. The notification is fire-and-forget — stub it so the mock
+  // surface stays complete.
+  notifyWorkspaceSelected: vi.fn(() => Promise.resolve()),
 }));
 
 import { createWorkspaceOrchestrated } from "./useCreateWorkspace";

--- a/src/ui/src/services/tauri.ts
+++ b/src/ui/src/services/tauri.ts
@@ -298,6 +298,17 @@ export function deleteWorkspace(id: string): Promise<void> {
   return invoke("delete_workspace", { id });
 }
 
+/**
+ * Tell the Rust SCM polling loop which workspace the user is currently
+ * viewing. Pass `null` when navigating to the dashboard or a repository
+ * overview so the backend drops its hot-tier focus. Selection drives the
+ * 30 s polling cadence for the focused workspace and lets idle workspaces
+ * back off to longer tier intervals.
+ */
+export function notifyWorkspaceSelected(workspaceId: string | null): Promise<void> {
+  return invoke("notify_workspace_selected", { workspaceId });
+}
+
 export interface GeneratedWorkspaceName {
   slug: string;
   display: string;

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -1,15 +1,13 @@
-import { invoke } from "@tauri-apps/api/core";
 import type { StateCreator } from "zustand";
+import { notifyWorkspaceSelected } from "../../services/tauri";
 import type { Workspace } from "../../types";
 import type { AppState } from "../useAppStore";
 
-// Fire-and-forget: tell the Rust SCM polling loop which workspace the user
-// is viewing so it can keep that workspace on a 30s cadence while letting
-// idle workspaces back off. Errors are swallowed because selection is a
-// pure UI action — a failed notification just means the backend keeps
-// polling on its prior tier, which is fine.
+// Fire-and-forget wrapper around the typed service call. Errors are
+// swallowed because selection is a pure UI action — a failed notification
+// just means the backend keeps polling on its prior tier, which is fine.
 function notifyBackendSelection(workspaceId: string | null) {
-  invoke("notify_workspace_selected", { workspaceId }).catch(() => {});
+  notifyWorkspaceSelected(workspaceId).catch(() => {});
 }
 
 export type WorkspaceEnvironmentStatus = "idle" | "preparing" | "ready" | "error";

--- a/src/ui/src/stores/slices/workspacesSlice.ts
+++ b/src/ui/src/stores/slices/workspacesSlice.ts
@@ -1,6 +1,16 @@
+import { invoke } from "@tauri-apps/api/core";
 import type { StateCreator } from "zustand";
 import type { Workspace } from "../../types";
 import type { AppState } from "../useAppStore";
+
+// Fire-and-forget: tell the Rust SCM polling loop which workspace the user
+// is viewing so it can keep that workspace on a 30s cadence while letting
+// idle workspaces back off. Errors are swallowed because selection is a
+// pure UI action — a failed notification just means the backend keeps
+// polling on its prior tier, which is fine.
+function notifyBackendSelection(workspaceId: string | null) {
+  invoke("notify_workspace_selected", { workspaceId }).catch(() => {});
+}
 
 export type WorkspaceEnvironmentStatus = "idle" | "preparing" | "ready" | "error";
 
@@ -190,6 +200,7 @@ export const createWorkspacesSlice: StateCreator<
   selectWorkspace: (id) =>
     set((s) => {
       if (id === s.selectedWorkspaceId) return s;
+      notifyBackendSelection(id);
 
       // Save the outgoing workspace's active diff selection, or clear it if
       // the user left that workspace in chat view (e.g. they clicked a chat
@@ -271,6 +282,9 @@ export const createWorkspacesSlice: StateCreator<
         // store mutation that would re-render every subscriber.
         return s;
       }
+      // Picking a repository clears any selected workspace, so the backend
+      // should drop its hot-tier focus too.
+      if (id && s.selectedWorkspaceId) notifyBackendSelection(null);
       return {
         selectedRepositoryId: id,
         // Picking a project clears any open workspace so the project-scoped
@@ -284,6 +298,7 @@ export const createWorkspacesSlice: StateCreator<
       if (s.selectedWorkspaceId === null && s.selectedRepositoryId === null) {
         return s;
       }
+      if (s.selectedWorkspaceId) notifyBackendSelection(null);
       return { selectedWorkspaceId: null, selectedRepositoryId: null };
     }),
   setWorkspaceEnvironment: (id, status, error) =>


### PR DESCRIPTION
## Summary

The SCM polling loop fired `list_pull_requests` + `ci_status` for **every active workspace every 30s**, generating ~80 plugin subprocess calls and provider API hits per cycle for a typical multi-workspace setup. Logging added in #746 made this visible as ongoing battery and rate-limit pressure for workspaces the user hasn't touched in days.

This change introduces a four-tier polling cadence driven by selection and in-memory activity tracking:

| Tier | Interval | Condition |
|---|---|---|
| **Hot** | 30 s | Selected workspace, agent running, or active within last 1 h |
| **Warm** | 5 min | Last activity within 24 h |
| **Cold** | 30 min | Last activity within 7 days |
| **Stale** | 1 h | Older than 7 days (or never seen) |

The outer loop still ticks every 30 s — that's the smallest tier interval — but each tick filters down to workspaces whose tier window has elapsed since the last successful poll. Selecting a workspace clears its last-polled stamp so the next tick refreshes it immediately.

```mermaid
flowchart LR
    Tick[30s tick] --> Snap[Snapshot:<br/>selected_workspace_id<br/>workspace_activity<br/>scm_last_polled<br/>running agents]
    Snap --> Filter{For each active workspace:<br/>tier_interval &lt;= elapsed?}
    Filter -->|yes| Poll[poll_workspace_scm]
    Filter -->|no| Skip[skip]
    Poll --> Stamp[Update scm_last_polled]
    Stamp --> Emit[Emit scm-data-updated]
```

**Activity signals** (all in-memory on `AppState`):
- Workspace selection via new `notify_workspace_selected` Tauri command, wired into `selectWorkspace` / `selectRepository` / `goToDashboard` Zustand setters.
- Start of every user-initiated chat turn (`send_chat_message`).
- On startup, seeded from `MAX(chat_messages.created_at)` per workspace so recently-used workspaces start in the right tier rather than all landing in stale.

No DB migration — the activity and last-polled maps live in `AppState`.

## Complexity Notes

- **Inner cache short-circuit is preserved.** `poll_workspace_scm` still has its own 30s cache check (`last_fetched.elapsed().as_secs() < 30`). With the new outer tier filter, this is mostly redundant for hot-tier workspaces and never fires for warm/cold/stale, but it remains as defense-in-depth against collisions between background polling and on-demand `load_scm_detail` calls.
- **"Unknown workspace" treated as stale, not hot.** When a workspace has no entry in `workspace_activity` (e.g. fresh app with no chat history), `tier_interval` returns 1h. This is deliberate — if it returned 30s, a fresh app with N workspaces would temporarily hammer all of them at startup before the startup seed populates. The seed bumps known workspaces into their correct tier; truly-never-used workspaces stay cold.
- **Auto-archive on PR-merged is unaffected.** The merge check still runs after every successful poll regardless of tier — it just runs less often for idle workspaces, which is the whole point.
- **Memory footprint of the in-memory maps grows monotonically** with workspaces (`HashMap<String, Instant>`). Each entry is ~40 bytes; even thousands of workspaces is negligible, but if it ever matters, a cleanup pass when workspaces archive/delete would be straightforward.

## Test Steps

Automated coverage:
1. Run `cargo test -p claudette-tauri tier_` — 8 new unit tests for `tier_interval` covering selected, agent-running, recent / 24h / 7d / >7d idle, unknown workspace, and "selection of unrelated workspace doesn't promote this one."
2. Run `cargo test -p claudette -p claudette-server -p claudette-cli --all-features` — 1094 backend tests.
3. Run `cd src/ui && bun run test` — 1833 frontend tests.

Manual verification (dev build):
1. Start the dev app via `./scripts/dev.sh` with several workspaces (mix of recently-used and idle ones).
2. Set `RUST_LOG=claudette::scm=debug` and tail the log.
3. After the initial poll cycle settles, watch for the `polling cycle` debug line — `due_count` should drop well below the active workspace count once initial polls complete.
4. Switch the selected workspace in the sidebar; verify the newly-selected workspace appears in the very next `due_count` batch (within 30 s) and the previously-selected one stops appearing.
5. Trigger an agent turn in a non-selected workspace; verify that workspace stays on the 30 s cadence for the duration of the turn and for ~1 h afterward.
6. Leave the app idle for several minutes; verify previously-warm workspaces decay into the 5-min cadence (no more 30 s churn for non-selected, non-running workspaces).
7. Confirm the PR banner on the selected workspace still updates within ~30 s of a real GitHub change, and sidebar PR badges for non-selected workspaces still eventually refresh (just at the slower cadence).

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (if applicable)