### PR TITLE
docs(site): document macOS and Windows permission prompts

### DIFF
--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -33,6 +33,55 @@ Before using Claudette, ensure you have **Claude Code** installed and authentica
 claude /login
 ```
 
+## macOS permission prompts
+
+After install, macOS may surface a few first-run permission prompts. Each is gated by Apple's TCC (Transparency, Consent, and Control) system and only fires the first time Claudette uses the underlying capability — none of them appear at launch.
+
+### "Claudette wants permission to update or delete other applications."
+
+This is macOS's **App Management** prompt (Ventura 13+). It appears the first time Claudette installs its own update — the signed Tauri updater fetches a new build from the [GitHub release feed](https://github.com/utensils/Claudette/releases/latest), verifies the minisign signature against the public key embedded in the app, and replaces the `Claudette.app` bundle in `/Applications`. macOS sees one app modifying another app bundle on disk and requires you to grant the permission once.
+
+- **Grant it** to enable in-app auto-updates. The permission is scoped to Claudette — it does not let Claudette touch any other application.
+- **Deny it** and you'll need to update manually by downloading the latest `.dmg` from [Releases](https://github.com/utensils/Claudette/releases/latest) and replacing the bundle in `/Applications` yourself.
+- The choice can be changed at any time in **System Settings → Privacy & Security → App Management → Claudette**.
+
+If you installed Claudette outside `/Applications` (e.g. ran it directly from `~/Downloads`), the prompt may not appear until the first time the updater tries to swap the bundle.
+
+### "Claudette would like to find and connect to devices on your local network."
+
+This is macOS's **Local Network** prompt (Sonoma 14+). It appears shortly after first launch because Claudette runs an mDNS browser that discovers other Claudette instances on your LAN to populate the **Nearby** section of the sidebar (used by [remote workspaces](/claudette/features/remote-workspaces/)). The browser is read-only — Claudette doesn't advertise itself unless you run the standalone `claudette-server` binary.
+
+- **Grant it** to see nearby Claudette servers in the sidebar and use remote workspaces over the LAN.
+- **Deny it** and the app keeps working — the Nearby list just stays empty. Direct connections to a server by IP/hostname still work, since those don't need mDNS.
+- Toggle later in **System Settings → Privacy & Security → Local Network → Claudette**.
+
+### "Claudette would like to send you notifications."
+
+The standard macOS notification prompt. It fires at first launch so the app can post native banners later for events like *agent finished a turn*, *agent is asking a question*, and *plan needs review*. See [Notifications](/claudette/features/notifications/) for the per-event toggles inside the app.
+
+- **Grant it** for OS-level banners and click-to-navigate (clicking a banner focuses the relevant workspace and chat).
+- **Deny it** and in-app indicators (sidebar badges, tray tooltip, optional custom sound) still work — only the native banners are suppressed.
+- Toggle later in **System Settings → Notifications → Claudette**.
+
+### "Claudette wants to use the microphone" / "speech recognition"
+
+These fire the first time you click the chat composer's mic button. See [Voice Input → Apple Speech](/claudette/features/voice-input/#apple-speech) for the full setup.
+
+### "Claudette wants to control Terminal" (or "iTerm")
+
+This is macOS's **Automation** prompt. It fires the first time you launch a TUI editor or open a workspace path in an external Terminal.app or iTerm2 window — Claudette sends an Apple Event to ask the terminal app to open a new window `cd`'d into the worktree. Denying it disables that one launch target but doesn't affect anything else.
+
+All of these can be reviewed or changed later in **System Settings → Privacy & Security**.
+
+## Windows network prompt
+
+If you run the standalone `claudette-server` binary (used to share workspaces with another machine via [remote workspaces](/claudette/features/remote-workspaces/)), Windows Defender Firewall will ask whether to allow it to communicate on Private or Public networks. The Tauri GUI on its own does **not** trigger this — it only opens a local IPC named pipe for the [CLI client](/claudette/features/cli-client/), which isn't a network surface.
+
+- Choose **Private networks** unless you intentionally want to expose the server on a public/coffee-shop network.
+- Change later in **Windows Security → Firewall & network protection → Allow an app through firewall**.
+
+Windows builds in CI are unsigned `.exe` files, so **Microsoft Defender SmartScreen** may also warn the first time you run Claudette — click **More info → Run anyway** to proceed.
+
 ## Build from Source
 
 If you prefer to build from source, you'll need:

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -35,7 +35,7 @@ claude /login
 
 ## macOS permission prompts
 
-After install, macOS may surface a few first-run permission prompts. Each is gated by Apple's TCC (Transparency, Consent, and Control) system and only fires the first time Claudette uses the underlying capability — none of them appear at launch.
+After install, macOS may surface a few first-run permission prompts. Each is gated by Apple's TCC (Transparency, Consent, and Control) system and fires the first time Claudette exercises the underlying capability. Two of them — **Local Network** and **Notifications** — fire at or shortly after first launch, because the capabilities they gate (mDNS discovery, the notification subsystem) are initialized during app startup. The rest are deferred until you actually use the feature that needs them.
 
 ### "Claudette wants permission to update or delete other applications."
 
@@ -75,7 +75,7 @@ All of these can be reviewed or changed later in **System Settings → Privacy &
 
 ## Windows network prompt
 
-If you run the standalone `claudette-server` binary (used to share workspaces with another machine via [remote workspaces](/claudette/features/remote-workspaces/)), Windows Defender Firewall will ask whether to allow it to communicate on Private or Public networks. The Tauri GUI on its own does **not** trigger this — it only opens a local IPC named pipe for the [CLI client](/claudette/features/cli-client/), which isn't a network surface.
+If you run the standalone `claudette-server` binary (used to share workspaces with another machine via [remote workspaces](/claudette/features/remote-workspaces/)), Windows Defender Firewall will ask whether to allow it to communicate on Private or Public networks. The Tauri GUI on its own does **not** trigger this prompt — it doesn't accept inbound LAN traffic. It exposes a local IPC named pipe for the [CLI client](/claudette/features/cli-client/), and any TCP sockets it opens (e.g. the dev-only debug eval server) bind to `127.0.0.1`, which Windows Firewall exempts from the network-access dialog.
 
 - Choose **Private networks** unless you intentionally want to expose the server on a public/coffee-shop network.
 - Change later in **Windows Security → Firewall & network protection → Allow an app through firewall**.


### PR DESCRIPTION
## Summary

Backfill documentation for the first-run OS permission prompts a user can see after installing Claudette. Five subsections added to the Installation page, plus a short Windows section:

| Prompt | When it fires | Caused by |
|---|---|---|
| **App Management** ("update or delete other applications") | First in-app update install | Tauri auto-updater swapping `Claudette.app` in `/Applications` (`src-tauri/src/commands/updater.rs`, `tauri.conf.json` updater plugin) |
| **Local Network** | Shortly after first launch | `mdns::start_mdns_browser` in `src-tauri/src/main.rs:592` populating the Nearby list for remote workspaces |
| **Notifications** | At first launch | `notification_macos::init` → `UNUserNotificationCenter.requestAuthorization` (`src-tauri/src/main.rs:751`) |
| **Microphone / Speech Recognition** | First click on the chat composer mic | Cross-links to existing `voice-input.mdx` |
| **Automation** ("control Terminal" / iTerm) | First "Open in Terminal" / TUI editor launch | `osascript` Apple Events in `src-tauri/src/commands/apps.rs`, `commands/workspace.rs` |
| **Windows Defender Firewall** | First run of standalone `claudette-server` | `TcpListener::bind` in `src-server/src/lib.rs` (NOT the Tauri GUI — that uses a named pipe, no network surface) |

Motivated by a user question about the App Management prompt specifically. Audited the codebase end-to-end (see below) so the rest of the prompt surface is captured at the same time.

## Complexity notes

- **Audit confirmed no other TCC prompts are reachable**: no Accessibility, Input Monitoring, Screen Recording, Camera, Full Disk Access, Files & Folders, or Sequoia clipboard-paste prompts. The hold-to-talk hotkey is an in-webview keydown/keyup listener (`src/ui/src/hooks/useVoiceHotkey.ts`), not a global hotkey, so it doesn't require Accessibility.
- The mDNS-at-launch and notification-auth-at-launch behaviors are intentional per CLAUDE.md's privacy-prompt contract (which forbids audio/speech prompts at launch but explicitly allows these two). Doc treats them as expected, not as bugs.
- Cross-links use Starlight's auto-slugged anchors (`#apple-speech`) — verified by build, not hand-rolled.

## Test steps

1. `cd site && bun install --frozen-lockfile && bun run build`
   - Expect: 46 pages built, no errors.
2. Open `site/dist/getting-started/installation/index.html` and search for "Local Network", "Notifications", "Automation", "App Management", "Windows network prompt" — all five subsections should be present with rendered headings.
3. Click each of the four internal cross-links in the new section (Voice Input → Apple Speech, Notifications, Remote workspaces, CLI client) — all should resolve, none should 404.
4. Sanity-check the prose against the actual prompt wording you see on macOS 14+ (Sonoma) by triggering any one of the prompts. The doc uses Apple's canonical phrasings so it should match.

## Checklist

- [x] Docs build (`bun run build` in `site/`) passes
- [x] Internal links resolve
- [x] No content changes outside `site/`
- [x] No lockfile churn (reverted incidental `bun.lockb` rewrite before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)