### PR TITLE
feat(chat): collapse setup-script output in the transcript

### DIFF
--- a/site/src/content/docs/features/parallel-agents.mdx
+++ b/site/src/content/docs/features/parallel-agents.mdx
@@ -89,6 +89,8 @@ A workspace can run a script when it's created and another when it's archived. U
 
 Configure them per repository in **Settings > Repository > Setup scripts** / **Archive scripts**. See [Per-Repo Settings](/claudette/features/per-repo-settings/) for the full schema.
 
+When a setup script finishes, its output lands in the new workspace's chat transcript as a collapsed entry — click it to expand the full log (handy when a script prints thousands of lines, like `bun install`). A run that fails or times out is highlighted in the transcript, expanded automatically, and raises a toast so you don't miss it scrolling past.
+
 ## Fanning Out from the CLI
 
 The flagship use case for the [`claudette` CLI](/claudette/features/cli-client/): a phase-of-work plan that creates N workspaces and dispatches a prompt to each.

--- a/site/src/content/docs/features/parallel-agents.mdx
+++ b/site/src/content/docs/features/parallel-agents.mdx
@@ -89,7 +89,7 @@ A workspace can run a script when it's created and another when it's archived. U
 
 Configure them per repository in **Settings > Repository > Setup scripts** / **Archive scripts**. See [Per-Repo Settings](/claudette/features/per-repo-settings/) for the full schema.
 
-While a setup script runs, the new workspace's chat transcript shows a "running" entry with a spinner and an elapsed-seconds counter (a `bun install` can take 10-20s). When it finishes, that entry becomes the result: a collapsed chip you can click to expand the full log. A run that fails or times out is highlighted, expanded automatically, and raises a toast so you don't miss it scrolling past.
+While a setup script runs, the new workspace's chat transcript shows a "running" entry with a spinner and an elapsed-seconds counter (a `bun install` can take 10-20s). When it finishes, the result appears as a collapsed chip you can click to expand the full log. A run that fails or times out is highlighted, expanded automatically, and raises a toast so you don't miss it scrolling past.
 
 ## Fanning Out from the CLI
 

--- a/site/src/content/docs/features/parallel-agents.mdx
+++ b/site/src/content/docs/features/parallel-agents.mdx
@@ -89,7 +89,7 @@ A workspace can run a script when it's created and another when it's archived. U
 
 Configure them per repository in **Settings > Repository > Setup scripts** / **Archive scripts**. See [Per-Repo Settings](/claudette/features/per-repo-settings/) for the full schema.
 
-When a setup script finishes, its output lands in the new workspace's chat transcript as a collapsed entry — click it to expand the full log (handy when a script prints thousands of lines, like `bun install`). A run that fails or times out is highlighted in the transcript, expanded automatically, and raises a toast so you don't miss it scrolling past.
+While a setup script runs, the new workspace's chat transcript shows a "running" entry with a spinner and an elapsed-seconds counter (a `bun install` can take 10-20s). When it finishes, that entry becomes the result: a collapsed chip you can click to expand the full log. A run that fails or times out is highlighted, expanded automatically, and raises a toast so you don't miss it scrolling past.
 
 ## Fanning Out from the CLI
 

--- a/src/ui/src/components/chat/ChatPanel.tsx
+++ b/src/ui/src/components/chat/ChatPanel.tsx
@@ -79,6 +79,7 @@ import { StreamingMessage } from "./StreamingMessage";
 import { MessagesWithTurns } from "./MessagesWithTurns";
 import { ChatAuthFailureCallout } from "../auth/ChatAuthFailureCallout";
 import { CliInvocationBanner } from "./CliInvocationBanner";
+import { SetupScriptBanner } from "./SetupScriptBanner";
 import { CurrentTurnTaskProgress } from "./CurrentTurnTaskProgress";
 import { ChatInputArea } from "./ChatInputArea";
 import { EMPTY_ACTIVITIES } from "./chatConstants";
@@ -102,6 +103,9 @@ export function ChatPanel() {
   const repositories = useAppStore((s) => s.repositories);
   const chatMessages = useAppStore((s) => s.chatMessages);
   const setChatMessages = useAppStore((s) => s.setChatMessages);
+  const runningSetupScriptSource = useAppStore((s) =>
+    activeSessionId ? s.runningSetupScripts[activeSessionId] : undefined,
+  );
   const hydrateCompletedTurns = useAppStore((s) => s.hydrateCompletedTurns);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
   const enqueueTerminalCommand = useAppStore((s) => s.enqueueTerminalCommand);
@@ -1410,7 +1414,7 @@ export function ChatPanel() {
             invocation={cliInvocation}
             sessionId={activeChatSessionRecord?.id}
           />
-          {messages.length === 0 && !hasStreaming ? (
+          {messages.length === 0 && !hasStreaming && !runningSetupScriptSource ? (
             <div className={styles.empty}>
               Send a message to start a conversation
             </div>
@@ -1466,6 +1470,17 @@ export function ChatPanel() {
                   autoStartKey={chatAuthLoginRequestId}
                   autoStartedKey={chatAuthLoginStartedRequestId}
                   onAutoStarted={setChatAuthLoginStartedRequestId}
+                />
+              )}
+
+              {runningSetupScriptSource && activeSessionId && (
+                <SetupScriptBanner
+                  outcome={{
+                    source: runningSetupScriptSource,
+                    status: "running",
+                    output: "",
+                  }}
+                  messageId={`setup-running:${activeSessionId}`}
                 />
               )}
 

--- a/src/ui/src/components/chat/MessagesWithTurns.tsx
+++ b/src/ui/src/components/chat/MessagesWithTurns.tsx
@@ -13,6 +13,7 @@ import { ThinkingBlock } from "./ThinkingBlock";
 import { collapsedToolGroupKey } from "./collapsedToolGroupKey";
 import { CompactionDivider } from "./CompactionDivider";
 import { SyntheticContinuationMessage } from "./SyntheticContinuationMessage";
+import { SetupScriptBanner } from "./SetupScriptBanner";
 import { MessageAttachment, isTextDataMediaType } from "./MessageAttachment";
 import {
   type DownloadableAttachment,
@@ -32,6 +33,7 @@ import {
   parseCompactionSentinel,
   parseSyntheticSummarySentinel,
 } from "../../utils/compactionSentinel";
+import { parseSetupScriptMessage } from "../../utils/setupScriptMessage";
 import { renderUltrathinkText } from "./ultrathink";
 import {
   processActivities,
@@ -767,6 +769,16 @@ export const MessagesWithTurns = memo(function MessagesWithTurns({
                 {renderTurns(globalOffset + idx)}
                 {renderLiveToolActivity(globalOffset + idx)}
                 <SyntheticContinuationMessage body={syntheticBody} />
+              </React.Fragment>
+            );
+          }
+          const setupOutcome = parseSetupScriptMessage(msg.content);
+          if (setupOutcome) {
+            return (
+              <React.Fragment key={msg.id}>
+                {renderTurns(globalOffset + idx)}
+                {renderLiveToolActivity(globalOffset + idx)}
+                <SetupScriptBanner outcome={setupOutcome} messageId={msg.id} />
               </React.Fragment>
             );
           }

--- a/src/ui/src/components/chat/SetupScriptBanner.module.css
+++ b/src/ui/src/components/chat/SetupScriptBanner.module.css
@@ -1,0 +1,184 @@
+/* Setup-script output chip in the chat transcript. Mirrors
+   CliInvocationBanner: a collapsed pill that expands on click. A failed or
+   timed-out run carries a danger treatment (`.failed`) so it's still
+   noticeable even when collapsed. */
+
+.banner {
+  margin: 6px 0 14px 0;
+  border: 1px solid var(--divider);
+  background: var(--sidebar-bg);
+  border-radius: var(--radius-lg);
+  font-size: var(--fs-sm);
+  /* Sits inside `.messages` (a flex-column scroll container) — without an
+     explicit floor it could be squeezed to its border under sibling
+     pressure. Always reserve space for the content. */
+  flex-shrink: 0;
+  overflow: hidden;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease;
+}
+
+.banner:hover {
+  border-color: rgba(var(--accent-primary-rgb), 0.35);
+}
+
+.expanded {
+  border-color: rgba(var(--accent-primary-rgb), 0.35);
+  background: var(--chat-input-bg);
+}
+
+/* Danger treatment for failed / timed-out runs — kept on the collapsed chip
+   too so the failure draws the eye even after the user collapses it. */
+.failed {
+  border-color: var(--error-border);
+  background: var(--error-bg);
+}
+
+.failed:hover {
+  border-color: var(--error-border);
+  background: var(--error-hover);
+}
+
+.failed.expanded {
+  border-color: var(--error-border);
+  background: var(--error-hover);
+}
+
+/* ── Header (always visible — collapsed pill) ── */
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-height: 32px;
+  padding: 4px 6px 4px 4px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  padding: 4px 6px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: var(--fs-sm);
+  text-align: left;
+  border-radius: var(--radius-md);
+}
+
+.toggle:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
+}
+
+/* Same row layout as `.toggle` for the no-output case where there's nothing
+   to expand — keeps the chip's height and alignment identical. */
+.staticHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  padding: 4px 6px 4px 26px;
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  transition: transform 140ms ease;
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+  color: var(--accent-primary);
+}
+
+.statusIcon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.failed .statusIcon {
+  color: var(--status-stopped);
+}
+
+.summary {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  /* Wrap rather than ellipsize — the summary is the only thing visible while
+     collapsed; truncating it hid the status when the panel narrowed. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.failed .summary {
+  color: var(--status-stopped);
+}
+
+.copyButton {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.copyButton:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+/* ── Expanded body ── */
+
+.body {
+  padding: 4px 12px 12px 30px;
+  border-top: 1px dashed var(--divider);
+  /* Match CliInvocationBanner — fade the expanded content in rather than a
+     hard pop. */
+  animation: setupBannerReveal 140ms ease-out;
+}
+
+.failed .body {
+  border-top-color: var(--error-border);
+}
+
+@keyframes setupBannerReveal {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.output {
+  margin: 8px 0 0;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  /* Long install logs shouldn't push the transcript around — cap the height
+     and let the block scroll. */
+  max-height: 40vh;
+  overflow-y: auto;
+}

--- a/src/ui/src/components/chat/SetupScriptBanner.module.css
+++ b/src/ui/src/components/chat/SetupScriptBanner.module.css
@@ -28,6 +28,12 @@
   background: var(--chat-input-bg);
 }
 
+/* In-flight: a quiet accent border so the chip reads as "working", paired
+   with the spinning icon below. */
+.running {
+  border-color: rgba(var(--accent-primary-rgb), 0.35);
+}
+
 /* Danger treatment for failed / timed-out runs — kept on the collapsed chip
    too so the failure draws the eye even after the user collapses it. */
 .failed {
@@ -107,6 +113,31 @@
 
 .failed .statusIcon {
   color: var(--status-stopped);
+}
+
+/* Spinning loader icon for the in-flight state. */
+.spinner {
+  animation: setupBannerSpin 0.8s linear infinite;
+}
+
+@keyframes setupBannerSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+
+/* Elapsed-seconds counter shown next to the "running" label. */
+.elapsed {
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .summary {

--- a/src/ui/src/components/chat/SetupScriptBanner.test.tsx
+++ b/src/ui/src/components/chat/SetupScriptBanner.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// CopyButton pulls in clipboard plumbing we don't need here — stub it to a
+// plain marker so the banner's own structure is what we assert against.
+vi.mock("../shared/CopyButton", () => ({
+  CopyButton: () => <button data-testid="copy-button">copy</button>,
+}));
+
+import { SetupScriptBanner } from "./SetupScriptBanner";
+import type { SetupScriptOutcome } from "../../utils/setupScriptMessage";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(
+  outcome: SetupScriptOutcome,
+  messageId = "msg-1",
+): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(<SetupScriptBanner outcome={outcome} messageId={messageId} />);
+  });
+  return container;
+}
+
+function banner(container: HTMLElement): HTMLElement {
+  return container.querySelector("[data-testid='setup-script-banner']") as HTMLElement;
+}
+
+describe("SetupScriptBanner", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      mountedRoots.forEach((r) => r.unmount());
+    });
+    mountedContainers.forEach((c) => c.remove());
+    mountedRoots.length = 0;
+    mountedContainers.length = 0;
+  });
+
+  it("renders a completed run collapsed (no output body, no toggle button)", async () => {
+    const container = await render({
+      source: "settings",
+      status: "completed",
+      output: "Resolved 1657 packages\ndone",
+    });
+    expect(banner(container).dataset.status).toBe("completed");
+    // No <pre> shown while collapsed.
+    expect(container.querySelector("pre")).toBeNull();
+    // The toggle button exists (there is output to reveal) but the body is hidden.
+    const toggle = container.querySelector("button[aria-expanded]") as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("auto-expands a failed run and surfaces the output", async () => {
+    const container = await render({
+      source: "settings",
+      status: "failed",
+      output: "npm ERR! something broke",
+    });
+    const b = banner(container);
+    expect(b.dataset.status).toBe("failed");
+    // Danger class is applied so the chip stays noticeable.
+    expect(b.className).toMatch(/failed/);
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toBe("npm ERR! something broke");
+    const toggle = container.querySelector("button[aria-expanded]") as HTMLButtonElement;
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("toggling persists the choice to sessionStorage", async () => {
+    const container = await render(
+      { source: "settings", status: "completed", output: "lots of logs" },
+      "msg-toggle",
+    );
+    const toggle = container.querySelector("button[aria-expanded]") as HTMLButtonElement;
+    await act(async () => {
+      toggle.click();
+    });
+    expect(container.querySelector("pre")?.textContent).toBe("lots of logs");
+    expect(sessionStorage.getItem("claudette.setupScriptBanner.expanded:msg-toggle")).toBe("1");
+    await act(async () => {
+      (container.querySelector("button[aria-expanded]") as HTMLButtonElement).click();
+    });
+    expect(container.querySelector("pre")).toBeNull();
+    expect(sessionStorage.getItem("claudette.setupScriptBanner.expanded:msg-toggle")).toBe("0");
+  });
+
+  it("a stored collapse choice overrides the failure default", async () => {
+    sessionStorage.setItem("claudette.setupScriptBanner.expanded:msg-stored", "0");
+    const container = await render(
+      { source: "settings", status: "failed", output: "broke" },
+      "msg-stored",
+    );
+    const toggle = container.querySelector("button[aria-expanded]") as HTMLButtonElement;
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("renders a static chip with no toggle or copy button when output is empty", async () => {
+    const container = await render({ source: "settings", status: "completed", output: "" });
+    expect(container.querySelector("button[aria-expanded]")).toBeNull();
+    expect(container.querySelector("[data-testid='copy-button']")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+    // The summary is still present.
+    expect(container.textContent).toContain("setup_script_label");
+  });
+
+  it("shows a copy button only when there is output", async () => {
+    const withOutput = await render(
+      { source: "settings", status: "completed", output: "x" },
+      "msg-copy-1",
+    );
+    expect(withOutput.querySelector("[data-testid='copy-button']")).not.toBeNull();
+  });
+});

--- a/src/ui/src/components/chat/SetupScriptBanner.test.tsx
+++ b/src/ui/src/components/chat/SetupScriptBanner.test.tsx
@@ -56,6 +56,22 @@ describe("SetupScriptBanner", () => {
     mountedContainers.length = 0;
   });
 
+  it("renders the running placeholder with a spinner and no toggle/copy/output", async () => {
+    const container = await render({ source: "settings", status: "running", output: "" });
+    const b = banner(container);
+    expect(b.dataset.status).toBe("running");
+    // Not a failure — no danger class while running.
+    expect(b.className).not.toMatch(/failed/);
+    expect(b.className).toMatch(/running/);
+    // Nothing to expand or copy yet.
+    expect(container.querySelector("button[aria-expanded]")).toBeNull();
+    expect(container.querySelector("[data-testid='copy-button']")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+    // Spinner icon is present (lucide renders an <svg>); the running label too.
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.textContent).toContain("setup_script_status_running");
+  });
+
   it("renders a completed run collapsed (no output body, no toggle button)", async () => {
     const container = await render({
       source: "settings",

--- a/src/ui/src/components/chat/SetupScriptBanner.test.tsx
+++ b/src/ui/src/components/chat/SetupScriptBanner.test.tsx
@@ -72,7 +72,7 @@ describe("SetupScriptBanner", () => {
     expect(container.textContent).toContain("setup_script_status_running");
   });
 
-  it("renders a completed run collapsed (no output body, no toggle button)", async () => {
+  it("renders a completed run collapsed — toggle present, output body hidden", async () => {
     const container = await render({
       source: "settings",
       status: "completed",

--- a/src/ui/src/components/chat/SetupScriptBanner.tsx
+++ b/src/ui/src/components/chat/SetupScriptBanner.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { AlertTriangle, ChevronRight, Wrench } from "lucide-react";
+import { AlertTriangle, ChevronRight, Loader2, Wrench } from "lucide-react";
 import { CopyButton } from "../shared/CopyButton";
 import type { SetupScriptOutcome } from "../../utils/setupScriptMessage";
 import styles from "./SetupScriptBanner.module.css";
@@ -18,19 +18,27 @@ interface Props {
 /**
  * A repo setup script's stdout/stderr, rendered as a compact one-line chip in
  * the transcript instead of a screenful of install logs — same affordance as
- * `CliInvocationBanner` for the `claude` invocation. Collapsed by default for
- * a successful run; a failed or timed-out run gets a danger treatment and
- * starts expanded so it isn't missed. Clicking the header toggles the full
- * output. When the run produced no output there's nothing to expand, so the
- * chip renders without a toggle.
+ * `CliInvocationBanner` for the `claude` invocation.
+ *
+ * - **running** — a spinner + elapsed seconds while the script executes (a
+ *   `bun install` can take 10-20s; the chip is the reassurance it's working).
+ * - **completed** — collapsed by default; click to expand the full output.
+ * - **failed / timed out** — danger treatment, expanded by default so it isn't
+ *   missed.
+ *
+ * When the run produced no output there's nothing to expand, so the chip
+ * renders without a toggle.
  */
 export function SetupScriptBanner({ outcome, messageId }: Props) {
   const { t } = useTranslation("chat");
 
-  const isFailure = outcome.status !== "completed";
+  const isRunning = outcome.status === "running";
+  const isFailure = outcome.status === "failed" || outcome.status === "timed-out";
   const hasOutput = outcome.output.trim().length > 0;
   const storageKey = `claudette.setupScriptBanner.expanded:${messageId}`;
   const bodyId = `${storageKey}-body`;
+
+  const elapsedSeconds = useElapsedSeconds(isRunning);
 
   const [expanded, setExpanded] = useState<boolean>(() =>
     readExpanded(storageKey, isFailure),
@@ -39,7 +47,8 @@ export function SetupScriptBanner({ outcome, messageId }: Props) {
   // `useState`'s lazy initializer only runs on first mount. The parent keys
   // each banner by `msg.id`, so `messageId` is effectively stable — but mirror
   // `CliInvocationBanner`'s resync so a remount with a different message (or a
-  // status flip) re-derives the default rather than sticking to the old value.
+  // status flip, e.g. running → failed) re-derives the default rather than
+  // sticking to the old value.
   useEffect(() => {
     setExpanded(readExpanded(storageKey, isFailure));
   }, [storageKey, isFailure]);
@@ -56,8 +65,9 @@ export function SetupScriptBanner({ outcome, messageId }: Props) {
     });
   }, [storageKey]);
 
-  const statusLabel =
-    outcome.status === "failed"
+  const statusLabel = isRunning
+    ? t("setup_script_status_running")
+    : outcome.status === "failed"
       ? t("setup_script_status_failed")
       : outcome.status === "timed-out"
         ? t("setup_script_status_timed_out")
@@ -73,11 +83,17 @@ export function SetupScriptBanner({ outcome, messageId }: Props) {
     [hasOutput, outcome.output],
   );
 
-  const Icon = isFailure ? AlertTriangle : Wrench;
+  const Icon = isRunning ? Loader2 : isFailure ? AlertTriangle : Wrench;
+  const iconClass = isRunning
+    ? `${styles.statusIcon} ${styles.spinner}`
+    : styles.statusIcon;
+  // `hasOutput` is always false while running (no output yet), so the running
+  // chip naturally takes the static-header / no-toggle / no-copy path.
+  const canExpand = hasOutput;
 
   return (
     <div
-      className={`${styles.banner} ${expanded ? styles.expanded : ""} ${isFailure ? styles.failed : ""}`}
+      className={`${styles.banner} ${expanded ? styles.expanded : ""} ${isRunning ? styles.running : ""} ${isFailure ? styles.failed : ""}`}
       data-testid="setup-script-banner"
       data-status={outcome.status}
     >
@@ -85,7 +101,7 @@ export function SetupScriptBanner({ outcome, messageId }: Props) {
           CliInvocationBanner — nesting the copy button inside the toggle
           would be invalid HTML and break keyboard/screen-reader behavior. */}
       <div className={styles.header}>
-        {hasOutput ? (
+        {canExpand ? (
           <button
             type="button"
             className={styles.toggle}
@@ -99,16 +115,19 @@ export function SetupScriptBanner({ outcome, messageId }: Props) {
               className={`${styles.chevron} ${expanded ? styles.chevronOpen : ""}`}
               aria-hidden
             />
-            <Icon size={13} className={styles.statusIcon} aria-hidden />
+            <Icon size={13} className={iconClass} aria-hidden />
             <span className={styles.summary}>{summary}</span>
           </button>
         ) : (
           <div className={styles.staticHeader}>
-            <Icon size={13} className={styles.statusIcon} aria-hidden />
+            <Icon size={13} className={iconClass} aria-hidden />
             <span className={styles.summary}>{summary}</span>
+            {isRunning && elapsedSeconds > 0 && (
+              <span className={styles.elapsed}>· {elapsedSeconds}s</span>
+            )}
           </div>
         )}
-        {hasOutput && (
+        {canExpand && (
           <CopyButton
             variant="bare"
             className={styles.copyButton}
@@ -123,7 +142,7 @@ export function SetupScriptBanner({ outcome, messageId }: Props) {
         )}
       </div>
 
-      {hasOutput && expanded && (
+      {canExpand && expanded && (
         <div id={bodyId} className={styles.body}>
           <pre className={styles.output}>{outcome.output}</pre>
         </div>
@@ -143,4 +162,29 @@ function readExpanded(key: string, defaultExpanded: boolean): boolean {
     /* ignore */
   }
   return defaultExpanded;
+}
+
+/** Whole seconds since the banner started showing the `running` state. We can
+ *  only date it from when the placeholder message mounted (the run started a
+ *  beat earlier), which is close enough for a reassurance counter. Resets and
+ *  stops once `active` goes false. */
+function useElapsedSeconds(active: boolean): number {
+  const [seconds, setSeconds] = useState(0);
+  const startRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!active) {
+      startRef.current = null;
+      setSeconds(0);
+      return;
+    }
+    startRef.current = Date.now();
+    setSeconds(0);
+    const id = window.setInterval(() => {
+      if (startRef.current != null) {
+        setSeconds(Math.floor((Date.now() - startRef.current) / 1000));
+      }
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+  return seconds;
 }

--- a/src/ui/src/components/chat/SetupScriptBanner.tsx
+++ b/src/ui/src/components/chat/SetupScriptBanner.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle, ChevronRight, Wrench } from "lucide-react";
+import { CopyButton } from "../shared/CopyButton";
+import type { SetupScriptOutcome } from "../../utils/setupScriptMessage";
+import styles from "./SetupScriptBanner.module.css";
+
+interface Props {
+  outcome: SetupScriptOutcome;
+  /**
+   * Id of the `System` message this banner renders in place of. Scopes the
+   * expand/collapse memory so two setup runs in the same chat session keep
+   * independent state, and so the choice survives a refresh.
+   */
+  messageId: string;
+}
+
+/**
+ * A repo setup script's stdout/stderr, rendered as a compact one-line chip in
+ * the transcript instead of a screenful of install logs — same affordance as
+ * `CliInvocationBanner` for the `claude` invocation. Collapsed by default for
+ * a successful run; a failed or timed-out run gets a danger treatment and
+ * starts expanded so it isn't missed. Clicking the header toggles the full
+ * output. When the run produced no output there's nothing to expand, so the
+ * chip renders without a toggle.
+ */
+export function SetupScriptBanner({ outcome, messageId }: Props) {
+  const { t } = useTranslation("chat");
+
+  const isFailure = outcome.status !== "completed";
+  const hasOutput = outcome.output.trim().length > 0;
+  const storageKey = `claudette.setupScriptBanner.expanded:${messageId}`;
+  const bodyId = `${storageKey}-body`;
+
+  const [expanded, setExpanded] = useState<boolean>(() =>
+    readExpanded(storageKey, isFailure),
+  );
+
+  // `useState`'s lazy initializer only runs on first mount. The parent keys
+  // each banner by `msg.id`, so `messageId` is effectively stable — but mirror
+  // `CliInvocationBanner`'s resync so a remount with a different message (or a
+  // status flip) re-derives the default rather than sticking to the old value.
+  useEffect(() => {
+    setExpanded(readExpanded(storageKey, isFailure));
+  }, [storageKey, isFailure]);
+
+  const handleToggle = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev;
+      try {
+        sessionStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        /* ignore quota / privacy errors */
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  const statusLabel =
+    outcome.status === "failed"
+      ? t("setup_script_status_failed")
+      : outcome.status === "timed-out"
+        ? t("setup_script_status_timed_out")
+        : t("setup_script_status_completed");
+
+  const summary = useMemo(() => {
+    const src = outcome.source ? ` (${outcome.source})` : "";
+    return `${t("setup_script_label")}${src} · ${statusLabel}`;
+  }, [outcome.source, statusLabel, t]);
+
+  const copySource = useCallback(
+    () => (hasOutput ? outcome.output : null),
+    [hasOutput, outcome.output],
+  );
+
+  const Icon = isFailure ? AlertTriangle : Wrench;
+
+  return (
+    <div
+      className={`${styles.banner} ${expanded ? styles.expanded : ""} ${isFailure ? styles.failed : ""}`}
+      data-testid="setup-script-banner"
+      data-status={outcome.status}
+    >
+      {/* Same non-interactive-container-with-sibling-buttons shape as
+          CliInvocationBanner — nesting the copy button inside the toggle
+          would be invalid HTML and break keyboard/screen-reader behavior. */}
+      <div className={styles.header}>
+        {hasOutput ? (
+          <button
+            type="button"
+            className={styles.toggle}
+            onClick={handleToggle}
+            aria-expanded={expanded}
+            aria-controls={bodyId}
+            title={expanded ? t("setup_script_collapse") : t("setup_script_expand")}
+          >
+            <ChevronRight
+              size={14}
+              className={`${styles.chevron} ${expanded ? styles.chevronOpen : ""}`}
+              aria-hidden
+            />
+            <Icon size={13} className={styles.statusIcon} aria-hidden />
+            <span className={styles.summary}>{summary}</span>
+          </button>
+        ) : (
+          <div className={styles.staticHeader}>
+            <Icon size={13} className={styles.statusIcon} aria-hidden />
+            <span className={styles.summary}>{summary}</span>
+          </div>
+        )}
+        {hasOutput && (
+          <CopyButton
+            variant="bare"
+            className={styles.copyButton}
+            source={copySource}
+            tooltip={{
+              copy: t("setup_script_copy"),
+              copied: t("setup_script_copied"),
+            }}
+            ariaLabel={t("setup_script_copy")}
+            stopPropagation
+          />
+        )}
+      </div>
+
+      {hasOutput && expanded && (
+        <div id={bodyId} className={styles.body}>
+          <pre className={styles.output}>{outcome.output}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Read the persisted expand choice, falling back to `defaultExpanded` (true
+ *  for failed/timed-out runs) when nothing's been stored yet. */
+function readExpanded(key: string, defaultExpanded: boolean): boolean {
+  try {
+    const stored = sessionStorage.getItem(key);
+    if (stored === "1") return true;
+    if (stored === "0") return false;
+  } catch {
+    /* ignore */
+  }
+  return defaultExpanded;
+}

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -15,10 +15,7 @@ import {
 } from "../../services/tauri";
 import { applySelectedModel } from "../chat/applySelectedModel";
 import { buildModelRegistry } from "../chat/modelRegistry";
-import {
-  recordSetupScriptError,
-  recordSetupScriptResult,
-} from "../../utils/setupScriptMessage";
+import { runAndRecordSetupScript } from "../../utils/setupScriptMessage";
 import type { ThemeDefinition } from "../../types/theme";
 import { scoreCommand } from "./searchScore";
 import {
@@ -188,15 +185,18 @@ export function CommandPalette() {
         if (script) {
           if (repo?.setup_script_auto_run) {
             const wsId = result.workspace.id;
-            const recorderDeps = {
-              addChatMessage,
-              addToast,
-              workspaceName: result.workspace.name,
-            };
-            runWorkspaceSetup(wsId).then((sr) => {
-              if (sr) recordSetupScriptResult(sessionId, wsId, sr, recorderDeps);
-            }).catch((err) => {
-              recordSetupScriptError(sessionId, wsId, err, recorderDeps);
+            runAndRecordSetupScript({
+              sessionId,
+              workspaceId: wsId,
+              source,
+              run: () => runWorkspaceSetup(wsId),
+              deps: {
+                addChatMessage,
+                updateChatMessage: useAppStore.getState().updateChatMessage,
+                removeChatMessage: useAppStore.getState().removeChatMessage,
+                addToast,
+                workspaceName: result.workspace.name,
+              },
             });
           } else {
             openModal("confirmSetupScript", {

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -15,6 +15,10 @@ import {
 } from "../../services/tauri";
 import { applySelectedModel } from "../chat/applySelectedModel";
 import { buildModelRegistry } from "../chat/modelRegistry";
+import {
+  recordSetupScriptError,
+  recordSetupScriptResult,
+} from "../../utils/setupScriptMessage";
 import type { ThemeDefinition } from "../../types/theme";
 import { scoreCommand } from "./searchScore";
 import {
@@ -57,6 +61,7 @@ export function CommandPalette() {
   const addWorkspace = useAppStore((s) => s.addWorkspace);
   const selectWorkspace = useAppStore((s) => s.selectWorkspace);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
+  const addToast = useAppStore((s) => s.addToast);
   const updateWorkspace = useAppStore((s) => s.updateWorkspace);
   const currentThemeId = useAppStore((s) => s.currentThemeId);
   const setCurrentThemeId = useAppStore((s) => s.setCurrentThemeId);
@@ -183,34 +188,15 @@ export function CommandPalette() {
         if (script) {
           if (repo?.setup_script_auto_run) {
             const wsId = result.workspace.id;
+            const recorderDeps = {
+              addChatMessage,
+              addToast,
+              workspaceName: result.workspace.name,
+            };
             runWorkspaceSetup(wsId).then((sr) => {
-              if (sr) {
-                const lbl = sr.source === "repo" ? ".claudette.json" : "settings";
-                const status = sr.success ? "completed" : sr.timed_out ? "timed out" : "failed";
-                addChatMessage(sessionId, {
-                  id: crypto.randomUUID(),
-                  workspace_id: wsId,
-                  chat_session_id: sessionId,
-                  role: "System",
-                  content: `Setup script (${lbl}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
-                  cost_usd: null, duration_ms: null,
-                  created_at: new Date().toISOString(),
-                  thinking: null,
-                  input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null,
-                });
-              }
+              if (sr) recordSetupScriptResult(sessionId, wsId, sr, recorderDeps);
             }).catch((err) => {
-              addChatMessage(sessionId, {
-                id: crypto.randomUUID(),
-                workspace_id: wsId,
-                chat_session_id: sessionId,
-                role: "System",
-                content: `Setup script failed: ${err}`,
-                cost_usd: null, duration_ms: null,
-                created_at: new Date().toISOString(),
-                thinking: null,
-                input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null,
-              });
+              recordSetupScriptError(sessionId, wsId, err, recorderDeps);
             });
           } else {
             openModal("confirmSetupScript", {
@@ -228,7 +214,7 @@ export function CommandPalette() {
     } catch (e) {
       console.error("Failed to create workspace:", e);
     }
-  }, [addWorkspace, selectWorkspace, addChatMessage, openModal]);
+  }, [addWorkspace, selectWorkspace, addChatMessage, addToast, openModal]);
 
   const enterThemeMode = useCallback(() => {
     setMode("theme");

--- a/src/ui/src/components/command-palette/CommandPalette.tsx
+++ b/src/ui/src/components/command-palette/CommandPalette.tsx
@@ -192,8 +192,7 @@ export function CommandPalette() {
               run: () => runWorkspaceSetup(wsId),
               deps: {
                 addChatMessage,
-                updateChatMessage: useAppStore.getState().updateChatMessage,
-                removeChatMessage: useAppStore.getState().removeChatMessage,
+                setRunningSetupScript: useAppStore.getState().setRunningSetupScript,
                 addToast,
                 workspaceName: result.workspace.name,
               },

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -2,6 +2,10 @@ import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { runWorkspaceSetup, setSetupScriptAutoRun } from "../../services/tauri";
+import {
+  recordSetupScriptError,
+  recordSetupScriptResult,
+} from "../../utils/setupScriptMessage";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
@@ -11,6 +15,7 @@ export function ConfirmSetupScriptModal() {
   const closeModal = useAppStore((s) => s.closeModal);
   const modalData = useAppStore((s) => s.modalData);
   const addChatMessage = useAppStore((s) => s.addChatMessage);
+  const addToast = useAppStore((s) => s.addToast);
   const updateRepository = useAppStore((s) => s.updateRepository);
   const [loading, setLoading] = useState(false);
   const [alwaysRun, setAlwaysRun] = useState(false);
@@ -23,6 +28,9 @@ export function ConfirmSetupScriptModal() {
 
   const handleRun = async () => {
     setLoading(true);
+    const workspaceName = useAppStore
+      .getState()
+      .workspaces.find((w) => w.id === workspaceId)?.name;
     try {
       if (alwaysRun && repoId) {
         await setSetupScriptAutoRun(repoId, true);
@@ -30,44 +38,18 @@ export function ConfirmSetupScriptModal() {
       }
       const sr = await runWorkspaceSetup(workspaceId);
       if (sr) {
-        const label = sr.source === "repo" ? ".claudette.json" : "settings";
-        const status = sr.success
-          ? "completed"
-          : sr.timed_out
-            ? "timed out"
-            : "failed";
-        addChatMessage(sessionId, {
-          id: crypto.randomUUID(),
-          workspace_id: workspaceId,
-          chat_session_id: sessionId,
-          role: "System",
-          content: `Setup script (${label}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
-          cost_usd: null,
-          duration_ms: null,
-          created_at: new Date().toISOString(),
-          thinking: null,
-          input_tokens: null,
-          output_tokens: null,
-          cache_read_tokens: null,
-          cache_creation_tokens: null,
+        recordSetupScriptResult(sessionId, workspaceId, sr, {
+          addChatMessage,
+          addToast,
+          workspaceName,
         });
       }
       closeModal();
     } catch (e) {
-      addChatMessage(sessionId, {
-        id: crypto.randomUUID(),
-        workspace_id: workspaceId,
-        chat_session_id: sessionId,
-        role: "System",
-        content: `Setup script failed: ${e}`,
-        cost_usd: null,
-        duration_ms: null,
-        created_at: new Date().toISOString(),
-        thinking: null,
-        input_tokens: null,
-        output_tokens: null,
-        cache_read_tokens: null,
-        cache_creation_tokens: null,
+      recordSetupScriptError(sessionId, workspaceId, e, {
+        addChatMessage,
+        addToast,
+        workspaceName,
       });
       closeModal();
     }

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -2,7 +2,10 @@ import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { runWorkspaceSetup, setSetupScriptAutoRun } from "../../services/tauri";
-import { runAndRecordSetupScript } from "../../utils/setupScriptMessage";
+import {
+  runAndRecordSetupScript,
+  type SetupScriptSource,
+} from "../../utils/setupScriptMessage";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
@@ -20,7 +23,7 @@ export function ConfirmSetupScriptModal() {
   const workspaceId = modalData.workspaceId as string;
   const sessionId = modalData.sessionId as string;
   const script = modalData.script as string;
-  const source = modalData.source as string;
+  const source = modalData.source as SetupScriptSource;
   const repoId = modalData.repoId as string;
 
   const handleRun = async () => {

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -36,9 +36,9 @@ export function ConfirmSetupScriptModal() {
         console.error("Failed to persist setup-script auto-run preference:", e);
       }
     }
-    // Fire-and-forget: the run posts a "running" placeholder to the transcript
-    // right away and swaps it for the result when it finishes, so there's no
-    // need to keep the modal open blocking on it.
+    // Fire-and-forget: the run flags the session as "setup running" (ChatPanel
+    // shows the spinner banner) and appends the result when it finishes, so
+    // there's no need to keep the modal open blocking on it.
     runAndRecordSetupScript({
       sessionId,
       workspaceId,
@@ -46,8 +46,7 @@ export function ConfirmSetupScriptModal() {
       run: () => runWorkspaceSetup(workspaceId),
       deps: {
         addChatMessage,
-        updateChatMessage: store.updateChatMessage,
-        removeChatMessage: store.removeChatMessage,
+        setRunningSetupScript: store.setRunningSetupScript,
         addToast,
         workspaceName: store.workspaces.find((w) => w.id === workspaceId)?.name,
       },

--- a/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
+++ b/src/ui/src/components/modals/ConfirmSetupScriptModal.tsx
@@ -2,10 +2,7 @@ import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/useAppStore";
 import { runWorkspaceSetup, setSetupScriptAutoRun } from "../../services/tauri";
-import {
-  recordSetupScriptError,
-  recordSetupScriptResult,
-} from "../../utils/setupScriptMessage";
+import { runAndRecordSetupScript } from "../../utils/setupScriptMessage";
 import { Modal } from "./Modal";
 import shared from "./shared.module.css";
 
@@ -28,31 +25,34 @@ export function ConfirmSetupScriptModal() {
 
   const handleRun = async () => {
     setLoading(true);
-    const workspaceName = useAppStore
-      .getState()
-      .workspaces.find((w) => w.id === workspaceId)?.name;
-    try {
-      if (alwaysRun && repoId) {
+    const store = useAppStore.getState();
+    if (alwaysRun && repoId) {
+      try {
         await setSetupScriptAutoRun(repoId, true);
         updateRepository(repoId, { setup_script_auto_run: true });
+      } catch (e) {
+        // Persisting the auto-run preference failed — log it, but still run
+        // the script the user just confirmed.
+        console.error("Failed to persist setup-script auto-run preference:", e);
       }
-      const sr = await runWorkspaceSetup(workspaceId);
-      if (sr) {
-        recordSetupScriptResult(sessionId, workspaceId, sr, {
-          addChatMessage,
-          addToast,
-          workspaceName,
-        });
-      }
-      closeModal();
-    } catch (e) {
-      recordSetupScriptError(sessionId, workspaceId, e, {
-        addChatMessage,
-        addToast,
-        workspaceName,
-      });
-      closeModal();
     }
+    // Fire-and-forget: the run posts a "running" placeholder to the transcript
+    // right away and swaps it for the result when it finishes, so there's no
+    // need to keep the modal open blocking on it.
+    runAndRecordSetupScript({
+      sessionId,
+      workspaceId,
+      source,
+      run: () => runWorkspaceSetup(workspaceId),
+      deps: {
+        addChatMessage,
+        updateChatMessage: store.updateChatMessage,
+        removeChatMessage: store.removeChatMessage,
+        addToast,
+        workspaceName: store.workspaces.find((w) => w.id === workspaceId)?.name,
+      },
+    });
+    closeModal();
   };
 
   const label = source === "repo" ? ".claudette.json" : t("setup_script_source_repo_settings");

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -283,8 +283,7 @@ export const Sidebar = memo(function Sidebar() {
               run: () => runWorkspaceSetup(wsId),
               deps: {
                 addChatMessage,
-                updateChatMessage: useAppStore.getState().updateChatMessage,
-                removeChatMessage: useAppStore.getState().removeChatMessage,
+                setRunningSetupScript: useAppStore.getState().setRunningSetupScript,
                 addToast,
                 workspaceName: result.workspace.name,
               },

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -48,6 +48,10 @@ import {
   buildWorkspaceContextMenuItems,
   type WorkspaceContextMenuLabels,
 } from "./workspaceContextMenu";
+import {
+  recordSetupScriptError,
+  recordSetupScriptResult,
+} from "../../utils/setupScriptMessage";
 import type { ChatSession } from "../../types";
 import styles from "./Sidebar.module.css";
 
@@ -275,34 +279,15 @@ export const Sidebar = memo(function Sidebar() {
         if (script) {
           if (repo?.setup_script_auto_run) {
             const wsId = result.workspace.id;
+            const recorderDeps = {
+              addChatMessage,
+              addToast,
+              workspaceName: result.workspace.name,
+            };
             runWorkspaceSetup(wsId).then((sr) => {
-              if (sr) {
-                const lbl = sr.source === "repo" ? ".claudette.json" : "settings";
-                const status = sr.success ? "completed" : sr.timed_out ? "timed out" : "failed";
-                addChatMessage(sessionId, {
-                  id: crypto.randomUUID(),
-                  workspace_id: wsId,
-                  chat_session_id: sessionId,
-                  role: "System",
-                  content: `Setup script (${lbl}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
-                  cost_usd: null, duration_ms: null,
-                  created_at: new Date().toISOString(),
-                  thinking: null,
-                  input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null,
-                });
-              }
+              if (sr) recordSetupScriptResult(sessionId, wsId, sr, recorderDeps);
             }).catch((err) => {
-              addChatMessage(sessionId, {
-                id: crypto.randomUUID(),
-                workspace_id: wsId,
-                chat_session_id: sessionId,
-                role: "System",
-                content: `Setup script failed: ${err}`,
-                cost_usd: null, duration_ms: null,
-                created_at: new Date().toISOString(),
-                thinking: null,
-                input_tokens: null, output_tokens: null, cache_read_tokens: null, cache_creation_tokens: null,
-              });
+              recordSetupScriptError(sessionId, wsId, err, recorderDeps);
             });
           } else {
             openModal("confirmSetupScript", {
@@ -324,7 +309,7 @@ export const Sidebar = memo(function Sidebar() {
     } finally {
       creatingRef.current = false;
     }
-  }, [addWorkspace, selectWorkspace, addChatMessage, openModal, setCreatingWorkspace]);
+  }, [addWorkspace, selectWorkspace, addChatMessage, addToast, openModal, setCreatingWorkspace]);
 
   const filteredWorkspaces = useMemo(
     () => workspaces.filter((ws) => {

--- a/src/ui/src/components/sidebar/Sidebar.tsx
+++ b/src/ui/src/components/sidebar/Sidebar.tsx
@@ -48,10 +48,7 @@ import {
   buildWorkspaceContextMenuItems,
   type WorkspaceContextMenuLabels,
 } from "./workspaceContextMenu";
-import {
-  recordSetupScriptError,
-  recordSetupScriptResult,
-} from "../../utils/setupScriptMessage";
+import { runAndRecordSetupScript } from "../../utils/setupScriptMessage";
 import type { ChatSession } from "../../types";
 import styles from "./Sidebar.module.css";
 
@@ -279,15 +276,18 @@ export const Sidebar = memo(function Sidebar() {
         if (script) {
           if (repo?.setup_script_auto_run) {
             const wsId = result.workspace.id;
-            const recorderDeps = {
-              addChatMessage,
-              addToast,
-              workspaceName: result.workspace.name,
-            };
-            runWorkspaceSetup(wsId).then((sr) => {
-              if (sr) recordSetupScriptResult(sessionId, wsId, sr, recorderDeps);
-            }).catch((err) => {
-              recordSetupScriptError(sessionId, wsId, err, recorderDeps);
+            runAndRecordSetupScript({
+              sessionId,
+              workspaceId: wsId,
+              source,
+              run: () => runWorkspaceSetup(wsId),
+              deps: {
+                addChatMessage,
+                updateChatMessage: useAppStore.getState().updateChatMessage,
+                removeChatMessage: useAppStore.getState().removeChatMessage,
+                addToast,
+                workspaceName: result.workspace.name,
+              },
             });
           } else {
             openModal("confirmSetupScript", {

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -112,8 +112,7 @@ export async function createWorkspaceOrchestrated(
             run: () => runWorkspaceSetup(wsId),
             deps: {
               addChatMessage: store.addChatMessage,
-              updateChatMessage: store.updateChatMessage,
-              removeChatMessage: store.removeChatMessage,
+              setRunningSetupScript: store.setRunningSetupScript,
               addToast: store.addToast,
               workspaceName: result.workspace.name,
             },

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -6,6 +6,10 @@ import {
   getRepoConfig,
   runWorkspaceSetup,
 } from "../services/tauri";
+import {
+  recordSetupScriptError,
+  recordSetupScriptResult,
+} from "../utils/setupScriptMessage";
 
 /** Outcome surfaced to callers so they can show toasts or chain follow-up work
  *  without prying into the store. The orchestration still performs the core
@@ -103,47 +107,18 @@ export async function createWorkspaceOrchestrated(
       if (script) {
         if (repo?.setup_script_auto_run) {
           const wsId = result.workspace.id;
+          const recorderDeps = {
+            addChatMessage: useAppStore.getState().addChatMessage,
+            addToast: useAppStore.getState().addToast,
+            workspaceName: result.workspace.name,
+          };
           runWorkspaceSetup(wsId)
             .then((sr) => {
               if (!sr) return;
-              const lbl = sr.source === "repo" ? ".claudette.json" : "settings";
-              const status = sr.success
-                ? "completed"
-                : sr.timed_out
-                  ? "timed out"
-                  : "failed";
-              useAppStore.getState().addChatMessage(sessionId, {
-                id: crypto.randomUUID(),
-                workspace_id: wsId,
-                chat_session_id: sessionId,
-                role: "System",
-                content: `Setup script (${lbl}) ${status}${sr.output ? `:\n${sr.output}` : ""}`,
-                cost_usd: null,
-                duration_ms: null,
-                created_at: new Date().toISOString(),
-                thinking: null,
-                input_tokens: null,
-                output_tokens: null,
-                cache_read_tokens: null,
-                cache_creation_tokens: null,
-              });
+              recordSetupScriptResult(sessionId, wsId, sr, recorderDeps);
             })
             .catch((err) => {
-              useAppStore.getState().addChatMessage(sessionId, {
-                id: crypto.randomUUID(),
-                workspace_id: wsId,
-                chat_session_id: sessionId,
-                role: "System",
-                content: `Setup script failed: ${err}`,
-                cost_usd: null,
-                duration_ms: null,
-                created_at: new Date().toISOString(),
-                thinking: null,
-                input_tokens: null,
-                output_tokens: null,
-                cache_read_tokens: null,
-                cache_creation_tokens: null,
-              });
+              recordSetupScriptError(sessionId, wsId, err, recorderDeps);
             });
         } else {
           useAppStore.getState().openModal("confirmSetupScript", {

--- a/src/ui/src/hooks/useCreateWorkspace.ts
+++ b/src/ui/src/hooks/useCreateWorkspace.ts
@@ -6,10 +6,7 @@ import {
   getRepoConfig,
   runWorkspaceSetup,
 } from "../services/tauri";
-import {
-  recordSetupScriptError,
-  recordSetupScriptResult,
-} from "../utils/setupScriptMessage";
+import { runAndRecordSetupScript } from "../utils/setupScriptMessage";
 
 /** Outcome surfaced to callers so they can show toasts or chain follow-up work
  *  without prying into the store. The orchestration still performs the core
@@ -107,19 +104,20 @@ export async function createWorkspaceOrchestrated(
       if (script) {
         if (repo?.setup_script_auto_run) {
           const wsId = result.workspace.id;
-          const recorderDeps = {
-            addChatMessage: useAppStore.getState().addChatMessage,
-            addToast: useAppStore.getState().addToast,
-            workspaceName: result.workspace.name,
-          };
-          runWorkspaceSetup(wsId)
-            .then((sr) => {
-              if (!sr) return;
-              recordSetupScriptResult(sessionId, wsId, sr, recorderDeps);
-            })
-            .catch((err) => {
-              recordSetupScriptError(sessionId, wsId, err, recorderDeps);
-            });
+          const store = useAppStore.getState();
+          runAndRecordSetupScript({
+            sessionId,
+            workspaceId: wsId,
+            source,
+            run: () => runWorkspaceSetup(wsId),
+            deps: {
+              addChatMessage: store.addChatMessage,
+              updateChatMessage: store.updateChatMessage,
+              removeChatMessage: store.removeChatMessage,
+              addToast: store.addToast,
+              workspaceName: result.workspace.name,
+            },
+          });
         } else {
           useAppStore.getState().openModal("confirmSetupScript", {
             workspaceId: result.workspace.id,

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -147,6 +147,7 @@
   "cli_invocation_prompt_label": "prompt",
 
   "setup_script_label": "setup script",
+  "setup_script_status_running": "running",
   "setup_script_status_completed": "completed",
   "setup_script_status_failed": "failed",
   "setup_script_status_timed_out": "timed out",

--- a/src/ui/src/locales/en/chat.json
+++ b/src/ui/src/locales/en/chat.json
@@ -146,6 +146,15 @@
   "cli_invocation_copied": "Copied",
   "cli_invocation_prompt_label": "prompt",
 
+  "setup_script_label": "setup script",
+  "setup_script_status_completed": "completed",
+  "setup_script_status_failed": "failed",
+  "setup_script_status_timed_out": "timed out",
+  "setup_script_expand": "Show setup script output",
+  "setup_script_collapse": "Hide setup script output",
+  "setup_script_copy": "Copy setup script output",
+  "setup_script_copied": "Copied",
+
   "mcp_unknown_error": "unknown",
 
   "diff_loading": "Loading diff...",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -146,6 +146,7 @@
   "cli_invocation_prompt_label": "prompt",
 
   "setup_script_label": "script de configuración",
+  "setup_script_status_running": "ejecutándose",
   "setup_script_status_completed": "completado",
   "setup_script_status_failed": "falló",
   "setup_script_status_timed_out": "tiempo agotado",

--- a/src/ui/src/locales/es/chat.json
+++ b/src/ui/src/locales/es/chat.json
@@ -145,6 +145,15 @@
   "cli_invocation_copied": "Copiado",
   "cli_invocation_prompt_label": "prompt",
 
+  "setup_script_label": "script de configuración",
+  "setup_script_status_completed": "completado",
+  "setup_script_status_failed": "falló",
+  "setup_script_status_timed_out": "tiempo agotado",
+  "setup_script_expand": "Mostrar salida del script de configuración",
+  "setup_script_collapse": "Ocultar salida del script de configuración",
+  "setup_script_copy": "Copiar salida del script de configuración",
+  "setup_script_copied": "Copiado",
+
   "mcp_unknown_error": "desconocido",
 
   "diff_loading": "Cargando diff...",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -143,6 +143,15 @@
   "cli_invocation_copied": "コピーしました",
   "cli_invocation_prompt_label": "プロンプト",
 
+  "setup_script_label": "セットアップスクリプト",
+  "setup_script_status_completed": "完了",
+  "setup_script_status_failed": "失敗",
+  "setup_script_status_timed_out": "タイムアウト",
+  "setup_script_expand": "セットアップスクリプトの出力を表示",
+  "setup_script_collapse": "セットアップスクリプトの出力を隠す",
+  "setup_script_copy": "セットアップスクリプトの出力をコピー",
+  "setup_script_copied": "コピーしました",
+
   "mcp_unknown_error": "不明",
 
   "diff_loading": "差分を読み込み中...",

--- a/src/ui/src/locales/ja/chat.json
+++ b/src/ui/src/locales/ja/chat.json
@@ -144,6 +144,7 @@
   "cli_invocation_prompt_label": "プロンプト",
 
   "setup_script_label": "セットアップスクリプト",
+  "setup_script_status_running": "実行中",
   "setup_script_status_completed": "完了",
   "setup_script_status_failed": "失敗",
   "setup_script_status_timed_out": "タイムアウト",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -145,6 +145,15 @@
   "cli_invocation_copied": "Copiado",
   "cli_invocation_prompt_label": "prompt",
 
+  "setup_script_label": "script de configuração",
+  "setup_script_status_completed": "concluído",
+  "setup_script_status_failed": "falhou",
+  "setup_script_status_timed_out": "tempo esgotado",
+  "setup_script_expand": "Mostrar saída do script de configuração",
+  "setup_script_collapse": "Ocultar saída do script de configuração",
+  "setup_script_copy": "Copiar saída do script de configuração",
+  "setup_script_copied": "Copiado",
+
   "mcp_unknown_error": "desconhecido",
 
   "diff_loading": "Carregando diff...",

--- a/src/ui/src/locales/pt-BR/chat.json
+++ b/src/ui/src/locales/pt-BR/chat.json
@@ -146,6 +146,7 @@
   "cli_invocation_prompt_label": "prompt",
 
   "setup_script_label": "script de configuração",
+  "setup_script_status_running": "em execução",
   "setup_script_status_completed": "concluído",
   "setup_script_status_failed": "falhou",
   "setup_script_status_timed_out": "tempo esgotado",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -144,6 +144,7 @@
   "cli_invocation_prompt_label": "提示",
 
   "setup_script_label": "安装脚本",
+  "setup_script_status_running": "运行中",
   "setup_script_status_completed": "已完成",
   "setup_script_status_failed": "失败",
   "setup_script_status_timed_out": "已超时",

--- a/src/ui/src/locales/zh-CN/chat.json
+++ b/src/ui/src/locales/zh-CN/chat.json
@@ -143,6 +143,15 @@
   "cli_invocation_copied": "已复制",
   "cli_invocation_prompt_label": "提示",
 
+  "setup_script_label": "安装脚本",
+  "setup_script_status_completed": "已完成",
+  "setup_script_status_failed": "失败",
+  "setup_script_status_timed_out": "已超时",
+  "setup_script_expand": "显示安装脚本输出",
+  "setup_script_collapse": "隐藏安装脚本输出",
+  "setup_script_copy": "复制安装脚本输出",
+  "setup_script_copied": "已复制",
+
   "mcp_unknown_error": "未知",
 
   "diff_loading": "加载差异...",

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -143,13 +143,15 @@ export interface ChatSlice {
     options?: { persisted?: boolean },
   ) => void;
   /** Sessions with a repo setup script currently executing, keyed by chat
-   *  session id; the value is the script source (`"repo"` / `"settings"`) for
-   *  the running-banner label. Lives here rather than as a `System` message so
-   *  the post-creation chat-history reload (which replaces `chatMessages`
-   *  wholesale) can't wipe the in-flight indicator. Cleared when the run
-   *  settles; the result is then appended as a normal message. */
+   *  session id; the value is the user-facing source *label* shown in the
+   *  running banner (`".claudette.json"` for repo config, `"settings"` for the
+   *  repo setting) — the same spelling the eventual result message renders, not
+   *  the raw `"repo"`/`"settings"` source. Lives here rather than as a `System`
+   *  message so the post-creation chat-history reload (which replaces
+   *  `chatMessages` wholesale) can't wipe the in-flight indicator. Cleared when
+   *  the run settles; the result is then appended as a normal message. */
   runningSetupScripts: Record<string, string>;
-  setRunningSetupScript: (sessionId: string, source: string | null) => void;
+  setRunningSetupScript: (sessionId: string, label: string | null) => void;
   setStreamingContent: (sessionId: string, content: string) => void;
   appendStreamingContent: (sessionId: string, text: string) => void;
   setPendingTypewriter: (sessionId: string, messageId: string, text: string) => void;
@@ -363,17 +365,17 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
       };
     }),
   runningSetupScripts: {},
-  setRunningSetupScript: (sessionId, source) =>
+  setRunningSetupScript: (sessionId, label) =>
     set((s) => {
-      if (source === null) {
+      if (label === null) {
         if (!(sessionId in s.runningSetupScripts)) return {};
         const next = { ...s.runningSetupScripts };
         delete next[sessionId];
         return { runningSetupScripts: next };
       }
-      if (s.runningSetupScripts[sessionId] === source) return {};
+      if (s.runningSetupScripts[sessionId] === label) return {};
       return {
-        runningSetupScripts: { ...s.runningSetupScripts, [sessionId]: source },
+        runningSetupScripts: { ...s.runningSetupScripts, [sessionId]: label },
       };
     }),
   setStreamingContent: (sessionId, content) =>

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -142,21 +142,14 @@ export interface ChatSlice {
     message: ChatMessage,
     options?: { persisted?: boolean },
   ) => void;
-  /** Patch fields on an already-appended message, matched by `id`. No-op if
-   *  the id isn't present. Used for client-only messages that mutate in place
-   *  (e.g. the setup-script "running" placeholder flipping to its result).
-   *  Does not touch pagination — only `persisted` messages affect that, and a
-   *  patch never changes a message's persisted-ness. */
-  updateChatMessage: (
-    sessionId: string,
-    messageId: string,
-    updates: Partial<ChatMessage>,
-  ) => void;
-  /** Drop a message by `id`. Intended for client-only placeholders that turn
-   *  out to have nothing to show; never call this for a `persisted` message —
-   *  `totalCount` is left untouched, so removing a DB-backed message would
-   *  desync `globalOffset`. */
-  removeChatMessage: (sessionId: string, messageId: string) => void;
+  /** Sessions with a repo setup script currently executing, keyed by chat
+   *  session id; the value is the script source (`"repo"` / `"settings"`) for
+   *  the running-banner label. Lives here rather than as a `System` message so
+   *  the post-creation chat-history reload (which replaces `chatMessages`
+   *  wholesale) can't wipe the in-flight indicator. Cleared when the run
+   *  settles; the result is then appended as a normal message. */
+  runningSetupScripts: Record<string, string>;
+  setRunningSetupScript: (sessionId: string, source: string | null) => void;
   setStreamingContent: (sessionId: string, content: string) => void;
   appendStreamingContent: (sessionId: string, text: string) => void;
   setPendingTypewriter: (sessionId: string, messageId: string, text: string) => void;
@@ -369,38 +362,19 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
           : {}),
       };
     }),
-  updateChatMessage: (sessionId, messageId, updates) =>
+  runningSetupScripts: {},
+  setRunningSetupScript: (sessionId, source) =>
     set((s) => {
-      const list = s.chatMessages[sessionId];
-      if (!list) return {};
-      const idx = list.findIndex((m) => m.id === messageId);
-      if (idx === -1) return {};
-      const patched = { ...list[idx], ...updates };
-      const next = [...list];
-      next[idx] = patched;
-      return {
-        chatMessages: { ...s.chatMessages, [sessionId]: next },
-        ...(s.lastMessages[sessionId]?.id === messageId
-          ? { lastMessages: { ...s.lastMessages, [sessionId]: patched } }
-          : {}),
-      };
-    }),
-  removeChatMessage: (sessionId, messageId) =>
-    set((s) => {
-      const list = s.chatMessages[sessionId];
-      if (!list || !list.some((m) => m.id === messageId)) return {};
-      const next = list.filter((m) => m.id !== messageId);
-      const partial: Partial<typeof s> = {
-        chatMessages: { ...s.chatMessages, [sessionId]: next },
-      };
-      if (s.lastMessages[sessionId]?.id === messageId) {
-        const lastMessages = { ...s.lastMessages };
-        const newLast = next[next.length - 1];
-        if (newLast) lastMessages[sessionId] = newLast;
-        else delete lastMessages[sessionId];
-        partial.lastMessages = lastMessages;
+      if (source === null) {
+        if (!(sessionId in s.runningSetupScripts)) return {};
+        const next = { ...s.runningSetupScripts };
+        delete next[sessionId];
+        return { runningSetupScripts: next };
       }
-      return partial;
+      if (s.runningSetupScripts[sessionId] === source) return {};
+      return {
+        runningSetupScripts: { ...s.runningSetupScripts, [sessionId]: source },
+      };
     }),
   setStreamingContent: (sessionId, content) =>
     set((s) => ({

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -142,6 +142,21 @@ export interface ChatSlice {
     message: ChatMessage,
     options?: { persisted?: boolean },
   ) => void;
+  /** Patch fields on an already-appended message, matched by `id`. No-op if
+   *  the id isn't present. Used for client-only messages that mutate in place
+   *  (e.g. the setup-script "running" placeholder flipping to its result).
+   *  Does not touch pagination — only `persisted` messages affect that, and a
+   *  patch never changes a message's persisted-ness. */
+  updateChatMessage: (
+    sessionId: string,
+    messageId: string,
+    updates: Partial<ChatMessage>,
+  ) => void;
+  /** Drop a message by `id`. Intended for client-only placeholders that turn
+   *  out to have nothing to show; never call this for a `persisted` message —
+   *  `totalCount` is left untouched, so removing a DB-backed message would
+   *  desync `globalOffset`. */
+  removeChatMessage: (sessionId: string, messageId: string) => void;
   setStreamingContent: (sessionId: string, content: string) => void;
   appendStreamingContent: (sessionId: string, text: string) => void;
   setPendingTypewriter: (sessionId: string, messageId: string, text: string) => void;
@@ -353,6 +368,39 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
             }
           : {}),
       };
+    }),
+  updateChatMessage: (sessionId, messageId, updates) =>
+    set((s) => {
+      const list = s.chatMessages[sessionId];
+      if (!list) return {};
+      const idx = list.findIndex((m) => m.id === messageId);
+      if (idx === -1) return {};
+      const patched = { ...list[idx], ...updates };
+      const next = [...list];
+      next[idx] = patched;
+      return {
+        chatMessages: { ...s.chatMessages, [sessionId]: next },
+        ...(s.lastMessages[sessionId]?.id === messageId
+          ? { lastMessages: { ...s.lastMessages, [sessionId]: patched } }
+          : {}),
+      };
+    }),
+  removeChatMessage: (sessionId, messageId) =>
+    set((s) => {
+      const list = s.chatMessages[sessionId];
+      if (!list || !list.some((m) => m.id === messageId)) return {};
+      const next = list.filter((m) => m.id !== messageId);
+      const partial: Partial<typeof s> = {
+        chatMessages: { ...s.chatMessages, [sessionId]: next },
+      };
+      if (s.lastMessages[sessionId]?.id === messageId) {
+        const lastMessages = { ...s.lastMessages };
+        const newLast = next[next.length - 1];
+        if (newLast) lastMessages[sessionId] = newLast;
+        else delete lastMessages[sessionId];
+        partial.lastMessages = lastMessages;
+      }
+      return partial;
     }),
   setStreamingContent: (sessionId, content) =>
     set((s) => ({

--- a/src/ui/src/utils/setupScriptMessage.test.ts
+++ b/src/ui/src/utils/setupScriptMessage.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi } from "vitest";
 import {
   buildSetupScriptContent,
   buildSetupScriptErrorContent,
+  buildSetupScriptRunningContent,
   parseSetupScriptMessage,
-  recordSetupScriptResult,
-  recordSetupScriptError,
+  runAndRecordSetupScript,
+  type SetupScriptRecorderDeps,
 } from "./setupScriptMessage";
 import type { SetupResult } from "../types/repository";
 
@@ -20,7 +21,17 @@ function result(over: Partial<SetupResult> = {}): SetupResult {
   };
 }
 
-describe("buildSetupScriptContent / parseSetupScriptMessage", () => {
+function makeDeps(over: Partial<SetupScriptRecorderDeps> = {}): SetupScriptRecorderDeps {
+  return {
+    addChatMessage: vi.fn(),
+    updateChatMessage: vi.fn(),
+    removeChatMessage: vi.fn(),
+    addToast: vi.fn(),
+    ...over,
+  };
+}
+
+describe("build / parse setup-script content", () => {
   it("round-trips a completed run with output", () => {
     const sr = result({ output: "Resolved 1657 packages\ndone" });
     const content = buildSetupScriptContent(sr);
@@ -70,6 +81,16 @@ describe("buildSetupScriptContent / parseSetupScriptMessage", () => {
     });
   });
 
+  it("round-trips the running placeholder", () => {
+    expect(buildSetupScriptRunningContent("settings")).toBe("Setup script (settings) running");
+    expect(buildSetupScriptRunningContent("repo")).toBe("Setup script (.claudette.json) running");
+    expect(parseSetupScriptMessage("Setup script (settings) running")).toEqual({
+      source: "settings",
+      status: "running",
+      output: "",
+    });
+  });
+
   it("parses the catch-path error message", () => {
     const content = buildSetupScriptErrorContent(new Error("spawn failed"));
     expect(content).toBe("Setup script failed: Error: spawn failed");
@@ -84,46 +105,93 @@ describe("buildSetupScriptContent / parseSetupScriptMessage", () => {
     expect(parseSetupScriptMessage("")).toBeNull();
     expect(parseSetupScriptMessage("Just a regular system note")).toBeNull();
     expect(parseSetupScriptMessage("COMPACTION:manual:1:2:3")).toBeNull();
-    expect(parseSetupScriptMessage("Setup script (settings) is running")).toBeNull();
+    expect(parseSetupScriptMessage("Setup script (settings) is queued")).toBeNull();
   });
 });
 
-describe("recordSetupScriptResult / recordSetupScriptError", () => {
-  it("appends a System message and no toast on success", () => {
-    const addChatMessage = vi.fn();
-    const addToast = vi.fn();
-    recordSetupScriptResult("sess", "ws", result({ output: "ok" }), { addChatMessage, addToast });
-    expect(addChatMessage).toHaveBeenCalledTimes(1);
-    const [sessionId, msg] = addChatMessage.mock.calls[0];
-    expect(sessionId).toBe("sess");
-    expect(msg).toMatchObject({
+describe("runAndRecordSetupScript", () => {
+  it("posts a client-only running placeholder, then swaps it for the result", async () => {
+    const deps = makeDeps();
+    let resolveRun!: (v: SetupResult | null) => void;
+    runAndRecordSetupScript({
+      sessionId: "sess",
+      workspaceId: "ws",
+      source: "settings",
+      run: () => new Promise<SetupResult | null>((res) => { resolveRun = res; }),
+      deps,
+    });
+
+    // Placeholder posted immediately, not persisted.
+    expect(deps.addChatMessage).toHaveBeenCalledTimes(1);
+    const [, placeholderMsg, options] = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(placeholderMsg).toMatchObject({
       role: "System",
-      workspace_id: "ws",
-      chat_session_id: "sess",
+      content: "Setup script (settings) running",
+    });
+    expect(options).toEqual({ persisted: false });
+
+    resolveRun(result({ output: "ok" }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(deps.updateChatMessage).toHaveBeenCalledWith("sess", placeholderMsg.id, {
       content: "Setup script (settings) completed:\nok",
     });
-    expect(addToast).not.toHaveBeenCalled();
+    expect(deps.removeChatMessage).not.toHaveBeenCalled();
+    expect(deps.addToast).not.toHaveBeenCalled();
   });
 
-  it("raises a failure toast when the run did not succeed", () => {
-    const addChatMessage = vi.fn();
-    const addToast = vi.fn();
-    recordSetupScriptResult("sess", "ws", result({ success: false, exit_code: 1, output: "boom" }), {
-      addChatMessage,
-      addToast,
-      workspaceName: "twisted-tarragon",
+  it("raises a failure toast and swaps to the failed content", async () => {
+    const deps = makeDeps({ workspaceName: "twisted-tarragon" });
+    runAndRecordSetupScript({
+      sessionId: "sess",
+      workspaceId: "ws",
+      source: "settings",
+      run: async () => result({ success: false, exit_code: 1, output: "boom" }),
+      deps,
     });
-    expect(addChatMessage).toHaveBeenCalledTimes(1);
-    expect(addToast).toHaveBeenCalledTimes(1);
-    expect(addToast.mock.calls[0][0]).toContain("twisted-tarragon");
+    await Promise.resolve();
+    await Promise.resolve();
+    const placeholderId = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].id;
+    expect(deps.updateChatMessage).toHaveBeenCalledWith("sess", placeholderId, {
+      content: "Setup script (settings) failed:\nboom",
+    });
+    expect(deps.addToast).toHaveBeenCalledTimes(1);
+    expect((deps.addToast as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain("twisted-tarragon");
   });
 
-  it("records the catch-path message and a toast", () => {
-    const addChatMessage = vi.fn();
-    const addToast = vi.fn();
-    recordSetupScriptError("sess", "ws", new Error("nope"), { addChatMessage, addToast });
-    expect(addChatMessage).toHaveBeenCalledTimes(1);
-    expect(addChatMessage.mock.calls[0][1].content).toBe("Setup script failed: Error: nope");
-    expect(addToast).toHaveBeenCalledTimes(1);
+  it("swaps to the catch-path content and toasts when run() rejects", async () => {
+    const deps = makeDeps();
+    runAndRecordSetupScript({
+      sessionId: "sess",
+      workspaceId: "ws",
+      source: "repo",
+      run: async () => { throw new Error("nope"); },
+      deps,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const placeholderId = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].id;
+    expect(deps.updateChatMessage).toHaveBeenCalledWith("sess", placeholderId, {
+      content: "Setup script failed: Error: nope",
+    });
+    expect(deps.addToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes the placeholder when no script actually ran", async () => {
+    const deps = makeDeps();
+    runAndRecordSetupScript({
+      sessionId: "sess",
+      workspaceId: "ws",
+      source: "settings",
+      run: async () => null,
+      deps,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const placeholderId = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].id;
+    expect(deps.removeChatMessage).toHaveBeenCalledWith("sess", placeholderId);
+    expect(deps.updateChatMessage).not.toHaveBeenCalled();
+    expect(deps.addToast).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/src/utils/setupScriptMessage.test.ts
+++ b/src/ui/src/utils/setupScriptMessage.test.ts
@@ -125,6 +125,24 @@ describe("runAndRecordSetupScript", () => {
     expect(deps.addToast).not.toHaveBeenCalled();
   });
 
+  it("stores the user-facing label for a repo-config script so the running banner matches the result", async () => {
+    const deps = makeDeps();
+    runAndRecordSetupScript({
+      sessionId: "sess",
+      workspaceId: "ws",
+      source: "repo",
+      run: async () => result({ source: "repo", output: "ok" }),
+      deps,
+    });
+    // Running banner label: ".claudette.json" — not the raw "repo" — matching
+    // what `buildSetupScriptContent` writes for the completed entry.
+    expect(deps.setRunningSetupScript).toHaveBeenNthCalledWith(1, "sess", ".claudette.json");
+    await Promise.resolve();
+    await Promise.resolve();
+    const [, msg] = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(msg.content).toBe("Setup script (.claudette.json) completed:\nok");
+  });
+
   it("raises a failure toast and appends the failed content", async () => {
     const deps = makeDeps({ workspaceName: "twisted-tarragon" });
     runAndRecordSetupScript({

--- a/src/ui/src/utils/setupScriptMessage.test.ts
+++ b/src/ui/src/utils/setupScriptMessage.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import {
   buildSetupScriptContent,
   buildSetupScriptErrorContent,
-  buildSetupScriptRunningContent,
   parseSetupScriptMessage,
   runAndRecordSetupScript,
   type SetupScriptRecorderDeps,
@@ -24,8 +23,7 @@ function result(over: Partial<SetupResult> = {}): SetupResult {
 function makeDeps(over: Partial<SetupScriptRecorderDeps> = {}): SetupScriptRecorderDeps {
   return {
     addChatMessage: vi.fn(),
-    updateChatMessage: vi.fn(),
-    removeChatMessage: vi.fn(),
+    setRunningSetupScript: vi.fn(),
     addToast: vi.fn(),
     ...over,
   };
@@ -81,16 +79,6 @@ describe("build / parse setup-script content", () => {
     });
   });
 
-  it("round-trips the running placeholder", () => {
-    expect(buildSetupScriptRunningContent("settings")).toBe("Setup script (settings) running");
-    expect(buildSetupScriptRunningContent("repo")).toBe("Setup script (.claudette.json) running");
-    expect(parseSetupScriptMessage("Setup script (settings) running")).toEqual({
-      source: "settings",
-      status: "running",
-      output: "",
-    });
-  });
-
   it("parses the catch-path error message", () => {
     const content = buildSetupScriptErrorContent(new Error("spawn failed"));
     expect(content).toBe("Setup script failed: Error: spawn failed");
@@ -105,12 +93,13 @@ describe("build / parse setup-script content", () => {
     expect(parseSetupScriptMessage("")).toBeNull();
     expect(parseSetupScriptMessage("Just a regular system note")).toBeNull();
     expect(parseSetupScriptMessage("COMPACTION:manual:1:2:3")).toBeNull();
-    expect(parseSetupScriptMessage("Setup script (settings) is queued")).toBeNull();
+    // "running" is never a message — it lives in the store, not the transcript.
+    expect(parseSetupScriptMessage("Setup script (settings) running")).toBeNull();
   });
 });
 
 describe("runAndRecordSetupScript", () => {
-  it("posts a client-only running placeholder, then swaps it for the result", async () => {
+  it("flags the session running, then clears it and appends the result", async () => {
     const deps = makeDeps();
     let resolveRun!: (v: SetupResult | null) => void;
     runAndRecordSetupScript({
@@ -121,27 +110,22 @@ describe("runAndRecordSetupScript", () => {
       deps,
     });
 
-    // Placeholder posted immediately, not persisted.
-    expect(deps.addChatMessage).toHaveBeenCalledTimes(1);
-    const [, placeholderMsg, options] = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(placeholderMsg).toMatchObject({
-      role: "System",
-      content: "Setup script (settings) running",
-    });
-    expect(options).toEqual({ persisted: false });
+    expect(deps.setRunningSetupScript).toHaveBeenCalledWith("sess", "settings");
+    expect(deps.addChatMessage).not.toHaveBeenCalled();
 
     resolveRun(result({ output: "ok" }));
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(deps.updateChatMessage).toHaveBeenCalledWith("sess", placeholderMsg.id, {
-      content: "Setup script (settings) completed:\nok",
-    });
-    expect(deps.removeChatMessage).not.toHaveBeenCalled();
+    expect(deps.setRunningSetupScript).toHaveBeenLastCalledWith("sess", null);
+    expect(deps.addChatMessage).toHaveBeenCalledTimes(1);
+    const [, msg, options] = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(msg).toMatchObject({ role: "System", content: "Setup script (settings) completed:\nok" });
+    expect(options).toEqual({ persisted: false });
     expect(deps.addToast).not.toHaveBeenCalled();
   });
 
-  it("raises a failure toast and swaps to the failed content", async () => {
+  it("raises a failure toast and appends the failed content", async () => {
     const deps = makeDeps({ workspaceName: "twisted-tarragon" });
     runAndRecordSetupScript({
       sessionId: "sess",
@@ -152,15 +136,14 @@ describe("runAndRecordSetupScript", () => {
     });
     await Promise.resolve();
     await Promise.resolve();
-    const placeholderId = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].id;
-    expect(deps.updateChatMessage).toHaveBeenCalledWith("sess", placeholderId, {
-      content: "Setup script (settings) failed:\nboom",
-    });
+    expect(deps.setRunningSetupScript).toHaveBeenLastCalledWith("sess", null);
+    const [, msg] = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(msg.content).toBe("Setup script (settings) failed:\nboom");
     expect(deps.addToast).toHaveBeenCalledTimes(1);
     expect((deps.addToast as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain("twisted-tarragon");
   });
 
-  it("swaps to the catch-path content and toasts when run() rejects", async () => {
+  it("appends the catch-path content and toasts when run() rejects", async () => {
     const deps = makeDeps();
     runAndRecordSetupScript({
       sessionId: "sess",
@@ -171,14 +154,13 @@ describe("runAndRecordSetupScript", () => {
     });
     await Promise.resolve();
     await Promise.resolve();
-    const placeholderId = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].id;
-    expect(deps.updateChatMessage).toHaveBeenCalledWith("sess", placeholderId, {
-      content: "Setup script failed: Error: nope",
-    });
+    expect(deps.setRunningSetupScript).toHaveBeenLastCalledWith("sess", null);
+    const [, msg] = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(msg.content).toBe("Setup script failed: Error: nope");
     expect(deps.addToast).toHaveBeenCalledTimes(1);
   });
 
-  it("removes the placeholder when no script actually ran", async () => {
+  it("clears the running flag and appends nothing when no script actually ran", async () => {
     const deps = makeDeps();
     runAndRecordSetupScript({
       sessionId: "sess",
@@ -189,9 +171,8 @@ describe("runAndRecordSetupScript", () => {
     });
     await Promise.resolve();
     await Promise.resolve();
-    const placeholderId = (deps.addChatMessage as ReturnType<typeof vi.fn>).mock.calls[0][1].id;
-    expect(deps.removeChatMessage).toHaveBeenCalledWith("sess", placeholderId);
-    expect(deps.updateChatMessage).not.toHaveBeenCalled();
+    expect(deps.setRunningSetupScript).toHaveBeenLastCalledWith("sess", null);
+    expect(deps.addChatMessage).not.toHaveBeenCalled();
     expect(deps.addToast).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/src/utils/setupScriptMessage.test.ts
+++ b/src/ui/src/utils/setupScriptMessage.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildSetupScriptContent,
+  buildSetupScriptErrorContent,
+  parseSetupScriptMessage,
+  recordSetupScriptResult,
+  recordSetupScriptError,
+} from "./setupScriptMessage";
+import type { SetupResult } from "../types/repository";
+
+function result(over: Partial<SetupResult> = {}): SetupResult {
+  return {
+    source: "settings",
+    script: "bun install",
+    output: "",
+    exit_code: 0,
+    success: true,
+    timed_out: false,
+    ...over,
+  };
+}
+
+describe("buildSetupScriptContent / parseSetupScriptMessage", () => {
+  it("round-trips a completed run with output", () => {
+    const sr = result({ output: "Resolved 1657 packages\ndone" });
+    const content = buildSetupScriptContent(sr);
+    expect(content).toBe("Setup script (settings) completed:\nResolved 1657 packages\ndone");
+    expect(parseSetupScriptMessage(content)).toEqual({
+      source: "settings",
+      status: "completed",
+      output: "Resolved 1657 packages\ndone",
+    });
+  });
+
+  it("round-trips a completed run with no output", () => {
+    const content = buildSetupScriptContent(result({ output: "" }));
+    expect(content).toBe("Setup script (settings) completed");
+    expect(parseSetupScriptMessage(content)).toEqual({
+      source: "settings",
+      status: "completed",
+      output: "",
+    });
+  });
+
+  it("uses the .claudette.json label for repo-config scripts", () => {
+    const content = buildSetupScriptContent(result({ source: "repo", output: "ok" }));
+    expect(content).toBe("Setup script (.claudette.json) completed:\nok");
+    expect(parseSetupScriptMessage(content)?.source).toBe(".claudette.json");
+  });
+
+  it("maps an unsuccessful run to failed", () => {
+    const content = buildSetupScriptContent(result({ success: false, exit_code: 1, output: "boom" }));
+    expect(content).toBe("Setup script (settings) failed:\nboom");
+    expect(parseSetupScriptMessage(content)).toEqual({
+      source: "settings",
+      status: "failed",
+      output: "boom",
+    });
+  });
+
+  it("maps a timed-out run to timed-out", () => {
+    const content = buildSetupScriptContent(
+      result({ success: false, exit_code: null, timed_out: true, output: "slow…" }),
+    );
+    expect(content).toBe("Setup script (settings) timed out:\nslow…");
+    expect(parseSetupScriptMessage(content)).toEqual({
+      source: "settings",
+      status: "timed-out",
+      output: "slow…",
+    });
+  });
+
+  it("parses the catch-path error message", () => {
+    const content = buildSetupScriptErrorContent(new Error("spawn failed"));
+    expect(content).toBe("Setup script failed: Error: spawn failed");
+    expect(parseSetupScriptMessage(content)).toEqual({
+      source: null,
+      status: "failed",
+      output: "Error: spawn failed",
+    });
+  });
+
+  it("returns null for unrelated content", () => {
+    expect(parseSetupScriptMessage("")).toBeNull();
+    expect(parseSetupScriptMessage("Just a regular system note")).toBeNull();
+    expect(parseSetupScriptMessage("COMPACTION:manual:1:2:3")).toBeNull();
+    expect(parseSetupScriptMessage("Setup script (settings) is running")).toBeNull();
+  });
+});
+
+describe("recordSetupScriptResult / recordSetupScriptError", () => {
+  it("appends a System message and no toast on success", () => {
+    const addChatMessage = vi.fn();
+    const addToast = vi.fn();
+    recordSetupScriptResult("sess", "ws", result({ output: "ok" }), { addChatMessage, addToast });
+    expect(addChatMessage).toHaveBeenCalledTimes(1);
+    const [sessionId, msg] = addChatMessage.mock.calls[0];
+    expect(sessionId).toBe("sess");
+    expect(msg).toMatchObject({
+      role: "System",
+      workspace_id: "ws",
+      chat_session_id: "sess",
+      content: "Setup script (settings) completed:\nok",
+    });
+    expect(addToast).not.toHaveBeenCalled();
+  });
+
+  it("raises a failure toast when the run did not succeed", () => {
+    const addChatMessage = vi.fn();
+    const addToast = vi.fn();
+    recordSetupScriptResult("sess", "ws", result({ success: false, exit_code: 1, output: "boom" }), {
+      addChatMessage,
+      addToast,
+      workspaceName: "twisted-tarragon",
+    });
+    expect(addChatMessage).toHaveBeenCalledTimes(1);
+    expect(addToast).toHaveBeenCalledTimes(1);
+    expect(addToast.mock.calls[0][0]).toContain("twisted-tarragon");
+  });
+
+  it("records the catch-path message and a toast", () => {
+    const addChatMessage = vi.fn();
+    const addToast = vi.fn();
+    recordSetupScriptError("sess", "ws", new Error("nope"), { addChatMessage, addToast });
+    expect(addChatMessage).toHaveBeenCalledTimes(1);
+    expect(addChatMessage.mock.calls[0][1].content).toBe("Setup script failed: Error: nope");
+    expect(addToast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/src/utils/setupScriptMessage.ts
+++ b/src/ui/src/utils/setupScriptMessage.ts
@@ -16,8 +16,13 @@ export interface SetupScriptOutcome {
   output: string;
 }
 
-/** The user-facing label embedded in the message content. Kept here so the
- *  builders and the parser agree on exactly one spelling. */
+/** Where a setup script came from: `"repo"` is `.claudette.json` (committed
+ *  repo config), `"settings"` is the repo-level setting in Claudette. */
+export type SetupScriptSource = "repo" | "settings";
+
+/** The user-facing label embedded in the message content / running banner.
+ *  Kept here so the builders, the parser, and the running banner all agree on
+ *  exactly one spelling. */
 function sourceLabel(source: string): string {
   return source === "repo" ? ".claudette.json" : "settings";
 }
@@ -121,13 +126,15 @@ function failureToast(deps: SetupScriptRecorderDeps): void {
 export function runAndRecordSetupScript(opts: {
   sessionId: string;
   workspaceId: string;
-  /** `"repo"` (`.claudette.json`) or `"settings"` — the running-banner label. */
-  source: string;
+  source: SetupScriptSource;
   run: () => Promise<SetupResult | null>;
   deps: SetupScriptRecorderDeps;
 }): void {
   const { sessionId, workspaceId, source, run, deps } = opts;
-  deps.setRunningSetupScript(sessionId, source);
+  // Store the user-facing label, not the raw source, so the running banner
+  // reads `(.claudette.json)` / `(settings)` — matching the completed entry,
+  // which `buildSetupScriptContent` writes with the same `sourceLabel`.
+  deps.setRunningSetupScript(sessionId, sourceLabel(source));
   run()
     .then((sr) => {
       deps.setRunningSetupScript(sessionId, null);

--- a/src/ui/src/utils/setupScriptMessage.ts
+++ b/src/ui/src/utils/setupScriptMessage.ts
@@ -1,0 +1,119 @@
+import type { ChatMessage } from "../types/chat";
+import type { SetupResult } from "../types/repository";
+
+/** Outcome of a setup-script run, reconstructed from the `System` chat
+ *  message the run is persisted as. `output` is the combined stdout/stderr
+ *  the script produced (possibly empty). */
+export type SetupScriptStatus = "completed" | "failed" | "timed-out";
+
+export interface SetupScriptOutcome {
+  /** `.claudette.json` (repo config) or `settings` (repo-level setting), or
+   *  `null` for the catch-path message which doesn't carry a source. */
+  source: string | null;
+  status: SetupScriptStatus;
+  output: string;
+}
+
+/** The user-facing label embedded in the message content. Kept here so the
+ *  builders and the parser agree on exactly one spelling. */
+function sourceLabel(source: string): string {
+  return source === "repo" ? ".claudette.json" : "settings";
+}
+
+/** Build the `System` message content string for a finished setup run. This
+ *  is the canonical place the wire format lives — `parseSetupScriptMessage`
+ *  is its inverse, and `MessagesWithTurns` renders off the parsed shape. */
+export function buildSetupScriptContent(sr: SetupResult): string {
+  const label = sourceLabel(sr.source);
+  const status = sr.success ? "completed" : sr.timed_out ? "timed out" : "failed";
+  return `Setup script (${label}) ${status}${sr.output ? `:\n${sr.output}` : ""}`;
+}
+
+/** Build the content string for the catch path (the run threw before it
+ *  could report a structured result). */
+export function buildSetupScriptErrorContent(err: unknown): string {
+  return `Setup script failed: ${err}`;
+}
+
+const COMPLETED_RE = /^Setup script \((.+?)\) (completed|failed|timed out)(?::\n([\s\S]*))?$/;
+const ERROR_RE = /^Setup script failed: ([\s\S]*)$/;
+
+/** Parse a setup-script `System` message back into structured form. Returns
+ *  `null` for any content that isn't one of the two setup-script shapes, so
+ *  callers can fall through to generic message rendering. */
+export function parseSetupScriptMessage(content: string): SetupScriptOutcome | null {
+  const m = COMPLETED_RE.exec(content);
+  if (m) {
+    const status: SetupScriptStatus = m[2] === "timed out" ? "timed-out" : (m[2] as SetupScriptStatus);
+    return { source: m[1], status, output: m[3] ?? "" };
+  }
+  const e = ERROR_RE.exec(content);
+  if (e) {
+    return { source: null, status: "failed", output: e[1] };
+  }
+  return null;
+}
+
+function blankSystemMessage(
+  sessionId: string,
+  workspaceId: string,
+  content: string,
+): ChatMessage {
+  return {
+    id: crypto.randomUUID(),
+    workspace_id: workspaceId,
+    chat_session_id: sessionId,
+    role: "System",
+    content,
+    cost_usd: null,
+    duration_ms: null,
+    created_at: new Date().toISOString(),
+    thinking: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cache_creation_tokens: null,
+  };
+}
+
+/** Store hooks the recorder needs. Passed in rather than importing the store
+ *  here so this module stays a leaf (parse/build are pure and trivially
+ *  testable; no Zustand wiring pulled into util tests). */
+export interface SetupScriptRecorderDeps {
+  addChatMessage: (sessionId: string, message: ChatMessage) => void;
+  addToast: (message: string) => void;
+  /** Display name of the workspace, for the failure toast. */
+  workspaceName?: string | null;
+}
+
+function failureToast(deps: SetupScriptRecorderDeps): void {
+  const where = deps.workspaceName ? `“${deps.workspaceName}”` : "this workspace";
+  deps.addToast(`Setup script for ${where} failed — see the transcript`);
+}
+
+/** Append the `System` message for a finished setup run to its chat session,
+ *  and — if the run failed or timed out — raise a one-time toast so the
+ *  failure isn't missed when it scrolls past in the transcript. Shared by all
+ *  four sites that kick off a setup script (workspace creation, the sidebar,
+ *  the command palette, and the confirm-setup modal). */
+export function recordSetupScriptResult(
+  sessionId: string,
+  workspaceId: string,
+  sr: SetupResult,
+  deps: SetupScriptRecorderDeps,
+): void {
+  deps.addChatMessage(sessionId, blankSystemMessage(sessionId, workspaceId, buildSetupScriptContent(sr)));
+  if (!sr.success) failureToast(deps);
+}
+
+/** Append the catch-path `System` message (the run threw) and raise the
+ *  failure toast. */
+export function recordSetupScriptError(
+  sessionId: string,
+  workspaceId: string,
+  err: unknown,
+  deps: SetupScriptRecorderDeps,
+): void {
+  deps.addChatMessage(sessionId, blankSystemMessage(sessionId, workspaceId, buildSetupScriptErrorContent(err)));
+  failureToast(deps);
+}

--- a/src/ui/src/utils/setupScriptMessage.ts
+++ b/src/ui/src/utils/setupScriptMessage.ts
@@ -1,10 +1,11 @@
 import type { ChatMessage } from "../types/chat";
 import type { SetupResult } from "../types/repository";
 
-/** Outcome of a setup-script run, reconstructed from the `System` chat
- *  message the run is persisted as. `output` is the combined stdout/stderr
- *  the script produced (possibly empty). */
-export type SetupScriptStatus = "completed" | "failed" | "timed-out";
+/** State of a setup-script run, reconstructed from the `System` chat message
+ *  it's represented by. `running` is the in-flight placeholder; the rest are
+ *  terminal. `output` is the combined stdout/stderr (empty while `running`,
+ *  and often empty for a `completed` run that printed nothing). */
+export type SetupScriptStatus = "running" | "completed" | "failed" | "timed-out";
 
 export interface SetupScriptOutcome {
   /** `.claudette.json` (repo config) or `settings` (repo-level setting), or
@@ -18,6 +19,14 @@ export interface SetupScriptOutcome {
  *  builders and the parser agree on exactly one spelling. */
 function sourceLabel(source: string): string {
   return source === "repo" ? ".claudette.json" : "settings";
+}
+
+/** Content for the in-flight placeholder, posted before the script is spawned
+ *  and swapped in place once it finishes. `source` is the frontend's guess
+ *  (`"repo"` / `"settings"`); the result message uses the authoritative
+ *  `SetupResult.source`. */
+export function buildSetupScriptRunningContent(source: string): string {
+  return `Setup script (${sourceLabel(source)}) running`;
 }
 
 /** Build the `System` message content string for a finished setup run. This
@@ -35,16 +44,17 @@ export function buildSetupScriptErrorContent(err: unknown): string {
   return `Setup script failed: ${err}`;
 }
 
-const COMPLETED_RE = /^Setup script \((.+?)\) (completed|failed|timed out)(?::\n([\s\S]*))?$/;
+const SETUP_RE = /^Setup script \((.+?)\) (completed|failed|timed out|running)(?::\n([\s\S]*))?$/;
 const ERROR_RE = /^Setup script failed: ([\s\S]*)$/;
 
 /** Parse a setup-script `System` message back into structured form. Returns
- *  `null` for any content that isn't one of the two setup-script shapes, so
- *  callers can fall through to generic message rendering. */
+ *  `null` for any content that isn't one of these shapes, so callers can fall
+ *  through to generic message rendering. */
 export function parseSetupScriptMessage(content: string): SetupScriptOutcome | null {
-  const m = COMPLETED_RE.exec(content);
+  const m = SETUP_RE.exec(content);
   if (m) {
-    const status: SetupScriptStatus = m[2] === "timed out" ? "timed-out" : (m[2] as SetupScriptStatus);
+    const raw = m[2];
+    const status: SetupScriptStatus = raw === "timed out" ? "timed-out" : (raw as SetupScriptStatus);
     return { source: m[1], status, output: m[3] ?? "" };
   }
   const e = ERROR_RE.exec(content);
@@ -58,9 +68,10 @@ function blankSystemMessage(
   sessionId: string,
   workspaceId: string,
   content: string,
+  id: string,
 ): ChatMessage {
   return {
-    id: crypto.randomUUID(),
+    id,
     workspace_id: workspaceId,
     chat_session_id: sessionId,
     role: "System",
@@ -77,10 +88,20 @@ function blankSystemMessage(
 }
 
 /** Store hooks the recorder needs. Passed in rather than importing the store
- *  here so this module stays a leaf (parse/build are pure and trivially
+ *  here so this module stays a leaf (`parse`/`build` are pure and trivially
  *  testable; no Zustand wiring pulled into util tests). */
 export interface SetupScriptRecorderDeps {
-  addChatMessage: (sessionId: string, message: ChatMessage) => void;
+  addChatMessage: (
+    sessionId: string,
+    message: ChatMessage,
+    options?: { persisted?: boolean },
+  ) => void;
+  updateChatMessage: (
+    sessionId: string,
+    messageId: string,
+    updates: Partial<ChatMessage>,
+  ) => void;
+  removeChatMessage: (sessionId: string, messageId: string) => void;
   addToast: (message: string) => void;
   /** Display name of the workspace, for the failure toast. */
   workspaceName?: string | null;
@@ -91,29 +112,50 @@ function failureToast(deps: SetupScriptRecorderDeps): void {
   deps.addToast(`Setup script for ${where} failed — see the transcript`);
 }
 
-/** Append the `System` message for a finished setup run to its chat session,
- *  and — if the run failed or timed out — raise a one-time toast so the
- *  failure isn't missed when it scrolls past in the transcript. Shared by all
- *  four sites that kick off a setup script (workspace creation, the sidebar,
- *  the command palette, and the confirm-setup modal). */
-export function recordSetupScriptResult(
-  sessionId: string,
-  workspaceId: string,
-  sr: SetupResult,
-  deps: SetupScriptRecorderDeps,
-): void {
-  deps.addChatMessage(sessionId, blankSystemMessage(sessionId, workspaceId, buildSetupScriptContent(sr)));
-  if (!sr.success) failureToast(deps);
-}
-
-/** Append the catch-path `System` message (the run threw) and raise the
- *  failure toast. */
-export function recordSetupScriptError(
-  sessionId: string,
-  workspaceId: string,
-  err: unknown,
-  deps: SetupScriptRecorderDeps,
-): void {
-  deps.addChatMessage(sessionId, blankSystemMessage(sessionId, workspaceId, buildSetupScriptErrorContent(err)));
-  failureToast(deps);
+/**
+ * Post a "Setup script (…) running" placeholder to the chat session, kick off
+ * `run()` (typically `() => runWorkspaceSetup(workspaceId)`), and when it
+ * settles swap the placeholder *in place* for the result message — or the
+ * catch-path error, or simply remove it if nothing actually ran. A failed or
+ * timed-out run also raises a one-time toast. Fire-and-forget: callers don't
+ * await. Shared by all four sites that start a setup script (workspace
+ * creation, the sidebar, the command palette, and the confirm-setup modal).
+ *
+ * The placeholder is client-only (`persisted: false`) — setup-script messages
+ * aren't written to the DB, and the placeholder must not bump pagination
+ * counts.
+ */
+export function runAndRecordSetupScript(opts: {
+  sessionId: string;
+  workspaceId: string;
+  /** `"repo"` (`.claudette.json`) or `"settings"` — drives the placeholder label. */
+  source: string;
+  run: () => Promise<SetupResult | null>;
+  deps: SetupScriptRecorderDeps;
+}): void {
+  const { sessionId, workspaceId, source, run, deps } = opts;
+  const placeholderId = crypto.randomUUID();
+  deps.addChatMessage(
+    sessionId,
+    blankSystemMessage(sessionId, workspaceId, buildSetupScriptRunningContent(source), placeholderId),
+    { persisted: false },
+  );
+  run()
+    .then((sr) => {
+      if (!sr) {
+        // No script actually resolved on the backend — drop the placeholder.
+        deps.removeChatMessage(sessionId, placeholderId);
+        return;
+      }
+      deps.updateChatMessage(sessionId, placeholderId, {
+        content: buildSetupScriptContent(sr),
+      });
+      if (!sr.success) failureToast(deps);
+    })
+    .catch((err) => {
+      deps.updateChatMessage(sessionId, placeholderId, {
+        content: buildSetupScriptErrorContent(err),
+      });
+      failureToast(deps);
+    });
 }

--- a/src/ui/src/utils/setupScriptMessage.ts
+++ b/src/ui/src/utils/setupScriptMessage.ts
@@ -95,8 +95,10 @@ export interface SetupScriptRecorderDeps {
     options?: { persisted?: boolean },
   ) => void;
   /** `setRunningSetupScript` from the chat slice — flag the session as having a
-   *  setup script in flight (value = source label), or `null` to clear. */
-  setRunningSetupScript: (sessionId: string, source: string | null) => void;
+   *  setup script in flight, passing the user-facing source *label*
+   *  (`.claudette.json` / `settings`) for the running banner, or `null` to
+   *  clear. `runAndRecordSetupScript` does the source→label conversion. */
+  setRunningSetupScript: (sessionId: string, label: string | null) => void;
   addToast: (message: string) => void;
   /** Display name of the workspace, for the failure toast. */
   workspaceName?: string | null;

--- a/src/ui/src/utils/setupScriptMessage.ts
+++ b/src/ui/src/utils/setupScriptMessage.ts
@@ -1,10 +1,11 @@
 import type { ChatMessage } from "../types/chat";
 import type { SetupResult } from "../types/repository";
 
-/** State of a setup-script run, reconstructed from the `System` chat message
- *  it's represented by. `running` is the in-flight placeholder; the rest are
- *  terminal. `output` is the combined stdout/stderr (empty while `running`,
- *  and often empty for a `completed` run that printed nothing). */
+/** State of a setup-script run. `running` is the in-flight indicator (rendered
+ *  straight from the `runningSetupScripts` store field, not a chat message);
+ *  the rest are terminal and reconstructed from the result `System` message.
+ *  `output` is the combined stdout/stderr (empty while `running`, and often
+ *  empty for a `completed` run that printed nothing). */
 export type SetupScriptStatus = "running" | "completed" | "failed" | "timed-out";
 
 export interface SetupScriptOutcome {
@@ -19,14 +20,6 @@ export interface SetupScriptOutcome {
  *  builders and the parser agree on exactly one spelling. */
 function sourceLabel(source: string): string {
   return source === "repo" ? ".claudette.json" : "settings";
-}
-
-/** Content for the in-flight placeholder, posted before the script is spawned
- *  and swapped in place once it finishes. `source` is the frontend's guess
- *  (`"repo"` / `"settings"`); the result message uses the authoritative
- *  `SetupResult.source`. */
-export function buildSetupScriptRunningContent(source: string): string {
-  return `Setup script (${sourceLabel(source)}) running`;
 }
 
 /** Build the `System` message content string for a finished setup run. This
@@ -44,12 +37,13 @@ export function buildSetupScriptErrorContent(err: unknown): string {
   return `Setup script failed: ${err}`;
 }
 
-const SETUP_RE = /^Setup script \((.+?)\) (completed|failed|timed out|running)(?::\n([\s\S]*))?$/;
+const SETUP_RE = /^Setup script \((.+?)\) (completed|failed|timed out)(?::\n([\s\S]*))?$/;
 const ERROR_RE = /^Setup script failed: ([\s\S]*)$/;
 
-/** Parse a setup-script `System` message back into structured form. Returns
- *  `null` for any content that isn't one of these shapes, so callers can fall
- *  through to generic message rendering. */
+/** Parse a setup-script result `System` message back into structured form
+ *  (only the terminal states — `running` is never a message). Returns `null`
+ *  for any content that isn't one of these shapes, so callers can fall through
+ *  to generic message rendering. */
 export function parseSetupScriptMessage(content: string): SetupScriptOutcome | null {
   const m = SETUP_RE.exec(content);
   if (m) {
@@ -68,10 +62,9 @@ function blankSystemMessage(
   sessionId: string,
   workspaceId: string,
   content: string,
-  id: string,
 ): ChatMessage {
   return {
-    id,
+    id: crypto.randomUUID(),
     workspace_id: workspaceId,
     chat_session_id: sessionId,
     role: "System",
@@ -96,12 +89,9 @@ export interface SetupScriptRecorderDeps {
     message: ChatMessage,
     options?: { persisted?: boolean },
   ) => void;
-  updateChatMessage: (
-    sessionId: string,
-    messageId: string,
-    updates: Partial<ChatMessage>,
-  ) => void;
-  removeChatMessage: (sessionId: string, messageId: string) => void;
+  /** `setRunningSetupScript` from the chat slice — flag the session as having a
+   *  setup script in flight (value = source label), or `null` to clear. */
+  setRunningSetupScript: (sessionId: string, source: string | null) => void;
   addToast: (message: string) => void;
   /** Display name of the workspace, for the failure toast. */
   workspaceName?: string | null;
@@ -113,49 +103,49 @@ function failureToast(deps: SetupScriptRecorderDeps): void {
 }
 
 /**
- * Post a "Setup script (…) running" placeholder to the chat session, kick off
- * `run()` (typically `() => runWorkspaceSetup(workspaceId)`), and when it
- * settles swap the placeholder *in place* for the result message — or the
- * catch-path error, or simply remove it if nothing actually ran. A failed or
- * timed-out run also raises a one-time toast. Fire-and-forget: callers don't
- * await. Shared by all four sites that start a setup script (workspace
- * creation, the sidebar, the command palette, and the confirm-setup modal).
+ * Mark the session as "setup script running" (so ChatPanel shows the spinner
+ * banner), kick off `run()` (typically `() => runWorkspaceSetup(workspaceId)`),
+ * and when it settles clear that flag and append the result `System` message —
+ * or the catch-path error message, or nothing if no script actually ran. A
+ * failed or timed-out run also raises a one-time toast. Fire-and-forget:
+ * callers don't await. Shared by all four sites that start a setup script
+ * (workspace creation, the sidebar, the command palette, and the confirm-setup
+ * modal).
  *
- * The placeholder is client-only (`persisted: false`) — setup-script messages
- * aren't written to the DB, and the placeholder must not bump pagination
- * counts.
+ * The running state is kept in a dedicated store field, *not* a chat message,
+ * because the post-creation chat-history reload replaces `chatMessages`
+ * wholesale and would wipe an in-flight placeholder. The result message is
+ * appended client-only (`persisted: false`) — setup-script messages aren't
+ * written to the DB, so they must not bump pagination counts.
  */
 export function runAndRecordSetupScript(opts: {
   sessionId: string;
   workspaceId: string;
-  /** `"repo"` (`.claudette.json`) or `"settings"` — drives the placeholder label. */
+  /** `"repo"` (`.claudette.json`) or `"settings"` — the running-banner label. */
   source: string;
   run: () => Promise<SetupResult | null>;
   deps: SetupScriptRecorderDeps;
 }): void {
   const { sessionId, workspaceId, source, run, deps } = opts;
-  const placeholderId = crypto.randomUUID();
-  deps.addChatMessage(
-    sessionId,
-    blankSystemMessage(sessionId, workspaceId, buildSetupScriptRunningContent(source), placeholderId),
-    { persisted: false },
-  );
+  deps.setRunningSetupScript(sessionId, source);
   run()
     .then((sr) => {
-      if (!sr) {
-        // No script actually resolved on the backend — drop the placeholder.
-        deps.removeChatMessage(sessionId, placeholderId);
-        return;
-      }
-      deps.updateChatMessage(sessionId, placeholderId, {
-        content: buildSetupScriptContent(sr),
-      });
+      deps.setRunningSetupScript(sessionId, null);
+      if (!sr) return;
+      deps.addChatMessage(
+        sessionId,
+        blankSystemMessage(sessionId, workspaceId, buildSetupScriptContent(sr)),
+        { persisted: false },
+      );
       if (!sr.success) failureToast(deps);
     })
     .catch((err) => {
-      deps.updateChatMessage(sessionId, placeholderId, {
-        content: buildSetupScriptErrorContent(err),
-      });
+      deps.setRunningSetupScript(sessionId, null);
+      deps.addChatMessage(
+        sessionId,
+        blankSystemMessage(sessionId, workspaceId, buildSetupScriptErrorContent(err)),
+        { persisted: false },
+      );
       failureToast(deps);
     });
 }


### PR DESCRIPTION
### Summary

When a repo has a setup script (e.g. `bun install`), its full stdout/stderr was dumped into the chat transcript as a single multi-line `System` message — scrolling the conversation for screenfuls of install logs before you reach the actual chat. This change renders it as a compact, expandable chip instead (mirroring the existing `CliInvocationBanner`), **and** adds a live running indicator while the script executes:

- **running** → a spinner + elapsed-seconds counter shown in the transcript while the script runs (a `bun install` can take 10-20s, so it's the reassurance it's working). Tracked in a dedicated store field, not a chat message.
- **completed** → collapsed one-line chip (`setup script (settings) · completed`); click the chevron to expand the full output in a scrollable `<pre>`. Collapse choice persists per-message via `sessionStorage`.
- **failed / timeout** → danger styling (red border/tint, alert icon), **starts expanded**, and raises a one-time toast (`Setup script for "<workspace>" failed — see the transcript`).
- **no output** → static chip, nothing to expand.

All four setup-script call sites (`ConfirmSetupScriptModal`, `CommandPalette`, `useCreateWorkspace`, `Sidebar`) funnel through one fire-and-forget helper `runAndRecordSetupScript`, which flags the session running, then on completion clears the flag and appends the result/error message (or nothing if no script ran). The confirm-setup modal is consequently non-blocking — it closes immediately and the transcript shows progress, instead of holding a "Running…" button.

The result-message wire format is unchanged for completed/failed runs; setup-script messages remain client-only (`persisted: false` — they were never written to the DB).

### Complexity Notes

- **Why a store field, not a placeholder message** (third commit fixes a regression in the second): a client-only "running" `System` message added at workspace-creation time races the post-creation `loadChatHistoryPage` → `setChatMessages([])` that fires when `ChatPanel` mounts the new session. When the reload won, the placeholder — and the in-place result update — vanished and the transcript stayed empty. History reloads only replace `chatMessages`, so the in-flight state lives in a separate `runningSetupScripts` store field that ChatPanel renders from; the result is appended as a normal message once the run is done (long after any reload).
- **Parse-based dispatch for the result, not a new data type.** The completed/failed result is still a `role: "System"` `ChatMessage` whose `content` follows a fixed string shape; `MessagesWithTurns.tsx`'s existing sentinel ladder gains `parseSetupScriptMessage → SetupScriptBanner`. Non-setup System messages are untouched.
- **`setupScriptMessage.ts` is a leaf module** — `runAndRecordSetupScript` takes the store actions as params rather than importing the Zustand store, keeping `parse`/`build` pure and unit-testable.
- **Modal behavior change**: `ConfirmSetupScriptModal` is now non-blocking; if persisting the auto-run preference fails it logs (instead of the old behavior of posting a misleading `Setup script failed: <preference error>` message).
- The failure toast string is plain English in the util (the util is intentionally store/i18n-free); the banner labels are i18n'd across all 5 locales.

### Test Steps

1. `cd src/ui && bunx tsc -b && bun run test && bun run lint && bun run lint:css` — all green (also `cargo fmt --all --check`; no Rust changed).
2. Run the app (`./scripts/dev.sh`). In a repo with a slow-ish setup script (`bun install`):
   - Create a workspace → the transcript immediately shows `setup script (settings) · running` with a spinner and a ticking `· Ns` counter. When it finishes, the result appears as a collapsed `· completed` chip. Click it → expands the full log; collapse, refresh the workspace → stays collapsed.
3. Make the setup script exit non-zero (`exit 1`) and re-run it via the command-palette / sidebar action, or via the confirm modal (note the modal now closes right away) → running → red-bordered, **expanded**, and a toast fires once.
4. Reload a workspace that had a setup-script message from before this change → renders as the new chip (format preserved).
5. Confirm a normal multi-line System message (plan-mode dump) still renders as markdown, unaffected.

### Checklist

- [x] Tests added/updated (`setupScriptMessage.test.ts`, `SetupScriptBanner.test.tsx`)
- [x] Documentation updated (`site/src/content/docs/features/parallel-agents.mdx`)
