### PR TITLE
fix(windows): suppress cmd.exe window flash on session-name generation

### DIFF
--- a/src/agent/naming.rs
+++ b/src/agent/naming.rs
@@ -248,6 +248,11 @@ pub async fn generate_session_name(
 
     let claude_path = resolve_claude_path().await;
     let mut cmd = Command::new(&claude_path);
+    // Without CREATE_NO_WINDOW the background `claude --print` spawn allocates
+    // a fresh console and a black cmd.exe window flashes on screen for the
+    // duration of the Haiku call. The sibling `generate_branch_name` already
+    // does this; keep them in sync.
+    cmd.no_console_window();
     cmd.stdin(std::process::Stdio::null())
         .env("PATH", crate::env::enriched_path());
     cmd.current_dir(worktree_path);


### PR DESCRIPTION
## Summary

On Windows, starting a new chat session caused a black `cmd.exe` window to briefly flash on screen and then disappear. Reported on Discord:

> new sessions on windows kick off an external cmd lol... gotta love it

## Root cause

`src/agent/naming.rs::generate_session_name` spawns `claude --print` in the background after the user sends their first message — this is the Haiku call that produces the 3-6 word chat-session name shown in the sidebar. The `Command::new` builder was missing `.no_console_window()`, so on Windows the GUI-spawned child got `CreateProcessW`-default behaviour: a fresh console window allocated for the lifetime of the child.

The sibling `generate_branch_name` directly above (lines 160–235) already calls `.no_console_window()`. The two functions are near-duplicate setup code — `generate_session_name` was added later and the call was simply forgotten. `CommandWindowExt` is already imported on line 7.

## Fix

One added line + a 4-line comment pointing at the sibling so the symmetry is visible to anyone extending this module:

```rust
let mut cmd = Command::new(&claude_path);
// Without CREATE_NO_WINDOW the background `claude --print` spawn allocates
// a fresh console and a black cmd.exe window flashes on screen for the
// duration of the Haiku call. The sibling `generate_branch_name` already
// does this; keep them in sync.
cmd.no_console_window();
```

## Verification

- `cargo fmt --all --check` clean
- `cargo check -p claudette --all-features` clean
- `RUSTFLAGS=-Dwarnings cargo clippy -p claudette --all-targets --all-features` clean (CI command)
- `cargo test -p claudette --lib agent::naming` — 14 / 14 pass

## Why no new test

Per-callsite assertions that the flag is set would require spawning real subprocesses, which `src/agent/naming.rs` deliberately avoids (its existing tests cover pure helpers — sanitization, custom-title persistence). The `CommandWindowExt` trait itself has full unit tests in `src/process.rs`: trait shape, idempotency, exact flag values for both `CREATE_NO_WINDOW` and `CREATE_NEW_CONSOLE`, and a real Windows-gated spawn-with-flag end-to-end test. So the mechanism is well-tested; the per-callsite oversight is the failure mode, and that lives or dies by reviewer attention.

## Related

A separate Discord report ("first character of typed input duplicated in integrated terminal — `clear` → `cclear`") is being tracked separately — it surfaced after #752 switched the Windows default shell to PowerShell, and the right fix requires live investigation via `/claudette-debug` rather than a guess. Will land in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)