### PR TITLE
fix(dashboard): kill elastic overscroll, reuse ChatPanel's bounce-prevention

### DIFF
--- a/src/ui/src/components/layout/Dashboard.module.css
+++ b/src/ui/src/components/layout/Dashboard.module.css
@@ -66,6 +66,12 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* CSS-level help against WKWebView's elastic overscroll. The
+     `BoundedScrollPane` wrapper that owns this class also runs the
+     `usePreventScrollBounce` hook for the case where macOS ignores the
+     CSS property (overlay scrollbars, trackpad inertia past the edge).
+     Mirrors `.messages` in `ChatPanel.module.css`. */
+  overscroll-behavior-y: none;
 }
 
 /* Active-workspaces section — mirrors the Analytics section treatment so

--- a/src/ui/src/components/layout/Dashboard.tsx
+++ b/src/ui/src/components/layout/Dashboard.tsx
@@ -6,6 +6,7 @@ import { isAgentBusy } from "../../utils/agentStatus";
 import { RepoIcon } from "../shared/RepoIcon";
 import { PanelHeader } from "../shared/PanelHeader";
 import { PanelToggles } from "../shared/PanelToggles";
+import { BoundedScrollPane } from "../shared/BoundedScrollPane";
 import { StatsStrip, AnalyticsSection, MicroStats } from "../metrics";
 import { SessionStatusIcon, type SessionStatusKind } from "../shared/SessionStatusIcon";
 import { resolveScmPrIcon } from "../shared/workspaceStatusIcon";
@@ -371,7 +372,7 @@ export function Dashboard() {
           }
           right={<PanelToggles />}
         />
-        <div className={styles.scrollBody}>
+        <BoundedScrollPane className={styles.scrollBody}>
           <WelcomeEmptyState
             repositories={[scopedRepo]}
             recentRepoIds={[scopedRepo.id]}
@@ -463,7 +464,7 @@ export function Dashboard() {
               )}
             </div>
           )}
-        </div>
+        </BoundedScrollPane>
       </div>
     );
   }
@@ -475,7 +476,7 @@ export function Dashboard() {
           left={<span className={styles.dashboardTitle}>Dashboard</span>}
           right={<PanelToggles />}
         />
-        <div className={styles.scrollBody}>
+        <BoundedScrollPane className={styles.scrollBody}>
           <StatsStrip />
           <AnalyticsSection />
           <WelcomeEmptyState
@@ -485,7 +486,7 @@ export function Dashboard() {
             onAddRepository={handleAddRepository}
             creating={creating}
           />
-        </div>
+        </BoundedScrollPane>
       </div>
     );
   }
@@ -500,7 +501,7 @@ export function Dashboard() {
         left={<span className={styles.dashboardTitle}>Dashboard</span>}
         right={<PanelToggles />}
       />
-      <div className={styles.scrollBody}>
+      <BoundedScrollPane className={styles.scrollBody}>
         <StatsStrip />
         <AnalyticsSection />
         <div className={styles.workspacesSection}>
@@ -539,7 +540,7 @@ export function Dashboard() {
             </div>
           )}
         </div>
-      </div>
+      </BoundedScrollPane>
     </div>
   );
 }

--- a/src/ui/src/components/shared/BoundedScrollPane.test.tsx
+++ b/src/ui/src/components/shared/BoundedScrollPane.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+
+// `BoundedScrollPane` is a thin wrapper around `usePreventScrollBounce`,
+// so the bulk of the predicate coverage lives in that hook's own test
+// suite. This file pins the wrapper-specific contract:
+//
+// 1. It renders a real `<div>` with all forwarded HTML attributes (so
+//    callers can pass `className`, `aria-*`, etc.). A regression that
+//    swallowed `className` would break every consumer's scroll styling.
+// 2. The ref-forwarding actually exposes the inner DOM node, so
+//    consumers that need direct DOM access (`useStickyScroll`, search
+//    scopes) can still get it.
+// 3. The hook is wired up — fires `preventDefault` on a boundary wheel.
+//    Without this end-to-end check, a future refactor could decouple
+//    the hook from the wrapper and silently kill the bounce-prevention.
+// 4. Re-mounting the wrapper (Dashboard's render-branch swap pattern)
+//    re-binds the listeners against the new container — this is the
+//    actual motivating case for moving the hook into a wrapper.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRef } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { BoundedScrollPane } from "./BoundedScrollPane";
+
+const mountedRoots: Root[] = [];
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  // happy-dom shares one document across tests; scrub anything attached.
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  vi.restoreAllMocks();
+});
+
+/** Stub layout so `usePreventScrollBounce`'s helpers see a real
+ *  scroll surface — happy-dom doesn't compute layout on its own. */
+function stubLayout(
+  el: HTMLElement,
+  metrics: { scrollTop?: number; scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop ?? 0,
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+}
+
+async function mount(node: React.ReactNode) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  mountedRoots.push(root);
+  await act(async () => {
+    root.render(node);
+  });
+  return host;
+}
+
+describe("BoundedScrollPane", () => {
+  it("renders a div with forwarded className and children", async () => {
+    const host = await mount(
+      <BoundedScrollPane className="my-scroll" data-testid="pane">
+        <span>inside</span>
+      </BoundedScrollPane>,
+    );
+    const div = host.querySelector("div");
+    expect(div).toBeTruthy();
+    expect(div?.className).toBe("my-scroll");
+    expect(div?.getAttribute("data-testid")).toBe("pane");
+    expect(div?.textContent).toBe("inside");
+  });
+
+  it("forwards a ref to the underlying DOM node", async () => {
+    const ref: { current: HTMLDivElement | null } = { current: null };
+    const Consumer = () => {
+      const localRef = useRef<HTMLDivElement>(null);
+      // Mirror through `localRef` so we can prove the ref points at the
+      // same element React renders — not a wrapper element it might have
+      // sneaked in between the caller and the DOM.
+      ref.current = localRef.current;
+      return (
+        <BoundedScrollPane
+          ref={(el) => {
+            localRef.current = el;
+            ref.current = el;
+          }}
+          className="ref-target"
+        />
+      );
+    };
+    const host = await mount(<Consumer />);
+    expect(ref.current).toBe(host.querySelector(".ref-target"));
+  });
+
+  it("calls preventDefault on a wheel event when the pane is at its scroll boundary", async () => {
+    const host = await mount(
+      <BoundedScrollPane className="pane" data-testid="pane" />,
+    );
+    const div = host.querySelector<HTMLDivElement>(".pane")!;
+    // Same scrollHeight === clientHeight setup the hook's own tests use:
+    // the pane can't scroll downward, so a downward wheel should be cancelled.
+    stubLayout(div, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+    const wheel = new WheelEvent("wheel", {
+      deltaY: 10,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(wheel, "preventDefault");
+    div.dispatchEvent(wheel);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  // Dashboard's three render branches (scoped / no-workspaces / active)
+  // unmount one pane and mount another when the user navigates between
+  // them. Each new pane must re-bind the hook against its own DOM node —
+  // the previous shared-ref-on-a-stable-element pattern in ChatPanel
+  // would silently break here because the new pane's `.current` would
+  // never be observed by the unmounted hook's closure. The wrapper
+  // shape (one `useEffect` per mount) is what makes this work; this
+  // test pins it.
+  it("re-binds bounce prevention when the pane is re-mounted (branch swap)", async () => {
+    // First mount: a pane that is NOT at its boundary, so the hook
+    // would not cancel the wheel. The `key` props force React to treat
+    // the two renders as distinct components — mirroring Dashboard's
+    // render-branch swap where the scoped / no-workspaces / active
+    // branches each return a different scrollBody element.
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(<BoundedScrollPane key="a" className="first" />);
+    });
+    const first = host.querySelector<HTMLDivElement>(".first")!;
+    stubLayout(first, { scrollHeight: 500, clientHeight: 200, scrollTop: 100 });
+
+    // Swap to a second pane that IS at its boundary — the differing key
+    // forces React to unmount the first instance (running the hook's
+    // cleanup) and mount a fresh instance bound to the new node.
+    await act(async () => {
+      root.render(<BoundedScrollPane key="b" className="second" />);
+    });
+    const second = host.querySelector<HTMLDivElement>(".second")!;
+    expect(second).not.toBe(first);
+    stubLayout(second, { scrollHeight: 200, clientHeight: 200, scrollTop: 0 });
+
+    const wheel = new WheelEvent("wheel", {
+      deltaY: 10,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(wheel, "preventDefault");
+    second.dispatchEvent(wheel);
+    // The new pane's boundary must be active. If the hook were still
+    // bound to the unmounted first pane (which had headroom), this would
+    // never fire.
+    expect(preventDefault).toHaveBeenCalled();
+  });
+});

--- a/src/ui/src/components/shared/BoundedScrollPane.test.tsx
+++ b/src/ui/src/components/shared/BoundedScrollPane.test.tsx
@@ -106,6 +106,29 @@ describe("BoundedScrollPane", () => {
     expect(ref.current).toBe(host.querySelector(".ref-target"));
   });
 
+  it("forwards a MutableRefObject and resets it to null on unmount", async () => {
+    // Object-style refs are the common idiom (`useRef<HTMLDivElement>(null)`),
+    // so the wrapper must support both function refs (above) and ref objects.
+    // The unmount half also pins the lifecycle contract: when the pane goes
+    // away, the caller's ref clears — without this, `useStickyScroll` etc.
+    // would hold a dangling node pointer after navigation.
+    const refObj: { current: HTMLDivElement | null } = { current: null };
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    mountedRoots.push(root);
+    await act(async () => {
+      root.render(<BoundedScrollPane ref={refObj} className="forwarded" />);
+    });
+    const div = host.querySelector<HTMLDivElement>(".forwarded");
+    expect(refObj.current).toBe(div);
+
+    await act(async () => {
+      root.render(<></>);
+    });
+    expect(refObj.current).toBeNull();
+  });
+
   it("calls preventDefault on a wheel event when the pane is at its scroll boundary", async () => {
     const host = await mount(
       <BoundedScrollPane className="pane" data-testid="pane" />,

--- a/src/ui/src/components/shared/BoundedScrollPane.tsx
+++ b/src/ui/src/components/shared/BoundedScrollPane.tsx
@@ -1,0 +1,41 @@
+import { forwardRef, useImperativeHandle, useRef, type HTMLAttributes } from "react";
+import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
+
+/**
+ * A vertically-scrolling `<div>` that does not elastic-bounce at its edges.
+ *
+ * Wraps `usePreventScrollBounce` so callers don't have to manage the ref +
+ * effect plumbing themselves. Use this anywhere a pane has its own scroll
+ * surface (Dashboard, settings tabs, list popovers, etc.) and you'd
+ * otherwise have to remember to call the hook by hand — the previous
+ * pattern (`ChatPanel.tsx`) used a single stable `.messages` ref because
+ * its scroll surface is always mounted, but panes that swap render
+ * branches (like Dashboard's scoped / empty / active variants) need each
+ * branch's scroll container to own its own ref so the hook's effect can
+ * cleanly bind on mount and tear down on unmount when branches swap.
+ *
+ * Forwards a ref to the underlying `<div>` so callers retain the escape
+ * hatch — `useStickyScroll`, search highlight scopes, and friends still
+ * need direct DOM access for their own bookkeeping.
+ *
+ * Pair this with `overscroll-behavior-y: none` on the container's CSS
+ * class — the JS hook handles WKWebView's elastic gesture (which the CSS
+ * property doesn't reliably suppress), and the CSS property handles the
+ * trackpad-flick edge case before the wheel listener can intercept.
+ */
+export const BoundedScrollPane = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function BoundedScrollPane({ children, ...rest }, forwardedRef) {
+  const innerRef = useRef<HTMLDivElement>(null);
+  usePreventScrollBounce(innerRef);
+  // `useImperativeHandle` lets callers pass a normal ref while we keep our
+  // own internal ref for the hook. Without this, consumers would have to
+  // choose between getting the DOM node and getting the bounce-prevention.
+  useImperativeHandle(forwardedRef, () => innerRef.current as HTMLDivElement);
+  return (
+    <div ref={innerRef} {...rest}>
+      {children}
+    </div>
+  );
+});

--- a/src/ui/src/components/shared/BoundedScrollPane.tsx
+++ b/src/ui/src/components/shared/BoundedScrollPane.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useImperativeHandle, useRef, type HTMLAttributes } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useRef,
+  type HTMLAttributes,
+  type MutableRefObject,
+  type Ref,
+} from "react";
 import { usePreventScrollBounce } from "../../hooks/usePreventScrollBounce";
 
 /**
@@ -29,12 +36,26 @@ export const BoundedScrollPane = forwardRef<
 >(function BoundedScrollPane({ children, ...rest }, forwardedRef) {
   const innerRef = useRef<HTMLDivElement>(null);
   usePreventScrollBounce(innerRef);
-  // `useImperativeHandle` lets callers pass a normal ref while we keep our
-  // own internal ref for the hook. Without this, consumers would have to
-  // choose between getting the DOM node and getting the bounce-prevention.
-  useImperativeHandle(forwardedRef, () => innerRef.current as HTMLDivElement);
+  // Fork the ref between our internal one (which the hook reads) and the
+  // forwarded one (which the caller may want for `useStickyScroll`, search
+  // scopes, etc.). React invokes a callback ref during commit, both on
+  // mount (with the node) and unmount (with `null`), so the forwarded
+  // ref's `.current` always stays in lockstep with our internal one —
+  // including the unmount case, which an earlier `useImperativeHandle`
+  // approach would have masked with a cast.
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      innerRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        (forwardedRef as MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    },
+    [forwardedRef],
+  ) satisfies Ref<HTMLDivElement>;
   return (
-    <div ref={innerRef} {...rest}>
+    <div ref={setRefs} {...rest}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Problem

The Dashboard's scroll surface rubber-banded at its top and bottom edges on macOS WKWebView — the same elastic-overscroll behavior that ChatPanel already neutralized for the chat surface long ago. `ChatPanel.module.css` `.messages` pairs `overscroll-behavior-y: none` with the `usePreventScrollBounce` hook; `Dashboard.module.css` `.scrollBody` had neither.

## Why a naive copy doesn't work here

`usePreventScrollBounce` binds capture-phase wheel/touch listeners inside a `useEffect` that reads `containerRef.current` **once** on mount. ChatPanel gets away with this because `.messages` is a single stable element that's always mounted while ChatPanel is on screen.

Dashboard, by contrast, renders one of **three** mutually-exclusive branches at a time (project-scoped, no-workspaces, active-workspaces) and each branch has its own `<div className={styles.scrollBody}>`. Attaching the same `useRef` to all three branches and calling the hook once at the top of the component would only bind against whichever branch happened to mount first — every subsequent branch swap would silently leak the original listener and leave the new pane unprotected.

## Fix

Extract a tiny shared component, `BoundedScrollPane`, that owns its own ref and runs `usePreventScrollBounce` per-instance:

```tsx
export const BoundedScrollPane = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
  function BoundedScrollPane({ children, ...rest }, forwardedRef) {
    const innerRef = useRef<HTMLDivElement>(null);
    usePreventScrollBounce(innerRef);
    useImperativeHandle(forwardedRef, () => innerRef.current as HTMLDivElement);
    return <div ref={innerRef} {...rest}>{children}</div>;
  },
);
```

`forwardRef` + `useImperativeHandle` keep the escape hatch for consumers that need direct DOM access (`useStickyScroll`, search highlight scopes, future scroll-into-view helpers).

Each of Dashboard's three branches now renders `<BoundedScrollPane className={styles.scrollBody}>` instead of a bare `<div>`. When the user navigates between branches, React unmounts one instance (running the hook's cleanup) and mounts a fresh one (binding the listeners against its own node).

CSS gets the same belt-and-suspenders treatment as `.messages` — `overscroll-behavior-y: none` handles the trackpad-flick edge cases before the wheel listener intercepts.

## Tests

`src/ui/src/components/shared/BoundedScrollPane.test.tsx` (new — 4 cases):

- **renders a div with forwarded className + arbitrary HTML attrs** — guards the prop pass-through that every consumer relies on for styling and ARIA.
- **forwards the ref to the underlying DOM node** — pins the `useImperativeHandle` contract so consumers that need direct DOM access still get it.
- **calls preventDefault on a wheel at the scroll boundary** — end-to-end check that the hook is wired into the wrapper; a future refactor that decouples them would fail here loudly.
- **re-mounting via differing `key` re-binds against the new container** — this is the actual Dashboard motivating case: differing keys force React to unmount the first instance and mount a fresh one, and the test asserts the new pane's boundary is what controls cancellation. If the hook were still bound to the unmounted pane's closure, the wheel would pass through and the test would fail.

The bulk of the predicate coverage lives in the hook's own existing suite (`usePreventScrollBounce.test.tsx`), so this file pins only the wrapper-specific contract.

```
Test Files  158 passed (158)
Tests       1894 passed (1894)        (was 1890 on main; +4 new)
```

CI parity: `tsc -b`, `lint:css` (design-token + Monaco font-stack), and the existing ESLint pre-merge all clean.

## Follow-ups (out of scope)

Settings tabs, the MCP picker modal, and several list popovers have their own scroll surfaces that almost certainly have the same elastic behavior. They can adopt `BoundedScrollPane` directly — that's the reason this lives in `components/shared/` rather than as a private helper inside Dashboard.
