### PR TITLE
fix: preserve initial terminal output

### DIFF
--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -990,10 +990,16 @@ export const TerminalPanel = memo(function TerminalPanel() {
         try {
           let ptyId: number | null = null;
           const earlyOutput: EarlyPtyOutputBuffer = new Map();
+          const existingPtyIds = new Set(
+            Array.from(instancesRef.current.values())
+              .map((existing) => existing.ptyId)
+              .filter((existingPtyId) => existingPtyId >= 0),
+          );
           const rawUnlisten = await listen<PtyOutputPayload>(
             "pty-output",
             (event) => {
               if (ptyId === null) {
+                if (existingPtyIds.has(event.payload.pty_id)) return;
                 bufferEarlyPtyOutput(earlyOutput, event.payload);
                 return;
               }

--- a/src/ui/src/components/terminal/TerminalPanel.tsx
+++ b/src/ui/src/components/terminal/TerminalPanel.tsx
@@ -76,6 +76,12 @@ import {
   type TabDropPlacement,
 } from "./terminalPanelLogic";
 import {
+  bufferEarlyPtyOutput,
+  flushEarlyPtyOutput,
+  type EarlyPtyOutputBuffer,
+  type PtyOutputPayload,
+} from "./terminalPtyOutputBuffer";
+import {
   AttachmentContextMenu,
   type AttachmentContextMenuItem,
 } from "../chat/AttachmentContextMenu";
@@ -83,11 +89,6 @@ import { viewportToFixed } from "../../utils/zoom";
 import { reclaimScrollLines } from "./terminalReclaim";
 import "@xterm/xterm/css/xterm.css";
 import styles from "./TerminalPanel.module.css";
-
-interface PtyOutputPayload {
-  pty_id: number;
-  data: number[];
-}
 
 interface AgentTaskOutputPayload {
   tab_id: number;
@@ -987,6 +988,33 @@ export const TerminalPanel = memo(function TerminalPanel() {
       // by the time we resolve, close the PTY we just spawned and bail.
       (async () => {
         try {
+          let ptyId: number | null = null;
+          const earlyOutput: EarlyPtyOutputBuffer = new Map();
+          const rawUnlisten = await listen<PtyOutputPayload>(
+            "pty-output",
+            (event) => {
+              if (ptyId === null) {
+                bufferEarlyPtyOutput(earlyOutput, event.payload);
+                return;
+              }
+              if (event.payload.pty_id === ptyId) {
+                term.write(new Uint8Array(event.payload.data));
+              }
+            },
+          );
+          let disposed = false;
+          const unlistenFn = () => {
+            if (disposed) return;
+            disposed = true;
+            earlyOutput.clear();
+            rawUnlisten();
+          };
+          if (instancesRef.current.get(spec.leafId) !== inst) {
+            unlistenFn();
+            return;
+          }
+          inst.unlisten = unlistenFn;
+
           const state = useAppStore.getState();
           const currentWs = state.workspaces.find(
             (w) => w.id === spec.workspaceId,
@@ -996,7 +1024,7 @@ export const TerminalPanel = memo(function TerminalPanel() {
             : undefined;
           const defaults = state.defaultBranches;
           await waitForWorkspaceEnvironment(spec.workspaceId);
-          const ptyId = await spawnPty(
+          const spawnedPtyId = await spawnPty(
             spec.worktreePath,
             currentWs?.name ?? "",
             spec.workspaceId,
@@ -1006,30 +1034,29 @@ export const TerminalPanel = memo(function TerminalPanel() {
           );
           const stillExists = instancesRef.current.get(spec.leafId);
           if (stillExists !== inst) {
-            closePtyBestEffort(ptyId);
+            unlistenFn();
+            closePtyBestEffort(spawnedPtyId);
             return;
           }
-          inst.ptyId = ptyId;
-          setPanePtyId(spec.tabId, spec.leafId, ptyId);
-
-          const unlistenFn = await listen<PtyOutputPayload>(
-            "pty-output",
-            (event) => {
-              if (event.payload.pty_id === ptyId) {
-                term.write(new Uint8Array(event.payload.data));
-              }
-            },
+          const activePtyId = spawnedPtyId;
+          ptyId = activePtyId;
+          inst.ptyId = activePtyId;
+          setPanePtyId(spec.tabId, spec.leafId, activePtyId);
+          flushEarlyPtyOutput(
+            earlyOutput,
+            activePtyId,
+            (data) => term.write(new Uint8Array(data)),
           );
+          earlyOutput.clear();
           if (instancesRef.current.get(spec.leafId) !== inst) {
             unlistenFn();
-            closePtyBestEffort(ptyId);
+            closePtyBestEffort(activePtyId);
             return;
           }
-          inst.unlisten = unlistenFn;
 
           term.onData((data) => {
             const bytes = Array.from(terminalInputEncoder.encode(data));
-            writePty(ptyId, bytes);
+            writePty(activePtyId, bytes);
           });
           term.onResize(({ cols, rows }) => {
             forwardPtyResize(inst, { cols, rows });
@@ -1038,6 +1065,10 @@ export const TerminalPanel = memo(function TerminalPanel() {
           safeFit(inst);
           forwardPtyResize(inst);
         } catch (e) {
+          if (inst.ptyId < 0 && inst.unlisten) {
+            inst.unlisten();
+            inst.unlisten = null;
+          }
           console.error("Failed to spawn PTY:", e);
           const msg = e instanceof Error ? e.message : String(e);
           setPaneSpawnError(spec.tabId, spec.leafId, msg);

--- a/src/ui/src/components/terminal/terminalPtyOutputBuffer.test.ts
+++ b/src/ui/src/components/terminal/terminalPtyOutputBuffer.test.ts
@@ -31,4 +31,19 @@ describe("terminalPtyOutputBuffer", () => {
 
     expect(flushed).toEqual([[3, 4], [5]]);
   });
+
+  it("trims without shifting stored chunks on every eviction", () => {
+    const buffer: EarlyPtyOutputBuffer = new Map();
+    for (let i = 0; i < 40; i += 1) {
+      bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [i] }, 40);
+    }
+    bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [40] }, 40);
+
+    const flushed: number[][] = [];
+    flushEarlyPtyOutput(buffer, 1, (data) => flushed.push(data));
+
+    expect(flushed).toHaveLength(40);
+    expect(flushed[0]).toEqual([1]);
+    expect(flushed.at(-1)).toEqual([40]);
+  });
 });

--- a/src/ui/src/components/terminal/terminalPtyOutputBuffer.test.ts
+++ b/src/ui/src/components/terminal/terminalPtyOutputBuffer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  bufferEarlyPtyOutput,
+  flushEarlyPtyOutput,
+  type EarlyPtyOutputBuffer,
+} from "./terminalPtyOutputBuffer";
+
+describe("terminalPtyOutputBuffer", () => {
+  it("flushes only the chunks for the claimed PTY id", () => {
+    const buffer: EarlyPtyOutputBuffer = new Map();
+    bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [65] });
+    bufferEarlyPtyOutput(buffer, { pty_id: 2, data: [66] });
+    bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [67] });
+
+    const flushed: number[][] = [];
+    flushEarlyPtyOutput(buffer, 1, (data) => flushed.push(data));
+
+    expect(flushed).toEqual([[65], [67]]);
+    expect(buffer.has(1)).toBe(false);
+    expect(buffer.get(2)?.chunks).toEqual([[66]]);
+  });
+
+  it("keeps the newest chunks when the byte limit is exceeded", () => {
+    const buffer: EarlyPtyOutputBuffer = new Map();
+    bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [1, 2] }, 4);
+    bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [3, 4] }, 4);
+    bufferEarlyPtyOutput(buffer, { pty_id: 1, data: [5] }, 4);
+
+    const flushed: number[][] = [];
+    flushEarlyPtyOutput(buffer, 1, (data) => flushed.push(data));
+
+    expect(flushed).toEqual([[3, 4], [5]]);
+  });
+});

--- a/src/ui/src/components/terminal/terminalPtyOutputBuffer.ts
+++ b/src/ui/src/components/terminal/terminalPtyOutputBuffer.ts
@@ -1,0 +1,58 @@
+export const EARLY_PTY_OUTPUT_BUFFER_BYTE_LIMIT = 128 * 1024;
+
+export interface PtyOutputPayload {
+  pty_id: number;
+  data: number[];
+}
+
+interface BufferedPtyOutput {
+  chunks: number[][];
+  bytes: number;
+}
+
+export type EarlyPtyOutputBuffer = Map<number, BufferedPtyOutput>;
+
+/**
+ * Buffer PTY output observed before the frontend knows which backend pty_id
+ * belongs to the just-spawned terminal pane. The backend starts its reader
+ * before `spawn_pty` resolves, so the shell's first prompt can otherwise be
+ * emitted before the pane subscribes to it.
+ */
+export function bufferEarlyPtyOutput(
+  buffer: EarlyPtyOutputBuffer,
+  payload: PtyOutputPayload,
+  limitBytes = EARLY_PTY_OUTPUT_BUFFER_BYTE_LIMIT,
+) {
+  if (payload.data.length === 0 || limitBytes <= 0) return;
+
+  let entry = buffer.get(payload.pty_id);
+  if (!entry) {
+    entry = { chunks: [], bytes: 0 };
+    buffer.set(payload.pty_id, entry);
+  }
+
+  entry.chunks.push(payload.data);
+  entry.bytes += payload.data.length;
+
+  while (entry.bytes > limitBytes && entry.chunks.length > 0) {
+    const removed = entry.chunks.shift();
+    entry.bytes -= removed?.length ?? 0;
+  }
+
+  if (entry.chunks.length === 0) {
+    buffer.delete(payload.pty_id);
+  }
+}
+
+export function flushEarlyPtyOutput(
+  buffer: EarlyPtyOutputBuffer,
+  ptyId: number,
+  write: (data: number[]) => void,
+) {
+  const entry = buffer.get(ptyId);
+  if (!entry) return;
+  buffer.delete(ptyId);
+  for (const chunk of entry.chunks) {
+    write(chunk);
+  }
+}

--- a/src/ui/src/components/terminal/terminalPtyOutputBuffer.ts
+++ b/src/ui/src/components/terminal/terminalPtyOutputBuffer.ts
@@ -8,6 +8,7 @@ export interface PtyOutputPayload {
 interface BufferedPtyOutput {
   chunks: number[][];
   bytes: number;
+  start: number;
 }
 
 export type EarlyPtyOutputBuffer = Map<number, BufferedPtyOutput>;
@@ -27,20 +28,24 @@ export function bufferEarlyPtyOutput(
 
   let entry = buffer.get(payload.pty_id);
   if (!entry) {
-    entry = { chunks: [], bytes: 0 };
+    entry = { chunks: [], bytes: 0, start: 0 };
     buffer.set(payload.pty_id, entry);
   }
 
   entry.chunks.push(payload.data);
   entry.bytes += payload.data.length;
 
-  while (entry.bytes > limitBytes && entry.chunks.length > 0) {
-    const removed = entry.chunks.shift();
+  while (entry.bytes > limitBytes && entry.start < entry.chunks.length) {
+    const removed = entry.chunks[entry.start];
     entry.bytes -= removed?.length ?? 0;
+    entry.start += 1;
   }
 
-  if (entry.chunks.length === 0) {
+  if (entry.start >= entry.chunks.length) {
     buffer.delete(payload.pty_id);
+  } else if (entry.start > 32 && entry.start * 2 > entry.chunks.length) {
+    entry.chunks = entry.chunks.slice(entry.start);
+    entry.start = 0;
   }
 }
 
@@ -52,7 +57,9 @@ export function flushEarlyPtyOutput(
   const entry = buffer.get(ptyId);
   if (!entry) return;
   buffer.delete(ptyId);
-  for (const chunk of entry.chunks) {
+  for (let i = entry.start; i < entry.chunks.length; i += 1) {
+    const chunk = entry.chunks[i];
+    if (!chunk) continue;
     write(chunk);
   }
 }


### PR DESCRIPTION
## Summary
- Subscribe to PTY output before spawning the terminal process so the first shell prompt is not missed.
- Buffer early PTY output by backend PTY id and flush the matching chunks once spawn returns.
- Add focused regression coverage for early PTY output buffering.

## Root Cause
`spawn_pty` can emit `pty-output` before the frontend knows the returned PTY id and attaches its listener. With direnv/env-provider delays during new workspace creation, Terminal 1 could appear stuck at a blank cursor because the initial prompt was lost.

## Validation
- `cd src/ui && bun run test terminalPtyOutputBuffer terminalLeafManager`
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint` (existing unrelated warnings only)
- UAT passed