### PR TITLE
fix(chat): suppress project context in Haiku rename calls + log silent failures

### DIFF
--- a/src-tauri/src/commands/chat/naming.rs
+++ b/src-tauri/src/commands/chat/naming.rs
@@ -29,14 +29,30 @@ pub(crate) async fn try_auto_rename(
     .await
     {
         Ok(s) => s,
-        Err(_) => return,
+        Err(e) => {
+            tracing::warn!(
+                target: "claudette::chat",
+                workspace_id = %ws_id,
+                error = %e,
+                "auto-rename: generate_branch_name failed",
+            );
+            return;
+        }
     };
 
     // Resolve the configured branch prefix.
     let prefix = {
         let db = match Database::open(db_path) {
             Ok(db) => db,
-            Err(_) => return,
+            Err(e) => {
+                tracing::warn!(
+                    target: "claudette::chat",
+                    workspace_id = %ws_id,
+                    error = %e,
+                    "auto-rename: Database::open failed (reading branch prefix)",
+                );
+                return;
+            }
         };
         let (mode, custom) = claudette::ops::workspace::read_branch_prefix_settings(&db);
         // Drop db before the async call (Database is not Sync).
@@ -51,7 +67,15 @@ pub(crate) async fn try_auto_rename(
 
         let db = match Database::open(db_path) {
             Ok(db) => db,
-            Err(_) => return,
+            Err(e) => {
+                tracing::warn!(
+                    target: "claudette::chat",
+                    workspace_id = %ws_id,
+                    error = %e,
+                    "auto-rename: Database::open failed (renaming workspace)",
+                );
+                return;
+            }
         };
 
         match db.rename_workspace(ws_id, candidate, &new_branch) {
@@ -65,6 +89,13 @@ pub(crate) async fn try_auto_rename(
                     if e.to_string().contains("already exists") {
                         continue;
                     }
+                    tracing::warn!(
+                        target: "claudette::chat",
+                        workspace_id = %ws_id,
+                        error = %e,
+                        new_branch = %new_branch,
+                        "auto-rename: git rename_branch failed",
+                    );
                     return;
                 }
 
@@ -81,10 +112,27 @@ pub(crate) async fn try_auto_rename(
                 if e.to_string().contains("UNIQUE constraint failed") {
                     continue;
                 }
+                tracing::warn!(
+                    target: "claudette::chat",
+                    workspace_id = %ws_id,
+                    error = %e,
+                    candidate = %candidate,
+                    "auto-rename: db.rename_workspace failed",
+                );
                 return;
             }
         }
     }
+
+    // All candidate slugs collided. Without this log the workspace silently
+    // stays on its placeholder name and the one-shot claim makes it
+    // unrecoverable on later turns.
+    tracing::warn!(
+        target: "claudette::chat",
+        workspace_id = %ws_id,
+        slug = %slug,
+        "auto-rename: all candidate slugs collided",
+    );
 }
 
 /// Background task: ask Haiku for a short session name and persist it. All

--- a/src/agent/naming.rs
+++ b/src/agent/naming.rs
@@ -181,7 +181,6 @@ pub async fn generate_branch_name(
     cmd.no_console_window();
     cmd.stdin(std::process::Stdio::null())
         .env("PATH", crate::env::enriched_path());
-    // Run in the user's worktree so the CLI loads *their* project context.
     cmd.current_dir(worktree_path);
     let user_message = format!(
         "Generate a short git branch name slug for the following task. \

--- a/src/agent/naming.rs
+++ b/src/agent/naming.rs
@@ -157,11 +157,12 @@ fn transcript_has_custom_title(path: &Path, session_id: &str) -> Result<bool, St
 /// first prompt. Returns a sanitized branch slug (e.g. `fix-login-timeout`).
 ///
 /// `worktree_path` is used as the subprocess CWD so the CLI picks up the
-/// user's git context and `ws_env`-resolved env vars, but project context
-/// (CLAUDE.md, `.mcp.json`, project `.claude/settings.json`) is intentionally
-/// suppressed via `--system-prompt`, `--setting-sources user`, and
-/// `--tools ""`. A user project's CLAUDE.md plus MCP tool catalog can easily
-/// exceed Haiku's input window, and slug generation doesn't need that context.
+/// user's git context. Project context (CLAUDE.md, `.mcp.json`, project
+/// `.claude/settings.json`) is intentionally suppressed via `--system-prompt`,
+/// `--setting-sources user`, and `--tools ""`. A user project's CLAUDE.md
+/// plus MCP tool catalog can easily exceed Haiku's input window, and slug
+/// generation doesn't need that context. (`ws_env` env vars are applied
+/// separately via `env.apply` — they don't depend on CWD.)
 pub async fn generate_branch_name(
     prompt_text: &str,
     worktree_path: &str,

--- a/src/agent/naming.rs
+++ b/src/agent/naming.rs
@@ -155,8 +155,13 @@ fn transcript_has_custom_title(path: &Path, session_id: &str) -> Result<bool, St
 
 /// Call Claude Haiku to generate a short branch name slug from the user's
 /// first prompt. Returns a sanitized branch slug (e.g. `fix-login-timeout`).
-/// `worktree_path` sets the subprocess CWD so the CLI picks up the correct
-/// project context (CLAUDE.md) for the user's workspace — not Claudette's own.
+///
+/// `worktree_path` is used as the subprocess CWD so the CLI picks up the
+/// user's git context and `ws_env`-resolved env vars, but project context
+/// (CLAUDE.md, `.mcp.json`, project `.claude/settings.json`) is intentionally
+/// suppressed via `--system-prompt`, `--setting-sources user`, and
+/// `--tools ""`. A user project's CLAUDE.md plus MCP tool catalog can easily
+/// exceed Haiku's input window, and slug generation doesn't need that context.
 pub async fn generate_branch_name(
     prompt_text: &str,
     worktree_path: &str,
@@ -200,8 +205,19 @@ pub async fn generate_branch_name(
         "text",
         "--model",
         "claude-haiku-4-5",
-        "--append-system-prompt",
+        // Replace the default system prompt instead of appending so the CLI
+        // skips CLAUDE.md auto-discovery — user project context can exceed
+        // Haiku's input window, and slug generation doesn't need it.
+        "--system-prompt",
         &system_prompt,
+        // Skip project + local settings so the CLI doesn't pull in
+        // `.mcp.json` tool catalogs or `.claude/settings.json` overrides.
+        "--setting-sources",
+        "user",
+        // No tools needed for a one-shot slug — keeps the system prompt
+        // free of tool definitions.
+        "--tools",
+        "",
         &user_message,
     ]);
 
@@ -261,14 +277,22 @@ pub async fn generate_session_name(
     let system_prompt = "You are a chat-session namer. Output ONLY a short \
          descriptive name — never answer or complete the task itself."
         .to_string();
+    // Same context-suppression flags as `generate_branch_name` above — see
+    // that function's doc comment for the rationale. A user project's
+    // CLAUDE.md + MCP tool catalog can overflow Haiku's input window and
+    // session-name generation doesn't need that context either.
     cmd.args([
         "--print",
         "--output-format",
         "text",
         "--model",
         "claude-haiku-4-5",
-        "--append-system-prompt",
+        "--system-prompt",
         &system_prompt,
+        "--setting-sources",
+        "user",
+        "--tools",
+        "",
         &user_message,
     ]);
 

--- a/src/agent/naming.rs
+++ b/src/agent/naming.rs
@@ -204,19 +204,23 @@ pub async fn generate_branch_name(
         "text",
         "--model",
         "claude-haiku-4-5",
+        // `--tools` is variadic (`<tools...>`) and greedily consumes every
+        // following arg until the next `--flag`. Place it *before* another
+        // option so the variadic terminates after the empty-string value;
+        // otherwise it eats the positional prompt and the CLI fails with
+        // "Input must be provided either through stdin or as a prompt
+        // argument when using --print".
+        "--tools",
+        "",
+        // Skip project + local settings so the CLI doesn't pull in
+        // `.mcp.json` tool catalogs or `.claude/settings.json` overrides.
+        "--setting-sources",
+        "user",
         // Replace the default system prompt instead of appending so the CLI
         // skips CLAUDE.md auto-discovery — user project context can exceed
         // Haiku's input window, and slug generation doesn't need it.
         "--system-prompt",
         &system_prompt,
-        // Skip project + local settings so the CLI doesn't pull in
-        // `.mcp.json` tool catalogs or `.claude/settings.json` overrides.
-        "--setting-sources",
-        "user",
-        // No tools needed for a one-shot slug — keeps the system prompt
-        // free of tool definitions.
-        "--tools",
-        "",
         &user_message,
     ]);
 
@@ -277,21 +281,20 @@ pub async fn generate_session_name(
          descriptive name — never answer or complete the task itself."
         .to_string();
     // Same context-suppression flags as `generate_branch_name` above — see
-    // that function's doc comment for the rationale. A user project's
-    // CLAUDE.md + MCP tool catalog can overflow Haiku's input window and
-    // session-name generation doesn't need that context either.
+    // that function for the variadic-`--tools` ordering rationale and the
+    // overall context-stripping intent.
     cmd.args([
         "--print",
         "--output-format",
         "text",
         "--model",
         "claude-haiku-4-5",
-        "--system-prompt",
-        &system_prompt,
-        "--setting-sources",
-        "user",
         "--tools",
         "",
+        "--setting-sources",
+        "user",
+        "--system-prompt",
+        &system_prompt,
         &user_message,
     ]);
 


### PR DESCRIPTION
## Summary

- **Root cause of the silent auto-rename failures**: the Haiku branch / session-name subprocess shelled out from the user's worktree with `--append-system-prompt`, so the Claude CLI auto-loaded the project's `CLAUDE.md`, `.mcp.json` tool catalog, and `.claude/settings.json` into the system prompt. A non-trivial `CLAUDE.md` overflowed Haiku's input window and the call died with `Prompt is too long`. On a representative production DB this stranded **~92% of new workspaces** on their placeholder `<adjective>-<plant>` slug (5 successes out of 44 claimed renames).
- Switch both `agent::generate_branch_name` and `agent::generate_session_name` to `--system-prompt` (replaces the default system prompt instead of appending — bypasses `CLAUDE.md` auto-discovery), plus `--setting-sources user` (skip project + local settings) and `--tools ""` (no tool catalog). Slug generation never needed project context.
- Add `tracing::warn!` to all five silent `return` paths in `try_auto_rename` plus the candidate-loop fall-through. The claim flag is intentionally one-shot ("flag tracks the claim, not the outcome"), so a single transient failure permanently stranded the workspace with no log signal. Logs now match the existing `claim_branch_auto_rename failed` style under `target=claudette::chat`.

## Test plan

- [x] `cargo check -p claudette -p claudette-tauri --all-features` clean with `RUSTFLAGS="-Dwarnings"`
- [x] `cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features` clean (CI scope)
- [x] No new clippy warnings in either edited file under `cargo clippy -p claudette-tauri`
- [x] `cargo test -p claudette --lib agent::naming` — 14/14 pass
- [x] `cargo test -p claudette-tauri commands::chat` — 42/42 pass
- [x] `cd src/ui && bunx tsc -b` clean
- [x] Manually reproduced the failure: `claude --print --output-format text --model claude-haiku-4-5 ... "test prompt"` from a real worktree returns `Prompt is too long`; the same call from `/tmp` succeeds — confirming project-context loading is the trigger.
- [ ] Manual UAT once merged / built: reset `branch_auto_rename_claimed = 0` on a stuck workspace, send a prompt, confirm `workspace-renamed` fires and the branch flips to a real slug; verify `target=claudette::chat` warn logs surface any remaining stage-specific failure (Haiku / DB / git).