### PR TITLE
docs(site): remove remote workspaces pillar from landing page

### DIFF
--- a/site/src/components/Pillars.astro
+++ b/site/src/components/Pillars.astro
@@ -25,27 +25,15 @@ const pillars = [
     media: { caption: 'composer w/ segmented meter + /compact', filename: 'context.webm', meta: '.webm · ~10s loop', src: 'videos/context.webm' },
     flip: true,
   },
-  {
-    num: '03 / Remote workspaces',
-    title: 'Drive a session running on another machine.',
-    desc: 'Point Claudette at a beefy dev box. mDNS finds it on your LAN; encrypted WebSocket and trust-on-first-use keep it private. The UI is identical — local and remote agents live side by side.',
-    bullets: [
-      'TLS encrypted, certificate-pinned, no relay',
-      'Embedded server — no separate install needed',
-      'Auto-discovered via mDNS, paired with a token',
-    ],
-    media: { caption: '"Nearby" section, pair, connect', filename: 'remote-workspaces.webm', meta: '.webm · ~12s loop' },
-    flip: false,
-  },
 ];
 ---
 
 <section class="pillars-section" id="pillars">
   <div class="container">
     <header class="section-head">
-      <span class="eyebrow">Three things you won't find elsewhere</span>
+      <span class="eyebrow">Two things you won't find elsewhere</span>
       <h2>Built for how you actually work with Claude Code.</h2>
-      <p>One app, multiple agents on the same repo, real visibility into what the model is doing, and a path off your laptop when you need more horsepower.</p>
+      <p>One app, multiple agents on the same repo, and real visibility into what the model is doing.</p>
     </header>
 
     <div class="pillars">

--- a/site/src/components/Pillars.astro
+++ b/site/src/components/Pillars.astro
@@ -26,12 +26,16 @@ const pillars = [
     flip: true,
   },
 ];
+
+const NUMBER_WORDS = ['Zero', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine'];
+const pillarCount = NUMBER_WORDS[pillars.length] ?? String(pillars.length);
+const eyebrow = `${pillarCount} thing${pillars.length === 1 ? '' : 's'} you won't find elsewhere`;
 ---
 
 <section class="pillars-section" id="pillars">
   <div class="container">
     <header class="section-head">
-      <span class="eyebrow">Two things you won't find elsewhere</span>
+      <span class="eyebrow">{eyebrow}</span>
       <h2>Built for how you actually work with Claude Code.</h2>
       <p>One app, multiple agents on the same repo, and real visibility into what the model is doing.</p>
     </header>


### PR DESCRIPTION
### Summary

Removes the `03 / Remote workspaces` pillar — the "Drive a session running on another machine." block — from the marketing landing page (`site/src/components/Pillars.astro`). The section is data-driven, so this is a single entry removed from the `pillars` array.

Also realigns the surrounding copy so the section still reads cleanly:
- Eyebrow: "Three things you won't find elsewhere" → "Two things you won't find elsewhere"
- Intro paragraph: dropped the "a path off your laptop when you need more horsepower" clause that referred to remote workspaces.

The `pillar-media` template still has the static "demo loop" fallback branch (now unreachable since both remaining pillars set `media.src`) — left in place intentionally so restoring the pillar is a one-object paste.

### Test Steps

1. `cd site && bun install && bun run build` (or `npm install && npm run build`) — build succeeds.
2. `bun run dev`, open the landing page, scroll to the `#pillars` section.
3. Verify only two pillars render: "Run Claude Code on every branch at once." and "See your token budget as it happens."
4. Verify the eyebrow reads "Two things you won't find elsewhere" and the intro paragraph no longer mentions remote workspaces / horsepower.

### Checklist
- [ ] Tests added/updated — n/a (static marketing copy, no test surface)
- [x] Documentation updated (if applicable) — this *is* a docs/site change