### PR TITLE
fix: prevent archived workspace overflow

### DIFF
--- a/src/ui/src/components/layout/WelcomeEmptyState.module.css
+++ b/src/ui/src/components/layout/WelcomeEmptyState.module.css
@@ -3,12 +3,17 @@
    landing matches this card's typography and density. */
 
 .welcome {
-  flex: 1;
+  flex: 1 0 auto;
   display: flex;
   align-items: flex-start;
   justify-content: center;
   padding: 40px 24px 56px;
-  min-height: 0;
+  /*
+    This panel often has siblings in Dashboard, including the project-scoped
+    archived workspace list. It should expand into spare vertical space, but
+    it must not shrink below the card's own height or the card will paint over
+    the following sections inside the scroll pane.
+  */
 }
 
 .card {


### PR DESCRIPTION
## Summary
- Prevent the dashboard welcome card from shrinking below its content height when archived workspaces are expanded.
- Keep the project-scoped dashboard scroll pane responsible for the overflow instead of letting the card paint over archived rows.

## Root Cause
The welcome empty-state wrapper used `flex: 1` together with `min-height: 0`, so it could collapse smaller than the card content when sibling sections were present in the scroll pane.

## Validation
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run build`