### PR TITLE
fix(chat): highlight selected question options

### DIFF
--- a/src/ui/src/components/chat/AgentQuestionCard.module.css
+++ b/src/ui/src/components/chat/AgentQuestionCard.module.css
@@ -114,7 +114,15 @@
 }
 
 .optionLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-weight: 500;
+}
+
+.optionLabel::before {
+  content: "";
+  display: none;
 }
 
 .optionDesc {
@@ -122,10 +130,29 @@
   color: var(--text-dim);
 }
 
-.optionSelected {
+.option.optionSelected,
+.option.optionSelected:hover {
   border-color: var(--accent-primary);
-  background: rgba(var(--accent-primary-rgb), 0.08);
-  box-shadow: 0 0 0 1px rgba(var(--accent-primary-rgb), 0.1);
+  background: rgba(var(--accent-primary-rgb), 0.16);
+  box-shadow: 0 0 0 1px rgba(var(--accent-primary-rgb), 0.3);
+}
+
+.option.optionSelected .optionLabel {
+  color: var(--accent-primary);
+}
+
+.option.optionSelected .optionLabel::before {
+  content: "\2713";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  color: var(--on-accent);
+  font-size: 10px;
+  line-height: 1;
 }
 
 .confirmBtn {

--- a/src/ui/src/components/chat/AgentQuestionCard.test.tsx
+++ b/src/ui/src/components/chat/AgentQuestionCard.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentQuestion } from "../../stores/useAppStore";
+import { AgentQuestionCard } from "./AgentQuestionCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mountedRoots: Root[] = [];
+const mountedContainers: HTMLElement[] = [];
+
+async function render(node: ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  mountedContainers.push(container);
+  await act(async () => {
+    root.render(node);
+  });
+  return container;
+}
+
+function buttonNamed(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find((node) =>
+    node.textContent?.includes(label),
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`button ${label} not found`);
+  }
+  return button;
+}
+
+async function click(button: HTMLButtonElement): Promise<void> {
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+afterEach(async () => {
+  for (const root of mountedRoots.splice(0).reverse()) {
+    await act(async () => {
+      root.unmount();
+    });
+  }
+  for (const container of mountedContainers.splice(0)) {
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("AgentQuestionCard", () => {
+  it("immediately marks single-question multi-select options as pressed", async () => {
+    const question: AgentQuestion = {
+      sessionId: "s1",
+      toolUseId: "tool1",
+      questions: [
+        {
+          question: "Pick targets",
+          multiSelect: true,
+          options: [{ label: "Unit" }, { label: "Integration" }],
+        },
+      ],
+    };
+
+    const container = await render(
+      <AgentQuestionCard question={question} onRespond={vi.fn()} />,
+    );
+    const unit = buttonNamed(container, "Unit");
+
+    expect(unit.getAttribute("aria-pressed")).toBe("false");
+    await click(unit);
+    expect(unit.getAttribute("aria-pressed")).toBe("true");
+    await click(unit);
+    expect(unit.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("immediately marks multi-question wizard multi-select options as pressed", async () => {
+    const question: AgentQuestion = {
+      sessionId: "s1",
+      toolUseId: "tool1",
+      questions: [
+        {
+          question: "Pick checks",
+          multiSelect: true,
+          options: [{ label: "Lint" }, { label: "Typecheck" }],
+        },
+        {
+          question: "Ship it?",
+          options: [{ label: "Yes" }],
+        },
+      ],
+    };
+
+    const container = await render(
+      <AgentQuestionCard question={question} onRespond={vi.fn()} />,
+    );
+    const lint = buttonNamed(container, "Lint");
+
+    expect(lint.getAttribute("aria-pressed")).toBe("false");
+    await click(lint);
+    expect(lint.getAttribute("aria-pressed")).toBe("true");
+    await click(lint);
+    expect(lint.getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/src/ui/src/components/chat/AgentQuestionCard.tsx
+++ b/src/ui/src/components/chat/AgentQuestionCard.tsx
@@ -71,8 +71,10 @@ export function AgentQuestionCard({
                 const isSelected = currentSelections.has(optIdx);
                 return (
                   <button
+                    type="button"
                     key={optIdx}
                     className={`${styles.option} ${isSelected ? styles.optionSelected : ""}`}
+                    aria-pressed={isMulti ? isSelected : undefined}
                     onClick={() => toggleSingle(optIdx)}
                   >
                     <span className={styles.optionLabel}>{opt.label}</span>
@@ -254,8 +256,10 @@ export function AgentQuestionCard({
               const isSelected = currentSelections.has(optIdx);
               return (
                 <button
+                  type="button"
                   key={optIdx}
                   className={`${styles.option} ${isSelected ? styles.optionSelected : ""}`}
+                  aria-pressed={isMultiSelect ? isSelected : undefined}
                   onClick={() => handleOptionClick(optIdx)}
                 >
                   <span className={styles.optionLabel}>{opt.label}</span>

--- a/src/ui/src/components/chat/chatLayoutCss.test.ts
+++ b/src/ui/src/components/chat/chatLayoutCss.test.ts
@@ -89,3 +89,21 @@ describe("ThinkingBlock.module.css invariants", () => {
     expect(body).toMatch(/overflow-y:\s*auto\s*;/);
   });
 });
+
+describe("AgentQuestionCard.module.css invariants", () => {
+  it("selected question options keep their selected styling while hovered", () => {
+    const css = readCss("AgentQuestionCard.module.css");
+    const hoverBody = ruleBody(css, ".option:hover");
+    const selectedHoverMatch = css.match(
+      /\.option\.optionSelected,\s*\.option\.optionSelected:hover\s*{([^}]*)}/,
+    );
+    if (!selectedHoverMatch) {
+      throw new Error("selected option hover rule not found in CSS");
+    }
+    const selectedHoverBody = selectedHoverMatch[1];
+
+    expect(hoverBody).toMatch(/background:\s*rgba\(var\(--accent-primary-rgb\),\s*0\.05\)\s*;/);
+    expect(selectedHoverBody).toMatch(/border-color:\s*var\(--accent-primary\)\s*;/);
+    expect(selectedHoverBody).toMatch(/background:\s*rgba\(var\(--accent-primary-rgb\),\s*0\.16\)\s*;/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the multi-select agent question option highlight regression reported in #791. Selected options now keep their selected styling even while the pointer remains hovered over the clicked button, so the click gives immediate visual feedback instead of looking like it did nothing.

Closes #791

## Root Cause

`AgentQuestionCard.module.css` applied `.option:hover` with higher specificity than `.optionSelected`. After a multi-select option was clicked, React updated the selected state correctly, but the hover rule kept overriding the selected background and border until the pointer left the button. The selected background was also too close to the hover tint, making the state hard to perceive.

## Changes

- Added an explicit selected-hover selector so selected options retain the accent border and selected background while hovered.
- Strengthened the selected visual state and added a small check indicator for clearer feedback.
- Added `aria-pressed` on multi-select option buttons in both the single-question and multi-question wizard paths so the pressed state updates immediately in the DOM.
- Added regression tests covering single-question and wizard multi-select toggles plus a CSS invariant for the selected-hover rule.

## Validation

- User verified the UI fix manually.
- `bun run test -- AgentQuestionCard.test.tsx chatLayoutCss.test.ts`
- `bunx tsc -b`
- `bun run lint:css`
- `bunx eslint src/components/chat/AgentQuestionCard.tsx src/components/chat/AgentQuestionCard.test.tsx src/components/chat/chatLayoutCss.test.ts`
- `git diff --check`
