### PR TITLE
fix: preserve queued messages on agent stop

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -77,6 +77,8 @@ While an agent turn is running, you can queue follow-up messages. Type into the 
 
 Use the **Steer** action in the queue popover to send any queued item into the currently running turn instead of waiting for the queue to drain. Pressing **Cmd/Ctrl + Enter** steers the freshly typed composer text when the composer has text or attachments; when the composer is empty, the shortcut steers the top queued item. This is the lowest-friction way to course-correct without stopping the agent.
 
+If you stop the running agent with **Escape** or the stop button, queued messages stay in the popover and stop auto-draining. You can send a fresh prompt from the composer, send one queued message manually, cancel individual queued messages, or clear the queue.
+
 From the [CLI](/claudette/features/cli-client/):
 
 ```sh

--- a/site/src/content/docs/features/keyboard-shortcuts.mdx
+++ b/site/src/content/docs/features/keyboard-shortcuts.mdx
@@ -85,6 +85,8 @@ When multiple overlays are open, `Escape` dismisses them in this order:
 5. Diff panel
 6. Stop running agent
 
+Stopping an agent with `Escape` preserves queued chat messages and pauses automatic queue delivery until you choose what to send next.
+
 ## Keyboard Hint Badges
 
 When you hold `⌘` (macOS) or `Ctrl` (Linux) without pressing another key, Claudette shows shortcut badges on relevant UI elements — sidebar toggle, diff panel, terminal, and settings buttons. Release the modifier key to hide them. Hover tooltips show the same current binding when the related shortcut is enabled.

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -297,10 +297,19 @@ export function ChatPanel() {
         ? s.queuedMessages[activeSessionId] ?? EMPTY_QUEUED_MESSAGES
         : EMPTY_QUEUED_MESSAGES,
   );
+  const queuedMessageAutoDispatchPaused = useAppStore(
+    (s) =>
+      activeSessionId
+        ? s.queuedMessageAutoDispatchPaused[activeSessionId] === true
+        : false,
+  );
   const setQueuedMessage = useAppStore((s) => s.setQueuedMessage);
   const updateQueuedMessage = useAppStore((s) => s.updateQueuedMessage);
   const removeQueuedMessage = useAppStore((s) => s.removeQueuedMessage);
   const clearQueuedMessage = useAppStore((s) => s.clearQueuedMessage);
+  const setQueuedMessageAutoDispatchPaused = useAppStore(
+    (s) => s.setQueuedMessageAutoDispatchPaused,
+  );
   const addCheckpoint = useAppStore((s) => s.addCheckpoint);
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
@@ -751,6 +760,7 @@ export function ChatPanel() {
       activeSessionId,
       hasNextQueuedMessage: !!nextQueuedMessage,
       isEditingQueuedMessage,
+      isAutoDispatchPaused: queuedMessageAutoDispatchPaused,
       autoDispatchQueuedId: autoDispatchQueuedIdRef.current,
     })) {
       return;
@@ -773,6 +783,7 @@ export function ChatPanel() {
     activeSessionId,
     queuedMessages,
     isEditingQueuedMessage,
+    queuedMessageAutoDispatchPaused,
     removeQueuedMessage,
   ]);
 
@@ -890,15 +901,19 @@ export function ChatPanel() {
       setError("Mid-turn steering is not yet supported for remote workspaces");
       return;
     }
-    if (!isRunning) {
-      setError("No running agent turn to steer");
-      return;
-    }
 
     const sessionId = activeSessionId;
     const { content, mentionedFiles, attachments } = queuedMessage;
     const messageId = crypto.randomUUID();
     setError(null);
+
+    if (!isRunning) {
+      const filesSet = mentionedFiles?.length ? new Set(mentionedFiles) : undefined;
+      removeQueuedMessage(sessionId, queuedMessage.id);
+      await handleSend(content, filesSet, attachments);
+      return;
+    }
+
     setIsSteeringQueued(true);
     setPendingSteerContent(content.trim() || null);
     removeQueuedMessage(sessionId, queuedMessage.id);
@@ -1199,6 +1214,8 @@ export function ChatPanel() {
       return;
     }
 
+    setQueuedMessageAutoDispatchPaused(sessionId, false);
+
     // Clear any pending agent question or plan approval — the user is sending
     // a new message (answer from a card or manual override). Also release any
     // stuck typewriter drain from the previous turn so the completed message
@@ -1296,8 +1313,12 @@ export function ChatPanel() {
   const handleStop = async () => {
     if (!activeSessionId || !selectedWorkspaceId) return;
     const sessionId = activeSessionId;
-    // Clear queued message — stopping means the user wants to take control.
-    clearQueuedMessagesAndCancelEdit(sessionId);
+    // A manual stop means the user wants control of the next turn. Keep the
+    // queue visible, but stop the idle auto-drain from consuming it.
+    if (queuedMessages.length > 0) {
+      setQueuedMessageAutoDispatchPaused(sessionId, true);
+      setIsEditingQueuedMessage(false);
+    }
     try {
       if (ws?.remote_connection_id) {
         await sendRemoteCommand(ws.remote_connection_id, "stop_agent", {

--- a/src/ui/src/components/chat/QueuedMessagesPopover.tsx
+++ b/src/ui/src/components/chat/QueuedMessagesPopover.tsx
@@ -206,16 +206,16 @@ export function QueuedMessagesPopover({
                     <button
                       className={styles.queuedSteer}
                       onClick={() => onSteerMessage(message.id)}
-                      disabled={isSteeringQueued || !isRunning}
-                      data-tooltip={steerQueuedTooltip}
-                      aria-label={t("steer_queued")}
+                      disabled={isSteeringQueued}
+                      data-tooltip={isRunning ? steerQueuedTooltip : t("send_message")}
+                      aria-label={isRunning ? t("steer_queued") : t("send_message")}
                     >
                       {isSteeringQueued ? (
                         <LoaderCircle size={14} className={styles.queuedSteerSpinner} />
                       ) : (
                         <SendHorizontal size={14} />
                       )}
-                      <span>{t("steer_queued_short")}</span>
+                      <span>{isRunning ? t("steer_queued_short") : t("agent_question_send")}</span>
                     </button>
                   )}
                 </>

--- a/src/ui/src/components/chat/queuedMessageEditing.test.ts
+++ b/src/ui/src/components/chat/queuedMessageEditing.test.ts
@@ -39,6 +39,21 @@ describe("queuedMessageEditing", () => {
         activeSessionId: "session-1",
         hasNextQueuedMessage: true,
         isEditingQueuedMessage: true,
+        isAutoDispatchPaused: false,
+        autoDispatchQueuedId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-dispatch while queued auto-dispatch is manually paused", () => {
+    expect(
+      shouldAutoDispatchQueuedMessage({
+        isSteeringQueued: false,
+        isRunning: false,
+        activeSessionId: "session-1",
+        hasNextQueuedMessage: true,
+        isEditingQueuedMessage: false,
+        isAutoDispatchPaused: true,
         autoDispatchQueuedId: null,
       }),
     ).toBe(false);
@@ -52,6 +67,7 @@ describe("queuedMessageEditing", () => {
         activeSessionId: "session-1",
         hasNextQueuedMessage: true,
         isEditingQueuedMessage: false,
+        isAutoDispatchPaused: false,
         autoDispatchQueuedId: null,
       }),
     ).toBe(true);

--- a/src/ui/src/components/chat/queuedMessageEditing.ts
+++ b/src/ui/src/components/chat/queuedMessageEditing.ts
@@ -30,6 +30,7 @@ interface AutoDispatchQueuedMessageArgs {
   activeSessionId: string | null;
   hasNextQueuedMessage: boolean;
   isEditingQueuedMessage: boolean;
+  isAutoDispatchPaused: boolean;
   autoDispatchQueuedId: string | null;
 }
 
@@ -39,6 +40,7 @@ export function shouldAutoDispatchQueuedMessage({
   activeSessionId,
   hasNextQueuedMessage,
   isEditingQueuedMessage,
+  isAutoDispatchPaused,
   autoDispatchQueuedId,
 }: AutoDispatchQueuedMessageArgs): boolean {
   return (
@@ -47,6 +49,7 @@ export function shouldAutoDispatchQueuedMessage({
     !!activeSessionId &&
     hasNextQueuedMessage &&
     !isEditingQueuedMessage &&
+    !isAutoDispatchPaused &&
     !autoDispatchQueuedId
   );
 }

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -324,7 +324,14 @@ export function CommandPalette() {
         setEffortLevel,
         selectedModel,
         persistSetting: (key: string, value: string) => setAppSetting(key, value).catch(console.error),
-        stopAgent: (sessionId: string) => stopAgent(sessionId),
+        stopAgent: (sessionId: string) => {
+          const state = useAppStore.getState();
+          const queue = state.queuedMessages[sessionId];
+          if (queue && queue.length > 0) {
+            state.setQueuedMessageAutoDispatchPaused(sessionId, true);
+          }
+          return stopAgent(sessionId);
+        },
         resetAgentSession: (sessionId: string) => resetAgentSession(sessionId),
         clearAgentQuestion: (sessionId: string) => clearAgentQuestion(sessionId),
         clearPlanApproval: (sessionId: string) => clearPlanApproval(sessionId),

--- a/src/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/src/hooks/useKeyboardShortcuts.ts
@@ -83,8 +83,14 @@ export function useKeyboardShortcuts() {
                 selectedWorkspaceId
               ];
             if (sessionId) {
-              // Clear queued message — user is taking manual control.
-              useAppStore.getState().clearQueuedMessage(sessionId);
+              const queue = useAppStore.getState().queuedMessages[sessionId];
+              if (queue && queue.length > 0) {
+                // A manual stop means the user wants control of the next turn.
+                // Keep queued prompts visible, but prevent idle auto-drain.
+                useAppStore
+                  .getState()
+                  .setQueuedMessageAutoDispatchPaused(sessionId, true);
+              }
               // Route through remote or local stop path. `stop_agent` is a
               // per-session command now — pass the active session id.
               const stopPromise = ws.remote_connection_id

--- a/src/ui/src/stores/slices/agentInteractionSlice.ts
+++ b/src/ui/src/stores/slices/agentInteractionSlice.ts
@@ -73,6 +73,7 @@ export interface AgentInteractionSlice {
   setChatSearchMatchIndex: (wsId: string, idx: number) => void;
 
   queuedMessages: Record<string, QueuedMessage[]>;
+  queuedMessageAutoDispatchPaused: Record<string, boolean>;
   setQueuedMessage: (
     sessionId: string,
     content: string,
@@ -86,6 +87,7 @@ export interface AgentInteractionSlice {
   ) => void;
   removeQueuedMessage: (sessionId: string, queuedMessageId: string) => void;
   clearQueuedMessage: (sessionId: string) => void;
+  setQueuedMessageAutoDispatchPaused: (sessionId: string, paused: boolean) => void;
 }
 
 export const createAgentInteractionSlice: StateCreator<
@@ -181,6 +183,7 @@ export const createAgentInteractionSlice: StateCreator<
     }),
 
   queuedMessages: {},
+  queuedMessageAutoDispatchPaused: {},
   setQueuedMessage: (sessionId, content, mentionedFiles, attachments) =>
     set((s) => ({
       queuedMessages: {
@@ -224,7 +227,14 @@ export const createAgentInteractionSlice: StateCreator<
       );
       if (remaining.length === 0) {
         const { [sessionId]: _, ...rest } = s.queuedMessages;
-        return { queuedMessages: rest };
+        const {
+          [sessionId]: _paused,
+          ...pausedRest
+        } = s.queuedMessageAutoDispatchPaused;
+        return {
+          queuedMessages: rest,
+          queuedMessageAutoDispatchPaused: pausedRest,
+        };
       }
       return {
         queuedMessages: {
@@ -236,6 +246,31 @@ export const createAgentInteractionSlice: StateCreator<
   clearQueuedMessage: (sessionId) =>
     set((s) => {
       const { [sessionId]: _, ...rest } = s.queuedMessages;
-      return { queuedMessages: rest };
+      const {
+        [sessionId]: _paused,
+        ...pausedRest
+      } = s.queuedMessageAutoDispatchPaused;
+      return {
+        queuedMessages: rest,
+        queuedMessageAutoDispatchPaused: pausedRest,
+      };
+    }),
+  setQueuedMessageAutoDispatchPaused: (sessionId, paused) =>
+    set((s) => {
+      const current = s.queuedMessageAutoDispatchPaused[sessionId] === true;
+      if (current === paused) return s;
+      if (!paused) {
+        const {
+          [sessionId]: _,
+          ...rest
+        } = s.queuedMessageAutoDispatchPaused;
+        return { queuedMessageAutoDispatchPaused: rest };
+      }
+      return {
+        queuedMessageAutoDispatchPaused: {
+          ...s.queuedMessageAutoDispatchPaused,
+          [sessionId]: true,
+        },
+      };
     }),
 });

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -218,6 +218,51 @@ describe("finishTypewriterDrain (per-workspace)", () => {
   });
 });
 
+describe("queued message auto-dispatch pause", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      queuedMessages: {},
+      queuedMessageAutoDispatchPaused: {},
+    });
+  });
+
+  it("can pause queued auto-dispatch without dropping queued messages", () => {
+    const store = useAppStore.getState();
+    store.setQueuedMessage(WS_ID, "follow up");
+    store.setQueuedMessageAutoDispatchPaused(WS_ID, true);
+
+    const state = useAppStore.getState();
+    expect(state.queuedMessages[WS_ID]).toHaveLength(1);
+    expect(state.queuedMessages[WS_ID]?.[0]?.content).toBe("follow up");
+    expect(state.queuedMessageAutoDispatchPaused[WS_ID]).toBe(true);
+  });
+
+  it("clears the pause when the queued session is emptied", () => {
+    const store = useAppStore.getState();
+    store.setQueuedMessage(WS_ID, "follow up");
+    store.setQueuedMessageAutoDispatchPaused(WS_ID, true);
+
+    const queuedId = useAppStore.getState().queuedMessages[WS_ID]?.[0]?.id;
+    expect(queuedId).toBeTruthy();
+    store.removeQueuedMessage(WS_ID, queuedId!);
+
+    const state = useAppStore.getState();
+    expect(state.queuedMessages[WS_ID]).toBeUndefined();
+    expect(state.queuedMessageAutoDispatchPaused[WS_ID]).toBeUndefined();
+  });
+
+  it("clears the pause when the queue is cleared", () => {
+    const store = useAppStore.getState();
+    store.setQueuedMessage(WS_ID, "follow up");
+    store.setQueuedMessageAutoDispatchPaused(WS_ID, true);
+    store.clearQueuedMessage(WS_ID);
+
+    const state = useAppStore.getState();
+    expect(state.queuedMessages[WS_ID]).toBeUndefined();
+    expect(state.queuedMessageAutoDispatchPaused[WS_ID]).toBeUndefined();
+  });
+});
+
 describe("plugin settings routing", () => {
   beforeEach(() => {
     useAppStore.setState({

--- a/src/ui/src/stores/useAppStore.test.ts
+++ b/src/ui/src/stores/useAppStore.test.ts
@@ -219,6 +219,8 @@ describe("finishTypewriterDrain (per-workspace)", () => {
 });
 
 describe("queued message auto-dispatch pause", () => {
+  const SESSION_ID = "test-session";
+
   beforeEach(() => {
     useAppStore.setState({
       queuedMessages: {},
@@ -228,38 +230,38 @@ describe("queued message auto-dispatch pause", () => {
 
   it("can pause queued auto-dispatch without dropping queued messages", () => {
     const store = useAppStore.getState();
-    store.setQueuedMessage(WS_ID, "follow up");
-    store.setQueuedMessageAutoDispatchPaused(WS_ID, true);
+    store.setQueuedMessage(SESSION_ID, "follow up");
+    store.setQueuedMessageAutoDispatchPaused(SESSION_ID, true);
 
     const state = useAppStore.getState();
-    expect(state.queuedMessages[WS_ID]).toHaveLength(1);
-    expect(state.queuedMessages[WS_ID]?.[0]?.content).toBe("follow up");
-    expect(state.queuedMessageAutoDispatchPaused[WS_ID]).toBe(true);
+    expect(state.queuedMessages[SESSION_ID]).toHaveLength(1);
+    expect(state.queuedMessages[SESSION_ID]?.[0]?.content).toBe("follow up");
+    expect(state.queuedMessageAutoDispatchPaused[SESSION_ID]).toBe(true);
   });
 
   it("clears the pause when the queued session is emptied", () => {
     const store = useAppStore.getState();
-    store.setQueuedMessage(WS_ID, "follow up");
-    store.setQueuedMessageAutoDispatchPaused(WS_ID, true);
+    store.setQueuedMessage(SESSION_ID, "follow up");
+    store.setQueuedMessageAutoDispatchPaused(SESSION_ID, true);
 
-    const queuedId = useAppStore.getState().queuedMessages[WS_ID]?.[0]?.id;
+    const queuedId = useAppStore.getState().queuedMessages[SESSION_ID]?.[0]?.id;
     expect(queuedId).toBeTruthy();
-    store.removeQueuedMessage(WS_ID, queuedId!);
+    store.removeQueuedMessage(SESSION_ID, queuedId!);
 
     const state = useAppStore.getState();
-    expect(state.queuedMessages[WS_ID]).toBeUndefined();
-    expect(state.queuedMessageAutoDispatchPaused[WS_ID]).toBeUndefined();
+    expect(state.queuedMessages[SESSION_ID]).toBeUndefined();
+    expect(state.queuedMessageAutoDispatchPaused[SESSION_ID]).toBeUndefined();
   });
 
   it("clears the pause when the queue is cleared", () => {
     const store = useAppStore.getState();
-    store.setQueuedMessage(WS_ID, "follow up");
-    store.setQueuedMessageAutoDispatchPaused(WS_ID, true);
-    store.clearQueuedMessage(WS_ID);
+    store.setQueuedMessage(SESSION_ID, "follow up");
+    store.setQueuedMessageAutoDispatchPaused(SESSION_ID, true);
+    store.clearQueuedMessage(SESSION_ID);
 
     const state = useAppStore.getState();
-    expect(state.queuedMessages[WS_ID]).toBeUndefined();
-    expect(state.queuedMessageAutoDispatchPaused[WS_ID]).toBeUndefined();
+    expect(state.queuedMessages[SESSION_ID]).toBeUndefined();
+    expect(state.queuedMessageAutoDispatchPaused[SESSION_ID]).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Preserve queued chat messages when users manually stop a running agent from the stop button, Escape shortcut, or command palette.
- Add a per-session `queuedMessageAutoDispatchPaused` flag so preserved queued prompts stay visible but do not auto-drain immediately after the stop completes.
- Keep explicit user control after a stop: users can send a fresh composer prompt, manually send one queued item, cancel individual queued items, or clear the whole queue.
- Fix the queued-item manual send path so the queued-item button works after the stopped session becomes idle.
- Clear the paused auto-dispatch flag when a new turn starts, so normal queued-message draining resumes after the user has taken control.
- Update the user docs for mid-turn steering and Escape behavior.

## Root Cause
Stopping an agent previously cleared the frontend-owned queued-message list. Preserving the list alone was not enough because the existing idle auto-dispatch effect would immediately consume the first queued message when the stopped session transitioned back to idle. The fix separates queue contents from queue delivery by pausing auto-dispatch only for manual stops.

## User Impact
After pressing Stop or Escape, queued prompts are no longer lost. The queue remains visible and editable through existing controls, and delivery only resumes once the user explicitly sends something or chooses a queued item.

## Copilot Follow-up
- Removed an unreachable idle-send guard in `handleSteerQueuedMessage`, allowing queued items to be manually sent when the agent is stopped/idle.
- Cleared `queuedMessageAutoDispatchPaused` when `handleSend` starts a new turn, preventing queue delivery from staying paused indefinitely across later turns.

## Validation
- `nix develop -c bash -lc 'cd src/ui && bunx tsc -b'`\n- `nix develop -c bash -lc 'cd src/ui && bun run test -- useAppStore.test.ts ChatInputArea.test.ts && bun run build'`\n- `nix develop -c bash -lc 'cd src/ui && bun run lint -- src/components/chat/ChatPanel.tsx src/hooks/useKeyboardShortcuts.ts src/components/command-palette/CommandPalette.tsx src/stores/useAppStore.test.ts src/stores/slices/agentInteractionSlice.ts'` (0 errors; existing warning-only lint state)\n- `git diff --check`