### PR TITLE
fix: detect JetBrains Toolbox IDEs

### DIFF
--- a/site/src/content/docs/features/parallel-agents.mdx
+++ b/site/src/content/docs/features/parallel-agents.mdx
@@ -72,7 +72,7 @@ Press **Escape** to stop a running agent at any time.
 
 ## Workspace Context Menu
 
-Use the opener in the workspace header to launch the current worktree in a detected editor, file manager, terminal, or IDE. The primary button uses the detected app's native icon and opens the first preferred app; the chevron shows the full app list and a copy-path action. JetBrains IDEs such as IntelliJ IDEA, PyCharm, PhpStorm, DataGrip, GoLand, CLion, Rider, RubyMine, RustRover, DataSpell, and WebStorm are detected from the standard app install plus JetBrains Toolbox launcher scripts.
+Use the opener in the workspace header to launch the current worktree in a detected editor, file manager, terminal, or IDE. The primary button uses the detected app's native icon and opens the first preferred app; the chevron shows the full app list and a copy-path action. JetBrains IDEs such as IntelliJ IDEA, PyCharm, PhpStorm, WebStorm, DataGrip, DataSpell, GoLand, CLion, Rider, RubyMine, RustRover, Aqua, Fleet, and Writerside are detected from the standard app install plus JetBrains Toolbox launcher scripts.
 
 The sidebar workspace menu's **Open in Terminal** action uses the detected terminal list too. Configure **Settings > General > Default terminal** to pin Ghostty, iTerm2, Alacritty, Warp, or another detected terminal; leave it on **Auto** to use the first detected terminal.
 

--- a/site/src/content/docs/features/parallel-agents.mdx
+++ b/site/src/content/docs/features/parallel-agents.mdx
@@ -72,7 +72,7 @@ Press **Escape** to stop a running agent at any time.
 
 ## Workspace Context Menu
 
-Use the opener in the workspace header to launch the current worktree in a detected editor, file manager, terminal, or IDE. The primary button uses the detected app's native icon and opens the first preferred app; the chevron shows the full app list and a copy-path action.
+Use the opener in the workspace header to launch the current worktree in a detected editor, file manager, terminal, or IDE. The primary button uses the detected app's native icon and opens the first preferred app; the chevron shows the full app list and a copy-path action. JetBrains IDEs such as IntelliJ IDEA, PyCharm, PhpStorm, DataGrip, GoLand, CLion, Rider, RubyMine, RustRover, DataSpell, and WebStorm are detected from the standard app install plus JetBrains Toolbox launcher scripts.
 
 The sidebar workspace menu's **Open in Terminal** action uses the detected terminal list too. Configure **Settings > General > Default terminal** to pin Ghostty, iTerm2, Alacritty, Warp, or another detected terminal; leave it on **Auto** to use the first detected terminal.
 

--- a/src-tauri/default-apps.json
+++ b/src-tauri/default-apps.json
@@ -218,6 +218,15 @@
       "open_args": ["{}"]
     },
     {
+      "id": "aqua",
+      "name": "Aqua",
+      "category": "ide",
+      "bin_names": ["aqua"],
+      "mac_app_names": ["Aqua.app"],
+      "windows_exe_names": ["aqua64.exe", "aqua.exe"],
+      "open_args": ["{}"]
+    },
+    {
       "id": "datagrip",
       "name": "DataGrip",
       "category": "ide",
@@ -233,6 +242,15 @@
       "bin_names": ["dataspell"],
       "mac_app_names": ["DataSpell.app"],
       "windows_exe_names": ["dataspell64.exe", "dataspell.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "fleet",
+      "name": "Fleet",
+      "category": "ide",
+      "bin_names": ["fleet"],
+      "mac_app_names": ["Fleet.app"],
+      "windows_exe_names": ["fleet.exe"],
       "open_args": ["{}"]
     },
     {
@@ -302,6 +320,15 @@
       "bin_names": ["webstorm"],
       "mac_app_names": ["WebStorm.app"],
       "windows_exe_names": ["webstorm64.exe", "webstorm.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "writerside",
+      "name": "Writerside",
+      "category": "ide",
+      "bin_names": ["writerside"],
+      "mac_app_names": ["Writerside.app"],
+      "windows_exe_names": ["writerside64.exe", "writerside.exe"],
       "open_args": ["{}"]
     },
     {

--- a/src-tauri/default-apps.json
+++ b/src-tauri/default-apps.json
@@ -199,8 +199,109 @@
       "name": "IntelliJ IDEA",
       "category": "ide",
       "bin_names": ["idea"],
-      "mac_app_names": ["IntelliJ IDEA.app", "IntelliJ IDEA CE.app"],
+      "mac_app_names": [
+        "IntelliJ IDEA.app",
+        "IntelliJ IDEA Ultimate.app",
+        "IntelliJ IDEA CE.app",
+        "IntelliJ IDEA Community Edition.app"
+      ],
       "windows_exe_names": ["idea64.exe", "idea.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "clion",
+      "name": "CLion",
+      "category": "ide",
+      "bin_names": ["clion"],
+      "mac_app_names": ["CLion.app"],
+      "windows_exe_names": ["clion64.exe", "clion.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "datagrip",
+      "name": "DataGrip",
+      "category": "ide",
+      "bin_names": ["datagrip"],
+      "mac_app_names": ["DataGrip.app"],
+      "windows_exe_names": ["datagrip64.exe", "datagrip.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "dataspell",
+      "name": "DataSpell",
+      "category": "ide",
+      "bin_names": ["dataspell"],
+      "mac_app_names": ["DataSpell.app"],
+      "windows_exe_names": ["dataspell64.exe", "dataspell.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "goland",
+      "name": "GoLand",
+      "category": "ide",
+      "bin_names": ["goland"],
+      "mac_app_names": ["GoLand.app"],
+      "windows_exe_names": ["goland64.exe", "goland.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "phpstorm",
+      "name": "PhpStorm",
+      "category": "ide",
+      "bin_names": ["phpstorm"],
+      "mac_app_names": ["PhpStorm.app"],
+      "windows_exe_names": ["phpstorm64.exe", "phpstorm.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "pycharm",
+      "name": "PyCharm",
+      "category": "ide",
+      "bin_names": ["pycharm"],
+      "mac_app_names": [
+        "PyCharm.app",
+        "PyCharm Professional.app",
+        "PyCharm Professional Edition.app",
+        "PyCharm CE.app",
+        "PyCharm Community Edition.app"
+      ],
+      "windows_exe_names": ["pycharm64.exe", "pycharm.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "rider",
+      "name": "Rider",
+      "category": "ide",
+      "bin_names": ["rider"],
+      "mac_app_names": ["Rider.app"],
+      "windows_exe_names": ["rider64.exe", "rider.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "rubymine",
+      "name": "RubyMine",
+      "category": "ide",
+      "bin_names": ["rubymine"],
+      "mac_app_names": ["RubyMine.app"],
+      "windows_exe_names": ["rubymine64.exe", "rubymine.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "rustrover",
+      "name": "RustRover",
+      "category": "ide",
+      "bin_names": ["rustrover"],
+      "mac_app_names": ["RustRover.app"],
+      "windows_exe_names": ["rustrover64.exe", "rustrover.exe"],
+      "open_args": ["{}"]
+    },
+    {
+      "id": "webstorm",
+      "name": "WebStorm",
+      "category": "ide",
+      "bin_names": ["webstorm"],
+      "mac_app_names": ["WebStorm.app"],
+      "windows_exe_names": ["webstorm64.exe", "webstorm.exe"],
       "open_args": ["{}"]
     },
     {

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -219,6 +219,41 @@ fn load_apps_config() -> AppsConfig {
 /// Well-known PATH prefixes that macOS GUI apps may not inherit.
 const EXTRA_PATH_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin", "/usr/local/sbin"];
 
+#[cfg(target_os = "macos")]
+fn jetbrains_toolbox_script_dirs(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join("Library")
+            .join("Application Support")
+            .join("JetBrains")
+            .join("Toolbox")
+            .join("scripts"),
+    ]
+}
+
+#[cfg(target_os = "linux")]
+fn jetbrains_toolbox_script_dirs(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join(".local")
+            .join("share")
+            .join("JetBrains")
+            .join("Toolbox")
+            .join("scripts"),
+    ]
+}
+
+#[cfg(windows)]
+fn jetbrains_toolbox_script_dirs(_home: &Path) -> Vec<PathBuf> {
+    dirs::data_local_dir()
+        .map(|dir| dir.join("JetBrains").join("Toolbox").join("scripts"))
+        .into_iter()
+        .collect()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn jetbrains_toolbox_script_dirs(_home: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
 /// Build the list of directories to scan for binaries.
 fn build_path_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
@@ -228,6 +263,7 @@ fn build_path_dirs() -> Vec<PathBuf> {
     }
     if let Some(home) = dirs::home_dir() {
         dirs.push(home.join(".local/bin"));
+        dirs.extend(jetbrains_toolbox_script_dirs(&home));
     }
 
     if let Some(path_var) = std::env::var_os("PATH") {
@@ -1728,6 +1764,12 @@ mod tests {
         assert!(config.apps.iter().any(|a| a.id == "cursor"));
         assert!(config.apps.iter().any(|a| a.id == "windows-terminal"));
         assert!(config.apps.iter().any(|a| a.id == "cmd"));
+        for id in JETBRAINS_IDE_IDS {
+            assert!(
+                config.apps.iter().any(|a| a.id == *id),
+                "missing JetBrains IDE default entry for {id}"
+            );
+        }
     }
 
     /// Backfilling `windows_exe_names` on a user entry that lacks it
@@ -1821,6 +1863,91 @@ mod tests {
         assert_eq!(
             merged.apps[0].windows_exe_names,
             vec!["PortableCode.exe".to_string()]
+        );
+    }
+
+    const JETBRAINS_IDE_IDS: &[&str] = &[
+        "intellij",
+        "clion",
+        "datagrip",
+        "dataspell",
+        "goland",
+        "phpstorm",
+        "pycharm",
+        "rider",
+        "rubymine",
+        "rustrover",
+        "webstorm",
+    ];
+
+    #[test]
+    fn detect_finds_jetbrains_ides_from_default_config_when_launchers_are_on_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        for id in JETBRAINS_IDE_IDS {
+            let bin = tmp.path().join(default_bin_name_for_app(id));
+            std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+
+        let config: AppsConfig =
+            serde_json::from_str(DEFAULT_APPS_JSON).expect("default-apps.json must parse");
+
+        let detected = detect_with_paths(&config, &[tmp.path().to_path_buf()]);
+        for id in JETBRAINS_IDE_IDS {
+            let app = detected
+                .iter()
+                .find(|app| app.id == *id)
+                .unwrap_or_else(|| panic!("{id} should be detected from the embedded defaults"));
+            assert_eq!(app.category, AppCategory::Ide);
+            assert_eq!(
+                app.detected_path,
+                tmp.path()
+                    .join(default_bin_name_for_app(id))
+                    .to_string_lossy()
+                    .to_string()
+            );
+        }
+    }
+
+    fn default_bin_name_for_app(id: &str) -> &str {
+        if id == "intellij" { "idea" } else { id }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn jetbrains_toolbox_script_dirs_include_macos_toolbox_location() {
+        let home = Path::new("/Users/example");
+        assert_eq!(
+            jetbrains_toolbox_script_dirs(home),
+            vec![
+                PathBuf::from("/Users/example")
+                    .join("Library")
+                    .join("Application Support")
+                    .join("JetBrains")
+                    .join("Toolbox")
+                    .join("scripts")
+            ],
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn jetbrains_toolbox_script_dirs_include_linux_toolbox_location() {
+        let home = Path::new("/home/example");
+        assert_eq!(
+            jetbrains_toolbox_script_dirs(home),
+            vec![
+                PathBuf::from("/home/example")
+                    .join(".local")
+                    .join("share")
+                    .join("JetBrains")
+                    .join("Toolbox")
+                    .join("scripts")
+            ],
         );
     }
 

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -220,29 +220,33 @@ fn load_apps_config() -> AppsConfig {
 const EXTRA_PATH_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin", "/usr/local/sbin"];
 
 #[cfg(target_os = "macos")]
-fn jetbrains_toolbox_script_dirs(home: &Path) -> Vec<PathBuf> {
-    vec![
+fn jetbrains_toolbox_script_dirs(home: Option<&Path>) -> Vec<PathBuf> {
+    home.map(|home| {
         home.join("Library")
             .join("Application Support")
             .join("JetBrains")
             .join("Toolbox")
-            .join("scripts"),
-    ]
+            .join("scripts")
+    })
+    .into_iter()
+    .collect()
 }
 
 #[cfg(target_os = "linux")]
-fn jetbrains_toolbox_script_dirs(home: &Path) -> Vec<PathBuf> {
-    vec![
+fn jetbrains_toolbox_script_dirs(home: Option<&Path>) -> Vec<PathBuf> {
+    home.map(|home| {
         home.join(".local")
             .join("share")
             .join("JetBrains")
             .join("Toolbox")
-            .join("scripts"),
-    ]
+            .join("scripts")
+    })
+    .into_iter()
+    .collect()
 }
 
 #[cfg(windows)]
-fn jetbrains_toolbox_script_dirs(_home: &Path) -> Vec<PathBuf> {
+fn jetbrains_toolbox_script_dirs(_home: Option<&Path>) -> Vec<PathBuf> {
     dirs::data_local_dir()
         .map(|dir| dir.join("JetBrains").join("Toolbox").join("scripts"))
         .into_iter()
@@ -250,7 +254,7 @@ fn jetbrains_toolbox_script_dirs(_home: &Path) -> Vec<PathBuf> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
-fn jetbrains_toolbox_script_dirs(_home: &Path) -> Vec<PathBuf> {
+fn jetbrains_toolbox_script_dirs(_home: Option<&Path>) -> Vec<PathBuf> {
     Vec::new()
 }
 
@@ -261,10 +265,11 @@ fn build_path_dirs() -> Vec<PathBuf> {
     for dir in EXTRA_PATH_DIRS {
         dirs.push(PathBuf::from(dir));
     }
-    if let Some(home) = dirs::home_dir() {
+    let home_dir = dirs::home_dir();
+    if let Some(home) = home_dir.as_ref() {
         dirs.push(home.join(".local/bin"));
-        dirs.extend(jetbrains_toolbox_script_dirs(&home));
     }
+    dirs.extend(jetbrains_toolbox_script_dirs(home_dir.as_deref()));
 
     if let Some(path_var) = std::env::var_os("PATH") {
         for dir in std::env::split_paths(&path_var) {
@@ -1868,9 +1873,11 @@ mod tests {
 
     const JETBRAINS_IDE_IDS: &[&str] = &[
         "intellij",
+        "aqua",
         "clion",
         "datagrip",
         "dataspell",
+        "fleet",
         "goland",
         "phpstorm",
         "pycharm",
@@ -1878,7 +1885,36 @@ mod tests {
         "rubymine",
         "rustrover",
         "webstorm",
+        "writerside",
     ];
+
+    #[test]
+    fn embedded_jetbrains_entries_have_cross_platform_detection_metadata() {
+        let config: AppsConfig =
+            serde_json::from_str(DEFAULT_APPS_JSON).expect("default-apps.json must parse");
+
+        for id in JETBRAINS_IDE_IDS {
+            let entry = config
+                .apps
+                .iter()
+                .find(|app| app.id == *id)
+                .unwrap_or_else(|| panic!("missing JetBrains IDE default entry for {id}"));
+            assert_eq!(entry.category, AppCategory::Ide);
+            assert!(
+                !entry.bin_names.is_empty(),
+                "{id} needs Unix/Linux launcher names"
+            );
+            assert!(
+                !entry.mac_app_names.is_empty(),
+                "{id} needs macOS app bundle names"
+            );
+            assert!(
+                !entry.windows_exe_names.is_empty(),
+                "{id} needs Windows exe names"
+            );
+            assert_eq!(entry.open_args, vec!["{}".to_string()]);
+        }
+    }
 
     #[test]
     fn detect_finds_jetbrains_ides_from_default_config_when_launchers_are_on_path() {
@@ -1922,7 +1958,7 @@ mod tests {
     fn jetbrains_toolbox_script_dirs_include_macos_toolbox_location() {
         let home = Path::new("/Users/example");
         assert_eq!(
-            jetbrains_toolbox_script_dirs(home),
+            jetbrains_toolbox_script_dirs(Some(home)),
             vec![
                 PathBuf::from("/Users/example")
                     .join("Library")
@@ -1939,7 +1975,7 @@ mod tests {
     fn jetbrains_toolbox_script_dirs_include_linux_toolbox_location() {
         let home = Path::new("/home/example");
         assert_eq!(
-            jetbrains_toolbox_script_dirs(home),
+            jetbrains_toolbox_script_dirs(Some(home)),
             vec![
                 PathBuf::from("/home/example")
                     .join(".local")
@@ -1949,6 +1985,20 @@ mod tests {
                     .join("scripts")
             ],
         );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn jetbrains_toolbox_script_dirs_include_windows_toolbox_location_without_home() {
+        let dirs = jetbrains_toolbox_script_dirs(None);
+        if let Some(local_data) = dirs::data_local_dir() {
+            assert_eq!(
+                dirs,
+                vec![local_data.join("JetBrains").join("Toolbox").join("scripts")],
+            );
+        } else {
+            assert!(dirs.is_empty());
+        }
     }
 
     /// End-to-end Windows-only regression test for icon extraction.


### PR DESCRIPTION
## Summary
- add default Open In entries for JetBrains IDEs beyond IntelliJ, including WebStorm, PyCharm, PhpStorm, DataGrip, GoLand, CLion, Rider, RubyMine, RustRover, and DataSpell
- scan JetBrains Toolbox launcher script directories on macOS, Linux, and Windows when detecting app binaries
- document JetBrains IDE detection in the workspace opener docs

Closes #780

## Validation
- installed WebStorm via Homebrew cask
- reproduced pre-fix dev app detection: WebStorm was not returned by `detect_installed_apps`
- verified post-fix via `/claudette-debug`: installed JetBrains launchers are detected, including Toolbox paths for IntelliJ/PyCharm/RubyMine and WebStorm
- `nix develop -c jq empty src-tauri/default-apps.json`
- `nix develop -c cargo fmt --all --check`
- `nix develop -c cargo test -p claudette-tauri commands::apps::tests`

## Notes
- `nix develop -c cargo clippy -p claudette-tauri --all-targets --all-features -- -D warnings` was attempted, but the Tauri crate currently fails on pre-existing clippy warnings outside this change (`boot_probation.rs`, `commands/diff.rs`, `commands/env.rs`, and older `commands/apps.rs` lints).
