### PR TITLE
feat(chat): surface skill activations as their own transcript entry

### DIFF
--- a/site/src/content/docs/features/slash-commands.mdx
+++ b/site/src/content/docs/features/slash-commands.mdx
@@ -77,6 +77,8 @@ A "skill" is a slash command backed by a directory rather than a single file —
 
 The skill's directory name is the command name; `SKILL.md` provides the seeded prompt and frontmatter.
 
+When the agent pulls in a skill mid-turn, the chat transcript shows a `✦ <skill name> activated` marker (wand icon) as its own entry — not bundled into the collapsible "N tool calls" group, the same way agent runs and thinking blocks stand on their own — so you can see which skills shaped a response at a glance.
+
 ## Plugin-contributed commands
 
 Enabled Claude Code plugins (managed via the **Plugins** settings panel) can ship their own commands and skills. They appear in the picker tagged with their plugin's name. See the Claude Code documentation for plugin authoring; Claudette discovers them automatically once installed.

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -168,6 +168,15 @@
   padding: 6px 2px;
 }
 
+/* When the message leads with a Thinking block, that block already
+   carries its own 4px top margin — don't stack the message's 6px top
+   padding on top of it, or the Thinking box ends up farther below the
+   preceding entry (skill marker, tool-call group, …) than those
+   entries sit from one another. */
+.messageLeadingThinking {
+  padding-top: 0;
+}
+
 /* System messages — subtle inline pill */
 .role_System {
   background: var(--chat-system-bg);
@@ -1009,6 +1018,65 @@
 
 .toolSummary::before {
   content: "  ";
+  color: var(--text-faint);
+}
+
+/* "<skill> activated" marker — its own transcript entry, sized to match
+   the tool-group and thinking blocks it sits among (mirrors `.turnSummary`
+   + `.turnHeader` / ThinkingBlock `.container` + `.header`). Non-interactive,
+   so no pointer cursor or expand chevron. */
+.skillBlock {
+  border: 1px solid var(--divider);
+  border-radius: 6px;
+  margin: 4px 0;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: border-color var(--transition-fast);
+}
+
+.skillBlock:hover {
+  border-color: var(--text-faint);
+}
+
+/* Inline tool-display mode: shed the box so the marker sits flush with
+   the compact, borderless rows around it (mirrors `.containerInline` /
+   `.inlineTurnActivities .toolActivity`). */
+.skillBlockInline {
+  border: none;
+  border-radius: 0;
+  margin: 0;
+}
+
+.skillBlockInline:hover {
+  border-color: transparent;
+}
+
+.skillActivation {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.skillActivationInline {
+  padding: 2px 8px;
+}
+
+.skillActivationIcon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.skillActivationName {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.skillActivationSuffix {
   color: var(--text-faint);
 }
 

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -41,6 +41,7 @@ import type { TaskTrackerResult, TrackedTask } from "../../hooks/useTaskTracker"
 import { debugChat } from "../../utils/chatDebug";
 import styles from "./ChatPanel.module.css";
 import { TurnSummary } from "./TurnSummary";
+import { ToolActivityRow } from "./ToolActivityRow";
 import { ToolActivitiesSection } from "./ToolActivitiesSection";
 import { TurnFooter } from "./TurnFooter";
 import { TurnEditSummaryCard } from "./EditChangeSummary";
@@ -49,7 +50,10 @@ import {
 } from "./editActivitySummary";
 import { PdfThumbnail } from "./PdfThumbnail";
 import { MessageCopyButton } from "./MessageCopyButton";
-import { groupToolActivitiesForDisplay } from "./toolActivityGroups";
+import {
+  groupToolActivitiesForDisplay,
+  type ToolActivityDisplayGroup,
+} from "./toolActivityGroups";
 import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { cleanClaudeAuthError, isClaudeAuthError } from "../auth/claudeAuth";
 import {
@@ -253,6 +257,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
         globalIdx: number;
         activities: CompletedTurn["activities"];
         label: string;
+        kind: ToolActivityDisplayGroup["kind"];
         showFooter: boolean;
       }>
     > = {};
@@ -301,8 +306,18 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
           activities,
           toolDisplayMode,
         );
-        const finalGroupIndex =
-          position === turn.afterMessageIndex ? displayGroups.length - 1 : -1;
+        // The turn footer attaches to the last display group at the
+        // turn's final position — unless that group is a skill marker.
+        // Skills aren't tool calls; they render flat and flush, so the
+        // footer falls through to the standalone path (below) and stays
+        // at the bottom of the turn instead of landing above the marker.
+        let finalGroupIndex = -1;
+        if (position === turn.afterMessageIndex) {
+          const last = displayGroups.length - 1;
+          if (last >= 0 && displayGroups[last].kind !== "skill") {
+            finalGroupIndex = last;
+          }
+        }
         hasFinalGroup ||= finalGroupIndex >= 0;
         displayGroups.forEach((group, groupIndex) => {
           (groupsByPosition[position] ??= []).push({
@@ -310,6 +325,7 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
             globalIdx,
             activities: group.activities,
             label: group.label,
+            kind: group.kind,
             showFooter: groupIndex === finalGroupIndex,
           });
         });
@@ -578,7 +594,21 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
     if (groupEntries.length === 0 && footerEntries.length === 0) return null;
     return (
       <>
-        {groupEntries.map(({ turn, globalIdx, activities, label, showFooter }) => {
+        {groupEntries.map(({ turn, globalIdx, activities, label, kind, showFooter }) => {
+          // Skills aren't tool calls — render the flat "<skill> activated"
+          // marker, never a collapsible TurnSummary. (`showFooter` is
+          // always false for skill groups; see the layout builder.)
+          if (kind === "skill" && activities[0]) {
+            return (
+              <ToolActivityRow
+                key={`${turn.id}:${position}:skill:${activities[0].toolUseId}`}
+                activity={activities[0]}
+                searchQuery={searchQuery}
+                worktreePath={worktreePath}
+                inline={toolDisplayMode === "inline"}
+              />
+            );
+          }
           // A single turn can produce multiple display groups when
           // chronologically-interleaved messages split its activities;
           // each group needs its own collapse state so clicking one
@@ -747,7 +777,13 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
             {renderTurns(globalOffset + idx)}
             {renderLiveToolActivity(globalOffset + idx)}
             {msg.id === pendingMessageId ? streamingMessageNode : (
-              <div className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}`}>
+              <div
+                className={`${styles.message} ${styles[roleClassKey(msg.role, msg.content)]}${
+                  msg.role === "Assistant" && msg.thinking && showThinkingBlocks
+                    ? ` ${styles.messageLeadingThinking}`
+                    : ""
+                }`}
+              >
                 {msg.role === "User" && (
                   <div className={styles.roleLabel}>{t("you_label")}</div>
                 )}

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -220,6 +220,34 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Read");
   });
 
+  it("renders skill activations as a flat marker, never inside the collapsed tool group", async () => {
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-1"
+        toolDisplayMode="grouped"
+        searchQuery=""
+        activities={[
+          activity("Skill", {
+            toolUseId: "Skill-1",
+            inputJson: JSON.stringify({ skill: "commit-changes" }),
+          }),
+          activity("Bash", { toolUseId: "Bash-1", resultText: "done" }),
+          activity("Read", { toolUseId: "Read-1", resultText: "done" }),
+        ]}
+      />,
+    );
+
+    // The skill breaks the run of direct tools (like an agent does): the
+    // two tools collapse into the pill, the skill marker stays visible.
+    expect(container.textContent).toContain("2 tool calls");
+    expect(container.textContent).toContain("commit-changes");
+    expect(container.textContent).toContain("activated");
+    expect(container.textContent).not.toContain("Bash");
+    expect(container.textContent).not.toContain("Read");
+    // No collapsible wrapper around the skill marker itself.
+    expect(container.querySelector(`.${styles.skillActivation}`)).toBeTruthy();
+  });
+
   it("collapses grouped live calls by default — even while still running", async () => {
     // Intentional behavior change: with grouped tool calls on (the
     // default for new users), live tool groups start collapsed

--- a/src/ui/src/components/chat/ToolActivitiesSection.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.tsx
@@ -44,7 +44,17 @@ export const ToolActivitiesSection = memo(function ToolActivitiesSection({
       aria-atomic="true"
     >
       {displayGroups.map((group) =>
-        group.kind === "agent" && group.activities[0] ? (
+        group.kind === "skill" && group.activities[0] ? (
+          // Skills aren't tool calls — render the flat "<skill> activated"
+          // marker directly, never inside a collapsible group.
+          <ToolActivityRow
+            key={group.activities[0].toolUseId}
+            activity={group.activities[0]}
+            searchQuery={searchQuery}
+            worktreePath={worktreePath}
+            inline={toolDisplayMode === "inline"}
+          />
+        ) : group.kind === "agent" && group.activities[0] ? (
           // Inline mode keeps the legacy always-expanded Agent rendering;
           // grouped mode wraps the same component with a chevron+toggle
           // and a default-collapsed-while-running stance so live Agent

--- a/src/ui/src/components/chat/ToolActivityRow.test.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.test.tsx
@@ -202,6 +202,38 @@ describe("ToolActivityRow", () => {
     expect(container.innerHTML).toContain('data-highlight-lang="json"');
   });
 
+  it("renders Skill invocations as a '<skill> activated' marker without a chevron", async () => {
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Skill", {
+          inputJson: JSON.stringify({ skill: "commit-changes", args: "wip" }),
+          summary: "commit-changes wip",
+        })}
+        searchQuery=""
+      />,
+    );
+
+    expect(container.textContent).toContain("commit-changes");
+    expect(container.textContent).toContain("activated");
+    // No expand affordance and no raw "Skill" tool-name label.
+    expect(container.querySelector("button[aria-expanded]")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("falls back to the summary's first token when Skill input lacks a skill field", async () => {
+    const container = await render(
+      <ToolActivityRow
+        activity={activity("Skill", {
+          inputJson: "{}",
+          summary: "rebase-on-main",
+        })}
+        searchQuery=""
+      />,
+    );
+
+    expect(container.textContent).toContain("rebase-on-main activated");
+  });
+
   it("renders edit details with real multiline strings instead of JSON escapes", async () => {
     const input = {
       file_path: "/repo/src/types.rs",

--- a/src/ui/src/components/chat/ToolActivityRow.tsx
+++ b/src/ui/src/components/chat/ToolActivityRow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useReducer, type MouseEvent } from "react";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, WandSparkles } from "lucide-react";
 import type { ToolActivity } from "../../stores/useAppStore";
 import { useAppStore } from "../../stores/useAppStore";
 import { extractToolSummary, relativizePath } from "../../hooks/toolSummary";
@@ -11,11 +11,18 @@ import { CodeBlock } from "./CodeBlock";
 import { InlineEditSummary } from "./EditChangeSummary";
 import { summarizeToolActivityEdit } from "./editActivitySummary";
 import { resolveToolSummary } from "./toolMetadata";
+import { isSkillActivity, skillActivationName } from "./toolActivityGroups";
 
 interface ToolActivityRowProps {
   activity: ToolActivity;
   searchQuery: string;
   worktreePath?: string | null;
+  /** Inline tool-display mode: drop the boxed chrome (border / outer
+   *  margin / generous padding) so the row sits flush like its
+   *  neighbours. Only consumed by the skill marker — generic tool rows
+   *  pick up the compact treatment from a `.inlineTurnActivities`
+   *  ancestor instead. */
+  inline?: boolean;
 }
 
 interface ToolDetails {
@@ -23,7 +30,60 @@ interface ToolDetails {
   lang: string | null;
 }
 
-export function ToolActivityRow({
+export function ToolActivityRow(props: ToolActivityRowProps) {
+  // Skill invocations get a distinct, non-expandable presentation — a
+  // "<skill> activated" marker with the wand icon — instead of the
+  // generic tool row, so a glance at the transcript shows which skills
+  // the agent pulled in. Dispatched here (rather than an early return
+  // inside the body) so the generic row's hooks stay unconditional.
+  if (isSkillActivity(props.activity)) {
+    return (
+      <SkillActivationRow
+        activity={props.activity}
+        searchQuery={props.searchQuery}
+        inline={props.inline}
+      />
+    );
+  }
+  return <GenericToolActivityRow {...props} />;
+}
+
+function SkillActivationRow({
+  activity,
+  searchQuery,
+  inline,
+}: {
+  activity: ToolActivity;
+  searchQuery: string;
+  inline?: boolean;
+}) {
+  const skillName = skillActivationName(activity);
+  return (
+    <div
+      className={inline ? `${styles.skillBlock} ${styles.skillBlockInline}` : styles.skillBlock}
+    >
+      <div
+        className={
+          inline
+            ? `${styles.skillActivation} ${styles.skillActivationInline}`
+            : styles.skillActivation
+        }
+      >
+        <WandSparkles
+          size={13}
+          aria-hidden="true"
+          className={styles.skillActivationIcon}
+        />
+        <span className={styles.skillActivationName}>
+          <HighlightedPlainText text={skillName} query={searchQuery} />
+        </span>
+        <span className={styles.skillActivationSuffix}> activated</span>
+      </div>
+    </div>
+  );
+}
+
+function GenericToolActivityRow({
   activity,
   searchQuery,
   worktreePath,

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -118,6 +118,7 @@ export function TurnSummary({
         activity={act}
         searchQuery={searchQuery}
         worktreePath={worktreePath}
+        inline={inline}
       />
     );
   });

--- a/src/ui/src/components/chat/toolActivityGroups.test.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.test.ts
@@ -3,6 +3,7 @@ import type { ToolActivity } from "../../stores/useAppStore";
 import {
   groupHasRunningActivity,
   groupToolActivitiesForDisplay,
+  skillActivationName,
 } from "./toolActivityGroups";
 
 function activity(
@@ -88,6 +89,50 @@ describe("toolActivityGroups", () => {
   it("labels unnamed agents without a duplicated fallback", () => {
     expect(groupToolActivitiesForDisplay([activity("Agent")])[0]?.label).toBe(
       "Agent",
+    );
+  });
+
+  it("breaks a run of direct tools out around a skill, like an agent", () => {
+    const groups = groupToolActivitiesForDisplay([
+      activity("Bash"),
+      activity("Skill", {
+        inputJson: JSON.stringify({ skill: "commit-changes" }),
+      }),
+      activity("Read"),
+    ]);
+
+    expect(groups.map((g) => g.kind)).toEqual(["tools", "skill", "tools"]);
+    expect(groups.map((g) => g.label)).toEqual([
+      "1 tool call",
+      "commit-changes",
+      "1 tool call",
+    ]);
+    expect(groups[1]?.activities.map((a) => a.toolName)).toEqual(["Skill"]);
+  });
+
+  it("gives each skill its own group in inline mode", () => {
+    const groups = groupToolActivitiesForDisplay(
+      [
+        activity("Skill", { inputJson: JSON.stringify({ skill: "rebase-on-main" }) }),
+      ],
+      "inline",
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.kind).toBe("skill");
+    expect(groups[0]?.label).toBe("rebase-on-main");
+  });
+
+  it("derives the skill name from input, then summary, then a default", () => {
+    expect(
+      skillActivationName(
+        activity("Skill", { inputJson: JSON.stringify({ skill: "  pull-request  " }) }),
+      ),
+    ).toBe("pull-request");
+    expect(
+      skillActivationName(activity("Skill", { inputJson: "{}", summary: "commit-changes wip" })),
+    ).toBe("commit-changes");
+    expect(skillActivationName(activity("Skill", { inputJson: "not json", summary: "" }))).toBe(
+      "Skill",
     );
   });
 });

--- a/src/ui/src/components/chat/toolActivityGroups.ts
+++ b/src/ui/src/components/chat/toolActivityGroups.ts
@@ -3,7 +3,7 @@ import type { ToolActivity } from "../../stores/useAppStore";
 
 export type ToolActivityDisplayGroup = {
   key: string;
-  kind: "tools" | "agent";
+  kind: "tools" | "agent" | "skill";
   label: string;
   activities: ToolActivity[];
 };
@@ -31,7 +31,11 @@ export function groupToolActivitiesForDisplay(
   };
 
   for (const activity of activities) {
-    if (isAgentActivity(activity)) {
+    // Agents and skills are first-class transcript entries, not tool
+    // calls — they break a run of direct tools and render on their own
+    // (agents as a collapsible group, skills as a flat "activated"
+    // marker) rather than getting bundled into the "N tool calls" pill.
+    if (isAgentActivity(activity) || isSkillActivity(activity)) {
       flushDirectTools();
       groups.push(activityDisplayGroup(activity));
       continue;
@@ -45,6 +49,32 @@ export function groupToolActivitiesForDisplay(
 
 export function isAgentActivity(activity: ToolActivity): boolean {
   return activity.toolName === "Agent";
+}
+
+export function isSkillActivity(activity: ToolActivity): boolean {
+  return activity.toolName === "Skill";
+}
+
+/** Skill name from the `Skill` tool input (`{ "skill": "..." }`), falling
+ *  back to the first token of the activity summary, then "Skill". Shared by
+ *  the group label and the rendered "<skill> activated" marker. */
+export function skillActivationName(activity: ToolActivity): string {
+  try {
+    const parsed = JSON.parse(activity.inputJson || "{}") as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as { skill?: unknown }).skill === "string"
+    ) {
+      const skill = (parsed as { skill: string }).skill.trim();
+      if (skill) return skill;
+    }
+  } catch {
+    // Fall through to the summary-derived fallback below.
+  }
+  const fromSummary = activity.summary?.trim().split(/\s+/)[0] ?? "";
+  return fromSummary || "Skill";
 }
 
 export function groupHasRunningActivity(
@@ -66,11 +96,26 @@ function toolCallLabel(count: number): string {
 }
 
 function activityDisplayGroup(activity: ToolActivity): ToolActivityDisplayGroup {
-  const agent = isAgentActivity(activity);
+  if (isAgentActivity(activity)) {
+    return {
+      key: `agent:${activity.toolUseId}`,
+      kind: "agent",
+      label: agentGroupLabel(activity),
+      activities: [activity],
+    };
+  }
+  if (isSkillActivity(activity)) {
+    return {
+      key: `skill:${activity.toolUseId}`,
+      kind: "skill",
+      label: skillActivationName(activity),
+      activities: [activity],
+    };
+  }
   return {
-    key: `${agent ? "agent" : "tool"}:${activity.toolUseId}`,
-    kind: agent ? "agent" : "tools",
-    label: agent ? agentGroupLabel(activity) : activity.toolName,
+    key: `tool:${activity.toolUseId}`,
+    kind: "tools",
+    label: activity.toolName,
     activities: [activity],
   };
 }


### PR DESCRIPTION
### Summary

When the agent invokes the `Skill` tool, the chat now renders a flat **`✦ <skill name> activated`** marker (wand-sparkles icon) instead of a generic tool row. Skills are treated as first-class transcript entries — like agent runs and thinking blocks — rather than being bundled into the collapsible "N tool calls" group:

- `groupToolActivitiesForDisplay` gains a `kind: "skill"` group. A `Skill` activity breaks a run of direct tools and emits its own group (mirrors how `Agent` is handled). New helpers: `isSkillActivity()`, `skillActivationName()` (input `skill` field → first token of summary → `"Skill"`).
- `ToolActivityRow` dispatches `Skill` activities to a `SkillActivationRow` (non-expandable; boxed `.skillBlock` sized 1:1 with `.turnSummary` / ThinkingBlock `.container`, plus a borderless `.skillBlockInline` variant for inline tool-display mode).
- `ToolActivitiesSection` (live turns) and `MessagesWithTurns` (replayed turns) render `kind === "skill"` groups as the flat marker, never inside a collapsible wrapper. In `MessagesWithTurns`, the turn footer no longer attaches to a trailing skill group — it falls through to the standalone-footer path so it stays at the bottom of the turn.

It also fixes an unrelated-but-adjacent spacing quirk: an assistant message that leads with a Thinking block now drops its `padding-top` (`.messageLeadingThinking`), so the Thinking box sits the same distance below a preceding entry (skill marker, tool-call group, …) as those entries sit from one another (was 16px vs 10px; now uniformly 10px).

```mermaid
flowchart LR
  A[tool activities] --> G{groupToolActivitiesForDisplay}
  G -->|run of direct tools| T["kind: tools<br/>(collapsible 'N tool calls')"]
  G -->|Agent| AG["kind: agent<br/>(collapsible group)"]
  G -->|Skill| SK["kind: skill<br/>(flat '✦ name activated')"]
  T --> R1[ToolActivitiesSection / MessagesWithTurns]
  AG --> R1
  SK --> R1
```

### Complexity Notes

- **`MessagesWithTurns` turn-footer routing** — `finalGroupIndex` now skips trailing `skill` groups; if a turn ends on a skill marker, `hasFinalGroup` stays false and the footer renders via the existing `finalFooterByPosition` path. Worth a look to confirm the footer/edit-summary still land correctly for turns that end on a skill.
- **`.messageLeadingThinking` side effect** — an assistant message that leads with thinking and is preceded *directly* by a user message now sits 6px below the user bubble instead of 12px. Looked intentional (user bubble has its own bg/padding/`margin-top: 20px`); flag if it reads too tight.
- **`ToolActivityRow` now takes an `inline?` prop** — consumed only by the skill marker; generic tool rows still inherit the compact treatment from a `.inlineTurnActivities` ancestor and ignore it.

### Test Steps

1. Start a workspace and have the agent invoke a skill (e.g. type `/commit-changes` or any slash command backed by a skill, or let the agent call one mid-turn).
2. Confirm the chat shows a `✦ <skill name> activated` row with the wand icon — *not* folded into a "N tool calls" group, and not expandable.
3. With a turn that has tool calls *and* a skill, confirm the tools collapse into the pill while the skill marker stays visible alongside it.
4. Eyeball vertical spacing: the gap above the skill marker (to a tool-call group) should match the gap below it (to a following Thinking block) — both ~10px.
5. Toggle **Settings → … → tool display** to *inline* mode; the skill marker should render flush/borderless like the rows around it.
6. Reload the workspace (replay from DB) and confirm completed turns still show the skill marker, footers, and edit summaries correctly.
7. `cd src/ui && bunx tsc -b && bun run lint && bun run lint:css && bun run test` — all green.

### Checklist
- [x] Tests added/updated (`toolActivityGroups.test.ts`, `ToolActivitiesSection.test.tsx`, `ToolActivityRow.test.tsx`)
- [x] Documentation updated (`site/src/content/docs/features/slash-commands.mdx`)