### PR TITLE
feat: add workspace task history

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
             { slug: 'features/diff-viewer' },
             { slug: 'features/file-editor' },
             { slug: 'features/integrated-terminal' },
+            { slug: 'features/task-history' },
             { slug: 'features/notifications' },
             { slug: 'features/voice-input' },
             { slug: 'features/keyboard-shortcuts' },

--- a/site/src/content/docs/features/task-history.mdx
+++ b/site/src/content/docs/features/task-history.mdx
@@ -1,0 +1,20 @@
+---
+title: Task History
+description: Review current and previous Claude task lists for a workspace.
+---
+
+Claude often rewrites its task list as work shifts. Claudette keeps the latest checklist visible while preserving earlier runs in the workspace's **Tasks** tab.
+
+## Current Tasks
+
+Open the right sidebar and choose **Tasks**. The **Current** section shows the selected chat session's active task list, including status updates from Claude's task and todo tools.
+
+The tab badge counts the active checklist items plus preserved historical runs, so a workspace with older task lists still signals that there is task context to review.
+
+## Historical Runs
+
+When Claude replaces a checklist with a materially different one, Claudette moves the previous checklist into **History**. Runs are grouped by chat session and start collapsed so the current work stays easy to scan.
+
+Each run header shows the run number and completion count. Expand a run to see the final saved checklist snapshot, including completed and pending items. Archived chat sessions are included and labeled so long-running workspace history stays available even after you clean up old tabs.
+
+Task history is derived from the saved conversation and tool activity for the workspace. It survives app restarts, but clearing, deleting, or rolling back the underlying chat history also changes the derived task history.

--- a/src-server/src/handler.rs
+++ b/src-server/src/handler.rs
@@ -33,6 +33,10 @@ pub async fn handle_request(
             let chat_session_id = param_chat_session_id(&params);
             handle_load_chat_history(state, &chat_session_id).await
         }
+        "load_completed_turns" => {
+            let chat_session_id = param_chat_session_id(&params);
+            handle_load_completed_turns(state, &chat_session_id)
+        }
         "send_chat_message" => {
             let chat_session_id = param_chat_session_id(&params);
             let content = param_str(&params, "content");
@@ -1184,6 +1188,17 @@ fn handle_list_chat_sessions(
         .list_chat_sessions_for_workspace(workspace_id, include_archived)
         .map_err(|e| e.to_string())?;
     serde_json::to_value(sessions).map_err(|e| e.to_string())
+}
+
+fn handle_load_completed_turns(
+    state: &ServerState,
+    chat_session_id: &str,
+) -> Result<serde_json::Value, String> {
+    let db = open_db(state)?;
+    let turns = db
+        .list_completed_turns_for_session(chat_session_id)
+        .map_err(|e| e.to_string())?;
+    serde_json::to_value(turns).map_err(|e| e.to_string())
 }
 
 fn handle_get_chat_session(

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -6,7 +6,7 @@ import {
 } from "../../utils/pollingIntervals";
 import { ChevronRight, Undo2, Trash2, Plus, Minus, FilePenLine } from "lucide-react";
 import { useAppStore, selectActiveSessionId } from "../../stores/useAppStore";
-import { useTaskTracker } from "../../hooks/useTaskTracker";
+import { useWorkspaceTaskHistory } from "../../hooks/useWorkspaceTaskHistory";
 import {
   discardFile,
   discardFiles,
@@ -92,7 +92,8 @@ export const RightSidebar = memo(function RightSidebar() {
   const loadDiffInFlightCount = useRef(0);
 
   const activeSessionId = useAppStore(selectActiveSessionId);
-  const { totalCount: taskCount } = useTaskTracker(activeSessionId);
+  const taskHistory = useWorkspaceTaskHistory(selectedWorkspaceId, activeSessionId);
+  const taskCount = taskHistory.totalBadgeCount;
 
   // Local-only stage/unstage/discard UI state. None of these git index
   // operations are bridged through the remote server (matches revert_file),
@@ -692,7 +693,7 @@ export const RightSidebar = memo(function RightSidebar() {
 
       {activeTab === "tasks" && (
         selectedWorkspaceId
-          ? <TaskList sessionId={activeSessionId} />
+          ? <TaskList taskHistory={taskHistory} />
           : <div className={styles.list}><div className={styles.empty}>No workspace selected</div></div>
       )}
 

--- a/src/ui/src/components/right-sidebar/RightSidebar.tsx
+++ b/src/ui/src/components/right-sidebar/RightSidebar.tsx
@@ -92,7 +92,11 @@ export const RightSidebar = memo(function RightSidebar() {
   const loadDiffInFlightCount = useRef(0);
 
   const activeSessionId = useAppStore(selectActiveSessionId);
-  const taskHistory = useWorkspaceTaskHistory(selectedWorkspaceId, activeSessionId);
+  const taskHistory = useWorkspaceTaskHistory(
+    selectedWorkspaceId,
+    activeSessionId,
+    activeTab === "tasks",
+  );
   const taskCount = taskHistory.totalBadgeCount;
 
   // Local-only stage/unstage/discard UI state. None of these git index

--- a/src/ui/src/components/right-sidebar/TaskList.module.css
+++ b/src/ui/src/components/right-sidebar/TaskList.module.css
@@ -11,6 +11,115 @@
   font-size: var(--body-size);
 }
 
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 10px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 8px;
+  color: var(--text-dim);
+  font-size: var(--caption-size);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.sectionMeta {
+  color: var(--text-dim);
+  font-weight: 500;
+  text-transform: none;
+}
+
+.sessionGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-bottom: 4px;
+}
+
+.sessionHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 5px 8px 2px;
+}
+
+.sessionName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: var(--body-size);
+  font-weight: 600;
+}
+
+.archivedBadge {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  font-size: var(--caption-size);
+}
+
+.run {
+  display: flex;
+  flex-direction: column;
+}
+
+.runHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 28px;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--body-size);
+  text-align: left;
+  cursor: pointer;
+}
+
+.runHeader:hover {
+  background: var(--hover-bg);
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  transition: transform var(--transition-fast);
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+.runTitle {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runMeta {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  font-size: var(--caption-size);
+}
+
+.runTasks {
+  padding-left: 18px;
+}
+
 .task {
   display: flex;
   align-items: flex-start;

--- a/src/ui/src/components/right-sidebar/TaskList.test.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { WorkspaceTaskHistoryResult } from "../../hooks/useWorkspaceTaskHistory";
+import { TaskList } from "./TaskList";
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+});
+
+function taskHistory(): WorkspaceTaskHistoryResult {
+  return {
+    current: {
+      tasks: [
+        {
+          id: "current-1",
+          description: "Ship the current fix",
+          status: "in_progress",
+          source: "todo",
+        },
+      ],
+      completedCount: 0,
+      totalCount: 1,
+    },
+    sessions: [
+      {
+        session: {
+          id: "session-1",
+          workspace_id: "ws-1",
+          session_id: "claude-session-1",
+          name: "Previous run",
+          name_edited: false,
+          turn_count: 3,
+          sort_order: 0,
+          status: "Archived",
+          created_at: "2026-05-12T00:00:00Z",
+          archived_at: "2026-05-12T01:00:00Z",
+          cli_invocation: null,
+          agent_status: "Idle",
+          needs_attention: false,
+          attention_kind: null,
+        },
+        runs: [
+          {
+            id: "run-1",
+            sequence: 1,
+            tasks: [
+              {
+                id: "old-1",
+                description: "Preserve old checklist",
+                status: "completed",
+                source: "todo",
+              },
+            ],
+            completedCount: 1,
+            totalCount: 1,
+          },
+        ],
+      },
+    ],
+    historyRunCount: 1,
+    totalBadgeCount: 2,
+    loading: false,
+  };
+}
+
+describe("TaskList", () => {
+  it("renders current tasks and collapsed session history", async () => {
+    const container = await render(<TaskList taskHistory={taskHistory()} />);
+
+    expect(container.textContent).toContain("Current");
+    expect(container.textContent).toContain("Ship the current fix");
+    expect(container.textContent).toContain("History");
+    expect(container.textContent).toContain("Previous run");
+    expect(container.textContent).toContain("Archived");
+    expect(container.textContent).toContain("Run 1");
+    expect(container.textContent).not.toContain("Preserve old checklist");
+  });
+
+  it("expands a historical run to show its preserved tasks", async () => {
+    const container = await render(<TaskList taskHistory={taskHistory()} />);
+    const runButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Run 1"),
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      runButton.click();
+    });
+
+    expect(container.textContent).toContain("Preserve old checklist");
+  });
+});

--- a/src/ui/src/components/right-sidebar/TaskList.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.tsx
@@ -176,7 +176,7 @@ export const TaskList = memo(function TaskList({
                     onToggle={() =>
                       setExpandedRuns((prev) => ({
                         ...prev,
-                        [key]: !expanded,
+                        [key]: !(prev[key] === true),
                       }))
                     }
                   />

--- a/src/ui/src/components/right-sidebar/TaskList.tsx
+++ b/src/ui/src/components/right-sidebar/TaskList.tsx
@@ -1,6 +1,11 @@
-import { memo } from "react";
-import { useTaskTracker } from "../../hooks/useTaskTracker";
-import type { TrackedTask, TaskStatus } from "../../hooks/useTaskTracker";
+import { memo, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import type {
+  TaskRun,
+  TaskStatus,
+  TrackedTask,
+} from "../../hooks/useTaskTracker";
+import type { WorkspaceTaskHistoryResult } from "../../hooks/useWorkspaceTaskHistory";
 import styles from "./TaskList.module.css";
 
 function statusIcon(status: TaskStatus): string {
@@ -66,26 +71,121 @@ function TaskItem({ task }: { task: TrackedTask }) {
   );
 }
 
-export const TaskList = memo(function TaskList({
-  sessionId,
-}: {
-  sessionId: string | null;
-}) {
-  const { tasks } = useTaskTracker(sessionId);
+function TaskRows({ tasks }: { tasks: TrackedTask[] }) {
+  return (
+    <>
+      {tasks.map((task) => (
+        <TaskItem key={`${task.source}-${task.id}-${task.description}`} task={task} />
+      ))}
+    </>
+  );
+}
 
-  if (tasks.length === 0) {
+function RunSummary({
+  run,
+  expanded,
+  onToggle,
+}: {
+  run: TaskRun;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className={styles.run}>
+      <button
+        type="button"
+        className={styles.runHeader}
+        onClick={onToggle}
+        aria-expanded={expanded}
+      >
+        <ChevronRight
+          size={14}
+          className={`${styles.chevron} ${expanded ? styles.chevronOpen : ""}`}
+          aria-hidden="true"
+        />
+        <span className={styles.runTitle}>Run {run.sequence}</span>
+        <span className={styles.runMeta}>
+          {run.completedCount}/{run.totalCount}
+        </span>
+      </button>
+      {expanded && (
+        <div className={styles.runTasks}>
+          <TaskRows tasks={run.tasks} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const TaskList = memo(function TaskList({
+  taskHistory,
+}: {
+  taskHistory: WorkspaceTaskHistoryResult;
+}) {
+  const [expandedRuns, setExpandedRuns] = useState<Record<string, boolean>>({});
+  const { current, sessions, loading } = taskHistory;
+  const hasCurrent = current.tasks.length > 0;
+  const hasHistory = sessions.length > 0;
+
+  if (!hasCurrent && !hasHistory) {
     return (
       <div className={styles.list}>
-        <div className={styles.empty}>No tasks</div>
+        <div className={styles.empty}>{loading ? "Loading tasks..." : "No tasks"}</div>
       </div>
     );
   }
 
   return (
     <div className={styles.list}>
-      {tasks.map((task) => (
-        <TaskItem key={`${task.source}-${task.id}`} task={task} />
-      ))}
+      {hasCurrent && (
+        <section className={styles.section} aria-label="Current tasks">
+          <div className={styles.sectionHeader}>
+            <span>Current</span>
+            <span className={styles.sectionMeta}>
+              {current.completedCount}/{current.totalCount}
+            </span>
+          </div>
+          <TaskRows tasks={current.tasks} />
+        </section>
+      )}
+
+      {hasHistory && (
+        <section className={styles.section} aria-label="Task history">
+          <div className={styles.sectionHeader}>
+            <span>History</span>
+            <span className={styles.sectionMeta}>
+              {taskHistory.historyRunCount}
+            </span>
+          </div>
+          {sessions.map(({ session, runs }) => (
+            <div key={session.id} className={styles.sessionGroup}>
+              <div className={styles.sessionHeader}>
+                <span className={styles.sessionName}>{session.name}</span>
+                {session.status === "Archived" && (
+                  <span className={styles.archivedBadge}>Archived</span>
+                )}
+              </div>
+              {runs.map((run) => {
+                const key = `${session.id}:${run.id}`;
+                const expanded = expandedRuns[key] === true;
+                return (
+                  <RunSummary
+                    key={key}
+                    run={run}
+                    expanded={expanded}
+                    onToggle={() =>
+                      setExpandedRuns((prev) => ({
+                        ...prev,
+                        [key]: !expanded,
+                      }))
+                    }
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </section>
+      )}
     </div>
   );
 });

--- a/src/ui/src/hooks/useTaskTracker.test.ts
+++ b/src/ui/src/hooks/useTaskTracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { deriveTasks, extractTaskId } from "./useTaskTracker";
+import { deriveTasks, deriveTaskState, extractTaskId } from "./useTaskTracker";
 import type { ToolActivity, CompletedTurn } from "../stores/useAppStore";
 
 /** Helper to build a minimal ToolActivity. */
@@ -245,5 +245,114 @@ describe("deriveTasks", () => {
     expect(result.totalCount).toBe(2);
     expect(result.tasks[0].id).toBe("_t1");
     expect(result.tasks[1].id).toBe("_t2");
+  });
+});
+
+// ── deriveTaskState history ──────────────────────────────────
+
+describe("deriveTaskState", () => {
+  it("archives a replaced TodoWrite run", () => {
+    const first = turn([
+      activity("TodoWrite", {
+        todos: [
+          { content: "Inspect auth flow", status: "completed" },
+          { content: "Patch token refresh", status: "completed" },
+        ],
+      }),
+    ]);
+    const second = [
+      activity("TodoWrite", {
+        todos: [
+          { content: "Write release notes", status: "in_progress" },
+          { content: "Update screenshots", status: "pending" },
+        ],
+      }),
+    ];
+
+    const result = deriveTaskState([first], second);
+
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0]).toMatchObject({
+      completedCount: 2,
+      totalCount: 2,
+    });
+    expect(result.history[0].tasks.map((task) => task.description)).toEqual([
+      "Inspect auth flow",
+      "Patch token refresh",
+    ]);
+    expect(result.current.tasks.map((task) => task.description)).toEqual([
+      "Write release notes",
+      "Update screenshots",
+    ]);
+  });
+
+  it("does not archive status-only TodoWrite updates", () => {
+    const first = turn([
+      activity("TodoWrite", {
+        todos: [
+          { content: "Build UI", status: "pending" },
+          { content: "Run tests", status: "pending" },
+        ],
+      }),
+    ]);
+    const second = [
+      activity("TodoWrite", {
+        todos: [
+          { content: "Run tests", status: "pending" },
+          { content: "Build UI", status: "completed" },
+        ],
+      }),
+    ];
+
+    const result = deriveTaskState([first], second);
+
+    expect(result.history).toHaveLength(0);
+    expect(result.current.completedCount).toBe(1);
+    expect(result.current.tasks.map((task) => task.description)).toEqual([
+      "Run tests",
+      "Build UI",
+    ]);
+  });
+
+  it("keeps completed todos current until a replacement arrives", () => {
+    const completed = [
+      activity("TodoWrite", {
+        todos: [
+          { content: "Edit files", status: "completed" },
+          { content: "Verify build", status: "completed" },
+        ],
+      }),
+    ];
+
+    const result = deriveTaskState([turn(completed)], []);
+
+    expect(result.history).toHaveLength(0);
+    expect(result.current.completedCount).toBe(2);
+    expect(result.current.totalCount).toBe(2);
+  });
+
+  it("archives the current run when Claude clears todos with an empty list", () => {
+    const first = turn([
+      activity("TodoWrite", {
+        todos: [
+          { content: "Implement feature", status: "completed" },
+          { content: "Verify feature", status: "completed" },
+        ],
+      }),
+    ]);
+    const clear = [
+      activity("TodoWrite", {
+        todos: [],
+      }),
+    ];
+
+    const result = deriveTaskState([first], clear);
+
+    expect(result.history).toHaveLength(1);
+    expect(result.history[0].tasks.map((task) => task.description)).toEqual([
+      "Implement feature",
+      "Verify feature",
+    ]);
+    expect(result.current.tasks).toEqual([]);
   });
 });

--- a/src/ui/src/hooks/useTaskTracker.ts
+++ b/src/ui/src/hooks/useTaskTracker.ts
@@ -36,6 +36,11 @@ export interface TaskTrackerWithHistory {
   history: TaskRun[];
 }
 
+export interface TaskActivityTurn {
+  id: string;
+  activities: ToolActivity[];
+}
+
 const EMPTY_ACTIVITIES: ToolActivity[] = [];
 const EMPTY_TURNS: CompletedTurn[] = [];
 const EMPTY_RESULT: TaskTrackerResult = {
@@ -346,7 +351,7 @@ export function deriveTasks(
 }
 
 export function deriveTaskState(
-  completedTurns: CompletedTurn[],
+  completedTurns: TaskActivityTurn[],
   toolActivities: ToolActivity[],
 ): TaskTrackerWithHistory {
   if (completedTurns.length === 0 && toolActivities.length === 0) {

--- a/src/ui/src/hooks/useTaskTracker.ts
+++ b/src/ui/src/hooks/useTaskTracker.ts
@@ -23,12 +23,29 @@ export interface TaskTrackerResult {
   totalCount: number;
 }
 
+export interface TaskRun extends TaskTrackerResult {
+  id: string;
+  sequence: number;
+  startedAt?: string;
+  updatedAt?: string;
+  turnId?: string;
+}
+
+export interface TaskTrackerWithHistory {
+  current: TaskTrackerResult;
+  history: TaskRun[];
+}
+
 const EMPTY_ACTIVITIES: ToolActivity[] = [];
 const EMPTY_TURNS: CompletedTurn[] = [];
 const EMPTY_RESULT: TaskTrackerResult = {
   tasks: [],
   completedCount: 0,
   totalCount: 0,
+};
+const EMPTY_WITH_HISTORY: TaskTrackerWithHistory = {
+  current: EMPTY_RESULT,
+  history: [],
 };
 
 /** Normalise status strings from Claude's TaskCreate/TaskUpdate/TodoWrite inputs. */
@@ -124,25 +141,34 @@ export function processActivities(
       case "TodoWrite": {
         const todos = input.todos;
         if (!Array.isArray(todos)) break;
-        // TodoWrite is a full replacement — clear all previous todo items
         todoMap.clear();
-        for (const item of todos) {
-          if (!item || typeof item !== "object") continue;
-          const id = String(
-            (item as Record<string, unknown>).id ?? `_d${nextSyntheticId.value++}`
-          );
-          todoMap.set(id, {
-            id,
-            description: String((item as Record<string, unknown>).content ?? ""),
-            status: normalizeStatus((item as Record<string, unknown>).status as string | undefined),
-            priority: normalizePriority((item as Record<string, unknown>).priority as string | undefined),
-            source: "todo",
-          });
+        for (const task of parseTodoTasks(todos, nextSyntheticId)) {
+          todoMap.set(task.id, task);
         }
         break;
       }
     }
   }
+}
+
+function parseTodoTasks(
+  todos: unknown[],
+  nextSyntheticId: { value: number },
+): TrackedTask[] {
+  const tasks: TrackedTask[] = [];
+  for (const item of todos) {
+    if (!item || typeof item !== "object") continue;
+    const raw = item as Record<string, unknown>;
+    const id = String(raw.id ?? `_d${nextSyntheticId.value++}`);
+    tasks.push({
+      id,
+      description: String(raw.content ?? ""),
+      status: normalizeStatus(raw.status as string | undefined),
+      priority: normalizePriority(raw.priority as string | undefined),
+      source: "todo",
+    });
+  }
+  return tasks;
 }
 
 function normalizePriority(
@@ -154,6 +180,148 @@ function normalizePriority(
   if (s === "low" || s === "l") return "low";
   if (s === "medium" || s === "m" || s === "med") return "medium";
   return undefined;
+}
+
+function taskResult(tasks: TrackedTask[]): TaskTrackerResult {
+  if (tasks.length === 0) return EMPTY_RESULT;
+  return {
+    tasks,
+    completedCount: tasks.filter((t) => t.status === "completed").length,
+    totalCount: tasks.length,
+  };
+}
+
+interface TodoRunDraft {
+  id: string;
+  sequence: number;
+  tasks: TrackedTask[];
+  startedAt?: string;
+  updatedAt?: string;
+  turnId?: string;
+}
+
+function normalizeTaskContent(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function taskContentSet(tasks: TrackedTask[]): Set<string> {
+  return new Set(
+    tasks
+      .map((task) => normalizeTaskContent(task.description))
+      .filter(Boolean),
+  );
+}
+
+function isReplacedTodoRun(previous: TrackedTask[], next: TrackedTask[]): boolean {
+  if (previous.length === 0 || next.length === 0) return false;
+
+  const previousSet = taskContentSet(previous);
+  const nextSet = taskContentSet(next);
+  if (previousSet.size === 0 || nextSet.size === 0) return false;
+
+  let intersection = 0;
+  for (const item of previousSet) {
+    if (nextSet.has(item)) intersection++;
+  }
+
+  if (Math.min(previousSet.size, nextSet.size) <= 1) {
+    return intersection === 0;
+  }
+
+  const union = new Set([...previousSet, ...nextSet]).size;
+  return union > 0 && intersection / union < 0.25;
+}
+
+function finalizeTodoRun(run: TodoRunDraft): TaskRun {
+  const result = taskResult(run.tasks);
+  return {
+    ...result,
+    id: run.id,
+    sequence: run.sequence,
+    startedAt: run.startedAt,
+    updatedAt: run.updatedAt,
+    turnId: run.turnId,
+  };
+}
+
+function deriveTaskStateFromEntries(
+  entries: { activities: ToolActivity[]; turnId?: string }[],
+): TaskTrackerWithHistory {
+  const taskMap = new Map<string, TrackedTask>();
+  const todoMap = new Map<string, TrackedTask>();
+  const nextSyntheticId = { value: 1 };
+  const history: TaskRun[] = [];
+  let todoRun: TodoRunDraft | null = null;
+  let runSequence = 1;
+
+  for (const entry of entries) {
+    for (const act of entry.activities) {
+      if (act.toolName !== "TodoWrite") {
+        processActivities([act], taskMap, todoMap, nextSyntheticId);
+        continue;
+      }
+
+      let input: Record<string, unknown>;
+      try {
+        input = JSON.parse(act.inputJson);
+      } catch {
+        continue;
+      }
+      const todos = input.todos;
+      if (!Array.isArray(todos)) continue;
+
+      const tasks = parseTodoTasks(todos, nextSyntheticId);
+      todoMap.clear();
+      for (const task of tasks) {
+        todoMap.set(task.id, task);
+      }
+
+      if (tasks.length === 0) {
+        if (todoRun) {
+          history.push(finalizeTodoRun(todoRun));
+          todoRun = null;
+        }
+        continue;
+      }
+
+      if (!todoRun) {
+        todoRun = {
+          id: `todo-run-${runSequence}`,
+          sequence: runSequence++,
+          tasks,
+          startedAt: act.startedAt,
+          updatedAt: act.startedAt,
+          turnId: entry.turnId,
+        };
+        continue;
+      }
+
+      if (isReplacedTodoRun(todoRun.tasks, tasks)) {
+        history.push(finalizeTodoRun(todoRun));
+        todoRun = {
+          id: `todo-run-${runSequence}`,
+          sequence: runSequence++,
+          tasks,
+          startedAt: act.startedAt,
+          updatedAt: act.startedAt,
+          turnId: entry.turnId,
+        };
+      } else {
+        todoRun = {
+          ...todoRun,
+          tasks,
+          updatedAt: act.startedAt ?? todoRun.updatedAt,
+          turnId: entry.turnId,
+        };
+      }
+    }
+  }
+
+  const tasks = [...taskMap.values(), ...todoMap.values()];
+  return {
+    current: taskResult(tasks),
+    history,
+  };
 }
 
 /**
@@ -174,10 +342,24 @@ export function deriveTasks(
   processActivities(toolActivities, taskMap, todoMap, nextSyntheticId);
 
   const tasks = [...taskMap.values(), ...todoMap.values()];
-  if (tasks.length === 0) return EMPTY_RESULT;
+  return taskResult(tasks);
+}
 
-  const completedCount = tasks.filter((t) => t.status === "completed").length;
-  return { tasks, completedCount, totalCount: tasks.length };
+export function deriveTaskState(
+  completedTurns: CompletedTurn[],
+  toolActivities: ToolActivity[],
+): TaskTrackerWithHistory {
+  if (completedTurns.length === 0 && toolActivities.length === 0) {
+    return EMPTY_WITH_HISTORY;
+  }
+
+  return deriveTaskStateFromEntries([
+    ...completedTurns.map((turn) => ({
+      activities: turn.activities,
+      turnId: turn.id,
+    })),
+    { activities: toolActivities },
+  ]);
 }
 
 const TASK_TOOL_NAMES = new Set([
@@ -203,6 +385,12 @@ export function hasTaskActivity(activities: ToolActivity[]): boolean {
  * TaskCreate, TaskUpdate, TaskStop, and TodoWrite tool calls.
  */
 export function useTaskTracker(sessionId: string | null): TaskTrackerResult {
+  return useTaskTrackerWithHistory(sessionId).current;
+}
+
+export function useTaskTrackerWithHistory(
+  sessionId: string | null,
+): TaskTrackerWithHistory {
   const completedTurns = useAppStore(
     (s) => (sessionId ? s.completedTurns[sessionId] : null) ?? EMPTY_TURNS
   );
@@ -211,7 +399,7 @@ export function useTaskTracker(sessionId: string | null): TaskTrackerResult {
   );
 
   return useMemo(
-    () => (sessionId ? deriveTasks(completedTurns, toolActivities) : EMPTY_RESULT),
+    () => (sessionId ? deriveTaskState(completedTurns, toolActivities) : EMPTY_WITH_HISTORY),
     [sessionId, completedTurns, toolActivities]
   );
 }

--- a/src/ui/src/hooks/useWorkspaceTaskHistory.ts
+++ b/src/ui/src/hooks/useWorkspaceTaskHistory.ts
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAppStore } from "../stores/useAppStore";
-import type {
-  AgentToolCall,
-  CompletedTurn,
-  ToolActivity,
-} from "../stores/useAppStore";
+import type { AgentToolCall, ToolActivity } from "../stores/useAppStore";
 import {
   loadCompletedTurns,
   listChatSessions,
@@ -15,6 +11,7 @@ import type { CompletedTurnData } from "../types/checkpoint";
 import {
   deriveTaskState,
   useTaskTrackerWithHistory,
+  type TaskActivityTurn,
   type TaskRun,
   type TaskTrackerResult,
 } from "./useTaskTracker";
@@ -56,7 +53,7 @@ function parseAgentToolCalls(value: string): AgentToolCall[] | undefined {
   }
 }
 
-function turnFromData(data: CompletedTurnData): CompletedTurn {
+function turnFromData(data: CompletedTurnData): TaskActivityTurn {
   return {
     id: data.checkpoint_id,
     activities: data.activities.map<ToolActivity>((activity) => ({
@@ -74,10 +71,6 @@ function turnFromData(data: CompletedTurnData): CompletedTurn {
       agentStatus: activity.agent_status,
       agentToolCalls: parseAgentToolCalls(activity.agent_tool_calls_json),
     })),
-    messageCount: data.message_count,
-    collapsed: true,
-    afterMessageIndex: data.turn_index,
-    commitHash: data.commit_hash,
   };
 }
 
@@ -97,7 +90,7 @@ function mergeSessions(
 async function loadSessionTurns(
   sessionId: string,
   remoteConnectionId: string | null,
-): Promise<CompletedTurn[]> {
+): Promise<TaskActivityTurn[]> {
   const data = remoteConnectionId
     ? ((await sendRemoteCommand(remoteConnectionId, "load_completed_turns", {
         chat_session_id: sessionId,
@@ -121,7 +114,7 @@ export function useWorkspaceTaskHistory(
   const activeState = useTaskTrackerWithHistory(activeSessionId);
   const [fetchedSessions, setFetchedSessions] = useState<ChatSession[]>([]);
   const [turnsBySession, setTurnsBySession] = useState<
-    Record<string, CompletedTurn[]>
+    Record<string, TaskActivityTurn[]>
   >({});
   const [loadingSessions, setLoadingSessions] = useState(false);
   const [loadingTurns, setLoadingTurns] = useState(false);
@@ -194,13 +187,19 @@ export function useWorkspaceTaskHistory(
           ] as const;
         } catch (err) {
           console.error("Failed to load task history turns:", err);
-          return [session.id, []] as const;
+          return null;
         }
       }),
     )
       .then((entries) => {
         if (cancelled) return;
-        setTurnsBySession(Object.fromEntries(entries));
+        setTurnsBySession((prev) => {
+          const next = { ...prev };
+          for (const entry of entries) {
+            if (entry) next[entry[0]] = entry[1];
+          }
+          return next;
+        });
       })
       .finally(() => {
         if (!cancelled) setLoadingTurns(false);

--- a/src/ui/src/hooks/useWorkspaceTaskHistory.ts
+++ b/src/ui/src/hooks/useWorkspaceTaskHistory.ts
@@ -92,16 +92,40 @@ async function loadSessionTurns(
   remoteConnectionId: string | null,
 ): Promise<TaskActivityTurn[]> {
   const data = remoteConnectionId
-    ? ((await sendRemoteCommand(remoteConnectionId, "load_completed_turns", {
+    ? await sendRemoteCommand(remoteConnectionId, "load_completed_turns", {
         chat_session_id: sessionId,
-      })) as CompletedTurnData[])
+      })
     : await loadCompletedTurns(sessionId);
+
+  if (!Array.isArray(data)) {
+    throw new Error("Remote completed turns response was not an array");
+  }
+
   return data.map(turnFromData);
+}
+
+async function loadWorkspaceSessions(
+  workspaceId: string,
+  remoteConnectionId: string | null,
+): Promise<ChatSession[]> {
+  const data = remoteConnectionId
+    ? await sendRemoteCommand(remoteConnectionId, "list_chat_sessions", {
+        workspace_id: workspaceId,
+        include_archived: true,
+      })
+    : await listChatSessions(workspaceId, true);
+
+  if (!Array.isArray(data)) {
+    throw new Error("Remote chat sessions response was not an array");
+  }
+
+  return data;
 }
 
 export function useWorkspaceTaskHistory(
   workspaceId: string | null,
   activeSessionId: string | null,
+  historyEnabled = true,
 ): WorkspaceTaskHistoryResult {
   const workspace = useAppStore((s) =>
     workspaceId ? s.workspaces.find((ws) => ws.id === workspaceId) : null,
@@ -126,20 +150,14 @@ export function useWorkspaceTaskHistory(
     setFetchedSessions([]);
     setTurnsBySession({});
 
-    if (!workspaceId) {
+    if (!workspaceId || !historyEnabled) {
       setLoadingSessions(false);
       return;
     }
 
     setLoadingSessions(true);
-    const load = remoteConnectionId
-      ? sendRemoteCommand(remoteConnectionId, "list_chat_sessions", {
-          workspace_id: workspaceId,
-          include_archived: true,
-        }) as Promise<ChatSession[]>
-      : listChatSessions(workspaceId, true);
 
-    load
+    loadWorkspaceSessions(workspaceId, remoteConnectionId)
       .then((sessions) => {
         if (!cancelled) setFetchedSessions(sessions);
       })
@@ -153,7 +171,7 @@ export function useWorkspaceTaskHistory(
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, remoteConnectionId]);
+  }, [workspaceId, remoteConnectionId, historyEnabled]);
 
   const sessions = useMemo(
     () => mergeSessions(fetchedSessions, storeSessions),
@@ -162,7 +180,7 @@ export function useWorkspaceTaskHistory(
 
   useEffect(() => {
     let cancelled = false;
-    if (!workspaceId || sessions.length === 0) {
+    if (!workspaceId || !historyEnabled || sessions.length === 0) {
       setTurnsBySession({});
       setLoadingTurns(false);
       return;
@@ -208,7 +226,7 @@ export function useWorkspaceTaskHistory(
     return () => {
       cancelled = true;
     };
-  }, [workspaceId, sessions, activeSessionId, remoteConnectionId]);
+  }, [workspaceId, sessions, activeSessionId, remoteConnectionId, historyEnabled]);
 
   if (!workspaceId) return EMPTY_RESULT;
 

--- a/src/ui/src/hooks/useWorkspaceTaskHistory.ts
+++ b/src/ui/src/hooks/useWorkspaceTaskHistory.ts
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAppStore } from "../stores/useAppStore";
+import type {
+  AgentToolCall,
+  CompletedTurn,
+  ToolActivity,
+} from "../stores/useAppStore";
+import {
+  loadCompletedTurns,
+  listChatSessions,
+  sendRemoteCommand,
+} from "../services/tauri";
+import type { ChatSession } from "../types/chat";
+import type { CompletedTurnData } from "../types/checkpoint";
+import {
+  deriveTaskState,
+  useTaskTrackerWithHistory,
+  type TaskRun,
+  type TaskTrackerResult,
+} from "./useTaskTracker";
+
+export interface SessionTaskHistory {
+  session: ChatSession;
+  runs: TaskRun[];
+}
+
+export interface WorkspaceTaskHistoryResult {
+  current: TaskTrackerResult;
+  sessions: SessionTaskHistory[];
+  historyRunCount: number;
+  totalBadgeCount: number;
+  loading: boolean;
+}
+
+const EMPTY_CURRENT: TaskTrackerResult = {
+  tasks: [],
+  completedCount: 0,
+  totalCount: 0,
+};
+
+const EMPTY_RESULT: WorkspaceTaskHistoryResult = {
+  current: EMPTY_CURRENT,
+  sessions: [],
+  historyRunCount: 0,
+  totalBadgeCount: 0,
+  loading: false,
+};
+const EMPTY_SESSIONS: ChatSession[] = [];
+
+function parseAgentToolCalls(value: string): AgentToolCall[] | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as AgentToolCall[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function turnFromData(data: CompletedTurnData): CompletedTurn {
+  return {
+    id: data.checkpoint_id,
+    activities: data.activities.map<ToolActivity>((activity) => ({
+      toolUseId: activity.tool_use_id,
+      toolName: activity.tool_name,
+      inputJson: activity.input_json,
+      resultText: activity.result_text,
+      collapsed: true,
+      summary: activity.summary,
+      assistantMessageOrdinal: activity.assistant_message_ordinal,
+      agentTaskId: activity.agent_task_id,
+      agentDescription: activity.agent_description,
+      agentLastToolName: activity.agent_last_tool_name,
+      agentToolUseCount: activity.agent_tool_use_count,
+      agentStatus: activity.agent_status,
+      agentToolCalls: parseAgentToolCalls(activity.agent_tool_calls_json),
+    })),
+    messageCount: data.message_count,
+    collapsed: true,
+    afterMessageIndex: data.turn_index,
+    commitHash: data.commit_hash,
+  };
+}
+
+function mergeSessions(
+  fetched: ChatSession[],
+  storeSessions: ChatSession[],
+): ChatSession[] {
+  const byId = new Map<string, ChatSession>();
+  for (const session of fetched) byId.set(session.id, session);
+  for (const session of storeSessions) byId.set(session.id, session);
+  return [...byId.values()].sort((a, b) => {
+    if (a.status !== b.status) return a.status === "Active" ? -1 : 1;
+    return a.sort_order - b.sort_order;
+  });
+}
+
+async function loadSessionTurns(
+  sessionId: string,
+  remoteConnectionId: string | null,
+): Promise<CompletedTurn[]> {
+  const data = remoteConnectionId
+    ? ((await sendRemoteCommand(remoteConnectionId, "load_completed_turns", {
+        chat_session_id: sessionId,
+      })) as CompletedTurnData[])
+    : await loadCompletedTurns(sessionId);
+  return data.map(turnFromData);
+}
+
+export function useWorkspaceTaskHistory(
+  workspaceId: string | null,
+  activeSessionId: string | null,
+): WorkspaceTaskHistoryResult {
+  const workspace = useAppStore((s) =>
+    workspaceId ? s.workspaces.find((ws) => ws.id === workspaceId) : null,
+  );
+  const storeSessions = useAppStore((s) =>
+    workspaceId
+      ? (s.sessionsByWorkspace[workspaceId] ?? EMPTY_SESSIONS)
+      : EMPTY_SESSIONS,
+  );
+  const activeState = useTaskTrackerWithHistory(activeSessionId);
+  const [fetchedSessions, setFetchedSessions] = useState<ChatSession[]>([]);
+  const [turnsBySession, setTurnsBySession] = useState<
+    Record<string, CompletedTurn[]>
+  >({});
+  const [loadingSessions, setLoadingSessions] = useState(false);
+  const [loadingTurns, setLoadingTurns] = useState(false);
+
+  const remoteConnectionId = workspace?.remote_connection_id ?? null;
+
+  useEffect(() => {
+    let cancelled = false;
+    setFetchedSessions([]);
+    setTurnsBySession({});
+
+    if (!workspaceId) {
+      setLoadingSessions(false);
+      return;
+    }
+
+    setLoadingSessions(true);
+    const load = remoteConnectionId
+      ? sendRemoteCommand(remoteConnectionId, "list_chat_sessions", {
+          workspace_id: workspaceId,
+          include_archived: true,
+        }) as Promise<ChatSession[]>
+      : listChatSessions(workspaceId, true);
+
+    load
+      .then((sessions) => {
+        if (!cancelled) setFetchedSessions(sessions);
+      })
+      .catch((err) => {
+        console.error("Failed to load task history sessions:", err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingSessions(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, remoteConnectionId]);
+
+  const sessions = useMemo(
+    () => mergeSessions(fetchedSessions, storeSessions),
+    [fetchedSessions, storeSessions],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!workspaceId || sessions.length === 0) {
+      setTurnsBySession({});
+      setLoadingTurns(false);
+      return;
+    }
+
+    const sessionsToLoad = sessions.filter(
+      (session) => session.id !== activeSessionId,
+    );
+    if (sessionsToLoad.length === 0) {
+      setTurnsBySession({});
+      setLoadingTurns(false);
+      return;
+    }
+
+    setLoadingTurns(true);
+    Promise.all(
+      sessionsToLoad.map(async (session) => {
+        try {
+          return [
+            session.id,
+            await loadSessionTurns(session.id, remoteConnectionId),
+          ] as const;
+        } catch (err) {
+          console.error("Failed to load task history turns:", err);
+          return [session.id, []] as const;
+        }
+      }),
+    )
+      .then((entries) => {
+        if (cancelled) return;
+        setTurnsBySession(Object.fromEntries(entries));
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTurns(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, sessions, activeSessionId, remoteConnectionId]);
+
+  if (!workspaceId) return EMPTY_RESULT;
+
+  const histories: SessionTaskHistory[] = [];
+  for (const session of sessions) {
+    const state =
+      session.id === activeSessionId
+        ? activeState
+        : deriveTaskState(turnsBySession[session.id] ?? [], []);
+    if (state.history.length > 0) {
+      histories.push({ session, runs: state.history });
+    }
+  }
+
+  const historyRunCount = histories.reduce(
+    (sum, session) => sum + session.runs.length,
+    0,
+  );
+
+  return {
+    current: activeState.current,
+    sessions: histories,
+    historyRunCount,
+    totalBadgeCount: activeState.current.totalCount + historyRunCount,
+    loading: loadingSessions || loadingTurns,
+  };
+}


### PR DESCRIPTION
## Summary

Adds workspace-level task history for Claude-generated task lists in the right sidebar. The active session's current tasks remain visible at the top, while materially replaced `TodoWrite` checklists are preserved as collapsed historical runs grouped by chat session.

## What changed

- Added derived task-run history on top of existing persisted turn/tool activity data, with no database migration.
- Preserved the current task tracker behavior for `TaskCreate`, `TaskUpdate`, `TaskStop`, and the latest active `TodoWrite` checklist.
- Added workspace aggregation that loads active and archived sessions, derives historical runs per session, and merges live active-session state for current accuracy.
- Updated the right sidebar Tasks tab to show `Current` tasks plus collapsed `History` sections with per-run completion counts and archived-session labels.
- Added remote server support for `load_completed_turns` so remote workspaces can render the same derived history.
- Documented the feature in the docs site and added it to the sidebar navigation.

## Replacement behavior

A prior checklist becomes history when a later non-empty `TodoWrite` list has low normalized content overlap with it. Status-only updates, reordered lists, and partial edits stay in the same current run. An empty `TodoWrite` archives the current run and clears the current checklist.

## User impact

Long-running workspaces no longer lose visibility into earlier Claude task lists when Claude rewrites its checklist for a new phase of work. Users can inspect old runs by session without making the current checklist harder to scan.

## Validation

- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test -- useTaskTracker TaskList`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run lint` (passes with pre-existing warnings only)
- `nix develop -c cargo check -p claudette-server`
- `nix develop -c cargo fmt --all --check`
- `git diff --check`