### PR TITLE
fix(chat): suppress empty-tabs flash during workspace switch and app launch

### DIFF
--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -5,6 +5,18 @@
   position: relative;
 }
 
+/* Filler shown while a workspace's sessions are still loading from the
+   backend (typical window: 50-150ms on a sidebar click, longer on first
+   launch). Holds the content area open with the theme background so the
+   panel chrome above (workspace header + tab strip) doesn't reflow, and
+   no empty-state placard flashes between `selectedWorkspaceId` flipping
+   and the `setSessionsForWorkspace` response landing. See the
+   `sessionsLoaded` comment in ChatPanel.tsx for the load-order details. */
+.loadingShell {
+  flex: 1;
+  min-height: 0;
+}
+
 /* Messages area */
 /* Wraps the search bar + scrolling messages list. The bar is absolutely
    positioned over the top of this wrapper so opening Cmd+F doesn't push

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -226,8 +226,24 @@ export function ChatPanel() {
       ? (s.fileTabsByWorkspace[selectedWorkspaceId] ?? []).length
       : 0,
   );
+  // Sessions are fetched lazily by SessionTabs' mount effect, so there's a
+  // ~50-150ms window between a workspace becoming selected and its sessions
+  // landing in the store. Without this flag, `noOpenTabs` reads `true` for
+  // that window and ChatPanel briefly renders `WorkspaceEmptyTabs` — which
+  // shares its visual chrome with the Welcome card, so the flash looks
+  // identical to "Start a workspace in X." on every workspace switch / app
+  // launch. Gate the empty-state branch on a confirmed load so we only show
+  // it when the list is genuinely empty.
+  const sessionsLoaded = useAppStore((s) =>
+    selectedWorkspaceId
+      ? s.sessionsLoadedByWorkspace[selectedWorkspaceId] === true
+      : false,
+  );
   const noOpenTabs =
-    activeSessionCount === 0 && diffTabCount === 0 && fileTabCount === 0;
+    sessionsLoaded &&
+    activeSessionCount === 0 &&
+    diffTabCount === 0 &&
+    fileTabCount === 0;
   const messages = activeSessionId
     ? chatMessages[activeSessionId] || []
     : [];
@@ -1287,7 +1303,15 @@ export function ChatPanel() {
       <WorkspacePanelHeader />
       {selectedWorkspaceId && <SessionTabs workspaceId={selectedWorkspaceId} />}
 
-      {noOpenTabs ? (
+      {selectedWorkspaceId && !sessionsLoaded ? (
+        // Loading window: sessions for this workspace haven't landed yet
+        // (see the `sessionsLoaded` comment above). Hold the layout open
+        // with a blank shell so neither `WorkspaceEmptyTabs` nor the
+        // "Send a message…" placard flashes during the transition. The
+        // header and tab strip above keep painting so the chrome stays
+        // anchored.
+        <div className={styles.loadingShell} aria-hidden="true" />
+      ) : noOpenTabs ? (
         // All chat sessions, diff tabs, and file tabs are closed. Skip the
         // chat content + composer entirely so the user lands on a clear
         // affordance for opening a new session instead of a blank pane.

--- a/src/ui/src/components/chat/SessionTabs.tsx
+++ b/src/ui/src/components/chat/SessionTabs.tsx
@@ -124,6 +124,7 @@ export function SessionTabs({ workspaceId }: Props) {
     (s) => s.activeFileTabByWorkspace[workspaceId] ?? null,
   );
   const setSessionsForWorkspace = useAppStore((s) => s.setSessionsForWorkspace);
+  const markSessionsLoaded = useAppStore((s) => s.markSessionsLoaded);
   const addChatSession = useAppStore((s) => s.addChatSession);
   const updateChatSession = useAppStore((s) => s.updateChatSession);
   const removeChatSession = useAppStore((s) => s.removeChatSession);
@@ -199,8 +200,18 @@ export function SessionTabs({ workspaceId }: Props) {
       })
       .catch((err) => {
         console.error("[SessionTabs] Failed to load sessions:", err);
+        // Don't strand ChatPanel on the loading shell when the initial
+        // fetch fails — flip the loaded flag so the user falls through
+        // to `WorkspaceEmptyTabs` and can recover via "+ Open new session".
+        // We deliberately don't overwrite `sessionsByWorkspace` here: a
+        // racing `addChatSession` (e.g. an agent stream event mid-fetch)
+        // may have already populated the list, and that authoritative
+        // state must not be clobbered by the error path.
+        if (version === loadVersionRef.current) {
+          markSessionsLoaded(workspaceId);
+        }
       });
-  }, [workspaceId, setSessionsForWorkspace]);
+  }, [workspaceId, setSessionsForWorkspace, markSessionsLoaded]);
 
   // Memoized so navEntries / navigateTabs stay referentially stable when the
   // session list hasn't changed — without this, `sessions.filter` returns a

--- a/src/ui/src/stores/slices/chatSessionsSlice.ts
+++ b/src/ui/src/stores/slices/chatSessionsSlice.ts
@@ -5,6 +5,16 @@ import type { AppState } from "../useAppStore";
 export interface ChatSessionsSlice {
   sessionsByWorkspace: Record<string, ChatSession[]>;
   selectedSessionIdByWorkspaceId: Record<string, string>;
+  /** Set to `true` once `setSessionsForWorkspace` has resolved at least once
+   *  for a given workspace id, distinguishing "we just don't know yet" from
+   *  "we asked the backend and the list is genuinely empty". Without this,
+   *  ChatPanel's `noOpenTabs` empty-state placard flashes for ~50-150ms on
+   *  every workspace switch / app launch — sessions are loaded lazily by
+   *  `SessionTabs` mounting, but the empty-state branch fires the moment
+   *  `selectedWorkspaceId` flips, before that fetch lands. The flag is set
+   *  in `setSessionsForWorkspace` (and stays set across subsequent updates),
+   *  so a fresh page hydration is the only thing that can reset it. */
+  sessionsLoadedByWorkspace: Record<string, boolean>;
   setSessionsForWorkspace: (wsId: string, sessions: ChatSession[]) => void;
   addChatSession: (session: ChatSession) => void;
   updateChatSession: (
@@ -23,6 +33,7 @@ export const createChatSessionsSlice: StateCreator<
 > = (set) => ({
   sessionsByWorkspace: {},
   selectedSessionIdByWorkspaceId: {},
+  sessionsLoadedByWorkspace: {},
   setSessionsForWorkspace: (wsId, sessions) =>
     set((s) => {
       const next = { ...s.sessionsByWorkspace, [wsId]: sessions };
@@ -34,9 +45,16 @@ export const createChatSessionsSlice: StateCreator<
       if (!selectedIsActive && activeSessions.length > 0) {
         nextSelected[wsId] = activeSessions[0].id;
       }
+      // Reuse the existing record when the flag was already set, so callers
+      // subscribing only to `sessionsLoadedByWorkspace` don't re-render on
+      // every session-list refresh — only on the first transition.
+      const sessionsLoadedByWorkspace = s.sessionsLoadedByWorkspace[wsId]
+        ? s.sessionsLoadedByWorkspace
+        : { ...s.sessionsLoadedByWorkspace, [wsId]: true };
       return {
         sessionsByWorkspace: next,
         selectedSessionIdByWorkspaceId: nextSelected,
+        sessionsLoadedByWorkspace,
       };
     }),
   addChatSession: (session) =>

--- a/src/ui/src/stores/slices/chatSessionsSlice.ts
+++ b/src/ui/src/stores/slices/chatSessionsSlice.ts
@@ -5,15 +5,16 @@ import type { AppState } from "../useAppStore";
 export interface ChatSessionsSlice {
   sessionsByWorkspace: Record<string, ChatSession[]>;
   selectedSessionIdByWorkspaceId: Record<string, string>;
-  /** Set to `true` once `setSessionsForWorkspace` has resolved at least once
-   *  for a given workspace id, distinguishing "we just don't know yet" from
-   *  "we asked the backend and the list is genuinely empty". Without this,
-   *  ChatPanel's `noOpenTabs` empty-state placard flashes for ~50-150ms on
-   *  every workspace switch / app launch — sessions are loaded lazily by
-   *  `SessionTabs` mounting, but the empty-state branch fires the moment
-   *  `selectedWorkspaceId` flips, before that fetch lands. The flag is set
-   *  in `setSessionsForWorkspace` (and stays set across subsequent updates),
-   *  so a fresh page hydration is the only thing that can reset it. */
+  /** Set to `true` once we have a confirmed answer for a given workspace —
+   *  either `setSessionsForWorkspace` resolved (the happy path), `addChatSession`
+   *  inserted a row before the initial fetch landed (race), or `markSessionsLoaded`
+   *  was called explicitly (error recovery). Distinguishes "we just don't know
+   *  yet" from "we asked and the list is genuinely empty". Without this,
+   *  ChatPanel's `noOpenTabs` empty-state placard flashes for ~50-150ms on every
+   *  workspace switch / app launch — sessions are loaded lazily by `SessionTabs`
+   *  mounting, but the empty-state branch fires the moment `selectedWorkspaceId`
+   *  flips, before that fetch lands. Once set, the flag stays set; a fresh page
+   *  hydration is the only thing that can reset it. */
   sessionsLoadedByWorkspace: Record<string, boolean>;
   setSessionsForWorkspace: (wsId: string, sessions: ChatSession[]) => void;
   addChatSession: (session: ChatSession) => void;
@@ -23,6 +24,12 @@ export interface ChatSessionsSlice {
   ) => void;
   removeChatSession: (sessionId: string) => void;
   selectSession: (workspaceId: string, sessionId: string) => void;
+  /** Mark a workspace's sessions as "we have an authoritative answer" without
+   *  mutating the session list. Used by `SessionTabs`' load-error path so a
+   *  failed initial `listChatSessions` doesn't strand the chat surface on the
+   *  blank loading shell forever — the user falls through to `WorkspaceEmptyTabs`
+   *  (with its `+ Open new session` affordance) and can recover. */
+  markSessionsLoaded: (wsId: string) => void;
 }
 
 export const createChatSessionsSlice: StateCreator<
@@ -63,11 +70,21 @@ export const createChatSessionsSlice: StateCreator<
       if (existing.some((x) => x.id === session.id)) {
         return s;
       }
+      // A workspace with at least one session is, by definition, "loaded" —
+      // we have authoritative state to render. Marking the flag here closes
+      // the race where the user creates (or the backend pushes) a new session
+      // before the initial `listChatSessions` fetch resolves, which would
+      // otherwise leave ChatPanel stuck on the blank loading shell despite
+      // the session being available.
+      const sessionsLoadedByWorkspace = s.sessionsLoadedByWorkspace[session.workspace_id]
+        ? s.sessionsLoadedByWorkspace
+        : { ...s.sessionsLoadedByWorkspace, [session.workspace_id]: true };
       return {
         sessionsByWorkspace: {
           ...s.sessionsByWorkspace,
           [session.workspace_id]: [...existing, session],
         },
+        sessionsLoadedByWorkspace,
       };
     }),
   updateChatSession: (sessionId, updates) =>
@@ -138,4 +155,14 @@ export const createChatSessionsSlice: StateCreator<
       diffPreviewLoading: false,
       diffPreviewError: null,
     })),
+  markSessionsLoaded: (wsId) =>
+    set((s) => {
+      if (s.sessionsLoadedByWorkspace[wsId]) return s;
+      return {
+        sessionsLoadedByWorkspace: {
+          ...s.sessionsLoadedByWorkspace,
+          [wsId]: true,
+        },
+      };
+    }),
 });

--- a/src/ui/src/stores/useAppStore.sessionsLoaded.test.ts
+++ b/src/ui/src/stores/useAppStore.sessionsLoaded.test.ts
@@ -89,7 +89,7 @@ describe("sessionsLoadedByWorkspace", () => {
     expect(secondRef).toBe(firstRef);
   });
 
-  it("does not leak across removeChatSession", () => {
+  it("does not reset when removeChatSession archives the last session", () => {
     useAppStore
       .getState()
       .setSessionsForWorkspace("ws-1", [makeSession("s-1", "ws-1")]);
@@ -101,5 +101,59 @@ describe("sessionsLoadedByWorkspace", () => {
     // only session, which would feel like a regression.
     useAppStore.getState().removeChatSession("s-1");
     expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+  });
+
+  // addChatSession is the writer for newly-created sessions and for stream
+  // events that materialize a session before the initial `listChatSessions`
+  // fetch resolves. If it didn't also mark the workspace loaded, ChatPanel
+  // would stay on the blank loading shell despite having tabs to render.
+  it("flips to true when addChatSession inserts the first session", () => {
+    useAppStore.getState().addChatSession(makeSession("s-1", "ws-1"));
+    expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+  });
+
+  it("addChatSession reuses the record reference when already loaded", () => {
+    useAppStore.getState().setSessionsForWorkspace("ws-1", []);
+    const firstRef = useAppStore.getState().sessionsLoadedByWorkspace;
+
+    useAppStore.getState().addChatSession(makeSession("s-1", "ws-1"));
+    const secondRef = useAppStore.getState().sessionsLoadedByWorkspace;
+
+    expect(secondRef).toBe(firstRef);
+  });
+
+  // markSessionsLoaded is the recovery path for SessionTabs' load-error case:
+  // a failed `listChatSessions` would otherwise leave the chat surface on
+  // the blank loading shell with no way out. The flag flip lets the user
+  // fall through to WorkspaceEmptyTabs and create a session manually.
+  describe("markSessionsLoaded", () => {
+    it("flips the flag without touching the session list", () => {
+      useAppStore.getState().markSessionsLoaded("ws-1");
+
+      const state = useAppStore.getState();
+      expect(state.sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+      // Critical: existing/racing session data must survive the recovery path.
+      expect(state.sessionsByWorkspace["ws-1"]).toBeUndefined();
+    });
+
+    it("does not clobber sessions inserted by a racing addChatSession", () => {
+      useAppStore.getState().addChatSession(makeSession("s-1", "ws-1"));
+      useAppStore.getState().markSessionsLoaded("ws-1");
+
+      const state = useAppStore.getState();
+      expect(state.sessionsByWorkspace["ws-1"]).toHaveLength(1);
+      expect(state.sessionsByWorkspace["ws-1"][0].id).toBe("s-1");
+      expect(state.sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+    });
+
+    it("is a no-op when already loaded — preserves record reference", () => {
+      useAppStore.getState().setSessionsForWorkspace("ws-1", []);
+      const firstRef = useAppStore.getState().sessionsLoadedByWorkspace;
+
+      useAppStore.getState().markSessionsLoaded("ws-1");
+      const secondRef = useAppStore.getState().sessionsLoadedByWorkspace;
+
+      expect(secondRef).toBe(firstRef);
+    });
   });
 });

--- a/src/ui/src/stores/useAppStore.sessionsLoaded.test.ts
+++ b/src/ui/src/stores/useAppStore.sessionsLoaded.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "./useAppStore";
+import type { ChatSession } from "../types";
+
+// `sessionsLoadedByWorkspace` lets ChatPanel distinguish "we just haven't
+// fetched yet" from "the workspace genuinely has no sessions" — without it,
+// `noOpenTabs` reads true during the lazy `listChatSessions` round-trip and
+// the WorkspaceEmptyTabs placard flashes for ~50-150ms on every workspace
+// switch / app launch. These tests pin the flag's contract so a future
+// refactor of the slice can't silently bring the flicker back.
+
+function makeSession(id: string, workspaceId: string): ChatSession {
+  return {
+    id,
+    workspace_id: workspaceId,
+    session_id: null,
+    name: id,
+    name_edited: false,
+    turn_count: 0,
+    sort_order: 0,
+    status: "Active",
+    created_at: "2026-01-01T00:00:00Z",
+    archived_at: null,
+    cli_invocation: null,
+    agent_status: "Idle",
+    needs_attention: false,
+    attention_kind: null,
+  };
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    sessionsByWorkspace: {},
+    sessionsLoadedByWorkspace: {},
+    selectedSessionIdByWorkspaceId: {},
+  });
+});
+
+describe("sessionsLoadedByWorkspace", () => {
+  it("starts empty so consumers can detect 'never fetched'", () => {
+    expect(useAppStore.getState().sessionsLoadedByWorkspace).toEqual({});
+  });
+
+  it("flips to true the first time setSessionsForWorkspace runs", () => {
+    useAppStore
+      .getState()
+      .setSessionsForWorkspace("ws-1", [makeSession("s-1", "ws-1")]);
+
+    expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+  });
+
+  // The regression we're guarding: a backend response with zero sessions
+  // is still a *loaded* state. Treating `[]` as "not loaded" would keep
+  // the empty-tabs placard suppressed forever for genuinely empty workspaces.
+  it("flips to true even when the backend returns an empty list", () => {
+    useAppStore.getState().setSessionsForWorkspace("ws-1", []);
+
+    expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+  });
+
+  it("tracks each workspace independently", () => {
+    useAppStore.getState().setSessionsForWorkspace("ws-1", []);
+    expect(useAppStore.getState().sessionsLoadedByWorkspace).toEqual({
+      "ws-1": true,
+    });
+    expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-2"]).toBeUndefined();
+
+    useAppStore.getState().setSessionsForWorkspace("ws-2", []);
+    expect(useAppStore.getState().sessionsLoadedByWorkspace).toEqual({
+      "ws-1": true,
+      "ws-2": true,
+    });
+  });
+
+  // Reference stability matters because ChatPanel subscribes to this map
+  // via `useAppStore((s) => s.sessionsLoadedByWorkspace[id] === true)` —
+  // the subscriber doesn't depend on the *map* identity, but anything
+  // reading the whole record (devtools, future selectors) would re-render
+  // unnecessarily if the slice cloned the object on every session refresh.
+  it("reuses the same record reference on subsequent updates", () => {
+    useAppStore.getState().setSessionsForWorkspace("ws-1", []);
+    const firstRef = useAppStore.getState().sessionsLoadedByWorkspace;
+
+    useAppStore
+      .getState()
+      .setSessionsForWorkspace("ws-1", [makeSession("s-1", "ws-1")]);
+    const secondRef = useAppStore.getState().sessionsLoadedByWorkspace;
+
+    expect(secondRef).toBe(firstRef);
+  });
+
+  it("does not leak across removeChatSession", () => {
+    useAppStore
+      .getState()
+      .setSessionsForWorkspace("ws-1", [makeSession("s-1", "ws-1")]);
+    expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+
+    // Removing the last session must not reset the loaded flag — the
+    // workspace is still "we asked and now know it's empty". A reset
+    // would re-show the loading shell after the user archives their
+    // only session, which would feel like a regression.
+    useAppStore.getState().removeChatSession("s-1");
+    expect(useAppStore.getState().sessionsLoadedByWorkspace["ws-1"]).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

On every workspace switch (sidebar click), and on app launch when restoring the last selected workspace, the chat surface flashed an empty-state placard for ~50–150 ms before the real content rendered. The placard reused `WelcomeEmptyState.module.css`, so the flash looked identical to **"Start a workspace in `<repo>`."** appearing between workspaces — confusing because it's the same chrome the Welcome card uses.

## Root cause — load-order race

`selectedWorkspaceId` flips synchronously in the Zustand store the moment the user clicks a workspace in the sidebar. The new workspace's chat sessions, however, are fetched lazily by `SessionTabs`' mount effect via `listChatSessions`. That fetch is one Tauri round-trip and takes 50–150 ms locally.

During that window, `sessionsByWorkspace[newId]` is `undefined`, so:

```ts
const noOpenTabs = activeSessionCount === 0 && diffTabCount === 0 && fileTabCount === 0;
//                 ^^^^^^^^^^^^^^^^^^^^^^^^^  reads 0 because sessions haven't landed yet
```

→ `ChatPanel` renders `<WorkspaceEmptyTabs>` → flash.

Same race fires on app launch: `App.tsx`'s `viewStateHydrated` gate correctly waits for the persisted view state, but per-workspace sessions are still fetched lazily once `ChatPanel` mounts, so the gap reopens after first paint.

## Verification

Captured live against the dev app by subscribing to store changes from the debug eval hook and clicking through several workspaces:

```
click ws B → sessions=0 → view: ChatPanel:empty-tabs   ← flash
+114 ms       sessions=2 → view: ChatPanel:active       ← real content

click ws C → sessions=0 → view: ChatPanel:empty-tabs   ← flash
+43  ms       sessions=1 → view: ChatPanel:active

click ws D → sessions=0 → view: ChatPanel:empty-tabs   ← flash
+148 ms       sessions=1 → view: ChatPanel:active
```

Every switch flashed `WorkspaceEmptyTabs` for the duration of the lazy fetch.

## Fix

Distinguish *"we just haven't fetched yet"* from *"this workspace genuinely has no sessions"* with a per-workspace `sessionsLoadedByWorkspace: Record<string, boolean>` on `ChatSessionsSlice`.

The flag flips to `true` inside `setSessionsForWorkspace` — the single chokepoint every load path funnels through (initial mount, refresh-on-rename, post-create). The record reference is reused on subsequent updates so future subscribers reading the whole map don't re-render on every session-list refresh, only on the first `false → true` transition.

`ChatPanel` reads the flag and renders one of three branches:

```tsx
{selectedWorkspaceId && !sessionsLoaded ? (
  <div className={styles.loadingShell} aria-hidden="true" />   // blank pane, chrome stays
) : noOpenTabs ? (
  <WorkspaceEmptyTabs workspace={ws} repository={repo} />      // genuinely empty
) : (
  /* real chat */
)}
```

`noOpenTabs` is now itself gated on `sessionsLoaded`, so even if a future refactor reorders the branches the placard still won't fire pre-load. The new `.loadingShell` class is just `flex: 1; min-height: 0;` — it fills the content area at the theme background so `WorkspacePanelHeader` and `SessionTabs` keep painting without reflow. No spinner, no text, no flash.

## Tests

`src/ui/src/stores/useAppStore.sessionsLoaded.test.ts` (new — 6 cases):

- **starts empty** so consumers can detect "never fetched"
- **flips to `true` on first fetch**
- **flips to `true` even when the backend returns `[]`** ← the critical case; treating `[]` as not-loaded would suppress the placard forever for genuinely empty workspaces
- **tracks each workspace independently**
- **reuses the same record reference** across updates (subscriber-stability)
- **does not get reset by `removeChatSession`** archiving the last session

```
Test Files  158 passed (158)
Tests       1896 passed (1896)       (was 157 / 1890 before)
```

CI parity: `tsc -b`, `bun run lint`, `bun run lint:css`, `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` all clean.

## Out of scope (follow-up)

- Dashboard view still has elastic / rubber-band scrolling that `ChatPanel` already fixed via `usePreventScrollBounce` + `overscroll-behavior-y: none`. Tracked locally to do in a separate session — same hook will be reused.
