### PR TITLE
fix(chat): resize oversized image attachments

### DIFF
--- a/site/src/content/docs/getting-started/workflow.mdx
+++ b/site/src/content/docs/getting-started/workflow.mdx
@@ -40,3 +40,4 @@ The integrated terminal (`⌘/Ctrl + `` ` ``) runs inside each workspace's workt
 - **Set up a setup script** in [repo settings](/claudette/features/per-repo-settings/) so each new workspace starts with dependencies installed
 - **Configure an archive script** to push final commits or stash uncommitted work before a workspace is removed
 - **Use @-mentions** to reference specific files in your prompt (type `@` and start typing a filename)
+- **Attach screenshots and files** from the composer when visual context helps; large raster images are resized before being sent to the agent

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -664,32 +664,37 @@ export function ChatInputArea({
     const isPdf = SUPPORTED_DOCUMENT_TYPES.has(file.type);
     const isImage = SUPPORTED_IMAGE_TYPES.has(file.type);
     const isText = isTextFile(file.type);
-    const sizeLimit = maxSizeFor(file.type);
-    if (file.size > sizeLimit) {
+    const prepared = isImage
+      ? await import("../../utils/imageAttachment").then((m) => m.prepareImageAttachment(file))
+      : { blob: file, mediaType: file.type };
+    const attachmentBlob = prepared.blob;
+    const mediaType = prepared.mediaType;
+    const sizeLimit = maxSizeFor(mediaType);
+    if (attachmentBlob.size > sizeLimit) {
       console.warn(
-        `File too large: ${(file.size / 1024 / 1024).toFixed(1)} MB (max ${(sizeLimit / 1024 / 1024).toFixed(1)} MB)`,
+        `File too large: ${(attachmentBlob.size / 1024 / 1024).toFixed(1)} MB (max ${(sizeLimit / 1024 / 1024).toFixed(1)} MB)`,
       );
       return;
     }
-    const data_base64 = await fileToBase64(file);
+    const data_base64 = await fileToBase64(attachmentBlob);
     let preview_url: string;
     if (isPdf) {
       const { generatePdfThumbnail } = await import("../../utils/pdfThumbnail");
-      preview_url = await generatePdfThumbnail(await file.arrayBuffer()).catch(() => "");
+      preview_url = await generatePdfThumbnail(await attachmentBlob.arrayBuffer()).catch(() => "");
       if (!preview_url) return;
     } else if (isImage) {
-      preview_url = URL.createObjectURL(file);
+      preview_url = URL.createObjectURL(attachmentBlob);
     } else {
       preview_url = "";
     }
     const att: PendingAttachment = {
       id: crypto.randomUUID(),
       filename,
-      media_type: file.type,
+      media_type: mediaType,
       data_base64,
       preview_url,
-      size_bytes: file.size,
-      text_content: isText ? (textContent ?? await file.text()) : null,
+      size_bytes: attachmentBlob.size,
+      text_content: isText ? (textContent ?? await attachmentBlob.text()) : null,
     };
     setPendingAttachmentsBoth(sessionId, (prev) => {
       if (prev.length >= MAX_ATTACHMENTS) {

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -665,8 +665,10 @@ export function ChatInputArea({
     const isImage = SUPPORTED_IMAGE_TYPES.has(file.type);
     const isText = isTextFile(file.type);
     const prepared = isImage
-      ? await import("../../utils/imageAttachment").then((m) => m.prepareImageAttachment(file))
-      : { blob: file, mediaType: file.type };
+      ? await import("../../utils/imageAttachment").then((m) =>
+          m.prepareImageAttachment(file, filename),
+        )
+      : { blob: file, mediaType: file.type, filename };
     const attachmentBlob = prepared.blob;
     const mediaType = prepared.mediaType;
     const sizeLimit = maxSizeFor(mediaType);
@@ -689,7 +691,7 @@ export function ChatInputArea({
     }
     const att: PendingAttachment = {
       id: crypto.randomUUID(),
-      filename,
+      filename: prepared.filename,
       media_type: mediaType,
       data_base64,
       preview_url,

--- a/src/ui/src/utils/imageAttachment.test.ts
+++ b/src/ui/src/utils/imageAttachment.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_IMAGE_SIZE } from "./attachmentValidation";
+import { prepareImageAttachment } from "./imageAttachment";
+
+const originalCreateElement = document.createElement.bind(document);
+
+describe("prepareImageAttachment", () => {
+  let createImageBitmapMock: ReturnType<typeof vi.fn>;
+  let drawImage: ReturnType<typeof vi.fn>;
+  let toBlobResult: Blob | null;
+
+  beforeEach(() => {
+    drawImage = vi.fn();
+    toBlobResult = new Blob([new Uint8Array(32)], { type: "image/jpeg" });
+    createImageBitmapMock = vi.fn().mockResolvedValue({
+      width: 4000,
+      height: 3000,
+      close: vi.fn(),
+    });
+    vi.stubGlobal("createImageBitmap", createImageBitmapMock);
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName !== "canvas") return originalCreateElement(tagName);
+
+      const canvas = originalCreateElement("canvas") as HTMLCanvasElement;
+      vi.spyOn(canvas, "getContext").mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D);
+      vi.spyOn(canvas, "toBlob").mockImplementation((callback: BlobCallback) => callback(toBlobResult));
+      return canvas;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("passes through unsupported image formats", async () => {
+    const file = new Blob([new Uint8Array(MAX_IMAGE_SIZE + 1)], { type: "image/gif" });
+
+    const result = await prepareImageAttachment(file, "animation.gif");
+
+    expect(result).toEqual({ blob: file, mediaType: "image/gif", filename: "animation.gif" });
+    expect(createImageBitmapMock).not.toHaveBeenCalled();
+  });
+
+  it("passes through supported images that are already small enough", async () => {
+    const file = new Blob([new Uint8Array(128)], { type: "image/png" });
+
+    const result = await prepareImageAttachment(file, "small.png");
+
+    expect(result).toEqual({ blob: file, mediaType: "image/png", filename: "small.png" });
+    expect(createImageBitmapMock).not.toHaveBeenCalled();
+  });
+
+  it("resizes oversized raster images to JPEG and updates the filename", async () => {
+    const file = new Blob([new Uint8Array(MAX_IMAGE_SIZE + 1)], { type: "image/png" });
+
+    const result = await prepareImageAttachment(file, "screenshot.png");
+
+    expect(createImageBitmapMock).toHaveBeenCalledWith(file);
+    expect(drawImage).toHaveBeenCalledOnce();
+    expect(result.blob).toBe(toBlobResult);
+    expect(result.mediaType).toBe("image/jpeg");
+    expect(result.filename).toBe("screenshot.jpg");
+  });
+
+  it("falls back to the original image when canvas encoding fails", async () => {
+    const file = new Blob([new Uint8Array(MAX_IMAGE_SIZE + 1)], { type: "image/webp" });
+    toBlobResult = null;
+
+    const result = await prepareImageAttachment(file, "large.webp");
+
+    expect(result).toEqual({ blob: file, mediaType: "image/webp", filename: "large.webp" });
+  });
+
+  it("falls back to the original image when re-encoding is not smaller", async () => {
+    const file = new Blob([new Uint8Array(MAX_IMAGE_SIZE + 1)], { type: "image/jpeg" });
+    toBlobResult = new Blob([new Uint8Array(MAX_IMAGE_SIZE + 2)], { type: "image/jpeg" });
+
+    const result = await prepareImageAttachment(file, "photo.jpeg");
+
+    expect(result).toEqual({ blob: file, mediaType: "image/jpeg", filename: "photo.jpeg" });
+  });
+});

--- a/src/ui/src/utils/imageAttachment.ts
+++ b/src/ui/src/utils/imageAttachment.ts
@@ -1,0 +1,49 @@
+export interface PreparedImageAttachment {
+  blob: Blob;
+  mediaType: string;
+}
+
+const MAX_LONG_EDGE = 2000;
+const TARGET_IMAGE_BYTES = 3.75 * 1024 * 1024;
+const JPEG_QUALITY = 0.82;
+const RESIZABLE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+export async function prepareImageAttachment(file: Blob): Promise<PreparedImageAttachment> {
+  if (!RESIZABLE_IMAGE_TYPES.has(file.type) || file.size <= TARGET_IMAGE_BYTES) {
+    return { blob: file, mediaType: file.type };
+  }
+
+  try {
+    const bitmap = await createImageBitmap(file);
+    try {
+      const scale = Math.min(1, MAX_LONG_EDGE / Math.max(bitmap.width, bitmap.height));
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+      canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return { blob: file, mediaType: file.type };
+
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      const blob = await canvasToBlob(canvas, "image/jpeg", JPEG_QUALITY);
+      canvas.width = 0;
+      canvas.height = 0;
+
+      if (!blob || blob.size >= file.size) {
+        return { blob: file, mediaType: file.type };
+      }
+      return { blob, mediaType: blob.type || "image/jpeg" };
+    } finally {
+      bitmap.close();
+    }
+  } catch {
+    return { blob: file, mediaType: file.type };
+  }
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number,
+): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, quality));
+}

--- a/src/ui/src/utils/imageAttachment.ts
+++ b/src/ui/src/utils/imageAttachment.ts
@@ -1,16 +1,21 @@
+import { MAX_IMAGE_SIZE } from "./attachmentValidation";
+
 export interface PreparedImageAttachment {
   blob: Blob;
   mediaType: string;
+  filename: string;
 }
 
 const MAX_LONG_EDGE = 2000;
-const TARGET_IMAGE_BYTES = 3.75 * 1024 * 1024;
 const JPEG_QUALITY = 0.82;
 const RESIZABLE_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
 
-export async function prepareImageAttachment(file: Blob): Promise<PreparedImageAttachment> {
-  if (!RESIZABLE_IMAGE_TYPES.has(file.type) || file.size <= TARGET_IMAGE_BYTES) {
-    return { blob: file, mediaType: file.type };
+export async function prepareImageAttachment(
+  file: Blob,
+  filename: string,
+): Promise<PreparedImageAttachment> {
+  if (!RESIZABLE_IMAGE_TYPES.has(file.type) || file.size <= MAX_IMAGE_SIZE) {
+    return { blob: file, mediaType: file.type, filename };
   }
 
   try {
@@ -21,7 +26,7 @@ export async function prepareImageAttachment(file: Blob): Promise<PreparedImageA
       canvas.width = Math.max(1, Math.round(bitmap.width * scale));
       canvas.height = Math.max(1, Math.round(bitmap.height * scale));
       const ctx = canvas.getContext("2d");
-      if (!ctx) return { blob: file, mediaType: file.type };
+      if (!ctx) return { blob: file, mediaType: file.type, filename };
 
       ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
       const blob = await canvasToBlob(canvas, "image/jpeg", JPEG_QUALITY);
@@ -29,15 +34,23 @@ export async function prepareImageAttachment(file: Blob): Promise<PreparedImageA
       canvas.height = 0;
 
       if (!blob || blob.size >= file.size) {
-        return { blob: file, mediaType: file.type };
+        return { blob: file, mediaType: file.type, filename };
       }
-      return { blob, mediaType: blob.type || "image/jpeg" };
+      const mediaType = blob.type || "image/jpeg";
+      return { blob, mediaType, filename: filenameForMediaType(filename, mediaType) };
     } finally {
       bitmap.close();
     }
   } catch {
-    return { blob: file, mediaType: file.type };
+    return { blob: file, mediaType: file.type, filename };
   }
+}
+
+function filenameForMediaType(filename: string, mediaType: string): string {
+  if (mediaType !== "image/jpeg") return filename;
+  const dot = filename.lastIndexOf(".");
+  const stem = dot > 0 ? filename.slice(0, dot) : filename;
+  return `${stem}.jpg`;
 }
 
 function canvasToBlob(


### PR DESCRIPTION
## Summary
- Resize oversized PNG/JPEG/WebP chat attachments in the composer before base64 encoding
- Preserve SVG/GIF pass-through behavior and fall back to the original blob if browser resizing fails
- Document that large raster screenshots are resized before sending to the agent

## Test plan
- [x] nix develop -c cargo fmt --all --check
- [x] nix develop -c cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features
- [x] nix develop -c bash -lc 'cd src/ui && bunx tsc -b'
- [x] nix develop -c bash -lc 'cd src/ui && bun run test attachments.test.ts'
- [x] nix develop -c bash -lc 'cd src/ui && bun run lint'
- [x] nix develop -c bash -lc 'cd src/ui && bun run lint:css'