### PR TITLE
fix: stabilize context meter during env startup

### DIFF
--- a/src-tauri/src/commands/chat/remote_control.rs
+++ b/src-tauri/src/commands/chat/remote_control.rs
@@ -5,8 +5,9 @@ use claudette::agent::{
     UserEventMessage, UserMessageContent,
 };
 use claudette::chat::{
-    BuildAssistantArgs, CheckpointArgs, build_assistant_chat_message, create_turn_checkpoint,
-    extract_assistant_text, extract_event_thinking,
+    BuildAssistantArgs, CheckpointArgs, assistant_usage_fields_from_result,
+    build_assistant_chat_message, create_turn_checkpoint, extract_assistant_text,
+    extract_event_thinking,
 };
 use claudette::db::Database;
 use claudette::env::WorkspaceEnv;
@@ -1015,6 +1016,7 @@ async fn ensure_remote_control_monitor(
                     && let Some(ref msg_id) = last_assistant_msg_id
                 {
                     if let Some(usage) = usage {
+                        let usage = assistant_usage_fields_from_result(usage);
                         let _ = db.update_chat_message_usage_if_missing(
                             msg_id,
                             usage.input_tokens,

--- a/src-tauri/src/commands/chat/send.rs
+++ b/src-tauri/src/commands/chat/send.rs
@@ -13,9 +13,10 @@ use claudette::agent::{
 };
 use claudette::base64_decode;
 use claudette::chat::{
-    BuildAssistantArgs, CheckpointArgs, RequestedFlags, SessionFlags, build_assistant_chat_message,
-    build_compaction_sentinel, build_permission_response, create_turn_checkpoint,
-    extract_assistant_text, extract_event_thinking, persistent_session_flags_drifted,
+    BuildAssistantArgs, CheckpointArgs, RequestedFlags, SessionFlags,
+    assistant_usage_fields_from_result, build_assistant_chat_message, build_compaction_sentinel,
+    build_permission_response, create_turn_checkpoint, extract_assistant_text,
+    extract_event_thinking, persistent_session_flags_drifted,
 };
 use claudette::db::{CLAUDETTE_TERMINAL_TITLE, Database};
 use claudette::env::WorkspaceEnv;
@@ -814,6 +815,7 @@ fn schedule_background_task_wake(
                 && let Some(ref msg_id) = last_assistant_msg_id
             {
                 if let Some(usage) = usage {
+                    let usage = assistant_usage_fields_from_result(usage);
                     let _ = db.update_chat_message_usage_if_missing(
                         msg_id,
                         usage.input_tokens,
@@ -3372,6 +3374,7 @@ pub async fn send_chat_message(
                     && let Some(ref msg_id) = last_assistant_msg_id
                 {
                     if let Some(usage) = usage {
+                        let usage = assistant_usage_fields_from_result(usage);
                         let _ = db.update_chat_message_usage_if_missing(
                             msg_id,
                             usage.input_tokens,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -190,6 +190,40 @@ pub struct BuildAssistantArgs<'a> {
     pub created_at: String,
 }
 
+/// Token fields to persist on an assistant message when the only available
+/// source is a `result.usage` event.
+pub struct AssistantUsageFields {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_input_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+}
+
+/// Pick the per-call usage that should hydrate the ContextMeter on reload.
+///
+/// `result.usage` top-level fields are aggregates across internal tool-use
+/// iterations. Persisting those into `chat_messages` makes reload hydration
+/// over-report context until the live stream corrects it. When the CLI includes
+/// `iterations`, the first entry is the final API call's usage and matches what
+/// the live ContextMeter uses.
+pub fn assistant_usage_fields_from_result(usage: &TokenUsage) -> AssistantUsageFields {
+    if let Some(iteration) = usage.iterations.as_ref().and_then(|items| items.first()) {
+        return AssistantUsageFields {
+            input_tokens: iteration.input_tokens,
+            output_tokens: iteration.output_tokens,
+            cache_read_input_tokens: iteration.cache_read_input_tokens,
+            cache_creation_input_tokens: iteration.cache_creation_input_tokens,
+        };
+    }
+
+    AssistantUsageFields {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_read_input_tokens: usage.cache_read_input_tokens,
+        cache_creation_input_tokens: usage.cache_creation_input_tokens,
+    }
+}
+
 /// Build the `ChatMessage` row to persist for an assistant turn message.
 /// Maps `TokenUsage` into the four per-message token fields when present.
 pub fn build_assistant_chat_message(args: BuildAssistantArgs<'_>) -> ChatMessage {
@@ -345,6 +379,7 @@ pub async fn create_turn_checkpoint(args: CheckpointArgs<'_>) -> Option<Conversa
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::TokenUsageIteration;
     use serde_json::json;
 
     use std::path::PathBuf;
@@ -789,6 +824,45 @@ mod tests {
         assert_eq!(m.output_tokens, Some(7));
         assert_eq!(m.cache_creation_tokens, None);
         assert_eq!(m.cache_read_tokens, Some(99));
+    }
+
+    #[test]
+    fn assistant_usage_fields_from_result_prefers_iteration_usage() {
+        let usage = TokenUsage {
+            input_tokens: 62,
+            output_tokens: 41_322,
+            cache_creation_input_tokens: Some(153_239),
+            cache_read_input_tokens: Some(4_695_413),
+            iterations: Some(vec![TokenUsageIteration {
+                input_tokens: 1,
+                output_tokens: 611,
+                cache_creation_input_tokens: Some(573),
+                cache_read_input_tokens: Some(131_890),
+            }]),
+        };
+
+        let fields = assistant_usage_fields_from_result(&usage);
+        assert_eq!(fields.input_tokens, 1);
+        assert_eq!(fields.output_tokens, 611);
+        assert_eq!(fields.cache_creation_input_tokens, Some(573));
+        assert_eq!(fields.cache_read_input_tokens, Some(131_890));
+    }
+
+    #[test]
+    fn assistant_usage_fields_from_result_falls_back_to_aggregate() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: Some(5_000),
+            iterations: None,
+        };
+
+        let fields = assistant_usage_fields_from_result(&usage);
+        assert_eq!(fields.input_tokens, 100);
+        assert_eq!(fields.output_tokens, 20);
+        assert_eq!(fields.cache_creation_input_tokens, None);
+        assert_eq!(fields.cache_read_input_tokens, Some(5_000));
     }
 
     #[test]

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -303,6 +303,12 @@ export function ChatInputArea({
   const pluginRefreshToken = useAppStore((s) => s.pluginRefreshToken);
   const openSettings = useAppStore((s) => s.openSettings);
 
+  useEffect(() => {
+    if (workspaceEnvironmentPreparing) {
+      setContextPopoverOpen(false);
+    }
+  }, [workspaceEnvironmentPreparing]);
+
   const insertTranscript = useCallback((transcript: string) => {
     const ta = textareaRef.current;
     const start = ta?.selectionStart ?? cursorPos;

--- a/src/ui/src/components/chat/ChatInputArea.tsx
+++ b/src/ui/src/components/chat/ChatInputArea.tsx
@@ -1362,6 +1362,7 @@ export function ChatInputArea({
             ref={meterRef}
             sessionId={sessionId}
             onClick={() => setContextPopoverOpen((v) => !v)}
+            suspended={workspaceEnvironmentPreparing}
           />
           {voice.state === "recording" && (
             <VoiceMeter
@@ -1452,7 +1453,7 @@ export function ChatInputArea({
           >
             {isRunning ? <Square size={16} /> : <Send size={16} />}
           </button>
-          {contextPopoverOpen && (
+          {contextPopoverOpen && !workspaceEnvironmentPreparing && (
             <ContextPopover
               sessionId={sessionId}
               onClose={() => setContextPopoverOpen(false)}

--- a/src/ui/src/components/chat/composer/SegmentedMeter.tsx
+++ b/src/ui/src/components/chat/composer/SegmentedMeter.tsx
@@ -11,15 +11,16 @@ const CELL_COUNT = 10;
 interface SegmentedMeterProps {
   sessionId: string;
   onClick: () => void;
+  suspended?: boolean;
 }
 
 export const SegmentedMeter = forwardRef<HTMLButtonElement, SegmentedMeterProps>(
-function SegmentedMeter({ sessionId, onClick }, ref) {
+function SegmentedMeter({ sessionId, onClick, suspended = false }, ref) {
   const usage = useAppStore((s) => s.latestTurnUsage[sessionId]);
 
   const model = useSelectedModelEntry(sessionId);
   const state = computeMeterState(usage, model?.contextWindowTokens);
-  if (!state) return null;
+  if (suspended || !state) return null;
 
   const ratio = state.totalTokens / state.capacity;
   const band = segmentedBand(ratio);


### PR DESCRIPTION
## Summary
- Persist per-call assistant usage from `result.usage.iterations[0]` when result usage is the only available backend token source.
- Keep the composer context meter and popover hidden while workspace env providers are still preparing.

## Root cause
Third-party/gateway backends can miss `message_delta` usage, so reload hydration could fall back to top-level `result.usage`. That top-level payload is aggregated across internal tool-use iterations, which made the meter temporarily show an inflated context count during env startup until the live agent stream replaced it with the correct per-call usage.

## Validation
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run lint` (0 errors; existing warnings only)
- `SDKROOT="$(xcrun --show-sdk-path)" CC="$(xcrun --find clang)" CXX="$(xcrun --find clang++)" CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$(xcrun --find clang)" CARGO_TARGET_DIR=/tmp/claudette-codex-target cargo test -p claudette --lib assistant_usage_fields_from_result`