### PR TITLE
feat(chat): render sub-agent transcript details

### DIFF
--- a/site/src/content/docs/features/agent-configuration.mdx
+++ b/site/src/content/docs/features/agent-configuration.mdx
@@ -56,6 +56,8 @@ When `Settings > Appearance > Extended tool call output` is enabled, tool-call r
 
 The expanded state sticks to each tool call while the chat panel re-renders, so you can keep a long query or command open while later tool activity streams in.
 
+Sub-agent runs from the Agent tool render as their own expandable transcript blocks instead of being mixed into adjacent tool-call groups. Expanding one shows the delegated prompt, captured thinking blocks, nested tool calls, live progress, and the final result returned to the parent agent.
+
 ## Fast Mode
 
 Fast mode prioritizes speed over depth. When enabled, the agent uses quicker, more concise responses.

--- a/src/agent_mcp/hook.rs
+++ b/src/agent_mcp/hook.rs
@@ -73,7 +73,7 @@ fn enrich_subagent_stop(input: &mut serde_json::Value) {
     if obj
         .get("last_assistant_message")
         .and_then(serde_json::Value::as_str)
-        .is_none_or(str::is_empty)
+        .is_none_or(|message| message.trim().is_empty())
         && let Some(result) = snapshot.final_result
     {
         obj.insert(
@@ -237,6 +237,26 @@ mod tests {
             serde_json::json!(["plan"])
         );
         assert!(input.get("claudette_agent_final_result").is_none());
+    }
+
+    #[test]
+    fn enriches_subagent_stop_overwrites_blank_cli_result() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"from transcript"}}]}}}}"#
+        )
+        .unwrap();
+        let mut input = serde_json::json!({
+            "hook_event_name": "SubagentStop",
+            "agent_transcript_path": file.path().to_string_lossy(),
+            "last_assistant_message": "   "
+        });
+
+        enrich_subagent_stop(&mut input);
+
+        assert_eq!(input["last_assistant_message"], "   ");
+        assert_eq!(input["claudette_agent_final_result"], "from transcript");
     }
 
     #[test]

--- a/src/agent_mcp/hook.rs
+++ b/src/agent_mcp/hook.rs
@@ -5,7 +5,8 @@
 //! already-running per-session bridge so the Tauri UI can show nested
 //! subagent tool activity without scraping DEBUG logs.
 
-use std::io;
+use std::io::{self, BufRead};
+use std::path::Path;
 
 use tokio::io::AsyncReadExt;
 
@@ -22,8 +23,9 @@ pub async fn run_stdin() -> io::Result<()> {
 
     let mut input = String::new();
     tokio::io::stdin().read_to_string(&mut input).await?;
-    let hook_input = serde_json::from_str::<serde_json::Value>(&input)
+    let mut hook_input = serde_json::from_str::<serde_json::Value>(&input)
         .map_err(|e| io::Error::other(format!("parse hook input: {e}")))?;
+    enrich_subagent_stop(&mut hook_input);
 
     let req = BridgeRequest {
         token,
@@ -31,4 +33,171 @@ pub async fn run_stdin() -> io::Result<()> {
     };
     let _ = super::server::send_to_bridge(&socket_addr, &req).await;
     Ok(())
+}
+
+fn enrich_subagent_stop(input: &mut serde_json::Value) {
+    let Some(obj) = input.as_object_mut() else {
+        return;
+    };
+    if obj
+        .get("hook_event_name")
+        .and_then(serde_json::Value::as_str)
+        != Some("SubagentStop")
+    {
+        return;
+    }
+
+    let path = obj
+        .get("agent_transcript_path")
+        .or_else(|| obj.get("transcript_path"))
+        .and_then(serde_json::Value::as_str);
+    let Some(path) = path else {
+        return;
+    };
+    let Ok(snapshot) = extract_subagent_transcript_snapshot(Path::new(path)) else {
+        return;
+    };
+
+    if !snapshot.thinking_blocks.is_empty() {
+        obj.insert(
+            "claudette_agent_thinking_blocks".to_string(),
+            serde_json::json!(snapshot.thinking_blocks),
+        );
+    }
+    if obj
+        .get("last_assistant_message")
+        .and_then(serde_json::Value::as_str)
+        .is_none_or(str::is_empty)
+    {
+        if let Some(result) = snapshot.final_result {
+            obj.insert(
+                "claudette_agent_final_result".to_string(),
+                serde_json::Value::String(result),
+            );
+        }
+    }
+}
+
+struct SubagentTranscriptSnapshot {
+    thinking_blocks: Vec<String>,
+    final_result: Option<String>,
+}
+
+fn extract_subagent_transcript_snapshot(path: &Path) -> io::Result<SubagentTranscriptSnapshot> {
+    let file = std::fs::File::open(path)?;
+    let reader = std::io::BufReader::new(file);
+    let mut thinking_blocks = Vec::new();
+    let mut final_result = None;
+
+    for line in reader.lines() {
+        let line = line?;
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let Some(content) = assistant_content_blocks(&value) else {
+            continue;
+        };
+
+        let mut text_blocks = Vec::new();
+        for block in content {
+            let Some(block_type) = block.get("type").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            match block_type {
+                "thinking" => {
+                    if let Some(thinking) =
+                        block.get("thinking").and_then(serde_json::Value::as_str)
+                    {
+                        let thinking = thinking.trim();
+                        if !thinking.is_empty() {
+                            thinking_blocks.push(thinking.to_string());
+                        }
+                    }
+                }
+                "text" => {
+                    if let Some(text) = block.get("text").and_then(serde_json::Value::as_str) {
+                        let text = text.trim();
+                        if !text.is_empty() {
+                            text_blocks.push(text.to_string());
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !text_blocks.is_empty() {
+            final_result = Some(text_blocks.join("\n\n"));
+        }
+    }
+
+    Ok(SubagentTranscriptSnapshot {
+        thinking_blocks,
+        final_result,
+    })
+}
+
+fn assistant_content_blocks(value: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    if value.get("type").and_then(serde_json::Value::as_str) != Some("assistant") {
+        return None;
+    }
+    value
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .or_else(|| value.get("content"))
+        .and_then(serde_json::Value::as_array)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn extracts_thinking_and_last_assistant_text_from_subagent_transcript() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"thinking","thinking":" first thought "}},{{"type":"text","text":"intermediate"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(file, r#"{{"type":"user","message":{{"content":[]}}}}"#).unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"thinking","thinking":"second thought"}},{{"type":"text","text":"final answer"}}]}}}}"#
+        )
+        .unwrap();
+
+        let snapshot = extract_subagent_transcript_snapshot(file.path()).unwrap();
+
+        assert_eq!(
+            snapshot.thinking_blocks,
+            vec!["first thought".to_string(), "second thought".to_string()]
+        );
+        assert_eq!(snapshot.final_result.as_deref(), Some("final answer"));
+    }
+
+    #[test]
+    fn enriches_subagent_stop_without_overwriting_cli_result() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"thinking","thinking":"plan"}},{{"type":"text","text":"from transcript"}}]}}}}"#
+        )
+        .unwrap();
+        let mut input = serde_json::json!({
+            "hook_event_name": "SubagentStop",
+            "agent_transcript_path": file.path().to_string_lossy(),
+            "last_assistant_message": "from hook"
+        });
+
+        enrich_subagent_stop(&mut input);
+
+        assert_eq!(input["last_assistant_message"], "from hook");
+        assert_eq!(
+            input["claudette_agent_thinking_blocks"],
+            serde_json::json!(["plan"])
+        );
+        assert!(input.get("claudette_agent_final_result").is_none());
+    }
 }

--- a/src/agent_mcp/hook.rs
+++ b/src/agent_mcp/hook.rs
@@ -5,12 +5,18 @@
 //! already-running per-session bridge so the Tauri UI can show nested
 //! subagent tool activity without scraping DEBUG logs.
 
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use tokio::io::AsyncReadExt;
 
 use crate::agent_mcp::protocol::{BridgePayload, BridgeRequest};
+
+const MAX_TRANSCRIPT_TAIL_BYTES: u64 = 512 * 1024;
+const MAX_TRANSCRIPT_LINES: usize = 2_000;
+const MAX_THINKING_BLOCKS: usize = 32;
+const MAX_THINKING_TOTAL_CHARS: usize = 32_000;
+const MAX_RESULT_CHARS: usize = 32_000;
 
 /// Run a one-shot hook forwarder.
 pub async fn run_stdin() -> io::Result<()> {
@@ -68,13 +74,12 @@ fn enrich_subagent_stop(input: &mut serde_json::Value) {
         .get("last_assistant_message")
         .and_then(serde_json::Value::as_str)
         .is_none_or(str::is_empty)
+        && let Some(result) = snapshot.final_result
     {
-        if let Some(result) = snapshot.final_result {
-            obj.insert(
-                "claudette_agent_final_result".to_string(),
-                serde_json::Value::String(result),
-            );
-        }
+        obj.insert(
+            "claudette_agent_final_result".to_string(),
+            serde_json::Value::String(result),
+        );
     }
 }
 
@@ -84,12 +89,13 @@ struct SubagentTranscriptSnapshot {
 }
 
 fn extract_subagent_transcript_snapshot(path: &Path) -> io::Result<SubagentTranscriptSnapshot> {
-    let file = std::fs::File::open(path)?;
-    let reader = std::io::BufReader::new(file);
+    let tail = read_transcript_tail(path)?;
+    let reader = std::io::BufReader::new(std::io::Cursor::new(tail));
     let mut thinking_blocks = Vec::new();
+    let mut thinking_chars = 0usize;
     let mut final_result = None;
 
-    for line in reader.lines() {
+    for line in reader.lines().take(MAX_TRANSCRIPT_LINES) {
         let line = line?;
         let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
             continue;
@@ -108,10 +114,7 @@ fn extract_subagent_transcript_snapshot(path: &Path) -> io::Result<SubagentTrans
                     if let Some(thinking) =
                         block.get("thinking").and_then(serde_json::Value::as_str)
                     {
-                        let thinking = thinking.trim();
-                        if !thinking.is_empty() {
-                            thinking_blocks.push(thinking.to_string());
-                        }
+                        push_capped_thinking(&mut thinking_blocks, &mut thinking_chars, thinking);
                     }
                 }
                 "text" => {
@@ -127,7 +130,7 @@ fn extract_subagent_transcript_snapshot(path: &Path) -> io::Result<SubagentTrans
         }
 
         if !text_blocks.is_empty() {
-            final_result = Some(text_blocks.join("\n\n"));
+            final_result = Some(truncate_chars(&text_blocks.join("\n\n"), MAX_RESULT_CHARS));
         }
     }
 
@@ -135,6 +138,41 @@ fn extract_subagent_transcript_snapshot(path: &Path) -> io::Result<SubagentTrans
         thinking_blocks,
         final_result,
     })
+}
+
+fn read_transcript_tail(path: &Path) -> io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    let start = len.saturating_sub(MAX_TRANSCRIPT_TAIL_BYTES);
+    if start > 0 {
+        file.seek(SeekFrom::Start(start))?;
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    if start > 0
+        && let Some(pos) = bytes.iter().position(|b| *b == b'\n')
+    {
+        bytes.drain(..=pos);
+    }
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn push_capped_thinking(blocks: &mut Vec<String>, total_chars: &mut usize, thinking: &str) {
+    if blocks.len() >= MAX_THINKING_BLOCKS || *total_chars >= MAX_THINKING_TOTAL_CHARS {
+        return;
+    }
+    let thinking = thinking.trim();
+    if thinking.is_empty() {
+        return;
+    }
+    let remaining = MAX_THINKING_TOTAL_CHARS - *total_chars;
+    let capped = truncate_chars(thinking, remaining);
+    *total_chars += capped.chars().count();
+    blocks.push(capped);
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
 }
 
 fn assistant_content_blocks(value: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
@@ -199,5 +237,27 @@ mod tests {
             serde_json::json!(["plan"])
         );
         assert!(input.get("claudette_agent_final_result").is_none());
+    }
+
+    #[test]
+    fn transcript_snapshot_is_bounded_to_tail_and_field_caps() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&vec![b'x'; (MAX_TRANSCRIPT_TAIL_BYTES + 128) as usize])
+            .unwrap();
+        writeln!(file).unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"thinking","thinking":" tail thought "}},{{"type":"text","text":"{}"}}]}}}}"#,
+            "y".repeat(MAX_RESULT_CHARS + 128)
+        )
+        .unwrap();
+
+        let snapshot = extract_subagent_transcript_snapshot(file.path()).unwrap();
+
+        assert_eq!(snapshot.thinking_blocks, vec!["tail thought".to_string()]);
+        assert_eq!(
+            snapshot.final_result.as_ref().map(|s| s.chars().count()),
+            Some(MAX_RESULT_CHARS)
+        );
     }
 }

--- a/src/db/checkpoint.rs
+++ b/src/db/checkpoint.rs
@@ -263,9 +263,10 @@ impl Database {
                     id, checkpoint_id, tool_use_id, tool_name, input_json,
                     result_text, summary, sort_order, assistant_message_ordinal,
                     agent_task_id, agent_description, agent_last_tool_name,
-                    agent_tool_use_count, agent_status, agent_tool_calls_json
+                    agent_tool_use_count, agent_status, agent_tool_calls_json,
+                    agent_thinking_blocks_json, agent_result_text
                  )
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             )?;
             for a in activities {
                 stmt.execute(params![
@@ -284,6 +285,8 @@ impl Database {
                     a.agent_tool_use_count,
                     a.agent_status,
                     a.agent_tool_calls_json,
+                    a.agent_thinking_blocks_json,
+                    a.agent_result_text,
                 ])?;
             }
         }
@@ -321,9 +324,10 @@ impl Database {
                     id, checkpoint_id, tool_use_id, tool_name, input_json,
                     result_text, summary, sort_order, assistant_message_ordinal,
                     agent_task_id, agent_description, agent_last_tool_name,
-                    agent_tool_use_count, agent_status, agent_tool_calls_json
+                    agent_tool_use_count, agent_status, agent_tool_calls_json,
+                    agent_thinking_blocks_json, agent_result_text
                  )
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             )?;
             for a in activities {
                 stmt.execute(params![
@@ -342,6 +346,8 @@ impl Database {
                     a.agent_tool_use_count,
                     a.agent_status,
                     a.agent_tool_calls_json,
+                    a.agent_thinking_blocks_json,
+                    a.agent_result_text,
                 ])?;
             }
         }
@@ -364,7 +370,8 @@ impl Database {
                     ta.input_json, ta.result_text, ta.summary, ta.sort_order,
                     ta.assistant_message_ordinal, ta.agent_task_id,
                     ta.agent_description, ta.agent_last_tool_name,
-                    ta.agent_tool_use_count, ta.agent_status, ta.agent_tool_calls_json
+                    ta.agent_tool_use_count, ta.agent_status, ta.agent_tool_calls_json,
+                    ta.agent_thinking_blocks_json, ta.agent_result_text
              FROM turn_tool_activities ta
              JOIN conversation_checkpoints cp ON ta.checkpoint_id = cp.id
              WHERE cp.workspace_id = ?1
@@ -388,6 +395,8 @@ impl Database {
                     agent_tool_use_count: row.get(12)?,
                     agent_status: row.get(13)?,
                     agent_tool_calls_json: row.get(14)?,
+                    agent_thinking_blocks_json: row.get(15)?,
+                    agent_result_text: row.get(16)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -468,7 +477,8 @@ impl Database {
                     ta.input_json, ta.result_text, ta.summary, ta.sort_order,
                     ta.assistant_message_ordinal, ta.agent_task_id,
                     ta.agent_description, ta.agent_last_tool_name,
-                    ta.agent_tool_use_count, ta.agent_status, ta.agent_tool_calls_json
+                    ta.agent_tool_use_count, ta.agent_status, ta.agent_tool_calls_json,
+                    ta.agent_thinking_blocks_json, ta.agent_result_text
              FROM turn_tool_activities ta
              JOIN conversation_checkpoints cp ON ta.checkpoint_id = cp.id
              WHERE cp.chat_session_id = ?1
@@ -492,6 +502,8 @@ impl Database {
                     agent_tool_use_count: row.get(12)?,
                     agent_status: row.get(13)?,
                     agent_tool_calls_json: row.get(14)?,
+                    agent_thinking_blocks_json: row.get(15)?,
+                    agent_result_text: row.get(16)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -574,6 +586,8 @@ mod tests {
             agent_tool_use_count: None,
             agent_status: None,
             agent_tool_calls_json: "[]".into(),
+            agent_thinking_blocks_json: "[]".into(),
+            agent_result_text: None,
         }
     }
 

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -425,6 +425,8 @@ fn copy_history(
                     agent_tool_use_count: a.agent_tool_use_count,
                     agent_status: a.agent_status.clone(),
                     agent_tool_calls_json: a.agent_tool_calls_json.clone(),
+                    agent_thinking_blocks_json: a.agent_thinking_blocks_json.clone(),
+                    agent_result_text: a.agent_result_text.clone(),
                 })
                 .collect();
             db.insert_turn_tool_activities(&remapped)?;
@@ -641,6 +643,8 @@ mod tests {
             agent_tool_use_count: None,
             agent_status: None,
             agent_tool_calls_json: "[]".into(),
+            agent_thinking_blocks_json: "[]".into(),
+            agent_result_text: None,
         }])
         .unwrap();
         db.insert_turn_tool_activities(&[TurnToolActivity {
@@ -659,6 +663,8 @@ mod tests {
             agent_tool_use_count: None,
             agent_status: None,
             agent_tool_calls_json: "[]".into(),
+            agent_thinking_blocks_json: "[]".into(),
+            agent_result_text: None,
         }])
         .unwrap();
         db

--- a/src/migrations/20260513144558_turn_tool_activity_agent_transcript.sql
+++ b/src/migrations/20260513144558_turn_tool_activity_agent_transcript.sql
@@ -1,0 +1,2 @@
+ALTER TABLE turn_tool_activities ADD COLUMN agent_thinking_blocks_json TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE turn_tool_activities ADD COLUMN agent_result_text TEXT;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -224,4 +224,9 @@ pub const MIGRATIONS: &[Migration] = &[
         sql: include_str!("20260511131643_pinned_prompts_toggle_overrides.sql"),
         legacy_version: None,
     },
+    Migration {
+        id: "20260513144558_turn_tool_activity_agent_transcript",
+        sql: include_str!("20260513144558_turn_tool_activity_agent_transcript.sql"),
+        legacy_version: None,
+    },
 ];

--- a/src/model/checkpoint.rs
+++ b/src/model/checkpoint.rs
@@ -44,6 +44,14 @@ pub struct TurnToolActivity {
     pub agent_tool_use_count: Option<i32>,
     pub agent_status: Option<String>,
     pub agent_tool_calls_json: String,
+    #[serde(default = "empty_json_array")]
+    pub agent_thinking_blocks_json: String,
+    #[serde(default)]
+    pub agent_result_text: Option<String>,
+}
+
+fn empty_json_array() -> String {
+    "[]".to_string()
 }
 
 /// Grouped checkpoint + activities for loading completed turns.

--- a/src/ui/src/components/chat/AgentToolCallGroup.tsx
+++ b/src/ui/src/components/chat/AgentToolCallGroup.tsx
@@ -6,10 +6,13 @@ import styles from "./ChatPanel.module.css";
 import { toolColor } from "./chatHelpers";
 import {
   activitySummaryText,
+  agentPromptText,
   agentToolCallSummary,
 } from "./agentToolCallRendering";
 import { InlineEditSummary } from "./EditChangeSummary";
 import { summarizeAgentToolCallEdit } from "./editActivitySummary";
+import { ThinkingBlock } from "./ThinkingBlock";
+import { HighlightedMessageMarkdown } from "./HighlightedMessageMarkdown";
 
 export function AgentToolCallGroup({
   activity,
@@ -36,7 +39,10 @@ export function AgentToolCallGroup({
   onToggle?: () => void;
 }) {
   const summary = activitySummaryText(activity);
+  const prompt = agentPromptText(activity);
   const calls = activity.agentToolCalls ?? [];
+  const thinkingBlocks = activity.agentThinkingBlocks ?? [];
+  const resultText = activity.agentResultText || activity.resultText;
   // Inline mode is the legacy "show everything inline" rendering; do
   // not let collapse semantics leak into it. Only when an explicit
   // toggle has been wired (the new live-agent wrapper) do we render
@@ -99,38 +105,77 @@ export function AgentToolCallGroup({
         </div>
       )}
       {!isCollapsed && (
-        <div className={styles.agentToolCallList}>
-          {calls.map((call) => {
-            const callSummary = agentToolCallSummary(call);
-            const editSummary = summarizeAgentToolCallEdit(call);
-            return (
-              <div key={call.toolUseId} className={styles.agentToolCall}>
-                {editSummary ? (
-                  <InlineEditSummary
-                    summary={editSummary}
-                    searchQuery={searchQuery}
-                    worktreePath={worktreePath}
-                  />
-                ) : (
-                  <span
-                    className={styles.agentToolCallName}
-                    style={{ color: toolColor(call.toolName) }}
-                  >
-                    {call.toolName}
-                  </span>
-                )}
-                {!editSummary && callSummary && (
-                  <span className={styles.agentToolCallSummary}>
-                    <HighlightedPlainText
-                      text={relativizePath(callSummary, worktreePath)}
-                      query={searchQuery}
-                    />
-                  </span>
-                )}
-                <span className={styles.agentToolCallStatus}>{call.status}</span>
+        <div className={styles.agentNestedChat}>
+          {prompt && (
+            <div className={styles.agentNestedMessage}>
+              <div className={styles.agentNestedRole}>Prompt</div>
+              <div className={styles.agentNestedText}>
+                <HighlightedPlainText
+                  text={relativizePath(prompt, worktreePath)}
+                  query={searchQuery}
+                />
               </div>
-            );
-          })}
+            </div>
+          )}
+          {thinkingBlocks.map((thinking, index) => (
+            <ThinkingBlock
+              key={`${activity.toolUseId}:thinking:${index}`}
+              content={thinking}
+              isStreaming={false}
+              searchQuery={searchQuery}
+            />
+          ))}
+          {calls.length > 0 && (
+            <div className={styles.agentNestedSection}>
+              <div className={styles.agentNestedRole}>Tool calls</div>
+              <div className={styles.agentToolCallList}>
+                {calls.map((call) => {
+                  const callSummary = agentToolCallSummary(call);
+                  const editSummary = summarizeAgentToolCallEdit(call);
+                  return (
+                    <div key={call.toolUseId} className={styles.agentToolCall}>
+                      {editSummary ? (
+                        <InlineEditSummary
+                          summary={editSummary}
+                          searchQuery={searchQuery}
+                          worktreePath={worktreePath}
+                        />
+                      ) : (
+                        <span
+                          className={styles.agentToolCallName}
+                          style={{ color: toolColor(call.toolName) }}
+                        >
+                          {call.toolName}
+                        </span>
+                      )}
+                      {!editSummary && callSummary && (
+                        <span className={styles.agentToolCallSummary}>
+                          <HighlightedPlainText
+                            text={relativizePath(callSummary, worktreePath)}
+                            query={searchQuery}
+                          />
+                        </span>
+                      )}
+                      <span className={styles.agentToolCallStatus}>
+                        {call.status}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          {resultText && (
+            <div className={styles.agentNestedMessage}>
+              <div className={styles.agentNestedRole}>Result</div>
+              <div className={styles.agentNestedMarkdown}>
+                <HighlightedMessageMarkdown
+                  content={resultText}
+                  query={searchQuery}
+                />
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/ui/src/components/chat/AgentToolCallGroup.tsx
+++ b/src/ui/src/components/chat/AgentToolCallGroup.tsx
@@ -54,7 +54,7 @@ export function AgentToolCallGroup({
         role: "button" as const,
         tabIndex: 0,
         "aria-expanded": !isCollapsed,
-        "aria-label": `${isCollapsed ? "Expand" : "Collapse"} ${activity.toolName} tool call list`,
+        "aria-label": `${isCollapsed ? "Expand" : "Collapse"} ${activity.toolName} transcript details`,
         onClick: onToggle,
         onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
           if (e.key === "Enter" || e.key === " ") {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -443,7 +443,6 @@
   border: 1px solid var(--divider);
   border-radius: 6px;
   margin: 4px 0;
-  cursor: pointer;
   transition: border-color var(--transition-fast);
   overflow: hidden;
   flex-shrink: 0;
@@ -461,6 +460,10 @@
   background: transparent;
   font-size: 12px;
   transition: background var(--transition-fast);
+}
+
+.turnHeader[role="button"] {
+  cursor: pointer;
 }
 
 .turnSummary:hover > .turnHeader {
@@ -1138,6 +1141,10 @@
   gap: 0;
   padding: 6px 8px 2px 8px;
   min-width: 0;
+}
+
+.agentToolGroupHeader[role="button"] {
+  cursor: pointer;
 }
 
 .agentToolGroupInline .agentToolGroupHeader {

--- a/src/ui/src/components/chat/ChatPanel.module.css
+++ b/src/ui/src/components/chat/ChatPanel.module.css
@@ -1147,11 +1147,59 @@
 .agentToolCallList {
   display: grid;
   gap: 2px;
-  padding: 0 8px 6px 24px;
+  padding: 0;
 }
 
 .agentToolGroupInline .agentToolCallList {
   padding: 0 8px 2px 24px;
+}
+
+.agentNestedChat {
+  display: grid;
+  gap: 8px;
+  padding: 6px 8px 8px 24px;
+}
+
+.agentNestedMessage,
+.agentNestedSection {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.agentNestedRole {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.agentNestedText {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.agentNestedMarkdown {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.agentNestedMarkdown > *:first-child {
+  margin-top: 0;
+}
+
+.agentNestedMarkdown > *:last-child {
+  margin-bottom: 0;
 }
 
 .agentToolCall {

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -471,6 +471,32 @@ describe("ToolActivitiesSection", () => {
     expect(container.textContent).toContain("Bash");
   });
 
+  it("does not force-expand ordinary tool groups for result-text search matches", async () => {
+    // Agent transcript search includes final results, but ordinary
+    // tool-result payloads can be large and noisy. Keep the older
+    // generic-tool contract: summaries/searchable inputs can open a
+    // group, raw result text alone does not.
+    const container = await render(
+      <ToolActivitiesSection
+        sessionId="session-result-search"
+        toolDisplayMode="grouped"
+        searchQuery="secret-result-token"
+        activities={[
+          activity("Bash", {
+            toolUseId: "result-search-1",
+            resultText: "secret-result-token",
+          }),
+        ]}
+      />,
+    );
+
+    const header = container.querySelector(
+      '[role="button"][aria-expanded]',
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).not.toContain("Bash");
+  });
+
   it("persists collapse state via the chatSlice so it survives running→completed transition", async () => {
     // The unified slice key (`tools:${first toolUseId}`) is shared
     // with `MessagesWithTurns`'s `TurnSummary` rendering, so a user's
@@ -1056,6 +1082,88 @@ describe("ToolActivitiesSection", () => {
 });
 
 describe("TurnSummary", () => {
+  it("only toggles completed ordinary tool groups from the header", async () => {
+    const onToggle = vi.fn();
+    const container = await render(
+      <TurnSummary
+        turn={completedTurn([
+          activity("Bash", {
+            summary: "echo selectable text",
+            resultText: "selectable output",
+          }),
+        ])}
+        collapsed={false}
+        onToggle={onToggle}
+        assistantText=""
+        searchQuery=""
+      />,
+    );
+
+    const activities = container.querySelector(
+      `.${styles.turnActivities}`,
+    ) as HTMLElement;
+    expect(activities).toBeTruthy();
+
+    await act(async () => {
+      activities.click();
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+
+    const header = container.querySelector(
+      `.${styles.turnHeader}[role="button"]`,
+    ) as HTMLElement;
+    await act(async () => {
+      header.click();
+    });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("only toggles completed Agent groups from the turn header", async () => {
+    const onToggle = vi.fn();
+    const container = await render(
+      <TurnSummary
+        turn={completedTurn([
+          activity("Agent", {
+            agentDescription: "Review selectable content",
+            agentResultText: "selectable agent result",
+            agentThinkingBlocks: ["selectable thinking"],
+            agentToolCalls: [
+              {
+                toolUseId: "nested-1",
+                toolName: "Read",
+                agentId: "agent-1",
+                status: "completed",
+                startedAt: "2026-05-08T00:00:00Z",
+              },
+            ],
+          }),
+        ])}
+        collapsed={false}
+        onToggle={onToggle}
+        assistantText=""
+        searchQuery=""
+      />,
+    );
+
+    const nestedChat = container.querySelector(
+      `.${styles.agentNestedChat}`,
+    ) as HTMLElement;
+    expect(nestedChat).toBeTruthy();
+
+    await act(async () => {
+      nestedChat.click();
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+
+    const header = container.querySelector(
+      `.${styles.turnHeader}[role="button"]`,
+    ) as HTMLElement;
+    await act(async () => {
+      header.click();
+    });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
   it("renders completed inline Agent calls without the summary card chrome", async () => {
     const agent = activity("Agent", {
       agentDescription: "Review changes",

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -183,6 +183,42 @@ describe("AgentToolCallGroup", () => {
     expect(container.textContent).toContain("+3");
     expect(container.textContent).toContain("-2");
   });
+
+  it("renders an expanded Agent block as a nested mini-chat", async () => {
+    const container = await render(
+      <AgentToolCallGroup
+        activity={activity("Agent", {
+          inputJson: JSON.stringify({
+            description: "Audit UI",
+            prompt: "Check the toolbar state handling.",
+          }),
+          agentThinkingBlocks: ["Read the relevant toolbar code first."],
+          agentToolCalls: [
+            {
+              toolUseId: "nested-chat-1",
+              toolName: "Read",
+              agentId: "agent-1",
+              status: "completed",
+              startedAt: "2026-05-08T00:00:00Z",
+            },
+          ],
+          agentResultText: "The toolbar state handling is consistent.",
+        })}
+        searchQuery="relevant"
+        collapsed={false}
+        onToggle={() => {}}
+      />,
+    );
+
+    expect(container.textContent).toContain("Prompt");
+    expect(container.textContent).toContain("Check the toolbar state handling.");
+    expect(container.textContent).toContain("Thinking");
+    expect(container.textContent).toContain("Read the relevant toolbar code first.");
+    expect(container.textContent).toContain("Tool calls");
+    expect(container.textContent).toContain("Read");
+    expect(container.textContent).toContain("Result");
+    expect(container.textContent).toContain("The toolbar state handling is consistent.");
+  });
 });
 
 describe("ToolActivitiesSection", () => {

--- a/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
+++ b/src/ui/src/components/chat/ToolActivitiesSection.test.tsx
@@ -154,6 +154,25 @@ describe("AgentToolCallGroup", () => {
     expect(container.textContent).toContain("Read");
   });
 
+  it("describes the collapsible Agent transcript accurately", async () => {
+    const container = await render(
+      <AgentToolCallGroup
+        activity={activity("Agent", { agentDescription: "Audit UI" })}
+        searchQuery=""
+        collapsed
+        onToggle={() => {}}
+      />,
+    );
+
+    const header = container.querySelector(
+      `.${styles.agentToolGroupHeader}[role="button"]`,
+    ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("false");
+    expect(header.getAttribute("aria-label")).toBe(
+      "Expand Agent transcript details",
+    );
+  });
+
   it("renders nested edit calls as editing rows with churn stats", async () => {
     const container = await render(
       <AgentToolCallGroup
@@ -1112,6 +1131,8 @@ describe("TurnSummary", () => {
     const header = container.querySelector(
       `.${styles.turnHeader}[role="button"]`,
     ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(header.getAttribute("aria-controls")).toBe(activities.id);
     await act(async () => {
       header.click();
     });
@@ -1158,6 +1179,8 @@ describe("TurnSummary", () => {
     const header = container.querySelector(
       `.${styles.turnHeader}[role="button"]`,
     ) as HTMLElement;
+    expect(header.getAttribute("aria-expanded")).toBe("true");
+    expect(header.getAttribute("aria-controls")).toBeTruthy();
     await act(async () => {
       header.click();
     });

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import type { CompletedTurn, ToolActivity } from "../../stores/useAppStore";
 import type { TaskTrackerResult } from "../../hooks/useTaskTracker";
 import styles from "./ChatPanel.module.css";
@@ -74,6 +74,7 @@ export function TurnSummary({
   const hasTokens =
     typeof turn.inputTokens === "number" && typeof turn.outputTokens === "number";
   const hasCopy = assistantText.length > 0;
+  const activitiesId = useId();
   const hasFork = !!onFork;
   const hasRollback = !!onRollback;
   const shouldShowFooter =
@@ -133,6 +134,8 @@ export function TurnSummary({
             className={styles.turnHeader}
             role="button"
             tabIndex={0}
+            aria-expanded={isExpanded}
+            aria-controls={activitiesId}
             onClick={onToggle}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -152,7 +155,9 @@ export function TurnSummary({
             </span>
           </div>
           {isExpanded && (
-            <div className={styles.turnActivities}>{renderedActivities}</div>
+            <div id={activitiesId} className={styles.turnActivities}>
+              {renderedActivities}
+            </div>
           )}
         </div>
       )}

--- a/src/ui/src/components/chat/TurnSummary.tsx
+++ b/src/ui/src/components/chat/TurnSummary.tsx
@@ -128,19 +128,19 @@ export function TurnSummary({
       {inline ? (
         <div className={styles.inlineTurnActivities}>{renderedActivities}</div>
       ) : (
-        <div
-          className={styles.turnSummary}
-          role="button"
-          tabIndex={0}
-          onClick={onToggle}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              onToggle();
-            }
-          }}
-        >
-          <div className={styles.turnHeader}>
+        <div className={styles.turnSummary}>
+          <div
+            className={styles.turnHeader}
+            role="button"
+            tabIndex={0}
+            onClick={onToggle}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onToggle();
+              }
+            }}
+          >
             <span className={styles.toolChevron}>{isExpanded ? "⌄" : "›"}</span>
             <span className={styles.turnLabel}>
               {label ??

--- a/src/ui/src/components/chat/agentToolCallRendering.ts
+++ b/src/ui/src/components/chat/agentToolCallRendering.ts
@@ -14,6 +14,22 @@ export function activityMatchesSearch(
   const normalizedQuery = query.toLowerCase();
   const summary = relativizePath(activitySummaryText(activity), worktreePath);
   if (summary.toLowerCase().includes(normalizedQuery)) return true;
+  const prompt = relativizePath(agentPromptText(activity), worktreePath);
+  if (prompt.toLowerCase().includes(normalizedQuery)) return true;
+  if (
+    (activity.agentResultText ?? activity.resultText)
+      .toLowerCase()
+      .includes(normalizedQuery)
+  ) {
+    return true;
+  }
+  if (
+    (activity.agentThinkingBlocks ?? []).some((block) =>
+      block.toLowerCase().includes(normalizedQuery),
+    )
+  ) {
+    return true;
+  }
   return (activity.agentToolCalls ?? []).some((call) =>
     relativizePath(agentToolCallSummary(call), worktreePath)
       .toLowerCase()
@@ -30,11 +46,33 @@ export function activitySummaryText(activity: ToolActivity): string {
   );
 }
 
+export function agentPromptText(activity: ToolActivity): string {
+  try {
+    const parsed = JSON.parse(activity.inputJson || "{}") as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return "";
+    }
+    const input = parsed as Record<string, unknown>;
+    return (
+      stringField(input.prompt) ||
+      stringField(input.description) ||
+      stringField(input.task) ||
+      ""
+    );
+  } catch {
+    return "";
+  }
+}
+
 export function agentToolCallSummary(call: AgentToolCall): string {
   const inputSummary = extractToolSummary(call.toolName, safeJson(call.input));
   if (inputSummary) return inputSummary;
   if (call.error) return call.error;
   return valuePreview(call.input ?? call.response);
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function safeJson(value: unknown): string {

--- a/src/ui/src/components/chat/agentToolCallRendering.ts
+++ b/src/ui/src/components/chat/agentToolCallRendering.ts
@@ -14,13 +14,11 @@ export function activityMatchesSearch(
   const normalizedQuery = query.toLowerCase();
   const summary = relativizePath(activitySummaryText(activity), worktreePath);
   if (summary.toLowerCase().includes(normalizedQuery)) return true;
+  if (!isAgentTranscriptActivity(activity)) return false;
+
   const prompt = relativizePath(agentPromptText(activity), worktreePath);
   if (prompt.toLowerCase().includes(normalizedQuery)) return true;
-  if (
-    (activity.agentResultText ?? activity.resultText)
-      .toLowerCase()
-      .includes(normalizedQuery)
-  ) {
+  if ((activity.agentResultText ?? "").toLowerCase().includes(normalizedQuery)) {
     return true;
   }
   if (
@@ -35,6 +33,10 @@ export function activityMatchesSearch(
       .toLowerCase()
       .includes(normalizedQuery),
   );
+}
+
+function isAgentTranscriptActivity(activity: ToolActivity): boolean {
+  return activity.toolName === "Agent" || !!activity.agentTaskId;
 }
 
 export function activitySummaryText(activity: ToolActivity): string {

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -33,10 +33,9 @@ function stringFromUnknown(value: unknown): string | undefined {
 
 function stringArrayFromUnknown(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
-  return value.filter(
-    (item): item is string =>
-      typeof item === "string" && item.trim().length > 0,
-  );
+  return value
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter((item) => item.length > 0);
 }
 
 interface AgentHookEventPayload {

--- a/src/ui/src/hooks/useAgentStream.ts
+++ b/src/ui/src/hooks/useAgentStream.ts
@@ -27,6 +27,18 @@ import { applyCommandLineEvent } from "./useAgentStreamLogic";
 
 const ASK_USER_QUESTION_TOOL = "AskUserQuestion";
 
+function stringFromUnknown(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringArrayFromUnknown(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string =>
+      typeof item === "string" && item.trim().length > 0,
+  );
+}
+
 interface AgentHookEventPayload {
   workspace_id: string;
   chat_session_id: string;
@@ -39,6 +51,9 @@ interface AgentHookEventPayload {
     tool_response?: unknown;
     tool_use_id?: string;
     error?: string;
+    last_assistant_message?: unknown;
+    claudette_agent_final_result?: unknown;
+    claudette_agent_thinking_blocks?: unknown;
   };
 }
 
@@ -623,6 +638,33 @@ export function useAgentStream() {
         return;
       }
 
+      if (hookName === "SubagentStop") {
+        const activity = (
+          useAppStore.getState().toolActivities[sessionId] || []
+        ).find(
+          (item) =>
+            item.agentTaskId === agentId ||
+            item.toolUseId === input.tool_use_id ||
+            item.toolUseId === agentId,
+        );
+        if (!activity) return;
+        const finalResult =
+          stringFromUnknown(input.last_assistant_message) ??
+          stringFromUnknown(input.claudette_agent_final_result);
+        const thinkingBlocks = stringArrayFromUnknown(
+          input.claudette_agent_thinking_blocks,
+        );
+        const updates: Parameters<typeof updateToolActivity>[2] = {
+          agentStatus: input.error ? "failed" : "completed",
+        };
+        if (finalResult) updates.agentResultText = finalResult;
+        if (thinkingBlocks.length > 0) {
+          updates.agentThinkingBlocks = thinkingBlocks;
+        }
+        updateToolActivity(sessionId, activity.toolUseId, updates);
+        return;
+      }
+
       if (
         hookName !== "PreToolUse" &&
         hookName !== "PostToolUse" &&
@@ -667,7 +709,7 @@ export function useAgentStream() {
       active = false;
       unlisten.then((fn) => fn());
     };
-  }, [upsertAgentToolCall]);
+  }, [upsertAgentToolCall, updateToolActivity]);
 
   // Listen for `agent-permission-prompt` — emitted by the Rust bridge the
   // moment a CLI `control_request: can_use_tool` is captured for
@@ -812,6 +854,10 @@ export function useAgentStream() {
               agent_tool_use_count: a.agentToolUseCount ?? null,
               agent_status: a.agentStatus ?? null,
               agent_tool_calls_json: JSON.stringify(a.agentToolCalls ?? []),
+              agent_thinking_blocks_json: JSON.stringify(
+                a.agentThinkingBlocks ?? [],
+              ),
+              agent_result_text: a.agentResultText ?? null,
             }));
             return saveTurnToolActivities(checkpoint.id, messageCount, activities);
           })()

--- a/src/ui/src/hooks/useWorkspaceTaskHistory.ts
+++ b/src/ui/src/hooks/useWorkspaceTaskHistory.ts
@@ -53,6 +53,17 @@ function parseAgentToolCalls(value: string): AgentToolCall[] | undefined {
   }
 }
 
+function parseStringArray(value: string): string[] | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function turnFromData(data: CompletedTurnData): TaskActivityTurn {
   return {
     id: data.checkpoint_id,
@@ -70,6 +81,8 @@ function turnFromData(data: CompletedTurnData): TaskActivityTurn {
       agentToolUseCount: activity.agent_tool_use_count,
       agentStatus: activity.agent_status,
       agentToolCalls: parseAgentToolCalls(activity.agent_tool_calls_json),
+      agentThinkingBlocks: parseStringArray(activity.agent_thinking_blocks_json),
+      agentResultText: activity.agent_result_text,
     })),
   };
 }

--- a/src/ui/src/stores/slices/chatSlice.ts
+++ b/src/ui/src/stores/slices/chatSlice.ts
@@ -20,6 +20,8 @@ export interface ToolActivity {
   agentToolUseCount?: number | null;
   agentStatus?: string | null;
   agentToolCalls?: AgentToolCall[];
+  agentThinkingBlocks?: string[];
+  agentResultText?: string | null;
 }
 
 export interface AgentToolCall {
@@ -542,6 +544,8 @@ export const createChatSlice: StateCreator<AppState, [], [], ChatSlice> = (
           agentToolUseCount: a.agentToolUseCount,
           agentStatus: a.agentStatus,
           agentToolCalls: a.agentToolCalls,
+          agentThinkingBlocks: a.agentThinkingBlocks,
+          agentResultText: a.agentResultText,
         })),
         messageCount,
         collapsed: true,

--- a/src/ui/src/types/checkpoint.ts
+++ b/src/ui/src/types/checkpoint.ts
@@ -25,6 +25,8 @@ export interface TurnToolActivityData {
   agent_tool_use_count: number | null;
   agent_status: string | null;
   agent_tool_calls_json: string;
+  agent_thinking_blocks_json: string;
+  agent_result_text: string | null;
 }
 
 export interface CompletedTurnData {

--- a/src/ui/src/utils/reconstructTurns.test.ts
+++ b/src/ui/src/utils/reconstructTurns.test.ts
@@ -51,6 +51,8 @@ function makeTurnData(
       agent_tool_use_count: null,
       agent_status: null,
       agent_tool_calls_json: "[]",
+      agent_thinking_blocks_json: "[]",
+      agent_result_text: null,
     })),
   };
 }
@@ -338,6 +340,8 @@ describe("reconstructCompletedTurns", () => {
             agent_tool_use_count: null,
             agent_status: null,
             agent_tool_calls_json: "[]",
+            agent_thinking_blocks_json: "[]",
+            agent_result_text: null,
           },
         ],
       },

--- a/src/ui/src/utils/reconstructTurns.ts
+++ b/src/ui/src/utils/reconstructTurns.ts
@@ -92,6 +92,8 @@ export function reconstructCompletedTurns(
         agentToolUseCount: a.agent_tool_use_count,
         agentStatus: a.agent_status,
         agentToolCalls: parseAgentToolCalls(a.agent_tool_calls_json),
+        agentThinkingBlocks: parseStringArray(a.agent_thinking_blocks_json),
+        agentResultText: a.agent_result_text,
       })),
       messageCount: td.message_count,
       collapsed: true,
@@ -111,6 +113,18 @@ function parseAgentToolCalls(value: string | null | undefined) {
   try {
     const parsed = JSON.parse(value);
     return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseStringArray(value: string | null | undefined) {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

Closes #563.

This finishes the remaining sub-agent transcript rendering work on top of the earlier first-class Agent block grouping. Agent/Task invocations now preserve and display the useful parts of the delegated run instead of only showing a generic tool row.

## What Changed

- Enrich `SubagentStop` hook payloads by reading the Claude Code sub-agent JSONL transcript and extracting bounded thinking blocks plus the final assistant text.
- Persist sub-agent transcript details on `turn_tool_activities` via `agent_thinking_blocks_json` and `agent_result_text`.
- Rehydrate the new fields through completed-turn reconstruction and workspace task history.
- Render expanded Agent blocks as nested mini-chat panels with delegated prompt, expandable thinking blocks, nested tool-call list, and final result markdown.
- Extend chat search so matches inside sub-agent prompt, thinking, nested tool calls, and result force only Agent blocks open; ordinary tool calls keep their prior search behavior.
- Keep collapse/expand behavior scoped to completed-turn headers so text inside expanded Agent and ordinary tool-call blocks remains selectable.
- Document the Agent block behavior in the agent configuration docs.

## Review Follow-Up

- Bounded transcript extraction to a tail window with line, thinking block, thinking character, and result character caps.
- Trimmed streamed thinking block strings before storing them.
- Added regression coverage for ordinary result-text search, bounded transcript extraction, and header-only collapse toggling for both ordinary and Agent completed blocks.

## User Impact

Sub-agent runs are no longer opaque. When an Agent/Task invocation expands, users can inspect what was delegated, how the sub-agent reasoned when thinking is available, which nested tools it used, and what final answer came back to the parent agent. Expanded content behaves like the rest of the transcript: users can click into it to select text without collapsing the block.

## Verification

- UAT passed locally.
- `cd src/ui && bunx tsc -b`
- `cd src/ui && bun run test -- ToolActivitiesSection.test.tsx reconstructTurns.test.ts`
- `cd src/ui && bun run lint:css`
- `cd src/ui && bun run lint` — passes with existing warnings outside this change
- `nix develop -c cargo fmt --all`
- `nix develop -c env RUSTFLAGS="-Dwarnings" cargo clippy -p claudette -p claudette-server -p claudette-cli --all-targets --all-features`
- `nix develop -c cargo test -p claudette agent_mcp::hook`
- `nix develop -c cargo test -p claudette db::checkpoint`
- `nix develop -c cargo test -p claudette db::tests::test_fresh_db_applies_all_migrations`
- `nix develop -c cargo test -p claudette fork::tests::copy_history_copies_up_to_checkpoint_and_remaps_ids`
- `git diff --check`

## Known Caveat

A broad `nix develop -c cargo test -p claudette` compiled and ran, but six existing watcher timing tests failed waiting for filesystem callbacks within 3 seconds:

- `env_provider::watcher::tests::multiple_keys_on_same_path_both_fire`
- `env_provider::watcher::tests::register_then_modify_fires_callback`
- `env_provider::watcher::tests::watch_retry_picks_up_later_created_file`
- `file_watcher::tests::re_register_drops_stale_paths`
- `file_watcher::tests::register_then_modify_fires_callback`
- `file_watcher::tests::two_workspaces_share_path_dedupe`

The directly affected hook, DB/migration, fork, TypeScript, and UI tests passed.