### PR TITLE
fix(workspace): self-heal a stale sidebar row when env prep reports it's gone

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -594,6 +594,11 @@ pub async fn delete_workspace(
 
     let workspaces = db.list_workspaces().map_err(|e| e.to_string())?;
     let Some(ws) = workspaces.iter().find(|w| w.id == id) else {
+        // The row is already gone — delete is idempotent. Still announce
+        // it: a sidebar row can outlive its DB row (a prior delete whose
+        // IPC response WebView2 dropped), and this `workspaces-changed`
+        // event is the backstop that reconciles that ghost away.
+        TauriHooks::new(app.clone()).workspace_changed(&id, WorkspaceChangeKind::Deleted);
         return Ok(());
     };
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -655,7 +655,16 @@ pub async fn delete_workspace(
         let _ = app.emit("mcp-status-cleared", &repo_id);
     }
 
-    crate::tray::rebuild_tray(&app);
+    // Announce the delete through the shared hooks (rebuilds the tray and
+    // emits `workspaces-changed { kind: "deleted" }`). This was previously
+    // a bare `rebuild_tray` call, leaving the frontend's `removeWorkspace`
+    // entirely dependent on the IPC response to this command making it
+    // back — if it was dropped (WebView2 occasionally does this) the
+    // sidebar row became a ghost with no event-based backstop, unlike the
+    // archive path which already routes through `OpsHooks`. The event is
+    // idempotent on the frontend (`removeWorkspace` filters by id), so the
+    // common case where the `.then` handler also fires is harmless.
+    TauriHooks::new(app.clone()).workspace_changed(&id, WorkspaceChangeKind::Deleted);
 
     Ok(())
 }

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { __TEST__ } from "./useWorkspaceEnvironmentPreparation";
 
-const { looksLikeTrustError } = __TEST__;
+const { looksLikeTrustError, looksLikeMissingWorkspace } = __TEST__;
 
 describe("looksLikeTrustError", () => {
   it("matches the legacy mise-not-trusted error string", () => {
@@ -34,5 +34,29 @@ describe("looksLikeTrustError", () => {
 
   it("matches case-insensitively", () => {
     expect(looksLikeTrustError("FILE IS NOT TRUSTED")).toBe(true);
+  });
+});
+
+describe("looksLikeMissingWorkspace", () => {
+  it("matches the backend's 'Workspace not found' error verbatim", () => {
+    // The exact string `resolve_target_from_db` returns in
+    // `src-tauri/src/commands/env.rs` when the workspace id has no DB row.
+    expect(looksLikeMissingWorkspace("Workspace not found")).toBe(true);
+  });
+
+  it("matches case-insensitively and when wrapped in other text", () => {
+    expect(looksLikeMissingWorkspace("error: workspace not found")).toBe(true);
+  });
+
+  it("returns false for unrelated env-provider errors", () => {
+    expect(
+      looksLikeMissingWorkspace(
+        "Environment provider failed: env-mise: TOML parse error",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a generic 'not found' that isn't about the workspace", () => {
+    expect(looksLikeMissingWorkspace("Repository not found")).toBe(false);
   });
 });

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.test.tsx
@@ -690,4 +690,35 @@ describe("useWorkspaceEnvironmentPreparation", () => {
       "Workspace environment failed: Error: direnv blocked",
     );
   });
+
+  it("drops a ghost workspace from the store when prep reports 'Workspace not found'", async () => {
+    // The backend's `prepare_workspace_environment` returns the bare
+    // string "Workspace not found" (via `resolve_target_from_db`) when the
+    // selected workspace id no longer has a DB row — i.e. it was cleaned
+    // up but its sidebar row lingered. Instead of stranding an
+    // unactionable error toast next to the ghost, the hook removes it.
+    serviceMocks.prepareWorkspaceEnvironment.mockRejectedValue(
+      "Workspace not found",
+    );
+    useAppStore.setState({
+      selectedWorkspaceId: "ws-1",
+      workspaces: [makeWorkspace()],
+    });
+
+    await renderHarness();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const state = useAppStore.getState();
+    expect(state.workspaces.find((w) => w.id === "ws-1")).toBeUndefined();
+    // `removeWorkspace` also clears the selection and the env entry.
+    expect(state.selectedWorkspaceId).toBeNull();
+    expect(state.workspaceEnvironment["ws-1"]).toBeUndefined();
+    // The toast is informational, not the old "Workspace environment
+    // failed: …" dead end.
+    expect(state.toasts.at(-1)?.message).toBe(
+      "Workspace no longer exists — removed from the sidebar.",
+    );
+  });
 });

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -72,6 +72,23 @@ function trustPayloadSignature(payload: WorkspaceEnvTrustNeededPayload): string 
   });
 }
 
+/**
+ * Match the error `prepare_workspace_environment` returns when the
+ * workspace id no longer resolves to a DB row — `"Workspace not found"`,
+ * raised by `resolve_target_from_db` in `src-tauri/src/commands/env.rs`.
+ *
+ * A workspace in this state is a ghost: the worktree + DB row were torn
+ * down (a delete whose `workspaces-changed` event we missed, a worktree
+ * pruned out from under us, a desync after a crash) but the sidebar row
+ * lingers. The toast for this case is a dead end — there's no recover
+ * action — so the right move is to drop the row instead of stranding an
+ * unactionable error next to it. See the `.catch` in the per-selection
+ * effect below.
+ */
+function looksLikeMissingWorkspace(message: string): boolean {
+  return message.toLowerCase().includes("workspace not found");
+}
+
 export function useWorkspaceEnvironmentPreparation() {
   const selectedWorkspaceId = useAppStore((s) => s.selectedWorkspaceId);
   const selectedWorkspaceRemoteConnectionId = useAppStore((s) => {
@@ -87,6 +104,7 @@ export function useWorkspaceEnvironmentPreparation() {
   );
   const addToast = useAppStore((s) => s.addToast);
   const openModal = useAppStore((s) => s.openModal);
+  const removeWorkspace = useAppStore((s) => s.removeWorkspace);
   const promptedTrustSignaturesRef = useRef<Map<string, string>>(new Map());
 
   const openTrustModalOnce = useCallback((payload: WorkspaceEnvTrustNeededPayload) => {
@@ -257,6 +275,17 @@ export function useWorkspaceEnvironmentPreparation() {
       .catch((err) => {
         if (cancelled) return;
         const message = String(err);
+        // The workspace row is gone from the DB but still showing in the
+        // sidebar (a delete whose `workspaces-changed` event we missed, a
+        // worktree pruned externally, a post-crash desync). Nothing the
+        // user can do with a ghost row — drop it and deselect instead of
+        // parking an unactionable "Workspace not found" error next to a
+        // row that will only fail the same way on every interaction.
+        if (looksLikeMissingWorkspace(message)) {
+          removeWorkspace(workspaceId);
+          addToast("Workspace no longer exists — removed from the sidebar.");
+          return;
+        }
         setWorkspaceEnvironment(workspaceId, "error", message);
         // Trust-class failures are routed through the
         // `workspace_env_trust_needed` event + EnvTrustModal — the
@@ -283,9 +312,10 @@ export function useWorkspaceEnvironmentPreparation() {
     setWorkspaceEnvironment,
     addToast,
     openTrustModalOnce,
+    removeWorkspace,
   ]);
 }
 
 // Internal: exposed for vitest. The hook is the only production
 // consumer.
-export const __TEST__ = { looksLikeTrustError };
+export const __TEST__ = { looksLikeTrustError, looksLikeMissingWorkspace };

--- a/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
+++ b/src/ui/src/hooks/useWorkspaceEnvironmentPreparation.ts
@@ -80,7 +80,7 @@ function trustPayloadSignature(payload: WorkspaceEnvTrustNeededPayload): string 
  * A workspace in this state is a ghost: the worktree + DB row were torn
  * down (a delete whose `workspaces-changed` event we missed, a worktree
  * pruned out from under us, a desync after a crash) but the sidebar row
- * lingers. The toast for this case is a dead end — there's no recover
+ * lingers. The toast for this case is a dead end — there's no recovery
  * action — so the right move is to drop the row instead of stranding an
  * unactionable error next to it. See the `.catch` in the per-selection
  * effect below.


### PR DESCRIPTION
### Summary

A workspace that's been cleaned up otherwise can still linger in the sidebar — and selecting it then surfaces a dead-end toast: *"Workspace environment failed: Workspace not found"* — with no way to get rid of the row short of restarting.

Two changes:

1. **Self-heal on the env-prep path (frontend).** `prepare_workspace_environment` returns the bare string `"Workspace not found"` (from `resolve_target_from_db` in `commands/env.rs`) when the selected workspace has no DB row. The per-selection env-prep effect now treats that as the reconcile signal: it calls `removeWorkspace(id)` (which also clears the selection + env entry) and shows a short informational toast instead of the unactionable error.

2. **Close the gap that produced the ghost (backend).** `delete_workspace` was the *one* workspace-lifecycle command that didn't emit `workspaces-changed` — it relied entirely on the IPC response reaching the webview so the caller could `removeWorkspace`. (Archive/restore go through `ops_workspace::*` → `TauriHooks::workspace_changed`; CLI/remote deletes get the event too.) If that response was dropped — WebView2 occasionally does this, there's a whole comment about it in `useWorkspaceEnvironmentPreparation.ts` — or the frontend threw before `removeWorkspace`, the row became an orphan with no event-based recovery. `delete_workspace` now announces the delete through `TauriHooks::workspace_changed(&id, WorkspaceChangeKind::Deleted)`, matching the other paths. The event is idempotent on the frontend (`removeWorkspace` filters by id), so the common case where the `.then` handler also fires is harmless.

```mermaid
flowchart TD
    A[delete_workspace command] --> B[DB row + worktree removed]
    B --> C{IPC response reaches webview?}
    C -- yes --> D[caller calls removeWorkspace - row gone]
    C -- "no (dropped)" --> E[before: ghost row lingers forever]
    B --> F["NEW: TauriHooks.workspace_changed(Deleted)<br/>→ emits workspaces-changed"]
    F --> G[App.tsx listener → removeWorkspace - row gone]
    E -.-> H[user selects ghost row]
    H --> I["prepare_workspace_environment → 'Workspace not found'"]
    I --> J[NEW: removeWorkspace + informational toast]
```

### Complexity Notes

- The `"Workspace not found"` match is a substring check (`looksLikeMissingWorkspace`), mirroring the existing `looksLikeTrustError` pattern. It's the literal string the backend returns; a deliberately narrow match so unrelated `… not found` errors (e.g. `Repository not found`) still toast normally.
- `useWorkspaceEnvironmentPreparation.ts` had a parallel change land on `main` (trust-modal dedup) — the rebase conflict was resolved by keeping both: `removeWorkspace` subscription + the new helper alongside `openTrustModalOnce`/`promptedTrustSignaturesRef`.
- The `delete_workspace` change replaces a bare `crate::tray::rebuild_tray(&app)` — `TauriHooks::workspace_changed` calls `rebuild_tray` itself, so tray behavior is unchanged.

### Test Steps

1. **Self-heal path** — with the app running, hard-delete a workspace's DB row out from under the GUI (e.g. via the debug eval server, or `git worktree remove` + `claudette workspace …` shenanigans, or stop the app, delete the row in SQLite, restart). Select the now-orphaned sidebar row. Expected: the row disappears and a toast says *"Workspace no longer exists — removed from the sidebar."* — no `Workspace environment failed` error.
2. **Normal delete still works** — delete a workspace via the sidebar context menu → Delete. The row should vanish exactly as before; check there's no double-removal glitch (it's idempotent).
3. **Other env errors unaffected** — in a workspace with a blocked `.envrc`, confirm the trust modal still appears and (for a non-trust provider error) the `Workspace environment failed: …` toast still fires.
4. `cd src/ui && bunx tsc -b && bun run test` — all green (1976 tests). `cargo fmt --all --check` and `cargo check -p claudette-tauri` clean.

### Checklist
- [x] Tests added/updated
- [x] Documentation updated (if applicable) — n/a; this is resilience/bug-fix behavior (a ghost row self-healing), not a new user-configurable surface